### PR TITLE
CI: temporary gast pin to fix CI (workaround)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
             # `asv` pin because of slowdowns reported in gh-15568
-            pip install mpmath gmpy2 "asv==0.4.2" pythran ninja meson click rich-click doit pydevtool pooch
+            pip install mpmath gmpy2 "asv==0.4.2" pythran ninja meson click rich-click doit pydevtool pooch gast==0.5.3
             pip install pybind11
             # extra benchmark deps
             pip install pyfftw cffi pytest

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -56,13 +56,13 @@ jobs:
     - name: Install Python packages
       if: matrix.python-version == '3.10'
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch gast==0.5.3
 
     - name: Install Python packages from repositories
       if: matrix.python-version == '3.11'
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
-        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch
+        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch gast==0.5.3
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install git+https://github.com/mesonbuild/meson.git
 
@@ -164,7 +164,7 @@ jobs:
         # Install build dependencies. Use meson-python from its main branch,
         # most convenient to test in this job because we're using pip without
         # build isolation here.
-        python -m pip install numpy pybind11 pythran cython pytest ninja
+        python -m pip install numpy pybind11 pythran cython pytest ninja gast==0.5.3
         python -m pip install git+https://github.com/mesonbuild/meson-python.git
         # Non-isolated build, so we use dependencies installed inside the source tree
         python -m pip install -U pip  # need pip >=23 for `--config-settings`
@@ -230,7 +230,7 @@ jobs:
         run: |
           pip install "numpy==1.21.6" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython wheel
+          pip install build meson-python ninja pythran pybind11 cython wheel gast==0.5.3
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
 
@@ -295,7 +295,7 @@ jobs:
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
         # Use pytest-xdist<4.0 due to https://github.com/pytest-dev/pytest-cov/issues/557
         # can update once pytest-cov>4.0 and remove warning filtering in pytest.ini
-        python -m pip install --pre --upgrade pytest pytest-cov "pytest-xdist<4.0" pybind11 mpmath gmpy2 pythran threadpoolctl pooch matplotlib
+        python -m pip install --pre --upgrade pytest pytest-cov "pytest-xdist<4.0" pybind11 mpmath gmpy2 pythran threadpoolctl pooch matplotlib gast==0.5.3
 
     - name:  Prepare compiler cache
       id:    prep-ccache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool gast==0.5.3
       - name: Install OpenBLAS
         shell: bash
         run: |
@@ -101,7 +101,7 @@ jobs:
         run: |
           # 1.22.3 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.3 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+          python -m pip install numpy==1.22.3 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool gast==0.5.3
 
       - name: Build
         run: |
@@ -210,7 +210,7 @@ jobs:
         run: |
           # pyproject.toml currently states this numpy minimum version.
           python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-          python -m pip install cython numpy==1.22.3 pybind11 pythran pytest pooch
+          python -m pip install cython numpy==1.22.3 pybind11 pythran pytest pooch gast==0.5.3
 
       - name: Build
         run: |

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -58,7 +58,7 @@ linux_aarch64_test_task:
     ln -s $(which python3.10) python
     export PATH=$PWD:$PATH
 
-    python -m pip install meson ninja numpy cython pybind11 pythran cython
+    python -m pip install meson ninja numpy cython pybind11 pythran cython gast==0.5.3
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     
@@ -99,7 +99,7 @@ musllinux_amd64_test_task:
     cd $_CWD
     python -m pip install cython
     pip install --upgrade --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-    python -m pip install meson ninja pybind11 pythran pytest
+    python -m pip install meson ninja pybind11 pythran pytest gast==0.5.3
     python -m pip install click rich_click doit pydevtool pooch
 
     # pin setuptools to get around https://github.com/scipy/scipy/issues/17475
@@ -139,7 +139,7 @@ macos_arm64_test_task:
     source scipy-dev/bin/activate
     popd
 
-    python -m pip install meson ninja numpy cython pybind11 pythran cython
+    python -m pip install meson ninja numpy cython pybind11 pythran cython gast==0.5.3
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   # scipy.datasets dependency
   - pooch
   - pythran>=0.11.0
+  - gast==0.5.3
   # For testing and benchmarking
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     "Cython>=0.29.33",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.12.0",
+    "gast==0.5.3", # WORKAROUND FOR gh18390
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)
     "wheel",


### PR DESCRIPTION
Speculative. I may need to make afew commits to get everything working. Once I've done so I'll squash it to a single commit, which will make it easier to `git revert`. I'm not sure what reverting will do to the git history.