### PR TITLE
DOC: soften wording on import guidelines, mention lazy loading

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -41,25 +41,26 @@ to import modules/functions/objects from SciPy.
 Guidelines for importing functions from SciPy
 ---------------------------------------------
 
-The scipy namespace itself only contains functions imported from numpy.  These
+The SciPy namespace itself only contains functions imported from NumPy. These
 functions still exist for backwards compatibility, but should be imported from
-numpy directly.
+NumPy directly.
 
-Everything in the namespaces of scipy submodules is public.  In general, it is
-recommended to import functions from submodule namespaces.  For example, the
-function ``curve_fit`` (defined in scipy/optimize/_minpack_py.py) should be
+Everything in the namespaces of SciPy submodules is public. In general in
+Python, it is recommended to make use of namespaces. For example, the
+function ``curve_fit`` (defined in ``scipy/optimize/_minpack_py.py``) should be
 imported like this::
+
+  import scipy as sp
+  result = sp.optimize.curve_fit(...)
+
+Or alternatively one could use the submodule as a namespace like so::
 
   from scipy import optimize
   result = optimize.curve_fit(...)
 
-This form of importing submodules is preferred for all submodules except
-``scipy.io`` (because ``io`` is also the name of a module in the Python
-stdlib)::
-
-  from scipy import interpolate
-  from scipy import integrate
-  import scipy.io as spio
+.. warning:: For ``scipy.io`` prefer the use of  ``import scipy as sp``
+             because ``io`` is also the name of a module in the Python
+             stdlib.
 
 In some cases, the public API is one level deeper.  For example, the
 ``scipy.sparse.linalg`` module is public, and the functions it contains are not
@@ -77,8 +78,15 @@ distribution if the second form is chosen::
   distributions.lomax(...)
 
 In that case, the second form can be chosen **if** it is documented in the next
-section that the submodule in question is public.
+section that the submodule in question is public. Of course you can still use::
 
+  import scipy as sp
+  sp.stats.lomax(...)
+  # or
+  sp.stats.distributions.lomax(...)
+
+.. note:: SciPy is using a lazy loading mechanism which means that modules
+          are only loaded in memory when you first try to access them.
 
 API definition
 --------------

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -50,15 +50,15 @@ Python, it is recommended to make use of namespaces. For example, the
 function ``curve_fit`` (defined in ``scipy/optimize/_minpack_py.py``) should be
 imported like this::
 
-  import scipy as sp
-  result = sp.optimize.curve_fit(...)
+  import scipy
+  result = scipy.optimize.curve_fit(...)
 
 Or alternatively one could use the submodule as a namespace like so::
 
   from scipy import optimize
   result = optimize.curve_fit(...)
 
-.. warning:: For ``scipy.io`` prefer the use of  ``import scipy as sp``
+.. warning:: For ``scipy.io`` prefer the use of  ``import scipy``
              because ``io`` is also the name of a module in the Python
              stdlib.
 
@@ -80,10 +80,10 @@ distribution if the second form is chosen::
 In that case, the second form can be chosen **if** it is documented in the next
 section that the submodule in question is public. Of course you can still use::
 
-  import scipy as sp
-  sp.stats.lomax(...)
+  import scipy
+  scipy.stats.lomax(...)
   # or
-  sp.stats.distributions.lomax(...)
+  scipy.stats.distributions.lomax(...)
 
 .. note:: SciPy is using a lazy loading mechanism which means that modules
           are only loaded in memory when you first try to access them.

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -86,9 +86,9 @@ section that the submodule in question is public. Of course you can still use::
 
 .. note::
 
-    The ``scipy`` namespace itself only contains functions imported from NumPy.
+    The ``scipy`` namespace itself also contains functions imported from ``numpy``.
     These functions still exist for backwards compatibility, but should be
-    imported from NumPy directly.
+    imported from ``numpy`` directly.
 
 API definition
 --------------

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -41,10 +41,6 @@ to import modules/functions/objects from SciPy.
 Guidelines for importing functions from SciPy
 ---------------------------------------------
 
-The SciPy namespace itself only contains functions imported from NumPy. These
-functions still exist for backwards compatibility, but should be imported from
-NumPy directly.
-
 Everything in the namespaces of SciPy submodules is public. In general in
 Python, it is recommended to make use of namespaces. For example, the
 function ``curve_fit`` (defined in ``scipy/optimize/_minpack_py.py``) should be
@@ -87,6 +83,12 @@ section that the submodule in question is public. Of course you can still use::
 
 .. note:: SciPy is using a lazy loading mechanism which means that modules
           are only loaded in memory when you first try to access them.
+
+.. note::
+
+    The ``scipy`` namespace itself only contains functions imported from NumPy.
+    These functions still exist for backwards compatibility, but should be
+    imported from NumPy directly.
 
 API definition
 --------------

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -54,9 +54,9 @@ Or alternatively one could use the submodule as a namespace like so::
   from scipy import optimize
   result = optimize.curve_fit(...)
 
-.. warning:: For ``scipy.io`` prefer the use of  ``import scipy``
-             because ``io`` is also the name of a module in the Python
-             stdlib.
+.. note:: For ``scipy.io`` prefer the use of  ``import scipy``
+          because ``io`` is also the name of a module in the Python
+          stdlib.
 
 In some cases, the public API is one level deeper.  For example, the
 ``scipy.sparse.linalg`` module is public, and the functions it contains are not


### PR DESCRIPTION
Now that we have lazy imports (well since a few releases), we really can use things like ~`import scipy as sp`~ `import scipy`. Some of our dependent such as NetworkX even updated their whole codebase (not sure if finished, but I know they started) to take advantage of that.

Here I just propose to adjust our recommendations about import style and show that it's possible. I am not going down the road of recommending anything, simply showing this is possible and adjusting the wording around that.