### PR TITLE
MAINT:sparse.linalg: Use _NoValue for deprecated kwargs

### DIFF
--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -17,7 +17,7 @@ def _get_atol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
                "deprecated in favor of 'rtol' and will be removed in SciPy "
                "v.1.14.0. Until then, if set, it will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
-        rtol = float(tol)
+        rtol = float(tol) if tol is not None else rtol
 
     if atol == 'legacy':
         warnings.warn("scipy.sparse.linalg.{name} called with `atol` set to "

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -3,15 +3,16 @@ import numpy as np
 from scipy.sparse.linalg._interface import LinearOperator
 from .utils import make_system
 from scipy.linalg import get_lapack_funcs
+from scipy._lib.deprecation import _NoValue
 
 __all__ = ['bicg', 'bicgstab', 'cg', 'cgs', 'gmres', 'qmr']
 
 
-def _get_atol(name, b, tol=None, atol=0., rtol=1e-5):
+def _get_atol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
     """
     A helper function to handle tolerance deprecations and normalization
     """
-    if tol is not None:
+    if tol is not _NoValue:
         msg = (f"'scipy.sparse.linalg.{name}' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
                "v.1.14.0. Until then, if set, will override 'rtol'.")
@@ -31,7 +32,7 @@ def _get_atol(name, b, tol=None, atol=0., rtol=1e-5):
     return atol
 
 
-def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
+def bicg(A, b, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
          atol=0., rtol=1e-5):
     """Use BIConjugate Gradient iteration to solve ``Ax = b``.
 
@@ -159,7 +160,7 @@ def bicg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
         return postprocess(x), maxiter
 
 
-def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
+def bicgstab(A, b, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
              atol=0., rtol=1e-5):
     """Use BIConjugate Gradient STABilized iteration to solve ``Ax = b``.
 
@@ -301,8 +302,8 @@ def bicgstab(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
         return postprocess(x), maxiter
 
 
-def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
-       rtol=1e-5):
+def cg(A, b, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
+       atol=0., rtol=1e-5):
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
 
     Parameters
@@ -415,7 +416,7 @@ def cg(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None, atol=0.,
         return postprocess(x), maxiter
 
 
-def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
+def cgs(A, b, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
         atol=0., rtol=1e-5):
     """Use Conjugate Gradient Squared iteration to solve ``Ax = b``.
 
@@ -567,7 +568,7 @@ def cgs(A, b, x0=None, tol=None, maxiter=None, M=None, callback=None,
         return postprocess(x), maxiter
 
 
-def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
+def gmres(A, b, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
           callback=None, restrt=None, atol=0., callback_type=None,
           rtol=1e-5):
     """
@@ -853,8 +854,8 @@ def gmres(A, b, x0=None, tol=None, restart=None, maxiter=None, M=None,
     return postprocess(x), info
 
 
-def qmr(A, b, x0=None, tol=None, maxiter=None, M1=None, M2=None, callback=None,
-        atol=0., rtol=1e-5):
+def qmr(A, b, x0=None, tol=_NoValue, maxiter=None, M1=None, M2=None,
+        callback=None, atol=0., rtol=1e-5):
     """Use Quasi-Minimal Residual iteration to solve ``Ax = b``.
 
     Parameters

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -15,7 +15,7 @@ def _get_atol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
     if tol is not _NoValue:
         msg = (f"'scipy.sparse.linalg.{name}' keyword argument 'tol' is "
                "deprecated in favor of 'rtol' and will be removed in SciPy "
-               "v.1.14.0. Until then, if set, will override 'rtol'.")
+               "v.1.14.0. Until then, if set, it will override 'rtol'.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         rtol = float(tol)
 
@@ -569,7 +569,7 @@ def cgs(A, b, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
 
 
 def gmres(A, b, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
-          callback=None, restrt=None, atol=0., callback_type=None,
+          callback=None, restrt=_NoValue, atol=0., callback_type=None,
           rtol=1e-5):
     """
     Use Generalized Minimal RESidual iteration to solve ``Ax = b``.
@@ -623,7 +623,7 @@ def gmres(A, b, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
 
         .. deprecated:: 0.11.0
            `gmres` keyword argument `restrt` is deprecated in favor of
-           `restart` and will be removed in SciPy 1.12.0.
+           `restart` and will be removed in SciPy 1.14.0.
     tol : float, optional, deprecated
 
         .. deprecated 1.12.0
@@ -670,15 +670,15 @@ def gmres(A, b, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
     """
 
     # Handle the deprecation frenzy
-    if restrt and restart:
-        raise ValueError("Cannot specify both restart and restrt"
+    if restrt not in (None, _NoValue) and restart:
+        raise ValueError("Cannot specify both 'restart' and 'restrt'"
                          " keywords. Also 'rstrt' is deprecated."
-                         " and will be removed in SciPy 1.12.0. Use "
+                         " and will be removed in SciPy 1.14.0. Use "
                          "'restart' instad.")
-    if restrt is not None:
+    if restrt is not _NoValue:
         msg = ("'gmres' keyword argument 'restrt' is deprecated "
                "in favor of 'restart' and will be removed in SciPy"
-               " 1.12.0. Until then, if set, 'rstrt' will override 'restart'."
+               " 1.14.0. Until then, if set, 'rstrt' will override 'restart'."
                )
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
         restart = restrt


### PR DESCRIPTION
#### Reference issue
Continuation of #18488, as per #18624


#### What does this implement/fix?
Adds deprecation `_NoValue` check mechanism to iterative solvers in order to deprecate the `tol`  keyword. 
