### PR TITLE
MAINT: fix `halflogistic.fit` for bad location guess

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4301,8 +4301,15 @@ class halflogistic_gen(rv_continuous):
             return scale
 
         # location is independent from the scale
-        # if not given, it is the minimum data point ([1] Equation 2.3)
-        loc = floc if floc is not None else np.min(data)
+        data_min = np.min(data)
+        if floc is not None:
+            if data_min < floc:
+                # There are values that are less than the specified loc.
+                raise FitDataError("halflogistic", lower=floc, upper=np.inf)
+            loc = floc
+        else:
+            # if not provided, location MLE is the minimal data point
+            loc = data_min
 
         # scale depends on location
         scale = fscale if fscale is not None else find_scale(data, loc)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1201,6 +1201,11 @@ class TestHalfLogistic:
 
         _assert_less_or_close_loglike(stats.halflogistic, data, **kwds)
 
+    def test_fit_bad_floc(self):
+        msg = r" Maximum likelihood estimation with 'halflogistic' requires"
+        with assert_raises(FitDataError, match=msg):
+            stats.halflogistic.fit([0, 2, 4], floc=1)
+
 
 class TestHalfgennorm:
     def test_expon(self):


### PR DESCRIPTION
#### What does this implement/fix?
The MLE of the location parameter for the halflogistic distribution is the minimal data point. If a user provides a location guess `floc` that is higher than the minimal data point, this point would be outside of the support of the fitted distribution. Instead, throw an error that this is an invalid parameter.

Followup of #18726 and related to #18760 .