### PR TITLE
DOC: fix doc of scipy.io.loadmat about varmats_from_mat

### DIFF
--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -312,7 +312,7 @@ class MatFile5Reader(MatFileReader):
             if name in mdict:
                 warnings.warn('Duplicate variable name "%s" in stream'
                               ' - replacing previous with new\n'
-                              'Consider mio5.varmats_from_mat to split '
+                              'Consider _mio5.varmats_from_mat to split '
                               'file into single variable files' % name,
                               MatReadWarning, stacklevel=2)
             if name == '':


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


#### Reference issue
No issue

#### What does this implement/fix?


When using `scipy.io.loadmat` we can have the following message:

```
MatReadWarning: Duplicate variable name XXXX in stream - replacing previous with new
Consider mio5.varmats_from_mat to split file into single variable files
```

If we use `scipy.io.matlab.mio5.varmats_from_mat` we then get:
```
DeprecationWarning: Please use `varmats_from_mat` from the `scipy.io.matlab` namespace, the `scipy.io.matlab.mio5` namespace is deprecated.
```

If we use `scipy.io.matlab.varmats_from_mat`we have: 
```
AttributeError: module 'scipy.io.matlab' has no attribute 'varmats_from_mat'
```

We need to use `scipy.io.matlab._mio5.varmats_from_mat`


This change the doc from the function `get_variables` which is used by `scipy.io.loadmat` to directly point to `_mio5` instead of `mio5`.

#### Additional information

