### PR TITLE
TST: optimize: filter RuntimeWarning that does not indicate test failure

### DIFF
--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1169,6 +1169,7 @@ class TestOptimizeSimple(CheckOptimize):
             assert func(sol1.x) < func(sol2.x), f"{method}: {func(sol1.x)} vs. {func(sol2.x)}"
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')  # See gh-18547
     @pytest.mark.parametrize('method',
                              ['fmin', 'fmin_powell', 'fmin_cg', 'fmin_bfgs',
                               'fmin_ncg', 'fmin_l_bfgs_b', 'fmin_tnc',


### PR DESCRIPTION
#### Reference issue
Closes gh-18547

#### What does this implement/fix?
gh-18547 notes an occasional failure of `test_minimize_callback_copies_array` due to `fmin` (Nelder-Mead) not converging within the specified 3500 iterations. On my machine, `minimize` with `method='nelder-mead'` takes 3420 iterations on this problem, and I seem to remember the behavior of this method being somewhat sensitive to architecture, so I am not surprised that on some architectures the number of iterations occasionally exceeds 3500 iterations. Rather than change the problem or loosen the number of iterations, this fixes the problem by filtering the warning.

#### Additional information
`UserWarning`s are already filtered here, so I am not sure why we'd need to catch `RuntimeWarning`s. After all, there are likely to be other tests in which these warnings would cause failure if there is a problem.
