### PR TITLE
DEP: vendor sklearn's mechanism to deprecate passing kwargs positionally

### DIFF
--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -152,3 +152,60 @@ def deprecate_cython_api(module, routine_name, new_name=None, message=None):
     if not has_fused:
         d[_DeprecationHelperStr(routine_name, depdoc)] = d.pop(routine_name)
 
+
+# taken from scikit-learn, see
+# https://github.com/scikit-learn/scikit-learn/blob/1.3.0/sklearn/utils/validation.py#L38
+def _deprecate_positional_args(func=None, *, version="1.3"):
+    """Decorator for methods that issues warnings for positional arguments.
+
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
+
+    Parameters
+    ----------
+    func : callable, default=None
+        Function to check arguments on.
+    version : callable, default="1.3"
+        The version when positional arguments will result in error.
+    """
+
+    def _inner_deprecate_positional_args(f):
+        sig = signature(f)
+        kwonly_args = []
+        all_args = []
+
+        for name, param in sig.parameters.items():
+            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                all_args.append(name)
+            elif param.kind == Parameter.KEYWORD_ONLY:
+                kwonly_args.append(name)
+
+        @wraps(f)
+        def inner_f(*args, **kwargs):
+            extra_args = len(args) - len(all_args)
+            if extra_args <= 0:
+                return f(*args, **kwargs)
+
+            # extra_args > 0
+            args_msg = [
+                "{}={}".format(name, arg)
+                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
+            ]
+            args_msg = ", ".join(args_msg)
+            warnings.warn(
+                (
+                    f"Pass {args_msg} as keyword args. From version "
+                    f"{version} passing these as positional arguments "
+                    "will result in an error"
+                ),
+                FutureWarning,
+            )
+            kwargs.update(zip(sig.parameters, args))
+            return f(**kwargs)
+
+        return inner_f
+
+    if func is not None:
+        return _inner_deprecate_positional_args(func)
+
+    return _inner_deprecate_positional_args

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from scipy.special import roots_legendre
 from scipy.special import gammaln, logsumexp
 from scipy._lib._util import _rng_spawn
-from scipy._lib.deprecation import _NoValue
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'romb',
@@ -550,10 +550,12 @@ def simps(y, x=None, dx=1.0, axis=-1, even=_NoValue):
     msg = ("'scipy.integrate.simps' is deprecated in favour of "
            "'scipy.integrate.simpson' and will be removed in SciPy 1.14.0")
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    # we don't deprecate positional use as the wrapper is going away completely
     return simpson(y, x=x, dx=dx, axis=axis, even=even)
 
 
-def simpson(y, x=None, dx=1.0, axis=-1, even=_NoValue):
+@_deprecate_positional_args(version="1.14")
+def simpson(y, *, x=None, dx=1.0, axis=-1, even=_NoValue):
     """
     Integrate y(x) using samples along the given axis and the composite
     Simpson's rule. If x is None, spacing of dx is assumed.

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -231,11 +231,13 @@ class TestQuadrature:
         assert_allclose(simpson(y, x=x, axis=0), zero_axis)
         assert_allclose(simpson(y, x=x, axis=-1), default_axis)
 
-    def test_simpson_even_is_deprecated(self):
+    def test_simpson_deprecations(self):
         x = np.linspace(0, 3, 4)
         y = x**2
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match="The 'even' keyword is deprecated"):
             simpson(y, x=x, even='first')
+        with pytest.deprecated_call(match="use keyword arguments"):
+            simpson(y, x)
 
     @pytest.mark.parametrize('droplast', [False, True])
     def test_simpson_2d_integer_no_x(self, droplast):


### PR DESCRIPTION
This does the main preparation work for #18703, and puts it into action for one of the functions from #18624 that doesn't have a dedicated issue.

I want to get the infrastructure in place first, and then have separate PRs for each of the deprecations, because even though I have most commits ready, there will probably be some discussions around consistency within a given module, where to set the keyword-cutoff etc. These discussions shouldn't be mixed between all the different functions from wildly different modules.