### PR TITLE
MAINT: forward port 1.11.0 relnotes

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.10.1 (stable)",
+        "name": "1.11.0 (stable)",
+        "version":"1.11.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.11.0/"
+    },
+    {
+        "name": "1.10.1",
         "version":"1.10.1",
         "url": "https://docs.scipy.org/doc/scipy-1.10.1/"
     },

--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.11.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.11.0 is not released yet!
-
 .. contents::
 
 SciPy 1.11.0 is the culmination of 6 months of hard work. It contains
@@ -26,11 +24,12 @@ For running on PyPy, PyPy3 6.0+ is required.
 Highlights of this release
 **************************
 
-- Several `scipy.sparse` array API improvements, including a new public base
-  class distinct from the older matrix class, proper 64-bit index support,
-  and numerous deprecations paving the way to a modern sparse array experience.
-- Added three new statistical distributions, and wide-ranging performance and
-  precision improvements to several other statistical distributions.
+- Several `scipy.sparse` array API improvements, including `sparse.sparray`, a new
+  public base class distinct from the older `sparse.spmatrix` class,
+  proper 64-bit index support, and numerous deprecations paving the way to a
+  modern sparse array experience.
+- `scipy.stats` added tools for survival analysis, multiple hypothesis testing,
+  sensitivity analysis, and working with censored data.
 - A new function was added for quasi-Monte Carlo integration, and linear
   algebra functions ``det`` and ``lu`` now accept nD-arrays.
 - An ``axes`` argument was added broadly to ``ndimage`` functions, facilitating
@@ -106,23 +105,20 @@ New features
 
 `scipy.sparse` improvements
 ===========================
-- `scipy.sparse` array (not matrix) classes now return a sparse array instead
-  of a dense array when divided by a dense array.
-- A new public base class `scipy.sparse.sparray` was introduced, allowing
+- A new public base class `scipy.sparse.sparray` was introduced, allowing further
+  extension of the sparse array API (such as the support for 1-dimensional
+  sparse arrays) without breaking backwards compatibility.
   `isinstance(x, scipy.sparse.sparray)` to select the new sparse array classes,
   while `isinstance(x, scipy.sparse.spmatrix)` selects only the old sparse
-  matrix types.
-- The behavior of `scipy.sparse.isspmatrix()` was updated to return True for
-  only the sparse matrix types. If you want to check for either sparse arrays
-  or sparse matrices, use `scipy.sparse.issparse()` instead. (Previously,
-  these had identical behavior.)
-- Sparse arrays constructed with 64-bit indices will no longer automatically
-  downcast to 32-bit.
-- A new `scipy.sparse.diags_array` function was added, which behaves like the
-  existing `scipy.sparse.diags` function except that it returns a sparse
-  array instead of a sparse matrix.
-- ``argmin`` and ``argmax`` methods now return the correct result when no
-  implicit zeros are present.
+  matrix classes.
+- Division of sparse arrays by a dense array now returns sparse arrays.
+- `scipy.sparse.isspmatrix` now only returns `True` for the sparse matrices instances.
+  `scipy.sparse.issparse` now has to be used instead to check for instances of sparse
+  arrays or instances of sparse matrices.
+- Sparse arrays constructed with int64 indices will no longer automatically
+  downcast to int32.
+- The ``argmin`` and ``argmax`` methods now return the correct result when explicit
+  zeros are present.
 
 `scipy.sparse.linalg` improvements
 ==================================
@@ -159,7 +155,7 @@ New Features
   experimental groups against the mean of a control group.
 - `scipy.stats.ecdf` for computing the empirical CDF and complementary
   CDF (survival function / SF) from uncensored or right-censored data. This
-  function is also useful for survival analysis / Kaplain-Meier estimation.
+  function is also useful for survival analysis / Kaplan-Meier estimation.
 - `scipy.stats.logrank` to compare survival functions underlying samples.
 - `scipy.stats.false_discovery_control` for adjusting p-values to control the
   false discovery rate of multiple hypothesis tests using the
@@ -170,7 +166,7 @@ New Features
 - Filliben's goodness of fit test as ``method='Filliben'`` of
   `scipy.stats.goodness_of_fit`.
 - `scipy.stats.ttest_ind` has a new method, ``confidence_interval`` for
-  computing confidence intervals.
+  computing a confidence interval of the difference between means.
 - `scipy.stats.MonteCarloMethod`, `scipy.stats.PermutationMethod`, and
   `scipy.stats.BootstrapMethod` are new classes to configure resampling and/or
   Monte Carlo versions of hypothesis tests. They can currently be used with
@@ -325,11 +321,12 @@ Authors
 
 * h-vetinari (69)
 * Oriol Abril-Pla (1) +
+* Tom Adamczewski (1) +
 * Anton Akhmerov (13)
 * Andrey Akinshin (1) +
 * alice (1) +
 * Oren Amsalem (1)
-* Ross Barnowski (11)
+* Ross Barnowski (13)
 * Christoph Baumgarten (2)
 * Dawson Beatty (1) +
 * Doron Behar (1) +
@@ -338,14 +335,15 @@ Authors
 * boeleman (1) +
 * Jack Borchanian (1) +
 * Matt Borland (3) +
-* Jake Bowhay (40)
+* Jake Bowhay (41)
+* Larry Bradley (1) +
 * Sienna Brent (1) +
 * Matthew Brett (1)
-* Evgeni Burovski (38)
+* Evgeni Burovski (39)
 * Matthias Bussonnier (2)
 * Maria Cann (1) +
 * Alfredo Carella (1) +
-* CJ Carey (18)
+* CJ Carey (34)
 * Hood Chatham (2)
 * Anirudh Dagar (3)
 * Alberto Defendi (1) +
@@ -364,45 +362,46 @@ Authors
 * Stefano Frazzetto (1) +
 * Neil Girdhar (1)
 * Caden Gobat (1) +
-* Ralf Gommers (146)
+* Ralf Gommers (153)
 * GonVas (1) +
 * Marco Gorelli (1)
 * Brett Graham (2) +
-* Matt Haberland (385)
+* Matt Haberland (388)
 * harshvardhan2707 (1) +
 * Alex Herbert (1) +
 * Guillaume Horel (1)
 * Geert-Jan Huizing (1) +
 * Jakob Jakobson (2)
-* Julien Jerphanion (5)
+* Julien Jerphanion (10)
 * jyuv (2)
 * Rajarshi Karmakar (1) +
 * Ganesh Kathiresan (3) +
 * Robert Kern (4)
-* Andrew Knyazev (3)
+* Andrew Knyazev (4)
 * Sergey Koposov (1)
 * Rishi Kulkarni (2) +
 * Eric Larson (1)
 * Zoufiné Lauer-Bare (2) +
 * Antony Lee (3)
 * Gregory R. Lee (8)
-* Guillaume Lemaitre (1) +
+* Guillaume Lemaitre (2) +
 * lilinjie (2) +
 * Yannis Linardos (1) +
 * Christian Lorentzen (5)
 * Loïc Estève (1)
+* Adam Lugowski (1) +
 * Charlie Marsh (2) +
 * Boris Martin (1) +
-* Nicholas McKibben (10)
-* Melissa Weber Mendonça (57)
+* Nicholas McKibben (11)
+* Melissa Weber Mendonça (58)
 * Michał Górny (1) +
-* Jarrod Millman (2)
+* Jarrod Millman (5)
 * Stefanie Molin (2) +
 * Mark W. Mueller (1) +
 * mustafacevik (1) +
 * Takumasa N (1) +
 * nboudrie (1)
-* Andrew Nelson (111)
+* Andrew Nelson (112)
 * Nico Schlömer (4)
 * Lysandros Nikolaou (2) +
 * Kyle Oman (1)
@@ -415,9 +414,9 @@ Authors
 * Ilhan Polat (32)
 * Quentin Barthélemy (1)
 * Matteo Raso (12) +
-* Tyler Reddy (97)
+* Tyler Reddy (143)
 * Lucas Roberts (1)
-* Pamphile Roy (224)
+* Pamphile Roy (225)
 * Jordan Rupprecht (1) +
 * Atsushi Sakai (11)
 * Omar Salman (7) +
@@ -426,10 +425,10 @@ Authors
 * Saumya (1) +
 * Daniel Schmitz (79)
 * Henry Schreiner (2) +
-* Dan Schult (3) +
+* Dan Schult (8) +
 * Eli Schwartz (6)
 * Tomer Sery (2) +
-* Scott Shambaugh (4) +
+* Scott Shambaugh (10) +
 * Gagandeep Singh (1)
 * Ethan Steinberg (6) +
 * stepeos (2) +
@@ -440,10 +439,10 @@ Authors
 * Tartopohm (2)
 * Logan Thomas (2) +
 * Jacopo Tissino (1) +
-* Matus Valo (10) +
+* Matus Valo (12) +
 * Jacob Vanderplas (2)
 * Christian Veenhuis (1) +
-* Isaac Virshup (1)
+* Isaac Virshup (3)
 * Stefan van der Walt (14)
 * Warren Weckesser (63)
 * windows-server-2003 (1)
@@ -455,7 +454,7 @@ Authors
 * Zaikun ZHANG (1) +
 * Alex Zverianskii (1) +
 
-A total of 131 people contributed to this release.
+A total of 134 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -649,7 +648,16 @@ Issues closed for 1.11.0
 * `#18497 <https://github.com/scipy/scipy/issues/18497>`__: MAINT, BUG: guard against non-finite kd-tree queries
 * `#18498 <https://github.com/scipy/scipy/issues/18498>`__: TST: interpolate overflow xslow tests (low priority)
 * `#18525 <https://github.com/scipy/scipy/issues/18525>`__: DOC: sparse doc build warning causing failure (including in CI)
+* `#18535 <https://github.com/scipy/scipy/issues/18535>`__: DOC: Dev branch docs render Dev TOC while viewing API Reference
 * `#18547 <https://github.com/scipy/scipy/issues/18547>`__: CI: occasionally failing test \`test_minimize_callback_copies_array[fmin]\`
+* `#18595 <https://github.com/scipy/scipy/issues/18595>`__: BUG: dev.py notes needs a small shim
+* `#18597 <https://github.com/scipy/scipy/issues/18597>`__: CI, BUG: Cirrus wheel upload fails on maintenance branch
+* `#18600 <https://github.com/scipy/scipy/issues/18600>`__: BUG: SciPy 1.11.0rc1 not buildable on PPC due to boost submodule
+* `#18632 <https://github.com/scipy/scipy/issues/18632>`__: 1.11.0rc1: remaining test failures in conda-forge
+* `#18634 <https://github.com/scipy/scipy/issues/18634>`__: BUG: stats.truncnorm.moments yields error for moment order greater...
+* `#18654 <https://github.com/scipy/scipy/issues/18654>`__: BUG: ci/circleci: build_scipy broken
+* `#18675 <https://github.com/scipy/scipy/issues/18675>`__: BUG: \`signal.detrend\` on main no longer accepts a sequence...
+* `#18732 <https://github.com/scipy/scipy/issues/18732>`__: TST, MAINT: some tests blocking 1.11.0 on MacOS ARM64 with NumPy...
 
 ************************
 Pull requests for 1.11.0
@@ -1146,5 +1154,26 @@ Pull requests for 1.11.0
 * `#18551 <https://github.com/scipy/scipy/pull/18551>`__: Replace sparse __getattr__ with properties
 * `#18553 <https://github.com/scipy/scipy/pull/18553>`__: BENCH: sparse: Add a benchmark for sparse matrix power
 * `#18554 <https://github.com/scipy/scipy/pull/18554>`__: BUG: sparse: Fix DIA.tocoo canonical format setting
+* `#18556 <https://github.com/scipy/scipy/pull/18556>`__: MAINT: io: replace isspmatrix with issparse in mmio module
 * `#18560 <https://github.com/scipy/scipy/pull/18560>`__: MAINT: integrate: revert\`full_output\` deprecation / result...
 * `#18562 <https://github.com/scipy/scipy/pull/18562>`__: fix doc strings for csr_array and friends
+* `#18563 <https://github.com/scipy/scipy/pull/18563>`__: DOC: SciPy 1.11.0 release notes
+* `#18591 <https://github.com/scipy/scipy/pull/18591>`__: MAINT: version bounds for 1.11.0rc1
+* `#18596 <https://github.com/scipy/scipy/pull/18596>`__: DOC: Fix sidebar for API reference pages
+* `#18598 <https://github.com/scipy/scipy/pull/18598>`__: CI: fix wheel upload to anaconda [wheel build]
+* `#18599 <https://github.com/scipy/scipy/pull/18599>`__: Revert "ENH: sparse: Add _array version of \`diags\` creation...
+* `#18608 <https://github.com/scipy/scipy/pull/18608>`__: Fix typo of module name in deprecation warning
+* `#18629 <https://github.com/scipy/scipy/pull/18629>`__: Mark \`void\` functions as \`noexcept\` in _rotation.pyx
+* `#18630 <https://github.com/scipy/scipy/pull/18630>`__: MAINT: stats: remove long double support for all boost ufuncs
+* `#18636 <https://github.com/scipy/scipy/pull/18636>`__: MAINT: stats.truncnorm/stats.betaprime: fix _munp for higher...
+* `#18657 <https://github.com/scipy/scipy/pull/18657>`__: MAINT: fix 'no such option' error in build_scipy CI
+* `#18658 <https://github.com/scipy/scipy/pull/18658>`__: TST: fix two test failures that showed up on conda-forge
+* `#18659 <https://github.com/scipy/scipy/pull/18659>`__: DOC: \`scipy._sensitivity_analysis\`: correct statement about...
+* `#18671 <https://github.com/scipy/scipy/pull/18671>`__: MAINT: backports for 1.11.0rc2
+* `#18672 <https://github.com/scipy/scipy/pull/18672>`__: BUG: small shim for release process
+* `#18676 <https://github.com/scipy/scipy/pull/18676>`__: BUG: signal: fix detrend with array-like bp
+* `#18697 <https://github.com/scipy/scipy/pull/18697>`__: MAINT: NumPy 1.25.0 shims for arm64
+* `#18698 <https://github.com/scipy/scipy/pull/18698>`__: DEP: interpolate: delay interp2d deprecation and update link
+* `#18724 <https://github.com/scipy/scipy/pull/18724>`__: MAINT, REL: prepare for SciPy 1.11.0 "final"
+* `#18737 <https://github.com/scipy/scipy/pull/18737>`__: TST: flaky TestSOSFreqz::test_fs_param
+* `#18738 <https://github.com/scipy/scipy/pull/18738>`__: TST: flaky \`test_complex_iir_dlti\`


### PR DESCRIPTION
* forward port `1.11.0` release notes following the final release this afternoon

* also adjust the version switcher in our docs to match new stable release