### PR TITLE
BLD: revert to using published wheels [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,11 +133,11 @@ jobs:
           # required so that cp312 can grab a nightly wheel
           # can remove when cp312 is release and we don't need to search
           # other wheel locations.
-          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=1
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=0
 
           CIBW_ENVIRONMENT_WINDOWS: >
             PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
-            PIP_PRE=1
+            PIP_PRE=0
             PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           # setting SDKROOT necessary when using the gfortran compiler
@@ -152,7 +152,7 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=10.9
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
-            PIP_PRE=1
+            PIP_PRE=0
             PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -131,14 +131,14 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
 
           # required so that cp312 can grab a nightly wheel
-          # can remove when cp312 is release and we don't need to search
+          # can remove when cp312 is released and we don't need to search
           # other wheel locations.
-          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=0
+          # CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=0
 
           CIBW_ENVIRONMENT_WINDOWS: >
             PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
-            PIP_PRE=0
-            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            # PIP_PRE=0
+            # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh
@@ -152,8 +152,8 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=10.9
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
-            PIP_PRE=0
-            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            # PIP_PRE=0
+            # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,11 +133,12 @@ jobs:
           # required so that cp312 can grab a nightly wheel
           # can remove when cp312 is released and we don't need to search
           # other wheel locations.
-          # CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple PIP_PRE=0
+          # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+          CIBW_ENVIRONMENT: PIP_PRE=1
 
           CIBW_ENVIRONMENT_WINDOWS: >
             PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
-            # PIP_PRE=0
+            PIP_PRE=1
             # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           # setting SDKROOT necessary when using the gfortran compiler
@@ -152,7 +153,7 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=10.9
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
-            # PIP_PRE=0
+            PIP_PRE=1
             # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -31,7 +31,7 @@ cirrus_wheels_linux_aarch64_task:
     CIBW_PRERELEASE_PYTHONS: True
     CIBW_ENVIRONMENT: >
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      PIP_PRE=1
+      PIP_PRE=0
 
   build_script: |
     apt install -y python3-venv python-is-python3
@@ -60,7 +60,7 @@ cirrus_wheels_macos_arm64_task:
       MACOSX_DEPLOYMENT_TARGET=12.0
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      PIP_PRE=1
+      PIP_PRE=0
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -29,9 +29,9 @@ cirrus_wheels_linux_aarch64_task:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
     CIBW_PRERELEASE_PYTHONS: True
-    #    CIBW_ENVIRONMENT: >
+    CIBW_ENVIRONMENT: >
+      PIP_PRE=1
     #      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    #      PIP_PRE=0
 
   build_script: |
     apt install -y python3-venv python-is-python3
@@ -59,8 +59,8 @@ cirrus_wheels_macos_arm64_task:
     CIBW_ENVIRONMENT: >
       MACOSX_DEPLOYMENT_TARGET=12.0
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
+      PIP_PRE=1
       # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      # PIP_PRE=0
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -29,9 +29,9 @@ cirrus_wheels_linux_aarch64_task:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
     CIBW_PRERELEASE_PYTHONS: True
-    CIBW_ENVIRONMENT: >
-      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      PIP_PRE=0
+    #    CIBW_ENVIRONMENT: >
+    #      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    #      PIP_PRE=0
 
   build_script: |
     apt install -y python3-venv python-is-python3
@@ -59,8 +59,8 @@ cirrus_wheels_macos_arm64_task:
     CIBW_ENVIRONMENT: >
       MACOSX_DEPLOYMENT_TARGET=12.0
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
-      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      PIP_PRE=0
+      # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      # PIP_PRE=0
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/


### PR DESCRIPTION
Try and unblock cp312 (and the entire wheel build) by not installing numpy 2.0, only published versions.