### PR TITLE
DOC: Fix broken link to installation guide in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ manipulate numbers on a computer and display or publish the results, give
 SciPy a try!
 
 For the installation instructions, see `our install
-guide <https://docs.scipy.org/doc/scipy/getting_started.html#installation>`__.
+guide <https://scipy.org/install/>`__.
 
 
 Call for Contributions


### PR DESCRIPTION
#### Reference issue
Addresses part 1/2 in #18788 

#### What does this implement/fix?
Fix the broken (outdated) link to the installation guide in the README.rst.

#### Additional information
[skip ci]