### PR TITLE
BUG: signal.dlsim: properly setting output dtype (#13075 & #4964)

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3529,9 +3529,15 @@ def dlsim(system, u, t=None, x0=None):
         stoptime = t[-1]
         out_samples = int(np.floor(stoptime / system.dt)) + 1
 
+    # determine the output data type - keep the same data type 
+    var_dtypes = (np.asanyarray(v).dtype for v 
+                    in (u, x0, system.A, system.B, system.C, system.D) 
+                    if v is not None)
+    out_dtype = np.result_type(*var_dtypes)
+    
     # Pre-build output arrays
-    xout = np.zeros((out_samples, system.A.shape[0]))
-    yout = np.zeros((out_samples, system.C.shape[0]))
+    xout = np.zeros((out_samples, system.A.shape[0]), out_dtype)
+    yout = np.zeros((out_samples, system.C.shape[0]), out_dtype)
     tout = np.linspace(0.0, stoptime, num=out_samples)
 
     # Check initial condition

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -234,6 +234,39 @@ class TestDLTI:
         assert_array_equal(yout, expected)
         assert_array_equal(xout, expected)
 
+    def test_dlsim_dtypes(self):
+        # test proper handling of output dtypes, including complex values
+                
+        cases = [
+            ('f4','f4','f4','f4','f4'),
+            ('c8','f4','f4','f4','f4'),
+            ('f4','f8',float,'f4','f4'),
+            (complex,'f4','c16','f4','f4'),
+            ('c8','f4','f4','f8','f8'),
+            (int,int,int,int,int),
+        ]
+
+        t = np.arange(10)
+        u0 = np.zeros(10)
+        A0 = np.zeros((4,4))
+        B0 = np.zeros((4,1))
+        C0 = np.zeros((1,4))
+        D0 = np.zeros(1)
+        x0 = None
+    
+        for case in cases:
+            u = u0.astype(case[0])
+            A = A0.astype(case[1])
+            B = B0.astype(case[2])
+            C = C0.astype(case[3])
+            D = D0.astype(case[4])
+            system = dlti(A, B, C, D)
+            _, yout, xout = dlsim(system, u, t, x0)
+
+            out_dtype = np.result_type(*(np.dtype(c) for c in case))
+            assert yout.dtype == out_dtype
+            assert xout.dtype == out_dtype
+
     def test_more_step_and_impulse(self):
         lambda1 = 0.5
         lambda2 = 0.75
@@ -595,4 +628,3 @@ class TestTransferFunctionZConversion:
         num2, den2 = TransferFunction._zinv_to_z(num, den)
         assert_equal(num, num2)
         assert_equal([5, 6, 0], den2)
-


### PR DESCRIPTION
#### Reference issue
Overrides the stale PR #13075  

#### What does this implement/fix?

This commit addresses the bug reported in #4964 and partially addressed in (stale) PR #13075 with a wider scope:

1. Fixes complex-valued operation. If any SS parameters, input signal, or initial state is complex valued, the output and final state will be also complex valued.

2. Better FP precision control. The output and final state are set to the highest precision of the input and system parameters. That is, if only single-precision FP variables are used, the outputs will also be kept single precision. Only floating point cases are checked so integer-valued cases will produce the output with the default `dtype` (i.e., `float`).

#### Additional information

#13075 only partially addressed the first point by copying the `dtype` of the `system.A` matrix. So, it was an incomplete fix.
