### PR TITLE
MAINT: Harmonized documentation for Interpolator classes

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -378,7 +378,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
     x : ndarray, shape (npoints, )
         1-D array of monotonically increasing real values.
     y : ndarray, shape (..., npoints, ...)
-        N-D array of real values. The length of ``y`` along the *first* axis
+        N-D array of real values. The length of ``y`` along the interpolation axis
         must be equal to the length of ``x``. Use the ``axis`` parameter to
         select the interpolation axis.
     axis : int, optional

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -164,15 +164,16 @@ class PchipInterpolator(CubicHermiteSpline):
 
     Parameters
     ----------
-    x : ndarray
+    x : ndarray, shape (npoints, )
         A 1-D array of monotonically increasing real values. ``x`` cannot
         include duplicate values (otherwise f is overspecified)
-    y : ndarray
-        A 1-D array of real values. ``y``'s length along the interpolation
+    y : ndarray, shape (..., npoints, ...)
+        A 1-D array of real values. ``y``'s length along the *first*
         axis must be equal to the length of ``x``. If N-D array, use ``axis``
         parameter to select correct axis.
     axis : int, optional
-        Axis in the y array corresponding to the x-coordinate values.
+        Axis in the y array corresponding to the x-coordinate values. Interpolation
+        defaults to the first axis of ``y``.
     extrapolate : bool, optional
         Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs.
@@ -374,11 +375,12 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
     Parameters
     ----------
-    x : ndarray, shape (m, )
+    x : ndarray, shape (npoints, )
         1-D array of monotonically increasing real values.
-    y : ndarray, shape (m, ...)
-        N-D array of real values. The length of ``y`` along the first axis
-        must be equal to the length of ``x``.
+    y : ndarray, shape (..., npoints, ...)
+        N-D array of real values. The length of ``y`` along the *first* axis
+        must be equal to the length of ``x``. If N-D array, use ``axis``
+        parameter to select correct axis.
     axis : int, optional
         Specifies the axis of ``y`` along which to interpolate. Interpolation
         defaults to the first axis of ``y``.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -168,12 +168,12 @@ class PchipInterpolator(CubicHermiteSpline):
         A 1-D array of monotonically increasing real values. ``x`` cannot
         include duplicate values (otherwise f is overspecified)
     y : ndarray, shape (..., npoints, ...)
-        A 1-D array of real values. ``y``'s length along the *first*
-        axis must be equal to the length of ``x``. If N-D array, use ``axis``
-        parameter to select correct axis.
+        A N-D array of real values. ``y``'s length along the interpolation
+        axis must be equal to the length of ``x``. Use the ``axis``
+        parameter to select the interpolation axis.
     axis : int, optional
-        Axis in the y array corresponding to the x-coordinate values. Interpolation
-        defaults to the first axis of ``y``.
+        Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
+        to ``axis=0``.
     extrapolate : bool, optional
         Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs.
@@ -379,11 +379,11 @@ class Akima1DInterpolator(CubicHermiteSpline):
         1-D array of monotonically increasing real values.
     y : ndarray, shape (..., npoints, ...)
         N-D array of real values. The length of ``y`` along the *first* axis
-        must be equal to the length of ``x``. If N-D array, use ``axis``
-        parameter to select correct axis.
+        must be equal to the length of ``x``. Use the ``axis`` parameter to
+        select the interpolation axis.
     axis : int, optional
-        Specifies the axis of ``y`` along which to interpolate. Interpolation
-        defaults to the first axis of ``y``.
+        Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
+        to ``axis=0``.
 
     Methods
     -------

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -396,9 +396,10 @@ class interp1d(_Interpolator1D):
     x : (npoints, ) array_like
         A 1-D array of real values.
     y : (..., npoints, ...) array_like
-        A N-D array of real values. The length of `y` along the *last*
-        axis must be equal to the length of `x`. If N-D array, use ``axis``
-        parameter to select correct axis.
+        A N-D array of real values. The length of `y` along the interpolation
+        axis must be equal to the length of `x`. Use the ``axis`` parameter
+        to select correct axis. Unlike other interpolators, the default
+        interpolation axis is the last axis of `y`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string or as an integer
         specifying the order of the spline interpolator to use.
@@ -411,8 +412,8 @@ class interp1d(_Interpolator1D):
         in that 'nearest-up' rounds up and 'nearest' rounds down. Default
         is 'linear'.
     axis : int, optional
-        Specifies the axis of `y` along which to interpolate.
-        Interpolation defaults to the *last* axis of `y`.
+        Axis in the ``y`` array corresponding to the x-coordinate values. Unlike
+        other interpolators, defaults to ``axis=-1``.
     copy : bool, optional
         If True, the class makes internal copies of x and y.
         If False, references to `x` and `y` are used. The default is to copy.

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -393,11 +393,12 @@ class interp1d(_Interpolator1D):
 
     Parameters
     ----------
-    x : (N,) array_like
+    x : (npoints, ) array_like
         A 1-D array of real values.
-    y : (...,N,...) array_like
-        A N-D array of real values. The length of `y` along the interpolation
-        axis must be equal to the length of `x`.
+    y : (..., npoints, ...) array_like
+        A N-D array of real values. The length of `y` along the *last*
+        axis must be equal to the length of `x`. If N-D array, use ``axis``
+        parameter to select correct axis.
     kind : str or int, optional
         Specifies the kind of interpolation as a string or as an integer
         specifying the order of the spline interpolator to use.
@@ -411,7 +412,7 @@ class interp1d(_Interpolator1D):
         is 'linear'.
     axis : int, optional
         Specifies the axis of `y` along which to interpolate.
-        Interpolation defaults to the last axis of `y`.
+        Interpolation defaults to the *last* axis of `y`.
     copy : bool, optional
         If True, the class makes internal copies of x and y.
         If False, references to `x` and `y` are used. The default is to copy.

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -30,7 +30,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
     Parameters
     ----------
-    x : (npoints, ndims) N-D ndarray of floats
+    x : (npoints, ndims) 2-D ndarray of floats
         Data point coordinates.
     y : (npoints, ) 1-D ndarray of float or complex
         Data values.

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -30,9 +30,9 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
     Parameters
     ----------
-    x : (Npoints, Ndims) ndarray of floats
+    x : (npoints, ndims) N-D ndarray of floats
         Data point coordinates.
-    y : (Npoints,) ndarray of float or complex
+    y : (npoints, ) 1-D ndarray of float or complex
         Data values.
     rescale : boolean, optional
         Rescale points to unit cube before performing interpolation.

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -235,11 +235,13 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
 
     Parameters
     ----------
-    xi : array_like, length N
+    xi : array_like, shape (npoints, )
         Known x-coordinates. Must be sorted in increasing order.
-    yi : array_like
+    yi : array_like, shape (..., npoints, ...)
         Known y-coordinates. When an xi occurs two or more times in
-        a row, the corresponding yi's represent derivative values.
+        a row, the corresponding yi's represent derivative values. The length of `yi`
+        along the *first* axis must be equal to the length of `xi`. If N-D array,
+        use ``axis`` parameter to select correct axis.
     axis : int, optional
         Axis in the yi array corresponding to the x-coordinate values.
 
@@ -520,12 +522,14 @@ class BarycentricInterpolator(_Interpolator1D):
 
     Parameters
     ----------
-    xi : array_like
+    xi : array_like, shape (npoints, )
         1-D array of x coordinates of the points the polynomial
         should pass through
-    yi : array_like, optional
+    yi : array_like, shape (..., npoints, ...), optional
         The y coordinates of the points the polynomial should pass through.
         If None, the y values will be supplied later via the `set_y` method.
+        The length of `yi` along the *first* axis must be equal to the length
+        of `xi`. If N-D array, use ``axis`` parameter to select correct axis.
     axis : int, optional
         Axis in the yi array corresponding to the x-coordinate values.
 

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -240,10 +240,11 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
     yi : array_like, shape (..., npoints, ...)
         Known y-coordinates. When an xi occurs two or more times in
         a row, the corresponding yi's represent derivative values. The length of `yi`
-        along the *first* axis must be equal to the length of `xi`. If N-D array,
-        use ``axis`` parameter to select correct axis.
+        along the interpolation axis must be equal to the length of `xi`. Use the
+        `axis` parameter to select the correct axis.
     axis : int, optional
-        Axis in the yi array corresponding to the x-coordinate values.
+        Axis in the `yi` array corresponding to the x-coordinate values. Defaults to
+        ``axis=0``.
 
     Notes
     -----
@@ -526,12 +527,13 @@ class BarycentricInterpolator(_Interpolator1D):
         1-D array of x coordinates of the points the polynomial
         should pass through
     yi : array_like, shape (..., npoints, ...), optional
-        The y coordinates of the points the polynomial should pass through.
+        N-D array of y coordinates of the points the polynomial should pass through.
         If None, the y values will be supplied later via the `set_y` method.
-        The length of `yi` along the *first* axis must be equal to the length
-        of `xi`. If N-D array, use ``axis`` parameter to select correct axis.
+        The length of `yi` along the interpolation axis must be equal to the length
+        of `xi`. Use the ``axis`` parameter to select correct axis.
     axis : int, optional
-        Axis in the yi array corresponding to the x-coordinate values.
+        Axis in the yi array corresponding to the x-coordinate values. Defaults
+        to ``axis=0``.
 
     Notes
     -----

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -136,15 +136,16 @@ class RBFInterpolator:
 
     Parameters
     ----------
-    y : (P, N) array_like
+    y : (npoints, ndims) array_like
         Data point coordinates.
-    d : (P, ...) array_like
-        Data values at `y`.
+    d : (npoints, ...) array_like
+        Data values at `y`. The length of `d` along the *first* axis must be
+        equal to the length of `y`.
     neighbors : int, optional
         If specified, the value of the interpolant at each evaluation point
         will be computed using only this many nearest data points. All the data
         points are used by default.
-    smoothing : float or (P,) array_like, optional
+    smoothing : float or (npoints, ) array_like, optional
         Smoothing parameter. The interpolant perfectly fits the data when this
         is set to 0. For large values, the interpolant approaches a least
         squares fit of a polynomial with the specified degree. Default is 0.

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -137,10 +137,11 @@ class RBFInterpolator:
     Parameters
     ----------
     y : (npoints, ndims) array_like
-        Data point coordinates.
+        2-D array of data point coordinates.
     d : (npoints, ...) array_like
-        Data values at `y`. The length of `d` along the *first* axis must be
-        equal to the length of `y`.
+        N-D array of data values at `y`. The length of `d` along the first
+        axis must be equal to the length of `y`. Unlike some interpolators, the
+        interpolation axis cannot be changed.
     neighbors : int, optional
         If specified, the value of the interpolant at each evaluation point
         will be computed using only this many nearest data points. All the data

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -220,7 +220,8 @@ class LinearNDInterpolator(NDInterpolatorBase):
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
         Data point coordinates, or a precomputed Delaunay triangulation.
     values : ndarray of float or complex, shape (npoints, ...)
-        Data values.
+        Data values at `points`.  The length of `values` along the
+        *first* axis must be equal to the length of `points`.
     fill_value : float, optional
         Value used to fill in for requested points outside of the
         convex hull of the input points.  If not provided, then
@@ -810,7 +811,8 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
         Data point coordinates, or a precomputed Delaunay triangulation.
     values : ndarray of float or complex, shape (npoints, ...)
-        Data values.
+        Data values at `points`. The length of `values` along the
+        *first* axis must be equal to the length of `points`.
     fill_value : float, optional
         Value used to fill in for requested points outside of the
         convex hull of the input points.  If not provided, then

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -218,10 +218,11 @@ class LinearNDInterpolator(NDInterpolatorBase):
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
-        Data point coordinates, or a precomputed Delaunay triangulation.
+        2-D array of data point coordinates, or a precomputed Delaunay triangulation.
     values : ndarray of float or complex, shape (npoints, ...)
-        Data values at `points`.  The length of `values` along the
-        *first* axis must be equal to the length of `points`.
+        N-D array of data values at `points`.  The length of `values` along the
+        first axis must be equal to the length of `points`. Unlike some
+        interpolators, the interpolation axis cannot be changed.
     fill_value : float, optional
         Value used to fill in for requested points outside of the
         convex hull of the input points.  If not provided, then
@@ -809,10 +810,11 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
-        Data point coordinates, or a precomputed Delaunay triangulation.
+        2-D array of data point coordinates, or a precomputed Delaunay triangulation.
     values : ndarray of float or complex, shape (npoints, ...)
-        Data values at `points`. The length of `values` along the
-        *first* axis must be equal to the length of `points`.
+        N-D array of data values at `points`. The length of `values` along the
+        first axis must be equal to the length of `points`. Unlike some
+        interpolators, the interpolation axis cannot be changed.
     fill_value : float, optional
         Value used to fill in for requested points outside of the
         convex hull of the input points.  If not provided, then


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/18165#issue-1629330543
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
In the documentation, I harmonized and clarified the dimensions of the inputs of *Interpolator objects. I chose the `(npoints, ndims)` convention. In addition, since the legacy class `interp1d` uses the last axis and other interpolators use the first axis by default, I emphasized the default value in the docstring.
<!--Please explain your changes.-->

#### Additional information
This is a modest change but I'm hoping to motivate more ambitious harmonization of the interpolation module.  In particular, naming the inputs `points` and `values` in all interpolators would make it easier for the user (see my original issue). In addition, some interpolators allow specifying the interpolation axis while others don't, which prevents the user from seamlessly interchanging one interpolator for another.

Best,

GJ
