### PR TITLE
MAINT: Switch to latest ASV, use mamba solver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,7 @@ jobs:
             pip install cython
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
-            # `asv` pin because of slowdowns reported in gh-15568
-            pip install mpmath gmpy2 "asv==0.4.2" pythran ninja meson click rich-click doit pydevtool pooch
+            pip install mpmath gmpy2 "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84" pythran ninja meson click rich-click doit pydevtool pooch
             pip install pybind11
             # extra benchmark deps
             pip install pyfftw cffi pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
             export SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0
             export OPENBLAS_NUM_THREADS=1
-            time asv --config asv.conf.json dev -m CircleCI --quick --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
+            time asv --config asv.conf.json run -m CircleCI --quick --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
             asv --config asv.conf.json publish
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
             pip install mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch
-            pip "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84"
+            pip install asv>=0.6.0
             pip install pybind11
             # extra benchmark deps
             pip install pyfftw cffi pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,8 @@ jobs:
             pip install cython
             pip install numpy==1.23.5
             pip install -r doc_requirements.txt
-            pip install mpmath gmpy2 "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84" pythran ninja meson click rich-click doit pydevtool pooch
+            pip install mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch
+            pip "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84"
             pip install pybind11
             # extra benchmark deps
             pip install pyfftw cffi pytest
@@ -150,7 +151,7 @@ jobs:
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
             export SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0
             export OPENBLAS_NUM_THREADS=1
-            time asv --config asv.conf.json dev -m CircleCI --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
+            time asv --config asv.conf.json dev -m CircleCI --quick --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
             asv --config asv.conf.json publish
 
       - store_artifacts:

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -59,6 +59,7 @@
     // determined by looking for tools on the PATH environment
     // variable.
     // "environment_type": "virtualenv",
+    "environment_type": "mamba",
     "build_cache_size": 10,
 
     // The directory (relative to the current directory) that raw benchmark

--- a/dev.py
+++ b/dev.py
@@ -876,7 +876,7 @@ class Bench(Task):
                 print("Running benchmarks for Scipy version %s at %s"
                       % (version, mod_path))
                 cmd = ['asv', 'run', '--dry-run', '--show-stderr',
-                       '--python=same'] + bench_args
+                       '--python=same', '--quick'] + bench_args
                 retval = cls.run_asv(dirs, cmd)
                 sys.exit(retval)
             else:
@@ -910,7 +910,7 @@ class Bench(Task):
                 commit_a = out.strip()
                 cmd_compare = [
                     'asv', 'continuous', '--show-stderr', '--factor', '1.05',
-                    commit_a, commit_b
+                    '--quick', commit_a, commit_b
                 ] + bench_args
                 cls.run_asv(dirs, cmd_compare)
                 sys.exit(1)

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-timeout
-  - asv<0.5
   # For type annotations
   - mypy
   - typing_extensions
@@ -54,3 +53,8 @@ dependencies:
   # For linting
   - ruff
   - cython-lint
+  - pip
+  # Modern asv [benchmarking]
+  - mamba
+  - pip:
+      git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84

--- a/environment.yml
+++ b/environment.yml
@@ -59,4 +59,4 @@ dependencies:
   - pympler
   - pip
   - pip:
-      - "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84"
+      - asv>=0.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -53,8 +53,10 @@ dependencies:
   # For linting
   - ruff
   - cython-lint
-  - pip
-  # Modern asv [benchmarking]
+  # Modern asv (not released yet), plus its dependencies (as on conda-forge)
   - mamba
+  - json5
+  - pympler
+  - pip
   - pip:
-      git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84
+      - "git+https://github.com/airspeed-velocity/asv@d4c868e52943894688e2db6abbf1ba2ab179cb84"


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/scipy/scipy/issues/18849.
#### What does this implement/fix?
<!--Please explain your changes.-->
Switches to the latest ASV, this can be changed to a pinned release once `asv` has a new release. Also uses the faster `mamba` solver.
#### Additional information
<!--Any additional information you think is important.-->
N/A.