### PR TITLE
MAINT: Simplify codespaces env activation

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,3 +11,7 @@ micromamba env create -f environment.yml --yes
 # user (same applies to `conda activate`)
 
 git submodule update --init
+
+# Enables users to activate environment without having to specify the full path
+echo "envs_dirs:
+  - /home/codespace/micromamba/envs" > /opt/conda/.condarc

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -107,7 +107,7 @@ many. For more detailed instructions, see the :ref:`contributor-toc`.
     When creating a codespace for the ``scipy/scipy`` repository, the default
     2-core machine type works; 4-core will build and work a bit faster (but of
     course at a cost of halving your number of free usage hours). Once your
-    codespace has started, you can run ``mamba activate scipy-dev`` and your
+    codespace has started, you can run ``conda activate scipy-dev`` and your
     development environment is completely set up - you can then follow the
     relevant parts of the SciPy documentation to build, test, develop, write
     docs, and contribute to SciPy.


### PR DESCRIPTION
Allows activation of dev environment in codespaces with `conda activate scipy-dev`.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Similar to https://github.com/numpy/numpy/pull/23965, since currently it is not possible to activate the environment created on codespaces without using the full path (meaning you need to do `conda activate /home/codespace/micromamba/envs/scipy-dev`).

I have also updated the documentation since I couldn't use `mamba activate` on the codespace, but using conda instead should not change anything for anyone using the environment.