### PR TITLE
DEV: Add Windows specific instructions to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - python
   - cython
-  - compilers
+  - compilers # Currently unavailable for Windows. Comment out this line and download Rtools and add <path>\ucrt64\bin\ to your path: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
   - meson
   - meson-python
   - ninja


### PR DESCRIPTION
#### What does this implement/fix?
In windows, the `compilers` package is unavailble, but unfortunately anaconda doesn't support system specific `yml` files.
I have added the comment to help future developers which work on windows and hopefully save them some time debugging and searching the issues section.
