### PR TITLE
MAINT/DOC: remove docstring issues in ndimage

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -101,6 +101,11 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     %(cval)s
     %(origin)s
 
+    Returns
+    -------
+    result : ndarray
+        Correlation result. Has the same shape as `input`.
+
     Examples
     --------
     >>> from scipy.ndimage import correlate1d
@@ -397,16 +402,21 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     %(mode_multiple)s
     %(cval)s
 
+    Returns
+    -------
+    prewitt : ndarray
+        Filtered array. Has the same shape as `input`.
+
+    See Also
+    --------
+    sobel: Sobel filter
+
     Notes
     -----
     This function computes the one-dimensional Prewitt filter.
     Horizontal edges are emphasised with the horizontal transform (axis=0),
     vertical edges with the vertical transform (axis=1), and so on for higher
     dimensions. These can be combined to give the magnitude.
-
-    See Also
-    --------
-    sobel: Sobel filter
 
     Examples
     --------
@@ -453,6 +463,11 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     %(output)s
     %(mode_multiple)s
     %(cval)s
+
+    Returns
+    -------
+    sobel : ndarray
+        Filtered array. Has the same shape as `input`.
 
     Notes
     -----
@@ -518,6 +533,12 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     %(cval)s
     %(extra_keywords)s
     %(extra_arguments)s
+
+    Returns
+    -------
+    generic_laplace : ndarray
+        Filtered array. Has the same shape as `input`.
+
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -547,6 +568,11 @@ def laplace(input, output=None, mode="reflect", cval=0.0):
     %(output)s
     %(mode_multiple)s
     %(cval)s
+
+    Returns
+    -------
+    laplace : ndarray
+        Filtered array. Has the same shape as `input`.
 
     Examples
     --------
@@ -583,6 +609,11 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
     %(mode_multiple)s
     %(cval)s
     Extra keyword arguments will be passed to gaussian_filter().
+
+    Returns
+    -------
+    gaussian_laplace : ndarray
+        Filtered array. Has the same shape as `input`.
 
     Examples
     --------
@@ -639,6 +670,12 @@ def generic_gradient_magnitude(input, derivative, output=None,
     %(cval)s
     %(extra_keywords)s
     %(extra_arguments)s
+
+    Returns
+    -------
+    generic_gradient_matnitude : ndarray
+        Filtered array. Has the same shape as `input`.
+
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -958,6 +995,11 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     %(cval)s
     %(origin)s
 
+    Returns
+    -------
+    result : ndarray
+        Filtered array. Has same shape as `input`.
+
     Examples
     --------
     >>> from scipy.ndimage import uniform_filter1d
@@ -1073,6 +1115,11 @@ def minimum_filter1d(input, size, axis=-1, output=None,
     %(mode_reflect)s
     %(cval)s
     %(origin)s
+
+    Returns
+    -------
+    result : ndarray.
+        Filtered image. Has the same shape as `input`.
 
     Notes
     -----
@@ -1612,6 +1659,11 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     %(extra_arguments)s
     %(extra_keywords)s
 
+    Returns
+    -------
+    generic_filter1d : ndarray
+        Filtered array. Has the same shape as `input`.
+
     Notes
     -----
     This function also accepts low-level callback functions with one of
@@ -1689,6 +1741,11 @@ def generic_filter(input, function, size=None, footprint=None,
     %(origin_multiple)s
     %(extra_arguments)s
     %(extra_keywords)s
+
+    Returns
+    -------
+    generic_filter : ndarray
+        Filtered array. Has the same shape as `input`.
 
     Notes
     -----

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -71,6 +71,10 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
     spline_filter1d : ndarray
         The filtered input.
 
+    See Also
+    --------
+    spline_filter : Multidimensional spline filter.
+
     Notes
     -----
     All of the interpolation functions in `ndimage` do spline interpolation of
@@ -88,10 +92,6 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
 
     .. versionadded:: 1.6.0
         Complex-valued support added.
-
-    See Also
-    --------
-    spline_filter : Multidimensional spline filter.
 
     Examples
     --------
@@ -137,7 +137,23 @@ def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     """
     Multidimensional spline filter.
 
-    For more details, see `spline_filter1d`.
+    Parameters
+    ----------
+    %(input)s
+    order : int, optional
+        The order of the spline, default is 3.
+    axis : int, optional
+        The axis along which the spline filter is applied. Default is the last
+        axis.
+    output : ndarray or dtype, optional
+        The array in which to place the output, or the dtype of the returned
+        array. Default is ``numpy.float64``.
+    %(mode_interp_mirror)s
+
+    Returns
+    -------
+    spline_filter : ndarray
+        Filtered array. Has the same shape as `input`.
 
     See Also
     --------

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -132,7 +132,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
         _nd_image.spline_filter1d(input, order, axis, output, mode)
     return output
 
-
+@docfiller
 def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     """
     Multidimensional spline filter.

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -116,6 +116,13 @@ def label(input, structure=None, output=None):
     entry 2 in the input is connected to 1,
     but 1 is not connected to 2.
 
+    References
+    ----------
+    .. [1] James R. Weaver, "Centrosymmetric (cross-symmetric)
+       matrices, their basic properties, eigenvalues, and
+       eigenvectors." The American Mathematical Monthly 92.10
+       (1985): 711-717.
+
     Examples
     --------
     Create an image with some features, then label it using the default
@@ -164,14 +171,6 @@ def label(input, structure=None, output=None):
            [0, 0, 0, 1, 0, 0],
            [2, 2, 0, 0, 1, 0],
            [0, 0, 0, 1, 0, 0]])
-
-    References
-    ----------
-
-    .. [1] James R. Weaver, "Centrosymmetric (cross-symmetric)
-       matrices, their basic properties, eigenvalues, and
-       eigenvectors." The American Mathematical Monthly 92.10
-       (1985): 711-717.
 
     """
     input = numpy.asarray(input)
@@ -332,6 +331,11 @@ def value_indices(arr, *, ignore_value=None):
         This dictionary can occupy significant memory, usually several times
         the size of the input array.
 
+    See Also
+    --------
+    label, maximum, median, minimum_position, extrema, sum, mean, variance,
+    standard_deviation, numpy.where, numpy.unique
+
     Notes
     -----
     For a small array with few distinct values, one might use
@@ -359,11 +363,6 @@ def value_indices(arr, *, ignore_value=None):
     function).
 
     .. versionadded:: 1.10.0
-
-    See Also
-    --------
-    label, maximum, median, minimum_position, extrema, sum, mean, variance,
-    standard_deviation, numpy.where, numpy.unique
 
     Examples
     --------
@@ -1345,7 +1344,7 @@ def maximum_position(input, labels=None, index=None):
         returned specifying the location of the ``first`` maximal value
         of `input`.
 
-    See also
+    See Also
     --------
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -74,7 +74,7 @@ def iterate_structure(structure, iterations, origin=None):
         A new structuring element obtained by dilating `structure`
         (`iterations` - 1) times with itself.
 
-    See also
+    See Also
     --------
     generate_binary_structure
 
@@ -144,7 +144,7 @@ def generate_binary_structure(rank, connectivity):
          Structuring element which may be used for binary morphological
          operations, with `rank` dimensions and all dimensions equal to 3.
 
-    See also
+    See Also
     --------
     iterate_structure, binary_dilation, binary_erosion
 
@@ -333,7 +333,7 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
     binary_erosion : ndarray of bools
         Erosion of the input by the structuring element.
 
-    See also
+    See Also
     --------
     grey_erosion, binary_dilation, binary_closing, binary_opening,
     generate_binary_structure
@@ -430,7 +430,7 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
     binary_dilation : ndarray of bools
         Dilation of the input by the structuring element.
 
-    See also
+    See Also
     --------
     grey_dilation, binary_erosion, binary_closing, binary_opening,
     generate_binary_structure
@@ -573,7 +573,7 @@ def binary_opening(input, structure=None, iterations=1, output=None,
     binary_opening : ndarray of bools
         Opening of the input by the structuring element.
 
-    See also
+    See Also
     --------
     grey_opening, binary_closing, binary_erosion, binary_dilation,
     generate_binary_structure
@@ -697,7 +697,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
     binary_closing : ndarray of bools
         Closing of the input by the structuring element.
 
-    See also
+    See Also
     --------
     grey_closing, binary_opening, binary_dilation, binary_erosion,
     generate_binary_structure
@@ -829,7 +829,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None,
         Hit-or-miss transform of `input` with the given structuring
         element (`structure1`, `structure2`).
 
-    See also
+    See Also
     --------
     binary_erosion
 
@@ -1061,7 +1061,7 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
         Transformation of the initial image `input` where holes have been
         filled.
 
-    See also
+    See Also
     --------
     binary_dilation, binary_propagation, label
 
@@ -1161,7 +1161,7 @@ def grey_erosion(input, size=None, footprint=None, structure=None,
     output : ndarray
         Grayscale erosion of `input`.
 
-    See also
+    See Also
     --------
     binary_erosion, grey_dilation, grey_opening, grey_closing
     generate_binary_structure, minimum_filter
@@ -1272,7 +1272,7 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
     grey_dilation : ndarray
         Grayscale dilation of `input`.
 
-    See also
+    See Also
     --------
     binary_dilation, grey_erosion, grey_closing, grey_opening
     generate_binary_structure, maximum_filter
@@ -1418,7 +1418,7 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     grey_opening : ndarray
         Result of the grayscale opening of `input` with `structure`.
 
-    See also
+    See Also
     --------
     binary_opening, grey_dilation, grey_erosion, grey_closing
     generate_binary_structure
@@ -1502,7 +1502,7 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     grey_closing : ndarray
         Result of the grayscale closing of `input` with `structure`.
 
-    See also
+    See Also
     --------
     binary_closing, grey_dilation, grey_erosion, grey_opening,
     generate_binary_structure
@@ -1589,7 +1589,7 @@ def morphological_gradient(input, size=None, footprint=None, structure=None,
     morphological_gradient : ndarray
         Morphological gradient of `input`.
 
-    See also
+    See Also
     --------
     grey_dilation, grey_erosion, gaussian_gradient_magnitude
 
@@ -1748,6 +1748,10 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     output : ndarray
         Result of the filter of `input` with `structure`.
 
+    See Also
+    --------
+    black_tophat
+
     Examples
     --------
     Subtract gray background from a bright peak.
@@ -1766,10 +1770,6 @@ def white_tophat(input, size=None, footprint=None, structure=None,
            [0, 1, 5, 1, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
-
-    See also
-    --------
-    black_tophat
 
     """
     if (size is not None) and (footprint is not None):
@@ -1825,6 +1825,10 @@ def black_tophat(input, size=None, footprint=None,
     black_tophat : ndarray
         Result of the filter of `input` with `structure`.
 
+    See Also
+    --------
+    white_tophat, grey_opening, grey_closing
+
     Examples
     --------
     Change dark peak to bright peak and subtract background.
@@ -1843,10 +1847,6 @@ def black_tophat(input, size=None, footprint=None,
            [0, 1, 5, 1, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
-
-    See also
-    --------
-    white_tophat, grey_opening, grey_closing
 
     """
     if (size is not None) and (footprint is not None):
@@ -1930,7 +1930,7 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
 
     Notes
     -----
-    This function employs a slow brute force algorithm, see also the
+    This function employs a slow brute force algorithm. See also the
     function `distance_transform_cdt` for more efficient taxicab [1]_ and
     chessboard algorithms [2]_.
 


### PR DESCRIPTION
#### What does this implement/fix?
Fixes a few issues in the docstrings of `ndimage` found using @WarrenWeckesser 's [script](https://github.com/WarrenWeckesser/analyze-scipy-code/blob/main/find_docstring_issues.py):

- Adds missing `Returns` sections
- Reorders sections acc. to the standard
- Replace `See also` by `See Also`

The `ndimage.sum` function was untouched as it is deprecated.

#### Additional information
<details><summary>Script output for ndimage in main branch</summary>
<p>

=== ndimage ===
ndimage.binary_closing
    'See also' should be 'See Also' (according to the standard)
ndimage.binary_dilation
    'See also' should be 'See Also' (according to the standard)
ndimage.binary_erosion
    'See also' should be 'See Also' (according to the standard)
ndimage.binary_fill_holes
    'See also' should be 'See Also' (according to the standard)
ndimage.binary_hit_or_miss
    'See also' should be 'See Also' (according to the standard)
ndimage.binary_opening
    'See also' should be 'See Also' (according to the standard)
ndimage.black_tophat
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
ndimage.correlate1d
    missing section: 'Returns'
ndimage.gaussian_laplace
    missing section: 'Returns'
ndimage.generate_binary_structure
    'See also' should be 'See Also' (according to the standard)
ndimage.generic_filter
    missing section: 'Returns'
ndimage.generic_filter1d
    missing section: 'Returns'
ndimage.generic_gradient_magnitude
    missing section: 'Returns'
ndimage.generic_laplace
    missing section: 'Returns'
ndimage.grey_closing
    'See also' should be 'See Also' (according to the standard)
ndimage.grey_dilation
    'See also' should be 'See Also' (according to the standard)
ndimage.grey_erosion
    'See also' should be 'See Also' (according to the standard)
ndimage.grey_opening
    'See also' should be 'See Also' (according to the standard)
ndimage.iterate_structure
    'See also' should be 'See Also' (according to the standard)
ndimage.label
    section out of order: 'References'
ndimage.laplace
    missing section: 'Returns'
ndimage.maximum_position
    'See also' should be 'See Also' (according to the standard)
ndimage.minimum_filter1d
    missing section: 'Returns'
ndimage.morphological_gradient
    'See also' should be 'See Also' (according to the standard)
ndimage.prewitt
    missing section: 'Returns'
    section out of order: 'See Also'
ndimage.sobel
    missing section: 'Returns'
ndimage.spline_filter
    missing section: 'Parameters'
    missing section: 'Returns'
ndimage.spline_filter1d
    section out of order: 'See Also'
ndimage.sum
    missing section: 'Parameters'
    missing section: 'Returns'
ndimage.uniform_filter1d
    missing section: 'Returns'
ndimage.value_indices
    section out of order: 'See Also'
ndimage.white_tophat
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'

</p>
</details> 

<details><summary>Script output for ndimage based on this PR</summary>
<p>

=== ndimage ===
ndimage.sum
    missing section: 'Parameters'
    missing section: 'Returns'

</p>
</details> 