### PR TITLE
ENH: optimize.curve_fit: reduce overhead of lightweight memoization

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -502,11 +502,17 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=False,
 
 
 def _lightweight_memoizer(f):
-    # very shallow memoization - only remember the first set of parameters
-    # and corresponding function value to address gh-13670
+    # very shallow memoization to address gh-13670: only remember the first set
+    # of parameters and corresponding function value, and only attempt to use
+    # them twice (the number of times the function is evaluated at x0).
     def _memoized_func(params):
+        if _memoized_func.last_val is None:
+            return f(params)
+
         if np.all(_memoized_func.last_params == params):
             return _memoized_func.last_val
+        elif _memoized_func.last_params is not None:
+            _memoized_func.last_val = None
 
         val = f(params)
 
@@ -517,7 +523,7 @@ def _lightweight_memoizer(f):
         return val
 
     _memoized_func.last_params = None
-    _memoized_func.last_val = None
+    _memoized_func.last_val = np.nan
     return _memoized_func
 
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -506,13 +506,13 @@ def _lightweight_memoizer(f):
     # of parameters and corresponding function value, and only attempt to use
     # them twice (the number of times the function is evaluated at x0).
     def _memoized_func(params):
-        if _memoized_func.last_val is None:
+        if _memoized_func.skip_lookup:
             return f(params)
 
         if np.all(_memoized_func.last_params == params):
             return _memoized_func.last_val
         elif _memoized_func.last_params is not None:
-            _memoized_func.last_val = None
+            _memoized_func.skip_lookup = True
 
         val = f(params)
 
@@ -523,7 +523,8 @@ def _lightweight_memoizer(f):
         return val
 
     _memoized_func.last_params = None
-    _memoized_func.last_val = np.nan
+    _memoized_func.last_val = None
+    _memoized_func.skip_lookup = False
     return _memoized_func
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-18864

#### What does this implement/fix?
In gh-17688, a memoizer was added to wrap the callable passed to `curve_fit`. It remembers the function value at the initial point (only) because the callable is called repeatedly at this point. 

Currently, even after the optimizer has moved on from the initial point, the memoizer determines whether to use the memoized function value or to re-evaluate the function by comparing the argument point against the memoized initial point. This comparison is slow (microseconds) due to the overhead of `np.all`.

This PR takes advantage of the observation that after moving on from the initial point, the optimizer does not return to it, so the "expensive" comparison can be replaced with a faster one. Now, the memoizer remembers when the optimizer has moved away from the initial point, and thereafter immediately resorts to evaluating the function.

#### More information
Initially, I wrote this PR to use a new variable `_memoized_func.skip_lookup`, which starts as `False` and is set to `True` after the optimizer moves on from the initial point. I refactored it to re-use the existing variable `_memoized_func.last_val`. In retrospect, this makes the control flow logic a bit less obvious, and it doesn't really reduce diff. Let me know if you'd like me to change it back.