### PR TITLE
BLD: detect `xsimd` if it's installed and add to pythran dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,10 @@ tempita = files('scipy/_build_utils/tempita.py')
 use_pythran = get_option('use-pythran')
 if use_pythran
   pythran = find_program('pythran', native: true)
+  # xsimd is unvendored from pythran by conda-forge, and due to a compiler
+  # activation bug the default <prefix>/include/ may not be visible (see
+  # gh-15698). Hence look for xsimd explicitly.
+  xsimd_dep = dependency('xsimd', required: false)
 endif
 
 subdir('scipy')

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -105,7 +105,10 @@ print(incdir)
       check: true
     ).stdout().strip()
   endif
-  pythran_dep = declare_dependency(include_directories: incdir_pythran)
+  pythran_dep = declare_dependency(
+    include_directories: incdir_pythran,
+    dependencies: xsimd_dep,
+  )
 else
   pythran_dep = []
 endif


### PR DESCRIPTION
Fixes `xsimd/xsimd.hpp: No such file or directory`, as reported in gh-15698 and gh-18415.

The root cause of that issue is a compiler activation issue that occurs with some of the more niche shells with conda, as discussed in the last comments of gh-15698. The `required: false` should make this robust.

A useful side-effect is that the `xsimd` version is now reported in the build config terminal output:
```
Program pythran found: YES (/home/rgommers/mambaforge/envs/scipy-dev/bin/pythran)
Dependency xsimd found: YES 8.0.5
```