### PR TITLE
ENH:stats: Add _isf method to loglaplace

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6143,6 +6143,9 @@ class loglaplace_gen(rv_continuous):
     def _ppf(self, q, c):
         return np.where(q < 0.5, (2.0*q)**(1.0/c), (2*(1.0-q))**(-1.0/c))
 
+    def _isf(self, q, c):
+        return np.where(q > 0.5, (2.0*(1.0 - q))**(1.0/c), (2*q)**(-1.0/c))
+
     def _munp(self, n, c):
         return c**2 / (c**2 - n**2)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3024,6 +3024,15 @@ class TestLogLaplace:
         ref = [0.99999999995, 5e-31, 5e-76]
         assert_allclose(stats.loglaplace.sf(x, c), ref, rtol=1e-15)
 
+    def test_isf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 100; LogLaplace(c=c).isf(q).
+        c = 3.25
+        q = [0.8, 0.1, 1e-10, 1e-20, 1e-40]
+        ref = [0.7543222539245642, 1.6408455124660906, 964.4916294395846,
+               1151387.578354072, 1640845512466.0906]
+        assert_allclose(stats.loglaplace.isf(q, c), ref, rtol=1e-14)
+
 
 class TestPowerlaw:
 

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -349,6 +349,12 @@ class LogLaplace(ReferenceDistribution):
         else:
             return c / 2 * x**(-c - mp.one)
 
+    def _ppf(self, q, guess, c):
+        if q < 0.5:
+            return (2.0 * q)**(mp.one / c)
+        else:
+            return (2 * (mp.one - q))**(-mp.one / c)
+
 
 class Normal(ReferenceDistribution):
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Overrides and adds the inverse survival function for the LogLaplace distribution to improve its accuracy
- Adds _ppf in the reference distribution
- Adds tests for the isf function.

#### Additional information
<!--Any additional information you think is important.-->
CC: @mdhaber 