### PR TITLE
ENH: Allow `sparse_mtx.transpose(axes=(1, 0))`

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -518,7 +518,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
     toarray.__doc__ = _spbase.toarray.__doc__
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -302,7 +302,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 raise ValueError('negative column index found')
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -112,7 +112,7 @@ class _csc_base(_cs_matrix):
     _format = 'csc'
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -140,7 +140,7 @@ class _csr_base(_cs_matrix):
     _format = 'csr'
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -325,7 +325,7 @@ class _dia_base(_data_matrix):
     todia.__doc__ = _spbase.todia.__doc__
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -367,7 +367,7 @@ class _dok_base(_spbase, IndexMixin):
         return dict.__reduce__(self)
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None:
+        if axes is not None and axes != (1, 0):
             raise ValueError("Sparse matrices do not support "
                              "an 'axes' parameter because swapping "
                              "dimensions is the only logical permutation.")

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1823,6 +1823,7 @@ class _TestCommon:
 
             assert_array_equal(a.toarray(), b)
             assert_array_equal(a.transpose().toarray(), dat)
+            assert_array_equal(datsp.transpose(axes=(1, 0)).toarray(), b)
             assert_equal(a.dtype, b.dtype)
 
         # See gh-5987


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #19161

#### What does this implement/fix?
<!--Please explain your changes.-->

Allows `sparse_mtx.transpose(axes=(1, 0))`, since that is equivalent to `sparse_mtx.T`

#### Additional information
<!--Any additional information you think is important.-->

Probably an enhancement, maybe a bug fix?