### PR TITLE
DOC: optimize.minimize_scalar: note limitations and suggest alternatives

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -100,6 +100,8 @@ quasi-Newton methods implementing this interface are:
    BFGS - Broyden-Fletcher-Goldfarb-Shanno (BFGS) Hessian update strategy.
    SR1 - Symmetric-rank-1 Hessian update strategy.
 
+.. _global_optimization:
+
 Global optimization
 -------------------
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -837,7 +837,7 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     valid `bracket` triple is provided. If a three-point bracket cannot be
     found, consider `scipy.optimize.minimize`. Also, all methods are intended
     only for local minimization. When the function of interest has more than
-    one local minimum, consider :ref:`_global_optimization`.
+    one local minimum, consider :ref:`global_optimization`.
 
     **Custom minimizers**
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -753,7 +753,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
 def minimize_scalar(fun, bracket=None, bounds=None, args=(),
                     method=None, tol=None, options=None):
-    """Minimization of scalar function of one variable.
+    """Local minimization of scalar function of one variable.
 
     Parameters
     ----------
@@ -832,6 +832,12 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     Method :ref:`Bounded <optimize.minimize_scalar-bounded>` can
     perform bounded minimization [2]_ [3]_. It uses the Brent method to find a
     local minimum in the interval x1 < xopt < x2.
+
+    Note that the Brent and Golden methods do not guarantee success unless a
+    valid `bracket` triple is provided. If a three-point bracket cannot be
+    found, consider `scipy.optimize.minimize`. Also, all methods are intended
+    only for local minimization. When the function of interest has more than
+    one local minimum, consider :ref:`_global_optimization`.
 
     **Custom minimizers**
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -834,7 +834,7 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     local minimum in the interval x1 < xopt < x2.
 
     Note that the Brent and Golden methods do not guarantee success unless a
-    valid `bracket` triple is provided. If a three-point bracket cannot be
+    valid ``bracket`` triple is provided. If a three-point bracket cannot be
     found, consider `scipy.optimize.minimize`. Also, all methods are intended
     only for local minimization. When the function of interest has more than
     one local minimum, consider :ref:`global_optimization`.


### PR DESCRIPTION
#### Reference issue
Closes gh-19185

#### What does this implement/fix?
gh-19185 noted the failure of `minimize_scalar` to find the global minimum of a function. This PR emphasizes that `minimize_scalar` is for local minimization and suggests alternative SciPy that may be a better fit for some problems.