### PR TITLE
ENH: Implemented custom mutation / crossover functions for DifferentialEvolution

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -257,9 +257,17 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         .. versionadded:: 1.9.0
         
     strategy_func : callable, optional
-        If a custom strategy function is provided, it will be called instead
-        of the default function in order to mutate and/or recombine solution
-        vectors. It should return a new candidate vector.
+        A user provided differential evolution strategy that constructs a trial
+        vector. Must be in the form
+        ``strategy_func(candidate: int, population: np.ndarray, rng=None)``,
+        where ``candidate`` is an integer specifying which entry of the
+        population is being evolved, ``population`` is an array of shape
+        ``(total_popsize, N)`` containing all the population members, and
+        ``rng`` is the random number generator being used within the solver.
+        ``candidate``  will be in the range ``[0, total_popsize)``.
+        ``strategy_func`` must return a trial vector with shape `(N,)`. The
+        fitness of this trial vector is compared against the fitness of
+        ``population[candidate]``.
         
         .. versionadded:: 1.12.0
 
@@ -669,10 +677,18 @@ class DifferentialEvolutionSolver:
         ignored if ``workers != 1``.
         This option will override the `updating` keyword to
         ``updating='deferred'``.
-    strategy_func : fn(candidate, population, rng=None)
-        If a custom strategy function is provided, it will be called instead
-        of the default function in order to mutate and/or recombine solution
-        vectors. It should return a new candidate vector.
+    strategy_func : callable, optional
+        A user provided differential evolution strategy that constructs a trial
+        vector. Must be in the form
+        ``strategy_func(candidate: int, population: np.ndarray, rng=None)``,
+        where ``candidate`` is an integer specifying which entry of the
+        population is being evolved, ``population`` is an array of shape
+        ``(total_popsize, N)`` containing all the population members, and
+        ``rng`` is the random number generator being used within the solver.
+        ``candidate``  will be in the range ``[0, total_popsize)``.
+        ``strategy_func`` must return a trial vector with shape `(N,)`. The
+        fitness of this trial vector is compared against the fitness of
+        ``population[candidate]``.
     """
 
     # Dispatch of mutation strategy method (binomial or exponential).

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1614,7 +1614,20 @@ class DifferentialEvolutionSolver:
 
     def _mutate(self, candidate):
         """Create a trial vector based on a mutation strategy."""
-        
+        rng = self.random_number_generator
+
+        if callable(self.strategy_func):
+            _population = self._scale_parameters(self.population)
+            trial = np.array(
+                self.strategy_func(candidate, _population, rng=rng), dtype=float
+            )
+            if trial.shape != (self.parameter_count,):
+                raise RuntimeError(
+                    "strategy_func must have signature"
+                    " f(candidate: int, population: np.ndarray, rng=None)"
+                    " returning an array of shape (N,)"
+                )
+            return self._unscale_parameters(trial)
         trial = np.copy(self.population[candidate])
         rng = self.random_number_generator
     

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -261,7 +261,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         of the default function in order to mutate and/or recombine solution
         vectors. It should return a new candidate vector.
         
-        .. versionadded:: 1.11.3
+        .. versionadded:: 1.12.0
 
     Returns
     -------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -702,12 +702,13 @@ class DifferentialEvolutionSolver:
                  vectorized=False, strategy_func=None):
 
         # Note: mutation_func is ignored if strategy_func is provided
+        self.strategy_func = None
         if strategy in self._binomial:	
             self.mutation_func = getattr(self, self._binomial[strategy])
         elif strategy in self._exponential:
             self.mutation_func = getattr(self, self._exponential[strategy])
         elif callable(strategy_func):
-            self.mutation_func = strategy_func
+            self.strategy_func = strategy_func
         else:
             raise ValueError("Please select a valid mutation strategy")
         self.strategy = strategy

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -261,7 +261,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         of the default function in order to mutate and/or recombine solution
         vectors. It should return a new candidate vector.
         
-        .. versionadded:: TBA
+        .. versionadded:: 1.11.3
 
     Returns
     -------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -256,7 +256,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
         .. versionadded:: 1.9.0
         
-    strategy_func : fn(candidate, population, rng=None)
+    strategy_func : callable, optional
         If a custom strategy function is provided, it will be called instead
         of the default function in order to mutate and/or recombine solution
         vectors. It should return a new candidate vector.

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -701,7 +701,6 @@ class DifferentialEvolutionSolver:
                  workers=1, constraints=(), x0=None, *, integrality=None,
                  vectorized=False, strategy_func=None):
 
-        self.strategy_func = strategy_func
 
         # Note: mutation_func is ignored if strategy_func is provided
         if strategy in self._binomial:	

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -707,6 +707,8 @@ class DifferentialEvolutionSolver:
             self.mutation_func = getattr(self, self._binomial[strategy])
         elif strategy in self._exponential:
             self.mutation_func = getattr(self, self._exponential[strategy])
+        elif callable(strategy_func):
+            self.mutation_func = strategy_func
         else:
             raise ValueError("Please select a valid mutation strategy")
         self.strategy = strategy

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -701,7 +701,6 @@ class DifferentialEvolutionSolver:
                  workers=1, constraints=(), x0=None, *, integrality=None,
                  vectorized=False, strategy_func=None):
 
-
         # Note: mutation_func is ignored if strategy_func is provided
         if strategy in self._binomial:	
             self.mutation_func = getattr(self, self._binomial[strategy])
@@ -1631,13 +1630,13 @@ class DifferentialEvolutionSolver:
 
         trial = np.copy(self.population[candidate])
         fill_point = rng.choice(self.parameter_count)
-    
+
         if self.strategy in ['currenttobest1exp', 'currenttobest1bin']:
             bprime = self.mutation_func(candidate,
                                         self._select_samples(candidate, 5))
         else:
             bprime = self.mutation_func(self._select_samples(candidate, 5))
-    
+
         if self.strategy in self._binomial:
             crossovers = rng.uniform(size=self.parameter_count)
             crossovers = crossovers < self.cross_over_probability

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1574,3 +1574,26 @@ class TestDifferentialEvolutionSolver:
         # after the '=', so if necessary, the text could be reduced to, say,
         # "MAXCV = 0.".
         assert "MAXCV = 0.414" in result.message
+
+    def test_strategy_func(self):
+
+        init = [(-8, 0.5)] * 5
+        bounds = [(-8.0,8.0)] * 2
+
+        def func(x):
+            return abs(x[0]) * abs(x[1])
+            
+        def custom_strategy_fn(candidate, population, rng):
+            assert(np.array_equal(candidate, [-8, 0.5]) or np.array_equal(candidate, [2.0, -1.0]))
+            return [2.0, -1.0]	# Ignore the candidate; just be recognizable.
+
+        result = differential_evolution(func,
+                                        init=init,
+                                        bounds=bounds,
+                                        popsize=5,
+                                        maxiter=2,
+                                        polish=False,
+                                        strategy_func=custom_strategy_fn)
+        assert(result.success is True)
+        assert np.array_equal(result.x, [2.0, -1.0]) 
+

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1576,7 +1576,6 @@ class TestDifferentialEvolutionSolver:
         assert "MAXCV = 0.414" in result.message
 
     def test_strategy_func(self):
-        init = [(-8, 0.5)] * 5
         bounds = [(-8.0,8.0)] * 2
 
         def func(x):
@@ -1584,12 +1583,10 @@ class TestDifferentialEvolutionSolver:
 
         def custom_strategy_fn(candidate, population, rng):
             t = population[candidate]
-            assert np.array_equal(t, [-8, 0.5]) or np.array_equal(t, [2.0, -1.0])
             return [2.0, -1.0]	# Ignore the candidate; just be recognizable.
 
         result = differential_evolution(
             func,
-            init=init,
             bounds=bounds,
             popsize=5,
             maxiter=2,

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1576,24 +1576,25 @@ class TestDifferentialEvolutionSolver:
         assert "MAXCV = 0.414" in result.message
 
     def test_strategy_func(self):
-
         init = [(-8, 0.5)] * 5
         bounds = [(-8.0,8.0)] * 2
 
         def func(x):
             return abs(x[0]) * abs(x[1])
-            
+
         def custom_strategy_fn(candidate, population, rng):
-            assert(np.array_equal(candidate, [-8, 0.5]) or np.array_equal(candidate, [2.0, -1.0]))
+            t = population[candidate]
+            assert np.array_equal(t, [-8, 0.5]) or np.array_equal(t, [2.0, -1.0])
             return [2.0, -1.0]	# Ignore the candidate; just be recognizable.
 
-        result = differential_evolution(func,
-                                        init=init,
-                                        bounds=bounds,
-                                        popsize=5,
-                                        maxiter=2,
-                                        polish=False,
-                                        strategy_func=custom_strategy_fn)
-        assert(result.success is True)
-        assert np.array_equal(result.x, [2.0, -1.0]) 
-
+        result = differential_evolution(
+            func,
+            init=init,
+            bounds=bounds,
+            popsize=5,
+            maxiter=2,
+            polish=False,
+            strategy_func=custom_strategy_fn
+        )
+        assert result.success is True
+        assert_equal(result.x, [2.0, -1.0])


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Implements custom user-specified mutation / crossover functions for DifferentialEvolution

#### Additional information
As per a discussion on the mailing list.  This gives the user full control over the mutation and crossover process by letting them provide their own function:

    strategy_func : fn(candidate, population, rng=None)
        If a custom strategy function is provided, it will be called instead
        of the default function in order to mutate and/or recombine solution
        vectors. It should return a new candidate vector.
