### PR TITLE
MAINT: `rv_discrete` should raise with duplicate `xk` in `values`

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3042,7 +3042,7 @@ class rv_discrete(rv_generic):
     values : tuple of two array_like, optional
         ``(xk, pk)`` where ``xk`` are integers and ``pk`` are the non-zero
         probabilities between 0 and 1 with ``sum(pk) = 1``. ``xk``
-        and ``pk`` must have the same shape.
+        and ``pk`` must have the same shape, and ``xk`` must be unique.
     inc : integer, optional
         Increment for the support of the distribution.
         Default is 1. (other values have not been tested)
@@ -3889,6 +3889,8 @@ class rv_sample(rv_discrete):
             raise ValueError("All elements of pk must be non-negative.")
         if not np.allclose(np.sum(pk), 1):
             raise ValueError("The sum of provided pk is not 1.")
+        if not len(set(np.ravel(xk))) == np.size(xk):
+            raise ValueError("xk may not contain duplicate values.")
 
         indx = np.argsort(np.ravel(xk))
         self.xk = np.take(np.ravel(xk), indx, 0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3520,6 +3520,10 @@ class TestRvDiscrete:
         pk = [0.3, 0.3, 0.3, 0.3, -0.2]
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
+        xk = [1, 1]
+        pk = [0.5, 0.5]
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
     def test_shape_rv_sample(self):
         # tests added for gh-9565
 


### PR DESCRIPTION
I believe `rv_discrete` should raise a `ValueError` when the `xk` in `values` contains duplicates. This PR adds this check and a test for it. Hopefully this is sensible.

At the moment the behavior depends on the order of the `xk`.


Old behavior:
```
>>> import numpy as np
>>> from scipy.stats import rv_discrete
>>> 
>>> dist = rv_discrete(values=((1, 1), (0.6, 0.4)))
>>> dist.pmf(1)
0.6
>>> dist = rv_discrete(values=((1, 1), (0.4, 0.6)))
>>> dist.pmf(1)
0.4
```

New behavior:
```
>>> import numpy as np
>>> from scipy.stats import rv_discrete
>>> dist = rv_discrete(values=((1, 1), (0.6, 0.4)))
ValueError("xk may not contain duplicate values.")
```

