### PR TITLE
TST: stats.cosine: modify test to silence failure

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8759,14 +8759,9 @@ def test_cosine_ppf_isf(p, expected):
 
 
 def test_cosine_logpdf_endpoints():
-    x = [-np.pi, np.pi]
-    c = np.cos(x)
-    assert_equal(c, -1)
-    with np.errstate(divide='ignore', invalid='ignore'):
-        res = np.log1p(c) - np.log(2 * np.pi)
-        assert_equal(res, -np.inf)
-    logp = stats.cosine.logpdf(x)
-    assert_equal(logp, [-np.inf, -np.inf])
+    # reference value calculated using mpmath assuming `np.cos(-1)` is four
+    # floating point numbers too high. See gh-18382.
+    assert_array_less(logp, -37.18838327496655)
 
 
 def test_distr_params_lists():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8759,7 +8759,12 @@ def test_cosine_ppf_isf(p, expected):
 
 
 def test_cosine_logpdf_endpoints():
-    logp = stats.cosine.logpdf([-np.pi, np.pi])
+    x = [-np.pi, np.pi]
+    c = np.cos(x)
+    assert_equal(c, -1)
+    res = np.log1p(c) - np.log(2 * np.pi)
+    assert_equal(res, -np.inf)
+    logp = stats.cosine.logpdf(x)
     assert_equal(logp, [-np.inf, -np.inf])
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8759,6 +8759,7 @@ def test_cosine_ppf_isf(p, expected):
 
 
 def test_cosine_logpdf_endpoints():
+    logp = stats.cosine.logpdf([-np.pi, np.pi])
     # reference value calculated using mpmath assuming `np.cos(-1)` is four
     # floating point numbers too high. See gh-18382.
     assert_array_less(logp, -37.18838327496655)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8762,8 +8762,9 @@ def test_cosine_logpdf_endpoints():
     x = [-np.pi, np.pi]
     c = np.cos(x)
     assert_equal(c, -1)
-    res = np.log1p(c) - np.log(2 * np.pi)
-    assert_equal(res, -np.inf)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        res = np.log1p(c) - np.log(2 * np.pi)
+        assert_equal(res, -np.inf)
     logp = stats.cosine.logpdf(x)
     assert_equal(logp, [-np.inf, -np.inf])
 


### PR DESCRIPTION
#### Reference issue
gh-18358
https://github.com/scipy/scipy/pull/18379#issuecomment-1526342877

#### What does this implement/fix?
Investigating one of the Linux Meson tests / Meson build 3.11 test failures noted in gh-18358.

