### PR TITLE
DEP: sparse.linalg: deprecate positional arguments for gcrotmk, lgmres, minres, tfqmr

### DIFF
--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.linalg import LinAlgError
 from scipy.linalg import (get_blas_funcs, qr, solve, svd, qr_insert, lstsq)
 from scipy.sparse.linalg._isolve.utils import make_system
+from scipy._lib.deprecation import _deprecate_positional_args
 
 
 __all__ = ['gcrotmk']
@@ -181,7 +182,8 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
     return Q, R, B, vs, zs, y, res
 
 
-def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+@_deprecate_positional_args(version="1.14.0")
+def gcrotmk(A, b, *, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             m=20, k=None, CU=None, discard_C=False, truncate='oldest',
             atol=None):
     """

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -183,7 +183,7 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
 
 
 @_deprecate_positional_args(version="1.14.0")
-def gcrotmk(A, b, *, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
             m=20, k=None, CU=None, discard_C=False, truncate='oldest',
             atol=None):
     """

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -33,7 +33,7 @@ def _get_atol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
 
 
 @_deprecate_positional_args(version="1.14")
-def bicg(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
+def bicg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
          atol=0., rtol=1e-5):
     """Use BIConjugate Gradient iteration to solve ``Ax = b``.
 
@@ -305,7 +305,7 @@ def bicgstab(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None,
 
 
 @_deprecate_positional_args(version="1.14")
-def cg(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
+def cg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
        atol=0., rtol=1e-5):
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
 
@@ -420,7 +420,7 @@ def cg(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
 
 
 @_deprecate_positional_args(version="1.14")
-def cgs(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
+def cgs(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
         atol=0., rtol=1e-5):
     """Use Conjugate Gradient Squared iteration to solve ``Ax = b``.
 
@@ -573,7 +573,7 @@ def cgs(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None, callback=None,
 
 
 @_deprecate_positional_args(version="1.14")
-def gmres(A, b, *, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
+def gmres(A, b, x0=None, *, tol=_NoValue, restart=None, maxiter=None, M=None,
           callback=None, restrt=_NoValue, atol=0., callback_type=None,
           rtol=1e-5):
     """
@@ -860,7 +860,7 @@ def gmres(A, b, *, x0=None, tol=_NoValue, restart=None, maxiter=None, M=None,
 
 
 @_deprecate_positional_args(version="1.14")
-def qmr(A, b, *, x0=None, tol=_NoValue, maxiter=None, M1=None, M2=None,
+def qmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M1=None, M2=None,
         callback=None, atol=0., rtol=1e-5):
     """Use Quasi-Minimal Residual iteration to solve ``Ax = b``.
 

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -14,7 +14,7 @@ __all__ = ['lgmres']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def lgmres(A, b, *, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
            prepend_outer_v=False, atol=None):
     """

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -6,13 +6,15 @@ import numpy as np
 from numpy.linalg import LinAlgError
 from scipy.linalg import get_blas_funcs
 from .utils import make_system
+from scipy._lib.deprecation import _deprecate_positional_args
 
 from ._gcrotmk import _fgmres
 
 __all__ = ['lgmres']
 
 
-def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+@_deprecate_positional_args(version="1.14.0")
+def lgmres(A, b, *, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
            prepend_outer_v=False, atol=None):
     """

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -3,11 +3,13 @@ from numpy.linalg import norm
 from math import sqrt
 
 from .utils import make_system
+from scipy._lib.deprecation import _deprecate_positional_args
 
 __all__ = ['minres']
 
 
-def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
+@_deprecate_positional_args(version="1.14.0")
+def minres(A, b, *, x0=None, shift=0.0, tol=1e-5, maxiter=None,
            M=None, callback=None, show=False, check=False):
     """
     Use MINimum RESidual iteration to solve Ax=b

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -9,7 +9,7 @@ __all__ = ['minres']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def minres(A, b, *, x0=None, shift=0.0, tol=1e-5, maxiter=None,
+def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
            M=None, callback=None, show=False, check=False):
     """
     Use MINimum RESidual iteration to solve Ax=b

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -550,9 +550,6 @@ def test_show(case, capsys):
 
 
 def test_positional_deprecation(solver):
-    if solver in (gcrotmk, lgmres, minres, tfqmr):
-        pytest.skip("positional arguments not yet deprecated")
-
     # from test_x0_working
     rng = np.random.default_rng(1685363802304750)
     n = 10

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -558,7 +558,7 @@ def test_positional_deprecation(solver):
     b = rng.random(n)
     x0 = rng.random(n)
     with pytest.deprecated_call(match="use keyword arguments"):
-        solver(A, b, x0)
+        solver(A, b, x0, 1e-5)
 
 
 class TestQMR:

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -7,7 +7,7 @@ __all__ = ['tfqmr']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def tfqmr(A, b, x0=None, *,tol=1e-5, maxiter=None, M=None,
+def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
           callback=None, atol=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -7,7 +7,7 @@ __all__ = ['tfqmr']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def tfqmr(A, b, *, x0=None, tol=1e-5, maxiter=None, M=None,
+def tfqmr(A, b, x0=None, *,tol=1e-5, maxiter=None, M=None,
           callback=None, atol=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -1,11 +1,13 @@
 import numpy as np
 from .utils import make_system
+from scipy._lib.deprecation import _deprecate_positional_args
 
 
 __all__ = ['tfqmr']
 
 
-def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
+@_deprecate_positional_args(version="1.14.0")
+def tfqmr(A, b, *, x0=None, tol=1e-5, maxiter=None, M=None,
           callback=None, atol=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #18934, towards #18703
#### What does this implement/fix?
<!--Please explain your changes.-->

> Agreed for adding `gcrotmk`, `lgmres`, `minres`, `tfqmr`. The artificial separation was due to Fortran removal efforts, but there is no distinction among these anymore.
#### Additional information
<!--Any additional information you think is important.-->
