### PR TITLE
BUG: integrate: expose ODEintWarning

### DIFF
--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -77,6 +77,7 @@ Fortran code. In some cases, it might be worth using this old API.
    odeint        -- General integration of ordinary differential equations.
    ode           -- Integrate ODE using VODE and ZVODE routines.
    complex_ode   -- Convert a complex-valued ODE to real-valued and integrate.
+   ODEintWarning -- Warning raised during the execution of `odeint`.
 
 
 Solving boundary value problems for ODE systems

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -1,6 +1,6 @@
 # Author: Travis Oliphant
 
-__all__ = ['odeint']
+__all__ = ['odeint', 'ODEintWarning']
 
 import numpy as np
 from . import _odepack
@@ -9,6 +9,7 @@ import warnings
 
 
 class ODEintWarning(Warning):
+    """Warning raised during the execution of `odeint`."""
     pass
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #17771
#### What does this implement/fix?
<!--Please explain your changes.-->

`ODEintWarning` is not currently exposed in the `scpy.integrate` namespace which means it is not possible to filter `ODEintWarning` during the execution of `odeint` without importing it from the deprecated `scipy.integrate.odepack` namespace. It was suggested by @WarrenWeckesser that this should be exposed in the `integrate` namespace.

#### Additional information
<!--Any additional information you think is important.-->
