### PR TITLE
MAINT: Move rvs_ratio_uniforms to sampling

### DIFF
--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -6,6 +6,11 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     Generate random samples from a probability density function using the
     ratio-of-uniforms method.
 
+    .. deprecated:: 1.12.0
+        `rvs_ratio_uniforms` is deprecated in favour of
+        `scipy.stats.sampling.RatioUniforms` from version 1.12.0 and will
+        be removed in SciPy 1.14.0
+
     Parameters
     ----------
     pdf : callable
@@ -39,12 +44,12 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
 
     Notes
     -----
-    Please refer to `scipy.stats.sampling.RatioUniforms` for the documentation
-    and use ``RatioUniforms`` instead of this function which is deprecated.
+    Please refer to `scipy.stats.sampling.RatioUniforms` for the documentation.
     """
     warnings.warn("Please use `RatioUniforms` from the "
                   "`scipy.stats.sampling` namespace. The "
-                  "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated.",
+                  "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated "
+                  "and will be removed in SciPy 1.14.0",
                   category=DeprecationWarning, stacklevel=2)
     gen = RatioUniforms(pdf, umax, vmin, vmax, c, random_state)
     return gen.rvs(size)

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -51,5 +51,6 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
                   "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated "
                   "and will be removed in SciPy 1.14.0",
                   category=DeprecationWarning, stacklevel=2)
-    gen = RatioUniforms(pdf, umax, vmin, vmax, c, random_state)
+    gen = RatioUniforms(pdf, umax=umax, vmin=vmin, vmax=vmax,
+                        c=c, random_state=random_state)
     return gen.rvs(size)

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -1,6 +1,5 @@
-import numpy as np
-from scipy._lib._util import check_random_state
-
+import warnings
+from scipy.stats.sampling import RatioUniforms
 
 def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     """
@@ -40,132 +39,12 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
 
     Notes
     -----
-    Given a univariate probability density function `pdf` and a constant `c`,
-    define the set ``A = {(u, v) : 0 < u <= sqrt(pdf(v/u + c))}``.
-    If `(U, V)` is a random vector uniformly distributed over `A`,
-    then `V/U + c` follows a distribution according to `pdf`.
-
-    The above result (see [1]_, [2]_) can be used to sample random variables
-    using only the pdf, i.e. no inversion of the cdf is required. Typical
-    choices of `c` are zero or the mode of `pdf`. The set `A` is a subset of
-    the rectangle ``R = [0, umax] x [vmin, vmax]`` where
-
-    - ``umax = sup sqrt(pdf(x))``
-    - ``vmin = inf (x - c) sqrt(pdf(x))``
-    - ``vmax = sup (x - c) sqrt(pdf(x))``
-
-    In particular, these values are finite if `pdf` is bounded and
-    ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
-    One can generate `(U, V)` uniformly on `R` and return
-    `V/U + c` if `(U, V)` are also in `A` which can be directly
-    verified.
-
-    The algorithm is not changed if one replaces `pdf` by k * `pdf` for any
-    constant k > 0. Thus, it is often convenient to work with a function
-    that is proportional to the probability density function by dropping
-    unnecessary normalization factors.
-
-    Intuitively, the method works well if `A` fills up most of the
-    enclosing rectangle such that the probability is high that `(U, V)`
-    lies in `A` whenever it lies in `R` as the number of required
-    iterations becomes too large otherwise. To be more precise, note that
-    the expected number of iterations to draw `(U, V)` uniformly
-    distributed on `R` such that `(U, V)` is also in `A` is given by
-    the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin) / area(pdf)``,
-    where `area(pdf)` is the integral of `pdf` (which is equal to one if the
-    probability density function is used but can take on other values if a
-    function proportional to the density is used). The equality holds since
-    the area of `A` is equal to 0.5 * area(pdf) (Theorem 7.1 in [1]_).
-    If the sampling fails to generate a single random variate after 50000
-    iterations (i.e. not a single draw is in `A`), an exception is raised.
-
-    If the bounding rectangle is not correctly specified (i.e. if it does not
-    contain `A`), the algorithm samples from a distribution different from
-    the one given by `pdf`. It is therefore recommended to perform a
-    test such as `~scipy.stats.kstest` as a check.
-
-    References
-    ----------
-    .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
-       Springer-Verlag, 1986.
-
-    .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
-       random variates", Statistics and Computing, 24(4), p. 547--557, 2014.
-
-    .. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
-       Variables Using the Ratio of Uniform Deviates",
-       ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy import stats
-    >>> rng = np.random.default_rng()
-
-    Simulate normally distributed random variables. It is easy to compute the
-    bounding rectangle explicitly in that case. For simplicity, we drop the
-    normalization factor of the density.
-
-    >>> f = lambda x: np.exp(-x**2 / 2)
-    >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-    >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-    >>> rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500,
-    ...                                random_state=rng)
-
-    The K-S test confirms that the random variates are indeed normally
-    distributed (normality is not rejected at 5% significance level):
-
-    >>> stats.kstest(rvs, 'norm')[1]
-    0.250634764150542
-
-    The exponential distribution provides another example where the bounding
-    rectangle can be determined explicitly.
-
-    >>> rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
-    ...                                vmin=0, vmax=2*np.exp(-1), size=1000,
-    ...                                random_state=rng)
-    >>> stats.kstest(rvs, 'expon')[1]
-    0.21121052054580314
-
+    Please refer to `scipy.stats.sampling.RatioUniforms` for the documentation
+    and use ``RatioUniforms`` instead of this function which is deprecated.
     """
-    if vmin >= vmax:
-        raise ValueError("vmin must be smaller than vmax.")
-
-    if umax <= 0:
-        raise ValueError("umax must be positive.")
-
-    size1d = tuple(np.atleast_1d(size))
-    N = np.prod(size1d)  # number of rvs needed, reshape upon return
-
-    # start sampling using ratio of uniforms method
-    rng = check_random_state(random_state)
-    x = np.zeros(N)
-    simulated, i = 0, 1
-
-    # loop until N rvs have been generated: expected runtime is finite.
-    # to avoid infinite loop, raise exception if not a single rv has been
-    # generated after 50000 tries. even if the expected numer of iterations
-    # is 1000, the probability of this event is (1-1/1000)**50000
-    # which is of order 10e-22
-    while simulated < N:
-        k = N - simulated
-        # simulate uniform rvs on [0, umax] and [vmin, vmax]
-        u1 = umax * rng.uniform(size=k)
-        v1 = rng.uniform(vmin, vmax, size=k)
-        # apply rejection method
-        rvs = v1 / u1 + c
-        accept = (u1**2 <= pdf(rvs))
-        num_accept = np.sum(accept)
-        if num_accept > 0:
-            x[simulated:(simulated + num_accept)] = rvs[accept]
-            simulated += num_accept
-
-        if (simulated == 0) and (i*N >= 50000):
-            msg = ("Not a single random variate could be generated in {} "
-                   "attempts. The ratio of uniforms method does not appear "
-                   "to work for the provided parameters. Please check the "
-                   "pdf and the bounds.".format(i*N))
-            raise RuntimeError(msg)
-        i += 1
-
-    return np.reshape(x, size1d)
+    warnings.warn("Please use `RatioUniforms` from the "
+                  "`scipy.stats.sampling` namespace. The "
+                  "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
+    gen = RatioUniforms(pdf, umax, vmin, vmax, c, random_state)
+    return gen.rvs(size)

--- a/scipy/stats/_sampling.py
+++ b/scipy/stats/_sampling.py
@@ -38,12 +38,12 @@ class RatioUniforms:
     -----
     Given a univariate probability density function `pdf` and a constant `c`,
     define the set ``A = {(u, v) : 0 < u <= sqrt(pdf(v/u + c))}``.
-    If `(U, V)` is a random vector uniformly distributed over `A`,
-    then `V/U + c` follows a distribution according to `pdf`.
+    If ``(U, V)`` is a random vector uniformly distributed over ``A``,
+    then ``V/U + c`` follows a distribution according to `pdf`.
 
     The above result (see [1]_, [2]_) can be used to sample random variables
-    using only the pdf, i.e. no inversion of the cdf is required. Typical
-    choices of `c` are zero or the mode of `pdf`. The set `A` is a subset of
+    using only the PDF, i.e. no inversion of the CDF is required. Typical
+    choices of `c` are zero or the mode of `pdf`. The set ``A`` is a subset of
     the rectangle ``R = [0, umax] x [vmin, vmax]`` where
 
     - ``umax = sup sqrt(pdf(x))``
@@ -52,8 +52,8 @@ class RatioUniforms:
 
     In particular, these values are finite if `pdf` is bounded and
     ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
-    One can generate `(U, V)` uniformly on `R` and return
-    `V/U + c` if `(U, V)` are also in `A` which can be directly
+    One can generate ``(U, V)`` uniformly on ``R`` and return
+    ``V/U + c`` if ``(U, V)`` are also in ``A`` which can be directly
     verified.
 
     The algorithm is not changed if one replaces `pdf` by k * `pdf` for any
@@ -61,22 +61,22 @@ class RatioUniforms:
     that is proportional to the probability density function by dropping
     unnecessary normalization factors.
 
-    Intuitively, the method works well if `A` fills up most of the
-    enclosing rectangle such that the probability is high that `(U, V)`
-    lies in `A` whenever it lies in `R` as the number of required
+    Intuitively, the method works well if ``A`` fills up most of the
+    enclosing rectangle such that the probability is high that ``(U, V)``
+    lies in ``A`` whenever it lies in ``R`` as the number of required
     iterations becomes too large otherwise. To be more precise, note that
-    the expected number of iterations to draw `(U, V)` uniformly
-    distributed on `R` such that `(U, V)` is also in `A` is given by
+    the expected number of iterations to draw ``(U, V)`` uniformly
+    distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
     the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin) / area(pdf)``,
     where `area(pdf)` is the integral of `pdf` (which is equal to one if the
     probability density function is used but can take on other values if a
     function proportional to the density is used). The equality holds since
-    the area of `A` is equal to 0.5 * area(pdf) (Theorem 7.1 in [1]_).
+    the area of ``A`` is equal to ``0.5 * area(pdf)`` (Theorem 7.1 in [1]_).
     If the sampling fails to generate a single random variate after 50000
-    iterations (i.e. not a single draw is in `A`), an exception is raised.
+    iterations (i.e. not a single draw is in ``A``), an exception is raised.
 
     If the bounding rectangle is not correctly specified (i.e. if it does not
-    contain `A`), the algorithm samples from a distribution different from
+    contain ``A``), the algorithm samples from a distribution different from
     the one given by `pdf`. It is therefore recommended to perform a
     test such as `~scipy.stats.kstest` as a check.
 
@@ -181,10 +181,12 @@ class RatioUniforms:
                 simulated += num_accept
 
             if (simulated == 0) and (i*N >= 50000):
-                msg = ("Not a single random variate could be generated in {} "
+                msg = (
+                    f"Not a single random variate could be generated in {i*N} "
                     "attempts. The ratio of uniforms method does not appear "
                     "to work for the provided parameters. Please check the "
-                    "pdf and the bounds.".format(i*N))
+                    "pdf and the bounds."
+                )
                 raise RuntimeError(msg)
             i += 1
 

--- a/scipy/stats/_sampling.py
+++ b/scipy/stats/_sampling.py
@@ -95,6 +95,7 @@ class RatioUniforms:
     Examples
     --------
     >>> import numpy as np
+    >>> from scipy import stats
     >>> from scipy.stats.sampling import RatioUniforms
     >>> rng = np.random.default_rng()
 

--- a/scipy/stats/_sampling.py
+++ b/scipy/stats/_sampling.py
@@ -1,0 +1,204 @@
+import numpy as np
+from scipy._lib._util import check_random_state
+
+
+class RatioUniforms:
+    """
+    Generate random samples from a probability density function using the
+    ratio-of-uniforms method.
+
+    Parameters
+    ----------
+    pdf : callable
+        A function with signature `pdf(x)` that is proportional to the
+        probability density function of the distribution.
+    umax : float
+        The upper bound of the bounding rectangle in the u-direction.
+    vmin : float
+        The lower bound of the bounding rectangle in the v-direction.
+    vmax : float
+        The upper bound of the bounding rectangle in the v-direction.
+    c : float, optional.
+        Shift parameter of ratio-of-uniforms method, see Notes. Default is 0.
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+
+        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+    Methods
+    -------
+    rvs
+
+    Notes
+    -----
+    Given a univariate probability density function `pdf` and a constant `c`,
+    define the set ``A = {(u, v) : 0 < u <= sqrt(pdf(v/u + c))}``.
+    If `(U, V)` is a random vector uniformly distributed over `A`,
+    then `V/U + c` follows a distribution according to `pdf`.
+
+    The above result (see [1]_, [2]_) can be used to sample random variables
+    using only the pdf, i.e. no inversion of the cdf is required. Typical
+    choices of `c` are zero or the mode of `pdf`. The set `A` is a subset of
+    the rectangle ``R = [0, umax] x [vmin, vmax]`` where
+
+    - ``umax = sup sqrt(pdf(x))``
+    - ``vmin = inf (x - c) sqrt(pdf(x))``
+    - ``vmax = sup (x - c) sqrt(pdf(x))``
+
+    In particular, these values are finite if `pdf` is bounded and
+    ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
+    One can generate `(U, V)` uniformly on `R` and return
+    `V/U + c` if `(U, V)` are also in `A` which can be directly
+    verified.
+
+    The algorithm is not changed if one replaces `pdf` by k * `pdf` for any
+    constant k > 0. Thus, it is often convenient to work with a function
+    that is proportional to the probability density function by dropping
+    unnecessary normalization factors.
+
+    Intuitively, the method works well if `A` fills up most of the
+    enclosing rectangle such that the probability is high that `(U, V)`
+    lies in `A` whenever it lies in `R` as the number of required
+    iterations becomes too large otherwise. To be more precise, note that
+    the expected number of iterations to draw `(U, V)` uniformly
+    distributed on `R` such that `(U, V)` is also in `A` is given by
+    the ratio ``area(R) / area(A) = 2 * umax * (vmax - vmin) / area(pdf)``,
+    where `area(pdf)` is the integral of `pdf` (which is equal to one if the
+    probability density function is used but can take on other values if a
+    function proportional to the density is used). The equality holds since
+    the area of `A` is equal to 0.5 * area(pdf) (Theorem 7.1 in [1]_).
+    If the sampling fails to generate a single random variate after 50000
+    iterations (i.e. not a single draw is in `A`), an exception is raised.
+
+    If the bounding rectangle is not correctly specified (i.e. if it does not
+    contain `A`), the algorithm samples from a distribution different from
+    the one given by `pdf`. It is therefore recommended to perform a
+    test such as `~scipy.stats.kstest` as a check.
+
+    References
+    ----------
+    .. [1] L. Devroye, "Non-Uniform Random Variate Generation",
+       Springer-Verlag, 1986.
+
+    .. [2] W. Hoermann and J. Leydold, "Generating generalized inverse Gaussian
+       random variates", Statistics and Computing, 24(4), p. 547--557, 2014.
+
+    .. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
+       Variables Using the Ratio of Uniform Deviates",
+       ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.stats.sampling import RatioUniforms
+    >>> rng = np.random.default_rng()
+
+    Simulate normally distributed random variables. It is easy to compute the
+    bounding rectangle explicitly in that case. For simplicity, we drop the
+    normalization factor of the density.
+
+    >>> f = lambda x: np.exp(-x**2 / 2)
+    >>> v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+    >>> umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
+    >>> gen = RatioUniforms(f, umax, vmin, vmax, random_state=rng)
+    >>> r = gen.rvs(size=2500)
+
+    The K-S test confirms that the random variates are indeed normally
+    distributed (normality is not rejected at 5% significance level):
+
+    >>> stats.kstest(r, 'norm')[1]
+    0.250634764150542
+
+    The exponential distribution provides another example where the bounding
+    rectangle can be determined explicitly.
+
+    >>> gen = RatioUniforms(lambda x: np.exp(-x), umax=1, vmin=0,
+    ...                     vmax=2*np.exp(-1), random_state=rng)
+    >>> r = gen.rvs(1000)
+    >>> stats.kstest(r, 'expon')[1]
+    0.21121052054580314
+
+    """
+    
+    def __init__(self, pdf, umax, vmin, vmax, c=0, random_state=None):
+        if vmin >= vmax:
+            raise ValueError("vmin must be smaller than vmax.")
+
+        if umax <= 0:
+            raise ValueError("umax must be positive.")
+        
+        self._pdf = pdf
+        self._umax = umax
+        self._vmin = vmin
+        self._vmax = vmax
+        self._c = c
+        self._rng = check_random_state(random_state)
+
+    def rvs(self, size=1, random_state=None):
+        """Sampling of random variates
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Number of random variates to be generated (default is 1).
+
+        Returns
+        -------
+        rvs : ndarray
+            The random variates distributed according to the probability
+            distribution defined by the pdf.
+        random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+
+        If `seed` is None, ``self.random_state`` is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+        """
+        size1d = tuple(np.atleast_1d(size))
+        N = np.prod(size1d)  # number of rvs needed, reshape upon return
+
+        # use self._rng unless a new random_state is provided
+        if random_state is not None:
+            rng = check_random_state(random_state)
+        else:
+            rng = self._rng
+
+        # start sampling using ratio of uniforms method
+        x = np.zeros(N)
+        simulated, i = 0, 1
+
+        # loop until N rvs have been generated: expected runtime is finite.
+        # to avoid infinite loop, raise exception if not a single rv has been
+        # generated after 50000 tries. even if the expected numer of iterations
+        # is 1000, the probability of this event is (1-1/1000)**50000
+        # which is of order 10e-22
+        while simulated < N:
+            k = N - simulated
+            # simulate uniform rvs on [0, umax] and [vmin, vmax]
+            u1 = self._umax * rng.uniform(size=k)
+            v1 = rng.uniform(self._vmin, self._vmax, size=k)
+            # apply rejection method
+            rvs = v1 / u1 + self._c
+            accept = (u1**2 <= self._pdf(rvs))
+            num_accept = np.sum(accept)
+            if num_accept > 0:
+                x[simulated:(simulated + num_accept)] = rvs[accept]
+                simulated += num_accept
+
+            if (simulated == 0) and (i*N >= 50000):
+                msg = ("Not a single random variate could be generated in {} "
+                    "attempts. The ratio of uniforms method does not appear "
+                    "to work for the provided parameters. Please check the "
+                    "pdf and the bounds.".format(i*N))
+                raise RuntimeError(msg)
+            i += 1
+
+        return np.reshape(x, size1d)

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -215,6 +215,7 @@ py3.install_sources([
     '_resampling.py',
     '_result_classes.py',
     '_rvs_sampling.py',
+    '_sampling.py',
     '_sensitivity_analysis.py',
     '_stats_mstats_common.py',
     '_stats_py.py',

--- a/scipy/stats/sampling.py
+++ b/scipy/stats/sampling.py
@@ -7,7 +7,9 @@ Random Number Generators (:mod:`scipy.stats.sampling`)
 
 This module contains a collection of random number generators to sample
 from univariate continuous and discrete distributions. It uses the
-implementation of a C library called "UNU.RAN".
+implementation of a C library called "UNU.RAN". The only exception is
+RatioUniforms, which is a pure Python implementation of the
+Ratio-of-Uniforms method.
 
 Generators Wrapped
 ==================
@@ -22,6 +24,7 @@ For continuous distributions
    NumericalInversePolynomial
    TransformedDensityRejection
    SimpleRatioUniforms
+   RatioUniforms
 
 For discrete distributions
 --------------------------
@@ -40,6 +43,7 @@ Warnings / Errors used in :mod:`scipy.stats.sampling`
 
    UNURANError
 """
+from ._sampling import RatioUniforms  # noqa: F401
 from ._unuran.unuran_wrapper import (  # noqa: F401
     TransformedDensityRejection,
     DiscreteAliasUrn,

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1375,9 +1375,9 @@ class TestRatioUniforms:
         # use KS test to check distribution of rvs
         # normal distribution
         f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-        gen = RatioUniforms(f, umax, vmin, vmax, random_state=12345)
+        v = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        u = np.sqrt(f(0))
+        gen = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=12345)
         assert_equal(stats.kstest(gen.rvs(2500), 'norm')[1] > 0.25, True)
 
         # exponential distribution
@@ -1388,43 +1388,41 @@ class TestRatioUniforms:
     def test_shape(self):
         # test shape of return value depending on size parameter
         f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
+        v = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        u = np.sqrt(f(0))
 
-        gen1 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
-        gen2 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
-        gen3 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
+        gen1 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
+        gen2 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
+        gen3 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
         r1, r2, r3 = gen1.rvs(3), gen2.rvs((3,)), gen3.rvs((3, 1))
         assert_equal(r1, r2)
         assert_equal(r2, r3.flatten())
         assert_equal(r1.shape, (3,))
         assert_equal(r3.shape, (3, 1))
 
-        gen4 = RatioUniforms(f, umax, vmin, vmax, random_state=12)
-        gen5 = RatioUniforms(f, umax, vmin, vmax, random_state=12)
+        gen4 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=12)
+        gen5 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=12)
         r4, r5 = gen4.rvs(size=(3, 3, 3)), gen5.rvs(size=27)
         assert_equal(r4.flatten(), r5)
         assert_equal(r4.shape, (3, 3, 3))
 
-        gen6 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
-        gen7 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
-        gen8 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
+        gen6 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
+        gen7 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
+        gen8 = RatioUniforms(f, umax=u, vmin=-v, vmax=v, random_state=1234)
         r6, r7, r8 = gen6.rvs(), gen7.rvs(1), gen8.rvs((1,))
         assert_equal(r6, r7)
         assert_equal(r7, r8)
 
     def test_random_state(self):
         f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-        gen1 = RatioUniforms(f, umax, vmin, vmax, random_state=1234)
+        v = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        umax = np.sqrt(f(0))
+        gen1 = RatioUniforms(f, umax=umax, vmin=-v, vmax=v, random_state=1234)
         r1 = gen1.rvs(10)
-        r2 = gen1.rvs(10, random_state=1234)
         np.random.seed(1234)
-        gen2 = RatioUniforms(f, umax, vmin, vmax)
-        r3 = gen2.rvs(10)
+        gen2 = RatioUniforms(f, umax=umax, vmin=-v, vmax=v)
+        r2 = gen2.rvs(10)
         assert_equal(r1, r2)
-        assert_equal(r1, r3)
 
     def test_exceptions(self):
         f = stats.norm.pdf

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1427,12 +1427,12 @@ class TestRatioUniforms:
     def test_exceptions(self):
         f = stats.norm.pdf
         # need vmin < vmax
-        assert_raises(ValueError,
-                      RatioUniforms, pdf=f, umax=1, vmin=3, vmax=1)
-        assert_raises(ValueError,
-                      RatioUniforms, pdf=f, umax=1, vmin=1, vmax=1)
+        with assert_raises(ValueError, match="vmin must be smaller than vmax"):
+            RatioUniforms(pdf=f, umax=1, vmin=3, vmax=1)
+        with assert_raises(ValueError, match="vmin must be smaller than vmax"):
+            RatioUniforms(pdf=f, umax=1, vmin=1, vmax=1)
         # need umax > 0
-        assert_raises(ValueError,
-                      RatioUniforms, pdf=f, umax=-1, vmin=1, vmax=1)
-        assert_raises(ValueError,
-                      RatioUniforms, pdf=f, umax=0, vmin=1, vmax=1)
+        with assert_raises(ValueError, match="umax must be positive"):
+            RatioUniforms(pdf=f, umax=-1, vmin=1, vmax=3)
+        with assert_raises(ValueError, match="umax must be positive"):
+            RatioUniforms(pdf=f, umax=0, vmin=1, vmax=3)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7659,15 +7659,15 @@ class TestRatioUniforms:
     as rvs_ratio_uniforms is deprecated and moved to stats.sampling """
     def test_consistency(self):
         f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-        gen = stats.sampling.RatioUniforms(f, umax, vmin, vmax,
+        v = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
+        umax = np.sqrt(f(0))
+        gen = stats.sampling.RatioUniforms(f, umax=umax, vmin=-v, vmax=v,
                                            random_state=12345)
         r1 = gen.rvs(10)
         deprecation_msg = ("Please use `RatioUniforms` from the "
                            "`scipy.stats.sampling` namespace.")
         with pytest.warns(DeprecationWarning, match=deprecation_msg):
-            r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=10,
+            r2 = stats.rvs_ratio_uniforms(f, umax, -v, v, size=10,
                                           random_state=12345)
         assert_equal(r1, r2)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7655,79 +7655,21 @@ class TestBrunnerMunzel:
 
 
 class TestRatioUniforms:
-    """ Tests for rvs_ratio_uniforms.
-    """
-
-    def test_rv_generation(self):
-        # use KS test to check distribution of rvs
-        # normal distribution
+    """ Tests for rvs_ratio_uniforms are in test_sampling.py,
+    as rvs_ratio_uniforms is deprecated and moved to stats.sampling """
+    def test_consistency(self):
         f = stats.norm.pdf
         v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
         umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-        rvs = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=2500,
-                                       random_state=12345)
-        assert_equal(stats.kstest(rvs, 'norm')[1] > 0.25, True)
-
-        # exponential distribution
-        rvs = stats.rvs_ratio_uniforms(lambda x: np.exp(-x), umax=1,
-                                       vmin=0, vmax=2*np.exp(-1),
-                                       size=1000, random_state=12345)
-        assert_equal(stats.kstest(rvs, 'expon')[1] > 0.25, True)
-
-    def test_shape(self):
-        # test shape of return value depending on size parameter
-        f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-
-        r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=3,
-                                      random_state=1234)
-        r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3,),
-                                      random_state=1234)
-        r3 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 1),
-                                      random_state=1234)
+        gen = stats.sampling.RatioUniforms(f, umax, vmin, vmax,
+                                           random_state=12345)
+        r1 = gen.rvs(10)
+        deprecation_msg = ("Please use `RatioUniforms` from the "
+                           "`scipy.stats.sampling` namespace.")
+        with pytest.warns(DeprecationWarning, match=deprecation_msg):
+            r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=10,
+                                          random_state=12345)
         assert_equal(r1, r2)
-        assert_equal(r2, r3.flatten())
-        assert_equal(r1.shape, (3,))
-        assert_equal(r3.shape, (3, 1))
-
-        r4 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 3, 3),
-                                      random_state=12)
-        r5 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=27,
-                                      random_state=12)
-        assert_equal(r4.flatten(), r5)
-        assert_equal(r4.shape, (3, 3, 3))
-
-        r6 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, random_state=1234)
-        r7 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=1,
-                                      random_state=1234)
-        r8 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(1, ),
-                                      random_state=1234)
-        assert_equal(r6, r7)
-        assert_equal(r7, r8)
-
-    def test_random_state(self):
-        f = stats.norm.pdf
-        v_bound = np.sqrt(f(np.sqrt(2))) * np.sqrt(2)
-        umax, vmin, vmax = np.sqrt(f(0)), -v_bound, v_bound
-        np.random.seed(1234)
-        r1 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4))
-        r2 = stats.rvs_ratio_uniforms(f, umax, vmin, vmax, size=(3, 4),
-                                      random_state=1234)
-        assert_equal(r1, r2)
-
-    def test_exceptions(self):
-        f = stats.norm.pdf
-        # need vmin < vmax
-        assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, umax=1, vmin=3, vmax=1)
-        assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, umax=1, vmin=1, vmax=1)
-        # need umax > 0
-        assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, umax=-1, vmin=1, vmax=1)
-        assert_raises(ValueError,
-                      stats.rvs_ratio_uniforms, pdf=f, umax=0, vmin=1, vmax=1)
 
 
 class TestMGCErrorWarnings:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
General sampling methods are in `stats.sampling`. `rvs_ratio_uniforms` was added to `stats` before the module `sampling` was created. This PR deprecates the function in stats. An equivalent class is created that is consistent to the other sampling methods. It also makes more sense from a performance perspective to initialize a few parameters once when an instance is created whereas `rvs_ratio_uniforms` computes these parameters every time again.

#### Additional information
N/A
