### PR TITLE
DEP: removal of kwargs nyq / Hz in firwin* and remez

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -16,19 +16,12 @@ __all__ = ['kaiser_beta', 'kaiser_atten', 'kaiserord',
            'firwin', 'firwin2', 'remez', 'firls', 'minimum_phase']
 
 
-def _get_fs(fs, nyq):
+def _get_fs(fs):
     """
-    Utility for replacing the argument 'nyq' (with default 1) with 'fs'.
+    Utility for replacing the argument fs with default 2.
     """
-    if nyq is None and fs is None:
+    if fs is None:
         fs = 2
-    elif nyq is not None:
-        if fs is not None:
-            raise ValueError("Values cannot be given for both 'nyq' and 'fs'.")
-        msg = ("Keyword argument 'nyq' is deprecated in favour of 'fs' and "
-               "will be removed in SciPy 1.12.0.")
-        warnings.warn(msg, DeprecationWarning, stacklevel=3)
-        fs = 2*nyq
     return fs
 
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -475,7 +475,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
 #
 # Rewritten by Warren Weckesser, 2010.
 
-def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
+def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming',
             antisymmetric=False, fs=None):
     """
     FIR filter design using the window method.
@@ -510,13 +510,6 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         Window function to use. Default is "hamming". See
         `scipy.signal.get_window` for the complete list of possible values.
         If None, no window function is applied.
-    nyq : float, optional, deprecated
-        This is the Nyquist frequency. Each frequency in `freq` must be
-        between 0 and `nyq`. Default is 1.
-
-        .. deprecated:: 1.0.0
-           `firwin2` keyword argument `nyq` is deprecated in favour of `fs` and
-           will be removed in SciPy 1.12.0.
     antisymmetric : bool, optional
         Whether resulting impulse response is symmetric/antisymmetric.
         See Notes for more details.
@@ -583,7 +576,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
     [-0.02286961 -0.06362756  0.57310236  0.57310236 -0.06362756 -0.02286961]
 
     """
-    nyq = 0.5 * _get_fs(fs, nyq)
+    nyq = 0.5 * _get_fs(fs)
 
     if len(freq) != len(gain):
         raise ValueError('freq and gain must be of same length.')

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -670,7 +670,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming',
     return out
 
 
-def remez(numtaps, bands, desired, weight=None, Hz=None, type='bandpass',
+def remez(numtaps, bands, desired, weight=None, type='bandpass',
           maxiter=25, grid_density=16, fs=None):
     """
     Calculate the minimax optimal filter using the Remez exchange algorithm.
@@ -695,12 +695,6 @@ def remez(numtaps, bands, desired, weight=None, Hz=None, type='bandpass',
     weight : array_like, optional
         A relative weighting to give to each band region. The length of
         `weight` has to be half the length of `bands`.
-    Hz : scalar, optional, deprecated
-        The sampling frequency in Hz. Default is 1.
-
-        .. deprecated:: 1.0.0
-           `remez` keyword argument `Hz` is deprecated in favour of `fs` and
-           will be removed in SciPy 1.12.0.
     type : {'bandpass', 'differentiator', 'hilbert'}, optional
         The type of filter:
 
@@ -828,15 +822,8 @@ def remez(numtaps, bands, desired, weight=None, Hz=None, type='bandpass',
     >>> plt.show()
 
     """
-    if Hz is None and fs is None:
+    if fs is None:
         fs = 1.0
-    elif Hz is not None:
-        if fs is not None:
-            raise ValueError("Values cannot be given for both 'Hz' and 'fs'.")
-        msg = ("'remez' keyword argument 'Hz' is deprecated in favour of 'fs'"
-               " and will be removed in SciPy 1.12.0.")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        fs = Hz
 
     # Convert type
     try:

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -841,7 +841,7 @@ def remez(numtaps, bands, desired, weight=None, type='bandpass',
                             maxiter, grid_density)
 
 
-def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
+def firls(numtaps, bands, desired, weight=None, fs=None):
     """
     FIR filter design using least-squares error minimization.
 
@@ -871,13 +871,6 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
         A relative weighting to give to each band region when solving
         the least squares problem. `weight` has to be half the size of
         `bands`.
-    nyq : float, optional, deprecated
-        This is the Nyquist frequency. Each frequency in `bands` must be
-        between 0 and `nyq` (inclusive). Default is 1.
-
-        .. deprecated:: 1.0.0
-           `firls` keyword argument `nyq` is deprecated in favour of `fs` and
-           will be removed in SciPy 1.12.0.
     fs : float, optional
         The sampling frequency of the signal. Each frequency in `bands`
         must be between 0 and ``fs/2`` (inclusive). Default is 2.
@@ -958,7 +951,7 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     >>> plt.show()
 
     """  # noqa
-    nyq = 0.5 * _get_fs(fs, nyq)
+    nyq = 0.5 * _get_fs(fs)
 
     numtaps = int(numtaps)
     if numtaps % 2 == 0 or numtaps < 1:

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -256,7 +256,7 @@ def kaiserord(ripple, width):
 
 
 def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
-           scale=True, nyq=None, fs=None):
+           scale=True, fs=None):
     """
     FIR filter design using the window method.
 
@@ -305,14 +305,6 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         - `fs/2` (the Nyquist frequency) if the first passband ends at
           `fs/2` (i.e the filter is a single band highpass filter);
           center of first passband otherwise
-
-    nyq : float, optional, deprecated
-        This is the Nyquist frequency. Each frequency in `cutoff` must be
-        between 0 and `nyq`. Default is 1.
-
-        .. deprecated:: 1.0.0
-           `firwin` keyword argument `nyq` is deprecated in favour of `fs` and
-           will be removed in SciPy 1.12.0.
     fs : float, optional
         The sampling frequency of the signal. Each frequency in `cutoff`
         must be between 0 and ``fs/2``.  Default is 2.
@@ -383,7 +375,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
     # The major enhancements to this function added in November 2010 were
     # developed by Tom Krauss (see ticket #902).
 
-    nyq = 0.5 * _get_fs(fs, nyq)
+    nyq = 0.5 * _get_fs(fs)
 
     cutoff = np.atleast_1d(cutoff) / float(nyq)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes 18579

#### What does this implement/fix?
Remove ```nyq``` and ```Hz``` argument references from ```signal/_fir_filter_design.py``` both in code and documentation

#### Additional information
