### PR TITLE
BUG: Fixes #19103 by adding back make_strictly_feasible to lsq trf.

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -12,7 +12,7 @@ from scipy.optimize._minimize import Bounds
 
 from .trf import trf
 from .dogbox import dogbox
-from .common import EPS, in_bounds
+from .common import EPS, in_bounds, make_strictly_feasible
 
 
 TERMINATION_MESSAGES = {
@@ -820,6 +820,9 @@ def least_squares(
     x_scale = check_x_scale(x_scale, x0)
 
     ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol, method)
+
+    if method == 'trf':
+        x0 = make_strictly_feasible(x0, lb, ub, rstep=0)
 
     def fun_wrapped(x):
         return np.atleast_1d(fun(x, *args, **kwargs))


### PR DESCRIPTION
This PR restores functionality of lsq trf for initial points on boundaries, but reduces boundary effects to a minimum. Since this is your implementation I was asked to ping you @nmayorov 

#### Reference issue
Example: Closes gh-19103

#### What does this implement/fix?
Adds back make_strictly_feasible to least_squares but with rstep=0.

Also adds regression test that fails on main, but passes on this branch. 

#### Additional information

The full story from the commit message:

PR #18896 removed make_strictly_feasible because it makes solutions
worse if they are close to the boundary.
However, the downstream algorithm that eventually solves the
optimization problem has some trouble with starting points that
are on the boundaries of a bounded optimization problem.
This either results in division by zero warnings, see #19102,
or in failure of finding the correct solution at all,
which is added as a regression test in this commit.
This PR brings back make_strictly_feasible but with the
smallest possible step from the boundary a floating point allows
by setting rstep=0 on the function make_strictly_feasible,
which uses np.nextafter to find such a point, hereby respecting
the strictly feasible point condition and minimizing boundary effects.
See strictly feasible points in interior-point methods for more context
https://nmayorov.wordpress.com/2015/06/19/trust-region-reflective-algorithm/
