### PR TITLE
BLD: tweaks to build dependencies and 3.12 classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,36 +10,29 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.12.1",
+    "meson-python>=0.13.1",
     "Cython>=0.29.35",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.12.0",
-    # `wheel` is needed for non-isolated builds, given that `meson-python`
-    # doesn't list it as a runtime requirement (at least in 0.5.0)
-    "wheel",
 
-    # NumPy dependencies - to update these, sync from
-    # https://github.com/scipy/oldest-supported-numpy/, and then
-    # update minimum version to match our install_requires min version
-    # ----------------------------------------------------------------
-
-    # now matches minimum supported version, keep here as separate requirement
-    # to be able to sync more easily with oldest-supported-numpy
+    # When numpy 2.0.0rc1 comes out, we should update this to build against 2.0,
+    # and then runtime depend on the range 1.22.X to <2.3. No need to switch to
+    # 1.25.2 in the meantime (1.25.x is the first version which exports older C
+    # API versions by default).
 
     # default numpy requirements
     "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-
-    # For Python versions which aren't yet officially supported,
-    # we specify an unpinned NumPy which allows source distributions
-    # to be used and allows wheels to be used as soon as they
-    # become available.
-    "numpy; python_version>='3.12'",
+    # For Python versions which aren't yet officially supported, we specify an
+    # unpinned NumPy which allows source distributions to be used and allows
+    # wheels to be used as soon as they become available.
+    "numpy>=1.26.0b1; python_version>='3.12'",
     "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
 ]
 
 [project]
 name = "SciPy"
+version = "1.12.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}
@@ -77,7 +70,6 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dynamic = ['version']
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
For the dependencies:

- put a lower bound on numpy version for Python 3.12; that pre-release   is the first version that will work.
- add comments around the future updates to the numpy build-time   dependency
- bump the minimum meson-python version
- remove `wheel` as a build dependency (the need for it went away with meson-python PR 215)

Closes gh-19082