### PR TITLE
ENH: makes `_covariance` a cached property

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -548,7 +548,6 @@ class CovViaCholesky(Covariance):
     def _covariance(self):
         return self._factor @ self._factor.T
 
-
     def _whiten(self, x):
         res = linalg.solve_triangular(self._factor, x.T, lower=True).T
         return res

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -541,9 +541,13 @@ class CovViaCholesky(Covariance):
         self._factor = L
         self._log_pdet = 2*np.log(np.diag(self._factor)).sum(axis=-1)
         self._rank = L.shape[-1]  # must be full rank for cholesky
-        self._covariance = L @ L.T
         self._shape = L.shape
         self._allow_singular = False
+
+    @cached_property
+    def _covariance(self):
+        return self._factor @ self._factor.T
+
 
     def _whiten(self, x):
         res = linalg.solve_triangular(self._factor, x.T, lower=True).T


### PR DESCRIPTION
This ensures it's only computed when a method demands it. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #18639, though the major performance problem is still due to the default behavior when providing the covariance matrix as an array. This makes circumventing it quicker, though. 

#### What does this implement/fix?
`colorize` and `whiten` for this subclass of `Covariance` do not require the covariance matrix to be computed, so this fix defers computation until the user asks. 

#### Additional information
<!--Any additional information you think is important.-->
