### PR TITLE
Mark `void` functions as `noexcept` in _rotation.pyx

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -98,7 +98,7 @@ cdef inline int _elementary_basis_index(uchar axis) noexcept:
 # canonical "positive" single cover
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _quat_canonical_single(double[:] q) nogil:
+cdef inline void _quat_canonical_single(double[:] q) noexcept nogil:
     if ((q[3] < 0)
         or (q[3] == 0 and q[0] < 0)
         or (q[3] == 0 and q[0] == 0 and q[1] < 0)
@@ -110,7 +110,7 @@ cdef inline void _quat_canonical_single(double[:] q) nogil:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _quat_canonical(double[:, :] q):
+cdef inline void _quat_canonical(double[:, :] q) noexcept:
     cdef Py_ssize_t n = q.shape[0]
     for ind in range(n):
         _quat_canonical_single(q[ind])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Related to #17334

#### What does this implement/fix?
Cython3 requires `noexcept` keyword to declare function not propagating exceptions.

#### Additional information

https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html
