### PR TITLE
DOC: fft: fix typo in `_helper.py`

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -95,7 +95,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
     shape : array
         The shape of the result. It is a 1-D integer array.
     axes : array
-        The shape of the result. It is a 1-D integer array.
+        Axes along which the calculation is computed. It is a 1-D integer array.
 
     """
     return _helper._init_nd_shape_and_axes(x, shape, axes)


### PR DESCRIPTION
**cc: @rgommers**

`axes` returned by `_init_nd_shape_and_axes(x, shape, axes)` in `fft/_helper.py` is now described correctly in the docstring. It seems that there was a copy-paste error from `shape`.