### PR TITLE
MAINT: stats.zscore: return correct result when 0th element is masked

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3147,10 +3147,13 @@ def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
     else:
         mn = a.mean(axis=axis, keepdims=True)
         std = a.std(axis=axis, ddof=ddof, keepdims=True)
-        if axis is None:
-            isconst = (a.item(0) == a).all()
-        else:
-            isconst = (_first(a, axis) == a).all(axis=axis, keepdims=True)
+        # The intent is to check whether all elements of `a` along `axis` are
+        # identical. Due to finite precision arithmetic, comparing elements
+        # against `mn` doesn't work. Previously, this compared elements to
+        # `_first`, but that extracts the element at index 0 regardless of
+        # whether it is masked. As a simple fix, compare against `min`.
+        a0 = a.min(axis=axis, keepdims=True)
+        isconst = (a == a0).all(axis=axis, keepdims=True)
 
     # Set std deviations that are 0 to 1 to avoid division by 0.
     std[isconst] = 1.0

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2720,6 +2720,26 @@ class TestZmapZscore:
                     1.136670895503])
         assert_allclose(desired, z)
 
+    def test_zscore_masked_element_0_gh19039(self):
+        # zscore returned all NaNs when 0th element was masked. See gh-19039.
+        rng = np.random.default_rng(8675309)
+        x = rng.standard_normal(10)
+        mask = np.zeros_like(x)
+        y = np.ma.masked_array(x, mask)
+        y.mask[0] = True
+
+        ref = stats.zscore(x[1:])  # compute reference from non-masked elements
+        assert not np.any(np.isnan(ref))
+        res = stats.zscore(y)
+        assert_allclose(res[1:], ref)
+        res = stats.zscore(y, axis=None)
+        assert_allclose(res[1:], ref)
+
+        y[1:] = y[1]  # when non-masked elements are identical, result is nan
+        res = stats.zscore(y)
+        assert_equal(res[1:], np.nan)
+        res = stats.zscore(y, axis=None)
+        assert_equal(res[1:], np.nan)
 
 class TestMedianAbsDeviation:
     def setup_class(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-19039

#### What does this implement/fix?
gh-19039 reported that `zscore` returned all NaNs when the 0th element of the input array is masked. This attempts to fix the bug.