### PR TITLE
BUG: Ensure cKDtree.query does not pass Pandas DataFrame to np.isfinite

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -791,7 +791,7 @@ cdef class cKDTree:
         if p < 1:
             raise ValueError("Only p-norms with 1<=p<=infinity permitted")
 
-        if not np.isfinite(x).all():
+        if not np.isfinite(x_arr).all():
             raise ValueError("'x' must be finite, check for nan or inf values")
 
         cdef:
@@ -944,7 +944,7 @@ cdef class cKDTree:
             const np.float64_t *vxx = <np.float64_t*>x_arr.data
             const np.float64_t *vrr = <np.float64_t*>r_arr.data
         
-        if not np.isfinite(x).all():
+        if not np.isfinite(x_arr).all():
             raise ValueError("'x' must be finite, check for nan or inf values")
 
         if rlen:


### PR DESCRIPTION

#### Reference issue
 Closes gh-18800

#### What does this implement/fix?
Pandas DataFrame does not always behave like an ndarray so we must
pass the coerced ndarray to np.isfinite.