### PR TITLE
DOC: remove twine GPG from rel docs

### DIFF
--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -186,11 +186,8 @@ For a release there are currently five places on the web to upload things to:
 
 Upload first the wheels and then the sdist::
 
-  twine upload -s REPO_ROOT/release/installers/*.whl
-  twine upload -s REPO_ROOT/release/installers/scipy-1.x.y.tar.gz
-
-If ``gpg2`` is preferred, then the above commands may also include
-``--sign-with gpg2``
+  twine upload REPO_ROOT/release/installers/*.whl
+  twine upload REPO_ROOT/release/installers/scipy-1.x.y.tar.gz
 
 **Github Releases:**
 


### PR DESCRIPTION
* Fixes #18691

* as noted there, GPG signing of our PyPI binaries and sdists is pointless and just ends up sending a warning email to the release manager, so let's remove it from our release process docs

* I think it is fine to leave the rest of the GPG setup instructions tough--we still aim to GPG sign our release tags for example

[skip actions] [skip cirrus]