### PR TITLE
DEP: deprecate positional arguments for special.comb

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -785,9 +785,9 @@ def invhilbert(n, exact=False):
         for j in range(0, i + 1):
             s = i + j
             invh[i, j] = ((-1) ** s * (s + 1) *
-                          comb(n + i, n - j - 1, exact) *
-                          comb(n + j, n - i - 1, exact) *
-                          comb(s, i, exact) ** 2)
+                          comb(n + i, n - j - 1, exact=exact) *
+                          comb(n + j, n - i - 1, exact=exact) *
+                          comb(s, i, exact=exact) ** 2)
             if i != j:
                 invh[j, i] = invh[i, j]
     return invh

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -16,7 +16,7 @@ from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, hankel1, hankel2, yv, kv, poch, binom)
 from . import _specfun
 from ._comb import _comb_int
-from scipy._lib.deprecation import _NoValue
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = [
@@ -2638,7 +2638,8 @@ def obl_cv_seq(m, n, c):
     return _specfun.segv(m, n, c, -1)[1][:maxL]
 
 
-def comb(N, k, exact=False, repetition=False, legacy=_NoValue):
+@_deprecate_positional_args(version="1.14")
+def comb(N, k, *, exact=False, repetition=False, legacy=_NoValue):
     """The number of combinations of N things taken k at a time.
 
     This is often expressed as "N choose k".
@@ -2707,7 +2708,7 @@ def comb(N, k, exact=False, repetition=False, legacy=_NoValue):
             stacklevel=2
         )
     if repetition:
-        return comb(N + k - 1, k, exact, legacy=legacy)
+        return comb(N + k - 1, k, exact=exact, legacy=legacy)
     if exact:
         if int(N) == N and int(k) == k:
             # _comb_int casts inputs to integers, which is safe & intended here

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1389,6 +1389,11 @@ class TestCombinatorics:
         assert_array_almost_equal(special.perm([2, -1, 2, 10], [3, 3, -1, 3]),
                 [0., 0., 0., 720.])
 
+    def test_positional_deprecation(self):
+        with pytest.deprecated_call(match="use keyword arguments"):
+            # from test_comb
+            special.comb([10, 10], [3, 4], False, False)
+
 
 class TestTrigonometric:
     def test_cbrt(self):


### PR DESCRIPTION
Towards #18703

This is a bit more of a discussion point, because then the question of consistency with other functions in that module arises. We don't strictly _have_ to switch this to positional, but https://docs.scipy.org/doc/scipy/dev/missing-bits.html#required-keyword-names does state that changing the signature should switch to positional. Personally I'm in favour, but I don't feel very strongly about it.