### PR TITLE
ENH:stats: Add _isf method to pareto

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7527,6 +7527,9 @@ class pareto_gen(rv_continuous):
     def _sf(self, x, b):
         return x**(-b)
 
+    def _isf(self, q, b):
+        return np.power(q, -1.0 / b)
+
     def _stats(self, b, moments='mv'):
         mu, mu2, g1, g2 = None, None, None, None
         if 'm' in moments:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -168,6 +168,8 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
         check_sample_meanvar_(m, v, rvs)
     check_cdf_ppf(distfn, arg, distname)
     check_sf_isf(distfn, arg, distname)
+    check_cdf_sf(distfn, arg, distname)
+    check_ppf_isf(distfn, arg, distname)
     check_pdf(distfn, arg, distname)
     check_pdf_logpdf(distfn, arg, distname)
     check_pdf_logpdf_at_endpoints(distfn, arg, distname)
@@ -586,10 +588,20 @@ def check_sf_isf(distfn, arg, msg):
     npt.assert_almost_equal(distfn.sf(distfn.isf([0.1, 0.5, 0.9], *arg), *arg),
                             [0.1, 0.5, 0.9], decimal=DECIMAL, err_msg=msg +
                             ' - sf-isf roundtrip')
+
+
+def check_cdf_sf(distfn, arg, msg):
     npt.assert_almost_equal(distfn.cdf([0.1, 0.9], *arg),
                             1.0 - distfn.sf([0.1, 0.9], *arg),
                             decimal=DECIMAL, err_msg=msg +
                             ' - cdf-sf relationship')
+
+
+def check_ppf_isf(distfn, arg, msg):
+    p = np.array([0.1, 0.9])
+    npt.assert_almost_equal(distfn.isf(p, *arg), distfn.ppf(1-p, *arg),
+                            decimal=DECIMAL, err_msg=msg +
+                            ' - ppf-isf relationship')
 
 
 def check_pdf(distfn, arg, msg):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9335,7 +9335,8 @@ class TestTruncPareto:
 
 
 @pytest.mark.parametrize("case", [("loglaplace", None, None, None),
-                                  ("lognorm", None, None, None),])
+                                  ("lognorm", None, None, None),
+                                  ("pareto", None, None, None),])
 def test_generic_sf_isf(case):
     distname, domain, atol, rtol = case
     domain = domain or (-290, 0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9334,19 +9334,34 @@ class TestTruncPareto:
             _assert_less_or_close_loglike(stats.truncpareto, data, **kwds)
 
 
-@pytest.mark.parametrize("case", [("loglaplace", None, None, None),
-                                  ("lognorm", None, None, None),
-                                  ("pareto", None, None, None),])
+# Cases are (distribution name, log10 of smallest probability mass to test,
+# log10 of the complement of the largest probability mass to test, atol,
+# rtol). None uses default values.
+@pytest.mark.parametrize("case", [("loglaplace", None, None, None, None),
+                                  ("lognorm", None, None, None, None),
+                                  ("pareto", None, None, None, None),])
 def test_sf_isf_overrides(case):
-    # A stronger test that supplements `test_continuous_basic.check_sf_isf`
-    # for distributions with overridden `sf` and `isf` methods.
-    distname, domain, atol, rtol = case
-    domain = domain or (-290, 0)
+    # Test that SF is the inverse of ISF. Supplements
+    # `test_continuous_basic.check_sf_isf` for distributions with overridden
+    # `sf` and `isf` methods.
+    distname, lp1, lp2, atol, rtol = case
+
+    lpm = np.log10(0.5)  # log10 of the probability mass at the median
+    lp1 = lp1 or -290
+    lp2 = lp2 or -14
     atol = atol or 0
     rtol = rtol or 1e-12
     dist = getattr(stats, distname)
     params = dict(distcont)[distname]
     dist_frozen = dist(*params)
-    ref = np.logspace(*domain)
+
+    # Test (very deep) right tail to median. We can benchmark with random
+    # (loguniform) points, but strictly logspaced points are fine for tests.
+    ref = np.logspace(lp1, lpm)
+    res = dist_frozen.sf(dist_frozen.isf(ref))
+    assert_allclose(res, ref, atol=atol, rtol=rtol)
+
+    # test median to left tail
+    ref = 1 - np.logspace(lp2, lpm, 20)
     res = dist_frozen.sf(dist_frozen.isf(ref))
     assert_allclose(res, ref, atol=atol, rtol=rtol)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2243,6 +2243,15 @@ class TestPareto:
         # method.
         _ = stats.pareto.fit(data)
 
+    def test_isf(self):
+        # reference values were generated using the reference distribution
+        # e.g. mp.dps = 100; Pareto(b=b).isf(q)
+        b = 2.62
+        q = [0.01, 2e-10, 3e-20, 4e-40]
+        ref = [5.7990757086193945, 5033.811495713687, 28280067.20126172,
+               1089887527714828.1]
+        assert_allclose(stats.pareto.isf(q, b), ref, rtol=1e-14)
+
 
 class TestGenpareto:
     def test_ab(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9323,3 +9323,18 @@ class TestTruncPareto:
                 stats.truncpareto.fit(data, **kwds)
         else:
             _assert_less_or_close_loglike(stats.truncpareto, data, **kwds)
+
+
+@pytest.mark.parametrize("case", [("loglaplace", None, None, None),
+                                  ("lognorm", None, None, None),])
+def test_generic_sf_isf(case):
+    distname, domain, atol, rtol = case
+    domain = domain or (-290, 0)
+    atol = atol or 0
+    rtol = rtol or 1e-12
+    dist = getattr(stats, distname)
+    params = dict(distcont)[distname]
+    dist_frozen = dist(*params)
+    ref = np.logspace(*domain)
+    res = dist_frozen.sf(dist_frozen.isf(ref))
+    assert_allclose(res, ref, atol=atol, rtol=rtol)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2243,15 +2243,6 @@ class TestPareto:
         # method.
         _ = stats.pareto.fit(data)
 
-    def test_isf(self):
-        # reference values were generated using the reference distribution
-        # e.g. mp.dps = 100; Pareto(b=b).isf(q)
-        b = 2.62
-        q = [0.01, 2e-10, 3e-20, 4e-40]
-        ref = [5.7990757086193945, 5033.811495713687, 28280067.20126172,
-               1089887527714828.1]
-        assert_allclose(stats.pareto.isf(q, b), ref, rtol=1e-14)
-
 
 class TestGenpareto:
     def test_ab(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9337,7 +9337,9 @@ class TestTruncPareto:
 @pytest.mark.parametrize("case", [("loglaplace", None, None, None),
                                   ("lognorm", None, None, None),
                                   ("pareto", None, None, None),])
-def test_generic_sf_isf(case):
+def test_sf_isf_overrides(case):
+    # A stronger test that supplements `test_continuous_basic.check_sf_isf`
+    # for distributions with overridden `sf` and `isf` methods.
     distname, domain, atol, rtol = case
     domain = domain or (-290, 0)
     atol = atol or 0

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -393,6 +393,21 @@ class NormInvGauss(ReferenceDistribution):
         return a * q**-1 * mp.besselk(1, alpha*q) * mp.exp(beta*x)
 
 
+class Pareto(ReferenceDistribution):
+
+    def __init__(self, *, b):
+        super().__init__(b=b)
+
+    def _support(self, b):
+        return 1, mp.inf
+
+    def _pdf(self, x, b):
+        return b / x**(b+1)
+
+    def _ppf(self, q, guess, b):
+        return mp.power(mp.one - q, -mp.one / b)
+
+
 class Pearson3(ReferenceDistribution):
     def __init__(self, *, skew):
         super().__init__(skew=skew)

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -393,21 +393,6 @@ class NormInvGauss(ReferenceDistribution):
         return a * q**-1 * mp.besselk(1, alpha*q) * mp.exp(beta*x)
 
 
-class Pareto(ReferenceDistribution):
-
-    def __init__(self, *, b):
-        super().__init__(b=b)
-
-    def _support(self, b):
-        return 1, mp.inf
-
-    def _pdf(self, x, b):
-        return b / x**(b+1)
-
-    def _ppf(self, q, guess, b):
-        return mp.power(mp.one - q, -mp.one / b)
-
-
 class Pearson3(ReferenceDistribution):
     def __init__(self, *, skew):
         super().__init__(skew=skew)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds the _isf method to the Pareto distribution in order to improve its precision
- Adds a reference distribution
- Adds tests to verify the _isf method

#### Additional information
<!--Any additional information you think is important.-->
