### PR TITLE
ENH: override halfnorm fit

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4371,10 +4371,20 @@ class halfnorm_gen(rv_continuous):
         data, floc, fscale = _check_fit_input_parameters(self, data,
                                                          args, kwds)
 
-        loc = floc if floc is not None else np.min(data)
+        data_min = np.min(data)
 
-        scale = (fscale if fscale is not None 
-                 else stats.moment(data, moment=2, center=loc)**0.5)
+        if floc is not None:
+            if data_min < floc:
+                # There are values that are less than the specified loc.
+                raise FitDataError("halfnorm", lower=floc, upper=np.inf)
+            loc = floc
+        else:
+            loc = data_min
+
+        if fscale is not None:
+            scale = fscale
+        else:
+            scale = stats.moment(data, moment=2, center=loc)**0.5
 
         return loc, scale
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4362,6 +4362,25 @@ class halfnorm_gen(rv_continuous):
     def _entropy(self):
         return 0.5*np.log(np.pi/2.0)+0.5
 
+    @inherit_docstring_from(rv_continuous)
+    def fit(self, data, *args, **kwds):
+        if kwds.pop('superfit', False):
+            return super().fit(data, *args, **kwds)
+
+        data, floc, fscale = _check_fit_input_parameters(self, data,
+                                                         args, kwds)
+
+        loc = floc if floc is not None else np.min(data)
+
+        def find_scale(data, loc):
+            n_observations = data.shape[0]
+            scale = np.sqrt(np.sum((data - loc)**2) / n_observations)
+            return scale
+
+        scale = fscale if fscale is not None else find_scale(data, loc)
+
+        return loc, scale
+
 
 halfnorm = halfnorm_gen(a=0.0, name='halfnorm')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4362,6 +4362,7 @@ class halfnorm_gen(rv_continuous):
     def _entropy(self):
         return 0.5*np.log(np.pi/2.0)+0.5
 
+    @_call_super_mom
     @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
         if kwds.pop('superfit', False):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4373,12 +4373,8 @@ class halfnorm_gen(rv_continuous):
 
         loc = floc if floc is not None else np.min(data)
 
-        def find_scale(data, loc):
-            n_observations = data.shape[0]
-            scale = np.sqrt(np.sum((data - loc)**2) / n_observations)
-            return scale
-
-        scale = fscale if fscale is not None else find_scale(data, loc)
+        scale = (fscale if fscale is not None 
+                 else stats.moment(data, moment=2, center=loc)**0.5)
 
         return loc, scale
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1173,6 +1173,12 @@ class TestHalfNorm:
 
         _assert_less_or_close_loglike(stats.halfnorm, data, **kwds)
 
+    def test_fit_error(self):
+        # `floc` bigger than the minimal data point
+        with pytest.raises(FitDataError):
+            stats.halfnorm.fit([1, 2, 3], floc=2)
+
+
 class TestHalfLogistic:
     # survival function reference values were computed with mpmath
     # from mpmath import mp

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1156,7 +1156,7 @@ class TestHalfNorm:
 
         rng = np.random.default_rng(6762668991392531563)
         data = stats.halfnorm.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
-                                      random_state=rng)
+                                  random_state=rng)
 
         if fix_loc and fix_scale:
             error_msg = ("All parameters fixed. There is nothing to "

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1147,6 +1147,31 @@ class TestHalfNorm:
     def test_cdf(self, x, ref):
         assert_allclose(stats.halfnorm.cdf(x), ref, rtol=1e-15)
 
+    @pytest.mark.parametrize("rvs_loc", [1e-5, 1e10])
+    @pytest.mark.parametrize("rvs_scale", [1e-2, 100, 1e8])
+    @pytest.mark.parametrize('fix_loc', [True, False])
+    @pytest.mark.parametrize('fix_scale', [True, False])
+    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale,
+                                    fix_loc, fix_scale):
+
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.halfnorm.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
+                                      random_state=rng)
+
+        if fix_loc and fix_scale:
+            error_msg = ("All parameters fixed. There is nothing to "
+                         "optimize.")
+            with pytest.raises(RuntimeError, match=error_msg):
+                stats.halflogistic.fit(data, floc=rvs_loc, fscale=rvs_scale)
+            return
+
+        kwds = {}
+        if fix_loc:
+            kwds['floc'] = rvs_loc
+        if fix_scale:
+            kwds['fscale'] = rvs_scale
+
+        _assert_less_or_close_loglike(stats.halfnorm, data, **kwds)
 
 class TestHalfLogistic:
     # survival function reference values were computed with mpmath


### PR DESCRIPTION
#### Reference issue
Part of #17832 and #11782

#### What does this implement/fix?
Adds an analytical fitting method for the halfnormal distribution. This one is a low hanging fruit compared to most other distributions. The default fit method works but is slow compared to the simple analytical result.

#### Additional information
*Math*

$$ p(x|\mu,\sigma)=\frac{\sqrt{2}}{\sigma\sqrt{\pi}}\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right) $$

The log likelihood for the parameters $\mu$, $\sigma$ given data ($x_1,...,x_n$) is then

$$ \ln p(\mu,\sigma|x_1,...x_n)=n(1/2\ln(2)-1/2\ln(\pi)-\ln(\sigma))-\sum_i^n\frac{(x_i-\mu)^2}{2\sigma^2}$$

As $x>0$, this is is a monotonically increasing function for $\mu$. The maximum likelihood is reached for $\mu=x_{min}$ as for a higher $\mu$, the minimal value $x_{min}$ would be outside of the support of the distribution (similar to the halflogistic distribution in #18695).

Setting the gradient to zero yields the regular variance which depends on the location:

$$ 
\begin{align}
\frac{\partial\ln p}{\partial \sigma} &= -\frac{n}{\sigma}+\sum_{i=1}^n\frac{(x_i-\mu)^2}{\sigma^3}=0 \\
\sigma & = \sqrt{\frac{\sum_i(x_i-\mu)^2}{n}}
\end{align}
$$

*Fit results for free parameters*

<details><summary>Details</summary>
<p>

import numpy as np
from scipy import stats
from time import perf_counter
import matplotlib.pyplot as plt
import os

rng = np.random.default_rng(2433006235492611347)
qrng = stats.qmc.Halton(6, seed=rng)

N = 1000
times_pr = np.full(N, np.nan)
times_super = np.full(N, np.nan)
nllfs_super = np.full(N, np.nan)
nllfs_pr = np.full(N, np.nan)


distribution = stats.halfnorm

for i in range(N):
    print(i)
    sample = qrng.random()
    sample = stats.qmc.scale(sample, [-3, -3, -3, 1, -3, -1], [2, 3, 3, 5, 2, 1])[0]
    _, loc, scale, size, floc = 10**sample[:5]
    size = int(size)

    dist = distribution(loc=loc, scale=scale)
    rvs = dist.rvs(size=size, random_state=rng)

    try:
        tic = perf_counter()
        loc_fit, scale_fit = distribution.fit(rvs)
        toc = perf_counter()
        nllf_pr = distribution.nnlf((loc_fit, scale_fit), rvs)
        nllfs_pr[i] = nllf_pr
        times_pr[i] = toc-tic

    except Exception as e:
        print(f"Failure: {e}")

    try:
        tic = perf_counter()
        loc_fit, scale_fit = distribution.fit(rvs, superfit=True)
        toc = perf_counter()
        nllf_super = distribution.nnlf((loc_fit, scale_fit), rvs)
        nllfs_super[i] = nllf_super
        times_super[i] = toc-tic

    except Exception as e:
        print(f"Failure: {e}")

nllf_diff = (nllfs_pr - nllfs_super)/np.abs(nllfs_super)
nllf_diff = nllf_diff[np.isfinite(nllf_diff)]
nllf_diff_good = -nllf_diff[nllf_diff < 0]
nllf_diff_bad = nllf_diff[nllf_diff > 0]

bins = np.arange(-6, 1.5, 0.25)
plt.hist(np.log10(times_pr), bins=bins, alpha=0.5)
plt.hist(np.log10(times_super), bins=bins, alpha=0.5)
plt.legend(('PR', 'main'))
plt.xlabel('log10 of `fit` execution time (s)')
plt.ylabel('Frequency')
plt.title('Histogram of log10 of `fit` execution time (s), free')
plt.savefig("Time_free.png")

plt.clf()
plt.hist(np.log10(nllf_diff_good), label="good", alpha=0.5)
plt.hist(np.log10(nllf_diff_bad), label="bad", alpha=0.5)
plt.xlabel('log10 of NLLF differences')
plt.ylabel('Frequency')
plt.title('Histogram of log10 of NLLF differences, free')
plt.legend()
plt.savefig("NNLF_Differences_free.png")

</p>
</details> 

![Time_free](https://github.com/scipy/scipy/assets/40656107/5bdb526b-7b1a-4554-b08f-00ae1ddc1c5e)
![NNLF_Differences_free](https://github.com/scipy/scipy/assets/40656107/b9695c91-ae3d-4b72-bf10-6ed76674ce78)

*Fit results for fixed location*
![Time_fix_floc](https://github.com/scipy/scipy/assets/40656107/1fe55a57-aedb-4ce4-9124-96f71fd0744c)
![NNLF_Differences_fix_floc](https://github.com/scipy/scipy/assets/40656107/1de91d6e-2b44-4ada-b3a2-20ccab8dba9e)

*Fit results for fixed scale*
![Time_fscale_fix](https://github.com/scipy/scipy/assets/40656107/e750117b-6868-472a-bb2e-34da267df8d6)
![NNLF_Differences_fscale_fix](https://github.com/scipy/scipy/assets/40656107/a136dce7-af20-43f2-82d5-0a7d02d9a426)

