### PR TITLE
TST: _lib: improve array API assertions

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -201,7 +201,6 @@ def _strict_check(actual, desired, xp,
     if check_namespace:
         _assert_matching_namespace(actual, desired)
 
-    actual = xp.asarray(actual)
     desired = xp.asarray(desired)
 
     if check_dtype:
@@ -216,6 +215,8 @@ def _strict_check(actual, desired, xp,
                 f"Actual: {actual.shape}\n"
                 f"Desired: {desired.shape}")
         _check_scalar(actual, desired, xp)
+
+    return desired
 
 
 def _assert_matching_namespace(actual, desired):
@@ -259,8 +260,8 @@ def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
                     check_shape=True, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
-    _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                  check_dtype=check_dtype, check_shape=check_shape)
+    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                            check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
     elif is_torch(xp):
@@ -275,8 +276,8 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_namespace=True,
                     check_dtype=True, check_shape=True, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
-    _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                  check_dtype=check_dtype, check_shape=check_shape)
+    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                            check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_allclose(actual, desired, rtol=rtol,
                                           atol=atol, err_msg=err_msg)
@@ -291,8 +292,8 @@ def xp_assert_less(actual, desired, check_namespace=True, check_dtype=True,
                    check_shape=True, err_msg='', verbose=True, xp=None):
     if xp is None:
         xp = array_namespace(actual)
-    _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                  check_dtype=check_dtype, check_shape=check_shape)
+    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                            check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_array_less(actual, desired,
                                             err_msg=err_msg, verbose=verbose)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -232,13 +232,10 @@ def _assert_matching_namespace(actual, desired):
 
 
 def _check_scalar(actual, desired):
-    if actual.shape == ():
-        if isinstance(actual, np.ndarray):
-            assert_(isinstance(desired, np.ndarray),
-                    "Desired a numpy scalar, but 0-D array given.")
-        else:
-            assert_(not isinstance(desired, np.ndarray),
-                    "Desired a 0-D array, but numpy scalar given.")
+    if np.isscalar(desired):
+        assert np.isscalar(actual), "Desired a scalar, but 0-D array given."
+    else:
+        assert not np.isscalar(actual), "Desired a 0-D array, but scalar given."
 
 
 def xp_assert_equal(actual, desired, err_msg='', xp=None):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -195,7 +195,7 @@ def is_torch(xp):
     return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.torch'
 
 
-def assert_equal(actual, desired, err_msg='', xp=None):
+def xp_assert_equal(actual, desired, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
@@ -208,7 +208,7 @@ def assert_equal(actual, desired, err_msg='', xp=None):
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
 
-def assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
+def xp_assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
@@ -221,7 +221,7 @@ def assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
                                       atol=atol, err_msg=err_msg)
 
 
-def assert_less(actual, desired, err_msg='', verbose=True, xp=None):
+def xp_assert_less(actual, desired, err_msg='', verbose=True, xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -231,8 +231,8 @@ def _assert_matching_namespace(actual, desired):
 
 def _check_scalar(actual, desired, xp):
     # Shape check alone is sufficient unless desired.shape == (). Also,
-    # only NumPy and CuPy distinguish between scalars and arrays, AFAICT.
-    if desired.shape != () or not (is_numpy(xp) or is_cupy(xp)):
+    # only NumPy distinguishes between scalars and arrays.
+    if desired.shape != () or not is_numpy(xp):
         return
     # We want to follow the conventions of the `xp` library. Libraries like
     # NumPy, for which `np.asarray(0)[()]` returns a scalar, tend to return

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -197,14 +197,11 @@ def is_torch(xp):
 
 
 def _strict_check(actual, desired, check_xp=True, check_dtype=True, check_shape=True):
-    try:
-        actual.dtype
-        desired.dtype
-    except AttributeError:
-        raise ValueError("Inputs should be arrays with a dtype attribute, "
-                         "python scalars and arrays are not accepted.")
     if check_xp:
         _assert_matching_namespace(actual, desired)
+    xp = array_namespace(actual)
+    actual = xp.asarray(actual)
+    desired = xp.asarray(desired)
     if check_dtype:
         assert_(actual.dtype == desired.dtype,
                 f"Desired dtype: {desired.dtype}, actual dtype: {actual.dtype}")
@@ -227,14 +224,17 @@ def _assert_matching_namespace(actual, desired):
 
 
 def _check_scalar(actual, desired):
-    if np.isscalar(desired):
-        assert np.isscalar(actual), "Desired a scalar, but 0-D array given."
-    else:
-        assert not np.isscalar(actual), "Desired a 0-D array, but scalar given."
+    for arr in actual:
+        if np.isscalar(desired):
+            assert np.isscalar(arr), "Desired a scalar, but ndarray given."
+        else:
+            assert not np.isscalar(arr), "Desired an ndarray, but scalar given."
 
 
-def xp_assert_equal(actual, desired, err_msg='', xp=None):
-    _strict_check(actual, desired)
+def xp_assert_equal(actual, desired, check_xp=True, check_dtype=True, 
+                    check_shape=True, err_msg='', xp=None):
+    _strict_check(actual, desired, check_xp=check_xp,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
@@ -247,8 +247,10 @@ def xp_assert_equal(actual, desired, err_msg='', xp=None):
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
 
-def xp_assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
-    _strict_check(actual, desired)
+def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_xp=True,
+                    check_dtype=True, check_shape=True, err_msg='', xp=None):
+    _strict_check(actual, desired, check_xp=check_xp,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
@@ -261,8 +263,10 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
                                       atol=atol, err_msg=err_msg)
 
 
-def xp_assert_less(actual, desired, err_msg='', verbose=True, xp=None):
-    _strict_check(actual, desired)
+def xp_assert_less(actual, desired, check_xp=True, check_dtype=True,
+                   check_shape=True, err_msg='', verbose=True, xp=None):
+    _strict_check(actual, desired, check_xp=check_xp,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -12,6 +12,7 @@ import os
 import warnings
 
 import numpy as np
+from numpy.testing import assert_
 import scipy._lib.array_api_compat.array_api_compat as array_api_compat
 from scipy._lib.array_api_compat.array_api_compat import size
 import scipy._lib.array_api_compat.array_api_compat.numpy as array_api_compat_numpy
@@ -193,6 +194,33 @@ def is_cupy(xp):
 
 def is_torch(xp):
     return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.torch'
+
+
+def _assert_matching_namespace(actual, desired):
+    desired_space = array_namespace(desired)
+    if isinstance(actual, tuple):
+        for arr in actual:
+            arr_space = array_namespace(arr)
+            assert arr_space == desired_space
+            if is_numpy(arr_space):
+                _check_scalar(actual, desired)
+    else:
+        actual_space = array_namespace(actual)
+        assert_(actual_space == desired_space,
+                "Namespaces do not match: "
+                f"{actual_space.__name__} and {desired_space.__name__}")
+        if is_numpy(actual_space):
+            _check_scalar(actual, desired)
+
+
+def _check_scalar(actual, desired):
+    if actual.shape == ():
+        if isinstance(actual, np.ndarray):
+            assert_(isinstance(desired, np.ndarray),
+                    "Desired a numpy scalar, but 0-D array given.")
+        else:
+            assert_(not isinstance(desired, np.ndarray),
+                    "Desired a 0-D array, but numpy scalar given.")
 
 
 def xp_assert_equal(actual, desired, err_msg='', xp=None):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -216,6 +216,7 @@ def _strict_check(actual, desired, xp,
                 f"Desired: {desired.shape}")
         _check_scalar(actual, desired, xp)
 
+    desired = xp.broadcast_to(desired, actual.shape)
     return desired
 
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -196,19 +196,26 @@ def is_torch(xp):
     return xp.__name__ == 'scipy._lib.array_api_compat.array_api_compat.torch'
 
 
-def _strict_check(actual, desired, check_xp=True, check_dtype=True, check_shape=True):
-    if check_xp:
+def _strict_check(actual, desired, xp,
+                  check_namespace=True, check_dtype=True, check_shape=True):
+    if check_namespace:
         _assert_matching_namespace(actual, desired)
-    xp = array_namespace(actual)
+
     actual = xp.asarray(actual)
     desired = xp.asarray(desired)
+
     if check_dtype:
         assert_(actual.dtype == desired.dtype,
-                f"Desired dtype: {desired.dtype}, actual dtype: {actual.dtype}")
+                "dtypes do not match.\n"
+                f"Actual: {actual.dtype}\n"
+                f"Desired: {desired.dtype}")
+
     if check_shape:
-        msg = (f"Array shapes are not equal: actual shape = {actual.shape}, "
-               f"desired shape = {desired.shape}")
-        assert_(actual.shape == desired.shape, msg)
+        assert_(actual.shape == desired.shape,
+                "Shapes do not match.\n"
+                f"Actual: {actual.shape}\n"
+                f"Desired: {desired.shape}")
+        _check_scalar(actual, desired, xp)
 
 
 def _assert_matching_namespace(actual, desired):
@@ -217,26 +224,43 @@ def _assert_matching_namespace(actual, desired):
     for arr in actual:
         arr_space = array_namespace(arr)
         assert_(arr_space == desired_space,
-                "Namespaces do not match: "
-                f"{arr_space.__name__} and {desired_space.__name__}")
-        if is_numpy(arr_space):
-            _check_scalar(actual, desired)
+                "Namespaces do not match.\n"
+                f"Actual: {arr_space.__name__}\n"
+                f"Desired: {desired_space.__name__}")
 
 
-def _check_scalar(actual, desired):
-    for arr in actual:
-        if np.isscalar(desired):
-            assert np.isscalar(arr), "Desired a scalar, but ndarray given."
-        else:
-            assert not np.isscalar(arr), "Desired an ndarray, but scalar given."
+def _check_scalar(actual, desired, xp):
+    # Shape check alone is sufficient unless desired.shape == (). Also,
+    # only NumPy and CuPy distinguish between scalars and arrays, AFAICT.
+    if desired.shape != () or not (is_numpy(xp) or is_cupy(xp)):
+        return
+    # We want to follow the conventions of the `xp` library. Libraries like
+    # NumPy, for which `np.asarray(0)[()]` returns a scalar, tend to return
+    # a scalar even when a 0D array might be more appropriate:
+    # import numpy as np
+    # np.mean([1, 2, 3])  # scalar, not 0d array
+    # np.asarray(0)*2  # scalar, not 0d array
+    # np.sin(np.asarray(0))  # scalar, not 0d array
+    # Libraries like CuPy, for which `cp.asarray(0)[()]` returns a 0D array,
+    # tend to return a 0D array in scenarios like those above.
+    # Therefore, regardless of whether the developer provides a scalar or 0D
+    # array for `desired`, we would typically want the type of `actual` to be
+    # the type of `desired[()]`. If the developer wants to override this
+    # behavior, they can set `check_shape=False`.
+    desired = desired[()]
+    assert_((xp.isscalar(actual) and xp.isscalar(desired)
+             or (not xp.isscalar(actual) and not xp.isscalar(desired))),
+            "Types do not match:\n"
+            f"Actual: {type(actual)}\n"
+            f"Desired: {type(desired)}")
 
 
-def xp_assert_equal(actual, desired, check_xp=True, check_dtype=True, 
+def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
                     check_shape=True, err_msg='', xp=None):
-    _strict_check(actual, desired, check_xp=check_xp,
-                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
+    _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
     elif is_torch(xp):
@@ -247,12 +271,12 @@ def xp_assert_equal(actual, desired, check_xp=True, check_dtype=True,
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
 
-def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_xp=True,
+def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_namespace=True,
                     check_dtype=True, check_shape=True, err_msg='', xp=None):
-    _strict_check(actual, desired, check_xp=check_xp,
-                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
+    _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_allclose(actual, desired, rtol=rtol,
                                           atol=atol, err_msg=err_msg)
@@ -263,12 +287,12 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_xp=True,
                                       atol=atol, err_msg=err_msg)
 
 
-def xp_assert_less(actual, desired, check_xp=True, check_dtype=True,
+def xp_assert_less(actual, desired, check_namespace=True, check_dtype=True,
                    check_shape=True, err_msg='', verbose=True, xp=None):
-    _strict_check(actual, desired, check_xp=check_xp,
-                  check_dtype=check_dtype, check_shape=check_shape)
     if xp is None:
         xp = array_namespace(actual)
+    _strict_check(actual, desired, xp, check_namespace=check_namespace,
+                  check_dtype=check_dtype, check_shape=check_shape)
     if is_cupy(xp):
         return xp.testing.assert_array_less(actual, desired,
                                             err_msg=err_msg, verbose=verbose)
@@ -292,12 +316,6 @@ def cov(x, *, xp=None):
     X = xp.asarray(X, dtype=dtype)
 
     avg = xp.mean(X, axis=1)
-    w_sum = xp.asarray(size(X) / size(avg), dtype=avg.dtype)
-    if w_sum.shape != avg.shape:
-        w_sum = copy(xp.broadcast_to(w_sum, avg.shape), xp=xp)
-
-    w_sum = w_sum[0]
-
     fact = X.shape[1] - 1
 
     if fact <= 0:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -199,12 +199,14 @@ def xp_assert_equal(actual, desired, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
+        assert actual.dtype == desired.dtype
         return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
     elif is_torch(xp):
         # PyTorch recommends using `rtol=0, atol=0` like this
         # to test for exact equality
         return xp.testing.assert_close(actual, desired, rtol=0, atol=0,
                                        msg=err_msg)
+    assert actual.dtype == desired.dtype
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
 
@@ -212,11 +214,13 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
+        assert actual.dtype == desired.dtype
         return xp.testing.assert_allclose(actual, desired, rtol=rtol,
                                           atol=atol, err_msg=err_msg)
     elif is_torch(xp):
         return xp.testing.assert_close(actual, desired, rtol=rtol,
                                        atol=atol, msg=err_msg)
+    assert actual.dtype == desired.dtype
     return np.testing.assert_allclose(actual, desired, rtol=rtol,
                                       atol=atol, err_msg=err_msg)
 
@@ -225,6 +229,7 @@ def xp_assert_less(actual, desired, err_msg='', verbose=True, xp=None):
     if xp is None:
         xp = array_namespace(actual)
     if is_cupy(xp):
+        assert actual.dtype == desired.dtype
         return xp.testing.assert_array_less(actual, desired,
                                             err_msg=err_msg, verbose=verbose)
     elif is_torch(xp):
@@ -232,6 +237,7 @@ def xp_assert_less(actual, desired, err_msg='', verbose=True, xp=None):
             actual = actual.cpu()
         if desired.device.type != 'cpu':
             desired = desired.cpu()
+    assert actual.dtype == desired.dtype
     return np.testing.assert_array_less(actual, desired,
                                         err_msg=err_msg, verbose=verbose)
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -215,19 +215,14 @@ def _strict_check(actual, desired, check_xp=True, check_dtype=True, check_shape=
 
 
 def _assert_matching_namespace(actual, desired):
+    actual = actual if isinstance(actual, tuple) else (actual,)
     desired_space = array_namespace(desired)
-    if isinstance(actual, tuple):
-        for arr in actual:
-            arr_space = array_namespace(arr)
-            assert arr_space == desired_space
-            if is_numpy(arr_space):
-                _check_scalar(actual, desired)
-    else:
-        actual_space = array_namespace(actual)
-        assert_(actual_space == desired_space,
+    for arr in actual:
+        arr_space = array_namespace(arr)
+        assert_(arr_space == desired_space,
                 "Namespaces do not match: "
-                f"{actual_space.__name__} and {desired_space.__name__}")
-        if is_numpy(actual_space):
+                f"{arr_space.__name__} and {desired_space.__name__}")
+        if is_numpy(arr_space):
             _check_scalar(actual, desired)
 
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -205,7 +205,7 @@ def xp_assert_equal(actual, desired, err_msg='', xp=None):
         # PyTorch recommends using `rtol=0, atol=0` like this
         # to test for exact equality
         return xp.testing.assert_close(actual, desired, rtol=0, atol=0,
-                                       msg=err_msg)
+                                       msg=err_msg, equal_nan=True)
     assert actual.dtype == desired.dtype
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
@@ -219,7 +219,7 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, err_msg='', xp=None):
                                           atol=atol, err_msg=err_msg)
     elif is_torch(xp):
         return xp.testing.assert_close(actual, desired, rtol=rtol,
-                                       atol=atol, msg=err_msg)
+                                       atol=atol, msg=err_msg, equal_nan=True)
     assert actual.dtype == desired.dtype
     return np.testing.assert_allclose(actual, desired, rtol=rtol,
                                       atol=atol, err_msg=err_msg)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -268,6 +268,7 @@ def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
     elif is_torch(xp):
         # PyTorch recommends using `rtol=0, atol=0` like this
         # to test for exact equality
+        err_msg = None if err_msg == '' else err_msg
         return xp.testing.assert_close(actual, desired, rtol=0, atol=0, equal_nan=True,
                                        check_dtype=False, msg=err_msg)
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
@@ -283,6 +284,7 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_namespace=True,
         return xp.testing.assert_allclose(actual, desired, rtol=rtol,
                                           atol=atol, err_msg=err_msg)
     elif is_torch(xp):
+        err_msg = None if err_msg == '' else err_msg
         return xp.testing.assert_close(actual, desired, rtol=rtol, atol=atol,
                                        equal_nan=True, check_dtype=False, msg=err_msg)
     return np.testing.assert_allclose(actual, desired, rtol=rtol,

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -12,7 +12,7 @@ import hypothesis.extra.numpy as npst
 from hypothesis import given, strategies, reproduce_failure  # noqa
 from scipy.conftest import array_api_compatible
 
-from scipy._lib._array_api import assert_equal as xp_assert_equal
+from scipy._lib._array_api import xp_assert_equal
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
                               getfullargspec_no_self, FullArgSpec,
                               rng_integers, _validate_int, _rename_parameter,

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -394,6 +394,8 @@ class TestLazywhere:
         if xp == np:
             ref1 = ref1.reshape(result_shape)
             ref2 = ref2.reshape(result_shape)
+            res1 = xp.asarray(res1)[()]
+            res2 = xp.asarray(res2)[()]
 
         isinstance(res1, type(xp.asarray([])))
         xp_assert_equal(res1, ref1)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -101,7 +101,7 @@ class TestArrayAPI:
     @array_api_compatible
     def test_check_scalar(self, xp):
         if not is_numpy(xp):
-            pytest.skip("Scalars only exist in NumPy in CuPy")
+            pytest.skip("Scalars only exist in NumPy")
 
         if is_numpy(xp):
             with pytest.raises(AssertionError, match="Types do not match."):

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -100,14 +100,10 @@ class TestArrayAPI:
 
     @array_api_compatible
     def test_check_scalar(self, xp):
-        if not (is_numpy(xp) or is_cupy(xp)):
+        if not is_numpy(xp):
             pytest.skip("Scalars only exist in NumPy in CuPy")
 
         if is_numpy(xp):
             with pytest.raises(AssertionError, match="Types do not match."):
                 xp_assert_equal(xp.asarray(0.), xp.float64(0))
             xp_assert_equal(xp.float64(0), xp.asarray(0.))
-        else:
-            with pytest.raises(AssertionError, match="Types do not match."):
-                xp_assert_equal(xp.float64(0), xp.asarray(0.))
-            xp_assert_equal(xp.asarray(0.), xp.float64(0))

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -3,8 +3,7 @@ import pytest
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, as_xparray, copy, xp_assert_equal,
-    is_numpy, is_cupy
+    _GLOBAL_CONFIG, array_namespace, as_xparray, copy, xp_assert_equal, is_numpy
 )
 import scipy._lib.array_api_compat.array_api_compat.numpy as np_compat
 

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, as_xparray, copy, assert_equal
+    _GLOBAL_CONFIG, array_namespace, as_xparray, copy, xp_assert_equal
 )
 
 
@@ -25,8 +25,8 @@ class TestArrayAPI:
     def test_asarray(self, xp):
         x, y = as_xparray([0, 1, 2], xp=xp), as_xparray(np.arange(3), xp=xp)
         ref = xp.asarray([0, 1, 2])
-        assert_equal(x, ref)
-        assert_equal(y, ref)
+        xp_assert_equal(x, ref)
+        xp_assert_equal(y, ref)
 
     @pytest.mark.filterwarnings("ignore: the matrix subclass")
     def test_raises(self):

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -85,7 +85,7 @@ class TestArrayAPI:
                 xp_assert_equal(x, y, **options)
 
         options = dict(check_namespace=False, check_dtype=True, check_shape=False)
-        if x.dtype == y.dtype:
+        if y.dtype.name in str(x.dtype):
             xp_assert_equal(x, y, **options)
         else:
             with pytest.raises(AssertionError, match="dtypes do not match."):


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/18930#issuecomment-1705759257 @mdhaber 

#### What does this implement/fix?
- the assertions are renamed with the `xp_` prefix to avoid conflict with `np.testing`.
- `assert actual.dtype == desired.dtype` is added. This is already checked by default for PyTorch in `assert_close` and `assert_equal`.