### PR TITLE
ENH: override sf for Pearson3 distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7713,6 +7713,23 @@ class pearson3_gen(rv_continuous):
 
         return ans
 
+    def _sf(self, x, skew):
+        ans, x, transx, mask, invmask, _, alpha, _ = (
+            self._preprocess(x, skew))
+
+        ans[mask] = _norm_sf(x[mask])
+
+        skew = np.broadcast_to(skew, invmask.shape)
+        invmask1a = np.logical_and(invmask, skew > 0)
+        invmask1b = skew[invmask] > 0
+        ans[invmask1a] = gamma.sf(transx[invmask1b], alpha[invmask1b])
+
+        invmask2a = np.logical_and(invmask, skew < 0)
+        invmask2b = skew[invmask] < 0
+        ans[invmask2a] = gamma.cdf(transx[invmask2b], alpha[invmask2b])
+
+        return ans
+
     def _rvs(self, skew, size=None, random_state=None):
         skew = np.broadcast_to(skew, size)
         ans, _, _, mask, invmask, beta, alpha, zeta = (

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2331,11 +2331,14 @@ class TestPearson3:
 
     def test_sf(self):
         # reference values were computed via the reference distribution, e.g.
-        # mp.dps = 500; Pearson3(skew=skew).sf(x)
-        skew = [0.1, 0.5, 1.0]
-        x = [5.0, 10.0, 50.0]
-        ref = [1.64721926440872e-06, 8.271911573556123e-11, 1.3149506021756343e-40]
-        assert_allclose(stats.pearson3.sf(x, skew), ref, rtol=1e-14)
+        # mp.dps = 50; Pearson3(skew=skew).sf(x). Check positive, negative,
+        # and zero skew due to branching.
+        skew = [0.1, 0.5, 1.0, -0.1]
+        x = [5.0, 10.0, 50.0, 8.0]
+        ref = [1.64721926440872e-06, 8.271911573556123e-11,
+               1.3149506021756343e-40, 2.763057937820296e-21]
+        assert_allclose(stats.pearson3.sf(x, skew), ref, rtol=2e-14)
+        assert_allclose(stats.pearson3.sf(x, 0), stats.norm.sf(x), rtol=2e-14)
 
 
 class TestKappa4:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2329,6 +2329,14 @@ class TestPearson3:
         assert_allclose(stats.pearson3.ppf(x, skew),
                         -stats.pearson3.isf(x, -skew))
 
+    def test_sf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 500; Pearson3(skew=skew).sf(x)
+        skew = [0.1, 0.5, 1.0]
+        x = [5.0, 10.0, 50.0]
+        ref = [1.64721926440872e-06, 8.271911573556123e-11, 1.3149506021756343e-40]
+        assert_allclose(stats.pearson3.sf(x, skew), ref, rtol=1e-14)
+
 
 class TestKappa4:
     def test_cdf_genpareto(self):

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -336,37 +336,13 @@ class NormInvGauss(ReferenceDistribution):
 class Pearson3(ReferenceDistribution):
     def __init__(self, *, skew):
         super().__init__(skew=skew)
-        self.norm2pearson_transition = mp.mpf(0.000016)
 
-    def _preprocess(self, x, skew):
-        loc = mp.zero
-        scale = mp.one
-
-        beta = 2.0 / (skew * scale)
-        alpha = (scale * beta) ** 2.0
-        zeta = loc - alpha / beta
-
-        transx = beta * (x - zeta)
-        return transx, beta, alpha, zeta
-
-    def _gamma_logpdf(self, x, a):
-        return (a - mp.one) * mp.log(x) - x - mp.loggamma(a)
-
-    def _logpdf(self, x, skew):
-        transx, beta, alpha, zeta = self._preprocess(x, skew)
-        if mp.fabs(skew) < self.norm2pearson_transition:
-            return mp.log(mp.npdf(x))
-
-        return mp.log(mp.fabs(beta)) + self._gamma_logpdf(transx, alpha)
-
-    def _sf(self, x, skew):
-        transx, beta, alpha, zeta = self._preprocess(x, skew)
-        if mp.fabs(skew) < self.norm2pearson_transition:
-            return mp.ncdf(-x)
-        elif skew > 0:
-            return mp.gammainc(alpha, transx, mp.inf, regularized=True)
-        else:
-            return mp.gammainc(alpha, 0, transx, regularized=True)
+    def _pdf(self, x, skew):
+        b = 2 / skew
+        a = b**2
+        c = -b
+        res = abs(b)/mp.gamma(a) * (b*(x-c))**(a-1) * mp.exp(-b*(x-c))
+        return res if abs(res.real) == res else 0
 
 
 class StudentT(ReferenceDistribution):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds and overrides the survival function for the Pearson3 distribution
- Adds a reference distribution for Pearson3
- Adds sets based on the reference distribution

#### Additional information
<!--Any additional information you think is important.-->
cc: @mdhaber 