### PR TITLE
DOC: optimize.OptimizeResult: note that not all listed attributes are present

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -211,8 +211,9 @@ class OptimizeResult(dict):
 
     Notes
     -----
-    `OptimizeResult` may have additional attributes not listed here depending
-    on the specific solver being used. Since this class is essentially a
+    Depending on the specific solver being used, `OptimizeResult` may
+    not have all attributes listed here, and they may have additional
+    attributes not listed here. Since this class is essentially a
     subclass of dict with attribute accessors, one can see which
     attributes are available using the `OptimizeResult.keys` method.
     """


### PR DESCRIPTION
#### Reference issue
gh-7281

#### What does this implement/fix?
gh-7281 noted that `maxcv` (maximum constraint violation) was not present in the `OptimizeResult` produced by all `minimize` `method`s.  Perhaps each `minimize` method should document the attributes that will produce, but in the meantime, this single list of possibilities should note that not all will be present in every `OptimizeResult`.