### PR TITLE
CI: fix issue with the last setup.py based job, due to Cython 3.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           # pyproject.toml currently states this numpy minimum version.
           python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-          python -m pip install cython numpy==1.22.4 pybind11 pythran pytest pooch
+          python -m pip install "cython<3.0" numpy==1.22.4 pybind11 pythran pytest pooch
 
       - name: Build
         run: |


### PR DESCRIPTION
[skip cirrus] [skip circle]

Fixes the `setup.py bdist_wheel` job that was failing with ([example log](https://github.com/scipy/scipy/actions/runs/5624524829/job/15241527677)):
```
 sf_error.obj : error LNK2001: unresolved external symbol wrap_PyUFunc_getfperr
```
