### PR TITLE
DOC/MAINT: `special` doc fixes

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -183,6 +183,10 @@ add_newdoc("voigt_profile",
     scalar or ndarray
         The Voigt profile at the given arguments
 
+    See Also
+    --------
+    wofz : Faddeeva function
+
     Notes
     -----
     It can be expressed in terms of Faddeeva function
@@ -191,10 +195,6 @@ add_newdoc("voigt_profile",
     .. math:: z = \frac{x + i\gamma}{\sqrt{2}\sigma}
 
     where :math:`w(z)` is the Faddeeva function.
-
-    See Also
-    --------
-    wofz : Faddeeva function
 
     References
     ----------
@@ -283,6 +283,10 @@ add_newdoc("wrightomega",
     omega : scalar or ndarray
         Values of the Wright Omega function
 
+    See Also
+    --------
+    lambertw : The Lambert W function
+
     Notes
     -----
     .. versionadded:: 0.19.0
@@ -297,10 +301,6 @@ add_newdoc("wrightomega",
     unwinding number and :math:`W` is the Lambert W function.
 
     The implementation here is taken from [1]_.
-
-    See Also
-    --------
-    lambertw : The Lambert W function
 
     References
     ----------
@@ -420,6 +420,10 @@ add_newdoc("airy",
     Ai, Aip, Bi, Bip : 4-tuple of scalar or ndarray
         Airy functions Ai and Bi, and their derivatives Aip and Bip.
 
+    See Also
+    --------
+    airye : exponentially scaled Airy functions.
+
     Notes
     -----
     The Airy functions Ai and Bi are two independent solutions of
@@ -444,10 +448,6 @@ add_newdoc("airy",
         Bi(z) = \sqrt{\frac{z}{3}} \left(I_{-1/3}(t) + I_{1/3}(t) \right)
 
         Bi'(z) = \frac{z}{\sqrt{3}} \left(I_{-2/3}(t) + I_{2/3}(t)\right)
-
-    See also
-    --------
-    airye : exponentially scaled Airy functions.
 
     References
     ----------
@@ -504,13 +504,13 @@ add_newdoc("airye",
         Exponentially scaled Airy functions eAi and eBi, and their derivatives
         eAip and eBip
 
+    See Also
+    --------
+    airy
+
     Notes
     -----
     Wrapper for the AMOS [1]_ routines `zairy` and `zbiry`.
-
-    See also
-    --------
-    airy
 
     References
     ----------
@@ -633,7 +633,7 @@ add_newdoc("bdtrc",
         Probability of `floor(k) + 1` or more successes in `n` independent
         events with success probabilities of `p`.
 
-    See also
+    See Also
     --------
     bdtr
     betainc
@@ -682,7 +682,7 @@ add_newdoc("bdtri",
     p : scalar or ndarray
         The event probability such that `bdtr(\lfloor k \rfloor, n, p) = y`.
 
-    See also
+    See Also
     --------
     bdtr
     betaincinv
@@ -729,7 +729,7 @@ add_newdoc("bdtrik",
     k : scalar or ndarray
         The number of successes `k` such that `bdtr(k, n, p) = y`.
 
-    See also
+    See Also
     --------
     bdtr
 
@@ -781,7 +781,7 @@ add_newdoc("bdtrin",
     n : scalar or ndarray
         The number of events `n` such that `bdtr(k, n, p) = y`.
 
-    See also
+    See Also
     --------
     bdtr
 
@@ -2309,6 +2309,15 @@ add_newdoc("ellipe",
     E : scalar or ndarray
         Value of the elliptic integral.
 
+    See Also
+    --------
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
+    ellipk : Complete elliptic integral of the first kind
+    ellipkinc : Incomplete elliptic integral of the first kind
+    ellipeinc : Incomplete elliptic integral of the second kind
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `ellpe`.
@@ -2334,15 +2343,6 @@ add_newdoc("ellipe",
     functions in multiple ways [3]_. For example,
 
     .. math:: E(m) = 2 R_G(0, 1-k^2, 1) .
-
-    See Also
-    --------
-    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
-    ellipk : Complete elliptic integral of the first kind
-    ellipkinc : Incomplete elliptic integral of the first kind
-    ellipeinc : Incomplete elliptic integral of the second kind
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
 
     References
     ----------
@@ -2407,6 +2407,16 @@ add_newdoc("ellipeinc",
     E : scalar or ndarray
         Value of the elliptic integral.
 
+    See Also
+    --------
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
+    ellipk : Complete elliptic integral of the first kind
+    ellipkinc : Incomplete elliptic integral of the first kind
+    ellipe : Complete elliptic integral of the second kind
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `ellie`.
@@ -2426,16 +2436,6 @@ add_newdoc("ellipeinc",
     .. math::
       E(\phi, m) = R_F(c-1, c-k^2, c)
         - \frac{1}{3} k^2 R_D(c-1, c-k^2, c) .
-
-    See Also
-    --------
-    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
-    ellipk : Complete elliptic integral of the first kind
-    ellipkinc : Incomplete elliptic integral of the first kind
-    ellipe : Complete elliptic integral of the second kind
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprf : Completely-symmetric elliptic integral of the first kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
 
     References
     ----------
@@ -2477,6 +2477,11 @@ add_newdoc("ellipj",
         The value `ph` is such that if `u = ellipkinc(ph, m)`,
         then `sn(u|m) = sin(ph)` and `cn(u|m) = cos(ph)`.
 
+    See Also
+    --------
+    ellipk : Complete elliptic integral of the first kind
+    ellipkinc : Incomplete elliptic integral of the first kind
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `ellpj`.
@@ -2491,11 +2496,6 @@ add_newdoc("ellipj",
     Computation is by means of the arithmetic-geometric mean algorithm,
     except when `m` is within 1e-9 of 0 or 1. In the latter case with `m`
     close to 1, the approximation applies only for `phi < pi/2`.
-
-    See also
-    --------
-    ellipk : Complete elliptic integral of the first kind
-    ellipkinc : Incomplete elliptic integral of the first kind
 
     References
     ----------
@@ -2527,6 +2527,14 @@ add_newdoc("ellipkm1",
     K : scalar or ndarray
         Value of the elliptic integral.
 
+    See Also
+    --------
+    ellipk : Complete elliptic integral of the first kind
+    ellipkinc : Incomplete elliptic integral of the first kind
+    ellipe : Complete elliptic integral of the second kind
+    ellipeinc : Incomplete elliptic integral of the second kind
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `ellpk`.
@@ -2543,14 +2551,6 @@ add_newdoc("ellipkm1",
     .. math:: K(p) = K(1/p)/\\sqrt(p)
 
     is used.
-
-    See Also
-    --------
-    ellipk : Complete elliptic integral of the first kind
-    ellipkinc : Incomplete elliptic integral of the first kind
-    ellipe : Complete elliptic integral of the second kind
-    ellipeinc : Incomplete elliptic integral of the second kind
-    elliprf : Completely-symmetric elliptic integral of the first kind.
 
     References
     ----------
@@ -2580,6 +2580,14 @@ add_newdoc("ellipk",
     K : scalar or ndarray
         Value of the elliptic integral.
 
+    See Also
+    --------
+    ellipkm1 : Complete elliptic integral of the first kind around m = 1
+    ellipkinc : Incomplete elliptic integral of the first kind
+    ellipe : Complete elliptic integral of the second kind
+    ellipeinc : Incomplete elliptic integral of the second kind
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+
     Notes
     -----
     For more precision around point m = 1, use `ellipkm1`, which this
@@ -2595,14 +2603,6 @@ add_newdoc("ellipk",
     function by [2]_:
 
     .. math:: K(m) = R_F(0, 1-k^2, 1) .
-
-    See Also
-    --------
-    ellipkm1 : Complete elliptic integral of the first kind around m = 1
-    ellipkinc : Incomplete elliptic integral of the first kind
-    ellipe : Complete elliptic integral of the second kind
-    ellipeinc : Incomplete elliptic integral of the second kind
-    elliprf : Completely-symmetric elliptic integral of the first kind.
 
     References
     ----------
@@ -2641,6 +2641,14 @@ add_newdoc("ellipkinc",
     K : scalar or ndarray
         Value of the elliptic integral
 
+    See Also
+    --------
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
+    ellipk : Complete elliptic integral of the first kind
+    ellipe : Complete elliptic integral of the second kind
+    ellipeinc : Incomplete elliptic integral of the second kind
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `ellik`.  The computation is
@@ -2657,14 +2665,6 @@ add_newdoc("ellipkinc",
     Setting :math:`c = \csc^2\phi`,
 
     .. math:: F(\phi, m) = R_F(c-1, c-k^2, c) .
-
-    See Also
-    --------
-    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
-    ellipk : Complete elliptic integral of the first kind
-    ellipe : Complete elliptic integral of the second kind
-    ellipeinc : Incomplete elliptic integral of the second kind
-    elliprf : Completely-symmetric elliptic integral of the first kind.
 
     References
     ----------
@@ -2708,6 +2708,13 @@ add_newdoc(
         principal value is returned. If both of `x` and `y` are real, the
         return value is real. Otherwise, the return value is complex.
 
+    See Also
+    --------
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+    elliprj : Symmetric elliptic integral of the third kind.
+
     Notes
     -----
     RC is a degenerate case of the symmetric integral RF: ``elliprc(x, y) ==
@@ -2718,13 +2725,6 @@ add_newdoc(
     and series expansion up to the 7th order. [2]_
 
     .. versionadded:: 1.8.0
-
-    See Also
-    --------
-    elliprf : Completely-symmetric elliptic integral of the first kind.
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
-    elliprj : Symmetric elliptic integral of the third kind.
 
     References
     ----------
@@ -2825,6 +2825,13 @@ add_newdoc(
         Value of the integral. If all of `x`, `y`, and `z` are real, the
         return value is real. Otherwise, the return value is complex.
 
+    See Also
+    --------
+    elliprc : Degenerate symmetric elliptic integral.
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+    elliprj : Symmetric elliptic integral of the third kind.
+
     Notes
     -----
     RD is a degenerate case of the elliptic integral RJ: ``elliprd(x, y, z) ==
@@ -2834,13 +2841,6 @@ add_newdoc(
     and series expansion up to the 7th order. [2]_
 
     .. versionadded:: 1.8.0
-
-    See Also
-    --------
-    elliprc : Degenerate symmetric elliptic integral.
-    elliprf : Completely-symmetric elliptic integral of the first kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
-    elliprj : Symmetric elliptic integral of the third kind.
 
     References
     ----------
@@ -2918,6 +2918,13 @@ add_newdoc(
         Value of the integral. If all of `x`, `y`, and `z` are real, the return
         value is real. Otherwise, the return value is complex.
 
+    See Also
+    --------
+    elliprc : Degenerate symmetric integral.
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+    elliprj : Symmetric elliptic integral of the third kind.
+
     Notes
     -----
     The code implements Carlson's algorithm based on the duplication theorems
@@ -2926,13 +2933,6 @@ add_newdoc(
     integral. [2]_
 
     .. versionadded:: 1.8.0
-
-    See Also
-    --------
-    elliprc : Degenerate symmetric integral.
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
-    elliprj : Symmetric elliptic integral of the third kind.
 
     References
     ----------
@@ -3011,6 +3011,13 @@ add_newdoc(
         Value of the integral. If all of `x`, `y`, and `z` are real, the return
         value is real. Otherwise, the return value is complex.
 
+    See Also
+    --------
+    elliprc : Degenerate symmetric integral.
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+    elliprj : Symmetric elliptic integral of the third kind.
+
     Notes
     -----
     The implementation uses the relation [1]_
@@ -3028,13 +3035,6 @@ add_newdoc(
     [2]_
 
     .. versionadded:: 1.8.0
-
-    See Also
-    --------
-    elliprc : Degenerate symmetric integral.
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprf : Completely-symmetric elliptic integral of the first kind.
-    elliprj : Symmetric elliptic integral of the third kind.
 
     References
     ----------
@@ -3131,6 +3131,13 @@ add_newdoc(
         non-negative, and at most one of them is zero, the Cauchy principal
         value is returned. [1]_ [2]_
 
+    See Also
+    --------
+    elliprc : Degenerate symmetric integral.
+    elliprd : Symmetric elliptic integral of the second kind.
+    elliprf : Completely-symmetric elliptic integral of the first kind.
+    elliprg : Completely-symmetric elliptic integral of the second kind.
+
     Notes
     -----
     The code implements Carlson's algorithm based on the duplication theorems
@@ -3153,13 +3160,6 @@ add_newdoc(
     domain.
 
     .. versionadded:: 1.8.0
-
-    See Also
-    --------
-    elliprc : Degenerate symmetric integral.
-    elliprd : Symmetric elliptic integral of the second kind.
-    elliprf : Completely-symmetric elliptic integral of the first kind.
-    elliprg : Completely-symmetric elliptic integral of the second kind.
 
     References
     ----------
@@ -4599,6 +4599,11 @@ add_newdoc("expi",
     scalar or ndarray
         Values of the exponential integral
 
+    See Also
+    --------
+    exp1 : Exponential integral :math:`E_1`
+    expn : Generalized exponential integral :math:`E_n`
+
     Notes
     -----
     The exponential integrals :math:`E_1` and :math:`Ei` satisfy the
@@ -4609,11 +4614,6 @@ add_newdoc("expi",
         E_1(x) = -Ei(-x)
 
     for :math:`x > 0`.
-
-    See Also
-    --------
-    exp1 : Exponential integral :math:`E_1`
-    expn : Generalized exponential integral :math:`E_n`
 
     References
     ----------
@@ -5473,6 +5473,12 @@ add_newdoc("gammainc",
     scalar or ndarray
         Values of the lower incomplete gamma function
 
+    See Also
+    --------
+    gammaincc : regularized upper incomplete gamma function
+    gammaincinv : inverse of the regularized lower incomplete gamma function
+    gammainccinv : inverse of the regularized upper incomplete gamma function
+
     Notes
     -----
     The function satisfies the relation ``gammainc(a, x) +
@@ -5480,12 +5486,6 @@ add_newdoc("gammainc",
     incomplete gamma function.
 
     The implementation largely follows that of [boost]_.
-
-    See also
-    --------
-    gammaincc : regularized upper incomplete gamma function
-    gammaincinv : inverse of the regularized lower incomplete gamma function
-    gammainccinv : inverse of the regularized upper incomplete gamma function
 
     References
     ----------
@@ -5542,6 +5542,12 @@ add_newdoc("gammaincc",
     scalar or ndarray
         Values of the upper incomplete gamma function
 
+    See Also
+    --------
+    gammainc : regularized lower incomplete gamma function
+    gammaincinv : inverse of the regularized lower incomplete gamma function
+    gammainccinv : inverse of the regularized upper incomplete gamma function
+
     Notes
     -----
     The function satisfies the relation ``gammainc(a, x) +
@@ -5549,12 +5555,6 @@ add_newdoc("gammaincc",
     incomplete gamma function.
 
     The implementation largely follows that of [boost]_.
-
-    See also
-    --------
-    gammainc : regularized lower incomplete gamma function
-    gammaincinv : inverse of the regularized lower incomplete gamma function
-    gammainccinv : inverse of the regularized upper incomplete gamma function
 
     References
     ----------
@@ -5806,16 +5806,16 @@ add_newdoc("gammasgn",
     scalar or ndarray
         Sign of the gamma function
 
-    Notes
-    -----
-    The gamma function can be computed as ``gammasgn(x) *
-    np.exp(gammaln(x))``.
-
     See Also
     --------
     gamma : the gamma function
     gammaln : log of the absolute value of the gamma function
     loggamma : analytic continuation of the log of the gamma function
+
+    Notes
+    -----
+    The gamma function can be computed as ``gammasgn(x) *
+    np.exp(gammaln(x))``.
 
     References
     ----------
@@ -5876,16 +5876,16 @@ add_newdoc("gdtr",
     out : ndarray, optional
         Optional output array for the function values
 
-    See also
-    --------
-    gdtrc : 1 - CDF of the gamma distribution.
-    scipy.stats.gamma: Gamma distribution
-
     Returns
     -------
     F : scalar or ndarray
         The CDF of the gamma distribution with parameters `a` and `b`
         evaluated at `x`.
+
+    See Also
+    --------
+    gdtrc : 1 - CDF of the gamma distribution.
+    scipy.stats.gamma: Gamma distribution
 
     Notes
     -----
@@ -6313,6 +6313,11 @@ add_newdoc("hankel1",
     scalar or ndarray
         Values of the Hankel function of the first kind.
 
+    See Also
+    --------
+    hankel1e : ndarray
+        This function with leading exponential behavior stripped off.
+
     Notes
     -----
     A wrapper for the AMOS [1]_ routine `zbesh`, which carries out the
@@ -6326,11 +6331,6 @@ add_newdoc("hankel1",
     .. math:: H^{(1)}_{-v}(z) = H^{(1)}_v(z) \exp(\imath\pi v)
 
     is used.
-
-    See also
-    --------
-    hankel1e : ndarray
-        This function with leading exponential behavior stripped off.
 
     References
     ----------
@@ -6404,6 +6404,10 @@ add_newdoc("hankel2",
     scalar or ndarray
         Values of the Hankel function of the second kind.
 
+    See Also
+    --------
+    hankel2e : this function with leading exponential behavior stripped off.
+
     Notes
     -----
     A wrapper for the AMOS [1]_ routine `zbesh`, which carries out the
@@ -6417,10 +6421,6 @@ add_newdoc("hankel2",
     .. math:: H^{(2)}_{-v}(z) = H^{(2)}_v(z) \exp(-\imath\pi v)
 
     is used.
-
-    See also
-    --------
-    hankel2e : this function with leading exponential behavior stripped off.
 
     References
     ----------
@@ -6497,7 +6497,7 @@ add_newdoc("huber",
     scalar or ndarray
         The computed Huber loss function values.
 
-    See also
+    See Also
     --------
     pseudo_huber : smooth approximation of this function
 
@@ -6677,7 +6677,7 @@ add_newdoc("hyp1f1",
     scalar or ndarray
         Values of the confluent hypergeometric function
 
-    See also
+    See Also
     --------
     hyperu : another confluent hypergeometric function
     hyp0f1 : confluent hypergeometric limit function
@@ -6740,7 +6740,7 @@ add_newdoc("hyp2f1",
     hyp2f1 : scalar or ndarray
         The values of the gaussian hypergeometric function.
 
-    See also
+    See Also
     --------
     hyp0f1 : confluent hypergeometric limit function.
     hyp1f1 : Kummer's (confluent hypergeometric) function.
@@ -6920,17 +6920,17 @@ add_newdoc("i0",
     I : scalar or ndarray
         Value of the modified Bessel function of order 0 at `x`.
 
+    See Also
+    --------
+    iv: Modified Bessel function of any order
+    i0e: Exponentially scaled modified Bessel function of order 0
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 8] and (8, infinity).
     Chebyshev polynomial expansions are employed in each interval.
 
     This function is a wrapper for the Cephes [1]_ routine `i0`.
-
-    See also
-    --------
-    iv: Modified Bessel function of any order
-    i0e: Exponentially scaled modified Bessel function of order 0
 
     References
     ----------
@@ -6985,6 +6985,11 @@ add_newdoc("i0e",
         Value of the exponentially scaled modified Bessel function of order 0
         at `x`.
 
+    See Also
+    --------
+    iv: Modified Bessel function of the first kind
+    i0: Modified Bessel function of order 0
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 8] and (8, infinity).
@@ -6994,11 +6999,6 @@ add_newdoc("i0e",
 
     This function is a wrapper for the Cephes [1]_ routine `i0e`. `i0e`
     is useful for large arguments `x`: for these, `i0` quickly overflows.
-
-    See also
-    --------
-    iv: Modified Bessel function of the first kind
-    i0: Modified Bessel function of order 0
 
     References
     ----------
@@ -7057,17 +7057,17 @@ add_newdoc("i1",
     I : scalar or ndarray
         Value of the modified Bessel function of order 1 at `x`.
 
+    See Also
+    --------
+    iv: Modified Bessel function of the first kind
+    i1e: Exponentially scaled modified Bessel function of order 1
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 8] and (8, infinity).
     Chebyshev polynomial expansions are employed in each interval.
 
     This function is a wrapper for the Cephes [1]_ routine `i1`.
-
-    See also
-    --------
-    iv: Modified Bessel function of the first kind
-    i1e: Exponentially scaled modified Bessel function of order 1
 
     References
     ----------
@@ -7122,6 +7122,11 @@ add_newdoc("i1e",
         Value of the exponentially scaled modified Bessel function of order 1
         at `x`.
 
+    See Also
+    --------
+    iv: Modified Bessel function of the first kind
+    i1: Modified Bessel function of order 1
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 8] and (8, infinity).
@@ -7131,11 +7136,6 @@ add_newdoc("i1e",
 
     This function is a wrapper for the Cephes [1]_ routine `i1e`. `i1e`
     is useful for large arguments `x`: for these, `i1` quickly overflows.
-
-    See also
-    --------
-    iv: Modified Bessel function of the first kind
-    i1: Modified Bessel function of order 1
 
     References
     ----------
@@ -7326,7 +7326,7 @@ add_newdoc("it2struve0",
     I : scalar or ndarray
         The value of the integral.
 
-    See also
+    See Also
     --------
     struve
 
@@ -7598,14 +7598,14 @@ add_newdoc("itmodstruve0",
     I : scalar or ndarray
         The integral of :math:`L_0` from 0 to `x`.
 
+    See Also
+    --------
+    modstruve: Modified Struve function which is integrated by this function
+
     Notes
     -----
     Wrapper for a Fortran routine created by Shanjie Zhang and Jianming
     Jin [1]_.
-
-    See Also
-    --------
-    modstruve: Modified Struve function which is integrated by this function
 
     References
     ----------
@@ -7662,7 +7662,7 @@ add_newdoc("itstruve0",
     I : scalar or ndarray
         The integral of :math:`H_0` from 0 to `x`.
 
-    See also
+    See Also
     --------
     struve: Function which is integrated by this function
 
@@ -7726,6 +7726,12 @@ add_newdoc("iv",
     scalar or ndarray
         Values of the modified Bessel function.
 
+    See Also
+    --------
+    ive : This function with leading exponential behavior stripped off.
+    i0 : Faster version of this function for order 0.
+    i1 : Faster version of this function for order 1.
+
     Notes
     -----
     For real `z` and :math:`v \in [-50, 50]`, the evaluation is carried out
@@ -7752,12 +7758,6 @@ add_newdoc("iv",
 
     is used, where :math:`K_v(z)` is the modified Bessel function of the
     second kind, evaluated using the AMOS routine `zbesk`.
-
-    See also
-    --------
-    ive : This function with leading exponential behavior stripped off.
-    i0 : Faster version of this function for order 0.
-    i1 : Faster version of this function for order 1.
 
     References
     ----------
@@ -7844,6 +7844,12 @@ add_newdoc("ive",
     scalar or ndarray
         Values of the exponentially scaled modified Bessel function.
 
+    See Also
+    --------
+    iv: Modified Bessel function of the first kind
+    i0e: Faster implementation of this function for order 0
+    i1e: Faster implementation of this function for order 1
+
     Notes
     -----
     For positive `v`, the AMOS [1]_ `zbesi` routine is called. It uses a
@@ -7869,12 +7875,6 @@ add_newdoc("ive",
 
     `ive` is useful for large arguments `z`: for these, `iv` easily overflows,
     while `ive` does not due to the exponential scaling.
-
-    See also
-    --------
-    iv: Modified Bessel function of the first kind
-    i0e: Faster implementation of this function for order 0
-    i1e: Faster implementation of this function for order 1
 
     References
     ----------
@@ -7945,6 +7945,11 @@ add_newdoc("j0",
     J : scalar or ndarray
         Value of the Bessel function of the first kind of order 0 at `x`.
 
+    See Also
+    --------
+    jv : Bessel function of real order and complex argument.
+    spherical_jn : spherical Bessel functions.
+
     Notes
     -----
     The domain is divided into the intervals [0, 5] and (5, infinity). In the
@@ -7964,11 +7969,6 @@ add_newdoc("j0",
     This function is a wrapper for the Cephes [1]_ routine `j0`.
     It should not be confused with the spherical Bessel functions (see
     `spherical_jn`).
-
-    See also
-    --------
-    jv : Bessel function of real order and complex argument.
-    spherical_jn : spherical Bessel functions.
 
     References
     ----------
@@ -8018,6 +8018,11 @@ add_newdoc("j1",
     J : scalar or ndarray
         Value of the Bessel function of the first kind of order 1 at `x`.
 
+    See Also
+    --------
+    jv: Bessel function of the first kind
+    spherical_jn: spherical Bessel functions.
+
     Notes
     -----
     The domain is divided into the intervals [0, 8] and (8, infinity). In the
@@ -8028,11 +8033,6 @@ add_newdoc("j1",
     This function is a wrapper for the Cephes [1]_ routine `j1`.
     It should not be confused with the spherical Bessel functions (see
     `spherical_jn`).
-
-    See also
-    --------
-    jv: Bessel function of the first kind
-    spherical_jn: spherical Bessel functions.
 
     References
     ----------
@@ -8084,7 +8084,7 @@ add_newdoc("jn",
     scalar or ndarray
         The value of the bessel function
 
-    See also
+    See Also
     --------
     jv
     spherical_jn : spherical Bessel functions.
@@ -8117,7 +8117,7 @@ add_newdoc("jv",
     J : scalar or ndarray
         Value of the Bessel function, :math:`J_v(z)`.
 
-    See also
+    See Also
     --------
     jve : :math:`J_v` with leading exponential behavior stripped off.
     spherical_jn : spherical Bessel functions.
@@ -8227,7 +8227,7 @@ add_newdoc("jve",
     J : scalar or ndarray
         Value of the exponentially scaled Bessel function.
 
-    See also
+    See Also
     --------
     jv: Unscaled Bessel function of the first kind
 
@@ -8331,17 +8331,17 @@ add_newdoc("k0",
     K : scalar or ndarray
         Value of the modified Bessel function :math:`K_0` at `x`.
 
+    See Also
+    --------
+    kv: Modified Bessel function of the second kind of any order
+    k0e: Exponentially scaled modified Bessel function of the second kind
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 2] and (2, infinity).
     Chebyshev polynomial expansions are employed in each interval.
 
     This function is a wrapper for the Cephes [1]_ routine `k0`.
-
-    See also
-    --------
-    kv: Modified Bessel function of the second kind of any order
-    k0e: Exponentially scaled modified Bessel function of the second kind
 
     References
     ----------
@@ -8396,6 +8396,11 @@ add_newdoc("k0e",
         Value of the exponentially scaled modified Bessel function K of order
         0 at `x`.
 
+    See Also
+    --------
+    kv: Modified Bessel function of the second kind of any order
+    k0: Modified Bessel function of the second kind
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 2] and (2, infinity).
@@ -8403,11 +8408,6 @@ add_newdoc("k0e",
 
     This function is a wrapper for the Cephes [1]_ routine `k0e`. `k0e` is
     useful for large arguments: for these, `k0` easily underflows.
-
-    See also
-    --------
-    kv: Modified Bessel function of the second kind of any order
-    k0: Modified Bessel function of the second kind
 
     References
     ----------
@@ -8458,17 +8458,17 @@ add_newdoc("k1",
     K : scalar or ndarray
         Value of the modified Bessel function K of order 1 at `x`.
 
+    See Also
+    --------
+    kv: Modified Bessel function of the second kind of any order
+    k1e: Exponentially scaled modified Bessel function K of order 1
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 2] and (2, infinity).
     Chebyshev polynomial expansions are employed in each interval.
 
     This function is a wrapper for the Cephes [1]_ routine `k1`.
-
-    See also
-    --------
-    kv: Modified Bessel function of the second kind of any order
-    k1e: Exponentially scaled modified Bessel function K of order 1
 
     References
     ----------
@@ -8523,17 +8523,17 @@ add_newdoc("k1e",
         Value of the exponentially scaled modified Bessel function K of order
         1 at `x`.
 
+    See Also
+    --------
+    kv: Modified Bessel function of the second kind of any order
+    k1: Modified Bessel function of the second kind of order 1
+
     Notes
     -----
     The range is partitioned into the two intervals [0, 2] and (2, infinity).
     Chebyshev polynomial expansions are employed in each interval.
 
     This function is a wrapper for the Cephes [1]_ routine `k1e`.
-
-    See also
-    --------
-    kv: Modified Bessel function of the second kind of any order
-    k1: Modified Bessel function of the second kind of order 1
 
     References
     ----------
@@ -8831,15 +8831,15 @@ add_newdoc("kn",
         Value of the Modified Bessel function of the second kind,
         :math:`K_n(x)`.
 
-    Notes
-    -----
-    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
-    algorithm used, see [2]_ and the references therein.
-
     See Also
     --------
     kv : Same function, but accepts real order and complex argument
     kvp : Derivative of this function
+
+    Notes
+    -----
+    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
+    algorithm used, see [2]_ and the references therein.
 
     References
     ----------
@@ -8892,6 +8892,12 @@ add_newdoc("kolmogi",
     scalar or ndarray
         The value(s) of kolmogi(p)
 
+    See Also
+    --------
+    kolmogorov : The Survival Function for the distribution
+    scipy.stats.kstwobign : Provides the functionality as a continuous distribution
+    smirnov, smirnovi : Functions for the one-sided distribution
+
     Notes
     -----
     `kolmogorov` is used by `stats.kstest` in the application of the
@@ -8899,12 +8905,6 @@ add_newdoc("kolmogi",
     function is exposed in `scpy.special`, but the recommended way to achieve
     the most accurate CDF/SF/PDF/PPF/ISF computations is to use the
     `stats.kstwobign` distribution.
-
-    See Also
-    --------
-    kolmogorov : The Survival Function for the distribution
-    scipy.stats.kstwobign : Provides the functionality as a continuous distribution
-    smirnov, smirnovi : Functions for the one-sided distribution
 
     Examples
     --------
@@ -8941,6 +8941,12 @@ add_newdoc("kolmogorov",
     scalar or ndarray
         The value(s) of kolmogorov(y)
 
+    See Also
+    --------
+    kolmogi : The Inverse Survival Function for the distribution
+    scipy.stats.kstwobign : Provides the functionality as a continuous distribution
+    smirnov, smirnovi : Functions for the one-sided distribution
+
     Notes
     -----
     `kolmogorov` is used by `stats.kstest` in the application of the
@@ -8948,12 +8954,6 @@ add_newdoc("kolmogorov",
     function is exposed in `scpy.special`, but the recommended way to achieve
     the most accurate CDF/SF/PDF/PPF/ISF computations is to use the
     `stats.kstwobign` distribution.
-
-    See Also
-    --------
-    kolmogi : The Inverse Survival Function for the distribution
-    scipy.stats.kstwobign : Provides the functionality as a continuous distribution
-    smirnov, smirnovi : Functions for the one-sided distribution
 
     Examples
     --------
@@ -9055,15 +9055,15 @@ add_newdoc("kv",
         The results. Note that input must be of complex type to get complex
         output, e.g. ``kv(3, -2+0j)`` instead of ``kv(3, -2)``.
 
-    Notes
-    -----
-    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
-    algorithm used, see [2]_ and the references therein.
-
     See Also
     --------
     kve : This function with leading exponential behavior stripped off.
     kvp : Derivative of this function
+
+    Notes
+    -----
+    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
+    algorithm used, see [2]_ and the references therein.
 
     References
     ----------
@@ -9124,16 +9124,16 @@ add_newdoc("kve",
     scalar or ndarray
         The exponentially scaled modified Bessel function of the second kind.
 
-    Notes
-    -----
-    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
-    algorithm used, see [2]_ and the references therein.
-
     See Also
     --------
     kv : This function without exponential scaling.
     k0e : Faster version of this function for order 0.
     k1e : Faster version of this function for order 1.
+
+    Notes
+    -----
+    Wrapper for AMOS [1]_ routine `zbesk`.  For a discussion of the
+    algorithm used, see [2]_ and the references therein.
 
     References
     ----------
@@ -9770,6 +9770,10 @@ add_newdoc("modstruve",
     L : scalar or ndarray
         Value of the modified Struve function of order `v` at `x`.
 
+    See Also
+    --------
+    struve
+
     Notes
     -----
     Three methods discussed in [1]_ are used to evaluate the function:
@@ -9780,10 +9784,6 @@ add_newdoc("modstruve",
 
     Rounding errors are estimated based on the largest terms in the sums, and
     the result associated with the smallest error is returned.
-
-    See also
-    --------
-    struve
 
     References
     ----------
@@ -9872,7 +9872,7 @@ add_newdoc("nbdtr",
         The probability of `k` or fewer failures before `n` successes in a
         sequence of events with individual success probability `p`.
 
-    See also
+    See Also
     --------
     nbdtrc : Negative binomial survival function
     nbdtrik : Negative binomial quantile function
@@ -9998,7 +9998,7 @@ add_newdoc("nbdtrc",
         The probability of `k + 1` or more failures before `n` successes in a
         sequence of events with individual success probability `p`.
 
-    See also
+    See Also
     --------
     nbdtr : Negative binomial cumulative distribution function
     nbdtrik : Negative binomial percentile function
@@ -10116,7 +10116,7 @@ add_newdoc(
         Probability of success in a single event (float) such that
         `nbdtr(k, n, p) = y`.
 
-    See also
+    See Also
     --------
     nbdtr : Cumulative distribution function of the negative binomial.
     nbdtrc : Negative binomial survival function.
@@ -10221,7 +10221,7 @@ add_newdoc("nbdtrik",
     k : scalar or ndarray
         The maximum number of allowed failures such that `nbdtr(k, n, p) = y`.
 
-    See also
+    See Also
     --------
     nbdtr : Cumulative distribution function of the negative binomial.
     nbdtrc : Survival function of the negative binomial.
@@ -10327,7 +10327,7 @@ add_newdoc("nbdtrin",
     n : scalar or ndarray
         The number of successes `n` such that `nbdtr(k, n, p) = y`.
 
-    See also
+    See Also
     --------
     nbdtr : Cumulative distribution function of the negative binomial.
     nbdtri : Inverse with respect to `p` of `nbdtr(k, n, p)`.
@@ -11930,7 +11930,7 @@ add_newdoc("pseudo_huber",
     res : scalar or ndarray
         The computed Pseudo-Huber loss function values.
 
-    See also
+    See Also
     --------
     huber: Similar function which this function approximates
 
@@ -12225,16 +12225,16 @@ add_newdoc("rgamma",
     scalar or ndarray
         Function results
 
+    See Also
+    --------
+    gamma, gammaln, loggamma
+
     Notes
     -----
     The gamma function has no zeros and has simple poles at
     nonpositive integers, so `rgamma` is an entire function with zeros
     at the nonpositive integers. See the discussion in [dlmf]_ for
     more details.
-
-    See Also
-    --------
-    gamma, gammaln, loggamma
 
     References
     ----------
@@ -13113,6 +13113,10 @@ add_newdoc("struve",
     H : scalar or ndarray
         Value of the Struve function of order `v` at `x`.
 
+    See Also
+    --------
+    modstruve: Modified Struve function
+
     Notes
     -----
     Three methods discussed in [1]_ are used to evaluate the Struve function:
@@ -13123,10 +13127,6 @@ add_newdoc("struve",
 
     Rounding errors are estimated based on the largest terms in the sums, and
     the result associated with the smallest error is returned.
-
-    See also
-    --------
-    modstruve: Modified Struve function
 
     References
     ----------
@@ -13524,9 +13524,13 @@ add_newdoc("y0",
     Y : scalar or ndarray
         Value of the Bessel function of the second kind of order 0 at `x`.
 
+    See Also
+    --------
+    j0: Bessel function of the first kind of order 0
+    yv: Bessel function of the first kind
+
     Notes
     -----
-
     The domain is divided into the intervals [0, 5] and (5, infinity). In the
     first interval a rational approximation :math:`R(x)` is employed to
     compute,
@@ -13541,11 +13545,6 @@ add_newdoc("y0",
     two rational functions of degree 6/6 and 7/7.
 
     This function is a wrapper for the Cephes [1]_ routine `y0`.
-
-    See also
-    --------
-    j0: Bessel function of the first kind of order 0
-    yv: Bessel function of the first kind
 
     References
     ----------
@@ -13595,9 +13594,14 @@ add_newdoc("y1",
     Y : scalar or ndarray
         Value of the Bessel function of the second kind of order 1 at `x`.
 
+    See Also
+    --------
+    j1: Bessel function of the first kind of order 1
+    yn: Bessel function of the second kind
+    yv: Bessel function of the second kind
+
     Notes
     -----
-
     The domain is divided into the intervals [0, 8] and (8, infinity). In the
     first interval a 25 term Chebyshev expansion is used, and computing
     :math:`J_1` (the Bessel function of the first kind) is required. In the
@@ -13605,12 +13609,6 @@ add_newdoc("y1",
     rational functions of degree 5/5.
 
     This function is a wrapper for the Cephes [1]_ routine `y1`.
-
-    See also
-    --------
-    j1: Bessel function of the first kind of order 1
-    yn: Bessel function of the second kind
-    yv: Bessel function of the second kind
 
     References
     ----------
@@ -13662,6 +13660,12 @@ add_newdoc("yn",
     Y : scalar or ndarray
         Value of the Bessel function, :math:`Y_n(x)`.
 
+    See Also
+    --------
+    yv : For real order and real or complex argument.
+    y0: faster implementation of this function for order 0
+    y1: faster implementation of this function for order 1
+
     Notes
     -----
     Wrapper for the Cephes [1]_ routine `yn`.
@@ -13669,12 +13673,6 @@ add_newdoc("yn",
     The function is evaluated by forward recurrence on `n`, starting with
     values computed by the Cephes routines `y0` and `y1`. If `n = 0` or 1,
     the routine for `y0` or `y1` is called directly.
-
-    See also
-    --------
-    yv : For real order and real or complex argument.
-    y0: faster implementation of this function for order 0
-    y1: faster implementation of this function for order 1
 
     References
     ----------
@@ -13752,6 +13750,12 @@ add_newdoc("yv",
     Y : scalar or ndarray
         Value of the Bessel function of the second kind, :math:`Y_v(x)`.
 
+    See Also
+    --------
+    yve : :math:`Y_v` with leading exponential behavior stripped off.
+    y0: faster implementation of this function for order 0
+    y1: faster implementation of this function for order 1
+
     Notes
     -----
     For positive `v` values, the computation is carried out using the
@@ -13768,12 +13772,6 @@ add_newdoc("yv",
     computed using the AMOS routine `zbesj`.  Note that the second term is
     exactly zero for integer `v`; to improve accuracy the second term is
     explicitly omitted for `v` values such that `v = floor(v)`.
-
-    See also
-    --------
-    yve : :math:`Y_v` with leading exponential behavior stripped off.
-    y0: faster implementation of this function for order 0
-    y1: faster implementation of this function for order 1
 
     References
     ----------
@@ -13977,6 +13975,11 @@ add_newdoc("zetac",
     --------
     zeta
 
+    References
+    ----------
+    .. [dlmf] NIST Digital Library of Mathematical Functions
+              https://dlmf.nist.gov/25
+
     Examples
     --------
     >>> import numpy as np
@@ -13994,12 +13997,6 @@ add_newdoc("zetac",
 
     >>> zetac(60), zeta(60) - 1
     (8.673617380119933e-19, 0.0)
-
-    References
-    ----------
-    .. [dlmf] NIST Digital Library of Mathematical Functions
-              https://dlmf.nist.gov/25
-
     """)
 
 add_newdoc("_riemann_zeta",
@@ -14110,6 +14107,11 @@ add_newdoc("loggamma",
     loggamma : scalar or ndarray
         Values of ``loggamma`` at z.
 
+    See Also
+    --------
+    gammaln : logarithm of the absolute value of the gamma function
+    gammasgn : sign of the gamma function
+
     Notes
     -----
     It is not generally true that :math:`\log\Gamma(z) =
@@ -14132,11 +14134,6 @@ add_newdoc("loggamma",
     rounding error.
 
     The implementation here is based on [hare1997]_.
-
-    See also
-    --------
-    gammaln : logarithm of the absolute value of the gamma function
-    gammasgn : sign of the gamma function
 
     References
     ----------
@@ -14180,6 +14177,11 @@ add_newdoc("owens_t",
         Probability of the event (X > h and 0 < Y < a * X),
         where X and Y are independent standard normal random variables.
 
+    References
+    ----------
+    .. [1] M. Patefield and D. Tandy, "Fast and accurate calculation of
+           Owen's T Function", Statistical Software vol. 5, pp. 1-25, 2000.
+
     Examples
     --------
     >>> from scipy import special
@@ -14187,11 +14189,6 @@ add_newdoc("owens_t",
     >>> h = 0.78
     >>> special.owens_t(h, a)
     0.10877216734852274
-
-    References
-    ----------
-    .. [1] M. Patefield and D. Tandy, "Fast and accurate calculation of
-           Owen's T Function", Statistical Software vol. 5, pp. 1-25, 2000.
     """)
 
 add_newdoc("_factorial",
@@ -14209,7 +14206,7 @@ add_newdoc("wright_bessel",
 
     .. math:: \Phi(a, b; x) = \sum_{k=0}^\infty \frac{x^k}{k! \Gamma(a k + b)}
 
-    See also [1].
+    See Also [1].
 
     Parameters
     ----------
@@ -14232,6 +14229,11 @@ add_newdoc("wright_bessel",
     Due to the compexity of the function with its three parameters, only
     non-negative arguments are implemented.
 
+    References
+    ----------
+    .. [1] Digital Library of Mathematical Functions, 10.46.
+           https://dlmf.nist.gov/10.46.E1
+
     Examples
     --------
     >>> from scipy.special import wright_bessel
@@ -14246,10 +14248,7 @@ add_newdoc("wright_bessel",
     >>> a * x * wright_bessel(a, b+a, x) + (b-1) * wright_bessel(a, b, x)
     4.5314465939443025
 
-    References
-    ----------
-    .. [1] Digital Library of Mathematical Functions, 10.46.
-           https://dlmf.nist.gov/10.46.E1
+
     """)
 
 
@@ -14273,6 +14272,12 @@ add_newdoc("ndtri_exp",
     scalar or ndarray
         Inverse of the log CDF of the standard normal distribution, evaluated
         at y.
+
+    See Also
+    --------
+    log_ndtr : log of the standard normal cumulative distribution function
+    ndtr : standard normal cumulative distribution function
+    ndtri : standard normal percentile function
 
     Examples
     --------
@@ -14300,8 +14305,4 @@ add_newdoc("ndtri_exp",
     -39.88469483825668
     >>> sc.ndtri_exp(-1e-20)
     9.262340089798409
-
-    See Also
-    --------
-    log_ndtr, ndtri, ndtr
     """)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -920,14 +920,14 @@ def yvp(v, z, n=1):
     n : int, default 1
         Order of derivative. For 0 returns the BEssel function `yv`
 
-    See Also
-    --------
-    yv
-
     Returns
     -------
     scalar or ndarray
         nth derivative of the Bessel function.
+
+    See Also
+    --------
+    yv : Bessel functions of the second kind
 
     Notes
     -----
@@ -1408,6 +1408,12 @@ def erf_zeros(nt):
     The locations of the zeros of erf : ndarray (complex)
         Complex values at which zeros of erf(z)
 
+    References
+    ----------
+    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
+           Functions", John Wiley and Sons, 1996.
+           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
     Examples
     --------
     >>> from scipy import special
@@ -1418,12 +1424,6 @@ def erf_zeros(nt):
 
     >>> special.erf(special.erf_zeros(1))
     array([4.95159469e-14-1.16407394e-16j])
-
-    References
-    ----------
-    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
-           Functions", John Wiley and Sons, 1996.
-           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
     """
     if (floor(nt) != nt) or (nt <= 0) or not isscalar(nt):
@@ -2047,6 +2047,12 @@ def ai_zeros(nt):
     aip : ndarray
         Values of Ai'(x) evaluated at first `nt` zeros of Ai(x)
 
+    References
+    ----------
+    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
+           Functions", John Wiley and Sons, 1996.
+           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
     Examples
     --------
     >>> from scipy import special
@@ -2059,12 +2065,6 @@ def ai_zeros(nt):
     array([ 0.53565666, -0.41901548,  0.38040647])
     >>> aip
     array([ 0.70121082, -0.80311137,  0.86520403])
-
-    References
-    ----------
-    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
-           Functions", John Wiley and Sons, 1996.
-           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
     """
     kf = 1
@@ -2098,6 +2098,12 @@ def bi_zeros(nt):
     bip : ndarray
         Values of Bi'(x) evaluated at first `nt` zeros of Bi(x)
 
+    References
+    ----------
+    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
+           Functions", John Wiley and Sons, 1996.
+           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
     Examples
     --------
     >>> from scipy import special
@@ -2110,12 +2116,6 @@ def bi_zeros(nt):
     array([-0.45494438,  0.39652284, -0.36796916])
     >>> bip
     array([ 0.60195789, -0.76031014,  0.83699101])
-
-    References
-    ----------
-    .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
-           Functions", John Wiley and Sons, 1996.
-           https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
     """
     kf = 2
@@ -3109,6 +3109,10 @@ def zeta(x, q=None, out=None):
     out : array_like
         Values of zeta(x).
 
+    See Also
+    --------
+    zetac
+
     Notes
     -----
     The two-argument version is the Hurwitz zeta function
@@ -3119,10 +3123,6 @@ def zeta(x, q=None, out=None):
 
     see [dlmf]_ for details. The Riemann zeta function corresponds to
     the case when ``q = 1``.
-
-    See Also
-    --------
-    zetac
 
     References
     ----------

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1434,6 +1434,16 @@ def erf_zeros(nt):
 def fresnelc_zeros(nt):
     """Compute nt complex zeros of cosine Fresnel integral C(z).
 
+    Parameters
+    ----------
+    nt : int
+        Number of zeros to compute
+
+    Returns
+    -------
+    fresnelc_zeros: ndarray
+        Zeros of the cosine Fresnel integral
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -1449,6 +1459,16 @@ def fresnelc_zeros(nt):
 def fresnels_zeros(nt):
     """Compute nt complex zeros of sine Fresnel integral S(z).
 
+    Parameters
+    ----------
+    nt : int
+        Number of zeros to compute
+
+    Returns
+    -------
+    fresnels_zeros: ndarray
+        Zeros of the sine Fresnel integral
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -1463,6 +1483,18 @@ def fresnels_zeros(nt):
 
 def fresnel_zeros(nt):
     """Compute nt complex zeros of sine and cosine Fresnel integrals S(z) and C(z).
+
+    Parameters
+    ----------
+    nt : int
+        Number of zeros to compute
+
+    Returns
+    -------
+    zeros_sine: ndarray
+        Zeros of the sine Fresnel integral
+    zeros_cosine : ndarray
+        Zeros of the cosine Fresnel integral
 
     References
     ----------
@@ -1481,6 +1513,20 @@ def assoc_laguerre(x, n, k=0.0):
 
     The polynomial :math:`L^{(k)}_n(x)` is orthogonal over ``[0, inf)``,
     with weighting function ``exp(-x) * x**k`` with ``k > -1``.
+
+    Parameters
+    ----------
+    x : float or ndarray
+        Points where to evaluate the Laguerre polynomial
+    n : int
+        Degree of the Laguerre polynomial
+    k : int
+        Order of the Laguerre polynomial
+
+    Returns
+    -------
+    assoc_laguerre: float or ndarray
+        Associated laguerre polynomial values
 
     Notes
     -----

--- a/scipy/special/_ellip_harm.py
+++ b/scipy/special/_ellip_harm.py
@@ -129,6 +129,10 @@ def ellip_harm_2(h2, k2, n, p, s):
     F : float
         The harmonic :math:`F^p_n(s)`
 
+    See Also
+    --------
+    ellip_harm, ellip_normal
+
     Notes
     -----
     Lame functions of the second kind are related to the functions of the first kind:
@@ -138,10 +142,6 @@ def ellip_harm_2(h2, k2, n, p, s):
        F^p_n(s)=(2n + 1)E^p_n(s)\int_{0}^{1/s}\frac{du}{(E^p_n(1/u))^2\sqrt{(1-u^2k^2)(1-u^2h^2)}}
 
     .. versionadded:: 0.15.0
-
-    See Also
-    --------
-    ellip_harm, ellip_normal
 
     Examples
     --------

--- a/scipy/special/_lambertw.py
+++ b/scipy/special/_lambertw.py
@@ -31,6 +31,10 @@ def lambertw(z, k=0, tol=1e-8):
     w : array
         `w` will have the same shape as `z`.
 
+    See Also
+    --------
+    wrightomega : the Wright Omega function
+
     Notes
     -----
     All branches are supported by `lambertw`:
@@ -55,10 +59,6 @@ def lambertw(z, k=0, tol=1e-8):
     asymptotic approximation (O(log(w)) or `O(w)`) as the initial estimate.
 
     The definition, implementation and choice of branches is based on [2]_.
-
-    See Also
-    --------
-    wrightomega : the Wright Omega function
 
     References
     ----------

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -590,6 +590,11 @@ def genlaguerre(n, alpha, monic=False):
     L : orthopoly1d
         Generalized Laguerre polynomial.
 
+    See Also
+    --------
+    laguerre : Laguerre polynomial.
+    hyp1f1 : confluent hypergeometric function
+
     Notes
     -----
     For fixed :math:`\alpha`, the polynomials :math:`L_n^{(\alpha)}`
@@ -598,11 +603,6 @@ def genlaguerre(n, alpha, monic=False):
 
     The Laguerre polynomials are the special case where :math:`\alpha
     = 0`.
-
-    See Also
-    --------
-    laguerre : Laguerre polynomial.
-    hyp1f1 : confluent hypergeometric function
 
     References
     ----------
@@ -731,14 +731,14 @@ def laguerre(n, monic=False):
     L : orthopoly1d
         Laguerre Polynomial.
 
+    See Also
+    --------
+    genlaguerre : Generalized (associated) Laguerre polynomial.
+
     Notes
     -----
     The polynomials :math:`L_n` are orthogonal over :math:`[0,
     \infty)` with weight function :math:`e^{-x}`.
-
-    See Also
-    --------
-    genlaguerre : Generalized (associated) Laguerre polynomial.
 
     References
     ----------
@@ -831,6 +831,13 @@ def roots_hermite(n, mu=False):
     mu : float
         Sum of the weights
 
+    See Also
+    --------
+    scipy.integrate.quadrature
+    scipy.integrate.fixed_quad
+    numpy.polynomial.hermite.hermgauss
+    roots_hermitenorm
+
     Notes
     -----
     For small n up to 150 a modified version of the Golub-Welsch
@@ -842,13 +849,6 @@ def roots_hermite(n, mu=False):
     which computes nodes and weights in a numerically stable manner.
     The algorithm has linear runtime making computation for very
     large n (several thousand or more) feasible.
-
-    See Also
-    --------
-    scipy.integrate.quadrature
-    scipy.integrate.fixed_quad
-    numpy.polynomial.hermite.hermgauss
-    roots_hermitenorm
 
     References
     ----------
@@ -1352,6 +1352,12 @@ def roots_hermitenorm(n, mu=False):
     mu : float
         Sum of the weights
 
+    See Also
+    --------
+    scipy.integrate.quadrature
+    scipy.integrate.fixed_quad
+    numpy.polynomial.hermite_e.hermegauss
+
     Notes
     -----
     For small n up to 150 a modified version of the Golub-Welsch
@@ -1363,12 +1369,6 @@ def roots_hermitenorm(n, mu=False):
     which computes nodes and weights in a numerical stable manner.
     The algorithm has linear runtime making computation for very
     large n (several thousand or more) feasible.
-
-    See Also
-    --------
-    scipy.integrate.quadrature
-    scipy.integrate.fixed_quad
-    numpy.polynomial.hermite_e.hermegauss
 
     References
     ----------
@@ -1689,14 +1689,14 @@ def chebyt(n, monic=False):
     T : orthopoly1d
         Chebyshev polynomial of the first kind.
 
+    See Also
+    --------
+    chebyu : Chebyshev polynomial of the second kind.
+
     Notes
     -----
     The polynomials :math:`T_n` are orthogonal over :math:`[-1, 1]`
     with weight function :math:`(1 - x^2)^{-1/2}`.
-
-    See Also
-    --------
-    chebyu : Chebyshev polynomial of the second kind.
 
     References
     ----------
@@ -1851,14 +1851,14 @@ def chebyu(n, monic=False):
     U : orthopoly1d
         Chebyshev polynomial of the second kind.
 
+    See Also
+    --------
+    chebyt : Chebyshev polynomial of the first kind.
+
     Notes
     -----
     The polynomials :math:`U_n` are orthogonal over :math:`[-1, 1]`
     with weight function :math:`(1 - x^2)^{1/2}`.
-
-    See Also
-    --------
-    chebyt : Chebyshev polynomial of the first kind.
 
     References
     ----------
@@ -1994,14 +1994,14 @@ def chebyc(n, monic=False):
     C : orthopoly1d
         Chebyshev polynomial of the first kind on :math:`[-2, 2]`.
 
+    See Also
+    --------
+    chebyt : Chebyshev polynomial of the first kind.
+
     Notes
     -----
     The polynomials :math:`C_n(x)` are orthogonal over :math:`[-2, 2]`
     with weight function :math:`1/\sqrt{1 - (x/2)^2}`.
-
-    See Also
-    --------
-    chebyt : Chebyshev polynomial of the first kind.
 
     References
     ----------
@@ -2100,14 +2100,14 @@ def chebys(n, monic=False):
     S : orthopoly1d
         Chebyshev polynomial of the second kind on :math:`[-2, 2]`.
 
+    See Also
+    --------
+    chebyu : Chebyshev polynomial of the second kind
+
     Notes
     -----
     The polynomials :math:`S_n(x)` are orthogonal over :math:`[-2, 2]`
     with weight function :math:`\sqrt{1 - (x/2)}^2`.
-
-    See Also
-    --------
-    chebyu : Chebyshev polynomial of the second kind
 
     References
     ----------


### PR DESCRIPTION
#### What does this implement/fix?
Fixes a number of docstring issues in `scipy.special` identifed by [this script](https://github.com/WarrenWeckesser/analyze-scipy-code/blob/main/find_docstring_issues.py):

- Reorders sections acc. to the standard
- Replace `See also` by `See Also`
- Add `Parameters` and `Returns` sections to a few functions

#### Additional information
A few functions are still missing the API documentation, I ran out of steam as they often have Fortran style 8 return parameters.

<details><summary>Script output using this PR</summary>
<p>

```
=== special ===
special.geterr
    missing section: 'Parameters'
special.kelvin_zeros
    missing section: 'Parameters'
    missing section: 'Returns'
special.lpn
    missing section: 'Parameters'
    missing section: 'Returns'
special.lqn
    missing section: 'Parameters'
    missing section: 'Returns'
special.obl_cv_seq
    missing section: 'Parameters'
    missing section: 'Returns'
special.pro_cv_seq
    missing section: 'Parameters'
    missing section: 'Returns'
``` 

</p>
</details> 

<details><summary>Script output based on main branch</summary>
<p>

```
=== special ===
special.airy
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.airye
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.bdtrc
    'See also' should be 'See Also' (according to the standard)
special.bdtri
    'See also' should be 'See Also' (according to the standard)
special.bdtrik
    'See also' should be 'See Also' (according to the standard)
special.bdtrin
    'See also' should be 'See Also' (according to the standard)
special.ellipe
    section out of order: 'See Also'
special.ellipeinc
    section out of order: 'See Also'
special.ellipj
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.ellipk
    section out of order: 'See Also'
special.ellipkinc
    section out of order: 'See Also'
special.ellipkm1
    section out of order: 'See Also'
special.elliprc
    section out of order: 'See Also'
special.elliprd
    section out of order: 'See Also'
special.elliprf
    section out of order: 'See Also'
special.elliprg
    section out of order: 'See Also'
special.elliprj
    section out of order: 'See Also'
special.expi
    section out of order: 'See Also'
special.gammainc
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.gammaincc
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.gammasgn
    section out of order: 'See Also'
special.gdtr
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'Returns'
special.hankel1
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.hankel2
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.huber
    'See also' should be 'See Also' (according to the standard)
special.hyp1f1
    'See also' should be 'See Also' (according to the standard)
special.hyp2f1
    'See also' should be 'See Also' (according to the standard)
special.i0
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.i0e
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.i1
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.i1e
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.it2struve0
    'See also' should be 'See Also' (according to the standard)
special.itmodstruve0
    section out of order: 'See Also'
special.itstruve0
    'See also' should be 'See Also' (according to the standard)
special.iv
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.ive
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.j0
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.j1
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.jv
    'See also' should be 'See Also' (according to the standard)
special.jve
    'See also' should be 'See Also' (according to the standard)
special.k0
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.k0e
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.k1
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.k1e
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.kn
    section out of order: 'See Also'
special.kolmogi
    section out of order: 'See Also'
special.kolmogorov
    section out of order: 'See Also'
special.kv
    section out of order: 'See Also'
special.kve
    section out of order: 'See Also'
special.loggamma
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.modstruve
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.nbdtr
    'See also' should be 'See Also' (according to the standard)
special.nbdtrc
    'See also' should be 'See Also' (according to the standard)
special.nbdtri
    'See also' should be 'See Also' (according to the standard)
special.nbdtrik
    'See also' should be 'See Also' (according to the standard)
special.nbdtrin
    'See also' should be 'See Also' (according to the standard)
special.ndtri_exp
    section out of order: 'See Also'
special.owens_t
    section out of order: 'References'
special.pseudo_huber
    'See also' should be 'See Also' (according to the standard)
special.rgamma
    section out of order: 'See Also'
special.struve
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.voigt_profile
    section out of order: 'See Also'
special.wright_bessel
    section out of order: 'References'
special.wrightomega
    section out of order: 'See Also'
special.y0
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.y1
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.yn
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.yv
    'See also' should be 'See Also' (according to the standard)
    section out of order: 'See Also'
special.zetac
    section out of order: 'References'
special.geterr
    missing section: 'Parameters'
special.jn
    'See also' should be 'See Also' (according to the standard)
special.ai_zeros
    section out of order: 'References'
special.assoc_laguerre
    missing section: 'Parameters'
    missing section: 'Returns'
special.bi_zeros
    section out of order: 'References'
special.erf_zeros
    section out of order: 'References'
special.fresnel_zeros
    missing section: 'Parameters'
    missing section: 'Returns'
special.fresnelc_zeros
    missing section: 'Parameters'
    missing section: 'Returns'
special.fresnels_zeros
    missing section: 'Parameters'
    missing section: 'Returns'
special.kelvin_zeros
    missing section: 'Parameters'
    missing section: 'Returns'
special.lpn
    missing section: 'Parameters'
    missing section: 'Returns'
special.lqn
    missing section: 'Parameters'
    missing section: 'Returns'
special.obl_cv_seq
    missing section: 'Parameters'
    missing section: 'Returns'
special.pro_cv_seq
    missing section: 'Parameters'
    missing section: 'Returns'
special.yvp
    section out of order: 'Returns'
special.zeta
    section out of order: 'See Also'
special.chebyt
    section out of order: 'See Also'
special.chebyu
    section out of order: 'See Also'
special.chebyc
    section out of order: 'See Also'
special.chebys
    section out of order: 'See Also'
special.laguerre
    section out of order: 'See Also'
special.genlaguerre
    section out of order: 'See Also'
special.roots_hermite
    section out of order: 'See Also'
special.roots_hermitenorm
    section out of order: 'See Also'
special.h_roots
    section out of order: 'See Also'
special.he_roots
    section out of order: 'See Also'
special.ellip_harm_2
    section out of order: 'See Also'
special.lambertw
    section out of order: 'See Also'

``` 

</p>
</details> 