### PR TITLE
 CI: move the musllinux Cirrus job to GHA, optimize other jobs

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,7 +17,7 @@ def main(ctx):
     # - commit message containing [wheel build]
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,7 +17,7 @@ def main(ctx):
     # - commit message containing [wheel build]
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/scipy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -22,7 +22,7 @@ jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc
@@ -65,7 +65,7 @@ jobs:
         python -m pip install click rich_click doit pydevtool pooch
         
         chmod +x tools/wheels/cibw_before_build_linux.sh
-        sudo tools/wheels/cibw_before_build_linux.sh --nightly .     
+        tools/wheels/cibw_before_build_linux.sh --nightly .     
 
     - name: test
       run: |

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -22,7 +22,7 @@ jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -30,7 +30,7 @@ jobs:
 
 
     steps:
-    - name: setup
+    - name: Get source
       run: |    
         apk update --quiet
 
@@ -52,11 +52,12 @@ jobs:
         git submodule update --init
 
 
-    - name: prep venv
+    - name: prep build environment
       run: |    
         cd $RUNNER_TEMP
         python -m venv test_env
         source test_env/bin/activate
+        cd $GITHUB_WORKSPACE
 
         python -m pip install cython numpy
         # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -1,0 +1,75 @@
+name: Test musllinux_x86_64
+
+on:
+  push:
+    branches:
+      - maintenance/**
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+
+permissions:
+   contents: read  # to fetch code (actions/checkout)
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
+jobs:
+  musllinux_x86_64:
+    runs-on: ubuntu-latest
+    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
+    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+    container:
+      # Use container used for building musllinux wheels
+      # it has git installed, all the pythons, etc
+      image: quay.io/pypa/musllinux_1_1_x86_64
+
+    #    env:
+    #      PATH: $PWD:$PATH
+
+    steps:
+    - name: setup
+      run: |    
+        apk update --quiet
+
+        apk add openblas-dev openblas build-base gfortran git
+
+        git config --global --add safe.directory $PWD 
+        
+        if [ $GITHUB_EVENT_NAME != pull_request ]; then
+            git clone --recursive --branch=$GITHUB_REF_NAME https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
+            git reset --hard $GITHUB_SHA
+        else        
+            git clone --recursive https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
+            git fetch origin $GITHUB_REF:my_ref_name
+            git checkout $GITHUB_BASE_REF
+            git -c user.email="you@example.com" merge --no-commit my_ref_name
+        fi
+
+        ln -s /usr/local/bin/python3.10 /usr/local/bin/python
+        git submodule update --init
+
+
+    - name: prep venv
+      run: |    
+        cd $RUNNER_TEMP
+        python -m venv test_env
+        source test_env/bin/activate
+
+        python -m pip install cython numpy
+        # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+        python -m pip install meson ninja pybind11 pythran pytest
+        python -m pip install click rich_click doit pydevtool pooch
+
+
+    - name: test
+      run: |
+        set -xe -o
+        cd $RUNNER_TEMP
+        source test_env/bin/activate
+        cd $GITHUB_WORKSPACE
+        python dev.py test

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -22,21 +22,19 @@ jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc
       image: quay.io/pypa/musllinux_1_1_x86_64
 
-    #    env:
-    #      PATH: $PWD:$PATH
 
     steps:
     - name: setup
       run: |    
         apk update --quiet
 
-        apk add openblas-dev openblas build-base gfortran git
+        apk add build-base gfortran git
 
         git config --global --add safe.directory $PWD 
         
@@ -64,7 +62,9 @@ jobs:
         # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install meson ninja pybind11 pythran pytest
         python -m pip install click rich_click doit pydevtool pooch
-
+        
+        chmod +x tools/wheels/cibw_before_build_linux.sh
+        sudo tools/wheels/cibw_before_build_linux.sh --nightly .     
 
     - name: test
       run: |

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -89,25 +89,25 @@ macos_arm64_test_task:
 
   <<: *MODIFIED_CLONE
 
-  #  ccache_cache:
-  #    folder: .ccache
-  #    populate_script:
-  #      - mkdir -p .ccache
-  #    fingerprint_key: ccache-macosx_arm64
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-macosx_arm64
 
   pip_cache:
     folder: /Users/admin/Library/Caches/pip
 
   prepare_env_script: |
-    brew install python@3.10
+    brew install python@3.10 ccache
 
     export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
     export PYTHONPATH=/opt/homebrew/lib/python3.10/site-packages
     
     echo "PYTHONPATH=$PYTHONPATH" >> $CIRRUS_ENV
     echo "_CWD=$PWD" >> $CIRRUS_ENV
     echo "PATH=$PATH" >> $CIRRUS_ENV
-    #    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
 
     python --version
 
@@ -137,11 +137,11 @@ macos_arm64_test_task:
     cd ..
     source test_env/bin/activate
     cd $_CWD
-    python dev.py build -j3
+    python dev.py build
     # ccache -s
 
   test_script: |
     cd ..
     source test_env/bin/activate
     cd $_CWD
-    python dev.py test -j3
+    python dev.py test

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -84,18 +84,22 @@ linux_aarch64_test_task:
 macos_arm64_test_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
-    cpu: 2
-    memory: 8G
 
   <<: *MODIFIED_CLONE
+
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-macosx_arm64
 
   pip_cache:
     folder: /Users/admin/Library/Caches/pip
 
   test_script: |
-    brew install python@3.10
+    brew install python@3.10 ccache
 
-    export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PATH=/opt/homebrew/opt/ccache/libexec:/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
     python --version
 
     # used for installing OpenBLAS/gfortran
@@ -103,6 +107,7 @@ macos_arm64_test_task:
 
     export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
     export CMAKE_PREFIX_PATH=/opt/arm64-builds/
+    export CCACHE_DIR=$PWD/.ccache
 
     pushd ~/
     python -m venv scipy-dev
@@ -118,6 +123,7 @@ macos_arm64_test_task:
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
 
-
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
-    python dev.py test -j2
+    python dev.py test -j3
+
+    ccache -s

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -46,7 +46,7 @@ linux_aarch64_test_task:
   pip_cache:
     folder: /root/.cache/pip
 
-  test_script: |
+  prepare_env_script: |
     apt-get update
     apt-get install -y --no-install-recommends software-properties-common gcc g++ gfortran pkg-config
     apt-get install -y --no-install-recommends libopenblas-dev libatlas-base-dev liblapack-dev ccache
@@ -62,10 +62,8 @@ linux_aarch64_test_task:
     # python3.10 -m ensurepip --default-pip --user
 
     ln -s $(which python3.10) python
-    export PATH=$PWD:$PATH
-
-    export CCACHE_DIR=$PWD/.ccache
-    export PATH=/usr/lib/ccache:$PATH
+    echo "PATH=/usr/lib/ccache:$PWD:$PATH" >> $CIRRUS_ENV
+    echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
@@ -75,9 +73,12 @@ linux_aarch64_test_task:
     # It may change over time!
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
-    
+
+  build_script: |
+    python dev.py build -j1
+
+  test_script: |
     python dev.py test -j1
-    
     ccache -s
 
 
@@ -87,27 +88,30 @@ macos_arm64_test_task:
 
   <<: *MODIFIED_CLONE
 
-  ccache_cache:
-    folder: .ccache
-    populate_script:
-      - mkdir -p .ccache
-    fingerprint_key: ccache-macosx_arm64
+  #  ccache_cache:
+  #    folder: .ccache
+  #    populate_script:
+  #      - mkdir -p .ccache
+  #    fingerprint_key: ccache-macosx_arm64
 
   pip_cache:
     folder: /Users/admin/Library/Caches/pip
 
-  test_script: |
-    brew install python@3.10 ccache
+  prepare_env_script: |
+    brew install python@3.10
 
-    export PATH=/opt/homebrew/opt/ccache/libexec:/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    echo "PATH=$PATH" >> $CIRRUS_ENV
+    #    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
+
     python --version
 
     # used for installing OpenBLAS/gfortran
     bash tools/wheels/cibw_before_build_macos.sh $PWD
 
-    export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
-    export CMAKE_PREFIX_PATH=/opt/arm64-builds/
-    export CCACHE_DIR=$PWD/.ccache
+    echo "PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig" >> $CIRRUS_ENV
+    echo "CMAKE_PREFIX_PATH=/opt/arm64-builds/" >> $CIRRUS_ENV
+    # export CCACHE_DIR=$PWD/.ccache
 
     pushd ~/
     python -m venv scipy-dev
@@ -123,7 +127,21 @@ macos_arm64_test_task:
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
 
-    export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
-    python dev.py test -j3
+    echo "DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib" >> $CIRRUS_ENV
 
-    ccache -s
+  build_script:
+    pushd ~/
+    python -m venv scipy-dev
+    source scipy-dev/bin/activate
+    popd
+    
+    python dev.py build -j3
+    # ccache -s
+
+  build_script:
+    pushd ~/
+    python -m venv scipy-dev
+    source scipy-dev/bin/activate
+    popd
+
+    python dev.py test -j3

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -62,7 +62,8 @@ linux_aarch64_test_task:
     # python3.10 -m ensurepip --default-pip --user
 
     ln -s $(which python3.10) python
-    echo "PATH=/usr/lib/ccache:$PWD:$PATH" >> $CIRRUS_ENV
+    export PATH=/usr/lib/ccache:$PWD:$PATH
+    echo "PATH=$PATH" >> $CIRRUS_ENV
     echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
@@ -101,6 +102,10 @@ macos_arm64_test_task:
     brew install python@3.10
 
     export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PYTHONPATH=/opt/homebrew/lib/python3.10/site-packages
+    
+    echo "PYTHONPATH=$PYTHONPATH" >> $CIRRUS_ENV
+    echo "_CWD=$PWD" >> $CIRRUS_ENV
     echo "PATH=$PATH" >> $CIRRUS_ENV
     #    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
 
@@ -108,15 +113,16 @@ macos_arm64_test_task:
 
     # used for installing OpenBLAS/gfortran
     bash tools/wheels/cibw_before_build_macos.sh $PWD
+    echo "DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib" >> $CIRRUS_ENV
 
     echo "PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig" >> $CIRRUS_ENV
     echo "CMAKE_PREFIX_PATH=/opt/arm64-builds/" >> $CIRRUS_ENV
     # export CCACHE_DIR=$PWD/.ccache
-
-    pushd ~/
-    python -m venv scipy-dev
-    source scipy-dev/bin/activate
-    popd
+    
+    cd ..
+    python -m venv test_env
+    source test_env/bin/activate
+    cd $_CWD
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
@@ -127,21 +133,15 @@ macos_arm64_test_task:
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
 
-    echo "DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib" >> $CIRRUS_ENV
-
-  build_script:
-    pushd ~/
-    python -m venv scipy-dev
-    source scipy-dev/bin/activate
-    popd
-    
+  build_script: |
+    cd ..
+    source test_env/bin/activate
+    cd $_CWD
     python dev.py build -j3
     # ccache -s
 
-  build_script:
-    pushd ~/
-    python -m venv scipy-dev
-    source scipy-dev/bin/activate
-    popd
-
+  test_script: |
+    cd ..
+    source test_env/bin/activate
+    cd $_CWD
     python dev.py test -j3

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -65,51 +65,6 @@ linux_aarch64_test_task:
     python dev.py test
 
 
-musllinux_amd64_test_task:
-  container:
-    image: alpine
-    cpu: 8
-    memory: 32G
-
-  env:
-    PATH: $PWD:$PATH
-
-  setup_script: |
-    # The alpine image doesn't have a git client. The first step is to get 
-    # git, then clone in the *MODIFIED_CLONE step. To make sure the clone step
-    # works we have to delete CIRRUS_WORKING_DIR (alpine doesn't have pushd).
-    # Because this is the default working directory we should cd to that folder
-    # a subsequent script.
-
-    apk update
-    apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
-    ln -sf $(which python3.10) python
-    
-    _CWD=$PWD
-    echo "_CWD=$(_CWD)" >> $CIRRUS_ENV
-    cd $CIRRUS_WORKING_DIR/..
-    rm -rf $CIRRUS_WORKING_DIR
-
-  pip_cache:
-    folder: ~/.cache/pip
-
-  <<: *MODIFIED_CLONE
-
-  python_dependencies_script: |
-    cd $_CWD
-    python -m pip install cython
-    pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-    python -m pip install meson ninja pybind11 pythran pytest
-    python -m pip install click rich_click doit pydevtool pooch
-
-  build_script: |
-    python dev.py build
-
-  test_script: |
-    set -xe -o
-    python dev.py test
-
-
 macos_arm64_test_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -76,14 +76,16 @@ linux_aarch64_test_task:
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
     
-    python dev.py test
+    python dev.py test -j2
     
     ccache -s
 
 
 macos_arm64_test_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
+    cpu: 2
+    memory: 8G
 
   <<: *MODIFIED_CLONE
 
@@ -118,4 +120,4 @@ macos_arm64_test_task:
 
 
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
-    python dev.py test
+    python dev.py test -j2

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -32,8 +32,8 @@ linux_aarch64_test_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 4
-    memory: 16G
+    cpu: 2
+    memory: 8G
 
   <<: *MODIFIED_CLONE
 

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -32,8 +32,8 @@ linux_aarch64_test_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 2
-    memory: 8G
+    cpu: 1
+    memory: 4G
 
   <<: *MODIFIED_CLONE
 
@@ -76,7 +76,7 @@ linux_aarch64_test_task:
     echo $(python -m pip cache dir)
     echo $(python -m pip cache list)
     
-    python dev.py test -j2
+    python dev.py test -j1
     
     ccache -s
 

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -69,7 +69,7 @@ linux_aarch64_test_task:
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
-    python -m pip install pytest pooch
+    python -m pip install pytest pooch pytest-xdist
     
     # this line tells us where the task keeps its pip cache. 
     # It may change over time!
@@ -116,7 +116,7 @@ macos_arm64_test_task:
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
-    python -m pip install pytest pooch
+    python -m pip install pytest pooch pytest-xdist
     
     # this line tells us where the task keeps its pip cache. 
     # It may change over time!

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -37,13 +37,19 @@ linux_aarch64_test_task:
 
   <<: *MODIFIED_CLONE
 
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-linux_aarch64
+
   pip_cache:
-    folder: ~/.cache/pip
+    folder: /root/.cache/pip
 
   test_script: |
     apt-get update
     apt-get install -y --no-install-recommends software-properties-common gcc g++ gfortran pkg-config
-    apt-get install -y --no-install-recommends libopenblas-dev libatlas-base-dev liblapack-dev
+    apt-get install -y --no-install-recommends libopenblas-dev libatlas-base-dev liblapack-dev ccache
 
     # When this task was written the linux image used ubuntu:jammy, for which
     # python3.10 is the default. If required different versions can be
@@ -58,11 +64,21 @@ linux_aarch64_test_task:
     ln -s $(which python3.10) python
     export PATH=$PWD:$PATH
 
+    export CCACHE_DIR=$PWD/.ccache
+    export PATH=/usr/lib/ccache:$PATH
+
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     
+    # this line tells us where the task keeps its pip cache. 
+    # It may change over time!
+    echo $(python -m pip cache dir)
+    echo $(python -m pip cache list)
+    
     python dev.py test
+    
+    ccache -s
 
 
 macos_arm64_test_task:
@@ -72,7 +88,7 @@ macos_arm64_test_task:
   <<: *MODIFIED_CLONE
 
   pip_cache:
-    folder: ~/.cache/pip
+    folder: /Users/admin/Library/Caches/pip
 
   test_script: |
     brew install python@3.10
@@ -94,5 +110,12 @@ macos_arm64_test_task:
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
+    
+    # this line tells us where the task keeps its pip cache. 
+    # It may change over time!
+    echo $(python -m pip cache dir)
+    echo $(python -m pip cache list)
+
+
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
     python dev.py test


### PR DESCRIPTION
Cirrus is going to start limiting free usage. This PR moves a musllinux_x86_64 job from cirrus to GHA. It also reduces the resources given to the linux_aarch64 job.

