### PR TITLE
ENH: stats: add informative error message to `boxcox_normmax` for non-positive input

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1117,7 +1117,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
     Parameters
     ----------
-    x : array_like, all entries must be positive
+    x : array_like, all entries must be positive, finite, non-NaN
         Input array.
     brack : 2-tuple, optional, default (-2.0, 2.0)
          The starting interval for a downhill bracket search for the default

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1118,7 +1118,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     Parameters
     ----------
     x : array_like
-        Input array. All entries must be positive and finite.
+        Input array. All entries must be positive, finite, real numbers.
     brack : 2-tuple, optional, default (-2.0, 2.0)
          The starting interval for a downhill bracket search for the default
          `optimize.brent` solver. Note that this is in most cases not
@@ -1279,7 +1279,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     except ValueError as e:
         if "infs or NaNs" in str(e):
             message = ("The `x` argument of `boxcox_normmax` must contain "
-                       "only positive, finite values.")
+                       "only positive, finite, real numbers.")
             raise ValueError(message) from e
         else:
             raise e

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1285,8 +1285,8 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
     if res is None:
         message = (
-            "the `optimizer` argument of `boxcox_norm` must return an object "
-            "containing the optimal `lmbda` in attribute `x`"
+            "the `optimizer` argument of `boxcox_norm`, if passed, must "
+            "return an object containing the optimal `lmbda` in attribute `x`"
         )
         raise ValueError(message)
     return res

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1279,13 +1279,13 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     except ValueError as e:
         if "infs or NaNs" in e.args[0]:
             raise ValueError(
-                "the `x` argument of `boxcox_norm` must only contain values "
+                "the `x` argument of `boxcox_normmax` must only contain values"
                 " that are positive, finite, and non-NaN"
             )
 
     if res is None:
         message = (
-            "the `optimizer` argument of `boxcox_norm`, if passed, must "
+            "the `optimizer` argument of `boxcox_normmax`, if passed, must "
             "return an object containing the optimal `lmbda` in attribute `x`"
         )
         raise ValueError(message)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1117,7 +1117,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
     Parameters
     ----------
-    x : array_like
+    x : array_like, all entries must be positive
         Input array.
     brack : 2-tuple, optional, default (-2.0, 2.0)
          The starting interval for a downhill bracket search for the default
@@ -1273,10 +1273,21 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         raise ValueError("Method %s not recognized." % method)
 
     optimfunc = methods[method]
-    res = optimfunc(x)
+
+    try:
+        res = optimfunc(x)
+    except ValueError as e:
+        if "infs or NaNs" in e.args[0]:
+            raise ValueError(
+                "the `x` argument of `boxcox_norm` must only contain values "
+                " that are positive, finite, and non-NaN"
+            )
+
     if res is None:
-        message = ("`optimizer` must return an object containing the optimal "
-                   "`lmbda` in attribute `x`")
+        message = (
+            "the `optimizer` argument of `boxcox_norm` must return an object "
+            "containing the optimal `lmbda` in attribute `x`"
+        )
         raise ValueError(message)
     return res
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1282,6 +1282,8 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
                 "the `x` argument of `boxcox_normmax` must only contain values"
                 " that are positive, finite, and non-NaN"
             )
+        else:
+            raise e
 
     if res is None:
         message = (

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1117,8 +1117,8 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
     Parameters
     ----------
-    x : array_like, all entries must be positive, finite, non-NaN
-        Input array.
+    x : array_like
+        Input array. All entries must be positive and finite.
     brack : 2-tuple, optional, default (-2.0, 2.0)
          The starting interval for a downhill bracket search for the default
          `optimize.brent` solver. Note that this is in most cases not
@@ -1277,19 +1277,16 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     try:
         res = optimfunc(x)
     except ValueError as e:
-        if "infs or NaNs" in e.args[0]:
-            raise ValueError(
-                "the `x` argument of `boxcox_normmax` must only contain values"
-                " that are positive, finite, and non-NaN"
-            )
+        if "infs or NaNs" in str(e):
+            message = ("The `x` argument of `boxcox_normmax` must contain "
+                       "only positive, finite values.")
+            raise ValueError(message) from e
         else:
             raise e
 
     if res is None:
-        message = (
-            "the `optimizer` argument of `boxcox_normmax`, if passed, must "
-            "return an object containing the optimal `lmbda` in attribute `x`"
-        )
+        message = ("The `optimizer` argument of `boxcox_normmax` must return "
+                   "an object containing the optimal `lmbda` in attribute `x`.")
         raise ValueError(message)
     return res
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1972,7 +1972,7 @@ class TestBoxcox:
         )
     def test_negative_x_value_raises_error(self, bad_x):
         """Test boxcox_normmax raises ValueError if x contains non-positive values."""
-        message = "only positive, finite values"
+        message = "only positive, finite, real numbers"
         with pytest.raises(ValueError, match=message):
             stats.boxcox_normmax(bad_x)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1963,9 +1963,16 @@ class TestBoxcox:
         def optimizer(fun):
             return 1
 
-        message = "`optimizer` must return an object containing the optimal..."
+        message = "return an object containing the optimal `lmbda`"
         with pytest.raises(ValueError, match=message):
             stats.boxcox(_boxcox_data, lmbda=None, optimizer=optimizer)
+
+    @pytest.mark.parametrize("bad_x", [np.array([1, -42]), np.array([np.nan, 42])])
+    def test_negative_x_value_raises_error(self, bad_x):
+        """Test boxcox_normmax raises ValueError if x contains non-positive values."""
+        message = "positive, finite, and non-NaN"
+        with pytest.raises(ValueError, match=message):
+            stats.boxcox_normmax(bad_x, lmbda=None)
 
 
 class TestBoxcoxNormmax:
@@ -2553,7 +2560,7 @@ class TestMedianTest:
         assert_allclose(s, 0.31250000000000006)
         assert_allclose(p, 0.57615012203057869)
         assert_equal(m, 4.0)
-        assert_equal(t, np.array([[0, 2],[2, 1]]))
+        assert_equal(t, np.array([[0, 2], [2, 1]]))
         assert_raises(ValueError, stats.median_test, x, y, nan_policy='raise')
 
     def test_basic(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1967,7 +1967,9 @@ class TestBoxcox:
         with pytest.raises(ValueError, match=message):
             stats.boxcox(_boxcox_data, lmbda=None, optimizer=optimizer)
 
-    @pytest.mark.parametrize("bad_x", [np.array([1, -42]), np.array([np.nan, 42])])
+    @pytest.mark.parametrize(
+            "bad_x", [np.array([1, -42, 12345.6]), np.array([np.nan, 42, 1])]
+        )
     def test_negative_x_value_raises_error(self, bad_x):
         """Test boxcox_normmax raises ValueError if x contains non-positive values."""
         message = "positive, finite, and non-NaN"

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1972,7 +1972,7 @@ class TestBoxcox:
         """Test boxcox_normmax raises ValueError if x contains non-positive values."""
         message = "positive, finite, and non-NaN"
         with pytest.raises(ValueError, match=message):
-            stats.boxcox_normmax(bad_x, lmbda=None)
+            stats.boxcox_normmax(bad_x)
 
 
 class TestBoxcoxNormmax:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1972,7 +1972,7 @@ class TestBoxcox:
         )
     def test_negative_x_value_raises_error(self, bad_x):
         """Test boxcox_normmax raises ValueError if x contains non-positive values."""
-        message = "positive, finite, and non-NaN"
+        message = "only positive, finite values"
         with pytest.raises(ValueError, match=message):
             stats.boxcox_normmax(bad_x)
 


### PR DESCRIPTION
#### Reference issue
See https://github.com/scipy/scipy/issues/18761

#### What does this implement/fix?

improves input checks and exception handling of `boxcox_normmax`

* adds an informative error message if the `x` argument has non-positive, non-finite, or NaN values
* adds this as a requirement/assume to the docstring
* improves the existing error message where `optimizer` returns `None`
* adds a test for the `x` and modifies the test for `optimizer` to match the new message
