### PR TITLE
ENH:sparse.linalg: Add LaplacianNd class to special sparse arrays

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -41,7 +41,7 @@ Direct methods for linear equation systems:
    :toctree: generated/
 
    spsolve -- Solve the sparse linear system Ax=b
-   spsolve_triangular -- Solve the sparse linear system Ax=b for a triangular matrix
+   spsolve_triangular -- Solve sparse linear system Ax=b for a triangular A.
    factorized -- Pre-factorize matrix to a function solving a linear system
    MatrixRankWarning -- Warning on exactly singular matrices
    use_solver -- Select direct solver to use
@@ -51,16 +51,16 @@ Iterative methods for linear equation systems:
 .. autosummary::
    :toctree: generated/
 
-   bicg -- Use BIConjugate Gradient iteration to solve A x = b
-   bicgstab -- Use BIConjugate Gradient STABilized iteration to solve A x = b
-   cg -- Use Conjugate Gradient iteration to solve A x = b
-   cgs -- Use Conjugate Gradient Squared iteration to solve A x = b
-   gmres -- Use Generalized Minimal RESidual iteration to solve A x = b
+   bicg -- Use BIConjugate Gradient iteration to solve Ax = b
+   bicgstab -- Use BIConjugate Gradient STABilized iteration to solve Ax = b
+   cg -- Use Conjugate Gradient iteration to solve Ax = b
+   cgs -- Use Conjugate Gradient Squared iteration to solve Ax = b
+   gmres -- Use Generalized Minimal RESidual iteration to solve Ax = b
    lgmres -- Solve a matrix equation using the LGMRES algorithm
    minres -- Use MINimum RESidual iteration to solve Ax = b
-   qmr -- Use Quasi-Minimal Residual iteration to solve A x = b
+   qmr -- Use Quasi-Minimal Residual iteration to solve Ax = b
    gcrotmk -- Solve a matrix equation using the GCROT(m,k) algorithm
-   tfqmr -- Use Transpose-Free Quasi-Minimal Residual iteration to solve A x = b
+   tfqmr -- Use Transpose-Free Quasi-Minimal Residual iteration to solve Ax = b
 
 Iterative methods for least-squares problems:
 
@@ -106,6 +106,14 @@ Complete or incomplete LU factorizations
    spilu -- Compute an incomplete LU decomposition for a sparse matrix
    SuperLU -- Object representing an LU factorization
 
+Sparse arrays with structure
+----------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   LaplacianNd -- Laplacian on a uniform rectangular grid in ``N`` dimensions
+
 Exceptions
 ----------
 
@@ -125,6 +133,7 @@ from ._matfuncs import *
 from ._onenormest import *
 from ._norm import *
 from ._expm_multiply import *
+from ._special_sparse_arrays import *
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import isolve, dsolve, interface, eigen, matfuncs

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -200,10 +200,10 @@ of_the_second_derivative
 
         if boundary_conditions not in ("dirichlet", "neumann", "periodic"):
             raise ValueError(
-                f"Unknown value {boundary_conditions!r} is given for"
-                " 'boundary_conditions' parameter."
-                " The valid options are 'dirichlet', 'periodic', and "
-                "'neumann' (default).")
+                f"Unknown value {boundary_conditions!r} is given for "
+                "'boundary_conditions' parameter. The valid options are "
+                "'dirichlet', 'periodic', and 'neumann' (default)."
+            )
 
         self.grid_shape = grid_shape
         self.boundary_conditions = boundary_conditions

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -245,7 +245,7 @@ of_the_second_derivative
         """
         grid_shape = self.grid_shape
         n = np.prod(grid_shape)
-        L = np.zeros([n, n], dtype=self.dtype)
+        L = np.zeros([n, n], dtype=np.int8)
         # Scratch arrays
         L_i = np.empty_like(L)
         Ltemp = np.empty_like(L)
@@ -295,7 +295,7 @@ of_the_second_derivative
 
             L += L_i
 
-        return L
+        return L.astype(self.dtype)
 
     def tosparse(self):
         """
@@ -310,11 +310,11 @@ of_the_second_derivative
         """
         N = len(self.grid_shape)
         p = np.prod(self.grid_shape)
-        L = dia_array((p, p), dtype=self.dtype)
+        L = dia_array((p, p), dtype=np.int8)
 
         for i in range(N):
             dim = self.grid_shape[i]
-            data = np.ones([3, dim], dtype=self.dtype)
+            data = np.ones([3, dim], dtype=np.int8)
             data[1, :] *= -2
 
             if self.boundary_conditions == "neumann":
@@ -322,21 +322,21 @@ of_the_second_derivative
                 data[1, -1] = -1
 
             L_i = dia_array((data, [-1, 0, 1]), shape=(dim, dim),
-                            dtype=self.dtype
+                            dtype=np.int8
                             )
 
             if self.boundary_conditions == "periodic":
-                t = dia_array((dim, dim), dtype=self.dtype)
+                t = dia_array((dim, dim), dtype=np.int8)
                 t.setdiag([1], k=-dim+1)
                 t.setdiag([1], k=dim-1)
                 L_i += t
 
             for j in range(i):
-                L_i = kron(eye(self.grid_shape[j], dtype=self.dtype), L_i)
+                L_i = kron(eye(self.grid_shape[j], dtype=np.int8), L_i)
             for j in range(i + 1, N):
-                L_i = kron(L_i, eye(self.grid_shape[j], dtype=self.dtype))
+                L_i = kron(L_i, eye(self.grid_shape[j], dtype=np.int8))
             L += L_i
-        return L
+        return L.astype(self.dtype)
 
     def _matvec(self, x):
         grid_shape = self.grid_shape

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -7,16 +7,17 @@ __all__ = ['LaplacianNd']
 
 class LaplacianNd(LinearOperator):
     """
-    The grid Laplacian in `N` dimensions and its eigenvalues.
+    The grid Laplacian in ``N`` dimensions and its eigenvalues.
 
     Construct Laplacian on a uniform rectangular grid in `N` dimensions
-    and output its eigenvalues. The Laplacian matrix `L` is square real
-    symmetric negative definite with signed interger entries and many zeros.
+    and output its eigenvalues. The Laplacian ``L`` is square, negative
+    definite, real symmetric, array with signed integer entries and zeros
+    otherwise.
 
     Parameters
     ----------
     grid_shape : tuple
-        A tuple of integers of length `N` (corresponding to the dimension of
+        A tuple of integers of length ``N`` (corresponding to the dimension of
         the Lapacian), where each entry gives the size of that dimension. The
         Laplacian matrix is square of the size ``np.prod(grid_shape)``.
     boundary_conditions : {'neumann', 'dirichlet', 'periodic'}, optional
@@ -103,13 +104,13 @@ of_the_second_derivative
     >>> np.array_equal(lap.tosparse().toarray(), lap.toarray())
     True
 
-    The two-dimensional Laplacian is illustrated on a regular
-    grid with ``grid_shape = (2, 3)`` points in each dimension.
+    The two-dimensional Laplacian is illustrated on a regular grid with
+    ``grid_shape = (2, 3)`` points in each dimension.
 
     >>> grid_shape = (2, 3)
     >>> n = np.prod(grid_shape)
 
-    Numeration of grid points is as follows.
+    Numeration of grid points is as follows:
 
     >>> np.arange(n).reshape(grid_shape + (-1,))
     array([[[0],
@@ -211,17 +212,17 @@ of_the_second_derivative
         super().__init__(dtype=dtype, shape=(N, N))
 
         indices = np.indices(grid_shape)
-        L = np.zeros(grid_shape)
+        Leig = np.zeros(grid_shape)
 
         for j, n in zip(indices, grid_shape):
             if boundary_conditions == "dirichlet":
-                L += -4 * np.sin(np.pi * (j + 1) / (2 * (n + 1))) ** 2
+                Leig += -4 * np.sin(np.pi * (j + 1) / (2 * (n + 1))) ** 2
             elif boundary_conditions == "neumann":
-                L += -4 * np.sin(np.pi * j / (2 * n)) ** 2
+                Leig += -4 * np.sin(np.pi * j / (2 * n)) ** 2
             else:  # boundary_conditions == "periodic"
-                L += -4 * np.sin(np.pi * np.floor((j + 1) / 2) / n) ** 2
+                Leig += -4 * np.sin(np.pi * np.floor((j + 1) / 2) / n) ** 2
 
-        self._eigenvalues = np.sort(L.ravel())
+        self._eigenvalues = np.sort(Leig.ravel())
 
     @property
     def eigenvalues(self):

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -19,7 +19,7 @@ class LaplacianNd(LinearOperator):
         A tuple of integers of length `N` (corresponding to the dimension of
         the Lapacian), where each entry gives the size of that dimension. The
         Laplacian matrix is square of the size ``np.prod(grid_shape)``.
-    boundary_conditions: {'neumann', 'dirichlet', 'periodic'}, optional
+    boundary_conditions : {'neumann', 'dirichlet', 'periodic'}, optional
         The type of the boundary conditions on the boundaries of the grid.
         Valid values are ``'dirichlet'`` or ``'neumann'``(default) or
         ``'periodic'``.

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -1,0 +1,359 @@
+import numpy as np
+from scipy.sparse.linalg import LinearOperator
+from scipy.sparse import kron, eye, dia_array
+
+__all__ = ['LaplacianNd']
+
+
+class LaplacianNd(LinearOperator):
+    """
+    The grid Laplacian in `N` dimensions and its eigenvalues.
+
+    Construct Laplacian on a uniform rectangular grid in `N` dimensions
+    and output its eigenvalues. The Laplacian matrix `L` is square real
+    symmetric negative definite with signed interger entries and many zeros.
+
+    Parameters
+    ----------
+    grid_shape : tuple
+        A tuple of integers of length `N` (corresponding to the dimension of
+        the Lapacian), where each entry gives the size of that dimension. The
+        Laplacian matrix is square of the size ``np.prod(grid_shape)``.
+    boundary_conditions: string
+        The type of the boundary conditions on the boundaries of the grid.
+        Valid values are ``'dirichlet'`` or ``'neumann'``(default) or
+        ``'periodic'``.
+    dtype : type
+        Numerical type of the array. Default is ``np.int8``.
+
+    Attributes
+    ----------
+    eigs : ndarray
+        Eigenvalues of the Laplacian matrix in ascending order.
+
+    Methods
+    -------
+    toarray: ndarray
+        The ``(n, n)`` Laplacian matrix in a dense 2D array format.
+    tosparse: sparse
+        The ``(n, n)`` Laplacian matrix in a sparse format.
+
+    .. versionadded:: 1.12.0
+
+    Notes
+    -----
+    Compared to the MATLAB/Octave implementation [1] of 1-, 2-, and 3-D
+    Laplacian, this code allows the arbitrary N-D case and the matrix-free
+    callable option, but is currently limited to pure dirichlet, neumann or
+    periodic boundary conditions only and outputs just the eigenvalues,
+    no eigenvectors.
+
+    The Laplacian matrix of a graph (`scipy.sparse.csgraph.laplacian`) of a
+    rectangular grid corresponds to the negative Laplacian with the neumann
+    conditions, i.e., ``boundary_conditions = 'neumann'``.
+
+    All eigenvalues and eigenvectors of the discrete Laplacian operator for
+    an ``N``-dimensional  regular grid of shape `grid_shape` with the grid
+    step size ``h=1`` are analytically known [2].
+
+    References
+    ----------
+    .. [1] https://github.com/lobpcg/blopex/blob/master/blopex_\
+tools/matlab/laplacian/laplacian.m
+    .. [2] https://w.wiki/7CVT
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse.linalg import LaplacianNd
+    >>> from scipy.sparse import diags, csgraph
+    >>> from scipy.linalg import eigvalsh
+
+    The one-dimensional Laplacian demonstrated below for pure neumann boundary
+    conditions on a regular grid with ``n=6`` grid points is exactly the
+    negative graph Laplacian for the undirected linear graph with ``n``
+    vertices using the sparse adjacency matrix ``G`` represented by the
+    famous tri-diagonal matrix:
+
+    >>> n = 6
+    >>> G = diags(np.ones(n - 1), 1, format="csr")
+    >>> Lf = csgraph.laplacian(G, symmetrized=True, form="function")
+    >>> grid_shape = (n, )
+    >>> lap = LaplacianNd(grid_shape, boundary_conditions='neumann')
+    >>> np.array_equal(lap.matmat(np.eye(n)), -Lf(np.eye(n)))
+    True
+
+    Since all matrix entries of the Laplacian are integers, ``'int8'`` is
+    the default dtype for storing matrix representations.
+
+    >>> lap.tosparse()
+    <6x6 sparse matrix of type '<class 'numpy.int8'>'
+        with 16 stored elements (3 diagonals) in DIAgonal format>
+    >>> lap.toarray()
+    array([[-1,  1,  0,  0,  0,  0],
+           [ 1, -2,  1,  0,  0,  0],
+           [ 0,  1, -2,  1,  0,  0],
+           [ 0,  0,  1, -2,  1,  0],
+           [ 0,  0,  0,  1, -2,  1],
+           [ 0,  0,  0,  0,  1, -1]], dtype=int8)
+    >>> np.array_equal(lap.matmat(np.eye(n)), lap.toarray())
+    True
+    >>> np.array_equal(lap.tosparse().toarray(), lap.toarray())
+    True
+
+    The two-dimensional Laplacian is illustrated on a regular
+    grid with ``grid_shape = (2, 3)`` points in each dimension.
+
+    >>> grid_shape = (2, 3)
+    >>> n = np.prod(grid_shape)
+
+    Numeration of grid points is as follows.
+
+    >>> np.arange(n).reshape(grid_shape + (-1,))
+    array([[[0],
+            [1],
+            [2]],
+    <BLANKLINE>
+           [[3],
+            [4],
+            [5]]])
+
+    Each of the boundary conditions ``'dirichlet'``, ``'periodic'``, and
+    ``'neumann'`` is illustrated separately; with ``'dirichlet'``
+
+    >>> lap = LaplacianNd(grid_shape, boundary_conditions='dirichlet')
+    >>> lap.tosparse()
+    <6x6 sparse array of type '<class 'numpy.int8'>'
+        with 20 stored elements in Compressed Sparse Row format>
+    >>> lap.toarray()
+    array([[-4,  1,  0,  1,  0,  0],
+           [ 1, -4,  1,  0,  1,  0],
+           [ 0,  1, -4,  0,  0,  1],
+           [ 1,  0,  0, -4,  1,  0],
+           [ 0,  1,  0,  1, -4,  1],
+           [ 0,  0,  1,  0,  1, -4]], dtype=int8)
+    >>> np.array_equal(lap.matmat(np.eye(n)), lap.toarray())
+    True
+    >>> np.array_equal(lap.tosparse().toarray(), lap.toarray())
+    True
+    >>> lap.eigs
+    array([-6.41421356, -5.        , -4.41421356, -3.58578644, -3.        ,
+           -1.58578644])
+    >>> eigvals = eigvalsh(lap.toarray().astype(np.float64))
+    >>> np.allclose(lap.eigs, eigvals)
+    True
+
+    with ``"periodic"``
+
+    >>> lap = LaplacianNd(grid_shape, boundary_conditions='periodic')
+    >>> lap.tosparse()
+    <6x6 sparse array of type '<class 'numpy.int8'>'
+        with 24 stored elements in Compressed Sparse Row format>
+    >>> lap.toarray()
+        array([[-4,  1,  1,  2,  0,  0],
+               [ 1, -4,  1,  0,  2,  0],
+               [ 1,  1, -4,  0,  0,  2],
+               [ 2,  0,  0, -4,  1,  1],
+               [ 0,  2,  0,  1, -4,  1],
+               [ 0,  0,  2,  1,  1, -4]], dtype=int8)
+    >>> np.array_equal(lap.matmat(np.eye(n)), lap.toarray())
+    True
+    >>> np.array_equal(lap.tosparse().toarray(), lap.toarray())
+    True
+    >>> lap.eigs
+    array([-7., -7., -4., -3., -3.,  0.])
+    >>> eigvals = eigvalsh(lap.toarray().astype(np.float64))
+    >>> np.allclose(lap.eigs, eigvals)
+    True
+
+    and with ``'neumann'``
+
+    >>> lap = LaplacianNd(grid_shape, boundary_conditions='neumann')
+    >>> lap.tosparse()
+    <6x6 sparse array of type '<class 'numpy.int8'>'
+        with 20 stored elements in Compressed Sparse Row format>
+    >>> lap.toarray()
+    array([[-2,  1,  0,  1,  0,  0],
+           [ 1, -3,  1,  0,  1,  0],
+           [ 0,  1, -2,  0,  0,  1],
+           [ 1,  0,  0, -2,  1,  0],
+           [ 0,  1,  0,  1, -3,  1],
+           [ 0,  0,  1,  0,  1, -2]])
+    >>> np.array_equal(lap.matmat(np.eye(n)), lap.toarray())
+    True
+    >>> np.array_equal(lap.tosparse().toarray(), lap.toarray())
+    True
+    >>> lap.eigs
+    array([-5., -3., -3., -2., -1.,  0.])
+    >>> eigvals = eigvalsh(lap.toarray().astype(np.float64))
+    >>> np.allclose(lap.eigs, eigvals)
+    True
+
+    """
+
+    def __init__(self, grid_shape, *,
+                 boundary_conditions="neumann",
+                 dtype=np.int8):
+
+        if boundary_conditions not in ("dirichlet", "neumann", "periodic"):
+            raise ValueError(
+                f"Unknown value '{boundary_conditions}' is given for"
+                " 'boundary_conditions' parameter."
+                " The valid options are 'dirichlet', 'periodic', and "
+                "'neumann' (default).")
+
+        self.grid_shape = grid_shape
+        self.boundary_conditions = boundary_conditions
+        self.dtype = dtype
+        # LaplacianNd folds all dimensions in `grid_shape` into a single one
+        N = np.prod(grid_shape)
+        super().__init__(dtype=self.dtype, shape=(N, N))
+
+        indices = np.indices(grid_shape)
+        L = np.zeros(grid_shape)
+
+        for j, n in zip(indices, grid_shape):
+            if boundary_conditions == "dirichlet":
+                L += -4 * np.sin(np.pi * (j + 1) / (2 * (n + 1))) ** 2
+            elif boundary_conditions == "neumann":
+                L += -4 * np.sin(np.pi * j / (2 * n)) ** 2
+            else:  # boundary_conditions == "periodic"
+                L += -4 * np.sin(np.pi * np.floor((j + 1) / 2) / n) ** 2
+
+        self._eigs = np.sort(L.ravel())
+
+    @property
+    def eigs(self):
+        return self._eigs
+
+    @eigs.setter
+    def eigs(self, value):
+        raise RuntimeError('"eigs" attribute is read-only and cannot be set.')
+
+    def toarray(self):
+        grid_shape = self.grid_shape
+        n = np.prod(grid_shape)
+        L = np.zeros([n, n], dtype=self.dtype)
+        # Scratch arrays
+        L_i = np.empty_like(L)
+        Ltemp = np.empty_like(L)
+
+        for ind, dim in enumerate(grid_shape):
+            # Start zeroing out L_i
+            L_i[:] = 0
+            # Allocate the top left corner with the kernel of L_i
+            # Einsum returns writable view of arrays
+            np.einsum("ii->i", L_i[:dim, :dim])[:] = -2
+            np.einsum("ii->i", L_i[: dim - 1, 1:dim])[:] = 1
+            np.einsum("ii->i", L_i[1:dim, : dim - 1])[:] = 1
+
+            if self.boundary_conditions == "neumann":
+                L_i[0, 0] = -1
+                L_i[dim - 1, dim - 1] = -1
+            elif self.boundary_conditions == "periodic":
+                if dim > 1:
+                    L_i[0, dim - 1] += 1
+                    L_i[dim - 1, 0] += 1
+                else:
+                    L_i[0, 0] += 1
+
+            # kron is too slow for large matrices hence the next two tricks
+            # 1- kron(eye, mat) is block_diag(mat, mat, ...)
+            # 2- kron(mat, eye) can be performed by 4d stride trick
+
+            # 1-
+            new_dim = dim
+            # for block_diag we tile the top left portion on the diagonal
+            if ind > 0:
+                tiles = np.prod(grid_shape[:ind])
+                for j in range(1, tiles):
+                    L_i[j*dim:(j+1)*dim, j*dim:(j+1)*dim] = L_i[:dim, :dim]
+                    new_dim += dim
+            # 2-
+            # we need the keep L_i, but reset the array
+            Ltemp[:new_dim, :new_dim] = L_i[:new_dim, :new_dim]
+            tiles = int(np.prod(grid_shape[ind+1:]))
+            # Zero out the top left, the rest is already 0
+            L_i[:new_dim, :new_dim] = 0
+            idx = [x for x in range(tiles)]
+            L_i.reshape(
+                (new_dim, tiles,
+                 new_dim, tiles)
+                )[:, idx, :, idx] = Ltemp[:new_dim, :new_dim]
+
+            L += L_i
+
+        return L
+
+    def tosparse(self):
+        N = len(self.grid_shape)
+        p = np.prod(self.grid_shape)
+        L = dia_array((p, p), dtype=self.dtype)
+
+        for i in range(N):
+            dim = self.grid_shape[i]
+            data = np.ones([3, dim], dtype=self.dtype)
+            data[1, :] *= -2
+
+            if self.boundary_conditions == "neumann":
+                data[1, 0] = -1
+                data[1, -1] = -1
+
+            L_i = dia_array((data, [-1, 0, 1]), shape=(dim, dim),
+                            dtype=self.dtype
+                            )
+
+            if self.boundary_conditions == "periodic":
+                t = dia_array((dim, dim), dtype=self.dtype)
+                t.setdiag([1], k=-dim+1)
+                t.setdiag([1], k=dim-1)
+                L_i += t
+
+            for j in range(i):
+                L_i = kron(eye(self.grid_shape[j], dtype=self.dtype), L_i)
+            for j in range(i + 1, N):
+                L_i = kron(L_i, eye(self.grid_shape[j], dtype=self.dtype))
+            L += L_i
+        return L
+
+    def _matvec(self, x):
+        grid_shape = self.grid_shape
+        N = len(grid_shape)
+        X = x.reshape(grid_shape + (-1,))
+        Y = -2 * N * X
+        for i in range(N):
+            Y += np.roll(X, 1, axis=i)
+            Y += np.roll(X, -1, axis=i)
+            if self.boundary_conditions in ("neumann", "dirichlet"):
+                Y[(slice(None),)*i + (0,) + (slice(None),)*(N-i-1)
+                  ] -= np.roll(X, 1, axis=i)[
+                    (slice(None),) * i + (0,) + (slice(None),) * (N-i-1)
+                ]
+                Y[
+                    (slice(None),) * i + (-1,) + (slice(None),) * (N-i-1)
+                ] -= np.roll(X, -1, axis=i)[
+                    (slice(None),) * i + (-1,) + (slice(None),) * (N-i-1)
+                ]
+
+                if self.boundary_conditions == "neumann":
+                    Y[
+                        (slice(None),) * i + (0,) + (slice(None),) * (N-i-1)
+                    ] += np.roll(X, 0, axis=i)[
+                        (slice(None),) * i + (0,) + (slice(None),) * (N-i-1)
+                    ]
+                    Y[
+                        (slice(None),) * i + (-1,) + (slice(None),) * (N-i-1)
+                    ] += np.roll(X, 0, axis=i)[
+                        (slice(None),) * i + (-1,) + (slice(None),) * (N-i-1)
+                    ]
+
+        return Y.reshape(-1, X.shape[-1])
+
+    def _matmat(self, x):
+        return self._matvec(x)
+
+    def _adjoint(self):
+        return self
+
+    def _transpose(self):
+        return self

--- a/scipy/sparse/linalg/meson.build
+++ b/scipy/sparse/linalg/meson.build
@@ -6,6 +6,7 @@ py3.install_sources([
     '_norm.py',
     '_onenormest.py',
     '_svdp.py',
+    '_special_sparse_arrays.py',
     'dsolve.py',
     'eigen.py',
     'interface.py',

--- a/scipy/sparse/linalg/tests/meson.build
+++ b/scipy/sparse/linalg/tests/meson.build
@@ -7,7 +7,8 @@ py3.install_sources([
     'test_norm.py',
     'test_onenormest.py',
     'test_propack.py',
-    'test_pydata_sparse.py'
+    'test_pydata_sparse.py',
+    'test_special_sparse_arrays.py'
   ],
   subdir: 'scipy/sparse/linalg/tests'
 )

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -74,7 +74,7 @@ class TestLaplacianNd:
     @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
     def test_eigenvalues(self, grid_shape, bc):
         lap = LaplacianNd(grid_shape, boundary_conditions=bc, dtype=np.float64)
-        eigenvalues = lap.eigs
+        eigenvalues = lap.eigenvalues
         L = lap.toarray()
         eigvals = eigh(L, eigvals_only=True)
         dtype = eigenvalues.dtype
@@ -102,7 +102,7 @@ class TestLaplacianNd:
     @pytest.mark.parametrize("dtype", ALLDTYPES)
     @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
     @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
-    def test_matmat(self, grid_shape, bc, dtype):
+    def test_dot(self, grid_shape, bc, dtype):
         lap = LaplacianNd(grid_shape, boundary_conditions=bc)
         n = np.prod(grid_shape)
         x0 = np.arange(n)

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -19,7 +19,6 @@ class TestLaplacianNd:
 
     @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
     def test_1d_specific_shape(self, bc):
-        bc = "neumann"
         lap = LaplacianNd(grid_shape=(6, ), boundary_conditions=bc)
         lapa = lap.toarray()
         if bc == 'neumann':

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -12,7 +12,7 @@ class TestLaplacianNd:
     """
     LaplacianNd tests
     """
-    INT_DTYPES = [np.int32, np.int64]
+    INT_DTYPES = [np.int8, np.int16, np.int32, np.int64]
     REAL_DTYPES = [np.float32, np.float64]
     COMPLEX_DTYPES = [np.complex64, np.complex128]
     ALLDTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES
@@ -93,7 +93,7 @@ class TestLaplacianNd:
     @pytest.mark.parametrize("dtype", ALLDTYPES)
     @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
     @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
-    def test_input_output_dtype_shape_consistency(self, grid_shape, bc, dtype):
+    def test_linearoperator_shape_dtype(self, grid_shape, bc, dtype):
         lap = LaplacianNd(grid_shape, boundary_conditions=bc, dtype=dtype)
         n = np.prod(grid_shape)
         assert lap.shape == (n, n)

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -1,0 +1,115 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+
+from scipy.sparse import diags, csgraph
+from scipy.linalg import eigh
+
+from scipy.sparse.linalg import LaplacianNd
+
+
+class TestLaplacianNd:
+    """
+    LaplacianNd tests
+    """
+    INT_DTYPES = [np.int32, np.int64]
+    REAL_DTYPES = [np.float32, np.float64]
+    COMPLEX_DTYPES = [np.complex64, np.complex128]
+    ALLDTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES
+
+    @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
+    def test_1d_specific_shape(self, bc):
+        bc = "neumann"
+        lap = LaplacianNd(grid_shape=(6, ), boundary_conditions=bc)
+        lapa = lap.toarray()
+        if bc == 'neumann':
+            a = np.array(
+                [
+                    [-1, 1, 0, 0, 0, 0],
+                    [1, -2, 1, 0, 0, 0],
+                    [0, 1, -2, 1, 0, 0],
+                    [0, 0, 1, -2, 1, 0],
+                    [0, 0, 0, 1, -2, 1],
+                    [0, 0, 0, 0, 1, -1],
+                ]
+            )
+        elif bc == 'dirichlet':
+            a = np.array(
+                [
+                    [-2, 1, 0, 0, 0, 0],
+                    [1, -2, 1, 0, 0, 0],
+                    [0, 1, -2, 1, 0, 0],
+                    [0, 0, 1, -2, 1, 0],
+                    [0, 0, 0, 1, -2, 1],
+                    [0, 0, 0, 0, 1, -2],
+                ]
+            )
+        else:
+            a = np.array(
+                [
+                    [-2, 1, 0, 0, 0, 1],
+                    [1, -2, 1, 0, 0, 0],
+                    [0, 1, -2, 1, 0, 0],
+                    [0, 0, 1, -2, 1, 0],
+                    [0, 0, 0, 1, -2, 1],
+                    [1, 0, 0, 0, 1, -2],
+                ]
+            )
+        assert_array_equal(a, lapa)
+
+    def test_1d_with_graph_laplacian(self):
+        n = 6
+        G = diags(np.ones(n - 1), 1, format="dia")
+        Lf = csgraph.laplacian(G, symmetrized=True, form="function")
+        La = csgraph.laplacian(G, symmetrized=True, form="array")
+        grid_shape = (n,)
+        bc = "neumann"
+        lap = LaplacianNd(grid_shape, boundary_conditions=bc)
+        assert_array_equal(lap(np.eye(n)), -Lf(np.eye(n)))
+        assert_array_equal(lap.toarray(), -La.toarray())
+        # https://github.com/numpy/numpy/issues/24351
+        assert_array_equal(lap.tosparse().toarray(), -La.toarray())
+
+    @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
+    def test_eigenvalues(self, grid_shape, bc):
+        lap = LaplacianNd(grid_shape, boundary_conditions=bc, dtype=np.float64)
+        eigenvalues = lap.eigs
+        L = lap.toarray()
+        eigvals = eigh(L, eigvals_only=True)
+        dtype = eigenvalues.dtype
+        n = np.prod(grid_shape)
+        atol = n * n * max(np.finfo(dtype).eps, np.finfo(np.double).eps)
+        assert_allclose(eigenvalues, eigvals, atol=atol)
+
+    @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
+    def test_toarray_tosparse_consistency(self, grid_shape, bc):
+        lap = LaplacianNd(grid_shape, boundary_conditions=bc)
+        n = np.prod(grid_shape)
+        assert_array_equal(lap.toarray(), lap(np.eye(n)))
+        assert_array_equal(lap.tosparse().toarray(), lap.toarray())
+
+    @pytest.mark.parametrize("dtype", ALLDTYPES)
+    @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
+    def test_input_output_dtype_shape_consistency(self, grid_shape, bc, dtype):
+        lap = LaplacianNd(grid_shape, boundary_conditions=bc, dtype=dtype)
+        n = np.prod(grid_shape)
+        assert lap.shape == (n, n)
+        assert lap.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", ALLDTYPES)
+    @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("bc", ['neumann', 'dirichlet', 'periodic'])
+    def test_matmat(self, grid_shape, bc, dtype):
+        lap = LaplacianNd(grid_shape, boundary_conditions=bc)
+        n = np.prod(grid_shape)
+        x0 = np.arange(n)[:, None]
+        x1 = x0.reshape((-1, 1))
+        x2 = np.arange(2 * n).reshape((n, 2))
+        input_set = [x0, x1, x2]
+        for x in input_set:
+            y = lap.matmat(x.astype(dtype))
+            assert x.shape == y.shape
+            assert y.dtype == dtype

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -105,11 +105,11 @@ class TestLaplacianNd:
     def test_matmat(self, grid_shape, bc, dtype):
         lap = LaplacianNd(grid_shape, boundary_conditions=bc)
         n = np.prod(grid_shape)
-        x0 = np.arange(n)[:, None]
+        x0 = np.arange(n)
         x1 = x0.reshape((-1, 1))
         x2 = np.arange(2 * n).reshape((n, 2))
         input_set = [x0, x1, x2]
         for x in input_set:
-            y = lap.matmat(x.astype(dtype))
+            y = lap.dot(x.astype(dtype))
             assert x.shape == y.shape
             assert y.dtype == dtype

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -98,6 +98,23 @@ class TestLaplacianNd:
         n = np.prod(grid_shape)
         assert lap.shape == (n, n)
         assert lap.dtype == dtype
+        assert_array_equal(
+            LaplacianNd(
+                grid_shape, boundary_conditions=bc, dtype=dtype
+            ).toarray(),
+            LaplacianNd(grid_shape, boundary_conditions=bc)
+            .toarray()
+            .astype(dtype),
+        )
+        assert_array_equal(
+            LaplacianNd(
+                grid_shape, boundary_conditions=bc, dtype=dtype
+            ).tosparse(),
+            LaplacianNd(grid_shape, boundary_conditions=bc)
+            .tosparse()
+            .astype(dtype),
+        )
+
 
     @pytest.mark.parametrize("dtype", ALLDTYPES)
     @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -107,14 +107,14 @@ class TestLaplacianNd:
             .astype(dtype),
         )
         assert_array_equal(
-            LaplacianNd(
-                grid_shape, boundary_conditions=bc, dtype=dtype
-            ).tosparse(),
+            LaplacianNd(grid_shape, boundary_conditions=bc, dtype=dtype)
+            .tosparse()
+            .toarray(),
             LaplacianNd(grid_shape, boundary_conditions=bc)
             .tosparse()
+            .toarray()
             .astype(dtype),
         )
-
 
     @pytest.mark.parametrize("dtype", ALLDTYPES)
     @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])


### PR DESCRIPTION
Add a new special matrix, of the Laplacian, in multiple formats with a public API for testing and benchmarking.
Transferred from https://github.com/scipy/scipy/pull/18845 to split it into 3 smaller and focused pieces as suggested by reviewers.

#### Reference issue
Closes gh-18940 partially. To fully close gh-18940, we need to add some actual usage of the new lalacian API for testing and/or benchmarking, etc.

#### What does this implement/fix?
The Laplacian is sometimes called a "fruit fly" for experiments in scientific computing due its popularity and importance in applications. Adding Laplacian matrices in various formats with a public API as a LinearOperattor class for testing and benchmarking with a comprehensive dosctring documentation.

The proposed news matrix formats are similar to those being used in https://github.com/scipy/scipy/pull/18954 for Sakurai and Mikota matrices, which in that PR are located in a private module. If this and https://github.com/scipy/scipy/pull/18954 get merged, the next natural step is to move Sakurai and Mikota matrices to public API next to the Laplacian.
