### PR TITLE
BUG: Fix approx derivative types

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -566,7 +566,7 @@ def _linear_operator_difference(fun, x0, f0, h, method):
 def _dense_difference(fun, x0, f0, h, use_one_sided, method):
     m = f0.size
     n = x0.size
-    J_transposed = np.empty((n, m))
+    J_transposed = np.empty((n, m), dtype=f0.dtype)
     h_vecs = np.diag(h)
 
     for i in range(h.size):

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -221,6 +221,12 @@ class TestApproxDerivativesDense:
         xp = np.asarray(x).item()
         return math.exp(xp)
 
+    def fun_complex_value(self, x):
+        return x * (1 + 1j)
+
+    def jac_complex_value(self, x):
+        return 1 + 1j
+
     def test_scalar_scalar(self):
         x0 = 1.0
         jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
@@ -424,6 +430,13 @@ class TestApproxDerivativesDense:
         # math.exp cannot handle complex arguments, hence this raises
         assert_raises(TypeError, approx_derivative, self.jac_non_numpy, x0,
                       **dict(method='cs'))
+
+    def test_complex_value(self):
+        x0 = 0
+        jac_true = self.jac_complex_value(x0)
+        jac_diff = approx_derivative(
+            self.fun_complex_value, x0, method='2-point')
+        assert_allclose(jac_diff, jac_true, rtol=1e-6)
 
     def test_fp(self):
         # checks that approx_derivative works for FP size other than 64.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
This is a proposed solution to #18772

#### What does this implement/fix?
The approcimated gradient of a function will have the same output type as the function itself. In particular, a complex-valued function with real argument(s) will have a derivative/gradient that is also a complex-valued function of real argument(s).

#### Additional information
I have not managed to run the tests locally due to apparently conflicting dependencies in the environment.yml.
