### PR TITLE
MAINT: Change `add_newdoc` import and remove `NINF`

### DIFF
--- a/scipy/odr/_add_newdocs.py
+++ b/scipy/odr/_add_newdocs.py
@@ -1,4 +1,4 @@
-from numpy import add_newdoc
+from numpy.lib import add_newdoc
 
 add_newdoc('scipy.odr', 'odr',
     """

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -34,7 +34,7 @@ from scipy import stats
 
 from numpy import (arange, putmask, ones, shape, ndarray, zeros, floor,
                    logical_and, log, sqrt, place, argmax, vectorize, asarray,
-                   nan, inf, isinf, NINF, empty)
+                   nan, inf, isinf, empty)
 
 import numpy as np
 from ._constants import _XMAX, _LOGXMAX
@@ -2026,7 +2026,7 @@ class rv_continuous(rv_generic):
         cond1 = self._support_mask(x, *args) & (scale > 0)
         cond = cond0 & cond1
         output = empty(shape(cond), dtyp)
-        output.fill(NINF)
+        output.fill(-inf)
         putmask(output, (1-cond0)+np.isnan(x), self.badvalue)
         if np.any(cond):
             goodargs = argsreduce(cond, *((x,)+args+(scale,)))
@@ -2110,7 +2110,7 @@ class rv_continuous(rv_generic):
         cond2 = (x >= _b) & cond0
         cond = cond0 & cond1
         output = empty(shape(cond), dtyp)
-        output.fill(NINF)
+        output.fill(-inf)
         place(output, (1-cond0)*(cond1 == cond1)+np.isnan(x), self.badvalue)
         place(output, cond2, 0.0)
         if np.any(cond):  # call only if at least 1 entry
@@ -2196,7 +2196,7 @@ class rv_continuous(rv_generic):
         cond2 = cond0 & (x <= _a)
         cond = cond0 & cond1
         output = empty(shape(cond), dtyp)
-        output.fill(NINF)
+        output.fill(-inf)
         place(output, (1-cond0)+np.isnan(x), self.badvalue)
         place(output, cond2, 0.0)
         if np.any(cond):
@@ -3413,7 +3413,7 @@ class rv_discrete(rv_generic):
             cond1 = cond1 & self._nonzero(k, *args)
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')
-        output.fill(NINF)
+        output.fill(-inf)
         place(output, (1-cond0) + np.isnan(k), self.badvalue)
         if np.any(cond):
             goodargs = argsreduce(cond, *((k,)+args))
@@ -3493,7 +3493,7 @@ class rv_discrete(rv_generic):
         cond2 = (k >= _b)
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')
-        output.fill(NINF)
+        output.fill(-inf)
         place(output, (1-cond0) + np.isnan(k), self.badvalue)
         place(output, cond2*(cond0 == cond0), 0.0)
 
@@ -3574,7 +3574,7 @@ class rv_discrete(rv_generic):
         cond2 = (k < _a) & cond0
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')
-        output.fill(NINF)
+        output.fill(-inf)
         place(output, (1-cond0) + np.isnan(k), self.badvalue)
         place(output, cond2, 0.0)
         if np.any(cond):


### PR DESCRIPTION
Hi @rgommers,
Here's one follow-up work related to https://github.com/numpy/numpy/pull/24357: 
- `NINF` that I skipped as it was imported directly instead of `np.NINF`
- One `add_newdoc` that was also imported directly from the main namespace (in other places it's already imported from `numpy.lib`)
