### PR TITLE
MAINT: stats: remove long double support for all boost ufuncs

### DIFF
--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -53,7 +53,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
     boost_hdr_name = boost_dist.split('_distribution')[0]
     unique_num_inputs = set({m.num_inputs for m in methods})
     has_NPY_FLOAT16 = 'NPY_FLOAT16' in types
-    has_NPY_LONGDOUBLE = 'NPY_LONGDOUBLE' in types
     line_joiner = ',\n    ' + ' '*12
     num_types = len(types)
     loop_fun = 'PyUFunc_T'
@@ -103,9 +102,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
             import_ufunc()
             '''))
 
-        if has_NPY_LONGDOUBLE:
-            warn('Boost stats NPY_LONGDOUBLE ufunc generation not '
-                 'currently not supported!')
         if has_NPY_FLOAT16:
             warn('Boost stats NPY_FLOAT16 ufunc generation not '
                  'currently not supported!')
@@ -120,7 +116,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
 
             for jj, T in enumerate(types):
                 ctype = {
-                    'NPY_LONGDOUBLE': 'longdouble',
                     'NPY_DOUBLE': 'double',
                     'NPY_FLOAT': 'float',
                     'NPY_FLOAT16': 'npy_half',

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -5,7 +5,6 @@ from warnings import warn
 from textwrap import dedent
 from shutil import copyfile
 import pathlib
-import sys
 import argparse
 
 from gen_func_defs_pxd import (  # type: ignore
@@ -105,7 +104,8 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
             '''))
 
         if has_NPY_LONGDOUBLE:
-            fp.write('ctypedef long double longdouble\n\n')
+            warn('Boost stats NPY_LONGDOUBLE ufunc generation not '
+                 'currently not supported!')
         if has_NPY_FLOAT16:
             warn('Boost stats NPY_FLOAT16 ufunc generation not '
                  'currently not supported!')
@@ -184,9 +184,6 @@ if __name__ == '__main__':
         x_funcs=_x_funcs,
         no_x_funcs=_no_x_funcs)
     float_types = ['NPY_FLOAT', 'NPY_DOUBLE']
-    # Don't generate the 'long double' ufunc loops on Windows.
-    if sys.platform != 'win32':
-        float_types.append('NPY_LONGDOUBLE')
     for b, s in _klass_mapper.items():
         _ufunc_gen(
             scipy_dist=s.scipy_name,

--- a/scipy/stats/tests/test_boost_ufuncs.py
+++ b/scipy/stats/tests/test_boost_ufuncs.py
@@ -5,8 +5,7 @@ from scipy.stats import _boost
 
 
 type_char_to_type_tol = {'f': (np.float32, 32*np.finfo(np.float32).eps),
-                         'd': (np.float64, 32*np.finfo(np.float64).eps),
-                         'g': (np.longdouble, 32*np.finfo(np.longdouble).eps)}
+                         'd': (np.float64, 32*np.finfo(np.float64).eps)}
 
 
 # Each item in this list is


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- closes gh-18600

#### What does this implement/fix?
<!--Please explain your changes.-->

- Before, `long double` code generation was only performed for non-Windows `scipy.stats` Boost ufuncs.  This PR removes problematic `long double` code generation for all platforms

#### Additional information
<!--Any additional information you think is important.-->
