### PR TITLE
ENH:stats: Add _isf method to lomax

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7693,6 +7693,9 @@ class lomax_gen(rv_continuous):
     def _ppf(self, q, c):
         return sc.expm1(-sc.log1p(-q)/c)
 
+    def _isf(self, q, c):
+        return q**(-1.0 / c) - 1
+
     def _stats(self, c):
         mu, mu2, g1, g2 = pareto.stats(c, loc=-1.0, moments='mvsk')
         return mu, mu2, g1, g2

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3034,6 +3034,19 @@ class TestLogLaplace:
         assert_allclose(stats.loglaplace.isf(q, c), ref, rtol=1e-14)
 
 
+class TestLomax:
+
+    def test_isf(self):
+        # reference values were generated using the reference distribution
+        # e.g. mp.dps=100;
+        # Lomax(c=c).isf(q)
+        c = [1.0, 5.0, 12.0, 20.5]
+        q = [3e-10, 9e-30, 5e-50, 6e-60]
+        ref = [3333333332.3333335, 644393.0149772542, 12834.688421125164,
+               773.2312038523736]
+        assert_allclose(stats.lomax.isf(q, c), ref, rtol=1e-15)
+
+
 class TestPowerlaw:
 
     # In the following data, `sf` was computed with mpmath.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9330,6 +9330,7 @@ class TestTruncPareto:
 # rtol). None uses default values.
 @pytest.mark.parametrize("case", [("loglaplace", None, None, None, None),
                                   ("lognorm", None, None, None, None),
+                                  ("lomax", None, None, None, None),
                                   ("pareto", None, None, None, None),])
 def test_sf_isf_overrides(case):
     # Test that SF is the inverse of ISF. Supplements

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3034,19 +3034,6 @@ class TestLogLaplace:
         assert_allclose(stats.loglaplace.isf(q, c), ref, rtol=1e-14)
 
 
-class TestLomax:
-
-    def test_isf(self):
-        # reference values were generated using the reference distribution
-        # e.g. mp.dps=100;
-        # Lomax(c=c).isf(q)
-        c = [1.0, 5.0, 12.0, 20.5]
-        q = [3e-10, 9e-30, 5e-50, 6e-60]
-        ref = [3333333332.3333335, 644393.0149772542, 12834.688421125164,
-               773.2312038523736]
-        assert_allclose(stats.lomax.isf(q, c), ref, rtol=1e-15)
-
-
 class TestPowerlaw:
 
     # In the following data, `sf` was computed with mpmath.

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -374,6 +374,21 @@ class LogNormal(ReferenceDistribution):
         return mp.ncdf(mp.log(x) / s)
 
 
+class Lomax(ReferenceDistribution):
+
+    def __init__(self, *, c):
+        super().__init__(c=c)
+
+    def _support(self, c):
+        return 0, mp.inf
+
+    def _pdf(self, x, c):
+        return c / (mp.one + x)**(c + mp.one)
+
+    def _ppf(self, q, guess, c):
+        return mp.expm1(-mp.log1p(-q) / c)
+
+
 class Normal(ReferenceDistribution):
 
     def _pdf(self, x):

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -374,21 +374,6 @@ class LogNormal(ReferenceDistribution):
         return mp.ncdf(mp.log(x) / s)
 
 
-class Lomax(ReferenceDistribution):
-
-    def __init__(self, *, c):
-        super().__init__(c=c)
-
-    def _support(self, c):
-        return 0, mp.inf
-
-    def _pdf(self, x, c):
-        return c / (mp.one + x)**(c + mp.one)
-
-    def _ppf(self, q, guess, c):
-        return mp.expm1(-mp.log1p(-q) / c)
-
-
 class Normal(ReferenceDistribution):
 
     def _pdf(self, x):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards: gh-17832

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds the _isf method to the Lomax distribution in order to improve its precision.

#### Additional information
<!--Any additional information you think is important.-->
