### PR TITLE
ENH: constructors for sparse arrays 

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -88,9 +88,11 @@ Building sparse matrices:
 
    eye - Sparse MxN matrix whose k-th diagonal is all ones
    identity - Identity matrix in sparse format
+   identity_array - Identity array in sparse format
    kron - kronecker product of two sparse matrices
    kronsum - kronecker sum of sparse matrices
    diags - Return a sparse matrix from diagonals
+   diags_array - Return a sparse matrix from diagonals
    spdiags - Return a sparse matrix from diagonals
    block_diag - Build a block diagonal sparse matrix
    tril - Lower triangular portion of a matrix in sparse format
@@ -101,6 +103,7 @@ Building sparse matrices:
    vstack - Stack sparse matrices vertically (row wise)
    rand - Random values in a given shape
    random - Random values in a given shape
+   random_array - Random values in a given shape
 
 Save and load sparse matrices:
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -115,9 +115,8 @@ Save and load sparse matrices:
 .. autosummary::
    :toctree: generated/
 
-   save_npz - Save a sparse matrix to a file using ``.npz`` format.
-   load_npz - Load a sparse matrix from a file using ``.npz`` format.
-   load_npz_array - Load a sparse array from a file using ``.npz`` format.
+   save_npz - Save a sparse matrix/array to a file using ``.npz`` format.
+   load_npz - Load a sparse matrix/array from a file using ``.npz`` format.
 
 Sparse tools:
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -80,30 +80,35 @@ Building sparse arrays:
    :toctree: generated/
 
    diags_array - Return a sparse array from diagonals
+   eye_array - Sparse MxN array whose k-th diagonal is all ones
+   random_array - Random values in a given shape array
+   block - Build a sparse array from sub-blocks
 
 Building sparse matrices:
 
 .. autosummary::
    :toctree: generated/
 
-   eye_array - Sparse MxN array whose k-th diagonal is all ones
    eye - Sparse MxN matrix whose k-th diagonal is all ones
-   identity - Identity matrix in sparse format
+   identity - Identity matrix in sparse matrix format
+   diags - Return a sparse matrix from diagonals
+   spdiags - Return a sparse matrix from diagonals
+   bmat - Build a sparse matrix from sparse sub-blocks
+   rand - Random values in a given shape matrix
+   random - Random values in a given shape matrix
+
+Building larger structures from smaller (array or matrix)
+
+.. autosummary::
+   :toctree: generated/
+
    kron - kronecker product of two sparse matrices
    kronsum - kronecker sum of sparse matrices
-   diags - Return a sparse matrix from diagonals
-   diags_array - Return a sparse matrix from diagonals
-   spdiags - Return a sparse matrix from diagonals
    block_diag - Build a block diagonal sparse matrix
    tril - Lower triangular portion of a matrix in sparse format
    triu - Upper triangular portion of a matrix in sparse format
-   block - Build a sparse array from sub-blocks
-   bmat - Build a sparse matrix from sub-blocks
    hstack - Stack sparse matrices horizontally (column wise)
    vstack - Stack sparse matrices vertically (row wise)
-   rand - Random values in a given shape
-   random - Random values in a given shape
-   random_array - Random values in a given shape
 
 Save and load sparse matrices:
 
@@ -112,13 +117,19 @@ Save and load sparse matrices:
 
    save_npz - Save a sparse matrix to a file using ``.npz`` format.
    load_npz - Load a sparse matrix from a file using ``.npz`` format.
+   load_npz_array - Load a sparse array from a file using ``.npz`` format.
 
-Sparse matrix tools:
+Sparse tools:
 
 .. autosummary::
    :toctree: generated/
 
    find
+
+Identifying sparse arrays:
+
+- use `isinstance(A, sparray)` to check whether an array or matrix.
+- use `A.format == 'csr'` to check the sparse format
 
 Identifying sparse matrices:
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -82,7 +82,7 @@ Building sparse arrays:
    diags_array - Return a sparse array from diagonals
    eye_array - Sparse MxN array whose k-th diagonal is all ones
    random_array - Random values in a given shape array
-   block - Build a sparse array from sub-blocks
+   block_array - Build a sparse array from sub-blocks
 
 Building sparse matrices:
 
@@ -128,7 +128,7 @@ Sparse tools:
 
 Identifying sparse arrays:
 
-- use `isinstance(A, sparray)` to check whether an array or matrix.
+- use `isinstance(A, sp.sparse.sparray)` to check whether an array or matrix.
 - use `A.format == 'csr'` to check the sparse format
 
 Identifying sparse matrices:

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -94,8 +94,8 @@ Building sparse matrices:
    diags - Return a sparse matrix from diagonals
    spdiags - Return a sparse matrix from diagonals
    bmat - Build a sparse matrix from sparse sub-blocks
-   rand - Random values in a given shape matrix
    random - Random values in a given shape matrix
+   rand - Random values in a given shape matrix (old interface)
 
 Building larger structures from smaller (array or matrix)
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -86,9 +86,9 @@ Building sparse matrices:
 .. autosummary::
    :toctree: generated/
 
+   eye_array - Sparse MxN array whose k-th diagonal is all ones
    eye - Sparse MxN matrix whose k-th diagonal is all ones
    identity - Identity matrix in sparse format
-   identity_array - Identity array in sparse format
    kron - kronecker product of two sparse matrices
    kronsum - kronecker sum of sparse matrices
    diags - Return a sparse matrix from diagonals

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -353,11 +353,11 @@ class _spbase:
         return self._imag()
 
     def __repr__(self):
-        _, format_name = _formats[self.format]
+        _, format = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        return f"<%dx%d sparse {sparse_cls} of type '%s'\n" \
-               "\twith %d stored elements in %s format>" % \
-               (self.shape + (self.dtype.type, self.nnz, format_name))
+        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
+                f"\twith {self.nnz} stored elements in {format} format>"
+               ) % self.shape
 
     def __str__(self):
         maxprint = self._getmaxprint()

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -353,11 +353,13 @@ class _spbase:
         return self._imag()
 
     def __repr__(self):
-        _, format = _formats[self.format]
+        _, format_name = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
-                f"\twith {self.nnz} stored elements in {format} format>"
-               ) % self.shape
+        shape_str = 'x'.join(str(x) for x in self.shape)
+        return (
+            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
+            f"\twith {self.nnz} stored elements in {format_name} format>"
+        )
 
     def __str__(self):
         maxprint = self._getmaxprint()

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -210,11 +210,14 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
     def __repr__(self):
-        _, format = _formats[self.format]
+        _, fmt = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
-                f"\twith {self.nnz} stored elements (blocksize = %dx%d)"
-                f" in {format} format>") % (self.shape + self.blocksize)
+        shape_str = 'x'.join(str(x) for x in self.shape)
+        blksz = 'x'.join(str(x) for x in self.blocksize)
+        return (
+            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
+            f"\twith {self.nnz} stored elements (blocksize = {blksz}) in {fmt} format>"
+        )
 
     def diagonal(self, k=0):
         rows, cols = self.shape

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -210,11 +210,11 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
     def __repr__(self):
-        format = _formats[self.format][1]
-        return ("<%dx%d sparse matrix of type '%s'\n"
-                "\twith %d stored elements (blocksize = %dx%d) in %s format>" %
-                (self.shape + (self.dtype.type, self.nnz) + self.blocksize +
-                 (format,)))
+        _, format = _formats[self.format]
+        sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
+        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
+                f"\twith {self.nnz} stored elements (blocksize = %dx%d)"
+                f" in {format} format>") % (self.shape + self.blocksize)
 
     def diagonal(self, k=0):
         rows, cols = self.shape

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1168,6 +1168,9 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
     >>> Y = X().rvs
     >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng, data_sampler=Y)
     """
+    # Use the more efficient RNG by default.
+    if random_state is None:
+        random_state = np.random.default_rng()
     data, ind = _random(shape, density, format, dtype, random_state, data_sampler)
     return coo_array((data, ind), shape=shape).asformat(format)
 
@@ -1182,10 +1185,7 @@ def _random(shape, density=0.01, format=None, dtype=None,
     # Number of non zero values
     size = int(round(density * tot_prod))
 
-    if random_state is None:
-        rng = np.random.default_rng()
-    else:
-        rng = check_random_state(random_state)
+    rng = check_random_state(random_state)
 
     if data_sampler is None:
         if np.issubdtype(dtype, np.integer):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1146,7 +1146,7 @@ def random_array(m, n=None, *, density=0.01, format='coo', dtype=None,
 
     Using a custom distribution:
 
-    >>> class CustomDistribution(stats.rv_continuous):
+    >>> class CustomDistribution(sp.stats.rv_continuous):
     ...     def _rvs(self,  size=None, random_state=None):
     ...         return random_state.standard_normal(size)
     >>> X = CustomDistribution(seed=rng)
@@ -1278,16 +1278,15 @@ def random(m, n, density=0.01, format='coo', dtype=None,
 
     Passing a ``np.random.Generator`` instance for better performance:
 
-    >>> from scipy.sparse import random
-    >>> from scipy import stats
+    >>> import scipy as sp
     >>> from numpy.random import default_rng
     >>> rng = default_rng()
-    >>> S = random(3, 4, density=0.25, random_state=rng)
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng)
 
     Proving a sampler for the values:
 
-    >>> rvs = stats.poisson(25, loc=10).rvs
-    >>> S = random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
+    >>> rvs = sp.stats.poisson(25, loc=10).rvs
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
     >>> S.A
     array([[ 36.,   0.,  33.,   0.],   # random
            [  0.,   0.,   0.,   0.],
@@ -1295,12 +1294,12 @@ def random(m, n, density=0.01, format='coo', dtype=None,
 
     Using a custom distribution:
 
-    >>> class CustomDistribution(stats.rv_continuous):
+    >>> class CustomDistribution(sp.stats.rv_continuous):
     ...     def _rvs(self,  size=None, random_state=None):
     ...         return random_state.standard_normal(size)
     >>> X = CustomDistribution(seed=rng)
     >>> Y = X()  # get a frozen version of the distribution
-    >>> S = random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
     >>> S.A
     array([[ 0.        ,  0.        ,  0.        ,  0.        ],   # random
            [ 0.13569738,  1.9467163 , -0.81205367,  0.        ],

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -5,7 +5,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
            'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag',
-           'diags_array', 'block', 'eye_array', 'random_array']
+           'diags_array', 'block_array', 'eye_array', 'random_array']
 
 import numbers
 import math
@@ -782,14 +782,14 @@ def bmat(blocks, format=None, dtype=None):
     """
     Build a sparse array or matrix from sparse sub-blocks
 
-    Note: `block` is preferred over `bmat`. They are the same function
+    Note: `block_array` is preferred over `bmat`. They are the same function
     except that `bmat` can return a deprecated sparse matrix.
     `bmat` returns a coo_matrix if none of the inputs are a sparse array.
 
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``block`` to take advantage
+        You are encouraged to use ``block_array`` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -812,7 +812,7 @@ def bmat(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block()`.
+        arrays, use `block_array()`.
 
     See Also
     --------
@@ -842,7 +842,7 @@ def bmat(blocks, format=None, dtype=None):
         return _block(blocks, format, dtype, return_spmatrix=True)
 
 
-def block(blocks, *, format=None, dtype=None):
+def block_array(blocks, *, format=None, dtype=None):
     """
     Build a sparse array from sparse sub-blocks
 
@@ -870,16 +870,16 @@ def block(blocks, *, format=None, dtype=None):
 
     Examples
     --------
-    >>> from scipy.sparse import coo_array, block
+    >>> from scipy.sparse import coo_array, block_array
     >>> A = coo_array([[1, 2], [3, 4]])
     >>> B = coo_array([[5], [6]])
     >>> C = coo_array([[7]])
-    >>> block([[A, B], [None, C]]).toarray()
+    >>> block_array([[A, B], [None, C]]).toarray()
     array([[1, 2, 5],
            [3, 4, 6],
            [0, 0, 7]])
 
-    >>> block([[A, None], [None, C]]).toarray()
+    >>> block_array([[A, None], [None, C]]).toarray()
     array([[1, 2, 0],
            [3, 4, 0],
            [0, 0, 7]])
@@ -1089,8 +1089,9 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
     dtype : dtype, optional (default: np.float64)
         type of the returned matrix values.
     random_state : {None, int, `Generator`, `RandomState`}, optional
-        The random number generator used for this function. We recommend using
-        this for every call with a `numpy.random.Generator` as it is much faster.
+        A random number generator to determine nonzero structure. We recommend using
+        a `numpy.random.Generator` manually provided for every call as it is much
+        faster than RandomState.
 
         - If `None` (or `np.random`), the `numpy.random.RandomState`
           singleton is used.

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -366,7 +366,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
             indptr = np.arange(n+1, dtype=idx_dtype)
             indices = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
+            cls = {'csr': csr_array, 'csc': csc_array}[format]
             return cls((data, indices, indptr), (n, n))
 
         elif format == 'coo':
@@ -374,7 +374,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
             row = np.arange(n, dtype=idx_dtype)
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            return coo_matrix((data, (row, col)), (n, n))
+            return coo_array((data, (row, col)), (n, n))
 
     data = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
     return diags_array(data, offsets=[k], shape=(m, n), dtype=dtype).asformat(format)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -338,7 +338,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
     k : int, optional
         Diagonal to place ones on. Default: 0 (main diagonal).
     dtype : dtype, optional
-        Data type of the matrix
+        Data type of the array
     format : str, optional (default: "dia")
         Sparse format of the result, e.g., format="csr", etc.
 
@@ -355,6 +355,22 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
             with 3 stored elements (1 diagonals) in DIAgonal format>
 
     """
+    # TODO: delete next 15 lines [combine with _eye()] once spmatrix removed
+    return _eye(m, n, k, dtype, format)
+
+
+def _eye(m, n, k, dtype, format, as_sparray=True):
+    if as_sparray:
+        csr_sparse = csr_array
+        csc_sparse = csc_array
+        coo_sparse = coo_array
+        diags_sparse = diags_array
+    else:
+        csr_sparse = csr_matrix
+        csc_sparse = csc_matrix
+        coo_sparse = coo_matrix
+        diags_sparse = diags
+
     if n is None:
         n = m
     m, n = int(m), int(n)
@@ -366,7 +382,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
             indptr = np.arange(n+1, dtype=idx_dtype)
             indices = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            cls = {'csr': csr_array, 'csc': csc_array}[format]
+            cls = {'csr': csr_sparse, 'csc': csc_sparse}[format]
             return cls((data, indices, indptr), (n, n))
 
         elif format == 'coo':
@@ -374,10 +390,10 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
             row = np.arange(n, dtype=idx_dtype)
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            return coo_array((data, (row, col)), (n, n))
+            return coo_sparse((data, (row, col)), (n, n))
 
     data = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
-    return diags_array(data, offsets=[k], shape=(m, n), dtype=dtype).asformat(format)
+    return diags_sparse(data, offsets=[k], shape=(m, n), dtype=dtype).asformat(format)
 
 
 def eye(m, n=None, k=0, dtype=float, format=None):
@@ -418,28 +434,7 @@ def eye(m, n=None, k=0, dtype=float, format=None):
         with 3 stored elements (1 diagonals) in DIAgonal format>
 
     """
-    if n is None:
-        n = m
-    m,n = int(m),int(n)
-
-    if m == n and k == 0:
-        # fast branch for special formats
-        if format in ['csr', 'csc']:
-            idx_dtype = get_index_dtype(maxval=n)
-            indptr = np.arange(n+1, dtype=idx_dtype)
-            indices = np.arange(n, dtype=idx_dtype)
-            data = np.ones(n, dtype=dtype)
-            cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
-            return cls((data,indices,indptr),(n,n))
-        elif format == 'coo':
-            idx_dtype = get_index_dtype(maxval=n)
-            row = np.arange(n, dtype=idx_dtype)
-            col = np.arange(n, dtype=idx_dtype)
-            data = np.ones(n, dtype=dtype)
-            return coo_matrix((data, (row, col)), (n, n))
-
-    data = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
-    return diags(data, offsets=[k], shape=(m, n), dtype=dtype).asformat(format)
+    return _eye(m, n, k, dtype, format, False)
 
 
 def kron(A, B, format=None):
@@ -480,7 +475,7 @@ def kron(A, B, format=None):
            [15, 20,  0,  0]])
 
     """
-    # delete next 10 lines and replace _sparse with _array when spmatrix removed
+    # TODO: delete next 10 lines and replace _sparse with _array when spmatrix removed
     if isinstance(A, sparray) or isinstance(B, sparray):
         # convert to local variables
         bsr_sparse = bsr_array
@@ -563,7 +558,7 @@ def kronsum(A, B, format=None):
     kronecker sum in a sparse matrix format
 
     """
-    # delete next 8 lines and replace _sparse with _array when spmatrix removed
+    # TODO: delete next 8 lines and replace _sparse with _array when spmatrix removed
     if isinstance(A, sparray) or isinstance(B, sparray):
         # convert to local variables
         coo_sparse = coo_array

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1183,7 +1183,7 @@ def _random(shape, density=0.01, format=None, dtype=None,
     size = int(round(density * tot_prod))
 
     if random_state is None:
-        random_state = np.random.random_rng()
+        rng = np.random.default_rng()
     else:
         rng = check_random_state(random_state)
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -816,7 +816,7 @@ def bmat(blocks, format=None, dtype=None):
 
     See Also
     --------
-    block
+    block_array
 
     Examples
     --------
@@ -1011,7 +1011,8 @@ def block_diag(mats, format=None, dtype=None):
 
     See Also
     --------
-    block, diags
+    block_array
+    diags_array
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1182,7 +1182,10 @@ def _random(shape, density=0.01, format=None, dtype=None,
     # Number of non zero values
     size = int(round(density * tot_prod))
 
-    rng = check_random_state(random_state)
+    if random_state is None:
+        random_state = np.random.random_rng()
+    else:
+        rng = check_random_state(random_state)
 
     if data_sampler is None:
         if np.issubdtype(dtype, np.integer):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -332,7 +332,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
     Parameters
     ----------
     m : int or tuple of ints
-        Number of rows or shape requested.
+        Number of rows requested.
     n : int, optional
         Number of columns. Default: `m`.
     k : int, optional
@@ -1115,8 +1115,7 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
         By default, uniform [0, 1) random values are used unless `dtype` is
         an integer (default uniform integers from that dtype) or
         complex (default uniform over the unit square in the complex plane).
-        Also by default the `random_state` rng is used e.g.
-        `random_state.uniform(size=size)`.
+        For these, the `random_state` rng is used e.g. `rng.uniform(size=size)`.
 
     Returns
     -------
@@ -1212,7 +1211,6 @@ def _random(shape, density=0.01, format=None, dtype=None,
             dsize = size - len(seen)
             seen.update(map(tuple, rng_integers(rng, shape, size=(dsize, ndim))))
         ind = tuple(np.array(list(seen)).T)
-        print("size(ind): ",tuple(a.shape for a in ind))
 
     # size kwarg allows eg data_sampler=partial(np.random.poisson, lam=5)
     vals = data_sampler(size=size).astype(dtype, copy=False)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -346,12 +346,12 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
     --------
     >>> import numpy as np
     >>> import scipy as sp
-    >>> sp.sparse.eye(3).toarray()
+    >>> sp.sparse.eye_array(3).toarray()
     array([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
-    >>> sp.sparse.eye(3, dtype=np.int8)
-    <3x3 sparse matrix of type '<class 'numpy.int8'>'
+    >>> sp.sparse.eye_array(3, dtype=np.int8)
+    <3x3 sparse array of type '<class 'numpy.int8'>'
             with 3 stored elements (1 diagonals) in DIAgonal format>
 
     """
@@ -1133,7 +1133,7 @@ def random_array(m, n=None, *, density=0.01, format='coo', dtype=None,
     >>> import numpy as np
     >>> import scipy as sp
     >>> rng = np.random.default_rng()
-    >>> S = random(3, 4, density=0.25, random_state=rng)
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng)
 
     Proving a sampler for the values:
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -201,6 +201,12 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     """
     Construct a sparse matrix from diagonals.
 
+    .. warning::
+
+        This function returns a sparse matrix -- not a sparse array.
+        You are encouraged to use ``diags_array`` to take advantage
+        of the sparse array functionality.
+
     Parameters
     ----------
     diagonals : sequence of array_like
@@ -225,12 +231,6 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     --------
     spdiags : construct matrix from diagonals
     diags_array : construct sparse array instead of sparse matrix
-
-    .. warning::
-
-        This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``diags_array`` to take advantage
-        of the sparse array functionality.
 
     Notes
     -----
@@ -303,15 +303,15 @@ def identity(n, dtype='d', format=None):
 
     Examples
     --------
-    >>> from scipy.sparse import identity
-    >>> identity(3).toarray()
+    >>> import scipy as sp
+    >>> sp.sparse.identity(3).toarray()
     array([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
-    >>> identity(3, dtype='int8', format='dia')
+    >>> sp.sparse.identity(3, dtype='int8', format='dia')
     <3x3 sparse matrix of type '<class 'numpy.int8'>'
             with 3 stored elements (1 diagonals) in DIAgonal format>
-    >>> eye_array(3, dtype='int8', format='dia')
+    >>> sp.sparse.eye_array(3, dtype='int8', format='dia')
     <3x3 sparse array of type '<class 'numpy.int8'>'
             with 3 stored elements (1 diagonals) in DIAgonal format>
 
@@ -350,7 +350,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
     array([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
-    >>> sparse.eye(3, dtype=np.int8)
+    >>> sp.sparse.eye(3, dtype=np.int8)
     <3x3 sparse matrix of type '<class 'numpy.int8'>'
             with 3 stored elements (1 diagonals) in DIAgonal format>
 
@@ -408,12 +408,12 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy import sparse
-    >>> sparse.eye(3).toarray()
+    >>> import scipy as sp
+    >>> sp.sparse.eye(3).toarray()
     array([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
-    >>> sparse.eye(3, dtype=np.int8)
+    >>> sp.sparse.eye(3, dtype=np.int8)
     <3x3 sparse matrix of type '<class 'numpy.int8'>'
         with 3 stored elements (1 diagonals) in DIAgonal format>
 
@@ -464,16 +464,16 @@ def kron(A, B, format=None):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy import sparse
-    >>> A = sparse.csr_array(np.array([[0, 2], [5, 0]]))
-    >>> B = sparse.csr_array(np.array([[1, 2], [3, 4]]))
-    >>> sparse.kron(A, B).toarray()
+    >>> import scipy as sp
+    >>> A = sp.sparse.csr_array(np.array([[0, 2], [5, 0]]))
+    >>> B = sp.sparse.csr_array(np.array([[1, 2], [3, 4]]))
+    >>> sp.sparse.kron(A, B).toarray()
     array([[ 0,  0,  2,  4],
            [ 0,  0,  6,  8],
            [ 5, 10,  0,  0],
            [15, 20,  0,  0]])
 
-    >>> sparse.kron(A, [[1, 2], [3, 4]]).toarray()
+    >>> sp.sparse.kron(A, [[1, 2], [3, 4]]).toarray()
     array([[ 0,  0,  2,  4],
            [ 0,  0,  6,  8],
            [ 5, 10,  0,  0],
@@ -1096,10 +1096,9 @@ def random_array(m, n=None, *, density=0.01, format='coo', dtype=None,
         sparse matrix format.
     dtype : dtype, optional
         type of the returned matrix values.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
+    random_state : {None, int, `Generator`, `RandomState`}, optional
         The random number generator used for this function. We recommend using
-        this for every call with a numpy Generator as it is much faster.
+        this for every call with a `numpy.random.Generator` as it is much faster.
 
         - If `seed` is None (or `np.random`), the `numpy.random.RandomState`
           singleton is used.
@@ -1131,16 +1130,15 @@ def random_array(m, n=None, *, density=0.01, format='coo', dtype=None,
 
     Passing a ``np.random.Generator`` instance for better performance:
 
-    >>> from scipy.sparse import random
-    >>> from scipy import stats
-    >>> from numpy.random import default_rng
-    >>> rng = default_rng()
+    >>> import numpy as np
+    >>> import scipy as sp
+    >>> rng = np.random.default_rng()
     >>> S = random(3, 4, density=0.25, random_state=rng)
 
     Proving a sampler for the values:
 
-    >>> rvs = stats.poisson(25, loc=10).rvs
-    >>> S = random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
+    >>> rvs = sp.stats.poisson(25, loc=10).rvs
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
     >>> S.A
     array([[ 36.,   0.,  33.,   0.],   # random
            [  0.,   0.,   0.,   0.],
@@ -1153,7 +1151,7 @@ def random_array(m, n=None, *, density=0.01, format='coo', dtype=None,
     ...         return random_state.standard_normal(size)
     >>> X = CustomDistribution(seed=rng)
     >>> Y = X()  # get a frozen version of the distribution
-    >>> S = random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
+    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
     >>> S.A
     array([[ 0.        ,  0.        ,  0.        ,  0.        ],   # random
            [ 0.13569738,  1.9467163 , -0.81205367,  0.        ],

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1128,12 +1128,12 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
 
     Default sampling uniformly from [0, 1):
 
-    >>> S = sp.sparse.random_array(3, 4, density=0.25, random_state=rng)
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng)
 
     Providing a sampler for the values:
 
     >>> rvs = sp.stats.poisson(25, loc=10).rvs
-    >>> S = sp.sparse.random_array(3, 4, density=0.25, random_state=rng, data_sampler=rvs)
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng, data_sampler=rvs)
     >>> S.toarray()
     array([[ 36.,   0.,  33.,   0.],   # random
            [  0.,   0.,   0.,   0.],
@@ -1144,15 +1144,15 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
 
     >>> def np_normal_squared(size=None, random_state=None):
     ...     return random_state.standard_normal(size) ** 2
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng,
-                             data_rvs=np_normal_squared)
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng,
+    ...                      data_rvs=np_normal_squared)
 
     Or we can build it from sp.stats style rvs functions:
 
     >>> def sp_stats_normal_squared(size=None, random_state=None):
     ...     std_normal = sp.stats.distributions.norm_gen().rvs
     ...     return std_normal(size=size, random_state=random_state) ** 2
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng,
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng,
     ...                      data_rvs=sp_stats_normal_squared)
 
     Or we can subclass sp.stats rv_continous or rv_discrete:
@@ -1162,7 +1162,7 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
     ...         return random_state.standard_normal(size) ** 2
     >>> X = NormalSquared(seed=rng)
     >>> Y = X()
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, random_state=rng, data_rvs=Y.rvs)
     """
     data, ind = _random(shape, density, format, dtype, random_state, data_sampler)
     return coo_array((data, ind), shape=shape).asformat(format)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -284,7 +284,10 @@ def identity(n, dtype='d', format=None):
     """Identity matrix in sparse format
 
     Returns an identity matrix with shape (n,n) using a given
-    sparse format and dtype.
+    sparse format and dtype. This differs from `eye_array` in
+    that it has a square shape with ones only on the main diagonal.
+    It is thus the multiplicative identity. `eye_array` allows
+    rectangular shapes and the diagonal can be offset from the main one.
 
     .. warning::
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -9,7 +9,6 @@ __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
 
 import numbers
 import math
-from functools import partial
 import numpy as np
 
 from scipy._lib._util import check_random_state, rng_integers

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -87,11 +87,11 @@ class _dia_base(_data_matrix):
             raise ValueError('offset array contains duplicate values')
 
     def __repr__(self):
-        format = _formats[self.format][1]
-        return "<%dx%d sparse matrix of type '%s'\n" \
-               "\twith %d stored elements (%d diagonals) in %s format>" % \
-               (self.shape + (self.dtype.type, self.nnz, self.data.shape[0],
-                              format))
+        _, format = _formats[self.format]
+        sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
+        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
+                f"\twith {self.nnz} stored elements ({self.data.shape[0]} diagonals)"
+                f" in {format} format>") % self.shape
 
     def _data_mask(self):
         """Returns a mask of the same shape as self.data, where

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -87,11 +87,14 @@ class _dia_base(_data_matrix):
             raise ValueError('offset array contains duplicate values')
 
     def __repr__(self):
-        _, format = _formats[self.format]
+        _, fmt = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        return (f"<%dx%d sparse {sparse_cls} of type '{self.dtype.type}'\n"
-                f"\twith {self.nnz} stored elements ({self.data.shape[0]} diagonals)"
-                f" in {format} format>") % self.shape
+        shape_str = 'x'.join(str(x) for x in self.shape)
+        ndiag = self.data.shape[0]
+        return (
+            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
+            f"\twith {self.nnz} stored elements ({ndiag} diagonals) in {fmt} format>"
+        )
 
     def _data_mask(self):
         """Returns a mask of the same shape as self.data, where

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -6,7 +6,8 @@ __docformat__ = "restructuredtext en"
 __all__ = ['find', 'tril', 'triu']
 
 
-from ._coo import coo_matrix
+from ._coo import coo_matrix, coo_array
+from ._base import sparray
 
 
 def find(A):
@@ -14,26 +15,26 @@ def find(A):
 
     Parameters
     ----------
-    A : dense or sparse matrix
+    A : dense or sparse array or matrix
         Matrix whose nonzero elements are desired.
 
     Returns
     -------
     (I,J,V) : tuple of arrays
         I,J, and V contain the row indices, column indices, and values
-        of the nonzero matrix entries.
+        of the nonzero entries.
 
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix, find
-    >>> A = csr_matrix([[7.0, 8.0, 0],[0, 0, 9.0]])
+    >>> from scipy.sparse import csr_array, find
+    >>> A = csr_array([[7.0, 8.0, 0],[0, 0, 9.0]])
     >>> find(A)
     (array([0, 0, 1], dtype=int32), array([0, 1, 2], dtype=int32), array([ 7.,  8.,  9.]))
 
     """
 
-    A = coo_matrix(A, copy=True)
+    A = coo_array(A, copy=True)
     A.sum_duplicates()
     # remove explicit zeros
     nz_mask = A.data != 0
@@ -41,16 +42,16 @@ def find(A):
 
 
 def tril(A, k=0, format=None):
-    """Return the lower triangular portion of a matrix in sparse format
+    """Return the lower triangular portion of a sparse array or matrix
 
-    Returns the elements on or below the k-th diagonal of the matrix A.
+    Returns the elements on or below the k-th diagonal of A.
         - k = 0 corresponds to the main diagonal
         - k > 0 is above the main diagonal
         - k < 0 is below the main diagonal
 
     Parameters
     ----------
-    A : dense or sparse matrix
+    A : dense or sparse array or matrix
         Matrix whose lower trianglar portion is desired.
     k : integer : optional
         The top-most diagonal of the lower triangle.
@@ -68,9 +69,9 @@ def tril(A, k=0, format=None):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix, tril
-    >>> A = csr_matrix([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
-    ...                dtype='int32')
+    >>> from scipy.sparse import csr_array, tril
+    >>> A = csr_array([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
+    ...               dtype='int32')
     >>> A.toarray()
     array([[1, 2, 0, 0, 3],
            [4, 5, 0, 6, 7],
@@ -90,28 +91,34 @@ def tril(A, k=0, format=None):
            [4, 0, 0, 0, 0],
            [0, 0, 0, 0, 0]])
     >>> tril(A, format='csc')
-    <3x5 sparse matrix of type '<class 'numpy.int32'>'
+    <3x5 sparse array of type '<class 'numpy.int32'>'
             with 4 stored elements in Compressed Sparse Column format>
 
     """
+    coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix
 
     # convert to COOrdinate format where things are easy
-    A = coo_matrix(A, copy=False)
+    A = coo_sparse(A, copy=False)
     mask = A.row + k >= A.col
-    return _masked_coo(A, mask).asformat(format)
+
+    row = A.row[mask]
+    col = A.col[mask]
+    data = A.data[mask]
+    new_coo = coo_sparse((data, (row, col)), shape=A.shape, dtype=A.dtype)
+    return new_coo.asformat(format)
 
 
 def triu(A, k=0, format=None):
-    """Return the upper triangular portion of a matrix in sparse format
+    """Return the upper triangular portion of a sparse array or matrix
 
-    Returns the elements on or above the k-th diagonal of the matrix A.
+    Returns the elements on or above the k-th diagonal of A.
         - k = 0 corresponds to the main diagonal
         - k > 0 is above the main diagonal
         - k < 0 is below the main diagonal
 
     Parameters
     ----------
-    A : dense or sparse matrix
+    A : dense or sparse array or matrix
         Matrix whose upper trianglar portion is desired.
     k : integer : optional
         The bottom-most diagonal of the upper triangle.
@@ -120,8 +127,9 @@ def triu(A, k=0, format=None):
 
     Returns
     -------
-    L : sparse matrix
+    L : sparse array or matrix 
         Upper triangular portion of A in sparse format.
+        Sparse array if A is a sparse array, otherwise matrix.
 
     See Also
     --------
@@ -129,8 +137,8 @@ def triu(A, k=0, format=None):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix, triu
-    >>> A = csr_matrix([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
+    >>> from scipy.sparse import csr_array, triu
+    >>> A = csr_array([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
     ...                dtype='int32')
     >>> A.toarray()
     array([[1, 2, 0, 0, 3],
@@ -151,19 +159,18 @@ def triu(A, k=0, format=None):
            [4, 5, 0, 6, 7],
            [0, 0, 8, 9, 0]])
     >>> triu(A, format='csc')
-    <3x5 sparse matrix of type '<class 'numpy.int32'>'
+    <3x5 sparse array of type '<class 'numpy.int32'>'
             with 8 stored elements in Compressed Sparse Column format>
 
     """
+    coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix
 
     # convert to COOrdinate format where things are easy
-    A = coo_matrix(A, copy=False)
+    A = coo_sparse(A, copy=False)
     mask = A.row + k <= A.col
-    return _masked_coo(A, mask).asformat(format)
 
-
-def _masked_coo(A, mask):
     row = A.row[mask]
     col = A.col[mask]
     data = A.data[mask]
-    return coo_matrix((data, (row, col)), shape=A.shape, dtype=A.dtype)
+    new_coo = coo_sparse((data, (row, col)), shape=A.shape, dtype=A.dtype)
+    return new_coo.asformat(format)

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -36,7 +36,7 @@ def save_npz(file, matrix, compressed=True):
 
     >>> import numpy as np
     >>> import scipy as sp
-    >>> sparse_matrix = sp.sparse.csc_matrix(np.array([[0, 0, 3], [4, 0, 0]]))
+    >>> sparse_matrix = sp.sparse.csc_matrix([[0, 0, 3], [4, 0, 0]])
     >>> sparse_matrix
     <2x3 sparse matrix of type '<class 'numpy.int64'>'
        with 2 stored elements in Compressed Sparse Column format>
@@ -106,7 +106,7 @@ def load_npz(file):
 
     >>> import numpy as np
     >>> import scipy as sp
-    >>> sparse_array = sp.sparse.csc_array(np.array([[0, 0, 3], [4, 0, 0]]))
+    >>> sparse_array = sp.sparse.csc_array([[0, 0, 3], [4, 0, 0]])
     >>> sparse_array
     <2x3 sparse array of type '<class 'numpy.int64'>'
        with 2 stored elements in Compressed Sparse Column format>
@@ -123,6 +123,12 @@ def load_npz(file):
     >>> sparse_array.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
+
+    In this example we force the result to be csr_array from csr_matrix
+    >>> sparse_matrix = sp.sparse.csc_matrix([[0, 0, 3], [4, 0, 0]])
+    >>> sp.sparse.save_npz('/tmp/sparse_matrix.npz', sparse_matrix)
+    >>> tmp = sp.sparse.load_npz('/tmp/sparse_matrix.npz')
+    >>> sparse_array = sp.sparse.csr_array(tmp)
     """
     with np.load(file, **PICKLE_KWARGS) as loaded:
         try:

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -18,7 +18,7 @@ def save_npz(file, matrix, compressed=True):
         where the data will be saved. If file is a string, the ``.npz``
         extension will be appended to the file name if it is not already
         there.
-    matrix: spmatrix or aparray
+    matrix: spmatrix or sparray
         The sparse matrix or array to save.
         Supported formats: ``csc``, ``csr``, ``bsr``, ``dia`` or coo``.
     compressed : bool, optional

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -161,4 +161,4 @@ def load_npz(file):
             return cls((loaded['data'], (loaded['row'], loaded['col'])), shape=loaded['shape'])
         else:
             raise NotImplementedError('Load is not implemented for '
-                                      'sparse matrix of format {}.'.format(sparse_format))
+                                      f'sparse matrix of format {sparse_format}.')

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -92,7 +92,7 @@ of_the_second_derivative
     the default dtype for storing matrix representations.
 
     >>> lap.tosparse()
-    <6x6 sparse matrix of type '<class 'numpy.int8'>'
+    <6x6 sparse array of type '<class 'numpy.int8'>'
         with 16 stored elements (3 diagonals) in DIAgonal format>
     >>> lap.toarray()
     array([[-1,  1,  0,  0,  0,  0],

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -297,6 +297,10 @@ class TestConstructUtils:
             assert_equal(I.format, fmt)
             assert_equal(I.toarray(), [[1,0,0],[0,1,0],[0,0,1]])
 
+    def test_eye_array_vs_matrix(self):
+        assert isinstance(construct.eye_array(3), sparray)
+        assert not isinstance(construct.eye(3), sparray)
+
     def test_kron(self):
         cases = []
 
@@ -717,6 +721,7 @@ class TestConstructUtils:
         # check random_array
         sparse_array = construct.random_array(10, 10, density=0.1265)
         assert_equal(sparse_array.count_nonzero(),13)
+        assert isinstance(sparse_array, sparray)
 
 
 def test_diags_array():

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -351,9 +351,6 @@ class TestConstructUtils:
 
     def test_kron_large(self):
         n = 2**16
-        # pre-sparse-array setup
-        # a = construct.eye(1, n, n-1)
-        # b = construct.eye(n, 1, 1-n)
         a = construct.diags_array([1], shape=(1, n), offsets=n-1)
         b = construct.diags_array([1], shape=(n, 1), offsets=1-n)
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -31,9 +31,9 @@ def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
 def _sprandn_array(m, n, density=0.01, format="coo", dtype=None, random_state=None):
     # Helper function for testing.
     random_state = check_random_state(random_state)
-    data_rng = random_state.standard_normal
+    data_sampler = random_state.standard_normal
     return construct.random_array((m, n), density=density, format=format, dtype=dtype,
-                                  random_state=random_state, data_rng=data_rng)
+                                  random_state=random_state, data_sampler=data_sampler)
 
 
 class TestConstructUtils:
@@ -719,6 +719,10 @@ class TestConstructUtils:
         sparse_array = construct.random_array((10, 10), density=0.1265)
         assert_equal(sparse_array.count_nonzero(),13)
         assert isinstance(sparse_array, sparray)
+        # check big size
+        shape = (2**33, 2**33)
+        sparse_array = construct.random_array(shape, density=2.7105e-17)
+        assert_equal(sparse_array.count_nonzero(),2000)
 
 
 def test_diags_array():

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -32,7 +32,7 @@ def _sprandn_array(m, n, density=0.01, format="coo", dtype=None, random_state=No
     # Helper function for testing.
     random_state = check_random_state(random_state)
     data_rng = random_state.standard_normal
-    return construct.random_array(m, n, density=density, format=format, dtype=dtype,
+    return construct.random_array((m, n), density=density, format=format, dtype=dtype,
                                   random_state=random_state, data_rng=data_rng)
 
 
@@ -708,7 +708,7 @@ class TestConstructUtils:
         # anything that np.dtype can convert to a dtype should be accepted
         # for the dtype
         construct.random(10, 10, dtype='d')
-        construct.random_array(10, 10, dtype='d')
+        construct.random_array((10, 10), dtype='d')
 
     def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
         # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.
@@ -716,7 +716,7 @@ class TestConstructUtils:
         sparse_matrix = construct.random(10, 10, density=0.1265)
         assert_equal(sparse_matrix.count_nonzero(),13)
         # check random_array
-        sparse_array = construct.random_array(10, 10, density=0.1265)
+        sparse_array = construct.random_array((10, 10), density=0.1265)
         assert_equal(sparse_array.count_nonzero(),13)
         assert isinstance(sparse_array, sparray)
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -235,15 +235,15 @@ class TestConstructUtils:
 
     @pytest.mark.parametrize("identity", [construct.identity, construct.eye_array])
     def test_identity(self, identity):
-        assert_equal(construct.identity(1).toarray(), [[1]])
-        assert_equal(construct.identity(2).toarray(), [[1,0],[0,1]])
+        assert_equal(identity(1).toarray(), [[1]])
+        assert_equal(identity(2).toarray(), [[1,0],[0,1]])
 
-        I = construct.identity(3, dtype='int8', format='dia')
+        I = identity(3, dtype='int8', format='dia')
         assert_equal(I.dtype, np.dtype('int8'))
         assert_equal(I.format, 'dia')
 
         for fmt in sparse_formats:
-            I = construct.identity(3, format=fmt)
+            I = identity(3, format=fmt)
             assert_equal(I.format, fmt)
             assert_equal(I.toarray(), [[1,0,0],[0,1,0],[0,0,1]])
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -33,7 +33,7 @@ def _sprandn_array(m, n, density=0.01, format="coo", dtype=None, random_state=No
     random_state = check_random_state(random_state)
     data_rng = random_state.standard_normal
     return construct.random_array(m, n, density=density, format=format, dtype=dtype,
-                                  random_state=random_state, data_random_state=data_rng)
+                                  random_state=random_state, data_rng=data_rng)
 
 
 class TestConstructUtils:

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -443,8 +443,8 @@ class TestConstructUtils:
         assert isinstance(construct.hstack([coo_matrix(A), coo_array(B)]), sparray)
         assert isinstance(construct.hstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
 
-    @pytest.mark.parametrize("block", (construct.bmat, construct.block))
-    def test_block_creation(self, block):
+    @pytest.mark.parametrize("block_array", (construct.bmat, construct.block_array))
+    def test_block_creation(self, block_array):
 
         A = coo_array([[1, 2], [3, 4]])
         B = coo_array([[5],[6]])
@@ -454,77 +454,75 @@ class TestConstructUtils:
         expected = array([[1, 2, 5],
                           [3, 4, 6],
                           [0, 0, 7]])
-        assert_equal(block([[A, B], [None, C]]).toarray(), expected)
+        assert_equal(block_array([[A, B], [None, C]]).toarray(), expected)
         E = csr_array((1, 2), dtype=np.int32)
-        assert_equal(block([[A.tocsr(), B.tocsr()],
-                                     [E, C.tocsr()]]).toarray(),
+        assert_equal(block_array([[A.tocsr(), B.tocsr()],
+                                  [E, C.tocsr()]]).toarray(),
                      expected)
-        assert_equal(block([[A.tocsc(), B.tocsc()],
-                                     [E.tocsc(), C.tocsc()]]).toarray(),
+        assert_equal(block_array([[A.tocsc(), B.tocsc()],
+                                  [E.tocsc(), C.tocsc()]]).toarray(),
                      expected)
 
         expected = array([[1, 2, 0],
                           [3, 4, 0],
                           [0, 0, 7]])
-        assert_equal(block([[A, None], [None, C]]).toarray(),
+        assert_equal(block_array([[A, None], [None, C]]).toarray(), expected)
+        assert_equal(block_array([[A.tocsr(), E.T.tocsr()],
+                                  [E, C.tocsr()]]).toarray(),
                      expected)
-        assert_equal(block([[A.tocsr(), E.T.tocsr()],
-                                     [E, C.tocsr()]]).toarray(),
-                     expected)
-        assert_equal(block([[A.tocsc(), E.T.tocsc()],
-                                     [E.tocsc(), C.tocsc()]]).toarray(),
+        assert_equal(block_array([[A.tocsc(), E.T.tocsc()],
+                                  [E.tocsc(), C.tocsc()]]).toarray(),
                      expected)
 
         Z = csr_array((1, 1), dtype=np.int32)
         expected = array([[0, 5],
                           [0, 6],
                           [7, 0]])
-        assert_equal(block([[None, B], [C, None]]).toarray(),
+        assert_equal(block_array([[None, B], [C, None]]).toarray(), expected)
+        assert_equal(block_array([[E.T.tocsr(), B.tocsr()],
+                                  [C.tocsr(), Z]]).toarray(),
                      expected)
-        assert_equal(block([[E.T.tocsr(), B.tocsr()],
-                                     [C.tocsr(), Z]]).toarray(),
-                     expected)
-        assert_equal(block([[E.T.tocsc(), B.tocsc()],
-                                     [C.tocsc(), Z.tocsc()]]).toarray(),
+        assert_equal(block_array([[E.T.tocsc(), B.tocsc()],
+                                  [C.tocsc(), Z.tocsc()]]).toarray(),
                      expected)
 
         expected = np.empty((0, 0))
-        assert_equal(block([[None, None]]).toarray(), expected)
-        assert_equal(block([[None, D], [D, None]]).toarray(),
+        assert_equal(block_array([[None, None]]).toarray(), expected)
+        assert_equal(block_array([[None, D], [D, None]]).toarray(),
                      expected)
 
         # test bug reported in gh-5976
         expected = array([[7]])
-        assert_equal(block([[None, D], [C, None]]).toarray(),
+        assert_equal(block_array([[None, D], [C, None]]).toarray(),
                      expected)
 
         # test failure cases
         with assert_raises(ValueError) as excinfo:
-            block([[A], [B]])
+            block_array([[A], [B]])
         excinfo.match(r'Got blocks\[1,0\]\.shape\[1\] == 1, expected 2')
 
         with assert_raises(ValueError) as excinfo:
-            block([[A.tocsr()], [B.tocsr()]])
+            block_array([[A.tocsr()], [B.tocsr()]])
         excinfo.match(r'incompatible dimensions for axis 1')
 
         with assert_raises(ValueError) as excinfo:
-            block([[A.tocsc()], [B.tocsc()]])
+            block_array([[A.tocsc()], [B.tocsc()]])
         excinfo.match(r'Mismatching dimensions along axis 1: ({1, 2}|{2, 1})')
 
         with assert_raises(ValueError) as excinfo:
-            block([[A, C]])
+            block_array([[A, C]])
         excinfo.match(r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2')
 
         with assert_raises(ValueError) as excinfo:
-            block([[A.tocsr(), C.tocsr()]])
+            block_array([[A.tocsr(), C.tocsr()]])
         excinfo.match(r'Mismatching dimensions along axis 0: ({1, 2}|{2, 1})')
 
         with assert_raises(ValueError) as excinfo:
-            block([[A.tocsc(), C.tocsc()]])
+            block_array([[A.tocsc(), C.tocsc()]])
         excinfo.match(r'incompatible dimensions for axis 0')
 
     def test_block_return_type(self):
-        block = construct.block
+        block = construct.block_array
 
         # csr format ensures we hit _compressed_sparse_stack
         # shape of F,G ensure we hit _stack_along_minor_axis

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -28,6 +28,14 @@ def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
                             random_state, data_rvs)
 
 
+def _sprandn_array(m, n, density=0.01, format="coo", dtype=None, random_state=None):
+    # Helper function for testing.
+    random_state = check_random_state(random_state)
+    data_rng = random_state.standard_normal
+    return construct.random_array(m, n, density=density, format=format, dtype=dtype,
+                                  random_state=random_state, data_random_state=data_rng)
+
+
 class TestConstructUtils:
     def test_spdiags(self):
         diags1 = array([[1, 2, 3, 4, 5]])
@@ -225,7 +233,8 @@ class TestConstructUtils:
         x = construct.diags([])
         assert_equal(x.shape, (0, 0))
 
-    def test_identity(self):
+    @pytest.mark.parametrize("identity", [construct.identity, construct.eye_array])
+    def test_identity(self, identity):
         assert_equal(construct.identity(1).toarray(), [[1]])
         assert_equal(construct.identity(2).toarray(), [[1,0],[0,1]])
 
@@ -238,13 +247,14 @@ class TestConstructUtils:
             assert_equal(I.format, fmt)
             assert_equal(I.toarray(), [[1,0,0],[0,1,0],[0,0,1]])
 
-    def test_eye(self):
-        assert_equal(construct.eye(1,1).toarray(), [[1]])
-        assert_equal(construct.eye(2,3).toarray(), [[1,0,0],[0,1,0]])
-        assert_equal(construct.eye(3,2).toarray(), [[1,0],[0,1],[0,0]])
-        assert_equal(construct.eye(3,3).toarray(), [[1,0,0],[0,1,0],[0,0,1]])
+    @pytest.mark.parametrize("eye", [construct.eye, construct.eye_array])
+    def test_eye(self, eye):
+        assert_equal(eye(1,1).toarray(), [[1]])
+        assert_equal(eye(2,3).toarray(), [[1,0,0],[0,1,0]])
+        assert_equal(eye(3,2).toarray(), [[1,0],[0,1],[0,0]])
+        assert_equal(eye(3,3).toarray(), [[1,0,0],[0,1,0],[0,0,1]])
 
-        assert_equal(construct.eye(3,3,dtype='int16').dtype, np.dtype('int16'))
+        assert_equal(eye(3,3,dtype='int16').dtype, np.dtype('int16'))
 
         for m in [3, 5]:
             for n in [3, 5]:
@@ -260,29 +270,30 @@ class TestConstructUtils:
                         with pytest.raises(
                             ValueError, match="Offset.*out of bounds"
                         ):
-                            construct.eye(m, n, k=k)
+                            eye(m, n, k=k)
 
                     else:
                         assert_equal(
-                            construct.eye(m, n, k=k).toarray(),
+                            eye(m, n, k=k).toarray(),
                             np.eye(m, n, k=k)
                         )
                         if m == n:
                             assert_equal(
-                                construct.eye(m, k=k).toarray(),
+                                eye(m, k=k).toarray(),
                                 np.eye(m, n, k=k)
                             )
 
-    def test_eye_one(self):
-        assert_equal(construct.eye(1).toarray(), [[1]])
-        assert_equal(construct.eye(2).toarray(), [[1,0],[0,1]])
+    @pytest.mark.parametrize("eye", [construct.eye, construct.eye_array])
+    def test_eye_one(self, eye):
+        assert_equal(eye(1).toarray(), [[1]])
+        assert_equal(eye(2).toarray(), [[1,0],[0,1]])
 
-        I = construct.eye(3, dtype='int8', format='dia')
+        I = eye(3, dtype='int8', format='dia')
         assert_equal(I.dtype, np.dtype('int8'))
         assert_equal(I.format, 'dia')
 
         for fmt in sparse_formats:
-            I = construct.eye(3, format=fmt)
+            I = eye(3, format=fmt)
             assert_equal(I.format, fmt)
             assert_equal(I.toarray(), [[1,0,0],[0,1,0],[0,0,1]])
 
@@ -303,18 +314,44 @@ class TestConstructUtils:
         cases.append(array([[0,1,0,2,0,5,8]]))
         cases.append(array([[0.5,0.125,0,3.25],[0,2.5,0,0]]))
 
+        # test all cases with some formats
         for a in cases:
+            ca = csr_array(a)
             for b in cases:
+                cb = csr_array(b)
                 expected = np.kron(a, b)
-                for fmt in sparse_formats:
-                    result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt)
+                for fmt in sparse_formats[1:4]:
+                    result = construct.kron(ca, cb, format=fmt)
                     assert_equal(result.format, fmt)
                     assert_array_equal(result.toarray(), expected)
+                    assert isinstance(result, sparray)
+
+        # test one case with all formats
+        a = cases[-1]
+        b = cases[-3]
+        ca = csr_array(a)
+        cb = csr_array(b)
+
+        expected = np.kron(a, b)
+        for fmt in sparse_formats:
+            result = construct.kron(ca, cb, format=fmt)
+            assert_equal(result.format, fmt)
+            assert_array_equal(result.toarray(), expected)
+            assert isinstance(result, sparray)
+
+        # check that spmatrix returned when both inputs are spmatrix
+        result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt)
+        assert_equal(result.format, fmt)
+        assert_array_equal(result.toarray(), expected)
+        assert isinstance(result, spmatrix)
 
     def test_kron_large(self):
         n = 2**16
-        a = construct.eye(1, n, n-1)
-        b = construct.eye(n, 1, 1-n)
+        # pre-sparse-array setup
+        # a = construct.eye(1, n, n-1)
+        # b = construct.eye(n, 1, 1-n)
+        a = construct.diags_array([1], shape=(1, n), offsets=n-1)
+        b = construct.diags_array([1], shape=(n, 1), offsets=1-n)
 
         construct.kron(a, a)
         construct.kron(b, b)
@@ -331,13 +368,16 @@ class TestConstructUtils:
         cases.append(array([[0,2,-6],[8,0,14],[0,3,0]]))
         cases.append(array([[1,0,0],[0,5,-1],[4,-2,8]]))
 
+        # test all cases with default format
         for a in cases:
             for b in cases:
-                result = construct.kronsum(
-                    csr_matrix(a), csr_matrix(b)).toarray()
-                expected = np.kron(np.eye(len(b)), a) + \
-                        np.kron(b, np.eye(len(a)))
-                assert_array_equal(result,expected)
+                result = construct.kronsum(csr_array(a), csr_array(b)).toarray()
+                expected = np.kron(np.eye(b.shape[0]), a) + np.kron(b, np.eye(a.shape[0]))
+                assert_array_equal(result, expected)
+
+        # check that spmatrix returned when both inputs are spmatrix
+        result = construct.kronsum(csr_matrix(a), csr_matrix(b)).toarray()
+        assert_array_equal(result, expected)
 
     @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
     def test_vstack(self, coo_cls):
@@ -353,14 +393,14 @@ class TestConstructUtils:
 
         assert_equal(construct.vstack([A.tocsr(), B.tocsr()]).toarray(),
                      expected)
-        result = construct.vstack([A.tocsr(), B.tocsr()], dtype=np.float32)
+        result = construct.vstack([A.tocsr(), B.tocsr()], format="csr", dtype=np.float32)
         assert_equal(result.dtype, np.float32)
         assert_equal(result.indices.dtype, np.int32)
         assert_equal(result.indptr.dtype, np.int32)
 
         assert_equal(construct.vstack([A.tocsc(), B.tocsc()]).toarray(),
                      expected)
-        result = construct.vstack([A.tocsc(), B.tocsc()], dtype=np.float32)
+        result = construct.vstack([A.tocsc(), B.tocsc()], format="csc", dtype=np.float32)
         assert_equal(result.dtype, np.float32)
         assert_equal(result.indices.dtype, np.int32)
         assert_equal(result.indptr.dtype, np.int32)
@@ -655,9 +695,11 @@ class TestConstructUtils:
         except AttributeError:
             pass
 
-        for random_state in random_states:
-            x = _sprandn(10, 20, density=0.5, dtype=np.float64,
-                         random_state=random_state)
+        for rs in random_states:
+            x = _sprandn(10, 20, density=0.5, dtype=np.float64, random_state=rs)
+            assert_(np.any(np.less(x.data, 0)))
+            assert_(np.any(np.less(1, x.data)))
+            x = _sprandn_array(10, 20, density=0.5, dtype=np.float64, random_state=rs)
             assert_(np.any(np.less(x.data, 0)))
             assert_(np.any(np.less(1, x.data)))
 
@@ -665,12 +707,16 @@ class TestConstructUtils:
         # anything that np.dtype can convert to a dtype should be accepted
         # for the dtype
         construct.random(10, 10, dtype='d')
+        construct.random_array(10, 10, dtype='d')
 
     def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
         # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.
         # 10 x 10 x 0.1265 = 12.65, which should be rounded up to 13, not 12.
         sparse_matrix = construct.random(10, 10, density=0.1265)
         assert_equal(sparse_matrix.count_nonzero(),13)
+        # check random_array
+        sparse_array = construct.random_array(10, 10, density=0.1265)
+        assert_equal(sparse_array.count_nonzero(),13)
 
 
 def test_diags_array():

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -1,7 +1,7 @@
 """test sparse matrix construction functions"""
 
 from numpy.testing import assert_equal
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, csr_array, sparray
 
 import numpy as np
 from scipy.sparse import _extract
@@ -10,24 +10,25 @@ from scipy.sparse import _extract
 class TestExtract:
     def setup_method(self):
         self.cases = [
-            csr_matrix([[1,2]]),
-            csr_matrix([[1,0]]),
-            csr_matrix([[0,0]]),
-            csr_matrix([[1],[2]]),
-            csr_matrix([[1],[0]]),
-            csr_matrix([[0],[0]]),
-            csr_matrix([[1,2],[3,4]]),
-            csr_matrix([[0,1],[0,0]]),
-            csr_matrix([[0,0],[1,0]]),
-            csr_matrix([[0,0],[0,0]]),
-            csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]),
-            csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]).T,
+            csr_array([[1,2]]),
+            csr_array([[1,0]]),
+            csr_array([[0,0]]),
+            csr_array([[1],[2]]),
+            csr_array([[1],[0]]),
+            csr_array([[0],[0]]),
+            csr_array([[1,2],[3,4]]),
+            csr_array([[0,1],[0,0]]),
+            csr_array([[0,0],[1,0]]),
+            csr_array([[0,0],[0,0]]),
+            csr_array([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]),
+            csr_array([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]).T,
         ]
 
-    def find(self):
+    def test_find(self):
         for A in self.cases:
             I,J,V = _extract.find(A)
-            assert_equal(A.toarray(), csr_matrix(((I,J),V), shape=A.shape))
+            B = csr_array((V,(I,J)), shape=A.shape)
+            assert_equal(A.toarray(), B.toarray())
 
     def test_tril(self):
         for A in self.cases:
@@ -40,3 +41,11 @@ class TestExtract:
             B = A.toarray()
             for k in [-3,-2,-1,0,1,2,3]:
                 assert_equal(_extract.triu(A,k=k).toarray(), np.triu(B,k=k))
+
+    def test_array_vs_matrix(self):
+        for A in self.cases:
+            assert isinstance(_extract.tril(A), sparray)
+            assert isinstance(_extract.triu(A), sparray)
+            M = csr_matrix(A)
+            assert not isinstance(_extract.tril(M), sparray)
+            assert not isinstance(_extract.triu(M), sparray)

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -5,8 +5,8 @@ import tempfile
 from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
 
-from scipy.sparse import (csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, save_npz, load_npz, dok_matrix)
+from scipy.sparse import (sparray, csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
+                          coo_matrix, dok_matrix, save_npz, load_npz, load_npz_array)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -47,6 +47,20 @@ def test_save_and_load_one_entry():
     dense_matrix[1,2] = 1
     _check_save_and_load(dense_matrix)
 
+def test_sparray_vs_spmatrix():
+    fd, tmpfile = tempfile.mkstemp(suffix='.npz')
+    os.close(fd)
+    try:
+        save_npz(tmpfile, csr_matrix([[1.2, 0, 0.9], [0, 0.3, 0]]))
+        loaded_matrix = load_npz(tmpfile)
+        loaded_array = load_npz_array(tmpfile)
+    finally:
+        os.remove(tmpfile)
+
+    assert not isinstance(loaded_matrix, sparray)
+    assert isinstance(loaded_array, sparray)
+    assert_(loaded_matrix.dtype == loaded_array.dtype)
+    assert_equal(loaded_matrix.toarray(), loaded_array.toarray())
 
 def test_malicious_load():
     class Executor:
@@ -60,6 +74,8 @@ def test_malicious_load():
 
         # Should raise a ValueError, not execute code
         assert_raises(ValueError, load_npz, tmpfile)
+        # Should raise a ValueError, not execute code
+        assert_raises(ValueError, load_npz_array, tmpfile)
     finally:
         os.remove(tmpfile)
 

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -6,7 +6,7 @@ from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
 
 from scipy.sparse import (sparray, csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, dok_matrix, save_npz, load_npz, load_npz_array)
+                          coo_matrix, dok_matrix, csr_array, save_npz, load_npz)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -48,12 +48,21 @@ def test_save_and_load_one_entry():
     _check_save_and_load(dense_matrix)
 
 def test_sparray_vs_spmatrix():
+    #save/load matrix
     fd, tmpfile = tempfile.mkstemp(suffix='.npz')
     os.close(fd)
     try:
         save_npz(tmpfile, csr_matrix([[1.2, 0, 0.9], [0, 0.3, 0]]))
         loaded_matrix = load_npz(tmpfile)
-        loaded_array = load_npz_array(tmpfile)
+    finally:
+        os.remove(tmpfile)
+
+    #save/load array
+    fd, tmpfile = tempfile.mkstemp(suffix='.npz')
+    os.close(fd)
+    try:
+        save_npz(tmpfile, csr_array([[1.2, 0, 0.9], [0, 0.3, 0]]))
+        loaded_array = load_npz(tmpfile)
     finally:
         os.remove(tmpfile)
 
@@ -74,8 +83,6 @@ def test_malicious_load():
 
         # Should raise a ValueError, not execute code
         assert_raises(ValueError, load_npz, tmpfile)
-        # Should raise a ValueError, not execute code
-        assert_raises(ValueError, load_npz_array, tmpfile)
     finally:
         os.remove(tmpfile)
 


### PR DESCRIPTION
I believe this provides the last part of the "Semantics of sparse arrays" issue.
Fixes #18592 

Other partial fixes of this issue have been included in #18538 and #18862 

This PR adds `eye_array` and `random_array` and adapts `kron` and `kronsum` to use sparse arrays when any of the inputs are sparse arrays. This completes the revision of the `_construct.py` module and the resulting functions are:

```python
# New functions recommended along with matrices being discouraged
def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None):
def eye_array(m, n=None, *, k=0, dtype=float, format=None):
def random_array(m, n, density=0.01, format='coo', dtype=None, random_state=None, data_random_state=None):
def block(blocks, format=None, dtype=None):

# Existing names that now return sparray or spmatrix dependent on input.
def kron(A, B, format=None):
def kronsum(A, B, format=None):
def hstack(blocks, format=None, dtype=None):
def vstack(blocks, format=None, dtype=None):
def block_diag(mats, format=None, dtype=None):
def tril(A, k=0, format=None):
def triu(A, k=0, format=None):

# Names that should be rewritten to return sparse arrays when sparse matrices are removed
def eye(m, n=None, k=0, dtype=float, format=None):
def random(m, n, density=0.01, format='coo', dtype=None,  random_state=None,  data_rvs=None):
def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):

# Names that should be removed when sparse matrices are removed
def bmat(blocks, format=None, dtype=None):
def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
def spdiags(data, diags, m=None, n=None, format=None):
def identity(n, dtype='d', format=None):
```

I have added warnings to doc_strings of discouraged functions recommending sparse arrays. These functions have warnings:
```
bmat
diags
spdiags
identity
eye
random
rand
```

Some changes that might need discussion:
- The new functions have keyword only arguments enforced. 
- For `random_array`, I've changed the keyword ``data_rvs`` to ``data_random_state``. though I would prefer ``data_rng``, I think `data_random_state` matches the library better.
- Should we deprecate some of these? If so, when?
- Are there other parts of the new function API that we should tweak while we're making this change?