### PR TITLE
MAINT: ensure cobyla objective returns scalar

### DIFF
--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -15,7 +15,8 @@ from threading import RLock
 
 import numpy as np
 from scipy.optimize import _cobyla as cobyla
-from ._optimize import OptimizeResult, _check_unknown_options
+from ._optimize import (OptimizeResult, _check_unknown_options,
+    _prepare_scalar_function)
 try:
     from itertools import izip
 except ImportError:
@@ -184,6 +185,7 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
         print(f"COBYLA failed to find a solution: {sol.message}")
     return sol['x']
 
+
 @synchronized
 def _minimize_cobyla(fun, x0, args=(), constraints=(),
                      rhobeg=1.0, tol=1e-4, maxiter=1000,
@@ -269,8 +271,12 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         cons_lengths.append(cons_length)
     m = sum(cons_lengths)
 
+    # create the ScalarFunction, cobyla doesn't require derivative function
+    _jac = lambda x: None
+    sf = _prepare_scalar_function(fun, x0, args=args, jac=_jac)
+
     def calcfc(x, con):
-        f = fun(np.copy(x), *args)
+        f = sf.fun(x)
         i = 0
         for size, c in izip(cons_lengths, constraints):
             con[i: i + size] = c['fun'](x, *c['args'])

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -272,7 +272,9 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
     m = sum(cons_lengths)
 
     # create the ScalarFunction, cobyla doesn't require derivative function
-    _jac = lambda x: None
+    def _jac(x, *args):
+        return None
+
     sf = _prepare_scalar_function(fun, x0, args=args, jac=_jac)
 
     def calcfc(x, con):


### PR DESCRIPTION
Related to #19034, #18781

@tylerjereddy, I think this is the preferred solution over the optimize bits for #19034. It's fixed at 'source', not at the test level. 