### PR TITLE
DOC: Fix _nan_allsame example prompt.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -615,11 +615,11 @@ def _nan_allsame(a, axis, keepdims=False):
     --------
     >>> import numpy as np
     >>> a = np.array([[ 3.,  3., nan,  3.],
-                      [ 1., nan,  2.,  4.],
-                      [nan, nan,  9., -1.],
-                      [nan,  5.,  4.,  3.],
-                      [ 2.,  2.,  2.,  2.],
-                      [nan, nan, nan, nan]])
+    ...               [ 1., nan,  2.,  4.],
+    ...               [nan, nan,  9., -1.],
+    ...               [nan,  5.,  4.,  3.],
+    ...               [ 2.,  2.,  2.,  2.],
+    ...               [nan, nan, nan, nan]])
     >>> _nan_allsame(a, axis=1, keepdims=True)
     array([[ True],
            [False],


### PR DESCRIPTION
without the leading prompt this is interpreted as the result the previous line should produce.

-- 

Note that `_nan_allsame` is used in a single place that uses `keepdims=True`, there might be some simplification possible