### PR TITLE
TST:sparse:Better test thread status

### DIFF
--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -706,7 +706,7 @@ class TestSplu:
                 self._internal_test_spilu_smoketest()
                 oks.append(True)
             except Exception:
-                pass
+                oks.append(False)
 
         threads = [threading.Thread(target=worker)
                    for k in range(20)]
@@ -715,7 +715,9 @@ class TestSplu:
         for t in threads:
             t.join()
 
-        assert_equal(len(oks), 20)
+        for t in threads:
+            assert t._started
+        assert all(oks)
 
 
 class TestSpsolveTriangular:


### PR DESCRIPTION
While I don't know why but one CI job is consistently getting errors about the thread test from SuperLU. This is a test PR for checking whether it is the start-up delay causing issues. In the meantime, added another method for start information.
