### PR TITLE
BLD: rename `setup.py` to `_setup.py` to signal it should no longer be used

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -214,6 +214,7 @@ jobs:
 
       - name: Build
         run: |
+          cp _setup.py setup.py
           python setup.py bdist_wheel
 
           # Vendor openblas.dll and the DLL's it depends on into the wheel 

--- a/_setup.py
+++ b/_setup.py
@@ -16,6 +16,19 @@ give SciPy a try!
 
 """
 
+
+# IMPORTANT:
+#
+#     THIS FILE IS INTENTIONALLY RENAMED FROM setup.py TO _setup.py
+#     IT IS ONLY KEPT IN THE REPO BECAUSE conda-forge STILL NEEDS IT
+#     FOR BUILDING SCIPY ON WINDOWS. IT SHOULD NOT BE USED BY ANYONE
+#     ELSE. USE `pip install .` OR ANOTHER INSTALL COMMAND USING A
+#     BUILD FRONTEND LIKE pip OR pypa/build TO INSTALL SCIPY FROM SOURCE.
+#
+#     SEE http://scipy.github.io/devdocs/building/index.html FOR BUILD
+#     INSTRUCTIONS.
+
+
 DOCLINES = (__doc__ or '').split("\n")
 
 import os

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -24,7 +24,7 @@ target-version = "py39"
 "scipy/stats/qmc.py" = ["F403"]
 "scipy/optimize/_linprog.py" = ["F401"]
 "scipy/optimize/_linprog_ip.py" = ["F401"]
-"setup.py" = ["ALL"]
+"_setup.py" = ["ALL"]
 
 [mccabe]
 # Unlike Flake8, default to a complexity level of 10.


### PR DESCRIPTION
See the added code comment in this commit for rationale of keeping `_setup.py` around. We got another two bug reports that used `python setup.py install` in the last day (gh-19022 and gh-19026), so it's time to make that impossible.

For those who really really need it, they can still manually rename `_setup.py` to `setup.py` for a while longer, but this should make it much clearer that we no longer support this install method (beyond the one conda-forge on Windows case).