### PR TITLE
MAINT: fix 'no such option' error in build_scipy CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: setup Python venv
           command: |
-            pip install --install-option="--no-cython-compile" cython
+            pip install cython
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
             # `asv` pin because of slowdowns reported in gh-15568


### PR DESCRIPTION
Pip's `--install-option` switch is deprecated.
Cython docs say the purpose of `--no-cython-compile` is for platforms that do not have wheels on PyPI, but they do have wheels for common Linux platforms that should cover this CI job.

See https://cython.readthedocs.io/en/latest/src/quickstart/install.html

Fixes gh-18654


