### PR TITLE
DOC: remove already-resolved deprecation warning filter

### DIFF
--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -121,10 +121,7 @@ def wrap_mangling_directive(base_directive):
                 if arg not in impl_args and arg not in special_args:
                     remove_arg(arg)
 
-            # XXX deprecation that we should fix someday using Signature (?)
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter('ignore')
-                signature = str(inspect.signature(obj))
+            signature = str(inspect.signature(obj))
 
             # Produce output
             self.options['noindex'] = True

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -20,17 +20,16 @@ Produces output similar to autodoc, except
 - See Also link to the actual function documentation is inserted
 
 """
-import sys, pydoc
+import sys
 import sphinx
 import inspect
 import textwrap
-import warnings
+import pydoc
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from numpydoc.numpydoc import mangle_docstrings
-from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx.domains.python import PythonDomain
 from scipy._lib._util import getfullargspec_no_self


### PR DESCRIPTION
#9623 added a warning filter for the use of `inspect.formatargspec`. #17301 fixed it, but didn't remove the warning filter.