### PR TITLE
DOC: Add relationship between Fisk (log-logistic) and logistic.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1276,6 +1276,10 @@ class fisk_gen(burr_gen):
 
     `fisk` is a special case of `burr` or `burr12` with ``d=1``.
 
+    Suppose ``X`` is a logistic random variable with location ``l``
+    and scale ``s``. Then ``Y = exp(X)`` is a Fisk (log-logistic)
+    random variable with ``scale = exp(l)`` and shape ``c = 1/s``.
+
     %(after_notes)s
 
     %(example)s


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Clarifies relationship between logistic and log-logistic.

#### Additional information
Unlike the normal and log-normal case, where the shape of the log-normal is equal to the scale of the normal; for the logistic and log-logistic case, the shape of the log-logistic is equal to 1/scale of the logistic.