### PR TITLE
TST, MAINT: skip fix for array API tests

### DIFF
--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -8,13 +8,6 @@ from scipy._lib._array_api import (
 )
 
 
-if not _GLOBAL_CONFIG["SCIPY_ARRAY_API"]:
-    pytest.skip(
-        "Array API test; set environment variable SCIPY_ARRAY_API=1 to run it",
-        allow_module_level=True
-    )
-
-
 def to_numpy(array, xp):
     """Convert `array` into a NumPy ndarray on the CPU. From sklearn."""
     xp_name = xp.__name__
@@ -29,67 +22,72 @@ def to_numpy(array, xp):
     return np.asarray(array)
 
 
-def test_array_namespace():
-    x, y = np.array([0, 1, 2]), np.array([0, 1, 2])
-    xp = array_namespace(x, y)
-    assert 'array_api_compat.numpy' in xp.__name__
-
-    _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = False
-    xp = array_namespace(x, y)
-    assert 'array_api_compat.numpy' in xp.__name__
-    _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = True
+@pytest.mark.skipif(not _GLOBAL_CONFIG["SCIPY_ARRAY_API"],
+        reason="Array API test; set environment variable SCIPY_ARRAY_API=1 to run it")
+class TestArrayAPI:
 
 
-@array_api_compatible
-def test_asarray(xp):
-    x, y = as_xparray([0, 1, 2], xp=xp), as_xparray(np.arange(3), xp=xp)
-    ref = np.array([0, 1, 2])
-    assert_equal(x, ref)
-    assert_equal(y, ref)
+    def test_array_namespace(self):
+        x, y = np.array([0, 1, 2]), np.array([0, 1, 2])
+        xp = array_namespace(x, y)
+        assert 'array_api_compat.numpy' in xp.__name__
+
+        _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = False
+        xp = array_namespace(x, y)
+        assert 'array_api_compat.numpy' in xp.__name__
+        _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = True
 
 
-@array_api_compatible
-def test_to_numpy(xp):
-    x = xp.asarray([0, 1, 2])
-    x = to_numpy(x, xp=xp)
-    assert isinstance(x, np.ndarray)
+    @array_api_compatible
+    def test_asarray(self, xp):
+        x, y = as_xparray([0, 1, 2], xp=xp), as_xparray(np.arange(3), xp=xp)
+        ref = np.array([0, 1, 2])
+        assert_equal(x, ref)
+        assert_equal(y, ref)
 
 
-@pytest.mark.filterwarnings("ignore: the matrix subclass")
-def test_raises():
-    msg = "'numpy.ma.MaskedArray' are not supported"
-    with pytest.raises(TypeError, match=msg):
-        array_namespace(np.ma.array(1), np.array(1))
-
-    msg = "'numpy.matrix' are not supported"
-    with pytest.raises(TypeError, match=msg):
-        array_namespace(np.array(1), np.matrix(1))
-
-    msg = ("An argument was coerced to an object array, "
-           "but object arrays are not supported.")
-    with pytest.raises(TypeError, match=msg):
-        array_namespace([object()])
+    @array_api_compatible
+    def test_to_numpy(self, xp):
+        x = xp.asarray([0, 1, 2])
+        x = to_numpy(x, xp=xp)
+        assert isinstance(x, np.ndarray)
 
 
-def test_array_likes():
-    # should be no exceptions
-    array_namespace([0, 1, 2])
-    array_namespace(1, 2, 3)
-    array_namespace(1)
+    @pytest.mark.filterwarnings("ignore: the matrix subclass")
+    def test_raises(self):
+        msg = "'numpy.ma.MaskedArray' are not supported"
+        with pytest.raises(TypeError, match=msg):
+            array_namespace(np.ma.array(1), np.array(1))
+
+        msg = "'numpy.matrix' are not supported"
+        with pytest.raises(TypeError, match=msg):
+            array_namespace(np.array(1), np.matrix(1))
+
+        msg = ("An argument was coerced to an object array, "
+               "but object arrays are not supported.")
+        with pytest.raises(TypeError, match=msg):
+            array_namespace([object()])
 
 
-@array_api_compatible
-def test_copy(xp):
-    for _xp in [xp, None]:
-        x = xp.asarray([1, 2, 3])
-        y = copy(x, xp=_xp)
-        # with numpy we'd want to use np.shared_memory, but that's not specified
-        # in the array-api
-        x[0] = 10
-        x[1] = 11
-        x[2] = 12
+    def test_array_likes(self):
+        # should be no exceptions
+        array_namespace([0, 1, 2])
+        array_namespace(1, 2, 3)
+        array_namespace(1)
 
-        assert x[0] != y[0]
-        assert x[1] != y[1]
-        assert x[2] != y[2]
-        assert id(x) != id(y)
+
+    @array_api_compatible
+    def test_copy(self, xp):
+        for _xp in [xp, None]:
+            x = xp.asarray([1, 2, 3])
+            y = copy(x, xp=_xp)
+            # with numpy we'd want to use np.shared_memory, but that's not specified
+            # in the array-api
+            x[0] = 10
+            x[1] = 11
+            x[2] = 12
+
+            assert x[0] != y[0]
+            assert x[1] != y[1]
+            assert x[2] != y[2]
+            assert id(x) != id(y)


### PR DESCRIPTION
* Fixes #19190

* the module-level skipping described in the above issue was causing spurious skips in some cases as described there, so move the tests in that module to a class guarded with a `skipif` mark, which seems to be the preferred approach anyway according to:
https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=pytest%20skip#pytest.skip

* on this branch I seem to get the expected behavior with i.e.,
- `python dev.py test -v -- -k "test_concatenate_int32_overflow" -rsx`
  - `59382 deselected`
- `python dev.py test -m full -v -- -k "test_concatenate_int32_overflow" -rsx`
  - `1 passed, 59381 deselected`
- `python dev.py test -v -t scipy/sparse/tests/test_construct.py::TestConstructUtils::test_concatenate_int32_overflow -- -rsx`
  - `1 deselected`
- `SCIPY_ARRAY_API=1 python dev.py test -v -t "scipy/_lib/tests/test_array_api.py" -b cupy -- -rsx`
  - just the two failures expected from gh-19194
- `python dev.py test -v -t "scipy/_lib/tests/test_array_api.py" -b cupy -- -rsx`
  - same (the backend setting implies the env var)
- `python dev.py test -v -t "scipy/_lib/tests/test_array_api.py" -- -rsx`
  - `6 skipped`
- `python dev.py test -j 32 -b all`
  - `3 failed, 44291 passed, 2546 skipped, 149 xfailed, 12 xpassed` (failures noted above + PyTorch issue from gh-18930)
- `SCIPY_DEVICE=cuda python dev.py test -j 32 -b all`
  - `3 failed, 44198 passed, 2639 skipped, 149 xfailed, 12 xpassed` (failures noted above + PyTorch issue from gh-18930)

* could there be a `pytest` bug here somewhere? Yeah, probably. But given that following their docs suggestion to avoid the global skip scope seems to solve the problem, I'm inclined not to spend much time providing a small reproducer upstream and debating with them. It is probably related to the `-k` option collecting every single test node vs. the hand-tuned selection of the single node on the command line.
