### PR TITLE
DOC: remove reference to no longer imported numpy funcs

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -5,11 +5,6 @@ SciPy: A scientific computing package for Python
 Documentation is available in the docstrings and
 online at https://docs.scipy.org.
 
-Contents
---------
-SciPy imports all the functions from the NumPy namespace, and in
-addition provides:
-
 Subpackages
 -----------
 Using any of these subpackages requires an explicit import. For example,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to https://github.com/scipy/scipy/pull/19067
#### What does this implement/fix?
<!--Please explain your changes.-->
Now the numpy namespace is not available through scipy the text removed in this pr is obsolete.
#### Additional information
<!--Any additional information you think is important.-->
