### PR TITLE
DOC/MAINT: typo: change Azure reference to Cirrus

### DIFF
--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -85,7 +85,7 @@ Skipping CI can be achieved by adding a special text in the commit message:
 Of course, you can combine these to skip multiple workflows.
 
 This skip information should be placed on a new line. In this example, we
-just updated a ``.rst`` file in the documentation and ask to skip Azure and
+just updated a ``.rst`` file in the documentation and ask to skip Cirrus and
 GitHub Actions' workflows::
 
     DOC: improve QMCEngine examples.


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
https://github.com/scipy/scipy/commit/582eedc2bfb20c12f7ec0fe0fd18e0775c9854a7 removed `[skip azp]` from the given example in `doc/source/dev/contributor/continuous_integration.rst`. However, the text still describes the example as skipping Azure.

This PR changes 'Azure' to 'Cirrus', to match the fact that `[skip cirrus]` is included in the example.