### PR TITLE
ENH: override halfcauchy distribution fit

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4214,11 +4214,9 @@ class halfcauchy_gen(rv_continuous):
             shifted_data = data - loc
             n = data.size
             shifted_data_squared = np.square(shifted_data)
-            x0 = np.median(shifted_data)
 
             def fun_to_solve(scale):
                 denominator = scale**2 + shifted_data_squared
-                f = 2 * np.sum(shifted_data_squared/denominator) - n
                 return 2 * np.sum(shifted_data_squared/denominator) - n
 
             small = np.finfo(1.0).tiny**0.5  # avoid underflow

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4219,11 +4219,10 @@ class halfcauchy_gen(rv_continuous):
             def fun_to_solve(scale):
                 denominator = scale**2 + shifted_data_squared
                 f = 2 * np.sum(shifted_data_squared/denominator) - n
-                grad = - 4 * np.sum(shifted_data_squared * scale
-                                    /denominator**2)
-                return f, grad
+                return 2 * np.sum(shifted_data_squared/denominator) - n
 
-            res = root_scalar(fun_to_solve, fprime=True, x0=x0)
+            small = np.finfo(1.0).tiny**0.5  # avoid underflow
+            res = root_scalar(fun_to_solve, bracket=(small, np.max(shifted_data)))
             return res.root
 
         if fscale is not None:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4189,6 +4189,50 @@ class halfcauchy_gen(rv_continuous):
     def _entropy(self):
         return np.log(2*np.pi)
 
+    @_call_super_mom
+    @inherit_docstring_from(rv_continuous)
+    def fit(self, data, *args, **kwds):
+        if kwds.pop('superfit', False):
+            return super().fit(data, *args, **kwds)
+
+        data, floc, fscale = _check_fit_input_parameters(self, data,
+                                                         args, kwds)
+
+        # location is independent from the scale
+        data_min = np.min(data)
+        if floc is not None:
+            if data_min < floc:
+                # There are values that are less than the specified loc.
+                raise FitDataError("halfcauchy", lower=floc, upper=np.inf)
+            loc = floc
+        else:
+            # if not provided, location MLE is the minimal data point
+            loc = data_min
+
+        # find scale
+        def find_scale(loc, data):
+            shifted_data = data - loc
+            n = data.size
+            shifted_data_squared = np.square(shifted_data)
+            x0 = np.median(shifted_data)
+
+            def fun_to_solve(scale):
+                denominator = scale**2 + shifted_data_squared
+                f = 2 * np.sum(shifted_data_squared/denominator) - n
+                grad = - 4 * np.sum(shifted_data_squared * scale
+                                    /denominator**2)
+                return f, grad
+
+            res = root_scalar(fun_to_solve, fprime=True, x0=x0)
+            return res.root
+
+        if fscale is not None:
+            scale = fscale
+        else:
+            scale = find_scale(loc, data)
+
+        return loc, scale
+
 
 halfcauchy = halfcauchy_gen(a=0.0, name='halfcauchy')
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1179,6 +1179,40 @@ class TestHalfNorm:
             stats.halfnorm.fit([1, 2, 3], floc=2)
 
 
+class TestHalfCauchy:
+
+    @pytest.mark.parametrize("rvs_loc", [1e-5, 1e10])
+    @pytest.mark.parametrize("rvs_scale", [1e-2, 1e8])
+    @pytest.mark.parametrize('fix_loc', [True, False])
+    @pytest.mark.parametrize('fix_scale', [True, False])
+    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale,
+                                    fix_loc, fix_scale):
+
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.halfnorm.rvs(loc=rvs_loc, scale=rvs_scale, size=1000,
+                                  random_state=rng)
+
+        if fix_loc and fix_scale:
+            error_msg = ("All parameters fixed. There is nothing to "
+                         "optimize.")
+            with pytest.raises(RuntimeError, match=error_msg):
+                stats.halfcauchy.fit(data, floc=rvs_loc, fscale=rvs_scale)
+            return
+
+        kwds = {}
+        if fix_loc:
+            kwds['floc'] = rvs_loc
+        if fix_scale:
+            kwds['fscale'] = rvs_scale
+
+        _assert_less_or_close_loglike(stats.halfcauchy, data, **kwds)
+
+    def test_fit_error(self):
+        # `floc` bigger than the minimal data point
+        with pytest.raises(FitDataError):
+            stats.halfcauchy.fit([1, 2, 3], floc=2)
+
+
 class TestHalfLogistic:
     # survival function reference values were computed with mpmath
     # from mpmath import mp


### PR DESCRIPTION
#### Reference issue
Part of #17832 and #11782

#### What does this implement/fix?
Overrides the `fit` method of the halfcauchy distribution.

#### Additional information
<details><summary>Math</summary>

As halfcauchy is only defined for $[\mu, \infty]$, the MLE of the location parameter is again the minimal data point (like in #18695 and #18760) . For the scale parameter, we end up with a root finding problem.

$$p(x|\mu,\sigma) =\frac{2}{\sigma\pi\left(1+\frac{(x-\mu)^2}{\sigma^2}\right)}$$

The log likelihood to observe the data points $(x_1,...,x_n)$ is then

$$\ln p(\mu,\sigma|x_1,...,x_n)=n(\ln(2)-\ln(\pi)-\ln(\sigma)) - \sum_{i=1}^n\ln\left(1+\frac{(x_i-\mu)^2}{\sigma^2}\right)$$
To maximize this, we set the gradient to zero:

$$\frac{\partial\ln(p)}{\partial\sigma}=-n\sigma-\sum_{i=1}^n\frac{-2(x_i-\mu)^2}{1+\frac{(x_i-\mu)^2}{\sigma^2}}\frac{1}{\sigma^3}$$
Simplifcation and setting to zero yields:
$$n - 2\sum_{i=1}^n\frac{(x_i-\mu)^2}{\sigma^2+(x_i-\mu)^2)}=0$$

This can be solved with a gradient based root finder starting from the median of the shifted data $x'=x - loc$.
</details> 

**Fit benchmarks**
Comparison against the generic fit method was carried out with QMC distributed parameters with the attached script. In all cases, the new fit performed better than the generic fit method.

<details><summary>Benchmark script</summary>

```python
import numpy as np
from scipy import stats
from time import perf_counter
import matplotlib.pyplot as plt
import os

rng = np.random.default_rng(2433006235492611347)
qrng = stats.qmc.Halton(6, seed=rng)

N = 1000
times_pr = np.full(N, np.nan)
times_super = np.full(N, np.nan)
nllfs_super = np.full(N, np.nan)
nllfs_pr = np.full(N, np.nan)


distribution = stats.halfcauchy

for i in range(N):
    print(i)
    sample = qrng.random()
    sample = stats.qmc.scale(sample, [-3, -3, -3, 1, -3, -1], [2, 3, 5, 5, 2, 1])[0]
    _, loc, scale, size, fscale = 10**sample[:5]
    size = int(size)

    dist = distribution(loc=loc, scale=scale)
    rvs = dist.rvs(size=size, random_state=rng)
    min_data = rvs.min()
    #if floc > min_data:
    #    floc = min_data * rng.random()
    try:
        tic = perf_counter()

        loc_fit, scale_fit = distribution.fit(rvs, fscale=fscale)
        toc = perf_counter()
        nllf_pr = distribution.nnlf((loc_fit, scale_fit), rvs)
        nllfs_pr[i] = nllf_pr
        times_pr[i] = toc-tic

    except Exception as e:
        print(f"Failure: {e}")

    try:
        tic = perf_counter()
        loc_fit, scale_fit = distribution.fit(rvs, superfit=True, fscale=fscale)
        toc = perf_counter()
        nllf_super = distribution.nnlf((loc_fit, scale_fit), rvs)
        nllfs_super[i] = nllf_super
        times_super[i] = toc-tic

    except Exception as e:
        print(f"Failure: {e}")

nllf_diff = (nllfs_pr - nllfs_super)/np.abs(nllfs_super)
nllf_diff = nllf_diff[np.isfinite(nllf_diff)]
nllf_diff_good = -nllf_diff[nllf_diff < 0]
nllf_diff_bad = nllf_diff[nllf_diff > 0]

bins = np.arange(-6, 1.5, 0.25)
plt.hist(np.log10(times_pr), bins=bins, alpha=0.5)
plt.hist(np.log10(times_super), bins=bins, alpha=0.5)
plt.legend(('PR', 'main'))
plt.xlabel('log10 of `fit` execution time (s)')
plt.ylabel('Frequency')
plt.title('Histogram of log10 of `fit` execution time (s), fscale fix')
plt.savefig("Time_fscale_fix.png")

plt.clf()
plt.hist(np.log10(nllf_diff_good), label="good", alpha=0.5)
plt.hist(np.log10(nllf_diff_bad), label="bad", alpha=0.5)
plt.xlabel('log10 of NLLF differences')
plt.ylabel('Frequency')
plt.title('Histogram of log10 of NLLF differences, fscale fix')
plt.legend()
plt.savefig("NNLF_Differences_fscale_fix.png")
``` 
</details> 

<details><summary>Fit performance for free parameters</summary>

![Time_free](https://github.com/scipy/scipy/assets/40656107/6a59cb0e-7533-4b2a-b32a-22988d83ae23)
![NNLF_Differences_free](https://github.com/scipy/scipy/assets/40656107/ec6384f0-f3ab-41fa-acec-a388b9cfb3fc)


</details> 

<details><summary>Fit performance for fixed location parameter</summary>

![Time_floc_fix](https://github.com/scipy/scipy/assets/40656107/059394fc-800b-4cb7-9127-7fc50603cbec)
![NNLF_Differences_floc_fix](https://github.com/scipy/scipy/assets/40656107/47e4049b-ca6b-4562-aaf4-b885e6f4a519)

</details> 

<details><summary>Fit performance for fixed scale parameter</summary>

![Time_fscale_fix](https://github.com/scipy/scipy/assets/40656107/d61cfc5c-b12d-4033-963d-ec004d492c7e)
![NNLF_Differences_fscale_fix](https://github.com/scipy/scipy/assets/40656107/9bc83356-51b9-4459-ad1c-306ced33eb14)


</details> 