### PR TITLE
BUG: interpolate: fix spalde with len(c) < len(t)

### DIFF
--- a/scipy/interpolate/fitpack/spalde.f
+++ b/scipy/interpolate/fitpack/spalde.f
@@ -1,4 +1,4 @@
-      recursive subroutine spalde(t,n,c,k1,x,d,ier)
+      recursive subroutine spalde(t,n,c,nc,k1,x,d,ier)
       implicit none
 c  subroutine spalde evaluates at a point x all the derivatives
 c              (j-1)
@@ -12,7 +12,8 @@ c
 c  input parameters:
 c    t    : array,length n, which contains the position of the knots.
 c    n    : integer, giving the total number of knots of s(x).
-c    c    : array,length n, which contains the b-spline coefficients.
+c    c    : array,length nc, which contains the b-spline coefficients.
+c    nc   : integer, giving the total number of coefficients (must be >= n-k1)
 c    k1   : integer, giving the order of s(x) (order=degree+1)
 c    x    : real, which contains the point where the derivatives must
 c           be evaluated.
@@ -49,10 +50,10 @@ c
 c  latest update : march 1987
 c
 c  ..scalar arguments..
-      integer n,k1,ier
+      integer n,nc,k1,ier
       real*8 x
 c  ..array arguments..
-      real*8 t(n),c(n),d(k1)
+      real*8 t(n),c(nc),d(k1)
 c  ..local scalars..
       integer l,nk1
 c  ..

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -170,12 +170,13 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(out) :: ier
      end subroutine sproot
 
-     subroutine spalde(t,n,c,k1,x,d,ier)
+     subroutine spalde(t,n,c,nc,k1,x,d,ier)
        ! d,ier = spalde(t,c,k1,x)
        threadsafe
        real*8 dimension(n) :: t
        integer intent(hide),depend(t) :: n=len(t)
-       real*8 dimension(n),depend(n),check(len(c)==n) :: c
+       real*8 dimension(nc), intent(in), depend(n,k1,t),check(len(c)>=n-k1) :: c
+       integer intent(hide), depend(c) :: nc=len(c)
        integer intent(in) :: k1
        real*8 intent(in) :: x
        real*8 dimension(k1),intent(out),depend(k1) :: d

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -482,3 +482,21 @@ def test_spalde_scalar_input():
     res = spalde(np.float64(1), tck)
     des = np.array([1., 3., 6., 6.])
     assert_almost_equal(res, des)
+
+
+def test_spalde_nc():
+    # regression test for https://github.com/scipy/scipy/issues/19002
+    # here len(t) = 29 and len(c) = 25 (== len(t) - k - 1) 
+    x = np.asarray([-10., -9., -8., -7., -6., -5., -4., -3., -2.5, -2., -1.5,
+                    -1., -0.5, 0., 0.5, 1., 1.5, 2., 2.5, 3., 4., 5., 6.],
+                    dtype="float")
+    t = [-10.0, -10.0, -10.0, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0,
+         -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0,
+         5.0, 6.0, 6.0, 6.0, 6.0]
+    c = np.asarray([1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
+    k = 3
+
+    res = spalde(x, (t, c, k))
+    res_splev = np.asarray([splev(x, (t, c, k), nu) for nu in range(4)])
+    assert_allclose(res, res_splev.T, atol=1e-15)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-19002

#### What does this implement/fix?
<!--Please explain your changes.-->

Make spalde work (again) with `len(c) < len(t), which was broken in https://github.com/scipy/scipy/pull/17303. 

Specifically, gh-17303 removed the handwritten `spalde` wrapper in favor of the f2py one. The former allowed `len(c) >= len(t) - k -1`, while the latter required `len(c) == len(t)`.

#### Additional information
<!--Any additional information you think is important.-->

The change is similar to https://github.com/scipy/scipy/pull/17038, https://github.com/scipy/scipy/pull/18195: we add an extra parameter for the length of the `c` array in Fortran and hide it in f2py.
