### PR TITLE
TST: add array-agnostic assertions

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -165,6 +165,18 @@ def copy(x, *, xp=None):
     return as_xparray(x, copy=True, xp=xp)
 
 
+def is_numpy(xp):
+    return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.numpy'
+
+
+def is_cupy(xp):
+    return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.cupy'
+
+
+def is_torch(xp):
+    return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.torch'
+
+
 def assert_equal(actual, desired, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -163,3 +163,44 @@ def copy(x, *, xp=None):
         xp = array_namespace(x)
 
     return as_xparray(x, copy=True, xp=xp)
+
+
+def assert_equal(actual, desired, err_msg='', xp=None):
+    if xp is None:
+        xp = array_namespace(actual)
+    if is_cupy(xp):
+        return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
+    elif is_torch(xp):
+        # PyTorch recommends using `rtol=0, atol=0` like this
+        # to test for exact equality
+        return xp.testing.assert_close(actual, desired, rtol=0, atol=0,
+                                       msg=err_msg)
+    return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
+
+
+def assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
+    if xp is None:
+        xp = array_namespace(actual)
+    if is_cupy(xp):
+        return xp.testing.assert_allclose(actual, desired, rtol=rtol,
+                                          atol=atol, err_msg=err_msg)
+    elif is_torch(xp):
+        return xp.testing.assert_close(actual, desired, rtol=rtol,
+                                       atol=atol, msg=err_msg)
+    return np.testing.assert_allclose(actual, desired, rtol=rtol,
+                                      atol=atol, err_msg=err_msg)
+
+
+def assert_less(actual, desired, err_msg='', verbose=True, xp=None):
+    if xp is None:
+        xp = array_namespace(actual)
+    if is_cupy(xp):
+        return xp.testing.assert_array_less(actual, desired,
+                                            err_msg=err_msg, verbose=verbose)
+    elif is_torch(xp):
+        if actual.device.type != 'cpu':
+            actual = actual.cpu()
+        if desired.device.type != 'cpu':
+            desired = desired.cpu()
+    return np.testing.assert_array_less(actual, desired,
+                                        err_msg=err_msg, verbose=verbose)


### PR DESCRIPTION
#### Reference issue
This comment from @mdhaber: https://github.com/scipy/scipy/pull/18930#discussion_r1304458805

#### What does this implement/fix?
Three new assertions in `_lib._array_api.py`:
```python
assert_equal(actual, desired, err_msg='', xp=None)

assert_close(actual, desired, rtol=None, atol=None, err_msg='', xp=None)`

assert_less(actual, desired, err_msg='', verbose=True, xp=None)`
```

Here, the appropriate testing function is used from `numpy`, `cupy` or `torch` based on:
1. If given, the `xp` parameter.
2. Otherwise, `array_namespace(actual)`.

#### Additional information
These functions are just to enable GPU testing internally in SciPy, hopefully concisely.

`torch` does not have an `assert_array_less` equivalent as far as I can see, so I have transferred to cpu and used `numpy.testing`.