### PR TITLE
MAINT: NumPy 1.25.x deprecations

### DIFF
--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -1113,7 +1113,7 @@ class levy_stable_gen(rv_continuous):
                     density_x, np.real(density), k=fft_interpolation_degree
                 )
                 data_out[data_mask] = np.array(
-                    [f.integral(self.a, x_1) for x_1 in _x]
+                    [f.integral(self.a, float(x_1.squeeze())) for x_1 in _x]
                 ).reshape(data_out[data_mask].shape)
 
         return data_out.T[0]


### PR DESCRIPTION
Related to gh-18781

* the SciPy `main` branch has `50` deprecation warnings from the NumPy `1.25.x` series that don't get caught by our testsuite for reasons previously discussed (the `pytest.ini` directive to produce an error apparently hits a NumPy `try/except` block and ends up silent); the `maintenance/1.11.x` branch has `4661` such warnings; it certainly makes sense to clean these up on `main`, and possibly to backport where practical

* `TestOptimizeSimple::test_no_increase` had an objective function that was returning an ndim-1 array instead of a float or 0-dim (scalar) array, so this was corrected to respect the requirement for 0-dim arrays to be treated as scalars in the NumPy `1.25.x` series

* a similar objective function adjustment was applied to `test_result_x_shape_when_len_x_is_one` to deal with an additional `23` warnings

* similarly, `splint()` in `fitpack` was adjusted to explicitly support 1-D array input to avoid the same deprecation warning; in this case, the docstring technically says `float` so I could see raising on 1-D array, though that's perhaps a bit extreme for now (deals with remaining `9` warnings)