### PR TITLE
DEBUG: pin meson-python

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           pip install "numpy==1.21.6" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython wheel
+          pip install build "meson-python<0.13.0" ninja pythran pybind11 cython wheel
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
 
@@ -291,7 +291,7 @@ jobs:
       run: |
         # TODO: unpin cython and move to -pre once issues with cython 3.0
         #       have been ironed out.
-        python -m pip install ninja meson meson-python wheel click rich_click pydevtool "cython==0.29.33"
+        python -m pip install ninja meson "meson-python<0.13.0" wheel click rich_click pydevtool "cython==0.29.33"
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
         # Use pytest-xdist<4.0 due to https://github.com/pytest-dev/pytest-cov/issues/557
         # can update once pytest-cov>4.0 and remove warning filtering in pytest.ini

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           # 1.22.3 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.3 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+          python -m pip install numpy==1.22.3 cython pybind11 pythran "meson-python<0.13.0" meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
 
       - name: Build
         run: |
@@ -148,7 +148,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          python -m pip install build delvewheel numpy cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch
+          python -m pip install build delvewheel numpy cython pybind11 "meson-python<0.13.0" meson ninja pytest pytest-xdist pytest-timeout pooch
 
       - name: Build
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.12.1",
+    "meson-python<0.13.0",
     "Cython>=0.29.33",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.12.0",


### PR DESCRIPTION
This is for debugging only--I can't reproduce the failure in gh-18390 locally, but it is showing up on Ubuntu Linux and Mac ARM in CI. The only dependency that recently got bumped in PyPI that I can find is `meson-python`, so just trying to see if the release on April 28th may be related by pinning it back.