### PR TITLE
MAINT: fix a number of issues in Cython code

### DIFF
--- a/scipy/_lib/_ccallback_c.pyx
+++ b/scipy/_lib/_ccallback_c.pyx
@@ -5,6 +5,7 @@ from cpython.pycapsule cimport (
 from cpython.long cimport PyLong_AsVoidPtr
 from libc.stdlib cimport free
 from libc.string cimport strdup
+from libc.math cimport sin
 
 from .ccallback cimport (ccallback_t, ccallback_prepare, ccallback_release, CCALLBACK_DEFAULTS,
                          ccallback_signature_t)
@@ -102,14 +103,6 @@ def check_capsule(item):
     return False
 
 
-#
-# Test code for src/ccallback.h
-#
-
-DEF ERROR_VALUE = 2
-
-from libc.math cimport sin
-
 sigs = [
     (b"double (double, int *, void *)", 0),
     (b"double (double, double, int *, void *)", 1)
@@ -185,7 +178,8 @@ cdef double plus1_cython(double a, int *error_flag, void *user_data) except * no
     """
     Implementation of a callable in Cython
     """
-    if a == ERROR_VALUE:
+    # 2.0 is ERROR_VALUE in the test code (src/_test_callback.c)
+    if a == 2.0:
         error_flag[0] = 1
         with gil:
             raise ValueError("failure...")

--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -24,10 +24,6 @@ ctypedef fused vq_type:
     float32_t
     float64_t
 
-# When the number of features is less than this number,
-# switch back to the naive algorithm to avoid high overhead.
-DEF NFEATURES_CUTOFF=5
-
 # Initialize the NumPy C API
 np.import_array()
 
@@ -81,8 +77,9 @@ cdef int _vq(vq_type *obs, vq_type *code_book,
         low_dist[i] is the Euclidean distance from obs[i] to the corresponding
         centroid.
     """
-    # Naive algorithm is preferred when nfeat is small
-    if nfeat < NFEATURES_CUTOFF:
+    # When the number of features is less than this number,
+    # switch back to the naive algorithm to avoid high overhead.
+    if nfeat < 5:
         _vq_small_nf(obs, code_book, ncodes, nfeat, nobs, codes, low_dist)
         return 0
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -26,6 +26,9 @@ np.import_array()
 
 include 'parameters.pxi'
 
+# EPS is the precision of DTYPE (float64, from parameters.pxi)
+DEF DTYPE_EPS = 1E-15
+
 
 class NegativeCycleError(Exception):
     def __init__(self, message=''):

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -8,9 +8,15 @@ pyx_files = [
   ['_traversal', '_traversal.pyx']
 ]
 
+cython_gen_csgraph = generator(cython,
+  arguments : cython_args,
+  output : '@BASENAME@.c',
+  depends : [_cython_tree, fs.copyfile('parameters.pxi')],
+)
+
 foreach pyx_file: pyx_files
   py3.extension_module(pyx_file[0],
-    cython_gen.process(pyx_file[1]),
+    cython_gen_csgraph.process(pyx_file[1]),
     c_args: cython_c_args,
     dependencies: np_dep,
     link_args: version_link_args,

--- a/scipy/sparse/csgraph/parameters.pxi
+++ b/scipy/sparse/csgraph/parameters.pxi
@@ -15,8 +15,5 @@ ctypedef fused int32_or_int64_b:
     np.int32_t
     np.int64_t
 
-# EPS is the precision of DTYPE
-DEF DTYPE_EPS = 1E-15
-
 # NULL_IDX is the index used in predecessor matrices to store a non-path
 DEF NULL_IDX = -9999

--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -23,8 +23,6 @@ cdef extern from "_complexstuff.h":
     np.npy_cdouble npy_csqrt(np.npy_cdouble z) nogil
     np.npy_cdouble npy_cpow(np.npy_cdouble x, np.npy_cdouble y) nogil
 
-DEF tol = 2.220446092504131e-16
-
 ctypedef double complex double_complex
 
 ctypedef fused number_t:
@@ -149,6 +147,7 @@ cdef inline double complex zlog1(double complex z) noexcept nogil:
         int n
         double complex coeff = -1
         double complex res = 0
+        double tol = 2.220446092504131e-16
 
     if zabs(z - 1) > 0.1:
         return zlog(z)

--- a/scipy/special/_digamma.pxd
+++ b/scipy/special/_digamma.pxd
@@ -17,12 +17,6 @@ from ._trig cimport sinpi, cospi
 from ._cephes cimport zeta, psi
 from . cimport sf_error
 
-# Use the asymptotic series for z away from the negative real axis
-# with abs(z) > smallabsz.
-DEF smallabsz = 16
-# Use the reflection principle for z with z.real < 0 that are within
-# smallimag of the negative real axis.
-DEF smallimag = 6
 # Relative tolerance for series
 DEF tol = 2.220446092504131e-16
 # All of the following were computed with mpmath
@@ -69,6 +63,12 @@ cdef inline double complex cdigamma(double complex z) noexcept nogil:
         double absz = zabs(z)
         double complex res = 0
         double complex init
+        # Use the asymptotic series for z away from the negative real axis
+        # with abs(z) > smallabsz.
+        int smallabsz = 16
+        # Use the reflection principle for z with z.real < 0 that are within
+        # smallimag of the negative real axis.
+        # int smallimag = 6  # unused below except in a comment
 
     if z.real <= 0 and ceil(z.real) == z:
         # Poles

--- a/scipy/special/_hyp2f1.pxd
+++ b/scipy/special/_hyp2f1.pxd
@@ -71,13 +71,6 @@ cdef extern from 'specfun_wrappers.h':
     ) nogil
 
 
-# Small value from Zhang and Jin's Fortran implementation.
-DEF EPS = 1e-15
-
-DEF SQRT_PI = 1.7724538509055159  # sqrt(M_PI)
-DEF LOG_PI_2 = 0.5723649429247001  # log(M_PI) / 2
-
-
 @cython.cdivision(True)
 cdef inline double complex hyp2f1_complex(
         double a, double b, double c, double complex z
@@ -88,6 +81,9 @@ cdef inline double complex hyp2f1_complex(
         double complex result
         bint a_neg_int, b_neg_int, c_non_pos_int
         bint c_minus_a_neg_int, c_minus_b_neg_int
+        # Small value from Zhang and Jin's Fortran implementation.
+        double EPS = 1e-15
+
     modulus_z = zabs(z)
     a_neg_int = a == trunc(a) and a < 0
     b_neg_int = b == trunc(b) and b < 0

--- a/scipy/special/_hypergeometric.pxd
+++ b/scipy/special/_hypergeometric.pxd
@@ -8,9 +8,6 @@ from ._cephes cimport expm1, poch
 cdef extern from 'specfun_wrappers.h':
     double hypU_wrap(double, double, double) nogil
 
-DEF EPS = 2.220446049250313e-16
-DEF ACCEPTABLE_RTOL = 1e-7
-
 
 @cython.cdivision(True)
 cdef inline double hyperu(double a, double b, double x) noexcept nogil:

--- a/scipy/special/_lambertw.pxd
+++ b/scipy/special/_lambertw.pxd
@@ -27,7 +27,6 @@ from ._evalpoly cimport cevalpoly
 from ._complexstuff cimport *
 
 DEF EXPN1 = 0.36787944117144232159553  # exp(-1)
-DEF OMEGA = 0.56714329040978387299997  # W(1, 0)
 
 
 @cython.cdivision(True)
@@ -36,6 +35,7 @@ cdef inline double complex lambertw_scalar(double complex z, long k, double tol)
     cdef double absz, p
     cdef double complex w
     cdef double complex ew, wew, wewz, wn
+    cdef double OMEGA = 0.56714329040978387299997  # W(1, 0)
 
     if zisnan(z):
         return z

--- a/scipy/special/_sici.pxd
+++ b/scipy/special/_sici.pxd
@@ -19,8 +19,6 @@ from ._complexstuff cimport (
 cdef extern from "specfun_wrappers.h":
     np.npy_cdouble cexpi_wrap(np.npy_cdouble) nogil
 
-DEF MAXITER = 100
-DEF TOL = 2.220446092504131e-16
 DEF EULER = 0.577215664901532860606512090082402431  # Euler constant
     
 
@@ -40,6 +38,8 @@ cdef inline void power_series(int sgn, double complex z,
     cdef:
         int n
         double complex fac, term1, term2
+        int MAXITER = 100
+        double tol = 2.220446092504131e-16
         
     fac = z
     s[0] = fac
@@ -51,7 +51,7 @@ cdef inline void power_series(int sgn, double complex z,
         fac *= z/(2*n + 1)
         term1 = fac/(2*n + 1)
         s[0] += term1
-        if zabs(term1) < TOL*zabs(s[0]) and zabs(term2) < TOL*zabs(c[0]):
+        if zabs(term1) < tol*zabs(s[0]) and zabs(term2) < tol*zabs(c[0]):
             break
 
     

--- a/scipy/special/_wright_bessel.pxd
+++ b/scipy/special/_wright_bessel.pxd
@@ -34,10 +34,6 @@ from . cimport sf_error
 
 # rgamma_zero: smallest value x for which rgamma(x) == 0 as x gets large
 DEF rgamma_zero = 178.47241115886637
-# exp_inf: smallest value x for which exp(x) == inf
-DEF exp_inf = 709.78271289338403
-# exp_zero: largest value x for which exp(x) == 0
-# DEF exp_zero = -745.13321910194117
 
 
 @cython.cdivision(True)
@@ -808,6 +804,8 @@ cdef inline double wright_bessel_scalar(double a, double b, double x) noexcept n
     cdef:
         double xk_k, res
         int order
+        # exp_inf: smallest value x for which exp(x) == inf
+        double exp_inf = 709.78271289338403
 
     if isnan(a) or isnan(b) or isnan(x):
         return NAN

--- a/scipy/stats/_ansari_swilk_statistics.pyx
+++ b/scipy/stats/_ansari_swilk_statistics.pyx
@@ -113,7 +113,7 @@ def gscale(int test, int other):
     return astart, a1, 0
 
 
-cdef inline void _start1(float[::1] a, int n) nogil noexcept:
+cdef inline void _start1(float[::1] a, int n) noexcept nogil:
     """
     Helper function for gscale function, see gscale docstring.
     """
@@ -124,7 +124,7 @@ cdef inline void _start1(float[::1] a, int n) nogil noexcept:
         a[lout-1] = 1
 
 
-cdef inline void _start2(float[::1] a, int n) nogil noexcept:
+cdef inline void _start2(float[::1] a, int n) noexcept nogil:
     """
     Helper function for gscale function, see gscale docstring.
     """
@@ -151,7 +151,7 @@ cdef inline void _start2(float[::1] a, int n) nogil noexcept:
 
 
 cdef inline int _frqadd(float[::1] a, float[::1] b, int lenb,
-                        int offset) nogil noexcept:
+                        int offset) noexcept nogil:
     """
     Helper function for gscale function, see gscale docstring.
     """
@@ -166,7 +166,7 @@ cdef inline int _frqadd(float[::1] a, float[::1] b, int lenb,
 
 
 cdef int _imply(float[::1] a, int curlen, int reslen, float[::1] b,
-                int offset) nogil noexcept:
+                int offset) noexcept nogil:
     """
     Helper function for gscale function, see gscale docstring.
     """
@@ -414,7 +414,7 @@ def swilk(double[::1] x, double[::1] a, bint init=False, int n1=-1):
     return w, pw, ifault
 
 
-cdef double _alnorm(double x, bint upper) nogil noexcept:
+cdef double _alnorm(double x, bint upper) noexcept nogil:
     """
     Helper function for swilk.
 
@@ -521,7 +521,7 @@ cdef double _ppnd(double p) noexcept:
     return (-temp if q < 0 else temp)  #, 0
 
 
-cdef double _poly(double[::1]c, int nord, double x) nogil noexcept:
+cdef double _poly(double[::1]c, int nord, double x) noexcept nogil:
     """
     Helper function for swilk function that evaluates polynomials.
     For some reason, the coefficients are given as

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -15,6 +15,7 @@ cimport scipy.special.cython_special as cs
 
 np.import_array()
 
+
 cdef double von_mises_cdf_series(double k, double x, unsigned int p) noexcept:
     cdef double s, c, sn, cn, R, V
     cdef unsigned int n
@@ -33,10 +34,9 @@ cdef double von_mises_cdf_series(double k, double x, unsigned int p) noexcept:
         return 0.5 + x / (2 * PI) + V / PI
 
 
-DEF SQRT2_PI = 0.79788456080286535588  # sqrt(2/pi)
-
-
 cdef von_mises_cdf_normalapprox(k, x):
+    cdef double SQRT2_PI = 0.79788456080286535588  # sqrt(2/pi)
+
     b = SQRT2_PI / scipy.special.i0e(k)  # Check for negative k
     z = b * np.sin(x / 2.)
     return scipy.stats.norm.cdf(z)


### PR DESCRIPTION
- fix a `nogil noexcept` statement that snuck back in (should be the other way around)
- fix a dependency issue in `csgraph` where changes to `parameters.pxi` did not trigger rebuilds correctly
- remove `DEF` statements where possible

The remaining `DEF` statements (quite a few are left) cannot easily be removed, they're waiting for support in Cython 3.x for `cdef const global_variable_name`.