### PR TITLE
TST: speed up `test_import_cycles`

### DIFF
--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -8,6 +8,7 @@ from .test_public_api import PUBLIC_MODULES
 # This is not necessarily true if there are import cycles present.
 
 def test_public_modules_importable():
-    for module in PUBLIC_MODULES:
-        cmd = f'import {module}'
-        subprocess.check_call([sys.executable, '-c', cmd])
+    pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])
+            for module in PUBLIC_MODULES]
+    for i, pid in enumerate(pids):
+        assert pid.wait() == 0, f'Failed to import {PUBLIC_MODULES[i]}'


### PR DESCRIPTION
#### What does this implement/fix?
This runs the same checks that the existing `test_import_cycles` does, but instead of running each Python subprocess one-by-one in blocking mode, it kicks off all the subprocesses in the background before checking that each one returned successfully.

On my local machine, this brings the `test_import_cycles` execution time from ~11s down to ~2.5s. It should also make it cheaper to add additional modules to the list that we're checking here.