### PR TITLE
MAINT Remove redundant checks in sparse arrays and sparse matrices

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -228,13 +228,16 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
         self.check_format(full_check=False)
 
     def check_format(self, full_check=True):
-        """check whether the matrix format is valid
+        """Check whether the matrix respects the BSR format.
 
-            *Parameters*:
-                full_check:
-                    True  - rigorous check, O(N) operations : default
-                    False - basic check, O(1) operations
-
+        Parameters
+        ----------
+        full_check : bool, optional
+            If `True`, run rigorous check, scanning arrays for valid values.
+            Note that activating those check might copy arrays for casting,
+            modifying indices and index pointers' inplace.
+            If `False`, run basic checks on attributes. O(1) operations.
+            Default is `True`.
         """
         M,N = self.shape
         R,C = self.blocksize
@@ -246,11 +249,6 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
         if self.indices.dtype.kind != 'i':
             warn("indices array has non-integer dtype (%s)"
                     % self.indices.dtype.name)
-
-        idx_dtype = self._get_index_dtype((self.indices, self.indptr))
-        self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
-        self.indices = np.asarray(self.indices, dtype=idx_dtype)
-        self.data = to_native(self.data)
 
         # check array shapes
         if self.indices.ndim != 1 or self.indptr.ndim != 1:
@@ -285,6 +283,10 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                     raise ValueError("index pointer values must form a "
                                         "non-decreasing sequence")
 
+            idx_dtype = self._get_index_dtype((self.indices, self.indptr))
+            self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
+            self.indices = np.asarray(self.indices, dtype=idx_dtype)
+            self.data = to_native(self.data)
         # if not self.has_sorted_indices():
         #    warn('Indices were not in sorted order. Sorting indices.')
         #    self.sort_indices(check_first=False)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -133,13 +133,16 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self._shape = check_shape(other.shape)
 
     def check_format(self, full_check=True):
-        """check whether the matrix format is valid
+        """Check whether the matrix respects the CSR or CSC format.
 
         Parameters
         ----------
         full_check : bool, optional
-            If `True`, rigorous check, O(N) operations. Otherwise
-            basic check, O(1) operations (default True).
+            If `True`, run rigorous check, scanning arrays for valid values.
+            Note that activating those check might copy arrays for casting,
+            modifying indices and index pointers' inplace.
+            If `False`, run basic checks on attributes. O(1) operations.
+            Default is `True`.
         """
         # use _swap to determine proper bounds
         major_name, minor_name = self._swap(('row', 'column'))
@@ -152,11 +155,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if self.indices.dtype.kind != 'i':
             warn("indices array has non-integer dtype ({})"
                  "".format(self.indices.dtype.name), stacklevel=3)
-
-        idx_dtype = self._get_index_dtype((self.indptr, self.indices))
-        self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
-        self.indices = np.asarray(self.indices, dtype=idx_dtype)
-        self.data = to_native(self.data)
 
         # check array shapes
         for x in [self.data.ndim, self.indices.ndim, self.indptr.ndim]:
@@ -191,6 +189,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 if np.diff(self.indptr).min() < 0:
                     raise ValueError("index pointer values must form a "
                                      "non-decreasing sequence")
+
+            idx_dtype = self._get_index_dtype((self.indptr, self.indices))
+            self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
+            self.indices = np.asarray(self.indices, dtype=idx_dtype)
+            self.data = to_native(self.data)
 
         # if not self.has_sorted_indices():
         #    warn('Indices were not in sorted order.  Sorting indices.')


### PR DESCRIPTION
#### Reference issue

Fix #10812.

#### What does this implement/fix?

Currently, some sparse formats are rerunning checks calling `get_index_dtype` which might scan all values or even copy arrays for downcasting

For instance:
 - CSR, CSC, and BSR implement checks in `check_format` (calling `get_index_dtype`) yet the contract of `check_format` is not respected by its implementation (addressed by cdc3305a3dd48449c919a3326dddb86604f469f0)

#### Additional information

Can add new modifications of checks if needed.
