### PR TITLE
ENH: stats.dirichlet: add covariance method

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1480,6 +1480,8 @@ class dirichlet_gen(multi_rv_generic):
         The mean of the Dirichlet distribution
     var(alpha)
         The variance of the Dirichlet distribution
+    cov(alpha)
+        The covariance of the Dirichlet distribution
     entropy(alpha)
         Compute the differential entropy of the Dirichlet distribution.
 
@@ -1672,6 +1674,26 @@ class dirichlet_gen(multi_rv_generic):
         out = (alpha * (alpha0 - alpha)) / ((alpha0 * alpha0) * (alpha0 + 1))
         return _squeeze_output(out)
 
+    def cov(self, alpha):
+        """Covariance matrix of the Dirichlet distribution.
+
+        Parameters
+        ----------
+        %(_dirichlet_doc_default_callparams)s
+
+        Returns
+        -------
+        cov : ndarray
+            The covariance matrix of the distribution.
+        """
+
+        alpha = _dirichlet_check_parameters(alpha)
+        alpha0 = np.sum(alpha)
+        a = alpha / alpha0
+
+        cov = (np.diag(a) - np.outer(a, a)) / (alpha0 + 1)
+        return _squeeze_output(cov)
+
     def entropy(self, alpha):
         """
         Differential entropy of the Dirichlet distribution.
@@ -1740,6 +1762,9 @@ class dirichlet_frozen(multi_rv_frozen):
     def var(self):
         return self._dist.var(self.alpha)
 
+    def cov(self):
+        return self._dist.cov(self.alpha)
+
     def entropy(self):
         return self._dist.entropy(self.alpha)
 
@@ -1749,7 +1774,7 @@ class dirichlet_frozen(multi_rv_frozen):
 
 # Set frozen generator docstrings from corresponding docstrings in
 # multivariate_normal_gen and fill in default strings in class docstrings
-for name in ['logpdf', 'pdf', 'rvs', 'mean', 'var', 'entropy']:
+for name in ['logpdf', 'pdf', 'rvs', 'mean', 'var', 'cov', 'entropy']:
     method = dirichlet_gen.__dict__[name]
     method_frozen = dirichlet_frozen.__dict__[name]
     method_frozen.__doc__ = doccer.docformat(

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1119,6 +1119,8 @@ class TestDirichlet:
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_mean_var_cov(self):
+        # Reference values calculated by hand and confirmed with Mathematica, e.g.
+        # `Covariance[DirichletDistribution[{ 1, 0.8, 0.2, 10^-300}]]`
         alpha = np.array([1., 0.8, 0.2])
         d = dirichlet(alpha)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1118,15 +1118,21 @@ class TestDirichlet:
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
-    def test_mean_and_var(self):
+    def test_mean_var_cov(self):
         alpha = np.array([1., 0.8, 0.2])
         d = dirichlet(alpha)
 
-        expected_var = [1. / 12., 0.08, 0.03]
         expected_mean = [0.5, 0.4, 0.1]
+        expected_var = [1. / 12., 0.08, 0.03]
+        expected_cov = [
+                [ 1. / 12, -1. / 15, -1. / 60],
+                [-1. / 15,  2. / 25, -1. / 75],
+                [-1. / 60, -1. / 75,  3. / 100],
+        ]
 
-        assert_array_almost_equal(d.var(), expected_var)
         assert_array_almost_equal(d.mean(), expected_mean)
+        assert_array_almost_equal(d.var(), expected_var)
+        assert_array_almost_equal(d.cov(), expected_cov)
 
     def test_scalar_values(self):
         alpha = np.array([0.2])


### PR DESCRIPTION
This PR adds a way to calculate the covariance matrix for Dirichlet distributions.  Some other multivariate distributions (e.g. multinomial) already provide this.  I used the following equation, which I got from [Wikipedia](https://en.wikipedia.org/wiki/Dirichlet_distribution):

$$
\mathrm{Cov}[X_i, X_j] = \frac{\delta_{ij} \hat{\alpha_i} - \hat{\alpha}_i \hat{\alpha}_j}{\alpha_0 + 1}
$$

Where:
- $\alpha_i$ is a concentration parameter.
- $\displaystyle \alpha_0 = \sum^K_{i=1} \alpha_i$ is the sum of all the concentration parameters.
- $\hat{\alpha}_i = \alpha_i / \alpha_0$
- $\delta_{ij}$ is the Kronecker delta function.

I haven't been able to run the test suite locally, due to some issue with LAPACK that I haven't figured out yet.  I'm hoping that there'll be a CI server that can run the tests for me.  That said, I have confirmed that the code I wrote passes the test I wrote, just not in the context of the whole scipy package.
