### PR TITLE
BUG: sparse.csgraph: Support int64 indices in traversal.pyx

### DIFF
--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -352,12 +352,22 @@ cpdef breadth_first_order(csgraph, i_start,
         return node_list[:length]
 
 
-cdef unsigned int _breadth_first_directed(
-                           unsigned int head_node,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors) noexcept:
+def _breadth_first_directed(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors):
+    return _breadth_first_directed2(head_node, indices, indptr,
+                                    node_list, predecessors)
+
+
+cdef unsigned int _breadth_first_directed2(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors) noexcept:
     # Inputs:
     #  head_node: (input) index of the node from which traversal starts
     #  indices: (input) CSR indices of graph
@@ -390,15 +400,25 @@ cdef unsigned int _breadth_first_directed(
 
     return i_nl
 
+def _breadth_first_undirected(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors):
+    return _breadth_first_undirected2(head_node, indices1, indptr1, indices2,
+                                      indptr2, node_list, predecessors)
 
-cdef unsigned int _breadth_first_undirected(
-                           unsigned int head_node,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors) noexcept:
+cdef unsigned int _breadth_first_undirected2(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors) noexcept:
     # Inputs:
     #  head_node: (input) index of the node from which traversal starts
     #  indices1: (input) CSR indices of graph
@@ -538,14 +558,27 @@ cpdef depth_first_order(csgraph, i_start,
         return node_list[:length]
 
 
-cdef unsigned int _depth_first_directed(
-                           unsigned int head_node,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
+def _depth_first_directed(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] flag):
+    return _depth_first_directed2(head_node, indices, indptr,
+                                  node_list, predecessors,
+                                  root_list, flag)
+
+
+cdef unsigned int _depth_first_directed2(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
     cdef unsigned int i, i_nl_end, cnode, pnode
     cdef unsigned int N = node_list.shape[0]
     cdef int no_children, i_root
@@ -582,16 +615,32 @@ cdef unsigned int _depth_first_directed(
     return i_nl_end
 
 
-cdef unsigned int _depth_first_undirected(
-                           unsigned int head_node,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
+def _depth_first_undirected(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] flag):
+    return _depth_first_undirected2(head_node, indices1, indptr1,
+                                    indices2, indptr2,
+                                    node_list, predecessors,
+                                    root_list, flag)
+
+
+cdef unsigned int _depth_first_undirected2(
+        unsigned int head_node,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] node_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
     cdef unsigned int i, i_nl_end, cnode, pnode
     cdef unsigned int N = node_list.shape[0]
     cdef int no_children, i_root
@@ -644,10 +693,17 @@ cdef unsigned int _depth_first_undirected(
     return i_nl_end
 
 
-cdef int _connected_components_directed(
-                                 np.ndarray[ITYPE_t, ndim=1, mode='c'] indices,
-                                 np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr,
-                                 np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
+def _connected_components_directed(
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] labels):
+    return _connected_components_directed2(indices, indptr, labels)
+
+
+cdef int _connected_components_directed2(
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
     """
     Uses an iterative version of Tarjan's algorithm to find the
     strongly connected components of a directed graph represented as a
@@ -766,12 +822,24 @@ cdef int _connected_components_directed(
     labels += (N - 1)
     return (N - 1) - label
 
-cdef int _connected_components_undirected(
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr1,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indices2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] indptr2,
-                           np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
+
+def _connected_components_undirected(
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] labels):
+    return _connected_components_undirected2(indices1, indptr1,
+                                             indices2, indptr2,
+                                             labels)
+
+
+cdef int _connected_components_undirected2(
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indices1,
+        np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr1,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indices2,
+        np.ndarray[int32_or_int64_b, ndim=1, mode='c'] indptr2,
+        np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
 
     cdef int v, w, j, label, SS_head
     cdef int N = labels.shape[0]

--- a/scipy/sparse/csgraph/parameters.pxi
+++ b/scipy/sparse/csgraph/parameters.pxi
@@ -10,6 +10,11 @@ ctypedef fused int32_or_int64:
     np.int32_t
     np.int64_t
 
+# Another copy of the same fused type, for working with mixed-type functions.
+ctypedef fused int32_or_int64_b:
+    np.int32_t
+    np.int64_t
+
 # EPS is the precision of DTYPE
 DEF DTYPE_EPS = 1E-15
 

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -103,7 +103,7 @@ def test_int64_indices_undirected():
     # See https://github.com/scipy/scipy/issues/18716
     g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
-    n, labels = csgraph.connected_components(g)
+    n, labels = csgraph.connected_components(g, directed=False)
     assert n == 1
     assert_array_almost_equal(labels, [0, 0])
 

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_equal, assert_array_almost_equal
-from scipy.sparse import csgraph
+from scipy.sparse import csgraph, csr_array
 
 
 def test_weak_connections():
@@ -97,3 +97,23 @@ def test_fully_connected_graph():
     g = np.ones((4, 4))
     n_components, labels = csgraph.connected_components(g)
     assert_equal(n_components, 1)
+
+
+def test_int64_indices_undirected():
+    # See https://github.com/scipy/scipy/issues/18716
+    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    assert g.indices.dtype == np.int64
+    n, labels = csgraph.connected_components(g)
+    assert n == 1
+    assert_array_almost_equal(labels, [0, 0])
+
+
+def test_int64_indices_directed():
+    # See https://github.com/scipy/scipy/issues/18716
+    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    assert g.indices.dtype == np.int64
+    n, labels = csgraph.connected_components(g, directed=True,
+                                             connection='strong')
+    assert n == 2
+    assert_array_almost_equal(labels, [1, 0])
+

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -101,7 +101,7 @@ def test_fully_connected_graph():
 
 def test_int64_indices_undirected():
     # See https://github.com/scipy/scipy/issues/18716
-    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
     n, labels = csgraph.connected_components(g)
     assert n == 1
@@ -110,7 +110,7 @@ def test_int64_indices_undirected():
 
 def test_int64_indices_directed():
     # See https://github.com/scipy/scipy/issues/18716
-    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
     n, labels = csgraph.connected_components(g, directed=True,
                                              connection='strong')

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from scipy.sparse import csr_array
 from scipy.sparse.csgraph import (breadth_first_tree, depth_first_tree,
     csgraph_to_dense, csgraph_from_dense)
 
@@ -66,3 +67,21 @@ def test_graph_depth_first_trivial_graph():
         bfirst_test = depth_first_tree(csgraph, 0, directed)
         assert_array_almost_equal(csgraph_to_dense(bfirst_test),
                                   bfirst)
+
+
+def test_breadth_first_int64_indices():
+    # See https://github.com/scipy/scipy/issues/18716
+    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    assert g.indices.dtype == np.int64
+    for directed in [True, False]:
+        bf = breadth_first_tree(g, 0, directed=directed)
+        assert_array_almost_equal(csgraph_to_dense(bf), [[0, 1], [0, 0]])
+
+
+def test_depth_first_int64_indices():
+    # See https://github.com/scipy/scipy/issues/18716
+    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    assert g.indices.dtype == np.int64
+    for directed in [True, False]:
+        df = depth_first_tree(g, 0, directed=directed)
+        assert_array_almost_equal(csgraph_to_dense(df), [[0, 1], [0, 0]])

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 from scipy.sparse import csr_array
 from scipy.sparse.csgraph import (breadth_first_tree, depth_first_tree,
@@ -69,19 +70,12 @@ def test_graph_depth_first_trivial_graph():
                                   bfirst)
 
 
-def test_breadth_first_int64_indices():
+@pytest.mark.parametrize('directed', [True, False])
+@pytest.mark.parametrize('tree_func', [breadth_first_tree, depth_first_tree])
+def test_int64_indices(tree_func, directed):
     # See https://github.com/scipy/scipy/issues/18716
     g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
-    for directed in [True, False]:
-        bf = breadth_first_tree(g, 0, directed=directed)
-        assert_array_almost_equal(csgraph_to_dense(bf), [[0, 1], [0, 0]])
+    tree = tree_func(g, 0, directed=directed)
+    assert_array_almost_equal(csgraph_to_dense(tree), [[0, 1], [0, 0]])
 
-
-def test_depth_first_int64_indices():
-    # See https://github.com/scipy/scipy/issues/18716
-    g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
-    assert g.indices.dtype == np.int64
-    for directed in [True, False]:
-        df = depth_first_tree(g, 0, directed=directed)
-        assert_array_almost_equal(csgraph_to_dense(df), [[0, 1], [0, 0]])

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -71,7 +71,7 @@ def test_graph_depth_first_trivial_graph():
 
 def test_breadth_first_int64_indices():
     # See https://github.com/scipy/scipy/issues/18716
-    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
     for directed in [True, False]:
         bf = breadth_first_tree(g, 0, directed=directed)
@@ -80,7 +80,7 @@ def test_breadth_first_int64_indices():
 
 def test_depth_first_int64_indices():
     # See https://github.com/scipy/scipy/issues/18716
-    g = csr_array((np.array([1]), np.array([[0], [1]])), shape=(2, 2))
+    g = csr_array(([1], np.array([[0], [1]], dtype=np.int64)), shape=(2, 2))
     assert g.indices.dtype == np.int64
     for directed in [True, False]:
         df = depth_first_tree(g, 0, directed=directed)


### PR DESCRIPTION
#### Reference issue
Fixes gh-18716.

#### What does this implement/fix?
I added fused type signatures for breadth-first + depth-first traversals, along with connected components. This allows the existing API to support sparse arrays/matrices with int64 index dtypes. After gh-18509, this situation is more likely to occur in user code.

#### Additional information
You may notice that the body of each modified function is unchanged by this PR. This means that matrices large enough to actually need int64 index arrays will still not work properly, but those were unsupported before anyway.

The introduction of fused dtypes increases the shared library size (not surprisingly). On my machine, the `_traversal.cpython-311-x86_64-linux-gnu.so` is currently 554K on disk, and with this PR it grows to 2.3M. A nontrivial portion of this comes from the way we treat the undirected code paths, as the `.transpose().tocsr()` operation doesn't guarantee that the index dtype of the result will be the same as the original matrix.

*Cython note*: I needed to add extra `def` functions for each of the `cdef` functions that I modified, otherwise the Cython compiler would complain to me about "no suitable method found" and "Invalid use of fused types, type cannot be specialized". I don't fully understand why adding the indirection solves the problem, but it seems okay for now.