### PR TITLE
DOC: `scipy._sensitivity_analysis`: correct statement about sums of Sobol' indices; and improve clarity and grammar

### DIFF
--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -379,23 +379,23 @@ def sobol_indices(
 
     :math:`S_{i}` corresponds to the first-order term which apprises the
     contribution of the i-th parameter, while :math:`S_{ij}` corresponds to the
-    second-order term which informs about the contribution of interactions between the
-    i-th and the j-th parameters. These equations can be generalized to compute
-    higher order terms; however, they are expensive to compute and their
-    interpretation is complex.
+    second-order term which informs about the contribution of interactions
+    between the i-th and the j-th parameters. These equations can be
+    generalized to compute higher order terms; however, they are expensive to
+    compute and their interpretation is complex.
     This is why only first order indices are provided.
 
-    Total order indices represent the global contribution of the parameters to the
-    variance of the QoI and are defined as:
+    Total order indices represent the global contribution of the parameters
+    to the variance of the QoI and are defined as:
 
     .. math::
 
         S_{T_i} = S_i + \sum_j S_{ij} + \sum_{j,k} S_{ijk} + ...
         = 1 - \frac{\mathbb{V}[\mathbb{E}(Y|x_{\sim i})]}{\mathbb{V}[Y]}.
 
-    First order indices sum to at most 1, while total order indices sum to at least 1.
-    If there are no interactions, then first and total order indices are equal, and both
-    first and total order indices sum to 1.
+    First order indices sum to at most 1, while total order indices sum to at
+    least 1. If there are no interactions, then first and total order indices
+    are equal, and both first and total order indices sum to 1.
 
     .. warning::
 

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -407,6 +407,9 @@ def sobol_indices(
         consider at minima ``n >= 2**12``. The more complex the model is,
         the more samples will be needed.
 
+        Even for a purely addiditive model, the indices may not sum to 1 due
+        to numerical noise.
+
     References
     ----------
     .. [1] Sobol, I. M.. "Sensitivity analysis for nonlinear mathematical

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -400,8 +400,9 @@ def sobol_indices(
         S_{T_i} = S_i + \sum_j S_{ij} + \sum_{j,k} S_{ijk} + ...
         = 1 - \frac{\mathbb{V}[\mathbb{E}(Y|x_{\sim i})]}{\mathbb{V}[Y]}.
 
-    First order indices sum to 1, while the sum of total order indices will be
-    greater than 1 if there are interactions.
+    First order indices sum to at most 1, while total order indices sum to at least 1.
+    If there are no interactions, then first and total order indices are equal, and both
+    first and total order indices sum to 1.
 
     .. warning::
 
@@ -412,10 +413,6 @@ def sobol_indices(
         the dimensionality of the problem. e.g. for a 3 dimension problem,
         consider at minima ``n >= 2**12``. The more complex the model is,
         the more samples will be needed.
-
-        If the parameters are not independent, the first-order indices would
-        not sum to 1.
-        Numerical noise can also contribute to this.
 
     References
     ----------

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -93,20 +93,12 @@ def sample_A_B(
 def sample_AB(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     """AB matrix.
 
-    AB: rows of B into A. Shape (d, d, n). See sec. 3 from [1]_.
+    AB: rows of B into A. Shape (d, d, n).
     - Copy A into d "pages"
     - In the first page, replace 1st rows of A with 1st row of B.
     ...
     - In the dth page, replace dth row of A with dth row of B.
     - return the stack of pages
-
-    References
-    ----------
-    .. [1] Saltelli, A., P. Annoni, I. Azzini, F. Campolongo, M. Ratto, and
-       S. Tarantola. "Variance based sensitivity analysis of model
-       output. Design and estimator for the total sensitivity index."
-       Computer Physics Communications, 181(2):259-270,
-       :doi:`10.1016/j.cpc.2009.09.018`, 2010.
     """
     d, n = A.shape
     AB = np.tile(A, (d, 1, 1))
@@ -286,15 +278,16 @@ def sobol_indices(
         different arrays. Keys must be: ``f_A``, ``f_B`` and ``f_AB``.
         ``f_A`` and ``f_B`` should have a shape ``(s, n)`` and ``f_AB``
         should have a shape ``(d, s, n)``.
-        This is an advanced feature and misuse can lead to incorrect analysis.
+        This is an advanced feature and misuse can lead to wrong analysis.
     n : int
         Number of samples used to generate the matrices ``A`` and ``B``.
         Must be a power of 2. The total number of points at which `func` is
         evaluated will be ``n*(d+2)``.
     dists : list(distributions), optional
-        List of each parameter's distribution.
+        List of each parameter's distribution. The distribution of parameters
+        depends on the application and should be carefully chosen.
         Parameters are assumed to be independently distributed, meaning there is
-        no constraint or relationship between them.
+        no constraint nor relationship between their values.
 
         Distributions must be an instance of a class with a ``ppf``
         method.
@@ -308,12 +301,13 @@ def sobol_indices(
             func(f_A: np.ndarray, f_B: np.ndarray, f_AB: np.ndarray)
             -> Tuple[np.ndarray, np.ndarray]
 
-        with ``f_A, f_B`` of shape ``(s, n)`` and ``f_AB`` of shape ``(d, s, n)``.
+        with ``f_A, f_B`` of shape ``(s, n)`` and ``f_AB`` of shape
+        ``(d, s, n)``.
         These arrays contain the function evaluations from three different sets
         of samples.
         The output is a tuple of the first and total indices with
         shape ``(s, d)``.
-        This is an advanced feature and misuse can lead to incorrect analysis.
+        This is an advanced feature and misuse can lead to wrong analysis.
     random_state : {None, int, `numpy.random.Generator`}, optional
         If `random_state` is an int or None, a new `numpy.random.Generator` is
         created using ``np.random.default_rng(random_state)``.
@@ -344,7 +338,7 @@ def sobol_indices(
 
     Notes
     -----
-    The Sobol' method [1]_, [2]_ is a variance-based sensitivity analysis which
+    The Sobol' method [1]_, [2]_ is a variance-based Sensitivity Analysis which
     obtains the contribution of each parameter to the variance of the
     quantities of interest (QoIs; i.e., the outputs of `func`).
     Respective contributions can be used to rank the parameters and
@@ -385,15 +379,14 @@ def sobol_indices(
 
     :math:`S_{i}` corresponds to the first-order term which apprises the
     contribution of the i-th parameter, while :math:`S_{ij}` corresponds to the
-    second-order term which captures the contribution of interactions between the
+    second-order term which informs about the contribution of interactions between the
     i-th and the j-th parameters. These equations can be generalized to compute
     higher order terms; however, they are expensive to compute and their
     interpretation is complex.
     This is why only first order indices are provided.
 
-    Total order indices represent the total contribution to the variance of the QoI
-    of each parameter (including all its interactions, of any order, with other parameters),
-    and are defined as:
+    Total order indices represent the global contribution of the parameters to the
+    variance of the QoI and are defined as:
 
     .. math::
 

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -93,12 +93,20 @@ def sample_A_B(
 def sample_AB(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     """AB matrix.
 
-    AB: rows of B into A. Shape (d, d, n).
+    AB: rows of B into A. Shape (d, d, n). See sec. 3 from [1]_.
     - Copy A into d "pages"
     - In the first page, replace 1st rows of A with 1st row of B.
     ...
     - In the dth page, replace dth row of A with dth row of B.
     - return the stack of pages
+
+    References
+    ----------
+    .. [1] Saltelli, A., P. Annoni, I. Azzini, F. Campolongo, M. Ratto, and
+       S. Tarantola. "Variance based sensitivity analysis of model
+       output. Design and estimator for the total sensitivity index."
+       Computer Physics Communications, 181(2):259-270,
+       :doi:`10.1016/j.cpc.2009.09.018`, 2010.
     """
     d, n = A.shape
     AB = np.tile(A, (d, 1, 1))
@@ -272,22 +280,21 @@ def sobol_indices(
           (number of output variables), and
         - ``n`` is the number of samples (see `n` below).
 
-        Function evaluations values must be finite.
+        Function evaluation values must be finite.
 
         If `func` is a dictionary, contains the function evaluations from three
         different arrays. Keys must be: ``f_A``, ``f_B`` and ``f_AB``.
         ``f_A`` and ``f_B`` should have a shape ``(s, n)`` and ``f_AB``
         should have a shape ``(d, s, n)``.
-        This is an advanced feature and misuse can lead to wrong analysis.
+        This is an advanced feature and misuse can lead to incorrect analysis.
     n : int
-        Number of samples use to generate the matrices ``A`` and ``B``.
+        Number of samples used to generate the matrices ``A`` and ``B``.
         Must be a power of 2. The total number of points at which `func` is
         evaluated will be ``n*(d+2)``.
     dists : list(distributions), optional
-        List of each parameter's distribution. The distribution of parameters
-        depends on the application and should be carefully chosen.
-        Parameter should be independently distributed meaning there should
-        be no constraint nor relationship between input parameters values.
+        List of each parameter's distribution.
+        Parameters are assumed to be independently distributed, meaning there is
+        no constraint or relationship between them.
 
         Distributions must be an instance of a class with a ``ppf``
         method.
@@ -301,12 +308,12 @@ def sobol_indices(
             func(f_A: np.ndarray, f_B: np.ndarray, f_AB: np.ndarray)
             -> Tuple[np.ndarray, np.ndarray]
 
-        with ``f_A, f_B`` of shape (s, n) and ``f_AB`` of shape (d, s, n).
+        with ``f_A, f_B`` of shape ``(s, n)`` and ``f_AB`` of shape ``(d, s, n)``.
         These arrays contain the function evaluations from three different sets
         of samples.
         The output is a tuple of the first and total indices with
-        shape (s, d).
-        This is an advanced feature and misuse can lead to wrong analysis.
+        shape ``(s, d)``.
+        This is an advanced feature and misuse can lead to incorrect analysis.
     random_state : {None, int, `numpy.random.Generator`}, optional
         If `random_state` is an int or None, a new `numpy.random.Generator` is
         created using ``np.random.default_rng(random_state)``.
@@ -331,13 +338,13 @@ def sobol_indices(
             A method providing confidence intervals on the indices.
             See `scipy.stats.bootstrap` for more details.
 
-            The bootstrapping is done on both first and total order indices
+            The bootstrapping is done on both first and total order indices,
             and they are available in `BootstrapSobolResult` as attributes
             ``first_order`` and ``total_order``.
 
     Notes
     -----
-    Sobol' method [1]_, [2]_ is a variance-based Sensitivity Analysis which
+    The Sobol' method [1]_, [2]_ is a variance-based sensitivity analysis which
     obtains the contribution of each parameter to the variance of the
     quantities of interest (QoIs; i.e., the outputs of `func`).
     Respective contributions can be used to rank the parameters and
@@ -378,14 +385,15 @@ def sobol_indices(
 
     :math:`S_{i}` corresponds to the first-order term which apprises the
     contribution of the i-th parameter, while :math:`S_{ij}` corresponds to the
-    second-order term which informs about the correlations between the
+    second-order term which captures the contribution of interactions between the
     i-th and the j-th parameters. These equations can be generalized to compute
     higher order terms; however, they are expensive to compute and their
     interpretation is complex.
     This is why only first order indices are provided.
 
-    Total indices represent the global contribution of the parameters on the
-    variance of the QoI and are defined as:
+    Total order indices represent the total contribution to the variance of the QoI
+    of each parameter (including all its interactions, of any order, with other parameters),
+    and are defined as:
 
     .. math::
 
@@ -531,7 +539,7 @@ def sobol_indices(
     >>> output = f_ishigami(sample.T)
 
     Now we can do scatter plots of the output with respect to each parameter.
-    This gives a visual way to understand how each parameter impact the
+    This gives a visual way to understand how each parameter impacts the
     output of the function.
 
     >>> fig, ax = plt.subplots(1, n_dim, figsize=(12, 4))

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -286,8 +286,8 @@ def sobol_indices(
     dists : list(distributions), optional
         List of each parameter's distribution. The distribution of parameters
         depends on the application and should be carefully chosen.
-        Parameters are assumed to be independently distributed, meaning there is
-        no constraint nor relationship between their values.
+        Parameters are assumed to be independently distributed, meaning there
+        is no constraint nor relationship between their values.
 
         Distributions must be an instance of a class with a ``ppf``
         method.


### PR DESCRIPTION
#### What does this implement/fix?
These are corrections to the documentation for `scipy.stats.sobol_indices`:

- **Correct wrong statements about sums of Sobol' indices**
- Some things reworded for greater clarity
- Some spelling, grammar, and formatting fixes throughout