### PR TITLE
MAINT: Use `sparse.diags` instead of `spdiags` internally.

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -348,8 +348,8 @@ def eye(m, n=None, k=0, dtype=float, format=None):
             data = np.ones(n, dtype=dtype)
             return coo_matrix((data, (row, col)), (n, n))
 
-    diags = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
-    return spdiags(diags, k, m, n).asformat(format)
+    data = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
+    return diags(data, offsets=[k], shape=(m, n), dtype=dtype).asformat(format)
 
 
 def kron(A, B, format=None):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -255,10 +255,12 @@ class TestConstructUtils:
                     # arrays with negative diagonals. Therefore sp.sparse.eye
                     # validates that diagonal offsets fall within the shape of
                     # the array. See gh-18555.
-                    if abs(k) > m or k > n:
-                        pytest.raises(
+                    if (k > 0 and k > n) or (k < 0 and abs(k) > m):
+                        with pytest.raises(
                             ValueError, match="Offset.*out of bounds"
-                        )
+                        ):
+                            construct.eye(m, n, k=k)
+
                     else:
                         assert_equal(
                             construct.eye(m, n, k=k).toarray(),


### PR DESCRIPTION
Modifies `sparse.eye()` to use `sparse.diags` internally instead of `sparse.spdiags`. This modifies the behavior in the case where the diagonal offset(s) are greater than the maximum shape of the array. Previously, this would result in a sparse array with 0 stored elements and, in the case of the DIA format, negative values for the  diagonals:

```python
# Current behavior
In [1]: import scipy as sp

In [2]: a = sp.sparse.eye(3, 3, -5)

In [3]: a
Out[3]: 
<3x3 sparse matrix of type '<class 'numpy.float64'>'
        with -2 stored elements (1 diagonals) in DIAgonal format>

In [4]: a.toarray()
Out[4]: 
array([[0., 0., 0.],
       [0., 0., 0.],
       [0., 0., 0.]])
```

With this PR, this scenario will instead raise a `ValueError` indicating that the resulting array would be empty due to the offsets being OOB:

```
# This PR
In [1]: import scipy as sp

In [2]: a = sp.sparse.eye(3, 3, -5)
Traceback (most recent call last)
   ...
ValueError: Offset -5 (index 0) out of bounds
```

#### Reference issue
Closes #18555 

#### Additional information
This proposal is predicated on the assumption that users generally don't intend to create empty sparse arrays with `eye()`/`identity()`. However, if this extra input validation is not desired, then an alternative approach would be to call the `dia_array` constructor directly instead of using `spdiags`. This would maintain the current behavior while getting rid of the dis-recommended usage of `spdiags` internally.

Removing the internal usage of `spdiags` will reduce the amount of duplication necessary to add new sparse array creation functions (e.g. `eye_array`).