### PR TITLE
ENH: add support for a scalar sigma in optimize.curve_fit

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -521,7 +521,7 @@ def _wrap_func(func, xdata, ydata, transform):
     if transform is None:
         def func_wrapped(params):
             return func(xdata, *params) - ydata
-    elif transform.ndim == 1:
+    elif transform.size == 1 or transform.ndim == 1:
         def func_wrapped(params):
             return transform * (func(xdata, *params) - ydata)
     else:
@@ -595,12 +595,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         initial values will all be 1 (if the number of parameters for the
         function can be determined using introspection, otherwise a
         ValueError is raised).
-    sigma : None or M-length sequence or MxM array, optional
+    sigma : None or scalar or M-length sequence or MxM array, optional
         Determines the uncertainty in `ydata`. If we define residuals as
         ``r = ydata - f(xdata, *popt)``, then the interpretation of `sigma`
         depends on its number of dimensions:
 
-            - A 1-D `sigma` should contain values of standard deviations of
+            - A scalar or 1-D `sigma` should contain values of standard deviations of
               errors in `ydata`. In this case, the optimized function is
               ``chisq = sum((r / sigma) ** 2)``.
 
@@ -926,8 +926,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     if sigma is not None:
         sigma = np.asarray(sigma)
 
-        # if 1-D, sigma are errors, define transform = 1/sigma
-        if sigma.shape == (ydata.size, ):
+        # if 1-D or a scalar, sigma are errors, define transform = 1/sigma
+        if sigma.size == 1 or sigma.shape == (ydata.size, ):
             transform = 1.0 / sigma
         # if 2-D, sigma is the covariance matrix,
         # define transform = L such that L L^T = C

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -853,6 +853,19 @@ class TestCurveFit:
                 assert_allclose(popt1, popt2, rtol=1.2e-7, atol=1e-14)
                 assert_allclose(pcov1, pcov2, rtol=1.2e-7, atol=1e-14)
 
+    def test_curvefit_scalar_sigma(self):
+        def func(x, a, b):
+            return a * x + b
+
+        x, y = self.x, self.y
+        for absolute_sigma in [False, True]:
+            _, pcov1 = curve_fit(func, x, y, sigma=2, absolute_sigma=absolute_sigma)
+            # Explicitly building the sigma 1D array
+            _, pcov2 = curve_fit(
+                func, x, y, sigma=np.full_like(y, 2), absolute_sigma=absolute_sigma
+            )
+            assert np.all(pcov1 == pcov2)
+
     def test_dtypes(self):
         # regression test for gh-9581: curve_fit fails if x and y dtypes differ
         x = np.arange(-3, 5)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -853,18 +853,18 @@ class TestCurveFit:
                 assert_allclose(popt1, popt2, rtol=1.2e-7, atol=1e-14)
                 assert_allclose(pcov1, pcov2, rtol=1.2e-7, atol=1e-14)
 
-    def test_curvefit_scalar_sigma(self):
+    @pytest.mark.parametrize("absolute_sigma", [False, True])
+    def test_curvefit_scalar_sigma(self, absolute_sigma):
         def func(x, a, b):
             return a * x + b
 
         x, y = self.x, self.y
-        for absolute_sigma in [False, True]:
-            _, pcov1 = curve_fit(func, x, y, sigma=2, absolute_sigma=absolute_sigma)
-            # Explicitly building the sigma 1D array
-            _, pcov2 = curve_fit(
+        _, pcov1 = curve_fit(func, x, y, sigma=2, absolute_sigma=absolute_sigma)
+        # Explicitly building the sigma 1D array
+        _, pcov2 = curve_fit(
                 func, x, y, sigma=np.full_like(y, 2), absolute_sigma=absolute_sigma
-            )
-            assert np.all(pcov1 == pcov2)
+        )
+        assert np.all(pcov1 == pcov2)
 
     def test_dtypes(self):
         # regression test for gh-9581: curve_fit fails if x and y dtypes differ


### PR DESCRIPTION
Before, a scalar value for sigma raised a ValueError:

```python
>>> curve_fit(..., sigma=2.0)
ValueError: `sigma` has incorrect shape.
```

Note that it only has an effect in the output when `absolute_sigma=True`.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

No reference issue.

#### What does this implement/fix?
<!--Please explain your changes.-->

Allows to use a number in `optimize.curve_fit(..., sigma=<number>)`,
which is both useful when using `absolute_sigma=True`,
or in wrapper functions such as:

```python
def fit_and_plot(func, x, y, yerr):
    p, _ = curve_fit(func, x, y, sigma=yerr)
    plt.errorbar(x, y, yerr)  # accepts a scalar for yerr
    plt.plot(x, func(x, *p))
```

#### Additional information
<!--Any additional information you think is important.-->

I added a test comparing a scalar sigma with an explicit 1D array full of that value. I chose the value to be different from `1`, since `sigma` is inverted inside `curve_fit` (`transform = 1.0 / sigma`),
and a value equal to `1` would not distinguish if that codepath is being taken. 