### PR TITLE
MAINT: prepare for SciPy 1.11.2

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -356,6 +356,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.21.6 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env Pillow mpmath pythran pooch meson && \
-        python dev.py build && \
+        python -m pip install numpy==1.21.6 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson && \
+        LD_LIBRARY_PATH=/usr/local/lib python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           pip install "numpy==1.21.6" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython wheel
+          pip install build meson-python ninja pythran pybind11 "cython<3.0.0" wheel
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
 

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -278,7 +278,7 @@ jobs:
 
         # Install OpenBLAS a la cibuildwheel.
         chmod +x tools/wheels/cibw_before_build_linux.sh
-        sudo tools/wheels/cibw_before_build_linux.sh .        
+        sudo tools/wheels/cibw_before_build_linux.sh --nightly .       
 
     - name: Caching Python dependencies
       uses: actions/cache@v3

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -230,9 +230,9 @@ jobs:
         run: |
           pip install "numpy==1.21.6" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 "cython<3.0.0" wheel
+          pip install build meson-python ninja pythran "pybind11<2.11.0" "cython<3.0.0" "wheel<0.41.0"
           # test deps
-          pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
+          pip install gmpy2 threadpoolctl mpmath pooch pythran "pybind11<2.11.0" pytest pytest-xdist==2.5.0 pytest-timeout
 
       - name: Build wheel and install
         run: |
@@ -255,7 +255,7 @@ jobs:
   prerelease_deps_coverage_64bit_blas:
     # TODO: re-enable ILP64 build.
     name: Prerelease deps and 64-bit BLAS
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    if: "github.repository == 'scipy/skip_on_release_branch'"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -1,0 +1,76 @@
+name: Test musllinux_x86_64
+
+on:
+  push:
+    branches:
+      - maintenance/**
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+
+permissions:
+   contents: read  # to fetch code (actions/checkout)
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
+jobs:
+  musllinux_x86_64:
+    runs-on: ubuntu-latest
+    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    container:
+      # Use container used for building musllinux wheels
+      # it has git installed, all the pythons, etc
+      image: quay.io/pypa/musllinux_1_1_x86_64
+
+
+    steps:
+    - name: Get source
+      run: |    
+        apk update --quiet
+
+        apk add build-base gfortran git
+
+        git config --global --add safe.directory $PWD 
+        
+        if [ $GITHUB_EVENT_NAME != pull_request ]; then
+            git clone --recursive --branch=$GITHUB_REF_NAME https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
+            git reset --hard $GITHUB_SHA
+        else        
+            git clone --recursive https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
+            git fetch origin $GITHUB_REF:my_ref_name
+            git checkout $GITHUB_BASE_REF
+            git -c user.email="you@example.com" merge --no-commit my_ref_name
+        fi
+
+        ln -s /usr/local/bin/python3.10 /usr/local/bin/python
+        git submodule update --init
+
+
+    - name: prep build environment
+      run: |    
+        cd $RUNNER_TEMP
+        python -m venv test_env
+        source test_env/bin/activate
+        cd $GITHUB_WORKSPACE
+
+        python -m pip install cython numpy
+        # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+        python -m pip install meson ninja pybind11 pythran pytest
+        python -m pip install click rich_click doit pydevtool pooch
+        
+        chmod +x tools/wheels/cibw_before_build_linux.sh
+        tools/wheels/cibw_before_build_linux.sh --nightly .     
+
+    - name: test
+      run: |
+        set -xe -o
+        cd $RUNNER_TEMP
+        source test_env/bin/activate
+        cd $GITHUB_WORKSPACE
+        python dev.py test

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -79,11 +79,10 @@ jobs:
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64]
         - [ubuntu-22.04, musllinux, x86_64]
-
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
-        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -124,11 +123,22 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.14.1
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+          CIBW_PRERELEASE_PYTHONS: True
+
+          # required so that cp312 can grab a nightly wheel
+          # can remove when cp312 is release and we don't need to search
+          # other wheel locations.
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1
+
+          CIBW_ENVIRONMENT_WINDOWS: >
+            PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
+            PIP_PRE=1
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh
@@ -142,6 +152,9 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=10.9
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
+            PIP_PRE=1
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -123,7 +123,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14.1
+        uses: pypa/cibuildwheel@v2.15.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -214,6 +214,7 @@ jobs:
 
       - name: Build
         run: |
+          cp _setup.py setup.py
           python setup.py bdist_wheel
 
           # Vendor openblas.dll and the DLL's it depends on into the wheel 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           # pyproject.toml currently states this numpy minimum version.
           python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-          python -m pip install cython numpy==1.22.3 pybind11 pythran pytest pooch
+          python -m pip install "cython<3.0.0" numpy==1.22.3 pybind11 pythran pytest pooch
 
       - name: Build
         run: |

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ manipulate numbers on a computer and display or publish the results, give
 SciPy a try!
 
 For the installation instructions, see `our install
-guide <https://docs.scipy.org/doc/scipy/getting_started.html#installation>`__.
+guide <https://scipy.org/install/>`__.
 
 
 Call for Contributions

--- a/_setup.py
+++ b/_setup.py
@@ -16,6 +16,19 @@ give SciPy a try!
 
 """
 
+
+# IMPORTANT:
+#
+#     THIS FILE IS INTENTIONALLY RENAMED FROM setup.py TO _setup.py
+#     IT IS ONLY KEPT IN THE REPO BECAUSE conda-forge STILL NEEDS IT
+#     FOR BUILDING SCIPY ON WINDOWS. IT SHOULD NOT BE USED BY ANYONE
+#     ELSE. USE `pip install .` OR ANOTHER INSTALL COMMAND USING A
+#     BUILD FRONTEND LIKE pip OR pypa/build TO INSTALL SCIPY FROM SOURCE.
+#
+#     SEE http://scipy.github.io/devdocs/building/index.html FOR BUILD
+#     INSTRUCTIONS.
+
+
 DOCLINES = (__doc__ or '').split("\n")
 
 import os

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -32,18 +32,24 @@ linux_aarch64_test_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 4
-    memory: 16G
+    cpu: 1
+    memory: 4G
 
   <<: *MODIFIED_CLONE
 
-  pip_cache:
-    folder: ~/.cache/pip
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-linux_aarch64
 
-  test_script: |
+  pip_cache:
+    folder: /root/.cache/pip
+
+  prepare_env_script: |
     apt-get update
     apt-get install -y --no-install-recommends software-properties-common gcc g++ gfortran pkg-config
-    apt-get install -y --no-install-recommends libopenblas-dev libatlas-base-dev liblapack-dev
+    apt-get install -y --no-install-recommends libopenblas-dev libatlas-base-dev liblapack-dev ccache
 
     # When this task was written the linux image used ubuntu:jammy, for which
     # python3.10 is the default. If required different versions can be
@@ -56,91 +62,86 @@ linux_aarch64_test_task:
     # python3.10 -m ensurepip --default-pip --user
 
     ln -s $(which python3.10) python
-    export PATH=$PWD:$PATH
+    export PATH=/usr/lib/ccache:$PWD:$PATH
+    echo "PATH=$PATH" >> $CIRRUS_ENV
+    echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
-    python -m pip install pytest pooch
+    python -m pip install pytest pooch pytest-xdist
     
-    python dev.py test
-
-
-musllinux_amd64_test_task:
-  container:
-    image: alpine
-    cpu: 8
-    memory: 32G
-
-  env:
-    PATH: $PWD:$PATH
-
-  setup_script: |
-    # The alpine image doesn't have a git client. The first step is to get 
-    # git, then clone in the *MODIFIED_CLONE step. To make sure the clone step
-    # works we have to delete CIRRUS_WORKING_DIR (alpine doesn't have pushd).
-    # Because this is the default working directory we should cd to that folder
-    # a subsequent script.
-
-    apk update
-    apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
-    ln -sf $(which python3.10) python
-    
-    _CWD=$PWD
-    echo "_CWD=$(_CWD)" >> $CIRRUS_ENV
-    cd $CIRRUS_WORKING_DIR/..
-    rm -rf $CIRRUS_WORKING_DIR
-
-  pip_cache:
-    folder: ~/.cache/pip
-
-  <<: *MODIFIED_CLONE
-
-  python_dependencies_script: |
-    cd $_CWD
-    python -m pip install cython
-    pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy<1.28.0"
-    python -m pip install meson ninja pybind11 pythran pytest
-    python -m pip install click rich_click doit pydevtool pooch
-
-    # pin setuptools to get around https://github.com/scipy/scipy/issues/17475
-    python -m pip install "setuptools<65.6.0"
+    # this line tells us where the task keeps its pip cache. 
+    # It may change over time!
+    echo $(python -m pip cache dir)
+    echo $(python -m pip cache list)
 
   build_script: |
-    python dev.py build
+    python dev.py build -j1
 
   test_script: |
-    set -xe -o
-    python dev.py test
+    python dev.py test -j1
+    ccache -s
 
 
 macos_arm64_test_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
 
   <<: *MODIFIED_CLONE
 
-  pip_cache:
-    folder: ~/.cache/pip
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-macosx_arm64
 
-  test_script: |
-    brew install python@3.10
+  pip_cache:
+    folder: /Users/admin/Library/Caches/pip
+
+  prepare_env_script: |
+    brew install python@3.10 ccache
 
     export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
+    export PYTHONPATH=/opt/homebrew/lib/python3.10/site-packages
+    
+    echo "PYTHONPATH=$PYTHONPATH" >> $CIRRUS_ENV
+    echo "_CWD=$PWD" >> $CIRRUS_ENV
+    echo "PATH=$PATH" >> $CIRRUS_ENV
+
     python --version
 
     # used for installing OpenBLAS/gfortran
     bash tools/wheels/cibw_before_build_macos.sh $PWD
+    echo "DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib" >> $CIRRUS_ENV
 
-    export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
-    export CMAKE_PREFIX_PATH=/opt/arm64-builds/
-
-    pushd ~/
-    python -m venv scipy-dev
-    source scipy-dev/bin/activate
-    popd
+    echo "PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig" >> $CIRRUS_ENV
+    echo "CMAKE_PREFIX_PATH=/opt/arm64-builds/" >> $CIRRUS_ENV
+    # export CCACHE_DIR=$PWD/.ccache
+    
+    cd ..
+    python -m venv test_env
+    source test_env/bin/activate
+    cd $_CWD
 
     python -m pip install meson ninja numpy cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
-    python -m pip install pytest pooch
-    export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
+    python -m pip install pytest pooch pytest-xdist
+    
+    # this line tells us where the task keeps its pip cache. 
+    # It may change over time!
+    echo $(python -m pip cache dir)
+    echo $(python -m pip cache list)
+
+  build_script: |
+    cd ..
+    source test_env/bin/activate
+    cd $_CWD
+    python dev.py build
+    # ccache -s
+
+  test_script: |
+    cd ..
+    source test_env/bin/activate
+    cd $_CWD
     python dev.py test

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -17,8 +17,8 @@ cirrus_wheels_linux_aarch64_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 4
-    memory: 8G
+    cpu: 2
+    memory: 4G
   matrix:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a
@@ -51,9 +51,8 @@ cirrus_wheels_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
     - env:
-       CIBW_BUILD: cp39-* cp310-*
-    - env:
-        CIBW_BUILD: cp311-* cp312-*
+       # building all four wheels in a single task takes ~45 mins
+       CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
     CIBW_PRERELEASE_PYTHONS: True

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.14.1
+    - python -m pip install cibuildwheel==2.15.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.12.0
+    - python -m pip install cibuildwheel==2.14.1
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:
@@ -24,9 +24,15 @@ cirrus_wheels_linux_aarch64_task:
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
     - env:
-        CIBW_BUILD: cp39-manylinux*
+        CIBW_BUILD: cp39-manylinux* cp310-manylinux*
     - env:
-        CIBW_BUILD: cp310-manylinux* cp311-manylinux*
+        CIBW_BUILD: cp311-manylinux* cp312-manylinux*
+  env:
+    CIBW_PRERELEASE_PYTHONS: True
+    CIBW_ENVIRONMENT: >
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_PRE=1
+
   build_script: |
     apt install -y python3-venv python-is-python3
     which python
@@ -45,12 +51,17 @@ cirrus_wheels_macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
     - env:
-        CIBW_BUILD: cp39-*
+       CIBW_BUILD: cp39-* cp310-*
     - env:
-        CIBW_BUILD: cp310-* cp311-*
+        CIBW_BUILD: cp311-* cp312-*
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
-    CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0 _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
+    CIBW_PRERELEASE_PYTHONS: True
+    CIBW_ENVIRONMENT: >
+      MACOSX_DEPLOYMENT_TARGET=12.0
+      _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_PRE=1
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/doc/source/release/1.11.2-notes.rst
+++ b/doc/source/release/1.11.2-notes.rst
@@ -5,19 +5,68 @@ SciPy 1.11.2 Release Notes
 .. contents::
 
 SciPy 1.11.2 is a bug-fix release with no new features
-compared to 1.11.1.
+compared to 1.11.1. Python 3.12 and musllinux wheels
+are provided with this release.
 
 
 
 Authors
 =======
 * Name (commits)
+* CJ Carey (3)
+* Dieter Werthmüller (1)
+* Ralf Gommers (2)
+* Matt Haberland (1)
+* jokasimr (1) +
+* Thilo Leitzbach (1) +
+* LemonBoy (1) +
+* Ellie Litwack (2) +
+* Sturla Molden (1)
+* Andrew Nelson (3)
+* Tyler Reddy (25)
+* Daniel Schmitz (6)
+* Dan Schult (2)
+* Matus Valo (1)
+* Stefan van der Walt (1)
+
+A total of 15 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.11.2
 ------------------------
 
+* `#4690 <https://github.com/scipy/scipy/issues/4690>`__: special.jn_zeros(281, 6) hangs
+* `#18398 <https://github.com/scipy/scipy/issues/18398>`__: BUG: \`loadmat\` fails to load matlab structures with anonymous...
+* `#18603 <https://github.com/scipy/scipy/issues/18603>`__: BUG: Floating point CSC with int64 indices doesn't work with...
+* `#18730 <https://github.com/scipy/scipy/issues/18730>`__: BUG: \`scipy.optimize.minimize\` fails when \`dtype=float32\`...
+* `#18788 <https://github.com/scipy/scipy/issues/18788>`__: DOC: Broken link to installation instructions in README.rst
+* `#18792 <https://github.com/scipy/scipy/issues/18792>`__: BUG: Build failure with Cython 3.0.0b3 if scipy is already installed
+* `#18793 <https://github.com/scipy/scipy/issues/18793>`__: BUG: optimize.least_squares with method='trf' yields wrong result...
+* `#18800 <https://github.com/scipy/scipy/issues/18800>`__: BUG: cKDtree.query no longer accepts DataFrame as input
+* `#19022 <https://github.com/scipy/scipy/issues/19022>`__: BUG: <Compilation of scipy 1.11 falls with python3.12>
+* `#19026 <https://github.com/scipy/scipy/issues/19026>`__: BUG: Compilation of scipy 1.10.1 and 1.11.1 fails with Python...
 
 
 Pull requests for 1.11.2
 ------------------------
+
+* `#18644 <https://github.com/scipy/scipy/pull/18644>`__: BUG: sparse.linalg: Cast index arrays to intc before calling...
+* `#18784 <https://github.com/scipy/scipy/pull/18784>`__: Allow johnsonsu parameters to be floats
+* `#18785 <https://github.com/scipy/scipy/pull/18785>`__: MAINT: stats: fix NumPy DeprecationWarnings
+* `#18787 <https://github.com/scipy/scipy/pull/18787>`__: REL, MAINT: prep for 1.11.2
+* `#18790 <https://github.com/scipy/scipy/pull/18790>`__: DOC: Fix broken link to installation guide in README
+* `#18804 <https://github.com/scipy/scipy/pull/18804>`__: BUG: Ensure cKDtree.query does not pass Pandas DataFrame to np.isfinite
+* `#18810 <https://github.com/scipy/scipy/pull/18810>`__: BLD: copy \`cython_optimize.pxd\` to build dir
+* `#18825 <https://github.com/scipy/scipy/pull/18825>`__: BUG: make \`L-BFGS-B\` optimizer work with single precision gradient
+* `#18831 <https://github.com/scipy/scipy/pull/18831>`__: BUG: io/matlab: Fix loading of mat files containing fn handles...
+* `#18859 <https://github.com/scipy/scipy/pull/18859>`__: BUG: make Bessel-roots function not hang and not skip roots
+* `#18894 <https://github.com/scipy/scipy/pull/18894>`__: DOC: linking interp1d docstring to tutorial
+* `#18896 <https://github.com/scipy/scipy/pull/18896>`__: BUG: lsq trf gives x=1e-10 if x0 is near a bound
+* `#18937 <https://github.com/scipy/scipy/pull/18937>`__: CI/BLD: create cp312 wheels
+* `#18961 <https://github.com/scipy/scipy/pull/18961>`__: DOC: Fix installation instructions using venv/pip
+* `#18985 <https://github.com/scipy/scipy/pull/18985>`__: CI: move the musllinux Cirrus job to GHA, optimize other jobs
+* `#18999 <https://github.com/scipy/scipy/pull/18999>`__: CI: reduce Cirrus CI usage during wheel builds
+* `#19025 <https://github.com/scipy/scipy/pull/19025>`__: BUG: pass unused xrtol in fmin_bfgs to _minimize_bfgs
+* `#19027 <https://github.com/scipy/scipy/pull/19027>`__: BLD: rename \`setup.py\` to \`_setup.py\` to signal it should...

--- a/doc/source/release/1.11.2-notes.rst
+++ b/doc/source/release/1.11.2-notes.rst
@@ -13,8 +13,10 @@ are provided with this release.
 Authors
 =======
 * Name (commits)
+* Evgeni Burovski (2)
 * CJ Carey (3)
 * Dieter Werthmüller (1)
+* elbarso (1) +
 * Ralf Gommers (2)
 * Matt Haberland (1)
 * jokasimr (1) +
@@ -22,14 +24,15 @@ Authors
 * LemonBoy (1) +
 * Ellie Litwack (2) +
 * Sturla Molden (1)
-* Andrew Nelson (3)
-* Tyler Reddy (25)
+* Andrew Nelson (5)
+* Tyler Reddy (39)
 * Daniel Schmitz (6)
 * Dan Schult (2)
+* Albert Steppi (1)
 * Matus Valo (1)
 * Stefan van der Walt (1)
 
-A total of 15 people contributed to this release.
+A total of 18 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -38,6 +41,7 @@ Issues closed for 1.11.2
 ------------------------
 
 * `#4690 <https://github.com/scipy/scipy/issues/4690>`__: special.jn_zeros(281, 6) hangs
+* `#12247 <https://github.com/scipy/scipy/issues/12247>`__: Complex matrix square root of positive semi-definite matrix
 * `#18398 <https://github.com/scipy/scipy/issues/18398>`__: BUG: \`loadmat\` fails to load matlab structures with anonymous...
 * `#18603 <https://github.com/scipy/scipy/issues/18603>`__: BUG: Floating point CSC with int64 indices doesn't work with...
 * `#18730 <https://github.com/scipy/scipy/issues/18730>`__: BUG: \`scipy.optimize.minimize\` fails when \`dtype=float32\`...
@@ -45,6 +49,7 @@ Issues closed for 1.11.2
 * `#18792 <https://github.com/scipy/scipy/issues/18792>`__: BUG: Build failure with Cython 3.0.0b3 if scipy is already installed
 * `#18793 <https://github.com/scipy/scipy/issues/18793>`__: BUG: optimize.least_squares with method='trf' yields wrong result...
 * `#18800 <https://github.com/scipy/scipy/issues/18800>`__: BUG: cKDtree.query no longer accepts DataFrame as input
+* `#19002 <https://github.com/scipy/scipy/issues/19002>`__: Spalde error with scipy 1.10: 0-th dimension must be fixed
 * `#19022 <https://github.com/scipy/scipy/issues/19022>`__: BUG: <Compilation of scipy 1.11 falls with python3.12>
 * `#19026 <https://github.com/scipy/scipy/issues/19026>`__: BUG: Compilation of scipy 1.10.1 and 1.11.1 fails with Python...
 
@@ -52,12 +57,14 @@ Issues closed for 1.11.2
 Pull requests for 1.11.2
 ------------------------
 
+* `#17918 <https://github.com/scipy/scipy/pull/17918>`__: BUG: Fix error in linalg/_matfuncs_sqrtm.py
 * `#18644 <https://github.com/scipy/scipy/pull/18644>`__: BUG: sparse.linalg: Cast index arrays to intc before calling...
 * `#18784 <https://github.com/scipy/scipy/pull/18784>`__: Allow johnsonsu parameters to be floats
 * `#18785 <https://github.com/scipy/scipy/pull/18785>`__: MAINT: stats: fix NumPy DeprecationWarnings
 * `#18787 <https://github.com/scipy/scipy/pull/18787>`__: REL, MAINT: prep for 1.11.2
 * `#18790 <https://github.com/scipy/scipy/pull/18790>`__: DOC: Fix broken link to installation guide in README
 * `#18804 <https://github.com/scipy/scipy/pull/18804>`__: BUG: Ensure cKDtree.query does not pass Pandas DataFrame to np.isfinite
+* `#18809 <https://github.com/scipy/scipy/pull/18809>`__: CI, MAINT: 32-bit Pillow pin
 * `#18810 <https://github.com/scipy/scipy/pull/18810>`__: BLD: copy \`cython_optimize.pxd\` to build dir
 * `#18825 <https://github.com/scipy/scipy/pull/18825>`__: BUG: make \`L-BFGS-B\` optimizer work with single precision gradient
 * `#18831 <https://github.com/scipy/scipy/pull/18831>`__: BUG: io/matlab: Fix loading of mat files containing fn handles...
@@ -68,5 +75,8 @@ Pull requests for 1.11.2
 * `#18961 <https://github.com/scipy/scipy/pull/18961>`__: DOC: Fix installation instructions using venv/pip
 * `#18985 <https://github.com/scipy/scipy/pull/18985>`__: CI: move the musllinux Cirrus job to GHA, optimize other jobs
 * `#18999 <https://github.com/scipy/scipy/pull/18999>`__: CI: reduce Cirrus CI usage during wheel builds
+* `#19004 <https://github.com/scipy/scipy/pull/19004>`__: BUG: interpolate: fix spalde with len(c) < len(t)
 * `#19025 <https://github.com/scipy/scipy/pull/19025>`__: BUG: pass unused xrtol in fmin_bfgs to _minimize_bfgs
 * `#19027 <https://github.com/scipy/scipy/pull/19027>`__: BLD: rename \`setup.py\` to \`_setup.py\` to signal it should...
+* `#19034 <https://github.com/scipy/scipy/pull/19034>`__: MAINT: NumPy 1.25.x deprecations
+* `#19054 <https://github.com/scipy/scipy/pull/19054>`__: MAINT: ensure cobyla objective returns scalar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ requires = [
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    "numpy; python_version>='3.12'",
     "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
+    "numpy==1.26.0b1; python_version>='3.12.0.rc1'",
 ]
 
 [project]

--- a/scipy/interpolate/fitpack/spalde.f
+++ b/scipy/interpolate/fitpack/spalde.f
@@ -1,4 +1,4 @@
-      recursive subroutine spalde(t,n,c,k1,x,d,ier)
+      recursive subroutine spalde(t,n,c,nc,k1,x,d,ier)
       implicit none
 c  subroutine spalde evaluates at a point x all the derivatives
 c              (j-1)
@@ -12,7 +12,8 @@ c
 c  input parameters:
 c    t    : array,length n, which contains the position of the knots.
 c    n    : integer, giving the total number of knots of s(x).
-c    c    : array,length n, which contains the b-spline coefficients.
+c    c    : array,length nc, which contains the b-spline coefficients.
+c    nc   : integer, giving the total number of coefficients (must be >= n-k1)
 c    k1   : integer, giving the order of s(x) (order=degree+1)
 c    x    : real, which contains the point where the derivatives must
 c           be evaluated.
@@ -49,10 +50,10 @@ c
 c  latest update : march 1987
 c
 c  ..scalar arguments..
-      integer n,k1,ier
+      integer n,nc,k1,ier
       real*8 x
 c  ..array arguments..
-      real*8 t(n),c(n),d(k1)
+      real*8 t(n),c(nc),d(k1)
 c  ..local scalars..
       integer l,nk1
 c  ..

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -170,12 +170,13 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(out) :: ier
      end subroutine sproot
 
-     subroutine spalde(t,n,c,k1,x,d,ier)
+     subroutine spalde(t,n,c,nc,k1,x,d,ier)
        ! d,ier = spalde(t,c,k1,x)
        threadsafe
        real*8 dimension(n) :: t
        integer intent(hide),depend(t) :: n=len(t)
-       real*8 dimension(n),depend(n),check(len(c)==n) :: c
+       real*8 dimension(nc), intent(in), depend(n,k1,t),check(len(c)>=n-k1) :: c
+       integer intent(hide), depend(c) :: nc=len(c)
        integer intent(in) :: k1
        real*8 intent(in) :: x
        real*8 dimension(k1),intent(out),depend(k1) :: d

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -482,3 +482,21 @@ def test_spalde_scalar_input():
     res = spalde(np.float64(1), tck)
     des = np.array([1., 3., 6., 6.])
     assert_almost_equal(res, des)
+
+
+def test_spalde_nc():
+    # regression test for https://github.com/scipy/scipy/issues/19002
+    # here len(t) = 29 and len(c) = 25 (== len(t) - k - 1) 
+    x = np.asarray([-10., -9., -8., -7., -6., -5., -4., -3., -2.5, -2., -1.5,
+                    -1., -0.5, 0., 0.5, 1., 1.5, 2., 2.5, 3., 4., 5., 6.],
+                    dtype="float")
+    t = [-10.0, -10.0, -10.0, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0,
+         -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0,
+         5.0, 6.0, 6.0, 6.0, 6.0]
+    c = np.asarray([1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
+    k = 3
+
+    res = spalde(x, (t, c, k))
+    res_splev = np.asarray([splev(x, (t, c, k), nu) for nu in range(4)])
+    assert_allclose(res, res_splev.T, atol=1e-15)

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -103,7 +103,7 @@ from ._streams import ZlibInputStream
 
 def _has_struct(elem):
     """Determine if elem is an array and if first array item is a struct."""
-    return (isinstance(elem, np.ndarray) and (elem.size > 0) and
+    return (isinstance(elem, np.ndarray) and (elem.size > 0) and (elem.ndim > 0) and
             isinstance(elem[0], mat_struct))
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1290,6 +1290,12 @@ def test_opaque():
     assert isinstance(data['parabola'].item()[3].item()[3], MatlabOpaque)
 
 
+def test_opaque_simplify():
+    """Test that we can read a MatlabOpaque object when simplify_cells=True."""
+    data = loadmat(pjoin(test_data_path, 'parabola.mat'), simplify_cells=True)
+    assert isinstance(data['parabola'], MatlabFunction)
+
+
 def test_deprecation():
     """Test that access to previous attributes still works."""
     # This should be accessible immediately from scipy.io import

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -274,7 +274,7 @@ def issymmetric(a, atol=None, rtol=None):
     The diagonal of the array is not scanned. Thus if there are infs, NaNs or
     similar problematic entries on the diagonal, they will be ignored. However,
     `numpy.inf` will be treated as a number, that is to say ``[[1, inf],
-    [inf, 2]]`` will return ``True``. On the other hand `numpy.NaN` is never
+    [inf, 2]]`` will return ``True``. On the other hand `numpy.nan` is never
     symmetric, say, ``[[1, nan], [nan, 2]]`` will return ``False``.
 
     When ``atol`` and/or ``rtol`` are set to , then the comparison is performed
@@ -400,7 +400,7 @@ def ishermitian(a, atol=None, rtol=None):
     For square empty arrays the result is returned True by convention.
 
     `numpy.inf` will be treated as a number, that is to say ``[[1, inf],
-    [inf, 2]]`` will return ``True``. On the other hand `numpy.NaN` is never
+    [inf, 2]]`` will return ``True``. On the other hand `numpy.nan` is never
     symmetric, say, ``[[1, nan], [nan, 2]]`` will return ``False``.
 
     When ``atol`` and/or ``rtol`` are set to , then the comparison is performed

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -172,7 +172,7 @@ def sqrtm(A, disp=True, blocksize=64):
     keep_it_real = np.isrealobj(A)
     if keep_it_real:
         T, Z = schur(A)
-        if not np.array_equal(T, np.triu(T)):
+        if not np.allclose(T, np.triu(T)):
             T, Z = rsf2csf(T, Z)
     else:
         T, Z = schur(A, output='complex')

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -556,7 +556,7 @@ class TestFractionalMatrixPower:
         A_sqrtm, info = sqrtm(A, disp=False)
         A_rem_power = _matfuncs_inv_ssq._remainder_matrix_power(A, 0.5)
         A_power = fractional_matrix_power(A, 0.5)
-        assert_array_equal(A_rem_power, A_power)
+        assert_allclose(A_rem_power, A_power, rtol=1e-10)
         assert_allclose(A_sqrtm, A_power)
         assert_allclose(A_sqrtm, A_funm_sqrt)
 

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -15,7 +15,8 @@ from threading import RLock
 
 import numpy as np
 from scipy.optimize import _cobyla as cobyla
-from ._optimize import OptimizeResult, _check_unknown_options
+from ._optimize import (OptimizeResult, _check_unknown_options,
+    _prepare_scalar_function)
 try:
     from itertools import izip
 except ImportError:
@@ -184,6 +185,7 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
         print(f"COBYLA failed to find a solution: {sol.message}")
     return sol['x']
 
+
 @synchronized
 def _minimize_cobyla(fun, x0, args=(), constraints=(),
                      rhobeg=1.0, tol=1e-4, maxiter=1000,
@@ -269,8 +271,12 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         cons_lengths.append(cons_length)
     m = sum(cons_lengths)
 
+    # create the ScalarFunction, cobyla doesn't require derivative function
+    _jac = lambda x: None
+    sf = _prepare_scalar_function(fun, x0, args=args, jac=_jac)
+
     def calcfc(x, con):
-        f = fun(np.copy(x), *args)
+        f = sf.fun(x)
         i = 0
         for size, c in izip(cons_lengths, constraints):
             con[i: i + size] = c['fun'](x, *c['args'])

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -272,7 +272,9 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
     m = sum(cons_lengths)
 
     # create the ScalarFunction, cobyla doesn't require derivative function
-    _jac = lambda x: None
+    def _jac(x, *args):
+        return None
+
     sf = _prepare_scalar_function(fun, x0, args=args, jac=_jac)
 
     def calcfc(x, con):

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -196,7 +196,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
             'callback': callback,
             'maxls': maxls}
 
-    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac.astype(np.float64),
+    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac,
                            bounds=bounds, **opts)
     d = {'grad': res['jac'],
          'task': res['message'],

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -183,6 +183,9 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         fun = func
         jac = fprime
 
+    # Fortran expects a double precision array for gradient
+    jac=jac.astype(np.float64)
+
     # build options
     callback = _wrap_callback(callback)
     opts = {'disp': disp,
@@ -196,8 +199,8 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
             'callback': callback,
             'maxls': maxls}
 
-    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac, bounds=bounds,
-                           **opts)
+    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac.astype(np.float64),
+                           bounds=bounds, **opts)
     d = {'grad': res['jac'],
          'task': res['message'],
          'funcalls': res['nfev'],
@@ -348,6 +351,8 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     n_iterations = 0
 
     while 1:
+        # convert gradient to double precision for Fortran
+        g = g.astype(np.float64)
         # x, f, g, wa, iwa, task, csave, lsave, isave, dsave = \
         _lbfgsb.setulb(m, x, low_bnd, upper_bnd, nbd, f, g, factr,
                        pgtol, wa, iwa, task, iprint, csave, lsave,

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -196,8 +196,8 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
             'callback': callback,
             'maxls': maxls}
 
-    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac,
-                           bounds=bounds, **opts)
+    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac, bounds=bounds,
+                           **opts)
     d = {'grad': res['jac'],
          'task': res['message'],
          'funcalls': res['nfev'],
@@ -348,7 +348,9 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     n_iterations = 0
 
     while 1:
-        # convert gradient to double precision for Fortran
+        # g may become float32 if a user provides a function that calculates
+        # the Jacobian in float32 (see gh-18730). The underlying Fortran code
+        # expects float64, so upcast it
         g = g.astype(np.float64)
         # x, f, g, wa, iwa, task, csave, lsave, isave, dsave = \
         _lbfgsb.setulb(m, x, low_bnd, upper_bnd, nbd, f, g, factr,

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -183,9 +183,6 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         fun = func
         jac = fprime
 
-    # Fortran expects a double precision array for gradient
-    jac=jac.astype(np.float64)
-
     # build options
     callback = _wrap_callback(callback)
     opts = {'disp': disp,

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -12,7 +12,7 @@ from scipy.optimize._minimize import Bounds
 
 from .trf import trf
 from .dogbox import dogbox
-from .common import EPS, in_bounds, make_strictly_feasible
+from .common import EPS, in_bounds
 
 
 TERMINATION_MESSAGES = {
@@ -823,9 +823,6 @@ def least_squares(
 
     def fun_wrapped(x):
         return np.atleast_1d(fun(x, *args, **kwargs))
-
-    if method == 'trf':
-        x0 = make_strictly_feasible(x0, lb, ub)
 
     f0 = fun_wrapped(x0)
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1353,7 +1353,8 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
             'eps': epsilon,
             'disp': disp,
             'maxiter': maxiter,
-            'return_all': retall}
+            'return_all': retall,
+            'xrtol': xrtol}
 
     callback = _wrap_callback(callback)
     res = _minimize_bfgs(f, x0, args, fprime, callback=callback, **opts)

--- a/scipy/optimize/cython_optimize.pxd
+++ b/scipy/optimize/cython_optimize.pxd
@@ -7,5 +7,5 @@
 # support. Changing it causes an ABI forward-compatibility break
 # (gh-11793), so we currently leave it as is (no further cimport
 # statements should be used in this file).
-from .cython_optimize._zeros cimport (
+from scipy.optimize.cython_optimize._zeros cimport (
     brentq, brenth, ridder, bisect, zeros_full_output)

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -17,6 +17,7 @@ cy_opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
   depends : [_cython_tree,
+    cython_optimize_pxd,
     _dummy_init_optimize,
     _dummy_init_cyoptimize])
 

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -228,10 +228,16 @@ endif
 
 _dummy_init_optimize = fs.copyfile('__init__.py')
 
+# Copying this .pxd file is only needed because of a Cython bug, see
+# discussion on SciPy PR gh-18810.
+cython_optimize_pxd = [
+  fs.copyfile('cython_optimize.pxd'),
+]
+
 opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, cython_blas_pxd, _dummy_init_optimize])
+  depends : [_cython_tree, cython_blas_pxd, cython_optimize_pxd, _dummy_init_optimize])
 
 _bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
 

--- a/scipy/optimize/tests/test_lbfgsb_setulb.py
+++ b/scipy/optimize/tests/test_lbfgsb_setulb.py
@@ -120,5 +120,5 @@ def test_gh_issue18730():
     def fun(x):
         return np.sum(x**2), (2*x).astype(np.float32)
 
-    res = minimize(fun, x0=np.array([1.]), jac=True, method="l-bfgs-b")
-    np.testing.assert_allclose(res.x, 0., atol=1e-15)
+    res = minimize(fun, x0=np.array([1., 1.]), jac=True, method="l-bfgs-b")
+    np.testing.assert_allclose(res.fun, 0., atol=1e-15)

--- a/scipy/optimize/tests/test_lbfgsb_setulb.py
+++ b/scipy/optimize/tests/test_lbfgsb_setulb.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.optimize import _lbfgsb
+from scipy.optimize import _lbfgsb, minimize
 
 
 def objfun(x):
@@ -114,3 +114,11 @@ def test_setulb_floatround():
 
         assert (x <= upper_bnd).all() and (x >= low_bnd).all(), (
             "_lbfgsb.setulb() stepped to a point outside of the bounds")
+
+
+def test_gh_issue18730():
+    def fun(x):
+        return np.sum(x**2), (2*x).astype(np.float32)
+
+    res = minimize(fun, x0=np.array([1.]), jac=True, method="l-bfgs-b")
+    np.testing.assert_allclose(res.x, 0., atol=1e-15)

--- a/scipy/optimize/tests/test_lbfgsb_setulb.py
+++ b/scipy/optimize/tests/test_lbfgsb_setulb.py
@@ -117,8 +117,12 @@ def test_setulb_floatround():
 
 
 def test_gh_issue18730():
-    def fun(x):
-        return np.sum(x**2), (2*x).astype(np.float32)
+    # issue 18730 reported that l-bfgs-b did not work with objectives
+    # returning single precision gradient arrays
+    def fun_single_precision(x):
+        x = x.astype(np.float32)
+        return np.sum(x**2), (2*x)
 
-    res = minimize(fun, x0=np.array([1., 1.]), jac=True, method="l-bfgs-b")
+    res = minimize(fun_single_precision, x0=np.array([1., 1.]), jac=True,
+                   method="l-bfgs-b")
     np.testing.assert_allclose(res.fun, 0., atol=1e-15)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -809,3 +809,16 @@ def test_fp32_gh12991():
     # used a step size for FP64 when the working space was FP32.
     assert res.nfev > 2
     assert_allclose(res.x, np.array([0.4082241, 0.15530563]), atol=5e-5)
+
+
+def test_gh_18793():
+    answer = 1e-12
+    initial_guess = 1.1e-12
+
+    def chi2(x):
+        return (x-answer)**2
+
+    res = least_squares(chi2, x0=initial_guess, bounds=(0, np.inf))
+    # if we choose an initial condition that is close to the solution
+    # we shouldn't return an answer that is further away from the solution
+    assert_allclose(res.x, answer, atol=initial_guess-answer)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
-            indices = A.indices.astype(np.intc, casting='safe', copy=False)
-            indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+            indices = A.indices.astype(np.intc, copy=False)
+            indptr = A.indptr.astype(np.intc, copy=False)
             options = dict(ColPerm=permc_spec)
             x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
@@ -404,8 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, casting='safe', copy=False)
-    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -499,8 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, casting='safe', copy=False)
-    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
+            indices = A.indices.astype(np.intc, copy=False)
+            indptr = A.indptr.astype(np.intc, copy=False)
             options = dict(ColPerm=permc_spec)
-            x, info = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr,
+            x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
             if info != 0:
                 warn("Matrix is exactly singular", MatrixRankWarning)
@@ -402,6 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -411,7 +415,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 
-    return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
+    return _superlu.gstrf(N, A.nnz, A.data, indices, indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=False, options=_options)
 
@@ -495,6 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    indices = A.indices.astype(np.intc, copy=False)
+    indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
@@ -506,7 +512,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (_options["ColPerm"] == "NATURAL"):
         _options["SymmetricMode"] = True
 
-    return _superlu.gstrf(N, A.nnz, A.data, A.indices, A.indptr,
+    return _superlu.gstrf(N, A.nnz, A.data, indices, indptr,
                           csc_construct_func=csc_construct_func,
                           ilu=True, options=_options)
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -269,8 +269,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             else:
                 flag = 0  # CSR format
 
-            indices = A.indices.astype(np.intc, copy=False)
-            indptr = A.indptr.astype(np.intc, copy=False)
+            indices = A.indices.astype(np.intc, casting='safe', copy=False)
+            indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
             options = dict(ColPerm=permc_spec)
             x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
@@ -404,8 +404,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, copy=False)
-    indptr = A.indptr.astype(np.intc, copy=False)
+    indices = A.indices.astype(np.intc, casting='safe', copy=False)
+    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
     if options is not None:
@@ -499,8 +499,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices = A.indices.astype(np.intc, copy=False)
-    indptr = A.indptr.astype(np.intc, copy=False)
+    indices = A.indices.astype(np.intc, casting='safe', copy=False)
+    indptr = A.indptr.astype(np.intc, casting='safe', copy=False)
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,
                     DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -404,6 +404,12 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
+    # check for safe downcasting
+    ii = np.iinfo(np.int32)
+    # check indices because they should be larger than indptr
+    if np.any(A.indices > ii.max || A.indices < ii.min):
+        raise ValueError("index values too large for SuperLU")
+
     indices = A.indices.astype(np.intc, copy=False)
     indptr = A.indptr.astype(np.intc, copy=False)
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
@@ -498,6 +504,12 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     M, N = A.shape
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
+
+    # check for safe downcasting
+    ii = np.iinfo(np.int32)
+    # check indices because they should be larger than indptr
+    if np.any(A.indices > ii.max || A.indices < ii.min):
+        raise ValueError("index values too large for SuperLU")
 
     indices = A.indices.astype(np.intc, copy=False)
     indptr = A.indptr.astype(np.intc, copy=False)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -125,13 +125,13 @@ def _get_umf_family(A):
 
 def _safe_downcast_indices(A):
     # check for safe downcasting
-    int32max = np.iinfo(np.int32).max
+    max_value = np.iinfo(np.intc).max
 
-    if indptr[-1] > int32max:  # indptr[-1] is max b/c indptr always sorted
+    if A.indptr[-1] > max_value:  # indptr[-1] is max b/c indptr always sorted
         raise ValueError("indptr values too large for SuperLU")
 
-    if max(*shape) > int32max:  # only check large enough arrays
-        if np.any(A.indices > int32max):
+    if max(*A.shape) > max_value:  # only check large enough arrays
+        if np.any(A.indices > max_value):
             raise ValueError("indices values too large for SuperLU")
 
     indices = A.indices.astype(np.intc, copy=False)

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -791,7 +791,7 @@ cdef class cKDTree:
         if p < 1:
             raise ValueError("Only p-norms with 1<=p<=infinity permitted")
 
-        if not np.isfinite(x).all():
+        if not np.isfinite(x_arr).all():
             raise ValueError("'x' must be finite, check for nan or inf values")
 
         cdef:
@@ -944,7 +944,7 @@ cdef class cKDTree:
             const np.float64_t *vxx = <np.float64_t*>x_arr.data
             const np.float64_t *vrr = <np.float64_t*>r_arr.data
         
-        if not np.isfinite(x).all():
+        if not np.isfinite(x_arr).all():
             raise ValueError("'x' must be finite, check for nan or inf values")
 
         if rlen:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11147,7 +11147,7 @@ class studentized_range_gen(rv_continuous):
             return integrate.nquad(llc, ranges=ranges, opts=opts)[0]
 
         ufunc = np.frompyfunc(_single_moment, 3, 1)
-        return np.float64(ufunc(K, k, df))
+        return np.asarray(ufunc(K, k, df), dtype=np.float64)[()]
 
     def _pdf(self, x, k, df):
 
@@ -11172,7 +11172,7 @@ class studentized_range_gen(rv_continuous):
             return integrate.nquad(llc, ranges=ranges, opts=opts)[0]
 
         ufunc = np.frompyfunc(_single_pdf, 3, 1)
-        return np.float64(ufunc(x, k, df))
+        return np.asarray(ufunc(x, k, df), dtype=np.float64)[()]
 
     def _cdf(self, x, k, df):
 
@@ -11201,7 +11201,7 @@ class studentized_range_gen(rv_continuous):
         ufunc = np.frompyfunc(_single_cdf, 3, 1)
 
         # clip p-values to ensure they are in [0, 1].
-        return np.clip(np.float64(ufunc(x, k, df)), 0, 1)
+        return np.clip(np.asarray(ufunc(x, k, df), dtype=np.float64)[()], 0, 1)
 
 
 studentized_range = studentized_range_gen(name='studentized_range', a=0,

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -1101,7 +1101,7 @@ class levy_stable_gen(rv_continuous):
                     density_x, np.real(density), k=fft_interpolation_degree
                 )
                 data_out[data_mask] = np.array(
-                    [f.integral(self.a, x_1) for x_1 in _x]
+                    [f.integral(self.a, float(x_1.squeeze())) for x_1 in _x]
                 ).reshape(data_out[data_mask].shape)
 
         return data_out.T[0]

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1066,7 +1066,7 @@ def _moment(a, moment, axis, *, mean=None):
 
         # Starting point for exponentiation by squares
         mean = (a.mean(axis, keepdims=True) if mean is None
-                else dtype(mean))
+                else np.asarray(mean, dtype=dtype)[()])
         a_zero_mean = a - mean
 
         eps = np.finfo(a_zero_mean.dtype).resolution * 10

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -24,7 +24,7 @@ target-version = "py39"
 "scipy/stats/qmc.py" = ["F403"]
 "scipy/optimize/_linprog.py" = ["F401"]
 "scipy/optimize/_linprog_ip.py" = ["F401"]
-"setup.py" = ["ALL"]
+"_setup.py" = ["ALL"]
 
 [mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -1,6 +1,18 @@
 set -xe
 
-PROJECT_DIR="$1"
+
+NIGHTLY_FLAG=""
+
+if [ "$#" -eq 1 ]; then
+    PROJECT_DIR="$1"
+elif [ "$#" -eq 2 ] && [ "$1" = "--nightly" ]; then
+    NIGHTLY_FLAG="--nightly"
+    PROJECT_DIR="$2"
+else
+    echo "Usage: $0 [--nightly] <project_dir>"
+    exit 1
+fi
+
 PLATFORM=$(PYTHONPATH=tools python -c "import openblas_support; print(openblas_support.get_plat())")
 
 printenv


### PR DESCRIPTION
SciPy `1.11.2` would tentatively include Python `3.12` and `musllinux` wheels, and a bunch of bug fixes.

Possible TODOs:

- [x] wait for the next NumPy release, which should have Python `3.12` wheels (I think this makes sense to do, and I believe upstream is working hard on this) -- if we'd prefer to delay `3.12` wheels to `1.11.3` let me know below
- [x] the CI/wheel infrastructure was updated/backported, so decent chance we may see some surprises with `[wheel build]` -- I may decide to do that here once rather than a bit later to reduce likelihood of a surprise during the release process proper (the net resource cost could be a fair bit higher if only discovered during rel process and then I need to patch/start over)
- [x] should we try to wrap up gh-18781? my impression from taking a stab at this in gh-19034 is that it is a can of worms because of potential `f2py` involvement...
- [x] we still have some open PRs with backport label--may be able to get some of those merged while we wait a little on NumPy `3.12` wheels and so on
- [ ] I feel like I may be missing a Cython stdout build bug of some sort that was affecting `networkx` or `scikit-image`? Maybe it is dealt with by something here, but that may be good to confirm, or maybe I'm just misremembering.

Backports Included so far:

- gh-18644
- gh-18785
- gh-18790
- gh-18804
- gh-18810
- gh-18825
- gh-18831
- gh-18859
- gh-18896
- gh-18937
- gh-18985
- gh-18999
- gh-19025
- gh-19027 
- gh-17918
- gh-18809
- gh-19004
- gh-19034
- gh-19054