### PR TITLE
TST: update nonlin tests for sparse arrays

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -477,16 +477,16 @@ def asjacobian(J):
 
         return Jacobian(matvec=lambda v: dot(J, v),
                         rmatvec=lambda v: dot(J.conj().T, v),
-                        solve=lambda v: solve(J, v),
-                        rsolve=lambda v: solve(J.conj().T, v),
+                        solve=lambda v, tol=0: solve(J, v),
+                        rsolve=lambda v, tol=0: solve(J.conj().T, v),
                         dtype=J.dtype, shape=J.shape)
-    elif scipy.sparse.isspmatrix(J):
+    elif scipy.sparse.issparse(J):
         if J.shape[0] != J.shape[1]:
             raise ValueError('matrix must be square')
-        return Jacobian(matvec=lambda v: J*v,
-                        rmatvec=lambda v: J.conj().T * v,
-                        solve=lambda v: spsolve(J, v),
-                        rsolve=lambda v: spsolve(J.conj().T, v),
+        return Jacobian(matvec=lambda v: J @ v,
+                        rmatvec=lambda v: J.conj().T @ v,
+                        solve=lambda v, tol=0: spsolve(J, v),
+                        rsolve=lambda v, tol=0: spsolve(J.conj().T, v),
                         dtype=J.dtype, shape=J.shape)
     elif hasattr(J, 'shape') and hasattr(J, 'dtype') and hasattr(J, 'solve'):
         return Jacobian(matvec=getattr(J, 'matvec'),
@@ -507,7 +507,7 @@ def asjacobian(J):
                 m = J(self.x)
                 if isinstance(m, np.ndarray):
                     return solve(m, v)
-                elif scipy.sparse.isspmatrix(m):
+                elif scipy.sparse.issparse(m):
                     return spsolve(m, v)
                 else:
                     raise ValueError("Unknown matrix type")
@@ -516,8 +516,8 @@ def asjacobian(J):
                 m = J(self.x)
                 if isinstance(m, np.ndarray):
                     return dot(m, v)
-                elif scipy.sparse.isspmatrix(m):
-                    return m*v
+                elif scipy.sparse.issparse(m):
+                    return m @ v
                 else:
                     raise ValueError("Unknown matrix type")
 
@@ -525,7 +525,7 @@ def asjacobian(J):
                 m = J(self.x)
                 if isinstance(m, np.ndarray):
                     return solve(m.conj().T, v)
-                elif scipy.sparse.isspmatrix(m):
+                elif scipy.sparse.issparse(m):
                     return spsolve(m.conj().T, v)
                 else:
                     raise ValueError("Unknown matrix type")
@@ -534,8 +534,8 @@ def asjacobian(J):
                 m = J(self.x)
                 if isinstance(m, np.ndarray):
                     return dot(m.conj().T, v)
-                elif scipy.sparse.isspmatrix(m):
-                    return m.conj().T * v
+                elif scipy.sparse.issparse(m):
+                    return m.conj().T @ v
                 else:
                     raise ValueError("Unknown matrix type")
         return Jac()

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -335,11 +335,11 @@ class TestLinear:
 
         sol = nonlin.nonlin_solve(func, np.zeros(b.shape[0]), jac, maxiter=2,
                                   f_tol=1e-6, line_search=None, verbose=0)
-        assert_(np.allclose(A @ sol, b, atol=1e-6))
+        np.testing.assert_allclose(A @ sol, b, atol=1e-6)
         # test jac input as array -- not a function
         sol = nonlin.nonlin_solve(func, np.zeros(b.shape[0]), A, maxiter=2,
                                   f_tol=1e-6, line_search=None, verbose=0)
-        assert_(np.allclose(A @ sol, b, atol=1e-6))
+        np.testing.assert_allclose(A @ sol, b, atol=1e-6)
 
     def test_jac_sparse(self):
         A = csr_array([[1, 2], [2, 1]])

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_
 import pytest
 
 from scipy.optimize import _nonlin as nonlin, root
+from scipy.sparse import csr_array
 from numpy import diag, dot
 from numpy.linalg import inv
 import numpy as np
@@ -324,6 +325,33 @@ class TestLinear:
         # Krylov methods solve linear systems exactly in N inner steps
         self._check(nonlin.KrylovJacobian, 20, 2, False, inner_m=10)
         self._check(nonlin.KrylovJacobian, 20, 2, True, inner_m=10)
+
+    def _check_autojac(self, A, b):
+        def func(x):
+            return A.dot(x) - b
+
+        def jac(v):
+            return A
+
+        sol = nonlin.nonlin_solve(func, np.zeros(b.shape[0]), jac, maxiter=2,
+                                  f_tol=1e-6, line_search=None, verbose=0)
+        assert_(np.allclose(A @ sol, b, atol=1e-6))
+        # test jac input as array -- not a function
+        sol = nonlin.nonlin_solve(func, np.zeros(b.shape[0]), A, maxiter=2,
+                                  f_tol=1e-6, line_search=None, verbose=0)
+        assert_(np.allclose(A @ sol, b, atol=1e-6))
+
+    def test_jac_sparse(self):
+        A = csr_array([[1, 2], [2, 1]])
+        b = np.array([1, -1])
+        self._check_autojac(A, b)
+        self._check_autojac((1 + 2j) * A, (2 + 2j) * b)
+
+    def test_jac_ndarray(self):
+        A = np.array([[1, 2], [2, 1]])
+        b = np.array([1, -1])
+        self._check_autojac(A, b)
+        self._check_autojac((1 + 2j) * A, (2 + 2j) * b)
 
 
 class TestJacobianDotSolve:


### PR DESCRIPTION
While updating _nonlin.py to use either spmatrix or sparray, I found that most of the code specific for sparse (and also for ndarray) wasn't tested and didn't work. The `solve` method of the Jacobian class has an argument `tol`. But the code to build special versions of the Jacobian didn't.  In particular, if someone inputs np.ndarray or sp.sparse.csr_matrix (or functions that return those types as the jacobian) the special handling code builds a `solve` method that doesn't have a `tol` input. Presumably the `tol` input to `solve` was added more recently than the code. 

Two possible fixes:  
1) remove the feature of building a Jacobian instance from a matrix or function that returns a matrix.
2) add tests for this feature and update the code to include a `tol` input.

This PR implements the 2nd option. I updated the tests and code to work for ndarray or sparse arrays. The code also works for spmatrix, but I don't test that as it should work when sparray works and the intent is for it to go away eventually. The extra tests add 0.07 secs to the tests on my computer.

If people would prefer to have this "build--jacobian-class-from-a-matrix-or-function-returning-a-matrix" code removed I can implement that instead.