### PR TITLE
MAINT: use `copy` utility from #19014 in `cluster`

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -134,7 +134,7 @@ from collections import deque
 import numpy as np
 from . import _hierarchy, _optimal_leaf_ordering
 import scipy.spatial.distance as distance
-from scipy._lib._array_api import array_namespace, as_xparray
+from scipy._lib._array_api import array_namespace, as_xparray, copy
 from scipy._lib._disjoint_set import DisjointSet
 
 
@@ -1358,7 +1358,7 @@ def cut_tree(Z, n_clusters=None, height=None):
 
     for i, node in enumerate(nodes):
         idx = node.pre_order()
-        this_group = as_xparray(last_group, copy=True, xp=xp)
+        this_group = copy(last_group, xp=xp)
         # TODO ARRAY_API complex indexing not supported
         this_group[idx] = xp.min(last_group[idx])
         this_group[this_group > xp.max(last_group[idx])] -= 1
@@ -1822,16 +1822,16 @@ def from_mlab_linkage(Z):
 
     # If it's empty, return it.
     if len(Zs) == 0 or (len(Zs) == 1 and Zs[0] == 0):
-        return as_xparray(Z, copy=True, xp=xp)
+        return copy(Z, xp=xp)
 
     if len(Zs) != 2:
         raise ValueError("The linkage array must be rectangular.")
 
     # If it contains no rows, return it.
     if Zs[0] == 0:
-        return as_xparray(Z, copy=True, xp=xp)
+        return copy(Z, xp=xp)
 
-    Zpart = as_xparray(Z, copy=True, xp=xp)
+    Zpart = copy(Z, xp=xp)
     if xp.min(Zpart[:, 0:2]) != 1.0 and xp.max(Zpart[:, 0:2]) != 2 * Zs[0]:
         raise ValueError('The format of the indices is not 1..N')
 
@@ -1922,10 +1922,10 @@ def to_mlab_linkage(Z):
     Z = as_xparray(Z, order='C', dtype=xp.float64)
     Zs = Z.shape
     if len(Zs) == 0 or (len(Zs) == 1 and Zs[0] == 0):
-        return as_xparray(Z, copy=True, xp=xp)
+        return copy(Z, xp=xp)
     is_valid_linkage(Z, throw=True, name='Z')
 
-    ZP = as_xparray(Z[:, 0:3], copy=True, xp=xp)
+    ZP = copy(Z[:, 0:3], xp=xp)
     ZP[:, 0:2] += 1.0
 
     return ZP

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2974,7 +2974,7 @@ def set_link_color_palette(palette):
     if palette is None:
         # reset to its default
         palette = _link_line_colors_default
-    elif type(palette) not in (list, tuple):
+    elif not isinstance(palette, (list, tuple)):
         raise TypeError("palette must be a list or tuple")
     _ptypes = [isinstance(p, str) for p in palette]
 
@@ -3277,7 +3277,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     is_valid_linkage(Z, throw=True, name='Z')
     Zs = Z.shape
     n = Zs[0] + 1
-    if type(p) in (int, float):
+    if isinstance(p, (int, float)):
         p = int(p)
     else:
         raise TypeError('The second argument must be a number')
@@ -4018,7 +4018,7 @@ def maxRstat(Z, R, i):
     is_valid_linkage(Z, throw=True, name='Z')
     is_valid_im(R, throw=True, name='R')
 
-    if type(i) is not int:
+    if not isinstance(i, int):
         raise TypeError('The third argument must be an integer.')
 
     if i < 0 or i > 3:

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -18,7 +18,7 @@ from scipy.conftest import (
     skip_if_array_api_backend,
 )
 from scipy.sparse._sputils import matrix
-from scipy._lib._array_api import SCIPY_ARRAY_API, as_xparray
+from scipy._lib._array_api import SCIPY_ARRAY_API, copy
 
 
 TESTDATA_2D = np.array([
@@ -276,7 +276,7 @@ class TestKMean:
         data1 = data[:, 0]
 
         initc = data1[:3]
-        code = as_xparray(initc, copy=True, xp=xp)
+        code = copy(initc, xp=xp)
         kmeans2(data1, code, iter=1)[0]
         kmeans2(data1, code, iter=2)[0]
 

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -68,7 +68,7 @@ import warnings
 import numpy as np
 from collections import deque
 from scipy._lib._array_api import (
-    as_xparray, array_namespace, size, atleast_nd
+    as_xparray, array_namespace, size, atleast_nd, copy
 )
 from scipy._lib._util import check_random_state, rng_integers
 from scipy.spatial.distance import cdist
@@ -769,7 +769,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
 
     xp = array_namespace(data, k)
     data = as_xparray(data, xp=xp, check_finite=check_finite)
-    code_book = as_xparray(k, xp=xp, copy=True)
+    code_book = copy(k, xp=xp)
     if data.ndim == 1:
         d = 1
     elif data.ndim == 2:


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
Applies the `copy` utility from #19014 to the code added to `cluster` in #18668.

#### Additional information
cc: @andyfaff 