### PR TITLE
ENH:stats: Add _sf and _isf methods to kappa3

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6859,6 +6859,7 @@ class kappa3_gen(rv_continuous):
         return x*(a + x**a)**(-1.0/a)
 
     def _sf(self, x, a):
+        x, a = np.broadcast_arrays(x, a)  # some code paths pass scalars
         sf = super()._sf(x, a)
 
         # When the SF is small, another formulation is typically more accurate.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6858,6 +6858,10 @@ class kappa3_gen(rv_continuous):
     def _cdf(self, x, a):
         return x*(a + x**a)**(-1.0/a)
 
+    def _sf(self, x, a):
+        lg = sc.xlog1py(-1.0 / a, a * x**-a)
+        return -sc.expm1(lg)
+
     def _ppf(self, q, a):
         return (a/(q**-a - 1.0))**(1.0/a)
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6861,6 +6861,11 @@ class kappa3_gen(rv_continuous):
     def _ppf(self, q, a):
         return (a/(q**-a - 1.0))**(1.0/a)
 
+    def _isf(self, q, a):
+        lg = sc.xlog1py(-a, -q)
+        denom = sc.expm1(lg)
+        return (a / denom)**(1.0 / a)
+
     def _stats(self, a):
         outputs = [None if np.any(i < a) else np.nan for i in range(1, 5)]
         return outputs[:]

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9328,7 +9328,8 @@ class TestTruncPareto:
 # Cases are (distribution name, log10 of smallest probability mass to test,
 # log10 of the complement of the largest probability mass to test, atol,
 # rtol). None uses default values.
-@pytest.mark.parametrize("case", [("loglaplace", None, None, None, None),
+@pytest.mark.parametrize("case", [("kappa3", None, None, None, None),
+                                  ("loglaplace", None, None, None, None),
                                   ("lognorm", None, None, None, None),
                                   ("pareto", None, None, None, None),])
 def test_sf_isf_overrides(case):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9325,6 +9325,16 @@ class TestTruncPareto:
             _assert_less_or_close_loglike(stats.truncpareto, data, **kwds)
 
 
+class TestKappa3:
+    def test_sf(self):
+        # During development of gh-18822, we found that the override of
+        # kappa3.sf could experience overflow where the version in main did
+        # not. Check that this does not happen in final implementation.
+        sf0 = 1 - stats.kappa3.cdf(0.5, 1e5)
+        sf1 = stats.kappa3.sf(0.5, 1e5)
+        assert_allclose(sf1, sf0)
+
+
 # Cases are (distribution name, log10 of smallest probability mass to test,
 # log10 of the complement of the largest probability mass to test, atol,
 # rtol). None uses default values.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2451,18 +2451,6 @@ class TestPearson3:
         assert_allclose(stats.pearson3.sf(x, 0), stats.norm.sf(x), rtol=2e-14)
 
 
-class TestKappa3:
-
-    def test_isf(self):
-        # reference values were generated using the reference distribution
-        # e.g. mp.dps = 100; Kappa3(a=a).isf(q)
-        a = [0.5, 2.0, 5.0, 10.0]
-        q = [0.001, 1e-15, 3e-30, 5e-50]
-        ref = [998500.4375312617, 31622776.60168377, 802741.5617602307,
-               85133.99225207846]
-        assert_allclose(stats.kappa3.isf(q, a), ref, rtol=1e-15)
-
-
 class TestKappa4:
     def test_cdf_genpareto(self):
         # h = 1 and k != 0 is generalized Pareto

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2451,6 +2451,18 @@ class TestPearson3:
         assert_allclose(stats.pearson3.sf(x, 0), stats.norm.sf(x), rtol=2e-14)
 
 
+class TestKappa3:
+
+    def test_isf(self):
+        # reference values were generated using the reference distribution
+        # e.g. mp.dps = 100; Kappa3(a=a).isf(q)
+        a = [0.5, 2.0, 5.0, 10.0]
+        q = [0.001, 1e-15, 3e-30, 5e-50]
+        ref = [998500.4375312617, 31622776.60168377, 802741.5617602307,
+               85133.99225207846]
+        assert_allclose(stats.kappa3.isf(q, a), ref, rtol=1e-15)
+
+
 class TestKappa4:
     def test_cdf_genpareto(self):
         # h = 1 and k != 0 is generalized Pareto

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -335,21 +335,6 @@ class Burr(ReferenceDistribution):
         return (p**(-1.0/d) - 1)**(-1.0/c)
 
 
-class Kappa3(ReferenceDistribution):
-
-    def __init__(self, *, a):
-        super().__init__(a=a)
-
-    def _support(self, a):
-        return 0, mp.inf
-
-    def _pdf(self, x, a):
-        return a * (a + x**a)**(-(a + 1) / a)
-
-    def _ppf(self, q, guess, a):
-        return (a / (q**-a - mp.one))**(mp.one / a)
-
-
 class LogLaplace(ReferenceDistribution):
 
     def __init__(self, *, c):

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -335,6 +335,21 @@ class Burr(ReferenceDistribution):
         return (p**(-1.0/d) - 1)**(-1.0/c)
 
 
+class Kappa3(ReferenceDistribution):
+
+    def __init__(self, *, a):
+        super().__init__(a=a)
+
+    def _support(self, a):
+        return 0, mp.inf
+
+    def _pdf(self, x, a):
+        return a * (a + x**a)**(-(a + 1) / a)
+
+    def _ppf(self, q, guess, a):
+        return (a / (q**-a - mp.one))**(mp.one / a)
+
+
 class LogLaplace(ReferenceDistribution):
 
     def __init__(self, *, c):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds the _isf method to the Kappa3 distribution to improve its precision

#### Additional information
<!--Any additional information you think is important.-->
