### PR TITLE
MAINT: clean up views/strides/dtypes utilities in `cluster.hierarcy`

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -380,7 +380,8 @@ cpdef void get_max_Rfield_for_each_cluster(double[:, :] Z, double[:, :] R,
     R : ndarray
         The R matrix.
     max_rfs : ndarray
-        The array to store the result.
+        The array to store the result. Note that this input arrays gets
+        modified in-place.
     n : int
         The number of observations.
     rf : int
@@ -440,7 +441,8 @@ cpdef get_max_dist_for_each_cluster(double[:, :] Z, double[:] MD, int n) noexcep
     Z : ndarray
         The linkage matrix.
     MD : ndarray
-        The array to store the result.
+        The array to store the result (hence this input array gets modified
+        in-place).
     n : int
         The number of observations.
     """
@@ -498,11 +500,13 @@ def inconsistent(double[:, :] Z, double[:, :] R, int n, int d):
     Z : ndarray
         The linkage matrix.
     R : ndarray
-        A (n - 1) x 4 matrix to store the result. The inconsistency statistics
-        `R[i]` are calculated over `d` levels below cluster i. `R[i, 0]` is the
-        mean of distances. `R[i, 1]` is the standard deviation of distances.
-        `R[i, 2]` is the number of clusters included. `R[i, 3]` is the
-        inconsistency coefficient.
+        A (n - 1) x 4 matrix to store the result (hence this input array is
+        modified in-place). The inconsistency statistics ``R[i]`` are calculated
+        over `d` levels below cluster ``i``.
+        ``R[i, 0]`` is the mean of distances.
+        ``R[i, 1]`` is the standard deviation of distances.
+        ``R[i, 2]`` is the number of clusters included.
+        ``R[i, 3]`` is the inconsistency coefficient.
 
         .. math:: \\frac{\\mathtt{Z[i,2]}-\\mathtt{R[i,0]}} {R[i,1]}
 
@@ -580,12 +584,9 @@ def leaders(double[:, :] Z, int[:] T, int[:] L, int[:] M, int nc, int n):
         The linkage matrix.
     T : ndarray
         The flat clusters assignment returned by `fcluster` or `fclusterdata`.
-    L : ndarray
-        `L` and `M` store the result. The leader of flat cluster `L[i]` is
-        node `M[i]`.
-    M : ndarray
-        `L` and `M` store the result. The leader of flat cluster `L[i]` is
-        node `M[i]`.
+    L, M : ndarray
+        `L` and `M` store the result (i.e., these inputs are modified
+        in-place). The leader of flat cluster ``L[i]`` is node ``M[i]``.
     nc : int
         The number of flat clusters.
     n : int
@@ -1124,7 +1125,8 @@ def prelist(double[:, :] Z, int[:] members, int n):
     Z : ndarray
         The linkage matrix.
     members : ndarray
-        The array to store the result.
+        The array to store the result. Note that this input array will be
+        modified in-place.
     n : int
         The number of observations.
     """

--- a/scipy/cluster/_optimal_leaf_ordering.pyx
+++ b/scipy/cluster/_optimal_leaf_ordering.pyx
@@ -423,8 +423,7 @@ def optimal_leaf_ordering(Z, D):
             v_r = original_order_to_sorted_order[int(v_r)]
 
         sorted_Z.append([v_l, v_r, v_size])
-    sorted_Z = np.array(sorted_Z).astype(np.int32).copy(order='C')
-
+    sorted_Z = np.array(sorted_Z, dtype=np.int32)
 
     # Sort distance matrix D by the leaf order
     sorted_D = sorted_D[sorted_leaves, :]

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -159,28 +159,6 @@ def _warning(s):
     warnings.warn('scipy.cluster: %s' % s, ClusterWarning, stacklevel=3)
 
 
-def _copy_array_if_base_present(a):
-    """
-    Copy the array if its base points to a parent array.
-    """
-    if a.base is not None:
-        return a.copy()
-    elif issubclass(a.dtype.type, np.float32):
-        return np.array(a, dtype=np.double)
-    else:
-        return a
-
-
-def _copy_arrays_if_base_present(T):
-    """
-    Accept a tuple of arrays T. Copies the array T[i] if its base array
-    points to an actual array. Otherwise, the reference is just copied.
-    This is useful if the arrays are being passed to a C function that
-    does not do proper striding.
-    """
-    return [_copy_array_if_base_present(a) for a in T]
-
-
 def single(y):
     """
     Perform single/min/nearest linkage on the condensed distance matrix ``y``.
@@ -1017,23 +995,24 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     >>> dn = dendrogram(Z)
     >>> plt.show()
     """
+    y = np.asarray(y, order='C', dtype=np.float64)
+
     if method not in _LINKAGE_METHODS:
         raise ValueError(f"Invalid method: {method}")
 
-    y = np.asarray(y, order='C', dtype=np.float64)
+    if method in _EUCLIDEAN_METHODS and metric != 'euclidean' and y.ndim == 2:
+        msg = f"`method={method}` requires the distance metric to be Euclidean"
+        raise ValueError(msg)
 
     if y.ndim == 1:
         distance.is_valid_y(y, throw=True, name='y')
-        [y] = _copy_arrays_if_base_present([y])
     elif y.ndim == 2:
-        if method in _EUCLIDEAN_METHODS and metric != 'euclidean':
-            raise ValueError("Method '{}' requires the distance metric "
-                             "to be Euclidean".format(method))
-        if y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0):
-            if np.all(y >= 0) and np.allclose(y, y.T):
-                _warning('The symmetric non-negative hollow observation '
-                         'matrix looks suspiciously like an uncondensed '
-                         'distance matrix')
+        if (y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0) and
+                np.all(y >= 0) and np.allclose(y, y.T)):
+            warnings.warn('The symmetric non-negative hollow observation '
+                          'matrix looks suspiciously like an uncondensed '
+                          'distance matrix',
+                          ClusterWarning, stacklevel=2)
         y = distance.pdist(y, metric)
     else:
         raise ValueError("`y` must be 1 or 2 dimensional.")
@@ -1520,13 +1499,13 @@ def optimal_leaf_ordering(Z, y, metric='euclidean'):
 
     if y.ndim == 1:
         distance.is_valid_y(y, throw=True, name='y')
-        [y] = _copy_arrays_if_base_present([y])
     elif y.ndim == 2:
-        if y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0):
-            if np.all(y >= 0) and np.allclose(y, y.T):
-                _warning('The symmetric non-negative hollow observation '
-                         'matrix looks suspiciously like an uncondensed '
-                         'distance matrix')
+        if (y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0) and
+                np.all(y >= 0) and np.allclose(y, y.T)):
+            warnings.warn('The symmetric non-negative hollow observation '
+                          'matrix looks suspiciously like an uncondensed '
+                          'distance matrix',
+                          ClusterWarning, stacklevel=2)
         y = distance.pdist(y, metric)
     else:
         raise ValueError("`y` must be 1 or 2 dimensional.")
@@ -1724,19 +1703,14 @@ def inconsistent(Z, d=2):
            [ 6.44583366,  6.76770586,  3.        ,  1.12682288]])
 
     """
-    Z = np.asarray(Z, order='c')
-
-    Zs = Z.shape
+    Z = np.asarray(Z, order='C', dtype=np.float64)
     is_valid_linkage(Z, throw=True, name='Z')
+
     if (not d == np.floor(d)) or d < 0:
         raise ValueError('The second argument d must be a nonnegative '
                          'integer value.')
 
-    # Since the C code does not support striding using strides.
-    # The dimensions are used instead.
-    [Z] = _copy_arrays_if_base_present([Z])
-
-    n = Zs[0] + 1
+    n = Z.shape[0] + 1
     R = np.zeros((n - 1, 4), dtype=np.double)
 
     _hierarchy.inconsistent(Z, R, int(n), int(d))
@@ -2447,7 +2421,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         The maximum depth to perform the inconsistency calculation.
         It has no meaning for the other criteria. Default is 2.
     R : ndarray, optional
-        The inconsistency matrix to use for the 'inconsistent'
+        The inconsistency matrix to use for the ``'inconsistent'``
         criterion. This matrix is computed if not provided.
     monocrit : ndarray, optional
         An array of length n-1. `monocrit[i]` is the
@@ -2533,35 +2507,29 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
     all data points to be merged together - so a single cluster is returned.
 
     """
-    Z = np.asarray(Z, order='c')
+    Z = np.asarray(Z, order='C', dtype=np.float64)
     is_valid_linkage(Z, throw=True, name='Z')
 
     n = Z.shape[0] + 1
     T = np.zeros((n,), dtype='i')
 
-    # Since the C code does not support striding using strides.
-    # The dimensions are used instead.
-    [Z] = _copy_arrays_if_base_present([Z])
+    if monocrit is not None:
+        monocrit = np.asarray(monocrit, order='C', dtype=np.float64)
 
     if criterion == 'inconsistent':
         if R is None:
             R = inconsistent(Z, depth)
         else:
-            R = np.asarray(R, order='c')
+            R = np.asarray(R, order='C', dtype=np.float64)
             is_valid_im(R, throw=True, name='R')
-            # Since the C code does not support striding using strides.
-            # The dimensions are used instead.
-            [R] = _copy_arrays_if_base_present([R])
         _hierarchy.cluster_in(Z, R, T, float(t), int(n))
     elif criterion == 'distance':
         _hierarchy.cluster_dist(Z, T, float(t), int(n))
     elif criterion == 'maxclust':
         _hierarchy.cluster_maxclust_dist(Z, T, int(n), int(t))
     elif criterion == 'monocrit':
-        [monocrit] = _copy_arrays_if_base_present([monocrit])
         _hierarchy.cluster_monocrit(Z, monocrit, T, float(t), int(n))
     elif criterion == 'maxclust_monocrit':
-        [monocrit] = _copy_arrays_if_base_present([monocrit])
         _hierarchy.cluster_maxclust_monocrit(Z, monocrit, T, int(n), int(t))
     else:
         raise ValueError('Invalid cluster formation criterion: %s'
@@ -2716,12 +2684,11 @@ def leaves_list(Z):
     >>> plt.show()
 
     """
-    Z = np.asarray(Z, order='c')
+    Z = np.asarray(Z, order='C', dtype=np.float64)
     is_valid_linkage(Z, throw=True, name='Z')
     n = Z.shape[0] + 1
     ML = np.zeros((n,), dtype='i')
-    [Z] = _copy_arrays_if_base_present([Z])
-    _hierarchy.prelist(Z, ML, int(n))
+    _hierarchy.prelist(Z, ML, n)
     return ML
 
 
@@ -3822,7 +3789,6 @@ def maxdists(Z):
 
     n = Z.shape[0] + 1
     MD = np.zeros((n - 1,))
-    [Z] = _copy_arrays_if_base_present([Z])
     _hierarchy.get_max_dist_for_each_cluster(Z, MD, int(n))
     return MD
 
@@ -3902,8 +3868,8 @@ def maxinconsts(Z, R):
            1.15470054])
 
     """
-    Z = np.asarray(Z, order='c')
-    R = np.asarray(R, order='c')
+    Z = np.asarray(Z, order='C', dtype=np.float64)
+    R = np.asarray(R, order='C', dtype=np.float64)
     is_valid_linkage(Z, throw=True, name='Z')
     is_valid_im(R, throw=True, name='R')
 
@@ -3912,7 +3878,6 @@ def maxinconsts(Z, R):
         raise ValueError("The inconsistency matrix and linkage matrix each "
                          "have a different number of rows.")
     MI = np.zeros((n - 1,))
-    [Z, R] = _copy_arrays_if_base_present([Z, R])
     _hierarchy.get_max_Rfield_for_each_cluster(Z, R, MI, int(n), 3)
     return MI
 
@@ -3994,12 +3959,14 @@ def maxRstat(Z, R, i):
            1.15470054])
 
     """
-    Z = np.asarray(Z, order='c')
-    R = np.asarray(R, order='c')
+    Z = np.asarray(Z, order='C', dtype=np.float64)
+    R = np.asarray(R, order='C', dtype=np.float64)
     is_valid_linkage(Z, throw=True, name='Z')
     is_valid_im(R, throw=True, name='R')
+
     if type(i) is not int:
         raise TypeError('The third argument must be an integer.')
+
     if i < 0 or i > 3:
         raise ValueError('i must be an integer between 0 and 3 inclusive.')
 
@@ -4009,7 +3976,6 @@ def maxRstat(Z, R, i):
 
     n = Z.shape[0] + 1
     MR = np.zeros((n - 1,))
-    [Z, R] = _copy_arrays_if_base_present([Z, R])
     _hierarchy.get_max_Rfield_for_each_cluster(Z, R, MR, int(n), i)
     return MR
 
@@ -4116,11 +4082,13 @@ def leaders(Z, T):
     array([1, 2, 3, 4], dtype=int32)
 
     """
-    Z = np.asarray(Z, order='c')
-    T = np.asarray(T, order='c')
+    Z = np.asarray(Z, order='C', dtype=np.float64)
+    T = np.asarray(T, order='C')
+    is_valid_linkage(Z, throw=True, name='Z')
+
     if type(T) != np.ndarray or T.dtype != 'i':
         raise TypeError('T must be a one-dimensional numpy array of integers.')
-    is_valid_linkage(Z, throw=True, name='Z')
+
     if len(T) != Z.shape[0] + 1:
         raise ValueError('Mismatch: len(T)!=Z.shape[0] + 1.')
 
@@ -4129,7 +4097,6 @@ def leaders(Z, T):
     L = np.zeros((kk,), dtype='i')
     M = np.zeros((kk,), dtype='i')
     n = Z.shape[0] + 1
-    [Z, T] = _copy_arrays_if_base_present([Z, T])
     s = _hierarchy.leaders(Z, T, L, M, int(kk), int(n))
     if s >= 0:
         raise ValueError(('T is not a valid assignment vector. Error found '


### PR DESCRIPTION
The utility functions cleaned up here (`_copy_arrays_if_base_present`, `_convert_to_bool`, `_convert_to_double`) were the cause of a couple of open review comments in gh-18668, where it wasn't clear whether or not changing them was preserving the existing semantics. In the process of looking into that, I also discovered some spurious double checks, weird conversion logic (`float32` arrays were converted to `float64`, but only if they weren't views; `float16` input remained unconverted) and some other code oddities. 

The key thing for removal of `_copy_arrays_if_base_present` was checking which input arrays for `_hierarchy.pyx` functions were being modified in-place, so I added some docs for that.