### PR TITLE
Clean up sparse array API

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1256,7 +1256,7 @@ class _sparray:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
 
 
-    ## All methods below are deprecated and should be released in
+    ## All methods below are deprecated and should be removed in
     ## scipy 1.13.0
     ##
     ## Also uncomment the definition of shape above.
@@ -1369,13 +1369,13 @@ class _sparray:
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getrow(i)
 
-    ## End 0.13 deprecated methods
+    ## End 1.13.0 deprecated methods
 
 
 def issparse(x):
     """Is x of a sparse array type?
 
-y    Parameters
+    Parameters
     ----------
     x
         object to check for being a sparse array

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -110,11 +110,11 @@ class _sparray:
                              " to be instantiated directly.")
         self.maxprint = maxprint
 
-    # Use this in 0.13:
+    # Use this in 1.13.0 and later:
     #
-    @property
-    def shape(self):
-       return self._shape
+    # @property
+    # def shape(self):
+    #   return self._shape
 
     def reshape(self, *args, **kwargs):
         """reshape(self, shape, order='C', copy=False)
@@ -714,7 +714,8 @@ class _sparray:
         if attr == 'A':
             if self._is_array:
                 warn(np.VisibleDeprecationWarning(
-                    "Please use `.todense()` instead"
+                    "`.A` is deprecated and will be removed in v1.13.0. "
+                    "Use `.todense()` instead."
                 ))
             return self.toarray()
         elif attr == 'T':
@@ -722,7 +723,8 @@ class _sparray:
         elif attr == 'H':
             if self._is_array:
                 warn(np.VisibleDeprecationWarning(
-                    "Please use `.conj().T` instead"
+                    "`.H` is deprecated and will be removed in v1.13.0. "
+                    "Please use `.conj().T` instead."
                 ))
             return self.transpose().conjugate()
         elif attr == 'real':
@@ -1255,18 +1257,26 @@ class _sparray:
 
 
     ## All methods below are deprecated and should be released in
-    ## scipy 0.13
+    ## scipy 1.13.0
+    ##
+    ## Also uncomment the definition of shape above.
 
     def get_shape(self):
         """Get shape of a sparse array."""
-        msg = "`get_shape` is deprecated. Use `X.shape` instead."
+        msg = (
+            "`get_shape` is deprecated and will be removed in v1.13.0; "
+            "use `X.shape` instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
 
         return self._shape
 
     def set_shape(self, shape):
         """See `reshape`."""
-        msg = "Shape assignment is deprecated. Use `reshape` instead."
+        msg = (
+            "Shape assignment is deprecated and will be removed in v1.13.0; "
+            "use `reshape` instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
 
         # Make sure copy is False since this is in place
@@ -1280,7 +1290,7 @@ class _sparray:
         """Upcast array to a floating point format (if necessary)"""
         msg = (
             "`asfptype` is an internal function, and is deprecated "
-            "as part of the public API."
+            "as part of the public API. It will be removed in v1.13.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._asfptype()
@@ -1289,14 +1299,17 @@ class _sparray:
         """Maximum number of elements to display when printed."""
         msg = (
             "`getmaxprint` is an internal function, and is deprecated "
-            "as part of the public API."
+            "as part of the public API. It will be removed in v1.13.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getmaxprint()
 
     def getformat(self):
         """Matrix storage format"""
-        msg = "`getformat` is deprecated; use `X.format` instead"
+        msg = (
+            "`getformat` is deprecated and will be removed in v1.13.0; "
+            "use `X.format` instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.format
 
@@ -1313,7 +1326,10 @@ class _sparray:
         --------
         count_nonzero : Number of non-zero entries
         """
-        msg = "`getnnz` is deprecated; use `X.nnz` instead"
+        msg = (
+            "`getnnz` is deprecated and will be removed in v1.13.0; "
+            "use `X.nnz` instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getnnz(axis=axis)
 
@@ -1325,7 +1341,8 @@ class _sparray:
         numpy.matrix.getH : NumPy's implementation of `getH` for matrices
         """
         msg = (
-            "`getH` is deprecated; use `X.conj().T` instead"
+            "`getH` is deprecated and will be removed in v1.13.0; "
+            "use `X.conj().T` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.conjugate().transpose()
@@ -1335,7 +1352,8 @@ class _sparray:
         array (column vector).
         """
         msg = (
-            f"`getcol` is deprecated; use `X[:, [{j}]]` instead"
+            "`getcol` is deprecated and will be removed in v1.13.0; "
+            f"use `X[:, [{j}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getcol(j)
@@ -1345,7 +1363,8 @@ class _sparray:
         array (row vector).
         """
         msg = (
-            f"`getrow` is deprecated; use `X[[{i}]]` instead"
+            "`getrow` is deprecated and will be removed in v1.13.0; "
+            f"use `X[[{i}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getrow(i)
@@ -1356,7 +1375,7 @@ class _sparray:
 def issparse(x):
     """Is x of a sparse array type?
 
-    Parameters
+y    Parameters
     ----------
     x
         object to check for being a sparse array

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -110,9 +110,11 @@ class _sparray:
                              " to be instantiated directly.")
         self.maxprint = maxprint
 
+    # Use this in 0.13:
+    #
     @property
     def shape(self):
-        return self._shape
+       return self._shape
 
     def reshape(self, *args, **kwargs):
         """reshape(self, shape, order='C', copy=False)
@@ -1250,6 +1252,105 @@ class _sparray:
             return out
         else:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
+
+
+    ## All methods below are deprecated and should be released in
+    ## scipy 0.13
+
+    def get_shape(self):
+        """Get shape of a sparse array."""
+        msg = "`get_shape` is deprecated. Use `X.shape` instead."
+        warn(msg, DeprecationWarning, stacklevel=2)
+
+        return self._shape
+
+    def set_shape(self, shape):
+        """See `reshape`."""
+        msg = "Shape assignment is deprecated. Use `reshape` instead."
+        warn(msg, DeprecationWarning, stacklevel=2)
+
+        # Make sure copy is False since this is in place
+        # Make sure format is unchanged because we are doing a __dict__ swap
+        new_self = self.reshape(shape, copy=False).asformat(self.format)
+        self.__dict__ = new_self.__dict__
+
+    shape = property(fget=lambda self: self._shape, fset=set_shape)  # noqa: F811
+
+    def asfptype(self):
+        """Upcast array to a floating point format (if necessary)"""
+        msg = (
+            "`asfptype` is an internal function, and is deprecated "
+            "as part of the public API."
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._asfptype()
+
+    def getmaxprint(self):
+        """Maximum number of elements to display when printed."""
+        msg = (
+            "`getmaxprint` is an internal function, and is deprecated "
+            "as part of the public API."
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._getmaxprint()
+
+    def getformat(self):
+        """Matrix storage format"""
+        msg = "`getformat` is deprecated; use `X.format` instead"
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self.format
+
+    def getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
+
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole array, in
+            each column, or in each row.
+
+        See also
+        --------
+        count_nonzero : Number of non-zero entries
+        """
+        msg = "`getnnz` is deprecated; use `X.nnz` instead"
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._getnnz(axis=axis)
+
+    def getH(self):
+        """Return the Hermitian transpose of this array.
+
+        See Also
+        --------
+        numpy.matrix.getH : NumPy's implementation of `getH` for matrices
+        """
+        msg = (
+            "`getH` is deprecated; use `X.conj().T` instead"
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self.conjugate().transpose()
+
+    def getcol(self, j):
+        """Returns a copy of column j of the array, as an (m x 1) sparse
+        array (column vector).
+        """
+        msg = (
+            f"`getcol` is deprecated; use `X[:, [{j}]]` instead"
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._getcol(j)
+
+    def getrow(self, i):
+        """Returns a copy of row i of the array, as a (1 x n) sparse
+        array (row vector).
+        """
+        msg = (
+            f"`getrow` is deprecated; use `X[[{i}]]` instead"
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._getrow(i)
+
+    ## End 0.13 deprecated methods
 
 
 def issparse(x):

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -117,7 +117,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
            [4, 4, 5, 5, 6, 6]])
 
     """
-    format = 'bsr'
+    _format = 'bsr'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):
         _data_matrix.__init__(self)
@@ -293,17 +293,17 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         return self.data.shape[1:]
     blocksize = property(fget=_get_blocksize)
 
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is not None:
-            raise NotImplementedError("getnnz over an axis is not implemented "
+            raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for BSR format")
         R,C = self.blocksize
         return int(self.indptr[-1] * R * C)
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
 
     def __repr__(self):
-        format = _formats[self.getformat()][1]
+        format = _formats[self.format][1]
         return ("<%dx%d sparse matrix of type '%s'\n"
                 "\twith %d stored elements (blocksize = %dx%d) in %s format>" %
                 (self.shape + (self.dtype.type, self.nnz) + self.blocksize +

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -105,7 +105,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         self.check_format(full_check=False)
 
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is None:
             return int(self.indptr[-1])
         else:
@@ -120,7 +120,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
 
     def _set_self(self, other, copy=False):
         """take the member variables of other and assign them to self"""

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -122,7 +122,7 @@ class coo_array(_data_matrix, _minmax_mixin):
            [0, 0, 0, 1]])
 
     """
-    format = 'coo'
+    _format = 'coo'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
@@ -237,7 +237,7 @@ class coo_array(_data_matrix, _minmax_mixin):
 
     reshape.__doc__ = _sparray.reshape.__doc__
 
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is None:
             nnz = len(self.data)
             if nnz != len(self.row) or nnz != len(self.col):
@@ -261,7 +261,7 @@ class coo_array(_data_matrix, _minmax_mixin):
         else:
             raise ValueError('axis out of bounds')
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
 
     def _check(self):
         """ Checks data structure for consistency """

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -104,7 +104,7 @@ class csc_array(_cs_matrix):
            [2, 3, 6]])
 
     """
-    format = 'csc'
+    _format = 'csc'
 
     def transpose(self, axes=None, copy=False):
         if axes is not None:
@@ -180,7 +180,7 @@ class csc_array(_cs_matrix):
 
     nonzero.__doc__ = _cs_matrix.nonzero.__doc__
 
-    def getrow(self, i):
+    def _getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n)
         CSR matrix (row vector).
         """
@@ -192,7 +192,7 @@ class csc_array(_cs_matrix):
             raise IndexError('index (%d) out of range' % i)
         return self._get_submatrix(minor=i).tocsr()
 
-    def getcol(self, i):
+    def _getcol(self, i):
         """Returns a copy of column i of the matrix, as a (m x 1)
         CSC matrix (column vector).
         """

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -278,13 +278,13 @@ class csr_array(_cs_matrix):
                               dtype=self.dtype, copy=False)
 
     def _get_intXarray(self, row, col):
-        return self.getrow(row)._minor_index_fancy(col)
+        return self._getrow(row)._minor_index_fancy(col)
 
     def _get_intXslice(self, row, col):
         if col.step in (1, None):
             return self._get_submatrix(row, col, copy=True)
         # TODO: uncomment this once it's faster:
-        # return self.getrow(row)._minor_slice(col)
+        # return self._getrow(row)._minor_slice(col)
 
         M, N = self.shape
         start, stop, stride = col.indices(N)

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -247,7 +247,7 @@ class csr_array(_cs_matrix):
             )
             i0 = i1
 
-    def getrow(self, i):
+    def _getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n)
         CSR matrix (row vector).
         """
@@ -262,7 +262,7 @@ class csr_array(_cs_matrix):
         return self.__class__((data, indices, indptr), shape=(1, N),
                               dtype=self.dtype, copy=False)
 
-    def getcol(self, i):
+    def _getcol(self, i):
         """Returns a copy of column i of the matrix, as a (m x 1)
         CSR matrix (column vector).
         """

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -80,15 +80,15 @@ class _data_matrix(_sparray):
 
     astype.__doc__ = _sparray.astype.__doc__
 
-    def conj(self, copy=True):
+    def conjugate(self, copy=True):
         if np.issubdtype(self.dtype, np.complexfloating):
-            return self._with_data(self.data.conj(), copy=copy)
+            return self._with_data(self.data.conjugate(), copy=copy)
         elif copy:
             return self.copy()
         else:
             return self
 
-    conj.__doc__ = _sparray.conj.__doc__
+    conjugate.__doc__ = _sparray.conjugate.__doc__
 
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -85,7 +85,7 @@ class dia_array(_data_matrix):
            [0., 0., 0., ..., 1., 2., 1.],
            [0., 0., 0., ..., 0., 1., 2.]])
     """
-    format = 'dia'
+    _format = 'dia'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
@@ -178,9 +178,9 @@ class dia_array(_data_matrix):
         mask = self._data_mask()
         return np.count_nonzero(self.data[mask])
 
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is not None:
-            raise NotImplementedError("getnnz over an axis is not implemented "
+            raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for DIA format")
         M,N = self.shape
         nnz = 0
@@ -191,7 +191,7 @@ class dia_array(_data_matrix):
                 nnz += min(M+k,N)
         return int(nnz)
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
     count_nonzero.__doc__ = _sparray.count_nonzero.__doc__
 
     def sum(self, axis=None, dtype=None, out=None):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -70,7 +70,7 @@ class dok_array(_sparray, IndexMixin, dict):
     ...         S[i, j] = i + j    # Update element
 
     """
-    format = 'dok'
+    _format = 'dok'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         dict.__init__(self)
@@ -117,24 +117,16 @@ class dok_array(_sparray, IndexMixin, dict):
         from other _sparray classes. Has no checking if `data` is valid."""
         return dict.update(self, data)
 
-    def set_shape(self, shape):
-        new_matrix = self.reshape(shape, copy=False).asformat(self.format)
-        self.__dict__ = new_matrix.__dict__
-        dict.clear(self)
-        dict.update(self, new_matrix)
-
-    shape = property(fget=_sparray.get_shape, fset=set_shape)
-
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is not None:
-            raise NotImplementedError("getnnz over an axis is not implemented "
+            raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for DOK format.")
         return dict.__len__(self)
 
     def count_nonzero(self):
         return sum(x != 0 for x in self.values())
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
     count_nonzero.__doc__ = _sparray.count_nonzero.__doc__
 
     def __len__(self):
@@ -457,6 +449,16 @@ def isspmatrix_dok(x):
 
 
 class dok_matrix(spmatrix, dok_array):
-    pass
+    def set_shape(self, shape):
+        new_matrix = self.reshape(shape, copy=False).asformat(self.format)
+        self.__dict__ = new_matrix.__dict__
+        dict.clear(self)
+        dict.update(self, new_matrix)
+
+    def get_shape(self):
+        """Get shape of a sparse array."""
+        return self._shape
+
+    shape = property(fget=get_shape, fset=set_shape)
 
 dok_matrix.__doc__ = _array_doc_to_matrix(dok_array.__doc__)

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -199,7 +199,7 @@ class IndexMixin:
             x[x < 0] += length
         return x
 
-    def getrow(self, i):
+    def _getrow(self, i):
         """Return a copy of row i of the matrix, as a (1 x n) row vector.
         """
         M, N = self.shape
@@ -210,7 +210,7 @@ class IndexMixin:
             i += M
         return self._get_intXslice(i, slice(None))
 
-    def getcol(self, i):
+    def _getcol(self, i):
         """Return a copy of column i of the matrix, as a (m x 1) column vector.
         """
         M, N = self.shape

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -79,7 +79,7 @@ class lil_array(_sparray, IndexMixin):
 
 
     """
-    format = 'lil'
+    _format = 'lil'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _sparray.__init__(self)
@@ -151,7 +151,7 @@ class lil_array(_sparray, IndexMixin):
     # Whenever the dimensions change, empty lists should be created for each
     # row
 
-    def getnnz(self, axis=None):
+    def _getnnz(self, axis=None):
         if axis is None:
             return sum([len(rowvals) for rowvals in self.data])
         if axis < 0:
@@ -169,7 +169,7 @@ class lil_array(_sparray, IndexMixin):
     def count_nonzero(self):
         return sum(np.count_nonzero(rowvals) for rowvals in self.data)
 
-    getnnz.__doc__ = _sparray.getnnz.__doc__
+    _getnnz.__doc__ = _sparray._getnnz.__doc__
     count_nonzero.__doc__ = _sparray.count_nonzero.__doc__
 
     def __str__(self):

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -78,6 +78,69 @@ class spmatrix:
             raise ValueError('exponent must be an integer')
         return NotImplemented
 
+    ## Backward compatibility
+
+    def set_shape(self, shape):
+        """See `reshape`."""
+        # Make sure copy is False since this is in place
+        # Make sure format is unchanged because we are doing a __dict__ swap
+        new_self = self.reshape(shape, copy=False).asformat(self.format)
+        self.__dict__ = new_self.__dict__
+
+    def get_shape(self):
+        """Get shape of a sparse array."""
+        return self._shape
+
+    shape = property(fget=get_shape, fset=set_shape)
+
+    def asfptype(self):
+        """Upcast array to a floating point format (if necessary)"""
+        return self._asfptype()
+
+    def getmaxprint(self):
+        """Maximum number of elements to display when printed."""
+        return self._getmaxprint()
+
+    def getformat(self):
+        """Matrix storage format"""
+        return self.format
+
+    def getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
+
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole array, in
+            each column, or in each row.
+
+        See also
+        --------
+        count_nonzero : Number of non-zero entries
+        """
+        return self._getnnz(axis=axis)
+
+    def getH(self):
+        """Return the Hermitian transpose of this array.
+
+        See Also
+        --------
+        numpy.matrix.getH : NumPy's implementation of `getH` for matrices
+        """
+        return self.conjugate().transpose()
+
+    def getcol(self, j):
+        """Returns a copy of column j of the array, as an (m x 1) sparse
+        array (column vector).
+        """
+        return self._getcol(j)
+
+    def getrow(self, i):
+        """Returns a copy of row i of the array, as a (1 x n) sparse
+        array (row vector).
+        """
+        return self._getrow(i)
+
 
 def _array_doc_to_matrix(docstr):
     # For opimized builds with stripped docstrings

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -222,7 +222,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
-    A = A.asfptype()  # upcast to a floating point format
+    A = A._asfptype()  # upcast to a floating point format
     result_dtype = np.promote_types(A.dtype, b.dtype)
     if A.dtype != result_dtype:
         A = A.astype(result_dtype)
@@ -396,7 +396,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
-    A = A.asfptype()  # upcast to a floating point format
+    A = A._asfptype()  # upcast to a floating point format
 
     M, N = A.shape
     if (M != N):
@@ -489,7 +489,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
-    A = A.asfptype()  # upcast to a floating point format
+    A = A._asfptype()  # upcast to a floating point format
 
     M, N = A.shape
     if (M != N):
@@ -552,7 +552,7 @@ def factorized(A):
             warn('splu converted its input to CSC format',
                  SparseEfficiencyWarning)
 
-        A = A.asfptype()  # upcast to a floating point format
+        A = A._asfptype()  # upcast to a floating point format
 
         if A.dtype.char not in 'dD':
             raise ValueError("convert matrix data to double, please, using"

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -3,6 +3,7 @@ python_sources = [
   'test_array_api.py',
   'test_base.py',
   'test_construct.py',
+  'test_deprecations.py',
   'test_csc.py',
   'test_csr.py',
   'test_extract.py',

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -168,8 +168,8 @@ def test_no_H_attr(A):
 
 @parametrize_sparrays
 def test_getrow_getcol(A):
-    assert A.getcol(0)._is_array
-    assert A.getrow(0)._is_array
+    assert A._getcol(0)._is_array
+    assert A._getrow(0)._is_array
 
 
 # -- linalg --

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -1,0 +1,34 @@
+import scipy as sp
+import pytest
+
+
+def test_array_api_deprecations():
+    X = sp.sparse.csr_array([
+        [1,2,3],
+        [4,0,6]
+    ])
+    msg = "1.13.0"
+
+    with pytest.deprecated_call(match=msg):
+        X.get_shape()
+
+    with pytest.deprecated_call(match=msg):
+        X.set_shape((2,3))
+
+    with pytest.deprecated_call(match=msg):
+        X.asfptype()
+
+    with pytest.deprecated_call(match=msg):
+        X.getmaxprint()
+
+    with pytest.deprecated_call(match=msg):
+        X.getnnz()
+
+    with pytest.deprecated_call(match=msg):
+        X.getH()
+
+    with pytest.deprecated_call(match=msg):
+        X.getcol(1).todense()
+
+    with pytest.deprecated_call(match=msg):
+        X.getrow(1).todense()


### PR DESCRIPTION
Makes private many functions that are used internally. These remain exposed in the older matrix API.
