### PR TITLE
DOC: Add missing equal sign to Lomb-Scargle periodogram equation

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1001,7 +1001,7 @@ variance is unity, the normalized Lomb-Scargle periodogram at frequency
 
 .. math::
 
-    P_{n}(f) \frac{1}{2}\left\{\frac{\left[\sum_{j}^{N_{t}}X_{j}\cos\omega(t_{j}-\tau)\right]^{2}}{\sum_{j}^{N_{t}}\cos^{2}\omega(t_{j}-\tau)}+\frac{\left[\sum_{j}^{N_{t}}X_{j}\sin\omega(t_{j}-\tau)\right]^{2}}{\sum_{j}^{N_{t}}\sin^{2}\omega(t_{j}-\tau)}\right\}.
+    P_{n}(f) = \frac{1}{2}\left\{\frac{\left[\sum_{j}^{N_{t}}X_{j}\cos\omega(t_{j}-\tau)\right]^{2}}{\sum_{j}^{N_{t}}\cos^{2}\omega(t_{j}-\tau)}+\frac{\left[\sum_{j}^{N_{t}}X_{j}\sin\omega(t_{j}-\tau)\right]^{2}}{\sum_{j}^{N_{t}}\sin^{2}\omega(t_{j}-\tau)}\right\}.
 
 Here, :math:`\omega \equiv 2\pi f` is the angular frequency. The frequency-dependent
 time offset :math:`\tau` is given by


### PR DESCRIPTION
#### Reference issue
Closes #18651

#### What does this implement/fix?
Add an equal sign in the doc
