### PR TITLE
DOC: Missing import in private _nan_allsame function docs.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -643,13 +643,13 @@ def _nan_allsame(a, axis, keepdims=False):
 
     Examples
     --------
-    >>> import numpy as np
-    >>> a = np.array([[ 3.,  3., nan,  3.],
-    ...               [ 1., nan,  2.,  4.],
-    ...               [nan, nan,  9., -1.],
-    ...               [nan,  5.,  4.,  3.],
-    ...               [ 2.,  2.,  2.,  2.],
-    ...               [nan, nan, nan, nan]])
+    >>> from numpy import nan, array
+    >>> a = array([[ 3.,  3., nan,  3.],
+    ...            [ 1., nan,  2.,  4.],
+    ...            [nan, nan,  9., -1.],
+    ...            [nan,  5.,  4.,  3.],
+    ...            [ 2.,  2.,  2.,  2.],
+    ...            [nan, nan, nan, nan]])
     >>> _nan_allsame(a, axis=1, keepdims=True)
     array([[ True],
            [False],


### PR DESCRIPTION
This is not doctested, but still, copy pasting the example fails because `nan` is undefined.

[skip ci]
