### PR TITLE
MAINT: integrate: revert`full_output` deprecation / result object change

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -678,16 +678,10 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
 
     Returns
     -------
-    res : QuadResult
-        An object with the following attributes:
-
-        integral : float
-            The result of the integration.
-        abserr : float
-            The maximum of the estimates of the absolute error in the
-            two integration results.
-        neval : dict, optional
-            The number of integrand evaluations.
+    y : float
+        The resultant integral.
+    abserr : float
+        An estimate of the error.
 
     See Also
     --------
@@ -820,16 +814,10 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     Returns
     -------
-    res : QuadResult
-        An object with the following attributes:
-
-        integral : float
-            The result of the integration.
-        abserr : float
-            The maximum of the estimates of the absolute error in the
-            three integration results.
-        neval : dict, optional
-            The number of integrand evaluations.
+    y : float
+        The resultant integral.
+    abserr : float
+        An estimate of the error.
 
     See Also
     --------
@@ -1016,8 +1004,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
 
     Returns
     -------
-    res : QuadResult
-        An object with the following attributes:
+    A result object with the following attributes:
 
         integral : float
             The result of the integration.

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -686,7 +686,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         abserr : float
             The maximum of the estimates of the absolute error in the
             two integration results.
-        neval : int
+        neval : dict, optional
             The number of integrand evaluations.
 
     See Also
@@ -828,7 +828,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         abserr : float
             The maximum of the estimates of the absolute error in the
             three integration results.
-        neval : int
+        neval : dict, optional
             The number of integrand evaluations.
 
     See Also
@@ -1024,7 +1024,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
         abserr : float
             The maximum of the estimates of the absolute error in the various
             integration results.
-        neval : int
+        neval : dict, optional
             The number of integrand evaluations.
 
     See Also

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 from functools import partial
 
-from scipy._lib._bunch import _make_tuple_bunch
 from . import _quadpack
 import numpy as np
 from numpy import Inf
@@ -927,12 +926,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
             opts={"epsabs": epsabs, "epsrel": epsrel})
 
 
-QuadratureResult = _make_tuple_bunch("QuadratureResult",
-                                     field_names=["integral", "abserr"],
-                                     extra_field_names=["neval"])
-
-
-def nquad(func, ranges, args=None, opts=None, full_output=None):
+def nquad(func, ranges, args=None, opts=None, full_output=False):
     r"""
     Integration over multiple variables.
 
@@ -997,22 +991,15 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
         The number of integrand function evaluations ``neval`` can be obtained
         by setting ``full_output=True`` when calling nquad.
 
-        .. deprecated:: 1.11.0
-           Parameter `full_output` is deprecated and will be removed in version
-           1.13.0. When `full_output` is unspecified, ``neval`` is provided
-           as an attribute of the result object.
-
     Returns
     -------
-    A result object with the following attributes:
-
-        integral : float
-            The result of the integration.
-        abserr : float
-            The maximum of the estimates of the absolute error in the various
-            integration results.
-        neval : dict, optional
-            The number of integrand evaluations.
+    result : float
+        The result of the integration.
+    abserr : float
+        The maximum of the estimates of the absolute error in the various
+        integration results.
+    out_dict : dict, optional
+        A dict containing additional information on the integration.
 
     See Also
     --------
@@ -1189,19 +1176,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
         opts = [_OptFunc(opts)] * depth
     else:
         opts = [opt if callable(opt) else _OptFunc(opt) for opt in opts]
-    res = _NQuad(func, ranges, opts, True).integrate(*args)
-
-    if full_output is not None:
-        msg = ("Use of parameter `full_output` is deprecated. Please leave "
-               "`full_output` unspecified; `neval` can now be accessed as an "
-               "attribute of the object returned by `scipy.integrate.nquad`.")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-    if full_output:
-        return res
-    else:
-        return QuadratureResult(integral=res[0], abserr=res[1],
-                                neval=res[2]['neval'])
+    return _NQuad(func, ranges, opts, full_output).integrate(*args)
 
 
 class _RangeFunc:

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose
 
 from scipy.integrate import quad_vec
 
@@ -35,11 +35,12 @@ def test_quad_vec_simple(quadrature):
         res, err = quad_vec(f, 0, 2, norm='max', points=(0.5, 1.0), **kwargs)
         assert_allclose(res, exact, rtol=0, atol=epsabs)
 
-        res = quad_vec(f, 0, 2, norm='max',
+        res, err, *rest = quad_vec(f, 0, 2, norm='max',
                                    epsrel=1e-8,
+                                   full_output=True,
                                    limit=10000,
                                    **kwargs)
-        assert_allclose(res.integral, exact, rtol=0, atol=epsabs)
+        assert_allclose(res, exact, rtol=0, atol=epsabs)
 
 
 @quadrature_params
@@ -86,10 +87,10 @@ def test_quad_vec_simple_inf(quadrature):
     exact = np.pi / np.e * np.sin(2)
     epsabs = 1e-5
 
-    res = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
-                   quadrature=quadrature)
-    assert res.status == 1
-    assert_allclose(res.integral, exact, rtol=0, atol=max(epsabs, 1.5 * res.abserr))
+    res, err, info = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
+                              quadrature=quadrature, full_output=True)
+    assert info.status == 1
+    assert_allclose(res, exact, rtol=0, atol=max(epsabs, 1.5 * err))
 
 
 def test_quad_vec_args():
@@ -143,23 +144,23 @@ def test_num_eval(quadrature):
         return x**5
 
     count = [0]
-    res = quad_vec(f, 0, 1, norm='max', quadrature=quadrature)
-    assert res.neval == count[0]
+    res = quad_vec(f, 0, 1, norm='max', full_output=True, quadrature=quadrature)
+    assert res[2].neval == count[0]
 
 
 def test_info():
     def f(x):
         return np.ones((3, 2, 1))
 
-    res = quad_vec(f, 0, 1, norm='max')
+    res, err, info = quad_vec(f, 0, 1, norm='max', full_output=True)
 
-    assert res.success is True
-    assert res.status == 0
-    assert res.message == 'Target precision reached.'
-    assert res.neval > 0
-    assert res.intervals.shape[1] == 2
-    assert res.integrals.shape == (res.intervals.shape[0], 3, 2, 1)
-    assert res.errors.shape == (res.intervals.shape[0],)
+    assert info.success is True
+    assert info.status == 0
+    assert info.message == 'Target precision reached.'
+    assert info.neval > 0
+    assert info.intervals.shape[1] == 2
+    assert info.integrals.shape == (info.intervals.shape[0], 3, 2, 1)
+    assert info.errors.shape == (info.intervals.shape[0],)
 
 
 def test_nan_inf():
@@ -169,11 +170,11 @@ def test_nan_inf():
     def f_inf(x):
         return np.inf if x < 0.1 else 1/x
 
-    res = quad_vec(f_nan, 0, 1)
-    assert res.status == 3
+    res, err, info = quad_vec(f_nan, 0, 1, full_output=True)
+    assert info.status == 3
 
-    res = quad_vec(f_inf, 0, 1)
-    assert res.status == 3
+    res, err, info = quad_vec(f_inf, 0, 1, full_output=True)
+    assert info.status == 3
 
 
 @pytest.mark.parametrize('a,b', [(0, 1), (0, np.inf), (np.inf, 0),
@@ -206,38 +207,3 @@ def test_points(a, b):
     for p in interval_sets:
         j = np.searchsorted(sorted(points), tuple(p))
         assert np.all(j == j[0])
-
-def test_result_object():
-        # Check that result object contains attributes 'success', 'status',
-        # 'neval', 'intervals', 'integrals', 'errors', 'message'.
-        # During the `full_output` deprecation period, also check
-        # that specifying `full_output` produces a warning and that values
-        # are the same whether `full_output` is True, False, or unspecified.
-        def func(x):
-            return x**2 + 1
-
-        res = quad_vec(func, 0, 4)
-        with np.testing.assert_warns(DeprecationWarning,
-                                     match="'full output"):
-            res2 = quad_vec(func, 0, 4, full_output=False)
-        with np.testing.assert_warns(DeprecationWarning,
-                                     match="'full output"):
-            res3 = quad_vec(func, 0, 4, full_output=True)
-
-        assert_equal(res, res2)
-        assert res.success == res2.success
-        assert res.status == res2.status
-        assert res.neval == res2.neval
-        assert_equal(res.intervals, res2.intervals)
-        assert_equal(res.integrals, res2.integrals)
-        assert_equal(res.errors, res2.errors)
-        assert_equal(res.message, res2.message)
-
-        assert_equal(res, res3[:2])
-        assert_equal(res.success, res3[2].success)
-        assert_equal(res.status, res3[2].status)
-        assert_equal(res.neval, res3[2].neval)
-        assert_equal(res.intervals, res3[2].intervals)
-        assert_equal(res.integrals, res3[2].integrals)
-        assert_equal(res.errors, res3[2].errors)
-        assert_equal(res.message, res3[2].message)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -540,6 +540,7 @@ class TestQuad:
 
 
 class TestNQuad:
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +
@@ -550,9 +551,9 @@ class TestNQuad:
             return {'points': [0.2*args[2] + 0.5 + 0.25*args[0]]}
 
         res = nquad(func1, [[0, 1], [-1, 1], [.13, .8], [-.15, 1]],
-                    opts=[opts_basic, {}, {}, {}])
-        assert_quad(res, 1.5267454070738635)
-        assert res.neval > 0 and res.neval < 4e5
+                    opts=[opts_basic, {}, {}, {}], full_output=True)
+        assert_quad(res[:-1], 1.5267454070738635)
+        assert_(res[-1]['neval'] > 0 and res[-1]['neval'] < 4e5)
 
     def test_variable_limits(self):
         scale = .1

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -2,7 +2,7 @@ import sys
 import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
-from numpy.testing import (assert_, assert_equal,
+from numpy.testing import (assert_,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
 
@@ -540,7 +540,6 @@ class TestQuad:
 
 
 class TestNQuad:
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +
@@ -676,23 +675,3 @@ class TestNQuad:
         except TypeError:
             assert False
 
-    def test_result_object(self):
-        # Check that result object contains attributes `integral`, `abserr`,
-        # and `neval`. During the `full_output` deprecation period, also check
-        # that specifying `full_output` produces a warning and that values
-        # are the same whether `full_output` is True, False, or unspecified.
-        def func(x):
-            return x**2 + 1
-
-        res = nquad(func, ranges=[[0, 4]])
-        with np.testing.assert_warns(DeprecationWarning):
-            res2 = nquad(func, ranges=[[0, 4]], full_output=False)
-        with np.testing.assert_warns(DeprecationWarning):
-            res3 = nquad(func, ranges=[[0, 4]], full_output=True)
-
-        assert_equal(res, res2)
-        assert res.integral == res2.integral
-        assert res.abserr == res2.abserr
-
-        assert_equal(res, res3[:2])
-        assert_equal(res.neval, res3[2]['neval'])

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -2,7 +2,7 @@ import sys
 import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
-from numpy.testing import (assert_equal,
+from numpy.testing import (assert_, assert_equal,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
 


### PR DESCRIPTION
#### Reference issue
gh-7816
gh-16086
gh-17837
gh-17964
gh-18298

#### What does this implement/fix?
gh-7816 suggested making `quad` return a bunch object with all of `quad`'s output information. This would eliminate the need for `full_output` and sidestep the decision tree that decides how many outputs to return.

gh-16086, gh-17837, and gh-17964 implemented this suggestion for `dblquad`, `tplquad`, `nquad`, and `quad_vec`.

gh-18298 got held up making this change for `quad` because the output information is much more complicated. I'd prefer to change all the related functions at the same time, so this reverts the changes to `dblquad`, `tplquad`,`nquad`, and `quad_vec` for the 1.11.0 release. We can revert the revert after branching and take our time with gh-18298.
