### PR TITLE
DOC: Document performance cliff for scipy.sparse.random

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -850,6 +850,18 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     """Generate a sparse matrix of the given shape and density with randomly
     distributed values.
 
+    .. warning::
+
+        Since numpy 1.17, passing ``np.random.Generator`` for ``random_state``
+        will lead to much faster execution times. For example:
+
+        >>> from scipy.sparse import random
+        >>> from numpy.random import default_rng
+        >>> random(100_000, 100_000, density=0.001, random_state=default_rng(0))
+
+        A much slower implementation is used by default for backwards
+        compatibility.
+
     Parameters
     ----------
     m, n : int

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -852,12 +852,9 @@ def random(m, n, density=0.01, format='coo', dtype=None,
 
     .. warning::
 
-        Since numpy 1.17, passing ``np.random.Generator`` for ``random_state``
-        will lead to much faster execution times. For example:
-
-        >>> from scipy.sparse import random
-        >>> from numpy.random import default_rng
-        >>> random(100_000, 100_000, density=0.001, random_state=default_rng(0))
+        Since numpy 1.17, passing a ``np.random.Generator`` (e.g.
+        ``np.random.default_rng`` for ``random_state`` will lead to much
+        faster execution times.
 
         A much slower implementation is used by default for backwards
         compatibility.
@@ -876,15 +873,16 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     random_state : {None, int, `numpy.random.Generator`,
                     `numpy.random.RandomState`}, optional
 
-        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-        singleton is used.
-        If `seed` is an int, a new ``RandomState`` instance is used,
-        seeded with `seed`.
-        If `seed` is already a ``Generator`` or ``RandomState`` instance then
-        that instance is used.
-        This random state will be used
-        for sampling the sparsity structure, but not necessarily for sampling
-        the values of the structurally nonzero entries of the matrix.
+        - If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+          singleton is used.
+        - If `seed` is an int, a new ``RandomState`` instance is used,
+          seeded with `seed`.
+        - If `seed` is already a ``Generator`` or ``RandomState`` instance then
+          that instance is used.
+
+        This random state will be used for sampling the sparsity structure, but
+        not necessarily for sampling the values of the structurally nonzero
+        entries of the matrix.
     data_rvs : callable, optional
         Samples a requested number of random values.
         This function should take a single argument specifying the length
@@ -898,16 +896,19 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     -------
     res : sparse matrix
 
-    Notes
-    -----
-    Only float types are supported for now.
-
     Examples
     --------
+
+    Passing a ``np.random.Generator`` instance for better performance:
+
     >>> from scipy.sparse import random
     >>> from scipy import stats
     >>> from numpy.random import default_rng
     >>> rng = default_rng()
+    >>> S = random(3, 4, density=0.25, random_state=rng)
+
+    Proving a sampler for the values:
+
     >>> rvs = stats.poisson(25, loc=10).rvs
     >>> S = random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
     >>> S.A
@@ -915,9 +916,9 @@ def random(m, n, density=0.01, format='coo', dtype=None,
            [  0.,   0.,   0.,   0.],
            [  0.,   0.,  36.,   0.]])
 
-    >>> from scipy.sparse import random
-    >>> from scipy.stats import rv_continuous
-    >>> class CustomDistribution(rv_continuous):
+    Using a custom distribution:
+
+    >>> class CustomDistribution(stats.rv_continuous):
     ...     def _rvs(self,  size=None, random_state=None):
     ...         return random_state.standard_normal(size)
     >>> X = CustomDistribution(seed=rng)
@@ -927,7 +928,6 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     array([[ 0.        ,  0.        ,  0.        ,  0.        ],   # random
            [ 0.13569738,  1.9467163 , -0.81205367,  0.        ],
            [ 0.        ,  0.        ,  0.        ,  0.        ]])
-
     """
     if density < 0 or density > 1:
         raise ValueError("density expected to be 0 <= density <= 1")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Documents current state of https://github.com/scipy/scipy/issues/9699

#### What does this implement/fix?

This documents that the default arguments for `sparse.random` perform poorly, and how to get much better performance.

#### Additional information

Example of performance:

```python
In [7]: %time result = sparse.random(100_000, 10000, density=0.01, random_state=np.random.default_rng())
CPU times: user 1.05 s, sys: 143 ms, total: 1.2 s
Wall time: 1.21 s

In [10]: %time result = sparse.random(100_000, 10000, density=0.01)
CPU times: user 1min 25s, sys: 2.43 s, total: 1min 27s
Wall time: 1min 27s
```
