### PR TITLE
BUG: Support sparse arrays in scipy.sparse.csgraph.laplacian

### DIFF
--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -456,7 +456,7 @@ def _laplacian_sparse(graph, normed, axis, copy, form, dtype, symmetrized):
     if symmetrized:
         m += m.T.conj()
 
-    w = m.sum(axis=axis).getA1() - m.diagonal()
+    w = np.asarray(m.sum(axis=axis)).ravel() - m.diagonal()
     if normed:
         m = m.tocoo(copy=needs_copy)
         isolated_node_mask = (w == 0)

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -403,11 +403,11 @@ def _laplacian_sparse_flo(graph, normed, axis, copy, form, dtype, symmetrized):
     if dtype is None:
         dtype = graph.dtype
 
-    graph_sum = graph.sum(axis=axis).getA1()
+    graph_sum = np.asarray(graph.sum(axis=axis)).ravel()
     graph_diagonal = graph.diagonal()
     diag = graph_sum - graph_diagonal
     if symmetrized:
-        graph_sum += graph.sum(axis=1 - axis).getA1()
+        graph_sum += np.asarray(graph.sum(axis=1 - axis)).ravel()
         diag = graph_sum - graph_diagonal - graph_diagonal
 
     if normed:

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -170,7 +170,9 @@ DTYPES = tuple(sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("arr_type", [np.array,
                                       sparse.csr_matrix,
-                                      sparse.coo_matrix])
+                                      sparse.coo_matrix,
+                                      sparse.csr_array,
+                                      sparse.coo_array])
 @pytest.mark.parametrize("copy", [True, False])
 @pytest.mark.parametrize("normed", [True, False])
 @pytest.mark.parametrize("use_out_degree", [True, False])
@@ -244,7 +246,11 @@ def test_sparse_formats(fmt, normed, copy):
 
 
 @pytest.mark.parametrize(
-    "arr_type", [np.asarray, sparse.csr_matrix, sparse.coo_matrix]
+    "arr_type", [np.asarray,
+                 sparse.csr_matrix,
+                 sparse.coo_matrix,
+                 sparse.csr_array,
+                 sparse.coo_array]
 )
 @pytest.mark.parametrize("form", ["array", "function", "lo"])
 def test_laplacian_symmetrized(arr_type, form):
@@ -301,7 +307,11 @@ def test_laplacian_symmetrized(arr_type, form):
 
 
 @pytest.mark.parametrize(
-    "arr_type", [np.asarray, sparse.csr_matrix, sparse.coo_matrix]
+    "arr_type", [np.asarray,
+                 sparse.csr_matrix,
+                 sparse.coo_matrix,
+                 sparse.csr_array,
+                 sparse.coo_array]
 )
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("normed", [True, False])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #19149 

#### What does this implement/fix?
<!--Please explain your changes.-->
Resolves `AttributeError` raised on sparse arrays in `scipy.sparse.csgraph.laplacian` (See #19149)

#### Additional information
<!--Any additional information you think is important.-->
This resolves/unblocks test coverage in scikit-learn/scikit-learn#27161
Tagging @perimosocordiae for review, as he reviewed the original issue