### PR TITLE
MAINT, TST: stats tests NEP 50

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1528,7 +1528,8 @@ def _pval_cvm_2samp_exact(s, m, n):
                 np.delete(tmp, i0, 1),
                 np.delete(g, i1, 1)
             ], 1)
-            tmp[0] += (a * v - b * u) ** 2
+            res = (a * v - b * u) ** 2
+            tmp[0] += res.astype(dtype)
             next_gs.append(tmp)
         gs = next_gs
     value, freq = gs[m]


### PR DESCRIPTION
* this drops us from 72 to 62 failures in full test suite with NEP50 turned on via `export NPY_PROMOTION_STATE=weak` with NumPy `1.25.2`; I'm revisiting this a bit as NumPy `2.0` prep continues

* the patch here adjusts a `stats` test to avoid asking NumPy to implicitly cast from a large width type to a smaller one, and taking on the explicit cast burden ourselves, which I think is consistent with usage of `min_scalar_type` in the control flow above it

* a sample of the original error is: `numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('int64') to dtype('uint32') with casting rule 'same_kind'`

[skip cirrus] [skip circle]

cc @seberg 