### PR TITLE
DOC: refactor reference sidebar logic

### DIFF
--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,9 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  <div class="bd-toc-item active">
-    {% if pagename.startswith("reference") %}
-    {{ generate_nav_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) }}
-    {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=2, collapse=True, titles_only=True) }}
-    {% endif %}
-  </div>
-</nav>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -197,6 +197,7 @@ html_theme_options = {
   "github_url": "https://github.com/scipy/scipy",
   "twitter_url": "https://twitter.com/SciPy_team",
   "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
+  "navigation_depth": 1,
   "switcher": {
       "json_url": "https://scipy.github.io/devdocs/_static/version_switcher.json",
       "version_match": version,

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -88,76 +88,8 @@ unlikely to be renamed or changed in an incompatible way, and if that is
 necessary, a deprecation warning will be raised for one SciPy release before the
 change is made.
 
-* `scipy`
-
-* `scipy.cluster`
-
-  - `scipy.cluster.vq`
-  - `scipy.cluster.hierarchy`
-
-* `scipy.constants`
-
-* `scipy.datasets`
-
-* `scipy.fft`
-
-* `scipy.fftpack`
-
-* `scipy.integrate`
-
-* `scipy.interpolate`
-
-* `scipy.io`
-
-  - `scipy.io.arff`
-  - `scipy.io.matlab`
-  - `scipy.io.wavfile`
-
-* `scipy.linalg`
-
-  - `scipy.linalg.blas`
-  - `scipy.linalg.cython_blas`
-  - `scipy.linalg.lapack`
-  - `scipy.linalg.cython_lapack`
-  - `scipy.linalg.interpolative`
-
-* `scipy.misc`
-
-* `scipy.ndimage`
-
-* `scipy.odr`
-
-* `scipy.optimize`
-
-  - `scipy.optimize.cython_optimize`
-
-* `scipy.signal`
-
-  - `scipy.signal.windows`
-
-* `scipy.sparse`
-
-  - `scipy.sparse.linalg`
-  - `scipy.sparse.csgraph`
-
-* `scipy.spatial`
-
-  - `scipy.spatial.distance`
-  - `scipy.spatial.transform`
-
-* `scipy.special`
-
-* `scipy.stats`
-
-  - `scipy.stats.contingency`
-  - ``scipy.stats.distributions``
-  - `scipy.stats.mstats`
-  - `scipy.stats.qmc`
-  - `scipy.stats.sampling`
-
 .. toctree::
    :maxdepth: 1
-   :hidden:
    :titlesonly:
 
    scipy <main_namespace>


### PR DESCRIPTION
Follow up of #18596

Somehow there are still issues with the deployment on GH pages. I could see it worked after we merged the PR, but then it was wrong again, and now it's working again...

This PR attempts to remove our custom logic for the toctree in the reference section. Hopefully that should solve it for good. The slight drawback is that it slightly changes what is presented on the index. But IMO it was not really a good design either way as Sphinx is supposed to be the one generating the toctree on the page vs doing a manual formatting.