### PR TITLE
ENH:stats: arcsine distribution additions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -546,7 +546,7 @@ anglit = anglit_gen(a=-np.pi/4, b=np.pi/4, name='anglit')
 
 
 def _arcsin_value(x):
-    return np.arcsin(2 * x - 1) / np.pi
+    return np.arcsin(2*x-1) / np.pi
 
 
 class arcsine_gen(rv_continuous):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -545,6 +545,10 @@ class anglit_gen(rv_continuous):
 anglit = anglit_gen(a=-np.pi/4, b=np.pi/4, name='anglit')
 
 
+def _arcsin_value(x):
+    return np.arcsin(2 * x - 1) / np.pi
+
+
 class arcsine_gen(rv_continuous):
     r"""An arcsine continuous random variable.
 
@@ -574,7 +578,10 @@ class arcsine_gen(rv_continuous):
             return 1.0/np.pi/np.sqrt(x*(1-x))
 
     def _cdf(self, x):
-        return 2.0/np.pi*np.arcsin(np.sqrt(x))
+        return 0.5 + _arcsin_value(x)
+
+    def _sf(self, x, *args):
+        return 0.5 - _arcsin_value(x)
 
     def _ppf(self, q):
         return np.sin(np.pi/2.0*q)**2.0

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -454,6 +454,56 @@ class TestArcsine:
         p = stats.arcsine.pdf([0, 1])
         assert_equal(p, [np.inf, np.inf])
 
+    # Expected values for arcsine.cdf were computed with mpmath:
+    #
+    #    from mpmath import mp
+    #    def arcsine_cdf(x):
+    #        x = mp.mpf(x)
+    #        return 0.5 + mp.asin(2*x-1) / mp.pi
+    #
+    # E.g.
+    #
+    #    >>> float(arcsine_cdf(0.9))
+    #    0.7951672353008665
+    #
+    @pytest.mark.parametrize(
+        'x, expected', [
+            (0.9, 0.7951672353008665),
+            (0.59999, 0.5640877193891672),
+            (0.125, 0.23005345616261585),
+            (6e-17, 4.7431868988034864e-09),
+            (3e-15, 3.4855163144609236e-08),
+            (1e-10, 6.366197987162092e-06),
+        ]
+    )
+    def test_cdf(self, x, expected):
+        cdf_value = stats.arcsine.cdf(x)
+        assert_allclose(cdf_value, expected, rtol=1e-14)
+
+    # Expected values for arcsine.sf were computed with mpmath:
+    #
+    #    from mpmath import mp
+    #    def arcsine_sf(x):
+    #        x = mp.mpf(x)
+    #        return return 0.5 - mp.asin(2*x-1) / mp.pi
+    #
+    # E.g.
+    #
+    #    >>> float(arcsine_sf(0.9))
+    #    0.20483276469913342
+    #
+    @pytest.mark.parametrize(
+        'x, expected', [
+            (0.9, 0.20483276469913342),
+            (0.9999999999, 6.366197987162092e-06),
+            (0.59999, 0.43591228061083276),
+            (6e-17, 0.999999995256813),
+        ]
+    )
+    def test_sf(self, x, expected):
+        sf_value = stats.arcsine.sf(x)
+        assert_allclose(sf_value, expected, rtol=1e-14)
+
 
 class TestBernoulli:
     def setup_method(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
arcsine distribition adjusments:
- Simplified definition of _cdf method
- Added the _sf method to override the default.

#### Additional information
<!--Any additional information you think is important.-->
None