### PR TITLE
TST: fix sparse constructor test with large memory footprint

### DIFF
--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -539,7 +539,7 @@ class TestConstructUtils:
         n = 33000
         A = csr_array(np.ones((n, n), dtype=bool))
         B = A.copy()
-        C = construct._compressed_sparse_stack((A,B), 0, False)
+        C = construct._compressed_sparse_stack((A, B), axis=0, return_spmatrix=False)
 
         assert_(np.all(np.equal(np.diff(C.indptr), n)))
         assert_equal(C.indices.dtype, np.int64)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -539,7 +539,8 @@ class TestConstructUtils:
         n = 33000
         A = csr_array(np.ones((n, n), dtype=bool))
         B = A.copy()
-        C = construct._compressed_sparse_stack((A, B), axis=0, return_spmatrix=False)
+        C = construct._compressed_sparse_stack((A, B), axis=0,
+                                               return_spmatrix=False)
 
         assert_(np.all(np.equal(np.diff(C.indptr), n)))
         assert_equal(C.indices.dtype, np.int64)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -539,7 +539,7 @@ class TestConstructUtils:
         n = 33000
         A = csr_array(np.ones((n, n), dtype=bool))
         B = A.copy()
-        C = construct._compressed_sparse_stack((A,B), 0)
+        C = construct._compressed_sparse_stack((A,B), 0, False)
 
         assert_(np.all(np.equal(np.diff(C.indptr), n)))
         assert_equal(C.indices.dtype, np.int64)


### PR DESCRIPTION
Fix test in test_construct that broke from #18862 because of change in private function. 

This wasn't seen by that PR because it doesn't run on a 32-bit machine.
Thanks @WarrenWeckesser !!