### PR TITLE
DOC: improve vonmises documentation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9972,11 +9972,71 @@ class vonmises_gen(rv_continuous):
     `vonmises_line` is the same distribution, defined on :math:`[-\pi, \pi]`
     on the real line. This is a regular (i.e. non-circular) distribution.
 
-    `vonmises` and `vonmises_line` take ``kappa`` as a shape parameter.
+    Note about distribution parameters: `vonmises` and `vonmises_line` take
+    ``kappa`` as a shape parameter and the ``scale`` parameter does not have
+    any effect.
 
-    %(after_notes)s
+    Examples
+    --------
+    Import the necessary modules.
 
-    %(example)s
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.stats import vonmises
+
+    Define distribution parameters: the circular mean $\mu$ has to be passed
+    via the ``loc`` (location) parameter and the concentration parameter
+    $\kappa$ as ``kappa``.
+
+    >>> loc = 0.5 * np.pi
+    >>> kappa = 1
+
+    Compute the probability density at ``x=0`` via the ``pdf`` method.
+
+    >>> vonmises.pdf(loc, kappa, 0)
+    0.12570826359722018
+
+    Verify that the percentile function ``ppf`` inverts the cumulative
+    distribution function ``cdf`` up to floating point accuracy.
+
+    >>> x = 1
+    >>> cdf_value = vonmises.cdf(loc=loc, kappa=kappa, x=x)
+    >>> ppf_value = vonmises.ppf(cdf_value, loc=loc, kappa=kappa)
+    >>> x, cdf_value, ppf_value
+    (1, 0.31489339900904967, 1.0000000000000004)
+
+    Draw 1000 random variates by calling the ``rvs`` method.
+
+    >>> number_of_samples = 1000
+    >>> samples = vonmises(loc=loc, kappa=kappa).rvs(number_of_samples)
+
+    Plot the von Mises density on a cartesian and polar grid to emphasize
+    that is is a circular distribution.
+
+    >>> fig = plt.figure(figsize=(8, 6))
+    >>> left = plt.subplot(121)
+    >>> right = plt.subplot(122, projection='polar')
+    >>> x = np.linspace(-np.pi, np.pi, 500)
+    >>> vonmises_pdf = vonmises.pdf(loc, kappa, x)
+    >>> ticks = [0, 0.15, 0.3]
+
+    The left image contains the cartesian plot.
+
+    >>> left.plot(x, vonmises_pdf)
+    >>> left.set_yticks(ticks)
+    >>> number_of_bins = int(np.sqrt(number_of_samples))
+    >>> left.hist(samples, density=True, bins=number_of_bins)
+    >>> left.set_title("Cartesian plot")
+    >>> left.grid(True)
+
+    The right image contains the polar plot.
+
+    >>> right.plot(x, vonmises_pdf, label="PDF")
+    >>> right.set_yticks(ticks)
+    >>> right.hist(samples, density=True, bins=number_of_bins,
+    ...            label="Histogram")
+    >>> right.set_title("Polar plot", pad=65)
+    >>> right.legend(bbox_to_anchor=(0.3, 1.35))
 
     """
     def _shape_info(self):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10013,7 +10013,7 @@ class vonmises_gen(rv_continuous):
     Plot the von Mises density on a cartesian and polar grid to emphasize
     that is is a circular distribution.
 
-    >>> fig = plt.figure(figsize=(8, 6))
+    >>> fig = plt.figure(figsize=(12, 6))
     >>> left = plt.subplot(121)
     >>> right = plt.subplot(122, projection='polar')
     >>> x = np.linspace(-np.pi, np.pi, 500)
@@ -10027,6 +10027,7 @@ class vonmises_gen(rv_continuous):
     >>> number_of_bins = int(np.sqrt(number_of_samples))
     >>> left.hist(samples, density=True, bins=number_of_bins)
     >>> left.set_title("Cartesian plot")
+    >>> left.set_xlim(-np.pi, np.pi)
     >>> left.grid(True)
 
     The right image contains the polar plot.
@@ -10035,8 +10036,8 @@ class vonmises_gen(rv_continuous):
     >>> right.set_yticks(ticks)
     >>> right.hist(samples, density=True, bins=number_of_bins,
     ...            label="Histogram")
-    >>> right.set_title("Polar plot", pad=65)
-    >>> right.legend(bbox_to_anchor=(0.3, 1.35))
+    >>> right.set_title("Polar plot")
+    >>> right.legend(bbox_to_anchor=(0.15, 1.06))
 
     """
     def _shape_info(self):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9973,8 +9973,9 @@ class vonmises_gen(rv_continuous):
     on the real line. This is a regular (i.e. non-circular) distribution.
 
     Note about distribution parameters: `vonmises` and `vonmises_line` take
-    ``kappa`` as a shape parameter and the ``scale`` parameter does not have
-    any effect.
+    ``kappa`` as a shape parameter (concentration) and ``loc`` as the location
+    (circular mean). A ``scale`` parameter is accepted but does not have any
+    effect.
 
     Examples
     --------
@@ -9984,12 +9985,10 @@ class vonmises_gen(rv_continuous):
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import vonmises
 
-    Define distribution parameters: the circular mean $\mu$ has to be passed
-    via the ``loc`` (location) parameter and the concentration parameter
-    $\kappa$ as ``kappa``.
+    Define distribution parameters.
 
-    >>> loc = 0.5 * np.pi
-    >>> kappa = 1
+    >>> loc = 0.5 * np.pi  # circular mean
+    >>> kappa = 1  # concentration
 
     Compute the probability density at ``x=0`` via the ``pdf`` method.
 
@@ -10010,7 +10009,7 @@ class vonmises_gen(rv_continuous):
     >>> number_of_samples = 1000
     >>> samples = vonmises(loc=loc, kappa=kappa).rvs(number_of_samples)
 
-    Plot the von Mises density on a cartesian and polar grid to emphasize
+    Plot the von Mises density on a Cartesian and polar grid to emphasize
     that is is a circular distribution.
 
     >>> fig = plt.figure(figsize=(8, 6))
@@ -10020,7 +10019,7 @@ class vonmises_gen(rv_continuous):
     >>> vonmises_pdf = vonmises.pdf(loc, kappa, x)
     >>> ticks = [0, 0.15, 0.3]
 
-    The left image contains the cartesian plot.
+    The left image contains the Cartesian plot.
 
     >>> left.plot(x, vonmises_pdf)
     >>> left.set_yticks(ticks)


### PR DESCRIPTION
#### Reference issue
The `vonmises` distribution is an odd one: circular, ``scale`` does not have any effect etc. This was not reflected especially in the examples section so far.

#### What does this implement/fix?
Overhaul vonmises notes and examples.