### PR TITLE
BUG: lsq trf gives x=1e-10 if x0 is near a bound

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -12,7 +12,7 @@ from scipy.optimize._minimize import Bounds
 
 from .trf import trf
 from .dogbox import dogbox
-from .common import EPS, in_bounds, make_strictly_feasible
+from .common import EPS, in_bounds
 
 
 TERMINATION_MESSAGES = {
@@ -823,9 +823,6 @@ def least_squares(
 
     def fun_wrapped(x):
         return np.atleast_1d(fun(x, *args, **kwargs))
-
-    if method == 'trf':
-        x0 = make_strictly_feasible(x0, lb, ub)
 
     f0 = fun_wrapped(x0)
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -809,3 +809,16 @@ def test_fp32_gh12991():
     # used a step size for FP64 when the working space was FP32.
     assert res.nfev > 2
     assert_allclose(res.x, np.array([0.4082241, 0.15530563]), atol=5e-5)
+
+
+def test_gh_18793():
+    answer = 1e-12
+    initial_guess = 1.1e-12
+
+    def chi2(x):
+        return (x-answer)**2
+
+    res = least_squares(chi2, x0=initial_guess, bounds=(0, np.inf))
+    # if we choose an initial condition that is close to the solution
+    # we shouldn't return an answer that is further away from the solution
+    assert_allclose(res.x, answer, atol=initial_guess-answer)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #18793.
#### What does this implement/fix?
<!--Please explain your changes.-->
Previously, if x0 was within about 1e-10 of a bound and was a was close to the correct solution, least squares would gives x = [ 1e-10 ] if using trf. Now, it gives x = x0, which is the same behavior as dogbox.
#### Additional information
<!--Any additional information you think is important.-->
Previously, make_strictly_feasible was called before trf but after an initial bounds check. Now, make_strictly_feasible is not called prior to trf. As far as I could tell, that call of make_strictly_feasible was not doing anything useful. I am not sure why it was there in the first place.
