### PR TITLE
DOC, MAINT: workaround for py311 docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,6 +183,12 @@ warnings.filterwarnings(
     message=r'There is no current event loop',
     category=DeprecationWarning,
 )
+# TODO: remove after gh-19228 resolved:
+warnings.filterwarnings(
+    'ignore',
+    message=r'.*path is deprecated.*',
+    category=DeprecationWarning,
+)
 
 # -----------------------------------------------------------------------------
 # HTML output


### PR DESCRIPTION
* temporary workaround to allow SciPy docs to build on `main` with Python `3.11` until
an upstream fix for gh-19228 is available

* I thought about guarding this filter by Python version, but didn't seem worth it,
but can change that if really desired

* locally, `python dev.py doc -j 32` has a `0` exit code/succeeds with `3.11`

[skip cirrus] [skip actions]