### PR TITLE
MAINT, REL: prepare for SciPy 1.11.0 "final"

### DIFF
--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.11.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.11.0 is not released yet!
-
 .. contents::
 
 SciPy 1.11.0 is the culmination of 6 months of hard work. It contains
@@ -337,7 +335,7 @@ Authors
 * boeleman (1) +
 * Jack Borchanian (1) +
 * Matt Borland (3) +
-* Jake Bowhay (40)
+* Jake Bowhay (41)
 * Larry Bradley (1) +
 * Sienna Brent (1) +
 * Matthew Brett (1)
@@ -364,17 +362,17 @@ Authors
 * Stefano Frazzetto (1) +
 * Neil Girdhar (1)
 * Caden Gobat (1) +
-* Ralf Gommers (152)
+* Ralf Gommers (153)
 * GonVas (1) +
 * Marco Gorelli (1)
 * Brett Graham (2) +
-* Matt Haberland (390)
+* Matt Haberland (388)
 * harshvardhan2707 (1) +
 * Alex Herbert (1) +
 * Guillaume Horel (1)
 * Geert-Jan Huizing (1) +
 * Jakob Jakobson (2)
-* Julien Jerphanion (14)
+* Julien Jerphanion (10)
 * jyuv (2)
 * Rajarshi Karmakar (1) +
 * Ganesh Kathiresan (3) +
@@ -416,7 +414,7 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (131)
+* Tyler Reddy (134)
 * Lucas Roberts (1)
 * Pamphile Roy (225)
 * Jordan Rupprecht (1) +
@@ -1170,5 +1168,8 @@ Pull requests for 1.11.0
 * `#18657 <https://github.com/scipy/scipy/pull/18657>`__: MAINT: fix 'no such option' error in build_scipy CI
 * `#18658 <https://github.com/scipy/scipy/pull/18658>`__: TST: fix two test failures that showed up on conda-forge
 * `#18659 <https://github.com/scipy/scipy/pull/18659>`__: DOC: \`scipy._sensitivity_analysis\`: correct statement about...
+* `#18671 <https://github.com/scipy/scipy/pull/18671>`__: MAINT: backports for 1.11.0rc2
 * `#18672 <https://github.com/scipy/scipy/pull/18672>`__: BUG: small shim for release process
 * `#18676 <https://github.com/scipy/scipy/pull/18676>`__: BUG: signal: fix detrend with array-like bp
+* `#18697 <https://github.com/scipy/scipy/pull/18697>`__: MAINT: NumPy 1.25.0 shims for arm64
+* `#18698 <https://github.com/scipy/scipy/pull/18698>`__: DEP: interpolate: delay interp2d deprecation and update link

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.11.0rc2',
+  version: '1.11.0',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -92,7 +92,7 @@ def lagrange(x, w):
 
 
 dep_mesg = """\
-`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0.
+`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.13.0.
 
 For legacy code, nearly bug-for-bug compatible replacements are
 `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -103,7 +103,7 @@ For scattered data, prefer `LinearNDInterpolator` or
 `CloughTocher2DInterpolator`.
 
 For more details see
-`https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff`
+`https://scipy.github.io/devdocs/notebooks/interp_transition_guide.html`
 """
 
 class interp2d:
@@ -114,7 +114,7 @@ class interp2d:
     .. deprecated:: 1.10.0
 
         `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy
-        1.12.0.
+        1.13.0.
 
         For legacy code, nearly bug-for-bug compatible replacements are
         `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -125,8 +125,8 @@ class interp2d:
         `CloughTocher2DInterpolator`.
 
         For more details see
-        `https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff
-        <https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff>`_
+        `https://scipy.github.io/devdocs/notebooks/interp_transition_guide.html
+        <https://scipy.github.io/devdocs/notebooks/interp_transition_guide.html>`_
 
 
     Interpolate over a 2-D grid.

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -84,7 +84,8 @@ def _highs_to_scipy_status_message(highs_status, highs_message):
 def _replace_inf(x):
     # Replace `np.inf` with CONST_INF
     infs = np.isinf(x)
-    x[infs] = np.sign(x[infs])*CONST_INF
+    with np.errstate(invalid="ignore"):
+        x[infs] = np.sign(x[infs])*CONST_INF
     return x
 
 
@@ -322,7 +323,8 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
 
     lb, ub = bounds.T.copy()  # separate bounds, copy->C-cntgs
     # highs_wrapper solves LHS <= A*x <= RHS, not equality constraints
-    lhs_ub = -np.ones_like(b_ub)*np.inf  # LHS of UB constraints is -inf
+    with np.errstate(invalid="ignore"):
+        lhs_ub = -np.ones_like(b_ub)*np.inf  # LHS of UB constraints is -inf
     rhs_ub = b_ub  # RHS of UB constraints is b_ub
     lhs_eq = b_eq  # Equality constaint is inequality
     rhs_eq = b_eq  # constraint with LHS=RHS

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -455,6 +455,7 @@ def test_zero_rhs(solver):
                 assert_allclose(x, 0, atol=1e-300)
 
 
+@pytest.mark.xfail(reason="see gh-18697")
 def test_maxiter_worsening(solver):
     if solver not in (gmres, lgmres):
         # these were skipped from the very beginning, see gh-9201; gh-14160

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -6,9 +6,9 @@ import argparse
 MAJOR = 1
 MINOR = 11
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 def get_version_info(source_root):


### PR DESCRIPTION
- [x] I propose we're ready to proceed with the "final" release of SciPy `1.11.0` -- @h-vetinari do you concur as conda-forge release manager? I haven't seen reports of problems apart from the 1 backport patch for MacOS ARM with latest NumPy.
- [x] remove doc note about SciPy `1.11.0` not being released yet
- [x] update release note lists one more time
- [x] `python dev.py test -j 12` local testing on Apple silicon with NumPy `1.25.0`
- [x] `python dev.py doc` local test on this branch
- [x] make release commit for SciPy `1.11.0` "final" unreleased (switches to released during final release process)

Backports included:

1. gh-18697
2. gh-18698

Note that there is still a large list of merged backport PRs, but they appear to be targeted for `1.10.x` series, and I'm not so sure we'll do `1.10.2` at this point anyway.