### PR TITLE
ENH: improve halflogistic distribution fitting with fixed parameters

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1182,18 +1182,16 @@ class TestHalfLogistic:
     def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale,
                                     fix_loc, fix_scale):
 
-        if fix_scale and fix_loc:
-            pytest.skip("Nothing to fit.")
-
         rng = np.random.default_rng(6762668991392531563)
         data = stats.halflogistic.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
                                       random_state=rng)
 
         kwds = {}
         if fix_loc and fix_scale:
-            loc, scale = stats.halflogistic.fit(data, floc=rvs_loc, fscale=rvs_scale)
-            assert loc == rvs_loc
-            assert scale == rvs_scale
+            error_msg = ("All parameters fixed. There is nothing to "
+                         "optimize.")
+            with pytest.raises(RuntimeError, match=error_msg):
+                stats.halflogistic.fit(data, floc=rvs_loc, fscale=rvs_scale)
             return
 
         if fix_loc:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1190,6 +1190,12 @@ class TestHalfLogistic:
                                       random_state=rng)
 
         kwds = {}
+        if fix_loc and fix_scale:
+            loc, scale = stats.halflogistic.fit(data, floc=rvs_loc, fscale=rvs_scale)
+            assert loc == rvs_loc
+            assert scale == rvs_scale
+            return
+
         if fix_loc:
             kwds['floc'] = rvs_loc
         if fix_scale:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1177,13 +1177,25 @@ class TestHalfLogistic:
 
     @pytest.mark.parametrize("rvs_loc", [1e-5, 1e10])
     @pytest.mark.parametrize("rvs_scale", [1e-2, 100, 1e8])
-    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale):
+    @pytest.mark.parametrize('fix_loc', [True, False])
+    @pytest.mark.parametrize('fix_scale', [True, False])
+    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale,
+                                    fix_loc, fix_scale):
+
+        if fix_scale and fix_loc:
+            pytest.skip("Nothing to fit.")
 
         rng = np.random.default_rng(6762668991392531563)
         data = stats.halflogistic.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
                                       random_state=rng)
 
-        _assert_less_or_close_loglike(stats.halflogistic, data)
+        kwds = {}
+        if fix_loc:
+            kwds['floc'] = rvs_loc
+        if fix_scale:
+            kwds['fscale'] = rvs_scale
+
+        _assert_less_or_close_loglike(stats.halflogistic, data, **kwds)
 
 
 class TestHalfgennorm:


### PR DESCRIPTION
#### Reference issue
Part of #11782 and follow up of #18695 

#### What does this implement/fix?
Overrides `halflogistic.fit` for fixed parameters.

#### Additional information
Comparisons with the generic fit method below. In both cases, performance is much better and fit quality the same.

*Location fixed*
![Loc_Fix_Time](https://github.com/scipy/scipy/assets/40656107/692f21af-ce2b-435f-b724-081736c5f3d3)
![Loc_fix_Rel_Improvements](https://github.com/scipy/scipy/assets/40656107/4218f006-2dac-4b27-8b18-3aad7acd4439)
![Loc_fix_Rel_Regressions](https://github.com/scipy/scipy/assets/40656107/84f86247-b8ee-43fe-af56-a6715542b4e1)

*Scale fixed*
![Scale_Fix_Time](https://github.com/scipy/scipy/assets/40656107/0c7f2d6c-2c85-40d1-b7c6-f32658e780ef)
![Scale_fix_Rel_Improvements](https://github.com/scipy/scipy/assets/40656107/e6eee21d-b94d-4e49-afc8-9221f0ffb202)
![Scale_fix_Rel_Regressions](https://github.com/scipy/scipy/assets/40656107/c02a225e-0c30-4a80-b117-a73f9a89b49b)

