### PR TITLE
MAINT: SciPy 1.11.1 backports

### DIFF
--- a/doc/source/release/1.11.1-notes.rst
+++ b/doc/source/release/1.11.1-notes.rst
@@ -5,19 +5,39 @@ SciPy 1.11.1 Release Notes
 .. contents::
 
 SciPy 1.11.1 is a bug-fix release with no new features
-compared to 1.11.0.
-
+compared to 1.11.0. In particular, a licensing issue
+discovered after the release of 1.11.0 has been addressed.
 
 
 Authors
 =======
-* Name (commits)
 
+* Name (commits)
+* h-vetinari (1)
+* Robert Kern (1)
+* Ilhan Polat (4)
+* Tyler Reddy (8)
+
+A total of 4 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.11.1
 ------------------------
 
+* `#18739 <https://github.com/scipy/scipy/issues/18739>`__: BUG: run method of scipy.odr.ODR class fails when delta0 parameter...
+* `#18751 <https://github.com/scipy/scipy/issues/18751>`__: BUG: segfault in \`scipy.linalg.lu\` on x86_64 windows and macos...
+* `#18753 <https://github.com/scipy/scipy/issues/18753>`__: BUG: factorial return type inconsistent for 0-dim arrays
+* `#18759 <https://github.com/scipy/scipy/issues/18759>`__: determinant of a 1x1 matrix returns an array, not a scalar
+* `#18765 <https://github.com/scipy/scipy/issues/18765>`__: Licensing concern
 
 
 Pull requests for 1.11.1
 ------------------------
+
+* `#18741 <https://github.com/scipy/scipy/pull/18741>`__: BUG: Fix work array construction for various weight shapes.
+* `#18747 <https://github.com/scipy/scipy/pull/18747>`__: REL, MAINT: prep for 1.11.1
+* `#18754 <https://github.com/scipy/scipy/pull/18754>`__: BUG: fix handling for \`factorial(..., exact=False)\` for 0-dim...
+* `#18762 <https://github.com/scipy/scipy/pull/18762>`__: FIX:linalg.lu:Guard against permute_l out of bound behavior
+* `#18763 <https://github.com/scipy/scipy/pull/18763>`__: MAINT:linalg.det:Return scalars for singleton inputs
+* `#18778 <https://github.com/scipy/scipy/pull/18778>`__: MAINT: fix unuran licensing

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -932,6 +932,23 @@ class TestDet:
     def setup_method(self):
         self.rng = np.random.default_rng(1680305949878959)
 
+    def test_1x1_all_singleton_dims(self):
+        a = np.array([[1]])
+        deta = det(a)
+        assert deta.dtype.char == 'd'
+        assert np.isscalar(deta)
+        assert deta == 1.
+        a = np.array([[[[1]]]], dtype='f')
+        deta = det(a)
+        assert deta.dtype.char == 'd'
+        assert np.isscalar(deta)
+        assert deta == 1.
+        a = np.array([[[1 + 3.j]]], dtype=np.complex64)
+        deta = det(a)
+        assert deta.dtype.char == 'D'
+        assert np.isscalar(deta)
+        assert deta == 1.+3.j
+
     def test_1by1_stacked_input_output(self):
         a = self.rng.random([4, 5, 1, 1], dtype=np.float32)
         deta = det(a)

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -899,10 +899,16 @@ class ODR:
         elif len(self.data.we.shape) == 3:
             ld2we, ldwe = self.data.we.shape[1:]
         else:
-            # Okay, this isn't precisely right, but for this calculation,
-            # it's fine
+            we = self.data.we
             ldwe = 1
-            ld2we = self.data.we.shape[1]
+            ld2we = 1
+            if we.ndim == 1 and q == 1:
+                ldwe = n
+            elif we.ndim == 2:
+                if we.shape == (q, q):
+                    ld2we = q
+                elif we.shape == (q, n):
+                    ldwe = n
 
         if self.job % 10 < 2:
             # ODR not OLS

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2930,7 +2930,11 @@ def factorial(n, exact=False):
         return _exact_factorialx_array(n)
     # we do not raise for non-integers with exact=True due to
     # historical reasons, though deprecation would be possible
-    return _ufuncs._factorial(n)
+    res = _ufuncs._factorial(n)
+    if isinstance(n, np.ndarray):
+        # _ufuncs._factorial does not maintain 0-dim arrays
+        return np.array(res)
+    return res
 
 
 def factorial2(n, exact=False):

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -119,7 +119,6 @@ unuran_sources = [
   '../../_lib/unuran/unuran/src/specfunct/cephes_polevl.c',
   '../../_lib/unuran/unuran/src/specfunct/cgamma.c',
   '../../_lib/unuran/unuran/src/specfunct/hypot.c',
-  '../../_lib/unuran/unuran/src/specfunct/log1p.c',
   '../../_lib/unuran/unuran/src/tests/chi2test.c',
   '../../_lib/unuran/unuran/src/tests/correlation.c',
   '../../_lib/unuran/unuran/src/tests/countpdf.c',


### PR DESCRIPTION
This release is happening pretty quickly to deal with a licensing issue.

Backports included:

1. gh-18741
2. gh-18754
3. gh-18762
4. gh-18763
5. gh-18778

And updated release notes accordingly. The testsuite seems fine locally, didn't check doc build.