### PR TITLE
BENCH: Remove factorial benchmarks

### DIFF
--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -3,15 +3,7 @@ import numpy as np
 from .common import Benchmark, with_attributes, safe_import
 
 with safe_import():
-    from scipy.special import (
-        ai_zeros,
-        bi_zeros,
-        erf,
-        expn,
-        factorial,
-        factorial2,
-        factorialk,
-    )
+    from scipy.special import ai_zeros, bi_zeros, erf, expn
 with safe_import():
     # wasn't always in scipy.special, so import separately
     from scipy.special import comb
@@ -73,91 +65,3 @@ class Expn(Benchmark):
 
     def time_expn_large_n(self):
         expn(self.n, self.x)
-
-
-class Factorial(Benchmark):
-    def setup(self, *args):
-        self.positive_ints = np.arange(10, 111, step=20, dtype=int)
-        self.negative_ints = -1 * self.positive_ints
-        self.positive_floats = np.linspace(100.2, 1000.8, num=10)
-        self.negative_floats = -1 * self.positive_floats
-
-    @with_attributes(params=[(100, 1000, 10000)],
-                     param_names=['n'])
-    def time_factorial_exact_false_scalar_positive_int(self, n):
-        factorial(n, exact=False)
-
-    def time_factorial_exact_false_scalar_negative_int(self):
-        factorial(-10000, exact=False)
-
-    @with_attributes(params=[(100.8, 1000.3, 10000.5)],
-                     param_names=['n'])
-    def time_factorial_exact_false_scalar_positive_float(self, n):
-        factorial(n, exact=False)
-
-    def time_factorial_exact_false_scalar_negative_float(self):
-        factorial(-10000.8, exact=False)
-
-    def time_factorial_exact_false_array_positive_int(self):
-        factorial(self.positive_ints, exact=False)
-
-    def time_factorial_exact_false_array_negative_int(self):
-        factorial(self.negative_ints, exact=False)
-
-    def time_factorial_exact_false_array_positive_float(self):
-        factorial(self.positive_floats, exact=False)
-
-    def time_factorial_exact_false_array_negative_float(self):
-        factorial(self.negative_floats, exact=False)
-
-    @with_attributes(params=[(100, 200, 400, 10_000, 20_000)],
-                     param_names=['n'])
-    def time_factorial_exact_true_scalar_positive_int(self, n):
-        factorial(n, exact=True)
-
-    def time_factorial_exact_true_scalar_negative_int(self):
-        factorial(-10000, exact=True)
-
-    def time_factorial_exact_true_array_positive_int(self):
-        factorial(self.positive_ints, exact=True)
-
-    def time_factorial_exact_true_array_negative_int(self):
-        factorial(self.negative_ints, exact=True)
-
-
-class Factorial2(Benchmark):
-    def setup(self, *args):
-        self.positive_ints = np.arange(100, 201, step=20, dtype=int)
-        self.negative_ints = -1 * self.positive_ints
-
-    @with_attributes(params=[(100, 200, 400)],
-                     param_names=['n'])
-    def time_factorial2_exact_false_scalar_positive_int(self, n):
-        factorial2(n, exact=False)
-
-    def time_factorial2_exact_false_scalar_negative_int(self):
-        factorial2(-10000, exact=False)
-
-    def time_factorial2_exact_false_array_positive_int(self):
-        factorial2(self.positive_ints, exact=False)
-
-    def time_factorial2_exact_false_array_negative_int(self):
-        factorial2(self.negative_ints, exact=False)
-
-    @with_attributes(params=[(100, 200, 400, 10_000, 20_000)],
-                     param_names=['n'])
-    def time_factorial2_exact_true_scalar_positive_int(self, n):
-        factorial2(n, exact=True)
-
-    def time_factorial2_exact_true_scalar_negative_int(self):
-        factorial2(-10000, exact=True)
-
-
-class FactorialK(Benchmark):
-    @with_attributes(params=[(100, 500, 10_000, 20_000), (3, 6, 9)],
-                     param_names=['n', 'k'])
-    def time_factorialk_exact_true_scalar_positive_int(self, n, k):
-        factorialk(n, k, exact=True)
-
-    def time_factorialk_exact_false_scalar_negative_int(self):
-        factorialk(-10000, 3, exact=True)


### PR DESCRIPTION
In #15664, @rgommers had commented:
> If this takes half a minute on my machine, it's probably double that in CI. Do we really need all these? Or can a good amount of these be removed after https://github.com/scipy/scipy/issues/15600 is fixed?

and
> We do need to care about running benchmarks in CI so they actually keep working, so half a minute is a lot.

and
> Once we have [gh-15600](https://github.com/scipy/scipy/issues/15600) merged too, please remember to trim these benchmarks down.

Now that the big factorial changes landed, this is reverting that PR (+ follow-ups). I don't mind if we keep _some_ combinations still around, but I don't know if that's really worth it. They have done their job.