### PR TITLE
API: Proposal to add `array` namespace for sparse array creation functions

### DIFF
--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -51,6 +51,7 @@ PUBLIC_MODULES = ["scipy." + s for s in [
     "signal",
     "signal.windows",
     "sparse",
+    "sparse.array",
     "sparse.linalg",
     "sparse.csgraph",
     "spatial",

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -282,6 +282,9 @@ from ._matrix import spmatrix
 from ._matrix_io import *
 from ._matrix_construct import *
 
+# Namespace for array creation functions
+from . import array
+
 # For backward compatibility with v0.19.
 from . import csgraph
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -277,10 +277,10 @@ from ._dok import *
 from ._coo import *
 from ._dia import *
 from ._bsr import *
-from ._construct import *
 from ._extract import *
 from ._matrix import spmatrix
 from ._matrix_io import *
+from ._matrix_construct import *
 
 # For backward compatibility with v0.19.
 from . import csgraph

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -392,7 +392,9 @@ class dia_array(_data_matrix):
     def tocoo(self, copy=False):
         num_rows, num_cols = self.shape
         num_offsets, offset_len = self.data.shape
-        offset_inds = np.arange(offset_len)
+
+        idx_dtype = self._get_index_dtype(maxval=max(self.shape))
+        offset_inds = np.arange(offset_len, dtype=idx_dtype)
 
         row = offset_inds - self.offsets[:,None]
         mask = (row >= 0)

--- a/scipy/sparse/_matrix_construct.py
+++ b/scipy/sparse/_matrix_construct.py
@@ -1,0 +1,93 @@
+"""Functions to construct sparse matrices
+"""
+
+__all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
+           'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag']
+
+from . import _construct
+from ._bsr import bsr_matrix
+from ._coo import coo_matrix
+from ._csc import csc_matrix
+from ._csr import csr_matrix
+from ._dia import dia_matrix
+from ._dok import dok_matrix
+from ._lil import lil_matrix
+from ._matrix import _array_doc_to_matrix
+
+_fmt_to_spmatrix = {
+    "bsr": bsr_matrix, "coo": coo_matrix, "csc": csc_matrix, "csr": csr_matrix,
+    "dia": dia_matrix, "dok": dok_matrix, "lil": lil_matrix,
+}
+
+
+def block_diag(mats, format=None, dtype=None):
+    A = _construct.block_diag(mats, format, dtype)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def bmat(blocks, format=None, dtype=None):
+    A = _construct.bmat(blocks, format, dtype)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
+    A = _construct.diags(diagonals, offsets, shape, format, dtype)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def eye(m, n=None, k=0, dtype=float, format=None):
+    A = _construct.eye(m, n, k, dtype, format)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def hstack(blocks, format=None, dtype=None):
+    A = _construct.hstack(blocks, format, dtype)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def identity(n, dtype='d', format=None):
+    A = _construct.identity(n, dtype, format)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def kron(A, B, format=None):
+    A = _construct.kron(A, B, format)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def kronsum(A, B, format=None):
+    A = _construct.kronsum(A, B, format)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def random(m, n, density=0.01, format='coo', dtype=None, random_state=None,
+           data_rvs=None):
+    A = _construct.random(m, n, density, format, dtype, random_state, data_rvs)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
+    A = _construct.rand(m, n, density, format, dtype, random_state)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def spdiags(data, diags, m, n, format=None):
+    A = _construct.spdiags(data, diags, m, n, format)
+    return _fmt_to_spmatrix[A.format](A)
+
+
+def vstack(blocks, format=None, dtype=None):
+    A = _construct.vstack(blocks, format, dtype)
+    return _fmt_to_spmatrix[A.format](A)
+
+block_diag.__doc__ = _array_doc_to_matrix(_construct.block_diag.__doc__)
+bmat.__doc__ = _array_doc_to_matrix(_construct.bmat.__doc__)
+diags.__doc__ = _array_doc_to_matrix(_construct.diags.__doc__)
+eye.__doc__ = _array_doc_to_matrix(_construct.eye.__doc__)
+hstack.__doc__ = _array_doc_to_matrix(_construct.hstack.__doc__)
+identity.__doc__ = _array_doc_to_matrix(_construct.identity.__doc__)
+kron.__doc__ = _array_doc_to_matrix(_construct.kron.__doc__)
+kronsum.__doc__ = _array_doc_to_matrix(_construct.kronsum.__doc__)
+random.__doc__ = _array_doc_to_matrix(_construct.random.__doc__)
+spdiags.__doc__ = _array_doc_to_matrix(_construct.spdiags.__doc__)
+vstack.__doc__ = _array_doc_to_matrix(_construct.vstack.__doc__)

--- a/scipy/sparse/array.py
+++ b/scipy/sparse/array.py
@@ -1,0 +1,7 @@
+"""Functions for creating sparse arrays
+"""
+
+__all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
+           'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag']
+
+from ._construct import *

--- a/scipy/sparse/meson.build
+++ b/scipy/sparse/meson.build
@@ -28,6 +28,7 @@ python_sources = [
   '_extract.py',
   '_index.py',
   '_lil.py',
+  '_matrix_construct.py',
   '_matrix_io.py',
   '_matrix.py',
   '_spfuncs.py',

--- a/scipy/sparse/meson.build
+++ b/scipy/sparse/meson.build
@@ -33,6 +33,7 @@ python_sources = [
   '_matrix.py',
   '_spfuncs.py',
   '_sputils.py',
+  'array.py',
   'base.py',
   'bsr.py',
   'compressed.py',

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -404,64 +404,107 @@ def test_index_dtype_compressed(cls, indices_attrs, expected_dtype):
 
 
 def test_default_is_matrix_diags():
-    m = scipy.sparse.diags([0, 1, 2])
+    inp = [0, 1, 2]
+    m = scipy.sparse.diags(inp)
     assert not m._is_array
+
+    a = scipy.sparse.array.diags(inp)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_default_is_matrix_eye():
     m = scipy.sparse.eye(3)
     assert not m._is_array
 
+    a = scipy.sparse.array.eye(3)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
+
 
 def test_default_is_matrix_spdiags():
-    m = scipy.sparse.spdiags([1, 2, 3], 0, 3, 3)
+    inp = ([1, 2, 3], 0, 3, 3)
+    m = scipy.sparse.spdiags(*inp)
     assert not m._is_array
+
+    a = scipy.sparse.array.spdiags(*inp)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_default_is_matrix_identity():
     m = scipy.sparse.identity(3)
     assert not m._is_array
 
+    a = scipy.sparse.array.identity(3)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
+
 
 def test_default_is_matrix_kron_dense():
-    m = scipy.sparse.kron(
-        np.array([[1, 2], [3, 4]]), np.array([[4, 3], [2, 1]])
-    )
+    inp = (np.array([[1, 2], [3, 4]]), np.array([[4, 3], [2, 1]]))
+    m = scipy.sparse.kron(*inp)
     assert not m._is_array
+
+    a = scipy.sparse.array.kron(*inp)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_default_is_matrix_kron_sparse():
-    m = scipy.sparse.kron(
-        np.array([[1, 2], [3, 4]]), np.array([[1, 0], [0, 0]])
-    )
+    inp = (np.array([[1, 2], [3, 4]]), np.array([[1, 0], [0, 0]]))
+    m = scipy.sparse.kron(*inp)
     assert not m._is_array
+
+    a = scipy.sparse.array.kron(*inp)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_default_is_matrix_kronsum():
-    m = scipy.sparse.kronsum(
-        np.array([[1, 0], [0, 1]]), np.array([[0, 1], [1, 0]])
-    )
+    inp = (np.array([[1, 0], [0, 1]]), np.array([[0, 1], [1, 0]]))
+    m = scipy.sparse.kronsum(*inp)
     assert not m._is_array
+
+    a = scipy.sparse.array.kronsum(*inp)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_default_is_matrix_random():
     m = scipy.sparse.random(3, 3)
     assert not m._is_array
 
+    a = scipy.sparse.array.random(3, 3)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
+
 
 def test_default_is_matrix_rand():
     m = scipy.sparse.rand(3, 3)
     assert not m._is_array
 
+    a = scipy.sparse.array.rand(3, 3)
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
-@pytest.mark.parametrize("fn", (scipy.sparse.hstack, scipy.sparse.vstack))
+
+@pytest.mark.parametrize("fn", ("hstack", "vstack"))
 def test_default_is_matrix_stacks(fn):
     """Same idea as `test_default_construction_fn_matrices`, but for the
     stacking creation functions."""
+    # Inputs
     A = scipy.sparse.coo_matrix(np.eye(2))
     B = scipy.sparse.coo_matrix([[0, 1], [1, 0]])
-    m = fn([A, B])
+
+    # Matrix and array version of creation function
+    mat_fn = getattr(scipy.sparse, fn)
+    ary_fn = getattr(scipy.sparse.array, fn)
+
+    m, a = mat_fn([A, B]), ary_fn([A, B])
     assert not m._is_array
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
 
 def test_blocks_default_construction_fn_matrices():
@@ -474,7 +517,13 @@ def test_blocks_default_construction_fn_matrices():
     # block diag
     m = scipy.sparse.block_diag((A, B, C))
     assert not m._is_array
+    a = scipy.sparse.array.block_diag((A, B, C))
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())
 
     # bmat
     m = scipy.sparse.bmat([[A, None], [None, C]])
     assert not m._is_array
+    a = scipy.sparse.array.bmat([[A, None], [None, C]])
+    assert a._is_array
+    npt.assert_array_equal(m.toarray(), a.toarray())

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -143,7 +143,8 @@ def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None,
         modules = [scipy.sparse._bsr, scipy.sparse._coo, scipy.sparse._csc,
                    scipy.sparse._csr, scipy.sparse._dia, scipy.sparse._dok,
                    scipy.sparse._lil, scipy.sparse._sputils,
-                   scipy.sparse._compressed, scipy.sparse._construct]
+                   scipy.sparse._compressed, scipy.sparse._construct,
+                   scipy.sparse._matrix_construct]
         try:
             for mod in modules:
                 backup.append((mod, 'get_index_dtype',


### PR DESCRIPTION
This supercedes #16033 , which predated #18044 which switched the inheritance hierarchy for sparray->spmatrix. This PR is the spiritual successor to #16033.

The focus of the proposal is the addition of a new namespace, tentatively named `scipy.sparse.array`, to expose versions of the sparse creation functions that return sparse arrays rather than sparse matrices.

This PR also applies the same philosophy as #18440 in flipping the default implementation of the sparse creation functions to use sparse arrays under-the-hood instead of matrices. User-space remains unaffected, i.e. `scipy.sparse.eye(3)` still returns a sparse matrix instead of a sparse array.