### PR TITLE
DEP: signal: deprecate cmplx_sort

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2464,7 +2464,19 @@ def hilbert2(x, N=None):
     return x
 
 
+_msg_cplx_sort="""cmplx_sort is deprecated in SciPy 1.12 and will be removed
+in SciPy 1.14. The exact equivalent for a numpy array argument is
+>>> def cmplx_sort(p):
+...    idx = np.argsort(abs(p))
+...    return np.take(p, idx, 0), idx
+"""
+
+@np.deprecate(message=_msg_cplx_sort)
 def cmplx_sort(p):
+    return _cmplx_sort(p)
+
+
+def _cmplx_sort(p):
     """Sort roots based on magnitude.
 
     Parameters
@@ -2802,7 +2814,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
 
     poles = np.roots(a)
     if b.size == 0:
-        return np.zeros(poles.shape), cmplx_sort(poles)[0], np.array([])
+        return np.zeros(poles.shape), _cmplx_sort(poles)[0], np.array([])
 
     if len(b) < len(a):
         k = np.empty(0)
@@ -2810,7 +2822,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
         k, b = np.polydiv(b, a)
 
     unique_poles, multiplicity = unique_roots(poles, tol=tol, rtype=rtype)
-    unique_poles, order = cmplx_sort(unique_poles)
+    unique_poles, order = _cmplx_sort(unique_poles)
     multiplicity = multiplicity[order]
 
     residues = _compute_residues(unique_poles, multiplicity, b)
@@ -2900,7 +2912,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
 
     poles = np.roots(a)
     if b.size == 0:
-        return np.zeros(poles.shape), cmplx_sort(poles)[0], np.array([])
+        return np.zeros(poles.shape), _cmplx_sort(poles)[0], np.array([])
 
     b_rev = b[::-1]
     a_rev = a[::-1]
@@ -2911,7 +2923,7 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
         k_rev, b_rev = np.polydiv(b_rev, a_rev)
 
     unique_poles, multiplicity = unique_roots(poles, tol=tol, rtype=rtype)
-    unique_poles, order = cmplx_sort(unique_poles)
+    unique_poles, order = _cmplx_sort(unique_poles)
     multiplicity = multiplicity[order]
 
     residues = _compute_residues(1 / unique_poles, multiplicity, b_rev)


### PR DESCRIPTION
Deprecate `scipy.signal.cmplx_sort`: a two-line helper which I doubt was ever meant to really be a part of scipy API.

