### PR TITLE
BUG: sparse: Fix DIA.tocoo canonical format setting

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -402,12 +402,11 @@ class _dia_base(_data_matrix):
         row = row[mask]
         col = np.tile(offset_inds, num_offsets)[mask.ravel()]
         data = self.data[mask]
-
-        A = self._coo_container(
-            (data, (row, col)), shape=self.shape, dtype=self.dtype
+        # Note: this cannot set has_canonical_format=True, because despite the
+        # lack of duplicates, we do not generate sorted indices.
+        return self._coo_container(
+            (data, (row, col)), shape=self.shape, dtype=self.dtype, copy=False
         )
-        A.has_canonical_format = True
-        return A
 
     tocoo.__doc__ = _spbase.tocoo.__doc__
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4427,6 +4427,12 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         expected = m.toarray()
         assert_array_equal(m.tocsc().toarray(), expected)
         assert_array_equal(m.tocsr().toarray(), expected)
+    
+    def test_tocoo_gh10050(self):
+        # regression test for gh-10050
+        m = dia_matrix([[1, 2], [3, 4]]).tocoo()
+        flat_inds = np.ravel_multi_index((m.row, m.col), m.shape)
+        assert m.has_canonical_format == (np.diff(flat_inds) > 0).all()
 
 
 TestDIA.init_class()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4432,7 +4432,8 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         # regression test for gh-10050
         m = dia_matrix([[1, 2], [3, 4]]).tocoo()
         flat_inds = np.ravel_multi_index((m.row, m.col), m.shape)
-        assert m.has_canonical_format == (np.diff(flat_inds) > 0).all()
+        inds_are_sorted = np.all(np.diff(flat_inds) > 0)
+        assert m.has_canonical_format == inds_are_sorted
 
 
 TestDIA.init_class()


### PR DESCRIPTION
#### Reference issue
Fixes gh-10050.

#### What does this implement/fix?
We were setting `has_canonical_format = True` because we knew there would be no duplicate indices, but our construction doesn't produce correctly-sorted index arrays. See the linked bug for more context.