### PR TITLE
ENH: optimize: c1 and c2 of scalar_search_wolfe to cg and newton-cg

### DIFF
--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -24,6 +24,12 @@ class LineSearchWarning(RuntimeWarning):
     pass
 
 
+def _check_c1_c2(c1, c2):
+    if not (0 < c1 < c2 < 1):
+        raise ValueError("'c1' and 'c2' do not satisfy"
+                         "'0 < c1 < c2 < 1'.")
+
+
 #------------------------------------------------------------------------------
 # Minpack's Wolfe line and scalar searches
 #------------------------------------------------------------------------------
@@ -131,6 +137,7 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     Uses routine DCSRCH from MINPACK.
 
     """
+    _check_c1_c2(c1, c2)
 
     if phi0 is None:
         phi0 = phi(0.)
@@ -378,6 +385,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
     1999, pp. 59-61.
 
     """
+    _check_c1_c2(c1, c2)
 
     if phi0 is None:
         phi0 = phi(0.)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1430,7 +1430,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     c1 : float, default: 1e-4
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
-        Parameter for curvature condition rule
+        Parameter for curvature condition rule.
 
     Notes
     -----
@@ -1615,7 +1615,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     c1 : float, default: 1e-4
         Parameter for Armijo condition rule.
     c2 : float, default: 0.4
-        Parameter for curvature condition rule
+        Parameter for curvature condition rule.
 
     Returns
     -------
@@ -1783,7 +1783,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     c1 : float, default: 1e-4
         Parameter for Armijo condition rule.
     c2 : float, default: 0.4
-        Parameter for curvature condition rule
+        Parameter for curvature condition rule.
 
     Notes
     -----
@@ -2050,7 +2050,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     c1 : float, default: 1e-4
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
-        Parameter for curvature condition rule
+        Parameter for curvature condition rule.
 
     Notes
     -----

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -271,12 +271,6 @@ class OptimizeWarning(UserWarning):
     pass
 
 
-def _check_c1_c2(c1, c2):
-    if not (0 < c1 < c2 < 1):
-        raise ValueError("'c1' and 'c2' do not satisfy"
-                         "'0 < c1 < c2 < 1'.")
-
-
 def _check_unknown_options(unknown_options):
     if unknown_options:
         msg = ", ".join(map(str, unknown_options.keys()))
@@ -1436,7 +1430,6 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     -----
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
-    _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)
     retall = return_all
 
@@ -1751,7 +1744,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
                  gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                  disp=False, return_all=False, finite_diff_rel_step=None,
-                 c1=1e-3, c2=0.4, **unknown_options):
+                 c1=1e-4, c2=0.4, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     conjugate gradient algorithm.
@@ -1789,7 +1782,6 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     -----
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
-    _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)
 
     retall = return_all
@@ -2056,7 +2048,6 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     -----
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
-    _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)
     if jac is None:
         raise ValueError('Jacobian is required for Newton-CG method')

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1293,9 +1293,10 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         Relative tolerance for `x`. Terminate successfully if step
         size is less than ``xk * xrtol`` where ``xk`` is the current
         parameter vector.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .9 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.9
+        Parameter for curvature condition rule
 
     Returns
     -------
@@ -1324,6 +1325,8 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     Optimize the function, `f`, whose gradient is given by `fprime`
     using the quasi-Newton method of Broyden, Fletcher, Goldfarb,
     and Shanno (BFGS).
+    
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
 
     See Also
     --------
@@ -1424,10 +1427,14 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     xrtol : float, default: 0
         Relative tolerance for `x`. Terminate successfully if step size is
         less than ``xk * xrtol`` where ``xk`` is the current parameter vector.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .9 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.9
+        Parameter for curvature condition rule
 
+    Notes
+    -----
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
     _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)
@@ -1560,7 +1567,7 @@ def _print_success_message_or_warn(warnflag, message, warntype=None):
 
 def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
             epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
-            callback=None, c1=1e-4, c2=.4):
+            callback=None, c1=1e-4, c2=0.4):
     """
     Minimize a function using a nonlinear conjugate gradient algorithm.
 
@@ -1605,9 +1612,10 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     callback : callable, optional
         An optional user-supplied function, called after each iteration.
         Called as ``callback(xk)``, where ``xk`` is the current value of `x0`.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .4 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.4
+        Parameter for curvature condition rule
 
     Returns
     -------
@@ -1660,6 +1668,8 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     4. `fprime` is not too large, e.g., has a norm less than 1000,
     5. The initial guess, `x0`, is reasonably close to `f` 's global
        minimizing point, `xopt`.
+
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
 
     References
     ----------
@@ -1741,7 +1751,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
                  gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                  disp=False, return_all=False, finite_diff_rel_step=None,
-                 c1=1e-3, c2=.4, **unknown_options):
+                 c1=1e-3, c2=0.4, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     conjugate gradient algorithm.
@@ -1770,9 +1780,14 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         possibly adjusted to fit into the bounds. For ``jac='3-point'``
         the sign of `h` is ignored. If None (default) then step is selected
         automatically.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .4 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.4
+        Parameter for curvature condition rule
+
+    Notes
+    -----
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
     _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)
@@ -1890,7 +1905,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
 
 def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
              epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
-             callback=None, c1=1e-3, c2=.9):
+             callback=None, c1=1e-3, c2=0.9):
     """
     Unconstrained minimization of a function using the Newton-CG method.
 
@@ -1928,9 +1943,10 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         If True, print convergence message.
     retall : bool, optional
         If True, return a list of results at each iteration.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .9 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.9
+        Parameter for curvature condition rule
 
     Returns
     -------
@@ -1977,6 +1993,8 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         or box constrained minimization. (Box constraints give
         lower and upper bounds for each variable separately.)
 
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
+
     References
     ----------
     Wright & Nocedal, 'Numerical Optimization', 1999, p. 140.
@@ -2007,7 +2025,7 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
 
 def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                        callback=None, xtol=1e-5, eps=_epsilon, maxiter=None,
-                       disp=False, return_all=False, c1=1e-3, c2=.9,
+                       disp=False, return_all=False, c1=1e-3, c2=0.9,
                        **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
@@ -2029,9 +2047,14 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     return_all : bool, optional
         Set to True to return a list of the best solution at each of the
         iterations.
-    c1, c2 : float, optional
-        Armijo condition rule and curvature condition rule. Must satisfy
-        ``0 < c1 < c2 < 1``. Default values are 1e-4 for `c1` and .9 for `c2`.
+    c1 : float, default: 1e-4
+        Parameter for Armijo condition rule.
+    c2 : float, default: 0.9
+        Parameter for curvature condition rule
+
+    Notes
+    -----
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
     """
     _check_c1_c2(c1, c2)
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1296,7 +1296,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     c1 : float, default: 1e-4
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
-        Parameter for curvature condition rule
+        Parameter for curvature condition rule.
 
     Returns
     -------

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -256,6 +256,15 @@ class CheckOptimizeParameterized(CheckOptimize):
         res_mod = optimize.minimize(optimize.rosen,
                                     x0, method='bfgs', options={'c2': 1e-2})
         assert res_default.nit > res_mod.nit
+    
+    @pytest.mark.parametrize(["c1", "c2"], [[0.5, 2],
+                                            [-0.1, 0.1],
+                                            [0.2, 0.1]])
+    def test_invalid_c1_c2(self, c1, c2):
+        with pytest.raises(ValueError, match="'c1' and 'c2'"):
+            x0 = [10.3, 20.7, 10.8, 1.9, -1.2]
+            optimize.minimize(optimize.rosen, x0, method='cg',
+                              options={'c1': c1, 'c2': c2})
 
     def test_powell(self):
         # Powell (direction set) optimization routine


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #19075
follow up #18977
#### What does this implement/fix?

<!--Please explain your changes.-->
As requested exposes  parameters c1 and c2 for cg and newton-cg as well.
#### Additional information
<!--Any additional information you think is important.-->
