### PR TITLE
BLD: more PROPACK fixes, removing timer code

### DIFF
--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -12,7 +12,6 @@ s_src = [
   'PROPACK/single/slanbpro.F',
   'PROPACK/single/slansvd.F',
   'PROPACK/single/slansvd_irl.F',
-  'PROPACK/single/smgs.pentium.F',
   'PROPACK/single/sreorth.F',
   'PROPACK/single/sritzvec.F',
   'PROPACK/single/ssafescal.F'
@@ -26,7 +25,6 @@ d_src = [
   'PROPACK/double/dlanbpro.F',
   'PROPACK/double/dlansvd.F',
   'PROPACK/double/dlansvd_irl.F',
-  'PROPACK/double/dmgs.pentium.F',
   'PROPACK/double/dreorth.F',
   'PROPACK/double/dritzvec.F',
   'PROPACK/double/dsafescal.F',
@@ -40,7 +38,6 @@ c_src = [
   'PROPACK/complex8/clanbpro.F',
   'PROPACK/complex8/clansvd.F',
   'PROPACK/complex8/clansvd_irl.F',
-  'PROPACK/complex8/cmgs.pentium.F',
   'PROPACK/complex8/creorth.F',
   'PROPACK/complex8/critzvec.F',
   'PROPACK/complex8/csafescal.F',
@@ -61,17 +58,22 @@ z_src = [
   'PROPACK/complex16/zlanbpro.F',
   'PROPACK/complex16/zlansvd.F',
   'PROPACK/complex16/zlansvd_irl.F',
-  'PROPACK/complex16/zmgs.pentium.F',
   'PROPACK/complex16/zreorth.F',
   'PROPACK/complex16/zritzvec.F',
   'PROPACK/complex16/zsafescal.F'
 ]
 
+# Use risc msg implementation for 64-bit machines, pentium for 32-bit
 if meson.get_compiler('cpp').sizeof('void*') > 4
   s_src += ['PROPACK/single/smgs.risc.F']
   d_src += ['PROPACK/double/dmgs.risc.F']
   c_src += ['PROPACK/complex8/cmgs.risc.F']
   z_src += ['PROPACK/complex16/zmgs.risc.F']
+else
+  s_src += ['PROPACK/single/smgs.pentium.F']
+  d_src += ['PROPACK/double/dmgs.pentium.F']
+  c_src += ['PROPACK/complex8/cmgs.pentium.F']
+  z_src += ['PROPACK/complex16/zmgs.pentium.F']
 endif
 
 elements = [
@@ -83,7 +85,7 @@ elements = [
 
 cargs_propack = ['-D_OPENMP']  # FIXME: _OPENMP is needed now, but not good!
 if use_g77_abi
-  # This define needs to be removed from PROPACK code, in favor of using
+  # FIXME: define needs to be removed from PROPACK code, in favor of using
   # `wcdotc` unconditionally, like is done in ARPACK.
   cargs_propack += ['-DSCIPY_USE_G77_CDOTC_WRAP=1']
 endif

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -7,7 +7,6 @@ s_src = [
   'PROPACK/single/printstat.F',
   'PROPACK/single/sblasext.F',
   'PROPACK/single/sbsvd.F',
-  'PROPACK/single/second.F',
   'PROPACK/single/sgemm_ovwr.F',
   'PROPACK/single/sgetu0.F',
   'PROPACK/single/slanbpro.F',
@@ -32,7 +31,6 @@ d_src = [
   'PROPACK/double/dritzvec.F',
   'PROPACK/double/dsafescal.F',
   'PROPACK/double/printstat.F',
-  'PROPACK/double/second.F'
 ]
 
 c_src = [
@@ -49,7 +47,6 @@ c_src = [
   'PROPACK/complex8/printstat.F',
   'PROPACK/complex8/sblasext.F',
   'PROPACK/complex8/sbsvd.F',
-  'PROPACK/complex8/second.F',
   'PROPACK/complex8/sgemm_ovwr.F'
 ]
 
@@ -58,7 +55,6 @@ z_src = [
   'PROPACK/complex16/dbsvd.F',
   'PROPACK/complex16/dgemm_ovwr.F',
   'PROPACK/complex16/printstat.F',
-  'PROPACK/complex16/second.F',
   'PROPACK/complex16/zblasext.F',
   'PROPACK/complex16/zgemm_ovwr.F',
   'PROPACK/complex16/zgetu0.F',

--- a/scipy/sparse/linalg/_propack/setup.py
+++ b/scipy/sparse/linalg/_propack/setup.py
@@ -48,11 +48,9 @@ def configuration(parent_package='', top_path=None):
         src_dir = pathlib.Path(__file__).parent / 'PROPACK' / directory
         src = list(src_dir.glob('*.F'))
         if _is_32bit():
-            # don't ask me why, 32-bit blows up without second.F
             src = [str(p) for p in src if 'risc' not in str(p)]
         else:
-            src = [str(p) for p in src
-                   if 'pentium' not in str(p) and 'second' not in str(p)]
+            src = [str(p) for p in src if 'pentium' not in str(p)]
 
         if not _is_32bit():
             # don't ask me why, 32-bit blows up with this wrapper


### PR DESCRIPTION
This `second` usage caused problems not only with Intel Fortran on Windows, but also with `-use-g77-abi` and MKL/Accelerate on macOS.
    
Closes gh-18415