### PR TITLE
MAINT/DOC: spatial: Document and test the double cover property for Rotation quaternions

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -793,9 +793,6 @@ cdef class Rotation:
         ``r.as_quat(canonical=False)``, ``r.inv()``, and composition using the
         ``*`` operator such as ``r*r``.
 
-    References
-    ----------
-
         Parameters
         ----------
         quat : array_like, shape (N, 4) or (4,)

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -785,6 +785,17 @@ cdef class Rotation:
 
         3D rotations can be represented using unit-norm quaternions [1]_.
 
+        Advanced users may be interested in the "double cover" of 3D space by
+        the quaternion representation [2]_. As of version 1.11.0, the
+        following subset (and only this subset) of operations on a `Rotation`
+        ``r`` corresponding to a quaternion ``q`` are guaranteed to preserve
+        the double cover property: ``r = Rotation.from_quat(q)``,
+        ``r.as_quat(canonical=False)``, ``r.inv()``, and composition using the
+        ``*`` operator such as ``r*r``.
+
+    References
+    ----------
+
         Parameters
         ----------
         quat : array_like, shape (N, 4) or (4,)
@@ -800,6 +811,8 @@ cdef class Rotation:
         References
         ----------
         .. [1] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        .. [2] Hanson, Andrew J. "Visualizing quaternions."
+            Morgan Kaufmann Publishers Inc., San Francisco, CA. 2006.
 
         Examples
         --------

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -56,7 +56,7 @@ def test_quat_double_to_canonical_single_cover():
         ])
     r = Rotation.from_quat(x)
     expected_quat = np.abs(x) / np.linalg.norm(x, axis=1)[:, None]
-    assert_array_almost_equal(r.as_quat(canonical=True), expected_quat)
+    assert_allclose(r.as_quat(canonical=True), expected_quat)
 
 
 def test_quat_double_cover():
@@ -65,30 +65,30 @@ def test_quat_double_cover():
     # Check from_quat and as_quat(canonical=False)
     q = np.array([0, 0, 0, -1])
     r = Rotation.from_quat(q)
-    assert all(q == r.as_quat(canonical=False))
+    assert_equal(q, r.as_quat(canonical=False))
 
     # Check composition and inverse
-    q = np.array([1, 0, 0, 1])/np.sqrt(2)
+    q = np.array([1, 0, 0, 1])/np.sqrt(2)  # 90 deg rotation about x
     r = Rotation.from_quat(q)
     r3 = r*r*r
-    assert_array_almost_equal(r.as_quat(canonical=False)*np.sqrt(2),
-                              [1, 0, 0, 1])
-    assert_array_almost_equal(r.inv().as_quat(canonical=False)*np.sqrt(2),
-                              [-1, 0, 0, 1])
-    assert_array_almost_equal(r3.as_quat(canonical=False)*np.sqrt(2),
-                              [1, 0, 0, -1])
-    assert_array_almost_equal(r3.inv().as_quat(canonical=False)*np.sqrt(2),
-                              [-1, 0, 0, -1])
+    assert_allclose(r.as_quat(canonical=False)*np.sqrt(2),
+                    [1, 0, 0, 1])
+    assert_allclose(r.inv().as_quat(canonical=False)*np.sqrt(2),
+                    [-1, 0, 0, 1])
+    assert_allclose(r3.as_quat(canonical=False)*np.sqrt(2),
+                    [1, 0, 0, -1])
+    assert_allclose(r3.inv().as_quat(canonical=False)*np.sqrt(2),
+                    [-1, 0, 0, -1])
 
     # More sanity checks
-    assert_array_almost_equal((r*r.inv()).as_quat(canonical=False),
-                              [0, 0, 0, 1])
-    assert_array_almost_equal((r3*r3.inv()).as_quat(canonical=False),
-                              [0, 0, 0, 1])
-    assert_array_almost_equal((r*r3).as_quat(canonical=False),
-                              [0, 0, 0, -1])
-    assert_array_almost_equal((r.inv()*r3.inv()).as_quat(canonical=False),
-                              [0, 0, 0, -1])
+    assert_allclose((r*r.inv()).as_quat(canonical=False),
+                    [0, 0, 0, 1])
+    assert_allclose((r3*r3.inv()).as_quat(canonical=False),
+                    [0, 0, 0, 1])
+    assert_allclose((r*r3).as_quat(canonical=False),
+                    [0, 0, 0, -1])
+    assert_allclose((r.inv()*r3.inv()).as_quat(canonical=False),
+                    [0, 0, 0, -1])
 
 
 def test_malformed_1d_from_quat():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -59,6 +59,38 @@ def test_quat_double_to_canonical_single_cover():
     assert_array_almost_equal(r.as_quat(canonical=True), expected_quat)
 
 
+def test_quat_double_cover():
+    # See the Rotation.from_quat() docstring for scope of the quaternion
+    # double cover property.
+    # Check from_quat and as_quat(canonical=False)
+    q = np.array([0, 0, 0, -1])
+    r = Rotation.from_quat(q)
+    assert all(q == r.as_quat(canonical=False))
+
+    # Check composition and inverse
+    q = np.array([1, 0, 0, 1])/np.sqrt(2)
+    r = Rotation.from_quat(q)
+    r3 = r*r*r
+    assert_array_almost_equal(r.as_quat(canonical=False)*np.sqrt(2),
+                              [1, 0, 0, 1])
+    assert_array_almost_equal(r.inv().as_quat(canonical=False)*np.sqrt(2),
+                              [-1, 0, 0, 1])
+    assert_array_almost_equal(r3.as_quat(canonical=False)*np.sqrt(2),
+                              [1, 0, 0, -1])
+    assert_array_almost_equal(r3.inv().as_quat(canonical=False)*np.sqrt(2),
+                              [-1, 0, 0, -1])
+
+    # More sanity checks
+    assert_array_almost_equal((r*r.inv()).as_quat(canonical=False),
+                              [0, 0, 0, 1])
+    assert_array_almost_equal((r3*r3.inv()).as_quat(canonical=False),
+                              [0, 0, 0, 1])
+    assert_array_almost_equal((r*r3).as_quat(canonical=False),
+                              [0, 0, 0, -1])
+    assert_array_almost_equal((r.inv()*r3.inv()).as_quat(canonical=False),
+                              [0, 0, 0, -1])
+
+
 def test_malformed_1d_from_quat():
     with pytest.raises(ValueError):
         Rotation.from_quat(np.array([1, 2, 3]))


### PR DESCRIPTION
#### What does this implement/fix?
We represent Rotations under the hood using unit quaternions. Quaternions have an interesting property in that they cover the space of rotations twice (the _SU(2)_ group), such that `q` and `-q` represent the same orientation of 3D space (the _SO(3)_ group). This can be thought of as representing 720 degrees of rotation instead of 360 degrees. For most use cases this is little more than trivia, however in some instances preserving this double cover property can be useful. See [here](https://caseymuratori.com/blog_0002) for an example.

In https://github.com/scipy/scipy/pull/17334 (released in v1.11.0), the `inv()` method was fixed to properly preserve the double cover behavior. This gives the Rotation class a minimally viable subset of methods to work in the double cover space. See also that issue for a lot more discussion about this behavior.

This PR adds documentation for this behavior, and some tests to ensure it does not regress in future updates.

I think it makes most sense to put this info in the `from_quat` docstring, but if the top level class docs is better I can move that over.

#### Additional information
The new reference is here, and appears to be open access. https://dl.acm.org/doi/book/10.5555/2821580
_Hanson, Andrew J. "Visualizing quaternions." Morgan Kaufmann Publishers Inc., San Francisco, CA. 2006._