### PR TITLE
MAINT: signal: replace `np.r_["-1", arrays]` by a more sane incantation

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -6,7 +6,7 @@ import warnings
 import numpy
 import numpy as np
 from numpy import (atleast_1d, poly, polyval, roots, real, asarray,
-                   resize, pi, absolute, logspace, r_, sqrt, tan, log10,
+                   resize, pi, absolute, sqrt, tan, log10,
                    arctan, arcsinh, sin, exp, cosh, arccosh, ceil, conjugate,
                    zeros, sinh, append, concatenate, prod, ones, full, array,
                    mintypecode)
@@ -104,13 +104,13 @@ def findfreqs(num, den, N, kind='ba'):
 
     ez = np.r_[ep[ep.imag >= 0], tz[(np.abs(tz) < 1e5) & (tz.imag >= 0)]]
 
-    integ = abs(ez) < 1e-10
-    hfreq = numpy.around(numpy.log10(numpy.max(3 * abs(ez.real + integ) +
-                                               1.5 * ez.imag)) + 0.5)
-    lfreq = numpy.around(numpy.log10(0.1 * numpy.min(abs(real(ez + integ)) +
-                                                     2 * ez.imag)) - 0.5)
+    integ = np.abs(ez) < 1e-10
+    hfreq = np.round(np.log10(np.max(3 * np.abs(ez.real + integ) +
+                                     1.5 * ez.imag)) + 0.5)
+    lfreq = np.round(np.log10(0.1 * np.min(np.abs((ez + integ).real) +
+                                           2 * ez.imag)) - 0.5)
 
-    w = logspace(lfreq, hfreq, N)
+    w = np.logspace(lfreq, hfreq, N)
     return w
 
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -102,9 +102,7 @@ def findfreqs(num, den, N, kind='ba'):
     if len(ep) == 0:
         ep = atleast_1d(-1000) + 0j
 
-    ez = r_['-1',
-            numpy.compress(ep.imag >= 0, ep, axis=-1),
-            numpy.compress((abs(tz) < 1e5) & (tz.imag >= 0), tz, axis=-1)]
+    ez = np.r_[ep[ep.imag >= 0], tz[(np.abs(tz) < 1e5) & (tz.imag >= 0)]]
 
     integ = abs(ez) < 1e-10
     hfreq = numpy.around(numpy.log10(numpy.max(3 * abs(ez.real + integ) +


### PR DESCRIPTION
TIL that `np.r_[]` accepts string arguments. Moreover, if the first argument is a string like `"-1"` it is interpreted as the axis along which to stack the other arguments. Ugh. 

Quoting https://numpy.org/doc/stable/reference/generated/numpy.r_.html : 

> A string integer specifies which axis to stack multiple comma separated arrays along. A string of two comma-
> separated integers allows indication of the minimum number of dimensions to force each entry into as the second 
> integer (the axis to concatenate along is still the first integer).

So this PR removes this usage from `signal.findfreqs`. Furthermore, use the fact that the inputs to `findfreqs` are documented to be 1D, so use that to simplify manipulations a bit.

And while I'm looking at this function, replace explicit `numpy.` with a more standard `np.`
