### PR TITLE
DOC: Add note connecting weibull_min to standard exponential.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2438,6 +2438,9 @@ class weibull_min_gen(rv_continuous):
     :math:`c=2` where Weibull distribution reduces to the `expon` and
     `rayleigh` distributions respectively.
 
+    Suppose ``X`` is a standard exponentially distributed random variable.
+    Then ``Y = X**k`` is `weibull_min` distributed with shape ``c = 1/k``.
+
     %(after_notes)s
 
     References

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2440,7 +2440,7 @@ class weibull_min_gen(rv_continuous):
 
     Suppose ``X`` is an exponentially distributed random variable with
     scale ``s``. Then ``Y = X**k`` is `weibull_min` distributed with shape
-    ``c = 1/k`` and scale `s**k`.
+    ``c = 1/k`` and scale ``s**k``.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2438,8 +2438,9 @@ class weibull_min_gen(rv_continuous):
     :math:`c=2` where Weibull distribution reduces to the `expon` and
     `rayleigh` distributions respectively.
 
-    Suppose ``X`` is a standard exponentially distributed random variable.
-    Then ``Y = X**k`` is `weibull_min` distributed with shape ``c = 1/k``.
+    Suppose ``X`` is an exponentially distributed random variable with
+    scale ``s``. Then ``Y = X**k`` is `weibull_min` distributed with shape
+    ``c = 1/k`` and scale `s**k`.
 
     %(after_notes)s
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Add note connecting weibull_min to standard exponential.

#### Additional information
Gives some intuition of Weibull minimum in terms of a well-known distribution, similar to the [note](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html) for the `lognorm` distribution.
