### PR TITLE
MAINT: optimize.differential_evolution: clarify that bounds must be finite

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -700,7 +700,7 @@ class DifferentialEvolutionSolver:
 
         if (np.size(self.limits, 0) != 2 or not
                 np.all(np.isfinite(self.limits))):
-            raise ValueError('bounds should be a sequence containing '
+            raise ValueError('bounds should be a sequence containing finite '
                              'real valued (min, max) pairs for each value'
                              ' in x')
 


### PR DESCRIPTION
#### Reference issue
closes gh-18953

#### What does this implement/fix?
When differential evolution is passed infinite bounds, the error message did not mention that the bounds need to be finite. This PR resolves the issue by adding the word "finite" to the error message.

#### Additional information
The requirement for bounds to be finite is already present in the documentation.