### PR TITLE
ENH: optimize: add inv Hess estimate in BFGS

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -31,6 +31,7 @@ import inspect
 from numpy import (atleast_1d, eye, argmin, zeros, shape, squeeze,
                    asarray, sqrt)
 import numpy as np
+from scipy.linalg import cholesky, issymmetric, LinAlgError
 from scipy.sparse.linalg import LinearOperator
 from ._linesearch import (line_search_wolfe1, line_search_wolfe2,
                           line_search_wolfe2 as line_search,
@@ -272,17 +273,17 @@ class OptimizeWarning(UserWarning):
 
 def _check_positive_definite(Hk):
     def is_pos_def(A):
-        if np.allclose(A, A.T):
+        if issymmetric(A, rtol=1e-05, atol=1e-08):
             try:
-                np.linalg.cholesky(A)
+                cholesky(A)
                 return True
-            except np.linalg.LinAlgError:
+            except LinAlgError:
                 return False
         else:
             return False
     if Hk is not None:
         if not is_pos_def(Hk):
-            raise ValueError("'hk_init' matrix must be positive definite.")
+            raise ValueError("'h0' matrix must be positive definite.")
         
 def _check_unknown_options(unknown_options):
     if unknown_options:
@@ -1266,7 +1267,7 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
 def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None, xrtol=0, c1=1e-4, c2=0.9, 
-              hk_init=None):
+              h0=None):
     """
     Minimize a function using the BFGS algorithm.
 
@@ -1307,7 +1308,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
         Parameter for curvature condition rule.
-    hk_init : None or ndarray, optional
+    h0 : None or ndarray, optional
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 
@@ -1387,7 +1388,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
             'xrtol': xrtol,
             'c1': c1,
             'c2': c2,
-            'hk_init': hk_init}
+            'h0': h0}
 
     callback = _wrap_callback(callback)
     res = _minimize_bfgs(f, x0, args, fprime, callback=callback, **opts)
@@ -1409,7 +1410,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
                    gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                    disp=False, return_all=False, finite_diff_rel_step=None,
                    xrtol=0, c1=1e-4, c2=0.9, 
-                   hk_init=None, **unknown_options):
+                   h0=None, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     BFGS algorithm.
@@ -1444,13 +1445,13 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Parameter for Armijo condition rule.
     c2 : float, default: .9
         Parameter for curvature condition rule.
-    hk_init : None or ndarray, optional
+    h0 : None or ndarray, optional
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 
     """
     _check_unknown_options(unknown_options)
-    _check_positive_definite(hk_init)
+    _check_positive_definite(h0)
     retall = return_all
 
     x0 = asarray(x0).flatten()
@@ -1471,7 +1472,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     k = 0
     N = len(x0)
     I = np.eye(N, dtype=int)
-    Hk = I if hk_init is None else hk_init
+    Hk = I if h0 is None else h0
 
     # Sets the initial step guess to dx ~ 1
     old_old_fval = old_fval + np.linalg.norm(gfk) / 2

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -285,6 +285,7 @@ def _check_positive_definite(Hk):
         if not is_pos_def(Hk):
             raise ValueError("'hess_inv0' matrix must be positive definite.")
         
+        
 def _check_unknown_options(unknown_options):
     if unknown_options:
         msg = ", ".join(map(str, unknown_options.keys()))

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1276,8 +1276,8 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     ----------
     f : callable ``f(x,*args)``
         Objective function to be minimized.
-    x0 : ndarray, shape (n,)
-        Initial guess.
+    x0 : ndarray
+        Initial guess, shape (n,)
     fprime : callable ``f'(x,*args)``, optional
         Gradient of f.
     args : tuple, optional
@@ -1309,8 +1309,8 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
         Parameter for curvature condition rule.
-    hess_inv0 : None or ndarray, optional, shape (n, n)
-        Initial inverse hessian estimate. If None (default) then the identity
+    hess_inv0 : None or ndarray, optional``
+        Initial inverse hessian estimate, shape (n, n). If None (default) then the identity
         matrix is used.
 
     Returns
@@ -1446,8 +1446,8 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Parameter for Armijo condition rule.
     c2 : float, default: .9
         Parameter for curvature condition rule.
-    hess_inv0 : None or ndarray, optional, shape (n, n)
-        Initial inverse hessian estimate. If None (default) then the identity
+    hess_inv0 : None or ndarray, optional
+        Initial inverse hessian estimate, shape (n, n). If None (default) then the identity
         matrix is used.
 
     """

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -273,7 +273,7 @@ class OptimizeWarning(UserWarning):
 
 def _check_positive_definite(Hk):
     def is_pos_def(A):
-        if issymmetric(A, rtol=1e-05, atol=1e-08):
+        if issymmetric(A):
             try:
                 cholesky(A)
                 return True

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -283,7 +283,7 @@ def _check_positive_definite(Hk):
             return False
     if Hk is not None:
         if not is_pos_def(Hk):
-            raise ValueError("'hess_inv0' matrix must be positive definite.")
+            raise ValueError("'hess_inv0' matrix isn't positive definite.")
         
         
 def _check_unknown_options(unknown_options):
@@ -1276,7 +1276,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     ----------
     f : callable ``f(x,*args)``
         Objective function to be minimized.
-    x0 : ndarray
+    x0 : ndarray, shape (n,)
         Initial guess.
     fprime : callable ``f'(x,*args)``, optional
         Gradient of f.
@@ -1309,7 +1309,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
         Parameter for curvature condition rule.
-    hess_inv0 : None or ndarray, optional
+    hess_inv0 : None or ndarray, optional, shape (n, n)
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 
@@ -1446,7 +1446,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Parameter for Armijo condition rule.
     c2 : float, default: .9
         Parameter for curvature condition rule.
-    hess_inv0 : None or ndarray, optional
+    hess_inv0 : None or ndarray, optional, shape (n, n)
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -283,7 +283,7 @@ def _check_positive_definite(Hk):
             return False
     if Hk is not None:
         if not is_pos_def(Hk):
-            raise ValueError("'h0' matrix must be positive definite.")
+            raise ValueError("'hess_inv0' matrix must be positive definite.")
         
 def _check_unknown_options(unknown_options):
     if unknown_options:
@@ -1267,7 +1267,7 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
 def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None, xrtol=0, c1=1e-4, c2=0.9, 
-              h0=None):
+              hess_inv0=None):
     """
     Minimize a function using the BFGS algorithm.
 
@@ -1308,7 +1308,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
         Parameter for curvature condition rule.
-    h0 : None or ndarray, optional
+    hess_inv0 : None or ndarray, optional
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 
@@ -1388,7 +1388,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
             'xrtol': xrtol,
             'c1': c1,
             'c2': c2,
-            'h0': h0}
+            'hess_inv0': hess_inv0}
 
     callback = _wrap_callback(callback)
     res = _minimize_bfgs(f, x0, args, fprime, callback=callback, **opts)
@@ -1410,7 +1410,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
                    gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                    disp=False, return_all=False, finite_diff_rel_step=None,
                    xrtol=0, c1=1e-4, c2=0.9, 
-                   h0=None, **unknown_options):
+                   hess_inv0=None, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     BFGS algorithm.
@@ -1445,13 +1445,13 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         Parameter for Armijo condition rule.
     c2 : float, default: .9
         Parameter for curvature condition rule.
-    h0 : None or ndarray, optional
+    hess_inv0 : None or ndarray, optional
         Initial inverse hessian estimate. If None (default) then the identity
         matrix is used.
 
     """
     _check_unknown_options(unknown_options)
-    _check_positive_definite(h0)
+    _check_positive_definite(hess_inv0)
     retall = return_all
 
     x0 = asarray(x0).flatten()
@@ -1472,7 +1472,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     k = 0
     N = len(x0)
     I = np.eye(N, dtype=int)
-    Hk = I if h0 is None else h0
+    Hk = I if hess_inv0 is None else hess_inv0
 
     # Sets the initial step guess to dx ~ 1
     old_old_fval = old_fval + np.linalg.norm(gfk) / 2

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -212,16 +212,20 @@ class CheckOptimizeParameterized(CheckOptimize):
                         atol=1e-14, rtol=1e-7)
     
     def test_bfgs_hess_inv0_neg(self):
-        # Ensure that BFGS only does not accept neg. def. initial inverse Hessian estimate.
-        with pytest.raises(ValueError, match="'hess_inv0' matrix must be positive definite."):
+        # Ensure that BFGS does not accept neg. def. initial inverse 
+        # Hessian estimate.
+        with pytest.raises(ValueError, match="'hess_inv0' matrix isn't "
+                           "positive definite."):
             x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
             opts = {'disp': self.disp, 'hess_inv0': -np.eye(5)}
             optimize.minimize(optimize.rosen, x0=x0, method='BFGS', args=(),
                               options=opts)
     
     def test_bfgs_hess_inv0_semipos(self):
-        # Ensure that BFGS does not accepts semi pos. def. initial inverse Hessian estimate.
-        with pytest.raises(ValueError, match="'hess_inv0' matrix must be positive definite."):
+        # Ensure that BFGS does not accept semi pos. def. initial inverse 
+        # Hessian estimate.
+        with pytest.raises(ValueError, match="'hess_inv0' matrix isn't "
+                           "positive definite."):
             x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
             hess_inv0 = np.eye(5)
             hess_inv0[0, 0] = 0
@@ -234,8 +238,10 @@ class CheckOptimizeParameterized(CheckOptimize):
         fun = optimize.rosen
         x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
         opts = {'disp': self.disp, 'hess_inv0': 1e-2 * np.eye(5)}
-        res = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options=opts)
-        res_true = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options={'disp': self.disp})
+        res = optimize.minimize(fun, x0=x0, method='BFGS', args=(), 
+                                options=opts)
+        res_true = optimize.minimize(fun, x0=x0, method='BFGS', args=(), 
+                                     options={'disp': self.disp})
         assert_allclose(res.fun, res_true.fun, atol=1e-6)
             
     @pytest.mark.filterwarnings('ignore::UserWarning')

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -210,6 +210,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                         [[0, -5.25060743e-01, 4.87748473e-01],
                          [0, -5.24885582e-01, 4.87530347e-01]],
                         atol=1e-14, rtol=1e-7)
+    
+    def test_bfgs_hk(self):
+        # Ensure that BFGS only accepts positive definite initial inverse Hessian estimate.
+        with pytest.raises(ValueError, match="'hk_init' matrix must be positive definite."):
+            x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
+            opts = {'disp': self.disp, 'hk_init': -np.eye(5)}
+            optimize.minimize(optimize.rosen, x0=x0, method='BFGS', args=(),
+                              options=opts)
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_bfgs_infinite(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -211,29 +211,29 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0, -5.24885582e-01, 4.87530347e-01]],
                         atol=1e-14, rtol=1e-7)
     
-    def test_bfgs_h0_neg(self):
+    def test_bfgs_hess_inv0_neg(self):
         # Ensure that BFGS only does not accept neg. def. initial inverse Hessian estimate.
-        with pytest.raises(ValueError, match="'h0' matrix must be positive definite."):
+        with pytest.raises(ValueError, match="'hess_inv0' matrix must be positive definite."):
             x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
-            opts = {'disp': self.disp, 'h0': -np.eye(5)}
+            opts = {'disp': self.disp, 'hess_inv0': -np.eye(5)}
             optimize.minimize(optimize.rosen, x0=x0, method='BFGS', args=(),
                               options=opts)
     
-    def test_bfgs_h0_semipos(self):
+    def test_bfgs_hess_inv0_semipos(self):
         # Ensure that BFGS does not accepts semi pos. def. initial inverse Hessian estimate.
-        with pytest.raises(ValueError, match="'h0' matrix must be positive definite."):
+        with pytest.raises(ValueError, match="'hess_inv0' matrix must be positive definite."):
             x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
-            h0 = np.eye(5)
-            h0[0, 0] = 0
-            opts = {'disp': self.disp, 'h0': h0}
+            hess_inv0 = np.eye(5)
+            hess_inv0[0, 0] = 0
+            opts = {'disp': self.disp, 'hess_inv0': hess_inv0}
             optimize.minimize(optimize.rosen, x0=x0, method='BFGS', args=(),
                               options=opts)
     
-    def test_bfgs_h0_sanity(self):
-        # Ensure that BFGS handles `h0` parameter correctly.
+    def test_bfgs_hess_inv0_sanity(self):
+        # Ensure that BFGS handles `hess_inv0` parameter correctly.
         fun = optimize.rosen
         x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
-        opts = {'disp': self.disp, 'h0': 1e-2 * np.eye(5)}
+        opts = {'disp': self.disp, 'hess_inv0': 1e-2 * np.eye(5)}
         res = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options=opts)
         res_true = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options={'disp': self.disp})
         assert_allclose(res.fun, res_true.fun, atol=1e-6)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -236,7 +236,7 @@ class CheckOptimizeParameterized(CheckOptimize):
         opts = {'disp': self.disp, 'h0': 1e-2 * np.eye(5)}
         res = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options=opts)
         res_true = optimize.minimize(fun, x0=x0, method='BFGS', args=(), options={'disp': self.disp})
-        assert_allclose(fun(res.x), fun(res_true.x), atol=1e-6)
+        assert_allclose(res.fun, res_true.fun, atol=1e-6)
             
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_bfgs_infinite(self):


### PR DESCRIPTION



<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes scipy#17864.

#### What does this implement/fix?
Add inverse Hessian estimate parameter `hk_init`  in `_minimize_bfgs`.

#### Additional information
`hk_init` is checked to be positive definite and initializes `Hk` if not `None` else `Hk` is set to identity. 
Add unit-test to ensure non positive definite `hk_init` are not allowed.
`hk_init`  is also added to `fmin_bfgs` signature.
