### PR TITLE
MAINT, TST: default_rng few tests

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -62,11 +62,9 @@ def test_check_random_state():
     rsi = check_random_state(None)
     assert_equal(type(rsi), np.random.RandomState)
     assert_raises(ValueError, check_random_state, 'a')
-    if hasattr(np.random, 'Generator'):
-        # np.random.Generator is only available in NumPy >= 1.17
-        rg = np.random.Generator(np.random.PCG64())
-        rsi = check_random_state(rg)
-        assert_equal(type(rsi), np.random.Generator)
+    rg = np.random.Generator(np.random.PCG64())
+    rsi = check_random_state(rg)
+    assert_equal(type(rsi), np.random.Generator)
 
 
 def test_getfullargspec_no_self():

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -324,12 +324,7 @@ class TestKMean:
         datas = [xp.reshape(data, (200, 2)), xp.reshape(data, (20, 20))[:10, :]]
         k = int(1e6)
         for data in datas:
-            # check that np.random.Generator can be used (numpy >= 1.17)
-            if hasattr(np.random, 'default_rng'):
-                rng = np.random.default_rng(1234)
-            else:
-                rng = np.random.RandomState(1234)
-
+            rng = np.random.default_rng(1234)
             init = _krandinit(data, k, rng, xp)
             orig_cov = xp.cov(data.T)
             init_cov = xp.cov(init.T)


### PR DESCRIPTION
* I noticed two tests where we should now be able to safely use `default_rng`/`random.Generator` while reviewing some other code--I think we are well past the minimum NumPy version required to do this, and already do it in other tests

[skip cirrus] [skip circle]