### PR TITLE
ENH: `linalg.solve_toeplitz`: add option to return reflection coefficients

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -634,10 +634,10 @@ def solve_toeplitz(c_or_cr, b, check_finite=True, *, return_reflection=False):
         of `b`.
     reflection_coeff : (M+1,) or (M+1, K) ndarray
         Toeplitz reflection coefficients. When the matrix formed by c is
-        symmetric Toeplitz and ``b`` is ``c[n:]``, as in the solution of
-        autoregressive systems, then ``reflection_coeff`` also correspond to
-        the partial autocorrelation function. Only returned when
-        return_reflection is True.
+        symmetric Toeplitz and `b` is ``c[n:]``, as in the solution of
+        autoregressive systems, then `reflection_coeff` also correspond to the
+        partial autocorrelation function. Only returned when return_reflection
+        is True.
 
     See Also
     --------

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -602,7 +602,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
     return x
 
 
-def solve_toeplitz(c_or_cr, b, check_finite=True, return_reflection=False):
+def solve_toeplitz(c_or_cr, b, check_finite=True, *, return_reflection=False):
     """Solve a Toeplitz system using Levinson Recursion
 
     The Toeplitz matrix has constant diagonals, with c as its first column

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -100,6 +100,22 @@ def test_reflection_coeffs():
     assert_allclose(reflection_coeffs_z, ref_z[:-1])
 
 
+@pytest.mark.parametrize('bshape', ((10,), (10, 3)))
+def test_return_reflection(bshape):
+    # Check that solve_toeplitz returns solution and reflection coefficients
+    # of correct shape
+
+    random = np.random.RandomState(1234)
+    c = random.randn(bshape[0])
+    b = random.randn(*bshape)
+
+    x_without_refl = solve_toeplitz(c, b)
+    x_with_refl, refl = solve_toeplitz(c, b, return_reflection=True)
+
+    assert_allclose(x_without_refl, x_with_refl)
+    assert refl.shape == (bshape[0] + 1, *bshape[1:])
+
+
 @pytest.mark.xfail(reason='Instability of Levinson iteration')
 def test_unstable():
     # this is a "Gaussian Toeplitz matrix", as mentioned in Example 2 of


### PR DESCRIPTION
**What does this implement/fix?**

Exposes the reflection coefficients as returned by the internal `levinson` function. As explained in the docstring for `levinson`, this is useful for getting the partial autocorrelation function when estimating the parameters of an autoregressive process.

`linalg.solve_toeplitz` will return a 2-tuple of the solution and the reflection coefficients if the optional `return_reflection=True` is passed. The default is `return_reflection=False`, in which case the function behaves the same as at present.