### PR TITLE
DOC: stats.lognorm: add example of the relationship between norm and lognorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6249,6 +6249,21 @@ class lognorm_gen(rv_continuous):
 
     %(example)s
 
+    The logarithm of a log-normally distributed random variable is
+    normally distributed:
+
+    >>> from scipy import stats
+    >>> fig, ax = plt.subplots(1, 1)
+    >>> mu, sigma = 2, 0.5
+    >>> X = stats.norm(loc=mu, scale=sigma)
+    >>> Y = stats.lognorm(s=sigma, scale=np.exp(mu))
+    >>> x = np.linspace(*X.interval(0.999))
+    >>> y = Y.rvs(size=10000)
+    >>> ax.plot(x, X.pdf(x), label='X (pdf)')
+    >>> ax.hist(np.log(y), density=True, bins=x, label='log(Y) (histogram)')
+    >>> ax.legend()
+    >>> plt.show()
+
     """
     _support_mask = rv_continuous._open_support_mask
 


### PR DESCRIPTION
#### Reference issue
Closes gh-18984

#### What does this implement/fix?
This adds an example to `scipy.stats.lognorm` to more fully address the requests of gh-18984.
