### PR TITLE
ENH: sparse.linalg: Implement matrix_power()

### DIFF
--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -52,31 +52,9 @@ class spmatrix:
 
     # Restore matrix power
     def __pow__(self, other):
-        M, N = self.shape
-        if M != N:
-            raise TypeError('sparse matrix is not square')
+        from .linalg import matrix_power
 
-        if isintlike(other):
-            other = int(other)
-            if other < 0:
-                raise ValueError('exponent must be >= 0')
-
-            if other == 0:
-                from ._construct import eye
-                return eye(M, dtype=self.dtype)
-
-            if other == 1:
-                return self.copy()
-
-            tmp = self.__pow__(other // 2)
-            if other % 2:
-                return self @ tmp @ tmp
-            else:
-                return tmp @ tmp
-
-        if isscalarlike(other):
-            raise ValueError('exponent must be an integer')
-        return NotImplemented
+        return matrix_power(self, other)
 
     ## Backward compatibility
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -51,7 +51,7 @@ class spmatrix:
     def __pow__(self, power):
         from .linalg import matrix_power
 
-        return matrix_power(self, other)
+        return matrix_power(self, power)
 
     ## Backward compatibility
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -1,6 +1,3 @@
-from ._sputils import isintlike, isscalarlike
-
-
 class spmatrix:
     """This class provides a base class for all sparse matrix classes.
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -48,7 +48,7 @@ class spmatrix:
         return self._rmul_dispatch(other)
 
     # Restore matrix power
-    def __pow__(self, other):
+    def __pow__(self, power):
         from .linalg import matrix_power
 
         return matrix_power(self, other)

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -22,6 +22,7 @@ Matrix Operations
    inv -- compute the sparse matrix inverse
    expm -- compute the sparse matrix exponential
    expm_multiply -- compute the product of a matrix exponential and a matrix
+   matrix_power -- compute the matrix power by raising a matrix to an exponent
 
 Matrix norms
 ------------

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -867,10 +867,8 @@ def matrix_power(A, power, structure=None):
     """
     Raise a square matrix to the integer power, `power`.
 
-    For positive integers, ``A**power`` is computed using repeated
-    matrix multiplications. If ``power==0``, the identity matrix of
-    the same shape as M is returned. If ``power < 0``, then the
-    inverse is computed and ``A`` is raised to ``abs(power)``
+    For non-negative integers, ``A**power`` is computed using repeated
+    matrix multiplications. Negative integers are not supported. 
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -863,7 +863,7 @@ def _ell(A, m):
     value = int(np.ceil(log2_alpha_div_u / (2 * m)))
     return max(value, 0)
 
-def matrix_power(A, power, structure=None):
+def matrix_power(A, power):
     """
     Raise a square matrix to the integer power, `power`.
 
@@ -875,13 +875,45 @@ def matrix_power(A, power, structure=None):
     A : (M, M) square sparse array or matrix
         sparse array that will be raised to power `power`
     power : int
-        Non-negative integer exponent used to raise sparse array `A`
+        Exponent used to raise sparse array `A`
 
     Returns
     -------
     A**power : (M, M) sparse array or matrix
         The output matrix will be the same shape as A, and will preserve
         the class of A, but the format of the output may be changed.
+    
+    Notes
+    -----
+    This uses a recursive implementation of the matrix power. For computing
+    the matrix power using a reasonably large `power`, this may be less efficient
+    than computing the product directly, using a*a*...*a. This is contingent upon
+    the number of nonzero entries in the matrix. 
+
+    .. versionadded:: 1.12.0
+
+    Examples
+    --------
+    >>> from scipy import sparse
+    >>> A = sparse.csc_array([[0,1,0],[1,0,1],[0,1,0]])
+    >>> A.todense()
+    array([[0, 1, 0],
+           [1, 0, 1],
+           [0, 1, 0]])
+    >>> (A @ A).todense()
+    array([[1, 0, 1],
+           [0, 2, 0],
+           [1, 0, 1]])
+    >>> A2 = sparse.linalg.matrix_power(A, 2)
+    >>> A2.todense()
+    array([[1, 0, 1],
+           [0, 2, 0],
+           [1, 0, 1]])
+    >>> A4 = sparse.linalg.matrix_power(A, 4)
+    >>> A4.todense()
+    array([[2, 0, 2],
+           [0, 4, 0],
+           [2, 0, 2]])
 
     """
     M, N = A.shape
@@ -891,7 +923,7 @@ def matrix_power(A, power, structure=None):
     if isintlike(power):
         power = int(power)
         if power < 0:
-            raise ValueError(f"{power=} but power must be >= 0")
+            raise ValueError('exponent must be >= 0')
 
         if power == 0:
             return eye(M, dtype=A.dtype)
@@ -905,4 +937,4 @@ def matrix_power(A, power, structure=None):
         else:
             return tmp @ tmp
     else:
-        raise ValueError(f"power is a {type(power)} must be an integer")
+        raise ValueError("exponent must be an integer")

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -875,7 +875,7 @@ def matrix_power(A, power, structure=None):
     A : (M, M) square sparse array or matrix
         sparse array that will be raised to power `power`
     power : int
-        Exponent used to raise sparse array `A`
+        Non-negative integer exponent used to raise sparse array `A`
 
     Returns
     -------

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -8,7 +8,7 @@ Sparse matrix functions
 #          Jake Vanderplas, August 2012 (Sparse Updates)
 #
 
-__all__ = ['expm', 'inv']
+__all__ = ['expm', 'inv', 'matrix_power']
 
 import numpy as np
 from scipy.linalg._basic import solve, solve_triangular
@@ -861,3 +861,34 @@ def _ell(A, m):
     log2_alpha_div_u = np.log2(alpha/u)
     value = int(np.ceil(log2_alpha_div_u / (2 * m)))
     return max(value, 0)
+
+def matrix_power(A, power, structure=None):
+    """
+    Raise a square matrix to the integer power, `power`.
+
+    For positive integers, ``A**power`` is computed using repeated
+    matrix multiplications. If ``power==0``, the identity matrix of
+    the same shape as M is returned. If ``power < 0``, then the
+    inverse is computed and ``A`` is raised to ``abs(power)``
+
+    Parameters
+    ----------
+    A : (M, M) square sparse array or matrix
+        sparse array that will be raised to power `power`
+    power : int
+        Exponent used to raise sparse array `A`
+
+    Returns
+    -------
+    A**power : (M, M) sparse array or matrix
+        The output matrix will be the same shape as A, and will preserve
+        the class of A, but the format of the output may be changed.
+
+    """
+    M, N = A.shape
+    if A.ndim != 2 or M != N:
+        raise ValueError("expected A to be like a square matrix")
+    A = A.tocsc()
+    return scipy.sparse.eye(M, dtype=A.dtype) @ MatrixPowerOperator(
+        A, power, structure=structure
+    )

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -887,8 +887,8 @@ def matrix_power(A, power):
     -----
     This uses a recursive implementation of the matrix power. For computing
     the matrix power using a reasonably large `power`, this may be less efficient
-    than computing the product directly, using a*a*...*a. This is contingent upon
-    the number of nonzero entries in the matrix. 
+    than computing the product directly, using A @ A @ ... @ A.
+    This is contingent upon the number of nonzero entries in the matrix. 
 
     .. versionadded:: 1.12.0
 

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -891,7 +891,7 @@ def matrix_power(A, power, structure=None):
     if isintlike(power):
         power = int(power)
         if power < 0:
-            raise ValueError('exponent must be >= 0')
+            raise ValueError(f"{power=} but power must be >= 0")
 
         if power == 0:
             return eye(M, dtype=A.dtype)

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -905,4 +905,4 @@ def matrix_power(A, power, structure=None):
         else:
             return tmp @ tmp
     else:
-        raise ValueError("exponent must be an integer")
+        raise ValueError(f"power is a {type(power)} must be an integer")

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -891,7 +891,7 @@ def matrix_power(A, power, structure=None):
         raise TypeError('sparse matrix is not square')
 
     if isintlike(power):
-        other = int(power)
+        power = int(power)
         if power < 0:
             raise ValueError('exponent must be >= 0')
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -8,16 +8,15 @@ import math
 
 import numpy as np
 from numpy import array, eye, exp, random
-from numpy.linalg import matrix_power
 from numpy.testing import (
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
         assert_array_almost_equal_nulp, suppress_warnings)
 
-from scipy.sparse import csc_matrix, SparseEfficiencyWarning
+from scipy.sparse import csc_matrix, csc_array, SparseEfficiencyWarning
 from scipy.sparse._construct import eye as speye
 from scipy.sparse.linalg._matfuncs import (expm, _expm,
         ProductOperator, MatrixPowerOperator,
-        _onenorm_matrix_power_nnm)
+        _onenorm_matrix_power_nnm, matrix_power)
 from scipy.sparse._sputils import matrix
 from scipy.linalg import logm
 from scipy.special import factorial, binom
@@ -66,6 +65,20 @@ def test_onenorm_matrix_power_nnm():
             observed = _onenorm_matrix_power_nnm(M, p)
             expected = np.linalg.norm(Mp, 1)
             assert_allclose(observed, expected)
+
+def test_matrix_power():
+    np.random.seed(1234)
+    row, col = np.random.randint(0, 4, size=(2, 6))
+    data = np.random.random(size=(6,))
+    Amat = csc_matrix((data, (row, col)), shape=(4, 4))
+    A = csc_array((data, (row, col)), shape=(4, 4))
+    Adense = A.toarray()
+    for power in (2, 5, 6):
+        Apow = matrix_power(A, power).toarray()
+        Amat_pow = (Amat**power).toarray()
+        Adense_pow = np.linalg.matrix_power(Adense, power)
+        assert_allclose(Apow, Adense_pow)
+        assert_allclose(Apow, Amat_pow)
 
 
 class TestExpM:
@@ -577,5 +590,5 @@ class TestOperators:
             A = np.random.randn(n, n)
             B = np.random.randn(n, k)
             op = MatrixPowerOperator(A, p)
-            assert_allclose(op.matmat(B), matrix_power(A, p).dot(B))
-            assert_allclose(op.T.matmat(B), matrix_power(A, p).T.dot(B))
+            assert_allclose(op.matmat(B), np.linalg.matrix_power(A, p).dot(B))
+            assert_allclose(op.T.matmat(B), np.linalg.matrix_power(A, p).T.dot(B))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1580,11 +1580,11 @@ class _TestCommon:
 
         # invalid exponents
         for exponent in [-1, 2.2, 1 + 3j]:
-            assert_raises(Exception, B.__pow__, exponent)
+            assert_raises(ValueError, B.__pow__, exponent)
 
         # nonsquare matrix
         B = self.spcreator(A[:3,:])
-        assert_raises(Exception, B.__pow__, 1)
+        assert_raises(TypeError, B.__pow__, 1)
 
     def test_rmatvec(self):
         M = self.spcreator(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))


### PR DESCRIPTION
#### Reference issue
No specific reference issue

#### What does this implement/fix?
This adds a `scipy.sparse.linalg.matrix_power()` analogue to `numpy.linalg.matrix_power()`. It uses the old `_spmatrix.__pow__()` recursive implementation, since `MatrixPowerOperator()` was quite a bit slower. 

