### PR TITLE
BUG: interpolate: add `mest` calculation logic for `UnivariateSpline.roots` backward compatibility

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -527,7 +527,9 @@ class UnivariateSpline:
         """
         k = self._data[5]
         if k == 3:
-            return _fitpack_impl.sproot(self._eval_args)
+            t = self._eval_args[0]
+            mest = 3 * (len(t) - 7)
+            return _fitpack_impl.sproot(self._eval_args, mest=mest)
         raise NotImplementedError('finding roots unsupported for '
                                   'non-cubic splines')
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -67,6 +67,12 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_almost_equal(spl.roots()[0], 1.050290639101332)
 
+    def test_roots_length(self): # for gh18335
+        x = np.linspace(0, 50 * np.pi, 1000)
+        y = np.cos(x)
+        spl = UnivariateSpline(x, y, s=0)
+        assert_equal(len(spl.roots()), 50)
+
     def test_derivatives(self):
         x = [1, 3, 5, 7, 9]
         y = [0, 4, 9, 12, 21]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #18335 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR #17091 cleaned up some FIPACK-related codes, but it broke the `UnivariateSpline.roots` behavior accidentally by changing `mest` argument default value.
So, this PR fixed it and added a test. 

#### Additional information
<!--Any additional information you think is important.-->
