### PR TITLE
MAINT: backports for 1.11.0rc2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: setup Python venv
           command: |
-            pip install --install-option="--no-cython-compile" cython
+            pip install cython
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
             # `asv` pin because of slowdowns reported in gh-15568

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -291,7 +291,7 @@ jobs:
       run: |
         python -m pip install "Cython>=3.0.0b3"
         python -m pip install ninja meson meson-python wheel click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy<1.28.0"
         # Use pytest-xdist<4.0 due to https://github.com/pytest-dev/pytest-cov/issues/557
         # can update once pytest-cov>4.0 and remove warning filtering in pytest.ini
         python -m pip install --pre --upgrade pytest pytest-cov "pytest-xdist<4.0" pybind11 mpmath gmpy2 pythran threadpoolctl pooch matplotlib

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -98,7 +98,7 @@ musllinux_amd64_test_task:
   python_dependencies_script: |
     cd $_CWD
     python -m pip install cython
-    pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy<1.28.0"
     python -m pip install meson ninja pybind11 pythran pytest
     python -m pip install click rich_click doit pydevtool pooch
 

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -114,12 +114,15 @@ cirrus_wheels_upload_task:
     if [[ $IS_PUSH == "true" ]] || [[ $IS_SCHEDULE_DISPATCH == "true" ]]; then
         apt-get update
         apt-get install -y curl wget
+
+        # install miniconda in the home directory. For some reason HOME isn't set by Cirrus
+        export HOME=$PWD
         
         # install miniconda for uploading to anaconda
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-        bash miniconda.sh -b -p ~/miniconda3
-        ~/miniconda3/bin/conda init bash
-        source ~/miniconda3/bin/activate
+        bash miniconda.sh -b -p $HOME/miniconda3
+        $HOME/miniconda3/bin/conda init bash
+        source $HOME/miniconda3/bin/activate
         conda install -y anaconda-client
         
         # The name of the zip file is derived from the `wheels_artifact` line.

--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -1,7 +1,7 @@
 [
     {
-        "name": "dev",
-        "version": "dev",
+        "name": "development",
+        "version": "development",
         "url": "https://scipy.github.io/devdocs/"
     },
     {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -204,7 +204,7 @@ html_theme_options = {
 }
 
 if 'dev' in version:
-    html_theme_options["switcher"]["version_match"] = "dev"
+    html_theme_options["switcher"]["version_match"] = "development"
 
 if 'versionwarning' in tags:  # noqa
     # Specific to docs.scipy.org deployment.

--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -341,7 +341,7 @@ Authors
 * Larry Bradley (1) +
 * Sienna Brent (1) +
 * Matthew Brett (1)
-* Evgeni Burovski (38)
+* Evgeni Burovski (39)
 * Matthias Bussonnier (2)
 * Maria Cann (1) +
 * Alfredo Carella (1) +
@@ -416,7 +416,7 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (128)
+* Tyler Reddy (131)
 * Lucas Roberts (1)
 * Pamphile Roy (225)
 * Jordan Rupprecht (1) +

--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -26,11 +26,12 @@ For running on PyPy, PyPy3 6.0+ is required.
 Highlights of this release
 **************************
 
-- Several `scipy.sparse` array API improvements, including a new public base
-  class distinct from the older matrix class, proper 64-bit index support,
-  and numerous deprecations paving the way to a modern sparse array experience.
-- Added three new statistical distributions, and wide-ranging performance and
-  precision improvements to several other statistical distributions.
+- Several `scipy.sparse` array API improvements, including `sparse.sparray`, a new
+  public base class distinct from the older `sparse.spmatrix` class,
+  proper 64-bit index support, and numerous deprecations paving the way to a
+  modern sparse array experience.
+- `scipy.stats` added tools for survival analysis, multiple hypothesis testing,
+  sensitivity analysis, and working with censored data.
 - A new function was added for quasi-Monte Carlo integration, and linear
   algebra functions ``det`` and ``lu`` now accept nD-arrays.
 - An ``axes`` argument was added broadly to ``ndimage`` functions, facilitating
@@ -106,23 +107,20 @@ New features
 
 `scipy.sparse` improvements
 ===========================
-- `scipy.sparse` array (not matrix) classes now return a sparse array instead
-  of a dense array when divided by a dense array.
-- A new public base class `scipy.sparse.sparray` was introduced, allowing
+- A new public base class `scipy.sparse.sparray` was introduced, allowing further
+  extension of the sparse array API (such as the support for 1-dimensional
+  sparse arrays) without breaking backwards compatibility.
   `isinstance(x, scipy.sparse.sparray)` to select the new sparse array classes,
   while `isinstance(x, scipy.sparse.spmatrix)` selects only the old sparse
-  matrix types.
-- The behavior of `scipy.sparse.isspmatrix()` was updated to return True for
-  only the sparse matrix types. If you want to check for either sparse arrays
-  or sparse matrices, use `scipy.sparse.issparse()` instead. (Previously,
-  these had identical behavior.)
-- Sparse arrays constructed with 64-bit indices will no longer automatically
-  downcast to 32-bit.
-- A new `scipy.sparse.diags_array` function was added, which behaves like the
-  existing `scipy.sparse.diags` function except that it returns a sparse
-  array instead of a sparse matrix.
-- ``argmin`` and ``argmax`` methods now return the correct result when no
-  implicit zeros are present.
+  matrix classes.
+- Division of sparse arrays by a dense array now returns sparse arrays.
+- `scipy.sparse.isspmatrix` now only returns `True` for the sparse matrices instances.
+  `scipy.sparse.issparse` now has to be used instead to check for instances of sparse
+  arrays or instances of sparse matrices.
+- Sparse arrays constructed with int64 indices will no longer automatically
+  downcast to int32.
+- The ``argmin`` and ``argmax`` methods now return the correct result when explicit
+  zeros are present.
 
 `scipy.sparse.linalg` improvements
 ==================================
@@ -159,7 +157,7 @@ New Features
   experimental groups against the mean of a control group.
 - `scipy.stats.ecdf` for computing the empirical CDF and complementary
   CDF (survival function / SF) from uncensored or right-censored data. This
-  function is also useful for survival analysis / Kaplain-Meier estimation.
+  function is also useful for survival analysis / Kaplan-Meier estimation.
 - `scipy.stats.logrank` to compare survival functions underlying samples.
 - `scipy.stats.false_discovery_control` for adjusting p-values to control the
   false discovery rate of multiple hypothesis tests using the
@@ -170,7 +168,7 @@ New Features
 - Filliben's goodness of fit test as ``method='Filliben'`` of
   `scipy.stats.goodness_of_fit`.
 - `scipy.stats.ttest_ind` has a new method, ``confidence_interval`` for
-  computing confidence intervals.
+  computing a confidence interval of the difference between means.
 - `scipy.stats.MonteCarloMethod`, `scipy.stats.PermutationMethod`, and
   `scipy.stats.BootstrapMethod` are new classes to configure resampling and/or
   Monte Carlo versions of hypothesis tests. They can currently be used with
@@ -366,17 +364,17 @@ Authors
 * Stefano Frazzetto (1) +
 * Neil Girdhar (1)
 * Caden Gobat (1) +
-* Ralf Gommers (149)
+* Ralf Gommers (152)
 * GonVas (1) +
 * Marco Gorelli (1)
 * Brett Graham (2) +
-* Matt Haberland (388)
+* Matt Haberland (390)
 * harshvardhan2707 (1) +
 * Alex Herbert (1) +
 * Guillaume Horel (1)
 * Geert-Jan Huizing (1) +
 * Jakob Jakobson (2)
-* Julien Jerphanion (10)
+* Julien Jerphanion (14)
 * jyuv (2)
 * Rajarshi Karmakar (1) +
 * Ganesh Kathiresan (3) +
@@ -396,7 +394,7 @@ Authors
 * Adam Lugowski (1) +
 * Charlie Marsh (2) +
 * Boris Martin (1) +
-* Nicholas McKibben (10)
+* Nicholas McKibben (11)
 * Melissa Weber Mendonça (58)
 * Michał Górny (1) +
 * Jarrod Millman (5)
@@ -418,7 +416,7 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (115)
+* Tyler Reddy (128)
 * Lucas Roberts (1)
 * Pamphile Roy (225)
 * Jordan Rupprecht (1) +
@@ -654,10 +652,13 @@ Issues closed for 1.11.0
 * `#18525 <https://github.com/scipy/scipy/issues/18525>`__: DOC: sparse doc build warning causing failure (including in CI)
 * `#18535 <https://github.com/scipy/scipy/issues/18535>`__: DOC: Dev branch docs render Dev TOC while viewing API Reference
 * `#18547 <https://github.com/scipy/scipy/issues/18547>`__: CI: occasionally failing test \`test_minimize_callback_copies_array[fmin]\`
+* `#18595 <https://github.com/scipy/scipy/issues/18595>`__: BUG: dev.py notes needs a small shim
 * `#18597 <https://github.com/scipy/scipy/issues/18597>`__: CI, BUG: Cirrus wheel upload fails on maintenance branch
+* `#18600 <https://github.com/scipy/scipy/issues/18600>`__: BUG: SciPy 1.11.0rc1 not buildable on PPC due to boost submodule
 * `#18632 <https://github.com/scipy/scipy/issues/18632>`__: 1.11.0rc1: remaining test failures in conda-forge
 * `#18634 <https://github.com/scipy/scipy/issues/18634>`__: BUG: stats.truncnorm.moments yields error for moment order greater...
 * `#18654 <https://github.com/scipy/scipy/issues/18654>`__: BUG: ci/circleci: build_scipy broken
+* `#18675 <https://github.com/scipy/scipy/issues/18675>`__: BUG: \`signal.detrend\` on main no longer accepts a sequence...
 
 ************************
 Pull requests for 1.11.0
@@ -1164,7 +1165,10 @@ Pull requests for 1.11.0
 * `#18599 <https://github.com/scipy/scipy/pull/18599>`__: Revert "ENH: sparse: Add _array version of \`diags\` creation...
 * `#18608 <https://github.com/scipy/scipy/pull/18608>`__: Fix typo of module name in deprecation warning
 * `#18629 <https://github.com/scipy/scipy/pull/18629>`__: Mark \`void\` functions as \`noexcept\` in _rotation.pyx
+* `#18630 <https://github.com/scipy/scipy/pull/18630>`__: MAINT: stats: remove long double support for all boost ufuncs
 * `#18636 <https://github.com/scipy/scipy/pull/18636>`__: MAINT: stats.truncnorm/stats.betaprime: fix _munp for higher...
 * `#18657 <https://github.com/scipy/scipy/pull/18657>`__: MAINT: fix 'no such option' error in build_scipy CI
 * `#18658 <https://github.com/scipy/scipy/pull/18658>`__: TST: fix two test failures that showed up on conda-forge
 * `#18659 <https://github.com/scipy/scipy/pull/18659>`__: DOC: \`scipy._sensitivity_analysis\`: correct statement about...
+* `#18672 <https://github.com/scipy/scipy/pull/18672>`__: BUG: small shim for release process
+* `#18676 <https://github.com/scipy/scipy/pull/18676>`__: BUG: signal: fix detrend with array-like bp

--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -325,11 +325,12 @@ Authors
 
 * h-vetinari (69)
 * Oriol Abril-Pla (1) +
+* Tom Adamczewski (1) +
 * Anton Akhmerov (13)
 * Andrey Akinshin (1) +
 * alice (1) +
 * Oren Amsalem (1)
-* Ross Barnowski (11)
+* Ross Barnowski (13)
 * Christoph Baumgarten (2)
 * Dawson Beatty (1) +
 * Doron Behar (1) +
@@ -339,13 +340,14 @@ Authors
 * Jack Borchanian (1) +
 * Matt Borland (3) +
 * Jake Bowhay (40)
+* Larry Bradley (1) +
 * Sienna Brent (1) +
 * Matthew Brett (1)
 * Evgeni Burovski (38)
 * Matthias Bussonnier (2)
 * Maria Cann (1) +
 * Alfredo Carella (1) +
-* CJ Carey (18)
+* CJ Carey (34)
 * Hood Chatham (2)
 * Anirudh Dagar (3)
 * Alberto Defendi (1) +
@@ -364,45 +366,46 @@ Authors
 * Stefano Frazzetto (1) +
 * Neil Girdhar (1)
 * Caden Gobat (1) +
-* Ralf Gommers (146)
+* Ralf Gommers (149)
 * GonVas (1) +
 * Marco Gorelli (1)
 * Brett Graham (2) +
-* Matt Haberland (385)
+* Matt Haberland (388)
 * harshvardhan2707 (1) +
 * Alex Herbert (1) +
 * Guillaume Horel (1)
 * Geert-Jan Huizing (1) +
 * Jakob Jakobson (2)
-* Julien Jerphanion (5)
+* Julien Jerphanion (10)
 * jyuv (2)
 * Rajarshi Karmakar (1) +
 * Ganesh Kathiresan (3) +
 * Robert Kern (4)
-* Andrew Knyazev (3)
+* Andrew Knyazev (4)
 * Sergey Koposov (1)
 * Rishi Kulkarni (2) +
 * Eric Larson (1)
 * Zoufiné Lauer-Bare (2) +
 * Antony Lee (3)
 * Gregory R. Lee (8)
-* Guillaume Lemaitre (1) +
+* Guillaume Lemaitre (2) +
 * lilinjie (2) +
 * Yannis Linardos (1) +
 * Christian Lorentzen (5)
 * Loïc Estève (1)
+* Adam Lugowski (1) +
 * Charlie Marsh (2) +
 * Boris Martin (1) +
 * Nicholas McKibben (10)
-* Melissa Weber Mendonça (57)
+* Melissa Weber Mendonça (58)
 * Michał Górny (1) +
-* Jarrod Millman (2)
+* Jarrod Millman (5)
 * Stefanie Molin (2) +
 * Mark W. Mueller (1) +
 * mustafacevik (1) +
 * Takumasa N (1) +
 * nboudrie (1)
-* Andrew Nelson (111)
+* Andrew Nelson (112)
 * Nico Schlömer (4)
 * Lysandros Nikolaou (2) +
 * Kyle Oman (1)
@@ -415,9 +418,9 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (97)
+* Tyler Reddy (115)
 * Lucas Roberts (1)
-* Pamphile Roy (224)
+* Pamphile Roy (225)
 * Jordan Rupprecht (1) +
 * Atsushi Sakai (11)
 * Omar Salman (7) +
@@ -426,10 +429,10 @@ Authors
 * Saumya (1) +
 * Daniel Schmitz (79)
 * Henry Schreiner (2) +
-* Dan Schult (3) +
+* Dan Schult (8) +
 * Eli Schwartz (6)
 * Tomer Sery (2) +
-* Scott Shambaugh (4) +
+* Scott Shambaugh (10) +
 * Gagandeep Singh (1)
 * Ethan Steinberg (6) +
 * stepeos (2) +
@@ -440,10 +443,10 @@ Authors
 * Tartopohm (2)
 * Logan Thomas (2) +
 * Jacopo Tissino (1) +
-* Matus Valo (10) +
+* Matus Valo (12) +
 * Jacob Vanderplas (2)
 * Christian Veenhuis (1) +
-* Isaac Virshup (1)
+* Isaac Virshup (3)
 * Stefan van der Walt (14)
 * Warren Weckesser (63)
 * windows-server-2003 (1)
@@ -455,7 +458,7 @@ Authors
 * Zaikun ZHANG (1) +
 * Alex Zverianskii (1) +
 
-A total of 131 people contributed to this release.
+A total of 134 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -649,7 +652,12 @@ Issues closed for 1.11.0
 * `#18497 <https://github.com/scipy/scipy/issues/18497>`__: MAINT, BUG: guard against non-finite kd-tree queries
 * `#18498 <https://github.com/scipy/scipy/issues/18498>`__: TST: interpolate overflow xslow tests (low priority)
 * `#18525 <https://github.com/scipy/scipy/issues/18525>`__: DOC: sparse doc build warning causing failure (including in CI)
+* `#18535 <https://github.com/scipy/scipy/issues/18535>`__: DOC: Dev branch docs render Dev TOC while viewing API Reference
 * `#18547 <https://github.com/scipy/scipy/issues/18547>`__: CI: occasionally failing test \`test_minimize_callback_copies_array[fmin]\`
+* `#18597 <https://github.com/scipy/scipy/issues/18597>`__: CI, BUG: Cirrus wheel upload fails on maintenance branch
+* `#18632 <https://github.com/scipy/scipy/issues/18632>`__: 1.11.0rc1: remaining test failures in conda-forge
+* `#18634 <https://github.com/scipy/scipy/issues/18634>`__: BUG: stats.truncnorm.moments yields error for moment order greater...
+* `#18654 <https://github.com/scipy/scipy/issues/18654>`__: BUG: ci/circleci: build_scipy broken
 
 ************************
 Pull requests for 1.11.0
@@ -1146,5 +1154,17 @@ Pull requests for 1.11.0
 * `#18551 <https://github.com/scipy/scipy/pull/18551>`__: Replace sparse __getattr__ with properties
 * `#18553 <https://github.com/scipy/scipy/pull/18553>`__: BENCH: sparse: Add a benchmark for sparse matrix power
 * `#18554 <https://github.com/scipy/scipy/pull/18554>`__: BUG: sparse: Fix DIA.tocoo canonical format setting
+* `#18556 <https://github.com/scipy/scipy/pull/18556>`__: MAINT: io: replace isspmatrix with issparse in mmio module
 * `#18560 <https://github.com/scipy/scipy/pull/18560>`__: MAINT: integrate: revert\`full_output\` deprecation / result...
 * `#18562 <https://github.com/scipy/scipy/pull/18562>`__: fix doc strings for csr_array and friends
+* `#18563 <https://github.com/scipy/scipy/pull/18563>`__: DOC: SciPy 1.11.0 release notes
+* `#18591 <https://github.com/scipy/scipy/pull/18591>`__: MAINT: version bounds for 1.11.0rc1
+* `#18596 <https://github.com/scipy/scipy/pull/18596>`__: DOC: Fix sidebar for API reference pages
+* `#18598 <https://github.com/scipy/scipy/pull/18598>`__: CI: fix wheel upload to anaconda [wheel build]
+* `#18599 <https://github.com/scipy/scipy/pull/18599>`__: Revert "ENH: sparse: Add _array version of \`diags\` creation...
+* `#18608 <https://github.com/scipy/scipy/pull/18608>`__: Fix typo of module name in deprecation warning
+* `#18629 <https://github.com/scipy/scipy/pull/18629>`__: Mark \`void\` functions as \`noexcept\` in _rotation.pyx
+* `#18636 <https://github.com/scipy/scipy/pull/18636>`__: MAINT: stats.truncnorm/stats.betaprime: fix _munp for higher...
+* `#18657 <https://github.com/scipy/scipy/pull/18657>`__: MAINT: fix 'no such option' error in build_scipy CI
+* `#18658 <https://github.com/scipy/scipy/pull/18658>`__: TST: fix two test failures that showed up on conda-forge
+* `#18659 <https://github.com/scipy/scipy/pull/18659>`__: DOC: \`scipy._sensitivity_analysis\`: correct statement about...

--- a/meson.build
+++ b/meson.build
@@ -53,9 +53,6 @@ endif
 if not cy.version().version_compare('>=0.29.35')
   error('SciPy requires Cython >= 0.29.35')
 endif
-if not cy.version().version_compare('<3.0')
-  error('SciPy requires Cython < 3.0')
-endif
 
 _global_c_args = cc.get_supported_arguments(
   '-Wno-unused-but-set-variable',

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy import (asarray, real, imag, conj, zeros, ndarray, concatenate,
                    ones, can_cast)
 
-from scipy.sparse import coo_matrix, isspmatrix
+from scipy.sparse import coo_matrix, issparse
 
 __all__ = ['mminfo', 'mmread', 'mmwrite', 'MMFile']
 
@@ -490,7 +490,7 @@ class MMFile:
         isherm = a.dtype.char in 'FD'
 
         # sparse input
-        if isspmatrix(a):
+        if issparse(a):
             # check if number of nonzero entries of lower and upper triangle
             # matrix are equal
             a = a.tocoo()
@@ -652,11 +652,6 @@ class MMFile:
                                                     self.entries, self.format,
                                                     self.field, self.symmetry)
 
-        try:
-            from scipy.sparse import coo_matrix
-        except ImportError:
-            coo_matrix = None
-
         dtype = self.DTYPES_BY_FIELD.get(field, None)
 
         has_symmetry = self.has_symmetry
@@ -715,39 +710,6 @@ class MMFile:
             else:
                 if not (i in [0, j] and j == cols):
                     raise ValueError("Parse error, did not read all lines.")
-
-        elif format == self.FORMAT_COORDINATE and coo_matrix is None:
-            # Read sparse matrix to dense when coo_matrix is not available.
-            a = zeros((rows, cols), dtype=dtype)
-            line = 1
-            k = 0
-            while line:
-                line = stream.readline()
-                # line.startswith('%')
-                if not line or line[0] in ['%', 37] or not line.strip():
-                    continue
-                l = line.split()
-                i, j = map(int, l[:2])
-                i, j = i-1, j-1
-                if is_integer:
-                    aij = int(l[2])
-                elif is_unsigned_integer:
-                    aij = int(l[2])
-                elif is_complex:
-                    aij = complex(*map(float, l[2:]))
-                else:
-                    aij = float(l[2])
-                a[i, j] = aij
-                if has_symmetry and i != j:
-                    if is_skew:
-                        a[j, i] = -aij
-                    elif is_herm:
-                        a[j, i] = conj(aij)
-                    else:
-                        a[j, i] = aij
-                k = k + 1
-            if not k == entries:
-                ValueError("Did not read all entries")
 
         elif format == self.FORMAT_COORDINATE:
             # Read sparse COOrdinate format
@@ -846,7 +808,7 @@ class MMFile:
                         a = a.astype('D')
 
         else:
-            if not isspmatrix(a):
+            if not issparse(a):
                 raise ValueError('unknown matrix type: %s' % type(a))
 
             rep = 'coordinate'

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,10 +1,11 @@
 import logging
+import sys
 
 import numpy
 import numpy as np
 import time
 from multiprocessing import Pool
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, IS_PYPY
 import pytest
 from pytest import raises as assert_raises, warns
 from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
@@ -690,6 +691,8 @@ class TestShgoArguments:
         """Test single function constraint passing"""
         SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
 
+    @pytest.mark.xfail(IS_PYPY and sys.platform == 'win32',
+            reason="Failing and fix in PyPy not planned (see gh-18632)")
     def test_10_finite_time(self):
         """Test single function constraint passing"""
         options = {'maxtime': 1e-15}

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -355,7 +355,7 @@ def deco(name):
     def wrapped(*args, **kwargs):
         warnings.warn(f"Importing {name} from 'scipy.signal' is deprecated "
                       "and will raise an error in SciPy 1.13.0. Please use "
-                      f"'scipy.signal.window.{name}' or the convenience "
+                      f"'scipy.signal.windows.{name}' or the convenience "
                       "function 'scipy.signal.get_window' instead.",
                       DeprecationWarning, stacklevel=2)
         return f(*args, **kwargs)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3560,7 +3560,7 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
     else:
         dshape = data.shape
         N = dshape[axis]
-        bp = np.sort(np.unique([0, bp, N]))
+        bp = np.sort(np.unique(np.concatenate(np.atleast_1d(0, bp, N))))
         if np.any(bp > N):
             raise ValueError("Breakpoints must be less than length "
                              "of data along given axis.")

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3606,6 +3606,20 @@ class TestDetrend:
         with assert_raises(ValueError):
             detrend(data, type="linear", bp=3)
 
+    @pytest.mark.parametrize('bp', [np.array([0, 2]), [0, 2]])
+    def test_detrend_array_bp(self, bp):
+        # regression test for https://github.com/scipy/scipy/issues/18675
+        rng = np.random.RandomState(12345)
+        x = rng.rand(10)
+       # bp = np.array([0, 2])
+
+        res = detrend(x, bp=bp)
+        res_scipy_191 = np.array([-4.44089210e-16, -2.22044605e-16,
+            -1.11128506e-01, -1.69470553e-01,  1.14710683e-01,  6.35468419e-02,
+            3.53533144e-01, -3.67877935e-02, -2.00417675e-02, -1.94362049e-01])
+
+        assert_allclose(res, res_scipy_191, atol=1e-14)
+
 
 class TestUniqueRoots:
     def test_real_no_repeat(self):

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -98,7 +98,7 @@ cdef inline int _elementary_basis_index(uchar axis) noexcept:
 # canonical "positive" single cover
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _quat_canonical_single(double[:] q) nogil:
+cdef inline void _quat_canonical_single(double[:] q) noexcept nogil:
     if ((q[3] < 0)
         or (q[3] == 0 and q[0] < 0)
         or (q[3] == 0 and q[0] == 0 and q[1] < 0)
@@ -110,7 +110,7 @@ cdef inline void _quat_canonical_single(double[:] q) nogil:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _quat_canonical(double[:, :] q):
+cdef inline void _quat_canonical(double[:, :] q) noexcept:
     cdef Py_ssize_t n = q.shape[0]
     for ind in range(n):
         _quat_canonical_single(q[ind])

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -75,7 +75,7 @@ class TestHyp1f1:
     ])
     def test_a_negative_integer(self, a, b, x, result):
         # Desired answers computed using Mpmath.
-        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1e-14)
+        assert_allclose(sc.hyp1f1(a, b, x), result, atol=0, rtol=1.5e-14)
 
     @pytest.mark.parametrize('a, b, x, expected', [
         (0.01, 150, -4, 0.99973683897677527773),        # gh-3492

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -5,7 +5,6 @@ from warnings import warn
 from textwrap import dedent
 from shutil import copyfile
 import pathlib
-import sys
 import argparse
 
 from gen_func_defs_pxd import (  # type: ignore
@@ -54,7 +53,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
     boost_hdr_name = boost_dist.split('_distribution')[0]
     unique_num_inputs = set({m.num_inputs for m in methods})
     has_NPY_FLOAT16 = 'NPY_FLOAT16' in types
-    has_NPY_LONGDOUBLE = 'NPY_LONGDOUBLE' in types
     line_joiner = ',\n    ' + ' '*12
     num_types = len(types)
     loop_fun = 'PyUFunc_T'
@@ -104,8 +102,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
             import_ufunc()
             '''))
 
-        if has_NPY_LONGDOUBLE:
-            fp.write('ctypedef long double longdouble\n\n')
         if has_NPY_FLOAT16:
             warn('Boost stats NPY_FLOAT16 ufunc generation not '
                  'currently not supported!')
@@ -120,7 +116,6 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
 
             for jj, T in enumerate(types):
                 ctype = {
-                    'NPY_LONGDOUBLE': 'longdouble',
                     'NPY_DOUBLE': 'double',
                     'NPY_FLOAT': 'float',
                     'NPY_FLOAT16': 'npy_half',
@@ -184,9 +179,6 @@ if __name__ == '__main__':
         x_funcs=_x_funcs,
         no_x_funcs=_no_x_funcs)
     float_types = ['NPY_FLOAT', 'NPY_DOUBLE']
-    # Don't generate the 'long double' ufunc loops on Windows.
-    if sys.platform != 'win32':
-        float_types.append('NPY_LONGDOUBLE')
     for b, s in _klass_mapper.items():
         _ufunc_gen(
             scipy_dist=s.scipy_name,

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -964,7 +964,10 @@ class betaprime_gen(rv_continuous):
                               ((b - 4.0)*(b - 3.0)*(b - 2.0)*(b - 1.0))),
                 fillvalue=np.inf)
         else:
-            raise NotImplementedError
+            return _lazywhere(b > n, (a, b),
+                              # sup=super() prevents late-binding issue
+                              lambda a, b, sup=super(): sup._munp(n, a, b),
+                              fillvalue=np.inf)
 
 
 betaprime = betaprime_gen(a=0.0, name='betaprime')
@@ -9344,7 +9347,7 @@ class truncnorm_gen(rv_continuous):
             Returns n-th moment. Defined only if n >= 0.
             Function cannot broadcast due to the loop over n
             """
-            pA, pB = self._pdf([a, b], a, b)
+            pA, pB = self._pdf(np.asarray([a, b]), a, b)
             probs = [pA, -pB]
             moments = [0, 1]
             for k in range(1, n+1):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -941,33 +941,10 @@ class betaprime_gen(rv_continuous):
         return out
 
     def _munp(self, n, a, b):
-        if n == 1.0:
-            return _lazywhere(
-                b > 1, (a, b),
-                lambda a, b: a/(b-1.0),
-                fillvalue=np.inf)
-        elif n == 2.0:
-            return _lazywhere(
-                b > 2, (a, b),
-                lambda a, b: a*(a+1.0)/((b-2.0)*(b-1.0)),
-                fillvalue=np.inf)
-        elif n == 3.0:
-            return _lazywhere(
-                b > 3, (a, b),
-                lambda a, b: (a*(a+1.0)*(a+2.0)
-                              / ((b-3.0)*(b-2.0)*(b-1.0))),
-                fillvalue=np.inf)
-        elif n == 4.0:
-            return _lazywhere(
-                b > 4, (a, b),
-                lambda a, b: (a*(a + 1.0)*(a + 2.0)*(a + 3.0) /
-                              ((b - 4.0)*(b - 3.0)*(b - 2.0)*(b - 1.0))),
-                fillvalue=np.inf)
-        else:
-            return _lazywhere(b > n, (a, b),
-                              # sup=super() prevents late-binding issue
-                              lambda a, b, sup=super(): sup._munp(n, a, b),
-                              fillvalue=np.inf)
+        return _lazywhere(
+            b > n, (a, b),
+            lambda a, b: np.prod([(a+i-1)/(b-i) for i in range(1, n+1)], axis=0),
+            fillvalue=np.inf)
 
 
 betaprime = betaprime_gen(a=0.0, name='betaprime')

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -272,7 +272,7 @@ def sobol_indices(
           (number of output variables), and
         - ``n`` is the number of samples (see `n` below).
 
-        Function evaluations values must be finite.
+        Function evaluation values must be finite.
 
         If `func` is a dictionary, contains the function evaluations from three
         different arrays. Keys must be: ``f_A``, ``f_B`` and ``f_AB``.
@@ -280,14 +280,14 @@ def sobol_indices(
         should have a shape ``(d, s, n)``.
         This is an advanced feature and misuse can lead to wrong analysis.
     n : int
-        Number of samples use to generate the matrices ``A`` and ``B``.
+        Number of samples used to generate the matrices ``A`` and ``B``.
         Must be a power of 2. The total number of points at which `func` is
         evaluated will be ``n*(d+2)``.
     dists : list(distributions), optional
         List of each parameter's distribution. The distribution of parameters
         depends on the application and should be carefully chosen.
-        Parameter should be independently distributed meaning there should
-        be no constraint nor relationship between input parameters values.
+        Parameters are assumed to be independently distributed, meaning there
+        is no constraint nor relationship between their values.
 
         Distributions must be an instance of a class with a ``ppf``
         method.
@@ -301,11 +301,12 @@ def sobol_indices(
             func(f_A: np.ndarray, f_B: np.ndarray, f_AB: np.ndarray)
             -> Tuple[np.ndarray, np.ndarray]
 
-        with ``f_A, f_B`` of shape (s, n) and ``f_AB`` of shape (d, s, n).
+        with ``f_A, f_B`` of shape ``(s, n)`` and ``f_AB`` of shape
+        ``(d, s, n)``.
         These arrays contain the function evaluations from three different sets
         of samples.
         The output is a tuple of the first and total indices with
-        shape (s, d).
+        shape ``(s, d)``.
         This is an advanced feature and misuse can lead to wrong analysis.
     random_state : {None, int, `numpy.random.Generator`}, optional
         If `random_state` is an int or None, a new `numpy.random.Generator` is
@@ -331,13 +332,13 @@ def sobol_indices(
             A method providing confidence intervals on the indices.
             See `scipy.stats.bootstrap` for more details.
 
-            The bootstrapping is done on both first and total order indices
+            The bootstrapping is done on both first and total order indices,
             and they are available in `BootstrapSobolResult` as attributes
             ``first_order`` and ``total_order``.
 
     Notes
     -----
-    Sobol' method [1]_, [2]_ is a variance-based Sensitivity Analysis which
+    The Sobol' method [1]_, [2]_ is a variance-based Sensitivity Analysis which
     obtains the contribution of each parameter to the variance of the
     quantities of interest (QoIs; i.e., the outputs of `func`).
     Respective contributions can be used to rank the parameters and
@@ -378,22 +379,23 @@ def sobol_indices(
 
     :math:`S_{i}` corresponds to the first-order term which apprises the
     contribution of the i-th parameter, while :math:`S_{ij}` corresponds to the
-    second-order term which informs about the correlations between the
-    i-th and the j-th parameters. These equations can be generalized to compute
-    higher order terms; however, they are expensive to compute and their
-    interpretation is complex.
+    second-order term which informs about the contribution of interactions
+    between the i-th and the j-th parameters. These equations can be
+    generalized to compute higher order terms; however, they are expensive to
+    compute and their interpretation is complex.
     This is why only first order indices are provided.
 
-    Total indices represent the global contribution of the parameters on the
-    variance of the QoI and are defined as:
+    Total order indices represent the global contribution of the parameters
+    to the variance of the QoI and are defined as:
 
     .. math::
 
         S_{T_i} = S_i + \sum_j S_{ij} + \sum_{j,k} S_{ijk} + ...
         = 1 - \frac{\mathbb{V}[\mathbb{E}(Y|x_{\sim i})]}{\mathbb{V}[Y]}.
 
-    First order indices sum to 1, while the sum of total order indices will be
-    greater than 1 if there are interactions.
+    First order indices sum to at most 1, while total order indices sum to at
+    least 1. If there are no interactions, then first and total order indices
+    are equal, and both first and total order indices sum to 1.
 
     .. warning::
 
@@ -405,9 +407,8 @@ def sobol_indices(
         consider at minima ``n >= 2**12``. The more complex the model is,
         the more samples will be needed.
 
-        If the parameters are not independent, the first-order indices would
-        not sum to 1.
-        Numerical noise can also contribute to this.
+        Even for a purely addiditive model, the indices may not sum to 1 due
+        to numerical noise.
 
     References
     ----------
@@ -531,7 +532,7 @@ def sobol_indices(
     >>> output = f_ishigami(sample.T)
 
     Now we can do scatter plots of the output with respect to each parameter.
-    This gives a visual way to understand how each parameter impact the
+    This gives a visual way to understand how each parameter impacts the
     output of the function.
 
     >>> fig, ax = plt.subplots(1, n_dim, figsize=(12, 4))

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -88,6 +88,19 @@ def check_kurt_expect(distfn, arg, m, v, k, msg):
         npt.assert_(np.isnan(k))
 
 
+def check_munp_expect(dist, args, msg):
+    # If _munp is overridden, test a higher moment. (Before gh-18634, some
+    # distributions had issues with moments 5 and higher.)
+    if dist._munp.__func__ != stats.rv_continuous._munp:
+        res = dist.moment(5, *args)  # shouldn't raise an error
+        ref = dist.expect(lambda x: x ** 5, args, lb=-np.inf, ub=np.inf)
+        if not np.isfinite(res):  # could be valid; automated test can't know
+            return
+        # loose tolerance, mostly to see whether _munp returns *something*
+        assert_allclose(res, ref, atol=1e-10, rtol=1e-4,
+                        err_msg=msg + ' - higher moment / _munp')
+
+
 def check_entropy(distfn, arg, msg):
     ent = distfn.entropy(*arg)
     npt.assert_(not np.isnan(ent), msg + 'test Entropy is nan')

--- a/scipy/stats/tests/test_boost_ufuncs.py
+++ b/scipy/stats/tests/test_boost_ufuncs.py
@@ -5,8 +5,7 @@ from scipy.stats import _boost
 
 
 type_char_to_type_tol = {'f': (np.float32, 32*np.finfo(np.float32).eps),
-                         'd': (np.float64, 32*np.finfo(np.float64).eps),
-                         'g': (np.longdouble, 32*np.finfo(np.longdouble).eps)}
+                         'd': (np.float64, 32*np.finfo(np.float64).eps)}
 
 
 # Each item in this list is

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -702,7 +702,7 @@ def check_loc_scale(distfn, arg, m, v, msg):
     # Make `loc` and `scale` arrays to catch bugs like gh-13580 where
     # `loc` and `scale` arrays improperly broadcast with shapes.
     loc, scale = np.array([10.0, 20.0]), np.array([10.0, 20.0])
-    mt, vt = distfn.stats(loc=loc, scale=scale, *arg)
+    mt, vt = distfn.stats(*arg, loc=loc, scale=scale)
     npt.assert_allclose(m*scale + loc, mt)
     npt.assert_allclose(v*scale*scale, vt)
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -17,7 +17,7 @@ from .common_tests import (check_normalization, check_moment,
                            check_meth_dtype, check_ppf_dtype,
                            check_cmplx_deriv,
                            check_pickling, check_rvs_broadcast,
-                           check_freezing,)
+                           check_freezing, check_munp_expect,)
 from scipy.stats._distr_params import distcont
 from scipy.stats._distn_infrastructure import rv_continuous_frozen
 
@@ -318,6 +318,8 @@ def test_moments(distname, arg, normalization_ok, higher_ok, moment_ok,
                    "The integral is probably divergent, or slowly convergent.")
         sup.filter(IntegrationWarning,
                    "The maximum number of subdivisions.")
+        sup.filter(IntegrationWarning,
+                   "The algorithm does not converge.")
 
         if is_xfailing:
             sup.filter(IntegrationWarning)
@@ -333,6 +335,7 @@ def test_moments(distname, arg, normalization_ok, higher_ok, moment_ok,
                 check_skew_expect(distfn, arg, m, v, s, distname)
                 check_var_expect(distfn, arg, m, v, distname)
                 check_kurt_expect(distfn, arg, m, v, k, distname)
+                check_munp_expect(distfn, arg, distname)
 
         check_loc_scale(distfn, arg, m, v, distname)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4263,6 +4263,17 @@ class TestBetaPrime:
         stats.betaprime.fit([0.1, 0.25, 0.3, 1.2, 1.6], floc=0, fscale=1)
         stats.betaprime(a=1, b=1).stats('mvsk')
 
+    def test_moment_gh18634(self):
+        # Testing for gh-18634 revealed that `betaprime` raised a
+        # NotImplementedError for higher moments. Check that this is
+        # resolved. Parameters are arbitrary but lie on either side of the
+        # moment order (5) to test both branches of `_lazywhere`. Reference
+        # values produced with Mathematica, e.g.
+        # `Moment[BetaPrimeDistribution[2,7],5]`
+        ref = [np.inf, 0.867096912929055]
+        res = stats.betaprime(2, [4.2, 7.1]).moment(5)
+        assert_allclose(res, ref)
+
 
 class TestGamma:
     def test_pdf(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1494,6 +1494,15 @@ class TestTruncnorm:
         assert_allclose(stats.truncnorm(a, b).logcdf(x), expected)
         assert_allclose(stats.truncnorm(-b, -a).logsf(-x), expected)
 
+    def test_moments_gh18634(self):
+        # gh-18634 reported that moments 5 and higher didn't work; check that
+        # this is resolved
+        res = stats.truncnorm(-2, 3).moment(5)
+        # From Mathematica:
+        # Moment[TruncatedDistribution[{-2, 3}, NormalDistribution[]], 5]
+        ref = 1.645309620208361
+        assert_allclose(res, ref)
+
 
 class TestGenLogistic:
 

--- a/tools/write_release_and_log.py
+++ b/tools/write_release_and_log.py
@@ -90,7 +90,7 @@ def compute_sha256(idirs):
 
 def write_release_task(filename='NOTES.txt'):
     idirs = Path('release')
-    source = Path(get_latest_release_doc('doc/release'))
+    source = Path(get_latest_release_doc('doc/source/release'))
     target = Path(filename)
     if target.exists():
         target.remove()


### PR DESCRIPTION
Still TODO:

- [x] need to deal with gh-18595 (that's easy enough)
- [x] `sparse` release notes likely need a bit of tweaking, or at least for the reversion that happened cc @perimosocordiae @stefanv 
- [x] good to check with `conda` release manager @h-vetinari if there are any concerns I'm not addressing?

Backports Included here:

1. gh-18659
2. gh-18658
3. gh-18657
4. gh-18636
5. gh-18629
6. gh-18608
7. gh-18598
8. gh-18596
9. gh-18556
10. gh-18630
11. gh-18672
12. gh-18676