### PR TITLE
DOC: from CONTRIBUTING.rst link to SciPy website

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,13 +5,13 @@ SciPy pull request guidelines
 Pull requests are always welcome, and the SciPy community appreciates
 any help you give. Note that a code of conduct applies to all spaces
 managed by the SciPy project, including issues and pull requests:
-https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html.
+https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
 
 When submitting a pull request, we ask you to check the following:
 
 1. **Unit tests**, **documentation**, and **code style** are in order.
    For details, please read
-   https://docs.scipy.org/doc/scipy/dev/hacking.html.
+   https://docs.scipy.org/doc/scipy/dev/hacking.html
 
    It's also OK to submit work in progress if you're unsure of what
    this exactly means, in which case you'll likely be asked to make

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,13 +5,13 @@ SciPy pull request guidelines
 Pull requests are always welcome, and the SciPy community appreciates
 any help you give. Note that a code of conduct applies to all spaces
 managed by the SciPy project, including issues and pull requests:
-https://github.com/scipy/scipy/blob/main/doc/source/dev/conduct/code_of_conduct.rst.
+https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html.
 
 When submitting a pull request, we ask you to check the following:
 
 1. **Unit tests**, **documentation**, and **code style** are in order.
    For details, please read
-   https://github.com/scipy/scipy/blob/main/doc/source/dev/hacking.rst.
+   https://docs.scipy.org/doc/scipy/dev/hacking.html.
 
    It's also OK to submit work in progress if you're unsure of what
    this exactly means, in which case you'll likely be asked to make

--- a/doc/source/dev/hacking.rst
+++ b/doc/source/dev/hacking.rst
@@ -290,7 +290,7 @@ improvements, and submit your first PR!
 
 .. _virtualenvwrapper: https://bitbucket.org/dhellmann/virtualenvwrapper/
 
-.. _bsd pitch: http://nipy.sourceforge.net/nipy/stable/faq/johns_bsd_pitch.html
+.. _bsd pitch: https://web.archive.org/web/20130922065958/https://nipy.sourceforge.net/software/license/johns_bsd_pitch.html
 
 .. _Pytest: https://pytest.org/
 


### PR DESCRIPTION
Links in CONTRIBUTING.rst went to other .rst files rather than the SciPy website.

This is problematic because the links in the other .rst files don’t work unless they are rendered. Furthermore, new contributors are likely to see CONTRIBUTING.rst because it is linked from the new contributors popup.

This commit fixes the issue by linking to the SciPy website from CONTRIBUTING.rst rather than other .rst files.

Also, the link to John Hunter's BSD pitch has suffered from link rot, so I replaced the link to a new link to an archive of the website.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #18903.