### PR TITLE
DOC: Fix notational variation in _lbfgsb_py.py: "pg_i" and "proj g_i" to "proj g_i"

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -91,7 +91,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
     pgtol : float, optional
         The iteration will stop when
         ``max{|proj g_i | i = 1, ..., n} <= pgtol``
-        where ``pg_i`` is the i-th component of the projected gradient.
+        where ``proj g_i`` is the i-th component of the projected gradient.
     epsilon : float, optional
         Step size used when `approx_grad` is True, for numerically
         calculating the gradient
@@ -234,7 +234,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= ftol``.
     gtol : float
         The iteration will stop when ``max{|proj g_i | i = 1, ..., n}
-        <= gtol`` where ``pg_i`` is the i-th component of the
+        <= gtol`` where ``proj g_i`` is the i-th component of the
         projected gradient.
     eps : float or ndarray
         If `jac is None` the absolute step size used for numerical


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

I noticed that there is a notational variation in docstring in [_lbfgsb_py.py](https://github.com/scipy/scipy/blob/f05674ac43c7dd2d82f37b7c702ff71366bffefb/scipy/optimize/_lbfgsb_py.py): both `pg_i` and `proj g_i` are used to denote the projected gradient.

This PR unifies them to `proj g_i` since `proj g` is used in other places too.

#### Additional information
<!--Any additional information you think is important.-->

[lbfgsb.f](https://github.com/scipy/scipy/blob/f05674ac43c7dd2d82f37b7c702ff71366bffefb/scipy/optimize/lbfgsb_src/lbfgsb.f) also has the same problem, but this file is left untouched.