### PR TITLE
DOC: remove old mention to Python 2.

### DIFF
--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -406,10 +406,6 @@ def varmats_from_mat(file_obj):
     >>> import numpy as np
     >>> from io import BytesIO
     >>> from scipy.io.matlab._mio5 import varmats_from_mat
-
-    BytesIO is from the ``io`` module in Python 3, and is ``cStringIO`` for
-    Python < 3.
-
     >>> mat_fileobj = BytesIO()
     >>> scipy.io.savemat(mat_fileobj, {'b': np.arange(10), 'a': 'a string'})
     >>> varmats = varmats_from_mat(mat_fileobj)


### PR DESCRIPTION
And join the two examples black, plus update to use `...` as a continuation prompt.

This should make it slightly easier to copy-past the example and make it clearer that it is a single example