### PR TITLE
DOC: add info about usage of ccache for benchmarks

### DIFF
--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -188,7 +188,5 @@ check out the ``asv find`` command and the ``--quick``,
 .. |7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32| replace:: ``7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32``
 .. _7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32: https://github.com/scipy/scipy/commit/7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32
 
-.. _ccurevisions documentation: https://git-scm.com/docs/gitrevisions#_specifying_ranges
-
 .. _ccache: https://ccache.dev
 .. _f90cache: https://perso.univ-rennes1.fr/edouard.canot/f90cache/

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -147,8 +147,13 @@ track its performance over time::
 
 .. note::
 
-   This will take a while, because SciPy has to be rebuilt for each
-   commit! For more information about specifying ranges of commits, see
+   This will take a while, because SciPy has to be rebuilt for each commit! To
+   speed up the building process of benchmarks you can install `ccache`_ and
+   `f90cache`_. The benchmark suite will automatically detect them if they are
+   installed in the ``/usr/lib`` and ``/usr/local/lib``. Otherwise you must add
+   them to the ``PATH`` environment variable.
+
+   For more information about specifying ranges of commits, see
    the `git revisions documentation`_.
 
 To "publish" the results (prepare them to be viewed) and "preview" them
@@ -182,3 +187,8 @@ check out the ``asv find`` command and the ``--quick``,
 
 .. |7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32| replace:: ``7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32``
 .. _7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32: https://github.com/scipy/scipy/commit/7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32
+
+.. _ccurevisions documentation: https://git-scm.com/docs/gitrevisions#_specifying_ranges
+
+.. _ccache: https://ccache.dev
+.. _f90cache: https://perso.univ-rennes1.fr/edouard.canot/f90cache/


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
  http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-11516

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds information about usage of ccache and f90cache to benchmark contributor documentation

#### Additional information
<!--Any additional information you think is important.-->
This is how the change looks like on my local build
![image](https://github.com/scipy/scipy/assets/2772557/4ab656ce-1085-48fd-88f1-b9d90dd2b88d)


---
This was done during EuroScipy 2023 sprint with mentor @Kai-Striega