### PR TITLE
BENCH: sparse: Add a benchmark for sparse matrix power

### DIFF
--- a/benchmarks/benchmarks/sparse_matrix_power.py
+++ b/benchmarks/benchmarks/sparse_matrix_power.py
@@ -6,7 +6,7 @@ with safe_import():
 
 class BenchMatrixPower(Benchmark):
     params = [
-        [0, 1, 2, 3],
+        [0, 1, 2, 3, 8, 9],
         [1000],
         [1e-6, 1e-3],
     ]

--- a/benchmarks/benchmarks/sparse_matrix_power.py
+++ b/benchmarks/benchmarks/sparse_matrix_power.py
@@ -1,0 +1,19 @@
+from .common import Benchmark, safe_import
+
+with safe_import():
+    from scipy.sparse import random
+
+
+class BenchMatrixPower(Benchmark):
+    params = [
+        [0, 1, 2, 3],
+        [1000],
+        [1e-6, 1e-3],
+    ]
+    param_names = ['x', 'N', 'density']
+
+    def setup(self, x: int, N: int, density: float):
+        self.A = random(N, N, density=density, format='csr')
+
+    def time_matrix_power(self, x: int, N: int, density: float):
+        self.A ** x


### PR DESCRIPTION
#### Reference issue
This should be helpful when evaluating the impact of gh-18544.

#### What does this implement/fix?
This adds a new benchmark file: `sparse_matrix_power.py`. Here are the results of running it via `dev.py bench`:

```
[100.00%] ··· sparse_matrix_power.BenchMatrixPower.time_matrix_power                                                                                                          ok
[100.00%] ··· === ============== ==============
              --           N / density
              --- -----------------------------
               x   1000 / 1e-06   1000 / 0.001
              === ============== ==============
               0     38.9±1μs       39.8±1μs
               1    45.1±0.8μs     45.0±0.8μs
               2     164±6μs        217±5μs
               3     285±5μs        386±9μs
              === ============== ==============
```
