### PR TITLE
BUG/TST: fix `test_array_api` for `cupy`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -133,7 +133,11 @@ def as_xparray(
         # container that is consistent with the input's namespace.
         array = xp.asarray(array)
     else:
-        array = xp.asarray(array, dtype=dtype, copy=copy)
+        try:
+            array = xp.asarray(array, dtype=dtype, copy=copy)
+        except TypeError:
+            coerced_xp = array_namespace(xp.asarray(3))
+            array = coerced_xp.asarray(array, dtype=dtype, copy=copy)
 
     if check_finite:
         _check_finite(array, xp)


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
On `main`, `python dev.py test -t scipy/_lib/tests/test_array_api.py -b cupy` gives the following two errors:

<details>

```
================================================================================================= FAILURES =================================================================================================
____________________________________________________________________________________________ test_asarray[cupy] ____________________________________________________________________________________________
scipy/_lib/tests/test_array_api.py:45: in test_asarray
    x, y = as_xparray([0, 1, 2], xp=xp), as_xparray(np.arange(3), xp=xp)
        xp         = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
scipy/_lib/_array_api.py:124: in as_xparray
    array = xp.asarray(array, dtype=dtype, copy=copy)
E   TypeError: asarray() got an unexpected keyword argument 'copy'
        array      = [0, 1, 2]
        check_finite = False
        copy       = None
        dtype      = None
        order      = None
        xp         = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
_____________________________________________________________________________________________ test_copy[cupy] ______________________________________________________________________________________________
scipy/_lib/tests/test_array_api.py:80: in test_copy
    y = copy(x, xp=_xp)
        _xp        = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
        x          = array([1, 2, 3])
        xp         = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
scipy/_lib/_array_api.py:165: in copy
    return as_xparray(x, copy=True, xp=xp)
        x          = array([1, 2, 3])
        xp         = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
scipy/_lib/_array_api.py:124: in as_xparray
    array = xp.asarray(array, dtype=dtype, copy=copy)
E   TypeError: asarray() got an unexpected keyword argument 'copy'
        array      = array([1, 2, 3])
        check_finite = False
        copy       = True
        dtype      = None
        order      = None
        xp         = <module 'cupy' from '/home/lucas/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/cupy/__init__.py'>
========================================================================================= short test summary info ==========================================================================================
FAILED scipy/_lib/tests/test_array_api.py::test_asarray[cupy] - TypeError: asarray() got an unexpected keyword argument 'copy'
FAILED scipy/_lib/tests/test_array_api.py::test_copy[cupy] - TypeError: asarray() got an unexpected keyword argument 'copy'
======================================================================================= 2 failed, 3 passed in 1.14s ========================================================================================

```

</details>

This is because `as_xparray` is trying to use the `copy` parameter of `xp.asarray` where `xp` is the 'raw' `cupy`, which doesn't exist. We should be using the `array_api_compat` version of `cupy` instead.

The pattern here, which matches https://github.com/scipy/scipy/pull/19051, is that we should only pass namespaces to the `xp` keyword that are compatible with the standard i.e. after using `array_namespace`.

For `copy`, this is relatively obvious: the `xp` keyword exists for performance reasons, to avoid calling `array_namespace` twice. The problem with the current test is that it calls `array_namespace` _zero_ times.

For `as_xparray`, this is less obvious: it may be that we want it to be able to accept 'raw' namespaces, and fetch the compat version itself. @tupui feel free to change that if wanted, but this PR fixes the issue for now.

---

On this branch, `python dev.py test -t scipy/_lib/tests/test_array_api.py -b cupy` now passes all tests.

---

Following https://github.com/scipy/scipy/pull/19157, this PR also removes the now unnecessary `to_numpy` (and the test for it), in favour of testing with our new `assert_equal` rather than `np.testing.assert_equal`.

#### Additional information

cc @andyfaff 
