### PR TITLE
DOC: Fix sidebar for API reference pages

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -1,7 +1,7 @@
 [
     {
-        "name": "dev",
-        "version": "dev",
+        "name": "development",
+        "version": "development",
         "url": "https://scipy.github.io/devdocs/"
     },
     {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -204,7 +204,7 @@ html_theme_options = {
 }
 
 if 'dev' in version:
-    html_theme_options["switcher"]["version_match"] = "dev"
+    html_theme_options["switcher"]["version_match"] = "development"
 
 if 'versionwarning' in tags:  # noqa
     # Specific to docs.scipy.org deployment.


### PR DESCRIPTION
[skip cirrus]

#### Reference issue
Addresses #18535

#### What does this implement/fix?
This is a workaround for #18535, and it may be unnecessary if we figure out the definitive source of that error.

UPDATE: After trying some options, changing the name of the development version on the version switcher seems to be the best solution.

#### Additional information
Could be related to #18031
