### PR TITLE
MAINT: should not be using np.float64() on arrays

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -521,8 +521,8 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h = np.diff(x, axis=axis)
         sl0 = tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
-        h0 = np.float64(h[sl0])
-        h1 = np.float64(h[sl1])
+        h0 = h[sl0].astype(float, copy=False)
+        h1 = h[sl1].astype(float, copy=False)
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1 != 0)


### PR DESCRIPTION
This is related to https://github.com/scipy/scipy/issues/18781.
When performing `integrate.simpson(np.array([1,2,3.]), x=np.array([1, 2, 3.]))` in a script I was experiencing `DeprecationWarning`s of the form reported #18781. The warning is also emitted with length 4 arrays.
These were not visible in the scipy test suite, probably because [this line](https://github.com/scipy/scipy/blob/main/scipy/integrate/tests/test_quadrature.py#L146C1-L146C1) meant that *all* `DeprecationWarning`s, including the numpy warnings, weren't visible.

The numpy warnings were caused by the lines:

```
h0 = np.float64(h[sl0])
h1 = np.float64(h[sl1])
```

If `h[sl0])` has length 1, then the `np.float64` call raises the warning (similar argument for `h1`). The warning doesn't occur if the length is greater than 1. The solution is to use `np.ndarray.astype`. `h[sl0]` will always be an array, so casting to float should always work. The test suite already examines a [case](https://github.com/scipy/scipy/blob/main/scipy/integrate/tests/test_quadrature.py#L214) where the integrate set has length 4.