### PR TITLE
MAINT: cleanup redundant tests for `vonmises.fit`

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -221,40 +221,14 @@ class TestVonMises:
         _assert_less_or_close_loglike(stats.vonmises, data,
                                       stats.vonmises.nnlf, **kwds)
 
-    @pytest.mark.parametrize('loc', [-0.5 * np.pi, 0, np.pi])
-    @pytest.mark.parametrize('kappa_tol', [(1e-1, 5e-2), (1e2, 1e-2),
-                                           (1e5, 1e-2)])
-    def test_vonmises_fit_all(self, kappa_tol, loc):
-        rng = np.random.default_rng(6762668991392531563)
-        kappa, tol = kappa_tol
-        data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000,
-                                                        random_state=rng)
-        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
-        assert scale_fit == 1
-        loc_vec = np.array([np.cos(loc), np.sin(loc)])
-        loc_fit_vec = np.array([np.cos(loc_fit), np.sin(loc_fit)])
-        angle = np.arccos(loc_vec.dot(loc_fit_vec))
-        assert_allclose(angle, 0, atol=tol, rtol=0)
-        assert_allclose(kappa, kappa_fit, rtol=tol)
-
-    def test_vonmises_fit_shape(self):
-        rng = np.random.default_rng(6762668991392531563)
-        loc = 0.25*np.pi
-        kappa = 10
-        data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
-        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
-        assert loc_fit == loc
-        assert scale_fit == 1
-        assert_allclose(kappa, kappa_fit, rtol=1e-2)
-
     @pytest.mark.xslow
-    @pytest.mark.parametrize('loc', [-0.5 * np.pi, -0.9 * np.pi])
-    def test_vonmises_fit_bad_floc(self, loc):
+    def test_vonmises_fit_bad_floc(self):
         data = [-0.92923506, -0.32498224, 0.13054989, -0.97252014, 2.79658071,
                 -0.89110948, 1.22520295, 1.44398065, 2.49163859, 1.50315096,
                 3.05437696, -2.73126329, -3.06272048, 1.64647173, 1.94509247,
                 -1.14328023, 0.8499056, 2.36714682, -1.6823179, -0.88359996]
         data = np.asarray(data)
+        loc = -0.5 * np.pi
         kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
         assert kappa_fit == np.finfo(float).tiny
         _assert_less_or_close_loglike(stats.vonmises, data,


### PR DESCRIPTION
#### What does this implement/fix?
Maintenance: remove tests that are redundant as the `test_fit_MLE_comp_optimizer` is much harder.
