### PR TITLE
ENH: stats: add support for `nan_policy=None`

### DIFF
--- a/doc/source/dev/api-dev/nan_policy.rst
+++ b/doc/source/dev/api-dev/nan_policy.rst
@@ -10,11 +10,11 @@ functions, we maintain a consistent API.
 The basic API
 -------------
 
-The parameter ``nan_policy`` accepts three possible strings: ``'omit'``,
-``'raise'`` and ``'propagate'``.  The meanings are:
+The parameter ``nan_policy`` accepts four possible values: ``'omit'``,
+``'raise'``, ``'propagate'``, and ``None``.  The meanings are:
 
 * ``nan_policy='omit'``:
-  Ignore occurrences of ``nan`` in the input.  Do not generate a warning
+  Eliminate occurrences of ``nan`` in the input.  Do not generate a warning
   if the input contains ``nan`` (unless the equivalent input with the
   ``nan`` values removed would generate a warning). For example, for the
   simple case of a function that accepts a single array and returns a
@@ -85,6 +85,10 @@ The parameter ``nan_policy`` accepts three possible strings: ``'omit'``,
       https://github.com/scipy/scipy/issues/7818
 
   for an example where that might lead to unexpected output.
+* ``nan_policy=None``:
+  Ignore the possibility of ``nan`` in the input;  just execute the function
+  without checking for ``nan``. Behavior with ``nan`` in the input is
+  implementation-dependent.
 
 
 ``nan_policy`` combined with an ``axis`` parameter

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -636,7 +636,9 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True,
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
 
-    if np.issubdtype(a.dtype, np.inexact):
+    if nan_policy is None:
+        contains_nan = False
+    elif np.issubdtype(a.dtype, np.inexact):
         # The summation method avoids creating a (potentially huge) array.
         if use_summation:
             with np.errstate(invalid='ignore', over='ignore'):

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -205,6 +205,16 @@ def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
                           unpacker, nan_policy, axis, data_generator)
 
 
+@pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
+                          "paired", "unpacker"), axis_nan_policy_cases)
+@pytest.mark.parametrize(("axis"), (1,))
+@pytest.mark.parametrize(("data_generator"), ("all_finite",))
+def test_axis_nan_policy_None(hypotest, args, kwds, n_samples, n_outputs,
+                              paired, unpacker, axis, data_generator):
+    _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
+                          unpacker, None, axis, data_generator)
+
+
 def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                           unpacker, nan_policy, axis, data_generator):
     # Tests the 1D and vectorized behavior of hypothesis tests against a


### PR DESCRIPTION
#### Reference issue
Closes gh-16595
gh-17852

#### What does this implement/fix?
gh-16595 noted the need for a `nan_policy` option that executes the function code without special consideration of NaNs. gh-17852 added `nan_policy` support to `optimize.curve_fit`, and it used `nan_policy=None` to refer to this new option because carefully defining the behavior of a `nan_policy='propagate'` seemed impractical.

This PR adds support for `nan_policy=None` to all functions wrapped by `_axis_nan_policy`. 

The rationale is that correct `nan_policy='propagate'` behavior can be impractical to define for some functions (e.g. `curve_fit`), so for these functions, another `nan_policy` option that does not require the overhead of checking for NaNs would be beneficial. Although some functions can conceivably implement `nan_policy='propagate'` without the overhead of checking for NaNs explicitly, most (all?) don't, whether they use `_axis_nan_policy` or not. Adding the new option to all functions allows the user to skip the overhead of NaN checks without changing all existing `nan_policy='propagate'` code paths. 

#### Additional information
For the distinction between `nan_policy=None` and `nan_policy='propagate'`, see [A Design Specification for `nan_policy`](https://docs.scipy.org/doc/scipy/dev/api-dev/nan_policy.html) as modified here.

For some functions, the output in the presence of NaNs will be identical whether `nan_policy=None` or  `nan_policy='propagate'`. One could make the point that a separate `nan_policy=None` option is not needed for these functions. I would respond that (eventually) we should accept both options for all functions that accept `nan_policy`, if only for consistency. Also, in the short term, note that many functions that accept `nan_policy` (all that use `scipy._util._contains_nan`, anyway) currently check for the presence of NaNs with `nan_policy='propagate'` whether or not they use this information it returns. Accepting `nan_policy=None` adds a way for the user to avoid this check without requiring developers to carefully assess whether the check is necessary for each function. 

Another opinion might be that `"propagate"` and `None` should mean the same thing. That sounds valid; I just don't think that's the current understanding of `"propagate"`.

This probably needs an email to the mailing list. I'll wait to get some feedback here before I send that.