### PR TITLE
DOC: clarify guidance on style modifications

### DIFF
--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -22,7 +22,7 @@ compliance before pushing your code:
    checks.
 
 -  It is recommended to leave existing style issues alone
-   unless they exist in files you are already modifying.
+   unless they exist in lines of code you are already modifying.
    This practice ensures that the codebase is gradually cleaned up
    without dedicating precious review time to style-only cleanups.
 


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
Changes "It is recommended to leave existing style issues alone unless they exist in files you are already modifying" to "It is recommended to leave existing style issues alone unless they exist in lines of code you are already modifying".

The clarification from _files_ to _lines of code_ should help to reduce the number of unwanted style modifications in PRs containing functional change (in other parts of the files).

#### Additional information
This tripped me up recently. After reading it, I assumed that any style corrections were welcome as long as they are in the files you are already modifying, but it now makes sense to me that maintainers do not want to have random style modifications mixed in to diffs.

From Ralf: ["Yes, that better communicates it."](https://github.com/scipy/scipy/pull/19005#discussion_r1321767298)