### PR TITLE
BUG: find_objects bool support

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -298,7 +298,7 @@ def find_objects(input, max_label=0):
            [0, 0, 1]])
 
     """
-    input = numpy.asarray(input)
+    input = numpy.asarray(input, dtype=int)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1390,3 +1390,10 @@ class TestWatershedIft:
         expected = [[1, 1],
                     [1, 1]]
         assert_array_almost_equal(out, expected)
+
+
+def test_gh_18780():
+    arr = np.array([[True, False, True]], dtype=bool)
+    result_bool = ndimage.find_objects(arr)
+    result_int = ndimage.find_objects(arr.astype(int))
+    assert result_bool == result_int


### PR DESCRIPTION
* Fixes #18780

* I added a regression test that reproduces when using our testsuite with NumPy `1.25.0` and SciPy `main` (the warning gets turned into an error by our development test suite)

* I haven't thought too much about the decision to support this more explicitly (i.e., with a test), but it sounds like we've been supporting it for a while and Stefan seems decisively in favor

* I'm pretty sure this will basically no-op for inputs that are the expected array type (no extra copy)

@stefanv is this what you're looking for? Important enough to backport? I don't really mind backporting if folks agree the deprecation warning is a sufficient nuisance I suppose. I've labelled this a bug, to match the issue, though that may be a bit harsh.