### PR TITLE
MAINT: sparse: Generalize isshape to (optionally) handle non-2d shapes

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -235,22 +235,21 @@ def isintlike(x):
     return True
 
 
-def isshape(x, nonneg=False):
-    """Is x a valid 2-tuple of dimensions?
+def isshape(x, nonneg=False, allow_ndim=False) -> bool:
+    """Is x a valid tuple of dimensions?
 
     If nonneg, also checks that the dimensions are non-negative.
+    If allow_ndim, shapes of any dimensionality are allowed.
     """
-    try:
-        # Assume it's a tuple of matrix dimensions (M, N)
-        (M, N) = x
-    except Exception:
+    ndim = len(x)
+    if not allow_ndim and ndim != 2:
         return False
-    else:
-        if isintlike(M) and isintlike(N):
-            if np.ndim(M) == 0 and np.ndim(N) == 0:
-                if not nonneg or (M >= 0 and N >= 0):
-                    return True
-        return False
+    for d in x:
+        if not isintlike(d) or np.ndim(d) != 0:
+            return False
+        if nonneg and d < 0:
+            return False
+    return True
 
 
 def issequence(t):

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -245,7 +245,7 @@ def isshape(x, nonneg=False, allow_ndim=False) -> bool:
     if not allow_ndim and ndim != 2:
         return False
     for d in x:
-        if not isintlike(d) or np.ndim(d) != 0:
+        if not isintlike(d):
             return False
         if nonneg and d < 0:
             return False

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -67,6 +67,14 @@ class TestSparseUtils:
         assert_equal(sputils.isshape((-1, 2), nonneg=True),False)
         assert_equal(sputils.isshape((2, -1), nonneg=True),False)
 
+        assert_equal(sputils.isshape((1.5, 2), allow_ndim=True), False)
+        assert_equal(sputils.isshape(([2], 2), allow_ndim=True), False)
+        assert_equal(sputils.isshape((2, 2, -2), nonneg=True, allow_ndim=True),
+                     False)
+        assert_equal(sputils.isshape((2,), allow_ndim=True), True)
+        assert_equal(sputils.isshape((2, 2,), allow_ndim=True), True)
+        assert_equal(sputils.isshape((2, 2, 2), allow_ndim=True), True)
+
     def test_issequence(self):
         assert_equal(sputils.issequence((1,)), True)
         assert_equal(sputils.issequence((1, 2, 3)), True)


### PR DESCRIPTION
This will be useful when adding nd-array support to sparse arrays. With the default kwargs, no existing behavior is changed.