### PR TITLE
Fix format property in _csr.py

### DIFF
--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -131,7 +131,7 @@ class csr_array(_cs_matrix):
            [0, 1, 1, 1]])
 
     """
-    format = 'csr'
+    _format = 'csr'
 
     def transpose(self, axes=None, copy=False):
         if axes is not None:

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -478,3 +478,13 @@ def test_blocks_default_construction_fn_matrices():
     # bmat
     m = scipy.sparse.bmat([[A, None], [None, C]])
     assert not m._is_array
+
+
+def test_format_property():
+    for fmt in sparray_types:
+        arr_cls = getattr(scipy.sparse, f"{fmt}_array")
+        M = arr_cls([[1, 2]])
+        assert M.format == fmt
+        assert M._format == fmt
+        with pytest.raises(AttributeError, match=r"can't set attribute"):
+            M.format = "qqq"

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -486,5 +486,5 @@ def test_format_property():
         M = arr_cls([[1, 2]])
         assert M.format == fmt
         assert M._format == fmt
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError):
             M.format = "qqq"

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -31,10 +31,9 @@ from pytest import raises as assert_raises
 import scipy.linalg
 
 import scipy.sparse as sparse
-from scipy.sparse import (
-    bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dia_matrix, dok_matrix, lil_matrix,
-    bsr_array, coo_array, csc_array, csr_array, dia_array, dok_array, lil_array,
-    eye, isspmatrix, SparseEfficiencyWarning)
+from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
+        coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
+        eye, isspmatrix, SparseEfficiencyWarning)
 from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
                                    get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
@@ -1253,18 +1252,6 @@ class _TestCommon:
         spbool = self.spmatrix(self.dat, dtype=bool)
         arrbool = dat.astype(bool)
         assert_array_equal(spbool.toarray(), arrbool)
-
-    def test_format_property(self):
-        ARR_CLASSES = [bsr_array, coo_array, csc_array, csr_array,
-                       dia_array, dok_array, lil_array]
-        formats = ["bsr", "coo", "csc", "csr", "dia", "dok", "lil"]
-        for xxx, cls in zip(formats, ARR_CLASSES):
-            M = cls([[1, 2]])
-            assert M.format == xxx
-            assert M._format == xxx
-            assert M._format == xxx
-            with pytest.raises(AttributeError, match=r"can't set attribute"):
-                M.format = "qqq"
 
     @sup_complex
     def test_astype(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -31,9 +31,10 @@ from pytest import raises as assert_raises
 import scipy.linalg
 
 import scipy.sparse as sparse
-from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
-        coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
-        eye, isspmatrix, SparseEfficiencyWarning)
+from scipy.sparse import (
+    bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dia_matrix, dok_matrix, lil_matrix,
+    bsr_array, coo_array, csc_array, csr_array, dia_array, dok_array, lil_array,
+    eye, isspmatrix, SparseEfficiencyWarning)
 from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
                                    get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
@@ -1252,6 +1253,18 @@ class _TestCommon:
         spbool = self.spmatrix(self.dat, dtype=bool)
         arrbool = dat.astype(bool)
         assert_array_equal(spbool.toarray(), arrbool)
+
+    def test_format_property(self):
+        ARR_CLASSES = [bsr_array, coo_array, csc_array, csr_array,
+                       dia_array, dok_array, lil_array]
+        formats = ["bsr", "coo", "csc", "csr", "dia", "dok", "lil"]
+        for xxx, cls in zip(formats, ARR_CLASSES):
+            M = cls([[1, 2]])
+            assert M.format == xxx
+            assert M._format == xxx
+            assert M._format == xxx
+            with pytest.raises(AttributeError, match=r"can't set attribute"):
+                M.format = "qqq"
 
     @sup_complex
     def test_astype(self):


### PR DESCRIPTION
Fix format property in _csr.py
The class attribute `format` was set instead of `_format` in _csr.py so the `format` property was blocked, and the exposed value was editable.

This fixes that and adds a test to check that the format property is not writable.