### PR TITLE
BUG: guard against non-finite kd-tree queries

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -791,6 +791,9 @@ cdef class cKDTree:
         if p < 1:
             raise ValueError("Only p-norms with 1<=p<=infinity permitted")
 
+        if not np.isfinite(x).all():
+            raise ValueError("'x' must be finite, check for nan or inf values")
+
         cdef:
             bool single = (x_arr.ndim == 1)
             bool nearest = False
@@ -940,6 +943,9 @@ cdef class cKDTree:
 
             const np.float64_t *vxx = <np.float64_t*>x_arr.data
             const np.float64_t *vrr = <np.float64_t*>r_arr.data
+        
+        if not np.isfinite(x).all():
+            raise ValueError("'x' must be finite, check for nan or inf values")
 
         if rlen:
             result = np.empty(retshape, dtype=np.intp)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1468,10 +1468,17 @@ def test_kdtree_nan():
         KDTree(data)
 
 
-def test_gh_18223():
+def test_nonfintite_inputs_gh_18223():
     rng = np.random.default_rng(12345)
     coords = rng.uniform(size=(100, 3), low=0.0, high=0.1)
-    KDTree(coords, balanced_tree=False, compact_nodes=False)
+    t = KDTree(coords, balanced_tree=False, compact_nodes=False)
+    bad_coord = [np.nan for _ in range(3)]
+
+    with pytest.raises(ValueError, match="must be finite"):
+        t.query(bad_coord)
+    with pytest.raises(ValueError, match="must be finite"):
+        t.query_ball_point(bad_coord, 1)
+
     coords[0, :] = np.nan
     with pytest.raises(ValueError, match="must be finite"):
         KDTree(coords, balanced_tree=True, compact_nodes=False)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1468,7 +1468,7 @@ def test_kdtree_nan():
         KDTree(data)
 
 
-def test_nonfintite_inputs_gh_18223():
+def test_nonfinite_inputs_gh_18223():
     rng = np.random.default_rng(12345)
     coords = rng.uniform(size=(100, 3), low=0.0, high=0.1)
     t = KDTree(coords, balanced_tree=False, compact_nodes=False)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #18497 
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds a check for finiteness to `query` and `query_ball_point`
#### Additional information
<!--Any additional information you think is important.-->
