### PR TITLE
DOC: stats.laplace_asymmetric: note relationship between scale and lambda

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5423,6 +5423,11 @@ class laplace_asymmetric_gen(rv_continuous):
 
     %(after_notes)s
 
+    Note that the scale parameter of some references is the reciprocal of
+    SciPy's ``scale``. For example, :math:`\lambda = 1/2` in the
+    parameterization of [1]_ is equivalent to ``scale = 2`` with
+    `laplace_asymmetric`.
+
     References
     ----------
     .. [1] "Asymmetric Laplace distribution", Wikipedia


### PR DESCRIPTION
#### Reference issue
Someone brought this to my attention outside of GitHub

#### What does this implement/fix?
The parameterization of the asymmetric Laplace distribution in its reference uses a scale parameter $\lambda$ that is the reciprocal of SciPy's `scale`. This PR documents the relationship between the two.

#### Additional information
Please check my math!
