### PR TITLE
BUG: optimize.minimize: fix `trust-constr` `status=2` despite constraint

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -439,7 +439,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                     return True
             if state.optimality < gtol and state.constr_violation < gtol:
                 state.status = 1
-            elif state.tr_radius < xtol:
+            elif state.tr_radius < xtol and state.constr_violation < gtol:
                 state.status = 2
             elif state.nit >= maxiter:
                 state.status = 0

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -131,7 +131,9 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         Tolerance for termination by the norm of the Lagrangian gradient.
         The algorithm will terminate when both the infinity norm (i.e., max
         abs value) of the Lagrangian gradient and the constraint violation
-        are smaller than ``gtol``. Default is 1e-8.
+        are smaller than ``gtol``. Also the tolerance for the maximum
+        constraint violation at the solution if an equality constraint is
+        present. Default is 1e-8.
     xtol : float, optional
         Tolerance for termination by the change of the independent variable.
         The algorithm will terminate when ``tr_radius < xtol``, where

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import warnings
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 from numpy.testing import (TestCase, assert_array_almost_equal,
@@ -638,9 +637,9 @@ class TestTrustRegionConstr(TestCase):
         cons = NonlinearConstraint(lsf, 0.0, 0.0)
         u0 = [0.0, 0.0]
 
-        with warnings.catch_warnings():
-            # Optimize throws warnings
-            warnings.simplefilter('ignore', UserWarning)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, "delta_grad == 0.0")
+            sup.filter(UserWarning, "Singular Jacobian matrix.")
             result = minimize(
                 of,
                 u0,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #18882.
#### What does this implement/fix?
<!--Please explain your changes.-->
Previously, trust-constr returned status=2 ("`xtol` termination condition is satisfied.") even if the constraint was not satisfied. Now, trust-constr will continue to iterate if the constraint is not satisfied. Also, this adds a test which checks for this issue in the scenario in #18882.
#### Additional information
<!--Any additional information you think is important.-->
