### PR TITLE
MAINT/DOC: add `fit` to multivariate normal methods in documentation

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -308,8 +308,10 @@ class multivariate_normal_gen(multi_rv_generic):
         Log of the cumulative distribution function.
     rvs(mean=None, cov=1, size=1, random_state=None)
         Draw random samples from a multivariate normal distribution.
-    entropy()
+    entropy(mean=None, cov=1)
         Compute the differential entropy of the multivariate normal.
+    fit(x, fix_mean=None, fix_cov=None)
+        Fit a multivariate normal distribution to data.
 
     Parameters
     ----------
@@ -4410,9 +4412,9 @@ class multivariate_t_gen(multi_rv_generic):
 
     References
     ----------
-    [1]     Arellano-Valle et al. "Shannon Entropy and Mutual Information for
-            Multivariate Skew-Elliptical Distributions". Scandinavian Journal
-            of Statistics. Vol. 40, issue 1.
+    .. [1] Arellano-Valle et al. "Shannon Entropy and Mutual Information for
+           Multivariate Skew-Elliptical Distributions". Scandinavian Journal
+           of Statistics. Vol. 40, issue 1.
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix?
The recently added `fit` function for the multivariate normal distribution does currently not show up in its methods: [see here](https://scipy.github.io/devdocs/reference/generated/scipy.stats.multivariate_normal.html#scipy-stats-multivariate-normal). This is added here.

Two additional fixes are:

- Correct default arguments for the `entropy` method of `multivariate_normal`
- Correct rendering of a reference of the `multivariate_t` distribution
