### PR TITLE
MAINT: remove lsim2/impulse2/step2 docstring examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -316,9 +316,6 @@ coverage_ignore_c_items = {}
 plot_pre_code = """
 import warnings
 for key in (
-        'lsim2 is deprecated',  # Deprecation of scipy.signal.lsim2
-        'impulse2 is deprecated',  # Deprecation of scipy.signal.impulse2
-        'step2 is deprecated',  # Deprecation of scipy.signal.step2
         'scipy.misc'  # scipy.misc deprecated in v1.10.0; use scipy.datasets
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1830,70 +1830,6 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
     If (num, den) is passed in for ``system``, coefficients for both the
     numerator and denominator should be specified in descending exponent
     order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
-
-    Examples
-    --------
-    We'll use `lsim2` to simulate an analog Bessel filter applied to
-    a signal.
-
-    >>> import numpy as np
-    >>> from scipy.signal import bessel, lsim2
-    >>> import matplotlib.pyplot as plt
-
-    Create a low-pass Bessel filter with a cutoff of 12 Hz.
-
-    >>> b, a = bessel(N=5, Wn=2*np.pi*12, btype='lowpass', analog=True)
-
-    Generate data to which the filter is applied.
-
-    >>> t = np.linspace(0, 1.25, 500, endpoint=False)
-
-    The input signal is the sum of three sinusoidal curves, with
-    frequencies 4 Hz, 40 Hz, and 80 Hz.  The filter should mostly
-    eliminate the 40 Hz and 80 Hz components, leaving just the 4 Hz signal.
-
-    >>> u = (np.cos(2*np.pi*4*t) + 0.6*np.sin(2*np.pi*40*t) +
-    ...      0.5*np.cos(2*np.pi*80*t))
-
-    Simulate the filter with `lsim2`.
-
-    >>> tout, yout, xout = lsim2((b, a), U=u, T=t)
-
-    Plot the result.
-
-    >>> plt.plot(t, u, 'r', alpha=0.5, linewidth=1, label='input')
-    >>> plt.plot(tout, yout, 'k', linewidth=1.5, label='output')
-    >>> plt.legend(loc='best', shadow=True, framealpha=1)
-    >>> plt.grid(alpha=0.3)
-    >>> plt.xlabel('t')
-    >>> plt.show()
-
-    In a second example, we simulate a double integrator ``y'' = u``, with
-    a constant input ``u = 1``.  We'll use the state space representation
-    of the integrator.
-
-    >>> from scipy.signal import lti
-    >>> A = np.array([[0, 1], [0, 0]])
-    >>> B = np.array([[0], [1]])
-    >>> C = np.array([[1, 0]])
-    >>> D = 0
-    >>> system = lti(A, B, C, D)
-
-    `t` and `u` define the time and input signal for the system to
-    be simulated.
-
-    >>> t = np.linspace(0, 5, num=50)
-    >>> u = np.ones_like(t)
-
-    Compute the simulation, and then plot `y`.  As expected, the plot shows
-    the curve ``y = 0.5*t**2``.
-
-    >>> tout, y, x = lsim2(system, u, t)
-    >>> plt.plot(t, y)
-    >>> plt.grid(alpha=0.3)
-    >>> plt.xlabel('t')
-    >>> plt.show()
-
     """
     warnings.warn("lsim2 is deprecated and will be removed from scipy 1.13. "
                   "Use the feature-equivalent lsim function.",
@@ -2348,20 +2284,6 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
     order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
 
     .. versionadded:: 0.8.0
-
-    Examples
-    --------
-    Compute the impulse response of a second order system with a repeated
-    root: ``x''(t) + 2*x'(t) + x(t) = u(t)``
-
-    >>> from scipy import signal
-
-    >>> system = ([1.0], [1.0, 2.0, 1.0])
-
-    >>> t, y = signal.impulse2(system)
-    >>> import matplotlib.pyplot as plt
-    >>> plt.plot(t, y)
-
     """
     warnings.warn("impulse2 is deprecated and will be removed from "
                   "scipy 1.13. Use the feature-equivalent impulse function.",
@@ -2522,21 +2444,6 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
     order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
 
     .. versionadded:: 0.8.0
-
-    Examples
-    --------
-    >>> from scipy import signal
-    >>> import matplotlib.pyplot as plt
-
-    >>> lti = signal.lti([1.0], [1.0, 1.0])
-    >>> t, y = signal.step2(lti)
-
-    >>> plt.plot(t, y)
-    >>> plt.xlabel('Time [s]')
-    >>> plt.ylabel('Amplitude')
-    >>> plt.title('Step response for 1. Order Lowpass')
-    >>> plt.grid()
-
     """
     warnings.warn("step2 is deprecated and will be removed from scipy 1.13. "
                   "Use the feature-equivalent step function.",


### PR DESCRIPTION
Alternative to #18471 as one of the [suggestions](https://github.com/scipy/scipy/pull/15929#issuecomment-1549065305) how to unbreak the doc build.

Closes #18471