### PR TITLE
MAINT: Reflect changes from `numpy` namespace refactor Part 5

### DIFF
--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -241,7 +241,7 @@ def _read_structure(f, array_desc, struct_desc):
                 raise Exception("Variable type %i not implemented" %
                                                             col['typecode'])
 
-    structure = np.recarray((nrows, ), dtype=dtype)
+    structure = np.rec.recarray((nrows, ), dtype=dtype)
 
     for i in range(nrows):
         for col in columns:
@@ -584,7 +584,7 @@ def _replace_heap(variable, heap):
 
         return True, variable
 
-    elif isinstance(variable, np.recarray):
+    elif isinstance(variable, np.rec.recarray):
 
         # Loop over records
         for ir, record in enumerate(variable):


### PR DESCRIPTION
Hi @rgommers,
Here's a PR that reflects changes introduced in https://github.com/numpy/numpy/pull/24587. (The only item that needs to be modified in SciPy is `np.recarray` access)