### PR TITLE
TST: stats: ReferenceDistribution: use complementary methods when available

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3274,19 +3274,16 @@ class TestStudentT:
         assert_equal(res[df_infmask], res_ex_inf)
         assert_equal(res[~df_infmask], res_ex_noinf)
 
-    # reference values were computed via the reference distribution
-    # mp.dps = 500
-    # e. g. StudentT(df=1e100).logpdf(1), StudentT(df=1e100).pdf(1)
 
-    @pytest.mark.parametrize("x, df, logpdf_ref, pdf_ref",
-                             [(1, 1e100,
-                               -1.4189385332046727, 0.24197072451914334),
-                              (1e3, 1e50, -500000.9189385332, 0.),
-                              (10, 1e20,
-                               -50.918938533204674, 7.69459862670642e-23),
-                              (1, 1,
-                               -1.8378770664093456, 0.15915494309189535)])
-    def test_logpdf_pdf(self, x, df, logpdf_ref, pdf_ref):
+    def test_logpdf_pdf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 500; StudentT(df=df).logpdf(x), StudentT(df=df).pdf(x)
+        x = [1, 1e3, 10, 1]
+        df = [1e100, 1e50, 1e20, 1]
+        logpdf_ref = [-1.4189385332046727, -500000.9189385332,
+                      -50.918938533204674, -1.8378770664093456]
+        pdf_ref = [0.24197072451914334, 0,
+                   7.69459862670642e-23, 0.15915494309189535]
         assert_allclose(stats.t.logpdf(x, df), logpdf_ref, rtol=1e-15)
         assert_allclose(stats.t.pdf(x, df), pdf_ref, rtol=1e-14)
 
@@ -3873,14 +3870,12 @@ class TestGenExpon:
 
 class TestTruncexpon:
 
-    # reference values were computed via the reference distribution
-    # mp.dps = 50
-    # TruncExpon(b=100).sf(99.999999)
-
-    @pytest.mark.parametrize("x, b, ref",
-                             [(19.999999, 20, 2.0611546593828472e-15),
-                              (99.999999, 100, 3.7200778266671455e-50)])
-    def test_sf_isf(self, x, b, ref):
+    def test_sf_isf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 50; TruncExpon(b=b).sf(x)
+        b = [20, 100]
+        x = [19.999999, 99.999999]
+        ref = [2.0611546593828472e-15, 3.7200778266671455e-50]
         assert_allclose(stats.truncexpon.sf(x, b), ref, rtol=1e-10)
         assert_allclose(stats.truncexpon.isf(ref, b), x, rtol=1e-12)
 

--- a/scipy/stats/tests/test_generation/reference_distribution_infrastructure_tests.py
+++ b/scipy/stats/tests/test_generation/reference_distribution_infrastructure_tests.py
@@ -53,3 +53,38 @@ def test_basic():
     assert_allclose(dist.var(), dist_ref.var(), rtol=rtol)
     assert_allclose(dist.skew(), dist_ref.stats('s'), rtol=rtol)
     assert_allclose(dist.kurtosis(), dist_ref.stats('k'), rtol=rtol)
+
+
+def test_complementary_method_use():
+    # Show that complementary methods are used as expected.
+    # E.g., use 1 - CDF to compute SF if CDF is overridden but SF is not
+
+    mp.dps = 50
+    x = np.linspace(0, 1, 10)
+    class MyDist(rd.ReferenceDistribution):
+        def _cdf(self, x):
+            return x
+
+    dist = MyDist()
+    assert_allclose(dist.sf(x), 1 - dist.cdf(x))
+
+    class MyDist(rd.ReferenceDistribution):
+        def _sf(self, x):
+            return 1-x
+
+    dist = MyDist()
+    assert_allclose(dist.cdf(x), 1 - dist.sf(x))
+
+    class MyDist(rd.ReferenceDistribution):
+        def _ppf(self, x, guess):
+            return x
+
+    dist = MyDist()
+    assert_allclose(dist.isf(x), dist.ppf(1-x))
+
+    class MyDist(rd.ReferenceDistribution):
+        def _isf(self, x, guess):
+            return 1-x
+
+    dist = MyDist()
+    assert_allclose(dist.ppf(x), dist.isf(1-x))


### PR DESCRIPTION
#### Reference issue
gh-18449
gh-18433

#### What does this implement/fix?
- gh-18449 added an `_sf` override to the `TruncExpon` reference distribution. It would be nice if calling `cdf` would use it (and take the complement) rather than integrating the pdf, right? This enhances the `ReferenceDistribution` infrastructure accordingly.
- gh-18449 added an `_sf` override because ["The PDF was not enough"](https://github.com/scipy/scipy/pull/18449#discussion_r1190403860). It was not enough because `_support` needed to be defined. This adds `_support` to the `TruncExpon` reference distribution and documents when it needs to be defined.
- In gh-18433, I suggested preferring defining multiple test cases in a single vectorized test rather than using parametrization for several little reasons:
  - The vectorized approach is (ever so slightly) faster.
  - The vectorized approach is (ever so slightly) less ugly.
  - (most importantly) The vectorized approach is easier to review.

The last suggestion was not accepted in gh-18433, but I think it's important enough to push for it. To review tests written like this, we just need to add the imports, copy-paste the arrays, and write some simple code like `StudentT(df=df).logpdf(x) - logpdf_ref` (or copy-paste snippets from the comments). Seeing that the results are zero confirms that the author copy-pasted the reference values faithfully (which [cannot be taken for granted](https://github.com/scipy/scipy/pull/18449#discussion_r1193132084)). This is easier than the alternatives when the tests are parametrized.

Parametrized tests absolutely have a place, but for the reasons above, I think vectorized tests should be preferred (where possible) when testing distribution accuracy. If there is no strong reason to maintain the status quo, let's use the most appropriate style for the job at hand.