### PR TITLE
BLD: start building wheels against numpy 2.0 [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,16 +130,22 @@ jobs:
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
           CIBW_PRERELEASE_PYTHONS: True
 
-          # required so that cp312 can grab a nightly wheel
-          # can remove when cp312 is released and we don't need to search
-          # other wheel locations.
-          # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-          CIBW_ENVIRONMENT: PIP_PRE=1
+          # TODO remove the CIBW_BEFORE_BUILD_* lines once there are
+          #  numpy2.0 wheels available on PyPI. Also remove/comment out the
+          # PIP_NO_BUILD_ISOLATION and PIP_EXTRA_INDEX_URL from CIBW_ENVIRONMENT
+          # (also for _MACOS and _WINDOWS below)
+          CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+          CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+          # Allow pip to find install nightly wheels if necessary
+          # Setting PIP_NO_BUILD_ISOLATION=false makes pip use build-isolation.
+          CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=false PIP_PRE=1 PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
 
           CIBW_ENVIRONMENT_WINDOWS: >
             PKG_CONFIG_PATH=c:/opt/64/lib/pkgconfig
             PIP_PRE=1
-            # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            PIP_NO_BUILD_ISOLATION=false
 
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh
@@ -154,7 +160,8 @@ jobs:
             MACOS_DEPLOYMENT_TARGET=10.9
             _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
             PIP_PRE=1
-            # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            PIP_NO_BUILD_ISOLATION=false
 
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -29,9 +29,13 @@ cirrus_wheels_linux_aarch64_task:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
     CIBW_PRERELEASE_PYTHONS: True
+    # TODO remove the CIBW_BEFORE_BUILD_LINUX line once there are numpy2.0 wheels available on PyPI.
+    # Also remove/comment out PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
+    CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
     CIBW_ENVIRONMENT: >
       PIP_PRE=1
-    #      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_NO_BUILD_ISOLATION=false
 
   build_script: |
     apt install -y python3-venv python-is-python3
@@ -60,7 +64,11 @@ cirrus_wheels_macos_arm64_task:
       MACOSX_DEPLOYMENT_TARGET=12.0
       _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"             
       PIP_PRE=1
-      # PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      PIP_NO_BUILD_ISOLATION=false
+    # TODO remove the following line once there are numpy2.0 wheels available on PyPI.
+    # Also remove PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
+    CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
 build-verbosity = "3"
 # gmpy2 and scikit-umfpack are usually added for testing. However, there are
 # currently wheels missing that make the test script fail.
-test-requires = ["pytest", "pytest-cov", "pytest-xdist", "asv", "mpmath", "threadpoolctl", "pooch", "hypothesis"]
+test-requires = ["pytest", "pytest-cov", "pytest-xdist", "mpmath", "threadpoolctl", "pooch", "hypothesis"]
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
This PR adjusts the wheel build process to build against numpy2.0. This is being done so that downstream users can start ferreting out possible issues in the lead-up to numpy 2.0.

@seberg 
@rgommers 

Also @tylerjereddy for visibility as release manager.