### PR TITLE
CI: put back an upper bound on setuptools in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - sphinx
   - numpydoc
   - ipython
+  - setuptools<67.3  # avoid pkg_resources deprecation warnings from MPL/scikit-umfpack
   - matplotlib
   - pydata-sphinx-theme==0.9.0
   - sphinx-design


### PR DESCRIPTION
More recent versions cause deprecation warnings to be emitted from `pkg_resources` by (at least) scikit-umfpack and `mpl_toolkits`. We don't need `setuptools` for anything anymore, but in a conda env it always gets installed anyway together with Python itself, so avoid the problematic versions (our test suite fails when warnings get emitted).

[skip cirrus] [skip circle]

The only relevant CI job here is the macOS one on GitHub Actions that uses a conda env.