### PR TITLE
MAINT: fix linter error in `_fitpack_impl.py`

### DIFF
--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -667,7 +667,7 @@ def bisplev(x, y, tck, dx=0, dy=0):
     if (len(x.shape) != 1) or (len(y.shape) != 1):
         raise ValueError("First two entries should be rank-1 arrays.")
 
-    msg = f"Too many data points to interpolate."
+    msg = "Too many data points to interpolate."
 
     _int_overflow(x.size * y.size, MemoryError, msg=msg)
 


### PR DESCRIPTION
Fix this linter error:

```
% python dev.py lint
scipy/interpolate/_fitpack_impl.py:670:11: F541 [*] f-string without any placeholders
Found 1 error.
[*] 1 potentially fixable with the --fix option.

%
```

Now:
```
% python dev.py lint
%
```
