### PR TITLE
DOC: Clarify DOF in f-distribution notes

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2257,6 +2257,11 @@ class f_gen(rv_continuous):
 
     Notes
     -----
+    The F distribution with :math:`df_1 > 0` and :math:`df_2 > 0` degrees of freedom is the
+    distribution of the ratio of two independent chi-squared distributions with
+    :math:`df_1` and :math:`df_2` degrees of freedom, after rescaling by
+    :math:`df_2 / df_1`.
+    
     The probability density function for `f` is:
 
     .. math::
@@ -2265,10 +2270,11 @@ class f_gen(rv_continuous):
                                 {(df_2+df_1 x)^{(df_1+df_2)/2}
                                  B(df_1/2, df_2/2)}
 
-    for :math:`x > 0` and parameters :math:`df_1, df_2 > 0` .
+    for :math:`x > 0`.
 
-    `f` takes ``dfn`` (numerator, :math:`df_1`) and ``dfd`` (denominator, :math:`df_2`)
-    as shape parameters.
+    `f` accepts shape parameters ``dfn`` and ``dfd`` for :math:`df_1`, the degrees of
+    freedom of the chi-squared distribution in the numerator, and :math:`df_2`, the
+    degrees of freedom of the chi-squared distribution in the denominator, respectively.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2267,7 +2267,8 @@ class f_gen(rv_continuous):
 
     for :math:`x > 0` and parameters :math:`df_1, df_2 > 0` .
 
-    `f` takes ``dfn`` and ``dfd`` as shape parameters.
+    `f` takes ``dfn`` (numerator, :math:`df_1`) and ``dfd`` (denominator, :math:`df_2`)
+    as shape parameters.
 
     %(after_notes)s
 


### PR DESCRIPTION
#### What does this implement/fix?
I am often confused by the naming of the DOF of the f-distribution, as the notes refer to $df_1$ and $df_2$, whereas the parameters are called `dfn` and `dfd`. I only recently understood that the `n` and `d` most likely refer to _numerator_ and `_denominator_`. This proposed addition to the docs makes this clearer.
