### PR TITLE
BUG: small shim for release process

### DIFF
--- a/tools/write_release_and_log.py
+++ b/tools/write_release_and_log.py
@@ -90,7 +90,7 @@ def compute_sha256(idirs):
 
 def write_release_task(filename='NOTES.txt'):
     idirs = Path('release')
-    source = Path(get_latest_release_doc('doc/release'))
+    source = Path(get_latest_release_doc('doc/source/release'))
     target = Path(filename)
     if target.exists():
         target.remove()


### PR DESCRIPTION
* Fixes #18595

* use `git apply` to directly apply the patch from gh-18595 that worked during the RC1 phase of current release cycle; I'll skip the CI--it isn't tested there which is why the patch is needed in the first place

[skip ci]