### PR TITLE
ENH: asymptotic expansion for beta entropy for large a and b

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -841,7 +841,7 @@ class beta_gen(rv_continuous):
             log_term = 0.5 * (
                 np.log(2*np.pi) + np.log(a) + np.log(b) - 3*np.log(sum_ab) + 1
             )
-            t1 = 100/sum_ab + 20*sum_ab**-2.0 + sum_ab**-3.0 - 2*sum_ab**-4.0
+            t1 = 110/sum_ab + 20*sum_ab**-2.0 + sum_ab**-3.0 - 2*sum_ab**-4.0
             t2 = -50/a - 10*a**-2.0 - a**-3.0 + a**-4.0
             t3 = -50/b - 10*b**-2.0 - b**-3.0 + b**-4.0
             return log_term + (t1 + t2 + t3) / 120

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -850,7 +850,7 @@ class beta_gen(rv_continuous):
             return log_term + t1 + t2 + t3
 
         return _lazywhere(
-            a >= 5e6 and b >= 5e6,
+            a >= 4.96e6 and b >= 4.96e6,
             (a, b),
             f=asymptotic_ab_large,
             f2=regular,

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -839,15 +839,12 @@ class beta_gen(rv_continuous):
         def asymptotic_ab_large(a, b):
             sum_ab = a + b
             log_term = 0.5 * (
-                np.log(2 * np.pi) + np.log(a) + np.log(b) - 3 * np.log(sum_ab) + 1
+                np.log(2*np.pi) + np.log(a) + np.log(b) - 3*np.log(sum_ab) + 1
             )
-            t1 = (
-                (110 * sum_ab**3 + 20 * sum_ab**2 + sum_ab - 2)
-                * sum_ab**-4.0 / 120
-            )
-            t2 = (1 - 50 * a**3 - 10 * a**2 - a) * a**-4.0 / 120
-            t3 = (1 - 50 * b**3 - 10 * b**2 - b) * b**-4.0 / 120
-            return log_term + t1 + t2 + t3
+            t1 = 100/sum_ab + 20*sum_ab**-2.0 + sum_ab**-3.0 - 2*sum_ab**-4.0
+            t2 = -50/a - 10*a**-2.0 - a**-3.0 + a**-4.0
+            t3 = -50/b - 10*b**-2.0 - b**-3.0 + b**-4.0
+            return log_term + (t1 + t2 + t3) / 120
 
         if a >= 4.96e6 and b >= 4.96e6:
             return asymptotic_ab_large(a, b)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -839,14 +839,14 @@ class beta_gen(rv_continuous):
         def asymptotic_ab_large(a, b):
             sum_ab = a + b
             log_term = 0.5 * (
-                np.log(2 * np.pi * a * b) - 3 * np.log(sum_ab) + 1
+                np.log(2 * np.pi) + np.log(a) + np.log(b) - 3 * np.log(sum_ab) + 1
             )
             t1 = (
                 (110 * sum_ab**3 + 20 * sum_ab**2 + sum_ab - 2)
-                / (120 * sum_ab**4)
+                * sum_ab**-4.0 / 120
             )
-            t2 = (1 - 50 * a**3 - 10 * a**2 - a) / (120 * a**4)
-            t3 = (1 - 50 * b**3 - 10 * b**2 - b) / (120 * b**4)
+            t2 = (1 - 50 * a**3 - 10 * a**2 - a) * a**-4.0 / 120
+            t3 = (1 - 50 * b**3 - 10 * b**2 - b) * b**-4.0 / 120
             return log_term + t1 + t2 + t3
 
         if a >= 4.96e6 and b >= 4.96e6:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -849,12 +849,10 @@ class beta_gen(rv_continuous):
             t3 = (1 - 50 * b**3 - 10 * b**2 - b) / (120 * b**4)
             return log_term + t1 + t2 + t3
 
-        return _lazywhere(
-            a >= 4.96e6 and b >= 4.96e6,
-            (a, b),
-            f=asymptotic_ab_large,
-            f2=regular,
-        )
+        if a >= 4.96e6 and b >= 4.96e6:
+            return asymptotic_ab_large(a, b)
+        else:
+            return regular(a, b)
 
 
 beta = beta_gen(a=0.0, b=1.0, name='beta')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -845,8 +845,8 @@ class beta_gen(rv_continuous):
                 (110 * sum_ab**3 + 20 * sum_ab**2 + sum_ab - 2)
                 / (120 * sum_ab**4)
             )
-            t2 = (1 - 50 * a**3 - 10 * a** 2 - a) / (120 * a** 4)
-            t3 = (1 - 50 * b**3 - 10 * b** 2 - b) / (120 * b** 4)
+            t2 = (1 - 50 * a**3 - 10 * a**2 - a) / (120 * a**4)
+            t3 = (1 - 50 * b**3 - 10 * b**2 - b) / (120 * b**4)
             return log_term + t1 + t2 + t3
 
         return _lazywhere(

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -832,8 +832,29 @@ class beta_gen(rv_continuous):
         return a, b, floc, fscale
 
     def _entropy(self, a, b):
-        return (sc.betaln(a, b) - (a - 1) * sc.psi(a) -
-                (b - 1) * sc.psi(b) + (a + b - 2) * sc.psi(a + b))
+        def regular(a, b):
+            return (sc.betaln(a, b) - (a - 1) * sc.psi(a) -
+                    (b - 1) * sc.psi(b) + (a + b - 2) * sc.psi(a + b))
+
+        def asymptotic_ab_large(a, b):
+            sum_ab = a + b
+            log_term = 0.5 * (
+                np.log(2 * np.pi * a * b) - 3 * np.log(sum_ab) + 1
+            )
+            t1 = (
+                (110 * sum_ab**3 + 20 * sum_ab**2 + sum_ab - 2)
+                / (120 * sum_ab**4)
+            )
+            t2 = (1 - 50 * a**3 - 10 * a** 2 - a) / (120 * a** 4)
+            t3 = (1 - 50 * b**3 - 10 * b** 2 - b) / (120 * b** 4)
+            return log_term + t1 + t2 + t3
+
+        return _lazywhere(
+            a >= 5e6 and b >= 5e6,
+            (a, b),
+            f=asymptotic_ab_large,
+            f2=regular,
+        )
 
 
 beta = beta_gen(a=0.0, b=1.0, name='beta')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4120,6 +4120,32 @@ class TestBeta:
     def test_entropy(self, a, b, ref):
         assert_allclose(stats.beta(a, b).entropy(), ref)
 
+    @pytest.mark.parametrize(
+        "a, b, ref, tol",
+        [
+            (1, 10, -1.4025850929940458, 1e-14),
+            (10, 20, -1.0567887388936708, 1e-13),
+            (100, 120, -1.977505747486833, 1e-13),
+            (1e10, 1e10+20, -11.133707703130474, 1e-11),
+            (1e20, 1e20+20, -22.6466331675757, 1e-15),
+            (1e30, 1e30+20, -34.15955863254593, 1e-15),
+            (1e50, 1e50+20, -57.185409562486385, 1e-15),
+        ]
+    )
+    def test_t_extreme_entropy(self, a, b, ref, tol):
+        # Reference values were calculated with mpmath:
+        # from mpmath import mp
+        # mp.dps = 500
+        #
+        # def beta_entropy_mpmath(a, b):
+        #     a = mp.mpf(a)
+        #     b = mp.mpf(b)
+        #     entropy = mp.log(mp.beta(a, b)) - (a - 1) * mp.digamma(a) -\
+        #               (b - 1) * mp.digamma(b) + (a + b - 2) * mp.digamma(a + b)
+        #     return float(entropy)
+        print(stats.beta(a, b).entropy())
+        assert_allclose(stats.beta(a, b).entropy(), ref, rtol=tol)
+
 
 class TestBetaPrime:
     # the test values are used in test_cdf_gh_17631 / test_ppf_gh_17631

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4125,10 +4125,9 @@ class TestBeta:
         [
             (1, 10, -1.4025850929940458, 1e-14),
             (10, 20, -1.0567887388936708, 1e-13),
-            (100, 120, -1.977505747486833, 1e-13),
+            (4e6, 4e6+20, -7.221686009678741, 1e-9),
+            (5e6, 5e6+10, -7.333257022834638, 1e-8),
             (1e10, 1e10+20, -11.133707703130474, 1e-11),
-            (1e20, 1e20+20, -22.6466331675757, 1e-15),
-            (1e30, 1e30+20, -34.15955863254593, 1e-15),
             (1e50, 1e50+20, -57.185409562486385, 1e-15),
         ]
     )
@@ -4140,8 +4139,10 @@ class TestBeta:
         # def beta_entropy_mpmath(a, b):
         #     a = mp.mpf(a)
         #     b = mp.mpf(b)
-        #     entropy = mp.log(mp.beta(a, b)) - (a - 1) * mp.digamma(a) -\
-        #               (b - 1) * mp.digamma(b) + (a + b - 2) * mp.digamma(a + b)
+        #     entropy = (
+        #       mp.log(mp.beta(a, b)) - (a - 1) * mp.digamma(a)
+        #       - (b - 1) * mp.digamma(b) + (a + b - 2) * mp.digamma(a + b)
+        #     )
         #     return float(entropy)
         print(stats.beta(a, b).entropy())
         assert_allclose(stats.beta(a, b).entropy(), ref, rtol=tol)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4144,7 +4144,6 @@ class TestBeta:
         #       - (b - 1) * mp.digamma(b) + (a + b - 2) * mp.digamma(a + b)
         #     )
         #     return float(entropy)
-        print(stats.beta(a, b).entropy())
         assert_allclose(stats.beta(a, b).entropy(), ref, rtol=tol)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4132,7 +4132,7 @@ class TestBeta:
             (1e50, 1e50+20, -57.185409562486385, 1e-15),
         ]
     )
-    def test_t_extreme_entropy(self, a, b, ref, tol):
+    def test_extreme_entropy(self, a, b, ref, tol):
         # Reference values were calculated with mpmath:
         # from mpmath import mp
         # mp.dps = 500


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-18093

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds an asymptotic expansion for the beta entropy when both a and b are large.
- Adds some tests.

#### Additional information
<!--Any additional information you think is important.-->
CC: @dschmitz89 