### PR TITLE
BLD: Avoid absolute pathnames in .pyx files

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -1232,6 +1232,7 @@ def get_declaration(ufunc, c_name, c_proto, cy_proto, header,
         # redeclare the function, so that the assumed
         # signature is checked at compile time
         new_name = f"{ufunc.cython_func_name(c_name)} \"{c_name}\""
+        proto_h_filename = os.path.basename(proto_h_filename)
         defs.append(f'cdef extern from r"{proto_h_filename}":')
         defs.append("    cdef %s" % (cy_proto.replace('(*)', new_name)))
         defs_h.append(f'#include "{header}"')


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #19101

#### What does this implement/fix?
<!--Please explain your changes.-->
Avoid absolute pathnames in `.pyx` files
to allow for reproducible builds
even when (unneeded) .pyx files are installed and shipped in OS packages.

#### Additional information
<!--Any additional information you think is important.-->

This patch was done while working on reproducible builds for openSUSE.

