### PR TITLE
BUG: Fixes how the length of argument x of linalg.blas.?gbmv is checked

### DIFF
--- a/scipy/linalg/fblas_l2.pyf.src
+++ b/scipy/linalg/fblas_l2.pyf.src
@@ -92,7 +92,7 @@ subroutine <prefix>gbmv(m,n,kl,ku,alpha,a,lda,x,incx,offx,beta,y,incy,offy,trans
 
   <ftype> dimension(*), intent(in) :: x
   check(offx>=0 && offx<len(x)) :: x
-  check(len(x)>offx+(trans==0?m-1:n-1)*abs(incx)) :: x
+  check(len(x)>offx+(trans==0?n-1:m-1)*abs(incx)) :: x
   depend(offx,n,incx) :: x
 
 end subroutine <prefix>gbmv

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -487,6 +487,11 @@ class TestFBLAS2Simple:
             y2 = alpha * A.dot(x) + beta * y
             assert_array_almost_equal(y1, y2)
 
+            y1 = func(m=m, n=n, ku=ku, kl=kl, alpha=alpha, a=Ab,
+                      x=y, y=x, beta=beta, trans=1)
+            y2 = alpha * A.T.dot(y) + beta * x
+            assert_array_almost_equal(y1, y2)
+
     def test_sbmv_hbmv(self):
         seed(1234)
         for ind, dtype in enumerate(DTYPES):


### PR DESCRIPTION
#### Reference issue
Closes #18647

#### What does this implement/fix?
Given an m×n banded matrix A, linalg.blas.?gbmv does
y <- α A x + β y     if trans==0
y <- α A^T x + β y   if trans==1 (and A^H if trans==2)
Therefore x must be of length n when trans==0 and m otherwise.
This commit fixes the current code, which does the opposite.