### PR TITLE
ENH: increase truncated exponential distribution sf/isf precision

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9125,6 +9125,12 @@ class truncexpon_gen(rv_continuous):
     def _ppf(self, q, b):
         return -sc.log1p(q*sc.expm1(-b))
 
+    def _sf(self, x, b):
+        return (np.exp(-b) - np.exp(-x))/sc.expm1(-b)
+
+    def _isf(self, q, b):
+        return -np.log(np.exp(-b) - q * sc.expm1(-b))
+
     def _munp(self, n, b):
         # wrong answer with formula, same as in continuous.pdf
         # return sc.gamman+1)-sc.gammainc1+n, b)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3871,6 +3871,19 @@ class TestGenExpon:
         ppf = stats.genexpon.ppf(p, a, b, c)
         assert_allclose(ppf, x, rtol=1e-14)
 
+class TestTruncexpon:
+
+    # reference values were computed via the reference distribution
+    # mp.dps = 50
+    # TruncExpon(b=100).sf(99.999999)
+
+    @pytest.mark.parametrize("x, b, ref",
+                             [(19.999999, 20, 2.0611546593828472e-15),
+                              (99.999999, 100, 3.7200778266200137e-50)])
+    def test_sf_isf(self, x, b, ref):
+        assert_allclose(stats.truncexpon.sf(x, b), ref, rtol=1e-10)
+        assert_allclose(stats.truncexpon.isf(ref, b), x, rtol=1e-12)
+
 
 class TestExponpow:
     def test_tail(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3879,7 +3879,7 @@ class TestTruncexpon:
 
     @pytest.mark.parametrize("x, b, ref",
                              [(19.999999, 20, 2.0611546593828472e-15),
-                              (99.999999, 100, 3.7200778266200137e-50)])
+                              (99.999999, 100, 3.7200778266671455e-50)])
     def test_sf_isf(self, x, b, ref):
         assert_allclose(stats.truncexpon.sf(x, b), ref, rtol=1e-10)
         assert_allclose(stats.truncexpon.isf(ref, b), x, rtol=1e-12)

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -297,11 +297,24 @@ class NormInvGauss(ReferenceDistribution):
         a = mp.pi**-1 * alpha * mp.exp(mp.sqrt(alpha**2 - beta**2))
         return a * q**-1 * mp.besselk(1, alpha*q) * mp.exp(beta*x)
 
+
 class StudentT(ReferenceDistribution):
 
     def __init(self, *, df):
-        super().__init(df=df)
+        super().__init__(df=df)
 
     def _pdf(self, x, df):
         return (mp.gamma((df + mp.one)/2)/(mp.sqrt(df * mp.pi) * mp.gamma(df/2))
                 * (mp.one + x*x/df)**(-(df + mp.one)/2))
+
+
+class TruncExpon(ReferenceDistribution):
+
+    def __init(self, *, b):
+        super().__init__(b=b)
+
+    def _pdf(self, x, b):
+        return -mp.exp(-x)/mp.expm1(-b)
+
+    def _sf(self, x, b):
+        return (mp.exp(-b) - mp.exp(-x))/mp.expm1(-b)

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -310,7 +310,7 @@ class StudentT(ReferenceDistribution):
 
 class TruncExpon(ReferenceDistribution):
 
-    def __init(self, *, b):
+    def __init__(self, *, b):
         super().__init__(b=b)
 
     def _pdf(self, x, b):


### PR DESCRIPTION
#### Reference issue
Part of #17832

#### What does this implement/fix?
Overrise survival and inverse survival function for the truncated exponential distribution.

#### Additional information
![image](https://github.com/scipy/scipy/assets/40656107/dacbd32f-67d3-4946-bd74-6c2987182693)

<details><summary>Plot generation</summary>
<p>

```python
import numpy as np
from scipy import special as sc
import matplotlib.pyplot as plt

def truncexpon_sf(x, b):
    return (np.exp(-b) - np.exp(-x))/sc.expm1(-b)

x = np.linspace(0, 100, 1000)
b = 100

plt.semilogy(x, stats.truncexpon.sf(x, b), label="main", ls="dashdot")
plt.semilogy(x, truncexpon_sf(x, b), label="PR", ls="dashed")
plt.legend()
plt.title(f"Trunc. Exponential survival function: $b={b}$")
``` 


</p>
</details> 