### PR TITLE
ENH: remove unnecessary root-find from skewnorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9002,6 +9002,11 @@ class skewnorm_gen(rv_continuous):
         def skew_d(d):  # skewness in terms of delta
             return (4-np.pi)/2 * ((d * np.sqrt(2 / np.pi))**3
                                   / (1 - 2*d**2 / np.pi)**(3/2))
+        def d_skew(skew):  # delta in terms of skewness
+            s_23 = np.abs(skew)**(2/3)
+            return np.sign(skew) * np.sqrt(
+                np.pi/2 * s_23 / (s_23 + ((4 - np.pi)/2)**(2/3))
+            )
 
         # If skewness of data is greater than max possible population skewness,
         # MoM won't provide a good guess. Get out early.
@@ -9023,7 +9028,7 @@ class skewnorm_gen(rv_continuous):
             # Solve for a that matches sample distribution skewness to sample
             # skewness.
             s = np.clip(s, -s_max, s_max)
-            d = root_scalar(lambda d: skew_d(d) - s, bracket=[-1, 1]).root
+            d = d_skew(s)
             with np.errstate(divide='ignore'):
                 a = np.sqrt(np.divide(d**2, (1-d**2)))*np.sign(s)
         else:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3774,10 +3774,10 @@ class TestSkewNorm:
         # test that MLE and MoM behave as expected under sign changes
         a6p, loc6p, scale6p = stats.skewnorm.fit(rvs, method='mle')
         a6m, loc6m, scale6m = stats.skewnorm.fit(-rvs, method='mle')
-        assert_allclose([-a6p, -loc6p, scale6p], [a6m, loc6m, scale6m])
+        assert_allclose([a6m, loc6m, scale6m], [-a6p, -loc6p, scale6p])
         a7p, loc7p, scale7p = stats.skewnorm.fit(rvs, method='mm')
         a7m, loc7m, scale7m = stats.skewnorm.fit(-rvs, method='mm')
-        assert_allclose([-a7p, -loc7p, scale7p], [a7m, loc7m, scale7m])
+        assert_allclose([a7m, loc7m, scale7m], [-a7p, -loc7p, scale7p])
 
 class TestExpon:
     def test_zero(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3755,22 +3755,29 @@ class TestSkewNorm:
         assert_allclose(res, ref)
 
         # Test behavior when skew of data is beyond maximum of skewnorm
-        rvs = stats.pareto.rvs(1, size=100, random_state=rng)
+        rvs2 = stats.pareto.rvs(1, size=100, random_state=rng)
 
         # MLE still works
-        res = stats.skewnorm.fit(rvs)
+        res = stats.skewnorm.fit(rvs2)
         assert np.all(np.isfinite(res))
 
         # MoM fits variance and skewness
-        a5, loc5, scale5 = stats.skewnorm.fit(rvs, method='mm')
+        a5, loc5, scale5 = stats.skewnorm.fit(rvs2, method='mm')
         assert np.isinf(a5)
         # distribution infrastruction doesn't allow infinite shape parameters
         # into _stats; it just bypasses it and produces NaNs. Calculate
         # moments manually.
-        m, v = np.mean(rvs), np.var(rvs)
+        m, v = np.mean(rvs2), np.var(rvs2)
         assert_allclose(m, loc5 + scale5 * np.sqrt(2/np.pi))
         assert_allclose(v, scale5**2 * (1 - 2 / np.pi))
 
+        # test that MLE and MoM behave as expected under sign changes
+        a6p, loc6p, scale6p = stats.skewnorm.fit(rvs, method='mle')
+        a6m, loc6m, scale6m = stats.skewnorm.fit(-rvs, method='mle')
+        assert_allclose([-a6p, -loc6p, scale6p], [a6m, loc6m, scale6m])
+        a7p, loc7p, scale7p = stats.skewnorm.fit(rvs, method='mm')
+        a7m, loc7m, scale7m = stats.skewnorm.fit(-rvs, method='mm')
+        assert_allclose([-a7p, -loc7p, scale7p], [a7m, loc7m, scale7m])
 
 class TestExpon:
     def test_zero(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Previously the `skew_d` function was inverted using `root_scalar`. However, there is a simple closed-form inverse, so use that instead.

#### Additional information
Reference for inverse function:
<https://en.wikipedia.org/wiki/Skew_normal_distribution#Estimation>

To demonstrate that the inverse function is correct:
```python
np.array_equal(d_skew([-s_max,s_max]), [-1, 1])
np.array_equal(d_skew(np.array([-s_max,s_max])), [-1, 1])

d_vals = np.linspace(-1, 1, 100)
s_vals = np.linspace(-s_max, s_max, 100)
assert_almost_equal(d_vals, d_skew(skew_d(d_vals)), decimal=15)
assert_almost_equal(s_vals, skew_d(d_skew(s_vals)), decimal=15)
```
I'm not sure how I could currently turn these into unit tests as the functions are only defined within the `skewnorm.fit` scope. If desired I could refactor them to be top-level in `scipy.stats._continuous_distns` and add these as tests.

The performance improvement is not as dramatic as I expected:
```python
from scipy.stats import skewnorm

# before
%timeit skewnorm.fit([1,2,3,3,4,4,4,5], method="mm")
673 µs ± 18.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# after
%timeit skewnorm.fit([1,2,3,3,4,4,4,5], method="mm")
616 µs ± 10.1 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
This is because the most expensive call is `s = stats.skew(data)`, while `root_scalar` is actually quite fast.