### PR TITLE
MAINT: optimize._chandrupatla: result object fixup

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -232,9 +232,10 @@ class OptimizeResult(dict):
                       'col_ind', 'nit', 'lower', 'upper', 'eqlin', 'ineqlin',
                       'converged', 'flag', 'function_calls', 'iterations',
                       'root']
+        order_keys = getattr(self, '_order_keys', order_keys)
         # 'slack', 'con' are redundant with residuals
         # 'crossover_nit' is probably not interesting to most users
-        omit_keys = {'slack', 'con', 'crossover_nit'}
+        omit_keys = {'slack', 'con', 'crossover_nit', '_order_keys'}
 
         def key(item):
             try:


### PR DESCRIPTION
#### Reference issue
Followup to gh-17719 

#### What does this implement/fix?
Previously, not all elements of `_chandrupatla`'s result object were being updated before being passed into the `callback` or after terminating due to the iteration limit. For example:

```python3
from scipy.optimize._zeros_py import _chandrupatla

def f(q):
    return (q - [-1.005263125, 0, 1])**3

def callback(res):
    print(res.xr)

res = _chandrupatla(f, -5, 5, maxiter=5, callback=callback)
print(res.x)
```
would produce:
```
[5. 5. 5.]
[5. 0. 5.]
[5. 0. 5.]
[5. 0. 5.]
[5. 0. 5.]
[5. 0. 5.]
[-5.  0. -5.]
```
The middle element was updated when it converged to the `root`, `0`. However, the other elements of the attributes were not updated because they didn't converge. 

This fixes that. Now:
```
[5. 5. 5.]
[0. 0. 5.]
[0.  0.  2.5]
[0.   0.   1.25]
[-0.625  0.     1.25 ]
[-0.9375  0.      1.25  ]
[-0.9375  0.      0.9375]
```

It also improves the order of the result object.

Was:
```
 success: [False  True False]
  status: [-2  0 -2]
     fun: [-6.375e+01  0.000e+00 -2.160e+02]
       x: [-5.000e+00  0.000e+00 -5.000e+00]
      xl: [-5.000e+00 -5.000e+00 -5.000e+00]
     nit: [5 1 5]
      fl: [-6.375e+01 -1.250e+02 -2.160e+02]
      xr: [ 5.000e+00  0.000e+00  5.000e+00]
      fr: [ 2.166e+02  0.000e+00  6.400e+01]
    nfev: [7 3 7]
```
Now:
```
     success: [False  True False]
      status: [-2  0 -2]
           x: [-9.375e-01  0.000e+00  9.375e-01]
         fun: [ 3.112e-04  0.000e+00 -2.441e-04]
         nit: [5 1 5]
        nfev: [7 3 7]
          xl: [-1.250e+00 -5.000e+00  9.375e-01]
          fl: [-1.466e-02 -1.250e+02 -2.441e-04]
          xr: [-9.375e-01  0.000e+00  1.250e+00]
          fr: [ 3.112e-04  0.000e+00  1.562e-02]
```

#### Additional information
I can also take the opportunity to generalize some of the helper functions in this PR if you'd like, @tupui. For instance:
- `_chandrupatla_initialize` can be generalized to accept any number of `x`-like inputs (not just `a`, `b`, but say `x1`, `x2`, `x3`).
- `_chandrupatla_prepare_result` can probably be generalized to prepare the result object with any set of elements
- The parts of `_chandrupatla_check_termination` after `if np.any(stop)` can probably be moved into a separate function.

That way, we can reuse them in the `_chandrupatla_minimize` PR so there is less to review.
