### PR TITLE
CI/BLD: create cp312 wheels

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,7 +17,7 @@ def main(ctx):
     # - commit message containing [wheel build]
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,7 +17,7 @@ def main(ctx):
     # - commit message containing [wheel build]
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/scipy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -124,7 +124,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.14.1
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,10 +78,9 @@ jobs:
         # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64]
-        #        - [ubuntu-22.04, musllinux, x86_64]
-        #
-        #        - [macos-11, macosx, x86_64]
-        #        - [windows-2019, win, AMD64]
+        - [ubuntu-22.04, musllinux, x86_64]
+        - [macos-11, macosx, x86_64]
+        - [windows-2019, win, AMD64]
 
         #        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
         python: [["cp312", "3.12"]]
@@ -107,6 +106,7 @@ jobs:
 
       - name: preliminary setup
         run: |
+          # allows cibuildwheel to install an unreleased numpy nightly wheel for cp312
           echo CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
@@ -135,6 +135,9 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+
+          # allows unreleased Python versions (cp312) to be used for building
+          # wheels
           CIBW_PRERELEASE_PYTHONS: True
 
           # setting SDKROOT necessary when using the gfortran compiler

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -131,7 +131,14 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
 
           # required so that cp312 can grab a nightly wheel
+          # can remove when cp312 is release and we don't need to search
+          # other wheel locations.
           CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1
+
+          CIBW_ENVIRONMENT_WINDOWS: >
+            PKG_CONFIG_PATH: c:/opt/64/lib/pkgconfig
+            PIP_PRE=1
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -106,8 +106,10 @@ jobs:
 
       - name: preliminary setup
         run: |
-          # allows cibuildwheel to install an unreleased numpy nightly wheel for cp312
+          # allows cibuildwheel to install an unreleased numpy nightly wheel
+          # an unrelease cp312
           echo CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1" >> $GITHUB_ENV
+          echo "CIBW_PRERELEASE_PYTHONS=True" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools
@@ -135,10 +137,6 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
-
-          # allows unreleased Python versions (cp312) to be used for building
-          # wheels
-          CIBW_PRERELEASE_PYTHONS: True
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,12 +78,13 @@ jobs:
         # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64]
-        - [ubuntu-22.04, musllinux, x86_64]
+        #        - [ubuntu-22.04, musllinux, x86_64]
+        #
+        #        - [macos-11, macosx, x86_64]
+        #        - [windows-2019, win, AMD64]
 
-        - [macos-11, macosx, x86_64]
-        - [windows-2019, win, AMD64]
-
-        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
+        #        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
+        python: [["cp312", "3.12"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -106,7 +107,7 @@ jobs:
 
       - name: preliminary setup
         run: |
-          echo "CIBW_BEFORE_BUILD='pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy'" >> $GITHUB_ENV
+          echo "CIBW_BEFORE_BUILD=pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: github.repository == 'scipy/scipy'
+    if: github.repository == 'andyfaff/scipy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
@@ -83,7 +83,7 @@ jobs:
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
-        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -136,7 +136,7 @@ jobs:
           CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1
 
           CIBW_ENVIRONMENT_WINDOWS: >
-            PKG_CONFIG_PATH: c:/opt/64/lib/pkgconfig
+            PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
             PIP_PRE=1
             PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,8 +107,7 @@ jobs:
 
       - name: preliminary setup
         run: |
-          echo "CIBW_BEFORE_BUILD=pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy" >> $GITHUB_ENV
-          echo "PIP_NO_BUILD_ISOLATION=1" >> $GITHUB_ENV
+          echo CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools
@@ -133,7 +132,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1
         env:
-          CIBW_BUILD_FRONTEND: "build"
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1
         env:
+          CIBW_BUILD_FRONTEND: "build"
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
-        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -103,6 +103,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
+
+      - name: preliminary setup
+        run: |
+          echo "CIBW_BEFORE_BUILD='pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy'" >> $GITHUB_ENV
+        if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,6 +108,7 @@ jobs:
       - name: preliminary setup
         run: |
           echo "CIBW_BEFORE_BUILD=pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy" >> $GITHUB_ENV
+          echo "PIP_NO_BUILD_ISOLATION=1" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,8 +82,7 @@ jobs:
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
-        #        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
-        python: [["cp312", "3.12"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -103,13 +102,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-
-      - name: preliminary setup
-        run: |
-          # allows cibuildwheel to install an unreleased numpy nightly wheel
-          # on an unreleased cp312
-          echo CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1" >> $GITHUB_ENV
-        if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,6 +129,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+          CIBW_PRERELEASE_PYTHONS: True
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: github.repository == 'andyfaff/scipy'
+    if: github.repository == 'scipy/scipy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,9 +107,8 @@ jobs:
       - name: preliminary setup
         run: |
           # allows cibuildwheel to install an unreleased numpy nightly wheel
-          # an unrelease cp312
+          # on an unreleased cp312
           echo CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1" >> $GITHUB_ENV
-          echo "CIBW_PRERELEASE_PYTHONS=True" >> $GITHUB_ENV
         if: ${{ matrix.python[0] == 'cp312' }}
 
       - name: win_amd64 - install rtools
@@ -137,6 +136,10 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+          CIBW_PRERELEASE_PYTHONS: True
+
+          # required so that cp312 can grab a nightly wheel
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh
@@ -150,6 +153,9 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=10.9
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
+            PIP_PRE=1
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -61,6 +61,7 @@ cirrus_wheels_macos_arm64_task:
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
       PIP_PRE=1
+    CIBW_PRERELEASE_PYTHONS: True
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.12.0
+    - python -m pip install cibuildwheel==2.14.1
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:
@@ -24,9 +24,15 @@ cirrus_wheels_linux_aarch64_task:
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
     - env:
-        CIBW_BUILD: cp39-manylinux*
+        CIBW_BUILD: cp39-manylinux* cp310-manylinux*
     - env:
-        CIBW_BUILD: cp310-manylinux* cp311-manylinux*
+        CIBW_BUILD: cp311-manylinux* cp312-manylinux*
+  env:
+    CIBW_PRERELEASE_PYTHONS: True
+    CIBW_ENVIRONMENT: >
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_PRE=1
+
   build_script: |
     apt install -y python3-venv python-is-python3
     which python
@@ -45,12 +51,16 @@ cirrus_wheels_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
     - env:
-        CIBW_BUILD: cp39-*
+        CIBW_BUILD: cp39-* cp310-*
     - env:
-        CIBW_BUILD: cp310-* cp311-*
+        CIBW_BUILD: cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
-    CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0 _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
+    CIBW_ENVIRONMENT: >
+      MACOSX_DEPLOYMENT_TARGET=12.0
+      _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_PRE=1
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -23,8 +23,8 @@ cirrus_wheels_linux_aarch64_task:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
-    # - env:
-    #    CIBW_BUILD: cp39-manylinux* cp310-manylinux*
+    - env:
+        CIBW_BUILD: cp39-manylinux* cp310-manylinux*
     - env:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
@@ -50,8 +50,8 @@ cirrus_wheels_macos_arm64_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
-    #- env:
-    #    CIBW_BUILD: cp39-* cp310-*
+    - env:
+       CIBW_BUILD: cp39-* cp310-*
     - env:
         CIBW_BUILD: cp311-* cp312-*
   env:

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -23,8 +23,8 @@ cirrus_wheels_linux_aarch64_task:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
-    - env:
-        CIBW_BUILD: cp39-manylinux* cp310-manylinux*
+    # - env:
+    #    CIBW_BUILD: cp39-manylinux* cp310-manylinux*
     - env:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
@@ -50,18 +50,18 @@ cirrus_wheels_macos_arm64_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
-    - env:
-        CIBW_BUILD: cp39-* cp310-*
+    #- env:
+    #    CIBW_BUILD: cp39-* cp310-*
     - env:
         CIBW_BUILD: cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+    CIBW_PRERELEASE_PYTHONS: True
     CIBW_ENVIRONMENT: >
       MACOSX_DEPLOYMENT_TARGET=12.0
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
       PIP_PRE=1
-    CIBW_PRERELEASE_PYTHONS: True
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/


### PR DESCRIPTION
This PR adds the machinery to build cp312 wheels for the as-yet unreleased Python 3.12