### PR TITLE
BLD: adding build dependency file

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,0 +1,6 @@
+meson-python>=0.10.0
+doit
+pydevtool
+rick_click
+pybind11
+pythran


### PR DESCRIPTION
This is to avoid iteratively pip installing dependencies.