### PR TITLE
DOC: odr: clarify `cov_beta` is not scaled by the residual variance

### DIFF
--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -555,7 +555,7 @@ class Output:
         Covariance matrix of the estimated parameters, of shape (p,p).
         Note that this `cov_beta` is not scaled by the residual variance 
         `res_var`, whereas `sd_beta` is. This means 
-        `np.sqrt(np.diag(output.cov_beta * output.res_var))` is the same 
+        ``np.sqrt(np.diag(output.cov_beta * output.res_var))`` is the same 
         result as `output.sd_beta`.
     delta : ndarray, optional
         Array of estimated errors in input variables, of same shape as `x`.

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -553,6 +553,10 @@ class Output:
         Standard deviations of the estimated parameters, of shape (p,).
     cov_beta : ndarray
         Covariance matrix of the estimated parameters, of shape (p,p).
+        Note that this `cov_beta` is not scaled by the residual variance 
+        `res_var`, whereas `sd_beta` is. This means 
+        `np.sqrt(np.diag(output.cov_beta * output.res_var))` is the same 
+        result as `output.sd_beta`.
     delta : ndarray, optional
         Array of estimated errors in input variables, of same shape as `x`.
     eps : ndarray, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #6842 
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR enhanced the `cov_beta` of the `odr.Output` to clarify  `cov_beta` is not scaled by the residual variance as discussed in #6842.

#### Additional information
<!--Any additional information you think is important.-->
