### PR TITLE
ENH: override isf for Burr distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1116,6 +1116,10 @@ class burr_gen(rv_continuous):
     def _ppf(self, q, c, d):
         return (q**(-1.0/d) - 1)**(-1.0/c)
 
+    def _isf(self, q, c, d):
+        _q = sc.xlog1py(-1.0 / d, -q)
+        return sc.expm1(_q) ** (-1.0 / c)
+
     def _stats(self, c, d):
         nc = np.arange(1, 5).reshape(4,1) / c
         # ek is the kth raw moment, e1 is the mean e2-e1**2 variance etc.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1303,6 +1303,9 @@ class fisk_gen(burr_gen):
     def _ppf(self, x, c):
         return burr._ppf(x, c, 1.0)
 
+    def _isf(self, q, c):
+        return burr._isf(q, c, 1.0)
+
     def _munp(self, n, c):
         return burr._munp(n, c, 1.0)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7109,6 +7109,21 @@ class TestBurr:
         assert_(np.isfinite(e3))
         assert_(np.isfinite(e4))
 
+    @pytest.mark.parametrize(
+        'q, expected',
+        [
+            (0.1, 1.9469686558286508),
+            (1e-10, 124.57309395989076),
+            (1e-20, 12457.309396155173),
+            (1e-40, 124573093.96155174),
+        ]
+    )
+    def test_burr_isf(self, q, expected):
+        c, d = 5.0, 3.0
+        assert_allclose(stats.burr.isf(q, c, d), expected, rtol=1e-14)
+
+
+
 
 class TestBurr12:
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7109,20 +7109,15 @@ class TestBurr:
         assert_(np.isfinite(e3))
         assert_(np.isfinite(e4))
 
-    @pytest.mark.parametrize(
-        'q, expected',
-        [
-            (0.1, 1.9469686558286508),
-            (1e-10, 124.57309395989076),
-            (1e-20, 12457.309396155173),
-            (1e-40, 124573093.96155174),
-        ]
-    )
-    def test_burr_isf(self, q, expected):
+    def test_burr_isf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 100
+        # Burr(c=c, d=d).sf(q).
         c, d = 5.0, 3.0
-        assert_allclose(stats.burr.isf(q, c, d), expected, rtol=1e-14)
-
-
+        q = [0.1, 1e-10, 1e-20, 1e-40]
+        ref = [1.9469686558286508, 124.57309395989076, 12457.309396155173,
+               124573093.96155174]
+        assert_allclose(stats.burr.isf(q, c, d), ref, rtol=1e-14)
 
 
 class TestBurr12:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7112,7 +7112,7 @@ class TestBurr:
     def test_burr_isf(self):
         # reference values were computed via the reference distribution, e.g.
         # mp.dps = 100
-        # Burr(c=c, d=d).sf(q).
+        # Burr(c=c, d=d).isf(q).
         c, d = 5.0, 3.0
         q = [0.1, 1e-10, 1e-20, 1e-40]
         ref = [1.9469686558286508, 124.57309395989076, 12457.309396155173,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7112,7 +7112,7 @@ class TestBurr:
     def test_burr_isf(self):
         # reference values were computed via the reference distribution, e.g.
         # mp.dps = 100
-        # Burr(c=c, d=d).isf(q).
+        # Burr(c=5, d=3).isf([0.1, 1e-10, 1e-20, 1e-40])
         c, d = 5.0, 3.0
         q = [0.1, 1e-10, 1e-20, 1e-40]
         ref = [1.9469686558286508, 124.57309395989076, 12457.309396155173,

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -320,6 +320,21 @@ class BetaPrime(ReferenceDistribution):
         return 1.0 - mp.betainc(a, b, 0, x/(1+x), regularized=True)
 
 
+class Burr(ReferenceDistribution):
+
+    def __init__(self, *, c, d):
+        super().__init__(c=c, d=d)
+
+    def _support(self, c, d):
+        return 0, mp.inf
+
+    def _pdf(self, x, c, d):
+        return c * d * x ** (-c - 1) * (1 + x ** (-c)) ** (-d - 1)
+
+    def _ppf(self, p, guess, c, d):
+        return (p**(-1.0/d) - 1)**(-1.0/c)
+
+
 class LogLaplace(ReferenceDistribution):
 
     def __init__(self, *, c):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Overrides and adds the inverse survival function of the Burr distribution in order to improve its precision
- Adds some tests.

#### Additional information
<!--Any additional information you think is important.-->
I still have to add the reference distribution if required.
CC: @mdhaber 