### PR TITLE
MAINT: stats.CovViaEigendecomposition: fix `_LA` attribute when covariance is singular

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -582,7 +582,7 @@ class CovViaEigendecomposition(Covariance):
         psuedo_reciprocals[i_zero] = 0
 
         self._LP = eigenvectors * psuedo_reciprocals
-        self._LA = eigenvectors * np.sqrt(positive_eigenvalues)
+        self._LA = eigenvectors * np.sqrt(eigenvalues)
         self._rank = positive_eigenvalues.shape[-1] - i_zero.sum(axis=-1)
         self._w = eigenvalues
         self._v = eigenvectors


### PR DESCRIPTION
#### Reference issue
Closes gh-19197

#### What does this implement/fix?
gh-19197 reported that `multivariate_normal.rvs` produced incorrect results when using a singular `Covariance` object generated by `from_eigenvalues`. This PR fixes the bug as explained in https://github.com/scipy/scipy/issues/19197#issuecomment-1708935759.
