### PR TITLE
MAINT: copy, array-api compatible utility function

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -138,15 +138,13 @@ def atleast_nd(x, *, ndim, xp):
     return x
 
 
-def copy(x, *, xp):
+def copy(x):
     """
     Copies an array.
 
     Parameters
     ----------
     x : array
-    xp : module
-        Common namespace.
 
     Returns
     -------
@@ -159,4 +157,5 @@ def copy(x, *, xp):
     `subok` and `order` keywords are not used. Furthermore, if `x` is a scalar
     an array will still be returned.
     """
+    xp = array_namespace(x)
     return xp.astype(x, x.dtype, copy=True)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -146,7 +146,7 @@ def copy(x, *, xp=None):
     ----------
     x : array
 
-    x: array_namespace
+    xp : array_namespace
 
     Returns
     -------

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -136,3 +136,27 @@ def atleast_nd(x, *, ndim, xp):
         x = xp.expand_dims(x, axis=0)
         x = atleast_nd(x, ndim=ndim, xp=xp)
     return x
+
+
+def copy(x, *, xp):
+    """
+    Copies an array.
+
+    Parameters
+    ----------
+    x : array
+    xp : module
+        Common namespace.
+
+    Returns
+    -------
+    copy : array
+        Copied array
+
+    Notes
+    -----
+    This copy function does not offer all the semantics of `np.copy`, i.e. the
+    `subok` and `order` keywords are not used. Furthermore, if `x` is a scalar
+    an array will still be returned.
+    """
+    return xp.astype(x, x.dtype, copy=True)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -158,4 +158,4 @@ def copy(x):
     an array will still be returned.
     """
     xp = array_namespace(x)
-    return xp.astype(x, x.dtype, copy=True)
+    return xp.asarray(x, copy=True)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -158,7 +158,8 @@ def copy(x, *, xp=None):
     This copy function does not offer all the semantics of `np.copy`, i.e. the
     `subok` and `order` keywords are not used.
     """
+    # Note: xp.asarray fails if xp is numpy.
     if xp is None:
         xp = array_namespace(x)
 
-    return xp.asarray(x, copy=True)
+    return as_xparray(x, copy=True, xp=xp)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -138,13 +138,15 @@ def atleast_nd(x, *, ndim, xp):
     return x
 
 
-def copy(x):
+def copy(x, *, xp=None):
     """
     Copies an array.
 
     Parameters
     ----------
     x : array
+
+    x: array_namespace
 
     Returns
     -------
@@ -154,8 +156,9 @@ def copy(x):
     Notes
     -----
     This copy function does not offer all the semantics of `np.copy`, i.e. the
-    `subok` and `order` keywords are not used. Furthermore, if `x` is a scalar
-    an array will still be returned.
+    `subok` and `order` keywords are not used.
     """
-    xp = array_namespace(x)
+    if xp is None:
+        xp = array_namespace(x)
+
     return xp.asarray(x, copy=True)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -76,14 +76,16 @@ def test_raises():
 @array_api_compatible
 def test_copy(xp):
     x = xp.asarray([1, 2, 3])
-    y = copy(x)
-    # with numpy we'd want to use np.shared_memory, but that's not specified
-    # in the array-api
-    x[0] = 10
-    x[1] = 11
-    x[2] = 12
 
-    assert x[0] != y[0]
-    assert x[1] != y[1]
-    assert x[2] != y[2]
-    assert id(x) != id(y)
+    for _xp in [xp, None]:
+        y = copy(x, xp=_xp)
+        # with numpy we'd want to use np.shared_memory, but that's not specified
+        # in the array-api
+        x[0] = 10
+        x[1] = 11
+        x[2] = 12
+
+        assert x[0] != y[0]
+        assert x[1] != y[1]
+        assert x[2] != y[2]
+        assert id(x) != id(y)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -87,6 +87,3 @@ def test_copy(xp):
     assert x[1] != y[1]
     assert x[2] != y[2]
     assert id(x) != id(y)
-
-    y = copy(1.0)
-    assert_equal(y[0], 1.0)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -76,7 +76,7 @@ def test_raises():
 @array_api_compatible
 def test_copy(xp):
     x = xp.asarray([1, 2, 3])
-    y = copy(x, xp)
+    y = copy(x)
     # with numpy we'd want to use np.shared_memory, but that's not specified
     # in the array-api
     x[0] = 10
@@ -87,3 +87,6 @@ def test_copy(xp):
     assert x[1] != y[1]
     assert x[2] != y[2]
     assert id(x) != id(y)
+
+    y = copy(1.0)
+    assert_equal(y[0], 1.0)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -75,9 +75,8 @@ def test_raises():
 
 @array_api_compatible
 def test_copy(xp):
-    x = xp.asarray([1, 2, 3])
-
     for _xp in [xp, None]:
+        x = xp.asarray([1, 2, 3])
         y = copy(x, xp=_xp)
         # with numpy we'd want to use np.shared_memory, but that's not specified
         # in the array-api

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -4,7 +4,7 @@ import pytest
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, as_xparray,
+    _GLOBAL_CONFIG, array_namespace, as_xparray, copy
 )
 
 
@@ -71,3 +71,19 @@ def test_raises():
 
     with pytest.raises(TypeError, match=msg):
         array_namespace(1)
+
+
+@array_api_compatible
+def test_copy(xp):
+    x = xp.asarray([1, 2, 3])
+    y = copy(x, xp)
+    # with numpy we'd want to use np.shared_memory, but that's not specified
+    # in the array-api
+    x[0] = 10
+    x[1] = 11
+    x[2] = 12
+
+    assert x[0] != y[0]
+    assert x[1] != y[1]
+    assert x[2] != y[2]
+    assert id(x) != id(y)


### PR DESCRIPTION
It seems to me that having an array-api compatible `copy` function would be quite useful. I have attempted to create one in this PR. Sorry, probably should've sent an item to scipy-dev, but I didn't think it would be controversial.