### PR TITLE
MAINT: optimize.root_scalar: handle args when method is newton and fprime is not provided

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -303,12 +303,12 @@ def root_scalar(f, args=(), method=None, bracket=None,
         if not fprime:
             # approximate fprime with finite differences
 
-            def fprime(x):
+            def fprime(x, *args):
                 # `root_scalar` doesn't actually seem to support vectorized
                 # use of `newton`. In that case, `approx_derivative` will
                 # always get scalar input. Nonetheless, it always returns an
                 # array, so we extract the element to produce scalar output.
-                return approx_derivative(f, x, method='2-point')[0]
+                return approx_derivative(f, x, method='2-point', args=args)[0]
 
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -808,6 +808,17 @@ class TestNewton(TestScalarRootFinders):
                 != res_newton_default.iterations
                 == res_newton_default.function_calls/2)  # newton 2-point diff
 
+    @pytest.mark.parametrize('kwargs', [dict(), {'method': 'newton'}])
+    def test_args_gh19090(self, kwargs):
+        def f(x, a, b):
+            assert a == 3
+            assert b == 1
+            return (x ** a - b)
+
+        res = optimize.root_scalar(f, x0=3, args=(3, 1), **kwargs)
+        assert res.converged
+        assert_allclose(res.root, 1)
+
 
 def test_gh_5555():
     root = 0.1


### PR DESCRIPTION
#### Reference issue
closes gh-19090

#### What does this implement/fix?
gh-19090 reported that `root_scalar` does not work when
- `method='newton'` (or Newton's method is chosen automatically)
- `fprime` is not provided
- `args` is passed to `root_scalar`

`args` was overlooked when the ability to use Newton's method without `fprime` was added by gh-17691. This PR fixes the bug.