### PR TITLE
BUG: signal: fix detrend with array-like bp

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3570,7 +3570,7 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
     else:
         dshape = data.shape
         N = dshape[axis]
-        bp = np.sort(np.unique([0, bp, N]))
+        bp = np.sort(np.unique(np.concatenate(np.atleast_1d(0, bp, N))))
         if np.any(bp > N):
             raise ValueError("Breakpoints must be less than length "
                              "of data along given axis.")

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3606,6 +3606,20 @@ class TestDetrend:
         with assert_raises(ValueError):
             detrend(data, type="linear", bp=3)
 
+    @pytest.mark.parametrize('bp', [np.array([0, 2]), [0, 2]])
+    def test_detrend_array_bp(self, bp):
+        # regression test for https://github.com/scipy/scipy/issues/18675
+        rng = np.random.RandomState(12345)
+        x = rng.rand(10)
+       # bp = np.array([0, 2])
+
+        res = detrend(x, bp=bp)
+        res_scipy_191 = np.array([-4.44089210e-16, -2.22044605e-16,
+            -1.11128506e-01, -1.69470553e-01,  1.14710683e-01,  6.35468419e-02,
+            3.53533144e-01, -3.67877935e-02, -2.00417675e-02, -1.94362049e-01])
+
+        assert_allclose(res, res_scipy_191, atol=1e-14)
+
 
 class TestUniqueRoots:
     def test_real_no_repeat(self):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-18675

#### What does this implement/fix?
<!--Please explain your changes.-->

Fix `scipy.signal.detrend` breakpoints argument being either a scalar or an array-like. 

#### Additional information
<!--Any additional information you think is important.-->

The array-like case was broken in a recent innocent-looking cleanup. It used to use `np.r_[scalar, scalar or 1D array_like, scalar]`, and `np.r_` was removed to be array API compatible. The whole function was undertested, so the problem slipped unnoticed.

In the fix, I'm trying to avoid `np.r_` (sigh) but then I'm not sure about `concatenate` and `atleast_1d`. 

Am tentatively marking this for a 1.11 backport @tylerjereddy 
