### PR TITLE
TST: stats/optimize: filter warnings in tests

### DIFF
--- a/scipy/optimize/tests/test__linprog_clean_inputs.py
+++ b/scipy/optimize/tests/test__linprog_clean_inputs.py
@@ -98,7 +98,6 @@ def test_too_few_dimensions():
     assert_raises(ValueError, _clean_inputs, _LPProblem(c=cb, A_eq=bad, b_eq=cb))
 
 
-@pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 def test_inconsistent_dimensions():
     m = 2
     n = 4
@@ -114,7 +113,10 @@ def test_inconsistent_dimensions():
     assert_raises(ValueError, _clean_inputs, _LPProblem(c=c, A_eq=Abad, b_eq=bgood))
     assert_raises(ValueError, _clean_inputs, _LPProblem(c=c, A_eq=Agood, b_eq=bbad))
     assert_raises(ValueError, _clean_inputs, _LPProblem(c=c, bounds=boundsbad))
-    assert_raises(ValueError, _clean_inputs, _LPProblem(c=c, bounds=[[1, 2], [2, 3], [3, 4], [4, 5, 6]]))
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(np.VisibleDeprecationWarning, "Creating an ndarray from ragged")
+        assert_raises(ValueError, _clean_inputs,
+                      _LPProblem(c=c, bounds=[[1, 2], [2, 3], [3, 4], [4, 5, 6]]))
 
 
 def test_type_errors():
@@ -238,13 +240,15 @@ def test__clean_inputs3():
     assert_(lp_cleaned.b_eq.shape == (2,), "")
 
 
-@pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 def test_bad_bounds():
     lp = _LPProblem(c=[1, 2])
 
     assert_raises(ValueError, _clean_inputs, lp._replace(bounds=(1, 2, 2)))
     assert_raises(ValueError, _clean_inputs, lp._replace(bounds=[(1, 2, 2)]))
-    assert_raises(ValueError, _clean_inputs, lp._replace(bounds=[(1, 2), (1, 2, 2)]))
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(np.VisibleDeprecationWarning, "Creating an ndarray from ragged")
+        assert_raises(ValueError, _clean_inputs,
+                      lp._replace(bounds=[(1, 2), (1, 2, 2)]))
     assert_raises(ValueError, _clean_inputs, lp._replace(bounds=[(1, 2), (1, 2), (1, 2)]))
 
     lp = _LPProblem(c=[1, 2, 3, 4])

--- a/scipy/optimize/tests/test__linprog_clean_inputs.py
+++ b/scipy/optimize/tests/test__linprog_clean_inputs.py
@@ -4,6 +4,7 @@ Unit test for Linear Programming via Simplex Algorithm.
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_equal
 from pytest import raises as assert_raises
+import pytest
 from scipy.optimize._linprog_util import _clean_inputs, _LPProblem
 from copy import deepcopy
 from datetime import date
@@ -97,6 +98,7 @@ def test_too_few_dimensions():
     assert_raises(ValueError, _clean_inputs, _LPProblem(c=cb, A_eq=bad, b_eq=cb))
 
 
+@pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 def test_inconsistent_dimensions():
     m = 2
     n = 4
@@ -236,6 +238,7 @@ def test__clean_inputs3():
     assert_(lp_cleaned.b_eq.shape == (2,), "")
 
 
+@pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 def test_bad_bounds():
     lp = _LPProblem(c=[1, 2])
 

--- a/scipy/optimize/tests/test__linprog_clean_inputs.py
+++ b/scipy/optimize/tests/test__linprog_clean_inputs.py
@@ -4,7 +4,6 @@ Unit test for Linear Programming via Simplex Algorithm.
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_equal
 from pytest import raises as assert_raises
-import pytest
 from scipy.optimize._linprog_util import _clean_inputs, _LPProblem
 from copy import deepcopy
 from datetime import date

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -478,6 +478,7 @@ class LinprogCommonTests:
         np.testing.assert_allclose(res.x, [1.8, 2.8])
         np.testing.assert_allclose(res.fun, -2.8)
 
+    @pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
     def test_invalid_inputs(self):
 
         def f(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -478,7 +478,6 @@ class LinprogCommonTests:
         np.testing.assert_allclose(res.x, [1.8, 2.8])
         np.testing.assert_allclose(res.fun, -2.8)
 
-    @pytest.mark.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
     def test_invalid_inputs(self):
 
         def f(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
@@ -487,7 +486,9 @@ class LinprogCommonTests:
 
         # Test ill-formatted bounds
         assert_raises(ValueError, f, [1, 2, 3], bounds=[(1, 2), (3, 4)])
-        assert_raises(ValueError, f, [1, 2, 3], bounds=[(1, 2), (3, 4), (3, 4, 5)])
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(np.VisibleDeprecationWarning, "Creating an ndarray from ragged")
+            assert_raises(ValueError, f, [1, 2, 3], bounds=[(1, 2), (3, 4), (3, 4, 5)])
         assert_raises(ValueError, f, [1, 2, 3], bounds=[(1, -2), (1, 2)])
 
         # Test other invalid inputs

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -5,7 +5,6 @@ from scipy.sparse import csc_matrix
 from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_less, assert_, assert_allclose,
                            suppress_warnings)
-from pytest import raises
 from scipy.optimize import (NonlinearConstraint,
                             LinearConstraint,
                             Bounds,
@@ -592,9 +591,10 @@ class TestTrustRegionConstr(TestCase):
 
     def test_raise_exception(self):
         prob = Maratos()
-
-        raises(ValueError, minimize, prob.fun, prob.x0, method='trust-constr',
-               jac='2-point', hess='2-point', constraints=prob.constr)
+        message = "Whenever the gradient is estimated via finite-differences"
+        with pytest.raises(ValueError, match=message):
+            minimize(prob.fun, prob.x0, method='trust-constr', jac='2-point',
+                     hess='2-point', constraints=prob.constr)
 
     def test_issue_9044(self):
         # https://github.com/scipy/scipy/issues/9044
@@ -762,7 +762,7 @@ class TestBoundedNelderMead:
     def test_invalid_bounds(self):
         prob = Rosenbrock()
         message = 'An upper bound is less than the corresponding lower bound.'
-        with raises(ValueError, match=message):
+        with pytest.raises(ValueError, match=message):
             bounds = Bounds([-np.inf, 1.0], [4.0, -5.0])
             minimize(prob.fun, [-10, 3],
                      method='Nelder-Mead',
@@ -772,8 +772,8 @@ class TestBoundedNelderMead:
                               "see gh-13846")
     def test_outside_bounds_warning(self):
         prob = Rosenbrock()
-        with raises(UserWarning, match=r"Initial guess is not within "
-                                       r"the specified bounds"):
+        message = "Initial guess is not within the specified bounds"
+        with pytest.warns(UserWarning, match=message):
             bounds = Bounds([-np.inf, 1.0], [4.0, 5.0])
             minimize(prob.fun, [-10, 8],
                      method='Nelder-Mead',

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -179,6 +179,8 @@ def nan_policy_1d(hypotest, data1d, unpacker, *args, n_outputs=2,
     return unpacker(hypotest(*data1d, *args, _no_deco=_no_deco, **kwds))
 
 
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore::UserWarning')
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
 @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
@@ -192,6 +194,8 @@ def test_axis_nan_policy_fast(hypotest, args, kwds, n_samples, n_outputs,
 
 
 @pytest.mark.slow
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore::UserWarning')
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
 @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
@@ -205,8 +209,6 @@ def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
                           unpacker, nan_policy, axis, data_generator)
 
 
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
-@pytest.mark.filterwarnings('ignore::UserWarning')
 def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                           unpacker, nan_policy, axis, data_generator):
     # Tests the 1D and vectorized behavior of hypothesis tests against a

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -205,6 +205,8 @@ def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
                           unpacker, nan_policy, axis, data_generator)
 
 
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore::UserWarning')
 def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                           unpacker, nan_policy, axis, data_generator):
     # Tests the 1D and vectorized behavior of hypothesis tests against a
@@ -325,6 +327,7 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             assert_equal(res[1].dtype, pvalues.dtype)
 
 
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
 @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/18394#issuecomment-1549058211

#### What does this implement/fix?
The following CI jobs (e.g. in gh-18455) show logs with many warnings from stats and optimize tests.
- Build with gcc-8
- cp311 (build sdist + wheel), full, no pythran)
- cp310 (setup.py bdist_wheel)

Whether the warnings should be produced by the underlying functions is a different issue; this PR ensures that the warnings are not logged.