### PR TITLE
BUG: special.logsumexp: fix precision issue

### DIFF
--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -139,6 +139,11 @@ def test_logsumexp_b_shape():
 
     logsumexp(a, b=b)
 
+def test_logsumexp_precision():
+    a = [0, -40]
+    expected = 4.248354255291589e-18
+    assert_almost_equal(logsumexp(a), expected)
+
 
 def test_softmax_fixtures():
     assert_allclose(softmax([1000, 0, 0, 0]), np.array([1, 0, 0, 0]),

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -142,7 +142,7 @@ def test_logsumexp_b_shape():
 def test_logsumexp_precision():
     a = [0, -40]
     expected = 4.248354255291589e-18
-    assert_almost_equal(logsumexp(a), expected)
+    assert_allclose(logsumexp(a), expected, rtol=1e-18)
 
 
 def test_softmax_fixtures():

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -140,9 +140,20 @@ def test_logsumexp_b_shape():
     logsumexp(a, b=b)
 
 def test_logsumexp_precision():
-    a = [0, -40]
-    expected = 4.248354255291589e-18
-    assert_allclose(logsumexp(a), expected, rtol=1e-18)
+
+    # values can be reproduced with mpmath as follows:
+    # with mp.extradps(20): return mp.log(mp.fsum([mp.exp(ai) for ai in a]))
+
+
+    assert_allclose(logsumexp([0, -40]), 4.248354255291589e-18, atol=1e-20)
+
+    expected = np.array([[1.92874985e-22, 2.61027907e-23, 1.96407613e-22], 
+                     [1.42516408e-21,1.42516408e-21, 2.86251946e-20]])
+    
+    a = np.array([[[0,-100,-50],[-52,0,-80],[0,-54,-50]],
+              [[0,-48,-np.infty],[-np.infty,0,-48],[0,-45,-60]]])
+    
+    assert_allclose(logsumexp(a, axis = 2), expected, atol = 1e-25)
 
 
 def test_softmax_fixtures():


### PR DESCRIPTION
Closes #18295. Updates scipy.special.logsumexp calculation with more precise logsumexp calculation outlined in #18295 where possible.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
