### PR TITLE
TST: stats.dgamma.pdf: adjust test that fails intermittently

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4508,7 +4508,8 @@ class TestDgamma:
         assert_allclose(res, ref)
 
         dist = stats.dgamma(a)
-        assert_equal(dist.pdf(x), res)
+        # There was an intermittent failure with assert_equal on Linux - 32 bit
+        assert_allclose(dist.pdf(x), res, rtol=5e-16)
 
     # mpmath was used to compute the expected values.
     # For x < 0, cdf(x, a) is mp.gammainc(a, -x, mp.inf, regularized=True)/2


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/18649, for example

#### What does this implement/fix?
An `assert_equal` in `scipy/stats/tests/test_distributions.py::TestDgamma::test_pdf` fails intermittently on Linux - 32 bit with `Max relative difference: 1.96922609e-16`. I think it's safe to turn this into an `assert_allclose` with tight relative tolerance.