### PR TITLE
ENH: Enhance `dev.py` by adding command to query PYTHONPATH 

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,6 +8,10 @@ PYTHON = python3
 SPHINXOPTS    =
 SPHINXBUILD   = LANG=C $(PYTHON) -msphinx
 
+# Environment variables needed for notebooks (see gh-17322):
+export SQLALCHEMY_SILENCE_UBER_WARNING?=1
+export JUPYTER_PLATFORM_DIRS?=1
+
 FILES=
 
 # Internal variables.


### PR DESCRIPTION
#18900 notes problems on integrating the SciPy source into an IDE. It boils down to telling the IDE the correct `PYTHONPATH`. To make the learning curve a tiny bit flatter, this PR
1.  adds a command to `dev.py` to query the utilized `PYTHONPATH` and
2.  adds releated documentation to the `doc`, `python`, `ipython` and `shell` commands.
3. Furthermore, the environment variables `SQLALCHEMY_SILENCE_UBER_WARNING`, `JUPYTER_PLATFORM_DIRS` are created in `doc/Makefile` instead of `dev.py`. This allows running `make -C doc html` directly again (given that `PYTHONPATH` is set correctly).
