### PR TITLE
DOC: stats.boxcox_normmax: correct minimize -> maximize

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1134,7 +1134,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
             normally-distributed.
 
         'mle'
-            Minimizes the log-likelihood `boxcox_llf`.  This is the method used
+            Maximizes the log-likelihood `boxcox_llf`.  This is the method used
             in `boxcox`.
 
         'all'
@@ -1144,10 +1144,11 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         `optimizer` is a callable that accepts one argument:
 
         fun : callable
-            The objective function to be optimized. `fun` accepts one argument,
-            the Box-Cox transform parameter `lmbda`, and returns the negative
-            log-likelihood function at the provided value. The job of `optimizer`
-            is to find the value of `lmbda` that minimizes `fun`.
+            The objective function to be minimized. `fun` accepts one argument,
+            the Box-Cox transform parameter `lmbda`, and returns the value of
+            the function (e.g., the negative log-likelihood) at the provided
+            argument. The job of `optimizer` is to find the value of `lmbda`
+            that *minimizes* `fun`.
 
         and returns an object, such as an instance of
         `scipy.optimize.OptimizeResult`, which holds the optimal value of


### PR DESCRIPTION
#### Reference issue
Closes gh-18748

#### What does this implement/fix?
gh-18748 noted that `scipy.stats.boxcox_normmax` documentation states

> Minimizes the log-likelihood `boxcox_llf`.

but `boxcox_llf` is the (positive) log-likelihood function to be *maximized*, not minimized. This PR corrects the mistake.

Maximization of the log-likelihood function is accomplished by minimizing the negative log-likelihood:

https://github.com/scipy/scipy/blob/2e16ec5bc62b7b7db21b37b838fc771c7d232006/scipy/stats/_morestats.py#L1256-L1259

This PR clarifies this point in the documentation of the `optimizer` parameter.
