### PR TITLE
MAINT: *sctype* replace NumPy 2.0

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -165,7 +165,7 @@ def _copy_array_if_base_present(a):
     """
     if a.base is not None:
         return a.copy()
-    elif np.issubsctype(a, np.float32):
+    elif issubclass(a.dtype.type, np.float32):
         return np.array(a, dtype=np.double)
     else:
         return a

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -300,7 +300,10 @@ class TestInterp1D:
         # regression test for gh-5898, where 1D linear interpolation has been
         # delegated to numpy.interp for all float dtypes, and the latter was
         # not handling e.g. np.float128.
-        for dtyp in np.sctypes["float"]:
+        for dtyp in [np.float16,
+                     np.float32,
+                     np.float64,
+                     np.longdouble]:
             x = np.arange(8, dtype=dtyp)
             y = x
             yp = interp1d(x, y, kind='linear')(x)

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -87,7 +87,13 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        output = numpy.sctypeDict[output]
+        # testsuite only appears to cover
+        # f->np.float32 here
+        f_dict = {"f": numpy.float32,
+                  "d": numpy.float64,
+                  "F": numpy.complex64,
+                  "D": numpy.complex128}
+        output = f_dict[output]
         if complex_output and numpy.dtype(output).kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -181,16 +181,12 @@ class TestConvolve(_TestConvolve):
         assert_raises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
     def test_convolve_method(self, n=100):
-        types = sum([t for _, t in np.sctypes.items()], [])
-        types = {np.dtype(t).name for t in types}
-
-        # These types include 'bool' and all precisions (int8, float32, etc)
-        # The removed types throw errors in correlate or fftconvolve
-        for dtype in ['complex256', 'complex192', 'float128', 'float96',
-                      'str', 'void', 'bytes', 'object', 'unicode', 'string']:
-            if dtype in types:
-                types.remove(dtype)
-
+        # this types data structure was manually encoded instead of
+        # using custom filters on the soon-to-be-removed np.sctypes
+        types = {'uint16', 'uint64', 'int64', 'int32',
+                 'complex128', 'float64', 'float16',
+                 'complex64', 'float32', 'int16',
+                 'uint8', 'uint32', 'int8', 'bool'}
         args = [(t1, t2, mode) for t1 in types for t2 in types
                                for mode in ['valid', 'full', 'same']]
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -101,8 +101,12 @@ def _get_umf_family(A):
         (np.complex128, np.int64): 'zl'
     }
 
-    f_type = np.sctypeDict[A.dtype.name]
-    i_type = np.sctypeDict[A.indices.dtype.name]
+    # A.dtype.name can only be "float64" or
+    # "complex128" in control flow
+    f_type = getattr(np, A.dtype.name)
+    # control flow may allow for more index
+    # types to get through here
+    i_type = getattr(np, A.indices.dtype.name)
 
     try:
         family = _families[(f_type, i_type)]


### PR DESCRIPTION
* replace `*sctype*` NumPy usage per https://github.com/numpy/numpy/issues/23999 and NEP52 in preparation for NumPy 2.0

* there seem to be straightforward replacements that still pass the testsuite in all cases

* `git grep -E -i "sctype"` is clean on this branch (only present in comments for clarity where needed)

* there may be better canonical ways to do some of these things in the future, though considerable confusion remains per https://github.com/numpy/numpy/issues/17325

* `UMFPACK`-related changes were not tested locally (wasn't particularly friendly for PyPI-based setup/venv)

[skip circle]