### PR TITLE
TST: flaky TestSOSFreqz::test_fs_param

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1041,7 +1041,7 @@ class TestSOSFreqz:
         # N = None, whole=True
         w1, h1 = sosfreqz(sos, whole=True, fs=fs)
         w2, h2 = sosfreqz(sos, whole=True)
-        assert_allclose(h1, h2)
+        assert_allclose(h1, h2, atol=1e-27)
         assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False


### PR DESCRIPTION
* deals with the 1 of the 2 Apple silicon test failures in gh-18732

* I was able to reproduce locally, but because it was flaky I needed `pytest-repeat` for
consistent failure:
`CC=clang CXX=clang++ FC=gfortran-12 python dev.py test -t scipy/signal/tests/test_filter_design.py::TestSOSFreqz::test_fs_param -- --count=200`

* I verified that with the provided patch/`atol` bump, we consistently pass even with `2000` repeats

[skip circle]