### PR TITLE
MAINT: simplifiy detrend

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3560,7 +3560,7 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
     else:
         dshape = data.shape
         N = dshape[axis]
-        bp = np.sort(np.unique(np.r_[0, bp, N]))
+        bp = np.sort(np.unique([0, bp, N]))
         if np.any(bp > N):
             raise ValueError("Breakpoints must be less than length "
                              "of data along given axis.")


### PR DESCRIPTION
* while working on gh-18286, I noticed that I could delete algorithmic code that wasn't array API compliant, and the SciPy test suite would still pass

* it seems that Evgeni caught some of this already in gh-18412, which was recently merged, but it looks like this usage of `np.r_` can also just be deleted without consequence in our test suite--so, I'd argue either we should delete it or the lack of a test for its requirement is pretty close to as serious as a bug (in which case, this proposed change should serve an effective catalyst for someone to explain and write the test)