### PR TITLE
BUG: accept `np`-coercible array-likes with array API flag set

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -38,7 +38,8 @@ def compliance_scipy(arrays):
     - Any array-like which is not Array API compatible or coercible by numpy
     - object arrays
     """
-    for array in arrays:
+    for i in range(len(arrays)):
+        array = arrays[i]
         if isinstance(array, np.ma.MaskedArray):
             raise TypeError("'numpy.ma.MaskedArray' are not supported")
         elif isinstance(array, np.matrix):
@@ -46,12 +47,13 @@ def compliance_scipy(arrays):
         elif not array_api_compat.is_array_api_obj(array):
             try:
                 array = np.asanyarray(array)
-                if array.dtype is np.dtype('O'):
-                    raise TypeError("An argument was coerced to an object array, "
-                                    "but object arrays are not supported.")
             except TypeError:
                 raise TypeError("Array is not Array API compatible or "
                                 "coercible by numpy")
+            if array.dtype is np.dtype('O'):
+                    raise TypeError("An argument was coerced to an object array, "
+                                    "but object arrays are not supported.")
+            arrays[i] = array
         elif array.dtype is np.dtype('O'):
             raise TypeError('object arrays are not supported')
     return arrays

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -51,8 +51,8 @@ def compliance_scipy(arrays):
                 raise TypeError("Array is not Array API compatible or "
                                 "coercible by numpy")
             if array.dtype is np.dtype('O'):
-                    raise TypeError("An argument was coerced to an object array, "
-                                    "but object arrays are not supported.")
+                raise TypeError("An argument was coerced to an object array, "
+                                "but object arrays are not supported.")
             arrays[i] = array
         elif array.dtype is np.dtype('O'):
             raise TypeError('object arrays are not supported')

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -65,6 +65,11 @@ def test_raises():
     with pytest.raises(TypeError, match=msg):
         array_namespace(np.array(1), np.matrix(1))
 
+    msg = ("An argument was coerced to an object array, "
+           "but object arrays are not supported.")
+    with pytest.raises(TypeError, match=msg):
+        array_namespace([object()])
+
 
 def test_array_likes():
     # should be no exceptions

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -66,6 +66,13 @@ def test_raises():
         array_namespace(np.array(1), np.matrix(1))
 
 
+def test_array_likes():
+    # should be no exceptions
+    array_namespace([0, 1, 2])
+    array_namespace(1, 2, 3)
+    array_namespace(1)
+
+
 @array_api_compatible
 def test_copy(xp):
     for _xp in [xp, None]:

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -65,13 +65,6 @@ def test_raises():
     with pytest.raises(TypeError, match=msg):
         array_namespace(np.array(1), np.matrix(1))
 
-    msg = "Only support Array API"
-    with pytest.raises(TypeError, match=msg):
-        array_namespace([0, 1, 2])
-
-    with pytest.raises(TypeError, match=msg):
-        array_namespace(1)
-
 
 @array_api_compatible
 def test_copy(xp):


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/19118.

#### What does this implement/fix?
`compliance_scipy` is modified to accept array-likes by coercing with `np.asanyarray`. Previously, they were rejected, which is unwanted for backwards compatibility reasons.

#### Additional information
This implementation may be suboptimal - I'm not confident that creating a new tuple and using `try` `except` is the right thing to do. But this seems to have the desired behaviour.

A follow-up may come in the future as @mdhaber has expressed a want to sometimes accept certain types of array like Masked arrays.