### PR TITLE
ENH: simpler syntax for checking feasibility of bounds

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -250,8 +250,15 @@ class Bounds:
         except ValueError:
             message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
             raise ValueError(message)
+        try:
+            lb = self.lb.astype(np.double)
+            ub = self.ub.astype(np.double)
+        except (ValueError, TypeError) as exc:
+            message = ("Lower and upper bounds must be reals")
+            raise ValueError(message) from exc
+
         if (self.lb > self.ub).any():
-            raise ValueError("One of the lower bounds is greater than an upper bound.")
+            raise ValueError("An upper bound is less than the corresponding lower bound.")
 
     def __init__(self, lb=-np.inf, ub=np.inf, keep_feasible=False):
         if issparse(lb) or issparse(ub):

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -250,6 +250,8 @@ class Bounds:
         except ValueError:
             message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
             raise ValueError(message)
+        if (self.lb > self.ub).any():
+            raise ValueError("One of the lower bounds is greater than an upper bound.")
 
     def __init__(self, lb=-np.inf, ub=np.inf, keep_feasible=False):
         if issparse(lb) or issparse(ub):
@@ -297,6 +299,26 @@ class Bounds:
             The lower and upper residuals
         """
         return x - self.lb, self.ub - x
+
+    def __contains__(self, x):
+        """Check whether the input is within the bounds.
+
+        Verifies for each element the bound constraint::
+
+            lb <= x <= ub
+
+        Parameters
+        ----------
+        x: array_like
+            Vector of independent variables
+
+        Returns
+        -------
+        inside: bool
+            Whether the input is within the bounds.
+
+        """
+        return not (np.any(lower_bound > x0) or np.any(x0 > upper_bound))
 
 
 class PreparedConstraint:

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -318,7 +318,8 @@ class Bounds:
             Whether the input is within the bounds.
 
         """
-        return not (np.any(lower_bound > x0) or np.any(x0 > upper_bound))
+        y = np.atleast_1d(x)
+        return not (np.any(self.lb > y) or np.any(y > self.ub))
 
 
 class PreparedConstraint:

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -242,6 +242,22 @@ class Bounds:
         Whether to keep the constraint components feasible throughout
         iterations. Must be broadcastable with `lb` and `ub`.
         Default is False. Has no effect for equality constraints.
+
+    Examples
+    --------
+    Consider two variables, where the first must not be negative,
+    and the second must be between 1 and 2:
+
+    >>> bounds = Bounds(lb=[0, 1], ub=[np.inf, 2])
+
+    We can check whether something is inside the bounds:
+
+    >>> assert [100, 1.5] in bounds
+    >>> assert [-1, 2.5] not in bounds
+
+    If all variables have the same constraint, a single value is enough:
+
+    >>> bounds = Bounds(0, 1)
     """
     def _input_validation(self):
         try:

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -248,6 +248,7 @@ class Bounds:
     Consider two variables, where the first must not be negative,
     and the second must be between 1 and 2:
 
+    >>> from scipy.optimize import Bounds
     >>> bounds = Bounds(lb=[0, 1], ub=[np.inf, 2])
 
     We can check whether something is inside the bounds:

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -991,10 +991,6 @@ def _add_to_array(x_in, i_fixed, x_fixed):
 def _validate_bounds(bounds, x0, meth):
     """Check that bounds are valid."""
 
-    msg = "An upper bound is less than the corresponding lower bound."
-    if np.any(bounds.ub < bounds.lb):
-        raise ValueError(msg)
-
     msg = "The number of bounds is not compatible with the length of `x0`."
     try:
         bounds.lb = np.broadcast_to(bounds.lb, x0.shape)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -834,9 +834,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     if bounds is not None:
         lower_bound, upper_bound = bounds.lb, bounds.ub
         # check bounds
-        if (lower_bound > upper_bound).any():
-            raise ValueError("Nelder Mead - one of the lower bounds is greater than an upper bound.")
-        if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
+        if x0 not in bounds:
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, 3)
 

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -217,6 +217,21 @@ class TestBounds:
         x0 = [-1, 2]
         np.testing.assert_allclose(bounds.residual(x0), ([1, 4], [5, 2]))
 
+    def test_inside(self):
+        bounds = Bounds([-2, -2], [4, 4])
+        assert [-1, 2] in bounds
+        assert [-2.4, 2] not in bounds
+        assert [-1, 4.000001] not in bounds
+        assert [-1, 3.99999] not in bounds
+        bounds = Bounds([-np.inf, 2, -np.inf], [2, np.inf, np.inf])
+        assert [0, 3, 0] in bounds
+        assert [0, 1, 0] not in bounds
+        assert [3, 3, 0] not in bounds
+        bounds = Bounds(-2, 4)
+        assert [2] in bounds
+        assert [2, 3, 1] in bounds
+        assert [2, 9, 1] not in bounds
+
 
 class TestLinearConstraint:
     def test_defaults(self):

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -212,6 +212,10 @@ class TestBounds:
         with pytest.raises(ValueError, match=message):
             Bounds([1, 2], [1, 2, 3])
 
+        message = "Lower and upper bounds must be reals"
+        with pytest.raises(ValueError, match=message):
+            Bounds(["3+4", 1], [1, 2])
+
     def test_residual(self):
         bounds = Bounds(-2, 4)
         x0 = [-1, 2]

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -222,7 +222,7 @@ class TestBounds:
         assert [-1, 2] in bounds
         assert [-2.4, 2] not in bounds
         assert [-1, 4.000001] not in bounds
-        assert [-1, 3.99999] not in bounds
+        assert [-1, 3.99999] in bounds
         bounds = Bounds([-np.inf, 2, -np.inf], [2, np.inf, np.inf])
         assert [0, 3, 0] in bounds
         assert [0, 1, 0] not in bounds

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -294,15 +294,15 @@ class TestDIRECT:
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 
-    @pytest.mark.parametrize("bounds",
-                             [Bounds([-1., -1], [-2, 1]),
-                              Bounds([-np.nan, -1], [-2, np.nan]),
+    @pytest.mark.parametrize("bounds_args",
+                             [([-1., -1], [-2, 1]),
+                              ([-np.nan, -1], [-2, np.nan]),
                               ]
                              )
-    def test_incorrect_bounds(self, bounds):
+    def test_incorrect_bounds(self, bounds_args):
         error_msg = 'Bounds are not consistent min < max'
         with pytest.raises(ValueError, match=error_msg):
-            direct(self.styblinski_tang, bounds)
+            direct(self.styblinski_tang, bounds_args)
 
     def test_inf_bounds(self):
         error_msg = 'Bounds must not be inf.'

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -66,6 +66,7 @@ def test_milp_iv():
     message = "`bounds.lb` and `bounds.ub` must contain reals and..."
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], bounds=([1, 2], [3, 4]))
+    message = "Lower and upper bounds must be reals"
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], bounds=([1, 2, 3], ["3+4", 4, 5]))
     with pytest.raises(ValueError, match=message):
@@ -111,14 +112,6 @@ def test_result():
     assert res.status == 1
     assert not res.success
     msg = "Time limit reached. (HiGHS Status 13:"
-    assert res.message.startswith(msg)
-    assert (res.fun is res.mip_dual_bound is res.mip_gap
-            is res.mip_node_count is res.x is None)
-
-    res = milp(1, bounds=(1, -1))
-    assert res.status == 2
-    assert not res.success
-    msg = "The problem is infeasible. (HiGHS Status 8:"
     assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
             is res.mip_node_count is res.x is None)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1574,11 +1574,6 @@ class TestOptimizeSimple(CheckOptimize):
         with pytest.raises(ValueError, match=msg):
             optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
 
-        bounds = Bounds([1, 6, 1], [3, 4, 2])
-        msg = 'An upper bound is less than the corresponding lower bound.'
-        with pytest.raises(ValueError, match=msg):
-            optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
-
     @pytest.mark.parametrize('method', ['bfgs', 'cg', 'newton-cg', 'powell'])
     def test_minimize_warnings_gh1953(self, method):
         # test that minimize methods produce warnings rather than just using


### PR DESCRIPTION
This PR enables writing `x in bounds` where `x` is a parameter vector and `bounds` is a Bounds object.
This may be useful within scipy, but for scipy users (me) it would be handy for generating feasible solutions:

```
while True:
   proposal = np.random.uniform(size=N)
   if proposal in bounds:
        break
```

Implementing this is scipy has the advantage of avoiding implementation details (accessing lower / upper bounds), since the Bounds object should know what to do (it already does via the `residual` function).

This is WIP and open for discussion, not sure if this is of interest for merging once done.