### PR TITLE
DOC: update windows instructions and move conda/mamba

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -287,6 +287,14 @@ virtual environments:
 
 .. tab-set::
 
+  .. tab-item:: Conda env
+
+    To create a ``scipy-dev`` development environment with every required and
+    optional dependency installed, run::
+
+        mamba env create -f environment.yml
+        mamba activate scipy-dev
+
   .. tab-item:: Virtual env or system Python
 
     .. note::
@@ -319,14 +327,6 @@ virtual environments:
 
        # Dev dependencies (static typing and linting)
        python -m pip mypy typing_extensions types-psutil pycodestyle ruff cython-lint
-
-  .. tab-item:: Conda env
-
-    To create a ``scipy-dev`` development environment with every required and
-    optional dependency installed, run::
-
-        mamba env create -f environment.yml
-        mamba activate scipy-dev
 
 To build SciPy in an activated development environment, run::
 

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -203,12 +203,26 @@ your system.
         invoking a Fortran compiler in the shell you use (e.g., ``gfortran
         --version`` or ``ifort --version``).
 
+  .. warning::
+
+       When using a conda environment it is possible that the environment
+       creation will not work due to an outdated Fortran compiler. If that
+       happens, remove the ``compilers`` entry from ``environment.yml`` and
+       try again. The Fortran compiler should be installed as described in
+       this section.
+
 
 Building SciPy from source
 --------------------------
 
 If you want to only install SciPy from source once and not do any development
-work, then the recommended way to build and install is to use ``pip``:
+work, then the recommended way to build and install is to use ``pip``.
+Otherwise, conda is recommended.
+
+.. note::
+
+    If you don't have a conda installation yet, we recommend using
+    Mambaforge_; any conda flavor will work though.
 
 .. tab-set::
 
@@ -308,22 +322,11 @@ virtual environments:
 
   .. tab-item:: Conda env
 
-    If you don't have a conda installation yet, we recommend using
-    Mambaforge_; any conda flavor will work though.
-
     To create a ``scipy-dev`` development environment with every required and
     optional dependency installed, run::
 
         mamba env create -f environment.yml
         mamba activate scipy-dev
-
-    .. note::
-
-       On Windows it is possible that the environment creation will not work due
-       to an outdated Fortran compiler. If that happens, remove the ``compilers``
-       entry from ``environment.yml`` and try again. The Fortran compiler should
-       be installed as described under the *Windows* tab of the *System-level
-       dependencies* section higher up.
 
 To build SciPy in an activated development environment, run::
 

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -224,6 +224,9 @@ Otherwise, conda is recommended.
     If you don't have a conda installation yet, we recommend using
     Mambaforge_; any conda flavor will work though.
 
+Building from source to use SciPy
+`````````````````````````````````
+
 .. tab-set::
 
   .. tab-item:: Conda env

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -203,13 +203,13 @@ your system.
         invoking a Fortran compiler in the shell you use (e.g., ``gfortran
         --version`` or ``ifort --version``).
 
-  .. warning::
+    .. warning::
 
-       When using a conda environment it is possible that the environment
-       creation will not work due to an outdated Fortran compiler. If that
-       happens, remove the ``compilers`` entry from ``environment.yml`` and
-       try again. The Fortran compiler should be installed as described in
-       this section.
+        When using a conda environment it is possible that the environment
+        creation will not work due to an outdated Fortran compiler. If that
+        happens, remove the ``compilers`` entry from ``environment.yml`` and
+        try again. The Fortran compiler should be installed as described in
+        this section.
 
 
 Building SciPy from source

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,15 @@
+# Please refer to https://scipy.github.io/devdocs/building/index.html
 # To use:
 #   $ conda env create -f environment.yml  # `mamba` works too for this command
 #   $ conda activate scipy-dev
 #
-# Also used to build the `scipy-dev` Docker image via GitHub Actions
 name: scipy-dev
 channels:
   - conda-forge
 dependencies:
   - python
   - cython
-  - compilers # Currently unavailable for Windows. Comment out this line and download Rtools and add <path>\ucrt64\bin\ to your path: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
+  - compilers  # Currently unavailable for Windows. Comment out this line and download Rtools and add <path>\ucrt64\bin\ to your path: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
   - meson
   - meson-python
   - ninja
@@ -20,6 +20,7 @@ dependencies:
   - pybind11
   # scipy.datasets dependency
   - pooch
+  # ---
   - pythran
   # For testing and benchmarking
   - pytest


### PR DESCRIPTION
Relates to #18806

This makes the instructions gotcha about building conda env on Windows more visible and move the note about mamba up too.