### PR TITLE
TST: interpolate: add a regression test for bisplev integer overflow

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -220,6 +220,7 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
 
     mxy = _mul_overflow_intp(mx, my);
     if (mxy < 0) {
+        PyErr_NoMemory();
         goto fail;
     }
 
@@ -236,6 +237,7 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
         /* lwrk = mx*(kx + 1 - nux) + my*(ky + 1 - nuy) + (nx - kx - 1)*(ny - ky - 1); */
         lwrk = _mul_overflow_f_int(nx - kx - 1, ny - ky - 1);
         if (lwrk < 0) {
+            PyErr_NoMemory();
             goto fail;
         }    
         lwrk += mx*(kx + 1 - nux) + my*(ky + 1 - nuy);
@@ -328,6 +330,7 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
     /* lcest = (nxest - kx - 1)*(nyest - ky - 1); */
     lcest = _mul_overflow_f_int(nxest - kx - 1, nyest - ky - 1);
     if (lcest < 0) {
+        PyErr_NoMemory();
         goto fail;
     }
     /* kwrk computation is unlikely to overflow if lcest above did not.*/

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -471,8 +471,7 @@ def test_gh_1766():
     tt_0 = np.arange(50)
     tt_1 = np.arange(50) * 3
     with pytest.raises(MemoryError):
-        v1 = bisplev(tt_0, tt_1, tck, 1, 1)
-
+        bisplev(tt_0, tt_1, tck, 1, 1)
 
 
 def test_spalde_scalar_input():

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -451,6 +451,30 @@ def test_bisplev_integer_overflow():
     assert_raises((RuntimeError, MemoryError), bisplev, xp, yp, tck)
 
 
+@pytest.mark.xslow
+def test_gh_1766():
+    # this should fail gracefully instead of segfaulting (int overflow)
+    size = 22
+    kx, ky = 3, 3
+    def f2(x, y):
+        return np.sin(x+y)
+
+    x = np.linspace(0, 10, size)
+    y = np.linspace(50, 700, size)
+    xy = makepairs(x, y)
+    tck = bisplrep(xy[0], xy[1], f2(xy[0], xy[1]), s=0, kx=kx, ky=ky)
+    # the size value here can either segfault
+    # or produce a MemoryError on main
+    tx_ty_size = 500000
+    tck[0] = np.arange(tx_ty_size)
+    tck[1] = np.arange(tx_ty_size) * 4
+    tt_0 = np.arange(50)
+    tt_1 = np.arange(50) * 3
+    with pytest.raises(MemoryError):
+        v1 = bisplev(tt_0, tt_1, tck, 1, 1)
+
+
+
 def test_spalde_scalar_input():
     # Ticket #629
     x = np.linspace(0, 10)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/18498
https://github.com/scipy/scipy/pull/17212

#### What does this implement/fix?
<!--Please explain your changes.-->

Add a regression test from https://github.com/scipy/scipy/pull/17212#pullrequestreview-1435450128, guarded by `@pytest.mark.xslow`.

Trying it locally, `$ SCIPY_XSLOW=1 python dev.py test -t scipy/interpolate/tests/test_fitpack.py::test_gh_1766`
passes locally, while without the env variable the test is skipped.

While at it, add `PyErr_NoMemory()` calls to convert RuntimeErrors into `MemoryErrors`. 

The test is constructed by @tylerjereddy ,  this is reflected in the commit authorship :-).

#### Additional information
<!--Any additional information you think is important.-->

The other place where gh-17212 checks for integer overflow seems to have some sort of a check at the python level, https://github.com/scipy/scipy/blob/main/scipy/interpolate/_fitpack_impl.py#L570
so I'd much rather merge in the test as is and move on.
