### PR TITLE
ENH: override sf in loglaplace distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6012,6 +6012,9 @@ class loglaplace_gen(rv_continuous):
     def _cdf(self, x, c):
         return np.where(x < 1, 0.5*x**c, 1-0.5*x**(-c))
 
+    def _sf(self, x, c):
+        return np.where(x < 1, 1 - 0.5*x**c, 0.5*x**(-c))
+
     def _ppf(self, q, c):
         return np.where(q < 0.5, (2.0*q)**(1.0/c), (2*(1.0-q))**(-1.0/c))
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2930,10 +2930,10 @@ class TestLogLaplace:
 
     def test_sf(self):
         # reference values were computed via the reference distribution, e.g.
-        # mp.dps = 50; LogLaplace(c=c).sf(x).
+        # mp.dps = 100; LogLaplace(c=c).sf(x).
         c = np.array([2.0, 3.0, 5.0])
-        x = np.array([1e5, 1e10, 1e15])
-        ref = [5e-11, 5e-31, 5e-76]
+        x = np.array([1e-5, 1e10, 1e15])
+        ref = [0.99999999995, 5e-31, 5e-76]
         assert_allclose(stats.loglaplace.sf(x, c), ref, rtol=1e-15)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2926,6 +2926,17 @@ class TestLaplace:
         assert_allclose(x, -np.log(2*p), rtol=1e-13)
 
 
+class TestLogLaplace:
+
+    def test_sf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 50; LogLaplace(c=c).sf(x).
+        c = np.array([2.0, 3.0, 5.0])
+        x = np.array([1e5, 1e10, 1e15])
+        ref = [5e-11, 5e-31, 5e-76]
+        assert_allclose(stats.loglaplace.sf(x, c), ref, rtol=1e-15)
+
+
 class TestPowerlaw:
 
     # In the following data, `sf` was computed with mpmath.

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -314,6 +314,24 @@ class BetaPrime(ReferenceDistribution):
         return 1.0 - mp.betainc(a, b, 0, x/(1+x), regularized=True)
 
 
+class LogLaplace(ReferenceDistribution):
+
+    def __init__(self, *, c):
+        super().__init__(c=c)
+
+    def _pdf(self, x, c):
+        if x < mp.one:
+            return c / 2.0 * x**(c - mp.one)
+        else:
+            return c / 2.0 * x**(-c - mp.one)
+
+    def _sf(self, x, c):
+        if x < mp.one:
+            return mp.one - 0.5 * x**c
+        else:
+            return 0.5 * x**(-c)
+
+
 class Normal(ReferenceDistribution):
 
     def _pdf(self, x):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Overrides and adds the survival function for LogLaplace distribution
- Adds a reference distribution for LogLaplace
- Adds tests to test the survival function

#### Additional information
<!--Any additional information you think is important.-->
cc: @mdhaber 