### PR TITLE
DOC: Fix character after trailing backticks

### DIFF
--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -126,9 +126,9 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         Thus, the return matrix `jac` from `Dfun` should have shape
         ``(ml + mu + 1, len(y0))`` when ``ml >=0`` or ``mu >=0``.
         The data in `jac` must be stored such that ``jac[i - j + mu, j]``
-        holds the derivative of the `i`th equation with respect to the `j`th
-        state variable.  If `col_deriv` is True, the transpose of this
-        `jac` must be returned.
+        holds the derivative of the ``i``\\ th equation with respect to the
+        ``j``\\ th state variable.  If `col_deriv` is True, the transpose of
+        this `jac` must be returned.
     rtol, atol : float, optional
         The input parameters `rtol` and `atol` determine the error
         control performed by the solver.  The solver will control the

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1803,7 +1803,7 @@ class BPoly(_PPolyBase):
         xi : array_like
             sorted 1-D array of x-coordinates
         yi : array_like or list of array_likes
-            ``yi[i][j]`` is the ``j``th derivative known at ``xi[i]``
+            ``yi[i][j]`` is the ``j``\\ th derivative known at ``xi[i]``
         orders : None or int or array_like of ints. Default: None.
             Specifies the degree of local polynomials. If not None, some
             derivatives are ignored.
@@ -1932,8 +1932,8 @@ class BPoly(_PPolyBase):
         xb : float
             Right-hand end point of the interval
         ya : array_like
-            Derivatives at `xa`. `ya[0]` is the value of the function, and
-            `ya[i]` for ``i > 0`` is the value of the ``i``th derivative.
+            Derivatives at `xa`. ``ya[0]`` is the value of the function, and
+            ``ya[i]`` for ``i > 0`` is the value of the ``i``\ th derivative.
         yb : array_like
             Derivatives at `xb`.
 

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -388,7 +388,7 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
     that would result if the 2-by-2 diagonal blocks of the real generalized
     Schur form of (A,B) were further reduced to triangular form using complex
     unitary transformations. If ALPHAI(j) is zero, then the jth eigenvalue is
-    real; if positive, then the ``j``th and ``(j+1)``st eigenvalues are a
+    real; if positive, then the ``j``\\ th and ``(j+1)``\\ st eigenvalues are a
     complex conjugate pair, with ``ALPHAI(j+1)`` negative.
 
     .. versionadded:: 0.17.0

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1157,7 +1157,7 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     min_snr : float, optional
         Minimum SNR ratio. Default 1. The signal is the value of
         the cwt matrix at the shortest length scale (``cwt[0, loc]``), the
-        noise is the `noise_perc`th percentile of datapoints contained within a
+        noise is the `noise_perc`\\ th percentile of datapoints contained within a
         window of `window_size` around ``cwt[0, loc]``.
     noise_perc : float, optional
         When calculating the noise floor, percentile of data points


### PR DESCRIPTION
Having charter directly after prevent docutils/sphinx from closing the interpreted-text/verbatim. One must use escaped space to have no spaces, (`\ `) double in r-docstring `\\ `.

See spec, and confirmed this is what happens when building the doc.

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#character-level-inline-markup-1

Change also singe backtick to double where relevant.
