### PR TITLE
BUG: fix overflow in stats.yeojohnson

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1503,6 +1503,7 @@ def _yeojohnson_transform(x, lmbda):
     if abs(lmbda) < np.spacing(1.):
         out[pos] = np.log1p(x[pos])
     else:  # lmbda != 0
+        # more stable version of: ((x + 1) ** lmbda - 1) / lmbda
         out[pos] = np.expm1(lmbda * np.log1p(x[pos])) / lmbda
 
     # when x < 0
@@ -1680,7 +1681,7 @@ def yeojohnson_normmax(x, brack=None):
             return optimize.brent(_neg_llf, brack=brack, args=(x,))
         x = np.asarray(x)
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
-        # Allow values up to 20x the maximum observed value to be safely
+        # Allow values up to 20 times the maximum observed value to be safely
         # transformed without over- or underflow.
         log1p_max_x = np.log1p(20 * np.max(np.abs(x)))
         # Use half of floating point's exponent range to allow safe computation

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1677,6 +1677,8 @@ def yeojohnson_normmax(x, brack=None):
     with np.errstate(invalid='ignore'):
         if not np.all(np.isfinite(x)):
             raise ValueError('Yeo-Johnson input must be finite.')
+        if np.all(x == 0):
+            return 1.0
         if brack is not None:
             return optimize.brent(_neg_llf, brack=brack, args=(x,))
         x = np.asarray(x)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1496,7 +1496,8 @@ def _yeojohnson_transform(x, lmbda):
     """Returns `x` transformed by the Yeo-Johnson power transform with given
     parameter `lmbda`.
     """
-    out = np.zeros_like(x)
+    dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
+    out = np.zeros_like(x, dtype=dtype)
     pos = x >= 0  # binary mask
 
     # when x >= 0
@@ -1694,7 +1695,7 @@ def yeojohnson_normmax(x, brack=None):
         # Compute the bounds by approximating the inverse of the Yeo-Johnson
         # transform on the smallest and largest floating point exponents, given
         # the largest data we expect to observe. See [1] for further details.
-        # [1] https://github.com/scipy/scipy/pull/18852
+        # [1] https://github.com/scipy/scipy/pull/18852#issuecomment-1630286174
         lb = log_tiny_float / log1p_max_x
         ub = log_max_float / log1p_max_x
         # Convert the bounds if all or some of the data is negative.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1680,8 +1680,10 @@ def yeojohnson_normmax(x, brack=None):
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
         b = np.log(np.finfo(dtype).eps)
         max_x = 20 * np.nanmax(np.abs(x))
-        lb = (np.log(np.finfo(dtype).tiny) - b) / 2 / np.log(max_x + 1)
-        ub = (np.log(np.finfo(dtype).max) + b) / 2 / np.log(max_x + 1)
+        lb = (np.log(np.finfo(dtype).tiny) - b) / 2 / np.log1p(max_x)
+        ub = (np.log(np.finfo(dtype).max) + b) / 2 / np.log1p(max_x)
+        if np.any(x < 0):
+            lb, ub = 2 - ub, 2 - lb
         tol_brent = 1.48e-08
         return optimize.fminbound(_neg_llf, lb, ub, args=(x,), xtol=tol_brent)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1697,9 +1697,11 @@ def yeojohnson_normmax(x, brack=None):
         # [1] https://github.com/scipy/scipy/pull/18852
         lb = log_tiny_float / log1p_max_x
         ub = log_max_float / log1p_max_x
-        # Convert the bounds if the data is negative.
-        if np.any(x < 0):
+        # Convert the bounds if all or some of the data is negative.
+        if np.all(x < 0):
             lb, ub = 2 - ub, 2 - lb
+        elif np.any(x < 0):
+            lb, ub = max(2 - ub, lb), min(2 - lb, ub)
         # Match `optimize.brent`'s tolerance.
         tol_brent = 1.48e-08
         return optimize.fminbound(_neg_llf, lb, ub, args=(x,), xtol=tol_brent)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2269,7 +2269,8 @@ class TestYeojohnson:
     @pytest.mark.parametrize('x', [
         np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
                   2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
-        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0])
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0]),
+        np.array([0, 0, 0])
     ])
     @pytest.mark.parametrize('scale', [1, 1e-12, 1e-32, 1e-150, 1e32, 1e200])
     @pytest.mark.parametrize('sign', [1, -1])

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2292,11 +2292,17 @@ class TestYeojohnson:
     @pytest.mark.parametrize('brack', [None, (-2, 2)])
     def test_integer_signed_data(self, x, sign, brack):
         with np.errstate(all="raise"):
-            lam_yeo = stats.yeojohnson_normmax(sign * x, brack=brack)
-            xt_yeo = stats.yeojohnson(sign * x, lmbda=lam_yeo)
-            assert np.all(np.sign(sign * x) == np.sign(xt_yeo))
-            assert np.isfinite(lam_yeo)
-            assert np.isfinite(np.var(xt_yeo))
+            x_int = sign * x
+            x_float = x_int.astype(np.float64)
+            lam_yeo_int = stats.yeojohnson_normmax(x_int, brack=brack)
+            xt_yeo_int = stats.yeojohnson(x_int, lmbda=lam_yeo_int)
+            lam_yeo_float = stats.yeojohnson_normmax(x_float, brack=brack)
+            xt_yeo_float = stats.yeojohnson(x_float, lmbda=lam_yeo_float)
+            assert np.all(np.sign(x_int) == np.sign(xt_yeo_int))
+            assert np.isfinite(lam_yeo_int)
+            assert np.isfinite(np.var(xt_yeo_int))
+            assert lam_yeo_int == lam_yeo_float
+            assert np.all(xt_yeo_int == xt_yeo_float)
 
 
 class TestYeojohnsonNormmax:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2229,6 +2229,39 @@ class TestYeojohnson:
         xt_box, lam_box = stats.boxcox(x + 1)
         assert_allclose(xt_yeo, xt_box, rtol=1e-6)
         assert_allclose(lam_yeo, lam_box, rtol=1e-6)
+    
+    def test_overflow_expr(self):
+        # non-regression test for gh-18389
+        x = np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
+                      2009.0, 1980.0, 1999.0, 2007.0, 1991.0])
+        
+        def optimizer(fun):
+            out = optimize.fminbound(fun, -lam_yeo, lam_yeo, xtol=1.48e-08)
+            result = optimize.OptimizeResult()
+            result.x = out
+            return result
+
+        with np.errstate(over="raise"):
+            xt_yeo, lam_yeo = stats.yeojohnson(x)
+            xt_box, lam_box = stats.boxcox(x + 1, optimizer=optimizer)
+            assert_allclose(lam_yeo, lam_box, rtol=1e-5)
+            assert_allclose(xt_yeo, xt_box, rtol=1e-5)
+    
+    def test_overflow_lam(self):
+        # non-regression test for gh-18389
+        x = np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0])
+
+        def optimizer(fun):
+            out = optimize.fminbound(fun, -lam_yeo, lam_yeo, xtol=1.48e-08)
+            result = optimize.OptimizeResult()
+            result.x = out
+            return result
+
+        with np.errstate(over="raise"):
+            xt_yeo, lam_yeo = stats.yeojohnson(x)
+            xt_box, lam_box = stats.boxcox(x + 1, optimizer=optimizer)
+            assert_allclose(lam_yeo, lam_box, rtol=1e-5)
+            assert_allclose(xt_yeo, xt_box, rtol=1e-5)
 
 
 class TestYeojohnsonNormmax:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2237,8 +2237,7 @@ class TestYeojohnson:
         np.array([-1.0, float("nan"), float("inf"), -float("inf"), 1.0])
     ])
     def test_nonfinite_input(self, x):
-        # non-regression test for gh-18389
-        with pytest.raises(ValueError, match='finite'):
+        with pytest.raises(ValueError, match='Yeo-Johnson input must be finite'):
             xt_yeo, lam_yeo = stats.yeojohnson(x)
 
     @pytest.mark.parametrize('x', [

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2230,26 +2230,15 @@ class TestYeojohnson:
         assert_allclose(xt_yeo, xt_box, rtol=1e-6)
         assert_allclose(lam_yeo, lam_box, rtol=1e-6)
     
-    def test_overflow_expr(self):
+    @pytest.mark.parametrize('x', [
+        # Attempt to trigger overflow in power expressions.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
+                  2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
+        # Attempt to trigger overflow with a large optimal lambda.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0])
+    ])
+    def test_overflow(self, x):
         # non-regression test for gh-18389
-        x = np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
-                      2009.0, 1980.0, 1999.0, 2007.0, 1991.0])
-        
-        def optimizer(fun):
-            out = optimize.fminbound(fun, -lam_yeo, lam_yeo, xtol=1.48e-08)
-            result = optimize.OptimizeResult()
-            result.x = out
-            return result
-
-        with np.errstate(over="raise"):
-            xt_yeo, lam_yeo = stats.yeojohnson(x)
-            xt_box, lam_box = stats.boxcox(x + 1, optimizer=optimizer)
-            assert_allclose(lam_yeo, lam_box, rtol=1e-5)
-            assert_allclose(xt_yeo, xt_box, rtol=1e-5)
-    
-    def test_overflow_lam(self):
-        # non-regression test for gh-18389
-        x = np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0])
 
         def optimizer(fun):
             out = optimize.fminbound(fun, -lam_yeo, lam_yeo, xtol=1.48e-08)
@@ -2257,9 +2246,11 @@ class TestYeojohnson:
             result.x = out
             return result
 
-        with np.errstate(over="raise"):
+        with np.errstate(over="raise", under="raise"):
             xt_yeo, lam_yeo = stats.yeojohnson(x)
             xt_box, lam_box = stats.boxcox(x + 1, optimizer=optimizer)
+            assert np.isfinite(np.var(xt_yeo))
+            assert np.isfinite(np.var(xt_box))
             assert_allclose(lam_yeo, lam_box, rtol=1e-5)
             assert_allclose(xt_yeo, xt_box, rtol=1e-5)
 


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/18389.

#### What does this implement/fix?
This PR fixes two sources of overflow in `stats.yeojohnson`:
1. The first source of overflow is caused by certain invocations of np.power with unbalanced bases and exponents.
2. The second source of overflow occurs when the optimal transform is beyond what floating point can represent.