### PR TITLE
TST: fix `TestODR.test_implicit` test failure with tolerance bump

### DIFF
--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -5,7 +5,8 @@ import os
 import numpy as np
 from numpy import pi
 from numpy.testing import (assert_array_almost_equal,
-                           assert_equal, assert_warns)
+                           assert_equal, assert_warns,
+                           assert_allclose)
 import pytest
 from pytest import raises as assert_raises
 
@@ -127,7 +128,7 @@ class TestODR:
             np.array([0.1113840353364371, 0.1097673310686467, 0.0041060738314314,
                 0.0027500347539902, 0.0034962501532468]),
         )
-        assert_array_almost_equal(
+        assert_allclose(
             out.cov_beta,
             np.array([[2.1089274602333052e+00, -1.9437686411979040e+00,
                   7.0263550868344446e-02, -4.7175267373474862e-02,
@@ -144,6 +145,7 @@ class TestODR:
                [5.2515575927380355e-02, -5.8822307501391467e-02,
                   1.4528860663055824e-03, -1.2692942951415293e-03,
                   2.0778813389755596e-03]]),
+            rtol=1e-6, atol=2e-6,
         )
 
     # Multi-variable Example


### PR DESCRIPTION
This was failing on macOS x86-64 in CI with:
```
E   Arrays are not almost equal to 6 decimals
E
E   Mismatched elements: 1 / 25 (4%)
E   Max absolute difference: 1.52291797e-06
E   Max relative difference: 8.81522156e-07
E    x: array([[ 2.108927e+00, -1.943767e+00,  7.026353e-02, -4.717525e-02,
E            5.251554e-02],
E          [-1.943767e+00,  2.048149e+00, -6.160049e-02,  4.626880e-02,...
E    y: array([[ 2.108927e+00, -1.943769e+00,  7.026355e-02, -4.717527e-02,
E            5.251558e-02],
E          [-1.943769e+00,  2.048151e+00, -6.160052e-02,  4.626883e-02,...
```

So it's a very small atol violation (1.52e-6, where decimal=6 implies 1.5e-6). Rather than bump to `decimal=5`, I decided to change the test to `assert_allclose` so the bump could be smaller.