### PR TITLE
DOC: add comment on args in solve_ivp (#18876)

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -181,7 +181,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     fun : callable
         Right-hand side of the system: the time derivative of the state ``y``
         at time ``t``. The calling signature is ``fun(t, y)``, where ``t`` is a
-        scalar and ``y`` is an ndarray with ``len(y) = len(y0)``. ``fun`` must
+        scalar and ``y`` is an ndarray with ``len(y) = len(y0)``. Additional
+        arguments need to be passed if ``args`` is used (see below). ``fun`` must
         return an array of the same shape as ``y``. See `vectorized` for more
         information.
     t_span : 2-member sequence
@@ -245,13 +246,14 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     events : callable, or list of callables, optional
         Events to track. If None (default), no events will be tracked.
         Each event occurs at the zeros of a continuous function of time and
-        state. Each function must have the signature ``event(t, y)`` and return
-        a float. The solver will find an accurate value of `t` at which
-        ``event(t, y(t)) = 0`` using a root-finding algorithm. By default, all
-        zeros will be found. The solver looks for a sign change over each step,
-        so if multiple zero crossings occur within one step, events may be
-        missed. Additionally each `event` function might have the following
-        attributes:
+        state. Each function must have the signature ``event(t, y)`` where
+        additional argument have to be passed if ``args`` is used (see below).
+        Each function must return a float. The solver will find an accurate
+        value of `t` at which ``event(t, y(t)) = 0`` using a root-finding
+        algorithm. By default, all zeros will be found. The solver looks for
+        a sign change over each step, so if multiple zero crossings occur
+        within one step, events may be missed. Additionally each `event`
+        function might have the following attributes:
 
             terminal: bool, optional
                 Whether to terminate integration if this event occurs.
@@ -319,6 +321,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
               be constant. Not supported by 'LSODA'.
             * If callable, the Jacobian is assumed to depend on both
               t and y; it will be called as ``jac(t, y)``, as necessary.
+              Additional arguments have to be passed if ``args`` is
+              used (see above).
               For 'Radau' and 'BDF' methods, the return value might be a
               sparse matrix.
             * If None (default), the Jacobian will be approximated by

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -182,9 +182,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         Right-hand side of the system: the time derivative of the state ``y``
         at time ``t``. The calling signature is ``fun(t, y)``, where ``t`` is a
         scalar and ``y`` is an ndarray with ``len(y) = len(y0)``. Additional
-        arguments need to be passed if ``args`` is used (see below). ``fun`` must
-        return an array of the same shape as ``y``. See `vectorized` for more
-        information.
+        arguments need to be passed if ``args`` is used (see documentation of
+        ``args`` argument). ``fun`` must return an array of the same shape as
+        ``y``. See `vectorized` for more information.
     t_span : 2-member sequence
         Interval of integration (t0, tf). The solver starts with t=t0 and
         integrates until it reaches t=tf. Both t0 and tf must be floats
@@ -247,13 +247,14 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         Events to track. If None (default), no events will be tracked.
         Each event occurs at the zeros of a continuous function of time and
         state. Each function must have the signature ``event(t, y)`` where
-        additional argument have to be passed if ``args`` is used (see below).
-        Each function must return a float. The solver will find an accurate
-        value of `t` at which ``event(t, y(t)) = 0`` using a root-finding
-        algorithm. By default, all zeros will be found. The solver looks for
-        a sign change over each step, so if multiple zero crossings occur
-        within one step, events may be missed. Additionally each `event`
-        function might have the following attributes:
+        additional argument have to be passed if ``args`` is used (see
+        documentation of ``args`` argument). Each function must return a
+        float. The solver will find an accurate value of `t` at which
+        ``event(t, y(t)) = 0`` using a root-finding algorithm. By default,
+        all zeros will be found. The solver looks for a sign change over
+        each step, so if multiple zero crossings occur within one step,
+        events may be missed. Additionally each `event` function might
+        have the following attributes:
 
             terminal: bool, optional
                 Whether to terminate integration if this event occurs.
@@ -322,7 +323,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
             * If callable, the Jacobian is assumed to depend on both
               t and y; it will be called as ``jac(t, y)``, as necessary.
               Additional arguments have to be passed if ``args`` is
-              used (see above).
+              used (see documentation of ``args`` argument).
               For 'Radau' and 'BDF' methods, the return value might be a
               sparse matrix.
             * If None (default), the Jacobian will be approximated by


### PR DESCRIPTION
[skip ci]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-18876

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR slightly extends the docstring of `solve_ivp`. Specifically, it adds remarks to  `fun`, `events`, and `jac`   that the signature has to be extended by `args` if it is used.

#### Additional information
<!--Any additional information you think is important.-->
