### PR TITLE
CI, MAINT: 32-bit Pillow pin

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -356,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
+        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"


### PR DESCRIPTION
* Pillow `10.0.0` was released July 1st, and probably changed its support policy for 32-bit Linux; I've pinned it to prevent from-source builds of Pillow failing for that CI job (we're seeing the progressive loss of support for 32-bit Linux I suppose, but this keeps it going a bit more perhaps)

* example recent failure: https://github.com/scipy/scipy/actions/runs/5437672719/jobs/9888394396?pr=18808

[skip cirrus] [skip circle]