### PR TITLE
DEP: linalg: deprecate positional args for eigh/eigvalsh

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -26,7 +26,7 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
 from scipy._lib._util import _asarray_validated
 from ._misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
-from scipy._lib.deprecation import _NoValue
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 _I = cast['F'](1j)
@@ -267,7 +267,8 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
-def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
+@_deprecate_positional_args(version="1.14.0")
+def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, turbo=_NoValue, eigvals=_NoValue, type=1,
          check_finite=True, subset_by_index=None, subset_by_value=None,
          driver=None):
@@ -898,7 +899,8 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
                homogeneous_eigvals=homogeneous_eigvals)
 
 
-def eigvalsh(a, b=None, lower=True, overwrite_a=False,
+@_deprecate_positional_args(version="1.14.0")
+def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
              overwrite_b=False, turbo=_NoValue, eigvals=_NoValue, type=1,
              check_finite=True, subset_by_index=None, subset_by_value=None,
              driver=None):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -877,6 +877,8 @@ class TestEigh:
         with pytest.warns(DeprecationWarning,
                           match="Keyword argument 'eigvals'"):
             method(np.zeros((2, 2)), eigvals=[0, 1])
+        with pytest.deprecated_call(match="use keyword arguments"):
+            method(np.zeros((2,2)), np.eye(2, 2), True)
 
     def test_deprecation_results(self):
         a = _random_hermitian_matrix(3)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
towards https://github.com/scipy/scipy/issues/18703
#### What does this implement/fix?
<!--Please explain your changes.-->
Perhaps some debate about where we want the `*`
#### Additional information
<!--Any additional information you think is important.-->
