### PR TITLE
Replace sparse __getattr__ with properties

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -724,9 +724,6 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
 
     if sparse:
         A = sps.csc_matrix(A)
-        A.T = A.transpose()  # A.T is defined for sparse matrices but is slow
-        # Redefine it to avoid calculating again
-        # This is fine as long as A doesn't change
 
     while go:
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -711,31 +711,39 @@ class _spbase:
     def __pow__(self, *args, **kwargs):
         return self.power(*args, **kwargs)
 
-    def __getattr__(self, attr):
-        if attr == 'A':
-            if self._is_array:
-                warn(np.VisibleDeprecationWarning(
-                    "`.A` is deprecated and will be removed in v1.13.0. "
-                    "Use `.todense()` instead."
-                ))
-            return self.toarray()
-        elif attr == 'T':
-            return self.transpose()
-        elif attr == 'H':
-            if self._is_array:
-                warn(np.VisibleDeprecationWarning(
-                    "`.H` is deprecated and will be removed in v1.13.0. "
-                    "Please use `.conj().T` instead."
-                ))
-            return self.transpose().conjugate()
-        elif attr == 'real':
-            return self._real()
-        elif attr == 'imag':
-            return self._imag()
-        elif attr == 'size':
-            return self._getnnz()
-        else:
-            raise AttributeError(attr + " not found")
+    @property
+    def A(self) -> np.ndarray:
+        if self._is_array:
+            warn(np.VisibleDeprecationWarning(
+                "`.A` is deprecated and will be removed in v1.13.0. "
+                "Use `.todense()` instead."
+            ))
+        return self.toarray()
+
+    @property
+    def T(self):
+        return self.transpose()
+
+    @property
+    def H(self):
+        if self._is_array:
+            warn(np.VisibleDeprecationWarning(
+                "`.H` is deprecated and will be removed in v1.13.0. "
+                "Please use `.conj().T` instead."
+            ))
+        return self.transpose().conjugate()
+
+    @property
+    def real(self):
+        return self._real()
+
+    @property
+    def imag(self):
+        return self._imag()
+
+    @property
+    def size(self):
+        return self._getnnz()
 
     def transpose(self, axes=None, copy=False):
         """

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -716,7 +716,7 @@ class _spbase:
         if self._is_array:
             warn(np.VisibleDeprecationWarning(
                 "`.A` is deprecated and will be removed in v1.13.0. "
-                "Use `.todense()` instead."
+                "Use `.toarray()` instead."
             ))
         return self.toarray()
 
@@ -729,9 +729,9 @@ class _spbase:
         if self._is_array:
             warn(np.VisibleDeprecationWarning(
                 "`.H` is deprecated and will be removed in v1.13.0. "
-                "Please use `.conj().T` instead."
+                "Please use `.T.conjugate()` instead."
             ))
-        return self.transpose().conjugate()
+        return self.T.conjugate()
 
     @property
     def real(self):


### PR DESCRIPTION
This PR replaces use of `__getattr__` in `_spbase` with properties. This should make code a bit more predictable, and generally "more pythonic/ standard"
