### PR TITLE
MAINT: stats: genexpon is no longer too slow for test_rvs_broadcast.

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -335,7 +335,7 @@ def test_moments(distname, arg, normalization_ok, higher_ok, moment_ok,
 
 @pytest.mark.parametrize('dist,shape_args', distcont)
 def test_rvs_broadcast(dist, shape_args):
-    if dist in ['gausshyper', 'genexpon', 'studentized_range']:
+    if dist in ['gausshyper', 'studentized_range']:
         pytest.skip("too slow")
 
     # If shape_only is True, it means the _rvs method of the


### PR DESCRIPTION
This is another follow-up to https://github.com/scipy/scipy/pull/17708.