### PR TITLE
DEP: scipy.stats.stats: clarify deprecation warnings

### DIFF
--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -1,5 +1,7 @@
 import functools
 import warnings
+from importlib import import_module
+
 
 __all__ = ["_deprecated"]
 
@@ -8,6 +10,29 @@ __all__ = ["_deprecated"]
 # be used over 'None' as the user could parse 'None' as a positional argument
 _NoValue = object()
 
+def _sub_module_deprecation(sub_module, module, all, name):
+    if name not in all:
+        raise AttributeError(
+            f"`scipy.{module}.{sub_module}` has no attribute `{name}`; furthermore, "
+            f"`scipy.{module}.{sub_module}` is deprecated and will be removed in "
+            "SciPy 2.0.0.")
+
+    attr = getattr(import_module(f"scipy.{module}"), name, None)
+
+    if attr is not None:
+        message = (f"Please import `{name}` from the `scipy.{module}` namespace; "
+                   f"the `scipy.{module}.{sub_module}` namespace is deprecated and "
+                   "will be removed in SciPy 2.0.0.")
+    else:
+        message = (f"`scipy.{module}.{sub_module}.{name}` is deprecated along with "
+                   f"the `scipy.{module}.{sub_module}` namespace. "
+                   f"`scipy.{module}.{sub_module}.{name}` will be removed in SciPy 1.13.0, and "
+                   f"the `scipy.{module}.{sub_module}` namespace will be removed in SciPy 2.0.0.")
+
+    warnings.warn(message, category=DeprecationWarning, stacklevel=3)
+
+    return getattr(import_module(f"scipy.{module}._{sub_module}"), name)
+    
 
 def _deprecated(msg, stacklevel=2):
     """Deprecate a function by emitting a warning on use."""

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -10,7 +10,7 @@ __all__ = ["_deprecated"]
 # be used over 'None' as the user could parse 'None' as a positional argument
 _NoValue = object()
 
-def _sub_module_deprecation(sub_module, module, all, name):
+def _sub_module_deprecation(sub_module, module, private_module, all, name):
     if name not in all:
         raise AttributeError(
             f"`scipy.{module}.{sub_module}` has no attribute `{name}`; furthermore, "
@@ -31,7 +31,7 @@ def _sub_module_deprecation(sub_module, module, all, name):
 
     warnings.warn(message, category=DeprecationWarning, stacklevel=3)
 
-    return getattr(import_module(f"scipy.{module}._{sub_module}"), name)
+    return getattr(import_module(f"scipy.{module}.{private_module}"), name)
     
 
 def _deprecated(msg, stacklevel=2):

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -10,28 +10,45 @@ __all__ = ["_deprecated"]
 # be used over 'None' as the user could parse 'None' as a positional argument
 _NoValue = object()
 
-def _sub_module_deprecation(sub_module, module, private_module, all, name):
-    if name not in all:
+def _sub_module_deprecation(*, sub_package, module, private_module, all,
+                            attribute):
+    """Helper function for deprecating modules that are public but were
+    intended to be private.
+
+    Parameters
+    ----------
+    sub_package : str
+        Subpackage the module belongs to eg. stats
+    module : str
+        Public but intended private module to deprecate
+    private_module : str
+        Private replacement for `module`
+    all : list
+        ``__all__`` belonging to `module`
+    attribute : str
+        The attribute in `module` being accessed
+    """
+    if attribute not in all:
         raise AttributeError(
-            f"`scipy.{module}.{sub_module}` has no attribute `{name}`; furthermore, "
-            f"`scipy.{module}.{sub_module}` is deprecated and will be removed in "
+            f"`scipy.{sub_package}.{module}` has no attribute `{attribute}`; furthermore, "
+            f"`scipy.{sub_package}.{module}` is deprecated and will be removed in "
             "SciPy 2.0.0.")
 
-    attr = getattr(import_module(f"scipy.{module}"), name, None)
+    attr = getattr(import_module(f"scipy.{sub_package}"), attribute, None)
 
     if attr is not None:
-        message = (f"Please import `{name}` from the `scipy.{module}` namespace; "
-                   f"the `scipy.{module}.{sub_module}` namespace is deprecated and "
+        message = (f"Please import `{attribute}` from the `scipy.{sub_package}` namespace; "
+                   f"the `scipy.{sub_package}.{module}` namespace is deprecated and "
                    "will be removed in SciPy 2.0.0.")
     else:
-        message = (f"`scipy.{module}.{sub_module}.{name}` is deprecated along with "
-                   f"the `scipy.{module}.{sub_module}` namespace. "
-                   f"`scipy.{module}.{sub_module}.{name}` will be removed in SciPy 1.13.0, and "
-                   f"the `scipy.{module}.{sub_module}` namespace will be removed in SciPy 2.0.0.")
+        message = (f"`scipy.{sub_package}.{module}.{attribute}` is deprecated along with "
+                   f"the `scipy.{sub_package}.{module}` namespace. "
+                   f"`scipy.{sub_package}.{module}.{attribute}` will be removed in SciPy 1.13.0, and "
+                   f"the `scipy.{sub_package}.{module}` namespace will be removed in SciPy 2.0.0.")
 
     warnings.warn(message, category=DeprecationWarning, stacklevel=3)
 
-    return getattr(import_module(f"scipy.{module}.{private_module}"), name)
+    return getattr(import_module(f"scipy.{sub_package}.{private_module}"), attribute)
     
 
 def _deprecated(msg, stacklevel=2):

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -316,7 +316,9 @@ def test_api_importable():
                              "{}".format(module_names))
 
 
-@pytest.mark.parametrize("module_name", PRIVATE_BUT_PRESENT_MODULES)
+@pytest.mark.parametrize("module_name",
+                         ['scipy.stats.stats',
+                          'scipy.stats.morestats'])
 def test_private_but_present_deprecation(module_name):
     # gh-18279, gh-17572, gh-17771 noted that deprecation warnings
     # for imports from private modules
@@ -325,9 +327,9 @@ def test_private_but_present_deprecation(module_name):
     sub_module_name = module_name.split(".")[1]
     sub_module = import_module(f"scipy.{sub_module_name}")
 
-    # Attributes that were formerly in `morestats` can still be imported from
-    # `morestats`, albeit with a deprecation warning. The specific message
-    # depends on whether the attribute is public in `scipy.stats` or not.
+    # Attributes that were formerly in `module_name` can still be imported from
+    # `module_name`, albeit with a deprecation warning. The specific message
+    # depends on whether the attribute is public in `scipy.xxx` or not.
     for attr_name in module.__all__:
         attr = getattr(sub_module, attr_name, None)
         if attr is None:
@@ -337,8 +339,8 @@ def test_private_but_present_deprecation(module_name):
         with pytest.warns(DeprecationWarning, match=message):
             getattr(module, attr_name)
 
-    # Attributes that were not in `morestats` get an error notifying the user
-    # that the attribute is not in `morestats` and that `morestats` is
+    # Attributes that were not in `module_name` get an error notifying the user
+    # that the attribute is not in `module_name` and that `module_name` is
     # deprecated.
     message = f"`{module_name}` is deprecated..."
     with pytest.raises(AttributeError, match=message):

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -324,19 +324,19 @@ def test_private_but_present_deprecation(module_name):
     # for imports from private modules
     # were misleading. Check that this is resolved.
     module = import_module(module_name)
-    sub_module_name = module_name.split(".")[1]
-    sub_module = import_module(f"scipy.{sub_module_name}")
+    sub_package_name = module_name.split(".")[1]
+    sub_package = import_module(f"scipy.{sub_package_name}")
 
     # Attributes that were formerly in `module_name` can still be imported from
     # `module_name`, albeit with a deprecation warning. The specific message
     # depends on whether the attribute is public in `scipy.xxx` or not.
     for attr_name in module.__all__:
-        attr = getattr(sub_module, attr_name, None)
+        attr = getattr(sub_package, attr_name, None)
         if attr is None:
             message = f"`{module_name}.{attr_name}` is deprecated..."
         else:
-            message = f"Please import `{attr_name}` from the `scipy.{sub_module_name}`..."
-        with pytest.warns(DeprecationWarning, match=message):
+            message = f"Please import `{attr_name}` from the `scipy.{sub_package_name}`..."
+        with pytest.deprecated_call(match=message):
             getattr(module, attr_name)
 
     # Attributes that were not in `module_name` get an error notifying the user

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -63,6 +63,11 @@ from scipy import stats
 from scipy.optimize import root_scalar
 from scipy._lib.deprecation import _NoValue
 
+# In __all__ but deprecated for removal in SciPy 1.13.0
+from scipy._lib._util import float_factorial  # noqa
+from scipy.stats._mstats_basic import (PointbiserialrResult, Ttest_1sampResult,
+                                       Ttest_relResult)  # noqa
+
 
 # Functions/classes in other files should be added in `__init__.py`, not here
 __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -65,7 +65,7 @@ from scipy._lib.deprecation import _NoValue
 
 # In __all__ but deprecated for removal in SciPy 1.13.0
 from scipy._lib._util import float_factorial  # noqa
-from scipy.stats._mstats_basic import (PointbiserialrResult, Ttest_1sampResult,
+from scipy.stats._mstats_basic import (PointbiserialrResult, Ttest_1sampResult,  # noqa
                                        Ttest_relResult)  # noqa
 
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -29,4 +29,6 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation("morestats", "stats", "_morestats", __all__, name)
+    return _sub_module_deprecation(sub_package="stats", module="morestats",
+                                   private_module="_morestats", all=__all__,
+                                   attribute=name)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -32,4 +32,4 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation("morestats", "stats", __all__, name)
+    return _sub_module_deprecation("morestats", "stats", "_morestats", __all__, name)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -5,6 +5,7 @@
 import scipy
 import warnings
 from . import _morestats
+from scipy._lib.deprecation import _sub_module_deprecation
 
 
 __all__ = [  # noqa: F822
@@ -31,24 +32,4 @@ def __dir__():
 
 
 def __getattr__(name):
-    if name not in __all__:
-        raise AttributeError(
-            f"`scipy.stats.morestats` has no attribute `{name}`; furthermore, "
-            "`scipy.stats.morestats` is deprecated and will be removed in "
-            "SciPy 2.0.0.")
-
-    attr = getattr(scipy.stats, name, None)
-
-    if attr is not None:
-        message = (f"Please import `{name}` from the `scipy.stats` namespace; "
-                   "the `scipy.stats.morestats` namespace is deprecated and "
-                   "will be removed in SciPy 2.0.0.")
-    else:
-        message = (f"`scipy.stats.morestats.{name}` is deprecated along with "
-                   "the `scipy.stats.morestats` namespace. "
-                   f"`scipy.stats.morestats.{name}` will be removed in SciPy 1.13.0, and "
-                   "the `scipy.stats.morestats` namespace will be removed in SciPy 2.0.0.")
-
-    warnings.warn(message, category=DeprecationWarning, stacklevel=2)
-
-    return getattr(_morestats, name)
+    return _sub_module_deprecation("morestats", "stats", __all__, name)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2,9 +2,6 @@
 # Use the `scipy.stats` namespace for importing the functions
 # included below.
 
-import scipy
-import warnings
-from . import _morestats
 from scipy._lib.deprecation import _sub_module_deprecation
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2,8 +2,6 @@
 # Use the `scipy.stats` namespace for importing the functions
 # included below.
 
-import warnings
-from . import _stats_py
 from scipy._lib.deprecation import _sub_module_deprecation
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4,23 +4,22 @@
 
 import warnings
 from . import _stats_py
+from scipy._lib.deprecation import _sub_module_deprecation
 
 
 __all__ = [  # noqa: F822
     'find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
     'tmin', 'tmax', 'tstd', 'tsem', 'moment',
     'skew', 'kurtosis', 'describe', 'skewtest', 'kurtosistest',
-    'normaltest', 'jarque_bera', 'itemfreq',
+    'normaltest', 'jarque_bera',
     'scoreatpercentile', 'percentileofscore',
     'cumfreq', 'relfreq', 'obrientransform',
     'sem', 'zmap', 'zscore', 'gzscore', 'iqr', 'gstd',
-    'median_absolute_deviation', 'median_abs_deviation',
+    'median_abs_deviation',
     'sigmaclip', 'trimboth', 'trim1', 'trim_mean',
-    'f_oneway', 'F_onewayConstantInputWarning',
-    'F_onewayBadInputSizesWarning',
-    'PearsonRConstantInputWarning', 'PearsonRNearConstantInputWarning',
+    'f_oneway',
     'pearsonr', 'fisher_exact',
-    'SpearmanRConstantInputWarning', 'spearmanr', 'pointbiserialr',
+    'spearmanr', 'pointbiserialr',
     'kendalltau', 'weightedtau', 'multiscale_graphcorr',
     'linregress', 'siegelslopes', 'theilslopes', 'ttest_1samp',
     'ttest_ind', 'ttest_ind_from_stats', 'ttest_rel',
@@ -34,11 +33,11 @@ __all__ = [  # noqa: F822
     'rng_integers', 'float_factorial', 'linalg', 'distributions',
     'mstats_basic', 'ModeResult', 'DescribeResult',
     'SkewtestResult', 'KurtosistestResult', 'NormaltestResult',
-    'Jarque_beraResult', 'HistogramResult', 'CumfreqResult',
+    'HistogramResult', 'CumfreqResult',
     'RelfreqResult', 'SigmaclipResult', 'F_onewayResult',
-    'AlexanderGovernResult', 'AlexanderGovernConstantInputWarning',
-    'SpearmanrResult', 'PointbiserialrResult', 'KendalltauResult',
-    'WeightedTauResult', 'MGCResult', 'Ttest_1sampResult', 'Ttest_indResult',
+    'AlexanderGovernResult',
+    'PointbiserialrResult',
+    'MGCResult', 'Ttest_1sampResult', 'Ttest_indResult',
     'Ttest_relResult', 'Power_divergenceResult', 'KstestResult',
     'Ks_2sampResult', 'RanksumsResult', 'KruskalResult',
     'FriedmanchisquareResult', 'BrunnerMunzelResult', 'RepeatedResults'
@@ -50,13 +49,4 @@ def __dir__():
 
 
 def __getattr__(name):
-    if name not in __all__:
-        raise AttributeError(
-            "scipy.stats.stats is deprecated and has no attribute "
-            f"{name}. Try looking in scipy.stats instead.")
-
-    warnings.warn(f"Please use `{name}` from the `scipy.stats` namespace, "
-                  "the `scipy.stats.stats` namespace is deprecated.",
-                  category=DeprecationWarning, stacklevel=2)
-
-    return getattr(_stats_py, name)
+    return _sub_module_deprecation("stats", "stats", "_stats_py", __all__, name)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -47,4 +47,6 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation("stats", "stats", "_stats_py", __all__, name)
+    return _sub_module_deprecation(sub_package="stats", module="stats",
+                                   private_module="_stats_py", all=__all__,
+                                   attribute=name)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2769,28 +2769,3 @@ class TestFDRControl:
         assert_array_equal(stats.false_discovery_control([0.25]), [0.25])
         assert_array_equal(stats.false_discovery_control(0.25), 0.25)
         assert_array_equal(stats.false_discovery_control([]), [])
-
-
-def test_morestats_deprecation():
-    # gh-18279 noted that deprecation warnings for imports from private modules
-    # were misleading. Check that this is resolved.
-    import scipy.stats.morestats as module
-
-    # Attributes that were formerly in `morestats` can still be imported from
-    # `morestats`, albeit with a deprecation warning. The specific message
-    # depends on whether the attribute is public in `scipy.stats` or not.
-    for attr_name in module.__all__:
-        attr = getattr(stats, attr_name, None)
-        if attr is None:
-            message = f"`scipy.stats.morestats.{attr_name}` is deprecated..."
-        else:
-            message = f"Please import `{attr_name}` from the `scipy.stats`..."
-        with pytest.warns(DeprecationWarning, match=message):
-            getattr(module, attr_name)
-
-    # Attributes that were not in `morestats` get an error notifying the user
-    # that the attribute is not in `morestats` and that `morestats` is
-    # deprecated.
-    message = "`scipy.stats.morestats` is deprecated..."
-    with pytest.raises(AttributeError, match=message):
-        getattr(module, "ekki")

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -143,11 +143,6 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.stats\.contingency\.margins',
     r'scipy\.stats\.reciprocal',  # alias for lognormal
     r'scipy\.stats\.trapz',   # alias for trapezoid
-    r'scipy\.stats\.F_onewayBadInputSizesWarning',  # shouldn't
-    r'scipy\.stats\.F_onewayConstantInputWarning',  # have
-    r'scipy\.stats\.PearsonRConstantInputWarning',  # been
-    r'scipy\.stats\.PearsonRNearConstantInputWarning',  # in
-    r'scipy\.stats\.SpearmanRConstantInputWarning',  # __all__
 ]
 # deprecated windows in scipy.signal namespace
 for name in ('barthann', 'bartlett', 'blackmanharris', 'blackman', 'bohman',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Future follow-ups will close:
https://github.com/scipy/scipy/issues/17572
https://github.com/scipy/scipy/issues/17771
https://github.com/scipy/scipy/issues/18279
Follow up to #18649
#### What does this implement/fix?
<!--Please explain your changes.-->
Takes Matt's solution and makes it more generic so that it can be applied to all private but present modules. See #18649 for a thorough explanation.

#### Additional information
<!--Any additional information you think is important.-->

@mdhaber @h-vetinari wanted to check this was along the lines of what you had in mind before continuing as it will take a fair amount of work. Also, the diff is going to be pretty large but not sure there is an easy way to break this up. On the plus side this has been quite effective at sniffing out things in `__all__` that either just don't exist or aren't importable.