### PR TITLE
TST: add regression test for sqrtm unexpectedly converting to complex

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -410,6 +410,12 @@ class TestSqrtM:
         assert_allclose(np.dot(R, R), M, atol=1e-14)
         assert_allclose(sqrtm(M), R, atol=1e-14)
 
+    def test_gh17918(self):
+        M = np.empty((19, 19))
+        M.fill(0.94)
+        np.fill_diagonal(M, 1)
+        assert np.isrealobj(sqrtm(M))
+
     def test_data_size_preservation_uint_in_float_out(self):
         M = np.zeros((10, 10), dtype=np.uint8)
         # input bit size is 8, but minimum float bit size is 16


### PR DESCRIPTION
#### Reference issue
Closes gh-#19049

#### What does this implement/fix?
Add regression test proposed by @tylerjereddy for the bug fix in #17918 that addressed real to numerical precision square roots of real matrices  being converted to complex matrices as seen in #12247.

