### PR TITLE
MAINT: stats.mode: improve `nan_policy` behavior

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -501,7 +501,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     contains_nan = [False]*len(samples)
 
                 # Addresses nan_policy == "propagate"
-                if any(contains_nan) and nan_policy == 'propagate':
+                if any(contains_nans) and (nan_policy == 'propagate'
+                                           and override['nan_propagation']):
                     res = np.full(n_out, np.nan)
                     res = _add_reduced_axes(res, reduced_axes, keepdims)
                     return tuple_to_result(*res)

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -493,21 +493,22 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             ndims = np.array([sample.ndim for sample in samples])
             if np.all(ndims <= 1):
                 # Addresses nan_policy == "raise"
-                contains_nans = []
-                for sample in samples:
-                    contains_nan, _ = _contains_nan(sample, nan_policy)
-                    contains_nans.append(contains_nan)
+                if nan_policy != 'propagate' or override['nan_propagation']:
+                    contains_nan = [_contains_nan(sample, nan_policy)[0]
+                                    for sample in samples]
+                else:
+                    # Behave as though there are no NaNs (even if there are)
+                    contains_nan = [False]*len(samples)
 
                 # Addresses nan_policy == "propagate"
-                if any(contains_nans) and (nan_policy == 'propagate'
-                                           and override['nan_propagation']):
+                if any(contains_nan) and nan_policy == 'propagate':
                     res = np.full(n_out, np.nan)
                     res = _add_reduced_axes(res, reduced_axes, keepdims)
                     return tuple_to_result(*res)
 
                 # Addresses nan_policy == "omit"
-                if any(contains_nans) and nan_policy == 'omit':
-                    # consider passing in contains_nans
+                if any(contains_nan) and nan_policy == 'omit':
+                    # consider passing in contains_nan
                     samples = _remove_nans(samples, paired)
 
                 # ideally, this is what the behavior would be:
@@ -540,7 +541,10 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             x = _broadcast_concatenate(samples, axis)
 
             # Addresses nan_policy == "raise"
-            contains_nan, _ = _contains_nan(x, nan_policy)
+            if nan_policy != 'propagate' or override['nan_propagation']:
+                contains_nan, _ = _contains_nan(x, nan_policy)
+            else:
+                contains_nan = False  # behave like there are no NaNs
 
             if vectorized and not contains_nan and not sentinel:
                 res = hypotest_fun_out(*samples, axis=axis, **kwds)

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -501,8 +501,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     contains_nan = [False]*len(samples)
 
                 # Addresses nan_policy == "propagate"
-                if any(contains_nans) and (nan_policy == 'propagate'
-                                           and override['nan_propagation']):
+                if any(contains_nan) and (nan_policy == 'propagate'
+                                          and override['nan_propagation']):
                     res = np.full(n_out, np.nan)
                     res = _add_reduced_axes(res, reduced_axes, keepdims)
                     return tuple_to_result(*res)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -507,7 +507,7 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
         message = ("Argument `a` is not recognized as numeric. "
                    "Support for input that cannot be coerced to a numeric "
                    "array was deprecated in SciPy 1.9.0 and removed in SciPy "
-                   "1.11.0. Please consider `pandas.DataFrame.mode`.")
+                   "1.11.0. Please consider `np.unique`.")
         raise TypeError(message)
 
     if a.size == 0:
@@ -8110,7 +8110,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     -------
     res: Power_divergenceResult
         An object containing attributes:
-        
+
         chisq : float or ndarray
             The chi-squared test statistic.  The value is a float if `axis` is
             None or `f_obs` and `f_exp` are 1-D.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2403,14 +2403,22 @@ class TestMode:
         assert_equal(res.count.ravel(), ref.count.ravel())
         assert res.count.shape == (1, 1)
 
-    def test_gh16952(self):
-        # Check that bug reported in gh-16952 is resolved
+    @pytest.mark.parametrize("nan_policy", ['propagate', 'omit'])
+    def test_gh16955(self, nan_policy):
+        # Check that bug reported in gh-16955 is resolved
         shape = (4, 3)
         data = np.ones(shape)
         data[0, 0] = np.nan
-        res = stats.mode(a=data, axis=1, keepdims=False, nan_policy="omit")
+        res = stats.mode(a=data, axis=1, keepdims=False, nan_policy=nan_policy)
         assert_array_equal(res.mode, [1, 1, 1, 1])
         assert_array_equal(res.count, [2, 3, 3, 3])
+
+        # Test with input from gh-16595. Support for non-numeric input
+        # was deprecated, so check for the appropriate error.
+        my_dtype = np.dtype([('asdf', np.uint8), ('qwer', np.float64, (3,))])
+        test = np.zeros(10, dtype=my_dtype)
+        with pytest.raises(TypeError, match="Argument `a` is not..."):
+            stats.mode(test, nan_policy=nan_policy)
 
     def test_gh9955(self):
         # The behavior of mode with empty slices (whether the input was empty


### PR DESCRIPTION
#### Reference issue
Closes gh-16595
gh-18394

#### What does this implement/fix?
gh-16595 noted two issues:

1. `stats.mode` performed an expensive NaN check that couldn't be skipped
2. for some input `dtype`s, `stats.mode` emitted a `RuntimeWarning` about checking for NaNs

This PR addresses item 1: it ensures that `_contains_nan` is not executed for `stats.mode` when `nan_policy='propagate'` (default). It's difficult to demonstrate this in a unit test, but this can be confirmed by running the following code in debug mode with a breakpoint in `scipy._lib._util._contains_nan`.
<details>

```python3
import numpy as np
from scipy import stats
x = [1, 2, np.nan]
print(stats.mode(x))  # ModeResult(mode=1.0, count=1)
print(stats.mode([x, x]))  # ModeResult(mode=array([ 1.,  2., nan]), count=array([2., 2., 2.]))
```
</details>

Item 2 has already been addressed in two ways.
- `stats.mode` no longer accepts non-numeric `dtype`s
- `_contains_nan` no longer emits the `RuntimeWarning` for any input

but this PR adds a test to confirm that the `RuntimeWarning` is no longer emitted.

@tirthasheshpatel I think this would be pretty easy for you to review.