### PR TITLE
REL, MAINT: prep for 1.11.3

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.11.3-notes
    release/1.11.2-notes
    release/1.11.1-notes
    release/1.11.0-notes

--- a/doc/source/release/1.11.3-notes.rst
+++ b/doc/source/release/1.11.3-notes.rst
@@ -1,0 +1,24 @@
+==========================
+SciPy 1.11.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.11.3 is a bug-fix release with no new features
+compared to 1.11.2.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+Issues closed for 1.11.3
+------------------------
+
+
+
+Pull requests for 1.11.3
+------------------------
+

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.11.2',
+  version: '1.11.3.dev0',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -5,8 +5,8 @@ import argparse
 
 MAJOR = 1
 MINOR = 11
-MICRO = 2
-ISRELEASED = True
+MICRO = 3
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
* prepare for SciPy `1.11.3`, in case we want/need it

[skip cirrus] [skip actions]