### PR TITLE
ENH: sparse arrays for hstack, vstack, bmat, block_diag. New block.

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -95,7 +95,8 @@ Building sparse matrices:
    block_diag - Build a block diagonal sparse matrix
    tril - Lower triangular portion of a matrix in sparse format
    triu - Upper triangular portion of a matrix in sparse format
-   bmat - Build a sparse matrix from sparse sub-blocks
+   block_array - Build a sparse array from sub-blocks
+   bmat - Build a sparse matrix from sub-blocks
    hstack - Stack sparse matrices horizontally (column wise)
    vstack - Stack sparse matrices vertically (row wise)
    rand - Random values in a given shape

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -95,7 +95,7 @@ Building sparse matrices:
    block_diag - Build a block diagonal sparse matrix
    tril - Lower triangular portion of a matrix in sparse format
    triu - Upper triangular portion of a matrix in sparse format
-   block_array - Build a sparse array from sub-blocks
+   block - Build a sparse array from sub-blocks
    bmat - Build a sparse matrix from sub-blocks
    hstack - Stack sparse matrices horizontally (column wise)
    vstack - Stack sparse matrices vertically (row wise)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -5,7 +5,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
            'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag',
-           'diags_array', 'block_array']
+           'diags_array', 'block']
 
 import numbers
 from functools import partial
@@ -604,7 +604,7 @@ def hstack(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block_array(hstack(blocks))` or convert one block
+        arrays, use `block(hstack(blocks))` or convert one block
         e.g. `blocks[0] = csr_array(blocks[0])`.
 
     See Also
@@ -623,9 +623,9 @@ def hstack(blocks, format=None, dtype=None):
     """
     blocks = np.asarray(blocks, dtype='object')
     if any(isinstance(b, sparray) for b in blocks.flat):
-        return _block_array([blocks], format, dtype)
+        return _block([blocks], format, dtype)
     else:
-        return _block_array([blocks], format, dtype, return_spmatrix=True)
+        return _block([blocks], format, dtype, return_spmatrix=True)
 
 
 def vstack(blocks, format=None, dtype=None):
@@ -651,7 +651,7 @@ def vstack(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block_array(vstack(blocks))` or convert one block
+        arrays, use `block(vstack(blocks))` or convert one block
         e.g. `blocks[0] = csr_array(blocks[0])`.
 
     See Also
@@ -671,16 +671,16 @@ def vstack(blocks, format=None, dtype=None):
     """
     blocks = np.asarray(blocks, dtype='object')
     if any(isinstance(b, sparray) for b in blocks.flat):
-        return _block_array([[b] for b in blocks], format, dtype)
+        return _block([[b] for b in blocks], format, dtype)
     else:
-        return _block_array([[b] for b in blocks], format, dtype, return_spmatrix=True)
+        return _block([[b] for b in blocks], format, dtype, return_spmatrix=True)
 
 
 def bmat(blocks, format=None, dtype=None):
     """
     Build a sparse array or matrix from sparse sub-blocks
 
-    Note: `block_array` is preferred over `bmat`. They are the same function
+    Note: `block` is preferred over `bmat`. They are the same function
     except that `bmat` can return a deprecated sparse matrix.
     `bmat` returns a coo_matrix if none of the inputs are a sparse array.
 
@@ -704,11 +704,11 @@ def bmat(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block_array()`.
+        arrays, use `block()`.
 
     See Also
     --------
-    block_array
+    block
 
     Examples
     --------
@@ -729,12 +729,12 @@ def bmat(blocks, format=None, dtype=None):
     """
     blocks = np.asarray(blocks, dtype='object')
     if any(isinstance(b, sparray) for b in blocks.flat):
-        return _block_array(blocks, format, dtype)
+        return _block(blocks, format, dtype)
     else:
-        return _block_array(blocks, format, dtype, return_spmatrix=True)
+        return _block(blocks, format, dtype, return_spmatrix=True)
 
 
-def block_array(blocks, *, format=None, dtype=None):
+def block(blocks, *, format=None, dtype=None):
     """
     Build a sparse array from sparse sub-blocks
 
@@ -753,7 +753,7 @@ def block_array(blocks, *, format=None, dtype=None):
 
     Returns
     -------
-    block_array : sparse array
+    block : sparse array
 
     See Also
     --------
@@ -762,25 +762,25 @@ def block_array(blocks, *, format=None, dtype=None):
 
     Examples
     --------
-    >>> from scipy.sparse import coo_array, block_array
+    >>> from scipy.sparse import coo_array, block
     >>> A = coo_array([[1, 2], [3, 4]])
     >>> B = coo_array([[5], [6]])
     >>> C = coo_array([[7]])
-    >>> block_array([[A, B], [None, C]]).toarray()
+    >>> block([[A, B], [None, C]]).toarray()
     array([[1, 2, 5],
            [3, 4, 6],
            [0, 0, 7]])
 
-    >>> block_array([[A, None], [None, C]]).toarray()
+    >>> block([[A, None], [None, C]]).toarray()
     array([[1, 2, 0],
            [3, 4, 0],
            [0, 0, 7]])
 
     """
-    return _block_array(blocks, format, dtype)
+    return _block(blocks, format, dtype)
 
 
-def _block_array(blocks, format, dtype, return_spmatrix=False):
+def _block(blocks, format, dtype, return_spmatrix=False):
     blocks = np.asarray(blocks, dtype='object')
 
     if blocks.ndim != 2:
@@ -902,7 +902,7 @@ def block_diag(mats, format=None, dtype=None):
 
     See Also
     --------
-    block_array, diags
+    block, diags
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -597,6 +597,16 @@ def hstack(blocks, format=None, dtype=None):
         The data-type of the output matrix. If not given, the dtype is
         determined from that of `blocks`.
 
+    Returns
+    -------
+    new_array : sparse matrix or array
+        If any block in blocks is a sparse array, return a sparse array.
+        Otherwise return a sparse matrix.
+
+        If you want a sparse array built from blocks that are not sparse
+        arrays, use `block_array(hstack(blocks))` or convert one block
+        e.g. `blocks[0] = csr_array(blocks[0])`.
+
     See Also
     --------
     vstack : stack sparse matrices vertically (row wise)
@@ -633,6 +643,16 @@ def vstack(blocks, format=None, dtype=None):
     dtype : dtype, optional
         The data-type of the output array. If not given, the dtype is
         determined from that of `blocks`.
+
+    Returns
+    -------
+    new_array : sparse matrix or array
+        If any block in blocks is a sparse array, return a sparse array.
+        Otherwise return a sparse matrix.
+
+        If you want a sparse array built from blocks that are not sparse
+        arrays, use `block_array(vstack(blocks))` or convert one block
+        e.g. `blocks[0] = csr_array(blocks[0])`.
 
     See Also
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -5,7 +5,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
            'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag',
-           'diags_array']
+           'diags_array', 'block_array']
 
 import numbers
 from functools import partial
@@ -16,12 +16,12 @@ from ._sputils import upcast, get_index_dtype, isscalarlike
 
 from ._sparsetools import csr_hstack
 from ._bsr import bsr_matrix
-from ._coo import coo_matrix
-from ._csc import csc_matrix
-from ._csr import csr_matrix
+from ._coo import coo_matrix, coo_array
+from ._csc import csc_matrix, csc_array
+from ._csr import csr_matrix, csr_array
 from ._dia import dia_matrix, dia_array
 
-from ._base import issparse
+from ._base import issparse, sparray
 
 
 def spdiags(data, diags, m=None, n=None, format=None):
@@ -481,9 +481,9 @@ def kronsum(A, B, format=None):
     return (L+R).asformat(format)  # since L + R is not always same format
 
 
-def _compressed_sparse_stack(blocks, axis):
+def _compressed_sparse_stack(blocks, axis, container):
     """
-    Stacking fast path for CSR/CSC matrices
+    Stacking fast path for CSR/CSC matrices or arrays
     (i) vstack for CSR, (ii) hstack for CSC.
     """
     other_axis = 1 if axis == 0 else 0
@@ -507,11 +507,20 @@ def _compressed_sparse_stack(blocks, axis):
         sum_dim += b.shape[axis]
         last_indptr += b.indptr[-1]
     indptr[-1] = last_indptr
+    # TODO remove this if-structure when sparse matrices removed
+    if container is coo_matrix:
+        if axis == 0:
+            return csr_matrix((data, indices, indptr),
+                              shape=(sum_dim, constant_dim))
+        else:
+            return csc_matrix((data, indices, indptr),
+                              shape=(constant_dim, sum_dim))
+
     if axis == 0:
-        return csr_matrix((data, indices, indptr),
+        return csr_array((data, indices, indptr),
                           shape=(sum_dim, constant_dim))
     else:
-        return csc_matrix((data, indices, indptr),
+        return csc_array((data, indices, indptr),
                           shape=(constant_dim, sum_dim))
 
 
@@ -565,10 +574,10 @@ def _stack_along_minor_axis(blocks, axis):
         data = np.empty(0, dtype=data_cat.dtype)
 
     if axis == 0:
-        return csc_matrix((data, indices, indptr),
+        return blocks[0]._csc_container((data, indices, indptr),
                           shape=(sum_dim, constant_dim))
     else:
-        return csr_matrix((data, indices, indptr),
+        return blocks[0]._csr_container((data, indices, indptr),
                           shape=(constant_dim, sum_dim))
 
 
@@ -602,23 +611,27 @@ def hstack(blocks, format=None, dtype=None):
            [3, 4, 6]])
 
     """
-    return bmat([blocks], format=format, dtype=dtype)
+    blocks = np.asarray(blocks, dtype='object')
+    if any(isinstance(b, sparray) for b in blocks.flat):
+        return _block_array([blocks], format, dtype, coo_array)
+    else:
+        return _block_array([blocks], format, dtype, coo_matrix)
 
 
 def vstack(blocks, format=None, dtype=None):
     """
-    Stack sparse matrices vertically (row wise)
+    Stack sparse arrays vertically (row wise)
 
     Parameters
     ----------
     blocks
-        sequence of sparse matrices with compatible shapes
+        sequence of sparse arrays with compatible shapes
     format : str, optional
         sparse format of the result (e.g., "csr")
-        by default an appropriate sparse matrix format is returned.
+        by default an appropriate sparse array format is returned.
         This choice is subject to change.
     dtype : dtype, optional
-        The data-type of the output matrix. If not given, the dtype is
+        The data-type of the output array. If not given, the dtype is
         determined from that of `blocks`.
 
     See Also
@@ -627,21 +640,29 @@ def vstack(blocks, format=None, dtype=None):
 
     Examples
     --------
-    >>> from scipy.sparse import coo_matrix, vstack
-    >>> A = coo_matrix([[1, 2], [3, 4]])
-    >>> B = coo_matrix([[5, 6]])
+    >>> from scipy.sparse import coo_array, vstack
+    >>> A = coo_array([[1, 2], [3, 4]])
+    >>> B = coo_array([[5, 6]])
     >>> vstack([A, B]).toarray()
     array([[1, 2],
            [3, 4],
            [5, 6]])
 
     """
-    return bmat([[b] for b in blocks], format=format, dtype=dtype)
+    blocks = np.asarray(blocks, dtype='object')
+    if any(isinstance(b, sparray) for b in blocks.flat):
+        return _block_array([[b] for b in blocks], format, dtype, coo_array)
+    else:
+        return _block_array([[b] for b in blocks], format, dtype, coo_matrix)
 
 
 def bmat(blocks, format=None, dtype=None):
     """
-    Build a sparse matrix from sparse sub-blocks
+    Build a sparse array or matrix from sparse sub-blocks
+
+    Note: `block_array` is preferred over `bmat`. They are the same function
+    except that `bmat` can return a deprecated sparse matrix.
+    `bmat` returns a coo_matrix if none of the inputs are a sparse array.
 
     Parameters
     ----------
@@ -658,18 +679,23 @@ def bmat(blocks, format=None, dtype=None):
 
     Returns
     -------
-    bmat : sparse matrix
+    bmat : sparse matrix or array
+        If any block in blocks is a sparse array, return a sparse array.
+        Otherwise return a sparse matrix.
+
+        If you want a sparse array built from blocks that are not sparse
+        arrays, use `block_array()`.
 
     See Also
     --------
-    block_diag, diags
+    block_array
 
     Examples
     --------
-    >>> from scipy.sparse import coo_matrix, bmat
-    >>> A = coo_matrix([[1, 2], [3, 4]])
-    >>> B = coo_matrix([[5], [6]])
-    >>> C = coo_matrix([[7]])
+    >>> from scipy.sparse import coo_array, bmat
+    >>> A = coo_array([[1, 2], [3, 4]])
+    >>> B = coo_array([[5], [6]])
+    >>> C = coo_array([[7]])
     >>> bmat([[A, B], [None, C]]).toarray()
     array([[1, 2, 5],
            [3, 4, 6],
@@ -681,7 +707,60 @@ def bmat(blocks, format=None, dtype=None):
            [0, 0, 7]])
 
     """
+    blocks = np.asarray(blocks, dtype='object')
+    if any(isinstance(b, sparray) for b in blocks.flat):
+        return _block_array(blocks, format, dtype, coo_array)
+    else:
+        return _block_array(blocks, format, dtype, coo_matrix)
 
+
+def block_array(blocks, *, format=None, dtype=None):
+    """
+    Build a sparse array from sparse sub-blocks
+
+    Parameters
+    ----------
+    blocks : array_like
+        Grid of sparse arrays with compatible shapes.
+        An entry of None implies an all-zero array.
+    format : {'bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil'}, optional
+        The sparse format of the result (e.g. "csr"). By default an
+        appropriate sparse array format is returned.
+        This choice is subject to change.
+    dtype : dtype, optional
+        The data-type of the output array. If not given, the dtype is
+        determined from that of `blocks`.
+
+    Returns
+    -------
+    block_array : sparse array
+
+    See Also
+    --------
+    block_diag : specify blocks along the main diagonals
+    diags : specify (possibly offset) diagonals
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_array, block_array
+    >>> A = coo_array([[1, 2], [3, 4]])
+    >>> B = coo_array([[5], [6]])
+    >>> C = coo_array([[7]])
+    >>> block_array([[A, B], [None, C]]).toarray()
+    array([[1, 2, 5],
+           [3, 4, 6],
+           [0, 0, 7]])
+
+    >>> block_array([[A, None], [None, C]]).toarray()
+    array([[1, 2, 0],
+           [3, 4, 0],
+           [0, 0, 7]])
+
+    """
+    return _block_array(blocks, format, dtype, coo_array)
+
+
+def _block_array(blocks, format, dtype, coo_container):
     blocks = np.asarray(blocks, dtype='object')
 
     if blocks.ndim != 2:
@@ -690,29 +769,29 @@ def bmat(blocks, format=None, dtype=None):
     M,N = blocks.shape
 
     # check for fast path cases
-    if (format in (None, 'csr') and all(isinstance(b, csr_matrix)
-                                        for b in blocks.flat)):
+    if (format in (None, 'csr') and
+        all(issparse(b) and b.format == "csr" for b in blocks.flat)
+    ):
         if N > 1:
-            # stack along columns (axis 1):
-            blocks = [[_stack_along_minor_axis(blocks[b, :], 1)]
-                      for b in range(M)]   # must have shape: (M, 1)
+            # stack along columns (axis 1): must have shape (M, 1)
+            blocks = [[_stack_along_minor_axis(blocks[b, :], 1)] for b in range(M)]
             blocks = np.asarray(blocks, dtype='object')
 
         # stack along rows (axis 0):
-        A = _compressed_sparse_stack(blocks[:, 0], 0)
+        A = _compressed_sparse_stack(blocks[:, 0], 0, coo_container)
         if dtype is not None:
             A = A.astype(dtype)
         return A
-    elif (format in (None, 'csc') and all(isinstance(b, csc_matrix)
-                                          for b in blocks.flat)):
+    elif (format in (None, 'csc') and
+          all(issparse(b) and b.format == "csc" for b in blocks.flat)
+    ):
         if M > 1:
-            # stack along rows (axis 0):
-            blocks = [[_stack_along_minor_axis(blocks[:, b], 0)
-                       for b in range(N)]]   # must have shape: (1, N)
+            # stack along rows (axis 0): must have shape (1, N)
+            blocks = [[_stack_along_minor_axis(blocks[:, b], 0) for b in range(N)]]
             blocks = np.asarray(blocks, dtype='object')
 
         # stack along columns (axis 1):
-        A = _compressed_sparse_stack(blocks[0, :], 1)
+        A = _compressed_sparse_stack(blocks[0, :], 1, coo_container)
         if dtype is not None:
             A = A.astype(dtype)
         return A
@@ -725,7 +804,7 @@ def bmat(blocks, format=None, dtype=None):
     for i in range(M):
         for j in range(N):
             if blocks[i,j] is not None:
-                A = coo_matrix(blocks[i,j])
+                A = coo_array(blocks[i,j])
                 blocks[i,j] = A
                 block_mask[i,j] = True
 
@@ -771,27 +850,28 @@ def bmat(blocks, format=None, dtype=None):
         np.add(B.col, col_offsets[j], out=col[idx], dtype=idx_dtype)
         nnz += B.nnz
 
-    return coo_matrix((data, (row, col)), shape=shape).asformat(format)
+    return coo_container((data, (row, col)), shape=shape).asformat(format)
 
 
 def block_diag(mats, format=None, dtype=None):
     """
-    Build a block diagonal sparse matrix from provided matrices.
+    Build a block diagonal sparse matrix or array from provided matrices.
 
     Parameters
     ----------
-    mats : sequence of matrices
-        Input matrices.
+    mats : sequence of matrices or arrays
+        Input matrices or arrays.
     format : str, optional
-        The sparse format of the result (e.g., "csr"). If not given, the matrix
+        The sparse format of the result (e.g., "csr"). If not given, the result
         is returned in "coo" format.
     dtype : dtype specifier, optional
-        The data-type of the output matrix. If not given, the dtype is
+        The data-type of the output. If not given, the dtype is
         determined from that of `blocks`.
 
     Returns
     -------
-    res : sparse matrix
+    res : sparse matrix or array
+        If any inputs are arrays, the output is an array
 
     Notes
     -----
@@ -800,14 +880,14 @@ def block_diag(mats, format=None, dtype=None):
 
     See Also
     --------
-    bmat, diags
+    block_array, diags
 
     Examples
     --------
-    >>> from scipy.sparse import coo_matrix, block_diag
-    >>> A = coo_matrix([[1, 2], [3, 4]])
-    >>> B = coo_matrix([[5], [6]])
-    >>> C = coo_matrix([[7]])
+    >>> from scipy.sparse import coo_array, block_diag
+    >>> A = coo_array([[1, 2], [3, 4]])
+    >>> B = coo_array([[5], [6]])
+    >>> C = coo_array([[7]])
     >>> block_diag((A, B, C)).toarray()
     array([[1, 2, 0, 0],
            [3, 4, 0, 0],
@@ -816,6 +896,11 @@ def block_diag(mats, format=None, dtype=None):
            [0, 0, 0, 7]])
 
     """
+    if any(isinstance(a, sparray) for a in mats):
+        container = coo_array
+    else:
+        container = coo_matrix
+
     row = []
     col = []
     data = []
@@ -823,7 +908,7 @@ def block_diag(mats, format=None, dtype=None):
     c_idx = 0
     for a in mats:
         if isinstance(a, (list, numbers.Number)):
-            a = coo_matrix(a)
+            a = coo_array(a)
         nrows, ncols = a.shape
         if issparse(a):
             a = a.tocoo()
@@ -840,7 +925,7 @@ def block_diag(mats, format=None, dtype=None):
     row = np.concatenate(row)
     col = np.concatenate(col)
     data = np.concatenate(data)
-    return coo_matrix((data, (row, col)),
+    return container((data, (row, col)),
                       shape=(r_idx, c_idx),
                       dtype=dtype).asformat(format)
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -893,7 +893,8 @@ def block_diag(mats, format=None, dtype=None):
     Returns
     -------
     res : sparse matrix or array
-        If any inputs are arrays, the output is an array
+        If at least one input is a sparse array, the output is a sparse array.
+        Otherwise the output is a sparse matrix.
 
     Notes
     -----

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -11,6 +11,7 @@ from scipy._lib._util import check_random_state
 
 from scipy.sparse import (csr_matrix, coo_matrix,
                           csr_array, coo_array,
+                          sparray, spmatrix,
                           _construct as construct)
 from scipy.sparse._construct import rand as sprand
 
@@ -306,7 +307,7 @@ class TestConstructUtils:
             for b in cases:
                 expected = np.kron(a, b)
                 for fmt in sparse_formats:
-                    result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt) 
+                    result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt)
                     assert_equal(result.format, fmt)
                     assert_array_equal(result.toarray(), expected)
 
@@ -364,10 +365,10 @@ class TestConstructUtils:
         assert_equal(result.indices.dtype, np.int32)
         assert_equal(result.indptr.dtype, np.int32)
 
-        assert construct.vstack([A, B])._is_array
-        assert not construct.vstack([coo_matrix(A), coo_matrix(B)])._is_array
-        assert construct.vstack([A, coo_matrix(B)])._is_array
-        assert construct.vstack([coo_matrix(A), B])._is_array
+        assert isinstance(construct.vstack([A, B]), sparray)
+        assert isinstance(construct.vstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
+        assert isinstance(construct.vstack([A, coo_matrix(B)]), sparray)
+        assert isinstance(construct.vstack([coo_matrix(A), B]), sparray)
 
     def test_hstack(self):
 
@@ -390,10 +391,10 @@ class TestConstructUtils:
                                       dtype=np.float32).dtype,
                      np.float32)
 
-        assert construct.hstack([A, B])._is_array
-        assert not construct.hstack([coo_matrix(A), coo_matrix(B)])._is_array
-        assert construct.hstack([A, coo_matrix(B)])._is_array
-        assert construct.hstack([coo_matrix(A), B])._is_array
+        assert isinstance(construct.hstack([A, B]), sparray)
+        assert isinstance(construct.hstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
+        assert isinstance(construct.hstack([A, coo_matrix(B)]), sparray)
+        assert isinstance(construct.hstack([coo_matrix(A), B]), sparray)
 
     @pytest.mark.parametrize("block_array", (construct.bmat, construct.block_array))
     def test_block_creation(self, block_array):
@@ -478,47 +479,47 @@ class TestConstructUtils:
     def test_block_array_return_type(self):
         block_array = construct.block_array
 
-        Flist, Glist = [[1, 2],[3, 4]], [[7], [5]]
-        Fm, Gm = csr_matrix(Flist), csr_matrix(Glist)
-        assert block_array([[None, Flist], [Glist, None]], format="csr")._is_array
-        assert block_array([[None, Fm], [Gm, None]], format="csr")._is_array
-        assert block_array([[Fm, Gm]], format="csr")._is_array
+        Fl, Gl = [[1, 2],[3, 4]], [[7], [5]]
+        Fm, Gm = csr_matrix(Fl), csr_matrix(Gl)
+        assert isinstance(block_array([[None, Fl], [Gl, None]], format="csr"), sparray)
+        assert isinstance(block_array([[None, Fm], [Gm, None]], format="csr"), sparray)
+        assert isinstance(block_array([[Fm, Gm]], format="csr"), sparray)
 
     def test_bmat_return_type(self):
         """This can be removed after sparse matrix is removed"""
         bmat = construct.bmat
         # check return type. if any input _is_array output array, else matrix
-        Flist, Glist = [[1, 2],[3, 4]], [[7], [5]]
-        Fm, Gm = csr_matrix(Flist), csr_matrix(Glist)
-        Fa, Ga = csr_array(Flist), csr_array(Glist)
-        assert bmat([[Fa, Ga]], format="csr")._is_array
-        assert not bmat([[Fm, Gm]], format="csr")._is_array
-        assert bmat([[None, Fa], [Ga, None]], format="csr")._is_array
-        assert bmat([[None, Fm], [Ga, None]], format="csr")._is_array
-        assert not bmat([[None, Fm], [Gm, None]], format="csr")._is_array
-        assert not bmat([[None, Flist], [Glist, None]], format="csr")._is_array
+        Fl, Gl = [[1, 2],[3, 4]], [[7], [5]]
+        Fm, Gm = csr_matrix(Fl), csr_matrix(Gl)
+        Fa, Ga = csr_array(Fl), csr_array(Gl)
+        assert isinstance(bmat([[Fa, Ga]], format="csr"), sparray)
+        assert isinstance(bmat([[Fm, Gm]], format="csr"), spmatrix)
+        assert isinstance(bmat([[None, Fa], [Ga, None]], format="csr"), sparray)
+        assert isinstance(bmat([[None, Fm], [Ga, None]], format="csr"), sparray)
+        assert isinstance(bmat([[None, Fm], [Gm, None]], format="csr"), spmatrix)
+        assert isinstance(bmat([[None, Fl], [Gl, None]], format="csr"), spmatrix)
 
         # type returned by _compressed_sparse_stack (all csr)
-        assert bmat([[Ga, Ga]], format="csr")._is_array
-        assert bmat([[Gm, Ga]], format="csr")._is_array
-        assert bmat([[Ga, Gm]], format="csr")._is_array
-        assert not bmat([[Gm, Gm]], format="csr")._is_array
+        assert isinstance(bmat([[Ga, Ga]], format="csr"), sparray)
+        assert isinstance(bmat([[Gm, Ga]], format="csr"), sparray)
+        assert isinstance(bmat([[Ga, Gm]], format="csr"), sparray)
+        assert isinstance(bmat([[Gm, Gm]], format="csr"), spmatrix)
         # shape is 2x2 so no _stack_along_minor_axis
-        assert bmat([[Fa, Fm]], format="csr")._is_array
-        assert not bmat([[Fm, Fm]], format="csr")._is_array
+        assert isinstance(bmat([[Fa, Fm]], format="csr"), sparray)
+        assert isinstance(bmat([[Fm, Fm]], format="csr"), spmatrix)
 
         # type returned by _compressed_sparse_stack (all csc)
-        assert bmat([[Gm.tocsc(), Ga.tocsc()]], format="csc")._is_array
-        assert not bmat([[Gm.tocsc(), Gm.tocsc()]], format="csc")._is_array
+        assert isinstance(bmat([[Gm.tocsc(), Ga.tocsc()]], format="csc"), sparray)
+        assert isinstance(bmat([[Gm.tocsc(), Gm.tocsc()]], format="csc"), spmatrix)
         # shape is 2x2 so no _stack_along_minor_axis
-        assert bmat([[Fa.tocsc(), Fm.tocsc()]], format="csr")._is_array
-        assert not bmat([[Fm.tocsc(), Fm.tocsc()]], format="csr")._is_array
+        assert isinstance(bmat([[Fa.tocsc(), Fm.tocsc()]], format="csr"), sparray)
+        assert isinstance(bmat([[Fm.tocsc(), Fm.tocsc()]], format="csr"), spmatrix)
 
         # type returned when mixed input
-        assert bmat([[Glist, Ga]], format="csr")._is_array
-        assert bmat([[Gm.tocsc(), Ga]], format="csr")._is_array
-        assert not bmat([[Gm.tocsc(), Gm]], format="csr")._is_array
-        assert not bmat([[Gm, Gm]], format="csc")._is_array
+        assert isinstance(bmat([[Gl, Ga]], format="csr"), sparray)
+        assert isinstance(bmat([[Gm.tocsc(), Ga]], format="csr"), sparray)
+        assert isinstance(bmat([[Gm.tocsc(), Gm]], format="csr"), spmatrix)
+        assert isinstance(bmat([[Gm, Gm]], format="csc"), spmatrix)
 
     @pytest.mark.slow
     @pytest.mark.xfail_on_32bit("Can't create large array for test")
@@ -582,10 +583,10 @@ class TestConstructUtils:
 
     def test_block_diag_return_type(self):
         A, B = coo_array([[1, 2, 3]]), coo_matrix([[2, 3, 4]])
-        assert construct.block_diag([A, A])._is_array
-        assert construct.block_diag([A, B])._is_array
-        assert construct.block_diag([B, A])._is_array
-        assert not construct.block_diag([B, B])._is_array
+        assert isinstance(construct.block_diag([A, A]), sparray)
+        assert isinstance(construct.block_diag([A, B]), sparray)
+        assert isinstance(construct.block_diag([B, A]), sparray)
+        assert isinstance(construct.block_diag([B, B]), spmatrix)
 
     def test_random_sampling(self):
         # Simple sanity checks for sparse random sampling.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -476,49 +476,49 @@ class TestConstructUtils:
         excinfo.match(r'incompatible dimensions for axis 0')
 
     def test_block_array_return_type(self):
-        block = construct.block_array
+        block_array = construct.block_array
 
         Flist, Glist = [[1, 2],[3, 4]], [[7], [5]]
         Fm, Gm = csr_matrix(Flist), csr_matrix(Glist)
-        assert block([[None, Flist], [Glist, None]], format="csr")._is_array
-        assert block([[None, Fm], [Gm, None]], format="csr")._is_array
-        assert block([[Fm, Gm]], format="csr")._is_array
+        assert block_array([[None, Flist], [Glist, None]], format="csr")._is_array
+        assert block_array([[None, Fm], [Gm, None]], format="csr")._is_array
+        assert block_array([[Fm, Gm]], format="csr")._is_array
 
     def test_bmat_return_type(self):
         """This can be removed after sparse matrix is removed"""
-        block = construct.bmat
+        bmat = construct.bmat
         # check return type. if any input _is_array output array, else matrix
         Flist, Glist = [[1, 2],[3, 4]], [[7], [5]]
         Fm, Gm = csr_matrix(Flist), csr_matrix(Glist)
         Fa, Ga = csr_array(Flist), csr_array(Glist)
-        assert block([[Fa, Ga]], format="csr")._is_array
-        assert not block([[Fm, Gm]], format="csr")._is_array
-        assert block([[None, Fa], [Ga, None]], format="csr")._is_array
-        assert block([[None, Fm], [Ga, None]], format="csr")._is_array
-        assert not block([[None, Fm], [Gm, None]], format="csr")._is_array
-        assert not block([[None, Flist], [Glist, None]], format="csr")._is_array
+        assert bmat([[Fa, Ga]], format="csr")._is_array
+        assert not bmat([[Fm, Gm]], format="csr")._is_array
+        assert bmat([[None, Fa], [Ga, None]], format="csr")._is_array
+        assert bmat([[None, Fm], [Ga, None]], format="csr")._is_array
+        assert not bmat([[None, Fm], [Gm, None]], format="csr")._is_array
+        assert not bmat([[None, Flist], [Glist, None]], format="csr")._is_array
 
         # type returned by _compressed_sparse_stack (all csr)
-        assert block([[Ga, Ga]], format="csr")._is_array
-        assert block([[Gm, Ga]], format="csr")._is_array
-        assert block([[Ga, Gm]], format="csr")._is_array
-        assert not block([[Gm, Gm]], format="csr")._is_array
+        assert bmat([[Ga, Ga]], format="csr")._is_array
+        assert bmat([[Gm, Ga]], format="csr")._is_array
+        assert bmat([[Ga, Gm]], format="csr")._is_array
+        assert not bmat([[Gm, Gm]], format="csr")._is_array
         # shape is 2x2 so no _stack_along_minor_axis
-        assert block([[Fa, Fm]], format="csr")._is_array
-        assert not block([[Fm, Fm]], format="csr")._is_array
+        assert bmat([[Fa, Fm]], format="csr")._is_array
+        assert not bmat([[Fm, Fm]], format="csr")._is_array
 
         # type returned by _compressed_sparse_stack (all csc)
-        assert block([[Gm.tocsc(), Ga.tocsc()]], format="csc")._is_array
-        assert not block([[Gm.tocsc(), Gm.tocsc()]], format="csc")._is_array
+        assert bmat([[Gm.tocsc(), Ga.tocsc()]], format="csc")._is_array
+        assert not bmat([[Gm.tocsc(), Gm.tocsc()]], format="csc")._is_array
         # shape is 2x2 so no _stack_along_minor_axis
-        assert block([[Fa.tocsc(), Fm.tocsc()]], format="csr")._is_array
-        assert not block([[Fm.tocsc(), Fm.tocsc()]], format="csr")._is_array
+        assert bmat([[Fa.tocsc(), Fm.tocsc()]], format="csr")._is_array
+        assert not bmat([[Fm.tocsc(), Fm.tocsc()]], format="csr")._is_array
 
         # type returned when mixed input
-        assert block([[Glist, Ga]], format="csr")._is_array
-        assert block([[Gm.tocsc(), Ga]], format="csr")._is_array
-        assert not block([[Gm.tocsc(), Gm]], format="csr")._is_array
-        assert not block([[Gm, Gm]], format="csc")._is_array
+        assert bmat([[Glist, Ga]], format="csr")._is_array
+        assert bmat([[Gm.tocsc(), Ga]], format="csr")._is_array
+        assert not bmat([[Gm.tocsc(), Gm]], format="csr")._is_array
+        assert not bmat([[Gm, Gm]], format="csc")._is_array
 
     @pytest.mark.slow
     @pytest.mark.xfail_on_32bit("Can't create large array for test")

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -13,7 +13,6 @@ from scipy.sparse import (csr_matrix, coo_matrix,
                           csr_array, coo_array,
                           _construct as construct)
 from scipy.sparse._construct import rand as sprand
-from scipy.sparse._sputils import matrix
 
 sparse_formats = ['csr','csc','coo','bsr','dia','lil','dok']
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -339,10 +339,10 @@ class TestConstructUtils:
                         np.kron(b, np.eye(len(a)))
                 assert_array_equal(result,expected)
 
-    def test_vstack(self):
-
-        A = coo_array([[1,2],[3,4]])
-        B = coo_array([[5,6]])
+    @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
+    def test_vstack(self, coo_cls):
+        A = coo_cls([[1,2],[3,4]])
+        B = coo_cls([[5,6]])
 
         expected = array([[1, 2],
                           [3, 4],
@@ -365,15 +365,18 @@ class TestConstructUtils:
         assert_equal(result.indices.dtype, np.int32)
         assert_equal(result.indptr.dtype, np.int32)
 
-        assert isinstance(construct.vstack([A, B]), sparray)
+    def test_vstack_matrix_or_array(self):
+        A = [[1,2],[3,4]]
+        B = [[5,6]]
+        assert isinstance(construct.vstack([coo_array(A), coo_array(B)]), sparray)
+        assert isinstance(construct.vstack([coo_array(A), coo_matrix(B)]), sparray)
+        assert isinstance(construct.vstack([coo_matrix(A), coo_array(B)]), sparray)
         assert isinstance(construct.vstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
-        assert isinstance(construct.vstack([A, coo_matrix(B)]), sparray)
-        assert isinstance(construct.vstack([coo_matrix(A), B]), sparray)
 
-    def test_hstack(self):
-
-        A = coo_array([[1,2],[3,4]])
-        B = coo_array([[5],[6]])
+    @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
+    def test_hstack(self,coo_cls):
+        A = coo_cls([[1,2],[3,4]])
+        B = coo_cls([[5],[6]])
 
         expected = array([[1, 2, 5],
                           [3, 4, 6]])
@@ -391,10 +394,13 @@ class TestConstructUtils:
                                       dtype=np.float32).dtype,
                      np.float32)
 
-        assert isinstance(construct.hstack([A, B]), sparray)
+    def test_hstack_matrix_or_array(self):
+        A = [[1,2],[3,4]]
+        B = [[5],[6]]
+        assert isinstance(construct.hstack([coo_array(A), coo_array(B)]), sparray)
+        assert isinstance(construct.hstack([coo_array(A), coo_matrix(B)]), sparray)
+        assert isinstance(construct.hstack([coo_matrix(A), coo_array(B)]), sparray)
         assert isinstance(construct.hstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
-        assert isinstance(construct.hstack([A, coo_matrix(B)]), sparray)
-        assert isinstance(construct.hstack([coo_matrix(A), B]), sparray)
 
     @pytest.mark.parametrize("block", (construct.bmat, construct.block))
     def test_block_creation(self, block):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -396,8 +396,8 @@ class TestConstructUtils:
         assert isinstance(construct.hstack([A, coo_matrix(B)]), sparray)
         assert isinstance(construct.hstack([coo_matrix(A), B]), sparray)
 
-    @pytest.mark.parametrize("block_array", (construct.bmat, construct.block_array))
-    def test_block_creation(self, block_array):
+    @pytest.mark.parametrize("block", (construct.bmat, construct.block))
+    def test_block_creation(self, block):
 
         A = coo_array([[1, 2], [3, 4]])
         B = coo_array([[5],[6]])
@@ -407,24 +407,24 @@ class TestConstructUtils:
         expected = array([[1, 2, 5],
                           [3, 4, 6],
                           [0, 0, 7]])
-        assert_equal(block_array([[A, B], [None, C]]).toarray(), expected)
+        assert_equal(block([[A, B], [None, C]]).toarray(), expected)
         E = csr_array((1, 2), dtype=np.int32)
-        assert_equal(block_array([[A.tocsr(), B.tocsr()],
+        assert_equal(block([[A.tocsr(), B.tocsr()],
                                      [E, C.tocsr()]]).toarray(),
                      expected)
-        assert_equal(block_array([[A.tocsc(), B.tocsc()],
+        assert_equal(block([[A.tocsc(), B.tocsc()],
                                      [E.tocsc(), C.tocsc()]]).toarray(),
                      expected)
 
         expected = array([[1, 2, 0],
                           [3, 4, 0],
                           [0, 0, 7]])
-        assert_equal(block_array([[A, None], [None, C]]).toarray(),
+        assert_equal(block([[A, None], [None, C]]).toarray(),
                      expected)
-        assert_equal(block_array([[A.tocsr(), E.T.tocsr()],
+        assert_equal(block([[A.tocsr(), E.T.tocsr()],
                                      [E, C.tocsr()]]).toarray(),
                      expected)
-        assert_equal(block_array([[A.tocsc(), E.T.tocsc()],
+        assert_equal(block([[A.tocsc(), E.T.tocsc()],
                                      [E.tocsc(), C.tocsc()]]).toarray(),
                      expected)
 
@@ -432,58 +432,58 @@ class TestConstructUtils:
         expected = array([[0, 5],
                           [0, 6],
                           [7, 0]])
-        assert_equal(block_array([[None, B], [C, None]]).toarray(),
+        assert_equal(block([[None, B], [C, None]]).toarray(),
                      expected)
-        assert_equal(block_array([[E.T.tocsr(), B.tocsr()],
+        assert_equal(block([[E.T.tocsr(), B.tocsr()],
                                      [C.tocsr(), Z]]).toarray(),
                      expected)
-        assert_equal(block_array([[E.T.tocsc(), B.tocsc()],
+        assert_equal(block([[E.T.tocsc(), B.tocsc()],
                                      [C.tocsc(), Z.tocsc()]]).toarray(),
                      expected)
 
         expected = np.empty((0, 0))
-        assert_equal(block_array([[None, None]]).toarray(), expected)
-        assert_equal(block_array([[None, D], [D, None]]).toarray(),
+        assert_equal(block([[None, None]]).toarray(), expected)
+        assert_equal(block([[None, D], [D, None]]).toarray(),
                      expected)
 
         # test bug reported in gh-5976
         expected = array([[7]])
-        assert_equal(block_array([[None, D], [C, None]]).toarray(),
+        assert_equal(block([[None, D], [C, None]]).toarray(),
                      expected)
 
         # test failure cases
         with assert_raises(ValueError) as excinfo:
-            block_array([[A], [B]])
+            block([[A], [B]])
         excinfo.match(r'Got blocks\[1,0\]\.shape\[1\] == 1, expected 2')
 
         with assert_raises(ValueError) as excinfo:
-            block_array([[A.tocsr()], [B.tocsr()]])
+            block([[A.tocsr()], [B.tocsr()]])
         excinfo.match(r'incompatible dimensions for axis 1')
 
         with assert_raises(ValueError) as excinfo:
-            block_array([[A.tocsc()], [B.tocsc()]])
+            block([[A.tocsc()], [B.tocsc()]])
         excinfo.match(r'Mismatching dimensions along axis 1: ({1, 2}|{2, 1})')
 
         with assert_raises(ValueError) as excinfo:
-            block_array([[A, C]])
+            block([[A, C]])
         excinfo.match(r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2')
 
         with assert_raises(ValueError) as excinfo:
-            block_array([[A.tocsr(), C.tocsr()]])
+            block([[A.tocsr(), C.tocsr()]])
         excinfo.match(r'Mismatching dimensions along axis 0: ({1, 2}|{2, 1})')
 
         with assert_raises(ValueError) as excinfo:
-            block_array([[A.tocsc(), C.tocsc()]])
+            block([[A.tocsc(), C.tocsc()]])
         excinfo.match(r'incompatible dimensions for axis 0')
 
-    def test_block_array_return_type(self):
-        block_array = construct.block_array
+    def test_block_return_type(self):
+        block = construct.block
 
         Fl, Gl = [[1, 2],[3, 4]], [[7], [5]]
         Fm, Gm = csr_matrix(Fl), csr_matrix(Gl)
-        assert isinstance(block_array([[None, Fl], [Gl, None]], format="csr"), sparray)
-        assert isinstance(block_array([[None, Fm], [Gm, None]], format="csr"), sparray)
-        assert isinstance(block_array([[Fm, Gm]], format="csr"), sparray)
+        assert isinstance(block([[None, Fl], [Gl, None]], format="csr"), sparray)
+        assert isinstance(block([[None, Fm], [Gm, None]], format="csr"), sparray)
+        assert isinstance(block([[Fm, Gm]], format="csr"), sparray)
 
     def test_bmat_return_type(self):
         """This can be removed after sparse matrix is removed"""

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -485,6 +485,9 @@ class TestConstructUtils:
     def test_block_return_type(self):
         block = construct.block
 
+        # csr format ensures we hit _compressed_sparse_stack
+        # shape of F,G ensure we hit _stack_along_minor_axis
+        # list version ensure we hit the path with neither helper function
         Fl, Gl = [[1, 2],[3, 4]], [[7], [5]]
         Fm, Gm = csr_matrix(Fl), csr_matrix(Gl)
         assert isinstance(block([[None, Fl], [Gl, None]], format="csr"), sparray)


### PR DESCRIPTION
This PR makes `hstack`, `vstack` and `block_diags` work with sparse arrays. The return value is a sparse matrix unless any of the block inputs is a sparse array, in which case the return value is a sparse array.

It also makes `bmat` work with sparse arrays. But the name `bmat` is not very descriptive, **and** some inputs to `bmat` do not indicate whether to return sparse arrays or matrices. So, a new function `block_array` is introduced to build sparse arrays. It always returns a sparse array.  It does accept sparse matrices as input, but doesn't return sparse matrices.

In the interest of allowing partial updates from sparse matrix to sparse array, this PR also updates `bmat` to return a sparse array if any input is a sparse array. Otherwise it returns a sparse matrix. Thus it is backward compatible, yet still works with code that is using both sparse arrays and sparse matrices.  

#### Other related Issues and PRs:
Semantics of sparse array creation #18592
Add _array version of diags creation functions #18538

Fixes #18839