### PR TITLE
MAINT: Move `trapezoid` implementation to SciPy

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -119,12 +119,32 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     >>> integrate.trapezoid(a, axis=1)
     array([2.,  8.])
     """
-    # Future-proofing, in case NumPy moves from trapz to trapezoid for the same
-    # reasons as SciPy
-    if hasattr(np, 'trapezoid'):
-        return np.trapezoid(y, x=x, dx=dx, axis=axis)
+    y = np.asanyarray(y)
+    if x is None:
+        d = dx
     else:
-        return np.trapz(y, x=x, dx=dx, axis=axis)
+        x = np.asanyarray(x)
+        if x.ndim == 1:
+            d = np.diff(x)
+            # reshape to correct shape
+            shape = [1]*y.ndim
+            shape[axis] = d.shape[0]
+            d = d.reshape(shape)
+        else:
+            d = np.diff(x, axis=axis)
+    nd = y.ndim
+    slice1 = [slice(None)]*nd
+    slice2 = [slice(None)]*nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    try:
+        ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
+    except ValueError:
+        # Operations didn't work, cast to ndarray
+        d = np.asarray(d)
+        y = np.asarray(y)
+        ret = np.add.reduce(d * (y[tuple(slice1)]+y[tuple(slice2)])/2.0, axis)
+    return ret
 
 
 # Note: alias kept for backwards compatibility. Rename was done

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -362,7 +362,7 @@ class TestTrapezoid:
         x = np.arange(-10, 10, .1)
         r = trapezoid(np.exp(-.5 * x ** 2) / np.sqrt(2 * np.pi), dx=0.1)
         # check integral of normal equals 1
-        assert_almost_equal(r, 1, 7)
+        assert_allclose(r, 1)
 
     def test_ndim(self):
         x = np.linspace(0, 1, 3)
@@ -387,19 +387,19 @@ class TestTrapezoid:
 
         # n-d `x`
         r = trapezoid(q, x=x[:, None, None], axis=0)
-        assert_almost_equal(r, qx)
+        assert_allclose(r, qx)
         r = trapezoid(q, x=y[None,:, None], axis=1)
-        assert_almost_equal(r, qy)
+        assert_allclose(r, qy)
         r = trapezoid(q, x=z[None, None,:], axis=2)
-        assert_almost_equal(r, qz)
+        assert_allclose(r, qz)
 
         # 1-d `x`
         r = trapezoid(q, x=x, axis=0)
-        assert_almost_equal(r, qx)
+        assert_allclose(r, qx)
         r = trapezoid(q, x=y, axis=1)
-        assert_almost_equal(r, qy)
+        assert_allclose(r, qy)
         r = trapezoid(q, x=z, axis=2)
-        assert_almost_equal(r, qz)
+        assert_allclose(r, qz)
 
     def test_masked(self):
         # Testing that masked arrays behave as if the function is 0 where
@@ -409,13 +409,13 @@ class TestTrapezoid:
         mask = x == 2
         ym = np.ma.array(y, mask=mask)
         r = 13.0  # sum(0.5 * (0 + 1) * 1.0 + 0.5 * (9 + 16))
-        assert_almost_equal(trapezoid(ym, x), r)
+        assert_allclose(trapezoid(ym, x), r)
 
         xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapezoid(ym, xm), r)
+        assert_allclose(trapezoid(ym, xm), r)
 
         xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapezoid(y, xm), r)
+        assert_allclose(trapezoid(y, xm), r)
 
     def test_trapz_alias(self):
         # Basic coverage test for the alias


### PR DESCRIPTION
Hi @rgommers,

One of the functions that will be deprecated and removed in numPy 2.0 is `np.trapz`. It's the only integration function that still lives in NumPy instead of SciPy's `scipy.integrate`. In this PR I move implementation and tests directly to SciPy to then remove the original one from NumPy. 