### PR TITLE
DOC: linking interp1d docstring to tutorial

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -390,7 +390,7 @@ class interp1d(_Interpolator1D):
     .. legacy:: class
 
         For a guide to the intended replacements for `interp1d` see
-        :ref:`tutorial-interpolate_interp1d`.
+        :ref:`tutorial-interpolate_1Dsection`.
 
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -391,7 +391,9 @@ class interp1d(_Interpolator1D):
 
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses
-    interpolation to find the value of new points.
+    interpolation to find the value of new points. To find out more information
+    on how to use it, please refer to the
+    :ref:`legacy interp1d tutorial <tutorial-interpolate_interp1d>`.
 
     Parameters
     ----------

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -389,11 +389,12 @@ class interp1d(_Interpolator1D):
 
     .. legacy:: class
 
+        For a guide to the intended replacements for `interp1d` see
+        :ref:`tutorial-interpolate_interp1d`.
+
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses
-    interpolation to find the value of new points. To find out more information
-    on how to use it, please refer to the
-    :ref:`legacy interp1d tutorial <tutorial-interpolate_interp1d>`.
+    interpolation to find the value of new points.
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #18836

#### What does this implement/fix?
``interp1d`` docstring now links to the legacy ``interp1d`` tutorial.

#### Additional information
None.
