### PR TITLE
MAINT: Remove usages of np.row_stack and np.in1d

### DIFF
--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -686,7 +686,7 @@ def test_odeint_banded_jacobian():
         return c.T.copy(order='C')
 
     def bjac_rows(y, t, c):
-        jac = np.row_stack((np.r_[0, np.diag(c, 1)],
+        jac = np.vstack((np.r_[0, np.diag(c, 1)],
                             np.diag(c),
                             np.r_[np.diag(c, -1), 0],
                             np.r_[np.diag(c, -2), 0, 0]))

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -204,7 +204,7 @@ class TestSplev:
         z = splev(t, tck)
         z0 = splev(t[0], tck)
         z1 = splev(t[1], tck)
-        assert_equal(z, np.row_stack((z0, z1)))
+        assert_equal(z, np.vstack((z0, z1)))
 
     def test_extrapolation_modes(self):
         # test extrapolation modes

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -9,6 +9,7 @@ from pytest import raises as assert_raises
 
 from scipy import signal
 from scipy.fft import fftfreq
+from scipy.integrate import trapezoid
 from scipy.signal import (periodogram, welch, lombscargle, coherence,
                           spectrogram, check_COLA, check_NOLA)
 from scipy.signal._spectral_py import _spectral_helper
@@ -525,7 +526,7 @@ class TestWelch:
             # Check peak height at signal frequency for 'spectrum'
             assert_allclose(p_spec[ii], A**2/2.0)
             # Check integrated spectrum RMS for 'density'
-            assert_allclose(np.sqrt(np.trapz(p_dens, freq)), A*np.sqrt(2)/2,
+            assert_allclose(np.sqrt(trapezoid(p_dens, freq)), A*np.sqrt(2)/2,
                             rtol=1e-3)
 
     def test_axis_rolling(self):

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -450,17 +450,17 @@ def _onenormest_core(A, AT, t, itmax):
         if t > 1:
             # (5)
             # Break if the most promising t vectors have been visited already.
-            if np.in1d(ind[:t], ind_hist).all():
+            if np.isin(ind[:t], ind_hist).all():
                 break
             # Put the most promising unvisited vectors at the front of the list
             # and put the visited vectors at the end of the list.
             # Preserve the order of the indices induced by the ordering of h.
-            seen = np.in1d(ind, ind_hist)
+            seen = np.isin(ind, ind_hist)
             ind = np.concatenate((ind[~seen], ind[seen]))
         for j in range(t):
             X[:, j] = elementary_vector(n, ind[j])
 
-        new_ind = ind[:t][~np.in1d(ind[:t], ind_hist)]
+        new_ind = ind[:t][~np.isin(ind[:t], ind_hist)]
         ind_hist = np.concatenate((ind_hist, new_ind))
         k += 1
     v = elementary_vector(n, ind_best)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2524,10 +2524,10 @@ class TestHyper:
         x = special.hyp0f1(x1, x2)
         expected = [1.0, 1.8134302039235093, 1.21482702689997]
         assert_allclose(x, expected, rtol=1e-12)
-        x = special.hyp0f1(np.row_stack([x1] * 2), x2)
-        assert_allclose(x, np.row_stack([expected] * 2), rtol=1e-12)
+        x = special.hyp0f1(np.vstack([x1] * 2), x2)
+        assert_allclose(x, np.vstack([expected] * 2), rtol=1e-12)
         assert_raises(ValueError, special.hyp0f1,
-                      np.row_stack([x1] * 3), [0, 1])
+                      np.vstack([x1] * 3), [0, 1])
 
     def test_hyp0f1_gh5764(self):
         # Just checks the point that failed; there's a more systematic
@@ -3562,10 +3562,10 @@ class TestPolygamma:
         expected = [-1.9635100260214238, 0.93480220054467933,
                     -0.23620405164172739]
         assert_almost_equal(special.polygamma(n, x), expected)
-        expected = np.row_stack([expected]*2)
-        assert_almost_equal(special.polygamma(n, np.row_stack([x]*2)),
+        expected = np.vstack([expected]*2)
+        assert_almost_equal(special.polygamma(n, np.vstack([x]*2)),
                             expected)
-        assert_almost_equal(special.polygamma(np.row_stack([n]*2), x),
+        assert_almost_equal(special.polygamma(np.vstack([n]*2), x),
                             expected)
 
 

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -108,7 +108,7 @@ def argstoarray(*args):
 
     Notes
     -----
-    `numpy.ma.row_stack` has identical behavior, but is called with a sequence
+    `numpy.ma.vstack` has identical behavior, but is called with a sequence
     of sequences.
 
     Examples
@@ -635,7 +635,7 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate',
         if axisout == 0:
             x = ma.column_stack((x, y))
         else:
-            x = ma.row_stack((x, y))
+            x = ma.vstack((x, y))
 
     if axisout == 1:
         # To simplify the code that follow (always use `n_obs, n_vars` shape)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5432,7 +5432,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         if axisout == 0:
             a = np.column_stack((a, b))
         else:
-            a = np.row_stack((a, b))
+            a = np.vstack((a, b))
 
     n_vars = a.shape[1 - axisout]
     n_obs = a.shape[axisout]


### PR DESCRIPTION
Hi @ngoldbaum,

This PR addresses changes present in https://github.com/numpy/numpy/pull/24445. 