### PR TITLE
MAINT: signal: simplify shape manipulations in signal.detrend

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3536,22 +3536,24 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
         if np.any(bp > N):
             raise ValueError("Breakpoints must be less than length "
                              "of data along given axis.")
-        Nreg = len(bp) - 1
+
         # Restructure data so that axis is along first dimension and
         #  all other dimensions are collapsed into second dimension
         rnk = len(dshape)
         if axis < 0:
             axis = axis + rnk
-        newdims = tuple(np.r_[axis, 0:axis, axis + 1:rnk])
-        newdata = data.transpose(newdims).reshape(N, -1)
+        newdata = np.moveaxis(data, axis, 0)
+        newdata_shape = newdata.shape
+        newdata = newdata.reshape(N, -1)
 
         if not overwrite_data:
             newdata = newdata.copy()  # make sure we have a copy
         if newdata.dtype.char not in 'dfDF':
             newdata = newdata.astype(dtype)
 
+#        Nreg = len(bp) - 1
         # Find leastsq fit and remove it for each piece
-        for m in range(Nreg):
+        for m in range(len(bp) - 1):
             Npts = bp[m + 1] - bp[m]
             A = np.ones((Npts, 2), dtype)
             A[:, 0] = np.arange(1, Npts + 1, dtype=dtype) / Npts
@@ -3560,11 +3562,8 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
             newdata[sl] = newdata[sl] - A @ coef
 
         # Put data back in original shape.
-        tdshape = np.take(dshape, newdims, 0)
-        ret = np.reshape(newdata, tuple(tdshape))
-        vals = list(range(1, rnk))
-        olddims = vals[:axis] + [0] + vals[axis:]
-        ret = np.transpose(ret, tuple(olddims))
+        newdata = newdata.reshape(newdata_shape)
+        ret = np.moveaxis(newdata, 0, axis)
         return ret
 
 


### PR DESCRIPTION
A follow-up to gh-18383. To operate on a given axis of an array, `detrend` restructures and flattens the input, subtracts the trend, and then restores the original shape. The shape/axis manipulations were equivalent to `np.moveaxis(data, axis, 0)`, ..., `np.moveaxis(data, 0, axis)` but written in a fairly obscure way (predating np.moveaxis, I suspect). So simplify it to hopefully improve readability.
