### PR TITLE
MAINT: remove np.r_["-1", ...] 

### DIFF
--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -275,9 +275,9 @@ def diagsvd(s, M, N):
     typ = part.dtype.char
     MorN = len(s)
     if MorN == M:
-        return r_['-1', part, zeros((M, N-M), typ)]
+        return numpy.hstack((part, zeros((M, N - M), dtype=typ)))
     elif MorN == N:
-        return r_[part, zeros((M-N, N), typ)]
+        return r_[part, zeros((M - N, N), dtype=typ)]
     else:
         raise ValueError("Length of s must be M or N.")
 

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -85,7 +85,7 @@ def tf2ss(num, den):
                 array([], float))
 
     # pad numerator to have same number of columns has denominator
-    num = r_['-1', zeros((num.shape[0], K - M), num.dtype), num]
+    num = np.hstack((np.zeros((num.shape[0], K - M), dtype=num.dtype), num))
 
     if num.shape[-1] > 0:
         D = atleast_2d(num[:, 0])


### PR DESCRIPTION
As a follow-up to https://github.com/scipy/scipy/pull/18692, remove two more instances of `np.r_["-1", ...]`. This is all what my grep-fu finds in the scipy codebase.
