### PR TITLE
DOC: Trailing character after closing backquote.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4832,7 +4832,7 @@ class geninvgauss_gen(rv_continuous):
 
         f(x, p, b) = x^{p-1} \exp(-b (x + 1/x) / 2) / (2 K_p(b))
 
-    where `x > 0`, `p` is a real number and `b > 0`([1]_).
+    where `x > 0`, `p` is a real number and `b > 0`\([1]_).
     :math:`K_p` is the modified Bessel function of second kind of order `p`
     (`scipy.special.kv`).
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -326,7 +326,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         of the statistic.
     batch : int, optional
         The number of resamples to process in each vectorized call to
-        `statistic`. Memory usage is O(`batch`*``n``), where ``n`` is the
+        `statistic`. Memory usage is O( `batch` * ``n`` ), where ``n`` is the
         sample size. Default is ``None``, in which case ``batch = n_resamples``
         (or ``batch = max(n_resamples, n)`` for ``method='BCa'``).
     vectorized : bool, optional
@@ -788,7 +788,7 @@ def monte_carlo_test(data, rvs, statistic, *, vectorized=None,
         used as the Monte Carlo null distribution.
     batch : int, optional
         The number of Monte Carlo samples to process in each call to
-        `statistic`. Memory usage is O(`batch`*``sample.size[axis]``). Default
+        `statistic`. Memory usage is O( `batch` * ``sample.size[axis]`` ). Default
         is ``None``, in which case `batch` equals `n_resamples`.
     alternative : {'two-sided', 'less', 'greater'}
         The alternative hypothesis for which the p-value is calculated.
@@ -1300,7 +1300,7 @@ def permutation_test(data, statistic, *, permutation_type='independent',
         data sets.
     batch : int, optional
         The number of permutations to process in each call to `statistic`.
-        Memory usage is O(`batch`*``n``), where ``n`` is the total size
+        Memory usage is O( `batch` * ``n`` ), where ``n`` is the total size
         of all samples, regardless of the value of `vectorized`. Default is
         ``None``, in which case ``batch`` is the number of permutations.
     alternative : {'two-sided', 'less', 'greater'}, optional


### PR DESCRIPTION
Those leads to improper parsing and rendering of the docs: See
https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.geninvgauss.html
and https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html and similar.

While I thought you could escape the * with a single backslash, it actually did not work
