### PR TITLE
BUG: sparse.linalg: Cast index arrays to intc before calling SuperLU functions

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
-            indices = A.indices.astype(np.intc, casting='safe', copy=False)
-            indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+            indices = A.indices.astype(np.intc, copy=False)
+            indptr = A.indptr.astype(np.intc, copy=False)
             options = dict(ColPerm=permc_spec)
             x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
@@ -404,8 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, casting='safe', copy=False)
-    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -499,8 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, casting='safe', copy=False)
-    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
+            indices = A.indices.astype(np.intc, copy=False)
+            indptr = A.indptr.astype(np.intc, copy=False)
             options = dict(ColPerm=permc_spec)
-            x, info = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr,
+            x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
             if info != 0:
                 warn("Matrix is exactly singular", MatrixRankWarning)
@@ -402,6 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -411,7 +415,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 
-    return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
+    return _superlu.gstrf(N, A.nnz, A.data, indices, indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=False, options=_options)
 
@@ -495,6 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
@@ -506,7 +512,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 
-    return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
+    return _superlu.gstrf(N, A.nnz, A.data, indices, indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=True, options=_options)
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
-            indices = A.indices.astype(np.intc, copy=False)
-            indptr = A.indptr.astype(np.intc, copy=False)
+            indices = A.indices.astype(np.intc, casting='safe', copy=False)
+            indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
             options = dict(ColPerm=permc_spec)
             x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
@@ -404,8 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, copy=False)
-    indptr = A.indptr.astype(np.intc, copy=False)
+    indices = A.indices.astype(np.intc, casting='safe', copy=False)
+    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -499,8 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, copy=False)
-    indptr = A.indptr.astype(np.intc, copy=False)
+    indices = A.indices.astype(np.intc, casting='safe', copy=False)
+    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -404,6 +404,12 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    # check for safe downcasting
+    ii = np.iinfo(np.int32)
+    # check indices because they should be larger than indptr
+    if np.any(A.indices > ii.max || A.indices < ii.min):
+        raise ValueError("index values too large for SuperLU")
+
     indices = A.indices.astype(np.intc, copy=False)
     indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
@@ -498,6 +504,12 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     M, N = A.shape
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
+
+    # check for safe downcasting
+    ii = np.iinfo(np.int32)
+    # check indices because they should be larger than indptr
+    if np.any(A.indices > ii.max || A.indices < ii.min):
+        raise ValueError("index values too large for SuperLU")
 
     indices = A.indices.astype(np.intc, copy=False)
     indptr = A.indptr.astype(np.intc, copy=False)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -125,13 +125,13 @@ def _get_umf_family(A):
 
 def _safe_downcast_indices(A):
     # check for safe downcasting
-    int32max = np.iinfo(np.int32).max
+    max_value = np.iinfo(np.intc).max
 
-    if indptr[-1] > int32max:  # indptr[-1] is max b/c indptr always sorted
+    if A.indptr[-1] > max_value:  # indptr[-1] is max b/c indptr always sorted
         raise ValueError("indptr values too large for SuperLU")
 
-    if max(*shape) > int32max:  # only check large enough arrays
-        if np.any(A.indices > int32max):
+    if max(*A.shape) > max_value:  # only check large enough arrays
+        if np.any(A.indices > max_value):
             raise ValueError("indices values too large for SuperLU")
 
     indices = A.indices.astype(np.intc, copy=False)


### PR DESCRIPTION
#### Reference issue
Fixes gh-18603.

#### What does this implement/fix?
The SuperLU code expects sparse matrix index arrays to have type `intc`, so this PR adds a cast prior to those calls. See the linked issue for context.
