### PR TITLE
DOC: add `noexcept` to `cython_optimize` docs

### DIFF
--- a/scipy/optimize/cython_optimize/__init__.py
+++ b/scipy/optimize/cython_optimize/__init__.py
@@ -22,7 +22,7 @@ The zeros functions in `~scipy.optimize.cython_optimize` expect a callback that
 takes a double for the scalar independent variable as the 1st argument and a
 user defined ``struct`` with any extra parameters as the 2nd argument. ::
 
-    double (*callback_type)(double, void*)
+    double (*callback_type)(double, void*) noexcept
 
 
 Examples
@@ -55,7 +55,7 @@ These are the basic steps:
 
 
        # user-defined callback
-       cdef double f(double x, void *args):
+       cdef double f(double x, void *args) noexcept:
            cdef test_params *myargs = <test_params *> args
            return myargs.C0 - math.exp(-(x - myargs.C1))
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

The `noexcept` marker was introduced by 50d0825, however the docs have not been updated. I found my cython code got broken after updating scipy, complaining about `Cannot assign type 'double (double, void *) except? -1' to 'callback_type'`. The issue was solved after I added `noexcept` to the callback functions.

#### What does this implement/fix?
<!--Please explain your changes.-->

Just a simple update of the docs.

<!--#### Additional information-->
<!--Any additional information you think is important.-->
