### PR TITLE
MAINT: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,12 +22,13 @@ meson*  @rgommers
 scipy/fft/*  @peterbell10
 scipy/fftpack/*  @peterbell10
 scipy/linalg/*  @larsoner @ilayn
+scipy/integrate/* @steppi
 scipy/interpolate/*  @ev-br
 scipy/optimize/*  @andyfaff
 scipy/signal/*  @larsoner @ilayn
 scipy/sparse/*  @perimosocordiae
 scipy/spatial/*  @tylerjereddy @peterbell10
-scipy/special/*  @person142
+scipy/special/*  @person142 @steppi
 scipy/stats/_distn_infrastructure  @andyfaff @ev-br
 scipy/stats/*distr*.py  @ev-br
 scipy/stats/_continuous_distns  @andyfaff


### PR DESCRIPTION
@tupui @mdhaber I missed gh-18045. I'd like to be added to CODEOWNERS for `special` and `integrate`. Currently, I mostly just review things I get pinged on, but I'd like to start taking a more active role in keeping on top of stuff for these two submodules.