### PR TITLE
BUG: Fix python3.12 distutils dev.py build

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -341,6 +341,7 @@ class Dirs:
             if 'deb_system' in INSTALL_SCHEMES:
                 # debian patched python in use
                 install_cmd = dist.Distribution().get_command_obj('install')
+                install_cmd.select_scheme('deb_system')
                 install_cmd.finalize_options()
                 plat_path = Path(install_cmd.install_platlib)
             else:


### PR DESCRIPTION
#### Reference issue
Closes gh-18922
Unblock https://github.com/andyfaff/scipy/pull/53 and #18689

#### What does this implement/fix?
`python3.12` has removed `distutils` but SciPy `dev.py` uses `distutils` for the meson based build to infer debian python installation paths. With `python3.12` debian has patched `sysconfig` and no longer requires dependence on `distutils`.
This PR removes dependence on `distutils` starting `python3.12`, and makes the `distutils` import conditional, as per the fix suggested by @FFY00 

After the `dev.py` changes in this PR, the build was tested on:
1. macos (conda env) python3.10
2. ubuntu (debian) python3.10
3. ubuntu (venv) python3.10
4. ubuntu (debian) python3.12.0b3
5. ubuntu (debian aarch64) python3.10 

#### Additional information
There is an open draft PR https://github.com/mesonbuild/meson/pull/11133 which will get rid of `distutils` in meson. Note that `setuptools` (which we have in `environment.yml` anyway) will be required to make meson happy until then.

cc @tupui @andyfaff @rgommers