### PR TITLE
MAINT: linalg: remove a stray np.cast

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -19,7 +19,7 @@ __all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
 import warnings
 
 import numpy
-from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
+from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
                    flatnonzero, conj, asarray, argsort, empty,
                    iscomplex, zeros, einsum, eye, inf)
 # Local imports
@@ -29,7 +29,7 @@ from .lapack import get_lapack_funcs, _compute_lwork
 from scipy._lib.deprecation import _NoValue
 
 
-_I = cast['F'](1j)
+_I = numpy.array(1j, dtype='F')
 
 
 def _make_complex_eigvecs(w, vin, dtype):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/numpy/numpy/pull/24144#issuecomment-1653602415

#### What does this implement/fix?
<!--Please explain your changes.-->

Remove a stray call to `np.cast`. 

#### Additional information
<!--Any additional information you think is important.-->

Now, without looking it up: what is the result of `_I = np.cast['F'](1j)` ?
