### PR TITLE
MAINT: bump minimal supported NumPy version to 1.22.4

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -356,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
+        python -m pip install numpy cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
         python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Setup Python deps
         run: |
-          pip install "numpy==1.21.6" &&
+          pip install "numpy==1.22.4" &&
           # build deps
           pip install build meson-python ninja pythran pybind11 cython wheel
           # test deps
@@ -356,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.21.6 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
+        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
         python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -356,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
-        python dev.py build && \
+        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
+        LD_LIBRARY_PATH=/usr/local/lib python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+          pip install numpy==1.22.4 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
       - name: Install OpenBLAS
         shell: bash
         run: |
@@ -99,9 +99,9 @@ jobs:
 
       - name: pip-packages
         run: |
-          # 1.22.3 is currently the oldest numpy usable on cp3.9 according
+          # 1.22.4 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.3 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+          python -m pip install numpy==1.22.4 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
 
       - name: Build
         run: |
@@ -210,7 +210,7 @@ jobs:
         run: |
           # pyproject.toml currently states this numpy minimum version.
           python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-          python -m pip install cython numpy==1.22.3 pybind11 pythran pytest pooch
+          python -m pip install cython numpy==1.22.4 pybind11 pythran pytest pooch
 
       - name: Build
         run: |

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -84,6 +84,7 @@ The table shows the NumPy versions suitable for each major Python version.
  1.9.2              >=3.8, <3.12                >=1.18.5, <1.26.0
  1.10               >=3.8, <3.12                >=1.19.5, <1.26.0
  1.11               >=3.9, <3.12                >=1.21.6, <1.27.0
+ 1.12               >=3.9, <3.13                >=1.22.4, <2.0.0
 =================  ========================    =======================
 
 In specific cases, such as a particular architecture, these requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,21 +25,9 @@ requires = [
 
     # now matches minimum supported version, keep here as separate requirement
     # to be able to sync more easily with oldest-supported-numpy
-    # loongarch64 requires numpy>=1.22.0
-    "numpy==1.22.0; platform_machine=='loongarch64'",
-
-    # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
-    # built with vc142. 1.22.3 is the first version that has 32-bit Windows
-    # wheels *and* was built with vc141. So use that:
-    "numpy==1.22.3; python_version=='3.9' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
-    "numpy==1.21.6; python_version=='3.9' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
-    # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
-    # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
-    # (see oldest-supported-numpy issues gh-28 and gh-45)
-    "numpy==1.21.6; python_version=='3.10' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
+    "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
@@ -66,7 +54,7 @@ requires-python = ">=3.9"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.21.6",
+    "numpy>=1.22.4",
 ]
 readme = "README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ maintainers = [
 requires-python = ">=3.9"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
-    # https://github.com/FFY00/meson-python/issues/29
+    # https://github.com/mesonbuild/meson-python/issues/29
     "numpy>=1.22.4",
 ]
 readme = "README.rst"

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -124,7 +124,7 @@ else:
     from scipy._lib import _pep440
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
-    np_minversion = '1.21.6'
+    np_minversion = '1.22.4'
     np_maxversion = '9.9.99'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -423,6 +423,7 @@ def test_interval(distname, shapes):
     npt.assert_equal(dist.interval(1, *shapes), (a-1, b))
 
 
+@pytest.mark.xfail_on_32bit("Sensible to machine precision")
 def test_rv_sample():
     # Thoroughly test rv_sample and check that gh-3758 is resolved
 

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -522,6 +522,7 @@ def test_re_bootstrap(additional_resamples):
                     rtol=1e-14)
 
 
+@pytest.mark.xfail_on_32bit("Sensible to machine precision")
 @pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
 def test_bootstrap_alternative(method):
     rng = np.random.default_rng(5894822712842015040)

--- a/setup.py
+++ b/setup.py
@@ -449,7 +449,7 @@ def setup_package():
     # Rationale: SciPy builds without deprecation warnings with N; deprecations
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
-    np_minversion = '1.21.6'
+    np_minversion = '1.22.4'
     np_maxversion = '9.9.99'
     python_minversion = '3.9'
     python_maxversion = '3.11'


### PR DESCRIPTION
Preparing for SciPy 1.12 where we would bump NumPy to be at least 1.22.4.

This follows [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html): NumPy 1.24 would just become the minimal supported version, so as before we are setting to the immediate previous stable release which is 1.22.4.

If I got this right this time, I think we can clean a bit the `pyproject.toml`.