### PR TITLE
DOC: stats: Correct levy_stable loc-scale note

### DIFF
--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -779,7 +779,7 @@ class levy_stable_gen(rv_continuous):
     equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
     ``y = (x - loc) / scale``, except in the ``S1`` parameterization if
     ``alpha == 1``.  In that case ``%(name)s.pdf(x, %(shapes)s, loc, scale)``
-     is identically equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
+    is identically equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
     ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.
     Note that shifting the location of a distribution
     does not make it a "noncentral" distribution.

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -780,7 +780,8 @@ class levy_stable_gen(rv_continuous):
     ``y = (x - loc) / scale``, except in the ``S1`` parameterization if
     ``alpha == 1``.  In that case ``%(name)s.pdf(x, %(shapes)s, loc, scale)``
     is identically equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
-    ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.
+    ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.\
+    See [NO2]_ Definition 1.8 for more information.
     Note that shifting the location of a distribution
     does not make it a "noncentral" distribution.
 
@@ -793,6 +794,8 @@ class levy_stable_gen(rv_continuous):
         to compute densities of stable distribution.
     .. [NO] Nolan, J., 1997. Numerical Calculation of Stable Densities and
         distributions Functions.
+    .. [NO2] Nolan, J., 2018. Stable Distributions: Models for Heavy Tailed
+        Data.
     .. [HO] Hopcraft, K. I., Jakeman, E., Tanner, R. M. J., 1999. Lévy random
         walks with fluctuating step number and multiscale behavior.
 

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -780,7 +780,7 @@ class levy_stable_gen(rv_continuous):
     ``y = (x - loc) / scale``, except in the ``S1`` parameterization if
     ``alpha == 1``.  In that case ``%(name)s.pdf(x, %(shapes)s, loc, scale)``
     is identically equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
-    ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.\
+    ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.
     See [NO2]_ Definition 1.8 for more information.
     Note that shifting the location of a distribution
     does not make it a "noncentral" distribution.

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -772,7 +772,17 @@ class levy_stable_gen(rv_continuous):
         For cdf calculations FFT calculation is considered experimental. Use
         Zolatarev's method instead (default).
 
-    %(after_notes)s
+    The probability density above is defined in the "standardized" form. To
+    shift and/or scale the distribution use the ``loc`` and ``scale``
+    parameters.
+    Generally ``%(name)s.pdf(x, %(shapes)s, loc, scale)`` is identically
+    equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
+    ``y = (x - loc) / scale``, except in the ``S1`` parameterization if
+    ``alpha == 1``.  In that case ``%(name)s.pdf(x, %(shapes)s, loc, scale)``
+     is identically equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
+    ``y = (x - loc - 2 * beta * scale * np.log(scale) / np.pi) / scale``.
+    Note that shifting the location of a distribution
+    does not make it a "noncentral" distribution.
 
     References
     ----------


### PR DESCRIPTION
Generic after_notes in stats.levy_stable doc string incorrectly asserted that the scale and location parameters
always behave in the usual way.  The `S1` parameterization has different scaling behavior when alpha==1.

[skip actions] [skip cirrus]

#### Reference issue
Closes gh-19140

#### What does this implement/fix?
Replace generic after_notes in levy_stable doc string to note exception for `S1` parameterization when alpha==1.

#### Additional information
For info on levy-stable parameterization scale and location, see [Stable Distributions](https://edspace.american.edu/jpnolan/wp-content/uploads/sites/1720/2020/09/Chap1.pdf), p. 9.