### PR TITLE
MAINT: Spherical Voronoi sort simplify

### DIFF
--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -18,63 +18,39 @@ np.import_array()
 
 __all__ = ['sort_vertices_of_regions']
 
-# array-filling placeholder that can never occur
-DEF ARRAY_FILLER = -2
-
-@cython.boundscheck(False)
-cdef void remaining_filter(np.npy_intp[:] remaining,
-                           np.npy_intp current_simplex) noexcept:
-    cdef np.npy_intp i
-    for i in range(remaining.shape[0]):
-        if remaining[i] == current_simplex:
-            remaining[i] = ARRAY_FILLER
-
 
 @cython.boundscheck(False)
 def sort_vertices_of_regions(int[:,::1] simplices, regions):
     cdef np.npy_intp n, k, s, i
     cdef np.npy_intp num_regions = len(regions)
-    cdef np.npy_intp current_simplex, current_vertex, remaining_count
-    cdef np.npy_intp cs_identified, remaining_size
+    cdef np.npy_intp current_simplex, current_vertex
+    cdef np.npy_intp remaining_size
     cdef np.npy_intp[:] remaining
     cdef np.npy_intp[:] sorted_vertices = np.empty(max([len(region) for region
                                                    in regions]),
                                                    dtype=np.intp)
 
     for n in range(num_regions):
-        remaining_count = 0
         remaining = np.asarray(regions[n][:])
         remaining_size = remaining.shape[0]
-        sorted_vertices[:] = ARRAY_FILLER
         current_simplex = remaining[0]
         for i in range(3):
             k = simplices[current_simplex, i]
             if k != n:
                 current_vertex = k
                 break
-        sorted_vertices[remaining_count] = current_simplex
-        remaining_count += 1
-        remaining_filter(remaining, current_simplex)
-        while remaining_size > remaining_count:
-            cs_identified = 0
+        for k in range(remaining_size):
+            sorted_vertices[k] = current_simplex
             for i in range(remaining_size):
-                if remaining[i] == ARRAY_FILLER:
+                if remaining[i] == sorted_vertices[k]:
                     continue
                 s = remaining[i]
                 for j in range(3):
                     if current_vertex == simplices[s, j]:
-                        current_simplex = remaining[i]
-                        cs_identified += 1
-                        break
-                if cs_identified > 0:
-                    break
+                        current_simplex = s
             for i in range(3):
                 s = simplices[current_simplex, i]
                 if s != n and s != current_vertex:
                     current_vertex = s
                     break
-            sorted_vertices[remaining_count] = current_simplex
-            remaining_count += 1
-            remaining_filter(remaining, current_simplex)
-        regions_arr = np.asarray(sorted_vertices)
-        regions[n] = list(regions_arr[regions_arr > ARRAY_FILLER])
+        regions[n] = list(np.asarray(sorted_vertices[:remaining_size]))


### PR DESCRIPTION
* `sort_vertices_of_regions()` was simplied to:
  * only a single call location for `remaining_filter()`
  * remove a spurious `break` check on `cs_identified`
  * with the above check removed, `cs_identified` can be removed (no longer used)
  * removed extra `sorted_vertices` and `remaining_count` lines by placing them strategically in the `while` loop
  * the `while` loop was then replaced with a `for` loop to avoid need for the silly `remaining_count` variable
  * another spurious `break` statement was removed
  * avoided unncessary usage of `ARRAY_FILLER` in `sorted_vertices` given that simple slicing of `sorted_vertices` can be used to deal with polygons with different edge counts
  * these simplifications then allowed me to determine that the algorithm was spending many lines of code dealing with this jagged polygon data structure situation, allowing for a dramatic simplification, removing the undesirable `DEF` constant and the `remaining_filter()` helper function thus became pointless

[skip circle] [skip cirrus]

~I was looking forward to trying to use `asv` to check performance, but either the latest version or some combination of build system modernizations seems to be catching me off guard with `mesonpy`-related errors when using `asv continuous` to compare two hashes/branches (I use `virtualenv` as the backend in the config file).~