### PR TITLE
MAINT: stats.burr12: moments are undefined when c*d <= order

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1231,8 +1231,12 @@ class burr12_gen(rv_continuous):
         return sc.expm1(-1/d * sc.log1p(-q))**(1/c)
 
     def _munp(self, n, c, d):
-        nc = 1. * n / c
-        return d * sc.beta(1.0 + nc, d - nc)
+        def moment_if_exists(n, c, d):
+            nc = 1. * n / c
+            return d * sc.beta(1.0 + nc, d - nc)
+
+        return _lazywhere(c * d > n, (n, c, d), moment_if_exists,
+                          fillvalue=np.nan)
 
 
 burr12 = burr12_gen(a=0.0, name='burr12')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7213,20 +7213,6 @@ class TestBurr12:
         delta = stats.burr12._delta_cdf(2e5, 4e5, 4, 8, scale=scale)
         assert_allclose(delta, expected, rtol=1e-13)
 
-
-    @pytest.mark.parametrize('n', range(6))
-    @pytest.mark.parametrize('c', [1.6, 2.6])
-    @pytest.mark.parametrize('d', [0.1, 1, 2])
-    def test_moments(self, n, c, d):
-        # gh-18838 reported that burr12 moments could be invalid. This was
-        # because moment n exists iff shape parameters c*d > n, but this was
-        # not checked in the implementation. Confirm that this is resolved.
-        res = stats.burr12(c, d).moment(n)
-        if c*d > n:
-            assert np.isfinite(res)
-        else:
-            assert np.isnan(res)
-
     def test_moments_edge(self):
         # gh-18838 reported that burr12 moments could be invalid; see above.
         # Check that this is resolved in an edge case where c*d == n, and


### PR DESCRIPTION
#### Reference issue
Closes gh-18838

#### What does this implement/fix?
gh-18838 reported that `burr12.stats` returned a negative variance. Moment $r$ of the Burr XII distribution is defined iff shapes $cd > r$, but this condition was not being checked in the implementation. This PR adds the check to the `_munp` method, returning `np.nan` if the condition is not met.

#### Additional information
We can certainly reduce the parameterization of `test_moments` or eliminate the test entirely, if desired. 