### PR TITLE
FIX make __iter__ consistent between sparse arrays and matrices

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -248,7 +248,7 @@ class _spbase:
 
     def __iter__(self):
         for r in range(self.shape[0]):
-            yield self[r, :]
+            yield self[[r], :]
 
     def _getmaxprint(self):
         """Maximum number of elements to display when printed."""

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -547,3 +547,13 @@ def test_isspmatrix_format(fmt, fn):
     # ndarray and array_likes are not sparse
     assert not fn(a.todense())
     assert not fn(m.todense())
+
+
+@pytest.mark.parametrize(
+    "sparse_format, expected_row_format",
+    [("csr", "csr"), ("csc", "csr"), ("dok", "dok"), ("lil", "lil")]
+)
+def test_iter(sparse_format, expected_row_format):
+    sparse_array = getattr(scipy.sparse, sparse_format + "_array")(A)
+    for row in sparse_array:
+        assert row.format == expected_row_format

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -555,5 +555,9 @@ def test_isspmatrix_format(fmt, fn):
 )
 def test_iter(sparse_format, expected_row_format):
     sparse_array = getattr(scipy.sparse, sparse_format + "_array")(A)
+    sparse_matrix = getattr(scipy.sparse, sparse_format + "_matrix")(A)
     for row in sparse_array:
+        assert row.format == expected_row_format
+
+    for row in sparse_matrix:
         assert row.format == expected_row_format


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR is a workaround the current `NotImplementedError`:

```python
In [1]: from scipy import sparse

In [2]: import numpy as np

In [3]: X = sparse.dok_array([[1, 2], [0, 3], [4, 0]])

In [4]: for row in X:
   ...:     print(row)
   ...: 
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Cell In[4], line 1
----> 1 for row in X:
      2     print(row)

File ~/mambaforge/envs/dev/lib/python3.10/site-packages/scipy/sparse/_base.py:252, in _spbase.__iter__(self)
    250 def __iter__(self):
    251     for r in range(self.shape[0]):
--> 252         yield self[r, :]

File ~/mambaforge/envs/dev/lib/python3.10/site-packages/scipy/sparse/_index.py:51, in IndexMixin.__getitem__(self, key)
     49     return self._get_intXint(row, col)
     50 elif isinstance(col, slice):
---> 51     self._raise_on_1d_array_slice()
     52     return self._get_intXslice(row, col)
     53 elif col.ndim == 1:

File ~/mambaforge/envs/dev/lib/python3.10/site-packages/scipy/sparse/_index.py:38, in IndexMixin._raise_on_1d_array_slice(self)
     30 """We do not currently support 1D sparse arrays.
     31 
     32 This function is called each time that a 1D array would
   (...)
     35 Once 1D sparse arrays are implemented, it should be removed.
     36 """
     37 if self._is_array:
---> 38     raise NotImplementedError(
     39         'We have not yet implemented 1D sparse slices; '
     40         'please index using explicit indices, e.g. `x[:, [0]]`'
     41     )

NotImplementedError: We have not yet implemented 1D sparse slices; please index using explicit indices, e.g. `x[:, [0]]`
```

It makes sparse arrays and sparse matrices behaving consistently in this regard.