### PR TITLE
MAINT: avoid `np.deprecate` and `np.core`, add `normalize_axis_index` util

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -16,6 +16,13 @@ from typing import (
 
 import numpy as np
 
+if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
+    from numpy.exceptions import AxisError
+else:
+    from numpy import AxisError
+
+
+
 IntNumber = Union[int, np.integer]
 DecimalNumber = Union[float, np.floating, np.integer]
 
@@ -729,3 +736,14 @@ def _get_nan(*data):
     data = [np.asarray(item) for item in data]
     dtype = np.result_type(*data, np.half)  # must be a float16 at least
     return np.array(np.nan, dtype=dtype)[()]
+
+
+def normalize_axis_index(axis, ndim):
+    # Check if `axis` is in the correct range and normalize it
+    if axis < -ndim or axis >= ndim:
+        msg = f"axis {axis} is out of bounds for array of dimension {ndim}"
+        raise AxisError(msg)
+
+    if axis < 0:
+        axis = axis + ndim
+    return axis

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -6,7 +6,6 @@ from functools import partial
 
 from . import _quadpack
 import numpy as np
-from numpy import Inf
 
 __all__ = ["quad", "dblquad", "tplquad", "nquad", "IntegrationWarning"]
 
@@ -489,7 +488,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
              7: "Abnormal termination of the routine.  The estimates for result\n  and error are less reliable.  It is assumed that the requested accuracy\n  has not been achieved.",
             'unknown': "Unknown error."}
 
-    if weight in ['cos','sin'] and (b == Inf or a == -Inf):
+    if weight in ['cos','sin'] and (b == np.inf or a == -np.inf):
         msgs[1] = "The maximum number of cycles allowed has been achieved., e.e.\n  of subintervals (a+(k-1)c, a+kc) where c = (2*int(abs(omega)+1))\n  *pi/abs(omega), for k = 1, 2, ..., lst.  One can allow more cycles by increasing the value of limlst.  Look at info['ierlst'] with full_output=1."
         msgs[4] = "The extrapolation table constructed for convergence acceleration\n  of the series formed by the integral contributions over the cycles, \n  does not converge to within the requested accuracy.  Look at \n  info['ierlst'] with full_output=1."
         msgs[7] = "Bad integrand behavior occurs within one or more of the cycles.\n  Location and type of the difficulty involved can be determined from \n  the vector info['ierlist'] obtained with full_output=1."
@@ -506,7 +505,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     if ier in [1,2,3,4,5,7]:
         if full_output:
-            if weight in ['cos', 'sin'] and (b == Inf or a == -Inf):
+            if weight in ['cos', 'sin'] and (b == np.inf or a == -np.inf):
                 return retval[:-1] + (msg, explain)
             else:
                 return retval[:-1] + (msg,)
@@ -519,7 +518,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             if epsrel < max(50 * sys.float_info.epsilon, 5e-29):
                 msg = ("If 'epsabs'<=0, 'epsrel' must be greater than both"
                        " 5e-29 and 50*(machine epsilon).")
-            elif weight in ['sin', 'cos'] and (abs(a) + abs(b) == Inf):
+            elif weight in ['sin', 'cos'] and (abs(a) + abs(b) == np.inf):
                 msg = ("Sine or cosine weighted intergals with infinite domain"
                        " must have 'epsabs'>0.")
 
@@ -540,7 +539,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             if maxp1 < 1:
                 msg = "Chebyshev moment limit maxp1 must be >=1."
 
-            elif weight in ('cos', 'sin') and abs(a+b) == Inf:  # QAWFE
+            elif weight in ('cos', 'sin') and abs(a+b) == np.inf:  # QAWFE
                 msg = "Cycle limit limlst must be >=3."
 
             elif weight.startswith('alg'):  # QAWSE
@@ -558,15 +557,15 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
 def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
     infbounds = 0
-    if (b != Inf and a != -Inf):
+    if (b != np.inf and a != -np.inf):
         pass   # standard integration
-    elif (b == Inf and a != -Inf):
+    elif (b == np.inf and a != -np.inf):
         infbounds = 1
         bound = a
-    elif (b == Inf and a == -Inf):
+    elif (b == np.inf and a == -np.inf):
         infbounds = 2
         bound = 0     # ignored
-    elif (b != Inf and a == -Inf):
+    elif (b != np.inf and a == -np.inf):
         infbounds = -1
         bound = b
     else:
@@ -597,7 +596,7 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
 
     if weight in ['cos','sin']:
         integr = strdict[weight]
-        if (b != Inf and a != -Inf):  # finite limits
+        if (b != np.inf and a != -np.inf):  # finite limits
             if wopts is None:         # no precomputed Chebyshev moments
                 return _quadpack._qawoe(func, a, b, wvar, integr, args, full_output,
                                         epsabs, epsrel, limit, maxp1,1)
@@ -607,10 +606,10 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
                 return _quadpack._qawoe(func, a, b, wvar, integr, args, full_output,
                                         epsabs, epsrel, limit, maxp1, 2, momcom, chebcom)
 
-        elif (b == Inf and a != -Inf):
+        elif (b == np.inf and a != -np.inf):
             return _quadpack._qawfe(func, a, wvar, integr, args, full_output,
                                     epsabs,limlst,limit,maxp1)
-        elif (b != Inf and a == -Inf):  # remap function and interval
+        elif (b != np.inf and a == -np.inf):  # remap function and interval
             if weight == 'cos':
                 def thefunc(x,*myargs):
                     y = -x
@@ -629,7 +628,7 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
         else:
             raise ValueError("Cannot integrate with this weight from -Inf to +Inf.")
     else:
-        if a in [-Inf,Inf] or b in [-Inf,Inf]:
+        if a in [-np.inf, np.inf] or b in [-np.inf, np.inf]:
             raise ValueError("Cannot integrate with this weight over an infinite interval.")
 
         if weight.startswith('alg'):

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -1,7 +1,7 @@
 import sys
 import math
 import numpy as np
-from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
+from numpy import sqrt, cos, sin, arctan, exp, log, pi
 from numpy.testing import (assert_,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
@@ -117,7 +117,7 @@ class TestMultivariateCtypesQuad:
 
     def test_indefinite(self):
         # 2) Infinite integration limits --- Euler's constant
-        assert_quad(quad(self._multivariate_indefinite, 0, Inf),
+        assert_quad(quad(self._multivariate_indefinite, 0, np.inf),
                     0.577215664901532860606512)
 
     def test_threadsafety(self):
@@ -138,7 +138,7 @@ class TestQuad:
         # 2) Infinite integration limits --- Euler's constant
         def myfunc(x):           # Euler's constant integrand
             return -exp(-x)*log(x)
-        assert_quad(quad(myfunc, 0, Inf), 0.577215664901532860606512)
+        assert_quad(quad(myfunc, 0, np.inf), 0.577215664901532860606512)
 
     def test_singular(self):
         # 3) Singular points in region of integration.
@@ -169,7 +169,7 @@ class TestQuad:
 
         a = 4.0
         ome = 3.0
-        assert_quad(quad(myfunc, 0, Inf, args=a, weight='sin', wvar=ome),
+        assert_quad(quad(myfunc, 0, np.inf, args=a, weight='sin', wvar=ome),
                     ome/(a**2 + ome**2))
 
     def test_cosine_weighted_infinite(self):
@@ -179,7 +179,7 @@ class TestQuad:
 
         a = 2.5
         ome = 2.3
-        assert_quad(quad(myfunc, -Inf, 0, args=a, weight='cos', wvar=ome),
+        assert_quad(quad(myfunc, -np.inf, 0, args=a, weight='cos', wvar=ome),
                     a/(a**2 + ome**2))
 
     def test_algebraic_log_weight(self):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2,7 +2,7 @@ import operator
 from math import prod
 
 import numpy as np
-from numpy.core.multiarray import normalize_axis_index
+from scipy._lib._util import normalize_axis_index
 from scipy.linalg import (get_lapack_funcs, LinAlgError,
                           cholesky_banded, cho_solve_banded,
                           solve, solve_banded)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,6 +1,7 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
 from math import prod
+import warnings
 
 import numpy as np
 from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
@@ -237,9 +238,10 @@ class interp2d:
     >>> plt.show()
     """
 
-    @np.deprecate(old_name='interp2d', message=dep_mesg)
     def __init__(self, x, y, z, kind='linear', copy=True, bounds_error=False,
                  fill_value=None):
+        warnings.warn(dep_mesg, DeprecationWarning, stacklevel=2)
+
         x = ravel(x)
         y = ravel(y)
         z = asarray(z)
@@ -295,7 +297,6 @@ class interp2d:
         self.x_min, self.x_max = np.amin(x), np.amax(x)
         self.y_min, self.y_max = np.amin(y), np.amax(y)
 
-    @np.deprecate(old_name='interp2d', message=dep_mesg)
     def __call__(self, x, y, dx=0, dy=0, assume_sorted=False):
         """Interpolate the function.
 
@@ -320,6 +321,7 @@ class interp2d:
         z : 2-D array with shape (len(y), len(x))
             The interpolated values.
         """
+        warnings.warn(dep_mesg, DeprecationWarning, stacklevel=2)
 
         x = atleast_1d(x)
         y = atleast_1d(y)

--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -584,7 +584,7 @@ def _replace_heap(variable, heap):
 
         return True, variable
 
-    elif isinstance(variable, np.core.records.recarray):
+    elif isinstance(variable, np.recarray):
 
         # Loop over records
         for ir, record in enumerate(variable):
@@ -596,7 +596,7 @@ def _replace_heap(variable, heap):
 
         return False, variable
 
-    elif isinstance(variable, np.core.records.record):
+    elif isinstance(variable, np.record):
 
         # Loop over values
         for iv, value in enumerate(variable):

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -4,7 +4,7 @@
 from itertools import product
 
 import numpy as np
-from numpy import (Inf, dot, diag, prod, logical_not, ravel, transpose,
+from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
 from numpy.lib.scimath import sqrt as csqrt
 
@@ -727,7 +727,7 @@ def funm(A, func, disp=True):
         minden = tol
     err = min(1, max(tol,(tol/minden)*norm(triu(T,1),1)))
     if prod(ravel(logical_not(isfinite(F))),axis=0):
-        err = Inf
+        err = np.inf
     if disp:
         if err > 1000*tol:
             print("funm result may be inaccurate, approximate err =", err)

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -33,7 +33,8 @@ import numbers
 import warnings
 import numpy
 import operator
-from numpy.core.multiarray import normalize_axis_index
+
+from scipy._lib._util import normalize_axis_index
 from . import _ni_support
 from . import _nd_image
 from . import _ni_docstrings

--- a/scipy/ndimage/_fourier.py
+++ b/scipy/ndimage/_fourier.py
@@ -29,7 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy
-from numpy.core.multiarray import normalize_axis_index
+from scipy._lib._util import normalize_axis_index
 from . import _ni_support
 from . import _nd_image
 

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -32,7 +32,7 @@ import itertools
 import warnings
 
 import numpy
-from numpy.core.multiarray import normalize_axis_index
+from scipy._lib._util import normalize_axis_index
 
 from scipy import special
 from . import _ni_support

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -14,7 +14,7 @@ __all__ = [  # noqa: F822
     'uniform_filter1d', 'uniform_filter', 'minimum_filter1d',
     'maximum_filter1d', 'minimum_filter', 'maximum_filter',
     'rank_filter', 'median_filter', 'percentile_filter',
-    'generic_filter1d', 'generic_filter', 'normalize_axis_index'
+    'generic_filter1d', 'generic_filter'
 ]
 
 

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -8,7 +8,7 @@ from . import _fourier
 
 __all__ = [  # noqa: F822
     'fourier_gaussian', 'fourier_uniform',
-    'fourier_ellipsoid', 'fourier_shift', 'normalize_axis_index'
+    'fourier_ellipsoid', 'fourier_shift'
 ]
 
 

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -10,7 +10,7 @@ __all__ = [  # noqa: F822
     'spline_filter1d', 'spline_filter',
     'geometric_transform', 'map_coordinates',
     'affine_transform', 'shift', 'zoom', 'rotate',
-    'normalize_axis_index', 'docfiller'
+    'docfiller'
 ]
 
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -29,7 +29,7 @@ import warnings
 import sys
 import inspect
 from numpy import (atleast_1d, eye, argmin, zeros, shape, squeeze,
-                   asarray, sqrt, Inf)
+                   asarray, sqrt)
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
 from ._linesearch import (line_search_wolfe1, line_search_wolfe2,
@@ -285,9 +285,9 @@ _epsilon = sqrt(np.finfo(float).eps)
 
 
 def vecnorm(x, ord=2):
-    if ord == Inf:
+    if ord == np.inf:
         return np.amax(np.abs(x))
-    elif ord == -Inf:
+    elif ord == -np.inf:
         return np.amin(np.abs(x))
     else:
         return np.sum(np.abs(x)**ord, axis=0)**(1.0 / ord)
@@ -1242,7 +1242,7 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
     return ret
 
 
-def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
+def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None, xrtol=0):
     """
@@ -1373,7 +1373,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
 
 
 def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
-                   gtol=1e-5, norm=Inf, eps=_epsilon, maxiter=None,
+                   gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                    disp=False, return_all=False, finite_diff_rel_step=None,
                    xrtol=0, **unknown_options):
     """
@@ -1534,8 +1534,9 @@ def _print_success_message_or_warn(warnflag, message, warntype=None):
         warnings.warn(message, warntype or OptimizeWarning, stacklevel=3)
 
 
-def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
-            maxiter=None, full_output=0, disp=1, retall=0, callback=None):
+def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
+            epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
+            callback=None):
     """
     Minimize a function using a nonlinear conjugate gradient algorithm.
 
@@ -1710,7 +1711,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
 
 
 def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
-                 gtol=1e-5, norm=Inf, eps=_epsilon, maxiter=None,
+                 gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                  disp=False, return_all=False, finite_diff_rel_step=None,
                  **unknown_options):
     """

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -9,7 +9,6 @@ from . import _optimize
 __all__ = [  # noqa: F822
     'Brent',
     'FD_METHODS',
-    'Inf',
     'LineSearchWarning',
     'MapWrapper',
     'MemoizeJac',

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -1,3 +1,5 @@
+import warnings
+
 from numpy import (logical_and, asarray, pi, zeros_like,
                    piecewise, array, arctan2, tan, zeros, arange, floor)
 from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
@@ -154,7 +156,6 @@ The exact equivalent (for a float array `x`) is
 """
 
 
-@np.deprecate(message=msg_bspline)
 def bspline(x, n):
     """B-spline basis function of order n.
 
@@ -199,6 +200,8 @@ def bspline(x, n):
     True
 
     """
+    warnings.warn(msg_bspline, DeprecationWarning, stacklevel=2)
+
     ax = -abs(asarray(x, dtype=float))
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
@@ -269,7 +272,6 @@ The exact equivalent (for a float array `x`) is
 """
 
 
-@np.deprecate(message=msg_cubic)
 def cubic(x):
     """A cubic B-spline.
 
@@ -310,6 +312,8 @@ def cubic(x):
     True
 
     """
+    warnings.warn(msg_cubic, DeprecationWarning, stacklevel=2)
+
     ax = abs(asarray(x, dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 1)
@@ -383,6 +387,8 @@ def quadratic(x):
     True
 
     """
+    warnings.warn(msg_quadratic, DeprecationWarning, stacklevel=2)
+
     ax = abs(asarray(x, dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 0.5)

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -2,8 +2,8 @@ import warnings
 
 from numpy import (logical_and, asarray, pi, zeros_like,
                    piecewise, array, arctan2, tan, zeros, arange, floor)
-from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
-                              less_equal, greater_equal)
+from numpy import (sqrt, exp, greater, less, cos, add, sin, less_equal,
+                   greater_equal)
 import numpy as np
 
 # From splinemodule.c

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -5,6 +5,8 @@ import operator
 import math
 from math import prod as _prod
 import timeit
+import warnings
+
 from scipy.spatial import cKDTree
 from . import _sigtools
 from ._ltisys import dlti
@@ -19,7 +21,6 @@ from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 from ._filter_design import cheby1, _validate_sos, zpk2sos
 from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
-import warnings
 
 
 __all__ = ['correlate', 'correlation_lags', 'correlate2d',
@@ -2469,8 +2470,8 @@ in SciPy 1.14. The exact equivalent for a numpy array argument is
 ...    return np.take(p, idx, 0), idx
 """
 
-@np.deprecate(message=_msg_cplx_sort)
 def cmplx_sort(p):
+    warnings.warn(_msg_cplx_sort, DeprecationWarning, stacklevel=2)
     return _cmplx_sort(p)
 
 

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -6,7 +6,7 @@ from scipy.sparse import issparse
 from scipy.sparse.linalg import svds
 import scipy.sparse as sp
 
-from numpy import Inf, sqrt, abs
+from numpy import sqrt, abs
 
 __all__ = ['norm']
 
@@ -149,11 +149,11 @@ def norm(x, ord=None, axis=None):
             #return _multi_svd_norm(x, row_axis, col_axis, amin)
         elif ord == 1:
             return abs(x).sum(axis=row_axis).max(axis=col_axis)[0,0]
-        elif ord == Inf:
+        elif ord == np.inf:
             return abs(x).sum(axis=col_axis).max(axis=row_axis)[0,0]
         elif ord == -1:
             return abs(x).sum(axis=row_axis).min(axis=col_axis)[0,0]
-        elif ord == -Inf:
+        elif ord == -np.inf:
             return abs(x).sum(axis=col_axis).min(axis=row_axis)[0,0]
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
@@ -165,9 +165,9 @@ def norm(x, ord=None, axis=None):
         if not (-nd <= a < nd):
             raise ValueError('Invalid axis %r for an array with shape %r' %
                              (axis, x.shape))
-        if ord == Inf:
+        if ord == np.inf:
             M = abs(x).max(axis=a)
-        elif ord == -Inf:
+        elif ord == -np.inf:
             M = abs(x).min(axis=a)
         elif ord == 0:
             # Zero norm

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -62,6 +62,7 @@ from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
 from scipy.optimize import root_scalar
 from scipy._lib.deprecation import _NoValue
+from scipy._lib._util import normalize_axis_index
 
 
 # Functions/classes in other files should be added in `__init__.py`, not here
@@ -3959,7 +3960,7 @@ def _create_f_oneway_nan_result(shape, axis):
     in certain degenerate conditions.  It creates return values that are
     all nan with the appropriate shape for the given `shape` and `axis`.
     """
-    axis = np.core.multiarray.normalize_axis_index(axis, len(shape))
+    axis = normalize_axis_index(axis, len(shape))
     shp = shape[:axis] + shape[axis+1:]
     if shp == ():
         f = np.nan
@@ -10209,8 +10210,7 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         if a.size == 0:
             # The return values of `normalize_axis_index` are ignored.  The
             # call validates `axis`, even though we won't use it.
-            # use scipy._lib._util._normalize_axis_index when available
-            np.core.multiarray.normalize_axis_index(axis, a.ndim)
+            normalize_axis_index(axis, a.ndim)
             dt = np.float64 if method == 'average' else np.int_
             return np.empty(a.shape, dtype=dt)
         return np.apply_along_axis(rankdata, axis, a, method,

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.core.multiarray import normalize_axis_index
-from scipy._lib._util import _nan_allsame, _contains_nan
+from scipy._lib._util import _nan_allsame, _contains_nan, normalize_axis_index
 from ._stats_py import _chk_asarray
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4768,7 +4768,7 @@ class TestLevyStable:
             Path(__file__).parent /
             'data/levy_stable/stable-Z1-pdf-sample-data.npy'
         )
-        data = np.core.records.fromarrays(data.T, names='x,p,alpha,beta,pct')
+        data = np.rec.fromarrays(data.T, names='x,p,alpha,beta,pct')
         return data
 
     @pytest.fixture
@@ -4812,7 +4812,7 @@ class TestLevyStable:
             Path(__file__).parent /
             'data/levy_stable/stable-Z1-cdf-sample-data.npy'
         )
-        data = np.core.records.fromarrays(data.T, names='x,p,alpha,beta,pct')
+        data = np.rec.fromarrays(data.T, names='x,p,alpha,beta,pct')
         return data
 
     @pytest.fixture
@@ -9223,7 +9223,7 @@ class TestRelativisticBW:
             Path(__file__).parent /
             'data/rel_breitwigner_pdf_sample_data_ROOT.npy'
         )
-        data = np.core.records.fromarrays(data.T, names='x,pdf,rho,gamma')
+        data = np.rec.fromarrays(data.T, names='x,pdf,rho,gamma')
         return data
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
`np.deprecate` will be deprecated soon, `np.core` is private and should start raising warnings at some point too. There was already a code comment about needing `normalize_axis_index` in `scipy._lib._util`, so I added it there.

EDIT: also cleaned up some more usages of `np.Inf`.