### PR TITLE
MAINT: more 1.11.0 backports

### DIFF
--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -414,7 +414,7 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (134)
+* Tyler Reddy (143)
 * Lucas Roberts (1)
 * Pamphile Roy (225)
 * Jordan Rupprecht (1) +
@@ -657,6 +657,7 @@ Issues closed for 1.11.0
 * `#18634 <https://github.com/scipy/scipy/issues/18634>`__: BUG: stats.truncnorm.moments yields error for moment order greater...
 * `#18654 <https://github.com/scipy/scipy/issues/18654>`__: BUG: ci/circleci: build_scipy broken
 * `#18675 <https://github.com/scipy/scipy/issues/18675>`__: BUG: \`signal.detrend\` on main no longer accepts a sequence...
+* `#18732 <https://github.com/scipy/scipy/issues/18732>`__: TST, MAINT: some tests blocking 1.11.0 on MacOS ARM64 with NumPy...
 
 ************************
 Pull requests for 1.11.0
@@ -1173,3 +1174,6 @@ Pull requests for 1.11.0
 * `#18676 <https://github.com/scipy/scipy/pull/18676>`__: BUG: signal: fix detrend with array-like bp
 * `#18697 <https://github.com/scipy/scipy/pull/18697>`__: MAINT: NumPy 1.25.0 shims for arm64
 * `#18698 <https://github.com/scipy/scipy/pull/18698>`__: DEP: interpolate: delay interp2d deprecation and update link
+* `#18724 <https://github.com/scipy/scipy/pull/18724>`__: MAINT, REL: prepare for SciPy 1.11.0 "final"
+* `#18737 <https://github.com/scipy/scipy/pull/18737>`__: TST: flaky TestSOSFreqz::test_fs_param
+* `#18738 <https://github.com/scipy/scipy/pull/18738>`__: TST: flaky \`test_complex_iir_dlti\`

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1041,7 +1041,7 @@ class TestSOSFreqz:
         # N = None, whole=True
         w1, h1 = sosfreqz(sos, whole=True, fs=fs)
         w2, h2 = sosfreqz(sos, whole=True)
-        assert_allclose(h1, h2)
+        assert_allclose(h1, h2, atol=1e-27)
         assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2658,7 +2658,7 @@ class TestDecimate:
         yzpref = signal.filtfilt(*signal.zpk2tf(z, p, k),
                                  u)[::2]
 
-        assert_equal(yzp, yzpref)
+        assert_allclose(yzp, yzpref, rtol=1e-10, atol=1e-13)
 
     def test_complex_fir_dlti(self):
         # centre frequency for filter [Hz]


### PR DESCRIPTION
There was a slight disruption in the `1.11.0` release process per gh-18732, so this backports two PRs to deal with that:

1. gh-18737
2. gh-18738

Release notes were updated accordingly.

Flushing the whole CI here is probably not necessary, but I'll allow it to happen since it is still cheaper in wallclock time than having the release process restarted and halted by a surprise later. Hopefully CI is happy enough though (a few known flakes we can ignore I think), and then I'll try to restart the release process today.