### PR TITLE
CI: reduce Cirrus CI usage during wheel builds

### DIFF
--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -17,8 +17,8 @@ cirrus_wheels_linux_aarch64_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 4
-    memory: 8G
+    cpu: 1
+    memory: 4G
   matrix:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a
@@ -51,9 +51,7 @@ cirrus_wheels_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
     - env:
-       CIBW_BUILD: cp39-* cp310-*
-    - env:
-        CIBW_BUILD: cp311-* cp312-*
+       CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
     CIBW_PRERELEASE_PYTHONS: True

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -17,7 +17,7 @@ cirrus_wheels_linux_aarch64_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 1
+    cpu: 2
     memory: 4G
   matrix:
     # build in a matrix because building and testing all four wheels in a
@@ -51,6 +51,7 @@ cirrus_wheels_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
     - env:
+       # building all four wheels in a single task takes ~45 mins
        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH


### PR DESCRIPTION
Attempt to reduce CI resources during wheel build. Linux build may be able to get away with a single CPU, rather than 4. Putting all macos builds into a single task may save because you save on the duplicated start up time.