### PR TITLE
MAINT: sparse.csgraph: Allow any valid MST in the tests

### DIFF
--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -1,65 +1,79 @@
 """Test the minimum spanning tree function"""
 import numpy as np
-from numpy.testing import assert_
 import numpy.testing as npt
+import pytest
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import minimum_spanning_tree
 
 
 def test_minimum_spanning_tree():
-
     # Create a graph with two connected components.
-    graph = [[0,1,0,0,0],
-             [1,0,0,0,0],
-             [0,0,0,8,5],
-             [0,0,8,0,1],
-             [0,0,5,1,0]]
-    graph = np.asarray(graph)
+    graph = np.array([[0,1,0,0,0],
+                      [1,0,0,0,0],
+                      [0,0,0,8,5],
+                      [0,0,8,0,1],
+                      [0,0,5,1,0]])
 
-    # Create the expected spanning tree.
-    expected = [[0,1,0,0,0],
-                [0,0,0,0,0],
-                [0,0,0,0,5],
-                [0,0,0,0,1],
-                [0,0,0,0,0]]
-    expected = np.asarray(expected)
+    # Create the expected spanning tree(s). With two connected components,
+    # we have four possible results (as each tree can be transposed).
+    expected_results = (
+        np.array([[0,1,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,0,0,5],
+                  [0,0,0,0,1],
+                  [0,0,0,0,0]], dtype=float),
+        np.array([[0,0,0,0,0],
+                  [1,0,0,0,0],
+                  [0,0,0,0,5],
+                  [0,0,0,0,1],
+                  [0,0,0,0,0]], dtype=float),
+        np.array([[0,1,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,5,1,0]], dtype=float),
+        np.array([[0,0,0,0,0],
+                  [1,0,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,0,0,0],
+                  [0,0,5,1,0]], dtype=float),
+    )
 
-    # Ensure minimum spanning tree code gives this expected output.
+    # Ensure minimum spanning tree code gives one of the expected outputs.
     csgraph = csr_matrix(graph)
-    mintree = minimum_spanning_tree(csgraph)
-    npt.assert_array_equal(mintree.toarray(), expected,
-        'Incorrect spanning tree found.')
+    mintree = minimum_spanning_tree(csgraph).toarray()
+    assert any(np.array_equal(mintree, tree) for tree in expected_results)
 
     # Ensure that the original graph was not modified.
     npt.assert_array_equal(csgraph.toarray(), graph,
         'Original graph was modified.')
 
     # Now let the algorithm modify the csgraph in place.
-    mintree = minimum_spanning_tree(csgraph, overwrite=True)
-    npt.assert_array_equal(mintree.toarray(), expected,
-        'Graph was not properly modified to contain MST.')
+    mintree2 = minimum_spanning_tree(csgraph, overwrite=True).toarray()
+    assert any(np.array_equal(mintree2, tree) for tree in expected_results)
 
+
+@pytest.mark.parametrize('N', [5, 10, 15, 20])
+def test_minimum_spanning_tree_random_graphs(N: int):
     np.random.seed(1234)
-    for N in (5, 10, 15, 20):
 
-        # Create a random graph.
-        graph = 3 + np.random.random((N, N))
-        csgraph = csr_matrix(graph)
+    # Create a random graph.
+    graph = 3 + np.random.random((N, N))
+    csgraph = csr_matrix(graph)
 
-        # The spanning tree has at most N - 1 edges.
-        mintree = minimum_spanning_tree(csgraph)
-        assert_(mintree.nnz < N)
+    # The spanning tree has at most N - 1 edges.
+    mintree = minimum_spanning_tree(csgraph)
+    assert mintree.nnz < N
 
-        # Set the sub diagonal to 1 to create a known spanning tree.
-        idx = np.arange(N-1)
-        graph[idx,idx+1] = 1
-        csgraph = csr_matrix(graph)
-        mintree = minimum_spanning_tree(csgraph)
+    # Set the sub diagonal to 1 to create a known spanning tree.
+    idx = np.arange(N - 1)
+    graph[idx, idx+1] = 1
+    csgraph = csr_matrix(graph)
+    mintree = minimum_spanning_tree(csgraph).toarray()
 
-        # We expect to see this pattern in the spanning tree and otherwise
-        # have this zero.
-        expected = np.zeros((N, N))
-        expected[idx, idx+1] = 1
+    # We expect to see this pattern in the spanning tree and otherwise
+    # have this zero.
+    expected = np.zeros((N, N))
+    expected[idx, idx+1] = 1
 
-        npt.assert_array_equal(mintree.toarray(), expected,
-            'Incorrect spanning tree found.')
+    npt.assert_array_equal(mintree, expected, 'Incorrect spanning tree found.')


### PR DESCRIPTION
#### Reference issue
Fixes gh-18494. See also related issue gh-17734.

#### What does this implement/fix?
Our tests were expecting a particular MST representation in the upper-right triangle of a sparse adjacency matrix, but it's technically also valid to have the edges appear in the lower-right triangle (as the MST is really an undirected graph). This test update checks for any of the four valid adjacency matrix representations of the true MST.

#### Additional information
I'm still not clear why/how the behavior of our MST code is changing on the same Linux platform between Python versions 3.10 and 3.11. Nothing in the MST Cython code seems to be doing anything particularly subtle, so at this point I'm assuming the discrepancy is in the generated code. We might still want to look into that, in case there are other functions that are affected.
