### PR TITLE
MAINT: ptp no method for NumPy 2.0

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -85,7 +85,7 @@ class NDInterpolatorBase:
             # scale to unit cube centered at 0
             self.offset = np.mean(points, axis=0)
             self.points = points - self.offset
-            self.scale = self.points.ptp(axis=0)
+            self.scale = np.ptp(points, axis=0)
             self.scale[~(self.scale > 0)] = 1.0  # avoid division by 0
             self.points /= self.scale
         

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -231,7 +231,7 @@ class TestSplder:
         self.spl = splrep(x, y)
 
         # double check that knots are non-uniform
-        assert_(np.diff(self.spl[0]).ptp() > 0)
+        assert_(np.ptp(np.diff(self.spl[0])) > 0)
 
     def test_inverse(self):
         # Check that antiderivative + derivative is identity.

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -923,7 +923,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
         out_bounds = rot_matrix @ [[0, 0, iy, iy],
                                    [0, ix, 0, ix]]
         # Compute the shape of the transformed input plane
-        out_plane_shape = (out_bounds.ptp(axis=1) + 0.5).astype(int)
+        out_plane_shape = (numpy.ptp(out_bounds, axis=1) + 0.5).astype(int)
     else:
         out_plane_shape = img_shape[axes]
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2005,13 +2005,13 @@ def test_gaussian_truncate():
     # Test gaussian_laplace
     y = ndimage.gaussian_laplace(x, sigma=2, truncate=3.5)
     nonzero_indices = numpy.nonzero(y != 0)[0]
-    n = nonzero_indices.ptp() + 1
+    n = numpy.ptp(nonzero_indices) + 1
     assert_equal(n, 15)
 
     # Test gaussian_gradient_magnitude
     y = ndimage.gaussian_gradient_magnitude(x, sigma=2, truncate=3.5)
     nonzero_indices = numpy.nonzero(y != 0)[0]
-    n = nonzero_indices.ptp() + 1
+    n = numpy.ptp(nonzero_indices) + 1
     assert_equal(n, 15)
 
 

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -26,7 +26,7 @@ def _held_figure(func, obj, ax=None, **kw):
 
 
 def _adjust_bounds(ax, points):
-    margin = 0.1 * points.ptp(axis=0)
+    margin = 0.1 * np.ptp(points, axis=0)
     xy_min = points.min(axis=0) - margin
     xy_max = points.max(axis=0) + margin
     ax.set_xlim(xy_min[0], xy_max[0])
@@ -230,7 +230,7 @@ def voronoi_plot_2d(vor, ax=None, **kw):
     line_alpha = kw.get('line_alpha', 1.0)
 
     center = vor.points.mean(axis=0)
-    ptp_bound = vor.points.ptp(axis=0)
+    ptp_bound = np.ptp(vor.points, axis=0)
 
     finite_segments = []
     infinite_segments = []

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8041,7 +8041,7 @@ class powerlaw_gen(rv_continuous):
             if fscale <= 0:
                 raise ValueError("Negative or zero `fscale` is outside the "
                                  "range allowed by the distribution.")
-            if fscale <= data.ptp():
+            if fscale <= np.ptp(data):
                 msg = "`fscale` must be greater than the range of data."
                 raise ValueError(msg)
 
@@ -9992,7 +9992,7 @@ class FitUniformFixedScaleDataError(FitDataError):
         self.args = (
             "Invalid values in `data`.  Maximum likelihood estimation with "
             "the uniform distribution and fixed scale requires that "
-            f"data.ptp() <= fscale, but data.ptp() = {ptp} and "
+            f"np.ptp(data) <= fscale, but np.ptp(data) = {ptp} and "
             f"fscale = {fscale}."
         )
 
@@ -10139,25 +10139,25 @@ class uniform_gen(rv_continuous):
         # while keeping loc <= x <= loc + scale.   So if neither loc nor scale
         # are fixed, the log-likelihood is maximized by choosing
         #     loc = x.min()
-        #     scale = x.ptp()
+        #     scale = np.ptp(x)
         # If loc is fixed, it must be less than or equal to x.min(), and then
         # the scale is
         #     scale = x.max() - loc
-        # If scale is fixed, it must not be less than x.ptp().  If scale is
-        # greater than x.ptp(), the solution is not unique.  Note that the
+        # If scale is fixed, it must not be less than np.ptp(x).  If scale is
+        # greater than np.ptp(x), the solution is not unique.  Note that the
         # likelihood does not depend on loc, except for the requirement that
         # loc <= x <= loc + scale.  All choices of loc for which
         #     x.max() - scale <= loc <= x.min()
         # have the same log-likelihood.  In this case, we choose loc such that
         # the support is centered over the interval [data.min(), data.max()]:
-        #     loc = x.min() = 0.5*(scale - x.ptp())
+        #     loc = x.min() = 0.5*(scale - np.ptp(x))
 
         if fscale is None:
             # scale is not fixed.
             if floc is None:
                 # loc is not fixed, scale is not fixed.
                 loc = data.min()
-                scale = data.ptp()
+                scale = np.ptp(data)
             else:
                 # loc is fixed, scale is not fixed.
                 loc = floc
@@ -10166,7 +10166,7 @@ class uniform_gen(rv_continuous):
                     raise FitDataError("uniform", lower=loc, upper=loc + scale)
         else:
             # loc is not fixed, scale is fixed.
-            ptp = data.ptp()
+            ptp = np.ptp(data)
             if ptp > fscale:
                 raise FitUniformFixedScaleDataError(ptp=ptp, fscale=fscale)
             # If ptp < fscale, the ML estimate is not unique; see the comments

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3077,7 +3077,7 @@ class TestPowerlaw:
         data = stats.powerlaw.rvs(a=a, loc=location, scale=scale, size=100,
                                   random_state=np.random.default_rng(5))
 
-        kwds = {'fscale': data.ptp() * 2}
+        kwds = {'fscale': np.ptp(data) * 2}
 
         _assert_less_or_close_loglike(stats.powerlaw, data, **kwds)
 
@@ -5734,7 +5734,7 @@ class TestFitMethod:
 
         loc, scale = stats.uniform.fit(x)
         assert_equal(loc, x.min())
-        assert_equal(scale, x.ptp())
+        assert_equal(scale, np.ptp(x))
 
         loc, scale = stats.uniform.fit(x, floc=0)
         assert_equal(loc, 0)


### PR DESCRIPTION
* as suggested in [NEP 52 niche methods section](https://numpy.org/neps/nep-0052-python-api-cleanup.html#cleaning-up-the-niche-methods-on-numpy-ndarray), in preparation for NumPy 2.0, stop using the `ndarray` `ptp()` method--it is considered niche and a candidate for removal in NumPy 2.0

* `git grep -E -i "[^py]\.ptp"` is clean on this branch (i.e., check for `.ptp` incantations that don't start with `numpy` or `np`)