### PR TITLE
MAINT: optimize._chandrupatla: refactor for code reuse

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -232,9 +232,10 @@ class OptimizeResult(dict):
                       'col_ind', 'nit', 'lower', 'upper', 'eqlin', 'ineqlin',
                       'converged', 'flag', 'function_calls', 'iterations',
                       'root']
+        order_keys = getattr(self, '_order_keys', order_keys)
         # 'slack', 'con' are redundant with residuals
         # 'crossover_nit' is probably not interesting to most users
-        omit_keys = {'slack', 'con', 'crossover_nit'}
+        omit_keys = {'slack', 'con', 'crossover_nit', '_order_keys'}
 
         def key(item):
             try:

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1514,7 +1514,8 @@ def _chandrupatla(func, a, b, *, args=(), xatol=_xtol, xrtol=_rtol,
     func, a, b, args, xatol, xrtol, fatol, frtol, maxiter, callback = res
 
     # Initialization
-    xs, fs, shape, dtype = _scalar_optimization_initialize(func, (a, b), args)
+    xs, fs, args, shape, dtype = _scalar_optimization_initialize(func, (a, b),
+                                                                 args)
     x1, x2 = xs
     f1, f2 = fs
     status = np.full_like(x1, _EINPROGRESS, dtype=int)  # in progress
@@ -1687,6 +1688,7 @@ def _scalar_optimization_loop(work, callback, shape, maxiter,
     res_dict['nit'] = res_dict['nit'].astype(int)
     res_dict['nfev'] = res_dict['nfev'].astype(int)
     res = OptimizeResult(res_dict)
+    work.args = args
 
     active = _scalar_optimization_check_termination(
         work, res, res_work_pairs, active, check_termination)
@@ -1700,20 +1702,9 @@ def _scalar_optimization_loop(work, callback, shape, maxiter,
     while work.nit < maxiter and active.size and not cb_terminate:
         x = pre_func_eval(work)
 
-        # For now, we assume that `func` requires arguments of the original
-        # shapes. However, `x` is compressed (contains only active elements).
-        # Therefore, we inflate `x` by creating a full-size array, copying the
-        # elements of `x` into it, and making it the expected shape.
-        # TODO: allow user to specify that `func` works with compressed input
-        x_full = res.x.copy()
-        x_full[active] = x
-        x_full = x_full.reshape(shape)[()]
-        f = func(x_full, *args)
+        f = func(x, *work.args)
+        f = np.asarray(f, dtype=dtype).ravel()
         work.nfev += 1
-        # Ensure that the output of `func` is an array of the appropriate
-        # dtype, ravel it (because we work with 1D arrays for simplicity), and
-        # compress it to contain only active elements.
-        f = np.asarray(f, dtype=dtype).ravel()[active]
 
         post_func_eval(x, f, work)
 
@@ -1766,7 +1757,7 @@ def _chandrupatla_iv(func, a, b, args, xatol, xrtol,
 
 
 def _scalar_optimization_initialize(func, xs, args):
-    """Initialize abscissa and function arrays for elementwise function
+    """Initialize abscissa, function, and args arrays for elementwise function
 
     Parameters
     ----------
@@ -1776,7 +1767,8 @@ def _scalar_optimization_initialize(func, xs, args):
             func(x: ndarray, *args) -> ndarray
 
         where each element of ``x`` is a finite real and ``args`` is a tuple,
-        which may contain an arbitrary number of components of any type(s).
+        which may contain an arbitrary number of arrays that are broadcastable
+        with ``x``.
     xs : tuple of arrays
         Finite real abscissa arrays. Must be broadcastable.
     args : tuple, optional
@@ -1784,13 +1776,14 @@ def _scalar_optimization_initialize(func, xs, args):
 
     Returns
     -------
-    xs, fs : tuple of arrays
+    xs, fs, args : tuple of arrays
         Broadcasted, writeable, 1D abscissa and function value arrays (or
-        NumPy floats, if appropriate) of the appropriate dtype.
+        NumPy floats, if appropriate). The dtypes of the `xs` and `fs` are
+        `xfat`; the dtype of the `args` are unchanged.
     shape : tuple of ints
         Original shape of broadcasted arrays.
-    xft : NumPy dtype
-        Result dtype of abscissae and function values determined using
+    xfat : NumPy dtype
+        Result dtype of abscissae, function values, and args determined using
         `np.result_type`, except integer types are promoted to `np.float64`.
 
     Raises
@@ -1804,36 +1797,36 @@ def _scalar_optimization_initialize(func, xs, args):
     an elementwise callable, abscissae, and arguments; e.g.
     `scipy.optimize._chandrupatla`.
     """
+    nx = len(xs)
+
     # Try to preserve `dtype`, but we need to ensure that the arguments are at
-    # least floats before passing them into the function because integers
-    # can overflow and cause failure.
+    # least floats before passing them into the function; integers can overflow
+    # and cause failure.
     # There might be benefit to combining the `xs` into a single array and
     # calling `func` once on the combined array. For now, keep them separate.
-    xs = np.broadcast_arrays(*xs)  # broadcast and rename
-    xt = np.result_type(*[x.dtype for x in xs])
-    xt = np.float64 if np.issubdtype(xt, np.integer) else xt
-    xs = [x.astype(xt, copy=False)[()] for x in xs]
-    fs = [func(x, *args) for x in xs]
+    xas = np.broadcast_arrays(*xs, *args)  # broadcast and rename
+    xat = np.result_type(*[xa.dtype for xa in xas])
+    xat = np.float64 if np.issubdtype(xat, np.integer) else xat
+    xs, args = xas[:nx], xas[nx:]
+    xs = [x.astype(xat, copy=False)[()] for x in xs]
+    fs = [np.asarray(func(x, *args)) for x in xs]
+    shape = xs[0].shape
 
-    # It's possible that the functions will return multiple outputs for each
-    # scalar input, so we need to broadcast again. All arrays need to be,
-    # writable, so we'll need to copy after broadcasting. Finally, we're going
-    # to be doing operations involving `x1`, `x2`, `f1`, and `f2` throughout,
-    # so figure out the right type from the outset.
-    xfs = np.broadcast_arrays(*xs, *fs)
-    xft = np.result_type(*[xf.dtype for xf in xfs])
-    xft = np.float64 if np.issubdtype(xft, np.integer) else xft
-    if not np.issubdtype(xft, np.floating):
+    # These algorithms tend to mix the dtypes of the abscissae and function
+    # values, so figure out what the result will be and convert them all to
+    # that time from the outset.
+    xfat = np.result_type(*([f.dtype for f in fs] + [xat]))
+    if not np.issubdtype(xfat, np.floating):
         raise ValueError("Abscissae and function output must be real numbers.")
-    xfs = [xf.astype(xt, copy=True)[()] for xf in xfs]
-    xs, fs = xfs[:int(len(xfs)/2)], xfs[int(len(xfs)/2):]
+    xs = [x.astype(xfat, copy=True)[()] for x in xs]
+    fs = [f.astype(xfat, copy=True)[()] for f in fs]
 
     # To ensure that we can do indexing, we'll work with at least 1d arrays,
     # but remember the appropriate shape of the output.
-    shape = xs[0].shape
     xs = [x.ravel() for x in xs]
     fs = [f.ravel() for f in fs]
-    return xs, fs, shape, xft
+    args = [arg.flatten() for arg in args]
+    return xs, fs, args, shape, xfat
 
 
 def _scalar_optimization_check_termination(work, res, res_work_pairs, active,
@@ -1852,7 +1845,9 @@ def _scalar_optimization_check_termination(work, res, res_work_pairs, active,
         # compress the arrays to avoid unnecessary computation
         proceed = ~stop
         active = active[proceed]
-        _scalar_optimization_compress_work(work, proceed)
+        for key, val in work.items():
+            work[key] = val[proceed] if isinstance(val, np.ndarray) else val
+        work.args = [arg[proceed] for arg in work.args]
 
     return active
 
@@ -1889,9 +1884,3 @@ def _scalar_optimization_prepare_result(work, res, res_work_pairs, active,
         res[key] = np.reshape(val, shape)[()]
     res['_order_keys'] = ['success'] + [i for i, j in res_work_pairs]
     return OptimizeResult(**res)
-
-
-def _scalar_optimization_compress_work(work, mask):
-    # Compress the array elements of the work object; keep only masked elements
-    for key, val in work.items():
-        work[key] = val[mask] if np.size(val) > 1 else val

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1679,7 +1679,7 @@ def _scalar_optimization_loop(work, callback, shape, maxiter,
     cb_terminate = False
 
     # Initialize the result object and active element index array
-    n_elements = int(np.product(shape)) or 1
+    n_elements = int(np.prod(shape)) or 1
     active = np.arange(n_elements)  # in-progress element indices
     res_dict = {i: np.zeros(n_elements, dtype=dtype) for i, j in res_work_pairs}
     res_dict['success'] = np.zeros(n_elements, dtype=bool)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -442,7 +442,7 @@ class TestChandrupatla(TestScalarRootFinders):
         with pytest.raises(ValueError, match=message):
             zeros._chandrupatla(None, -4, 4)
 
-        message = 'Bracket and function output must be real numbers.'
+        message = 'Abscissae and function output must be real numbers.'
         with pytest.raises(ValueError, match=message):
             zeros._chandrupatla(lambda x: x, -4+1j, 4)
 


### PR DESCRIPTION
#### Reference issue
Followup to gh-17719

#### What does this implement/fix?
This refactors `optimize._chandrupatla` so that elements of the code can be reused by other vectorized scalar optimization algorithms. All the code specific to Chandrupatla's rootfinder is preserved in `_chandrupatla`, and (almost) all the algorithm-independent parts are factored out into more general functions.

The benefit is that other scalar minimization, rootfinding, and bracket-finding algorithms (maybe univariate integration like gh-18650?) can rely on common code to take care of details that are often handled inconsistently (dtype, function evaluation and iteration count, callback interface). Perhaps more importantly, takes care of an important bookkeeping task that avoids unnecessary work: eliminating elements that have already terminated. I've seen 300x speed improvements for vectorized rootfinding with NumPy arrays (https://github.com/scipy/scipy/pull/17719#issuecomment-1547778146), and this can easily be extended to take advantage of GPU arrays types once that infrastructure matures (see gh-18668).

#### Additional information
Todo:
- [x] Factor out algorithm-independent parts of `prepare_result`
- [x] Improve documentation; naming
- [ ] (After review) Move algorithm-independent parts to separate file
- [ ] ~~Add generic, property-based tests~~ (separate PR)