### PR TITLE
MAINT: Fix lint warnings in `_traversal.pyx`

### DIFF
--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -184,8 +184,8 @@ def breadth_first_tree(csgraph, i_start, directed=True):
     Note that the resulting graph is a Directed Acyclic Graph which spans
     the graph.  A breadth-first tree from a given node is unique.
     """
-    node_list, predecessors = breadth_first_order(csgraph, i_start,
-                                                  directed, True)
+    _node_list, predecessors = breadth_first_order(csgraph, i_start,
+                                                   directed, True)
     return reconstruct_path(csgraph, predecessors, directed)
 
 
@@ -258,8 +258,8 @@ def depth_first_tree(csgraph, i_start, directed=True):
     had begun with the edge connecting nodes 0 and 3, the result would have
     been different.
     """
-    node_list, predecessors = depth_first_order(csgraph, i_start,
-                                                directed, True)
+    _node_list, predecessors = depth_first_order(csgraph, i_start,
+                                                 directed, True)
     return reconstruct_path(csgraph, predecessors, directed)
 
 


### PR DESCRIPTION
#### What does this implement/fix?
Fix this lint error:
```
scipy/sparse/csgraph/_traversal.pyx:187:5: 'node_list' defined but unused (try prefixing with underscore?)
scipy/sparse/csgraph/_traversal.pyx:261:5: 'node_list' defined but unused (try prefixing with underscore?)
```

Now the linter finds no issues:
```
% python dev.py lint
%
```
