### PR TITLE
BUG: freqz rfft grid fix

### DIFF
--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -105,13 +105,19 @@ class MedFilt2D(Benchmark):
 
 
 class FreqzRfft(Benchmark):
-    param_names = ['worN']
+    param_names = ['vector_input', 'whole', 'nyquist', 'worN']
     params = [
-        [64, 65, 128, 129, 256, 257, 512, 513],
+        [False, True],
+        [False, True],
+        [False, True],
+        [64, 65, 128, 129, 256, 257, 258, 512, 513, 65536, 65537, 65538],
     ]
 
-    def setup(self, worN):
-        self.y = np.random.RandomState(0).randn(worN,10000)[...,np.newaxis]
+    def setup(self, vector_input, whole, nyquist, worN):
+        self.y = np.zeros(worN)
+        self.y[worN//2] = 1.0
+        if vector_input:
+            self.y = np.repeat(self.y[:,np.newaxis], 1000, axis=-1)[...,np.newaxis]
 
-    def time_freqz(self, worN):
-        freqz(self.y, worN=worN)
+    def time_freqz(self, vector_input, whole, nyquist, worN):
+        freqz(self.y, whole=whole, include_nyquist=nyquist, worN=worN)

--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -6,7 +6,7 @@ from .common import Benchmark, safe_import
 
 with safe_import():
     from scipy.signal import (lfilter, firwin, decimate, butter, sosfilt,
-                              medfilt2d)
+                              medfilt2d, freqz)
 
 
 class Decimate(Benchmark):
@@ -102,3 +102,16 @@ class MedFilt2D(Benchmark):
 
     def peakmem_medfilt2d(self, threads):
         self._medfilt2d(threads)
+
+
+class FreqzRfft(Benchmark):
+    param_names = ['worN']
+    params = [
+        [64, 65, 128, 129, 256, 257, 512, 513],
+    ]
+
+    def setup(self, worN):
+        self.y = np.random.RandomState(0).randn(worN,10000)[...,np.newaxis]
+
+    def time_freqz(self, worN):
+        freqz(self.y, worN=worN)

--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -105,19 +105,16 @@ class MedFilt2D(Benchmark):
 
 
 class FreqzRfft(Benchmark):
-    param_names = ['vector_input', 'whole', 'nyquist', 'worN']
+    param_names = ['whole', 'nyquist', 'worN']
     params = [
-        [False, True],
         [False, True],
         [False, True],
         [64, 65, 128, 129, 256, 257, 258, 512, 513, 65536, 65537, 65538],
     ]
 
-    def setup(self, vector_input, whole, nyquist, worN):
+    def setup(self, whole, nyquist, worN):
         self.y = np.zeros(worN)
         self.y[worN//2] = 1.0
-        if vector_input:
-            self.y = np.repeat(self.y[:,np.newaxis], 1000, axis=-1)[...,np.newaxis]
 
-    def time_freqz(self, vector_input, whole, nyquist, worN):
+    def time_freqz(self, whole, nyquist, worN):
         freqz(self.y, whole=whole, include_nyquist=nyquist, worN=worN)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -445,12 +445,12 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
         lastpoint = 2 * pi if whole else pi
         # if include_nyquist is true and whole is false, w should
         # include end point
-        w = np.linspace(0, lastpoint, N, endpoint=include_nyquist and not whole)
-        if (a.size == 1 and N >= b.shape[0] and
-                sp_fft.next_fast_len(N) == N and
-                (b.ndim == 1 or (b.shape[-1] == 1))):
-            # if N is fast, 2 * N will be fast, too, so no need to check
-            n_fft = N if whole else N * 2
+        w = np.linspace(0, lastpoint, N,
+                        endpoint=include_nyquist and not whole)
+        n_fft = N if whole else 2 * (N - 1) if include_nyquist else 2 * N
+        if (a.size == 1 and (b.ndim == 1 or (b.shape[-1] == 1))
+                and n_fft >= b.shape[0]
+                and n_fft > 0):  # TODO: review threshold acc. to benchmark?
             if np.isrealobj(b) and np.isrealobj(a):
                 fft_func = sp_fft.rfft
             else:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -905,7 +905,7 @@ class TestFreqz:
                               (True, False, 257),
                               (True, True, 257)])
     def test_17289(self, whole, nyquist, worN):
-        d = [0,1]
+        d = [0, 1]
         w, Drfft = freqz(d, worN=32, whole=whole, include_nyquist=nyquist)
         _, Dpoly = freqz(d, worN=w)
         assert_allclose(Drfft, Dpoly)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -895,9 +895,18 @@ class TestFreqz:
 
     # https://github.com/scipy/scipy/issues/17289
     # https://github.com/scipy/scipy/issues/15273
-    def test_17289(self):
+    @pytest.mark.parametrize('whole,nyquist,worN',
+                             [(False, False, 32),
+                              (False, True, 32),
+                              (True, False, 32),
+                              (True, True, 32),
+                              (False, False, 257),
+                              (False, True, 257),
+                              (True, False, 257),
+                              (True, True, 257)])
+    def test_17289(self, whole, nyquist, worN):
         d = [0,1]
-        w, Drfft = freqz(d, worN=32, include_nyquist=True)
+        w, Drfft = freqz(d, worN=32, whole=whole, include_nyquist=nyquist)
         _, Dpoly = freqz(d, worN=w)
         assert_allclose(Drfft, Dpoly)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -899,7 +899,7 @@ class TestFreqz:
         d = [0,1]
         w, Drfft = freqz(d, worN=32, include_nyquist=True)
         _, Dpoly = freqz(d, worN=w)
-        assert_array_almost_equal(Drfft, Dpoly)
+        assert_allclose(Drfft, Dpoly)
 
 
 class TestSOSFreqz:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -893,6 +893,14 @@ class TestFreqz:
         assert_array_almost_equal(w1, w2)
         assert_array_almost_equal(h1, h2)
 
+    # https://github.com/scipy/scipy/issues/17289
+    # https://github.com/scipy/scipy/issues/15273
+    def test_17289(self):
+        d = [0,1]
+        w, Drfft = freqz(d, worN=32, include_nyquist=True)
+        _, Dpoly = freqz(d, worN=w)
+        assert_array_almost_equal(Drfft, Dpoly)
+
 
 class TestSOSFreqz:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
closes #17289 
closes #15273

#### What does this implement/fix?
`signal.freqz()` includes a mechanism to improve performance by using `numpy.fft` for certain parameters. The frequency grid created in `freqz()` is not consistent with the grid that is assumed by using `numpy.fft` (it is off by one) and thus the result is not correct. The test case added proves this: results are different for two calls of `freqz`, one where `numpy.fft` is used and one where the frequency bins are passed explicitly and the polynomial method is used.

#### Additional information
<!--Any additional information you think is important.-->
The fix effectively implement a new rule to select the set of parameters where `numpy.fft` will be used. The new rule is more permissive and does result in a consistent performance improvement, according to a new benchmark (see anecdotal results below).
