### PR TITLE
DEP: linalg: sharpen deprecation warning for pinv {,r}cond

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1443,7 +1443,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
     # backwards compatible only atol and rtol are both missing
     if ((rcond not in (_NoValue, None) or cond not in (_NoValue, None))
-         and (atol is None) and (rtol is None)):
+            and (atol is None) and (rtol is None)):
         atol = rcond if rcond not in (_NoValue, None) else cond
         rtol = 0.
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1361,7 +1361,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
         .. deprecated:: 1.7.0
             Deprecated in favor of ``rtol`` and ``atol`` parameters above and
-            will be removed in SciPy 1.14.0.
+            will be removed in SciPy 1.13.0.
 
         .. versionchanged:: 1.3.0
             Previously the default cutoff value was just ``eps*f`` where ``f``
@@ -1438,7 +1438,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
     if rcond is not _NoValue or cond is not _NoValue:
         warn('Use of the "cond" and "rcond" keywords are deprecated and '
-             'will be removed in SciPy 1.14.0. Use "atol" and '
+             'will be removed in SciPy 1.13.0. Use "atol" and '
              '"rtol" keywords instead', DeprecationWarning, stacklevel=2)
 
     # backwards compatible only atol and rtol are both missing

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1442,9 +1442,9 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
              '"rtol" keywords instead', DeprecationWarning, stacklevel=2)
 
     # backwards compatible only atol and rtol are both missing
-    if ((rcond is not _NoValue or cond is not _NoValue)
-        and (atol is None) and (rtol is None)):
-        atol = rcond if rcond is not _NoValue else cond
+    if ((rcond not in (_NoValue, None) or cond not in (_NoValue, None))
+         and (atol is None) and (rtol is None)):
+        atol = rcond if rcond not in (_NoValue, None) else cond
         rtol = 0.
 
     atol = 0. if atol is None else atol

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -14,6 +14,7 @@ from ._decomp import _asarray_validated
 from . import _decomp, _decomp_svd
 from ._solve_toeplitz import levinson
 from ._cythonized_array_utils import find_det_from_lu
+from scipy._lib.deprecation import _NoValue
 
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
            'solve_toeplitz', 'solve_circulant', 'inv', 'det', 'lstsq',
@@ -1317,7 +1318,7 @@ lstsq.default_lapack_driver = 'gelsd'
 
 
 def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
-         cond=None, rcond=None):
+         cond=_NoValue, rcond=_NoValue):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
@@ -1358,9 +1359,9 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
         the tolerances above are recommended instead. In fact, if provided,
         atol, rtol takes precedence over these keywords.
 
-        .. versionchanged:: 1.7.0
+        .. deprecated:: 1.7.0
             Deprecated in favor of ``rtol`` and ``atol`` parameters above and
-            will be removed in future versions of SciPy.
+            will be removed in SciPy 1.14.0.
 
         .. versionchanged:: 1.3.0
             Previously the default cutoff value was just ``eps*f`` where ``f``
@@ -1435,14 +1436,15 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
     t = u.dtype.char.lower()
     maxS = np.max(s)
 
-    if rcond or cond:
+    if rcond is not _NoValue or cond is not _NoValue:
         warn('Use of the "cond" and "rcond" keywords are deprecated and '
-             'will be removed in future versions of SciPy. Use "atol" and '
+             'will be removed in SciPy 1.14.0. Use "atol" and '
              '"rtol" keywords instead', DeprecationWarning, stacklevel=2)
 
     # backwards compatible only atol and rtol are both missing
-    if (rcond or cond) and (atol is None) and (rtol is None):
-        atol = rcond or cond
+    if ((rcond is not _NoValue or cond is not _NoValue)
+        and (atol is None) and (rtol is None)):
+        atol = rcond if rcond is not _NoValue else cond
         rtol = 0.
 
     atol = 0. if atol is None else atol

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1440,6 +1440,12 @@ class TestPinv:
         adiff2 = a_m @ a_p @ a_m - a_m
         assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
         assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
+    
+    def test_deprecation(self):
+        with pytest.deprecated_call(match='"cond" and "rcond"'):
+            pinv(np.ones((2,2)), cond=1)
+        with pytest.deprecated_call(match='"cond" and "rcond"'):
+            pinv(np.ones((2,2)), rcond=1)
 
 
 class TestPinvSymmetric:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1446,8 +1446,10 @@ class TestPinv:
     @pytest.mark.parametrize("rcond", [1, None, _NoValue])
     def test_deprecation(self, cond, rcond):
         if cond is _NoValue and rcond is _NoValue:
+            # the defaults if cond/rcond aren't set -> no warning
             pinv(np.ones((2,2)), cond=cond, rcond=rcond)
         else:
+            # at least one of cond/rcond has a user-supplied value -> warn
             with pytest.deprecated_call(match='"cond" and "rcond"'):
                 pinv(np.ones((2,2)), cond=cond, rcond=rcond)
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1442,11 +1442,14 @@ class TestPinv:
         assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
         assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
 
-    @pytest.mark.parametrize(["cond", "rcond"],
-                             [(1, 1), (1, _NoValue), (_NoValue, 1)])
+    @pytest.mark.parametrize("cond", [1, None, _NoValue])
+    @pytest.mark.parametrize("rcond", [1, None, _NoValue])
     def test_deprecation(self, cond, rcond):
-        with pytest.deprecated_call(match='"cond" and "rcond"'):
+        if cond is _NoValue and rcond is _NoValue:
             pinv(np.ones((2,2)), cond=cond, rcond=rcond)
+        else:
+            with pytest.deprecated_call(match='"cond" and "rcond"'):
+                pinv(np.ones((2,2)), cond=cond, rcond=rcond)
 
 
 class TestPinvSymmetric:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -20,6 +20,7 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinvh, norm,
 from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory, IS_MUSL
 from scipy.linalg.blas import HAS_ILP64
+from scipy._lib.deprecation import _NoValue
 
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
@@ -1440,12 +1441,12 @@ class TestPinv:
         adiff2 = a_m @ a_p @ a_m - a_m
         assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
         assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
-    
-    def test_deprecation(self):
+
+    @pytest.mark.parametrize(["cond", "rcond"],
+                             [(1, 1), (1, _NoValue), (_NoValue, 1)])
+    def test_deprecation(self, cond, rcond):
         with pytest.deprecated_call(match='"cond" and "rcond"'):
-            pinv(np.ones((2,2)), cond=1)
-        with pytest.deprecated_call(match='"cond" and "rcond"'):
-            pinv(np.ones((2,2)), rcond=1)
+            pinv(np.ones((2,2)), cond=cond, rcond=rcond)
 
 
 class TestPinvSymmetric:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Adds a specific version for removing `cond`/`rcond` and, whilst unlikely to be needed as the arguments are at the end of the signature, uses `_NoValue` to trigger the deprecation warning instead of `None`. Also adds a test which checks the deprecation warning is emitted.

#### Additional information
<!--Any additional information you think is important.-->
