### PR TITLE
ENH: stats.anderson_ksamp: re-add permutation version of test 

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2468,8 +2468,8 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
         # interpolation of probit of significance level
         pf = np.polyfit(critical, log(sig), 2)
         p = math.exp(np.polyval(pf, A2))
-
-    p = res.pvalue if method is not None else p
+    else:
+        p = res.pvalue if method is not None else p
 
     # create result object with alias for backward compatibility
     res = Anderson_ksampResult(A2, critical, p)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -453,8 +453,8 @@ class TestAndersonKSamp:
         assert_allclose(p, 0.0041, atol=0.00025)
 
         rng = np.random.default_rng(6989860141921615054)
-        res = stats.anderson_ksamp(samples, midrank=False,
-                                   n_resamples=9999, random_state=rng)
+        method = stats.PermutationMethod(n_resamples=9999, random_state=rng)
+        res = stats.anderson_ksamp(samples, midrank=False, method=method)
         assert_array_equal(res.statistic, Tk)
         assert_array_equal(res.critical_values, tm)
         assert_allclose(res.pvalue, p, atol=6e-4)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -420,6 +420,7 @@ class TestAndersonKSamp:
                                   tm[0:5], 4)
         assert_allclose(p, 0.0020, atol=0.00025)
 
+    @pytest.mark.slow
     def test_example2a(self):
         # Example data taken from an earlier technical report of
         # Scholz and Stephens
@@ -444,13 +445,19 @@ class TestAndersonKSamp:
         t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
                61, 34]
 
-        Tk, tm, p = stats.anderson_ksamp((t1, t2, t3, t4, t5, t6, t7, t8,
-                                          t9, t10, t11, t12, t13, t14),
-                                         midrank=False)
+        samples = (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+        Tk, tm, p = stats.anderson_ksamp(samples, midrank=False)
         assert_almost_equal(Tk, 3.288, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm[0:5], 4)
         assert_allclose(p, 0.0041, atol=0.00025)
+
+        rng = np.random.default_rng(6989860141921615054)
+        res = stats.anderson_ksamp(samples, midrank=False,
+                                   n_resamples=9999, random_state=rng)
+        assert_array_equal(res.statistic, Tk)
+        assert_array_equal(res.critical_values, tm)
+        assert_allclose(res.pvalue, p, atol=6e-4)
 
     def test_example2b(self):
         # Example data taken from an earlier technical report of


### PR DESCRIPTION
#### Reference issue
Closes gh-9527

#### What does this implement/fix?
gh-9527 asked for the `anderson_ksamp` to provide p-values beyond the range of tabulated values. 
gh-16996 did that by performing a permutation test rather than relying on interpolation from tables.
gh-18321 reverted gh-16996 so that we could agree on a more standard interface for adding permutation versions of tests before releasing the feature.
gh-18227 provided that standard interface, introducing a `PermutationMethod` class, which can be passed into a `method` parameter of hypothesis test functions.
This PR reverts gh-18321, adding back the permutation test functionality from gh-16996 but using this standard interface.

#### Additional information
```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(2409652456398)
samples = [rng.normal(size=50), rng.normal(loc=0.5, size=30)]

res = stats.anderson_ksamp(samples)
print(res.statistic, res.pvalue)  # 0.33300335288985067 0.24377853796812013

method = stats.PermutationMethod(random_state=rng)
res = stats.anderson_ksamp(samples, method=method)
print(res.statistic, res.pvalue)  # 0.33300335288985067 0.251
```
