### PR TITLE
BLD: special: fix dependencies for `_ellip_harm_2`

### DIFF
--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -318,12 +318,12 @@ cython_special_pxd = custom_target('_dummy_cython_special.pxd',
 uf_cython_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, _ufuncs_pxi_pxd_sources])
+  depends : [_cython_tree, _ufuncs_pxi_pxd_sources, cython_special_pxd])
 
 uf_cython_gen_cpp = generator(cython,
   arguments : cython_cplus_args,
   output : '@BASENAME@.cpp',
-  depends : [_cython_tree, _ufuncs_pxi_pxd_sources])
+  depends : [_cython_tree, _ufuncs_pxi_pxd_sources, cython_special_pxd])
 
 py3.extension_module('_ufuncs',
   [


### PR DESCRIPTION
Generating the source for `_ellip_harm_2` requires the `cython_special` module to already be compiled. Add a dependency for this. Note that it now must be a custom target because generators do not support extra dependencies.

Fixes: #19167

#### Reference issue
Closes gh-19167

#### What does this implement/fix?
Fix dependencies for `_ellip_harm_2` Cython generation.

#### Additional information
