### PR TITLE
BUG: Allow johnsonsu parameters to be floats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5368,7 +5368,7 @@ class johnsonsu_gen(rv_continuous):
         # Numerical improvements left to future enhancements.
         mu, mu2, g1, g2 = None, None, None, None
 
-        bn2 = b**-2
+        bn2 = b**-2.
         expbn2 = np.exp(bn2)
         a_b = a / b
 


### PR DESCRIPTION

#### Reference issue
Closes gh-18782

#### What does this implement/fix?
This allows the second argument to johnsonsu to be an integer.

#### Additional information
This returns the behavior to what it was before #18096. Let me know if you'd like a test to watch for this sort of regression again.
