### PR TITLE
BLD: DOC: fix Sphinx doc build caching behavior for `.dev` versions

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1028,9 +1028,15 @@ TARGETS: Sphinx build targets [default: 'html']
         ['--parallel', '-j'], default=1, metavar='N_JOBS',
         help="Number of parallel jobs"
     )
+    no_cache = Option(
+        ['--no-cache'], default=False, is_flag=True,
+        help="Forces a full rebuild of the docs. Note that this may be " + \
+             "needed in order to make docstring changes in C/Cython files " + \
+             "show up."
+    )
 
     @classmethod
-    def task_meta(cls, list_targets, parallel, args, **kwargs):
+    def task_meta(cls, list_targets, parallel, no_cache, args, **kwargs):
         if list_targets:  # list MAKE targets, remove default target
             task_dep = []
             targets = ''
@@ -1044,8 +1050,13 @@ TARGETS: Sphinx build targets [default: 'html']
         dirs = Dirs(build_args)
 
         make_params = [f'PYTHON="{sys.executable}"']
-        if parallel:
-            make_params.append(f'SPHINXOPTS="-j{parallel}"')
+        if parallel or no_cache:
+            sphinxopts = ""
+            if parallel:
+                sphinxopts += f"-j{parallel} "
+            if no_cache:
+                sphinxopts += "-E"
+            make_params.append(f'SPHINXOPTS="{sphinxopts}"')
 
         # Environment variables needed for notebooks
         # See gh-17322

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,8 +75,8 @@ copyright = '2008-%s, The SciPy community' % date.today().year
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-version = re.sub(r'\.dev-.*$', r'.dev', scipy.__version__)
-release = scipy.__version__
+version = re.sub(r'\.dev.*$', r'.dev', scipy.__version__)
+release = version
 
 if os.environ.get('CIRCLE_JOB', False) and \
         os.environ.get('CIRCLE_BRANCH', '') != 'main':


### PR DESCRIPTION
The regex for parsing `scipy.__version__` was off, causing Sphinx to do a full rebuild each time you made a commit when working on docs.

This change makes a commit a no-op for Sphinx caching, which reduces doc build time from ~14 minutes to ~14 seconds.

With or without the changes in `conf.py`, changes to docstrings in `.pyx` files or other non-Python files do not get picked up by Sphinx' caching system (this is a sphinx/autodoc bug). When making the caching behavior such that full rebuilds are less frequent, then of course the chance of such docstrings not being reflected in the html build output increases. Hence also add a `--no-cache` flag to `dev.py doc` to force a full rebuild.

[skip actions] [skip cirrus]