### PR TITLE
MAINT: optimize.root_scalar: ensure that root is a scalar

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -304,7 +304,11 @@ def root_scalar(f, args=(), method=None, bracket=None,
             # approximate fprime with finite differences
 
             def fprime(x):
-                return approx_derivative(f, x, method='2-point')
+                # `root_scalar` doesn't actually seem to support vectorized
+                # use of `newton`. In that case, `approx_derivative` will
+                # always get scalar input. Nonetheless, it always returns an
+                # array, so we extract the element to produce scalar output.
+                return approx_derivative(f, x, method='2-point')[0]
 
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -438,10 +438,13 @@ class TestNewton(TestScalarRootFinders):
         # `newton` uses the secant method when `x1` and `x2` are specified
         res_secant = newton(f1, x0=3, x1=2, tol=1e-6, full_output=True)[1]
 
-        # all three foun a root
+        # all three found a root
         assert_allclose(f1(res_newton_default.root), 0, atol=1e-6)
+        assert res_newton_default.root.shape == tuple()
         assert_allclose(f1(res_secant_default.root), 0, atol=1e-6)
+        assert res_secant_default.root.shape == tuple()
         assert_allclose(f1(res_secant.root), 0, atol=1e-6)
+        assert res_secant.root.shape == tuple()
 
         # Defaults are correct
         assert (res_secant_default.root


### PR DESCRIPTION
#### Reference issue
gh-17691

#### What does this implement/fix?
gh-17691 removed the restriction to use `scipy.optimize.root_scalar` with `method='newton'` without `fprime`; the derivative is calculated numerically by `approx_fprime`. However, `approx_fprime` returns an array even with scalar input, so `root_scalar` would end up returning an array with a single element rather than a scalar. This fixes the inconsistency by ensuring that the scalar derivative is extracted from the output of `approx_fprime`.

#### Additional information
```python3
import scipy as sp

def f(x):
    return (x - 1) * (x - 2)

res = sp.optimize.root_scalar(f, x0=0)
res.root.shape  # was (1,), now ()
```