### PR TITLE
ENH: Add ability to save cache path state with `datasets.CacheDir`

### DIFF
--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -21,6 +21,7 @@ Utility Methods
 .. autosummary::
    :toctree: generated/
 
+   CacheDir        -- Read and Set dataset cache directory.
    download_all    -- Download all the dataset files to specified path.
    clear_cache     -- Clear cached dataset directory.
 
@@ -79,10 +80,10 @@ the internet connectivity.
 
 from ._fetchers import face, ascent, electrocardiogram  # noqa: E402
 from ._download_all import download_all
-from ._utils import clear_cache
+from ._utils import clear_cache, CacheDir
 
 __all__ = ['ascent', 'electrocardiogram', 'face',
-           'download_all', 'clear_cache']
+           'download_all', 'clear_cache', 'CacheDir']
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -1,5 +1,6 @@
 from numpy import array, frombuffer, load
 from ._registry import registry, registry_urls
+from ._utils import CacheDir
 
 try:
     import pooch
@@ -7,12 +8,9 @@ except ImportError:
     pooch = None
     data_fetcher = None
 else:
+    cache_dir = CacheDir()
     data_fetcher = pooch.create(
-        # Use the default cache folder for the operating system
-        # Pooch uses appdirs (https://github.com/ActiveState/appdirs) to
-        # select an appropriate directory for the cache on each platform.
-        path=pooch.os_cache("scipy-data"),
-
+        path=cache_dir.get_cache_path(),
         # The remote data is on Github
         # base_url is a required param, even though we override this
         # using individual urls in the registry.
@@ -27,6 +25,8 @@ def fetch_data(dataset_name, data_fetcher=data_fetcher):
         raise ImportError("Missing optional dependency 'pooch' required "
                           "for scipy.datasets module. Please use pip or "
                           "conda to install 'pooch'.")
+    # Set path again in case of changes
+    data_fetcher.path = cache_dir.get_cache_path()
     # The "fetch" method returns the full path to the downloaded data file.
     return data_fetcher.fetch(dataset_name)
 

--- a/scipy/datasets/_registry.py
+++ b/scipy/datasets/_registry.py
@@ -24,3 +24,5 @@ method_files_map = {
     "electrocardiogram": ["ecg.dat"],
     "face": ["face.dat"]
 }
+
+_CACHE_DIR_FILE = '/tmp/scipy_datasets_cache_dir'

--- a/scipy/datasets/_registry.py
+++ b/scipy/datasets/_registry.py
@@ -2,6 +2,7 @@
 # This file serves as the dataset registry for SciPy Datasets SubModule.
 ##########################################################################
 
+import os
 
 # To generate the SHA256 hash, use the command
 # openssl sha256 <filename>
@@ -25,4 +26,7 @@ method_files_map = {
     "face": ["face.dat"]
 }
 
-_CACHE_DIR_FILE = '/tmp/scipy_datasets_cache_dir'
+if 'SCIPY_CACHE_TMP_FILE' in os.environ:
+    _CACHE_DIR_FILE = os.path.abspath(os.environ['SCIPY_CACHE_TMP_FILE'])
+else:
+    _CACHE_DIR_FILE = '/tmp/scipy_datasets_cache_dir'

--- a/scipy/datasets/_utils.py
+++ b/scipy/datasets/_utils.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from ._registry import method_files_map
+from ._registry import method_files_map, _CACHE_DIR_FILE
 
 try:
     import platformdirs
@@ -8,18 +8,57 @@ except ImportError:
     platformdirs = None  # type: ignore[assignment]
 
 
-def _clear_cache(datasets, cache_dir=None, method_map=None):
-    if method_map is None:
-        # Use SciPy Datasets method map
-        method_map = method_files_map
-    if cache_dir is None:
-        # Use default cache_dir path
+class CacheDir:
+    """
+    When a custom cache directory is required for scipy.datasets,
+    an object of CacheDir may be used to read the currently set cache
+    path or set it to a custom user defined path.
+
+    Examples
+    --------
+    >>> from scipy import datasets
+    >>> cache_dir = datasets.CacheDir()
+    >>> cache_path = cache_dir.get_cache_path()
+    >>> datasets.CacheDir().set_cache_path('./data_tmp')
+    >>> default_cache_path = cache_dir.default_cache_path
+    """
+    def __init__(self):
         if platformdirs is None:
             # platformdirs is pooch dependency
             raise ImportError("Missing optional dependency 'pooch' required "
                               "for scipy.datasets module. Please use pip or "
                               "conda to install 'pooch'.")
-        cache_dir = platformdirs.user_cache_dir("scipy-data")
+        # Use the default cache folder for the operating system. Pooch uses
+        # platformdirs (https://github.com/platformdirs/platformdirs)
+        # to select an appropriate directory for the cache on each platform.
+        self.default_cache_path = platformdirs.user_cache_dir("scipy-data")
+        self._cache_path = self.default_cache_path
+
+    def get_cache_path(self):
+        if os.path.exists(_CACHE_DIR_FILE):
+            with open(_CACHE_DIR_FILE) as f:
+                self._cache_path = f.read().strip()
+            return self._cache_path
+        else:
+            return self.default_cache_path
+
+    def set_cache_path(self, new_path=None):
+        if new_path:
+            self._cache_path = os.path.abspath(new_path)
+        else:
+            # fallback to default cache path
+            self._cache_path = self.default_cache_path
+        print(f"Cache path set to {self._cache_path}")
+        with open(_CACHE_DIR_FILE, 'w') as f:
+            f.write(self._cache_path+'\n')
+
+
+def _clear_cache(datasets, cache_dir=None, method_map=None):
+    if method_map is None:
+        # Use SciPy Datasets method map
+        method_map = method_files_map
+    if cache_dir is None:
+        cache_dir = CacheDir().get_cache_path()
 
     if not os.path.exists(cache_dir):
         print(f"Cache Directory {cache_dir} doesn't exist. Nothing to clear.")
@@ -28,6 +67,10 @@ def _clear_cache(datasets, cache_dir=None, method_map=None):
     if datasets is None:
         print(f"Cleaning the cache directory {cache_dir}!")
         shutil.rmtree(cache_dir)
+        if os.path.exists(_CACHE_DIR_FILE):
+            # Remove temporary file containing cache path
+            print(f"Cleaning the tmp file {_CACHE_DIR_FILE}!")
+            os.remove(_CACHE_DIR_FILE)
     else:
         if not isinstance(datasets, (list, tuple)):
             # single dataset method passed should be converted to list


### PR DESCRIPTION
#### Reference issue
Partial fix https://github.com/scipy/scipy/pull/17965.
Broader tracking issue for datasets: https://github.com/scipy/scipy/issues/16983

Useful for package maintainer/developers (like nixOS SciPy package) and other users who may want a custom path for storing pooch cache data.

#### What does this implement/fix?

On running `_download_script.py <user_provided_cache_path>` or calling `download_all(<user_provided_cache_path>)`, write a temporary file containing the `<user_provided_cache_path>`. This tmp file is used to read the cache path or can be  overwritten in case the user decides to call `set_cache_path` method of `CacheDir` class object described below.

This also implements a new class CacheDir (naming can be discussed), which has two public methods and one public attribute:
1. get_cache_path(self)
2. set_cache_path(self, new_path)
3. default_cache_path

The cache path should always be set via this class object method or by running `_download_all.py`/`download_all()`.

Note that this PR doesn't disable/skip any dataset tests.

#### Additional information

Question?
1. Is it fine to write a tmp file like `'/tmp/scipy_datasets_cache_dir'`? If the user has restricted permissions, then this can cause a problem. @rgommers mentioned that env variables approach has other issues like not being permanent enough across sessions, unless exported inside shell rc file by the user.

TODO: 
- [ ]  Create a separate PR to improve documentation on usage of `_download_all.py`.
- [ ]  Improve CacheDir class docs
- [ ]  Add tests for `CacheDir`
