### PR TITLE
WIP, ENH: signal: `test_spectral` array API support

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -153,7 +153,9 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
     xp = np if xp is None else xp
     # numpy does not yet support the `device` keyword
     # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
-    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+    if (hasattr(xp, 'fft') and xp.__name__ != 'numpy' and
+        "array_api_compat.numpy" not in xp.__name__ and
+        "cupy" not in xp.__name__):
         return xp.fft.fftfreq(n, d=d, device=device)
     if device is not None:
         raise ValueError('device parameter is not supported for input array type')
@@ -212,7 +214,9 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
     xp = np if xp is None else xp
     # numpy does not yet support the `device` keyword
     # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
-    if hasattr(xp, 'fft') and xp.__name__ != 'numpy':
+    if (hasattr(xp, 'fft') and xp.__name__ != 'numpy' and
+        "array_api_compat.numpy" not in xp.__name__ and
+        "cupy" not in xp.__name__):
         return xp.fft.rfftfreq(n, d=d, device=device)
     if device is not None:
         raise ValueError('device parameter is not supported for input array type')

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -4,7 +4,7 @@ import inspect
 from ._pocketfft import helper as _helper
 
 import numpy as np
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, is_numpy
 
 
 def next_fast_len(target, real=False):
@@ -154,8 +154,7 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
     # numpy does not yet support the `device` keyword
     # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
     if (hasattr(xp, 'fft') and xp.__name__ != 'numpy' and
-        "array_api_compat.numpy" not in xp.__name__ and
-        "cupy" not in xp.__name__):
+            not is_numpy(xp)):
         return xp.fft.fftfreq(n, d=d, device=device)
     if device is not None:
         raise ValueError('device parameter is not supported for input array type')
@@ -215,8 +214,7 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
     # numpy does not yet support the `device` keyword
     # `xp.__name__ != 'numpy'` should be removed when numpy is compatible
     if (hasattr(xp, 'fft') and xp.__name__ != 'numpy' and
-        "array_api_compat.numpy" not in xp.__name__ and
-        "cupy" not in xp.__name__):
+            not is_numpy(xp)):
         return xp.fft.rfftfreq(n, d=d, device=device)
     if device is not None:
         raise ValueError('device parameter is not supported for input array type')

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -3,6 +3,10 @@ Functions for acting on a axis of an array.
 """
 import numpy as np
 
+from scipy._lib._array_api import (
+    array_namespace,
+)
+
 
 def axis_slice(a, start=None, stop=None, step=None, axis=-1):
     """Take a slice along axis 'axis' from 'a'.
@@ -240,10 +244,11 @@ def zero_ext(x, n, axis=-1):
     """
     if n < 1:
         return x
+    xp = array_namespace(x)
     zeros_shape = list(x.shape)
     zeros_shape[axis] = n
-    zeros = np.zeros(zeros_shape, dtype=x.dtype)
-    ext = np.concatenate((zeros, x, zeros), axis=axis)
+    zeros = xp.zeros(zeros_shape, dtype=x.dtype)
+    ext = xp.concat((zeros, x, zeros), axis=axis)
     return ext
 
 

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -146,6 +146,8 @@ def even_ext(x, n, axis=-1):
     >>> plt.legend(loc='best')
     >>> plt.show()
     """
+    xp = array_namespace(x)
+    x = xp.asarray(x)
     if n < 1:
         return x
     if n > x.shape[axis] - 1:
@@ -154,10 +156,10 @@ def even_ext(x, n, axis=-1):
                          % (n, x.shape[axis] - 1))
     left_ext = axis_slice(x, start=n, stop=0, step=-1, axis=axis)
     right_ext = axis_slice(x, start=-2, stop=-(n + 2), step=-1, axis=axis)
-    ext = np.concatenate((left_ext,
-                          x,
-                          right_ext),
-                         axis=axis)
+    ext = xp.concat((left_ext,
+                     x,
+                     right_ext),
+                     axis=axis)
     return ext
 
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -29,7 +29,7 @@ import numpy as np
 import scipy.fft as fft_lib
 from scipy.signal import detrend
 from scipy.signal.windows import get_window
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, size, is_complex
 
 __all__ = ['ShortTimeFFT']
 
@@ -253,9 +253,10 @@ class ShortTimeFFT:
                  dual_win: np.ndarray | None = None,
                  scale_to: Literal['magnitude', 'psd'] | None = None,
                  phase_shift: int | None = 0):
-        if not (win.ndim == 1 and win.size > 0):
+        xp = array_namespace(win)
+        if not (win.ndim == 1 and size(win) > 0):
             raise ValueError(f"Parameter win must be 1d, but {win.shape=}!")
-        if not all(np.isfinite(win)):
+        if not all(xp.isfinite(win)):
             raise ValueError("Parameter win must have finite entries!")
         if not (hop >= 1 and isinstance(hop, int)):
             raise ValueError(f"Parameter {hop=} is not an integer >= 1!")
@@ -569,10 +570,11 @@ class ShortTimeFFT:
         Allowed values are 'twosided', 'centered', 'onesided', 'onesided2X'.
         See the property `fft_mode` for more details.
         """
+        xp = array_namespace(self.win)
         if t not in (fft_mode_types := get_args(FFT_MODE_TYPE)):
             raise ValueError(f"fft_mode='{t}' not in {fft_mode_types}!")
 
-        if t in {'onesided', 'onesided2X'} and np.iscomplexobj(self.win):
+        if t in {'onesided', 'onesided2X'} and is_complex(self.win, xp=xp):
             raise ValueError(f"One-sided spectra, i.e., fft_mode='{t}', " +
                              "are not allowed for complex-valued windows!")
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy.fft as fft_lib
 from scipy.signal import detrend
 from scipy.signal.windows import get_window
+from scipy._lib._array_api import array_namespace
 
 __all__ = ['ShortTimeFFT']
 
@@ -824,6 +825,7 @@ class ShortTimeFFT:
                                    (without detrending).
         :class:`scipy.signal.ShortTimeFFT`: Class this method belongs to.
         """
+        xp = array_namespace(x)
         if self.onesided_fft and np.iscomplexobj(x):
             raise ValueError(f"Complex-valued `x` not allowed for {self.fft_mode=}'! "
                              "Set property `fft_mode` to 'twosided' or 'centered'.")
@@ -838,7 +840,7 @@ class ShortTimeFFT:
             raise ValueError(f"{e_str} must be >= ceil(m_num/2) = {m2p}!")
 
         if x.ndim > 1:  # motivated by the NumPy broadcasting mechanisms:
-            x = np.moveaxis(x, axis, -1)
+            x = xp.moveaxis(x, axis, -1)
         # determine slice index range:
         p0, p1 = self.p_range(n, p0, p1)
         S_shape_1d = (self.f_pts, p1 - p0)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2132,7 +2132,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            raise NotImplementedError("input type '%s' not supported" % dtype)
+            raise NotImplementedError(f"input type '{dtype}' not supported")
 
         b = np.array(b, dtype=dtype)
         a = np.asarray(a, dtype=dtype)
@@ -4223,9 +4223,8 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
     if padtype not in ['even', 'odd', 'constant', None]:
-        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
-                          "must be 'even', 'odd', 'constant', or None.") %
-                         padtype)
+        raise ValueError(f"Unknown value '{padtype}' given to padtype.  padtype "
+                          "must be 'even', 'odd', 'constant', or None.")
 
     if padtype is None:
         padlen = 0
@@ -4342,7 +4341,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
         inputs.append(np.asarray(zi))
     dtype = np.result_type(*inputs)
     if dtype.char not in 'fdgFDGO':
-        raise NotImplementedError("input type '%s' not supported" % dtype)
+        raise NotImplementedError(f"input type '{dtype}' not supported")
     if zi is not None:
         zi = np.array(zi, dtype)  # make a copy so that we can operate in place
         if zi.shape != x_zi_shape:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3568,16 +3568,21 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
         raise ValueError("Trend type must be 'linear' or 'constant'.")
     data = xp.asarray(data)
     dtype = data.dtype
-    if data.dtype not in [xp.float32, xp.float64, xp.complex128, xp.complex64]:
+    if data.dtype not in [xp.float32, xp.float64, xp.complex64, xp.complex128]:
         dtype = xp.float64
     if type in ['constant', 'c']:
-        ret = data - xp.mean(xp.asarray(data, dtype=dtype), axis=axis, keepdims=True)
+        # TODO: array API standard requires real-valued types in xp.mean()
+        ret = data - xp.mean(xp.astype(data, dtype), axis=axis, keepdims=True)
         return ret
     else:
         dshape = data.shape
         N = dshape[axis]
         if isinstance(bp, int):
-            bp = xp.sort(xp.unique(xp.asarray([0, bp, N])))
+            try:
+                bp = xp.sort(xp.unique(xp.asarray([0, bp, N])))
+            except AttributeError:
+                bp = xp.sort(xp.unique_values(xp.asarray([0, bp, N])))
+
         else:
             bp = xp.asarray(bp)
             new_bp = xp.empty(size(bp) + 1)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -7,6 +7,9 @@ from math import prod as _prod
 import timeit
 import warnings
 
+from scipy._lib._array_api import (
+    array_namespace, size,
+)
 from scipy.spatial import cKDTree
 from . import _sigtools
 from ._ltisys import dlti
@@ -1956,8 +1959,8 @@ def medfilt2d(input, kernel_size=3):
     if kernel_size.shape == ():
         kernel_size = np.repeat(kernel_size.item(), 2)
 
-    for size in kernel_size:
-        if (size % 2) != 1:
+    for ksize in kernel_size:
+        if (ksize % 2) != 1:
             raise ValueError("Each element of kernel_size should be odd.")
 
     return _sigtools._medfilt2d(image, kernel_size)
@@ -3560,20 +3563,28 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
     0.06  # random
 
     """
+    xp = array_namespace(data)
     if type not in ['linear', 'l', 'constant', 'c']:
         raise ValueError("Trend type must be 'linear' or 'constant'.")
-    data = np.asarray(data)
-    dtype = data.dtype.char
-    if dtype not in 'dfDF':
-        dtype = 'd'
+    data = xp.asarray(data)
+    dtype = data.dtype
+    if data.dtype not in [xp.float32, xp.float64, xp.complex128, xp.complex64]:
+        dtype = xp.float64
     if type in ['constant', 'c']:
-        ret = data - np.mean(data, axis, keepdims=True)
+        ret = data - xp.mean(xp.asarray(data, dtype=dtype), axis=axis, keepdims=True)
         return ret
     else:
         dshape = data.shape
         N = dshape[axis]
-        bp = np.sort(np.unique(np.concatenate(np.atleast_1d(0, bp, N))))
-        if np.any(bp > N):
+        if isinstance(bp, int):
+            bp = xp.sort(xp.unique(xp.asarray([0, bp, N])))
+        else:
+            bp = xp.asarray(bp)
+            new_bp = xp.empty(size(bp) + 1)
+            new_bp[:size(bp)] = bp
+            new_bp[size(bp)] = N
+            bp = xp.sort(xp.unique(xp.asarray([0] + new_bp)))
+        if xp.any(bp > N):
             raise ValueError("Breakpoints must be less than length "
                              "of data along given axis.")
 
@@ -3582,28 +3593,32 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
         rnk = len(dshape)
         if axis < 0:
             axis = axis + rnk
-        newdata = np.moveaxis(data, axis, 0)
+        newdata = xp.moveaxis(data, axis, 0)
         newdata_shape = newdata.shape
         newdata = newdata.reshape(N, -1)
 
         if not overwrite_data:
-            newdata = newdata.copy()  # make sure we have a copy
-        if newdata.dtype.char not in 'dfDF':
+            newdata = xp.asarray(newdata, copy=True)  # make sure we have a copy
+        if newdata.dtype not in [xp.float64, xp.float32, xp.complex128, xp.complex64]:
             newdata = newdata.astype(dtype)
 
 #        Nreg = len(bp) - 1
         # Find leastsq fit and remove it for each piece
         for m in range(len(bp) - 1):
             Npts = bp[m + 1] - bp[m]
-            A = np.ones((Npts, 2), dtype)
-            A[:, 0] = np.arange(1, Npts + 1, dtype=dtype) / Npts
-            sl = slice(bp[m], bp[m + 1])
-            coef, resids, rank, s = linalg.lstsq(A, newdata[sl])
+            A = xp.ones((int(Npts), 2), dtype=dtype)
+            A[:, 0] = xp.arange(1, Npts + 1, dtype=dtype) / Npts
+            sl = slice(int(bp[m]), int(bp[m + 1]))
+            # NOTE: lstsq isn't in the array API standard
+            if "cupy" in xp.__name__ or "torch" in xp.__name__:
+                coef, resids, rank, s = xp.linalg.lstsq(A, newdata[sl], rcond=None)
+            else:
+                coef, resids, rank, s = linalg.lstsq(A, newdata[sl])
             newdata[sl] = newdata[sl] - A @ coef
 
         # Put data back in original shape.
         newdata = newdata.reshape(newdata_shape)
-        ret = np.moveaxis(newdata, 0, axis)
+        ret = xp.moveaxis(newdata, 0, axis)
         return ret
 
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy import fft as sp_fft
 from scipy._lib._array_api import (
-    array_namespace, size, is_complex, is_numpy, is_cupy, is_torch,
+    array_namespace, size, is_complex, is_cupy, is_torch,
 )
 from . import _signaltools
 from .windows import get_window
@@ -1790,8 +1790,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     """
     xp = array_namespace(y)
     if mode not in ['psd', 'stft']:
-        raise ValueError("Unknown value for mode %s, must be one of: "
-                         "{'psd', 'stft'}" % mode)
+        raise ValueError(f"Unknown value for mode {mode}, must be one of: "
+                         "{'psd', 'stft'}")
 
     boundary_funcs = {'even': even_ext,
                       'odd': odd_ext,
@@ -1800,8 +1800,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
                       None: None}
 
     if boundary not in boundary_funcs:
-        raise ValueError("Unknown boundary option '{}', must be one of: {}"
-                         .format(boundary, list(boundary_funcs.keys())))
+        boundary_keys = list(boundary_funcs.keys())
+        raise ValueError(f"Unknown boundary option '{boundary}',"
+                         f" must be one of: {boundary_keys}")
 
     # If x and y are the same object we can save ourselves some computation.
     same_data = y is x
@@ -1931,7 +1932,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     elif scaling == 'spectrum':
         scale = 1.0 / xp.sum(win) ** 2
     else:
-        raise ValueError('Unknown scaling: %r' % scaling)
+        raise ValueError(f'Unknown scaling: {scaling}')
 
     if mode == 'stft':
         scale = xp.sqrt(scale)

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1788,7 +1788,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
 
     .. versionadded:: 0.16.0
     """
-    xp = array_namespace(y)
+    xp = array_namespace(x, y)
     if mode not in ['psd', 'stft']:
         raise ValueError(f"Unknown value for mode {mode}, must be one of: "
                          "{'psd', 'stft'}")

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -2031,7 +2031,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
         result = x[..., xp.newaxis]
     else:
         step = nperseg - noverlap
-        result = xp.lib.stride_tricks.sliding_window_view(
+        # TODO: what to do about np.lib here for array API?
+        result = np.lib.stride_tricks.sliding_window_view(
             x, window_shape=nperseg, axis=-1, writeable=True
         )
         result = result[..., 0::step, :]

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1818,7 +1818,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         xouter.pop(axis)
         youter.pop(axis)
         try:
-            outershape = xp.broadcast(xp.empty(xouter), xp.empty(youter)).shape
+            outershape = xp.broadcast_arrays(xp.empty(xouter),
+                                             xp.empty(youter))[0].shape
         except ValueError as e:
             raise ValueError('x and y cannot be broadcast together.') from e
 
@@ -1843,11 +1844,11 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
             if x.shape[-1] < y.shape[-1]:
                 pad_shape = list(x.shape)
                 pad_shape[-1] = y.shape[-1] - x.shape[-1]
-                x = xp.concatenate((x, xp.zeros(pad_shape)), -1)
+                x = xp.concat((x, xp.zeros(pad_shape)), axis=-1)
             else:
                 pad_shape = list(y.shape)
                 pad_shape[-1] = x.shape[-1] - y.shape[-1]
-                y = xp.concatenate((y, xp.zeros(pad_shape)), -1)
+                y = xp.concat((y, xp.zeros(pad_shape)), axis=-1)
 
     if nperseg is not None:  # if specified by user
         nperseg = int(nperseg)

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -616,7 +616,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
             if average == 'median':
                 # xp.median must be passed real arrays for the desired result
                 bias = _median_bias(Pxy.shape[-1])
-                if Pxy.dtype in [xp.complex64, xp.complex128]:
+                if is_complex(Pxy, xp=xp):
                     Pxy = (xp.median(xp.real(Pxy), axis=-1)
                            + 1j * xp.median(xp.imag(Pxy), axis=-1))
                 else:
@@ -1933,7 +1933,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         else:
             sides = 'onesided'
             if not same_data:
-                if xp.is_complex(y, xp=xp):
+                if is_complex(y, xp=xp):
                     sides = 'twosided'
                     warnings.warn('Input data is complex, switching to '
                                   'return_onesided=False',

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -930,8 +930,12 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
 
     if isinstance(window, str) or type(window) is tuple:
         win = get_window(window, nperseg)
+        # NOTE: if window is a string or tuple, is it "ok"
+        # to assume we want to use NumPy under the hood?
+        xp = np
     else:
-        win = np.asarray(window)
+        xp = array_namespace(window)
+        win = xp.asarray(window)
         if len(win.shape) != 1:
             raise ValueError('window must be 1-D')
         if win.shape[0] != nperseg:
@@ -943,8 +947,8 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     if nperseg % step != 0:
         binsums[:nperseg % step] += win[-(nperseg % step):]
 
-    deviation = binsums - np.median(binsums)
-    return np.max(np.abs(deviation)) < tol
+    deviation = binsums - xp.median(binsums)
+    return xp.max(xp.abs(deviation)) < tol
 
 
 def check_NOLA(window, nperseg, noverlap, tol=1e-10):
@@ -1058,8 +1062,12 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
 
     if isinstance(window, str) or type(window) is tuple:
         win = get_window(window, nperseg)
+        # NOTE: if window is a string or tuple, is it "ok"
+        # to assume we want to use NumPy under the hood?
+        xp = np
     else:
-        win = np.asarray(window)
+        xp = array_namespace(window)
+        win = xp.asarray(window)
         if len(win.shape) != 1:
             raise ValueError('window must be 1-D')
         if win.shape[0] != nperseg:
@@ -1071,7 +1079,7 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
     if nperseg % step != 0:
         binsums[:nperseg % step] += win[-(nperseg % step):]**2
 
-    return np.min(binsums) > tol
+    return xp.min(binsums) > tol
 
 
 def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
@@ -1892,10 +1900,10 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         # I.e make x.shape[-1] = nperseg + (nseg-1)*nstep, with integer nseg
         nadd = (-(x.shape[-1]-nperseg) % nstep) % nperseg
         zeros_shape = list(x.shape[:-1]) + [nadd]
-        x = xp.concatenate((x, xp.zeros(zeros_shape)), axis=-1)
+        x = xp.concat((x, xp.zeros(zeros_shape)), axis=-1)
         if not same_data:
             zeros_shape = list(y.shape[:-1]) + [nadd]
-            y = xp.concatenate((y, xp.zeros(zeros_shape)), axis=-1)
+            y = xp.concat((y, xp.zeros(zeros_shape)), axis=-1)
 
     # Handle detrending and window functions
     if not detrend:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1684,6 +1684,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     >>> plt.show()
 
     """
+    xp = array_namespace(x)
     freqs, Pxx = welch(x, fs=fs, window=window, nperseg=nperseg,
                        noverlap=noverlap, nfft=nfft, detrend=detrend,
                        axis=axis)
@@ -1692,7 +1693,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     _, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
                  noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axis)
 
-    Cxy = np.abs(Pxy)**2 / Pxx / Pyy
+    Cxy = xp.abs(Pxy)**2 / Pxx / Pyy
 
     return freqs, Cxy
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -269,10 +269,11 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     2.0077340678640727
 
     """
-    x = np.asarray(x)
+    xp = array_namespace(x)
+    x = xp.asarray(x)
 
-    if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape)
+    if size(x) == 0:
+        return xp.empty(x.shape), xp.empty(x.shape)
 
     if window is None:
         window = 'boxcar'

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1778,7 +1778,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
 
     .. versionadded:: 0.16.0
     """
-    xp = array_namespace(x)
+    xp = array_namespace(y)
     if mode not in ['psd', 'stft']:
         raise ValueError("Unknown value for mode %s, must be one of: "
                          "{'psd', 'stft'}" % mode)

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1911,9 +1911,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         win = xp.astype(win, outdtype)
 
     if scaling == 'density':
-        scale = 1.0 / (fs * (win*win).sum())
+        scale = 1.0 / (fs * xp.sum(win*win))
     elif scaling == 'spectrum':
-        scale = 1.0 / win.sum()**2
+        scale = 1.0 / xp.sum(win) ** 2
     else:
         raise ValueError('Unknown scaling: %r' % scaling)
 
@@ -1921,11 +1921,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         scale = xp.sqrt(scale)
 
     if return_onesided:
-        try:
-            is_complex = xp.iscomplexobj(x)
-        except AttributeError:
-            # torch shim
-            is_complex = xp.is_complex(x)
+        is_complex = x.dtype in {xp.complex64, xp.complex128}
 
         if is_complex:
             sides = 'twosided'
@@ -2026,10 +2022,6 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
     result = detrend_func(result)
 
     # Apply window by multiplication
-    # NOTE: torch device shim -- needs
-    # deeper analysis
-    result_device = xp.device(result)
-    win = xp.to_device(win, result_device)
     result = win * result
 
     # Perform the fft. Acts on last axis by default. Zero-pads automatically

--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -29,6 +29,7 @@ from scipy.signal._arraytools import const_ext, even_ext, odd_ext, zero_ext
 from scipy.signal._short_time_fft import FFT_MODE_TYPE
 from scipy.signal._spectral_py import _spectral_helper, _triage_segments, \
     _median_bias
+from scipy._lib._array_api import array_namespace, is_complex
 
 
 def _stft_wrapper(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
@@ -300,14 +301,15 @@ def _spect_helper_csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     for testing the ShortTimeFFT implementation.
     """
 
+    xp = array_namespace(x)
     # The following lines are taken from the original _spectral_helper():
     same_data = y is x
     axis = int(axis)
 
     # Ensure we have np.arrays, get outdtype
-    x = np.asarray(x)
+    x = xp.asarray(x)
     if not same_data:
-        y = np.asarray(y)
+        y = xp.asarray(y)
     #     outdtype = np.result_type(x, y, np.complex64)
     # else:
     #     outdtype = np.result_type(x, np.complex64)
@@ -356,7 +358,7 @@ def _spect_helper_csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         raise ValueError('noverlap must be less than nperseg.')
     nstep = nperseg - noverlap
 
-    if np.iscomplexobj(x) and return_onesided:
+    if is_complex(x, xp=xp) and return_onesided:
         return_onesided = False
 
     # using cast() to make mypy happy:

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -31,6 +31,7 @@ from scipy.signal import get_window, welch, stft, istft, spectrogram
 from scipy.signal._short_time_fft import FFT_MODE_TYPE, \
     _calc_dual_canonical_window, ShortTimeFFT, PAD_TYPE
 from scipy.signal.windows import gaussian
+from scipy.conftest import array_api_compatible
 
 
 def test__calc_dual_canonical_window_roundtrip():
@@ -710,13 +711,16 @@ def test_roundtrip_complex_window(signal_type):
                     err_msg="Roundtrip for complex-valued window failed")
 
 
-def test_average_all_segments():
+@array_api_compatible
+@pytest.mark.skip_xp_backends(np_only=True)
+@pytest.mark.usefixtures("skip_xp_backends")
+def test_average_all_segments(xp):
     """Compare `welch` function with stft mean.
 
     Ported from `TestSpectrogram.test_average_all_segments` from file
     ``test__spectral.py``.
     """
-    x = np.random.randn(1024)
+    x = xp.asarray(np.random.randn(1024))
 
     fs = 1.0
     window = ('tukey', 0.25)
@@ -730,7 +734,7 @@ def test_average_all_segments():
                         p1=(len(x)-noverlap)//SFT.hop, k_offset=nperseg//2)
 
     assert_allclose(SFT.f, fw)
-    assert_allclose(np.mean(P, axis=-1), Pw)
+    assert_allclose(xp.mean(P, axis=-1), Pw)
 
 
 @pytest.mark.parametrize('window, N, nperseg, noverlap, mfft',

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -20,6 +20,7 @@ from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
 from scipy.conftest import array_api_compatible, skip_if_array_api_backend
 from scipy._lib.array_api_compat import array_api_compat
+from scipy._lib._array_api import xp_assert_close
 
 
 class TestPeriodogram:
@@ -255,12 +256,10 @@ class TestWelch:
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        np.linspace(0, 0.5, 5))
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
 
     # moveaxis not available in numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
@@ -273,12 +272,10 @@ class TestWelch:
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        np.arange(5.0)/9.0)
-        q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
+        xp_assert_close(f, xp.arange(5.0)/9.0)
+        q = xp.asarray([0.12477455, 0.23430933, 0.17072113, 0.17072113,
                       0.17072113])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # moveaxis not available in numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
@@ -287,16 +284,15 @@ class TestWelch:
     @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_twosided(self, xp):
-        x = xp.zeros(16)
+        x = xp.zeros(16, dtype=xp.float64)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, fftfreq(8, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111, 0.11111111,
+                      0.11111111, 0.11111111, 0.11111111, 0.07638889],
+                      dtype=xp.float64)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # moveaxis not available in numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
@@ -305,16 +301,14 @@ class TestWelch:
     @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_spectrum(self, xp):
-        x = xp.zeros(16)
+        x = xp.zeros(16, dtype=xp.float64)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, scaling='spectrum')
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        np.linspace(0, 0.5, 5))
-        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667,
-                      0.02083333])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.015625, 0.02864583, 0.04166667, 0.04166667,
+                      0.02083333], dtype=xp.float64)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # dtype casting issues with numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
@@ -327,12 +321,10 @@ class TestWelch:
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # casting issues with numpy.array_api backend
     @skip_if_array_api_backend("numpy.array_api")
@@ -345,12 +337,10 @@ class TestWelch:
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        np.arange(5.0)/9.0)
-        q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
+        xp_assert_close(f, xp.arange(5.0)/9.0)
+        q = xp.asarray([0.12477455, 0.23430933, 0.17072113, 0.17072113,
                       0.17072113])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # casting issues with numpy.array_api backend
     @skip_if_array_api_backend("numpy.array_api")
@@ -363,12 +353,10 @@ class TestWelch:
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
+        xp_assert_close(f, fftfreq(8, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # xp.mean() requires real types so skip
     # for backends that enforce that requirement
@@ -383,12 +371,10 @@ class TestWelch:
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(array_api_compat.to_device(f, "cpu"),
-                        fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
-                      0.55555556, 0.55555556, 0.55555556, 0.38194444])
-        assert_allclose(array_api_compat.to_device(p, "cpu"),
-                        q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, fftfreq(8, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.asarray([0.41666667, 0.38194444, 0.55555556, 0.55555556,
+                      0.55555556, 0.55555556, 0.55555556, 0.38194444], dtype=xp.float64)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     @array_api_compatible
     def test_unk_scaling(self, xp):
@@ -404,8 +390,7 @@ class TestWelch:
     def test_detrend_linear(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = welch(x, nperseg=10, detrend='linear')
-        p = array_api_compat.to_device(p, "cpu")
-        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+        xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
     # moveaxis not available in numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
@@ -417,12 +402,8 @@ class TestWelch:
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f1, p1 = welch(x, nperseg=10, detrend=False)
         f2, p2 = welch(x, nperseg=10, detrend=lambda x: x)
-        assert_allclose(array_api_compat.to_device(f1, "cpu"),
-                        array_api_compat.to_device(f2, "cpu"),
-                        atol=1e-15)
-        assert_allclose(array_api_compat.to_device(p1, "cpu"),
-                        array_api_compat.to_device(p2, "cpu"),
-                        atol=1e-15)
+        xp_assert_close(f1, f2, atol=1e-15)
+        xp_assert_close(p1, p2, atol=1e-15)
 
     # moveaxis not available in numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -19,6 +19,9 @@ from scipy.signal._spectral_py import _spectral_helper
 from scipy.signal.tests._scipy_spectral_test_shim import stft_compare as stft
 from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
+from scipy.conftest import array_api_compatible, skip_if_array_api_backend
+from scipy._lib.array_api_compat import array_api_compat
+from scipy._lib._array_api import SCIPY_ARRAY_API
 
 
 class TestPeriodogram:
@@ -243,150 +246,202 @@ class TestPeriodogram:
 
 
 class TestWelch:
-    def test_real_onesided_even(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_real_onesided_even(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.linspace(0, 0.5, 5))
 
-    def test_real_onesided_odd(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_real_onesided_odd(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.arange(5.0)/9.0)
         q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
                       0.17072113])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_real_twosided(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_real_twosided(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_real_spectrum(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_real_spectrum(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, scaling='spectrum')
-        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.linspace(0, 0.5, 5))
         q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667,
                       0.02083333])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_onesided_even(self):
-        x = np.zeros(16, dtype=int)
+    @array_api_compatible
+    def test_integer_onesided_even(self, xp):
+        x = xp.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_onesided_odd(self):
-        x = np.zeros(16, dtype=int)
+    @array_api_compatible
+    def test_integer_onesided_odd(self, xp):
+        x = xp.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.arange(5.0)/9.0)
         q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
                       0.17072113])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_twosided(self):
-        x = np.zeros(16, dtype=int)
+    @array_api_compatible
+    def test_integer_twosided(self, xp):
+        x = xp.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_complex(self):
-        x = np.zeros(16, np.complex128)
+    @array_api_compatible
+    def test_complex(self, xp):
+        x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        fftfreq(8, 1.0))
         q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
                       0.55555556, 0.55555556, 0.55555556, 0.38194444])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
-    def test_unk_scaling(self):
-        assert_raises(ValueError, welch, np.zeros(4, np.complex128),
+    @array_api_compatible
+    def test_unk_scaling(self, xp):
+        assert_raises(ValueError, welch, xp.zeros(4, dtype=xp.complex128),
                       scaling='foo', nperseg=4)
 
-    def test_detrend_linear(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_detrend_linear(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = welch(x, nperseg=10, detrend='linear')
+        p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
-    def test_no_detrending(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_no_detrending(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f1, p1 = welch(x, nperseg=10, detrend=False)
         f2, p2 = welch(x, nperseg=10, detrend=lambda x: x)
-        assert_allclose(f1, f2, atol=1e-15)
-        assert_allclose(p1, p2, atol=1e-15)
+        assert_allclose(array_api_compat.to_device(f1, "cpu"),
+                        array_api_compat.to_device(f2, "cpu"),
+                        atol=1e-15)
+        assert_allclose(array_api_compat.to_device(p1, "cpu"),
+                        array_api_compat.to_device(p2, "cpu"),
+                        atol=1e-15)
 
-    def test_detrend_external(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_detrend_external(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = welch(x, nperseg=10,
                      detrend=lambda seg: signal.detrend(seg, type='l'))
+        p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
-    def test_detrend_external_nd_m1(self):
-        x = np.arange(40, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_detrend_external_nd_m1(self, xp):
+        x = xp.arange(40, dtype=xp.float64) + 0.04
         x = x.reshape((2,2,10))
         f, p = welch(x, nperseg=10,
                      detrend=lambda seg: signal.detrend(seg, type='l'))
+        p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
-    def test_detrend_external_nd_0(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_detrend_external_nd_0(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
         x = x.reshape((2,1,10))
-        x = np.moveaxis(x, 2, 0)
+        x = xp.moveaxis(x, 2, 0)
         f, p = welch(x, nperseg=10, axis=0,
                      detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
+        p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
-    def test_nd_axis_m1(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_nd_axis_m1(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
         x = x.reshape((2,1,10))
         f, p = welch(x, nperseg=10)
         assert_array_equal(p.shape, (2, 1, 6))
-        assert_allclose(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
+        assert_allclose(array_api_compat.to_device(p[0,0,:], "cpu"),
+                        array_api_compat.to_device(p[1,0,:], "cpu"),
+                        atol=1e-13, rtol=1e-13)
         f0, p0 = welch(x[0,0,:], nperseg=10)
-        assert_allclose(p0[np.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13)
+        assert_allclose(array_api_compat.to_device(p0[None,:], "cpu"),
+                        array_api_compat.to_device(p[1,:], "cpu"),
+                        atol=1e-13, rtol=1e-13)
 
-    def test_nd_axis_0(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
+    @array_api_compatible
+    def test_nd_axis_0(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
         x = x.reshape((10,2,1))
         f, p = welch(x, nperseg=10, axis=0)
         assert_array_equal(p.shape, (6,2,1))
-        assert_allclose(p[:,0,0], p[:,1,0], atol=1e-13, rtol=1e-13)
+        assert_allclose(array_api_compat.to_device(p[:,0,0], "cpu"),
+                        array_api_compat.to_device(p[:,1,0], "cpu"),
+                        atol=1e-13, rtol=1e-13)
         f0, p0 = welch(x[:,0,0], nperseg=10)
-        assert_allclose(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
+        assert_allclose(array_api_compat.to_device(p0, "cpu"),
+                        array_api_compat.to_device(p[:,1,0], "cpu"),
+                        atol=1e-13, rtol=1e-13)
 
-    def test_window_external(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    @skip_if_array_api_backend('torch')
+    def test_window_external(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, 10, 'hann', nperseg=8)
         win = signal.get_window('hann', 8)
         fe, pe = welch(x, 10, win, nperseg=None)
-        assert_array_almost_equal_nulp(p, pe)
-        assert_array_almost_equal_nulp(f, fe)
+        assert_array_almost_equal_nulp(array_api_compat.to_device(p, "cpu"),
+                                       array_api_compat.to_device(pe, "cpu"))
+        assert_array_almost_equal_nulp(array_api_compat.to_device(f, "cpu"),
+                                       array_api_compat.to_device(fe, "cpu"))
         assert_array_equal(fe.shape, (5,))  # because win length used as nperseg
         assert_array_equal(pe.shape, (5,))
         assert_raises(ValueError, welch, x,
@@ -395,8 +450,10 @@ class TestWelch:
         assert_raises(ValueError, welch, x,
                       10, win_err, nperseg=None)  # win longer than signal
 
-    def test_empty_input(self):
-        f, p = welch([])
+    @array_api_compatible
+    def test_empty_input(self, xp):
+        val = xp.asarray([]) if SCIPY_ARRAY_API else []
+        f, p = welch(val)
         assert_array_equal(f.shape, (0,))
         assert_array_equal(p.shape, (0,))
         for shape in [(0,), (3,0), (0,5,2)]:
@@ -404,14 +461,16 @@ class TestWelch:
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    def test_empty_input_other_axis(self):
+    @array_api_compatible
+    def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
-            f, p = welch(np.empty(shape), axis=1)
+            f, p = welch(xp.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    def test_short_data(self):
-        x = np.zeros(8)
+    @array_api_compatible
+    def test_short_data(self, xp):
+        x = xp.zeros(8)
         x[0] = 1
         #for string-like window, input signal length < nperseg value gives
         #UserWarning, sets nperseg to x.shape[-1]
@@ -421,103 +480,129 @@ class TestWelch:
             f, p = welch(x,window='hann')  # default nperseg
             f1, p1 = welch(x,window='hann', nperseg=256)  # user-specified nperseg
         f2, p2 = welch(x, nperseg=8)  # valid nperseg, doesn't give warning
-        assert_allclose(f, f2)
-        assert_allclose(p, p2)
-        assert_allclose(f1, f2)
-        assert_allclose(p1, p2)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        array_api_compat.to_device(f2, "cpu"))
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        array_api_compat.to_device(p2, "cpu"))
+        assert_allclose(array_api_compat.to_device(f1, "cpu"),
+                        array_api_compat.to_device(f2, "cpu"))
+        assert_allclose(array_api_compat.to_device(p1, "cpu"),
+                        array_api_compat.to_device(p2, "cpu"))
 
-    def test_window_long_or_nd(self):
-        assert_raises(ValueError, welch, np.zeros(4), 1, np.array([1,1,1,1,1]))
-        assert_raises(ValueError, welch, np.zeros(4), 1,
-                      np.arange(6).reshape((2,3)))
+    @array_api_compatible
+    def test_window_long_or_nd(self, xp):
+        assert_raises(ValueError, welch, xp.zeros(4), 1, xp.asarray([1,1,1,1,1]))
+        assert_raises(ValueError, welch, xp.zeros(4), 1,
+                      xp.arange(6).reshape((2,3)))
 
-    def test_nondefault_noverlap(self):
-        x = np.zeros(64)
+    @array_api_compatible
+    def test_nondefault_noverlap(self, xp):
+        x = xp.zeros(64)
         x[::8] = 1
         f, p = welch(x, nperseg=16, noverlap=4)
         q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5.,
                       1./6.])
-        assert_allclose(p, q, atol=1e-12)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-12)
 
-    def test_bad_noverlap(self):
-        assert_raises(ValueError, welch, np.zeros(4), 1, 'hann', 2, 7)
+    @array_api_compatible
+    def test_bad_noverlap(self, xp):
+        assert_raises(ValueError, welch, xp.zeros(4), 1, 'hann', 2, 7)
 
-    def test_nfft_too_short(self):
-        assert_raises(ValueError, welch, np.ones(12), nfft=3, nperseg=4)
+    @array_api_compatible
+    def test_nfft_too_short(self, xp):
+        assert_raises(ValueError, welch, xp.ones(12), nfft=3, nperseg=4)
 
-    def test_real_onesided_even_32(self):
-        x = np.zeros(16, 'f')
+    @array_api_compatible
+    def test_real_onesided_even_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.linspace(0, 0.5, 5))
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+                        0.11111111], dtype=xp.float32)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        array_api_compat.to_device(q, "cpu"),
+                        atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    def test_real_onesided_odd_32(self):
-        x = np.zeros(16, 'f')
+    @array_api_compatible
+    def test_real_onesided_odd_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.12477458, 0.23430935, 0.17072113, 0.17072116,
-                      0.17072113], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.arange(5.0)/9.0)
+        q = xp.asarray([0.12477458, 0.23430935, 0.17072113, 0.17072116,
+                        0.17072113], dtype=xp.float32)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        array_api_compat.to_device(q, "cpu"),
+                        atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    def test_real_twosided_32(self):
-        x = np.zeros(16, 'f')
+    @array_api_compatible
+    def test_real_twosided_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.11111111,
-                      0.07638889], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        fftfreq(8, 1.0))
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111,
+                        0.11111111, 0.11111111, 0.11111111, 0.11111111,
+                        0.07638889], dtype=xp.float32)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        array_api_compat.to_device(q, "cpu"),
+                        atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    def test_complex_32(self):
-        x = np.zeros(16, 'F')
+    @array_api_compatible
+    def test_complex_32(self, xp):
+        x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
-                      0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        fftfreq(8, 1.0))
+        q = xp.asarray([0.41666666, 0.38194442, 0.55555552, 0.55555552,
+                      0.55555558, 0.55555552, 0.55555552, 0.38194442], dtype=xp.float32)
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        array_api_compat.to_device(q, "cpu"), atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype,
                 f'dtype mismatch, {p.dtype}, {q.dtype}')
 
-    def test_padded_freqs(self):
-        x = np.zeros(12)
+    @array_api_compatible
+    def test_padded_freqs(self, xp):
+        x = xp.zeros(12)
 
         nfft = 24
         f = fftfreq(nfft, 1.0)[:nfft//2+1]
         f[-1] *= -1
         fodd, _ = welch(x, nperseg=5, nfft=nfft)
         feven, _ = welch(x, nperseg=6, nfft=nfft)
-        assert_allclose(f, fodd)
-        assert_allclose(f, feven)
+        assert_allclose(f, array_api_compat.to_device(fodd, "cpu"))
+        assert_allclose(f, array_api_compat.to_device(feven, "cpu"))
 
         nfft = 25
         f = fftfreq(nfft, 1.0)[:(nfft + 1)//2]
         fodd, _ = welch(x, nperseg=5, nfft=nfft)
         feven, _ = welch(x, nperseg=6, nfft=nfft)
-        assert_allclose(f, fodd)
-        assert_allclose(f, feven)
+        assert_allclose(f, array_api_compat.to_device(fodd, "cpu"))
+        assert_allclose(f, array_api_compat.to_device(feven, "cpu"))
 
-    def test_window_correction(self):
+    @array_api_compatible
+    def test_window_correction(self, xp):
         A = 20
         fs = 1e4
         nperseg = int(fs//10)
         fsig = 300
         ii = int(fsig*nperseg//fs)  # Freq index of fsig
 
-        tt = np.arange(fs)/fs
-        x = A*np.sin(2*np.pi*fsig*tt)
+        tt = xp.arange(fs)/fs
+        x = A*xp.sin(2*xp.pi*fsig*tt)
 
         for window in ['hann', 'bartlett', ('tukey', 0.1), 'flattop']:
             _, p_spec = welch(x, fs=fs, nperseg=nperseg, window=window,
@@ -526,15 +611,18 @@ class TestWelch:
                                  scaling='density')
 
             # Check peak height at signal frequency for 'spectrum'
-            assert_allclose(p_spec[ii], A**2/2.0)
+            assert_allclose(array_api_compat.to_device(p_spec[ii], "cpu"),
+                            A**2/2.0, rtol=5e-7)
             # Check integrated spectrum RMS for 'density'
-            assert_allclose(np.sqrt(trapezoid(p_dens, freq)), A*np.sqrt(2)/2,
-                            rtol=1e-3)
+            assert_allclose(np.sqrt(np.trapz(array_api_compat.to_device(p_dens, "cpu"),
+                                             array_api_compat.to_device(freq, "cpu"))),
+                            A*np.sqrt(2)/2, rtol=1e-3)
 
-    def test_axis_rolling(self):
+    @array_api_compatible
+    def test_axis_rolling(self, xp):
         np.random.seed(1234)
 
-        x_flat = np.random.randn(1024)
+        x_flat = xp.asarray(np.random.randn(1024))
         _, p_flat = welch(x_flat)
 
         for a in range(3):
@@ -545,17 +633,24 @@ class TestWelch:
             _, p_plus = welch(x, axis=a)  # Positive axis index
             _, p_minus = welch(x, axis=a-x.ndim)  # Negative axis index
 
-            assert_equal(p_flat, p_plus.squeeze(), err_msg=a)
-            assert_equal(p_flat, p_minus.squeeze(), err_msg=a-x.ndim)
+            assert_array_equal(array_api_compat.to_device(p_flat, "cpu"),
+                               array_api_compat.to_device(p_plus.squeeze(), "cpu"),
+                               err_msg=a)
+            assert_array_equal(array_api_compat.to_device(p_flat, "cpu"),
+                               array_api_compat.to_device(p_minus.squeeze(), "cpu"),
+                               err_msg=a-x.ndim)
 
-    def test_average(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_average(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, average='median')
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([.1, .05, 0., 1.54074396e-33, 0.])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        q = np.asarray([.1, .05, 0., 1.54074396e-33, 0.])
+        assert_allclose(array_api_compat.to_device(f, "cpu"),
+                        np.linspace(0, 0.5, 5))
+        assert_allclose(array_api_compat.to_device(p, "cpu"),
+                        q, atol=1e-7, rtol=1e-7)
 
         assert_raises(ValueError, welch, x, nperseg=8,
                       average='unrecognised-average')
@@ -1608,8 +1703,8 @@ class TestSTFT:
         # Since x is real, its Fourier transform is conjugate symmetric, i.e.,
         # the missing 'second side' can be expressed through the 'first side':
         Zp1 = np.conj(Zp0[-2:0:-1, :])  # 'second side' is conjugate reversed
-        assert_allclose(Zp[:129, :], Zp0)
-        assert_allclose(Zp[129:, :], Zp1)
+        assert_allclose(Zp[:129, :], Zp0, atol=9e-16)
+        assert_allclose(Zp[129:, :], Zp1, atol=9e-16)
 
         # Calculate the spectral power:
         s2 = (np.sum(Zp0.real ** 2 + Zp0.imag ** 2, axis=0) +

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -298,9 +298,11 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # dtype casting issues with numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
     @array_api_compatible
     def test_integer_onesided_even(self, xp):
-        x = xp.zeros(16, dtype=int)
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
@@ -311,9 +313,11 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # casting issues with numpy.array_api backend
+    @skip_if_array_api_backend("numpy.array_api")
     @array_api_compatible
     def test_integer_onesided_odd(self, xp):
-        x = xp.zeros(16, dtype=int)
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
@@ -324,6 +328,8 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # casting issues with numpy.array_api backend
+    @skip_if_array_api_backend("numpy.array_api")
     @array_api_compatible
     def test_integer_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
@@ -337,6 +343,10 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # xp.mean() requires real types so skip
+    # for backends that enforce that requirement
+    # for now
+    @skip_if_array_api_backend('numpy.array_api')
     @array_api_compatible
     def test_complex(self, xp):
         x = xp.zeros(16, dtype=xp.complex128)
@@ -559,6 +569,10 @@ class TestWelch:
                         atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
+    # xp.mean() requires real types so skip
+    # for backends that enforce that requirement
+    # for now
+    @skip_if_array_api_backend('numpy.array_api')
     @array_api_compatible
     def test_complex_32(self, xp):
         x = xp.zeros(16, dtype=xp.complex64)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,8 +8,7 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy import signal
-from scipy.fft import fftfreq, rfftfreq, fft, irfft
-from scipy.integrate import trapezoid
+from scipy.fft import fftfreq
 from scipy.signal import (periodogram, welch, lombscargle, coherence,
                           spectrogram, check_COLA, check_NOLA)
 from scipy.signal.windows import hann
@@ -21,7 +20,6 @@ from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
 from scipy.conftest import array_api_compatible, skip_if_array_api_backend
 from scipy._lib.array_api_compat import array_api_compat
-from scipy._lib._array_api import SCIPY_ARRAY_API
 
 
 class TestPeriodogram:
@@ -246,6 +244,11 @@ class TestPeriodogram:
 
 
 class TestWelch:
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_onesided_even(self, xp):
         x = xp.zeros(16)
@@ -259,6 +262,11 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(f, "cpu"),
                         np.linspace(0, 0.5, 5))
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_onesided_odd(self, xp):
         x = xp.zeros(16)
@@ -272,6 +280,11 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_twosided(self, xp):
         x = xp.zeros(16)
@@ -285,6 +298,11 @@ class TestWelch:
         assert_allclose(array_api_compat.to_device(p, "cpu"),
                         q, atol=1e-7, rtol=1e-7)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_spectrum(self, xp):
         x = xp.zeros(16)
@@ -300,6 +318,9 @@ class TestWelch:
 
     # dtype casting issues with numpy.array_api
     @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_integer_onesided_even(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
@@ -315,6 +336,9 @@ class TestWelch:
 
     # casting issues with numpy.array_api backend
     @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_integer_onesided_odd(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
@@ -330,6 +354,9 @@ class TestWelch:
 
     # casting issues with numpy.array_api backend
     @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_integer_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
@@ -347,6 +374,9 @@ class TestWelch:
     # for backends that enforce that requirement
     # for now
     @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_complex(self, xp):
         x = xp.zeros(16, dtype=xp.complex128)
@@ -365,6 +395,11 @@ class TestWelch:
         assert_raises(ValueError, welch, xp.zeros(4, dtype=xp.complex128),
                       scaling='foo', nperseg=4)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_detrend_linear(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
@@ -372,6 +407,11 @@ class TestWelch:
         p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_no_detrending(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
@@ -384,6 +424,11 @@ class TestWelch:
                         array_api_compat.to_device(p2, "cpu"),
                         atol=1e-15)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_detrend_external(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
@@ -392,6 +437,11 @@ class TestWelch:
         p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_detrend_external_nd_m1(self, xp):
         x = xp.arange(40, dtype=xp.float64) + 0.04
@@ -401,6 +451,11 @@ class TestWelch:
         p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_detrend_external_nd_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
@@ -411,6 +466,11 @@ class TestWelch:
         p = array_api_compat.to_device(p, "cpu")
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_nd_axis_m1(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
@@ -425,6 +485,11 @@ class TestWelch:
                         array_api_compat.to_device(p[1,:], "cpu"),
                         atol=1e-13, rtol=1e-13)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_nd_axis_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
@@ -441,6 +506,11 @@ class TestWelch:
 
     @array_api_compatible
     @skip_if_array_api_backend('torch')
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     def test_window_external(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -478,6 +548,11 @@ class TestWelch:
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_short_data(self, xp):
         x = xp.zeros(8)
@@ -505,6 +580,11 @@ class TestWelch:
         assert_raises(ValueError, welch, xp.zeros(4), 1,
                       xp.reshape(xp.arange(6), (2,3)))
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_nondefault_noverlap(self, xp):
         x = xp.zeros(64)
@@ -523,6 +603,11 @@ class TestWelch:
     def test_nfft_too_short(self, xp):
         assert_raises(ValueError, welch, xp.ones(12), nfft=3, nperseg=4)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_onesided_even_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
@@ -538,6 +623,11 @@ class TestWelch:
                         atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_onesided_odd_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
@@ -553,6 +643,11 @@ class TestWelch:
                         atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_real_twosided_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
@@ -573,6 +668,9 @@ class TestWelch:
     # for backends that enforce that requirement
     # for now
     @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_complex_32(self, xp):
         x = xp.zeros(16, dtype=xp.complex64)
@@ -588,6 +686,11 @@ class TestWelch:
         assert_(p.dtype == q.dtype,
                 f'dtype mismatch, {p.dtype}, {q.dtype}')
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_padded_freqs(self, xp):
         x = xp.zeros(12)
@@ -607,6 +710,11 @@ class TestWelch:
         assert_allclose(f, array_api_compat.to_device(fodd, "cpu"))
         assert_allclose(f, array_api_compat.to_device(feven, "cpu"))
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_window_correction(self, xp):
         A = 20
@@ -632,6 +740,11 @@ class TestWelch:
                                              array_api_compat.to_device(freq, "cpu"))),
                             A*np.sqrt(2)/2, rtol=1e-3)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_axis_rolling(self, xp):
         np.random.seed(1234)
@@ -654,6 +767,11 @@ class TestWelch:
                                array_api_compat.to_device(p_minus.squeeze(), "cpu"),
                                err_msg=a-x.ndim)
 
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
     @array_api_compatible
     def test_average(self, xp):
         x = xp.zeros(16)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -18,18 +18,16 @@ from scipy.signal._spectral_py import _spectral_helper
 from scipy.signal.tests._scipy_spectral_test_shim import stft_compare as stft
 from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
-from scipy.conftest import array_api_compatible, skip_if_array_api_backend
-from scipy._lib.array_api_compat import array_api_compat
+from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal, copy, size
 
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 class TestPeriodogram:
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict"])
     def test_real_onesided_even(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -41,12 +39,9 @@ class TestPeriodogram:
         q /= 8
         xp_assert_close(p, q)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict"])
     def test_real_onesided_odd(self, xp):
         x = xp.zeros(15)
         x[0] = 1
@@ -57,12 +52,9 @@ class TestPeriodogram:
         q *= 2.0/15.0
         xp_assert_close(p, q, atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict"])
     def test_real_twosided(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -72,12 +64,9 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict"])
     def test_real_spectrum(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -86,12 +75,9 @@ class TestPeriodogram:
         xp_assert_close(f, xp.linspace(0, 0.5, 9))
         xp_assert_close(p, q/16.0)
 
-    # dtype casting issue for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_even(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -103,12 +89,9 @@ class TestPeriodogram:
         q /= 8
         xp_assert_close(p, q)
 
-    # dtype casting issue for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_odd(self, xp):
         x = xp.zeros(15, dtype=xp.int64)
         x[0] = 1
@@ -119,12 +102,9 @@ class TestPeriodogram:
         q *= 2.0/15.0
         xp_assert_close(p, q, atol=1e-15)
 
-    # dtype casting issue for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -134,13 +114,9 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q)
 
-    # xp.mean() requires real types so skip
-    # for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "xp.mean() requires real types for array_api_strict"])
     def test_complex(self, xp):
         x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
@@ -150,7 +126,6 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q, check_dtype=False)
 
-    @array_api_compatible
     def test_unk_scaling(self, xp):
         assert_raises(ValueError, periodogram, xp.zeros(4, dtype=xp.complex128),
                 scaling='foo')
@@ -159,15 +134,10 @@ class TestPeriodogram:
         sys.maxsize <= 2**32,
         reason="On some 32-bit tolerance issue"
     )
-    # torch hits nulp device coercion until
-    # we have nulp-style array API tests
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict",
+                               "torch hits nulp device coercion"])
     def test_nd_axis_m1(self, xp):
         x = xp.zeros(20, dtype=xp.float64)
         x = xp.reshape(x, (2, 1, 10))
@@ -182,15 +152,10 @@ class TestPeriodogram:
         sys.maxsize <= 2**32,
         reason="On some 32-bit tolerance issue"
     )
-    # torch hits nulp device coercion until
-    # we have nulp-style array API tests
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict",
+                               "torch hits nulp device coercion"])
     def test_nd_axis_0(self, xp):
         x = xp.zeros(20, dtype=xp.float64)
         x = xp.reshape(x, (10, 2, 1))
@@ -201,15 +166,10 @@ class TestPeriodogram:
         f0, p0 = periodogram(x[:,0,0])
         assert_array_almost_equal_nulp(p0, p[:,1,0])
 
-    # torch hits nulp device coercion until
-    # we have nulp-style array API tests
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict",
+                               "torch hits nulp device coercion"])
     def test_window_external(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -222,12 +182,9 @@ class TestPeriodogram:
         assert_raises(ValueError, periodogram, x,
                       10, win_err)  # win longer than signal
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_padded_fft(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -237,7 +194,6 @@ class TestPeriodogram:
         xp_assert_close(p, pp[::2])
         assert pp.shape == (17,)
 
-    @array_api_compatible
     def test_empty_input(self, xp):
         f, p = periodogram([])
         assert_array_equal(f.shape, (0,))
@@ -247,19 +203,15 @@ class TestPeriodogram:
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    @array_api_compatible
     def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
             f, p = periodogram(xp.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_short_nfft(self, xp):
         x = xp.zeros(18)
         x[0] = 1
@@ -271,12 +223,9 @@ class TestPeriodogram:
         q /= 8
         xp_assert_close(p, q)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_nfft_is_xshape(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -288,12 +237,9 @@ class TestPeriodogram:
         q /= 8
         xp_assert_close(p, q)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_real_onesided_even_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -305,12 +251,9 @@ class TestPeriodogram:
         q /= 8
         xp_assert_close(p, q)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_real_onesided_odd_32(self, xp):
         x = xp.zeros(15, dtype=xp.float32)
         x[0] = 1
@@ -321,12 +264,9 @@ class TestPeriodogram:
         q *= 2.0/15.0
         xp_assert_close(p, q, atol=1e-7)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "no moveaxis in array_api_strict"])
     def test_real_twosided_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -336,13 +276,9 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q)
 
-    # xp.mean() requires real types so skip
-    # for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "xp.mean() rqeuires real types for array_api_strict"])
     def test_complex_32(self, xp):
         x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
@@ -352,7 +288,6 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q)
 
-    @array_api_compatible
     def test_shorter_window_error(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -364,12 +299,9 @@ class TestPeriodogram:
 
 
 class TestWelch:
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_real_onesided_even(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -380,12 +312,9 @@ class TestWelch:
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
         xp_assert_close(f, xp.linspace(0, 0.5, 5))
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_real_onesided_odd(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -396,12 +325,9 @@ class TestWelch:
                       0.17072113])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_real_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.float64)
         x[0] = 1
@@ -413,12 +339,9 @@ class TestWelch:
                       dtype=xp.float64)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_real_spectrum(self, xp):
         x = xp.zeros(16, dtype=xp.float64)
         x[0] = 1
@@ -429,12 +352,9 @@ class TestWelch:
                       0.02083333], dtype=xp.float64)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # dtype casting issues with numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_onesided_even(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -445,12 +365,9 @@ class TestWelch:
                       0.11111111])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # casting issues with numpy.array_api backend
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_onesided_odd(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -461,12 +378,9 @@ class TestWelch:
                       0.17072113])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # casting issues with numpy.array_api backend
-    @skip_if_array_api_backend("numpy.array_api")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "dtype casting issue for array_api_strict"])
     def test_integer_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -477,14 +391,9 @@ class TestWelch:
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # xp.mean() requires real types so skip
-    # for backends that enforce that requirement
-    # for now
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "xp.mean() requires real types for array_api_strict"])
     def test_complex(self, xp):
         x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
@@ -495,28 +404,21 @@ class TestWelch:
                       0.55555556, 0.55555556, 0.55555556, 0.38194444], dtype=xp.float64)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    @array_api_compatible
     def test_unk_scaling(self, xp):
         assert_raises(ValueError, welch, xp.zeros(4, dtype=xp.complex128),
                       scaling='foo', nperseg=4)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_detrend_linear(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = welch(x, nperseg=10, detrend='linear')
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_no_detrending(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f1, p1 = welch(x, nperseg=10, detrend=False)
@@ -524,24 +426,18 @@ class TestWelch:
         xp_assert_close(f1, f2, atol=1e-15)
         xp_assert_close(p1, p2, atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_detrend_external(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = welch(x, nperseg=10,
                      detrend=lambda seg: signal.detrend(seg, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_detrend_external_nd_m1(self, xp):
         x = xp.arange(40, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2,2,10))
@@ -549,12 +445,9 @@ class TestWelch:
                      detrend=lambda seg: signal.detrend(seg, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_detrend_external_nd_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2, 1, 10))
@@ -563,12 +456,9 @@ class TestWelch:
                      detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_nd_axis_m1(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2,1,10))
@@ -578,12 +468,9 @@ class TestWelch:
         f0, p0 = welch(x[0,0,:], nperseg=10)
         xp_assert_close(p0[None,:], p[1,:], atol=1e-13, rtol=1e-13)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_nd_axis_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (10,2,1))
@@ -593,13 +480,10 @@ class TestWelch:
         f0, p0 = welch(x[:,0,0], nperseg=10)
         xp_assert_close(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
 
-    @array_api_compatible
-    @skip_if_array_api_backend('torch')
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict",
+                               "TODO: skip torch"])
     def test_window_external(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -619,7 +503,6 @@ class TestWelch:
         assert_raises(ValueError, welch, x,
                       10, win_err, nperseg=None)  # win longer than signal
 
-    @array_api_compatible
     def test_empty_input(self, xp):
         val = xp.asarray([])
         f, p = welch(val)
@@ -630,19 +513,15 @@ class TestWelch:
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    @array_api_compatible
     def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
             f, p = welch(xp.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_short_data(self, xp):
         x = xp.zeros(8)
         x[0] = 1
@@ -659,18 +538,14 @@ class TestWelch:
         xp_assert_close(f1, f2)
         xp_assert_close(p1, p2)
 
-    @array_api_compatible
     def test_window_long_or_nd(self, xp):
         assert_raises(ValueError, welch, xp.zeros(4), 1, xp.asarray([1,1,1,1,1]))
         assert_raises(ValueError, welch, xp.zeros(4), 1,
                       xp.reshape(xp.arange(6), (2,3)))
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_nondefault_noverlap(self, xp):
         x = xp.zeros(64)
         x[::8] = 1
@@ -679,20 +554,15 @@ class TestWelch:
                       1./6.])
         xp_assert_close(p, q, atol=1e-12)
 
-    @array_api_compatible
     def test_bad_noverlap(self, xp):
         assert_raises(ValueError, welch, xp.zeros(4), 1, 'hann', 2, 7)
 
-    @array_api_compatible
     def test_nfft_too_short(self, xp):
         assert_raises(ValueError, welch, xp.ones(12), nfft=3, nperseg=4)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_real_onesided_even_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -704,12 +574,9 @@ class TestWelch:
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
         assert p.dtype == q.dtype
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_real_onesided_odd_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -721,12 +588,9 @@ class TestWelch:
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
         assert p.dtype == q.dtype
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available for array_api_strict"])
     def test_real_twosided_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -739,14 +603,9 @@ class TestWelch:
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
         assert p.dtype == q.dtype
 
-    # xp.mean() requires real types so skip
-    # for backends that enforce that requirement
-    # for now
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "xp.mean() requires real types for array_api_strict"])
     def test_complex_32(self, xp):
         x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
@@ -759,12 +618,9 @@ class TestWelch:
         assert_(p.dtype == q.dtype,
                 f'dtype mismatch, {p.dtype}, {q.dtype}')
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_padded_freqs(self, xp):
         x = xp.zeros(12)
 
@@ -783,12 +639,9 @@ class TestWelch:
         xp_assert_close(fodd, f, check_namespace=False, check_dtype=False)
         xp_assert_close(feven, f, check_namespace=False, check_dtype=False)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_window_correction(self, xp):
         A = 20
         fs = 1e4
@@ -812,12 +665,9 @@ class TestWelch:
                                              array_api_compat.to_device(freq, "cpu"))),
                             A*np.sqrt(2)/2, rtol=1e-3)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_axis_rolling(self, xp):
         np.random.seed(1234)
 
@@ -835,12 +685,9 @@ class TestWelch:
             xp_assert_equal(p_flat, p_plus.squeeze(), err_msg=a)
             xp_assert_equal(p_flat, p_minus.squeeze(), err_msg=a-x.ndim)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict"])
     def test_average(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -855,14 +702,10 @@ class TestWelch:
 
 
 class TestCSD:
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_pad_shorter_x(self, xp):
         x = xp.zeros(8)
         y = xp.zeros(12)
@@ -874,14 +717,10 @@ class TestCSD:
         xp_assert_close(f1, f)
         xp_assert_close(c1, c)
 
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_pad_shorter_y(self, xp):
         x = xp.zeros(12)
         y = xp.zeros(8)
@@ -893,14 +732,10 @@ class TestCSD:
         xp_assert_close(f1, f)
         xp_assert_close(c1, c)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_onesided_even(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -911,14 +746,10 @@ class TestCSD:
                         0.11111111])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_onesided_odd(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -929,14 +760,10 @@ class TestCSD:
                         0.17072113])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_twosided(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -947,14 +774,10 @@ class TestCSD:
                         0.11111111, 0.11111111, 0.11111111, 0.07638889])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis absent from array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_spectrum(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -965,14 +788,10 @@ class TestCSD:
                         0.02083333])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # type casting error with numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "type casting error with array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_integer_onesided_even(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -983,14 +802,10 @@ class TestCSD:
                         0.11111111])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # type casting error with numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "type casting error with array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_integer_onesided_odd(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -1001,14 +816,10 @@ class TestCSD:
                         0.17072113])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # type casting error with numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "type casting error with array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_integer_twosided(self, xp):
         x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
@@ -1019,14 +830,10 @@ class TestCSD:
                         0.11111111, 0.11111111, 0.11111111, 0.07638889])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # xp.mean() requires real input for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "xp.mean() requires real input for array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_complex(self, xp):
         x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
@@ -1037,32 +844,23 @@ class TestCSD:
                         0.55555556, 0.55555556, 0.55555556, 0.38194444])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    @array_api_compatible
     def test_unk_scaling(self, xp):
         assert_raises(ValueError, csd, xp.zeros(4, dtype=xp.complex128),
                       xp.ones(4, dtype=xp.complex128), scaling='foo', nperseg=4)
 
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_detrend_linear(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = csd(x, x, nperseg=10, detrend='linear')
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_no_detrending(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f1, p1 = csd(x, x, nperseg=10, detrend=False)
@@ -1070,28 +868,20 @@ class TestCSD:
         xp_assert_close(f1, f2, atol=1e-15)
         xp_assert_close(p1, p2, atol=1e-15)
 
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_detrend_external(self, xp):
         x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = csd(x, x, nperseg=10,
                    detrend=lambda seg: signal.detrend(seg, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_detrend_external_nd_m1(self, xp):
         x = xp.arange(40, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2, 2, 10))
@@ -1099,14 +889,10 @@ class TestCSD:
                    detrend=lambda seg: signal.detrend(seg, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_detrend_external_nd_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2, 1, 10))
@@ -1115,14 +901,10 @@ class TestCSD:
                    detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_nd_axis_m1(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (2, 1, 10))
@@ -1132,14 +914,10 @@ class TestCSD:
         f0, p0 = csd(x[0,0,:], x[0,0,:], nperseg=10)
         xp_assert_close(p0[xp.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13, check_dtype=False)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_nd_axis_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
         x = xp.reshape(x, (10, 2, 1))
@@ -1149,14 +927,10 @@ class TestCSD:
         f0, p0 = csd(x[:,0,0], x[:,0,0], nperseg=10)
         xp_assert_close(p0, p[:,1,0], atol=1e-13, rtol=1e-13, check_dtype=False)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array_api_compat cupy doesn't support fft",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_window_external(self, xp):
         x = xp.zeros(16)
         x[0] = 1
@@ -1175,14 +949,10 @@ class TestCSD:
         assert_raises(ValueError, csd, x, x,
               10, win_err, nperseg=None)  # because win longer than signal
 
-    # torch max() expects reduction dim to be specified...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # the empty list input causes issues for CuPy
-    # (array-like support)
-    @skip_if_array_api_backend('cupy')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["array-like support issues for CuPy",
+                               "moveaxis not available in array_api_strict",
+                               "torch max() expects reduction dim to be specified"])
     def test_empty_input(self, xp):
         f, p = csd([], xp.zeros(10))
         assert f.shape == (0,)
@@ -1205,11 +975,9 @@ class TestCSD:
         assert f.shape == (5,0)
         assert p.shape == (5,0)
 
-    # torch max() expects reduction dim to be specified...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("array_api_strict", "torch",
+                      reasons=["moveaxis not available in array_api_strict",
+                               "torch max() expects reduction dim to be specified"])
     def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
             f, p = csd(xp.empty(shape), xp.empty(shape), axis=1)
@@ -1224,14 +992,10 @@ class TestCSD:
         assert f.shape == (10, 0, 3)
         assert p.shape == (10, 0, 3)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_short_data(self, xp):
         x = xp.zeros(8)
         x[0] = 1
@@ -1249,21 +1013,16 @@ class TestCSD:
         xp_assert_close(f1, f2)
         xp_assert_close(p1, p2)
 
-    @array_api_compatible
     def test_window_long_or_nd(self, xp):
         assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1,
                       xp.asarray([1,1,1,1,1]))
         assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1,
                       xp.reshape(xp.arange(6), (2, 3)))
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_nondefault_noverlap(self, xp):
         x = xp.zeros(64)
         x[::8] = 1
@@ -1272,24 +1031,18 @@ class TestCSD:
                         1./6.])
         xp_assert_close(p, q, atol=1e-12)
 
-    @array_api_compatible
     def test_bad_noverlap(self, xp):
         assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1, 'hann',
                       2, 7)
 
-    @array_api_compatible
     def test_nfft_too_short(self, xp):
         assert_raises(ValueError, csd, xp.ones(12), xp.zeros(12), nfft=3,
                       nperseg=4)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_onesided_even_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -1300,14 +1053,10 @@ class TestCSD:
                         0.11111111], xp.float32)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_onesided_odd_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -1318,14 +1067,10 @@ class TestCSD:
                         0.17072113], xp.float32)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not available in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_real_twosided_32(self, xp):
         x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
@@ -1337,14 +1082,10 @@ class TestCSD:
                         0.07638889], xp.float32)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # xp.mean() requires real input for numpy.array_api
-    @skip_if_array_api_backend("numpy.array_api")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "xp.mean requires real input for array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_complex_32(self, xp):
         x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
@@ -1355,14 +1096,10 @@ class TestCSD:
                         0.55555558, 0.55555552, 0.55555552, 0.38194442], xp.float32)
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_padded_freqs(self, xp):
         x = xp.zeros(12)
         y = xp.ones(12)
@@ -1382,14 +1119,10 @@ class TestCSD:
         xp_assert_close(fodd, f)
         xp_assert_close(feven, f)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict", "torch",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict",
+                               "torch hits messy np.pad codepath"])
     def test_copied_data(self, xp):
         x = np.random.randn(64)
         x = xp.asarray(x)
@@ -1409,12 +1142,9 @@ class TestCSD:
 
 
 class TestCoherence:
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict"])
     def test_identical_input(self, xp):
         x = np.random.randn(20)
         x = xp.asarray(x)
@@ -1427,12 +1157,9 @@ class TestCoherence:
         xp_assert_close(f, f1)
         xp_assert_close(C, C1, check_dtype=False)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict"])
     def test_phase_shifted_input(self, xp):
         x = np.random.randn(20)
         x = xp.asarray(x)
@@ -1447,12 +1174,9 @@ class TestCoherence:
 
 
 class TestSpectrogram:
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict"])
     def test_average_all_segments(self, xp):
         x = np.random.randn(1024)
         x = xp.asarray(x)
@@ -1467,12 +1191,9 @@ class TestSpectrogram:
         xp_assert_close(f, fw)
         xp_assert_close(xp.mean(P, axis=-1), Pw)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict"])
     def test_window_external(self, xp):
         x = np.random.randn(1024)
         x = xp.asarray(x)
@@ -1493,12 +1214,9 @@ class TestSpectrogram:
         assert_raises(ValueError, spectrogram, x,
                       fs, win_err, nperseg=None)  # win longer than signal
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "array_api_strict",
+                      reasons=["lack of fft support in array_api_compat cupy",
+                               "moveaxis not availabe in array_api_strict"])
     def test_short_data(self, xp):
         x = np.random.randn(1024)
         x = xp.asarray(x)
@@ -1521,14 +1239,8 @@ class TestSpectrogram:
         xp_assert_close(p1, p3)
 
 class TestLombscargle:
-    # _lombscargle is a Cython function, so we currently
-    # have to skip backends across the board here
-    # (there's an expectation of contiguous memory
-    # layout as well)
-    @skip_if_array_api_backend("numpy.array_api")
-    @skip_if_array_api_backend("cupy")
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends(np_only=True,
+                      reasons=["_lombscargle is a Cython function"])
     def test_frequency(self, xp):
         """Test if frequency location of peak corresponds to frequency of
         generated input signal.
@@ -1562,14 +1274,8 @@ class TestLombscargle:
         delta = f[1] - f[0]
         assert_(w - f[xp.argmax(P)] < (delta/2.))
 
-    # _lombscargle is a Cython function, so we currently
-    # have to skip backends across the board here
-    # (there's an expectation of contiguous memory
-    # layout as well)
-    @skip_if_array_api_backend("numpy.array_api")
-    @skip_if_array_api_backend("cupy")
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends(np_only=True,
+                      reasons=["_lombscargle is a Cython function"])
     def test_amplitude(self, xp):
         # Test if height of peak in normalized Lomb-Scargle periodogram
         # corresponds to amplitude of the generated input signal.
@@ -1604,12 +1310,9 @@ class TestLombscargle:
         # frequency is less than accuracy
         xp_assert_close(xp.max(pgram), ampl, rtol=0.035)
 
-    # here we only need to skip cupy and torch backends
-    # for the _lombscargle Cython function (I'm a little
-    # surprised numpy.array_api squeezed through here)
-    @skip_if_array_api_backend("cupy")
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends("cupy", "torch",
+                      reasons=["_lombscargle is a Cython function",
+                               "_lombscargle is a Cython function"])
     def test_precenter(self, xp):
         # Test if precenter gives the same result as manually precentering.
 
@@ -1641,14 +1344,8 @@ class TestLombscargle:
         # check if centering worked
         xp_assert_close(pgram, pgram2)
 
-    # _lombscargle is a Cython function, so we currently
-    # have to skip backends across the board here
-    # (there's an expectation of contiguous memory
-    # layout as well)
-    @skip_if_array_api_backend("numpy.array_api")
-    @skip_if_array_api_backend("cupy")
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends(np_only=True,
+                      reasons=["_lombscargle is a Cython function"])
     def test_normalize(self, xp):
         # Test normalize option of Lomb-Scarge.
 
@@ -1680,32 +1377,27 @@ class TestLombscargle:
         xp_assert_close(pgram * 2 / (x @ x), pgram2)
         xp_assert_close(xp.max(pgram2), 1.0, rtol=0.35)
 
-    # skips for Cython code in _lombscargle
-    @skip_if_array_api_backend("torch")
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy",
+                      reasons=["_lombscargle is a Cython function",
+                               "_lombscargle is a Cython function"])
     def test_wrong_shape(self, xp):
         t = xp.linspace(0, 1, 1)
         x = xp.linspace(0, 1, 2)
         f = xp.linspace(0, 1, 3)
         assert_raises(ValueError, lombscargle, t, x, f)
 
-    # skips for Cython code in _lombscargle
-    @skip_if_array_api_backend("torch")
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy",
+                      reasons=["_lombscargle is a Cython function",
+                               "_lombscargle is a Cython function"])
     def test_zero_division(self, xp):
         t = xp.zeros(1)
         x = xp.zeros(1)
         f = xp.zeros(1)
         assert_raises(ZeroDivisionError, lombscargle, t, x, f)
 
-    # here, CuPy is skipped because of Cython usage
-    # in _lombscargle, but "torch" gets skipped
-    # because of `endpoint` usage in linspace!
-    @skip_if_array_api_backend("torch")
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy",
+                      reasons=["endpoint usage in linspace",
+                               "_lombscargle is a Cython function"])
     def test_lombscargle_atan_vs_atan2(self, xp):
         # https://github.com/scipy/scipy/issues/3787
         # This raised a ZeroDivisionError.
@@ -1716,14 +1408,10 @@ class TestLombscargle:
 
 
 class TestSTFT:
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+                      reasons=["torch hits messy np.pad codepath",
+                               "lack of fft support in array_api_compat",
+                               "moveaxis not available in array_api_strict"])
     def test_input_validation(self, xp):
 
         def chk_VE(match):
@@ -1806,7 +1494,6 @@ class TestSTFT:
         with chk_VE(fr"Parameter {scaling=} not in \['spectrum', 'psd'\]!"):
             istft(z, scaling=scaling)
 
-    @array_api_compatible
     def test_check_COLA(self, xp):
         settings = [
                     ('boxcar', 10, 0),
@@ -1831,7 +1518,6 @@ class TestSTFT:
                             check_namespace=False,
                             check_shape=False)
 
-    @array_api_compatible
     def test_check_NOLA(self, xp):
         settings_pass = [
                     ('boxcar', 10, 0),
@@ -1882,14 +1568,10 @@ class TestSTFT:
                             check_namespace=check_namespace,
                             check_shape=False)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+                      reasons=["torch hits messy np.pad codepath",
+                               "lack of fft support in array_api_compat",
+                               "moveaxis not available in array_api_strict"])
     def test_average_all_segments(self, xp):
         np.random.seed(1234)
         x = np.random.randn(1024)
@@ -1911,14 +1593,10 @@ class TestSTFT:
         xp_assert_close(f, fw)
         xp_assert_close(xp.mean(xp.abs(Z)**2, axis=-1), Pw)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+                      reasons=["torch hits messy np.pad codepath",
+                               "lack of fft support in array_api_compat",
+                               "moveaxis not available in array_api_strict"])
     def test_permute_axes(self, xp):
         np.random.seed(1234)
         x = np.random.randn(1024)
@@ -1943,15 +1621,10 @@ class TestSTFT:
         xp_assert_close(Z1, Z2[:, 0, 0, :])
         xp_assert_close(x1, x2[:, 0, 0])
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
-    @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+                      reasons=["torch hits messy np.pad codepath",
+                               "lack of fft support in array_api_compat",
+                               "moveaxis not available in array_api_strict"])
     def test_roundtrip_real(self, scaling, xp):
         np.random.seed(1234)
 
@@ -1983,18 +1656,10 @@ class TestSTFT:
             xp_assert_close(t, tr, err_msg=msg, check_dtype=False)
             xp_assert_close(x, xr, err_msg=msg)
 
-    # for torch, we end up in a situation where x.imag is called
-    # but x is real; I think torch may formally be standard compliant
-    # in erroring out here based on:
-    # https://data-apis.org/array-api/latest/API_specification/generated/array_api.imag.html?highlight=imag#array_api.imag
-    # but skip for now
-    @skip_if_array_api_backend('torch')
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch errors out where x.imag is called but x is real (this may be standard compliant though: https://data-apis.org/array-api/latest/API_specification/generated/array_api.imag.html?highlight=imag#array_api.imag)",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_not_nola(self, xp):
         np.random.seed(1234)
 
@@ -2024,14 +1689,10 @@ class TestSTFT:
             with pytest.raises(AssertionError):
                 xp_assert_close(x, xr[:len(x)], err_msg=msg)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_nola_not_cola(self, xp):
         np.random.seed(1234)
 
@@ -2063,14 +1724,10 @@ class TestSTFT:
             xp_assert_close(t, tr[:len(t)], err_msg=msg, check_dtype=False)
             xp_assert_close(x, xr[:len(x)], err_msg=msg)
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_float32(self, xp):
         np.random.seed(1234)
 
@@ -2091,7 +1748,6 @@ class TestSTFT:
             xp_assert_close(t, t, err_msg=msg)
             xp_assert_close(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
 
-    @array_api_compatible
     @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
     def test_roundtrip_complex(self, scaling, xp):
         np.random.seed(1234)
@@ -2138,14 +1794,10 @@ class TestSTFT:
         xp_assert_close(t, tr, err_msg=msg, check_namespace=False, check_dtype=False)
         xp_assert_close(x, xr, err_msg=msg)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_boundary_extension(self, xp):
         np.random.seed(1234)
 
@@ -2180,14 +1832,10 @@ class TestSTFT:
                 xp_assert_close(x, xr, err_msg=msg)
                 xp_assert_close(x, xr_ext, err_msg=msg)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_padded_signal(self, xp):
         np.random.seed(1234)
 
@@ -2211,14 +1859,10 @@ class TestSTFT:
             xp_assert_close(t, tr[:t.size], err_msg=msg, check_dtype=False)
             xp_assert_close(x, xr[:x.size], err_msg=msg)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_padded_FFT(self, xp):
         np.random.seed(1234)
 
@@ -2255,14 +1899,10 @@ class TestSTFT:
             xp_assert_close(x, xr, err_msg=msg)
             xp_assert_close(xc, xcr, err_msg=msg)
 
-    # torch hits a messy np.pad codepath...
-    @skip_if_array_api_backend("torch")
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch hits messy np.pad codepath",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_axis_rolling(self, xp):
         np.random.seed(1234)
 
@@ -2290,15 +1930,10 @@ class TestSTFT:
         xp_assert_close(x_flat, x_transpose_m, err_msg='istft transpose minus')
         xp_assert_close(x_flat, x_transpose_p, err_msg='istft transpose plus')
 
-    # moveaxis not available in numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
-    # torch seems to have an issue with a slice that
-    # has a negative step?
-    @skip_if_array_api_backend("torch")
-    # skip cupy because array_api_compat doesn't support
-    # fft at this time
-    @skip_if_array_api_backend("cupy")
-    @array_api_compatible
+    @skip_xp_backends("torch", "cupy", "array_api_strict",
+            reasons=["torch has issue with slice with negative step",
+                     "lack of fft support in array_api_compat",
+                     "moveaxis not available in array_api_strict"])
     def test_roundtrip_scaling(self, xp):
         """Verify behavior of scaling parameter. """
         # Create 1024 sample cosine signal with amplitude 2:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -736,37 +736,61 @@ class TestWelch:
 
 
 class TestCSD:
-    def test_pad_shorter_x(self):
-        x = np.zeros(8)
-        y = np.zeros(12)
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    @array_api_compatible
+    def test_pad_shorter_x(self, xp):
+        x = xp.zeros(8)
+        y = xp.zeros(12)
 
-        f = np.linspace(0, 0.5, 7)
-        c = np.zeros(7,dtype=np.complex128)
+        f = xp.linspace(0, 0.5, 7)
+        c = xp.zeros(7, dtype=xp.complex128)
         f1, c1 = csd(x, y, nperseg=12)
 
-        assert_allclose(f, f1)
-        assert_allclose(c, c1)
+        xp_assert_close(f1, f)
+        xp_assert_close(c1, c)
 
-    def test_pad_shorter_y(self):
-        x = np.zeros(12)
-        y = np.zeros(8)
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    @array_api_compatible
+    def test_pad_shorter_y(self, xp):
+        x = xp.zeros(12)
+        y = xp.zeros(8)
 
-        f = np.linspace(0, 0.5, 7)
-        c = np.zeros(7,dtype=np.complex128)
+        f = xp.linspace(0, 0.5, 7)
+        c = xp.zeros(7, dtype=xp.complex128)
         f1, c1 = csd(x, y, nperseg=12)
 
-        assert_allclose(f, f1)
-        assert_allclose(c, c1)
+        xp_assert_close(f1, f)
+        xp_assert_close(c1, c)
 
-    def test_real_onesided_even(self):
-        x = np.zeros(16)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_even(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+                        0.11111111])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)
@@ -828,24 +852,41 @@ class TestCSD:
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_complex(self):
-        x = np.zeros(16, np.complex128)
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # xp.mean() requires real input for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    @array_api_compatible
+    def test_complex(self, xp):
+        x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
-                      0.55555556, 0.55555556, 0.55555556, 0.38194444])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, fftfreq(8, 1.0))
+        q = xp.asarray([0.41666667, 0.38194444, 0.55555556, 0.55555556,
+                        0.55555556, 0.55555556, 0.55555556, 0.38194444])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_unk_scaling(self):
-        assert_raises(ValueError, csd, np.zeros(4, np.complex128),
-                      np.ones(4, np.complex128), scaling='foo', nperseg=4)
+    @array_api_compatible
+    def test_unk_scaling(self, xp):
+        assert_raises(ValueError, csd, xp.zeros(4, dtype=xp.complex128),
+                      xp.ones(4, dtype=xp.complex128), scaling='foo', nperseg=4)
 
-    def test_detrend_linear(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_detrend_linear(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = csd(x, x, nperseg=10, detrend='linear')
-        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+        xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
     def test_no_detrending(self):
         x = np.arange(10, dtype=np.float64) + 0.04

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -150,40 +150,68 @@ class TestPeriodogram:
         q[0] = 0
         xp_assert_close(p, q, check_dtype=False)
 
-    def test_unk_scaling(self):
-        assert_raises(ValueError, periodogram, np.zeros(4, np.complex128),
+    @array_api_compatible
+    def test_unk_scaling(self, xp):
+        assert_raises(ValueError, periodogram, xp.zeros(4, dtype=xp.complex128),
                 scaling='foo')
 
     @pytest.mark.skipif(
         sys.maxsize <= 2**32,
         reason="On some 32-bit tolerance issue"
     )
-    def test_nd_axis_m1(self):
-        x = np.zeros(20, dtype=np.float64)
-        x = x.reshape((2,1,10))
+    # torch hits nulp device coercion until
+    # we have nulp-style array API tests
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nd_axis_m1(self, xp):
+        x = xp.zeros(20, dtype=xp.float64)
+        x = xp.reshape(x, (2, 1, 10))
         x[:,:,0] = 1.0
         f, p = periodogram(x)
-        assert_array_equal(p.shape, (2, 1, 6))
+        assert p.shape == (2, 1, 6)
         assert_array_almost_equal_nulp(p[0,0,:], p[1,0,:], 60)
         f0, p0 = periodogram(x[0,0,:])
-        assert_array_almost_equal_nulp(p0[np.newaxis,:], p[1,:], 60)
+        assert_array_almost_equal_nulp(p0[xp.newaxis,:], p[1,:], 60)
 
     @pytest.mark.skipif(
         sys.maxsize <= 2**32,
         reason="On some 32-bit tolerance issue"
     )
-    def test_nd_axis_0(self):
-        x = np.zeros(20, dtype=np.float64)
-        x = x.reshape((10,2,1))
+    # torch hits nulp device coercion until
+    # we have nulp-style array API tests
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nd_axis_0(self, xp):
+        x = xp.zeros(20, dtype=xp.float64)
+        x = xp.reshape(x, (10, 2, 1))
         x[0,:,:] = 1.0
         f, p = periodogram(x, axis=0)
-        assert_array_equal(p.shape, (6,2,1))
+        assert p.shape == (6, 2, 1)
         assert_array_almost_equal_nulp(p[:,0,0], p[:,1,0], 60)
         f0, p0 = periodogram(x[:,0,0])
         assert_array_almost_equal_nulp(p0, p[:,1,0])
 
-    def test_window_external(self):
-        x = np.zeros(16)
+    # torch hits nulp device coercion until
+    # we have nulp-style array API tests
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_window_external(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x, 10, 'hann')
         win = signal.get_window('hann', 16)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -24,82 +24,131 @@ from scipy._lib._array_api import xp_assert_close, xp_assert_equal, copy
 
 
 class TestPeriodogram:
-    def test_real_onesided_even(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_even(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9)
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        q = xp.ones(9)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_real_onesided_odd(self):
-        x = np.zeros(15)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_odd(self, xp):
+        x = xp.zeros(15)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.arange(8.0)/15.0)
-        q = np.ones(8)
+        xp_assert_close(f, xp.arange(8.0)/15.0)
+        q = xp.ones(8)
         q[0] = 0
         q *= 2.0/15.0
-        assert_allclose(p, q, atol=1e-15)
+        xp_assert_close(p, q, atol=1e-15)
 
-    def test_real_twosided(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_twosided(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 1/16.0)
+        xp_assert_close(f, fftfreq(16, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.full((16,), 1/16.0)
         q[0] = 0
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_real_spectrum(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_spectrum(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x, scaling='spectrum')
         g, q = periodogram(x, scaling='density')
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        assert_allclose(p, q/16.0)
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        xp_assert_close(p, q/16.0)
 
-    def test_integer_even(self):
-        x = np.zeros(16, dtype=int)
+    # dtype casting issue for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_integer_even(self, xp):
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9)
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        q = xp.ones(9)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_integer_odd(self):
-        x = np.zeros(15, dtype=int)
+    # dtype casting issue for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_integer_odd(self, xp):
+        x = xp.zeros(15, dtype=xp.int64)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.arange(8.0)/15.0)
-        q = np.ones(8)
+        xp_assert_close(f, xp.arange(8.0)/15.0)
+        q = xp.ones(8)
         q[0] = 0
         q *= 2.0/15.0
-        assert_allclose(p, q, atol=1e-15)
+        xp_assert_close(p, q, atol=1e-15)
 
-    def test_integer_twosided(self):
-        x = np.zeros(16, dtype=int)
+    # dtype casting issue for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_integer_twosided(self, xp):
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 1/16.0)
+        xp_assert_close(f, fftfreq(16, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.full((16,), 1/16.0)
         q[0] = 0
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_complex(self):
-        x = np.zeros(16, np.complex128)
+    # xp.mean() requires real types so skip
+    # for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_complex(self, xp):
+        x = xp.zeros(16, dtype=xp.complex128)
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 5.0/16.0)
+        xp_assert_close(f, fftfreq(16, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.full((16,), 5.0/16.0)
         q[0] = 0
-        assert_allclose(p, q)
+        xp_assert_close(p, q, check_dtype=False)
 
     def test_unk_scaling(self):
         assert_raises(ValueError, periodogram, np.zeros(4, np.complex128),

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -326,7 +326,7 @@ class TestWelch:
 
     @array_api_compatible
     def test_integer_twosided(self, xp):
-        x = xp.zeros(16, dtype=int)
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
@@ -385,7 +385,7 @@ class TestWelch:
     @array_api_compatible
     def test_detrend_external_nd_m1(self, xp):
         x = xp.arange(40, dtype=xp.float64) + 0.04
-        x = x.reshape((2,2,10))
+        x = xp.reshape(x, (2,2,10))
         f, p = welch(x, nperseg=10,
                      detrend=lambda seg: signal.detrend(seg, type='l'))
         p = array_api_compat.to_device(p, "cpu")
@@ -394,7 +394,7 @@ class TestWelch:
     @array_api_compatible
     def test_detrend_external_nd_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
-        x = x.reshape((2,1,10))
+        x = xp.reshape(x, (2,1,10))
         x = xp.moveaxis(x, 2, 0)
         f, p = welch(x, nperseg=10, axis=0,
                      detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
@@ -404,7 +404,7 @@ class TestWelch:
     @array_api_compatible
     def test_nd_axis_m1(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
-        x = x.reshape((2,1,10))
+        x = xp.reshape(x, (2,1,10))
         f, p = welch(x, nperseg=10)
         assert_array_equal(p.shape, (2, 1, 6))
         assert_allclose(array_api_compat.to_device(p[0,0,:], "cpu"),
@@ -418,7 +418,7 @@ class TestWelch:
     @array_api_compatible
     def test_nd_axis_0(self, xp):
         x = xp.arange(20, dtype=xp.float64) + 0.04
-        x = x.reshape((10,2,1))
+        x = xp.reshape(x, (10,2,1))
         f, p = welch(x, nperseg=10, axis=0)
         assert_array_equal(p.shape, (6,2,1))
         assert_allclose(array_api_compat.to_device(p[:,0,0], "cpu"),
@@ -452,7 +452,7 @@ class TestWelch:
 
     @array_api_compatible
     def test_empty_input(self, xp):
-        val = xp.asarray([]) if SCIPY_ARRAY_API else []
+        val = xp.asarray([])
         f, p = welch(val)
         assert_array_equal(f.shape, (0,))
         assert_array_equal(p.shape, (0,))
@@ -493,7 +493,7 @@ class TestWelch:
     def test_window_long_or_nd(self, xp):
         assert_raises(ValueError, welch, xp.zeros(4), 1, xp.asarray([1,1,1,1,1]))
         assert_raises(ValueError, welch, xp.zeros(4), 1,
-                      xp.arange(6).reshape((2,3)))
+                      xp.reshape(xp.arange(6), (2,3)))
 
     @array_api_compatible
     def test_nondefault_noverlap(self, xp):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -20,7 +20,7 @@ from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
 from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
 from scipy.conftest import array_api_compatible, skip_if_array_api_backend
 from scipy._lib.array_api_compat import array_api_compat
-from scipy._lib._array_api import xp_assert_close, xp_assert_equal
+from scipy._lib._array_api import xp_assert_close, xp_assert_equal, copy
 
 
 class TestPeriodogram:
@@ -792,65 +792,113 @@ class TestCSD:
                         0.11111111])
         xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_real_onesided_odd(self):
-        x = np.zeros(16)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_odd(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
-                      0.17072113])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, np.arange(5.0)/9.0)
+        q = xp.asarray([0.12477455, 0.23430933, 0.17072113, 0.17072113,
+                        0.17072113])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_real_twosided(self):
-        x = np.zeros(16)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_twosided(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, fftfreq(8, 1.0))
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111, 0.11111111,
+                        0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_real_spectrum(self):
-        x = np.zeros(16)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_spectrum(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, scaling='spectrum')
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667,
-                      0.02083333])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.015625, 0.02864583, 0.04166667, 0.04166667,
+                        0.02083333])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_onesided_even(self):
-        x = np.zeros(16, dtype=int)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # type casting error with numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_integer_onesided_even(self, xp):
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+                        0.11111111])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_onesided_odd(self):
-        x = np.zeros(16, dtype=int)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # type casting error with numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_integer_onesided_odd(self, xp):
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.12477455, 0.23430933, 0.17072113, 0.17072113,
-                      0.17072113])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, xp.arange(5.0)/9.0)
+        q = xp.asarray([0.12477455, 0.23430933, 0.17072113, 0.17072113,
+                        0.17072113])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_integer_twosided(self):
-        x = np.zeros(16, dtype=int)
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # type casting error with numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_integer_twosided(self, xp):
+        x = xp.zeros(16, dtype=xp.int64)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        xp_assert_close(f, fftfreq(8, 1.0))
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111, 0.11111111,
+                        0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
     # skip cupy because array_api_compat doesn't support
     # fft at this time
@@ -888,107 +936,185 @@ class TestCSD:
         f, p = csd(x, x, nperseg=10, detrend='linear')
         xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    def test_no_detrending(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_no_detrending(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f1, p1 = csd(x, x, nperseg=10, detrend=False)
         f2, p2 = csd(x, x, nperseg=10, detrend=lambda x: x)
-        assert_allclose(f1, f2, atol=1e-15)
-        assert_allclose(p1, p2, atol=1e-15)
+        xp_assert_close(f1, f2, atol=1e-15)
+        xp_assert_close(p1, p2, atol=1e-15)
 
-    def test_detrend_external(self):
-        x = np.arange(10, dtype=np.float64) + 0.04
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_detrend_external(self, xp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
         f, p = csd(x, x, nperseg=10,
                    detrend=lambda seg: signal.detrend(seg, type='l'))
-        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+        xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    def test_detrend_external_nd_m1(self):
-        x = np.arange(40, dtype=np.float64) + 0.04
-        x = x.reshape((2,2,10))
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    @array_api_compatible
+    def test_detrend_external_nd_m1(self, xp):
+        x = xp.arange(40, dtype=xp.float64) + 0.04
+        x = xp.reshape(x, (2, 2, 10))
         f, p = csd(x, x, nperseg=10,
                    detrend=lambda seg: signal.detrend(seg, type='l'))
-        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+        xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    def test_detrend_external_nd_0(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
-        x = x.reshape((2,1,10))
-        x = np.moveaxis(x, 2, 0)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_detrend_external_nd_0(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = xp.reshape(x, (2, 1, 10))
+        x = xp.moveaxis(x, 2, 0)
         f, p = csd(x, x, nperseg=10, axis=0,
                    detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
-        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+        xp_assert_close(p, xp.zeros_like(p), atol=1e-15)
 
-    def test_nd_axis_m1(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
-        x = x.reshape((2,1,10))
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nd_axis_m1(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = xp.reshape(x, (2, 1, 10))
         f, p = csd(x, x, nperseg=10)
-        assert_array_equal(p.shape, (2, 1, 6))
-        assert_allclose(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
+        assert p.shape == (2, 1, 6)
+        xp_assert_close(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
         f0, p0 = csd(x[0,0,:], x[0,0,:], nperseg=10)
-        assert_allclose(p0[np.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13)
+        xp_assert_close(p0[xp.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13, check_dtype=False)
 
-    def test_nd_axis_0(self):
-        x = np.arange(20, dtype=np.float64) + 0.04
-        x = x.reshape((10,2,1))
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nd_axis_0(self, xp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = xp.reshape(x, (10, 2, 1))
         f, p = csd(x, x, nperseg=10, axis=0)
-        assert_array_equal(p.shape, (6,2,1))
-        assert_allclose(p[:,0,0], p[:,1,0], atol=1e-13, rtol=1e-13)
+        assert p.shape == (6, 2, 1)
+        xp_assert_close(p[:,0,0], p[:,1,0], atol=1e-13, rtol=1e-13)
         f0, p0 = csd(x[:,0,0], x[:,0,0], nperseg=10)
-        assert_allclose(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
+        xp_assert_close(p0, p[:,1,0], atol=1e-13, rtol=1e-13, check_dtype=False)
 
-    def test_window_external(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_window_external(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, 10, 'hann', 8)
         win = signal.get_window('hann', 8)
         fe, pe = csd(x, x, 10, win, nperseg=None)
+        # TODO: no nulp array API testing funcs yet
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
-        assert_array_equal(fe.shape, (5,))  # because win length used as nperseg
-        assert_array_equal(pe.shape, (5,))
+        assert fe.shape == (5,)  # because win length used as nperseg
+        assert pe.shape == (5,)
         assert_raises(ValueError, csd, x, x,
                       10, win, nperseg=256)  # because nperseg != win.shape[-1]
         win_err = signal.get_window('hann', 32)
         assert_raises(ValueError, csd, x, x,
               10, win_err, nperseg=None)  # because win longer than signal
 
-    def test_empty_input(self):
-        f, p = csd([],np.zeros(10))
-        assert_array_equal(f.shape, (0,))
-        assert_array_equal(p.shape, (0,))
+    # torch max() expects reduction dim to be specified...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # the empty list input causes issues for CuPy
+    # (array-like support)
+    @skip_if_array_api_backend('cupy')
+    @array_api_compatible
+    def test_empty_input(self, xp):
+        f, p = csd([], xp.zeros(10))
+        assert f.shape == (0,)
+        assert p.shape == (0,)
 
-        f, p = csd(np.zeros(10),[])
-        assert_array_equal(f.shape, (0,))
-        assert_array_equal(p.shape, (0,))
+        f, p = csd(xp.zeros(10), [])
+        assert f.shape == (0,)
+        assert p.shape == (0,)
 
         for shape in [(0,), (3,0), (0,5,2)]:
-            f, p = csd(np.empty(shape), np.empty(shape))
-            assert_array_equal(f.shape, shape)
-            assert_array_equal(p.shape, shape)
+            f, p = csd(xp.empty(shape), xp.empty(shape))
+            assert f.shape == shape
+            assert p.shape == shape
 
-        f, p = csd(np.ones(10), np.empty((5,0)))
-        assert_array_equal(f.shape, (5,0))
-        assert_array_equal(p.shape, (5,0))
+        f, p = csd(xp.ones(10), xp.empty((5,0)))
+        assert f.shape == (5,0)
+        assert p.shape == (5,0)
 
-        f, p = csd(np.empty((5,0)), np.ones(10))
-        assert_array_equal(f.shape, (5,0))
-        assert_array_equal(p.shape, (5,0))
+        f, p = csd(xp.empty((5,0)), xp.ones(10))
+        assert f.shape == (5,0)
+        assert p.shape == (5,0)
 
-    def test_empty_input_other_axis(self):
+    # torch max() expects reduction dim to be specified...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
-            f, p = csd(np.empty(shape), np.empty(shape), axis=1)
-            assert_array_equal(f.shape, shape)
-            assert_array_equal(p.shape, shape)
+            f, p = csd(xp.empty(shape), xp.empty(shape), axis=1)
+            assert f.shape == shape
+            assert p.shape == shape
 
-        f, p = csd(np.empty((10,10,3)), np.zeros((10,0,1)), axis=1)
-        assert_array_equal(f.shape, (10,0,3))
-        assert_array_equal(p.shape, (10,0,3))
+        f, p = csd(xp.empty((10,10,3)), xp.zeros((10,0,1)), axis=1)
+        assert f.shape == (10, 0, 3)
+        assert p.shape == (10, 0, 3)
 
-        f, p = csd(np.empty((10,0,1)), np.zeros((10,10,3)), axis=1)
-        assert_array_equal(f.shape, (10,0,3))
-        assert_array_equal(p.shape, (10,0,3))
+        f, p = csd(xp.empty((10,0,1)), xp.zeros((10,10,3)), axis=1)
+        assert f.shape == (10, 0, 3)
+        assert p.shape == (10, 0, 3)
 
-    def test_short_data(self):
-        x = np.zeros(8)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_short_data(self, xp):
+        x = xp.zeros(8)
         x[0] = 1
 
         #for string-like window, input signal length < nperseg value gives
@@ -999,113 +1125,168 @@ class TestCSD:
             f, p = csd(x, x, window='hann')  # default nperseg
             f1, p1 = csd(x, x, window='hann', nperseg=256)  # user-specified nperseg
         f2, p2 = csd(x, x, nperseg=8)  # valid nperseg, doesn't give warning
-        assert_allclose(f, f2)
-        assert_allclose(p, p2)
-        assert_allclose(f1, f2)
-        assert_allclose(p1, p2)
+        xp_assert_close(f, f2)
+        xp_assert_close(p, p2)
+        xp_assert_close(f1, f2)
+        xp_assert_close(p1, p2)
 
-    def test_window_long_or_nd(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
-                      np.array([1,1,1,1,1]))
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
-                      np.arange(6).reshape((2,3)))
+    @array_api_compatible
+    def test_window_long_or_nd(self, xp):
+        assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1,
+                      xp.asarray([1,1,1,1,1]))
+        assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1,
+                      xp.reshape(xp.arange(6), (2, 3)))
 
-    def test_nondefault_noverlap(self):
-        x = np.zeros(64)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nondefault_noverlap(self, xp):
+        x = xp.zeros(64)
         x[::8] = 1
         f, p = csd(x, x, nperseg=16, noverlap=4)
-        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5.,
-                      1./6.])
-        assert_allclose(p, q, atol=1e-12)
+        q = xp.asarray([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5.,
+                        1./6.])
+        xp_assert_close(p, q, atol=1e-12)
 
-    def test_bad_noverlap(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hann',
+    @array_api_compatible
+    def test_bad_noverlap(self, xp):
+        assert_raises(ValueError, csd, xp.zeros(4), xp.ones(4), 1, 'hann',
                       2, 7)
 
-    def test_nfft_too_short(self):
-        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3,
+    @array_api_compatible
+    def test_nfft_too_short(self, xp):
+        assert_raises(ValueError, csd, xp.ones(12), xp.zeros(12), nfft=3,
                       nperseg=4)
 
-    def test_real_onesided_even_32(self):
-        x = np.zeros(16, 'f')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_real_onesided_even_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
-        assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(f, xp.linspace(0, 0.5, 5))
+        q = xp.asarray([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+                        0.11111111], xp.float32)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_real_onesided_odd_32(self):
-        x = np.zeros(16, 'f')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_real_onesided_odd_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
-        assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.12477458, 0.23430935, 0.17072113, 0.17072116,
-                      0.17072113], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(f, xp.arange(5.0)/9.0)
+        q = xp.asarray([0.12477458, 0.23430935, 0.17072113, 0.17072116,
+                        0.17072113], xp.float32)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_real_twosided_32(self):
-        x = np.zeros(16, 'f')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    @array_api_compatible
+    def test_real_twosided_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.11111111,
-                      0.07638889], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(f, fftfreq(8, 1.0))
+        q = xp.asarray([0.08333333, 0.07638889, 0.11111111,
+                        0.11111111, 0.11111111, 0.11111111, 0.11111111,
+                        0.07638889], xp.float32)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_complex_32(self):
-        x = np.zeros(16, 'F')
+    # xp.mean() requires real input for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_complex_32(self, xp):
+        x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8, return_onesided=False)
-        assert_allclose(f, fftfreq(8, 1.0))
-        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
-                      0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
-        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype,
-                f'dtype mismatch, {p.dtype}, {q.dtype}')
+        xp_assert_close(f, fftfreq(8, 1.0))
+        q = xp.asarray([0.41666666, 0.38194442, 0.55555552, 0.55555552,
+                        0.55555558, 0.55555552, 0.55555552, 0.38194442], xp.float32)
+        xp_assert_close(p, q, atol=1e-7, rtol=1e-7)
 
-    def test_padded_freqs(self):
-        x = np.zeros(12)
-        y = np.ones(12)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_padded_freqs(self, xp):
+        x = xp.zeros(12)
+        y = xp.ones(12)
 
         nfft = 24
         f = fftfreq(nfft, 1.0)[:nfft//2+1]
         f[-1] *= -1
         fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
         feven, _ = csd(x, y, nperseg=6, nfft=nfft)
-        assert_allclose(f, fodd)
-        assert_allclose(f, feven)
+        xp_assert_close(fodd, f)
+        xp_assert_close(feven, f)
 
         nfft = 25
         f = fftfreq(nfft, 1.0)[:(nfft + 1)//2]
         fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
         feven, _ = csd(x, y, nperseg=6, nfft=nfft)
-        assert_allclose(f, fodd)
-        assert_allclose(f, feven)
+        xp_assert_close(fodd, f)
+        xp_assert_close(feven, f)
 
-    def test_copied_data(self):
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_copied_data(self, xp):
         x = np.random.randn(64)
-        y = x.copy()
+        x = xp.asarray(x)
+        y = copy(x)
 
         _, p_same = csd(x, x, nperseg=8, average='mean',
                         return_onesided=False)
         _, p_copied = csd(x, y, nperseg=8, average='mean',
                           return_onesided=False)
-        assert_allclose(p_same, p_copied)
+        xp_assert_close(p_same, p_copied, check_dtype=False)
 
         _, p_same = csd(x, x, nperseg=8, average='median',
                         return_onesided=False)
         _, p_copied = csd(x, y, nperseg=8, average='median',
                           return_onesided=False)
-        assert_allclose(p_same, p_copied)
+        xp_assert_close(p_same, p_copied, check_dtype=False)
 
 
 class TestCoherence:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -222,97 +222,139 @@ class TestPeriodogram:
         assert_raises(ValueError, periodogram, x,
                       10, win_err)  # win longer than signal
 
-    def test_padded_fft(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_padded_fft(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x)
         fp, pp = periodogram(x, nfft=32)
-        assert_allclose(f, fp[::2])
-        assert_allclose(p, pp[::2])
-        assert_array_equal(pp.shape, (17,))
+        xp_assert_close(f, fp[::2])
+        xp_assert_close(p, pp[::2])
+        assert pp.shape == (17,)
 
-    def test_empty_input(self):
+    @array_api_compatible
+    def test_empty_input(self, xp):
         f, p = periodogram([])
         assert_array_equal(f.shape, (0,))
         assert_array_equal(p.shape, (0,))
         for shape in [(0,), (3,0), (0,5,2)]:
-            f, p = periodogram(np.empty(shape))
+            f, p = periodogram(xp.empty(shape))
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    def test_empty_input_other_axis(self):
+    @array_api_compatible
+    def test_empty_input_other_axis(self, xp):
         for shape in [(3,0), (0,5,2)]:
-            f, p = periodogram(np.empty(shape), axis=1)
+            f, p = periodogram(xp.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-    def test_short_nfft(self):
-        x = np.zeros(18)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_short_nfft(self, xp):
+        x = xp.zeros(18)
         x[0] = 1
         f, p = periodogram(x, nfft=16)
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9)
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        q = xp.ones(9)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_nfft_is_xshape(self):
-        x = np.zeros(16)
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_nfft_is_xshape(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         f, p = periodogram(x, nfft=16)
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9)
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        q = xp.ones(9)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
-        assert_allclose(p, q)
+        xp_assert_close(p, q)
 
-    def test_real_onesided_even_32(self):
-        x = np.zeros(16, 'f')
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_even_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.linspace(0, 0.5, 9))
-        q = np.ones(9, 'f')
+        xp_assert_close(f, xp.linspace(0, 0.5, 9))
+        q = xp.ones(9, dtype=xp.float32)
         q[0] = 0
         q[-1] /= 2.0
         q /= 8
-        assert_allclose(p, q)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(p, q)
 
-    def test_real_onesided_odd_32(self):
-        x = np.zeros(15, 'f')
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_onesided_odd_32(self, xp):
+        x = xp.zeros(15, dtype=xp.float32)
         x[0] = 1
         f, p = periodogram(x)
-        assert_allclose(f, np.arange(8.0)/15.0)
-        q = np.ones(8, 'f')
+        xp_assert_close(f, xp.arange(8.0)/15.0)
+        q = xp.ones(8, dtype=xp.float32)
         q[0] = 0
         q *= 2.0/15.0
-        assert_allclose(p, q, atol=1e-7)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(p, q, atol=1e-7)
 
-    def test_real_twosided_32(self):
-        x = np.zeros(16, 'f')
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_real_twosided_32(self, xp):
+        x = xp.zeros(16, dtype=xp.float32)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 1/16.0, 'f')
+        xp_assert_close(f, fftfreq(16, 1.0), check_namespace=False, check_dtype=False)
+        q = xp.full((16,), 1/16.0, dtype=xp.float32)
         q[0] = 0
-        assert_allclose(p, q)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(p, q)
 
-    def test_complex_32(self):
-        x = np.zeros(16, 'F')
+    # xp.mean() requires real types so skip
+    # for numpy.array_api
+    @skip_if_array_api_backend("numpy.array_api")
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_complex_32(self, xp):
+        x = xp.zeros(16, dtype=xp.complex64)
         x[0] = 1.0 + 2.0j
         f, p = periodogram(x, return_onesided=False)
-        assert_allclose(f, fftfreq(16, 1.0))
-        q = np.full(16, 5.0/16.0, 'f')
+        xp_assert_close(f, fftfreq(16, 1.0), check_dtype=False, check_namespace=False)
+        q = xp.full((16,), 5.0/16.0, dtype=xp.float32)
         q[0] = 0
-        assert_allclose(p, q)
-        assert_(p.dtype == q.dtype)
+        xp_assert_close(p, q)
 
-    def test_shorter_window_error(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_shorter_window_error(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         win = signal.get_window('hann', 10)
         expected_msg = ('the size of the window must be the same size '

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -660,7 +660,11 @@ class TestWelch:
             # Check peak height at signal frequency for 'spectrum'
             xp_assert_close(p_spec[ii], A**2/2.0, rtol=5e-7, check_namespace=False)
             # Check integrated spectrum RMS for 'density'
-            assert_allclose(np.sqrt(np.trapezoid(p_dens, freq)),
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0rc1":
+                trapezoid = np.trapezoid
+            else:
+                trapezoid = np.trapz
+            assert_allclose(np.sqrt(trapezoid(p_dens, freq)),
                             A*np.sqrt(2)/2, rtol=1e-3)
 
     @skip_xp_backends("cupy", "array_api_strict",
@@ -1660,7 +1664,7 @@ class TestSTFT:
             xp_assert_close(x, xr, err_msg=msg)
 
     @skip_xp_backends("torch", "cupy", "array_api_strict",
-            reasons=["torch error with x.imag called but x is real"
+            reasons=["torch error with x.imag called but x is real",
                      "lack of fft support in array_api_compat",
                      "moveaxis not available in array_api_strict"])
     def test_roundtrip_not_nola(self, xp):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -660,7 +660,7 @@ class TestWelch:
             # Check peak height at signal frequency for 'spectrum'
             xp_assert_close(p_spec[ii], A**2/2.0, rtol=5e-7, check_namespace=False)
             # Check integrated spectrum RMS for 'density'
-            assert_allclose(np.sqrt(np.trapz(p_dens, freq)),
+            assert_allclose(np.sqrt(np.trapezoid(p_dens, freq)),
                             A*np.sqrt(2)/2, rtol=1e-3)
 
     @skip_xp_backends("cupy", "array_api_strict",
@@ -910,7 +910,11 @@ class TestCSD:
         assert p.shape == (2, 1, 6)
         xp_assert_close(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
         f0, p0 = csd(x[0,0,:], x[0,0,:], nperseg=10)
-        xp_assert_close(p0[xp.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13, check_dtype=False)
+        xp_assert_close(p0[xp.newaxis,:],
+                        p[1,:],
+                        atol=1e-13,
+                        rtol=1e-13,
+                        check_dtype=False)
 
     @skip_xp_backends("cupy", "array_api_strict", "torch",
                       reasons=["array_api_compat cupy doesn't support fft",
@@ -1656,7 +1660,7 @@ class TestSTFT:
             xp_assert_close(x, xr, err_msg=msg)
 
     @skip_xp_backends("torch", "cupy", "array_api_strict",
-            reasons=["torch errors out where x.imag is called but x is real (this may be standard compliant though: https://data-apis.org/array-api/latest/API_specification/generated/array_api.imag.html?highlight=imag#array_api.imag)",
+            reasons=["torch error with x.imag called but x is real"
                      "lack of fft support in array_api_compat",
                      "moveaxis not available in array_api_strict"])
     def test_roundtrip_not_nola(self, xp):
@@ -1775,7 +1779,8 @@ class TestSTFT:
             msg = f'{window}, {nperseg}, {noverlap}'
             # NOTE: here and below it may not be surprising that namespace checks
             # fail because there are no input array types to key off of
-            xp_assert_close(t, tr, err_msg=msg, check_namespace=False, check_dtype=False)
+            xp_assert_close(t, tr, err_msg=msg,
+                            check_namespace=False, check_dtype=False)
             xp_assert_close(x, xr, err_msg=msg)
 
         # Check that asking for onesided switches to twosided

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1433,8 +1433,15 @@ class TestCoherence:
 
 
 class TestSpectrogram:
-    def test_average_all_segments(self):
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_average_all_segments(self, xp):
         x = np.random.randn(1024)
+        x = xp.asarray(x)
 
         fs = 1.0
         window = ('tukey', 0.25)
@@ -1443,11 +1450,18 @@ class TestSpectrogram:
 
         f, _, P = spectrogram(x, fs, window, nperseg, noverlap)
         fw, Pw = welch(x, fs, window, nperseg, noverlap)
-        assert_allclose(f, fw)
-        assert_allclose(np.mean(P, axis=-1), Pw)
+        xp_assert_close(f, fw)
+        xp_assert_close(xp.mean(P, axis=-1), Pw)
 
-    def test_window_external(self):
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_window_external(self, xp):
         x = np.random.randn(1024)
+        x = xp.asarray(x)
 
         fs = 1.0
         window = ('tukey', 0.25)
@@ -1465,8 +1479,15 @@ class TestSpectrogram:
         assert_raises(ValueError, spectrogram, x,
                       fs, win_err, nperseg=None)  # win longer than signal
 
-    def test_short_data(self):
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_short_data(self, xp):
         x = np.random.randn(1024)
+        x = xp.asarray(x)
         fs = 1.0
 
         #for string-like window, input signal length < nperseg value gives
@@ -1480,10 +1501,10 @@ class TestSpectrogram:
                                     nperseg=1025)  # user-specified nperseg
         f2, _, p2 = spectrogram(x, fs, nperseg=256)  # to compare w/default
         f3, _, p3 = spectrogram(x, fs, nperseg=1024)  # compare w/user-spec'd
-        assert_allclose(f, f2)
-        assert_allclose(p, p2)
-        assert_allclose(f1, f3)
-        assert_allclose(p1, p3)
+        xp_assert_close(f, f2)
+        xp_assert_close(p, p2)
+        xp_assert_close(f1, f3)
+        xp_assert_close(p1, p3)
 
 class TestLombscargle:
     def test_frequency(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1702,7 +1702,15 @@ class TestLombscargle:
 
 
 class TestSTFT:
-    def test_input_validation(self):
+    # torch hits a messy np.pad codepath...
+    @skip_if_array_api_backend("torch")
+    # moveaxis not available in numpy.array_api
+    @skip_if_array_api_backend('numpy.array_api')
+    # skip cupy because array_api_compat doesn't support
+    # fft at this time
+    @skip_if_array_api_backend("cupy")
+    @array_api_compatible
+    def test_input_validation(self, xp):
 
         def chk_VE(match):
             """Assert for a ValueError matching regexp `match`.
@@ -1717,9 +1725,9 @@ class TestSTFT:
         with chk_VE('noverlap must be less than nperseg.'):
             check_COLA('hann', 10, 20)
         with chk_VE('window must be 1-D'):
-            check_COLA(np.ones((2, 2)), 10, 0)
+            check_COLA(xp.ones((2, 2)), 10, 0)
         with chk_VE('window must have length of nperseg'):
-            check_COLA(np.ones(20), 10, 0)
+            check_COLA(xp.ones(20), 10, 0)
 
         # Checks for check_NOLA():
         with chk_VE('nperseg must be a positive integer'):
@@ -1727,21 +1735,21 @@ class TestSTFT:
         with chk_VE('noverlap must be less than nperseg'):
             check_NOLA('hann', 10, 20)
         with chk_VE('window must be 1-D'):
-            check_NOLA(np.ones((2, 2)), 10, 0)
+            check_NOLA(xp.ones((2, 2)), 10, 0)
         with chk_VE('window must have length of nperseg'):
-            check_NOLA(np.ones(20), 10, 0)
+            check_NOLA(xp.ones(20), 10, 0)
         with chk_VE('noverlap must be a nonnegative integer'):
             check_NOLA('hann', 64, -32)
 
-        x = np.zeros(1024)
+        x = xp.zeros(1024)
         z = stft(x)[2]
 
         # Checks for stft():
         with chk_VE('window must be 1-D'):
-            stft(x, window=np.ones((2, 2)))
+            stft(x, window=xp.ones((2, 2)))
         with chk_VE('value specified for nperseg is different ' +
                     'from length of window'):
-            stft(x, window=np.ones(10), nperseg=256)
+            stft(x, window=xp.ones(10), nperseg=256)
         with chk_VE('nperseg must be a positive integer'):
             stft(x, nperseg=-256)
         with chk_VE('noverlap must be less than nperseg.'):
@@ -1753,9 +1761,9 @@ class TestSTFT:
         with chk_VE('Input stft must be at least 2d!'):
             istft(x)
         with chk_VE('window must be 1-D'):
-            istft(z, window=np.ones((2, 2)))
+            istft(z, window=xp.ones((2, 2)))
         with chk_VE('window must have length of 256'):
-            istft(z, window=np.ones(10), nperseg=256)
+            istft(z, window=xp.ones(10), nperseg=256)
         with chk_VE('nperseg must be a positive integer'):
             istft(z, nperseg=-256)
         with chk_VE('noverlap must be less than nperseg.'):


### PR DESCRIPTION
Towards gh-20678

TODO: 

- [ ] get the original `welch` benchmarks from https://github.com/data-apis/scipy-2023-presentation working again... (and benchmarks for any other parts of `signal` covered here)
- [ ] can we live with adoption of array API in `signal` on a *per-test-module* basis like this?
- [ ] what to do about `sliding_window_view` view shenanigans; this has been discussed many times like at https://github.com/data-apis/array-api/issues/641#issuecomment-1604884351 and the conference proceedings paper
- [ ] scope relevant part of `signal` tests to array API CI

<details>
<summary> signal array API test module checklist, to be moved to an issue probably, since this PR now focuses on a more limited scope than all of signal </summary>

- [ ] test_result_type.py
- [ ] test_dltisys.py
- [ ] test_waveforms.py
- [ ] test_fir_filter_design.py
- [ ] test_windows.py
- [ ] test_czt.py
- [ ] test_max_len_seq.py
- [ ] test_wavelets.py (deprecated?)
- [x] test_spectral.py
- [ ] test_ltisys.py
- [ ] test_upfirdn.py
- [ ] test_filter_design.py
- [ ] test_savitzky_golay.py
- [ ] test_array_tools.py
- [ ] test_signaltools.py
- [ ] test_bsplines.py
- [ ] test_peak_finding.py
- [ ] test_cont2discrete.py
- [ ] test_short_time_fft.py

</details>