### PR TITLE
DEP: signal: deprecate importing window functions from signal namespace

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -386,7 +386,7 @@ for name in deprecated_windows:
 
 del deprecated_windows, name, deco
 
-__all__ = [s for s in dir() if not s.startswith('_') and s!="warnings"]
+__all__ = [s for s in dir() if not s.startswith('_') and s != "warnings"]
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -345,8 +345,7 @@ deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
                       'nuttall', 'blackmanharris', 'flattop', 'bartlett',
                       'barthann', 'hamming', 'kaiser', 'gaussian',
                       'general_gaussian', 'chebwin', 'cosine',
-                      'hann', 'exponential', 'tukey', 'taylor', 'lanczos',
-                      'dpss')
+                      'hann', 'exponential', 'tukey')
 
 
 def deco(name):
@@ -355,8 +354,9 @@ def deco(name):
 
     def wrapped(*args, **kwargs):
         warnings.warn(f"Importing {name} from 'scipy.signal' is deprecated "
-                      "as of SciPy 1.11.0 and will raise an error in SciPy "
-                      "1.13.0.",
+                      "and will raise an error in SciPy 1.13.0. Please use "
+                      f"'scipy.signal.window.{name}' or the convenience "
+                      "function 'scipy.signal.get_window' instead.",
                       DeprecationWarning, stacklevel=2)
         return f(*args, **kwargs)
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -306,6 +306,8 @@ repeatedly generate the same chirp signal with every call.  In these cases,
 use the classes to create a reusable function instead.
 
 """
+import warnings
+
 from . import _sigtools, windows
 from ._waveforms import *
 from ._max_len_seq import max_len_seq
@@ -343,7 +345,8 @@ deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
                       'nuttall', 'blackmanharris', 'flattop', 'bartlett',
                       'barthann', 'hamming', 'kaiser', 'gaussian',
                       'general_gaussian', 'chebwin', 'cosine',
-                      'hann', 'exponential', 'tukey')
+                      'hann', 'exponential', 'tukey', 'taylor', 'lanczos',
+                      'dpss')
 
 
 def deco(name):
@@ -351,6 +354,10 @@ def deco(name):
     # Add deprecation to docstring
 
     def wrapped(*args, **kwargs):
+        warnings.warn(f"Importing {name} from 'scipy.signal' is deprecated "
+                      "as of SciPy 1.11.0 and will raise an error in SciPy "
+                      "1.13.0.",
+                      DeprecationWarning, stacklevel=2)
         return f(*args, **kwargs)
 
     wrapped.__name__ = name
@@ -379,7 +386,7 @@ for name in deprecated_windows:
 
 del deprecated_windows, name, deco
 
-__all__ = [s for s in dir() if not s.startswith('_')]
+__all__ = [s for s in dir() if not s.startswith('_') and s!="warnings"]
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -41,6 +41,8 @@ window_funcs = [
 
 @pytest.mark.parametrize(["method", "args"], window_funcs)
 def test_deprecated_import(method, args):
+    if method in ('taylor', 'lanczos', 'dpss'):
+        pytest.skip("Deprecation test not applicable")
     func = getattr(signal, method)
     msg = f"Importing {method}"
     with pytest.deprecated_call(match=msg):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -6,10 +6,12 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose,
                            assert_equal, assert_, assert_array_less,
                            suppress_warnings)
+import pytest
 from pytest import raises as assert_raises
 
 from scipy.fft import fft
 from scipy.signal import windows, get_window, resample, hann as dep_hann
+from scipy import signal
 
 
 window_funcs = [
@@ -37,6 +39,13 @@ window_funcs = [
     ('lanczos', ()),
     ]
 
+@pytest.mark.parametrize(["method", "args"], window_funcs)
+def test_deprecated_import(method, args):
+    func = getattr(signal, method)
+    msg = f"Importing {method}"
+    with pytest.deprecated_call(match=msg):
+        func(1, *args)
+        
 
 class TestBartHann:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #18484
#### What does this implement/fix?
<!--Please explain your changes.-->
Since https://github.com/scipy/scipy/pull/7900 importing window functions from `scipy.signal` has been soft deprecated. This pr adds a warning, a schedule for removal, and a test.
#### Additional information
<!--Any additional information you think is important.-->
