### PR TITLE
ENH: Ensure that the result of divide(sparse, dense) is sparse

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -660,9 +660,10 @@ class _sparray:
         elif isdense(other):
             if not rdivide:
                 if true_divide:
-                    return np.true_divide(self.todense(), other)
+                    recip = np.true_divide(1., other)
                 else:
-                    return np.divide(self.todense(), other)
+                    recip = np.divide(1., other)
+                return self.multiply(recip)
             else:
                 if true_divide:
                     return np.true_divide(other, self.todense())

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -148,6 +148,10 @@ def test_pow(B):
 def test_sparse_divide(A):
     assert isinstance(A / A, np.ndarray)
 
+@parametrize_sparrays
+def test_sparse_dense_divide(A):
+    with pytest.warns(RuntimeWarning):
+        assert (A / A.todense())._is_array
 
 @parametrize_sparrays
 def test_dense_divide(A):


### PR DESCRIPTION
#### Reference issue
#15177

#### What does this implement/fix?
Previously, the result of `sparse / dense` returned a dense array. This PR ensures that `sparse/dense` is sparse. 


#### Additional information
@rossbar mentioned this behaviour and we decided to try to address it. This PR makes divide behave the same as multiply, which is desirable. 

In `output = sparse_a * dense_b`, `output` is a sparse array/matrix. This is understandable because the multiplication only needs to consider data within the sparse mask, so the resulting matrix is as sparse as `sparse_a`

For division, however, we have to be careful. In cases where a dense zero occurs within the sparse mask, `np.divide/np.true_divide` works correctly. However, in cases where `dense_b==0` outside of the sparse mask, we have to add `nan` values to `output`. This means that `output` may be more dense than `sparse_a`, but for many quotients, `output` should remain quite sparse. 