### PR TITLE
Fix PPoly readonly issue for c parameter

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -25,7 +25,7 @@ DEF MAX_DIMS = 64
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def evaluate(double_or_complex[:,:,::1] c,
+def evaluate(const double_or_complex[:,:,::1] c,
              const double[::1] x,
              const double[::1] xp,
              int dx,
@@ -102,7 +102,7 @@ def evaluate(double_or_complex[:,:,::1] c,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def evaluate_nd(double_or_complex[:,:,::1] c,
+def evaluate_nd(const double_or_complex[:,:,::1] c,
                 tuple xs,
                 int[:] ks,
                 double[:,:] xp,
@@ -318,7 +318,7 @@ def fix_continuity(double_or_complex[:,:,::1] c,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def integrate(double_or_complex[:,:,::1] c,
+def integrate(const double_or_complex[:,:,::1] c,
               const double[::1] x,
               double a,
               double b,
@@ -408,7 +408,7 @@ def integrate(double_or_complex[:,:,::1] c,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
+def real_roots(const double[:,:,::1] c, double[::1] x, double y, bint report_discont,
                bint extrapolate):
     """
     Compute real roots of a real-valued piecewise polynomial function.
@@ -649,7 +649,7 @@ cdef int find_interval_descending(const double *x,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef double_or_complex evaluate_poly1(double s, double_or_complex[:,:,::1] c, int ci, int cj, int dx) noexcept nogil:
+cdef double_or_complex evaluate_poly1(double s, const double_or_complex[:,:,::1] c, int ci, int cj, int dx) noexcept nogil:
     """
     Evaluate polynomial, derivative, or antiderivative in a single interval.
 
@@ -708,7 +708,7 @@ cdef double_or_complex evaluate_poly1(double s, double_or_complex[:,:,::1] c, in
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef int croots_poly1(double[:,:,::1] c, double y, int ci, int cj,
+cdef int croots_poly1(const double[:,:,::1] c, double y, int ci, int cj,
                       double* wr, double* wi, void **workspace) except -10:
     """
     Find all complex roots of a local polynomial.
@@ -867,7 +867,7 @@ cdef int croots_poly1(double[:,:,::1] c, double y, int ci, int cj,
     return order
 
 
-def _croots_poly1(double[:,:,::1] c, double_complex[:,:,::1] w, double y=0):
+def _croots_poly1(const double[:,:,::1] c, double_complex[:,:,::1] w, double y=0):
     """
     Find roots of polynomials.
 
@@ -932,7 +932,7 @@ def _croots_poly1(double[:,:,::1] c, double_complex[:,:,::1] w, double y=0):
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef double_or_complex evaluate_bpoly1(double_or_complex s,
-                                       double_or_complex[:,:,::1] c,
+                                       const double_or_complex[:,:,::1] c,
                                        int ci, int cj) noexcept nogil:
     """
     Evaluate polynomial in the Bernstein basis in a single interval.
@@ -983,7 +983,7 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef double_or_complex evaluate_bpoly1_deriv(double_or_complex s,
-                                             double_or_complex[:,:,::1] c,
+                                             const double_or_complex[:,:,::1] c,
                                              int ci, int cj,
                                              int nu,
                                              double_or_complex[:,:,::1] wrk) noexcept nogil:
@@ -1043,7 +1043,7 @@ cdef double_or_complex evaluate_bpoly1_deriv(double_or_complex s,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def evaluate_bernstein(double_or_complex[:,:,::1] c,
+def evaluate_bernstein(const double_or_complex[:,:,::1] c,
              double[::1] x,
              double[::1] xp,
              int nu,

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1204,6 +1204,7 @@ class TestPPoly:
 
         for writeable in (True, False):
             x.flags.writeable = writeable
+            c.flags.writeable = writeable
             f = PPoly(c, x)
             vals = f(xnew)
             assert_(np.isfinite(vals).all())


### PR DESCRIPTION
#### Reference issue
This is a follow up to #9769. which is possible since https://github.com/cython/cython/pull/5076

#### What does this implement/fix?
Allow to pass a readonly c parameter.
