### PR TITLE
MAINT: NumPy 1.25.0 shims for arm64

### DIFF
--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -84,7 +84,8 @@ def _highs_to_scipy_status_message(highs_status, highs_message):
 def _replace_inf(x):
     # Replace `np.inf` with CONST_INF
     infs = np.isinf(x)
-    x[infs] = np.sign(x[infs])*CONST_INF
+    with np.errstate(invalid="ignore"):
+        x[infs] = np.sign(x[infs])*CONST_INF
     return x
 
 
@@ -322,7 +323,8 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
 
     lb, ub = bounds.T.copy()  # separate bounds, copy->C-cntgs
     # highs_wrapper solves LHS <= A*x <= RHS, not equality constraints
-    lhs_ub = -np.ones_like(b_ub)*np.inf  # LHS of UB constraints is -inf
+    with np.errstate(invalid="ignore"):
+        lhs_ub = -np.ones_like(b_ub)*np.inf  # LHS of UB constraints is -inf
     rhs_ub = b_ub  # RHS of UB constraints is b_ub
     lhs_eq = b_eq  # Equality constaint is inequality
     rhs_eq = b_eq  # constraint with LHS=RHS

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -446,6 +446,7 @@ def test_zero_rhs(solver):
             assert_allclose(x, 0, atol=1e-300)
 
 
+@pytest.mark.xfail(reason="see gh-18697")
 def test_maxiter_worsening(solver):
     if solver not in (gmres, lgmres, qmr):
         # these were skipped from the very beginning, see gh-9201; gh-14160


### PR DESCRIPTION
* a few floating-point error shims to allow our testsuite to pass for MacOS arm64 with the recently-released NumPy `1.25.0` -- the issues were showing up in our Cirrus CI and I could also reproduce them locally on M2 max

* locally I still get a few errors, but those were present on M2 series prior to NumPy `1.25.0` per gh-18308, and I think this patch brings us back to that basically

* @seberg anything surprising here? seems pretty minor/harmless, right?

* perhaps this is worth a backport? I think this is one reason we try to be just a bit slower than NumPy in our release cycles