### PR TITLE
DOC: linalg: fix typos in pinv docs

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1414,8 +1414,8 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
     Here, ``A*`` denotes the conjugate transpose. The Moore-Penrose
     pseudoinverse is a unique ``B`` that satisfies all four of these
     conditions and exists for any ``A``. Note that, unlike the standard
-    matrix inverse, ``A`` does not have to be square matrix and have linearly
-    independant columns/rows.
+    matrix inverse, ``A`` does not have to be a square matrix or have
+    linearly independent columns/rows.
 
     As an example, we can calculate the Moore-Penrose pseudoinverse of a
     random non-square matrix and verify it satisfies the four conditions.

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1385,7 +1385,7 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
 
     See Also
     --------
-    pinvh : Moore-Penrose pseudoinverse of a hermititan matrix.
+    pinvh : Moore-Penrose pseudoinverse of a hermitian matrix.
 
     Notes
     -----
@@ -1414,7 +1414,7 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
     Here, ``A*`` denotes the conjugate transpose. The Moore-Penrose
     pseudoinverse is a unique ``B`` that satisfies all four of these
     conditions and exists for any ``A``. Note that, unlike the standard
-    matrix inverse, ``A`` does not have to be square or have
+    matrix inverse, ``A`` does not have to be square matrix and have linearly
     independant columns/rows.
 
     As an example, we can calculate the Moore-Penrose pseudoinverse of a


### PR DESCRIPTION
Fixed typo in documentation 
link of typo
https://github.com/scipy/scipy/blob/881b9fe85eae39015693ea3c83d406c252eebcab/scipy/linalg/_basic.py#L1385C55-L1385C55 https://github.com/scipy/scipy/blob/881b9fe85eae39015693ea3c83d406c252eebcab/scipy/linalg/_basic.py#L1415C9-L1415C9


Reference issue
DOC: typo in scipy.linalg.pinv.html #19063

What does this implement/fix?
Fixed the typo in documentation


