### PR TITLE
MAINT:ENH:sparse.linalg: Rewrite iterative solvers in Python, remove FORTRAN code

### DIFF
--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -77,7 +77,7 @@ def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     if tol is not None:
         msg = ("'scipy.sparse.linalg.bicg' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override 'rtol'.")
+               "v.1.13.0. Until then, if set, will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -91,10 +91,7 @@ def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     atol = max(float(atol), float(rtol) * float(np.linalg.norm(b)))
 
     n = len(b)
-    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
 
     if maxiter is None:
         maxiter = n*10
@@ -111,7 +108,7 @@ def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     # Dummy values to initialize vars, silence linter warnings
     rho_prev, p, ptilde = None, None, None
 
-    r = b - matvec(x) if x0 is not None else b.copy()
+    r = b - matvec(x) if x.any() else b.copy()
     rtilde = r.copy()
 
     for iteration in range(maxiter):
@@ -229,7 +226,7 @@ def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     if tol is not None:
         msg = ("'scipy.sparse.linalg.bicgstab' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override 'rtol'.")
+               "v.1.13.0. Until then, if set, will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -244,10 +241,7 @@ def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
 
     n = len(b)
 
-    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
 
     if maxiter is None:
         maxiter = n*10
@@ -267,7 +261,7 @@ def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     # Dummy values to initialize vars, silence linter warnings
     rho_prev, omega, alpha, p, v = None, None, None, None, None
 
-    r = b - matvec(x) if x0 is not None else b.copy()
+    r = b - matvec(x) if x.any() else b.copy()
     rtilde = r.copy()
 
     for iteration in range(maxiter):
@@ -392,7 +386,7 @@ def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
     if tol is not None:
         msg = ("'scipy.sparse.linalg.cg' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override 'rtol'.")
+               "v.1.13.0. Until then, if set, will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -409,9 +403,11 @@ def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
     if maxiter is None:
         maxiter = n*10
 
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
+
     matvec = A.matvec
     psolve = M.matvec
-    r = b - matvec(x) if x0 is not None else b.copy()
+    r = b - matvec(x) if x.any() else b.copy()
 
     # Is there any tolerance set? since b can be all 0.
     if atol == 0.:
@@ -419,10 +415,6 @@ def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
 
     # Dummy value to initialize var, silences warnings
     rho_prev, p = None, None
-    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
 
     for iteration in range(maxiter):
         if np.linalg.norm(r) < atol:  # Are we done?
@@ -524,7 +516,7 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     if tol is not None:
         msg = ("'scipy.sparse.linalg.cgs' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override 'rtol'.")
+               "v.1.13.0. Until then, if set, will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -538,10 +530,7 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     atol = max(float(atol), rtol * float(np.linalg.norm(b)))
     n = len(b)
 
-    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
 
     if maxiter is None:
         maxiter = n*10
@@ -551,7 +540,7 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
 
     rhotol = np.finfo(x.dtype.char).eps**2
 
-    r = b - matvec(x) if x0 is not None else b.copy()
+    r = b - matvec(x) if x.any() else b.copy()
 
     # Is there any tolerance set? since b can be all 0.
     if atol == 0.:
@@ -591,11 +580,9 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
             p += u
 
         else:  # First spin
-            p = np.empty_like(r)
-            u = np.empty_like(r)
+            p = r.copy()
+            u = r.copy()
             q = np.empty_like(r)
-            p[:] = r[:]
-            u[:] = r[:]
 
         phat = psolve(p)
         vhat = matvec(phat)
@@ -745,7 +732,7 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
     if tol is not None:
         msg = ("'gmres' keyword argument 'tol' is deprecated "
                "in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override `rtol`.")
+               "v.1.13.0. Until then, if set, will override `rtol`.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -781,10 +768,7 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
 
     eps = np.finfo(x.dtype.char).eps
 
-    if np.iscomplexobj(x):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
 
     if maxiter is None:
         maxiter = n*10
@@ -842,7 +826,7 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
 
     for iteration in range(maxiter):
         if iteration == 0:
-            r = b - matvec(x) if x0 is None else b.copy()
+            r = b - matvec(x) if x.any() else b.copy()
 
         v[0, :] = psolve(r)
         tmp = np.linalg.norm(v[0, :])
@@ -881,7 +865,7 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
                 h[col, [k, k + 1]] = [c*n0 + s*n1, -s.conj()*n0 + c*n1]
 
             # get and apply current rotation to h and S
-            c, s, mag = lartg(*h[col, [col, col+1]])
+            c, s, mag = lartg(h[col, col], h[col, col+1])
             givens[col, :] = [c, s]
             h[col, [col, col+1]] = mag, 0
 
@@ -899,20 +883,34 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
             if presid <= ptol or breakdown:
                 break
 
-        # Solve (col, col) upper triangular system
-        # allow trsv to pseudo-solve singular cases
+        # Solve h(col, col) upper triangular system and allow pseudo-solve
+        # singular cases as in (but without the f2py copies)
+        # y = trsv(h[:col+1, :col+1].T, S[:col+1])
+
         if h[col, col] == 0:
             S[col] = 0
 
-        y = trsv(h[:col+1, :col+1].T, S[:col+1])
+        y = np.zeros([col+1], dtype=x.dtype)
+        y[:] = S[:col+1]
+        for k in range(col, 0, -1):
+            if y[k] != 0:
+                y[k] /= h[k, k]
+                tmp = y[k]
+                y[:k] -= tmp*h[k, :k]
+        if y[0] != 0:
+            y[0] /= h[0, 0]
+
         x += y @ v[:col+1, :]
 
         # Legacy exit
-        if callback_type == 'legacy' and inner_iter > maxiter:
+        if callback_type == 'legacy' and inner_iter == maxiter:
             return postprocess(x), maxiter
 
         r = b - matvec(x)
         rnorm = np.linalg.norm(r)
+
+        if callback_type == 'x':
+            callback(x)
 
         if rnorm <= atol:
             break
@@ -1009,7 +1007,7 @@ def qmr(A, b, x0=None, tol=None, maxiter=None, M1=None, M2=None, callback=None,
     if tol is not None:
         msg = ("'scipy.sparse.linalg.qmr' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               " v.1.13.0. Until then, if set, will override 'rtol'.")
+               "v.1.13.0. Until then, if set, will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         rtol = float(tol)
 
@@ -1051,10 +1049,7 @@ def qmr(A, b, x0=None, tol=None, maxiter=None, M1=None, M2=None, callback=None,
     if maxiter is None:
         maxiter = n*10
 
-    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
-        dotprod = np.vdot
-    else:
-        dotprod = np.dot
+    dotprod = np.vdot if np.iscomplexobj(x) else np.dot
 
     rhotol = np.finfo(x.dtype.char).eps
     betatol = rhotol
@@ -1063,7 +1058,8 @@ def qmr(A, b, x0=None, tol=None, maxiter=None, M1=None, M2=None, callback=None,
     epsilontol = rhotol
     xitol = rhotol
 
-    r = b - A.matvec(x) if x0 is not None else b.copy()
+    r = b - A.matvec(x) if x.any() else b.copy()
+
     vtilde = r.copy()
     y = M1.matvec(vtilde)
     rho = np.linalg.norm(y)

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -1,6 +1,6 @@
 """Iterative methods for solving linear systems"""
 
-__all__ = ['bicg','bicgstab','cg','cgs','gmres','qmr']
+__all__ = ['bicg', 'bicgstab', 'cg', 'cgs', 'gmres', 'qmr']
 
 import warnings
 from textwrap import dedent
@@ -13,7 +13,7 @@ from .utils import make_system
 from scipy._lib._util import _aligned_zeros
 from scipy._lib._threadsafety import non_reentrant
 
-_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
+_type_conv = {'f': 's', 'd': 'd', 'F': 'c', 'D': 'z'}
 
 
 # Part of the docstring common to all iterative solvers
@@ -324,71 +324,70 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=
                True
 
                """)
-@non_reentrant()
-def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
+def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=0.):
     A, M, x, b, postprocess = make_system(A, M, x0, b)
-
     n = len(b)
+
     if maxiter is None:
         maxiter = n*10
 
     matvec = A.matvec
     psolve = M.matvec
-    ltr = _type_conv[x.dtype.char]
-    revcom = getattr(_iterative, ltr + 'cgrevcom')
+    r = b - matvec(x)
 
-    def get_residual():
-        return np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'cg')
-    if atol == 'exit':
-        return postprocess(x), 0
+    # Deprecate the legacy usage
+    if isinstance(atol, str):
+        warnings.warn("scipy.sparse.linalg.cg called with `atol` set to "
+                      "string, possibly with value 'legacy'. This behavior "
+                      "is deprecated and atol parameter only excepts floats."
+                      " In SciPy 1.13, this will result with an error.",
+                      category=DeprecationWarning, stacklevel=3)
+        tol = float(tol)
 
-    resid = atol
-    ndx1 = 1
-    ndx2 = -1
-    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
-    work = _aligned_zeros(4*n,dtype=x.dtype)
-    ijob = 1
-    info = 0
-    ftflag = True
-    iter_ = maxiter
-    while True:
-        olditer = iter_
-        x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \
-           revcom(b, x, work, iter_, resid, info, ndx1, ndx2, ijob)
-        if callback is not None and iter_ > olditer:
+        if np.linalg.norm(b) == 0:
+            atol = tol
+        else:
+            atol = tol * float(np.linalg.norm(b))
+    else:
+        atol = max(float(atol), tol * float(np.linalg.norm(b)))
+
+    # Is there any tolerance set? since b can be all 0.
+    if atol == 0.:
+        atol = 10*n*np.finfo(A.dtype).eps
+
+    # Dummy value to initialize var, silences warnings
+    rtz_prev, p = None, None
+    if (np.iscomplexobj(A) or np.iscomplexobj(b)):
+        dotprod = np.vdot
+    else:
+        dotprod = np.dot
+
+    for iteration in range(maxiter):
+        if np.linalg.norm(r) < atol:  # Are we done?
+            return postprocess(x), 0
+
+        z = psolve(r)
+        rtz_cur = dotprod(r, z)
+        if iteration > 0:
+            beta = rtz_cur / rtz_prev
+            p *= beta
+            p += z
+        else:  # First spin
+            p = np.empty_like(r)
+            p[:] = z[:]
+
+        q = matvec(p)
+        alpha = rtz_cur / dotprod(p, q)
+        x += alpha*p
+        r -= alpha*q
+        rtz_prev = rtz_cur
+
+        if callback:
             callback(x)
-        slice1 = slice(ndx1-1, ndx1-1+n)
-        slice2 = slice(ndx2-1, ndx2-1+n)
-        if (ijob == -1):
-            if callback is not None:
-                callback(x)
-            break
-        elif (ijob == 1):
-            work[slice2] *= sclr2
-            work[slice2] += sclr1*matvec(work[slice1])
-        elif (ijob == 2):
-            work[slice1] = psolve(work[slice2])
-        elif (ijob == 3):
-            work[slice2] *= sclr2
-            work[slice2] += sclr1*matvec(x)
-        elif (ijob == 4):
-            if ftflag:
-                info = -1
-                ftflag = False
-            resid, info = _stoptest(work[slice1], atol)
-            if info == 1 and iter_ > 1:
-                # recompute residual and recheck, to avoid
-                # accumulating rounding error
-                work[slice1] = b - matvec(x)
-                resid, info = _stoptest(work[slice1], atol)
-        ijob = 2
 
-    if info > 0 and iter_ == maxiter and not (resid <= atol):
-        # info isn't set appropriately otherwise
-        info = iter_
-
-    return postprocess(x), info
+    else:  # for loop exhausted
+        # Return incomplete progress
+        return postprocess(x), maxiter
 
 
 @set_docstring('Use Conjugate Gradient Squared iteration to solve ``Ax = b``.',

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -100,10 +100,6 @@ def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
 
     rhotol = np.finfo(x.dtype.char).eps**2
 
-    # Is there any tolerance set? since b can be all 0.
-    if atol == 0.:
-        atol = 1e-5
-
     # Dummy values to initialize vars, silence linter warnings
     rho_prev, p, ptilde = None, None, None
 
@@ -253,10 +249,6 @@ def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     # sqrt might have been meant instead.
     rhotol = np.finfo(x.dtype.char).eps**2
     omegatol = rhotol
-
-    # Is there any tolerance set? since b can be all 0.
-    if atol == 0.:
-        atol = 1e-5
 
     # Dummy values to initialize vars, silence linter warnings
     rho_prev, omega, alpha, p, v = None, None, None, None, None
@@ -409,10 +401,6 @@ def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
     psolve = M.matvec
     r = b - matvec(x) if x.any() else b.copy()
 
-    # Is there any tolerance set? since b can be all 0.
-    if atol == 0.:
-        atol = 1e-5
-
     # Dummy value to initialize var, silences warnings
     rho_prev, p = None, None
 
@@ -541,10 +529,6 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
     rhotol = np.finfo(x.dtype.char).eps**2
 
     r = b - matvec(x) if x.any() else b.copy()
-
-    # Is there any tolerance set? since b can be all 0.
-    if atol == 0.:
-        atol = 1e-5
 
     rtilde = r.copy()
     bnorm = np.linalg.norm(b)

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -353,9 +353,8 @@ def test_precond_inverse(case):
 
 
 def test_reentrancy():
-    non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
     reentrant = [lgmres, minres, gcrotmk, tfqmr]
-    for solver in reentrant + non_reentrant:
+    for solver in reentrant:
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
             _check_reentrancy(solver, solver in reentrant)
@@ -446,7 +445,7 @@ def test_zero_rhs(solver):
             if solver is not minres:
                 x, info = solver(A, b, tol=tol, atol=0, x0=ones(10))
                 if info == 0:
-                    assert_allclose(x, 0)
+                    assert_allclose(x, 0, atol=5e-15, rtol=0)
 
                 x, info = solver(A, b, tol=tol, atol=tol)
                 assert_equal(info, 0)

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -352,32 +352,6 @@ def test_precond_inverse(case):
             check_precond_inverse(solver, case)
 
 
-def test_reentrancy():
-    reentrant = [lgmres, minres, gcrotmk, tfqmr]
-    for solver in reentrant:
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, ".*called without specifying.*")
-            _check_reentrancy(solver, solver in reentrant)
-
-
-def _check_reentrancy(solver, is_reentrant):
-    def matvec(x):
-        A = np.array([[1.0, 0, 0], [0, 2.0, 0], [0, 0, 3.0]])
-        y, info = solver(A, x)
-        assert_equal(info, 0)
-        return y
-    b = np.array([1, 1./2, 1./3])
-    op = LinearOperator((3, 3), matvec=matvec, rmatvec=matvec,
-                        dtype=b.dtype)
-
-    if not is_reentrant:
-        assert_raises(RuntimeError, solver, op, b)
-    else:
-        y, info = solver(op, b)
-        assert_equal(info, 0)
-        assert_allclose(y, [1, 1, 1])
-
-
 @pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr,
                                     lgmres, gcrotmk])
 def test_atol(solver):


### PR DESCRIPTION
**This PR Is Moved to** #18488 

-------

As discussed in #18367 for `linalg.interpolative`, `iterative` solvers are also in the same state that it is almost impossible to implement any enhancements such as returning the iteration information and so on. This PR, reimplements all code in pure Python and with a bit of care to inplace operations thanks to NumPy no performance is lost.


#### Reference issue
Closes a few PRs will populate once done with tests
Related #15738 

#### Memory Lane for past discussions
#1466
#7623
#7624
#8400
#10341
#16050


#### What does this implement/fix?
- Rewrote all code in Python instead of using very old Fortran templates
- The performance is comparable and slightly faster with Python
- Removes all dependencies to [`_isolve/iterative`](https://github.com/scipy/scipy/tree/main/scipy/sparse/linalg/_isolve/iterative) Fortran code. 
- The `tol`/`atol` handling is just a mess and is waiting to be overhauled for at least 5 years. This PR will unite both issues.
- Most tests are dropin replacement passed. A few tests are now failing because these solvers were not meant to enter in certain branches but now they do because of more success. Those will be fixed. Several segfaults are avoided in the meantime that was annoying the CI for a very long time sporadically.
- Not my favorite coding style but I went the Fortran files line-by-line and tried to be as faithful as possible
