### PR TITLE
BUG, DOC: Correct `adsurl` value and add a general `url` field in CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -18,6 +18,6 @@
   year    = {2020},
   volume  = {17},
   pages   = {261--272},
-  adsurl  = {https://rdcu.be/b08Wh},
+  adsurl  = {https://ui.adsabs.harvard.edu/abs/2020NatMe..17..261V},
   doi     = {10.1038/s41592-019-0686-2},
 }

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -18,6 +18,7 @@
   year    = {2020},
   volume  = {17},
   pages   = {261--272},
+  url     = {https://doi.org/10.1038/s41592-019-0686-2},
   adsurl  = {https://ui.adsabs.harvard.edu/abs/2020NatMe..17..261V},
   doi     = {10.1038/s41592-019-0686-2},
 }


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
The repository's CITATION.bib file currently defines a value for the `adsurl` key that is *not*, in fact, an [ADS](https://ui.adsabs.harvard.edu/) URL. The [rdcu.be](https://rdcu.be/) link that's currently there is not what LaTeX/BibTeX styles and formatters that look for and/or use entries' `adsurl` keyword expect to find, and it's not the intended/generally accepted use of the keyword either. This PR corrects that, and provides a link to the [publication's ADS page](https://ui.adsabs.harvard.edu/abs/2020NatMe..17..261V).

#### Additional information
NASA's ADS (Astrophysics Data System) is a widely-used resource in the physics and astronomy scientific community. It is the "industry-standard" tool for searching/browsing scholarly works in the field. Many LaTeX bibstyles, including [AASTeX](https://journals.aas.org/aastexguide/), [MNRAS](https://academic.oup.com/mnras/pages/general_instructions#2.1%20LaTeX), and [A&A](https://www.aanda.org/for-authors/latex-issues/texnical-background-information), give special treatment to the value associated with the `adsurl` keyword in BibTeX entries.