### PR TITLE
ENH: sparse: Add _array version of `diags` creation functions.

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -74,6 +74,13 @@ Sparse matrix classes
 Functions
 ---------
 
+Building sparse arrays:
+
+.. autosummary::
+   :toctree: generated/
+
+   diags_array - Return a sparse array from diagonals
+
 Building sparse matrices:
 
 .. autosummary::

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -98,7 +98,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
 
     Notes
     -----
-    The result from `diags` is the sparse equivalent of::
+    The result from `diags_array` is the sparse equivalent of::
 
         np.diag(diagonals[0], offsets[0])
         + ...

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -105,6 +105,8 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
 
     Repeated diagonal offsets are disallowed.
 
+    .. versionadded:: 1.11
+
     Examples
     --------
     >>> from scipy.sparse import diags_array

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -22,7 +22,6 @@ from ._csr import csr_matrix
 from ._dia import dia_matrix, dia_array
 
 from ._base import issparse
-from ._matrix import _array_doc_to_matrix
 
 
 def spdiags(data, diags, m=None, n=None, format=None):
@@ -105,8 +104,6 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
         + np.diag(diagonals[k], offsets[k])
 
     Repeated diagonal offsets are disallowed.
-
-    .. versionadded:: 0.11
 
     Examples
     --------
@@ -192,9 +189,79 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
+    """
+    Construct a sparse matrix from diagonals.
+
+    Parameters
+    ----------
+    diagonals : sequence of array_like
+        Sequence of arrays containing the matrix diagonals,
+        corresponding to `offsets`.
+    offsets : sequence of int or an int, optional
+        Diagonals to set:
+          - k = 0  the main diagonal (default)
+          - k > 0  the kth upper diagonal
+          - k < 0  the kth lower diagonal
+    shape : tuple of int, optional
+        Shape of the result. If omitted, a square matrix large enough
+        to contain the diagonals is returned.
+    format : {"dia", "csr", "csc", "lil", ...}, optional
+        Matrix format of the result. By default (format=None) an
+        appropriate sparse matrix format is returned. This choice is
+        subject to change.
+    dtype : dtype, optional
+        Data type of the matrix.
+
+    See Also
+    --------
+    spdiags : construct matrix from diagonals
+
+    Notes
+    -----
+    This function differs from `spdiags` in the way it handles
+    off-diagonals.
+
+    The result from `diags` is the sparse equivalent of::
+
+        np.diag(diagonals[0], offsets[0])
+        + ...
+        + np.diag(diagonals[k], offsets[k])
+
+    Repeated diagonal offsets are disallowed.
+
+    .. versionadded:: 0.11
+
+    Examples
+    --------
+    >>> from scipy.sparse import diags
+    >>> diagonals = [[1, 2, 3, 4], [1, 2, 3], [1, 2]]
+    >>> diags(diagonals, [0, -1, 2]).toarray()
+    array([[1, 0, 1, 0],
+           [1, 2, 0, 2],
+           [0, 2, 3, 0],
+           [0, 0, 3, 4]])
+
+    Broadcasting of scalars is supported (but shape needs to be
+    specified):
+
+    >>> diags([1, -2, 1], [-1, 0, 1], shape=(4, 4)).toarray()
+    array([[-2.,  1.,  0.,  0.],
+           [ 1., -2.,  1.,  0.],
+           [ 0.,  1., -2.,  1.],
+           [ 0.,  0.,  1., -2.]])
+
+
+    If only one diagonal is wanted (as in `numpy.diag`), the following
+    works as well:
+
+    >>> diags([1, 2, 3], 1).toarray()
+    array([[ 0.,  1.,  0.,  0.],
+           [ 0.,  0.,  2.,  0.],
+           [ 0.,  0.,  0.,  3.],
+           [ 0.,  0.,  0.,  0.]])
+    """
     A = diags_array(diagonals, offsets=offsets, shape=shape, dtype=dtype)
     return dia_matrix(A).asformat(format)
-diags.__doc__ = _array_doc_to_matrix(diags_array.__doc__)
 
 
 def identity(n, dtype='d', format=None):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -72,7 +72,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
-def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None):
+def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None):
     """
     Construct a sparse array from diagonals.
 
@@ -112,7 +112,7 @@ def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None)
     --------
     >>> from scipy.sparse import diags_array
     >>> diagonals = [[1, 2, 3, 4], [1, 2, 3], [1, 2]]
-    >>> diags_array(diagonals, [0, -1, 2]).toarray()
+    >>> diags_array(diagonals, offsets=[0, -1, 2]).toarray()
     array([[1, 0, 1, 0],
            [1, 2, 0, 2],
            [0, 2, 3, 0],
@@ -121,7 +121,7 @@ def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None)
     Broadcasting of scalars is supported (but shape needs to be
     specified):
 
-    >>> diags_array([1, -2, 1], [-1, 0, 1], shape=(4, 4)).toarray()
+    >>> diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(4, 4)).toarray()
     array([[-2.,  1.,  0.,  0.],
            [ 1., -2.,  1.,  0.],
            [ 0.,  1., -2.,  1.],
@@ -131,7 +131,7 @@ def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None)
     If only one diagonal is wanted (as in `numpy.diag`), the following
     works as well:
 
-    >>> diags_array([1, 2, 3], 1).toarray()
+    >>> diags_array([1, 2, 3], offsets=1).toarray()
     array([[ 0.,  1.,  0.,  0.],
            [ 0.,  0.,  2.,  0.],
            [ 0.,  0.,  0.,  3.],
@@ -192,7 +192,7 @@ def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
-    A = diags_array(diagonals, offsets, shape=shape, dtype=dtype)
+    A = diags_array(diagonals, offsets=offsets, shape=shape, dtype=dtype)
     return dia_matrix(A).asformat(format)
 diags.__doc__ = _array_doc_to_matrix(diags_array.__doc__)
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -26,11 +26,6 @@ from ._lil import lil_matrix
 from ._base import issparse
 from ._matrix import _array_doc_to_matrix
 
-_fmt_to_spmatrix = {
-    "bsr": bsr_matrix, "coo": coo_matrix, "csc": csc_matrix, "csr": csr_matrix,
-    "dia": dia_matrix, "dok": dok_matrix, "lil": lil_matrix,
-}
-
 
 def spdiags(data, diags, m=None, n=None, format=None):
     """
@@ -199,8 +194,8 @@ def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
-    A = diags_array(diagonals, offsets, shape=shape, format=format, dtype=dtype)
-    return _fmt_to_spmatrix[A.format](A)
+    A = diags_array(diagonals, offsets, shape=shape, dtype=dtype)
+    return dia_matrix(A).asformat(format)
 diags.__doc__ = _array_doc_to_matrix(diags_array.__doc__)
 
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -79,7 +79,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
-def diags_array(diagonals, offsets=0, shape=None, format=None, dtype=None):
+def diags_array(diagonals, offsets=0, *, shape=None, format=None, dtype=None):
     """
     Construct a sparse array from diagonals.
 
@@ -199,7 +199,7 @@ def diags_array(diagonals, offsets=0, shape=None, format=None, dtype=None):
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
-    A = diags_array(diagonals, offsets, shape, format, dtype)
+    A = diags_array(diagonals, offsets, shape=shape, format=format, dtype=dtype)
     return _fmt_to_spmatrix[A.format](A)
 diags.__doc__ = _array_doc_to_matrix(diags_array.__doc__)
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -20,8 +20,6 @@ from ._coo import coo_matrix
 from ._csc import csc_matrix
 from ._csr import csr_matrix
 from ._dia import dia_matrix, dia_array
-from ._dok import dok_matrix
-from ._lil import lil_matrix
 
 from ._base import issparse
 from ._matrix import _array_doc_to_matrix

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -79,7 +79,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
-def diags_array(diagonals, offsets=0, *, shape=None, format=None, dtype=None):
+def diags_array(diagonals, /, offsets=0, *, shape=None, format=None, dtype=None):
     """
     Construct a sparse array from diagonals.
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -146,5 +146,4 @@ def _array_doc_to_matrix(docstr):
     return (
         docstr.replace('sparse arrays', 'sparse matrices')
               .replace('sparse array', 'sparse matrix')
-              .replace('diags_array', 'diags')
     )

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -146,4 +146,5 @@ def _array_doc_to_matrix(docstr):
     return (
         docstr.replace('sparse arrays', 'sparse matrices')
               .replace('sparse array', 'sparse matrix')
+              .replace('diags_array', 'diags')
     )

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -147,12 +147,12 @@ class TestConstructUtils:
 
         for d, o, shape, result in cases:
             err_msg = f"{d!r} {o!r} {shape!r} {result!r}"
-            assert_equal(construct.diags(d, o, shape=shape).toarray(),
+            assert_equal(construct.diags(d, offsets=o, shape=shape).toarray(),
                          result, err_msg=err_msg)
 
             if shape[0] == shape[1] and hasattr(d[0], '__len__') and len(d[0]) <= max(shape):
                 # should be able to find the shape automatically
-                assert_equal(construct.diags(d, o).toarray(), result,
+                assert_equal(construct.diags(d, offsets=o).toarray(), result,
                              err_msg=err_msg)
 
     def test_diags_default(self):
@@ -178,9 +178,9 @@ class TestConstructUtils:
         cases.append(([a], 0, None))
 
         for d, o, shape in cases:
-            assert_raises(ValueError, construct.diags, d, o, shape)
+            assert_raises(ValueError, construct.diags, d, offsets=o, shape=shape)
 
-        assert_raises(TypeError, construct.diags, [[None]], [0])
+        assert_raises(TypeError, construct.diags, [[None]], offsets=[0])
 
     def test_diags_vs_diag(self):
         # Check that
@@ -199,26 +199,26 @@ class TestConstructUtils:
 
             diagonals = [np.random.rand(n - abs(q)) for q in offsets]
 
-            mat = construct.diags(diagonals, offsets)
+            mat = construct.diags(diagonals, offsets=offsets)
             dense_mat = sum([np.diag(x, j) for x, j in zip(diagonals, offsets)])
 
             assert_array_almost_equal_nulp(mat.toarray(), dense_mat)
 
             if len(offsets) == 1:
-                mat = construct.diags(diagonals[0], offsets[0])
+                mat = construct.diags(diagonals[0], offsets=offsets[0])
                 dense_mat = np.diag(diagonals[0], offsets[0])
                 assert_array_almost_equal_nulp(mat.toarray(), dense_mat)
 
     def test_diags_dtype(self):
-        x = construct.diags([2.2], [0], shape=(2, 2), dtype=int)
+        x = construct.diags([2.2], offsets=[0], shape=(2, 2), dtype=int)
         assert_equal(x.dtype, int)
         assert_equal(x.toarray(), [[2, 0], [0, 2]])
 
     def test_diags_one_diagonal(self):
         d = list(range(5))
         for k in range(-5, 6):
-            assert_equal(construct.diags(d, k).toarray(),
-                         construct.diags([d], [k]).toarray())
+            assert_equal(construct.diags(d, offsets=k).toarray(),
+                         construct.diags([d], offsets=[k]).toarray())
 
     def test_diags_empty(self):
         x = construct.diags([])

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -580,3 +580,22 @@ class TestConstructUtils:
         sparse_matrix = construct.random(10, 10, density=0.1265)
         assert_equal(sparse_matrix.count_nonzero(),13)
 
+
+def test_diags_array():
+    """Tests of diags_array that do not rely on diags wrapper."""
+    diag = np.arange(1, 5)
+
+    assert_array_equal(construct.diags_array(diag).toarray(), np.diag(diag))
+
+    assert_array_equal(
+        construct.diags_array(diag, offsets=2).toarray(), np.diag(diag, k=2)
+    )
+
+    assert_array_equal(
+        construct.diags_array(diag, offsets=2, shape=(4, 4)).toarray(),
+        np.diag(diag, k=2)[:4, :4]
+    )
+
+    # Offset outside bounds when shape specified
+    with pytest.raises(ValueError, match=".*out of bounds"):
+        construct.diags(np.arange(1, 5), 5, shape=(4, 4))


### PR DESCRIPTION
Yet another API proposal for the creation functions. The proposal is to add new functions for array creation, where `_array` is added to the function name. This PR does so for a single function to illustrate the pattern: it adds a `diags_array`.

One motivation for adding new functions instead of adding a keyword argument as proposed in #16033 is that a new function affords the flexibility to change things about the signature to better support new/future code. For example, the signature of `sparse.random` implicitly only supports 2D arrays as the shape is indicated as individual arguments `m` and `n`. With a new function, the signature can be updated to expect a shape tuple instead:

```python
>>> a = sp.sparse.random_array((m, n))
```

Adding new functions also has other related benefits, e.g. the ability to introduce keyword-only arguments.

### Transition plan

The general path towards replacing scipy.sparse matrices with arrays would look something like:
 - `scipy.sparse.diags` will raise a deprecation warning recommending users switch to `scipy.sparse.diags_array`
 - When the deprecation expires, `diags_array` will become an alias of `diags`, which returns arrays.
 - `diags_array` will eventually itself be deprecated once the sparse matrix removal is complete