### PR TITLE
ENH: override sf for rdist distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8195,6 +8195,9 @@ class rdist_gen(rv_continuous):
     def _cdf(self, x, c):
         return beta._cdf((x + 1)/2, c/2, c/2)
 
+    def _sf(self, x, c):
+        return beta._sf((x + 1)/2, c/2, c/2)
+
     def _ppf(self, q, c):
         return 2*beta._ppf(q, c/2, c/2) - 1
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6638,7 +6638,7 @@ class TestRdist:
     # def rdist_sf_mpmath(x, c):
     #     x = mp.mpf(x)
     #     c = mp.mpf(c)
-    #     return float(mp.one - mp.betainc(c/2, c/2, 0, (x+1)/2, regularized=True))
+    #     return float(mp.betainc(c/2, c/2, (x+1)/2, mp.one, regularized=True))
     @pytest.mark.parametrize(
         "x, c, ref",
         [

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6632,6 +6632,25 @@ class TestRdist:
         assert_almost_equal(0.5*stats.beta(c/2, c/2).pdf((x + 1)/2),
                             stats.rdist(c).pdf(x))
 
+    # reference values were computed via mpmath
+    # from mpmath import mp
+    # mp.dps = 200
+    # def rdist_sf_mpmath(x, c):
+    #     x = mp.mpf(x)
+    #     c = mp.mpf(c)
+    #     return float(mp.one - mp.betainc(c/2, c/2, 0, (x+1)/2, regularized=True))
+    @pytest.mark.parametrize(
+        "x, c, ref",
+        [
+            (0.0001, 541, 0.49907251345565845),
+            (0.1, 241, 0.06000788166249205),
+            (0.5, 441, 1.0655898106047832e-29),
+            (0.8, 341, 6.025478373732215e-78),
+        ]
+    )
+    def test_rdist_sf(self, x, c, ref):
+        assert_allclose(stats.rdist.sf(x, c), ref, rtol=5e-14)
+
 
 class TestTrapezoid:
     def test_reduces_to_triang(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Override and add the sf method for rdist distribution
- Add some tests

#### Additional information
<!--Any additional information you think is important.-->
CC: @mdhaber Could you kindly have a look to see if this change makes sense? If it looks feasible then we can add the reference distribution to set up the tests.