### PR TITLE
TST: bump tolerance of `TestTruncexpon.test_is_isf` a little

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4104,7 +4104,7 @@ class TestTruncexpon:
         b = [20, 100]
         x = [19.999999, 99.999999]
         ref = [2.0611546593828472e-15, 3.7200778266671455e-50]
-        assert_allclose(stats.truncexpon.sf(x, b), ref, rtol=1e-10)
+        assert_allclose(stats.truncexpon.sf(x, b), ref, rtol=1.5e-10)
         assert_allclose(stats.truncexpon.isf(ref, b), x, rtol=1e-12)
 
 


### PR DESCRIPTION
This is failing for me locally with latest NumPy main, which has overhauled SIMD support. The test is quite new (from end of May '23), so it's not surprising to see a small test tolerance issue here.

[skip ci]