### PR TITLE
DEP: stats.kendalltau: remove deprecated parameter `initial_lexsort`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5591,8 +5591,8 @@ def pointbiserialr(x, y):
     return res
 
 
-def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
-               method='auto', variant='b', alternative='two-sided'):
+def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
+               alternative='two-sided'):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.
 
     Kendall's tau is a measure of the correspondence between two rankings.
@@ -5609,12 +5609,6 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
     x, y : array_like
         Arrays of rankings, of the same shape. If arrays are not 1-D, they
         will be flattened to 1-D.
-    initial_lexsort : bool, optional, deprecated
-        This argument is unused.
-
-        .. deprecated:: 1.10.0
-           `kendalltau` keyword argument `initial_lexsort` is deprecated as it
-           is unused and will be removed in SciPy 1.12.0.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
@@ -5829,11 +5823,6 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
     accurate results.
 
     """
-    if initial_lexsort is not None:
-        msg = ("'kendalltau' keyword argument 'initial_lexsort' is deprecated"
-               " as it is unused and will be removed in SciPy 1.12.0.")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1399,14 +1399,6 @@ def test_kendalltau_nan_2nd_arg():
     assert_allclose(r1.statistic, r2.statistic, atol=1e-15)
 
 
-def test_kendalltau_dep_initial_lexsort():
-    with pytest.warns(
-        DeprecationWarning,
-        match="'kendalltau' keyword argument 'initial_lexsort'"
-    ):
-        stats.kendalltau([], [], initial_lexsort=True)
-
-
 def test_kendalltau_gh18139_overflow():
     # gh-18139 reported an overflow in `kendalltau` that appeared after
     # SciPy 0.15.1. Check that this particular overflow does not occur.


### PR DESCRIPTION
#### Reference issue
Closes gh-18578

#### What does this implement/fix?
This removes deprecated parameter `initial_lexsort`.

#### Additional information
Marked as draft pending resolution of https://github.com/scipy/scipy/issues/18578#issuecomment-1569482707.