### PR TITLE
ENH: override halflogistic fit for free parameters

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4265,12 +4265,12 @@ class halflogistic_gen(rv_continuous):
             # scale is solution to a fix point problem ([1] 2.6)
             # first, precompute shifted data and constants
             mean_val = np.mean(data)
-            shifted_data = data - floc
-            mean_minus_min = mean_val - floc
+            shifted_data = data - loc
+            mean_minus_min = mean_val - loc
             n_observations = data.shape[0]
 
             # heuristically found promising starting point
-            scale = (np.max(data) - floc)/10
+            scale = (np.max(data) - loc)/10
             rtol = 1
 
             # find fix point by repeated application of eq. (2.6)
@@ -4279,10 +4279,10 @@ class halflogistic_gen(rv_continuous):
             #                         = expit(-x))
             while rtol > 1e-8:
                 sum_term = shifted_data * sc.expit(-shifted_data/scale)
-                scale_new = mean_minus_min - 2/n_samples * sum_term.sum()
+                scale_new = mean_minus_min - 2/n_observations * sum_term.sum()
                 rtol = abs((scale - scale_new)/scale)
                 scale = scale_new
-            return floc, scale
+            return loc, scale
 
 
 halflogistic = halflogistic_gen(a=0.0, name='halflogistic')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4202,8 +4202,8 @@ class halflogistic_gen(rv_continuous):
 
     References
     ----------
-    Asgharzadeh et al (2011). "Comparisons of Methods of Estimation for the
-    Half-Logistic Distribution". Selcuk J. Appl. Math. 93-108. 
+    .. [1] Asgharzadeh et al (2011). "Comparisons of Methods of Estimation for the
+           Half-Logistic Distribution". Selcuk J. Appl. Math. 93-108. 
 
     %(example)s
 
@@ -4259,15 +4259,15 @@ class halflogistic_gen(rv_continuous):
         if floc is not None or fscale is not None:
             return super().fit(data, *args, **kwds)
         else:
-            # location is the minumum sample
-            floc = np.min(data)
+            # location is the minimum of the sample ([1] Equation 2.3)
+            loc = np.min(data)
 
-            # scale is solution to a fix point problem
+            # scale is solution to a fix point problem ([1] 2.6)
             # first, precompute shifted data and constants
             mean_val = np.mean(data)
             shifted_data = data - floc
             mean_minus_min = mean_val - floc
-            n_samples = data.shape[0]
+            n_observations = data.shape[0]
 
             # heuristically found promising starting point
             scale = (np.max(data) - floc)/10
@@ -4275,8 +4275,8 @@ class halflogistic_gen(rv_continuous):
 
             # find fix point by repeated application of eq. (2.6)
             # simplify as
-            # exp(-a / x) / (1 + exp(-a / x)) = a / (1 + exp(a / x))
-            # =                                 a * expit(-a / x))
+            # exp(-x) / (1 + exp(-x)) = 1 / (1 + exp(x))
+            #                         = expit(-x))
             while rtol > 1e-8:
                 sum_term = shifted_data * sc.expit(-shifted_data/scale)
                 scale_new = mean_minus_min - 2/n_samples * sum_term.sum()

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4250,7 +4250,7 @@ class halflogistic_gen(rv_continuous):
     @_call_super_mom
     @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
-        if (isinstance(data, CensoredData)) or kwds.pop('superfit', False):
+        if kwds.pop('superfit', False):
             return super().fit(data, *args, **kwds)
 
         data, floc, fscale = _check_fit_input_parameters(self, data,
@@ -4281,7 +4281,7 @@ class halflogistic_gen(rv_continuous):
         # relative tolerance of fix point iterator
         rtol = 1e-8
         relative_residual = 1
-        shifted_mean = sorted_data.mean() #y_mean - y_min
+        shifted_mean = sorted_data.mean()  # y_mean - y_min
 
         # find fix point by repeated application of eq. (2.6)
         # simplify as

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4264,23 +4264,23 @@ class halflogistic_gen(rv_continuous):
 
             # scale is solution to a fix point problem ([1] 2.6)
             # first, precompute shifted data and constants
-            mean_val = np.mean(data)
             shifted_data = data - loc
-            mean_minus_min = mean_val - loc
+            mean_minus_min = shifted_data.mean()
             n_observations = data.shape[0]
 
             # heuristically found promising starting point
             scale = (np.max(data) - loc)/10
-            rtol = 1
+            rtol = 1e-8
+            relative_residual = 1
 
             # find fix point by repeated application of eq. (2.6)
             # simplify as
             # exp(-x) / (1 + exp(-x)) = 1 / (1 + exp(x))
             #                         = expit(-x))
-            while rtol > 1e-8:
+            while relative_residual > rtol:
                 sum_term = shifted_data * sc.expit(-shifted_data/scale)
                 scale_new = mean_minus_min - 2/n_observations * sum_term.sum()
-                rtol = abs((scale - scale_new)/scale)
+                relative_residual = abs((scale - scale_new)/scale)
                 scale = scale_new
             return loc, scale
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4248,6 +4248,8 @@ class halflogistic_gen(rv_continuous):
         return 2-np.log(2)
 
     def fit(self, data, *args, **kwds):
+        if (isinstance(data, CensoredData)):
+            data = data._uncensor()
         if kwds.pop('superfit', False):
             return super().fit(data, *args, **kwds)
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4256,31 +4256,31 @@ class halflogistic_gen(rv_continuous):
 
         if floc is not None or fscale is not None:
             return super().fit(data, *args, **kwds)
-        else:
-            # location is the minimum of the sample ([1] Equation 2.3)
-            loc = np.min(data)
 
-            # scale is solution to a fix point problem ([1] 2.6)
-            # first, precompute shifted data and constants
-            shifted_data = data - loc
-            mean_minus_min = shifted_data.mean()
-            n_observations = data.shape[0]
+        # location is the minimum of the sample ([1] Equation 2.3)
+        loc = np.min(data)
 
-            # heuristically found promising starting point
-            scale = (np.max(data) - loc)/10
-            rtol = 1e-8
-            relative_residual = 1
+        # scale is solution to a fix point problem ([1] 2.6)
+        # first, precompute shifted data and constants
+        shifted_data = data - loc
+        mean_minus_min = shifted_data.mean()
+        n_observations = data.shape[0]
 
-            # find fix point by repeated application of eq. (2.6)
-            # simplify as
-            # exp(-x) / (1 + exp(-x)) = 1 / (1 + exp(x))
-            #                         = expit(-x))
-            while relative_residual > rtol:
-                sum_term = shifted_data * sc.expit(-shifted_data/scale)
-                scale_new = mean_minus_min - 2/n_observations * sum_term.sum()
-                relative_residual = abs((scale - scale_new)/scale)
-                scale = scale_new
-            return loc, scale
+        # use approximate MLE as starting point ([1] 3.1)
+        scale = (np.max(data) - loc)/10
+        rtol = 1e-8
+        relative_residual = 1
+
+        # find fix point by repeated application of eq. (2.6)
+        # simplify as
+        # exp(-x) / (1 + exp(-x)) = 1 / (1 + exp(x))
+        #                         = expit(-x))
+        while relative_residual > rtol:
+            sum_term = shifted_data * sc.expit(-shifted_data/scale)
+            scale_new = mean_minus_min - 2/n_observations * sum_term.sum()
+            relative_residual = abs((scale - scale_new)/scale)
+            scale = scale_new
+        return loc, scale
 
 
 halflogistic = halflogistic_gen(a=0.0, name='halflogistic')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4247,6 +4247,8 @@ class halflogistic_gen(rv_continuous):
     def _entropy(self):
         return 2-np.log(2)
 
+    @_call_super_mom
+    @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
         if (isinstance(data, CensoredData)) or kwds.pop('superfit', False):
             return super().fit(data, *args, **kwds)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4266,7 +4266,7 @@ class halflogistic_gen(rv_continuous):
         # use approximate MLE as starting point ([1] 3.1)
         n_observations = data.shape[0]
         sorted_data = np.sort(data, axis=0)
-        p = np.arange(0, n_observations, 1)/(n_observations + 1)
+        p = np.arange(1, n_observations + 1)/(n_observations + 1)
         q = 1 - p
         pp1 = 1 + p
         alpha = p - 0.5 * q * pp1 * np.log(pp1 / q)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4248,9 +4248,7 @@ class halflogistic_gen(rv_continuous):
         return 2-np.log(2)
 
     def fit(self, data, *args, **kwds):
-        if (isinstance(data, CensoredData)):
-            data = data._uncensor()
-        if kwds.pop('superfit', False):
+        if (isinstance(data, CensoredData)) or kwds.pop('superfit', False):
             return super().fit(data, *args, **kwds)
 
         data, floc, fscale = _check_fit_input_parameters(self, data,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1175,6 +1175,17 @@ class TestHalfLogistic:
     def test_isf(self, q, ref):
         assert_allclose(stats.halflogistic.isf(q), ref, rtol=1e-15)
 
+    @pytest.mark.parametrize("rvs_loc", [1e-5, 1e10])
+    @pytest.mark.parametrize("rvs_scale", [1e-2, 100, 1e8])
+    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale):
+
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.halflogistic.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
+                                      random_state=rng)
+
+        _assert_less_or_close_loglike(stats.halflogistic, data,
+                                      stats.halflogistic.nnlf)
+
 
 class TestHalfgennorm:
     def test_expon(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1183,8 +1183,7 @@ class TestHalfLogistic:
         data = stats.halflogistic.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
                                       random_state=rng)
 
-        _assert_less_or_close_loglike(stats.halflogistic, data,
-                                      stats.halflogistic.nnlf)
+        _assert_less_or_close_loglike(stats.halflogistic, data)
 
 
 class TestHalfgennorm:


### PR DESCRIPTION
#### Reference issue
Related to #11782

#### What does this implement/fix?
Overrides the `fit` method for the half logistic distribution acc. to [this paper](https://www.researchgate.net/publication/253328579_Comparisons_of_Methods_of_Estimation_for_the_Half-Logistic_Distribution/citation/download). The case that `floc` is given by the user is also treated in the publication and left for a follow up intentionally to make review of this PR easier.

#### Additional information
In a nutshell: for data $(y_1, ..., y_n)$, we get

$$floc=y_{min}=min(y_1, ..., y_n)$$

For the scale $\sigma$:

$$ \sigma=f(\sigma)=y_{mean} - y_{min} - \frac{2}{n}\sum_{i=1}^n\frac{(y_i-y_{min})\exp(-(y_i-y_{min})/\sigma)}{1+\exp(-(y_i-y_{min})/\sigma)} $$

The paper proposed to solve this equation via the simple iterative sequence $\sigma_{i+1}=f(\sigma_i)$. In my tests, this worked quite well and better than rootfinding.