### PR TITLE
DOC: Change suggested virtual environment directory to .venv

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -315,7 +315,7 @@ virtual environments:
        is part of the Python stdlib. You can use any other tool; all we need is
        an activated Python environment.
 
-    Create and activate a virtual environment in a new directory named ``venv`` (
+    Create and activate a virtual environment in a new directory named ``.venv`` (
     note that the exact activation command may be different based on your OS and shell
     - see `"How venvs work" <https://docs.python.org/3/library/venv.html#how-venvs-work>`__
     in the ``venv`` docs).
@@ -327,24 +327,24 @@ virtual environments:
 
         ::
 
-          python -m venv venv
-          source venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
 
       .. tab-item:: macOS
         :sync: macos
 
         ::
 
-          python -m venv venv
-          source venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
 
       .. tab-item:: Windows
         :sync: windows
 
         ::
 
-          python -m venv venv
-          .\venv\Scripts\activate
+          python -m venv .venv
+          .\.venv\Scripts\activate
 
     Then install the Python-level dependencies (see ``pyproject.toml``) from
     PyPI with::


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Currently, the doc suggests using `venv` as the virtual environment directory, however `venv` is not present in `.gitignore`, whereas `.venv` is present.

#### Additional information
<!--Any additional information you think is important.-->
