### PR TITLE
TST: mark two tests of `lsq_linear` as xslow

### DIFF
--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -155,6 +155,7 @@ class BaseMixin:
         result = lsq_linear(A, b, method=self.method)
         assert_(result.cost < 1.1e-8)
 
+    @pytest.mark.xslow
     def test_large_rank_deficient(self):
         np.random.seed(0)
         n, m = np.sort(np.random.randint(2, 1000, size=2))


### PR DESCRIPTION
#### What does this implement/fix?

#### Additional information
There are two very slow tests that take almost 20 seconds each in `test_lsq_linear`. See for example [here](https://github.com/scipy/scipy/actions/runs/5338714760/jobs/9676458809?pr=18695).

![image](https://github.com/scipy/scipy/assets/40656107/310cbdbd-b3a2-44ed-8fa5-4240669a8cb0)

Both tests seem stable from what I have seen. To save some CI minutes, I marked them as xslow. 
