### PR TITLE
BLD: copy `cython_optimize.pxd` to build dir

### DIFF
--- a/scipy/optimize/cython_optimize.pxd
+++ b/scipy/optimize/cython_optimize.pxd
@@ -7,5 +7,5 @@
 # support. Changing it causes an ABI forward-compatibility break
 # (gh-11793), so we currently leave it as is (no further cimport
 # statements should be used in this file).
-from .cython_optimize._zeros cimport (
+from scipy.optimize.cython_optimize._zeros cimport (
     brentq, brenth, ridder, bisect, zeros_full_output)

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -17,6 +17,7 @@ cy_opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
   depends : [_cython_tree,
+    cython_optimize_pxd,
     _dummy_init_optimize,
     _dummy_init_cyoptimize])
 

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -206,14 +206,16 @@ endif
 
 _dummy_init_optimize = fs.copyfile('__init__.py')
 
-_cython_tree = [
+# Copying this .pxd file is only needed because of a Cython bug, see
+# discussion on SciPy PR gh-18810.
+cython_optimize_pxd = [
   fs.copyfile('cython_optimize.pxd'),
 ]
 
 opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, cython_blas_pxd, _dummy_init_optimize])
+  depends : [_cython_tree, cython_blas_pxd, cython_optimize_pxd, _dummy_init_optimize])
 
 _bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
 

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -206,6 +206,10 @@ endif
 
 _dummy_init_optimize = fs.copyfile('__init__.py')
 
+_cython_tree = [
+  fs.copyfile('cython_optimize.pxd'),
+]
+
 opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #18792

#### What does this implement/fix?

This PR adds forgotten parameter in `meson.build`. Other files seems to have similar params e.g. 

https://github.com/scipy/scipy/blob/8501b7c2fb8a7121aeef94489ece988043c463d0/scipy/meson.build#L243-L248

#### Additional information

Missing parameter causes that file `scipy/optimize/cython_optimize.pxd` is not copied into build dir and hence not picked by build system during build. But in case when scipy is already installed in virtual env., Cython is using `cython_optimize.pxd` from venv instead of from the source code.

This PR also fixes `cython_optimize.pxd` to be compilable in Cython 3 similar to PR #18242