### PR TITLE
DOC: Added example for tf2zpk function

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1083,6 +1083,18 @@ def tf2zpk(b, a):
     transfer function coefficients must first be converted to the "positive
     powers" form before finding the poles and zeros.
 
+    Examples
+    --------
+    Find the zeroes, poles and gain of 
+    a filter with the transfer function
+        
+        H(s) = 3s^2 / (s^2 + 5s + 13)
+        
+    >>> from scipy.signal._filter_design import tf2zpk
+    >>> tf2zpk([3, 0, 0], [1, 5, 13])
+    (   array([ 0.               ,  0.              ]), 
+        array([ -2.5+2.59807621j ,  -2.5-2.59807621j]), 
+        3.0)
     """
     b, a = normalize(b, a)
     b = (b + 0.0) / a[0]

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1091,7 +1091,7 @@ def tf2zpk(b, a):
     
         H(s) = \frac{3s^2}{s^2 + 5s + 13}
         
-    >>> from scipy.signal._filter_design import tf2zpk
+    >>> from scipy.signal import tf2zpk
     >>> tf2zpk([3, 0, 0], [1, 5, 13])
     (   array([ 0.               ,  0.              ]), 
         array([ -2.5+2.59807621j ,  -2.5-2.59807621j]), 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1087,8 +1087,9 @@ def tf2zpk(b, a):
     --------
     Find the zeroes, poles and gain of 
     a filter with the transfer function
-        
-        H(s) = 3s^2 / (s^2 + 5s + 13)
+    .. math::
+    
+        H(s) = \frac{3s^2}{s^2 + 5s + 13}
         
     >>> from scipy.signal._filter_design import tf2zpk
     >>> tf2zpk([3, 0, 0], [1, 5, 13])

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1087,6 +1087,7 @@ def tf2zpk(b, a):
     --------
     Find the zeroes, poles and gain of 
     a filter with the transfer function
+
     .. math::
     
         H(s) = \frac{3s^2}{s^2 + 5s + 13}


### PR DESCRIPTION
#### Reference issue
DOC: Add "Examples" to docstrings #7168

#### What does this implement/fix?
Added example for tf2zpk function. 
The code can be found in scipy/signal/_filter_design.py 

#### Additional information
Once my work accepted, I will add more examples for next PR.
[skip actions] [skip cirrus]
