### PR TITLE
DOC: signal: Updated Chebyshev 2 documentation

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4379,12 +4379,12 @@ def cheb1ap(N, rp):
 
 def cheb2ap(N, rs):
     """
-    Return (z,p,k) for Nth-order Chebyshev type I analog lowpass filter.
+    Return (z,p,k) for Nth-order Chebyshev type II analog lowpass filter.
 
-    The returned filter prototype has `rs` decibels of ripple in the stopband.
+    The returned filter prototype has attenuation of at least ``rs`` decibels in the stopband.
 
     The filter's angular (e.g. rad/s) cutoff frequency is normalized to 1,
-    defined as the point at which the gain first reaches ``-rs``.
+    defined as the point at which the gain first drops below ``-rs``.
 
     See Also
     --------

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4384,7 +4384,7 @@ def cheb2ap(N, rs):
     The returned filter prototype has attenuation of at least ``rs`` decibels in the stopband.
 
     The filter's angular (e.g. rad/s) cutoff frequency is normalized to 1,
-    defined as the point at which the gain first drops below ``-rs``.
+    defined as the point at which the attenuation first reaches ``rs``.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference issue
Documentation specifies that `cheb2ap` makes a Chebyshev type I filter, which is not correct. Chebyshev 2 filter defines the cutoff frequency as stop-band frequency or from which point gain is below `-rs`.

#### What does this implement/fix?
Fixes the documentation related to Chebyshev 2 filter.