### PR TITLE
TST: fix two test failures that showed up on conda-forge

### DIFF
--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,10 +1,11 @@
 import logging
+import sys
 
 import numpy
 import numpy as np
 import time
 from multiprocessing import Pool
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, IS_PYPY
 import pytest
 from pytest import raises as assert_raises, warns
 from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
@@ -690,6 +691,8 @@ class TestShgoArguments:
         """Test single function constraint passing"""
         SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
 
+    @pytest.mark.xfail(IS_PYPY and sys.platform == 'win32',
+            reason="Failing and fix in PyPy not planned (see gh-18632)")
     def test_10_finite_time(self):
         """Test single function constraint passing"""
         options = {'maxtime': 1e-15}

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -75,7 +75,7 @@ class TestHyp1f1:
     ])
     def test_a_negative_integer(self, a, b, x, result):
         # Desired answers computed using Mpmath.
-        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-14)
+        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1.5e-14)
 
     @pytest.mark.parametrize('a, b, x, expected', [
         (0.01, 150, -4, 0.99973683897677527773),        # gh-3492


### PR DESCRIPTION
The ppc64le one is a small test bump. The PyPy-on-Windows one is a real bug in PyPy, but it's not planned to be fixed any time soon, so the test is xfail-ed here.

Closes gh-18632

[skip circle] [skip cirrus]