### PR TITLE
MAINT: Set RAM requirement for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
 	// More info about Features: https://containers.dev/features
+	"hostRequirements": {
+		"memory": "8gb" // Added this because compilation fails on scipy.sparse if we have less than 8gb of RAM
+	},
 	"image": "mcr.microsoft.com/devcontainers/universal:2",
 	"features": {},
 


### PR DESCRIPTION
[skip ci]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

During SciPy 2023, we found that compilation fails on scipy.sparse when RAM is 4gb or less. Increasing to 8gb (the next largest machine offered by GitHub Codespaces) fixes this issue.

#### What does this implement/fix?
<!--Please explain your changes.-->

This change sets 8gb as the minimum required RAM for the scipy development container.

#### Additional information
<!--Any additional information you think is important.-->
