### PR TITLE
ENH: optimize: release the GIL while computing the LSAP solution

### DIFF
--- a/benchmarks/benchmarks/optimize_lap.py
+++ b/benchmarks/benchmarks/optimize_lap.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor, wait
+
 import numpy as np
 from .common import Benchmark, safe_import
 
@@ -50,3 +52,17 @@ class LinearAssignment(Benchmark):
 
     def time_evaluation(self, *args):
         linear_sum_assignment(self.cost_matrix)
+
+
+class ParallelLinearAssignment(Benchmark):
+    shape = (100, 100)
+    param_names = ['threads']
+    params = [[1, 2, 4]]
+
+    def setup(self, threads):
+        self.cost_matrices = [random_uniform(self.shape) for _ in range(20)]
+
+    def time_evaluation(self, threads):
+        with ThreadPoolExecutor(max_workers=threads) as pool:
+            wait({pool.submit(linear_sum_assignment, cost_matrix)
+                  for cost_matrix in self.cost_matrices})

--- a/scipy/optimize/_lsap.c
+++ b/scipy/optimize/_lsap.c
@@ -78,10 +78,17 @@ linear_sum_assignment(PyObject* self, PyObject* args, PyObject* kwargs)
     if (!b)
         goto cleanup;
 
-    int ret = solve_rectangular_linear_sum_assignment(
-      num_rows, num_cols, cost_matrix, maximize,
-      PyArray_DATA((PyArrayObject*)a),
-      PyArray_DATA((PyArrayObject*)b));
+    int64_t* a_ptr = PyArray_DATA((PyArrayObject*)a);
+    int64_t* b_ptr = PyArray_DATA((PyArrayObject*)b);
+    int ret;
+
+    Py_BEGIN_ALLOW_THREADS
+
+    ret = solve_rectangular_linear_sum_assignment(
+      num_rows, num_cols, cost_matrix, maximize, a_ptr, b_ptr);
+
+    Py_END_ALLOW_THREADS
+
     if (ret == RECTANGULAR_LSAP_INFEASIBLE) {
         PyErr_SetString(PyExc_ValueError, "cost matrix is infeasible");
         goto cleanup;


### PR DESCRIPTION
#### What does this implement/fix?

The LSAP (linear sum assignment problem) routine does the bulk of its work in solve_rectangular_linear_sum_assignment() using C-style pointers for data access after unwrapping the numpy arrays, so we can release the GIL during this computation. This permits threading the computation of independent LSAP problems.

The first commit is the change to the C-code to drop the GIL, and the second commit adds a timing benchmark test for computing the solution to independent LSAPs. I don't mind dropping the second commit if it is deemed to be unnecessary.

The timing results on my machine without the first commit are:

```
$ python dev.py bench -t optimize_lap.ParallelLinearAssignment

[  0.00%] ·· Benchmarking existing-py_node_bud213_shared_envs_scipy_20230706_bin_python
[ 50.00%] ··· Running (optimize_lap.ParallelLinearAssignment.time_evaluation--).
[100.00%] ··· optimize_lap.ParallelLinearAssignment.time_evaluation                                                                                                                                                                                                                                                        ok
[100.00%] ··· ========= =============
               threads               
              --------- -------------
                  1      8.22±0.04ms 
                  2       8.44±0.1ms 
                  4      8.68±0.09ms 
              ========= =============
```

And with the first commit, this becomes:

```
$ python dev.py bench -t optimize_lap.ParallelLinearAssignment

[  0.00%] ·· Benchmarking existing-py_node_bud213_shared_envs_scipy_20230706_bin_python
[ 50.00%] ··· Running (optimize_lap.ParallelLinearAssignment.time_evaluation--).
[100.00%] ··· optimize_lap.ParallelLinearAssignment.time_evaluation                                                                                                                                                                                                                                                        ok
[100.00%] ··· ========= =============
               threads               
              --------- -------------
                  1      7.77±0.07ms 
                  2       4.14±0.1ms 
                  4       2.86±0.4ms 
              ========= =============
```