### PR TITLE
MAINT: Import `fromarrays` from `rec`

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3699,7 +3699,7 @@ class TestJFSkewT:
         data = np.load(
             Path(__file__).parent / "data/jf_skew_t_gamlss_pdf_data.npy"
         )
-        return np.core.records.fromarrays(data, names="x,pdf,a,b")
+        return np.rec.fromarrays(data, names="x,pdf,a,b")
 
     @pytest.mark.parametrize("a,b", [(2, 3), (8, 4), (12, 13)])
     def test_compare_with_gamlss_r(self, gamlss_pdf_data, a, b):


### PR DESCRIPTION
Hi @rgommers,

This PR addresses changes introduced in https://github.com/numpy/numpy/pull/24634. I only found one place that imported `core` explicitly. This change is backward compatible. 