### PR TITLE
DOC: sparse: Document sparse canonical formats

### DIFF
--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -195,7 +195,8 @@ Now there are only five stored elements in our sparse array, and it is identical
 Canonical formats
 -----------------
 
-Several sparse array formats have "canonical formats" to allow for more efficient operations. Generally these consist of added restrictions like:
+Several sparse array formats have "canonical formats" to allow for more efficient operations.
+Generally these consist of added restrictions like:
 
 - No duplicate entries for any value
 - Sorted indices

--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -192,6 +192,29 @@ Now there are only five stored elements in our sparse array, and it is identical
           [0, 4, 1, 0],
           [0, 0, 5, 0]])
 
+Canonical formats
+-----------------
+
+Several sparse array formats have "canonical formats" to allow for more efficient operations. Generally these consist of added restrictions like:
+
+- No duplicate entries for any value
+- Sorted indices
+
+Classes with a canonical form include: :func:`coo_array()`, :func:`csr_array`, :func:`csc_array`, and :func:`bsr_array`.
+See the docstrings of these classes for details on each classes canonical representations.
+
+To check if an instance of these classes is in canonical form, use the ``.has_canonical_format`` attribute:
+
+   >>> coo = sparse.coo_array(([1, 1, 1], ([0, 2, 1], [0, 1, 2])))
+   >>> coo.has_canonical_format
+   False
+
+To convert an instance to canonical form, use the ``.sum_duplicates()`` method:
+
+   >>> coo.sum_duplicates()
+   >>> coo.has_canonical_format
+   True
+
 Next steps with sparse arrays 
 -------------------------------
 

--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -201,7 +201,7 @@ Generally these consist of added restrictions like:
 - No duplicate entries for any value
 - Sorted indices
 
-Classes with a canonical form include: :func:`coo_array()`, :func:`csr_array`, :func:`csc_array`, and :func:`bsr_array`.
+Classes with a canonical form include: :func:`coo_array`, :func:`csr_array`, :func:`csc_array`, and :func:`bsr_array`.
 See the docstrings of these classes for details on each classes canonical representations.
 
 To check if an instance of these classes is in canonical form, use the ``.has_canonical_format`` attribute:

--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -202,7 +202,7 @@ Generally these consist of added restrictions like:
 - Sorted indices
 
 Classes with a canonical form include: :func:`coo_array`, :func:`csr_array`, :func:`csc_array`, and :func:`bsr_array`.
-See the docstrings of these classes for details on each classes canonical representations.
+See the docstrings of these classes for details on each canonical representation.
 
 To check if an instance of these classes is in canonical form, use the ``.has_canonical_format`` attribute:
 

--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -206,7 +206,7 @@ See the docstrings of these classes for details on each canonical representation
 
 To check if an instance of these classes is in canonical form, use the ``.has_canonical_format`` attribute:
 
-   >>> coo = sparse.coo_array(([1, 1, 1], ([0, 2, 1], [0, 1, 2])))
+   >>> coo = sp.sparse.coo_array(([1, 1, 1], ([0, 2, 1], [0, 1, 2])))
    >>> coo.has_canonical_format
    False
 

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -88,6 +88,11 @@ class bsr_array(_cs_matrix, _minmax_mixin):
     If no blocksize is specified, a simple heuristic is applied to determine
     an appropriate blocksize.
 
+    **Canonical Format**
+
+    In canonical format, there are no duplicate blocks and indices are sorted
+    per row.
+
     Examples
     --------
     >>> from scipy.sparse import bsr_array

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -86,6 +86,18 @@ class coo_array(_data_matrix, _minmax_mixin):
           entries will be summed together.  This facilitates efficient
           construction of finite element matrices and the like. (see example)
 
+    Canonical COOrdinate format
+        - In order to perform fast operations on COO format arrays, it is
+          useful to enforce a canonical form.  There are three rules for this
+          form:
+            1. Indices are sorted by row, then column
+            2. No duplicate entries for (i,j) allowed
+        - You can tell if an array is in canonical COO form by checking
+          the property ``array.has_canonical_format``
+        - For arrays which are not in canonical format, the indices may not be sorted,
+          and there may be duplicated values for any (i, j) location. Canoncial format
+          COO arrays MAY have explicit zeros.
+        
     Examples
     --------
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -86,11 +86,11 @@ class coo_array(_data_matrix, _minmax_mixin):
           entries will be summed together.  This facilitates efficient
           construction of finite element matrices and the like. (see example)
 
-    Canonical COOrdinate format
-        - Entries sorted by row, then column indices sorted per row, 
+    Canonical format
+        - Entries sorted by row, then column indices sorted per row,
         - There are no duplicate entries (i.e. duplicate (i,j) locations)
         - Arrays MAY have explicit zeros.
-        
+
     Examples
     --------
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -87,16 +87,9 @@ class coo_array(_data_matrix, _minmax_mixin):
           construction of finite element matrices and the like. (see example)
 
     Canonical COOrdinate format
-        - In order to perform fast operations on COO format arrays, it is
-          useful to enforce a canonical form.  There are three rules for this
-          form:
-            1. Indices are sorted by row, then column
-            2. No duplicate entries for (i,j) allowed
-        - You can tell if an array is in canonical COO form by checking
-          the property ``array.has_canonical_format``
-        - For arrays which are not in canonical format, the indices may not be sorted,
-          and there may be duplicated values for any (i, j) location. Canoncial format
-          COO arrays MAY have explicit zeros.
+        - Entries sorted by row, then column indices sorted per row, 
+        - There are no duplicate entries (i.e. duplicate (i,j) locations)
+        - Arrays MAY have explicit zeros.
         
     Examples
     --------

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -87,7 +87,7 @@ class coo_array(_data_matrix, _minmax_mixin):
           construction of finite element matrices and the like. (see example)
 
     Canonical format
-        - Entries sorted by row, then column indices sorted per row,
+        - Entries and indices sorted by row, then column.
         - There are no duplicate entries (i.e. duplicate (i,j) locations)
         - Arrays MAY have explicit zeros.
 

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -77,7 +77,7 @@ class csc_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical format
-      - In the canonical format, CSC matrices have indices sorted per column, 
+      - In the canonical format, CSC matrices have indices sorted per column,
         and cannot contain duplicate entries.
 
     Examples

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -77,8 +77,8 @@ class csc_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical format
-      - In the canonical format, CSC matrices have indices sorted per column,
-        and cannot contain duplicate entries.
+      - Within each column, indices are sorted by row.
+      - There are no duplicate entries.
 
     Examples
     --------

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -79,6 +79,7 @@ class csc_array(_cs_matrix):
     Canonical format
       - In the canonical format, CSC matrices have indices sorted per row, 
         and cannot contain duplicate entries.
+
     Examples
     --------
 

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -77,7 +77,7 @@ class csc_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical format
-      - In the canonical format, CSC matrices have indices sorted per row, 
+      - In the canonical format, CSC matrices have indices sorted per column, 
         and cannot contain duplicate entries.
 
     Examples

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -76,7 +76,9 @@ class csc_array(_cs_matrix):
       - slow row slicing operations (consider CSR)
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
-
+    Canonical format
+      - In the canonical format, CSC matrices have indices sorted per row, 
+        and cannot contain duplicate entries.
     Examples
     --------
 

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -75,6 +75,10 @@ class csr_array(_cs_matrix):
       - slow column slicing operations (consider CSC)
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
+    Canonical Format
+        - In the canonical format, CSR matrices have indices sorted per row, 
+          and cannot contain duplicate entries.
+
     Examples
     --------
 

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -76,7 +76,7 @@ class csr_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical Format
-        - In the canonical format, CSR matrices have indices sorted per row, 
+        - In the canonical format, CSR matrices have indices sorted per row,
           and cannot contain duplicate entries.
 
     Examples

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -76,8 +76,8 @@ class csr_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical Format
-        - In the canonical format, CSR matrices have indices sorted per row,
-          and cannot contain duplicate entries.
+        - Within each column, indices are sorted by row.
+        - There are no duplicate entries.
 
     Examples
     --------

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -76,7 +76,7 @@ class csr_array(_cs_matrix):
       - changes to the sparsity structure are expensive (consider LIL or DOK)
 
     Canonical Format
-        - Within each column, indices are sorted by row.
+        - Within each row, indices are sorted by column.
         - There are no duplicate entries.
 
     Examples


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This documents that some sparse arrays formats have a canonical form, and explains what they are.

#### Additional information
<!--Any additional information you think is important.-->
