### PR TITLE
MAINT: Limit fittable data for von mises fisher distribution to 2D

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -6706,8 +6706,10 @@ class vonmises_fisher_gen(multi_rv_generic):
         Parameters
         ----------
         x : array-like
-            Data the distribution is fitted to. The last axis of `x` must
-            be unit vectors of norm 1.
+            Data the distribution is fitted to. Must be two dimensional.
+            The second axis of `x` must be unit vectors of norm 1 and
+            determine the dimensionality of the fitted
+            von Mises-Fisher distribution.
 
         Returns
         -------
@@ -6719,14 +6721,12 @@ class vonmises_fisher_gen(multi_rv_generic):
         """
         # validate input data
         x = np.asarray(x)
-        if x.ndim == 1:
-            raise ValueError("'x' must be at least two dimensional.")
+        if x.ndim != 2:
+            raise ValueError("'x' must be two dimensional.")
         if not np.allclose(np.linalg.norm(x, axis=-1), 1.):
             msg = "'x' must be unit vectors of norm 1 along last dimension."
             raise ValueError(msg)
         dim = x.shape[-1]
-        if x.ndim > 2:
-            x = x.reshape((math.prod(x.shape[:-1]), dim))
 
         # mu is simply the directional mean
         dirstats = directional_stats(x)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3136,7 +3136,6 @@ class TestVonMises_Fisher:
         # test that no warnings are encountered for high values
         rng = np.random.default_rng(2777937887058094419)
         mu = np.full((dim, ), 1/np.sqrt(dim))
-        #mu[0] = 1.
         vmf_dist = vonmises_fisher(mu, kappa, seed=rng)
         vmf_dist.rvs(10)
 
@@ -3340,7 +3339,7 @@ class TestVonMises_Fisher:
         mu = np.full((dim, ), 1/np.sqrt(dim))
         vmf_dist = vonmises_fisher(mu, kappa)
         rng = np.random.default_rng(2777937887058094419)
-        n_samples = (100, 100)
+        n_samples = 10000
         samples = vmf_dist.rvs(n_samples, random_state=rng)
         mu_fit, kappa_fit = vonmises_fisher.fit(samples)
         angular_error = np.arccos(mu.dot(mu_fit))
@@ -3349,7 +3348,7 @@ class TestVonMises_Fisher:
 
     def test_fit_error_one_dimensional_data(self):
         x = np.zeros((3, ))
-        msg = "'x' must be at least two dimensional."
+        msg = "'x' must be two dimensional."
         with pytest.raises(ValueError, match=msg):
             vonmises_fisher.fit(x)
 


### PR DESCRIPTION
#### Reference issue
THe new `vonmises_fisher` distribution currently accepts data with more than two dimensions in its `fit` method. In https://github.com/scipy/scipy/pull/18361 it was pointed out that that is different from the univariate distributions which only accept 1D data. For multivariate distributions, we should only accept 2D data then.
