### PR TITLE
MAINT: signal: Remove the cval parameter from the private function _pad_test.

### DIFF
--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -234,7 +234,7 @@ cdef DTYPE_t _extend_right(DTYPE_t *x, np.intp_t idx, np.intp_t len_x,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef _pad_test(np.ndarray[DTYPE_t] data, np.intp_t npre=0, np.intp_t npost=0,
-                object mode=0, DTYPE_t cval=0):
+                object mode=0):
     """1D test function for signal extension modes.
 
     Returns ``data extended by ``npre``, ``npost`` at the beginning, end.
@@ -264,9 +264,9 @@ cpdef _pad_test(np.ndarray[DTYPE_t] data, np.intp_t npre=0, np.intp_t npost=0,
     with nogil:
         for idx in range(-npre, len_x + npost, 1):
             if idx < 0:
-                xval = _extend_left(data_ptr, idx, len_x, _mode, cval)
+                xval = _extend_left(data_ptr, idx, len_x, _mode, 0.0)
             elif idx >= len_x:
-                xval = _extend_right(data_ptr, idx, len_x, _mode, cval)
+                xval = _extend_right(data_ptr, idx, len_x, _mode, 0.0)
             else:
                 xval = data_ptr[idx]
             out[cnt] = xval


### PR DESCRIPTION
The parameter `cval` in the private helper function `_pad_test` is not used, so remove it.  This change is inspired by a bug in Cython 3.0.1 (see SciPy issue gh-19132), and this change is a work-around for that bug, but since the parameter is unused and in a private function, there is no need to revert this change.
