### PR TITLE
ENH:stats: Add _isf method to lognorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6216,6 +6216,9 @@ class lognorm_gen(rv_continuous):
     def _logsf(self, x, s):
         return _norm_logsf(np.log(x) / s)
 
+    def _isf(self, q, s):
+        return np.exp(s * _norm_isf(q))
+
     def _stats(self, s):
         p = np.exp(s*s)
         mu = np.sqrt(p)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4112,6 +4112,15 @@ class TestLognorm:
 
         _assert_less_or_close_loglike(stats.lognorm, data, **kwds)
 
+    def test_isf(self):
+        # reference values were computed via the reference distribution, e.g.
+        # mp.dps = 100; LogNormal(s=s).isf(q=2e-10, guess=100).
+        s = 0.954
+        q = [0.1, 2e-10, 5e-20, 6e-40]
+        ref = [3.3960065375794937, 390.07632793595974, 5830.5020828128445,
+               287872.84087457904]
+        assert_allclose(stats.lognorm.isf(q, s), ref, rtol=1e-14)
+
 
 class TestBeta:
     def test_logpdf(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4114,7 +4114,9 @@ class TestLognorm:
 
     def test_isf(self):
         # reference values were computed via the reference distribution, e.g.
-        # mp.dps = 100; LogNormal(s=s).isf(q=2e-10, guess=100).
+        # mp.dps = 100;
+        # LogNormal(s=s).isf(q=0.1, guess=0)
+        # LogNormal(s=s).isf(q=2e-10, guess=100)
         s = 0.954
         q = [0.1, 2e-10, 5e-20, 6e-40]
         ref = [3.3960065375794937, 390.07632793595974, 5830.5020828128445,

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -350,6 +350,24 @@ class LogLaplace(ReferenceDistribution):
             return c / 2 * x**(-c - mp.one)
 
 
+class LogNormal(ReferenceDistribution):
+
+    def __init__(self, *, s):
+        super().__init__(s=s)
+
+    def _support(self, s):
+        return 0, mp.inf
+
+    def _pdf(self, x, s):
+        return (
+            mp.one / (s * x * mp.sqrt(2 * mp.pi))
+            * mp.exp(-mp.one / 2 * (mp.log(x) / s)**2)
+        )
+
+    def _cdf(self, x, s):
+        return mp.ncdf(mp.log(x) / s)
+
+
 class Normal(ReferenceDistribution):
 
     def _pdf(self, x):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds the _isf method to the log normal distribution to improve its precision
- Adds a reference log normal distribution
- Adds tests to verify the _isf method.

#### Additional information
<!--Any additional information you think is important.-->
CC: @mdhaber 