### PR TITLE
ENH: Update isspmatrix behavior

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1458,6 +1458,7 @@ def issparse(x):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.sparse import csr_array, csr_matrix, issparse
     >>> issparse(csr_matrix([[5]]))
     True

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -7,6 +7,8 @@ from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike,
                        matrix, validateaxis,)
 
+from ._matrix import spmatrix
+
 __all__ = ['isspmatrix', 'issparse',
            'SparseWarning', 'SparseEfficiencyWarning']
 
@@ -1442,7 +1444,7 @@ settable. To change the array shape, use `X.reshape` instead.
 
 
 def issparse(x):
-    """Is x of a sparse array type?
+    """Is `x` of a sparse array type?
 
     Parameters
     ----------
@@ -1452,11 +1454,7 @@ def issparse(x):
     Returns
     -------
     bool
-        True if x is a sparse array, False otherwise
-
-    Notes
-    -----
-    issparse and isspmatrix are aliases for the same function.
+        True if `x` is a sparse array, False otherwise
 
     Examples
     --------
@@ -1471,4 +1469,27 @@ def issparse(x):
     return isinstance(x, _sparray)
 
 
-isspmatrix = issparse
+def isspmatrix(x):
+    """Is `x` of a sparse matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a sparse matrix
+
+    Returns
+    -------
+    bool
+        True if `x` is a sparse matrix, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_array, csr_matrix, isspmatrix
+    >>> isspmatrix(csr_matrix([[5]]))
+    True
+    >>> isspmatrix(csr_array([[5]]))
+    False
+    >>> issparse(5)
+    False
+    """
+    return isinstance(x, spmatrix)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1454,7 +1454,7 @@ def issparse(x):
     Returns
     -------
     bool
-        True if `x` is a sparse array, False otherwise
+        True if `x` is a sparse array or a sparse matrix, False otherwise
 
     Examples
     --------

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1458,11 +1458,13 @@ def issparse(x):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_array, issparse
-    >>> issparse(csr_array([[5]]))
+    >>> from scipy.sparse import csr_array, csr_matrix, issparse
+    >>> issparse(csr_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import issparse
+    >>> issparse(csr_array([[5]])
+    True
+    >>> issparse(np.array([[5]]))
+    False
     >>> issparse(5)
     False
     """
@@ -1489,7 +1491,9 @@ def isspmatrix(x):
     True
     >>> isspmatrix(csr_array([[5]]))
     False
-    >>> issparse(5)
+    >>> isspmatrix(np.array([[5]]))
+    False
+    >>> isspmatrix(5)
     False
     """
     return isinstance(x, spmatrix)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1461,7 +1461,7 @@ def issparse(x):
     >>> from scipy.sparse import csr_array, csr_matrix, issparse
     >>> issparse(csr_matrix([[5]]))
     True
-    >>> issparse(csr_array([[5]])
+    >>> issparse(csr_array([[5]]))
     True
     >>> issparse(np.array([[5]]))
     False
@@ -1486,6 +1486,7 @@ def isspmatrix(x):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.sparse import csr_array, csr_matrix, isspmatrix
     >>> isspmatrix(csr_matrix([[5]]))
     True

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -710,7 +710,7 @@ def isspmatrix_bsr(x):
     Examples
     --------
     >>> from scipy.sparse import bsr_array, bsr_matrix, csr_matrix, isspmatrix_bsr
-    >>> isspmatrix_bsr(bsr_matrix([[5]])
+    >>> isspmatrix_bsr(bsr_matrix([[5]]))
     True
     >>> isspmatrix_bsr(bsr_array([[5]]))
     False

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -11,7 +11,7 @@ import numpy as np
 from ._matrix import spmatrix, _array_doc_to_matrix
 from ._data import _data_matrix, _minmax_mixin
 from ._compressed import _cs_matrix
-from ._base import isspmatrix, _formats, _sparray
+from ._base import issparse, _formats, _sparray
 from ._sputils import (isshape, getdtype, getdata, to_native, upcast,
                        check_shape)
 from . import _sparsetools
@@ -122,7 +122,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):
         _data_matrix.__init__(self)
 
-        if isspmatrix(arg1):
+        if issparse(arg1):
             if isspmatrix_bsr(arg1) and copy:
                 arg1 = arg1.copy()
             else:

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -695,7 +695,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
 
 
 def isspmatrix_bsr(x):
-    """Is x of a bsr_array type?
+    """Is `x` of a bsr_matrix type?
 
     Parameters
     ----------
@@ -705,19 +705,19 @@ def isspmatrix_bsr(x):
     Returns
     -------
     bool
-        True if x is a bsr matrix, False otherwise
+        True if `x` is a bsr matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import bsr_array, isspmatrix_bsr
-    >>> isspmatrix_bsr(bsr_array([[5]]))
+    >>> from scipy.sparse import bsr_array, bsr_matrix, csr_matrix, isspmatrix_bsr
+    >>> isspmatrix_bsr(bsr_matrix([[5]])
     True
-
-    >>> from scipy.sparse import bsr_array, csr_matrix, isspmatrix_bsr
+    >>> isspmatrix_bsr(bsr_array([[5]]))
+    False
     >>> isspmatrix_bsr(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, bsr_matrix) or isinstance(x, bsr_array)
+    return isinstance(x, bsr_matrix)
 
 
 class bsr_matrix(spmatrix, bsr_array):

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -372,14 +372,12 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         R,n = self.blocksize
 
         # convert to this format
-        if isspmatrix_bsr(other):
+        if isparse(other) and other.format == "bsr":
             C = other.blocksize[1]
         else:
             C = 1
 
-        from ._csr import isspmatrix_csr
-
-        if isspmatrix_csr(other) and n == 1:
+        if other.format == "csr" and n == 1:
             other = other.tobsr(blocksize=(n,C), copy=False)  # lightweight conversion
         else:
             other = other.tobsr(blocksize=(n,C))

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -372,7 +372,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         R,n = self.blocksize
 
         # convert to this format
-        if issparse(other) and other.format == "bsr":
+        if other.format == "bsr":
             C = other.blocksize[1]
         else:
             C = 1

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -372,7 +372,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         R,n = self.blocksize
 
         # convert to this format
-        if isparse(other) and other.format == "bsr":
+        if issparse(other) and other.format == "bsr":
             C = other.blocksize[1]
         else:
             C = 1

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -123,7 +123,7 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         _data_matrix.__init__(self)
 
         if issparse(arg1):
-            if isspmatrix_bsr(arg1) and copy:
+            if arg1.format == self.format and copy:
                 arg1 = arg1.copy()
             else:
                 arg1 = arg1.tobsr(blocksize=blocksize)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -7,7 +7,7 @@ import operator
 import numpy as np
 from scipy._lib._util import _prune_array
 
-from ._base import _sparray, isspmatrix, SparseEfficiencyWarning
+from ._base import _sparray, issparse, SparseEfficiencyWarning
 from ._data import _data_matrix, _minmax_mixin
 from . import _sparsetools
 from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,
@@ -25,7 +25,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
 
-        if isspmatrix(arg1):
+        if issparse(arg1):
             if arg1.format == self.format and copy:
                 arg1 = arg1.copy()
             else:
@@ -233,7 +233,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif is_pydata_spmatrix(other):
             return NotImplemented
         # Sparse other.
-        elif isspmatrix(other):
+        elif issparse(other):
             warn("Comparing sparse matrices using == is inefficient, try using"
                  " != instead.", SparseEfficiencyWarning, stacklevel=3)
             # TODO sparse broadcasting
@@ -271,7 +271,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif is_pydata_spmatrix(other):
             return NotImplemented
         # Sparse other.
-        elif isspmatrix(other):
+        elif issparse(other):
             # TODO sparse broadcasting
             if self.shape != other.shape:
                 return True
@@ -298,7 +298,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif isdense(other):
             return op(self.todense(), other)
         # Sparse other.
-        elif isspmatrix(other):
+        elif issparse(other):
             # TODO sparse broadcasting
             if self.shape != other.shape:
                 raise ValueError("inconsistent shapes")
@@ -369,7 +369,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if isscalarlike(other):
             return self._mul_scalar(other)
         # Sparse matrix or vector.
-        if isspmatrix(other):
+        if issparse(other):
             if self.shape == other.shape:
                 other = self.__class__(other)
                 return self._binopt(other, '_elmul_')
@@ -574,7 +574,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return mat
         elif isdense(other):
             return npop(self.todense(), other)
-        elif isspmatrix(other):
+        elif issparse(other):
             return self._binopt(other, op_name)
         else:
             raise ValueError("Operands not compatible.")

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ._matrix import spmatrix, _array_doc_to_matrix
 from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
-from ._base import isspmatrix, SparseEfficiencyWarning, _sparray
+from ._base import issparse, SparseEfficiencyWarning, _sparray
 from ._data import _data_matrix, _minmax_mixin
 from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index,
@@ -161,7 +161,7 @@ class coo_array(_data_matrix, _minmax_mixin):
                 self.data = getdata(obj, copy=copy, dtype=dtype)
                 self.has_canonical_format = False
         else:
-            if isspmatrix(arg1):
+            if issparse(arg1):
                 if isspmatrix_coo(arg1) and copy:
                     self.row = arg1.row.copy()
                     self.col = arg1.col.copy()

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -162,7 +162,7 @@ class coo_array(_data_matrix, _minmax_mixin):
                 self.has_canonical_format = False
         else:
             if issparse(arg1):
-                if isspmatrix_coo(arg1) and copy:
+                if arg1.format == self.format and copy:
                     self.row = arg1.row.copy()
                     self.col = arg1.col.copy()
                     self.data = arg1.data.copy()

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -595,7 +595,7 @@ class coo_array(_data_matrix, _minmax_mixin):
 
 
 def isspmatrix_coo(x):
-    """Is x of coo_array type?
+    """Is `x` of coo_matrix type?
 
     Parameters
     ----------
@@ -605,19 +605,19 @@ def isspmatrix_coo(x):
     Returns
     -------
     bool
-        True if x is a coo matrix, False otherwise
+        True if `x` is a coo matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import coo_array, isspmatrix_coo
-    >>> isspmatrix_coo(coo_array([[5]]))
+    >>> from scipy.sparse import coo_array, coo_matrix, csr_matrix, isspmatrix_coo
+    >>> isspmatrix_coo(coo_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import coo_array, csr_matrix, isspmatrix_coo
+    >>> isspmatrix_coo(coo_array([[5]]))
+    False
     >>> isspmatrix_coo(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, coo_matrix) or isinstance(x, coo_array)
+    return isinstance(x, coo_matrix)
 
 
 class coo_matrix(spmatrix, coo_array):

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -235,7 +235,7 @@ class csc_array(_cs_matrix):
 
 
 def isspmatrix_csc(x):
-    """Is x of csc_array type?
+    """Is `x` of csc_matrix type?
 
     Parameters
     ----------
@@ -245,19 +245,19 @@ def isspmatrix_csc(x):
     Returns
     -------
     bool
-        True if x is a csc matrix, False otherwise
+        True if `x` is a csc matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import csc_array, isspmatrix_csc
-    >>> isspmatrix_csc(csc_array([[5]]))
+    >>> from scipy.sparse import csc_array, csc_matrix, coo_matrix, isspmatrix_csc
+    >>> isspmatrix_csc(csc_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import csc_array, csr_matrix, isspmatrix_csc
+    >>> isspmatrix_csc(csc_array([[5]]))
+    False
     >>> isspmatrix_csc(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, csc_matrix) or isinstance(x, csc_array)
+    return isinstance(x, csc_matrix)
 
 
 class csc_matrix(spmatrix, csc_array):

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -254,7 +254,7 @@ def isspmatrix_csc(x):
     True
     >>> isspmatrix_csc(csc_array([[5]]))
     False
-    >>> isspmatrix_csc(csr_matrix([[5]]))
+    >>> isspmatrix_csc(coo_matrix([[5]]))
     False
     """
     return isinstance(x, csc_matrix)

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -332,7 +332,7 @@ class csr_array(_cs_matrix):
 
 
 def isspmatrix_csr(x):
-    """Is x of csr_array type?
+    """Is `x` of csr_matrix type?
 
     Parameters
     ----------
@@ -342,19 +342,19 @@ def isspmatrix_csr(x):
     Returns
     -------
     bool
-        True if x is a csr matrix, False otherwise
+        True if `x` is a csr matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import csr_array, isspmatrix_csr
-    >>> isspmatrix_csr(csr_array([[5]]))
+    >>> from scipy.sparse import csr_array, csr_matrix, coo_matrix, isspmatrix_csr
+    >>> isspmatrix_csr(csr_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import csc_matrix, csr_array, isspmatrix_csc
-    >>> isspmatrix_csr(csc_matrix([[5]]))
+    >>> isspmatrix_csr(csr_array([[5]]))
+    False
+    >>> isspmatrix_csr(coo_matrix([[5]]))
     False
     """
-    return isinstance(x, csr_matrix) or isinstance(x, csr_array)
+    return isinstance(x, csr_matrix)
 
 
 class csr_matrix(spmatrix, csr_array):

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -445,7 +445,7 @@ class dia_array(_data_matrix):
 
 
 def isspmatrix_dia(x):
-    """Is x of dia_array type?
+    """Is `x` of dia_matrix type?
 
     Parameters
     ----------
@@ -455,19 +455,19 @@ def isspmatrix_dia(x):
     Returns
     -------
     bool
-        True if x is a dia matrix, False otherwise
+        True if `x` is a dia matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import dia_array, isspmatrix_dia
-    >>> isspmatrix_dia(dia_array([[5]]))
+    >>> from scipy.sparse import dia_array, dia_matrix, coo_matrix, isspmatrix_dia
+    >>> isspmatrix_dia(dia_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import dia_array, csr_matrix, isspmatrix_dia
-    >>> isspmatrix_dia(csr_matrix([[5]]))
+    >>> isspmatrix_dia(dia_array([[5]]))
+    False
+    >>> isspmatrix_dia(coo_matrix([[5]]))
     False
     """
-    return isinstance(x, dia_matrix) or isinstance(x, dia_array)
+    return isinstance(x, dia_matrix)
 
 
 class dia_matrix(spmatrix, dia_array):

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -89,7 +89,7 @@ class dia_array(_data_matrix):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
 
-        if issparse(arg1)
+        if issparse(arg1):
             if arg1.format == "dia":
                 if copy:
                     arg1 = arg1.copy()

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -96,7 +96,7 @@ class dia_array(_data_matrix):
             self.offsets = arg1.offsets
             self._shape = check_shape(arg1.shape)
         elif issparse(arg1):
-            if isspmatrix_dia(arg1) and copy:
+            if arg1.format == self.format and copy:
                 A = arg1.copy()
             else:
                 A = arg1.todia()

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -7,7 +7,7 @@ __all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
 import numpy as np
 
 from ._matrix import spmatrix, _array_doc_to_matrix
-from ._base import isspmatrix, _formats, _sparray
+from ._base import issparse, _formats, _sparray
 from ._data import _data_matrix
 from ._sputils import (isshape, upcast_char, getdtype, get_sum_dtype, validateaxis, check_shape)
 from ._sparsetools import dia_matvec
@@ -95,7 +95,7 @@ class dia_array(_data_matrix):
             self.data = arg1.data
             self.offsets = arg1.offsets
             self._shape = check_shape(arg1.shape)
-        elif isspmatrix(arg1):
+        elif issparse(arg1):
             if isspmatrix_dia(arg1) and copy:
                 A = arg1.copy()
             else:

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -89,20 +89,21 @@ class dia_array(_data_matrix):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
 
-        if isspmatrix_dia(arg1):
-            if copy:
-                arg1 = arg1.copy()
-            self.data = arg1.data
-            self.offsets = arg1.offsets
-            self._shape = check_shape(arg1.shape)
-        elif issparse(arg1):
-            if arg1.format == self.format and copy:
-                A = arg1.copy()
+        if issparse(arg1)
+            if arg1.format == "dia":
+                if copy:
+                    arg1 = arg1.copy()
+                self.data = arg1.data
+                self.offsets = arg1.offsets
+                self._shape = check_shape(arg1.shape)
             else:
-                A = arg1.todia()
-            self.data = A.data
-            self.offsets = A.offsets
-            self._shape = check_shape(A.shape)
+                if arg1.format == self.format and copy:
+                    A = arg1.copy()
+                else:
+                    A = arg1.todia()
+                self.data = A.data
+                self.offsets = A.offsets
+                self._shape = check_shape(A.shape)
         elif isinstance(arg1, tuple):
             if isshape(arg1):
                 # It's a tuple of matrix dimensions (M, N)

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -8,7 +8,7 @@ import itertools
 import numpy as np
 
 from ._matrix import spmatrix, _array_doc_to_matrix
-from ._base import _sparray, isspmatrix
+from ._base import _sparray, issparse
 from ._index import IndexMixin
 from ._sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
                        upcast, upcast_scalar, check_shape)
@@ -80,7 +80,7 @@ class dok_array(_sparray, IndexMixin, dict):
         if isinstance(arg1, tuple) and isshape(arg1):  # (M,N)
             M, N = arg1
             self._shape = check_shape((M, N))
-        elif isspmatrix(arg1):  # Sparse ctor
+        elif issparse(arg1):  # Sparse ctor
             if isspmatrix_dok(arg1) and copy:
                 arg1 = arg1.copy()
             else:
@@ -257,7 +257,7 @@ class dok_array(_sparray, IndexMixin, dict):
             with np.errstate(over='ignore'):
                 dict.update(new,
                            ((k, new[k] + other[k]) for k in other.keys()))
-        elif isspmatrix(other):
+        elif issparse(other):
             csc = self.tocsc()
             new = csc + other
         elif isdense(other):
@@ -281,7 +281,7 @@ class dok_array(_sparray, IndexMixin, dict):
             dict.update(new, self)
             dict.update(new,
                        ((k, self[k] + other[k]) for k in other.keys()))
-        elif isspmatrix(other):
+        elif issparse(other):
             csc = self.tocsc()
             new = csc + other
         elif isdense(other):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -425,7 +425,7 @@ class dok_array(_sparray, IndexMixin, dict):
 
 
 def isspmatrix_dok(x):
-    """Is x of dok_array type?
+    """Is `x` of dok_array type?
 
     Parameters
     ----------
@@ -435,19 +435,19 @@ def isspmatrix_dok(x):
     Returns
     -------
     bool
-        True if x is a dok matrix, False otherwise
+        True if `x` is a dok matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import dok_array, isspmatrix_dok
-    >>> isspmatrix_dok(dok_array([[5]]))
+    >>> from scipy.sparse import dok_array, dok_matrix, coo_matrix, isspmatrix_dok
+    >>> isspmatrix_dok(dok_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import dok_array, csr_matrix, isspmatrix_dok
-    >>> isspmatrix_dok(csr_matrix([[5]]))
+    >>> isspmatrix_dok(dok_array([[5]]))
+    False
+    >>> isspmatrix_dok(coo_matrix([[5]]))
     False
     """
-    return isinstance(x, dok_matrix) or isinstance(x, dok_array)
+    return isinstance(x, dok_matrix)
 
 
 class dok_matrix(spmatrix, dok_array):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -246,20 +246,21 @@ class dok_array(_sparray, IndexMixin, dict):
                 if aij:
                     new[key] = aij
             # new.dtype.char = self.dtype.char
-        elif isspmatrix_dok(other):
-            if other.shape != self.shape:
-                raise ValueError("Matrix dimensions are not equal.")
-            # We could alternatively set the dimensions to the largest of
-            # the two matrices to be summed.  Would this be a good idea?
-            res_dtype = upcast(self.dtype, other.dtype)
-            new = self._dok_container(self.shape, dtype=res_dtype)
-            dict.update(new, self)
-            with np.errstate(over='ignore'):
-                dict.update(new,
-                           ((k, new[k] + other[k]) for k in other.keys()))
         elif issparse(other):
-            csc = self.tocsc()
-            new = csc + other
+            if other.format == "dok":
+                if other.shape != self.shape:
+                    raise ValueError("Matrix dimensions are not equal.")
+                # We could alternatively set the dimensions to the largest of
+                # the two matrices to be summed.  Would this be a good idea?
+                res_dtype = upcast(self.dtype, other.dtype)
+                new = self._dok_container(self.shape, dtype=res_dtype)
+                dict.update(new, self)
+                with np.errstate(over='ignore'):
+                    dict.update(new,
+                               ((k, new[k] + other[k]) for k in other.keys()))
+            else:
+                csc = self.tocsc()
+                new = csc + other
         elif isdense(other):
             new = self.todense() + other
         else:
@@ -274,16 +275,17 @@ class dok_array(_sparray, IndexMixin, dict):
                 aij = dict.get(self, (key), 0) + other
                 if aij:
                     new[key] = aij
-        elif isspmatrix_dok(other):
-            if other.shape != self.shape:
-                raise ValueError("Matrix dimensions are not equal.")
-            new = self._dok_container(self.shape, dtype=self.dtype)
-            dict.update(new, self)
-            dict.update(new,
-                       ((k, self[k] + other[k]) for k in other.keys()))
         elif issparse(other):
-            csc = self.tocsc()
-            new = csc + other
+            if other.format == "dok":
+                if other.shape != self.shape:
+                    raise ValueError("Matrix dimensions are not equal.")
+                new = self._dok_container(self.shape, dtype=self.dtype)
+                dict.update(new, self)
+                dict.update(new,
+                           ((k, self[k] + other[k]) for k in other.keys()))
+            else:
+                csc = self.tocsc()
+                new = csc + other
         elif isdense(other):
             new = other + self.todense()
         else:

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -81,7 +81,7 @@ class dok_array(_sparray, IndexMixin, dict):
             M, N = arg1
             self._shape = check_shape((M, N))
         elif issparse(arg1):  # Sparse ctor
-            if isspmatrix_dok(arg1) and copy:
+            if arg1.format == self.format and copy:
                 arg1 = arg1.copy()
             else:
                 arg1 = arg1.todok()

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -116,8 +116,8 @@ class IndexMixin:
         if i.shape != j.shape:
             raise IndexError('number of row and column indices differ')
 
-        from ._base import isspmatrix
-        if isspmatrix(x):
+        from ._base import issparse
+        if issparse(x):
             if i.ndim == 1:
                 # Inner indexing, so treat them like row vectors.
                 i = i[None]
@@ -266,7 +266,7 @@ def _unpack_index(index):
     Valid type for row/col is integer, slice, or array of integers.
     """
     # First, check if indexing with single boolean matrix.
-    from ._base import _sparray, isspmatrix
+    from ._base import _sparray, issparse
     if (isinstance(index, (_sparray, np.ndarray)) and
             index.ndim == 2 and index.dtype.kind == 'b'):
         return index.nonzero()
@@ -291,7 +291,7 @@ def _unpack_index(index):
         elif idx.ndim == 2:
             return idx.nonzero()
     # Next, check for validity and transform the index as needed.
-    if isspmatrix(row) or isspmatrix(col):
+    if issparse(row) or issparse(col):
         # Supporting sparse boolean indexing with both row and col does
         # not work because spmatrix.ndim is always 2.
         raise IndexError(

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -87,7 +87,7 @@ class lil_array(_sparray, IndexMixin):
 
         # First get the shape
         if issparse(arg1):
-            if isspmatrix_lil(arg1) and copy:
+            if arg1.format == "lil" and copy:
                 A = arg1.copy()
             else:
                 A = arg1.tolil()

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -522,7 +522,7 @@ def _prepare_index_for_memoryview(i, j, x=None):
 
 
 def isspmatrix_lil(x):
-    """Is x of lil_array type?
+    """Is `x` of lil_matrix type?
 
     Parameters
     ----------
@@ -532,19 +532,19 @@ def isspmatrix_lil(x):
     Returns
     -------
     bool
-        True if x is a lil matrix, False otherwise
+        True if `x` is a lil matrix, False otherwise
 
     Examples
     --------
-    >>> from scipy.sparse import lil_array, isspmatrix_lil
-    >>> isspmatrix_lil(lil_array([[5]]))
+    >>> from scipy.sparse import lil_array, lil_matrix, coo_matrix, isspmatrix_lil
+    >>> isspmatrix_lil(lil_matrix([[5]]))
     True
-
-    >>> from scipy.sparse import lil_array, csr_matrix, isspmatrix_lil
-    >>> isspmatrix_lil(csr_matrix([[5]]))
+    >>> isspmatrix_lil(lil_array([[5]]))
+    False
+    >>> isspmatrix_lil(coo_matrix([[5]]))
     False
     """
-    return isinstance(x, lil_matrix) or isinstance(x, lil_array)
+    return isinstance(x, lil_matrix)
 
 
 class lil_matrix(spmatrix, lil_array):

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -10,7 +10,7 @@ from bisect import bisect_left
 import numpy as np
 
 from ._matrix import spmatrix, _array_doc_to_matrix
-from ._base import _sparray, isspmatrix
+from ._base import _sparray, issparse
 from ._index import IndexMixin, INT_TYPES, _broadcast_arrays
 from ._sputils import (getdtype, isshape, isscalarlike, upcast_scalar,
                        check_shape, check_reshape_kwargs)
@@ -86,7 +86,7 @@ class lil_array(_sparray, IndexMixin):
         self.dtype = getdtype(dtype, arg1, default=float)
 
         # First get the shape
-        if isspmatrix(arg1):
+        if issparse(arg1):
             if isspmatrix_lil(arg1) and copy:
                 A = arg1.copy()
             else:
@@ -323,7 +323,7 @@ class lil_array(_sparray, IndexMixin):
             # Fast path for full-matrix sparse assignment.
             if (isinstance(row, slice) and isinstance(col, slice) and
                     row == slice(None) and col == slice(None) and
-                    isspmatrix(x) and x.shape == self.shape):
+                    issparse(x) and x.shape == self.shape):
                 x = self._lil_container(x, dtype=self.dtype)
                 self.rows = x.rows
                 self.data = x.data

--- a/scipy/sparse/_spfuncs.py
+++ b/scipy/sparse/_spfuncs.py
@@ -3,8 +3,8 @@
 
 __all__ = ['count_blocks','estimate_blocksize']
 
-from ._csr import isspmatrix_csr, csr_array
-from ._csc import isspmatrix_csc
+from ._base import issparse
+from ._csr import csr_array
 from ._sparsetools import csr_count_blocks
 
 
@@ -14,7 +14,7 @@ def estimate_blocksize(A,efficiency=0.7):
     Returns a blocksize=(r,c) such that
         - A.nnz / A.tobsr( (r,c) ).nnz > efficiency
     """
-    if not (isspmatrix_csr(A) or isspmatrix_csc(A)):
+    if not (issparse(A) and A.format in ("csc", "csr")):
         A = csr_array(A)
 
     if A.nnz == 0:
@@ -67,10 +67,10 @@ def count_blocks(A,blocksize):
     if r < 1 or c < 1:
         raise ValueError('r and c must be positive')
 
-    if isspmatrix_csr(A):
-        M,N = A.shape
-        return csr_count_blocks(M,N,r,c,A.indptr,A.indices)
-    elif isspmatrix_csc(A):
-        return count_blocks(A.T,(c,r))
-    else:
-        return count_blocks(csr_array(A),blocksize)
+    if issparse(A):
+        if A.format == "csr":
+            M,N = A.shape
+            return csr_count_blocks(M,N,r,c,A.indptr,A.indices)
+        elif A.format == "csc":
+            return count_blocks(A.T,(c,r))
+    return count_blocks(csr_array(A),blocksize)

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from scipy.sparse import csr_matrix, isspmatrix_csr
+from scipy.sparse import csr_matrix, issparse
 
 cimport numpy as np
 
@@ -224,7 +224,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     modifying the capacities of the new graph appropriately.
 
     """
-    if not isspmatrix_csr(csgraph):
+    if not (issparse(csgraph) and csgraph.format == "csr"):
         raise TypeError("graph must be in CSR format")
     if not issubclass(csgraph.dtype.type, np.integer):
         raise ValueError("graph capacities must be integers")

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -3,7 +3,7 @@ Laplacian of a compressed-sparse graph
 """
 
 import numpy as np
-from scipy.sparse import isspmatrix
+from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator
 
 
@@ -340,12 +340,12 @@ def laplacian(
 
     if form == "array":
         create_lap = (
-            _laplacian_sparse if isspmatrix(csgraph) else _laplacian_dense
+            _laplacian_sparse if issparse(csgraph) else _laplacian_dense
         )
     else:
         create_lap = (
             _laplacian_sparse_flo
-            if isspmatrix(csgraph)
+            if issparse(csgraph)
             else _laplacian_dense_flo
         )
 

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -6,7 +6,7 @@ cimport numpy as np
 from libc.math cimport INFINITY
 
 
-from scipy.sparse import isspmatrix_coo, isspmatrix_csc, isspmatrix_csr
+from scipy.sparse import issparse
 
 np.import_array()
 
@@ -130,10 +130,11 @@ def maximum_bipartite_matching(graph, perm_type='row'):
      [2 0 0 3]]
 
     """
-    if isspmatrix_csc(graph) or isspmatrix_coo(graph):
-        graph = graph.tocsr()
-    elif not isspmatrix_csr(graph):
+    if not issparse(graph):
+        raise TypeError("graph must be sparse")
+    if graph.format not in ("csr", "csc", "coo"):
         raise TypeError("graph must be in CSC, CSR, or COO format.")
+    graph = graph.tocsr()
     i, j = graph.shape
     x, y = _hopcroft_karp(graph.indices, graph.indptr, i, j)
     return np.asarray(x if perm_type == 'column' else y)
@@ -443,9 +444,9 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
     28.0
 
     """
-    if not isspmatrix_csr(biadjacency_matrix)\
-            and not isspmatrix_csc(biadjacency_matrix)\
-            and not isspmatrix_coo(biadjacency_matrix):
+    if not issparse(biadjacency_matrix):
+        raise TypeError("graph must be sparse")
+    if biadjacency_matrix.format not in ("csr", "csc", "coo"):
         raise TypeError("graph must be in CSC, CSR, or COO format.")
 
     if not (np.issubdtype(biadjacency_matrix.dtype, np.number) or
@@ -473,7 +474,7 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
     # The algorithm expects more columns than rows in the graph.
     if j < i:
         biadjacency_matrix_t = biadjacency_matrix.T
-        if not isspmatrix_csr(biadjacency_matrix_t):
+        if biadjacency_matrix_t.format != "csr":
             biadjacency_matrix_t = biadjacency_matrix_t.tocsr()
         b = np.asarray(_lapjvsp(biadjacency_matrix_t.indptr,
                                 biadjacency_matrix_t.indices,
@@ -482,7 +483,7 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
         indices = np.argsort(b)
         return (b[indices], a[indices])
     else:
-        if not isspmatrix_csr(biadjacency_matrix):
+        if biadjacency_matrix.format != "csr":
             biadjacency_matrix = biadjacency_matrix.tocsr()
         b = np.asarray(_lapjvsp(biadjacency_matrix.indptr,
                                 biadjacency_matrix.indices,

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -5,9 +5,7 @@
 import numpy as np
 cimport numpy as np
 from warnings import warn
-from scipy.sparse import (csr_matrix, issparse, isspmatrix_coo,
-                          isspmatrix_csc, isspmatrix_csr,
-                          SparseEfficiencyWarning)
+from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
 from . import maximum_bipartite_matching
 
 np.import_array()
@@ -70,7 +68,9 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     array([3, 2, 1, 0], dtype=int32)
     
     """
-    if not (isspmatrix_csc(graph) or isspmatrix_csr(graph)):
+    if not issparse(graph):
+        raise TypeError("Input graph must be sparse")
+    if graph.format not in ("csc", "csr"):
         raise TypeError('Input must be in CSC or CSR sparse matrix format.')
     nrows = graph.shape[0]
     if not symmetric_mode:
@@ -228,8 +228,8 @@ def structural_rank(graph):
     """
     if not issparse:
         raise TypeError('Input must be a sparse matrix')
-    if not isspmatrix_csr(graph):
-        if not (isspmatrix_csc(graph) or isspmatrix_coo(graph)):
+    if graph.format != "csr":
+        if graph.format not in ("csc", "coo"):
             warn('Input matrix should be in CSC, CSR, or COO matrix format',
                     SparseEfficiencyWarning)
         graph = csr_matrix(graph)

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -5,7 +5,7 @@
 import numpy as np
 cimport numpy as np
 from warnings import warn
-from scipy.sparse import (csr_matrix, isspmatrix, isspmatrix_coo,
+from scipy.sparse import (csr_matrix, issparse, isspmatrix_coo,
                           isspmatrix_csc, isspmatrix_csr,
                           SparseEfficiencyWarning)
 from . import maximum_bipartite_matching
@@ -226,7 +226,7 @@ def structural_rank(graph):
     4
 
     """
-    if not isspmatrix:
+    if not issparse:
         raise TypeError('Input must be a sparse matrix')
     if not isspmatrix_csr(graph):
         if not (isspmatrix_csc(graph) or isspmatrix_coo(graph)):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -14,7 +14,7 @@ import warnings
 import numpy as np
 cimport numpy as np
 
-from scipy.sparse import csr_matrix, isspmatrix
+from scipy.sparse import csr_matrix, issparse
 from scipy.sparse.csgraph._validation import validate_graph
 
 cimport cython
@@ -157,14 +157,14 @@ def shortest_path(csgraph, method='auto',
                    copy_if_dense=(not overwrite),
                    copy_if_sparse=(not overwrite))
 
-    cdef bint issparse
+    cdef bint is_sparse
     cdef ssize_t N      # XXX cdef ssize_t Nk fails in Python 3 (?)
 
     if method == 'auto':
         # guess fastest method based on number of nodes and edges
         N = csgraph.shape[0]
-        issparse = isspmatrix(csgraph)
-        if issparse:
+        is_sparse = issparse(csgraph)
+        if is_sparse:
             Nk = csgraph.nnz
             if csgraph.format in ('csr', 'csc', 'coo'):
                 edges = csgraph.data
@@ -301,7 +301,7 @@ def floyd_warshall(csgraph, directed=True,
     dist_matrix = validate_graph(csgraph, directed, DTYPE,
                                  csr_output=False,
                                  copy_if_dense=not overwrite)
-    if not isspmatrix(csgraph):
+    if not issparse(csgraph):
         # for dense array input, zero entries represent non-edge
         dist_matrix[dist_matrix == 0] = INFINITY
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -8,7 +8,7 @@ Tools and utilities for working with compressed sparse graphs
 import numpy as np
 cimport numpy as np
 
-from scipy.sparse import csr_matrix, isspmatrix,\
+from scipy.sparse import csr_matrix, issparse,\
     isspmatrix_csr, isspmatrix_csc, isspmatrix_lil
 
 np.import_array()
@@ -483,13 +483,13 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     # Fix issue #4018:
     # If `pind` and `indices` are empty arrays, `data` is a sparse matrix
     # (it is a numpy.matrix otherwise); handle this case separately.
-    if isspmatrix(data):
+    if issparse(data):
         data = data.todense()
     data = data.getA1()
 
     if not directed:
         data2 = csgraph[indices, pind]
-        if isspmatrix(data2):
+        if issparse(data2):
             data2 = data2.todense()
         data2 = data2.getA1()
         data[data == 0] = np.inf

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -8,8 +8,7 @@ Tools and utilities for working with compressed sparse graphs
 import numpy as np
 cimport numpy as np
 
-from scipy.sparse import csr_matrix, issparse,\
-    isspmatrix_csr, isspmatrix_csc, isspmatrix_lil
+from scipy.sparse import csr_matrix, issparse
 
 np.import_array()
 
@@ -315,10 +314,11 @@ def csgraph_to_dense(csgraph, null_value=0):
     """
     # Allow only csr, lil and csc matrices: other formats when converted to csr
     # combine duplicated edges: we don't want this to happen in the background.
-    if isspmatrix_csc(csgraph) or isspmatrix_lil(csgraph):
-        csgraph = csgraph.tocsr()
-    elif not isspmatrix_csr(csgraph):
+    if not issparse(csgraph):
+        raise ValueError("csgraph must be sparse")
+    if csgraph.format not in ("lil", "csc", "csr"):
         raise ValueError("csgraph must be lil, csr, or csc format")
+    csgraph = csgraph.tocsr()
 
     N = csgraph.shape[0]
     if csgraph.shape[1] != N:

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, isspmatrix_csc
+from scipy.sparse import csr_matrix, issparse
 from ._tools import csgraph_to_dense, csgraph_from_dense,\
     csgraph_masked_from_dense, csgraph_from_masked
 
@@ -17,7 +17,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
 
     # if undirected and csc storage, then transposing in-place
     # is quicker than later converting to csr.
-    if (not directed) and isspmatrix_csc(csgraph):
+    if (not directed) and issparse(csgraph) and csgraph.format == "csc":
         csgraph = csgraph.T
 
     if issparse(csgraph):

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix, isspmatrix_csc
+from scipy.sparse import csr_matrix, issparse, isspmatrix_csc
 from ._tools import csgraph_to_dense, csgraph_from_dense,\
     csgraph_masked_from_dense, csgraph_from_masked
 
@@ -20,7 +20,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
     if (not directed) and isspmatrix_csc(csgraph):
         csgraph = csgraph.T
 
-    if isspmatrix(csgraph):
+    if issparse(csgraph):
         if csr_output:
             csgraph = csr_matrix(csgraph, dtype=DTYPE, copy=copy_if_sparse)
         else:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 from numpy import asarray
-from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, issparse,
+from scipy.sparse import (issparse,
                           SparseEfficiencyWarning, csc_matrix, csr_matrix)
 from scipy.sparse._sputils import is_pydata_spmatrix
 from scipy.linalg import LinAlgError
@@ -209,7 +209,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     if is_pydata_spmatrix(A):
         A = A.to_scipy_sparse().tocsc()
 
-    if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
+    if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_matrix(A)
         warn('spsolve requires A be CSC or CSR matrix format',
                 SparseEfficiencyWarning)
@@ -264,7 +264,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             b_is_sparse = False
 
         if not b_is_sparse:
-            if isspmatrix_csc(A):
+            if A.format == "csc":
                 flag = 1  # CSC format
             else:
                 flag = 0  # CSR format
@@ -281,7 +281,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             # b is sparse
             Afactsolve = factorized(A)
 
-            if not (isspmatrix_csc(b) or is_pydata_spmatrix(b)):
+            if not (b.format == "csc" or is_pydata_spmatrix(b)):
                 warn('spsolve is more efficient when sparse b '
                      'is in the CSC matrix format', SparseEfficiencyWarning)
                 b = csc_matrix(b)
@@ -390,7 +390,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     else:
         csc_construct_func = csc_matrix
 
-    if not isspmatrix_csc(A):
+    if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
         warn('splu converted its input to CSC format', SparseEfficiencyWarning)
 
@@ -482,7 +482,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     else:
         csc_construct_func = csc_matrix
 
-    if not isspmatrix_csc(A):
+    if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
         warn('spilu converted its input to CSC format',
              SparseEfficiencyWarning)
@@ -547,7 +547,7 @@ def factorized(A):
         if noScikit:
             raise RuntimeError('Scikits.umfpack not installed.')
 
-        if not isspmatrix_csc(A):
+        if not (issparse(A) and A.format == "csc"):
             A = csc_matrix(A)
             warn('splu converted its input to CSC format',
                  SparseEfficiencyWarning)
@@ -638,7 +638,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         A = A.to_scipy_sparse().tocsr()
 
     # Check the input for correct type and format.
-    if not isspmatrix_csr(A):
+    if not (issparse(A) and A.format == "csr"):
         warn('CSR matrix format is required. Converting to CSR matrix.',
              SparseEfficiencyWarning)
         A = csr_matrix(A)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 from numpy import asarray
-from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, isspmatrix,
+from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, issparse,
                           SparseEfficiencyWarning, csc_matrix, csr_matrix)
 from scipy.sparse._sputils import is_pydata_spmatrix
 from scipy.linalg import LinAlgError
@@ -215,7 +215,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                 SparseEfficiencyWarning)
 
     # b is a vector only if b have shape (n,) or (n, 1)
-    b_is_sparse = isspmatrix(b) or is_pydata_spmatrix(b)
+    b_is_sparse = issparse(b) or is_pydata_spmatrix(b)
     if not b_is_sparse:
         b = asarray(b)
     b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -14,7 +14,7 @@ from pytest import raises as assert_raises
 import scipy.linalg
 from scipy.linalg import norm, inv
 from scipy.sparse import (spdiags, SparseEfficiencyWarning, csc_matrix,
-        csr_matrix, identity, isspmatrix, dok_matrix, lil_matrix, bsr_matrix)
+        csr_matrix, identity, issparse, dok_matrix, lil_matrix, bsr_matrix)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, use_solver, splu, spilu,
         MatrixRankWarning, _superlu, spsolve_triangular, factorized)
@@ -35,7 +35,7 @@ except ImportError:
     has_umfpack = False
 
 def toarray(a):
-    if isspmatrix(a):
+    if issparse(a):
         return a.toarray()
     else:
         return a
@@ -328,9 +328,9 @@ class TestLinsolve:
                 assert_array_almost_equal(toarray(x2), x, err_msg=repr((b, spmattype, 2)))
 
                 # dense vs. sparse output  ("vectors" are always dense)
-                if isspmatrix(b) and x.ndim > 1:
-                    assert_(isspmatrix(x1), repr((b, spmattype, 1)))
-                    assert_(isspmatrix(x2), repr((b, spmattype, 2)))
+                if issparse(b) and x.ndim > 1:
+                    assert_(issparse(x1), repr((b, spmattype, 1)))
+                    assert_(issparse(x2), repr((b, spmattype, 2)))
                 else:
                     assert_(isinstance(x1, np.ndarray), repr((b, spmattype, 1)))
                     assert_(isinstance(x2, np.ndarray), repr((b, spmattype, 2)))

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -38,7 +38,7 @@ Uses ARPACK: https://github.com/opencollab/arpack-ng
 import numpy as np
 import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
-from scipy.sparse import eye, issparse, isspmatrix, isspmatrix_csr
+from scipy.sparse import eye, issparse, isspmatrix_csr
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
 from scipy.sparse._sputils import isdense, is_pydata_spmatrix
 from scipy.sparse.linalg import gmres, splu

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -38,7 +38,7 @@ Uses ARPACK: https://github.com/opencollab/arpack-ng
 import numpy as np
 import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
-from scipy.sparse import eye, issparse, isspmatrix_csr
+from scipy.sparse import eye, issparse
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
 from scipy.sparse._sputils import isdense, is_pydata_spmatrix
 from scipy.sparse.linalg import gmres, splu
@@ -1038,7 +1038,7 @@ class IterOpInv(LinearOperator):
 
 def _fast_spmatrix_to_csc(A, hermitian=False):
     """Convert sparse matrix to CSC (by transposing, if possible)"""
-    if (isspmatrix_csr(A) and hermitian
+    if (A.format == "csr" and hermitian
             and not np.issubdtype(A.dtype, np.complexfloating)):
         return A.T
     elif is_pydata_spmatrix(A):

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1051,7 +1051,7 @@ def _fast_spmatrix_to_csc(A, hermitian=False):
 def get_inv_matvec(M, hermitian=False, tol=0):
     if isdense(M):
         return LuInv(M).matvec
-    elif isspmatrix(M) or is_pydata_spmatrix(M):
+    elif issparse(M) or is_pydata_spmatrix(M):
         M = _fast_spmatrix_to_csc(M, hermitian=hermitian)
         return SpLuInv(M).matvec
     else:
@@ -1072,7 +1072,7 @@ def get_OPinv_matvec(A, M, sigma, hermitian=False, tol=0):
                 A = A + 0j
             A.flat[::A.shape[1] + 1] -= sigma
             return LuInv(A).matvec
-        elif isspmatrix(A) or is_pydata_spmatrix(A):
+        elif issparse(A) or is_pydata_spmatrix(A):
             A = A - sigma * eye(A.shape[0])
             A = _fast_spmatrix_to_csc(A, hermitian=hermitian)
             return SpLuInv(A).matvec
@@ -1080,8 +1080,8 @@ def get_OPinv_matvec(A, M, sigma, hermitian=False, tol=0):
             return IterOpInv(_aslinearoperator_with_dtype(A),
                              M, sigma, tol=tol).matvec
     else:
-        if ((not isdense(A) and not isspmatrix(A) and not is_pydata_spmatrix(A)) or
-                (not isdense(M) and not isspmatrix(M) and not is_pydata_spmatrix(A))):
+        if ((not isdense(A) and not issparse(A) and not is_pydata_spmatrix(A)) or
+                (not isdense(M) and not issparse(M) and not is_pydata_spmatrix(A))):
             return IterOpInv(_aslinearoperator_with_dtype(A),
                              _aslinearoperator_with_dtype(M),
                              sigma, tol=tol).matvec

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -22,7 +22,7 @@ import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve,
                           cholesky, LinAlgError)
 from scipy.sparse.linalg import LinearOperator
-from scipy.sparse import isspmatrix
+from scipy.sparse import issparse
 from numpy import block as bmat
 
 __all__ = ["lobpcg"]
@@ -493,7 +493,7 @@ def lobpcg(
                         f"The shape {A.shape} of the primary matrix\n"
                         f"defined by a callable object is wrong.\n"
                     )
-            elif isspmatrix(A):
+            elif issparse(A):
                 A = A.toarray()
             else:
                 A = np.asarray(A)
@@ -513,7 +513,7 @@ def lobpcg(
                             f"The shape {B.shape} of the secondary matrix\n"
                             f"defined by a callable object is wrong.\n"
                         )
-                elif isspmatrix(B):
+                elif issparse(B):
                     B = B.toarray()
                 else:
                     B = np.asarray(B)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 import pytest
 
 from scipy.linalg import svd, null_space
-from scipy.sparse import csc_matrix, isspmatrix, spdiags, random
+from scipy.sparse import csc_matrix, issparse, spdiags, random
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 if os.environ.get("SCIPY_USE_PROPACK"):
     has_propack = True
@@ -23,7 +23,7 @@ from scipy.sparse.linalg._eigen.arpack import ArpackNoConvergence
 def sorted_svd(m, k, which='LM'):
     # Compute svd of a dense matrix m, and return singular vectors/values
     # sorted.
-    if isspmatrix(m):
+    if issparse(m):
         m = m.toarray()
     u, s, vh = svd(m)
     if which == 'LM':

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -16,7 +16,7 @@ __all__ = ['expm_multiply']
 
 def _exact_inf_norm(A):
     # A compatibility function which should eventually disappear.
-    if scipy.sparse.isspmatrix(A):
+    if scipy.sparse.issparse(A):
         return max(abs(A).sum(axis=1).flat)
     elif is_pydata_spmatrix(A):
         return max(abs(A).sum(axis=1))
@@ -26,7 +26,7 @@ def _exact_inf_norm(A):
 
 def _exact_1_norm(A):
     # A compatibility function which should eventually disappear.
-    if scipy.sparse.isspmatrix(A):
+    if scipy.sparse.issparse(A):
         return max(abs(A).sum(axis=0).flat)
     elif is_pydata_spmatrix(A):
         return max(abs(A).sum(axis=0))
@@ -91,7 +91,7 @@ def traceest(A, m3, seed=None):
 
 def _ident_like(A):
     # A compatibility function which should eventually disappear.
-    if scipy.sparse.isspmatrix(A):
+    if scipy.sparse.issparse(A):
         return scipy.sparse._construct.eye(A.shape[0], A.shape[1],
                 dtype=A.dtype, format=A.format)
     elif is_pydata_spmatrix(A):

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -92,8 +92,11 @@ def traceest(A, m3, seed=None):
 def _ident_like(A):
     # A compatibility function which should eventually disappear.
     if scipy.sparse.issparse(A):
-        return scipy.sparse._construct.eye(A.shape[0], A.shape[1],
-                dtype=A.dtype, format=A.format)
+        # Creates a sparse matrix in dia format
+        out = scipy.sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)
+        if isinstance(A, scipy.sparse.spmatrix):
+            return out.asformat(A.format)
+        return scipy.sparse.dia_array(out).asformat(A.format)
     elif is_pydata_spmatrix(A):
         import sparse
         return sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -44,7 +44,7 @@ import warnings
 
 import numpy as np
 
-from scipy.sparse import isspmatrix
+from scipy.sparse import issparse
 from scipy.sparse._sputils import isshape, isintlike, asmatrix, is_pydata_spmatrix
 
 __all__ = ['LinearOperator', 'aslinearoperator']
@@ -325,7 +325,7 @@ class LinearOperator:
         _matmat method to ensure that y has the correct type.
 
         """
-        if not (isspmatrix(X) or is_pydata_spmatrix(X)):
+        if not (issparse(X) or is_pydata_spmatrix(X)):
             X = np.asanyarray(X)
 
         if X.ndim != 2:
@@ -337,7 +337,7 @@ class LinearOperator:
         try:
             Y = self._matmat(X)
         except Exception as e:
-            if isspmatrix(X) or is_pydata_spmatrix(X):
+            if issparse(X) or is_pydata_spmatrix(X):
                 raise TypeError(
                     "Unable to multiply a LinearOperator with a sparse matrix."
                     " Wrap the matrix in aslinearoperator first."
@@ -371,7 +371,7 @@ class LinearOperator:
         This rmatmat wraps the user-specified rmatmat routine.
 
         """
-        if not (isspmatrix(X) or is_pydata_spmatrix(X)):
+        if not (issparse(X) or is_pydata_spmatrix(X)):
             X = np.asanyarray(X)
 
         if X.ndim != 2:
@@ -384,7 +384,7 @@ class LinearOperator:
         try:
             Y = self._rmatmat(X)
         except Exception as e:
-            if isspmatrix(X) or is_pydata_spmatrix(X):
+            if issparse(X) or is_pydata_spmatrix(X):
                 raise TypeError(
                     "Unable to multiply a LinearOperator with a sparse matrix."
                     " Wrap the matrix in aslinearoperator() first."
@@ -434,7 +434,7 @@ class LinearOperator:
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            if not isspmatrix(x) and not is_pydata_spmatrix(x):
+            if not issparse(x) and not is_pydata_spmatrix(x):
                 # Sparse matrices shouldn't be converted to numpy arrays.
                 x = np.asarray(x)
 
@@ -487,7 +487,7 @@ class LinearOperator:
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            if not isspmatrix(x) and not is_pydata_spmatrix(x):
+            if not issparse(x) and not is_pydata_spmatrix(x):
                 # Sparse matrices shouldn't be converted to numpy arrays.
                 x = np.asarray(x)
 
@@ -872,7 +872,7 @@ def aslinearoperator(A):
         A = np.atleast_2d(np.asarray(A))
         return MatrixLinearOperator(A)
 
-    elif isspmatrix(A) or is_pydata_spmatrix(A):
+    elif issparse(A) or is_pydata_spmatrix(A):
         return MatrixLinearOperator(A)
 
     else:

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -13,7 +13,7 @@ __all__ = ['expm', 'inv']
 import numpy as np
 from scipy.linalg._basic import solve, solve_triangular
 
-from scipy.sparse._base import isspmatrix
+from scipy.sparse._base import issparse
 from scipy.sparse.linalg import spsolve
 from scipy.sparse._sputils import is_pydata_spmatrix
 
@@ -67,7 +67,7 @@ def inv(A):
 
     """
     # Check input
-    if not (scipy.sparse.isspmatrix(A) or is_pydata_spmatrix(A)):
+    if not (scipy.sparse.issparse(A) or is_pydata_spmatrix(A)):
         raise TypeError('Input must be a sparse matrix')
 
     # Use sparse direct solver to solve "AX = I" accurately
@@ -111,7 +111,7 @@ def _onenorm_matrix_power_nnm(A, p):
 
 def _is_upper_triangular(A):
     # This function could possibly be of wider interest.
-    if isspmatrix(A):
+    if issparse(A):
         lower_part = scipy.sparse.tril(A, -1)
         # Check structural upper triangularity,
         # then coincidental upper triangularity if needed.
@@ -152,7 +152,7 @@ def _smart_matrix_product(A, B, alpha=None, structure=None):
         raise ValueError('expected B to be a rectangular matrix')
     f = None
     if structure == UPPER_TRIANGULAR:
-        if (not isspmatrix(A) and not isspmatrix(B)
+        if (not issparse(A) and not issparse(B)
                 and not is_pydata_spmatrix(A) and not is_pydata_spmatrix(B)):
             f, = scipy.linalg.get_blas_funcs(('trmm',), (A, B))
     if f is not None:
@@ -604,7 +604,7 @@ def _expm(A, use_exact_onenorm):
     # carefully handling sparse scenario
     if A.shape == (0, 0):
         out = np.zeros([0, 0], dtype=A.dtype)
-        if isspmatrix(A) or is_pydata_spmatrix(A):
+        if issparse(A) or is_pydata_spmatrix(A):
             return A.__class__(out)
         return out
 
@@ -614,13 +614,13 @@ def _expm(A, use_exact_onenorm):
 
         # Avoid indiscriminate casting to ndarray to
         # allow for sparse or other strange arrays
-        if isspmatrix(A) or is_pydata_spmatrix(A):
+        if issparse(A) or is_pydata_spmatrix(A):
             return A.__class__(out)
 
         return np.array(out)
 
     # Ensure input is of float type, to avoid integer overflows etc.
-    if ((isinstance(A, np.ndarray) or isspmatrix(A) or is_pydata_spmatrix(A))
+    if ((isinstance(A, np.ndarray) or issparse(A) or is_pydata_spmatrix(A))
             and not np.issubdtype(A.dtype, np.inexact)):
         A = A.astype(float)
 
@@ -702,7 +702,7 @@ def _solve_P_Q(U, V, structure=None):
     """
     P = U + V
     Q = -U + V
-    if isspmatrix(U) or is_pydata_spmatrix(U):
+    if issparse(U) or is_pydata_spmatrix(U):
         return spsolve(Q, P)
     elif structure is None:
         return solve(Q, P)

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -488,3 +488,33 @@ def test_format_property():
         assert M._format == fmt
         with pytest.raises(AttributeError):
             M.format = "qqq"
+
+
+def test_issparse():
+    m = scipy.sparse.eye(3)
+    a = scipy.sparse.csr_array(m)
+    assert not m._is_array
+    assert a._is_array
+
+    # Both sparse arrays and sparse matrices should be sparse
+    assert scipy.sparse.issparse(a)
+    assert scipy.sparse.issparse(m)
+
+    # ndarray and array_likes are not sparse
+    assert not scipy.sparse.issparse(a.todense())
+    assert not scipy.sparse.issparse(m.todense())
+
+
+def test_isspmatrix():
+    m = scipy.sparse.eye(3)
+    a = scipy.sparse.csr_array(m)
+    assert not m._is_array
+    assert a._is_array
+
+    # Should only be true for sparse matrices, not sparse arrays
+    assert not scipy.sparse.isspmatrix(a)
+    assert scipy.sparse.isspmatrix(m)
+
+    # ndarray and array_likes are not sparse
+    assert not scipy.sparse.isspmatrix(a.todense())
+    assert not scipy.sparse.isspmatrix(m.todense())

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -518,3 +518,30 @@ def test_isspmatrix():
     # ndarray and array_likes are not sparse
     assert not scipy.sparse.isspmatrix(a.todense())
     assert not scipy.sparse.isspmatrix(m.todense())
+
+
+@pytest.mark.parametrize(
+    ("fmt", "fn"),
+    (
+        ("bsr", scipy.sparse.isspmatrix_bsr),
+        ("coo", scipy.sparse.isspmatrix_coo),
+        ("csc", scipy.sparse.isspmatrix_csc),
+        ("csr", scipy.sparse.isspmatrix_csr),
+        ("dia", scipy.sparse.isspmatrix_dia),
+        ("dok", scipy.sparse.isspmatrix_dok),
+        ("lil", scipy.sparse.isspmatrix_lil),
+    ),
+)
+def test_isspmatrix_format(fmt, fn):
+    m = scipy.sparse.eye(3, format=fmt)
+    a = scipy.sparse.csr_array(m).asformat(fmt)
+    assert not m._is_array
+    assert a._is_array
+
+    # Should only be true for sparse matrices, not sparse arrays
+    assert not fn(a)
+    assert fn(m)
+
+    # ndarray and array_likes are not sparse
+    assert not fn(a.todense())
+    assert not fn(m.todense())

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -33,7 +33,7 @@ import scipy.linalg
 import scipy.sparse as sparse
 from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
-        eye, isspmatrix, SparseEfficiencyWarning)
+        eye, issparse, SparseEfficiencyWarning)
 from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
                                    get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
@@ -1528,7 +1528,7 @@ class _TestCommon:
                     assert_raises(ValueError, i.multiply, j)
                     continue
                 sp_mult = i.multiply(j)
-                if isspmatrix(sp_mult):
+                if issparse(sp_mult):
                     assert_almost_equal(sp_mult.toarray(), dense_mult)
                 else:
                     assert_almost_equal(sp_mult, dense_mult)
@@ -1596,7 +1596,7 @@ class _TestCommon:
         # test that A*x works for x with shape () (1,) (1,1) and (1,0)
         A = self.spcreator([[1],[2],[3]])
 
-        assert_(isspmatrix(A * array(1)))
+        assert_(issparse(A * array(1)))
         assert_equal((A * array(1)).toarray(), [[1], [2], [3]])
 
         assert_equal(A @ array([1]), array([1, 2, 3]))
@@ -2894,7 +2894,7 @@ class _TestFancyIndexing:
         S = self.spcreator(D)
 
         SIJ = S[I,J]
-        if isspmatrix(SIJ):
+        if issparse(SIJ):
             SIJ = SIJ.toarray()
         assert_equal(SIJ, D[I,J])
 
@@ -3142,7 +3142,7 @@ class _TestFancyMultidim:
             S = self.spcreator(D)
 
             SIJ = S[I,J]
-            if isspmatrix(SIJ):
+            if issparse(SIJ):
                 SIJ = SIJ.toarray()
             assert_equal(SIJ, D[I,J])
 
@@ -3800,7 +3800,7 @@ class TestCSR(sparse_test_class()):
         S = self.spcreator(D)
 
         SIJ = S[I,J]
-        if isspmatrix(SIJ):
+        if issparse(SIJ):
             SIJ = SIJ.toarray()
         assert_equal(SIJ, D[I,J])
 
@@ -4012,7 +4012,7 @@ class TestCSC(sparse_test_class()):
         S = self.spcreator(D)
 
         SIJ = S[I,J]
-        if isspmatrix(SIJ):
+        if issparse(SIJ):
             SIJ = SIJ.toarray()
         assert_equal(SIJ, D[I,J])
 


### PR DESCRIPTION
Closes #15790

Updates `isspmatrix` so that it is no longer an alias of `issparse`. After #18440, it became possible to define the functions so that `issparse` returns `True` for both sparse arrays and sparse matrices, while `isspmatrix` returns True *only* for sparse matrices and not sparse arrays. This makes the behavior of the functions more accurately reflect their name.

Note that this is a breaking change necessitating updating internal usage of `isspmatrix`. 