### PR TITLE
DOC: Fix installation instructions using venv/pip

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -326,10 +326,10 @@ virtual environments:
        python -m pip install pytest pytest-xdist pytest-timeout pooch threadpoolctl asv gmpy2 mpmath
 
        # Doc build dependencies
-       python -m pip sphinx "pydata-sphinx-theme==0.9.0" sphinx-design matplotlib numpydoc jupytext myst-nb
+       python -m pip install sphinx "pydata-sphinx-theme==0.9.0" sphinx-design matplotlib numpydoc jupytext myst-nb
 
        # Dev dependencies (static typing and linting)
-       python -m pip mypy typing_extensions types-psutil pycodestyle ruff cython-lint
+       python -m pip install mypy typing_extensions types-psutil pycodestyle ruff cython-lint
 
 To build SciPy in an activated development environment, run::
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Fixes a typo in the installation instructions for virtual env in "Building from source for SciPy development".

#### Additional information
<!--Any additional information you think is important.-->
