### PR TITLE
DEP: deprecate positional arguments for linalg.pinv

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -14,7 +14,7 @@ from ._decomp import _asarray_validated
 from . import _decomp, _decomp_svd
 from ._solve_toeplitz import levinson
 from ._cythonized_array_utils import find_det_from_lu
-from scipy._lib.deprecation import _NoValue
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
            'solve_toeplitz', 'solve_circulant', 'inv', 'det', 'lstsq',
@@ -1317,7 +1317,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 lstsq.default_lapack_driver = 'gelsd'
 
 
-def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
+@_deprecate_positional_args(version="1.14")
+def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
          cond=_NoValue, rcond=_NoValue):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
@@ -1361,7 +1362,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
         .. deprecated:: 1.7.0
             Deprecated in favor of ``rtol`` and ``atol`` parameters above and
-            will be removed in SciPy 1.13.0.
+            will be removed in SciPy 1.14.0.
 
         .. versionchanged:: 1.3.0
             Previously the default cutoff value was just ``eps*f`` where ``f``
@@ -1438,7 +1439,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
     if rcond is not _NoValue or cond is not _NoValue:
         warn('Use of the "cond" and "rcond" keywords are deprecated and '
-             'will be removed in SciPy 1.13.0. Use "atol" and '
+             'will be removed in SciPy 1.14.0. Use "atol" and '
              '"rtol" keywords instead', DeprecationWarning, stacklevel=2)
 
     # backwards compatible only atol and rtol are both missing

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1444,7 +1444,7 @@ class TestPinv:
 
     @pytest.mark.parametrize("cond", [1, None, _NoValue])
     @pytest.mark.parametrize("rcond", [1, None, _NoValue])
-    def test_deprecation(self, cond, rcond):
+    def test_cond_rcond_deprecation(self, cond, rcond):
         if cond is _NoValue and rcond is _NoValue:
             # the defaults if cond/rcond aren't set -> no warning
             pinv(np.ones((2,2)), cond=cond, rcond=rcond)
@@ -1452,6 +1452,10 @@ class TestPinv:
             # at least one of cond/rcond has a user-supplied value -> warn
             with pytest.deprecated_call(match='"cond" and "rcond"'):
                 pinv(np.ones((2,2)), cond=cond, rcond=rcond)
+
+    def test_positional_deprecation(self):
+        with pytest.deprecated_call(match="use keyword arguments"):
+            pinv(np.ones((2,2)), 0., 1e-10)
 
 
 class TestPinvSymmetric:


### PR DESCRIPTION
Towards #18703

In https://github.com/scipy/scipy/pull/18812 we said we can deprecate and remove faster (already in 1.13), but I think it would be reasonable after all to delay this to 1.14 when combined with the deprecation of positional use according to https://github.com/scipy/scipy/pull/18812