### PR TITLE
BUG: wavfile.write dtype checks not triggered when float/int is passed

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -770,8 +770,8 @@ def write(filename, rate, data):
 
     try:
         dkind = data.dtype.kind
-        if not (dkind == 'i' or dkind == 'f' or (dkind == 'u' and
-                                                 data.dtype.itemsize == 1)):
+        allowed_dtypes = ('int16', 'int32', 'uint8', 'float32')
+        if data.dtype.name not in allowed_dtypes:
             raise ValueError("Unsupported data type '%s'" % data.dtype)
 
         header_data = b''


### PR DESCRIPTION

#### What does this implement/fix?
`scipy.io.wavfile.write` dtype checks are wrong. Only float32, int16, int32 and uint8 dtypes are expected, whereas the code checks if the numpy array is a float, int or uint. This leads to silent errors if float16, int64 dtypes are passed.

