### PR TITLE
ENH: Reflect changes from numpy namespace refactor part 3

### DIFF
--- a/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
@@ -107,9 +107,10 @@ class Benchmark:
             return True
 
         # the solution should still be in bounds, otherwise immediate fail.
-        if np.any(x > np.asfarray(self.bounds)[:, 1]):
+        bounds = np.asarray(self.bounds, dtype=np.float64)
+        if np.any(x > bounds[:, 1]):
             return False
-        if np.any(x < np.asfarray(self.bounds)[:, 0]):
+        if np.any(x < bounds[:, 0]):
             return False
 
         # you found a lower global minimum.  This shouldn't happen.

--- a/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
@@ -2,10 +2,7 @@
 import numpy as np
 from numpy import abs, asarray
 
-from ..common import safe_import
-
-with safe_import():
-    from scipy.special import factorial
+from ..common import safe_import  # noqa:F401
 
 
 class Benchmark:

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -48,14 +48,14 @@ multiplication as default for the ``*`` operator, and contains ``I``
 and ``T`` members that serve as shortcuts for inverse and transpose:
 
     >>> import numpy as np
-    >>> A = np.mat('[1 2;3 4]')
+    >>> A = np.asmatrix('[1 2;3 4]')
     >>> A
     matrix([[1, 2],
             [3, 4]])
     >>> A.I
     matrix([[-2. ,  1. ],
             [ 1.5, -0.5]])
-    >>> b = np.mat('[5 6]')
+    >>> b = np.asmatrix('[5 6]')
     >>> b
     matrix([[5, 6]])
     >>> b.T
@@ -723,7 +723,7 @@ functions of matrices.
 The following example illustrates the Schur decomposition:
 
     >>> from scipy import linalg
-    >>> A = np.mat('[1 3 2; 1 4 5; 2 3 6]')
+    >>> A = np.asmatrix('[1 3 2; 1 4 5; 2 3 6]')
     >>> T, Z = linalg.schur(A)
     >>> T1, Z1 = linalg.schur(A, 'complex')
     >>> T2, Z2 = linalg.rsf2csf(T, Z)
@@ -746,7 +746,7 @@ The following example illustrates the Schur decomposition:
     array([[ 0.06833781,  0.88091091,  0.79568503],    # may vary
            [ 0.11857169,  0.44491892,  0.99594171],
            [ 0.12624999,  0.60264117,  0.77257633]])
-    >>> T, Z, T1, Z1, T2, Z2 = map(np.mat,(T,Z,T1,Z1,T2,Z2))
+    >>> T, Z, T1, Z1, T2, Z2 = map(np.asmatrix,(T,Z,T1,Z1,T2,Z2))
     >>> abs(A - Z*T*Z.H)  # same
     matrix([[  5.55111512e-16,   1.77635684e-15,   2.22044605e-15],
             [  0.00000000e+00,   3.99680289e-15,   8.88178420e-16],

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -259,7 +259,7 @@ def _asarray_validated(a, check_finite=True,
             raise ValueError('object arrays are not supported')
     if as_inexact:
         if not np.issubdtype(a.dtype, np.inexact):
-            a = toarray(a, dtype=np.float_)
+            a = toarray(a, dtype=np.float64)
     return a
 
 

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -90,7 +90,7 @@ def cluster_dist(double[:, :] Z, int[:] T, double cutoff, int n):
     n : int
         The number of observations.
     """
-    cdef double[:] max_dists = np.ndarray(n, dtype=np.double)
+    cdef double[:] max_dists = np.ndarray(n, dtype=np.float64)
     get_max_dist_for_each_cluster(Z, max_dists, n)
     cluster_monocrit(Z, max_dists, T, cutoff, n)
 
@@ -114,7 +114,7 @@ def cluster_in(double[:, :] Z, double[:, :] R, int[:] T, double cutoff, int n):
     n : int
         The number of observations.
     """
-    cdef double[:] max_inconsists = np.ndarray(n, dtype=np.double)
+    cdef double[:] max_inconsists = np.ndarray(n, dtype=np.float64)
     get_max_Rfield_for_each_cluster(Z, R, max_inconsists, n, 3)
     cluster_monocrit(Z, max_inconsists, T, cutoff, n)
 
@@ -135,7 +135,7 @@ def cluster_maxclust_dist(double[:, :] Z, int[:] T, int n, int mc):
     mc : int
         The maximum number of clusters.
     """
-    cdef double[:] max_dists = np.ndarray(n, dtype=np.double)
+    cdef double[:] max_dists = np.ndarray(n, dtype=np.float64)
     get_max_dist_for_each_cluster(Z, max_dists, n)
     # should use an O(n) algorithm
     cluster_maxclust_monocrit(Z, max_dists, T, n, mc)
@@ -698,7 +698,7 @@ def linkage(double[:] dists, np.npy_int64 n, int method):
     cdef np.npy_int64 i_start
     cdef double current_min
     # inter-cluster dists
-    cdef double[:] D = np.ndarray(n * (n - 1) / 2, dtype=np.double)
+    cdef double[:] D = np.ndarray(n * (n - 1) / 2, dtype=np.float64)
     # map the indices to node ids
     cdef int[:] id_map = np.ndarray(n, dtype=np.intc)
     cdef linkage_distance_update new_dist

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1652,7 +1652,7 @@ def cophenet(Z, Y=None):
     Z = as_xparray(Z, order='C', dtype=xp.float64, xp=xp)
     is_valid_linkage(Z, throw=True, name='Z')
     n = Z.shape[0] + 1
-    zz = np.zeros((n * (n-1)) // 2, dtype=np.double)
+    zz = np.zeros((n * (n-1)) // 2, dtype=np.float64)
 
     Z = np.asarray(Z)
     _hierarchy.cophenetic_distances(Z, zz, int(n))
@@ -1738,7 +1738,7 @@ def inconsistent(Z, d=2):
                          'integer value.')
 
     n = Z.shape[0] + 1
-    R = np.zeros((n - 1, 4), dtype=np.double)
+    R = np.zeros((n - 1, 4), dtype=np.float64)
 
     Z = np.asarray(Z)
     _hierarchy.inconsistent(Z, R, int(n), int(d))
@@ -1836,7 +1836,7 @@ def from_mlab_linkage(Z):
         raise ValueError('The format of the indices is not 1..N')
 
     Zpart[:, 0:2] -= 1.0
-    CS = np.zeros((Zs[0],), dtype=np.double)
+    CS = np.zeros((Zs[0],), dtype=np.float64)
     Zpart = np.asarray(Zpart)
     _hierarchy.calculate_cluster_sizes(Zpart, CS, int(Zs[0]) + 1)
     res = np.hstack([Zpart, CS.reshape(Zs[0], 1)])

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -226,7 +226,7 @@ class TestKMean:
         x = 10000 * np.random.randn(n, d) - 20000 * m1
         y = 10000 * np.random.randn(n, d) + 20000 * m2
 
-        data = np.empty((x.shape[0] + y.shape[0], d), np.double)
+        data = np.empty((x.shape[0] + y.shape[0], d), np.float64)
         data[:x.shape[0]] = x
         data[x.shape[0]:] = y
 

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -157,14 +157,14 @@ class _TestFFTBase:
 
 class TestLongDoubleFFT(_TestFFTBase):
     def setup_method(self):
-        self.cdt = np.longcomplex
+        self.cdt = np.clongdouble
         self.rdt = np.longdouble
 
 
 class TestDoubleFFT(_TestFFTBase):
     def setup_method(self):
         self.cdt = np.cdouble
-        self.rdt = np.double
+        self.rdt = np.float64
 
 
 class TestSingleFFT(_TestFFTBase):
@@ -273,7 +273,7 @@ class _TestIFFTBase:
                     reason="Long double is aliased to double")
 class TestLongDoubleIFFT(_TestIFFTBase):
     def setup_method(self):
-        self.cdt = np.longcomplex
+        self.cdt = np.clongdouble
         self.rdt = np.longdouble
         self.rtol = 1e-10
         self.atol = 1e-10
@@ -281,8 +281,8 @@ class TestLongDoubleIFFT(_TestIFFTBase):
 
 class TestDoubleIFFT(_TestIFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
         self.rtol = 1e-10
         self.atol = 1e-10
 
@@ -348,18 +348,18 @@ class _TestRFFTBase:
         assert_equal(x, expected)
         assert_equal(xs.data, expected)
 
-@pytest.mark.skipif(np.longfloat is np.float64,
+@pytest.mark.skipif(np.longdouble is np.float64,
                     reason="Long double is aliased to double")
 class TestRFFTLongDouble(_TestRFFTBase):
     def setup_method(self):
-        self.cdt = np.longcomplex
-        self.rdt = np.longfloat
+        self.cdt = np.clongdouble
+        self.rdt = np.longdouble
 
 
 class TestRFFTDouble(_TestRFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
 
 
 class TestRFFTSingle(_TestRFFTBase):
@@ -435,19 +435,19 @@ class _TestIRFFTBase:
 # self.ndec is bogus; we should have a assert_array_approx_equal for number of
 # significant digits
 
-@pytest.mark.skipif(np.longfloat is np.float64,
+@pytest.mark.skipif(np.longdouble is np.float64,
                     reason="Long double is aliased to double")
 class TestIRFFTLongDouble(_TestIRFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
         self.ndec = 14
 
 
 class TestIRFFTDouble(_TestIRFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
         self.ndec = 14
 
 
@@ -872,8 +872,8 @@ class FakeArray2:
 class TestOverwrite:
     """Check input overwrite behavior of the FFT functions."""
 
-    real_dtypes = [np.float32, np.float64, np.longfloat]
-    dtypes = real_dtypes + [np.complex64, np.complex128, np.longcomplex]
+    real_dtypes = [np.float32, np.float64, np.longdouble]
+    dtypes = real_dtypes + [np.complex64, np.complex128, np.clongdouble]
     fftsizes = [8, 16, 32]
 
     def _check(self, x, routine, fftsize, axis, overwrite_x, should_overwrite):
@@ -909,7 +909,7 @@ class TestOverwrite:
                                             ((16, 2), 0),
                                             ((2, 16), 1)])
     def test_fft_ifft(self, dtype, fftsize, overwrite_x, shape, axes):
-        overwritable = (np.longcomplex, np.complex128, np.complex64)
+        overwritable = (np.clongdouble, np.complex128, np.complex64)
         self._check_1d(fft, dtype, shape, axes, overwritable,
                        fftsize, overwrite_x)
         self._check_1d(ifft, dtype, shape, axes, overwritable,
@@ -984,7 +984,7 @@ class TestOverwrite:
                                             ((8, 16, 2), None),
                                             ((8, 16, 2), (0, 1, 2))])
     def test_fftn_ifftn(self, dtype, overwrite_x, shape, axes):
-        overwritable = (np.longcomplex, np.complex128, np.complex64)
+        overwritable = (np.clongdouble, np.complex128, np.complex64)
         self._check_nd_one(fftn, dtype, shape, axes, overwritable,
                            overwrite_x)
         self._check_nd_one(ifftn, dtype, shape, axes, overwritable,

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -20,7 +20,7 @@ def is_longdouble_binary_compatible():
         one = np.frombuffer(
             b'\x00\x00\x00\x00\x00\x00\x00\x80\xff\x3f\x00\x00\x00\x00\x00\x00',
             dtype='<f16')
-        return one == np.longfloat(1.)
+        return one == np.longdouble(1.)
     except TypeError:
         return False
 
@@ -49,7 +49,7 @@ def get_reference_data():
         FFTWDATA_LONGDOUBLE = np.load(
             join(fftpack_test_dir, 'fftw_longdouble_ref.npz'))
     else:
-        FFTWDATA_LONGDOUBLE = {k: v.astype(np.longfloat)
+        FFTWDATA_LONGDOUBLE = {k: v.astype(np.longdouble)
                                for k,v in FFTWDATA_DOUBLE.items()}
 
     ref = {
@@ -85,11 +85,11 @@ def mdata_xy(request):
 def fftw_dct_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
     dt = np.result_type(np.float32, dt)
-    if dt == np.double:
+    if dt == np.float64:
         data = get_reference_data()['FFTWDATA_DOUBLE']
     elif dt == np.float32:
         data = get_reference_data()['FFTWDATA_SINGLE']
-    elif dt == np.longfloat:
+    elif dt == np.longdouble:
         data = get_reference_data()['FFTWDATA_LONGDOUBLE']
     else:
         raise ValueError()
@@ -100,11 +100,11 @@ def fftw_dct_ref(type, size, dt):
 def fftw_dst_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
     dt = np.result_type(np.float32, dt)
-    if dt == np.double:
+    if dt == np.float64:
         data = get_reference_data()['FFTWDATA_DOUBLE']
     elif dt == np.float32:
         data = get_reference_data()['FFTWDATA_SINGLE']
-    elif dt == np.longfloat:
+    elif dt == np.longdouble:
         data = get_reference_data()['FFTWDATA_LONGDOUBLE']
     else:
         raise ValueError()
@@ -187,7 +187,7 @@ def naive_dst4(x, norm=None):
     return y
 
 
-@pytest.mark.parametrize('dtype', [np.complex64, np.complex128, np.longcomplex])
+@pytest.mark.parametrize('dtype', [np.complex64, np.complex128, np.clongdouble])
 @pytest.mark.parametrize('transform', [dct, dst, idct, idst])
 def test_complex(transform, dtype):
     y = transform(1j*np.arange(5, dtype=dtype))
@@ -203,66 +203,66 @@ DecMapType = Dict[
 # map (tranform, dtype, type) -> decimal
 dec_map: DecMapType = {
     # DCT
-    (dct, np.double, 1): 13,
+    (dct, np.float64, 1): 13,
     (dct, np.float32, 1): 6,
 
-    (dct, np.double, 2): 14,
+    (dct, np.float64, 2): 14,
     (dct, np.float32, 2): 5,
 
-    (dct, np.double, 3): 14,
+    (dct, np.float64, 3): 14,
     (dct, np.float32, 3): 5,
 
-    (dct, np.double, 4): 13,
+    (dct, np.float64, 4): 13,
     (dct, np.float32, 4): 6,
 
     # IDCT
-    (idct, np.double, 1): 14,
+    (idct, np.float64, 1): 14,
     (idct, np.float32, 1): 6,
 
-    (idct, np.double, 2): 14,
+    (idct, np.float64, 2): 14,
     (idct, np.float32, 2): 5,
 
-    (idct, np.double, 3): 14,
+    (idct, np.float64, 3): 14,
     (idct, np.float32, 3): 5,
 
-    (idct, np.double, 4): 14,
+    (idct, np.float64, 4): 14,
     (idct, np.float32, 4): 6,
 
     # DST
-    (dst, np.double, 1): 13,
+    (dst, np.float64, 1): 13,
     (dst, np.float32, 1): 6,
 
-    (dst, np.double, 2): 14,
+    (dst, np.float64, 2): 14,
     (dst, np.float32, 2): 6,
 
-    (dst, np.double, 3): 14,
+    (dst, np.float64, 3): 14,
     (dst, np.float32, 3): 7,
 
-    (dst, np.double, 4): 13,
+    (dst, np.float64, 4): 13,
     (dst, np.float32, 4): 6,
 
     # IDST
-    (idst, np.double, 1): 14,
+    (idst, np.float64, 1): 14,
     (idst, np.float32, 1): 6,
 
-    (idst, np.double, 2): 14,
+    (idst, np.float64, 2): 14,
     (idst, np.float32, 2): 6,
 
-    (idst, np.double, 3): 14,
+    (idst, np.float64, 3): 14,
     (idst, np.float32, 3): 6,
 
-    (idst, np.double, 4): 14,
+    (idst, np.float64, 4): 14,
     (idst, np.float32, 4): 6,
 }
 
 for k,v in dec_map.copy().items():
-    if k[1] == np.double:
+    if k[1] == np.float64:
         dec_map[(k[0], np.longdouble, k[2])] = v
     elif k[1] == np.float32:
         dec_map[(k[0], int, k[2])] = v
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
 class TestDCT:
     def test_definition(self, rdt, type, fftwdata_size):
@@ -289,7 +289,7 @@ class TestDCT:
                                       decimal=dec)
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dct1_definition_ortho(rdt, mdata_x):
     # Test orthornomal mode.
     dec = dec_map[(dct, rdt, 1)]
@@ -301,7 +301,7 @@ def test_dct1_definition_ortho(rdt, mdata_x):
     assert_allclose(y, y2, rtol=0., atol=np.max(y2)*10**(-dec))
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dct2_definition_matlab(mdata_xy, rdt):
     # Test correspondence with matlab (orthornomal mode).
     dt = np.result_type(np.float32, rdt)
@@ -314,7 +314,7 @@ def test_dct2_definition_matlab(mdata_xy, rdt):
     assert_array_almost_equal(y, yr, decimal=dec)
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dct3_definition_ortho(mdata_x, rdt):
     # Test orthornomal mode.
     x = np.array(mdata_x, dtype=rdt)
@@ -326,7 +326,7 @@ def test_dct3_definition_ortho(mdata_x, rdt):
     assert_array_almost_equal(xi, x, decimal=dec)
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dct4_definition_ortho(mdata_x, rdt):
     # Test orthornomal mode.
     x = np.array(mdata_x, dtype=rdt)
@@ -338,7 +338,7 @@ def test_dct4_definition_ortho(mdata_x, rdt):
     assert_allclose(y, y2, rtol=0., atol=np.max(y2)*10**(-dec))
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
 def test_idct_definition(fftwdata_size, rdt, type):
     xr, yr, dt = fftw_dct_ref(type, fftwdata_size, rdt)
@@ -348,7 +348,7 @@ def test_idct_definition(fftwdata_size, rdt, type):
     assert_allclose(x, xr, rtol=0., atol=np.max(xr)*10**(-dec))
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
 def test_definition(fftwdata_size, rdt, type):
     xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt)
@@ -358,7 +358,7 @@ def test_definition(fftwdata_size, rdt, type):
     assert_allclose(y, yr, rtol=0., atol=np.max(yr)*10**(-dec))
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dst1_definition_ortho(rdt, mdata_x):
     # Test orthornomal mode.
     dec = dec_map[(dst, rdt, 1)]
@@ -370,7 +370,7 @@ def test_dst1_definition_ortho(rdt, mdata_x):
     assert_allclose(y, y2, rtol=0., atol=np.max(y2)*10**(-dec))
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 def test_dst4_definition_ortho(rdt, mdata_x):
     # Test orthornomal mode.
     dec = dec_map[(dst, rdt, 4)]
@@ -382,7 +382,7 @@ def test_dst4_definition_ortho(rdt, mdata_x):
     assert_array_almost_equal(y, y2, decimal=dec)
 
 
-@pytest.mark.parametrize('rdt', [np.longfloat, np.double, np.float32, int])
+@pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
 def test_idst_definition(fftwdata_size, rdt, type):
     xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt)
@@ -393,7 +393,7 @@ def test_idst_definition(fftwdata_size, rdt, type):
 
 
 @pytest.mark.parametrize('routine', [dct, dst, idct, idst])
-@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.longfloat])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.longdouble])
 @pytest.mark.parametrize('shape, axis', [
     ((16,), -1), ((16, 2), 0), ((2, 16), 1)
 ])

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -245,7 +245,7 @@ class TestFFT1D:
                     assert_array_almost_equal(x_norm,
                                               np.linalg.norm(tmp))
 
-    @pytest.mark.parametrize("dtype", [np.half, np.single, np.double,
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
                                        np.longdouble])
     def test_dtypes(self, dtype):
         # make sure that all input precisions are accepted
@@ -257,8 +257,8 @@ class TestFFT1D:
 
 @pytest.mark.parametrize(
         "dtype",
-        [np.float32, np.float64, np.longfloat,
-         np.complex64, np.complex128, np.longcomplex])
+        [np.float32, np.float64, np.longdouble,
+         np.complex64, np.complex128, np.clongdouble])
 @pytest.mark.parametrize("order", ["F", 'non-contiguous'])
 @pytest.mark.parametrize(
         "fft",

--- a/scipy/fftpack/tests/gen_fftw_ref.py
+++ b/scipy/fftpack/tests/gen_fftw_ref.py
@@ -10,7 +10,7 @@ def gen_data(dt):
 
     if dt == np.float128:
         pg = './fftw_longdouble'
-    elif dt == np.double:
+    elif dt == np.float64:
         pg = './fftw_double'
     elif dt == np.float32:
         pg = './fftw_single'

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -148,8 +148,8 @@ class _TestFFTBase:
 
 class TestDoubleFFT(_TestFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
 
 
 class TestSingleFFT(_TestFFTBase):
@@ -255,8 +255,8 @@ class _TestIFFTBase:
 
 class TestDoubleIFFT(_TestIFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
 
 
 class TestSingleIFFT(_TestIFFTBase):
@@ -311,8 +311,8 @@ class _TestRFFTBase:
 
 class TestRFFTDouble(_TestRFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
 
 
 class TestRFFTSingle(_TestRFFTBase):
@@ -381,8 +381,8 @@ class _TestIRFFTBase:
 
 class TestIRFFTDouble(_TestIRFFTBase):
     def setup_method(self):
-        self.cdt = np.cdouble
-        self.rdt = np.double
+        self.cdt = np.complex128
+        self.rdt = np.float64
         self.ndec = 14
 
 

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -26,7 +26,7 @@ FFTWDATA_SIZES = FFTWDATA_DOUBLE['sizes']
 def fftw_dct_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
     dt = np.result_type(np.float32, dt)
-    if dt == np.double:
+    if dt == np.float64:
         data = FFTWDATA_DOUBLE
     elif dt == np.float32:
         data = FFTWDATA_SINGLE
@@ -39,7 +39,7 @@ def fftw_dct_ref(type, size, dt):
 def fftw_dst_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
     dt = np.result_type(np.float32, dt)
-    if dt == np.double:
+    if dt == np.float64:
         data = FFTWDATA_DOUBLE
     elif dt == np.float32:
         data = FFTWDATA_SINGLE
@@ -267,7 +267,7 @@ class _TestDCTIVBase(_TestDCTBase):
 
 class TestDCTIDouble(_TestDCTIBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 10
         self.type = 1
 
@@ -288,7 +288,7 @@ class TestDCTIInt(_TestDCTIBase):
 
 class TestDCTIIDouble(_TestDCTIIBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 10
         self.type = 2
 
@@ -309,7 +309,7 @@ class TestDCTIIInt(_TestDCTIIBase):
 
 class TestDCTIIIDouble(_TestDCTIIIBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 3
 
@@ -330,7 +330,7 @@ class TestDCTIIIInt(_TestDCTIIIBase):
 
 class TestDCTIVDouble(_TestDCTIVBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 3
 
@@ -374,7 +374,7 @@ class _TestIDCTBase:
 
 class TestIDCTIDouble(_TestIDCTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 10
         self.type = 1
 
@@ -395,7 +395,7 @@ class TestIDCTIInt(_TestIDCTBase):
 
 class TestIDCTIIDouble(_TestIDCTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 10
         self.type = 2
 
@@ -416,7 +416,7 @@ class TestIDCTIIInt(_TestIDCTBase):
 
 class TestIDCTIIIDouble(_TestIDCTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 3
 
@@ -436,7 +436,7 @@ class TestIDCTIIIInt(_TestIDCTBase):
 
 class TestIDCTIVDouble(_TestIDCTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 4
 
@@ -497,7 +497,7 @@ class _TestDSTIVBase(_TestDSTBase):
 
 class TestDSTIDouble(_TestDSTIBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 1
 
@@ -518,7 +518,7 @@ class TestDSTIInt(_TestDSTIBase):
 
 class TestDSTIIDouble(_TestDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 2
 
@@ -539,7 +539,7 @@ class TestDSTIIInt(_TestDSTBase):
 
 class TestDSTIIIDouble(_TestDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 3
 
@@ -560,7 +560,7 @@ class TestDSTIIIInt(_TestDSTBase):
 
 class TestDSTIVDouble(_TestDSTIVBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 4
 
@@ -604,7 +604,7 @@ class _TestIDSTBase:
 
 class TestIDSTIDouble(_TestIDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 1
 
@@ -625,7 +625,7 @@ class TestIDSTIInt(_TestIDSTBase):
 
 class TestIDSTIIDouble(_TestIDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 2
 
@@ -646,7 +646,7 @@ class TestIDSTIIInt(_TestIDSTBase):
 
 class TestIDSTIIIDouble(_TestIDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 14
         self.type = 3
 
@@ -667,7 +667,7 @@ class TestIDSTIIIInt(_TestIDSTBase):
 
 class TestIDSTIVDouble(_TestIDSTBase):
     def setup_method(self):
-        self.rdt = np.double
+        self.rdt = np.float64
         self.dec = 12
         self.type = 4
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -723,7 +723,7 @@ def simpson(y, *, x=None, dx=1.0, axis=-1, even=_NoValue):
             slice2 = tupleset(slice_all, axis, -2)
             slice3 = tupleset(slice_all, axis, -3)
 
-            h = np.asfarray([dx, dx])
+            h = np.asarray([dx, dx], dtype=np.float64)
             if x is not None:
                 # grab the last two spacings from the appropriate axis
                 hm2 = tupleset(slice_all, axis, slice(-2, -1, 1))

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -134,7 +134,7 @@ def evaluate_spline(const double[::1] t,
     if nu < 0:
         raise NotImplementedError("Cannot do derivative order %s." % nu)
 
-    cdef double[::1] work = np.empty(2*k+2, dtype=np.float_)
+    cdef double[::1] work = np.empty(2*k+2, dtype=np.float64)
 
     # evaluate
     with nogil:
@@ -217,7 +217,7 @@ def evaluate_all_bspl(const double[::1] t, int k, double xval, int m, int nu=0):
     >>> plt.show()
 
     """
-    bbb = np.empty(2*k+2, dtype=np.float_)
+    bbb = np.empty(2*k+2, dtype=np.float64)
     cdef double[::1] work = bbb
     _deBoor_D(&t[0], xval, k, m, nu, &work[0])
     return bbb[:k+1]
@@ -265,7 +265,7 @@ def _colloc(const double[::1] x, const double[::1] t, int k, double[::1, :] ab,
     cdef double xval
 
     kl = ku = k
-    cdef double[::1] wrk = np.empty(2*k + 2, dtype=np.float_)
+    cdef double[::1] wrk = np.empty(2*k + 2, dtype=np.float64)
 
     # collocation matrix
     with nogil:
@@ -320,7 +320,7 @@ def _handle_lhs_derivatives(const double[::1]t, int k, double xval,
     """
     cdef:
         int left, nu, a, clmn, row
-        double[::1] wrk = np.empty(2*k+2, dtype=np.float_)
+        double[::1] wrk = np.empty(2*k+2, dtype=np.float64)
 
     # derivatives @ xval
     with nogil:
@@ -387,7 +387,7 @@ def _norm_eq_lsq(const double[::1] x,
     cdef:
         int j, r, s, row, clmn, left, ci
         double xval, wval
-        double[::1] wrk = np.empty(2*k + 2, dtype=np.float_)
+        double[::1] wrk = np.empty(2*k + 2, dtype=np.float64)
 
     with nogil:
         left = k

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -20,9 +20,9 @@ __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
     if np.issubdtype(dtype, np.complexfloating):
-        return np.complex_
+        return np.complex128
     else:
-        return np.float_
+        return np.float64
 
 
 def _as_float_array(x, check_finite=False):
@@ -487,7 +487,7 @@ class BSpline:
             extrapolate = self.extrapolate
         x = np.asarray(x)
         x_shape, x_ndim = x.shape, x.ndim
-        x = np.ascontiguousarray(x.ravel(), dtype=np.float_)
+        x = np.ascontiguousarray(x.ravel(), dtype=np.float64)
 
         # With periodic extrapolation we map x to the segment
         # [self.t[k], self.t[n]].
@@ -683,7 +683,7 @@ class BSpline:
 
             if n_periods > 0:
                 # Evaluate the difference of antiderivatives.
-                x = np.asarray([ts, te], dtype=np.float_)
+                x = np.asarray([ts, te], dtype=np.float64)
                 _bspl.evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                       ka, x, 0, False, out)
                 integral = out[1] - out[0]
@@ -699,23 +699,23 @@ class BSpline:
             # If b <= te then we need to integrate over [a, b], otherwise
             # over [a, te] and from xs to what is remained.
             if b <= te:
-                x = np.asarray([a, b], dtype=np.float_)
+                x = np.asarray([a, b], dtype=np.float64)
                 _bspl.evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                       ka, x, 0, False, out)
                 integral += out[1] - out[0]
             else:
-                x = np.asarray([a, te], dtype=np.float_)
+                x = np.asarray([a, te], dtype=np.float64)
                 _bspl.evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                       ka, x, 0, False, out)
                 integral += out[1] - out[0]
 
-                x = np.asarray([ts, ts + b - te], dtype=np.float_)
+                x = np.asarray([ts, ts + b - te], dtype=np.float64)
                 _bspl.evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                       ka, x, 0, False, out)
                 integral += out[1] - out[0]
         else:
             # Evaluate the difference of antiderivatives.
-            x = np.asarray([a, b], dtype=np.float_)
+            x = np.asarray([a, b], dtype=np.float64)
             _bspl.evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                   ka, x, 0, extrapolate, out)
             integral = out[1] - out[0]
@@ -1104,7 +1104,7 @@ def _make_periodic_spline(x, y, t, k, axis):
     kul = int(k / 2)
 
     # kl = ku = k
-    ab = np.zeros((3 * k + 1, nt), dtype=np.float_, order='F')
+    ab = np.zeros((3 * k + 1, nt), dtype=np.float64, order='F')
 
     # upper right and lower left blocks
     ur = np.zeros((kul, kul))
@@ -1380,7 +1380,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     # set up the LHS: the collocation matrix + derivatives at boundaries
     kl = ku = k
-    ab = np.zeros((2*kl + ku + 1, nt), dtype=np.float_, order='F')
+    ab = np.zeros((2*kl + ku + 1, nt), dtype=np.float64, order='F')
     _bspl._colloc(x, t, k, ab, offset=nleft)
     if nleft > 0:
         _bspl._handle_lhs_derivatives(t, k, x[0], ab, kl, ku, deriv_l_ords)
@@ -1557,7 +1557,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     # rhs = A.T @ y for solving the LSQ problem  ``A.T @ A @ c = A.T @ y``
     lower = True
     extradim = prod(y.shape[1:])
-    ab = np.zeros((k+1, n), dtype=np.float_, order='F')
+    ab = np.zeros((k+1, n), dtype=np.float64, order='F')
     rhs = np.zeros((n, extradim), dtype=y.dtype, order='F')
     _bspl._norm_eq_lsq(x, t, k,
                        y.reshape(-1, extradim),

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1917,7 +1917,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
-        if np.issubclass_(w, float):
+        if issubclass(w, float):
             w = ones(len(theta)) * w
         nt_, tt_, np_, tp_, c, fp, ier = dfitpack.spherfit_smth(theta, phi,
                                                                 r, w=w, s=s,
@@ -2070,7 +2070,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
-        if np.issubclass_(w, float):
+        if issubclass(w, float):
             w = ones(len(theta)) * w
         nt_, np_ = 8 + len(tt), 8 + len(tp)
         tt_, tp_ = zeros((nt_,), float), zeros((np_,), float)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1917,8 +1917,6 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
-        if issubclass(w, float):
-            w = ones(len(theta)) * w
         nt_, tt_, np_, tp_, c, fp, ier = dfitpack.spherfit_smth(theta, phi,
                                                                 r, w=w, s=s,
                                                                 eps=eps)
@@ -2070,8 +2068,6 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
-        if issubclass(w, float):
-            w = ones(len(theta)) * w
         nt_, np_ = 8 + len(tt), 8 + len(tp)
         tt_, tp_ = zeros((nt_,), float), zeros((np_,), float)
         tt_[4:-4], tp_[4:-4] = tt, tp

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -21,7 +21,7 @@ __all__ = [
 
 import warnings
 
-from numpy import zeros, concatenate, ravel, diff, array, ones
+from numpy import zeros, concatenate, ravel, diff, array, ones  # noqa:F401
 import numpy as np
 
 from . import _fitpack_impl

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -531,7 +531,7 @@ class interp1d(_Interpolator1D):
 
         # Force-cast y to a floating-point type, if it's not yet one
         if not issubclass(y.dtype.type, np.inexact):
-            y = y.astype(np.float_)
+            y = y.astype(np.float64)
 
         # Backward compatibility
         self.axis = axis % y.ndim
@@ -590,7 +590,7 @@ class interp1d(_Interpolator1D):
                     fill_value = (np.take(self.y, 0, axis), np.nan)
             else:
                 # Check if we can delegate to numpy.interp (2x-10x faster).
-                np_types = (np.float_, np.int_)
+                np_types = (np.float64, np.int_)
                 cond = self.x.dtype in np_types and self.y.dtype in np_types
                 cond = cond and self.y.ndim == 1
                 cond = cond and not _do_extrapolate(fill_value)
@@ -857,9 +857,9 @@ class _PPolyBase:
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
                or np.issubdtype(self.c.dtype, np.complexfloating):
-            return np.complex_
+            return np.complex128
         else:
-            return np.float_
+            return np.float64
 
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):
@@ -1003,7 +1003,7 @@ class _PPolyBase:
             extrapolate = self.extrapolate
         x = np.asarray(x)
         x_shape, x_ndim = x.shape, x.ndim
-        x = np.ascontiguousarray(x.ravel(), dtype=np.float_)
+        x = np.ascontiguousarray(x.ravel(), dtype=np.float64)
 
         # With periodic extrapolation we map x to the segment
         # [self.x[0], self.x[-1]].
@@ -1976,9 +1976,9 @@ class BPoly(_PPolyBase):
         dta, dtb = ya.dtype, yb.dtype
         if (np.issubdtype(dta, np.complexfloating) or
                np.issubdtype(dtb, np.complexfloating)):
-            dt = np.complex_
+            dt = np.complex128
         else:
-            dt = np.float_
+            dt = np.float64
 
         na, nb = len(ya), len(yb)
         n = na + nb
@@ -2148,9 +2148,9 @@ class NdPPoly:
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
                or np.issubdtype(self.c.dtype, np.complexfloating):
-            return np.complex_
+            return np.complex128
         else:
-            return np.float_
+            return np.float64
 
     def _ensure_c_contiguous(self):
         if not self.c.flags.c_contiguous:
@@ -2196,7 +2196,7 @@ class NdPPoly:
 
         x = _ndim_coords_from_arrays(x)
         x_shape = x.shape
-        x = np.ascontiguousarray(x.reshape(-1, x.shape[-1]), dtype=np.float_)
+        x = np.ascontiguousarray(x.reshape(-1, x.shape[-1]), dtype=np.float64)
 
         if nu is None:
             nu = np.zeros((ndim,), dtype=np.intc)

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -11,9 +11,9 @@ __all__ = ["NdBSpline"]
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
     if np.issubdtype(dtype, np.complexfloating):
-        return np.complex_
+        return np.complex128
     else:
-        return np.float_
+        return np.float64
 
 
 class NdBSpline:

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -135,10 +135,10 @@ class _Interpolator1D:
     def _set_dtype(self, dtype, union=False):
         if np.issubdtype(dtype, np.complexfloating) \
                or np.issubdtype(self.dtype, np.complexfloating):
-            self.dtype = np.complex_
+            self.dtype = np.complex128
         else:
-            if not union or self.dtype != np.complex_:
-                self.dtype = np.float_
+            if not union or self.dtype != np.complex128:
+                self.dtype = np.float64
 
 
 class _Interpolator1DWithDerivatives(_Interpolator1D):
@@ -624,7 +624,7 @@ class BarycentricInterpolator(_Interpolator1DWithDerivatives):
         
         random_state = check_random_state(random_state)
 
-        self.xi = np.asfarray(xi)
+        self.xi = np.asarray(xi, dtype=np.float64)
         self.set_yi(yi)
         self.n = len(self.xi)
 

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -1094,9 +1094,9 @@ def evaluate_bernstein(const double_or_complex[:,:,::1] c,
 
     if nu > 0:
         if double_or_complex is double_complex:
-            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.complex_)
+            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.complex128)
         else:
-            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.float_)
+            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.float64)
 
 
     interval = 0

--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -220,7 +220,7 @@ class Rbf:
         # them as a single 2-D array `xi` of shape (n_args-1, array_size),
         # plus a 1-D array `di` for the values.
         # All arrays must have the same number of elements
-        self.xi = np.asarray([np.asarray(a, dtype=np.float_).flatten()
+        self.xi = np.asarray([np.asarray(a, dtype=np.float64).flatten()
                               for a in args[:-1]])
         self.N = self.xi.shape[-1]
 
@@ -285,6 +285,6 @@ class Rbf:
             shp = args[0].shape + (self._target_dim,)
         else:
             shp = args[0].shape
-        xa = np.asarray([a.flatten() for a in args], dtype=np.float_)
+        xa = np.asarray([a.flatten() for a in args], dtype=np.float64)
         r = self._call_norm(xa, self.xi)
         return np.dot(self._function(r), self.nodes).reshape(shp)

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -76,7 +76,7 @@ class NDInterpolatorBase:
         points = _ndim_coords_from_arrays(points)
 
         if need_contiguous:
-            points = np.ascontiguousarray(points, dtype=np.double)
+            points = np.ascontiguousarray(points, dtype=np.float64)
 
         if not rescale:
             self.scale = None
@@ -121,7 +121,9 @@ class NDInterpolatorBase:
             self.fill_value = complex(fill_value)
         else:
             if need_contiguous:
-                self.values = np.ascontiguousarray(self.values, dtype=np.double)
+                self.values = np.ascontiguousarray(
+                    self.values, dtype=np.float64
+                )
             self.fill_value = float(fill_value)
 
     def _check_call_shape(self, xi):
@@ -141,7 +143,7 @@ class NDInterpolatorBase:
         xi = self._check_call_shape(xi)
         interpolation_points_shape = xi.shape
         xi = xi.reshape(-1, xi.shape[-1])
-        xi = np.ascontiguousarray(xi, dtype=np.double)
+        xi = np.ascontiguousarray(xi, dtype=np.float64)
         return self._scale_x(xi), interpolation_points_shape
     
     @cython.boundscheck(False)
@@ -586,7 +588,7 @@ cpdef estimate_gradients_2d_global(tri, y, int maxiter=400, double tol=1e-6):
         y = y[:,None]
 
     y = y.reshape(tri.npoints, -1).T
-    y = np.ascontiguousarray(y, dtype=np.double)
+    y = np.ascontiguousarray(y, dtype=np.float64)
     yi = np.empty((y.shape[0], y.shape[1], 2))
 
     data = y

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1142,7 +1142,7 @@ class TestInterp:
 
     def test_quintic_derivs(self):
         k, n = 5, 7
-        x = np.arange(n).astype(np.float_)
+        x = np.arange(n).astype(np.float64)
         y = np.sin(x)
         der_l = [(1, -12.), (2, 1)]
         der_r = [(1, 8.), (2, 3.)]
@@ -1398,7 +1398,7 @@ def make_interp_full_matr(x, y, t, k):
     assert t.size == x.size + k + 1
     n = x.size
 
-    A = np.zeros((n, n), dtype=np.float_)
+    A = np.zeros((n, n), dtype=np.float64)
 
     for j in range(n):
         xval = x[j]
@@ -1421,7 +1421,7 @@ def make_lsq_full_matrix(x, y, t, k=3):
     m = x.size
     n = t.size - k - 1
 
-    A = np.zeros((m, n), dtype=np.float_)
+    A = np.zeros((m, n), dtype=np.float64)
 
     for j in range(m):
         xval = x[j]

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -21,8 +21,8 @@ class TestLinearNDInterpolation:
     def test_smoketest(self):
         # Test at single points
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
 
         yi = interpnd.LinearNDInterpolator(x, y)(x)
         assert_almost_equal(y, yi)
@@ -30,8 +30,8 @@ class TestLinearNDInterpolation:
     def test_smoketest_alternate(self):
         # Test at single points, alternate calling convention
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
 
         yi = interpnd.LinearNDInterpolator((x[:,0], x[:,1]), y)(x[:,0], x[:,1])
         assert_almost_equal(y, yi)
@@ -39,8 +39,8 @@ class TestLinearNDInterpolation:
     def test_complex_smoketest(self):
         # Test at single points
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         yi = interpnd.LinearNDInterpolator(x, y)(x)
@@ -49,8 +49,8 @@ class TestLinearNDInterpolation:
     def test_tri_input(self):
         # Test at single points
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
@@ -61,8 +61,8 @@ class TestLinearNDInterpolation:
         # Test barycentric interpolation on a square against a manual
         # implementation
 
-        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
-        values = np.array([1., 2., -3., 5.], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.float64)
+        values = np.array([1., 2., -3., 5.], dtype=np.float64)
 
         # NB: assume triangles (0, 1, 3) and (1, 2, 3)
         #
@@ -105,8 +105,8 @@ class TestLinearNDInterpolation:
     def test_smoketest_rescale(self):
         # Test at single points
         x = np.array([(0, 0), (-5, -5), (-5, 5), (5, 5), (2.5, 3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
 
         yi = interpnd.LinearNDInterpolator(x, y, rescale=True)(x)
         assert_almost_equal(y, yi)
@@ -115,8 +115,8 @@ class TestLinearNDInterpolation:
         # Test barycentric interpolation on a rectangle with rescaling
         # agaings the same implementation without rescaling
 
-        points = np.array([(0,0), (0,100), (10,100), (10,0)], dtype=np.double)
-        values = np.array([1., 2., -3., 5.], dtype=np.double)
+        points = np.array([(0,0), (0,100), (10,100), (10,0)], dtype=np.float64)
+        values = np.array([1., 2., -3., 5.], dtype=np.float64)
 
         xx, yy = np.broadcast_arrays(np.linspace(0, 10, 14)[:,None],
                                      np.linspace(0, 100, 14)[None,:])
@@ -132,8 +132,8 @@ class TestLinearNDInterpolation:
     def test_tripoints_input_rescale(self):
         # Test at single points
         x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
@@ -145,8 +145,8 @@ class TestLinearNDInterpolation:
     def test_tri_input_rescale(self):
         # Test at single points
         x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
@@ -277,8 +277,8 @@ class TestCloughTocher2DInterpolator:
     def test_tri_input(self):
         # Test at single points
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
@@ -288,8 +288,8 @@ class TestCloughTocher2DInterpolator:
     def test_tri_input_rescale(self):
         # Test at single points
         x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
@@ -301,8 +301,8 @@ class TestCloughTocher2DInterpolator:
     def test_tripoints_input_rescale(self):
         # Test at single points
         x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -805,7 +805,7 @@ class TestInterp1D:
             self._nd_check_interp(kind)
             self._nd_check_shape(kind)
 
-    def _check_complex(self, dtype=np.complex_, kind='linear'):
+    def _check_complex(self, dtype=np.complex128, kind='linear'):
         x = np.array([1, 2.5, 3, 3.1, 4, 6.4, 7.9, 8.0, 9.5, 10])
         y = x * x ** (1 + 2j)
         y = y.astype(dtype)

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -26,8 +26,8 @@ class TestGriddata:
 
     def test_alternative_call(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = (np.arange(x.shape[0], dtype=np.double)[:,None]
+                     dtype=np.float64)
+        y = (np.arange(x.shape[0], dtype=np.float64)[:,None]
              + np.array([0,1])[None,:])
 
         for method in ('nearest', 'linear', 'cubic'):
@@ -39,8 +39,8 @@ class TestGriddata:
 
     def test_multivalue_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = (np.arange(x.shape[0], dtype=np.double)[:,None]
+                     dtype=np.float64)
+        y = (np.arange(x.shape[0], dtype=np.float64)[:,None]
              + np.array([0,1])[None,:])
 
         for method in ('nearest', 'linear', 'cubic'):
@@ -51,8 +51,8 @@ class TestGriddata:
 
     def test_multipoint_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
 
         xi = x[:,None,:] + np.array([0,0,0])[None,:,None]
 
@@ -67,8 +67,8 @@ class TestGriddata:
 
     def test_complex_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 2j*y[::-1]
 
         xi = x[:,None,:] + np.array([0,0,0])[None,:,None]
@@ -129,9 +129,9 @@ class TestGriddata:
                             err_msg=method, atol=1e-10)
 
     def test_square_rescale_manual(self):
-        points = np.array([(0,0), (0,100), (10,100), (10,0), (1, 5)], dtype=np.double)
-        points_rescaled = np.array([(0,0), (0,1), (1,1), (1,0), (0.1, 0.05)], dtype=np.double)
-        values = np.array([1., 2., -3., 5., 9.], dtype=np.double)
+        points = np.array([(0,0), (0,100), (10,100), (10,0), (1, 5)], dtype=np.float64)
+        points_rescaled = np.array([(0,0), (0,1), (1,1), (1,0), (0.1, 0.05)], dtype=np.float64)
+        values = np.array([1., 2., -3., 5., 9.], dtype=np.float64)
 
         xx, yy = np.broadcast_arrays(np.linspace(0, 10, 14)[:,None],
                                      np.linspace(0, 100, 14)[None,:])
@@ -151,8 +151,8 @@ class TestGriddata:
     def test_xi_1d(self):
         # Check that 1-D xi is interpreted as a coordinate
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-        y = np.arange(x.shape[0], dtype=np.double)
+                     dtype=np.float64)
+        y = np.arange(x.shape[0], dtype=np.float64)
         y = y - 2j*y[::-1]
 
         xi = np.array([0.5, 0.5])

--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -100,7 +100,7 @@ class NominalAttribute(Attribute):
         super().__init__(name)
         self.values = values
         self.range = values
-        self.dtype = (np.string_, max(len(i) for i in values))
+        self.dtype = (np.bytes_, max(len(i) for i in values))
 
     @staticmethod
     def _get_nom_val(atrv):
@@ -172,7 +172,7 @@ class NumericAttribute(Attribute):
     def __init__(self, name):
         super().__init__(name)
         self.type_name = 'numeric'
-        self.dtype = np.float_
+        self.dtype = np.float64
 
     @classmethod
     def parse_attribute(cls, name, attr_string):

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -276,7 +276,7 @@ class TestRelationalAttribute:
 
     def test_data(self):
         dtype_instance = [('attr_date', 'datetime64[D]'),
-                          ('attr_number', np.float_)]
+                          ('attr_number', np.float64)]
 
         expected = [
             np.array([('1999-01-31', 1), ('1935-11-27', 10)],
@@ -316,7 +316,7 @@ class TestRelationalAttributeLong:
         assert_equal(relational.attributes[0].type_name, 'numeric')
 
     def test_data(self):
-        dtype_instance = [('attr_number', np.float_)]
+        dtype_instance = [('attr_number', np.float64)]
 
         expected = np.array([(n,) for n in range(30000)],
                             dtype=dtype_instance)
@@ -346,7 +346,7 @@ class TestQuotedNominal:
 
     def test_data(self):
 
-        age_dtype_instance = np.float_
+        age_dtype_instance = np.float64
         smoker_dtype_instance = '<S3'
 
         age_expected = np.array([
@@ -392,7 +392,7 @@ class TestQuotedNominalSpaces:
 
     def test_data(self):
 
-        age_dtype_instance = np.float_
+        age_dtype_instance = np.float64
         smoker_dtype_instance = '<S5'
 
         age_expected = np.array([

--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -518,7 +518,7 @@ class VarWriter4:
             raise TypeError('Cannot save object arrays in Mat4')
         elif dtt is np.void:
             raise TypeError('Cannot save void type arrays')
-        elif dtt in (np.unicode_, np.string_):
+        elif dtt in (np.str_, np.bytes_):
             self.write_char(arr, name)
             return
         self.write_numeric(arr, name)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -288,7 +288,7 @@ def _check_level(label, expected, actual):
                          expected[fn], actual[fn])
         return
     if ex_dtype.type in (str,  # string or bool
-                         np.unicode_,
+                         np.str_,
                          np.bool_):
         assert_equal(actual, expected, err_msg=label)
         return

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -90,7 +90,7 @@ def test_fortranfile_read_mixed_record():
     with FortranFile(filename, 'r', '<u4') as f:
         record = f.read_record('(3,3)<f8', '2<i4')
 
-    ax = np.arange(3*3).reshape(3, 3).astype(np.double)
+    ax = np.arange(3*3).reshape(3, 3).astype(np.float64)
     bx = np.array([-1, -2], dtype=np.int32)
 
     assert_equal(record[0], ax.T)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1771,7 +1771,7 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
         raise ValueError('Incompatible dimensions.')
 
     is_cmplx = np.iscomplexobj(r) or np.iscomplexobj(c) or np.iscomplexobj(b)
-    dtype = np.complex128 if is_cmplx else np.double
+    dtype = np.complex128 if is_cmplx else np.float64
     r, c, b = (np.asarray(i, dtype=dtype) for i in (r, c, b))
 
     if b.ndim == 1 and not keep_b_shape:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1596,13 +1596,13 @@ class TestMatrixNorms:
         # Not all of these are matrix norms in the most technical sense.
         np.random.seed(1234)
         for n, m in (1, 1), (1, 3), (3, 1), (4, 4), (4, 5), (5, 4):
-            for t in np.single, np.double, np.csingle, np.cdouble, np.int64:
+            for t in np.float32, np.float64, np.complex64, np.complex128, np.int64:
                 A = 10 * np.random.randn(n, m).astype(t)
                 if np.issubdtype(A.dtype, np.complexfloating):
                     A = (A + 10j * np.random.randn(n, m)).astype(t)
-                    t_high = np.cdouble
+                    t_high = np.complex128
                 else:
-                    t_high = np.double
+                    t_high = np.float64
                 for order in (None, 'fro', 1, -1, 2, -2, np.inf, -np.inf):
                     actual = norm(A, ord=order)
                     desired = np.linalg.norm(A, ord=order)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -61,7 +61,7 @@ def test_get_blas_funcs():
     assert_equal(f1.typecode, 'c')
 
     # extended precision complex
-    f1 = get_blas_funcs('gemm', dtype=np.longcomplex)
+    f1 = get_blas_funcs('gemm', dtype=np.clongdouble)
     assert_equal(f1.typecode, 'z')
 
     # check safe complex upcasting

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -74,7 +74,7 @@ class TestInterpolativeDecomposition:
         "rand,lin_op",
         [(False, False), (True, False), (True, True)])
     def test_real_id_fixed_precision(self, A, L, eps, rand, lin_op):
-        if _IS_32BIT and A.dtype == np.complex_ and rand:
+        if _IS_32BIT and A.dtype == np.complex128 and rand:
             pytest.xfail("bug in external fortran code")
         # Test ID routines on a Hilbert matrix.
         A_or_L = A if not lin_op else L
@@ -87,7 +87,7 @@ class TestInterpolativeDecomposition:
         "rand,lin_op",
         [(False, False), (True, False), (True, True)])
     def test_real_id_fixed_rank(self, A, L, eps, rank, rand, lin_op):
-        if _IS_32BIT and A.dtype == np.complex_ and rand:
+        if _IS_32BIT and A.dtype == np.complex128 and rand:
             pytest.xfail("bug in external fortran code")
         k = rank
         A_or_L = A if not lin_op else L
@@ -112,7 +112,7 @@ class TestInterpolativeDecomposition:
         "rand,lin_op",
         [(False, False), (True, False), (True, True)])
     def test_svd_fixed_precison(self, A, L, eps, rand, lin_op):
-        if _IS_32BIT and A.dtype == np.complex_ and rand:
+        if _IS_32BIT and A.dtype == np.complex128 and rand:
             pytest.xfail("bug in external fortran code")
         A_or_L = A if not lin_op else L
 
@@ -124,7 +124,7 @@ class TestInterpolativeDecomposition:
         "rand,lin_op",
         [(False, False), (True, False), (True, True)])
     def test_svd_fixed_rank(self, A, L, eps, rank, rand, lin_op):
-        if _IS_32BIT and A.dtype == np.complex_ and rand:
+        if _IS_32BIT and A.dtype == np.complex128 and rand:
             pytest.xfail("bug in external fortran code")
         k = rank
         A_or_L = A if not lin_op else L
@@ -224,11 +224,11 @@ class TestInterpolativeDecomposition:
         B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
         assert_allclose(A, B @ P)
 
-    @pytest.mark.parametrize("dtype", [np.float_, np.complex_])
+    @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
     @pytest.mark.parametrize("rand", [True, False])
     @pytest.mark.parametrize("eps", [1, 0.1])
     def test_bug_9793(self, dtype, rand, eps):
-        if _IS_32BIT and dtype == np.complex_ and rand:
+        if _IS_32BIT and dtype == np.complex128 and rand:
             pytest.xfail("bug in external fortran code")
         A = np.array([[-1, -1, -1, 0, 0, 0],
                       [0, 0, 0, 1, 1, 1],

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -972,7 +972,7 @@ class DifferentialEvolutionSolver:
             The population is clipped to the lower and upper bounds.
         """
         # make sure you're using a float array
-        popn = np.asfarray(init)
+        popn = np.asarray(init, dtype=np.float64)
 
         if (np.size(popn, 0) < 5 or
                 popn.shape[1] != self.parameter_count or

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -58,8 +58,8 @@ def _constraints_to_components(constraints):
             except TypeError as exc:
                 raise ValueError(message) from exc
         As.append(csc_array(constraint.A))
-        b_ls.append(np.atleast_1d(constraint.lb).astype(np.double))
-        b_us.append(np.atleast_1d(constraint.ub).astype(np.double))
+        b_ls.append(np.atleast_1d(constraint.lb).astype(np.float64))
+        b_us.append(np.atleast_1d(constraint.ub).astype(np.float64))
 
     if len(As) > 1:
         A = vstack(As, format="csc")
@@ -77,7 +77,7 @@ def _milp_iv(c, integrality, bounds, constraints, options):
     # objective IV
     if issparse(c):
         raise ValueError("`c` must be a dense array.")
-    c = np.atleast_1d(c).astype(np.double)
+    c = np.atleast_1d(c).astype(np.float64)
     if c.ndim != 1 or c.size == 0 or not np.all(np.isfinite(c)):
         message = ("`c` must be a one-dimensional array of finite numbers "
                    "with at least one element.")
@@ -109,8 +109,8 @@ def _milp_iv(c, integrality, bounds, constraints, options):
             raise ValueError(message) from exc
 
     try:
-        lb = np.broadcast_to(bounds.lb, c.shape).astype(np.double)
-        ub = np.broadcast_to(bounds.ub, c.shape).astype(np.double)
+        lb = np.broadcast_to(bounds.lb, c.shape).astype(np.float64)
+        ub = np.broadcast_to(bounds.ub, c.shape).astype(np.float64)
     except (ValueError, TypeError) as exc:
         message = ("`bounds.lb` and `bounds.ub` must contain reals and "
                    "be broadcastable to `c.shape`.")
@@ -131,7 +131,7 @@ def _milp_iv(c, integrality, bounds, constraints, options):
     if A.shape != (b_l.size, c.size):
         message = "The shape of `A` must be (len(b_l), len(c))."
         raise ValueError(message)
-    indptr, indices, data = A.indptr, A.indices, A.data.astype(np.double)
+    indptr, indices, data = A.indptr, A.indices, A.data.astype(np.float64)
 
     # options IV
     options = options or {}

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -35,7 +35,7 @@ def _as_inexact(x):
     """Return `x` as an array, of either floats or complex floats"""
     x = asarray(x)
     if not np.issubdtype(x.dtype, np.inexact):
-        return asarray(x, dtype=np.float_)
+        return asarray(x, dtype=np.float64)
     return x
 
 
@@ -325,7 +325,7 @@ class TerminationCondition:
                  iter=None, norm=maxnorm):
 
         if f_tol is None:
-            f_tol = np.finfo(np.float_).eps ** (1./3)
+            f_tol = np.finfo(np.float64).eps ** (1./3)
         if f_rtol is None:
             f_rtol = np.inf
         if x_tol is None:

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -823,7 +823,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     retall = return_all
 
     x0 = np.atleast_1d(x0).flatten()
-    x0 = np.asfarray(x0, x0.dtype)
+    dtype = x0.dtype if np.issubdtype(x0.dtype, np.inexact) else np.float64
+    x0 = np.asarray(x0, dtype=dtype)
 
     if adaptive:
         dim = float(len(x0))
@@ -866,7 +867,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
             sim[k + 1] = y
     else:
         sim = np.atleast_2d(initial_simplex).copy()
-        sim = np.asfarray(sim, sim.dtype)
+        dtype = sim.dtype if np.issubdtype(sim.dtype, np.inexact) else np.float64
+        sim = np.asarray(sim, dtype=dtype)
         if sim.ndim != 2 or sim.shape[0] != sim.shape[1] + 1:
             raise ValueError("`initial_simplex` should be an array of shape (N+1,N)")
         if len(x0) != sim.shape[1]:

--- a/scipy/optimize/tnc/_moduleTNC.pyx
+++ b/scipy/optimize/tnc/_moduleTNC.pyx
@@ -82,7 +82,7 @@ cdef int function(double x[], double *f, double g[], void *state) except 1:
 
     f[0] = <double> fx
 
-    gx = np.asfarray(gx)
+    gx = np.asarray(gx, dtype=np.float64)
     if gx.size != n:
         raise ValueError("tnc: gradient must have shape (len(x0),)")
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1569,7 +1569,7 @@ def medfilt(volume, kernel_size=None):
     numels = np.prod(kernel_size, axis=0)
     order = numels // 2
 
-    if volume.dtype in [np.bool_, np.complex128, np.clongdouble,
+    if volume.dtype in [np.bool_, np.complex64, np.complex128, np.clongdouble,
                         np.float16]:
         raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1569,7 +1569,7 @@ def medfilt(volume, kernel_size=None):
     numels = np.prod(kernel_size, axis=0)
     order = numels // 2
 
-    if volume.dtype in [np.bool_, np.cfloat, np.cdouble, np.clongdouble,
+    if volume.dtype in [np.bool_, np.complex128, np.clongdouble,
                         np.float16]:
         raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
 
@@ -1946,7 +1946,7 @@ def medfilt2d(input, kernel_size=3):
 
     # checking dtype.type, rather than just dtype, is necessary for
     # excluding np.longdouble with MS Visual C.
-    if image.dtype.type not in (np.ubyte, np.single, np.double):
+    if image.dtype.type not in (np.ubyte, np.float32, np.float64):
         return medfilt(image, kernel_size)
 
     if kernel_size is None:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1102,7 +1102,7 @@ class TestMedFilt:
             assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
 
 
-    @pytest.mark.parametrize('dtype', [np.bool_, np.complex128,
+    @pytest.mark.parametrize('dtype', [np.bool_, np.complex64, np.complex128,
                                        np.clongdouble, np.float16,])
     def test_invalid_dtypes(self, dtype):
         in_typed = np.array(self.IN, dtype=dtype)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1038,7 +1038,7 @@ class TestAllFreqConvolves:
                            match="all axes must be unique"):
             convapproach([1], [2], axes=[0, 0])
 
-    @pytest.mark.parametrize('dtype', [np.longfloat, np.longcomplex])
+    @pytest.mark.parametrize('dtype', [np.longdouble, np.clongdouble])
     def test_longdtype_input(self, dtype):
         x = np.random.random((27, 27)).astype(dtype)
         y = np.random.random((4, 4)).astype(dtype)
@@ -1102,7 +1102,7 @@ class TestMedFilt:
             assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
 
 
-    @pytest.mark.parametrize('dtype', [np.bool_, np.cfloat, np.cdouble,
+    @pytest.mark.parametrize('dtype', [np.bool_, np.complex128,
                                        np.clongdouble, np.float16,])
     def test_invalid_dtypes(self, dtype):
         in_typed = np.array(self.IN, dtype=dtype)
@@ -1937,7 +1937,7 @@ class TestCorrelateReal:
         # FFT implementations convert longdouble arguments down to
         # double so don't expect better precision, see gh-9520
         if res_dt == np.longdouble:
-            return self.equal_tolerance(np.double)
+            return self.equal_tolerance(np.float64)
         else:
             return self.equal_tolerance(res_dt)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2464,7 +2464,7 @@ def test_choose_conv_method():
 
             method_try, times = choose_conv_method(x, h, mode=mode, measure=True)
             assert_(method_try in {'fft', 'direct'})
-            assert_(type(times) is dict)
+            assert_(isinstance(times, dict))
             assert_('fft' in times.keys() and 'direct' in times.keys())
 
         n = 10

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -640,8 +640,8 @@ class _spbase:
                 else:
                     return np.divide(other, self.todense())
 
-            if true_divide and np.can_cast(self.dtype, np.float_):
-                return self.astype(np.float_)._mul_scalar(1./other)
+            if true_divide and np.can_cast(self.dtype, np.float64):
+                return self.astype(np.float64)._mul_scalar(1./other)
             else:
                 r = self._mul_scalar(1./other)
 
@@ -669,8 +669,8 @@ class _spbase:
                 return other._divide(self, true_divide, rdivide=False)
 
             self_csr = self.tocsr()
-            if true_divide and np.can_cast(self.dtype, np.float_):
-                return self_csr.astype(np.float_)._divide_sparse(other)
+            if true_divide and np.can_cast(self.dtype, np.float64):
+                return self_csr.astype(np.float64)._divide_sparse(other)
             else:
                 return self_csr._divide_sparse(other)
         else:

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -13,8 +13,8 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
                     np.uintc, np.int_, np.uint, np.longlong, np.ulonglong,
-                    np.single, np.double,
-                    np.longdouble, np.csingle, np.cdouble, np.clongdouble]
+                    np.float32, np.float64, np.longdouble, 
+                    np.complex64, np.complex128, np.clongdouble]
 
 _upcast_memo = {}
 

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -161,8 +161,8 @@ def _check_laplacian_dtype(
 
 
 INT_DTYPES = {np.intc, np.int_, np.longlong}
-REAL_DTYPES = {np.single, np.double, np.longdouble}
-COMPLEX_DTYPES = {np.csingle, np.cdouble, np.clongdouble}
+REAL_DTYPES = {np.float32, np.float64, np.longdouble}
+COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
 # use sorted tuple to ensure fixed order of tests
 DTYPES = tuple(sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
 

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -200,10 +200,10 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     Choices of the input matrix `A` numeric dtype may be limited.
     Only ``solver="lobpcg"`` supports all floating point dtypes
-    real: 'np.single', 'np.double', 'np.longdouble' and
-    complex: 'np.csingle', 'np.cdouble', 'np.clongdouble'.
+    real: 'np.float32', 'np.float64', 'np.longdouble' and
+    complex: 'np.complex64', 'np.complex128', 'np.clongdouble'.
     The ``solver="arpack"`` supports only
-    'np.single', 'np.double', and 'np.cdouble'.
+    'np.float32', 'np.float64', and 'np.complex128'.
 
     Examples
     --------

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -21,8 +21,8 @@ _IS_32BIT = (sys.maxsize < 2**32)
 
 INT_DTYPES = {np.intc, np.int_, np.longlong, np.uintc, np.uint, np.ulonglong}
 # np.half is unsupported on many test systems so excluded
-REAL_DTYPES = {np.single, np.double, np.longdouble}
-COMPLEX_DTYPES = {np.csingle, np.cdouble, np.clongdouble}
+REAL_DTYPES = {np.float32, np.float64, np.longdouble}
+COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
 # use sorted tuple to ensure fixed order of tests
 VDTYPES = tuple(sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
 MDTYPES = tuple(sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
@@ -119,7 +119,7 @@ def test_b_orthonormalize(n, m, Vdtype, Bdtype, BVdtype):
     BX = BX.astype(BVdtype)
     dtype = min(X.dtype, B.dtype, BX.dtype)
     # np.longdouble tol cannot be achieved on most systems
-    atol = m * n * max(np.finfo(dtype).eps, np.finfo(np.double).eps)
+    atol = m * n * max(np.finfo(dtype).eps, np.finfo(np.float64).eps)
 
     Xo, BXo, _ = _b_orthonormalize(lambda v: B @ v, X, BX)
     # Check in-place.

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -17,8 +17,8 @@ from scipy.sparse.linalg._expm_multiply import (_theta, _compute_p_max,
 
 IMPRECISE = {np.single, np.csingle}
 REAL_DTYPES = {np.intc, np.int_, np.longlong,
-               np.single, np.double, np.longdouble}
-COMPLEX_DTYPES = {np.csingle, np.cdouble, np.clongdouble}
+               np.float32, np.float64, np.longdouble}
+COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
 # use sorted tuple to ensure fixed order of tests
 DTYPES = tuple(sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -276,7 +276,7 @@ class TestAsLinearOperator:
                        for M, A in make_cases(original.T, np.float64)]
 
         original = np.array([[1, 2j, 3j], [4j, 5j, 6]])
-        self.cases += make_cases(original, np.comcomplex128plex_)
+        self.cases += make_cases(original, np.complex128)
         self.cases += [(interface.aslinearoperator(M).T, A.T)
                        for M, A in make_cases(original.T, np.complex128)]
         self.cases += [(interface.aslinearoperator(M).H, A.T.conj())

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -124,7 +124,7 @@ class TestLinearOperator:
             C = A / 5
             assert_equal(A @ np.array([1, 2, 3]), result)
 
-            assert_((2j*A).dtype == np.complex_)
+            assert_((2j*A).dtype == np.complex128)
 
             # Test division by non-scalar
             msg = "Can only divide a linear operator by a scalar."
@@ -276,11 +276,11 @@ class TestAsLinearOperator:
                        for M, A in make_cases(original.T, np.float64)]
 
         original = np.array([[1, 2j, 3j], [4j, 5j, 6]])
-        self.cases += make_cases(original, np.complex_)
+        self.cases += make_cases(original, np.comcomplex128plex_)
         self.cases += [(interface.aslinearoperator(M).T, A.T)
-                       for M, A in make_cases(original.T, np.complex_)]
+                       for M, A in make_cases(original.T, np.complex128)]
         self.cases += [(interface.aslinearoperator(M).H, A.T.conj())
-                       for M, A in make_cases(original.T, np.complex_)]
+                       for M, A in make_cases(original.T, np.complex128)]
 
     def test_basic(self):
 
@@ -292,7 +292,7 @@ class TestAsLinearOperator:
                   np.array([[1], [2], [3]])]
             ys = [np.array([1, 2]), np.array([[1], [2]])]
 
-            if A.dtype == np.complex_:
+            if A.dtype == np.complex128:
                 xs += [np.array([1, 2j, 3j]),
                        np.array([[1], [2j], [3j]])]
                 ys += [np.array([1, 2j]), np.array([[1], [2j]])]

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -179,7 +179,7 @@ def test_shifts(shifts, dtype):
 def test_shifts_accuracy():
     np.random.seed(0)
     n, k = 70, 10
-    A = np.random.random((n, n)).astype(np.double)
+    A = np.random.random((n, n)).astype(np.float64)
     u1, s1, vt1, _ = _svdp(A, k, shifts=None, which='SM', irl_mode=True)
     u2, s2, vt2, _ = _svdp(A, k, shifts=32, which='SM', irl_mode=True)
     # shifts <= 32 doesn't agree with shifts > 32

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -78,7 +78,7 @@ class TestLaplacianNd:
         eigvals = eigh(L, eigvals_only=True)
         dtype = eigenvalues.dtype
         n = np.prod(grid_shape)
-        atol = n * n * max(np.finfo(dtype).eps, np.finfo(np.double).eps)
+        atol = n * n * max(np.finfo(dtype).eps, np.finfo(np.float64).eps)
         assert_allclose(eigenvalues, eigvals, atol=atol)
 
     @pytest.mark.parametrize("grid_shape", [(6, ), (2, 3), (2, 3, 4)])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1915,7 +1915,7 @@ class _TestCommon:
             assert_equal(min_s.dtype, min_d.dtype)
 
         for dtype in self.math_dtypes:
-            for dtype2 in [np.int8, np.float_, np.complex_]:
+            for dtype2 in [np.int8, np.float64, np.complex128]:
                 for btype in ['scalar', 'scalar2', 'dense', 'sparse']:
                     check(np.dtype(dtype), np.dtype(dtype2), btype)
 
@@ -3677,7 +3677,7 @@ class TestCSR(sparse_test_class()):
             sup.filter(SparseEfficiencyWarning,
                        "Changing the sparsity structure of a csr_matrix is expensive")
             return csr_matrix(*args, **kwargs)
-    math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
+    math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
     def test_constructor1(self):
         b = array([[0, 4, 0],
@@ -3930,7 +3930,7 @@ class TestCSC(sparse_test_class()):
             sup.filter(SparseEfficiencyWarning,
                        "Changing the sparsity structure of a csc_matrix is expensive")
             return csc_matrix(*args, **kwargs)
-    math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
+    math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
     def test_constructor1(self):
         b = array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 2, 0, 3]], 'd')
@@ -4072,7 +4072,7 @@ TestCSC.init_class()
 
 class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
     spcreator = dok_matrix
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_mult(self):
         A = dok_matrix((10,10))
@@ -4173,7 +4173,7 @@ TestDOK.init_class()
 
 class TestLIL(sparse_test_class(minmax=False)):
     spcreator = lil_matrix
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_dot(self):
         A = zeros((10, 10), np.complex128)
@@ -4283,7 +4283,7 @@ class TestCOO(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spcreator = coo_matrix
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_constructor1(self):
         # unsorted triplet format
@@ -4416,7 +4416,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
                                 fancy_indexing=False, fancy_assign=False,
                                 minmax=False, nnz_axis=False)):
     spcreator = dia_matrix
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_constructor1(self):
         D = array([[1, 0, 3, 0],
@@ -4470,7 +4470,7 @@ class TestBSR(sparse_test_class(getset=False,
                                 fancy_indexing=False, fancy_assign=False,
                                 nnz_axis=False)):
     spcreator = bsr_matrix
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_constructor1(self):
         # check native BSR format constructor

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3838,7 +3838,7 @@ class TestCSR(sparse_test_class()):
         indptr = np.array([0, 2])
         M = csr_matrix((data, sorted_inds, indptr)).copy()
         assert_equal(True, M.has_sorted_indices)
-        assert type(M.has_sorted_indices) == bool
+        assert isinstance(M.has_sorted_indices, bool)
 
         M = csr_matrix((data, unsorted_inds, indptr)).copy()
         assert_equal(False, M.has_sorted_indices)
@@ -3870,7 +3870,7 @@ class TestCSR(sparse_test_class()):
 
         M = csr_matrix((data, indices, indptr)).copy()
         assert_equal(False, M.has_canonical_format)
-        assert type(M.has_canonical_format) == bool
+        assert isinstance(M.has_canonical_format, bool)
 
         # set by deduplicating
         M.sum_duplicates()

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -537,7 +537,7 @@ class TestConstructUtils:
                 assert_equal(x.nnz, 5)
 
             x1 = f(5, 10, density=0.1, random_state=4321)
-            assert_equal(x1.dtype, np.double)
+            assert_equal(x1.dtype, np.float64)
 
             x2 = f(5, 10, density=0.1,
                    random_state=np.random.RandomState(4321))

--- a/scipy/spatial/_procrustes.py
+++ b/scipy/spatial/_procrustes.py
@@ -97,8 +97,8 @@ def procrustes(data1, data2):
     0.0
 
     """
-    mtx1 = np.array(data1, dtype=np.double, copy=True)
-    mtx2 = np.array(data2, dtype=np.double, copy=True)
+    mtx1 = np.array(data1, dtype=np.float64, copy=True)
+    mtx2 = np.array(data2, dtype=np.float64, copy=True)
 
     if mtx1.ndim != 2 or mtx2.ndim != 2:
         raise ValueError("Input matrices must be two-dimensional")

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -172,7 +172,7 @@ class SphericalVoronoi:
                              '(i.e. `radius=1`).')
 
         self.radius = float(radius)
-        self.points = np.array(points).astype(np.double)
+        self.points = np.array(points).astype(np.float64)
         self._dim = self.points.shape[1]
         if center is None:
             self.center = np.zeros(self._dim)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -259,7 +259,7 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
                              "are required." % (m, n, n + 1))
         if isinstance(X, tuple):
             X = np.vstack(X)
-        CV = np.atleast_2d(np.cov(X.astype(np.double, copy=False).T))
+        CV = np.atleast_2d(np.cov(X.astype(np.float64, copy=False).T))
         VI = np.linalg.inv(CV).T.copy()
     kwargs["VI"] = _convert_to_double(VI)
     return kwargs
@@ -296,7 +296,7 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
     if V is None:
         if isinstance(X, tuple):
             X = np.vstack(X)
-        V = np.var(X.astype(np.double, copy=False), axis=0, ddof=1)
+        V = np.var(X.astype(np.float64, copy=False), axis=0, ddof=1)
     else:
         V = np.asarray(V, order='c')
         if len(V.shape) != 1:
@@ -318,7 +318,7 @@ def _validate_vector(u, dtype=None):
     raise ValueError("Input vector should be 1-D.")
 
 
-def _validate_weights(w, dtype=np.double):
+def _validate_weights(w, dtype=np.float64):
     w = _validate_vector(w, dtype=dtype)
     if np.any(w < 0):
         raise ValueError("Input weights should be all non-negative")
@@ -809,8 +809,8 @@ def jaccard(u, v, w=None):
         w = _validate_weights(w)
         nonzero = w * nonzero
         unequal_nonzero = w * unequal_nonzero
-    a = np.double(unequal_nonzero.sum())
-    b = np.double(nonzero.sum())
+    a = np.float64(unequal_nonzero.sum())
+    b = np.float64(nonzero.sum())
     return (a / b) if b != 0 else 0
 
 
@@ -1592,7 +1592,7 @@ def sokalsneath(u, v, w=None):
     return float(2.0 * (ntf + nft)) / denom
 
 
-_convert_to_double = partial(_convert_to_type, out_type=np.double)
+_convert_to_double = partial(_convert_to_type, out_type=np.float64)
 _convert_to_bool = partial(_convert_to_type, out_type=bool)
 
 # adding python-only wrappers to _distance_wrap module
@@ -1620,7 +1620,7 @@ class CDistMetricWrapper:
             return _cdist_callable(
                 XA, XB, metric=metric, out=out, w=w, **kwargs)
 
-        dm = _prepare_out_argument(out, np.double, (mA, mB))
+        dm = _prepare_out_argument(out, np.float64, (mA, mB))
         # get cdist wrapper
         cdist_fn = getattr(_distance_wrap, f'cdist_{metric_name}_{typ}_wrap')
         cdist_fn(XA, XB, dm, **kwargs)
@@ -1640,7 +1640,7 @@ class CDistWeightedMetricWrapper:
         metric_name = self.metric_name
         XA, XB, typ, kwargs = _validate_cdist_input(
             XA, XB, mA, mB, n, _METRICS[metric_name], **kwargs)
-        dm = _prepare_out_argument(out, np.double, (mA, mB))
+        dm = _prepare_out_argument(out, np.float64, (mA, mB))
 
         w = kwargs.pop('w', None)
         if w is not None:
@@ -1671,7 +1671,7 @@ class PDistMetricWrapper:
             return _pdist_callable(
                 X, metric=metric, out=out, w=w, **kwargs)
 
-        dm = _prepare_out_argument(out, np.double, (out_size,))
+        dm = _prepare_out_argument(out, np.float64, (out_size,))
         # get pdist wrapper
         pdist_fn = getattr(_distance_wrap, f'pdist_{metric_name}_{typ}_wrap')
         pdist_fn(X, dm, **kwargs)
@@ -1690,7 +1690,7 @@ class PDistWeightedMetricWrapper:
         X, typ, kwargs = _validate_pdist_input(
             X, m, n, _METRICS[metric_name], **kwargs)
         out_size = (m * (m - 1)) // 2
-        dm = _prepare_out_argument(out, np.double, (out_size,))
+        dm = _prepare_out_argument(out, np.float64, (out_size,))
 
         w = kwargs.pop('w', None)
         if w is not None:
@@ -2644,7 +2644,7 @@ def _prepare_out_argument(out, dtype, expected_shape):
         raise ValueError("Output array has incorrect shape.")
     if not out.flags.c_contiguous:
         raise ValueError("Output array must be C-contiguous.")
-    if out.dtype != np.double:
+    if out.dtype != np.float64:
         raise ValueError("Output array must be double type.")
     return out
 
@@ -2652,7 +2652,7 @@ def _prepare_out_argument(out, dtype, expected_shape):
 def _pdist_callable(X, *, out, metric, **kwargs):
     n = X.shape[0]
     out_size = (n * (n - 1)) // 2
-    dm = _prepare_out_argument(out, np.double, (out_size,))
+    dm = _prepare_out_argument(out, np.float64, (out_size,))
     k = 0
     for i in range(X.shape[0] - 1):
         for j in range(i + 1, X.shape[0]):
@@ -2664,7 +2664,7 @@ def _pdist_callable(X, *, out, metric, **kwargs):
 def _cdist_callable(XA, XB, *, out, metric, **kwargs):
     mA = XA.shape[0]
     mB = XB.shape[0]
-    dm = _prepare_out_argument(out, np.double, (mA, mB))
+    dm = _prepare_out_argument(out, np.float64, (mA, mB))
     for i in range(mA):
         for j in range(mB):
             dm[i, j] = metric(XA[i], XB[j], **kwargs)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -393,10 +393,10 @@ class TestCdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.double],
-                              'uint': [np.int_, np.float32, np.double],
-                              'int': [np.float32, np.double],
-                              'float32': [np.double]}
+        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.float64],
+                              'uint': [np.int_, np.float32, np.float64],
+                              'int': [np.float32, np.float64],
+                              'float32': [np.float64]}
 
     def test_cdist_extra_args(self, metric):
         # Tests that args and kwargs are correctly handled
@@ -561,11 +561,11 @@ class TestCdist:
 
             # Testing built-in metrics with extra args
             if metric == "seuclidean":
-                X12 = np.vstack([X1, X2]).astype(np.double)
+                X12 = np.vstack([X1, X2]).astype(np.float64)
                 V = np.var(X12, axis=0, ddof=1)
                 self._check_calling_conventions(X1, X2, metric, V=V)
             elif metric == "mahalanobis":
-                X12 = np.vstack([X1, X2]).astype(np.double)
+                X12 = np.vstack([X1, X2]).astype(np.float64)
                 V = np.atleast_2d(np.cov(X12.T))
                 VI = np.array(np.linalg.inv(V).T)
                 self._check_calling_conventions(X1, X2, metric, VI=VI)
@@ -607,7 +607,7 @@ class TestCdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        out1 = np.empty((out_r, out_c), dtype=np.double)
+        out1 = np.empty((out_r, out_c), dtype=np.float64)
         Y1 = cdist(X1, X2, metric, **kwargs)
         Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
 
@@ -618,14 +618,14 @@ class TestCdist:
         assert_(Y2 is out1)
 
         # test for incorrect shape
-        out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
+        out2 = np.empty((out_r-1, out_c+1), dtype=np.float64)
         with pytest.raises(ValueError):
             cdist(X1, X2, metric, out=out2, **kwargs)
 
         # test for C-contiguous order
         out3 = np.empty(
-            (2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
-        out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
+            (2 * out_r, 2 * out_c), dtype=np.float64)[::2, ::2]
+        out4 = np.empty((out_r, out_c), dtype=np.float64, order='F')
         with pytest.raises(ValueError):
             cdist(X1, X2, metric, out=out3, **kwargs)
         with pytest.raises(ValueError):
@@ -688,10 +688,10 @@ class TestPdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.double],
-                              'uint': [np.int_, np.float32, np.double],
-                              'int': [np.float32, np.double],
-                              'float32': [np.double]}
+        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.float64],
+                              'uint': [np.int_, np.float32, np.float64],
+                              'int': [np.float32, np.float64],
+                              'float32': [np.float64]}
 
     def test_pdist_extra_args(self, metric):
         # Tests that args and kwargs are correctly handled
@@ -1487,10 +1487,10 @@ class TestPdist:
 
             # Testing built-in metrics with extra args
             if metric == "seuclidean":
-                V = np.var(X.astype(np.double), axis=0, ddof=1)
+                V = np.var(X.astype(np.float64), axis=0, ddof=1)
                 self._check_calling_conventions(X, metric, V=V)
             elif metric == "mahalanobis":
-                V = np.atleast_2d(np.cov(X.astype(np.double).T))
+                V = np.atleast_2d(np.cov(X.astype(np.float64).T))
                 VI = np.array(np.linalg.inv(V).T)
                 self._check_calling_conventions(X, metric, VI=VI)
 
@@ -1528,7 +1528,7 @@ class TestPdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        out1 = np.empty(out_size, dtype=np.double)
+        out1 = np.empty(out_size, dtype=np.float64)
         Y_right = pdist(X, metric, **kwargs)
         Y_test1 = pdist(X, metric, out=out1, **kwargs)
 
@@ -1539,12 +1539,12 @@ class TestPdist:
         assert_(Y_test1 is out1)
 
         # test for incorrect shape
-        out2 = np.empty(out_size + 3, dtype=np.double)
+        out2 = np.empty(out_size + 3, dtype=np.float64)
         with pytest.raises(ValueError):
             pdist(X, metric, out=out2, **kwargs)
 
         # test for (C-)contiguous output
-        out3 = np.empty(2 * out_size, dtype=np.double)[::2]
+        out3 = np.empty(2 * out_size, dtype=np.float64)[::2]
         with pytest.raises(ValueError):
             pdist(X, metric, out=out3, **kwargs)
 
@@ -1805,21 +1805,21 @@ def is_valid_dm_throw(D):
 class TestIsValidDM:
 
     def test_is_valid_dm_improper_shape_1D_E(self):
-        D = np.zeros((5,), dtype=np.double)
+        D = np.zeros((5,), dtype=np.float64)
         with pytest.raises(ValueError):
             is_valid_dm_throw((D))
 
     def test_is_valid_dm_improper_shape_1D_F(self):
-        D = np.zeros((5,), dtype=np.double)
+        D = np.zeros((5,), dtype=np.float64)
         assert_equal(is_valid_dm(D), False)
 
     def test_is_valid_dm_improper_shape_3D_E(self):
-        D = np.zeros((3, 3, 3), dtype=np.double)
+        D = np.zeros((3, 3, 3), dtype=np.float64)
         with pytest.raises(ValueError):
             is_valid_dm_throw((D))
 
     def test_is_valid_dm_improper_shape_3D_F(self):
-        D = np.zeros((3, 3, 3), dtype=np.double)
+        D = np.zeros((3, 3, 3), dtype=np.float64)
         assert_equal(is_valid_dm(D), False)
 
     def test_is_valid_dm_nonzero_diagonal_E(self):
@@ -1851,7 +1851,7 @@ class TestIsValidDM:
         assert_equal(is_valid_dm(D), False)
 
     def test_is_valid_dm_correct_1_by_1(self):
-        D = np.zeros((1, 1), dtype=np.double)
+        D = np.zeros((1, 1), dtype=np.float64)
         assert_equal(is_valid_dm(D), True)
 
     def test_is_valid_dm_correct_2_by_2(self):
@@ -1885,21 +1885,21 @@ class TestIsValidY:
     # check.  Otherwise the input is expected to be valid.
 
     def test_is_valid_y_improper_shape_2D_E(self):
-        y = np.zeros((3, 3,), dtype=np.double)
+        y = np.zeros((3, 3,), dtype=np.float64)
         with pytest.raises(ValueError):
             is_valid_y_throw((y))
 
     def test_is_valid_y_improper_shape_2D_F(self):
-        y = np.zeros((3, 3,), dtype=np.double)
+        y = np.zeros((3, 3,), dtype=np.float64)
         assert_equal(is_valid_y(y), False)
 
     def test_is_valid_y_improper_shape_3D_E(self):
-        y = np.zeros((3, 3, 3), dtype=np.double)
+        y = np.zeros((3, 3, 3), dtype=np.float64)
         with pytest.raises(ValueError):
             is_valid_y_throw((y))
 
     def test_is_valid_y_improper_shape_3D_F(self):
-        y = np.zeros((3, 3, 3), dtype=np.double)
+        y = np.zeros((3, 3, 3), dtype=np.float64)
         assert_equal(is_valid_y(y), False)
 
     def test_is_valid_y_correct_2_by_2(self):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -59,7 +59,7 @@ pathological_data_1 = np.array([
 pathological_data_2 = np.array([
     [-1, -1], [-1, 0], [-1, 1],
     [0, -1], [0, 0], [0, 1],
-    [1, -1 - np.finfo(np.float_).eps], [1, 0], [1, 1],
+    [1, -1 - np.finfo(np.float64).eps], [1, 0], [1, 1],
 ])
 
 bug_2850_chunks = [np.random.rand(10, 2),
@@ -173,7 +173,7 @@ class TestUtilities:
 
     def test_find_simplex(self):
         # Simple check that simplex finding works
-        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.float64)
         tri = qhull.Delaunay(points)
 
         # +---+
@@ -196,8 +196,8 @@ class TestUtilities:
         # Compare plane distance from hyperplane equations obtained from Qhull
         # to manually computed plane equations
         x = np.array([(0,0), (1, 1), (1, 0), (0.99189033, 0.37674127),
-                      (0.99440079, 0.45182168)], dtype=np.double)
-        p = np.array([0.99966555, 0.15685619], dtype=np.double)
+                      (0.99440079, 0.45182168)], dtype=np.float64)
+        p = np.array([0.99966555, 0.15685619], dtype=np.float64)
 
         tri = qhull.Delaunay(x)
 
@@ -221,7 +221,7 @@ class TestUtilities:
 
     def test_convex_hull(self):
         # Simple check that the convex hull seems to works
-        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.float64)
         tri = qhull.Delaunay(points)
 
         # +---+
@@ -396,18 +396,18 @@ class TestVertexNeighborVertices:
         assert_equal(got, expected, err_msg=f"{got!r} != {expected!r}")
 
     def test_triangle(self):
-        points = np.array([(0,0), (0,1), (1,0)], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,0)], dtype=np.float64)
         tri = qhull.Delaunay(points)
         self._check(tri)
 
     def test_rectangle(self):
-        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.float64)
         tri = qhull.Delaunay(points)
         self._check(tri)
 
     def test_complicated(self):
         points = np.array([(0,0), (0,1), (1,1), (1,0),
-                           (0.5, 0.5), (0.9, 0.5)], dtype=np.double)
+                           (0.5, 0.5), (0.9, 0.5)], dtype=np.float64)
         tri = qhull.Delaunay(points)
         self._check(tri)
 
@@ -422,7 +422,7 @@ class TestDelaunay:
         assert_raises(ValueError, qhull.Delaunay, masked_array)
 
     def test_array_with_nans_fails(self):
-        points_with_nan = np.array([(0,0), (0,1), (1,1), (1,np.nan)], dtype=np.double)
+        points_with_nan = np.array([(0,0), (0,1), (1,1), (1,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.Delaunay, points_with_nan)
 
     def test_nd_simplex(self):
@@ -442,7 +442,7 @@ class TestDelaunay:
 
     def test_2d_square(self):
         # simple smoke test: 2d square
-        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
+        points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.float64)
         tri = qhull.Delaunay(points)
 
         assert_equal(tri.simplices, [[1, 3, 2], [3, 1, 0]])
@@ -601,7 +601,7 @@ class TestConvexHull:
         assert_raises(ValueError, qhull.ConvexHull, masked_array)
 
     def test_array_with_nans_fails(self):
-        points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.double)
+        points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.ConvexHull, points_with_nan)
 
     @pytest.mark.parametrize("name", sorted(DATASETS))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -25,7 +25,7 @@ import sys
 
 import numpy as np
 from numpy import (array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp,
-        log, zeros, sqrt, asarray, inf, nan_to_num, real, arctan, float_,
+        log, zeros, sqrt, asarray, inf, nan_to_num, real, arctan, double,
         array_equal)
 
 import pytest
@@ -1660,7 +1660,7 @@ class TestEllipCarlson:
         assert np.isinf(elliprd(1, 1, 0))
         assert np.isinf(elliprd(1, 1, complex(0, 0)))
         assert np.isinf(elliprd(0, 1, complex(0, 0)))
-        assert isnan(elliprd(1, 1, -np.finfo(np.double).tiny / 2.0))
+        assert isnan(elliprd(1, 1, -np.finfo(np.float64).tiny / 2.0))
         assert isnan(elliprd(1, 1, complex(-1, 0)))
         args = array([[0.0, 2.0, 1.0],
                       [2.0, 3.0, 4.0],
@@ -1775,7 +1775,7 @@ class TestEllipLegendreCarlsonIdentities:
     def setup_class(self):
         self.m_n1_1 = np.arange(-1., 1., 0.01)
         # For double, this is -(2**1024)
-        self.max_neg = finfo(float_).min
+        self.max_neg = finfo(double).min
         # Lots of very negative numbers
         self.very_neg_m = -1. * 2.**arange(-1 +
                                            np.log2(-self.max_neg), 0.,
@@ -1797,7 +1797,7 @@ class TestEllipLegendreCarlsonIdentities:
         But with the ellipkm1 function
         """
         # For double, this is 2**-1022
-        tiny = finfo(float_).tiny
+        tiny = finfo(double).tiny
         # All these small powers of 2, up to 2**-1
         m1 = tiny * 2.**arange(0., -np.log2(tiny))
         assert_allclose(ellipkm1(m1), elliprf(0., m1, 1.))
@@ -2152,7 +2152,7 @@ class TestFactorialFunctions:
             with pytest.warns(DeprecationWarning, match="Non-integer array.*"):
                 result = special.factorial(n, exact=exact)
                 # expected dtype is integer, unless there are NaNs
-                dtype = np.float_ if np.any(np.isnan(n)) else np.int_
+                dtype = np.float64 if np.any(np.isnan(n)) else np.int_
         elif exact and not np.issubdtype(n.dtype, np.integer):
             with pytest.raises(ValueError, match="factorial with exact=.*"):
                 special.factorial(n, exact=exact)
@@ -3181,11 +3181,11 @@ class TestBessel:
         assert_allclose(special.iv(-0.5, 1), 1.231200214592967)
 
     def iv_series(self, v, z, n=200):
-        k = arange(0, n).astype(float_)
+        k = arange(0, n).astype(double)
         r = (v+2*k)*log(.5*z) - special.gammaln(k+1) - special.gammaln(v+k+1)
         r[isnan(r)] = inf
         r = exp(r)
-        err = abs(r).max() * finfo(float_).eps * n + abs(r[-1])*10
+        err = abs(r).max() * finfo(double).eps * n + abs(r[-1])*10
         return r.sum(), err
 
     def test_i0_series(self):
@@ -3674,7 +3674,7 @@ class TestStruve:
         """Compute Struve function & error estimate from its power series."""
         k = arange(0, n)
         r = (-1)**k * (.5*z)**(2*k+v+1)/special.gamma(k+1.5)/special.gamma(k+v+1.5)
-        err = abs(r).max() * finfo(float_).eps * n
+        err = abs(r).max() * finfo(double).eps * n
         return r.sum(), err
 
     def test_vs_series(self):

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -605,7 +605,7 @@ def test_local(test):
     _test_factory(test)
 
 
-def _test_factory(test, dtype=np.double):
+def _test_factory(test, dtype=np.float64):
     """Boost test"""
     with suppress_warnings() as sup:
         sup.filter(IntegrationWarning, "The occurrence of roundoff error is detected")

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -39,7 +39,7 @@ def test_expi_complex():
         for p in np.linspace(0, 2*np.pi, 30):
             z = r*np.exp(1j*p)
             dataset.append((z, complex(mpmath.ei(z))))
-    dataset = np.array(dataset, dtype=np.complex_)
+    dataset = np.array(dataset, dtype=np.cdouble)
 
     FuncData(sc.expi, dataset, 0, 1).check()
 
@@ -135,7 +135,7 @@ def test_hyp2f1_strange_points():
     ]
     kw = dict(eliminate=True)
     dataset = [p + (float(mpmath.hyp2f1(*p, **kw)),) for p in pts]
-    dataset = np.array(dataset, dtype=np.float_)
+    dataset = np.array(dataset, dtype=np.float64)
 
     FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
 
@@ -166,7 +166,7 @@ def test_hyp2f1_real_some_points():
         (0.5, 1 - 270.5, 1.5, 0.999**2),  # from issue 1561
     ]
     dataset = [p + (float(mpmath.hyp2f1(*p)),) for p in pts]
-    dataset = np.array(dataset, dtype=np.float_)
+    dataset = np.array(dataset, dtype=np.float64)
 
     with np.errstate(invalid='ignore'):
         FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
@@ -189,7 +189,7 @@ def test_hyp2f1_some_points_2():
             return x
 
     dataset = [tuple(map(fev, p)) + (float(mpmath.hyp2f1(*p)),) for p in pts]
-    dataset = np.array(dataset, dtype=np.float_)
+    dataset = np.array(dataset, dtype=np.float64)
 
     FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
 
@@ -206,7 +206,7 @@ def test_hyp2f1_real_some():
                     except Exception:
                         continue
                     dataset.append((a, b, c, z, v))
-    dataset = np.array(dataset, dtype=np.float_)
+    dataset = np.array(dataset, dtype=np.float64)
 
     with np.errstate(invalid='ignore'):
         FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-9,
@@ -217,7 +217,7 @@ def test_hyp2f1_real_some():
 @pytest.mark.slow
 def test_hyp2f1_real_random():
     npoints = 500
-    dataset = np.zeros((npoints, 5), np.float_)
+    dataset = np.zeros((npoints, 5), np.float64)
 
     np.random.seed(1234)
     dataset[:, 0] = np.random.pareto(1.5, npoints)
@@ -308,7 +308,7 @@ def test_lpmv():
         return mpmath.legenp(nu, mu, x)
 
     dataset = [p + (mplegenp(p[1], p[0], p[2]),) for p in pts]
-    dataset = np.array(dataset, dtype=np.float_)
+    dataset = np.array(dataset, dtype=np.float64)
 
     def evf(mu, nu, x):
         return sc.lpmv(mu.astype(int), nu, x)
@@ -1013,7 +1013,7 @@ class TestSystematic:
     def test_exprel(self):
         assert_mpmath_equal(sc.exprel,
                             lambda x: mpmath.expm1(x)/x if x != 0 else mpmath.mpf('1.0'),
-                            [Arg(a=-np.log(np.finfo(np.double).max), b=np.log(np.finfo(np.double).max))])
+                            [Arg(a=-np.log(np.finfo(np.float64).max), b=np.log(np.finfo(np.float64).max))])
         assert_mpmath_equal(sc.exprel,
                             lambda x: mpmath.expm1(x)/x if x != 0 else mpmath.mpf('1.0'),
                             np.array([1e-12, 1e-24, 0, 1e12, 1e24, np.inf]), rtol=1e-11)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5104,7 +5104,7 @@ class geninvgauss_gen(rv_continuous):
                    "involving scipy.special.kve. Values replaced by NaN to "
                    "avoid incorrect results.")
             warnings.warn(msg, RuntimeWarning)
-            m = np.full_like(num, np.nan, dtype=np.double)
+            m = np.full_like(num, np.nan, dtype=np.float64)
             m[~inf_vals] = num[~inf_vals] / denom[~inf_vals]
         else:
             m = num / denom

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -604,10 +604,10 @@ def _get_wilcoxon_distr(n):
     Returns an array with the probabilities of all the possible ranks
     r = 0, ..., n*(n+1)/2
     """
-    c = np.ones(1, dtype=np.double)
+    c = np.ones(1, dtype=np.float64)
     for k in range(1, n + 1):
         prev_c = c
-        c = np.zeros(k * (k + 1) // 2 + 1, dtype=np.double)
+        c = np.zeros(k * (k + 1) // 2 + 1, dtype=np.float64)
         m = len(prev_c)
         c[:m] = prev_c * 0.5
         c[-m:] += prev_c * 0.5

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -15,7 +15,7 @@ __all__ = ['compare_medians_ms',
 
 
 import numpy as np
-from numpy import float_, int_, ndarray
+from numpy import double, int_, ndarray
 
 import numpy.ma as ma
 from numpy.ma import MaskedArray
@@ -62,7 +62,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
         # Don't use length here, in case we have a numpy scalar
         n = xsorted.size
 
-        hd = np.empty((2,len(prob)), float_)
+        hd = np.empty((2,len(prob)), double)
         if n < 2:
             hd.flat = np.nan
             if var:
@@ -86,7 +86,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
             return hd
         return hd[0]
     # Initialization & checks
-    data = ma.array(data, copy=False, dtype=float_)
+    data = ma.array(data, copy=False, dtype=double)
     p = np.array(prob, copy=False, ndmin=1)
     # Computes quantiles along axis (or globally)
     if (axis is None) or (data.ndim == 1):
@@ -155,7 +155,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         xsorted = np.sort(data.compressed())
         n = len(xsorted)
 
-        hdsd = np.empty(len(prob), float_)
+        hdsd = np.empty(len(prob), double)
         if n < 2:
             hdsd.flat = np.nan
 
@@ -175,7 +175,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         return hdsd
 
     # Initialization & checks
-    data = ma.array(data, copy=False, dtype=float_)
+    data = ma.array(data, copy=False, dtype=double)
     p = np.array(prob, copy=False, ndmin=1)
     # Computes quantiles along axis (or globally)
     if (axis is None):
@@ -262,8 +262,8 @@ def mjci(data, prob=[0.25,0.5,0.75], axis=None):
         prob = (np.array(p) * n + 0.5).astype(int_)
         betacdf = beta.cdf
 
-        mj = np.empty(len(prob), float_)
-        x = np.arange(1,n+1, dtype=float_) / n
+        mj = np.empty(len(prob), double)
+        x = np.arange(1,n+1, dtype=double) / n
         y = x - 1./n
         for (i,m) in enumerate(prob):
             W = betacdf(x,m-1,n-m) - betacdf(y,m-1,n-m)

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -15,7 +15,7 @@ __all__ = ['compare_medians_ms',
 
 
 import numpy as np
-from numpy import double, int_, ndarray
+from numpy import float64, int_, ndarray
 
 import numpy.ma as ma
 from numpy.ma import MaskedArray
@@ -62,7 +62,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
         # Don't use length here, in case we have a numpy scalar
         n = xsorted.size
 
-        hd = np.empty((2,len(prob)), double)
+        hd = np.empty((2,len(prob)), float64)
         if n < 2:
             hd.flat = np.nan
             if var:
@@ -86,7 +86,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
             return hd
         return hd[0]
     # Initialization & checks
-    data = ma.array(data, copy=False, dtype=double)
+    data = ma.array(data, copy=False, dtype=float64)
     p = np.array(prob, copy=False, ndmin=1)
     # Computes quantiles along axis (or globally)
     if (axis is None) or (data.ndim == 1):
@@ -155,7 +155,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         xsorted = np.sort(data.compressed())
         n = len(xsorted)
 
-        hdsd = np.empty(len(prob), double)
+        hdsd = np.empty(len(prob), float64)
         if n < 2:
             hdsd.flat = np.nan
 
@@ -175,7 +175,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         return hdsd
 
     # Initialization & checks
-    data = ma.array(data, copy=False, dtype=double)
+    data = ma.array(data, copy=False, dtype=float64)
     p = np.array(prob, copy=False, ndmin=1)
     # Computes quantiles along axis (or globally)
     if (axis is None):
@@ -262,8 +262,8 @@ def mjci(data, prob=[0.25,0.5,0.75], axis=None):
         prob = (np.array(p) * n + 0.5).astype(int_)
         betacdf = beta.cdf
 
-        mj = np.empty(len(prob), double)
-        x = np.arange(1,n+1, dtype=double) / n
+        mj = np.empty(len(prob), float64)
+        x = np.arange(1,n+1, dtype=float64) / n
         y = x - 1./n
         for (i,m) in enumerate(prob):
             W = betacdf(x,m-1,n-m) - betacdf(y,m-1,n-m)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -5091,8 +5091,8 @@ class multivariate_hypergeom_gen(multi_rv_generic):
     def _logpmf(self, x, M, m, n, mxcond, ncond):
         # This equation of the pmf comes from the relation,
         # n combine r = beta(n+1, 1) / beta(r+1, n-r+1)
-        num = np.zeros_like(m, dtype=np.float_)
-        den = np.zeros_like(n, dtype=np.float_)
+        num = np.zeros_like(m, dtype=np.float64)
+        den = np.zeros_like(n, dtype=np.float64)
         m, x = m[~mxcond], x[~mxcond]
         M, n = M[~ncond], n[~ncond]
         num[~mxcond] = (betaln(m+1, 1) - betaln(x+1, m-x+1))

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -11,7 +11,7 @@ __all__ = [  # noqa: F822
     'idealfourths',
     'median_cihs','mjci','mquantiles_cimj',
     'rsh',
-    'trimmed_mean_ci', 'float_', 'int_', 'ma', 'MaskedArray', 'mstats',
+    'trimmed_mean_ci', 'int_', 'ma', 'MaskedArray', 'mstats',
     'norm', 'beta', 't', 'binom'
 ]
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -242,7 +242,7 @@ def check_meth_dtype(distfn, arg, meths):
         x = x[(distfn.a < x) & (x < distfn.b)]
         for meth in meths:
             val = meth(x, *arg)
-            npt.assert_(val.dtype == np.float_)
+            npt.assert_(val.dtype == np.float64)
 
 
 def check_ppf_dtype(distfn, arg):
@@ -251,7 +251,7 @@ def check_ppf_dtype(distfn, arg):
     for q in q_cast:
         for meth in [distfn.ppf, distfn.isf]:
             val = meth(q, *arg)
-            npt.assert_(val.dtype == np.float_)
+            npt.assert_(val.dtype == np.float64)
 
 
 def check_cmplx_deriv(distfn, arg):

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2880,7 +2880,7 @@ class TestMultivariateHypergeom:
         assert_equal(cov3, cov4)
 
         cov5 = multivariate_hypergeom.cov(m=np.array([], np.int_), n=0)
-        cov6 = np.array([], dtype=np.float_).reshape(0, 0)
+        cov6 = np.array([], dtype=np.float64).reshape(0, 0)
         assert_allclose(cov5, cov6, rtol=1e-17)
         assert_(cov5.shape == (0, 0))
 


### PR DESCRIPTION
Hi @rgommers,
Here's a new PR with follow-up work related to https://github.com/numpy/numpy/pull/24376. Basically, I update all items that are being removed in Part 3 of "main namespace refactor" PRs (Also, I took opportunity to update `np.double` to `np.float64` in Python files, as preferred canonical name). 