### PR TITLE
MAINT: differentiable fns respect float width.  Closes #15602

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -3,6 +3,7 @@ import scipy.sparse as sps
 from ._numdiff import approx_derivative, group_columns
 from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy.sparse.linalg import LinearOperator
+from scipy._lib._array_api import atleast_nd, array_namespace
 
 
 FD_METHODS = ('2-point', '3-point', 'cs')
@@ -103,13 +104,14 @@ class ScalarFunction:
                              "to be estimated using one of the "
                              "quasi-Newton strategies.")
 
-        _x = np.atleast_1d(x0).copy()
-        _dtype = np.float
-        if np.issubdtype(_x.dtype, np.floating):
+        self.xp = xp = array_namespace(x0)
+        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _dtype = xp.float64
+        if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
 
-        # promotes to np.floating
-        self.x = _x.astype(_dtype)
+        # promotes to floating
+        self.x = xp.astype(_x, _dtype)
         self.x_dtype = _dtype
         self.n = self.x.size
         self.nfev = 0
@@ -237,8 +239,9 @@ class ScalarFunction:
                 self.g_prev = self.g
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                _x = np.atleast_1d(x).copy()
-                self.x = _x.astype(self.x_dtype)
+
+                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -247,8 +250,8 @@ class ScalarFunction:
             def update_x(x):
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                _x = np.atleast_1d(x).copy()
-                self.x = _x.astype(self.x_dtype)
+                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -331,13 +334,14 @@ class VectorFunction:
                              "be estimated using one of the quasi-Newton "
                              "strategies.")
 
-        _x = np.atleast_1d(x0).copy()
-        _dtype = np.float
-        if np.issubdtype(_x.dtype, np.floating):
+        self.xp = xp = array_namespace(x0)
+        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _dtype = xp.float64
+        if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
 
-        # promotes to np.floating
-        self.x = _x.astype(_dtype)
+        # promotes to floating
+        self.x = xp.astype(_x, _dtype)
         self.x_dtype = _dtype
 
         self.n = self.x.size
@@ -508,16 +512,16 @@ class VectorFunction:
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                _x = np.atleast_1d(x).copy()
-                self.x = _x.astype(self.x_dtype)
+                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                _x = np.atleast_1d(x).copy()
-                self.x = _x.astype(self.x_dtype)
+                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
@@ -587,13 +591,14 @@ class LinearVectorFunction:
 
         self.m, self.n = self.J.shape
 
-        _x = np.atleast_1d(x0).copy()
-        _dtype = np.float
-        if np.issubdtype(_x.dtype, np.floating):
+        self.xp = xp = array_namespace(x0)
+        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _dtype = xp.float64
+        if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
 
-        # promotes to np.floating
-        self.x = _x.astype(_dtype)
+        # promotes to floating
+        self.x = xp.astype(_x, _dtype)
         self.x_dtype = _dtype
 
         self.f = self.J.dot(self.x)
@@ -604,8 +609,8 @@ class LinearVectorFunction:
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            _x = np.atleast_1d(x).copy()
-            self.x = _x.astype(self.x_dtype)
+            _x = atleast_nd(x, ndim=1, xp=self.xp)
+            self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
 
     def fun(self, x):

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -103,8 +103,10 @@ class ScalarFunction:
                              "to be estimated using one of the "
                              "quasi-Newton strategies.")
 
-        # the astype call ensures that self.x is a copy of x0
-        self.x = np.atleast_1d(x0).astype(float)
+        _x = np.atleast_1d(x0).copy()
+        # promotes to np.floating
+        self.x = np.asfarray(_x, _x.dtype)
+        self.x_dtype = _x.dtype
         self.n = self.x.size
         self.nfev = 0
         self.ngev = 0
@@ -231,7 +233,7 @@ class ScalarFunction:
                 self.g_prev = self.g
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -240,7 +242,7 @@ class ScalarFunction:
             def update_x(x):
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -323,7 +325,11 @@ class VectorFunction:
                              "be estimated using one of the quasi-Newton "
                              "strategies.")
 
-        self.x = np.atleast_1d(x0).astype(float)
+        _x = np.atleast_1d(x0).copy()
+        # promotes to np.floating
+        self.x = np.asfarray(_x, _x.dtype)
+        self.x_dtype = _x.dtype
+
         self.n = self.x.size
         self.nfev = 0
         self.njev = 0
@@ -492,14 +498,14 @@ class VectorFunction:
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = np.atleast_1d(x).astype(float)
+                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
@@ -569,7 +575,11 @@ class LinearVectorFunction:
 
         self.m, self.n = self.J.shape
 
-        self.x = np.atleast_1d(x0).astype(float)
+        _x = np.atleast_1d(x0).copy()
+        # promotes to np.floating
+        self.x = np.asfarray(_x, _x.dtype)
+        self.x_dtype = _x.dtype
+
         self.f = self.J.dot(self.x)
         self.f_updated = True
 
@@ -578,7 +588,7 @@ class LinearVectorFunction:
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            self.x = np.atleast_1d(x).astype(float)
+            self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
             self.f_updated = False
 
     def fun(self, x):

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -104,9 +104,13 @@ class ScalarFunction:
                              "quasi-Newton strategies.")
 
         _x = np.atleast_1d(x0).copy()
+        _dtype = np.float
+        if np.issubdtype(_x.dtype, np.floating):
+            _dtype = _x.dtype
+
         # promotes to np.floating
-        self.x = np.asfarray(_x, _x.dtype)
-        self.x_dtype = _x.dtype
+        self.x = _x.astype(_dtype)
+        self.x_dtype = _dtype
         self.n = self.x.size
         self.nfev = 0
         self.ngev = 0
@@ -233,7 +237,8 @@ class ScalarFunction:
                 self.g_prev = self.g
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
+                _x = np.atleast_1d(x).copy()
+                self.x = _x.astype(self.x_dtype)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -242,7 +247,8 @@ class ScalarFunction:
             def update_x(x):
                 # ensure that self.x is a copy of x. Don't store a reference
                 # otherwise the memoization doesn't work properly.
-                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
+                _x = np.atleast_1d(x).copy()
+                self.x = _x.astype(self.x_dtype)
                 self.f_updated = False
                 self.g_updated = False
                 self.H_updated = False
@@ -326,9 +332,13 @@ class VectorFunction:
                              "strategies.")
 
         _x = np.atleast_1d(x0).copy()
+        _dtype = np.float
+        if np.issubdtype(_x.dtype, np.floating):
+            _dtype = _x.dtype
+
         # promotes to np.floating
-        self.x = np.asfarray(_x, _x.dtype)
-        self.x_dtype = _x.dtype
+        self.x = _x.astype(_dtype)
+        self.x_dtype = _dtype
 
         self.n = self.x.size
         self.nfev = 0
@@ -498,14 +508,16 @@ class VectorFunction:
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
+                _x = np.atleast_1d(x).copy()
+                self.x = _x.astype(self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
                 self._update_hess()
         else:
             def update_x(x):
-                self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
+                _x = np.atleast_1d(x).copy()
+                self.x = _x.astype(self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
                 self.H_updated = False
@@ -576,9 +588,13 @@ class LinearVectorFunction:
         self.m, self.n = self.J.shape
 
         _x = np.atleast_1d(x0).copy()
+        _dtype = np.float
+        if np.issubdtype(_x.dtype, np.floating):
+            _dtype = _x.dtype
+
         # promotes to np.floating
-        self.x = np.asfarray(_x, _x.dtype)
-        self.x_dtype = _x.dtype
+        self.x = _x.astype(_dtype)
+        self.x_dtype = _dtype
 
         self.f = self.J.dot(self.x)
         self.f_updated = True
@@ -588,7 +604,8 @@ class LinearVectorFunction:
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            self.x = np.asfarray(np.atleast_1d(x), self.x_dtype).copy()
+            _x = np.atleast_1d(x).copy()
+            self.x = _x.astype(self.x_dtype)
             self.f_updated = False
 
     def fun(self, x):

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -6,6 +6,7 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, csc_matrix, csr_matrix, coo_matrix, find
 from ._group_columns import group_dense, group_sparse
+from scipy._lib._array_api import atleast_nd, array_namespace
 
 
 def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
@@ -438,12 +439,14 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     if method not in ['2-point', '3-point', 'cs']:
         raise ValueError("Unknown method '%s'. " % method)
 
-    x0 = np.atleast_1d(x0)
-    _dtype = np.float
-    if np.issubdtype(x0.dtype, np.floating):
-        _dtype = x0.dtype
-    # promotes to np.floating
-    x0 = x0.astype(_dtype)
+    xp = array_namespace(x0)
+    _x = atleast_nd(x0, ndim=1, xp=xp)
+    _dtype = xp.float64
+    if xp.isdtype(_x.dtype, "real floating"):
+        _dtype = _x.dtype
+
+    # promotes to floating
+    x0 = xp.astype(_x, _dtype)
 
     if x0.ndim > 1:
         raise ValueError("`x0` must have at most 1 dimension.")
@@ -461,8 +464,8 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     def fun_wrapped(x):
         # send user function same fp type as x0. (but only if cs is not being
         # used
-        if np.issubdtype(x.dtype, np.floating):
-            x = x.astype(x, x0.dtype)
+        if xp.isdtype(x.dtype, "real floating"):
+            x = xp.astype(x, x0.dtype)
 
         f = np.atleast_1d(fun(x, *args, **kwargs))
         if f.ndim > 1:

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -455,6 +455,8 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
                          "`as_linear_operator` is True.")
 
     def fun_wrapped(x):
+        # send user function same fp type as x0. (but only if cs is not being
+        # used
         if np.issubdtype(x.dtype, np.floating):
             x = np.asfarray(x, x0.dtype)
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -439,7 +439,11 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         raise ValueError("Unknown method '%s'. " % method)
 
     x0 = np.atleast_1d(x0)
-    x0 = np.asfarray(x0, x0.dtype)
+    _dtype = np.float
+    if np.issubdtype(x0.dtype, np.floating):
+        _dtype = x0.dtype
+    # promotes to np.floating
+    x0 = x0.astype(_dtype)
 
     if x0.ndim > 1:
         raise ValueError("`x0` must have at most 1 dimension.")
@@ -458,7 +462,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         # send user function same fp type as x0. (but only if cs is not being
         # used
         if np.issubdtype(x.dtype, np.floating):
-            x = np.asfarray(x, x0.dtype)
+            x = x.astype(x, x0.dtype)
 
         f = np.atleast_1d(fun(x, *args, **kwargs))
         if f.ndim > 1:

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -439,6 +439,8 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         raise ValueError("Unknown method '%s'. " % method)
 
     x0 = np.atleast_1d(x0)
+    x0 = np.asfarray(x0, x0.dtype)
+
     if x0.ndim > 1:
         raise ValueError("`x0` must have at most 1 dimension.")
 
@@ -453,6 +455,9 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
                          "`as_linear_operator` is True.")
 
     def fun_wrapped(x):
+        if np.issubdtype(x.dtype, np.floating):
+            x = np.asfarray(x, x0.dtype)
+
         f = np.atleast_1d(fun(x, *args, **kwargs))
         if f.ndim > 1:
             raise RuntimeError("`fun` return value has "

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -450,10 +450,11 @@ class TestApproxDerivativesDense:
 
         # parameter vector is float64, func output is float32
         def err_fp32(p):
+            assert p.dtype == np.float32
             return err(p, x, y).astype(np.float32)
-        jac_fp = approx_derivative(err_fp32, p0,
+
+        jac_fp = approx_derivative(err_fp32, p0.astype(np.float32),
                                    method='2-point')
-        assert err_fp32(p0).dtype == np.float32
         assert_allclose(jac_fp, jac_fp64, atol=1e-3)
 
         # check upper bound of error on the derivative for 2-point

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -376,9 +376,6 @@ class TestScalarFunction(TestCase):
         res = sf.fun(x0)
         assert res.dtype == np.float32
 
-        # ScalarFunction.grad always returns np.float64
-        sf.grad(x0)
-
 
 class ExVectorialFunction:
 

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -362,6 +362,23 @@ class TestScalarFunction(TestCase):
         assert_equal(sf._lowest_f, 0.0)
         assert_equal(sf._lowest_x, [1.0, 1.0, 1.0])
 
+    def test_float_size(self):
+        x0 = np.array([2, 3, 4]).astype(np.float32)
+
+        # check that ScalarFunction/approx_derivative always send the correct
+        # float width
+        def rosen_(x):
+            assert x.dtype == np.float32
+            return rosen(x)
+
+        sf = ScalarFunction(rosen_, x0, (), '2-point', rosen_hess,
+                            None, (-np.inf, np.inf))
+        res = sf.fun(x0)
+        assert res.dtype == np.float32
+
+        # ScalarFunction.grad always returns np.float64
+        sf.grad(x0)
+
 
 class ExVectorialFunction:
 
@@ -373,12 +390,12 @@ class ExVectorialFunction:
     def fun(self, x):
         self.nfev += 1
         return np.array([2*(x[0]**2 + x[1]**2 - 1) - x[0],
-                         4*(x[0]**3 + x[1]**2 - 4) - 3*x[0]])
+                         4*(x[0]**3 + x[1]**2 - 4) - 3*x[0]], dtype=x.dtype)
 
     def jac(self, x):
         self.njev += 1
         return np.array([[4*x[0]-1, 4*x[1]],
-                         [12*x[0]**2-3, 8*x[1]]])
+                         [12*x[0]**2-3, 8*x[1]]], dtype=x.dtype)
 
     def hess(self, x, v):
         self.nhev += 1
@@ -654,6 +671,19 @@ class TestVectorialFunction(TestCase):
             x0[0] = 1.
             assert_equal(vf.fun(x0), ex.fun(x0))
             assert x0 is not vf.x
+
+    def test_float_size(self):
+        ex = ExVectorialFunction()
+        x0 = np.array([1.0, 0.0]).astype(np.float32)
+
+        vf = VectorFunction(ex.fun, x0, ex.jac, ex.hess, None, None,
+                            (-np.inf, np.inf), None)
+
+        res = vf.fun(x0)
+        assert res.dtype == np.float32
+
+        res = vf.jac(x0)
+        assert res.dtype == np.float32
 
 
 def test_LinearVectorFunction():


### PR DESCRIPTION
`ScalarFunction` and `VectorFunction` now send the same floating point type that was used to construct the differentiable function to the user supplied function.

`approx_derivative` is also updated to send the appropriate floating point type to the function to be differentiated.

`approx_derivative` (and by extension `ScalarFunction.grad`/`VectorFunction.jac`) still currently return`np.float64`. I'm not sure of the ramifications of changing the output of `approx_derivative` to match the most precise floating point type of the input and output.
For example `approx_derivative` could be called with `x0.dtype == np.float32`, but `fun(x0).dtype` could be `np.float64`, so it seemed natural to me to keep `np.float64` as the output. But If both input and output are `np.float32` then the return of `approx_derivative` could possibly be changed to `np.float32`. I'm not sure what effect this would have on the downstream consumers of `approx_derivative`.