### PR TITLE
MAINT: more NumPy API shims

### DIFF
--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -576,7 +576,7 @@ class BaseQRdelete(BaseQRdeltas):
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',
-               'float16', 'longdouble', 'longcomplex',
+               'float16', 'longdouble', 'clongdouble',
                'bool']
         a, q0, r0 = self.generate('tall')
         for dtype in dts:
@@ -1121,7 +1121,7 @@ class BaseQRinsert(BaseQRdeltas):
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',
-               'float16', 'longdouble', 'longcomplex',
+               'float16', 'longdouble', 'clongdouble',
                'bool']
         a, q0, r0, u0 = self.generate('sqr', which='row')
         for dtype in dts:
@@ -1555,7 +1555,7 @@ class BaseQRupdate(BaseQRdeltas):
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',
-               'float16', 'longdouble', 'longcomplex',
+               'float16', 'longdouble', 'clongdouble',
                'bool']
         a, q0, r0, u0, v0 = self.generate('tall')
         for dtype in dts:

--- a/scipy/special/tests/test_lambertw.py
+++ b/scipy/special/tests/test_lambertw.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_array_almost_equal
 from scipy.special import lambertw
-from numpy import nan, inf, pi, e, isnan, log, r_, array, complex_
+from numpy import nan, inf, pi, e, isnan, log, r_, array, complex128
 
 from scipy.special._testutils import FuncData
 
@@ -76,7 +76,7 @@ def test_values():
         (-0.448+0.4j,0, -0.11855133765652382241 + 0.66570534313583423116j),
         (-0.448-0.4j,0, -0.11855133765652382241 - 0.66570534313583423116j),
     ]
-    data = array(data, dtype=complex_)
+    data = array(data, dtype=complex128)
 
     def w(x, y):
         return lambertw(x, y.real.astype(int))


### PR DESCRIPTION
* to keep up with NumPy `2.0` related changes: https://github.com/numpy/numpy/pull/24376

* this cuts us down to 36 failures, 128 errors vs. 48 and 129, respectively, on `main`

[skip circle]