### PR TITLE
DEP: sparse: deprecate `isspmatrix` and `isspmatrix_fmt`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,6 +183,12 @@ warnings.filterwarnings(
     message=r'There is no current event loop',
     category=DeprecationWarning,
 )
+# warnings in sparse for isspmatrix and isspmatrix_fmt
+warnings.filterwarnings(
+    'ignore',
+    message=r'.*isspmatrix.*',
+    category=DeprecationWarning,
+)
 
 # -----------------------------------------------------------------------------
 # HTML output

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1490,6 +1490,12 @@ def issparse(x):
 def isspmatrix(x):
     """Is `x` of a sparse matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x)`` to test sparsity (sparray or spmatrix)
+        Use ``isinstance(x, scipy.sparse.spmatrix)`` to test sparse matrix
+
     Parameters
     ----------
     x
@@ -1513,4 +1519,8 @@ def isspmatrix(x):
     >>> isspmatrix(5)
     False
     """
+    warn('\nisspmatrix is deprecated and will be removed in v1.13.0\n'
+         'Use issparse(x) to check sparsity (sparray or spmatrix) or\n'
+         'isinstance(x, spmatrix) to check for sparse matrix',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, spmatrix)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -702,6 +702,12 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 def isspmatrix_bsr(x):
     """Is `x` of a bsr_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_bsr is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "bsr"`` to test sparsity & bsr format or
+        Use ``isinstance(x, scipy.sparse.bsr_matrix)`` to test for sparse matrix & bsr
+
     Parameters
     ----------
     x
@@ -722,6 +728,10 @@ def isspmatrix_bsr(x):
     >>> isspmatrix_bsr(csr_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_bsr is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "bsr"` to check sparsity and bsr format\n'
+         'or `isinstance(x, bsr_matrix)` to check for sparse matrix and bsr format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, bsr_matrix)
 
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -602,6 +602,12 @@ class _coo_base(_data_matrix, _minmax_mixin):
 def isspmatrix_coo(x):
     """Is `x` of coo_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_coo is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "coo"`` to test sparsity & coo format or
+        Use ``isinstance(x, scipy.sparse.coo_matrix)`` to test for sparse matrix & coo
+
     Parameters
     ----------
     x
@@ -622,6 +628,10 @@ def isspmatrix_coo(x):
     >>> isspmatrix_coo(csr_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_coo is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "coo"` to check sparsity and coo format\n'
+         'or `isinstance(x, coo_matrix)` to check for sparse matrix and coo format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, coo_matrix)
 
 

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -3,6 +3,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['csc_array', 'csc_matrix', 'isspmatrix_csc']
 
+from warnings import warn
 
 import numpy as np
 
@@ -240,6 +241,12 @@ class _csc_base(_cs_matrix):
 def isspmatrix_csc(x):
     """Is `x` of csc_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_csc is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "csc"`` to test sparsity & csc format or
+        Use ``isinstance(x, scipy.sparse.csc_matrix)`` to test for sparse matrix & csc
+
     Parameters
     ----------
     x
@@ -260,6 +267,10 @@ def isspmatrix_csc(x):
     >>> isspmatrix_csc(coo_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_csc is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "csc"` to check sparsity and csc format\n'
+         'or `isinstance(x, csc_matrix)` to check for sparse matrix and csc format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, csc_matrix)
 
 

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -1,4 +1,5 @@
 """Compressed Sparse Row matrix format"""
+from warnings import warn
 
 __docformat__ = "restructuredtext en"
 
@@ -338,6 +339,12 @@ class _csr_base(_cs_matrix):
 def isspmatrix_csr(x):
     """Is `x` of csr_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_csr is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "csr"`` to test sparsity & csr format or
+        Use ``isinstance(x, scipy.sparse.csr_matrix)`` to test for sparse matrix & csr
+
     Parameters
     ----------
     x
@@ -358,6 +365,10 @@ def isspmatrix_csr(x):
     >>> isspmatrix_csr(coo_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_csr is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "csr"` to check sparsity and csr format\n'
+         'or `isinstance(x, csr_matrix)` to check for sparse matrix and csr format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, csr_matrix)
 
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -1,4 +1,5 @@
 """Sparse DIAgonal format"""
+from warnings import warn
 
 __docformat__ = "restructuredtext en"
 
@@ -446,6 +447,12 @@ class _dia_base(_data_matrix):
 def isspmatrix_dia(x):
     """Is `x` of dia_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_dia is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "dia"`` to test sparsity & dia format or
+        Use ``isinstance(x, scipy.sparse.dia_matrix)`` to test for sparse matrix & dia
+
     Parameters
     ----------
     x
@@ -466,6 +473,10 @@ def isspmatrix_dia(x):
     >>> isspmatrix_dia(coo_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_dia is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "dia"` to check sparsity and dia format\n'
+         'or `isinstance(x, dia_matrix)` to check for sparse matrix and dia format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, dia_matrix)
 
 

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -1,4 +1,5 @@
 """Dictionary Of Keys based matrix"""
+from warnings import warn
 
 __docformat__ = "restructuredtext en"
 
@@ -427,6 +428,12 @@ class _dok_base(_spbase, IndexMixin, dict):
 def isspmatrix_dok(x):
     """Is `x` of dok_array type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_dok is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "dok"`` to test sparsity & dok format or
+        Use ``isinstance(x, scipy.sparse.dok_matrix)`` to test for sparse matrix & dok
+
     Parameters
     ----------
     x
@@ -447,6 +454,10 @@ def isspmatrix_dok(x):
     >>> isspmatrix_dok(coo_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_dok is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "dok"` to check sparsity and dok format\n'
+         'or `isinstance(x, dok_matrix)` to check for sparse matrix and dok format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, dok_matrix)
 
 

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -1,5 +1,6 @@
 """List of Lists sparse matrix class
 """
+from warnings import warn
 
 __docformat__ = "restructuredtext en"
 
@@ -524,6 +525,12 @@ def _prepare_index_for_memoryview(i, j, x=None):
 def isspmatrix_lil(x):
     """Is `x` of lil_matrix type?
 
+    .. deprecated:: 1.11.0
+
+        isspmatrix_lil is deprecated and will be removed in SciPy 1.13.0
+        Use ``issparse(x) and x.format == "lil"`` to test sparsity & lil format or
+        Use ``isinstance(x, scipy.sparse.lil_matrix)`` to test for sparse matrix & lil
+
     Parameters
     ----------
     x
@@ -544,6 +551,10 @@ def isspmatrix_lil(x):
     >>> isspmatrix_lil(coo_matrix([[5]]))
     False
     """
+    warn('\nisspmatrix_lil is deprecated and will be removed in SciPy 1.13.0\n'
+         'Use `issparse(x) and x.format == "lil"` to check sparsity and lil format\n'
+         'or `isinstance(x, lil_matrix)` to check for sparse matrix and lil format',
+         DeprecationWarning, stacklevel=2)
     return isinstance(x, lil_matrix)
 
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -506,18 +506,19 @@ def test_issparse():
 
 
 def test_isspmatrix():
-    m = scipy.sparse.eye(3)
-    a = scipy.sparse.csr_array(m)
-    assert not m._is_array
-    assert a._is_array
+    with pytest.deprecated_call(match='isspmatrix'):
+        m = scipy.sparse.eye(3)
+        a = scipy.sparse.csr_array(m)
+        assert not m._is_array
+        assert a._is_array
 
-    # Should only be true for sparse matrices, not sparse arrays
-    assert not scipy.sparse.isspmatrix(a)
-    assert scipy.sparse.isspmatrix(m)
+        # Should only be true for sparse matrices, not sparse arrays
+        assert not scipy.sparse.isspmatrix(a)
+        assert scipy.sparse.isspmatrix(m)
 
-    # ndarray and array_likes are not sparse
-    assert not scipy.sparse.isspmatrix(a.todense())
-    assert not scipy.sparse.isspmatrix(m.todense())
+        # ndarray and array_likes are not sparse
+        assert not scipy.sparse.isspmatrix(a.todense())
+        assert not scipy.sparse.isspmatrix(m.todense())
 
 
 @pytest.mark.parametrize(
@@ -533,15 +534,16 @@ def test_isspmatrix():
     ),
 )
 def test_isspmatrix_format(fmt, fn):
-    m = scipy.sparse.eye(3, format=fmt)
-    a = scipy.sparse.csr_array(m).asformat(fmt)
-    assert not m._is_array
-    assert a._is_array
+    with pytest.deprecated_call(match='isspmatrix'):
+        m = scipy.sparse.eye(3, format=fmt)
+        a = scipy.sparse.csr_array(m).asformat(fmt)
+        assert not m._is_array
+        assert a._is_array
 
-    # Should only be true for sparse matrices, not sparse arrays
-    assert not fn(a)
-    assert fn(m)
+        # Should only be true for sparse matrices, not sparse arrays
+        assert not fn(a)
+        assert fn(m)
 
-    # ndarray and array_likes are not sparse
-    assert not fn(a.todense())
-    assert not fn(m.todense())
+        # ndarray and array_likes are not sparse
+        assert not fn(a.todense())
+        assert not fn(m.todense())

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -32,3 +32,39 @@ def test_array_api_deprecations():
 
     with pytest.deprecated_call(match=msg):
         X.getrow(1).todense()
+
+
+def test_isspmatrix_deprecations():
+    msg = "1.13.0"
+
+    X = sp.sparse.csr_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix(X)
+
+    X = sp.sparse.bsr_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_bsr(X)
+
+    X = sp.sparse.coo_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_coo(X)
+
+    X = sp.sparse.csc_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_csc(X)
+
+    X = sp.sparse.csr_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_csr(X)
+
+    X = sp.sparse.dia_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_dia(X)
+
+    X = sp.sparse.dok_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_dok(X)
+
+    X = sp.sparse.lil_matrix([[1, 0], [0, 1]])
+    with pytest.deprecated_call(match=msg):
+        sp.sparse.isspmatrix_lil(X)


### PR DESCRIPTION
Deprecate `isspmatrix` and `isspmatrix_fmt`

This is unlikely to pass tests before #18556 is merged. So, its in draft PR mode now.