### PR TITLE
TST: fix precision of several linalg/sparse.linalg tests

### DIFF
--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -121,7 +121,7 @@ def test_ldl_type_size_combinations_complex(n, dtype):
 
     l, d1, p = ldl(x)
     u, d2, p = ldl(x, lower=0)
-    rtol = 1e-4 if dtype is complex64 else 1e-10
+    rtol = 2e-4 if dtype is complex64 else 1e-10
     assert_allclose(l.dot(d1).dot(l.conj().T), x, rtol=rtol, err_msg=msg1)
     assert_allclose(u.dot(d2).dot(u.conj().T), x, rtol=rtol, err_msg=msg1)
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -259,7 +259,7 @@ def test_fiedler_large_12():
 @pytest.mark.filterwarnings("ignore:Exited at iteration")
 @pytest.mark.filterwarnings("ignore:Exited postprocessing")
 def test_failure_to_run_iterations():
-    """Check that the code exists gracefully without breaking. Issue #10974.
+    """Check that the code exits gracefully without breaking. Issue #10974.
     The code may or not issue a warning, filtered out. Issue #15935, #17954.
     """
     rnd = np.random.RandomState(0)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -343,14 +343,16 @@ class SVDSCommonTests:
         v0a = rng.random(n)
         res1a = svds(A, k, v0=v0a, solver=self.solver, random_state=0)
         res2a = svds(A, k, v0=v0a, solver=self.solver, random_state=1)
-        assert_equal(res1a, res2a)
+        for idx in range(3):
+            assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
         # with the same v0, solutions are the same, and they are accurate
         v0b = rng.random(n)
         res1b = svds(A, k, v0=v0b, solver=self.solver, random_state=2)
         res2b = svds(A, k, v0=v0b, solver=self.solver, random_state=3)
-        assert_equal(res1b, res2b)
+        for idx in range(3):
+            assert_allclose(res1b[idx], res2b[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1b)
 
         # with different v0, solutions can be numerically different
@@ -376,13 +378,15 @@ class SVDSCommonTests:
         # with the same random_state, solutions are the same and accurate
         res1a = svds(A, k, solver=self.solver, random_state=0)
         res2a = svds(A, k, solver=self.solver, random_state=0)
-        assert_equal(res1a, res2a)
+        for idx in range(3):
+            assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
         # with the same random_state, solutions are the same and accurate
         res1b = svds(A, k, solver=self.solver, random_state=1)
         res2b = svds(A, k, solver=self.solver, random_state=1)
-        assert_equal(res1b, res2b)
+        for idx in range(3):
+            assert_allclose(res1b[idx], res2b[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1b)
 
         # with different random_state, solutions can be numerically different
@@ -409,7 +413,8 @@ class SVDSCommonTests:
         # with the same random_state, solutions are the same and accurate
         res1a = svds(A, k, solver=self.solver, random_state=random_state)
         res2a = svds(A, k, solver=self.solver, random_state=random_state_2)
-        assert_equal(res1a, res2a)
+        for idx in range(3):
+            assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
     @pytest.mark.parametrize("random_state", (None,


### PR DESCRIPTION
xref https://github.com/conda-forge/scipy-feedstock/pull/224 for these test failures. The `test_failure_to_run_iterations` issue that is the only failure for 3 OS/BLAS combinations was already fixed in `main`, so with this PR we should be close to most jobs passing again.

[skip cirrus] [skip circle]