### PR TITLE
ENH: linalg: Add wrapper for `?tgsyl`

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -400,36 +400,36 @@ subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,sca
     ! scaling factor chosen to avoid overflow.
 
 
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
+    callstatement (*f2py_func)(trans,&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
     callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
-    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
-    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
+    character optional,intent(in),check((*trans=='N')||(*trans=='T')) :: trans = 'N'
+    integer optional,intent(in),check(ijob>=0 && ijob<=4):: ijob = 1
     integer intent(hide),depend(a):: m = shape(a,1)
     integer intent(hide),depend(b):: n = shape(b,1)
      
-    <ftype2> intent(in),dimension(lda,m):: a
+    <ftype2> intent(in),dimension(m,m):: a
     integer intent(hide),depend(a):: lda = max(shape(a,0),1)
      
-    <ftype2> intent(in),dimension(ldb,n):: b
+    <ftype2> intent(in),dimension(n,n):: b
     integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
 
-    <ftype2> intent(in,copy,out,out=r),dimension(ldc,n):: c
+    <ftype2> intent(in,copy,out,out=r),dimension(m,n):: c
     integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
 
-    <ftype2> intent(in),dimension(ldd,m):: d
+    <ftype2> intent(in),dimension(m,m):: d
     integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
      
-    <ftype2> intent(in),dimension(lde,n):: e
+    <ftype2> intent(in),dimension(n,n):: e
     integer intent(hide),depend(e):: lde = max(shape(e,0),1)
 
-    <ftype2> intent(in,copy,out,out=l),dimension(ldf,n):: f
+    <ftype2> intent(in,copy,out,out=l),dimension(m,n):: f
     integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
     
     <ftype2> intent(out):: scale
     <ftype2> intent(out):: dif
-    <ftype2> intent(hide,cache),depend(lwork),dimension(MAX(1,lwork)):: work 
-    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && trans) ? lwork>=max(1,2*m*n):lwork>=n):: lwork = max(1,2*m*n)
+    <ftype2> intent(hide),depend(lwork),dimension(max(1,lwork)):: work 
+    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && (*trans=='N')) ? lwork>=max(1,2*m*n):(lwork>=n||lwork==-1)):: lwork = max(1,2*m*n)
     integer intent(out),depend(m,n),dimension(m+n+6):: iwork
     integer intent(out):: info
 
@@ -441,37 +441,37 @@ subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,l
     
     fortranname <prefix2>tgsyl
     
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,iwork,&info)
+    callstatement (*f2py_func)(trans,&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
     callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
-    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
-    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
-    integer intent(hide),depend(a):: m = shape(a,1)
-    integer intent(hide),depend(b):: n = shape(b,1)
+    character optional,intent(in),check((*trans=='N')||(*trans=='T')):: trans = 'N'
+    integer optional,intent(in),check(ijob>=0 && ijob<=4):: ijob = 0
+    integer intent(in),check(m>=0):: m 
+    integer intent(in),check(n>=0):: n 
      
-    <ftype2> intent(hide),dimension(lda,m):: a
-    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
+    <ftype2> intent(hide),dimension(m,m):: a 
+    integer intent(hide):: lda = max(m,1)
      
-    <ftype2> intent(hide),dimension(ldb,n):: b
-    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
+    <ftype2> intent(hide),dimension(n,n):: b
+    integer intent(hide):: ldb = max(n,1)
 
-    <ftype2> intent(hide,copy,out,out=r),dimension(ldc,n):: c
-    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
+    <ftype2> intent(hide),dimension(m,n):: c
+    integer intent(hide):: ldc = max(m,1)
 
-    <ftype2> intent(hide),dimension(ldd,m):: d
-    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
+    <ftype2> intent(hide),dimension(m,m):: d
+    integer intent(hide):: ldd = max(m,1)
      
-    <ftype2> intent(hide),dimension(lde,n):: e
-    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
+    <ftype2> intent(hide),dimension(n,n):: e
+    integer intent(hide):: lde = max(n,1)
 
-    <ftype2> intent(hide,copy,out,out=l),dimension(ldf,n):: f
-    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
+    <ftype2> intent(hide),dimension(m,n):: f
+    integer intent(hide):: ldf = max(m,1)
     
-    <ftype2> intent(out):: scale
-    <ftype2> intent(out):: dif
+    <ftype2> intent(hide):: scale
+    <ftype2> intent(hide):: dif
     <ftype2> intent(out):: work 
     integer intent(hide):: lwork = -1
-    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    integer intent(hide):: iwork
     integer intent(out):: info
 
 end subroutine <prefix2>tgsyl_lwork

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2399,4 +2399,4 @@ subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,l
     
     integer intent(out):: info
 
-end subroutine <prefix2>tgsyl_work
+end subroutine <prefix2>tgsyl_lwork

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2304,3 +2304,99 @@ subroutine ilaver(major, minor, patch)
     integer intent(out) :: minor
     integer intent(out) :: patch
 end subroutine ilaver
+
+subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
+
+    ! Solves the generalized Sylvester equation:
+    ! A * R - L * B = scale * C                
+    ! D * R - L * E = scale * F
+    ! where R and L are unknown m-by-n matrices, (A, D), (B, E) and
+    ! (C, F) are given matrix pairs of size m-by-m, n-by-n and m-by-n,
+    ! respectively, with real entries. (A, D) and (B, E) must be in
+    ! generalized (real) Schur canonical form, i.e. A, B are upper quasi
+    ! triangular and D, E are upper triangular.
+    ! The solution (R, L) overwrites (C, F). 0 <= SCALE <= 1 is an output
+    ! scaling factor chosen to avoid overflow.
+
+
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,&a,&lda,&b,&ldb,&c,&ldc,&d,&ldd,&e,&lde,&f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>,<ctype2>,<ctype2>*,F_INT*,F_INT*,F_INT*
+
+    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
+    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
+    integer intent(hide),depend(a):: m = shape(a,1)
+    integer intent(hide),depend(b):: n = shape(b,1)
+     
+    <ftype2> intent(in),dimension(lda,m):: a
+    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
+     
+    <ftype2> intent(in),dimension(ldb,n):: b
+    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
+
+    <ftype2> intent(in,copy,out,out=r),dimension(ldc,n):: c
+    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
+
+    <ftype2> intent(in),dimension(ldd,m):: d
+    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
+     
+    <ftype2> intent(in),dimension(lde,n):: e
+    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
+
+    <ftype2> intent(in,copy,out,out=l),dimension(ldf,n):: f
+    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
+    
+    <ftype2> intent(out):: dif
+    <ftype2> intent(out):: scal
+     
+    <ftype2> intent(hide,cache),depend(lwork),dimension(MAX(1,lwork)):: work 
+     
+    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((((ijob==1)||ijob==2))&&!trans)?(lwork>=max(1,2*m*n)):(lwork>=n||lwork==-1)):: lwork = max(1,2*m*n)
+    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    
+    integer intent(out):: info
+
+end subroutine <prefix2>tgsyl
+
+subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
+
+    ! lwork computation for ?TGSYL
+    
+    fortranname <prefix2>tgsyl
+    
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,&a,&lda,&b,&ldb,&c,&ldc,&d,&ldd,&e,&lde,&f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>,<ctype2>,<ctype2>*,F_INT*,F_INT*,F_INT*
+
+    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
+    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
+    integer intent(hide),depend(a):: m = shape(a,1)
+    integer intent(hide),depend(b):: n = shape(b,1)
+     
+    <ftype2> intent(hide),dimension(lda,m):: a
+    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
+     
+    <ftype2> intent(hide),dimension(ldb,n):: b
+    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
+
+    <ftype2> intent(hide,copy,out,out=r),dimension(ldc,n):: c
+    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
+
+    <ftype2> intent(hide),dimension(ldd,m):: d
+    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
+     
+    <ftype2> intent(hide),dimension(lde,n):: e
+    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
+
+    <ftype2> intent(hide,copy,out,out=l),dimension(ldf,n):: f
+    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
+    
+    <ftype2> intent(out):: dif
+    <ftype2> intent(out):: scal
+     
+    <ftype2> intent(out):: work 
+     
+    integer intent(hide):: lwork = -1
+    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    
+    integer intent(out):: info
+
+end subroutine <prefix2>tgsyl_work

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2319,8 +2319,8 @@ subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,sca
     ! scaling factor chosen to avoid overflow.
 
 
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,&a,&lda,&b,&ldb,&c,&ldc,&d,&ldd,&e,&lde,&f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
-    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>,<ctype2>,<ctype2>*,F_INT*,F_INT*,F_INT*
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
     integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
@@ -2345,14 +2345,11 @@ subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,sca
     <ftype2> intent(in,copy,out,out=l),dimension(ldf,n):: f
     integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
     
+    <ftype2> intent(out):: scale
     <ftype2> intent(out):: dif
-    <ftype2> intent(out):: scal
-     
     <ftype2> intent(hide,cache),depend(lwork),dimension(MAX(1,lwork)):: work 
-     
-    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((((ijob==1)||ijob==2))&&!trans)?(lwork>=max(1,2*m*n)):(lwork>=n||lwork==-1)):: lwork = max(1,2*m*n)
+    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && trans) ? lwork>=max(1,2*m*n):lwork>=n):: lwork = max(1,2*m*n)
     integer intent(out),depend(m,n),dimension(m+n+6):: iwork
-    
     integer intent(out):: info
 
 end subroutine <prefix2>tgsyl
@@ -2363,8 +2360,8 @@ subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,l
     
     fortranname <prefix2>tgsyl
     
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,&a,&lda,&b,&ldb,&c,&ldc,&d,&ldd,&e,&lde,&f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
-    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>,<ctype2>,<ctype2>*,F_INT*,F_INT*,F_INT*
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
     integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
@@ -2389,14 +2386,11 @@ subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,l
     <ftype2> intent(hide,copy,out,out=l),dimension(ldf,n):: f
     integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
     
+    <ftype2> intent(out):: scale
     <ftype2> intent(out):: dif
-    <ftype2> intent(out):: scal
-     
     <ftype2> intent(out):: work 
-     
     integer intent(hide):: lwork = -1
     integer intent(out),depend(m,n),dimension(m+n+6):: iwork
-    
     integer intent(out):: info
 
 end subroutine <prefix2>tgsyl_lwork

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -398,13 +398,12 @@ subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,sca
     ! triangular and D, E are upper triangular.
     ! The solution (R, L) overwrites (C, F). 0 <= SCALE <= 1 is an output
     ! scaling factor chosen to avoid overflow.
-
-
+    
     callstatement (*f2py_func)(trans,&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
     callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     character optional,intent(in),check((*trans=='N')||(*trans=='T')) :: trans = 'N'
-    integer optional,intent(in),check(ijob>=0 && ijob<=4):: ijob = 1
+    integer optional,intent(in),check(ijob>=0 && ijob<=4):: ijob = 0
     integer intent(hide),depend(a):: m = shape(a,1)
     integer intent(hide),depend(b):: n = shape(b,1)
      
@@ -430,51 +429,10 @@ subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,sca
     <ftype2> intent(out):: dif
     <ftype2> intent(hide),depend(lwork),dimension(max(1,lwork)):: work 
     integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && (*trans=='N')) ? lwork>=max(1,2*m*n):(lwork>=n||lwork==-1)):: lwork = max(1,2*m*n)
-    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    integer intent(hide),depend(m,n),dimension(m+n+6):: iwork
     integer intent(out):: info
 
 end subroutine <prefix2>tgsyl
-
-subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
-
-    ! lwork computation for ?TGSYL
-    
-    fortranname <prefix2>tgsyl
-    
-    callstatement (*f2py_func)(trans,&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,&iwork,&info)
-    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
-
-    character optional,intent(in),check((*trans=='N')||(*trans=='T')):: trans = 'N'
-    integer optional,intent(in),check(ijob>=0 && ijob<=4):: ijob = 0
-    integer intent(in),check(m>=0):: m 
-    integer intent(in),check(n>=0):: n 
-     
-    <ftype2> intent(hide),dimension(m,m):: a 
-    integer intent(hide):: lda = max(m,1)
-     
-    <ftype2> intent(hide),dimension(n,n):: b
-    integer intent(hide):: ldb = max(n,1)
-
-    <ftype2> intent(hide),dimension(m,n):: c
-    integer intent(hide):: ldc = max(m,1)
-
-    <ftype2> intent(hide),dimension(m,m):: d
-    integer intent(hide):: ldd = max(m,1)
-     
-    <ftype2> intent(hide),dimension(n,n):: e
-    integer intent(hide):: lde = max(n,1)
-
-    <ftype2> intent(hide),dimension(m,n):: f
-    integer intent(hide):: ldf = max(m,1)
-    
-    <ftype2> intent(hide):: scale
-    <ftype2> intent(hide):: dif
-    <ftype2> intent(out):: work 
-    integer intent(hide):: lwork = -1
-    integer intent(hide):: iwork
-    integer intent(out):: info
-
-end subroutine <prefix2>tgsyl_lwork
 
 subroutine <prefix2>pbtrf(lower,n,kd,ab,ldab,info)
     ! Compute Cholesky decomposition of banded symmetric positive definite

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -386,6 +386,96 @@ subroutine <prefix2c>tgsen_lwork(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,bet
 
 end subroutine <prefix2c>tgsen_lwork
 
+subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
+
+    ! Solves the generalized Sylvester equation:
+    ! A * R - L * B = scale * C                
+    ! D * R - L * E = scale * F
+    ! where R and L are unknown m-by-n matrices, (A, D), (B, E) and
+    ! (C, F) are given matrix pairs of size m-by-m, n-by-n and m-by-n,
+    ! respectively, with real entries. (A, D) and (B, E) must be in
+    ! generalized (real) Schur canonical form, i.e. A, B are upper quasi
+    ! triangular and D, E are upper triangular.
+    ! The solution (R, L) overwrites (C, F). 0 <= SCALE <= 1 is an output
+    ! scaling factor chosen to avoid overflow.
+
+
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
+
+    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
+    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
+    integer intent(hide),depend(a):: m = shape(a,1)
+    integer intent(hide),depend(b):: n = shape(b,1)
+     
+    <ftype2> intent(in),dimension(lda,m):: a
+    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
+     
+    <ftype2> intent(in),dimension(ldb,n):: b
+    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
+
+    <ftype2> intent(in,copy,out,out=r),dimension(ldc,n):: c
+    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
+
+    <ftype2> intent(in),dimension(ldd,m):: d
+    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
+     
+    <ftype2> intent(in),dimension(lde,n):: e
+    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
+
+    <ftype2> intent(in,copy,out,out=l),dimension(ldf,n):: f
+    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
+    
+    <ftype2> intent(out):: scale
+    <ftype2> intent(out):: dif
+    <ftype2> intent(hide,cache),depend(lwork),dimension(MAX(1,lwork)):: work 
+    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && trans) ? lwork>=max(1,2*m*n):lwork>=n):: lwork = max(1,2*m*n)
+    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    integer intent(out):: info
+
+end subroutine <prefix2>tgsyl
+
+subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
+
+    ! lwork computation for ?TGSYL
+    
+    fortranname <prefix2>tgsyl
+    
+    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,iwork,&info)
+    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
+
+    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
+    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
+    integer intent(hide),depend(a):: m = shape(a,1)
+    integer intent(hide),depend(b):: n = shape(b,1)
+     
+    <ftype2> intent(hide),dimension(lda,m):: a
+    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
+     
+    <ftype2> intent(hide),dimension(ldb,n):: b
+    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
+
+    <ftype2> intent(hide,copy,out,out=r),dimension(ldc,n):: c
+    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
+
+    <ftype2> intent(hide),dimension(ldd,m):: d
+    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
+     
+    <ftype2> intent(hide),dimension(lde,n):: e
+    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
+
+    <ftype2> intent(hide,copy,out,out=l),dimension(ldf,n):: f
+    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
+    
+    <ftype2> intent(out):: scale
+    <ftype2> intent(out):: dif
+    <ftype2> intent(out):: work 
+    integer intent(hide):: lwork = -1
+    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
+    integer intent(out):: info
+
+end subroutine <prefix2>tgsyl_lwork
+
 subroutine <prefix2>pbtrf(lower,n,kd,ab,ldab,info)
     ! Compute Cholesky decomposition of banded symmetric positive definite
     ! matrix:
@@ -2304,93 +2394,3 @@ subroutine ilaver(major, minor, patch)
     integer intent(out) :: minor
     integer intent(out) :: patch
 end subroutine ilaver
-
-subroutine <prefix2>tgsyl(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
-
-    ! Solves the generalized Sylvester equation:
-    ! A * R - L * B = scale * C                
-    ! D * R - L * E = scale * F
-    ! where R and L are unknown m-by-n matrices, (A, D), (B, E) and
-    ! (C, F) are given matrix pairs of size m-by-m, n-by-n and m-by-n,
-    ! respectively, with real entries. (A, D) and (B, E) must be in
-    ! generalized (real) Schur canonical form, i.e. A, B are upper quasi
-    ! triangular and D, E are upper triangular.
-    ! The solution (R, L) overwrites (C, F). 0 <= SCALE <= 1 is an output
-    ! scaling factor chosen to avoid overflow.
-
-
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,work,&lwork,iwork,&info)
-    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
-
-    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
-    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
-    integer intent(hide),depend(a):: m = shape(a,1)
-    integer intent(hide),depend(b):: n = shape(b,1)
-     
-    <ftype2> intent(in),dimension(lda,m):: a
-    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
-     
-    <ftype2> intent(in),dimension(ldb,n):: b
-    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
-
-    <ftype2> intent(in,copy,out,out=r),dimension(ldc,n):: c
-    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
-
-    <ftype2> intent(in),dimension(ldd,m):: d
-    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
-     
-    <ftype2> intent(in),dimension(lde,n):: e
-    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
-
-    <ftype2> intent(in,copy,out,out=l),dimension(ldf,n):: f
-    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
-    
-    <ftype2> intent(out):: scale
-    <ftype2> intent(out):: dif
-    <ftype2> intent(hide,cache),depend(lwork),dimension(MAX(1,lwork)):: work 
-    integer optional,intent(in),depend(ijob,trans,m,n),check ( ((ijob==1||ijob==2) && trans) ? lwork>=max(1,2*m*n):lwork>=n):: lwork = max(1,2*m*n)
-    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
-    integer intent(out):: info
-
-end subroutine <prefix2>tgsyl
-
-subroutine <prefix2>tgsyl_lwork(trans,ijob,m,n,a,lda,b,ldb,c,ldc,d,ldd,e,lde,f,ldf,scale,dif,work,lwork,iwork,info)
-
-    ! lwork computation for ?TGSYL
-    
-    fortranname <prefix2>tgsyl
-    
-    callstatement (*f2py_func)((trans?(trans==2?"C":"T"):"N"),&ijob,&m,&n,a,&lda,b,&ldb,c,&ldc,d,&ldd,e,&lde,f,&ldf,&scale,&dif,&work,&lwork,iwork,&info)
-    callprotoargument char*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*
-
-    integer optional,intent(in),check(trans>=0 && trans <=2):: trans = 0
-    integer optional,intent(in),check(ijob>=0 && ijob <=4):: ijob = 0
-    integer intent(hide),depend(a):: m = shape(a,1)
-    integer intent(hide),depend(b):: n = shape(b,1)
-     
-    <ftype2> intent(hide),dimension(lda,m):: a
-    integer intent(hide),depend(a):: lda = max(shape(a,0),1)
-     
-    <ftype2> intent(hide),dimension(ldb,n):: b
-    integer intent(hide),depend(b):: ldb = max(shape(b,0),1)
-
-    <ftype2> intent(hide,copy,out,out=r),dimension(ldc,n):: c
-    integer intent(hide),depend(c) :: ldc = max(shape(c,0),1)
-
-    <ftype2> intent(hide),dimension(ldd,m):: d
-    integer intent(hide),depend(d):: ldd = max(shape(d,0),1)
-     
-    <ftype2> intent(hide),dimension(lde,n):: e
-    integer intent(hide),depend(e):: lde = max(shape(e,0),1)
-
-    <ftype2> intent(hide,copy,out,out=l),dimension(ldf,n):: f
-    integer intent(hide),depend(f):: ldf = max(shape(f,0),1)
-    
-    <ftype2> intent(out):: scale
-    <ftype2> intent(out):: dif
-    <ftype2> intent(out):: work 
-    integer intent(hide):: lwork = -1
-    integer intent(out),depend(m,n),dimension(m+n+6):: iwork
-    integer intent(out):: info
-
-end subroutine <prefix2>tgsyl_lwork

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -660,6 +660,11 @@ All functions
    csytrf_lwork
    zsytrf_lwork
 
+   stgsyl
+   dtgsyl 
+   stgsyl_lwork
+   dtgsyl_lwork 
+   
    stbtrs
    dtbtrs
    ctbtrs

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -659,11 +659,6 @@ All functions
    dsytrf_lwork
    csytrf_lwork
    zsytrf_lwork
-
-   stgsyl
-   dtgsyl 
-   stgsyl_lwork
-   dtgsyl_lwork 
    
    stbtrs
    dtbtrs
@@ -699,6 +694,12 @@ All functions
    dtgsen_lwork
    ctgsen_lwork
    ztgsen_lwork
+
+   stgsyl
+   dtgsyl 
+   
+   stgsyl_lwork
+   dtgsyl_lwork 
 
    stpttf
    dtpttf

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -697,9 +697,6 @@ All functions
 
    stgsyl
    dtgsyl 
-   
-   stgsyl_lwork
-   dtgsyl_lwork 
 
    stpttf
    dtpttf

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -659,7 +659,7 @@ All functions
    dsytrf_lwork
    csytrf_lwork
    zsytrf_lwork
-   
+
    stbtrs
    dtbtrs
    ctbtrs
@@ -696,7 +696,7 @@ All functions
    ztgsen_lwork
 
    stgsyl
-   dtgsyl 
+   dtgsyl
 
    stpttf
    dtpttf

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3298,3 +3298,31 @@ def test_gges_tgsen(dtype):
 
     assert_allclose(s[0, 0] / t[0, 0], d2, rtol=0, atol=atol)
     assert_allclose(s[1, 1] / t[1, 1], d1, rtol=0, atol=atol)
+
+@pytest.mark.parametrize('dtype', REAL_DTYPES)
+@pytest.mark.parametrize('trans', ('N', 'T'))
+def test_tgsyl(dtype,trans):
+    
+    seed(1234)
+    atol = np.finfo(dtype).eps*100
+    
+    m, n = 15, 10
+    
+    a = np.triu(generate_random_dtype_array([m, m], dtype=dtype))
+    d = np.triu(generate_random_dtype_array([m, m], dtype=dtype))
+    b = np.triu(generate_random_dtype_array([n, n], dtype=dtype))
+    e = np.triu(generate_random_dtype_array([n, n], dtype=dtype))
+    c = np.triu(generate_random_dtype_array([m, n], dtype=dtype))
+    f = np.triu(generate_random_dtype_array([m, n], dtype=dtype))
+
+    tgsyl, tgsyl_lwork = get_lapack_funcs(
+        ('tgsyl','tgsyl_lwork'), dtype=dtype)
+    ijob =1
+    lwork = _compute_lwork(tgsyl_lwork,m, n)#, trans=trans, ijob=ijob)
+
+    print(lwork)
+    # off-by-one error in LAPACK, see gh-issue #13397
+    # lwork = (lwork[0]+1, lwork[1])
+
+    result = tgsyl(a,b,c,d,e,f,trans=trans,ijob=ijob)
+

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3358,7 +3358,7 @@ def test_tgsyl_NAG(a, b, c, d, e, f, rans, lans, dtype):
 def test_tgsyl(dtype, trans, ijob):
 
     seed(2023)
-    atol = 1e-3 if dtype == np.float32 else 1e-10
+    atol = 1e-2 if dtype == np.float32 else 1e-10
 
     m, n = 10, 15
 
@@ -3370,8 +3370,6 @@ def test_tgsyl(dtype, trans, ijob):
     f = generate_random_dtype_array([m, n], dtype=dtype)
 
     # Adjust the spectrum of the matrices to get a more precise solution
-    adjustment_m = np.eye(m, dtype=dtype)
-    adjustment_n = np.eye(n, dtype=dtype)
     a += np.eye(m, dtype=dtype)
     d -= np.diag(5*np.ones(m, dtype=dtype))
     b += np.eye(n, dtype=dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3341,8 +3341,8 @@ def test_tgsyl_NAG(a,b,c,d,e,f,r,l,dtype):
     rans,lans,scale,dif,info = tgsyl(a,b,c,d,e,f)
     
     assert_equal(info, 0)
-    assert_almost_equal(scale,1.0,decimal=4,err_msg="SCALE must be 1.0")
-    assert_almost_equal(dif,0.0,decimal=2,err_msg="DIF must be nearly 0")
+    assert_allclose(scale,1.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="SCALE must be 1.0")
+    assert_allclose(dif,0.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="DIF must be nearly 0")
     assert_allclose(rans,r,atol=atol,err_msg='Solution for unknown R of Sylvester equation is not correct')
     assert_allclose(lans,l,atol=atol,err_msg='Solution for unknown L of Sylvester equation is not correct')
     
@@ -3353,6 +3353,9 @@ def test_tgsyl(dtype,trans,ijob):
     
     seed(2023)
     atol = 1e-2
+    if(dtype==np.float32):
+        atol = 5e-2
+    
     m, n = 10, 15
     
     a,_ = schur(generate_random_dtype_array([m, m], dtype=dtype))
@@ -3369,7 +3372,7 @@ def test_tgsyl(dtype,trans,ijob):
 
     assert scale>=0.0,"SCALE must be non-negative"
     if (ijob==0):
-        assert_almost_equal(dif,0.0,decimal=4,err_msg="DIF must be 0 for ijob =0")
+        assert_allclose(dif,0.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="DIF must be 0 for ijob =0")
     else:
         assert dif>=0.0,"DIF must be non-negative"
     
@@ -3381,9 +3384,9 @@ def test_tgsyl(dtype,trans,ijob):
             lhs2 = d @ r - l @ e
             rhs2 = scale*f
         elif (trans=='T'):
-            lhs1 = np.transpose(a)@ r + np.transpose(d) @ l
+            lhs1 = np.transpose(a) @ r + np.transpose(d) @ l
             rhs1 = scale*c
-            lhs2 = r @np.transpose(b) + l @ np.transpose(e)
+            lhs2 = r @ np.transpose(b) + l @ np.transpose(e)
             rhs2 = -1.0*scale*f
 
         assert_allclose(lhs1,rhs1,atol=atol,err_msg='lhs1 and rhs1 of solved Sylvester equation do not match')

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3358,9 +3358,9 @@ def test_tgsyl_NAG(a, b, c, d, e, f, rans, lans, dtype):
 def test_tgsyl(dtype, trans, ijob):
 
     seed(2023)
-    atol = 1e-2
+    atol = 1e-10
     if dtype == np.float32:
-        atol = 5e-2
+        atol = 5e-3
 
     m, n = 10, 15
 
@@ -3370,6 +3370,11 @@ def test_tgsyl(dtype, trans, ijob):
     e = np.triu(generate_random_dtype_array([n, n], dtype=dtype))
     c = generate_random_dtype_array([m, n], dtype=dtype)
     f = generate_random_dtype_array([m, n], dtype=dtype)
+
+    # Adjust the spectrum of the matrices to get a more precise solution
+    adjustment = 5*np.eye(m, dtype=dtype)
+    a = a + adjustment
+    d = d - adjustment
 
     tgsyl = get_lapack_funcs(('tgsyl'), dtype=dtype)
     rout, lout, scale, dif, info = tgsyl(a, b, c, d, e, f,

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3299,95 +3299,104 @@ def test_gges_tgsen(dtype):
     assert_allclose(s[0, 0] / t[0, 0], d2, rtol=0, atol=atol)
     assert_allclose(s[1, 1] / t[1, 1], d1, rtol=0, atol=atol)
 
+
 @pytest.mark.parametrize(
-    "a,b,c,d,e,f,r,l",
-    [(np.array( [[  4.0,  1.0,  1.0,  2.0] ,
-                 [  0.0,  3.0,  4.0,  1.0] ,
-                 [  0.0,  1.0,  3.0,  1.0] ,
-                 [  0.0,  0.0,  0.0,  6.0]]),
-      np.array( [[  1.0,  1.0,  1.0,  1.0] ,
-                 [  0.0,  3.0,  4.0,  1.0] ,
-                 [  0.0,  1.0,  3.0,  1.0] ,
-                 [  0.0,  0.0,  0.0,  4.0]]),
-      np.array( [[ -4.0,  7.0,  1.0, 12.0] ,
-                 [ -9.0,  2.0, -2.0, -2.0] ,
-                 [ -4.0,  2.0, -2.0,  8.0] ,
-                 [ -7.0,  7.0, -6.0, 19.0]]),
-      np.array( [[  2.0,  1.0,  1.0,  3.0] ,
-                 [  0.0,  1.0,  2.0,  1.0] ,
-                 [  0.0,  0.0,  1.0,  1.0] ,
-                 [  0.0,  0.0,  0.0,  2.0]]),
-      np.array( [[  1.0,  1.0,  1.0,  2.0] ,
-                 [  0.0,  1.0,  4.0,  1.0] ,
-                 [  0.0,  0.0,  1.0,  1.0] ,
-                 [  0.0,  0.0,  0.0,  1.0]]),
-      np.array( [[ -7.0,  5.0,  0.0,  7.0] ,
-                 [ -5.0,  1.0, -8.0,  0.0] ,
-                 [ -1.0,  2.0, -3.0,  5.0] ,
-                 [ -3.0,  2.0,  0.0,  5.0]]),
-      np.array( [[  1.0,  1.0,  1.0,  1.0] ,
-                 [ -1.0,  2.0, -1.0, -1.0] ,
-                 [ -1.0,  1.0,  3.0,  1.0] ,
-                 [ -1.0,  1.0, -1.0,  4.0]]),
-     np.array(  [[  4.0, -1.0,  1.0, -1.0] ,
-                 [  1.0,  3.0, -1.0,  1.0] ,
-                 [ -1.0,  1.0,  2.0, -1.0] ,
-                 [  1.0, -1.0,  1.0,  1.0]]) )])
+    "a, b, c, d, e, f, rans, lans",
+    [(np.array([[4.0,   1.0,  1.0,  2.0],
+                [0.0,   3.0,  4.0,  1.0],
+                [0.0,   1.0,  3.0,  1.0],
+                [0.0,   0.0,  0.0,  6.0]]),
+      np.array([[1.0,   1.0,  1.0,  1.0],
+                [0.0,   3.0,  4.0,  1.0],
+                [0.0,   1.0,  3.0,  1.0],
+                [0.0,   0.0,  0.0,  4.0]]),
+      np.array([[-4.0,  7.0,  1.0, 12.0],
+                [-9.0,  2.0, -2.0, -2.0],
+                [-4.0,  2.0, -2.0,  8.0],
+                [-7.0,  7.0, -6.0, 19.0]]),
+      np.array([[2.0,   1.0,  1.0,  3.0],
+                [0.0,   1.0,  2.0,  1.0],
+                [0.0,   0.0,  1.0,  1.0],
+                [0.0,   0.0,  0.0,  2.0]]),
+      np.array([[1.0,   1.0,  1.0,  2.0],
+                [0.0,   1.0,  4.0,  1.0],
+                [0.0,   0.0,  1.0,  1.0],
+                [0.0,   0.0,  0.0,  1.0]]),
+      np.array([[-7.0,  5.0,  0.0,  7.0],
+                [-5.0,  1.0, -8.0,  0.0],
+                [-1.0,  2.0, -3.0,  5.0],
+                [-3.0,  2.0,  0.0,  5.0]]),
+      np.array([[1.0,   1.0,  1.0,  1.0],
+                [-1.0,  2.0, -1.0, -1.0],
+                [-1.0,  1.0,  3.0,  1.0],
+                [-1.0,  1.0, -1.0,  4.0]]),
+      np.array([[4.0,  -1.0,  1.0, -1.0],
+                [1.0,   3.0, -1.0,  1.0],
+                [-1.0,  1.0,  2.0, -1.0],
+                [1.0,  -1.0,  1.0,  1.0]]))])
 @pytest.mark.parametrize('dtype', REAL_DTYPES)
-def test_tgsyl_NAG(a,b,c,d,e,f,r,l,dtype):
+def test_tgsyl_NAG(a, b, c, d, e, f, rans, lans, dtype):
     atol = 1e-4
-    
+
     tgsyl = get_lapack_funcs(('tgsyl'), dtype=dtype)
-    rans,lans,scale,dif,info = tgsyl(a,b,c,d,e,f)
-    
+    rout, lout, scale, dif, info = tgsyl(a, b, c, d, e, f)
+
     assert_equal(info, 0)
-    assert_allclose(scale,1.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="SCALE must be 1.0")
-    assert_allclose(dif,0.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="DIF must be nearly 0")
-    assert_allclose(rans,r,atol=atol,err_msg='Solution for unknown R of Sylvester equation is not correct')
-    assert_allclose(lans,l,atol=atol,err_msg='Solution for unknown L of Sylvester equation is not correct')
-    
+    assert_allclose(scale, 1.0, rtol=0, atol=np.finfo(dtype).eps*100,
+                    err_msg="SCALE must be 1.0")
+    assert_allclose(dif, 0.0, rtol=0, atol=np.finfo(dtype).eps*100,
+                    err_msg="DIF must be nearly 0")
+    assert_allclose(rout, rans, atol=atol,
+                    err_msg="Solution for R is incorrect")
+    assert_allclose(lout, lans, atol=atol,
+                    err_msg="Solution for L is incorrect")
+
+
 @pytest.mark.parametrize('dtype', REAL_DTYPES)
 @pytest.mark.parametrize('trans', ('N', 'T'))
-@pytest.mark.parametrize('ijob', [0,1,2,3,4])
-def test_tgsyl(dtype,trans,ijob):
-    
+@pytest.mark.parametrize('ijob', [0, 1, 2, 3, 4])
+def test_tgsyl(dtype, trans, ijob):
+
     seed(2023)
     atol = 1e-2
-    if(dtype==np.float32):
+    if (dtype == np.float32):
         atol = 5e-2
-    
+
     m, n = 10, 15
-    
-    a,_ = schur(generate_random_dtype_array([m, m], dtype=dtype))
-    d   = np.triu(generate_random_dtype_array([m, m], dtype=dtype))
-    b,_ = schur(generate_random_dtype_array([n, n], dtype=dtype))
-    e   = np.triu(generate_random_dtype_array([n, n], dtype=dtype))
-    c   = generate_random_dtype_array([m, n], dtype=dtype)
-    f   = generate_random_dtype_array([m, n], dtype=dtype)
+
+    a, _ = schur(generate_random_dtype_array([m, m], dtype=dtype))
+    d = np.triu(generate_random_dtype_array([m, m], dtype=dtype))
+    b, _ = schur(generate_random_dtype_array([n, n], dtype=dtype))
+    e = np.triu(generate_random_dtype_array([n, n], dtype=dtype))
+    c = generate_random_dtype_array([m, n], dtype=dtype)
+    f = generate_random_dtype_array([m, n], dtype=dtype)
 
     tgsyl = get_lapack_funcs(('tgsyl'), dtype=dtype)
-        
-    r,l,scale,dif,info = tgsyl(a,b,c,d,e,f,trans=trans,ijob=ijob)
-    assert_equal(info,0,err_msg="INFO is non-zero")
+    rout, lout, scale, dif, info = tgsyl(a, b, c, d, e, f,
+                                         trans=trans, ijob=ijob)
 
-    assert scale>=0.0,"SCALE must be non-negative"
-    if (ijob==0):
-        assert_allclose(dif,0.0,rtol=0,atol=np.finfo(dtype).eps*100,err_msg="DIF must be 0 for ijob =0")
+    assert_equal(info, 0, err_msg="INFO is non-zero")
+    assert scale >= 0.0, "SCALE must be non-negative"
+    if (ijob == 0):
+        assert_allclose(dif, 0.0, rtol=0, atol=np.finfo(dtype).eps*100,
+                        err_msg="DIF must be 0 for ijob =0")
     else:
-        assert dif>=0.0,"DIF must be non-negative"
-    
-    #Only DIF is calculated for ijob = 3/4
-    if (ijob<=2):
-        if (trans=='N'):
-            lhs1 = a @ r - l @ b
+        assert dif >= 0.0, "DIF must be non-negative"
+
+    # Only DIF is calculated for ijob = 3/4
+    if (ijob <= 2):
+        if (trans == 'N'):
+            lhs1 = a @ rout - lout @ b
             rhs1 = scale*c
-            lhs2 = d @ r - l @ e
+            lhs2 = d @ rout - lout @ e
             rhs2 = scale*f
-        elif (trans=='T'):
-            lhs1 = np.transpose(a) @ r + np.transpose(d) @ l
+        elif (trans == 'T'):
+            lhs1 = np.transpose(a) @ rout + np.transpose(d) @ lout
             rhs1 = scale*c
-            lhs2 = r @ np.transpose(b) + l @ np.transpose(e)
+            lhs2 = rout @ np.transpose(b) + lout @ np.transpose(e)
             rhs2 = -1.0*scale*f
 
-        assert_allclose(lhs1,rhs1,atol=atol,err_msg='lhs1 and rhs1 of solved Sylvester equation do not match')
-        assert_allclose(lhs2,rhs2,atol=atol,err_msg='lhs2 and rhs2 of solved Sylvester equation do not match')
+        assert_allclose(lhs1, rhs1, atol=atol,
+                        err_msg='lhs1 and rhs1 do not match')
+        assert_allclose(lhs2, rhs2, atol=atol,
+                        err_msg='lhs2 and rhs2 do not match')

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3358,9 +3358,7 @@ def test_tgsyl_NAG(a, b, c, d, e, f, rans, lans, dtype):
 def test_tgsyl(dtype, trans, ijob):
 
     seed(2023)
-    atol = 1e-10
-    if dtype == np.float32:
-        atol = 5e-3
+    atol = 1e-4 if dtype == np.float32 else 1e-10
 
     m, n = 10, 15
 
@@ -3372,9 +3370,12 @@ def test_tgsyl(dtype, trans, ijob):
     f = generate_random_dtype_array([m, n], dtype=dtype)
 
     # Adjust the spectrum of the matrices to get a more precise solution
-    adjustment = 5*np.eye(m, dtype=dtype)
-    a = a + adjustment
-    d = d - adjustment
+    adjustment_m = np.eye(m, dtype=dtype)
+    adjustment_n = np.eye(n, dtype=dtype)
+    a += adjustment_m
+    d -= 5.0 * adjustment_m
+    b += adjustment_n
+    e -= 5.0 * adjustment_n
 
     tgsyl = get_lapack_funcs(('tgsyl'), dtype=dtype)
     rout, lout, scale, dif, info = tgsyl(a, b, c, d, e, f,

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3358,7 +3358,7 @@ def test_tgsyl_NAG(a, b, c, d, e, f, rans, lans, dtype):
 def test_tgsyl(dtype, trans, ijob):
 
     seed(2023)
-    atol = 1e-4 if dtype == np.float32 else 1e-10
+    atol = 1e-3 if dtype == np.float32 else 1e-10
 
     m, n = 10, 15
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3359,7 +3359,7 @@ def test_tgsyl(dtype, trans, ijob):
 
     seed(2023)
     atol = 1e-2
-    if (dtype == np.float32):
+    if dtype == np.float32:
         atol = 5e-2
 
     m, n = 10, 15
@@ -3377,20 +3377,20 @@ def test_tgsyl(dtype, trans, ijob):
 
     assert_equal(info, 0, err_msg="INFO is non-zero")
     assert scale >= 0.0, "SCALE must be non-negative"
-    if (ijob == 0):
+    if ijob == 0:
         assert_allclose(dif, 0.0, rtol=0, atol=np.finfo(dtype).eps*100,
                         err_msg="DIF must be 0 for ijob =0")
     else:
         assert dif >= 0.0, "DIF must be non-negative"
 
     # Only DIF is calculated for ijob = 3/4
-    if (ijob <= 2):
-        if (trans == 'N'):
+    if ijob <= 2:
+        if trans == 'N':
             lhs1 = a @ rout - lout @ b
             rhs1 = scale*c
             lhs2 = d @ rout - lout @ e
             rhs2 = scale*f
-        elif (trans == 'T'):
+        elif trans == 'T':
             lhs1 = np.transpose(a) @ rout + np.transpose(d) @ lout
             rhs1 = scale*c
             lhs2 = rout @ np.transpose(b) + lout @ np.transpose(e)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3372,10 +3372,10 @@ def test_tgsyl(dtype, trans, ijob):
     # Adjust the spectrum of the matrices to get a more precise solution
     adjustment_m = np.eye(m, dtype=dtype)
     adjustment_n = np.eye(n, dtype=dtype)
-    a += adjustment_m
-    d -= 5.0 * adjustment_m
-    b += adjustment_n
-    e -= 5.0 * adjustment_n
+    a += np.eye(m, dtype=dtype)
+    d -= np.diag(5*np.ones(m, dtype=dtype))
+    b += np.eye(n, dtype=dtype)
+    e -= np.diag(5*np.ones(n, dtype=dtype))
 
     tgsyl = get_lapack_funcs(('tgsyl'), dtype=dtype)
     rout, lout, scale, dif, info = tgsyl(a, b, c, d, e, f,
@@ -3402,7 +3402,7 @@ def test_tgsyl(dtype, trans, ijob):
             lhs2 = rout @ np.transpose(b) + lout @ np.transpose(e)
             rhs2 = -1.0*scale*f
 
-        assert_allclose(lhs1, rhs1, atol=atol,
+        assert_allclose(lhs1, rhs1, atol=atol, rtol=0.,
                         err_msg='lhs1 and rhs1 do not match')
-        assert_allclose(lhs2, rhs2, atol=atol,
+        assert_allclose(lhs2, rhs2, atol=atol, rtol=0.,
                         err_msg='lhs2 and rhs2 do not match')


### PR DESCRIPTION
Reference issue

Closes #18404 

What does this implement/fix?

This adds a low-level wrapper for Lapack functions <s/d>tgsyl

Additional information:
- Not final code. Help and review welcome
- In some tests I tried to calculate lhs and rhs of the sylvester equations after solution, but they don't seem to meet the desired accuracy of machine precision*100 that is used in other tests. So, I still have to debug. 
- For now I have these questions: 
>1) I'm not too sure what the input matrix forms should be. Lapack doc does say (a,b) and (d,e) should be quasi upper triangular and upper triangular respectively. Does quasi upper triangular mean block upper triangular? 
>2) How do we check the matrix forms like (quasi) triangular inside the template code? 
>3) I am still not sure how f2py is actually building the *.pyf.src template signature files. Does f2py itself have the mechanism to replace the templates or is there some extra build step somewhere to generate the actual *.pyf from the templates? 
>4) If you are aware of other sources for tests let me know (NAG is mentioned in code. But not sure where to find it.)