### PR TITLE
BLD: switch back to relative imports for Cython

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -289,8 +289,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install "Cython>=3.0.0b3"
-        python -m pip install ninja meson meson-python wheel click rich_click pydevtool
+        python -m pip install ninja meson meson-python wheel click rich_click pydevtool cython
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd
         # Use pytest-xdist<4.0 due to https://github.com/pytest-dev/pytest-cov/issues/557
@@ -357,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis && \
+        python -m pip install numpy==1.22.4 cython pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           # pyproject.toml currently states this numpy minimum version.
           python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-          python -m pip install "cython<3.0" numpy==1.22.4 pybind11 pythran pytest pooch hypothesis
+          python -m pip install cython numpy==1.22.4 pybind11 pythran pytest pooch hypothesis
 
       - name: Build
         run: |

--- a/meson.build
+++ b/meson.build
@@ -50,8 +50,8 @@ elif cc.get_id() == 'msvc'
           'when building with MSVC')
   endif
 endif
-if not cy.version().version_compare('>=0.29.35')
-  error('SciPy requires Cython >= 0.29.35')
+if not cy.version().version_compare('>=3.0.2')
+  error('SciPy requires Cython >= 3.0.2')
 endif
 
 _global_c_args = cc.get_supported_arguments(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.13.1",
-    "Cython>=0.29.35",  # when updating version, also update check in meson.build
+    "Cython>=3.0.2",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.12.0",
 

--- a/scipy/linalg.pxd
+++ b/scipy/linalg.pxd
@@ -1,1 +1,1 @@
-from scipy.linalg cimport cython_blas, cython_lapack
+from .linalg cimport cython_blas, cython_lapack

--- a/scipy/optimize/cython_optimize.pxd
+++ b/scipy/optimize/cython_optimize.pxd
@@ -7,5 +7,5 @@
 # support. Changing it causes an ABI forward-compatibility break
 # (gh-11793), so we currently leave it as is (no further cimport
 # statements should be used in this file).
-from scipy.optimize.cython_optimize._zeros cimport (
+from .cython_optimize._zeros cimport (
     brentq, brenth, ridder, bisect, zeros_full_output)

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -17,7 +17,6 @@ cy_opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
   depends : [_cython_tree,
-    cython_optimize_pxd,
     _dummy_init_optimize,
     _dummy_init_cyoptimize])
 

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -206,16 +206,10 @@ endif
 
 _dummy_init_optimize = fs.copyfile('__init__.py')
 
-# Copying this .pxd file is only needed because of a Cython bug, see
-# discussion on SciPy PR gh-18810.
-cython_optimize_pxd = [
-  fs.copyfile('cython_optimize.pxd'),
-]
-
 opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, cython_blas_pxd, cython_optimize_pxd, _dummy_init_optimize])
+  depends : [_cython_tree, cython_blas_pxd, _dummy_init_optimize])
 
 _bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
 

--- a/scipy/special.pxd
+++ b/scipy/special.pxd
@@ -1,1 +1,1 @@
-from scipy.special cimport cython_special
+from .special cimport cython_special


### PR DESCRIPTION
This got introduced as a work-around with [known](https://github.com/scipy/scipy/pull/18242#discussion_r1156510577) problems (see #18242 & #17234), and now became relevant again in #18792.

I don't expect this to pass, but wanted to see what's the status, resp. what's necessary to debug (on the cython side).