### PR TITLE
DOC: optimize: add use of functools.partial to tutorial

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -115,6 +115,14 @@ the objective function as keyword arguments.
     >>> print(res.x)
     [1.         1.         1.         1.         0.99999999]
 
+Another alternative is to use :py:func:`functools.partial`.
+
+    >>> from functools import partial
+    >>> partial_rosen = partial(rosen_with_args, a=0.5, b=1.)
+    >>> res = minimize(partial_rosen, x0, method='nelder-mead',
+    ...                options={'xatol': 1e-8,})
+    >>> print(res.x)
+    [1.         1.         1.         1.         0.99999999]
 
 Broyden-Fletcher-Goldfarb-Shanno algorithm (``method='BFGS'``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
#### Reference issue
gh-18456

#### What does this implement/fix?
This adds an example of using `functools.partial` when `args`/`kwargs` are not parameters of a `scipy.optimize` function.

@scottshambaugh 
