### PR TITLE
TST: flaky `test_complex_iir_dlti`

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2658,7 +2658,7 @@ class TestDecimate:
         yzpref = signal.filtfilt(*signal.zpk2tf(z, p, k),
                                  u)[::2]
 
-        assert_equal(yzp, yzpref)
+        assert_allclose(yzp, yzpref, rtol=1e-10, atol=1e-13)
 
     def test_complex_fir_dlti(self):
         # centre frequency for filter [Hz]


### PR DESCRIPTION
* deals with the second part of gh-18732

* I was able to reproduce locally, but this one was even flakier--analysis of patch success below, and possibly related to subtle low-level MacOS ARM issues upstream in https://github.com/numpy/numpy/issues/23996 (NumPy `1.25.0`)

* before this patch, 4 trials of this command with `pytest-repeat`:
`CC=clang CXX=clang++ FC=gfortran-12 python dev.py test -t scipy/signal/tests/test_signaltools.py::TestDecimate::test_complex_iir_dlti -- --count=20000`
`81 failed, 19919 passed in 43.68s`
`81 failed, 19919 passed in 43.79s`
`20000 passed in 33.24s`
`43 failed, 19957 passed in 35.17s`

* after this patch, 6 trials of the same command:
`20000 passed in 30.44s`
`20000 passed in 33.08s`
`20000 passed in 33.46s`
`20000 passed in 33.45s`
`20000 passed in 33.56s`
`20000 passed in 33.30s`

[skip circle]