### PR TITLE
try stable sort in mst tree ordering

### DIFF
--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -101,6 +101,8 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     rank = np.zeros(N, dtype=ITYPE)
     predecessors = np.arange(N, dtype=ITYPE)
 
+    # Stable sort is a necessary but not sufficient operation
+    # to get to a canonical representation of solutions.
     i_sort = np.argsort(data, kind='stable').astype(ITYPE)
     row_indices = np.zeros(len(data), dtype=ITYPE)
 

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -101,7 +101,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     rank = np.zeros(N, dtype=ITYPE)
     predecessors = np.arange(N, dtype=ITYPE)
 
-    i_sort = np.argsort(data).astype(ITYPE)
+    i_sort = np.argsort(data, kind='stable').astype(ITYPE)
     row_indices = np.zeros(len(data), dtype=ITYPE)
 
     _min_spanning_tree(data, indices, indptr, i_sort,


### PR DESCRIPTION
#### Reference issue
Supersedes https://github.com/scipy/scipy/pull/18520, fixes https://github.com/scipy/scipy/issues/18494. 

#### What does this implement/fix?
This tries to ensure that the `numpy.argsort()` used in the minimum spanning tree implementation is stable across runs. This seeks to solve the instability noted in #18494 where the minimum spanning tree result flips between two equivalent representations of the same tree depending on platform. 

#### Additional information
This may not be enough to address the issue, and we may still need to return msts within only the upper triangle. (see #18520). 
