### PR TITLE
MAINT: ensure Nelder-Mead respects floating point type

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -814,7 +814,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     maxfun = maxfev
     retall = return_all
 
-    x0 = asfarray(x0).flatten()
+    x0 = np.atleast_1d(x0).flatten()
+    x0 = np.asfarray(x0, x0.dtype)
 
     if adaptive:
         dim = float(len(x0))
@@ -856,7 +857,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
                 y[k] = zdelt
             sim[k + 1] = y
     else:
-        sim = np.asfarray(initial_simplex).copy()
+        sim = np.atleast_2d(initial_simplex).copy()
+        sim = np.asfarray(sim, sim.dtype)
         if sim.ndim != 2 or sim.shape[0] != sim.shape[1] + 1:
             raise ValueError("`initial_simplex` should be an array of shape (N+1,N)")
         if len(x0) != sim.shape[1]:

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -29,7 +29,7 @@ import warnings
 import sys
 import inspect
 from numpy import (atleast_1d, eye, argmin, zeros, shape, squeeze,
-                   asarray, sqrt, Inf, asfarray)
+                   asarray, sqrt, Inf)
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
 from ._linesearch import (line_search_wolfe1, line_search_wolfe2,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -599,6 +599,16 @@ def test_neldermead_iteration_num():
     assert res.nit <= 339
 
 
+def test_neldermead_respect_fp():
+    # Nelder-Mead should respect the fp type of the input + function
+    x0 = np.array([5.0, 4.0]).astype(np.float32)
+    def rosen_(x):
+        assert x.dtype == np.float32
+        return optimize.rosen(x)
+
+    optimize.minimize(rosen_, x0, method='Nelder-Mead')
+
+
 def test_neldermead_xatol_fatol():
     # gh4484
     # test we can call with fatol, xatol specified


### PR DESCRIPTION
Nelder-Mead is supposed to respect the floating point type of `x0`. However, I suspect that it wasn't due to the use of `x0 = asfarray(x0).flatten()` at the start of `_minimize_neldermead`. This always casts to `np.float64`.
However, if you add a dtype then np.asfarray respects the floating point type, i.e.:
```
np.asfarray(x0, x0.dtype)
```

This PR makes the appropriate changes to Nelder-Mead and adds a test that asserts that the function is supplied with an appropriate fp type.