### PR TITLE
MAINT: sparse: Deprecate multi-Ellipsis indexing

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -1,13 +1,10 @@
 """Indexing mixin for sparse matrix classes.
 """
 import numpy as np
+from warnings import warn
 from ._sputils import isintlike
 
-try:
-    INT_TYPES = (int, long, np.integer)
-except NameError:
-    # long is not defined in Python3
-    INT_TYPES = (int, np.integer)
+INT_TYPES = (int, np.integer)
 
 
 def _broadcast_arrays(a, b):
@@ -318,16 +315,14 @@ def _check_ellipsis(index):
     if not isinstance(index, tuple):
         return index
 
-    # TODO: Deprecate this multiple-ellipsis handling,
-    #       as numpy no longer supports it.
-
-    # Find first ellipsis.
-    for j, v in enumerate(index):
-        if v is Ellipsis:
-            first_ellipsis = j
-            break
-    else:
+    # Find any Ellipsis objects.
+    ellipsis_indices = [i for i, v in enumerate(index) if v is Ellipsis]
+    if not ellipsis_indices:
         return index
+    if len(ellipsis_indices) > 1:
+        warn('multi-Ellipsis indexing is deprecated will be removed in v1.13.',
+             DeprecationWarning, stacklevel=2)
+    first_ellipsis = ellipsis_indices[0]
 
     # Try to expand it using shortcuts for common cases
     if len(index) == 1:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2585,12 +2585,18 @@ class _TestSlicing:
         b = asmatrix(arange(50).reshape(5,10))
         a = self.spcreator(b)
 
-        assert_array_equal(a[..., ...].toarray(), b[:, :].A)
-        assert_array_equal(a[..., ..., ...].toarray(), b[:, :].A)
-        assert_array_equal(a[1, ..., ...].toarray(), b[1, :].A)
-        assert_array_equal(a[1:, ..., ...].toarray(), b[1:, :].A)
-        assert_array_equal(a[..., ..., 1:].toarray(), b[:, 1:].A)
-        assert_array_equal(a[..., ..., 1].toarray(), b[:, 1].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[..., ...].toarray(), b[:, :].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[..., ..., ...].toarray(), b[:, :].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[1, ..., ...].toarray(), b[1, :].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[1:, ..., ...].toarray(), b[1:, :].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[..., ..., 1:].toarray(), b[:, 1:].A)
+        with pytest.deprecated_call(match='removed in v1.13'):
+            assert_array_equal(a[..., ..., 1].toarray(), b[:, 1].A)
 
 
 class _TestSlicingAssign:


### PR DESCRIPTION
#### Reference issue
Fixes gh-18485.

I have a separate branch to do the cleanup, but that will have to wait until the deprecation period is over.

As a bonus change, I removed an old Python2-specific workaround.