### PR TITLE
MAINT: signal: avoid eval/exec in hilbert2

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2444,16 +2444,14 @@ def hilbert2(x, N=None):
     Xf = sp_fft.fft2(x, N, axes=(0, 1))
     h1 = np.zeros(N[0], dtype=Xf.dtype)
     h2 = np.zeros(N[1], dtype=Xf.dtype)
-    for p in range(2):
-        h = eval("h%d" % (p + 1))
-        N1 = N[p]
+    for h in (h1, h2):
+        N1 = h.shape[0]
         if N1 % 2 == 0:
             h[0] = h[N1 // 2] = 1
             h[1:N1 // 2] = 2
         else:
             h[0] = 1
             h[1:(N1 + 1) // 2] = 2
-        exec("h%d = h" % (p + 1), globals(), locals())
 
     h = h1[:, np.newaxis] * h2[np.newaxis, :]
     k = x.ndim


### PR DESCRIPTION
Pure maintenance: using eval/exec for iterating over a 2-tuple feels a bit unnecessary.