### PR TITLE
TST/MAINT: cluster: use new array API assertions

### DIFF
--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -53,6 +53,7 @@ from scipy.conftest import (
     skip_if_array_api_gpu,
     skip_if_array_api_backend,
 )
+from scipy._lib._array_api import xp_assert_close
 
 from . import hierarchy_test_data
 
@@ -71,6 +72,7 @@ except Exception:
 
 
 class TestLinkage:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_linkage_non_finite_elements_in_distance_matrix(self, xp):
@@ -95,7 +97,7 @@ class TestLinkage:
         # Tests linkage(Y, method) on the tdist data set.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), method)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_' + method)
-        assert_allclose(Z, expectedZ, atol=1e-10)
+        xp_assert_close(Z, expectedZ, atol=1e-10)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -107,12 +109,12 @@ class TestLinkage:
         # Tests linkage(Y, method) on the Q data set.
         Z = linkage(xp.asarray(hierarchy_test_data.X), method)
         expectedZ = getattr(hierarchy_test_data, 'linkage_X_' + method)
-        assert_allclose(Z, expectedZ, atol=1e-06)
+        xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
         y = scipy.spatial.distance.pdist(hierarchy_test_data.X,
                                          metric="euclidean")
         Z = linkage(xp.asarray(y), method)
-        assert_allclose(Z, expectedZ, atol=1e-06)
+        xp_assert_close(Z, expectedZ, atol=1e-06)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -125,17 +127,18 @@ class TestLinkage:
         for method, code in _LINKAGE_METHODS.items():
             Z_trivial = _hierarchy.linkage(d, n, code)
             Z = linkage(xp.asarray(d), method)
-            assert_allclose(Z_trivial, Z, rtol=1e-14, atol=1e-15)
+            xp_assert_close(Z, Z_trivial, rtol=1e-14, atol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_optimal_leaf_ordering(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), optimal_ordering=True)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_single_olo')
-        assert_allclose(Z, expectedZ, atol=1e-10)
+        xp_assert_close(Z, expectedZ, atol=1e-10)
 
 
 class TestLinkageTies:
+
     _expectations = {
         'single': np.array([[0, 1, 1.41421356, 2],
                             [2, 3, 1.41421356, 3]]),
@@ -163,10 +166,11 @@ class TestLinkageTies:
         X = xp.asarray([[-1, -1], [0, 0], [1, 1]])
         Z = linkage(X, method=method)
         expectedZ = self._expectations[method]
-        assert_allclose(Z, expectedZ, atol=1e-06)
+        xp_assert_close(Z, expectedZ, atol=1e-06)
 
 
 class TestInconsistent:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_inconsistent_tdist(self, xp):
@@ -175,11 +179,12 @@ class TestInconsistent:
 
     def check_inconsistent_tdist(self, depth, xp):
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
-        assert_allclose(inconsistent(Z, depth),
+        xp_assert_close(inconsistent(Z, depth),
                         hierarchy_test_data.inconsistent_ytdist[depth])
 
 
 class TestCopheneticDistance:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_linkage_cophenet_tdist_Z(self, xp):
@@ -188,7 +193,7 @@ class TestCopheneticDistance:
                                 295, 138, 219, 295, 295])
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
         M = cophenet(Z)
-        assert_allclose(M, expectedM, atol=1e-10)
+        xp_assert_close(M, expectedM, atol=1e-10)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -199,11 +204,12 @@ class TestCopheneticDistance:
         expectedM = xp.asarray([268, 295, 255, 255, 295, 295, 268, 268, 295, 295,
                                 295, 138, 219, 295, 295])
         expectedc = 0.639931296433393415057366837573
-        assert_allclose(c, expectedc, atol=1e-10)
-        assert_allclose(M, expectedM, atol=1e-10)
+        xp_assert_close(c, expectedc, atol=1e-10)
+        xp_assert_close(M, expectedM, atol=1e-10)
 
 
 class TestMLabLinkageConversion:
+
     @skip_if_array_api
     def test_mlab_linkage_conversion_empty(self):
         # Tests from/to_mlab_linkage on empty linkage array.
@@ -217,8 +223,8 @@ class TestMLabLinkageConversion:
         # Tests from/to_mlab_linkage on linkage array with single row.
         Z = xp.asarray([[0., 1., 3., 2.]])
         Zm = xp.asarray([[1, 2, 3]])
-        assert_allclose(from_mlab_linkage(Zm), Z, rtol=1e-15)
-        assert_allclose(to_mlab_linkage(Z), Zm, rtol=1e-15)
+        xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15)
+        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -232,11 +238,12 @@ class TestMLabLinkageConversion:
                         [1., 8., 268., 4.],
                         [6., 9., 295., 6.]],
                        dtype=xp.float64)
-        assert_allclose(from_mlab_linkage(Zm), Z, rtol=1e-15)
-        assert_allclose(to_mlab_linkage(Z), Zm, rtol=1e-15)
+        xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15)
+        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15)
 
 
 class TestFcluster:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_fclusterdata(self, xp):
@@ -293,6 +300,7 @@ class TestFcluster:
 
 
 class TestLeaders:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_leaders_single(self, xp):
@@ -309,6 +317,7 @@ class TestLeaders:
 
 
 class TestIsIsomorphic:
+
     @skip_if_array_api
     def test_is_isomorphic_1(self):
         # Tests is_isomorphic on test case #1 (one flat cluster, different labellings)
@@ -394,6 +403,7 @@ class TestIsIsomorphic:
 
 
 class TestIsValidLinkage:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_is_valid_linkage_various_size(self, xp):
@@ -492,6 +502,7 @@ class TestIsValidLinkage:
 
 
 class TestIsValidInconsistent:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_is_valid_im_int_type(self, xp):
@@ -581,6 +592,7 @@ class TestIsValidInconsistent:
 
 
 class TestNumObsLinkage:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_num_obs_linkage_empty(self, xp):
@@ -614,6 +626,7 @@ class TestNumObsLinkage:
 
 
 class TestLeavesList:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_leaves_list_1x4(self, xp):
@@ -658,6 +671,7 @@ class TestLeavesList:
 
 
 class TestCorrespond:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_correspond_empty(self, xp):
@@ -695,8 +709,8 @@ class TestCorrespond:
             y2 = xp.asarray(y2)
             Z = linkage(y)
             Z2 = linkage(y2)
-            assert_equal(correspond(Z, y2), False)
-            assert_equal(correspond(Z2, y), False)
+            assert not correspond(Z, y2)
+            assert not correspond(Z2, y)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -711,8 +725,8 @@ class TestCorrespond:
             y2 = xp.asarray(y2)
             Z = linkage(y)
             Z2 = linkage(y2)
-            assert_equal(correspond(Z, y2), False)
-            assert_equal(correspond(Z2, y), False)
+            assert not correspond(Z, y2)
+            assert not correspond(Z2, y)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -727,6 +741,7 @@ class TestCorrespond:
 
 
 class TestIsMonotonic:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_is_monotonic_empty(self, xp):
@@ -739,7 +754,7 @@ class TestIsMonotonic:
     def test_is_monotonic_1x4(self, xp):
         # Tests is_monotonic(Z) on 1x4 linkage. Expecting True.
         Z = xp.asarray([[0, 1, 0.3, 2]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), True)
+        assert is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -747,7 +762,7 @@ class TestIsMonotonic:
         # Tests is_monotonic(Z) on 2x4 linkage. Expecting True.
         Z = xp.asarray([[0, 1, 0.3, 2],
                         [2, 3, 0.4, 3]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), True)
+        assert is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -755,7 +770,7 @@ class TestIsMonotonic:
         # Tests is_monotonic(Z) on 2x4 linkage. Expecting False.
         Z = xp.asarray([[0, 1, 0.4, 2],
                         [2, 3, 0.3, 3]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), False)
+        assert not is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -764,7 +779,7 @@ class TestIsMonotonic:
         Z = xp.asarray([[0, 1, 0.3, 2],
                         [2, 3, 0.4, 2],
                         [4, 5, 0.6, 4]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), True)
+        assert is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -773,7 +788,7 @@ class TestIsMonotonic:
         Z = xp.asarray([[0, 1, 0.3, 2],
                         [2, 3, 0.2, 2],
                         [4, 5, 0.6, 4]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), False)
+        assert not is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -782,7 +797,7 @@ class TestIsMonotonic:
         Z = xp.asarray([[0, 1, 0.8, 2],
                         [2, 3, 0.4, 2],
                         [4, 5, 0.6, 4]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), False)
+        assert not is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -791,7 +806,7 @@ class TestIsMonotonic:
         Z = xp.asarray([[0, 1, 0.3, 2],
                         [2, 3, 0.4, 2],
                         [4, 5, 0.2, 4]], dtype=xp.float64)
-        assert_allclose(is_monotonic(Z), False)
+        assert not is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -799,7 +814,7 @@ class TestIsMonotonic:
         # Tests is_monotonic(Z) on clustering generated by single linkage on
         # tdist data set. Expecting True.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
-        assert_allclose(is_monotonic(Z), True)
+        assert is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -808,7 +823,7 @@ class TestIsMonotonic:
         # tdist data set. Perturbing. Expecting False.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
         Z[2,2] = 0.0
-        assert_allclose(is_monotonic(Z), False)
+        assert not is_monotonic(Z)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -817,10 +832,11 @@ class TestIsMonotonic:
         # Q data set. Expecting True.
         X = xp.asarray(hierarchy_test_data.Q_X)
         Z = linkage(X, 'single')
-        assert_allclose(is_monotonic(Z), True)
+        assert is_monotonic(Z)
 
 
 class TestMaxDists:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_maxdists_empty_linkage(self, xp):
@@ -835,7 +851,7 @@ class TestMaxDists:
         Z = xp.asarray([[0, 1, 0.3, 4]], dtype=xp.float64)
         MD = maxdists(Z)
         expectedMD = calculate_maximum_distances(Z, xp)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -849,10 +865,11 @@ class TestMaxDists:
         Z = linkage(X, method)
         MD = maxdists(Z)
         expectedMD = calculate_maximum_distances(Z, xp)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
 
 class TestMaxInconsts:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_maxinconsts_empty_linkage(self, xp):
@@ -878,7 +895,7 @@ class TestMaxInconsts:
         R = xp.asarray([[0, 0, 0, 0.3]], dtype=xp.float64)
         MD = maxinconsts(Z, R)
         expectedMD = calculate_maximum_inconsistencies(Z, R, xp=xp)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -893,10 +910,11 @@ class TestMaxInconsts:
         R = inconsistent(Z)
         MD = maxinconsts(Z, R)
         expectedMD = calculate_maximum_inconsistencies(Z, R, xp=xp)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
 
 class TestMaxRStat:
+
     @array_api_compatible
     def test_maxRstat_invalid_index(self, xp):
         for i in [3.3, -1, 4]:
@@ -948,7 +966,7 @@ class TestMaxRStat:
         R = xp.asarray([[0, 0, 0, 0.3]], dtype=xp.float64)
         MD = maxRstat(Z, R, 1)
         expectedMD = calculate_maximum_inconsistencies(Z, R, 1, xp)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -963,11 +981,12 @@ class TestMaxRStat:
         Z = linkage(X, method)
         R = inconsistent(Z)
         MD = maxRstat(Z, R, 1)
-        expectedMD = calculate_maximum_inconsistencies(Z, R, 1)
-        assert_allclose(MD, expectedMD, atol=1e-15)
+        expectedMD = calculate_maximum_inconsistencies(Z, R, 1, xp)
+        xp_assert_close(MD, expectedMD, atol=1e-15)
 
 
 class TestDendrogram:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_dendrogram_single_linkage_tdist(self, xp):
@@ -1058,8 +1077,8 @@ class TestDendrogram:
             if orientation in ['top', 'bottom']
             else ax.get_yticklabels()[0]
         )
-        assert_allclose(testlabel.get_rotation(), 90, rtol=1e-15)
-        assert_allclose(testlabel.get_size(), 20, rtol=1e-15)
+        assert_equal(testlabel.get_rotation(), 90)
+        assert_equal(testlabel.get_size(), 20)
         dendrogram(Z, ax=ax, orientation=orientation,
                    leaf_rotation=90)
         testlabel = (
@@ -1067,7 +1086,7 @@ class TestDendrogram:
             if orientation in ['top', 'bottom']
             else ax.get_yticklabels()[0]
         )
-        assert_allclose(testlabel.get_rotation(), 90, rtol=1e-15)
+        assert_equal(testlabel.get_rotation(), 90)
         dendrogram(Z, ax=ax, orientation=orientation,
                    leaf_font_size=20)
         testlabel = (
@@ -1075,7 +1094,7 @@ class TestDendrogram:
             if orientation in ['top', 'bottom']
             else ax.get_yticklabels()[0]
         )
-        assert_allclose(testlabel.get_size(), 20, rtol=1e-15)
+        assert_equal(testlabel.get_size(), 20)
         plt.close()
 
         # test plotting to gca (will import pylab)
@@ -1224,7 +1243,7 @@ def test_euclidean_linkage_value_error(xp):
 def test_2x2_linkage(xp):
     Z1 = linkage(xp.asarray([1]), method='single', metric='euclidean')
     Z2 = linkage(xp.asarray([[0, 1], [0, 0]]), method='single', metric='euclidean')
-    assert_allclose(Z1, Z2, rtol=1e-15)
+    xp_assert_close(Z1, Z2, rtol=1e-15)
 
 
 @skip_if_array_api_gpu
@@ -1253,22 +1272,22 @@ def test_cut_tree(xp):
     Z = scipy.cluster.hierarchy.ward(X)
     cutree = cut_tree(Z)
 
-    assert_allclose(cutree[:, 0], xp.arange(nobs), rtol=1e-15)
-    assert_allclose(cutree[:, -1], xp.zeros(nobs), rtol=1e-15)
+    xp_assert_close(cutree[:, 0], xp.arange(nobs), rtol=1e-15)
+    xp_assert_close(cutree[:, -1], xp.zeros(nobs), rtol=1e-15)
     assert_equal(np.asarray(cutree).max(0), np.arange(nobs - 1, -1, -1))
 
-    assert_allclose(cutree[:, [-5]], cut_tree(Z, n_clusters=5), rtol=1e-15)
-    assert_allclose(cutree[:, [-5, -10]], cut_tree(Z, n_clusters=[5, 10]), rtol=1e-15)
-    assert_allclose(cutree[:, [-10, -5]], cut_tree(Z, n_clusters=[10, 5]), rtol=1e-15)
+    xp_assert_close(cutree[:, [-5]], cut_tree(Z, n_clusters=5), rtol=1e-15)
+    xp_assert_close(cutree[:, [-5, -10]], cut_tree(Z, n_clusters=[5, 10]), rtol=1e-15)
+    xp_assert_close(cutree[:, [-10, -5]], cut_tree(Z, n_clusters=[10, 5]), rtol=1e-15)
 
     nodes = _order_cluster_tree(Z)
     heights = xp.asarray([node.dist for node in nodes])
 
-    assert_allclose(cutree[:, np.searchsorted(heights, [5])],
+    xp_assert_close(cutree[:, np.searchsorted(heights, [5])],
                     cut_tree(Z, height=5), rtol=1e-15)
-    assert_allclose(cutree[:, np.searchsorted(heights, [5, 10])],
+    xp_assert_close(cutree[:, np.searchsorted(heights, [5, 10])],
                     cut_tree(Z, height=[5, 10]), rtol=1e-15)
-    assert_allclose(cutree[:, np.searchsorted(heights, [10, 5])],
+    xp_assert_close(cutree[:, np.searchsorted(heights, [10, 5])],
                     cut_tree(Z, height=[10, 5]), rtol=1e-15)
 
 
@@ -1279,13 +1298,13 @@ def test_optimal_leaf_ordering(xp):
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.ytdist)),
                               xp.asarray(hierarchy_test_data.ytdist))
     expectedZ = hierarchy_test_data.linkage_ytdist_single_olo
-    assert_allclose(Z, expectedZ, atol=1e-10)
+    xp_assert_close(Z, expectedZ, atol=1e-10)
 
     # test with the observation matrix X
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.X), 'ward'),
                               xp.asarray(hierarchy_test_data.X))
     expectedZ = hierarchy_test_data.linkage_X_ward_olo
-    assert_allclose(Z, expectedZ, atol=1e-06)
+    xp_assert_close(Z, expectedZ, atol=1e-06)
 
 
 @skip_if_array_api

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -193,7 +193,7 @@ class TestCopheneticDistance:
                                 295, 138, 219, 295, 295])
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
         M = cophenet(Z)
-        xp_assert_close(M, expectedM, atol=1e-10, check_dtype=False)
+        xp_assert_close(M, xp.asarray(expectedM, dtype=xp.float64), atol=1e-10)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -202,10 +202,10 @@ class TestCopheneticDistance:
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
         (c, M) = cophenet(Z, xp.asarray(hierarchy_test_data.ytdist))
         expectedM = xp.asarray([268, 295, 255, 255, 295, 295, 268, 268, 295, 295,
-                                295, 138, 219, 295, 295])
-        expectedc = xp.asarray(0.639931296433393415057366837573)[()]
-        xp_assert_close(c, expectedc, atol=1e-10, check_dtype=False)
-        xp_assert_close(M, expectedM, atol=1e-10, check_dtype=False)
+                                295, 138, 219, 295, 295], dtype=xp.float64)
+        expectedc = xp.asarray(0.639931296433393415057366837573, dtype=xp.float64)[()]
+        xp_assert_close(c, expectedc, atol=1e-10)
+        xp_assert_close(M, expectedM, atol=1e-10)
 
 
 class TestMLabLinkageConversion:
@@ -223,8 +223,10 @@ class TestMLabLinkageConversion:
         # Tests from/to_mlab_linkage on linkage array with single row.
         Z = xp.asarray([[0., 1., 3., 2.]])
         Zm = xp.asarray([[1, 2, 3]])
-        xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15, check_dtype=False)
-        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15, check_dtype=False)
+        xp_assert_close(from_mlab_linkage(Zm), xp.asarray(Z, dtype=xp.float64),
+                        rtol=1e-15)
+        xp_assert_close(to_mlab_linkage(Z), xp.asarray(Zm, dtype=xp.float64),
+                        rtol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -239,7 +241,8 @@ class TestMLabLinkageConversion:
                         [6., 9., 295., 6.]],
                        dtype=xp.float64)
         xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15)
-        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15, check_dtype=False)
+        xp_assert_close(to_mlab_linkage(Z), xp.asarray(Zm, dtype=xp.float64),
+                        rtol=1e-15)
 
 
 class TestFcluster:
@@ -1273,6 +1276,7 @@ def test_cut_tree(xp):
     Z = scipy.cluster.hierarchy.ward(X)
     cutree = cut_tree(Z)
 
+    # cutree.dtype varies between int32 and int64 over platforms
     xp_assert_close(cutree[:, 0], xp.arange(nobs), rtol=1e-15, check_dtype=False)
     xp_assert_close(cutree[:, -1], xp.zeros(nobs), rtol=1e-15, check_dtype=False)
     assert_equal(np.asarray(cutree).max(0), np.arange(nobs - 1, -1, -1))

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1192,7 +1192,7 @@ class TestDendrogram:
 def calculate_maximum_distances(Z, xp):
     # Used for testing correctness of maxdists.
     n = Z.shape[0] + 1
-    B = xp.zeros((n-1,))
+    B = xp.zeros((n-1,), dtype=Z.dtype)
     q = xp.zeros((3,))
     for i in range(0, n - 1):
         q[:] = 0.0
@@ -1210,7 +1210,8 @@ def calculate_maximum_distances(Z, xp):
 def calculate_maximum_inconsistencies(Z, R, k=3, xp=np):
     # Used for testing correctness of maxinconsts.
     n = Z.shape[0] + 1
-    B = xp.zeros((n-1,))
+    dtype = xp.result_type(Z, R)
+    B = xp.zeros((n-1,), dtype=dtype)
     q = xp.zeros((3,))
     for i in range(0, n - 1):
         q[:] = 0.0

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -97,7 +97,7 @@ class TestLinkage:
         # Tests linkage(Y, method) on the tdist data set.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), method)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_' + method)
-        xp_assert_close(Z, expectedZ, atol=1e-10)
+        xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -114,7 +114,7 @@ class TestLinkage:
         y = scipy.spatial.distance.pdist(hierarchy_test_data.X,
                                          metric="euclidean")
         Z = linkage(xp.asarray(y), method)
-        xp_assert_close(Z, expectedZ, atol=1e-06)
+        xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -127,14 +127,14 @@ class TestLinkage:
         for method, code in _LINKAGE_METHODS.items():
             Z_trivial = _hierarchy.linkage(d, n, code)
             Z = linkage(xp.asarray(d), method)
-            xp_assert_close(Z, Z_trivial, rtol=1e-14, atol=1e-15)
+            xp_assert_close(Z, xp.asarray(Z_trivial), rtol=1e-14, atol=1e-15)
 
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_optimal_leaf_ordering(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), optimal_ordering=True)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_single_olo')
-        xp_assert_close(Z, expectedZ, atol=1e-10)
+        xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
 
 class TestLinkageTies:
@@ -166,7 +166,7 @@ class TestLinkageTies:
         X = xp.asarray([[-1, -1], [0, 0], [1, 1]])
         Z = linkage(X, method=method)
         expectedZ = self._expectations[method]
-        xp_assert_close(Z, expectedZ, atol=1e-06)
+        xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
 class TestInconsistent:
@@ -180,7 +180,7 @@ class TestInconsistent:
     def check_inconsistent_tdist(self, depth, xp):
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
         xp_assert_close(inconsistent(Z, depth),
-                        hierarchy_test_data.inconsistent_ytdist[depth])
+                        xp.asarray(hierarchy_test_data.inconsistent_ytdist[depth]))
 
 
 class TestCopheneticDistance:
@@ -203,7 +203,7 @@ class TestCopheneticDistance:
         (c, M) = cophenet(Z, xp.asarray(hierarchy_test_data.ytdist))
         expectedM = xp.asarray([268, 295, 255, 255, 295, 295, 268, 268, 295, 295,
                                 295, 138, 219, 295, 295])
-        expectedc = 0.639931296433393415057366837573
+        expectedc = xp.asarray(0.639931296433393415057366837573)[()]
         xp_assert_close(c, expectedc, atol=1e-10)
         xp_assert_close(M, expectedM, atol=1e-10)
 
@@ -1298,13 +1298,13 @@ def test_optimal_leaf_ordering(xp):
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.ytdist)),
                               xp.asarray(hierarchy_test_data.ytdist))
     expectedZ = hierarchy_test_data.linkage_ytdist_single_olo
-    xp_assert_close(Z, expectedZ, atol=1e-10)
+    xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
     # test with the observation matrix X
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.X), 'ward'),
                               xp.asarray(hierarchy_test_data.X))
     expectedZ = hierarchy_test_data.linkage_X_ward_olo
-    xp_assert_close(Z, expectedZ, atol=1e-06)
+    xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
 @skip_if_array_api

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -193,7 +193,7 @@ class TestCopheneticDistance:
                                 295, 138, 219, 295, 295])
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
         M = cophenet(Z)
-        xp_assert_close(M, expectedM, atol=1e-10)
+        xp_assert_close(M, expectedM, atol=1e-10, check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -204,8 +204,8 @@ class TestCopheneticDistance:
         expectedM = xp.asarray([268, 295, 255, 255, 295, 295, 268, 268, 295, 295,
                                 295, 138, 219, 295, 295])
         expectedc = xp.asarray(0.639931296433393415057366837573)[()]
-        xp_assert_close(c, expectedc, atol=1e-10)
-        xp_assert_close(M, expectedM, atol=1e-10)
+        xp_assert_close(c, expectedc, atol=1e-10, check_dtype=False)
+        xp_assert_close(M, expectedM, atol=1e-10, check_dtype=False)
 
 
 class TestMLabLinkageConversion:
@@ -223,8 +223,8 @@ class TestMLabLinkageConversion:
         # Tests from/to_mlab_linkage on linkage array with single row.
         Z = xp.asarray([[0., 1., 3., 2.]])
         Zm = xp.asarray([[1, 2, 3]])
-        xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15)
-        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15)
+        xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15, check_dtype=False)
+        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15, check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -239,7 +239,7 @@ class TestMLabLinkageConversion:
                         [6., 9., 295., 6.]],
                        dtype=xp.float64)
         xp_assert_close(from_mlab_linkage(Zm), Z, rtol=1e-15)
-        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15)
+        xp_assert_close(to_mlab_linkage(Z), Zm, rtol=1e-15, check_dtype=False)
 
 
 class TestFcluster:
@@ -1274,7 +1274,7 @@ def test_cut_tree(xp):
     cutree = cut_tree(Z)
 
     xp_assert_close(cutree[:, 0], xp.arange(nobs), rtol=1e-15)
-    xp_assert_close(cutree[:, -1], xp.zeros(nobs), rtol=1e-15)
+    xp_assert_close(cutree[:, -1], xp.zeros(nobs), rtol=1e-15, check_dtype=False)
     assert_equal(np.asarray(cutree).max(0), np.arange(nobs - 1, -1, -1))
 
     xp_assert_close(cutree[:, [-5]], cut_tree(Z, n_clusters=5), rtol=1e-15)

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1273,7 +1273,7 @@ def test_cut_tree(xp):
     Z = scipy.cluster.hierarchy.ward(X)
     cutree = cut_tree(Z)
 
-    xp_assert_close(cutree[:, 0], xp.arange(nobs), rtol=1e-15)
+    xp_assert_close(cutree[:, 0], xp.arange(nobs), rtol=1e-15, check_dtype=False)
     xp_assert_close(cutree[:, -1], xp.zeros(nobs), rtol=1e-15, check_dtype=False)
     assert_equal(np.asarray(cutree).max(0), np.arange(nobs - 1, -1, -1))
 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -154,7 +154,7 @@ class TestVq:
         data = xp.asarray(data)
         initc = xp.asarray(initc)
         ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-        xp_assert_equal(ta, xp.asarray(a))
+        xp_assert_equal(ta, xp.asarray(a), check_dtype=False)
         xp_assert_equal(tb, xp.asarray(b))
 
     @skip_if_array_api
@@ -179,7 +179,7 @@ class TestVq:
             xp.asarray(X), xp.asarray(code_book)
         )
         xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0))
+        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
 
         X = X.astype(np.float32)
         code_book = code_book.astype(np.float32)
@@ -188,8 +188,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0))
+        xp_assert_close(dis1, xp.asarray(dis0), 1e-5, check_dtype=False)
+        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -202,7 +202,7 @@ class TestVq:
             xp.asarray(X), xp.asarray(code_book)
         )
         xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0))
+        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
 
 
 # Whole class skipped on GPU for now;
@@ -350,8 +350,8 @@ class TestKMean:
         # Regression test for gh-1774
         x = xp.asarray([1, 2, 3, 4, 10], dtype=xp.float64)
         res = kmeans(x, xp.asarray(1), thresh=1e16)
-        xp_assert_close(res[0], xp.asarray([4.]))
-        xp_assert_close(res[1], xp.asarray(2.3999999999999999)[()])
+        xp_assert_close(res[0], xp.asarray([4.]), check_dtype=False)
+        xp_assert_close(res[1], xp.asarray(2.3999999999999999)[()], check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -361,7 +361,7 @@ class TestKMean:
                                [-3.153375, 3.3945]])
         np.random.seed(42)
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), xp.asarray(2), minit='++')
-        xp_assert_close(res, prev_res)
+        xp_assert_close(res, prev_res, check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -387,8 +387,8 @@ class TestKMean:
         # Regression test for gh-8727
         obs = xp.asarray([-3, -1, 0, 1, 1, 8], dtype=xp.float64)
         res = kmeans(obs, xp.asarray([-3., 0.99]))
-        xp_assert_close(res[0], xp.asarray([-0.4,  8.]))
-        xp_assert_close(res[1], xp.asarray(1.0666666666666667)[()])
+        xp_assert_close(res[0], xp.asarray([-0.4,  8.]), check_dtype=False)
+        xp_assert_close(res[1], xp.asarray(1.0666666666666667)[()], check_dtype=False)
 
     @skip_if_array_api
     def test_kmeans_and_kmeans2_random_seed(self):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -134,7 +134,7 @@ class TestVq:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             label1 = py_vq(tp(X), tp(initc))[0]
-            xp_assert_equal(label1, xp.asarray(LABEL1))
+            xp_assert_equal(label1, xp.asarray(LABEL1), check_dtype=False)
 
     @skip_if_array_api
     def test_vq(self):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -134,7 +134,7 @@ class TestVq:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             label1 = py_vq(tp(X), tp(initc))[0]
-            xp_assert_equal(label1, xp.asarray(LABEL1), check_dtype=False)
+            xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64))
 
     @skip_if_array_api
     def test_vq(self):
@@ -154,7 +154,7 @@ class TestVq:
         data = xp.asarray(data)
         initc = xp.asarray(initc)
         ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-        xp_assert_equal(ta, xp.asarray(a), check_dtype=False)
+        xp_assert_equal(ta, xp.asarray(a, dtype=xp.int64))
         xp_assert_equal(tb, xp.asarray(b))
 
     @skip_if_array_api
@@ -178,8 +178,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
+        xp_assert_close(dis1, xp.asarray(dis0), rtol=1e-5)
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
 
         X = X.astype(np.float32)
         code_book = code_book.astype(np.float32)
@@ -188,8 +188,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis1, xp.asarray(dis0), 1e-5, check_dtype=False)
-        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
+        xp_assert_close(dis1, xp.asarray(dis0, dtype=xp.float64), rtol=1e-5)
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -202,7 +202,7 @@ class TestVq:
             xp.asarray(X), xp.asarray(code_book)
         )
         xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0), check_dtype=False)
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
 
 
 # Whole class skipped on GPU for now;
@@ -350,18 +350,18 @@ class TestKMean:
         # Regression test for gh-1774
         x = xp.asarray([1, 2, 3, 4, 10], dtype=xp.float64)
         res = kmeans(x, xp.asarray(1), thresh=1e16)
-        xp_assert_close(res[0], xp.asarray([4.]), check_dtype=False)
-        xp_assert_close(res[1], xp.asarray(2.3999999999999999)[()], check_dtype=False)
+        xp_assert_close(res[0], xp.asarray([4.], dtype=xp.float64))
+        xp_assert_close(res[1], xp.asarray(2.3999999999999999, dtype=xp.float64)[()])
 
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_kmeans2_kpp_low_dim(self, xp):
         # Regression test for gh-11462
         prev_res = xp.asarray([[-1.95266667, 0.898],
-                               [-3.153375, 3.3945]])
+                               [-3.153375, 3.3945]], dtype=xp.float64)
         np.random.seed(42)
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), xp.asarray(2), minit='++')
-        xp_assert_close(res, prev_res, check_dtype=False)
+        xp_assert_close(res, prev_res)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -387,8 +387,8 @@ class TestKMean:
         # Regression test for gh-8727
         obs = xp.asarray([-3, -1, 0, 1, 1, 8], dtype=xp.float64)
         res = kmeans(obs, xp.asarray([-3., 0.99]))
-        xp_assert_close(res[0], xp.asarray([-0.4,  8.]), check_dtype=False)
-        xp_assert_close(res[1], xp.asarray(1.0666666666666667)[()], check_dtype=False)
+        xp_assert_close(res[0], xp.asarray([-0.4,  8.], dtype=xp.float64))
+        xp_assert_close(res[1], xp.asarray(1.0666666666666667, dtype=xp.float64)[()])
 
     @skip_if_array_api
     def test_kmeans_and_kmeans2_random_seed(self):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -379,7 +379,7 @@ class TestKMean:
 
         data = xp.asarray(data)
         res, _ = kmeans2(data, xp.asarray(2), minit='++')
-        xp_assert_close(res, xp.asarray(centers), rtol=0.2)
+        xp_assert_equal(xp.sign(res), xp.sign(xp.asarray(centers)))
 
     @skip_if_array_api_gpu
     @array_api_compatible

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -134,7 +134,7 @@ class TestVq:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             label1 = py_vq(tp(X), tp(initc))[0]
-            xp_assert_equal(label1, LABEL1)
+            xp_assert_equal(label1, xp.asarray(LABEL1))
 
     @skip_if_array_api
     def test_vq(self):
@@ -154,8 +154,8 @@ class TestVq:
         data = xp.asarray(data)
         initc = xp.asarray(initc)
         ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-        xp_assert_equal(a, ta)
-        xp_assert_equal(b, tb)
+        xp_assert_equal(ta, xp.asarray(a))
+        xp_assert_equal(tb, xp.asarray(b))
 
     @skip_if_array_api
     def test__vq_sametype(self):
@@ -178,8 +178,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis0, dis1, 1e-5)
-        xp_assert_equal(codes0, codes1)
+        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
+        xp_assert_equal(codes1, xp.asarray(codes0))
 
         X = X.astype(np.float32)
         code_book = code_book.astype(np.float32)
@@ -188,8 +188,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis0, dis1, 1e-5)
-        xp_assert_equal(codes0, codes1)
+        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
+        xp_assert_equal(codes1, xp.asarray(codes0))
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -201,8 +201,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis0, dis1, 1e-5)
-        xp_assert_equal(codes0, codes1)
+        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
+        xp_assert_equal(codes1, xp.asarray(codes0))
 
 
 # Whole class skipped on GPU for now;
@@ -236,7 +236,7 @@ class TestKMean:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             code1 = kmeans(tp(X), tp(initc), iter=1)[0]
-            xp_assert_close(code1, CODET2)
+            xp_assert_close(code1, xp.asarray(CODET2))
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -266,8 +266,8 @@ class TestKMean:
             code1 = kmeans2(tp(X), tp(initc), iter=1)[0]
             code2 = kmeans2(tp(X), tp(initc), iter=2)[0]
 
-            xp_assert_close(code1, CODET1)
-            xp_assert_close(code2, CODET2)
+            xp_assert_close(code1, xp.asarray(CODET1))
+            xp_assert_close(code2, xp.asarray(CODET2))
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -351,7 +351,7 @@ class TestKMean:
         x = xp.asarray([1, 2, 3, 4, 10], dtype=xp.float64)
         res = kmeans(x, xp.asarray(1), thresh=1e16)
         xp_assert_close(res[0], xp.asarray([4.]))
-        xp_assert_close(res[1], 2.3999999999999999)
+        xp_assert_close(res[1], xp.asarray(2.3999999999999999)[()])
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -379,7 +379,7 @@ class TestKMean:
 
         data = xp.asarray(data)
         res, _ = kmeans2(data, xp.asarray(2), minit='++')
-        xp_assert_close(res, centers, rtol=0.2)
+        xp_assert_close(res, xp.asarray(centers), rtol=0.2)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -388,7 +388,7 @@ class TestKMean:
         obs = xp.asarray([-3, -1, 0, 1, 1, 8], dtype=xp.float64)
         res = kmeans(obs, xp.asarray([-3., 0.99]))
         xp_assert_close(res[0], xp.asarray([-0.4,  8.]))
-        xp_assert_close(res[1], 1.0666666666666667)
+        xp_assert_close(res[1], xp.asarray(1.0666666666666667)[()])
 
     @skip_if_array_api
     def test_kmeans_and_kmeans2_random_seed(self):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -133,8 +133,10 @@ class TestVq:
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
+            # label1.dtype varies between int32 and int64 over platforms
             label1 = py_vq(tp(X), tp(initc))[0]
-            xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64))
+            xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64),
+                            check_dtype=False)
 
     @skip_if_array_api
     def test_vq(self):
@@ -154,7 +156,8 @@ class TestVq:
         data = xp.asarray(data)
         initc = xp.asarray(initc)
         ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-        xp_assert_equal(ta, xp.asarray(a, dtype=xp.int64))
+        # ta.dtype varies between int32 and int64 over platforms
+        xp_assert_equal(ta, xp.asarray(a, dtype=xp.int64), check_dtype=False)
         xp_assert_equal(tb, xp.asarray(b))
 
     @skip_if_array_api
@@ -179,7 +182,8 @@ class TestVq:
             xp.asarray(X), xp.asarray(code_book)
         )
         xp_assert_close(dis1, xp.asarray(dis0), rtol=1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
+        # codes1.dtype varies between int32 and int64 over platforms
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64), check_dtype=False)
 
         X = X.astype(np.float32)
         code_book = code_book.astype(np.float32)
@@ -189,7 +193,8 @@ class TestVq:
             xp.asarray(X), xp.asarray(code_book)
         )
         xp_assert_close(dis1, xp.asarray(dis0, dtype=xp.float64), rtol=1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
+        # codes1.dtype varies between int32 and int64 over platforms
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64), check_dtype=False)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -201,8 +206,9 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        xp_assert_close(dis1, xp.asarray(dis0), 1e-5)
-        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64))
+        xp_assert_close(dis1, xp.asarray(dis0), rtol=1e-5)
+        # codes1.dtype varies between int32 and int64 over platforms
+        xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64), check_dtype=False)
 
 
 # Whole class skipped on GPU for now;

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -2,9 +2,9 @@ import warnings
 import sys
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_allclose, assert_equal, assert_,
-                           suppress_warnings)
+from numpy.testing import (
+    assert_array_equal, assert_allclose, assert_equal, assert_, suppress_warnings
+)
 import pytest
 from pytest import raises as assert_raises
 
@@ -19,9 +19,7 @@ from scipy.conftest import (
 from scipy.sparse._sputils import matrix
 
 from scipy._lib._array_api import (
-    SCIPY_ARRAY_API,
-    copy,
-    cov
+    SCIPY_ARRAY_API, copy, cov, xp_assert_close, xp_assert_equal
 )
 
 TESTDATA_2D = np.array([
@@ -81,6 +79,7 @@ LABEL1 = np.array([0, 1, 2, 2, 2, 2, 1, 2, 1, 1, 1])
 
 
 class TestWhiten:
+
     @array_api_compatible
     def test_whiten(self, xp):
         desired = xp.asarray([[5.08738849, 2.97091878],
@@ -94,17 +93,13 @@ class TestWhiten:
                           [0.87545741, 0.00735733],
                           [0.85124403, 0.26499712],
                           [0.45067590, 0.45464607]])
-        if "cupy" in xp.__name__:
-            import cupy as cp
-            cp.testing.assert_allclose(whiten(obs), desired, rtol=1e-5)
-        else:
-            assert_allclose(whiten(obs), desired, rtol=1e-5)
+        xp_assert_close(whiten(obs), desired, rtol=1e-5)
 
     @array_api_compatible
     def test_whiten_zero_std(self, xp):
-        desired = np.array([[0., 1.0, 2.86666544],
-                            [0., 1.0, 1.32460034],
-                            [0., 1.0, 3.74382172]])
+        desired = xp.asarray([[0., 1.0, 2.86666544],
+                              [0., 1.0, 1.32460034],
+                              [0., 1.0, 3.74382172]])
 
         obs = xp.asarray([[0., 1., 0.74109533],
                           [0., 1., 0.34243798],
@@ -112,11 +107,7 @@ class TestWhiten:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
 
-            if "cupy" in xp.__name__:
-                import cupy as cp
-                cp.testing.assert_allclose(whiten(obs), desired, rtol=1e-5)
-            else:
-                assert_allclose(whiten(obs), desired, rtol=1e-5)
+            xp_assert_close(whiten(obs), desired, rtol=1e-5)
 
             assert_equal(len(w), 1)
             assert_(issubclass(w[-1].category, RuntimeWarning))
@@ -135,6 +126,7 @@ class TestWhiten:
 
 
 class TestVq:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_py_vq(self, xp):
@@ -142,7 +134,7 @@ class TestVq:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             label1 = py_vq(tp(X), tp(initc))[0]
-            assert_array_equal(label1, LABEL1)
+            xp_assert_equal(label1, LABEL1)
 
     @skip_if_array_api
     def test_vq(self):
@@ -162,8 +154,8 @@ class TestVq:
         data = xp.asarray(data)
         initc = xp.asarray(initc)
         ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-        assert_array_equal(a, ta)
-        assert_array_equal(b, tb)
+        xp_assert_equal(a, ta)
+        xp_assert_equal(b, tb)
 
     @skip_if_array_api
     def test__vq_sametype(self):
@@ -186,8 +178,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        assert_allclose(dis0, dis1, 1e-5)
-        assert_array_equal(codes0, codes1)
+        xp_assert_close(dis0, dis1, 1e-5)
+        xp_assert_equal(codes0, codes1)
 
         X = X.astype(np.float32)
         code_book = code_book.astype(np.float32)
@@ -196,8 +188,8 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        assert_allclose(dis0, dis1, 1e-5)
-        assert_array_equal(codes0, codes1)
+        xp_assert_close(dis0, dis1, 1e-5)
+        xp_assert_equal(codes0, codes1)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -209,13 +201,14 @@ class TestVq:
         codes1, dis1 = py_vq(
             xp.asarray(X), xp.asarray(code_book)
         )
-        assert_allclose(dis0, dis1, 1e-5)
-        assert_array_equal(codes0, codes1)
+        xp_assert_close(dis0, dis1, 1e-5)
+        xp_assert_equal(codes0, codes1)
 
 
 # Whole class skipped on GPU for now;
 # once pdist/cdist are hooked up for CuPy, more tests will work
 class TestKMean:
+
     @skip_if_array_api_gpu
     @array_api_compatible
     def test_large_features(self, xp):
@@ -243,7 +236,7 @@ class TestKMean:
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
             code1 = kmeans(tp(X), tp(initc), iter=1)[0]
-            assert_array_almost_equal(code1, CODET2)
+            xp_assert_close(code1, CODET2)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -273,8 +266,8 @@ class TestKMean:
             code1 = kmeans2(tp(X), tp(initc), iter=1)[0]
             code2 = kmeans2(tp(X), tp(initc), iter=2)[0]
 
-            assert_array_almost_equal(code1, CODET1)
-            assert_array_almost_equal(code2, CODET2)
+            xp_assert_close(code1, CODET1)
+            xp_assert_close(code2, CODET2)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -336,7 +329,7 @@ class TestKMean:
             init = _krandinit(data, k, rng, xp)
             orig_cov = cov(data.T)
             init_cov = cov(init.T)
-            assert_allclose(orig_cov, init_cov, atol=1e-2)
+            xp_assert_close(orig_cov, init_cov, atol=1e-2)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -357,8 +350,8 @@ class TestKMean:
         # Regression test for gh-1774
         x = xp.asarray([1, 2, 3, 4, 10], dtype=xp.float64)
         res = kmeans(x, xp.asarray(1), thresh=1e16)
-        assert_allclose(res[0], xp.asarray([4.]))
-        assert_allclose(res[1], 2.3999999999999999)
+        xp_assert_close(res[0], xp.asarray([4.]))
+        xp_assert_close(res[1], 2.3999999999999999)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -368,7 +361,7 @@ class TestKMean:
                                [-3.153375, 3.3945]])
         np.random.seed(42)
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), xp.asarray(2), minit='++')
-        assert_allclose(res, prev_res)
+        xp_assert_close(res, prev_res)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -386,7 +379,7 @@ class TestKMean:
 
         data = xp.asarray(data)
         res, _ = kmeans2(data, xp.asarray(2), minit='++')
-        assert_array_almost_equal(res, centers, decimal=0)
+        xp_assert_close(res, centers, rtol=0.2)
 
     @skip_if_array_api_gpu
     @array_api_compatible
@@ -394,8 +387,8 @@ class TestKMean:
         # Regression test for gh-8727
         obs = xp.asarray([-3, -1, 0, 1, 1, 8], dtype=xp.float64)
         res = kmeans(obs, xp.asarray([-3., 0.99]))
-        assert_allclose(res[0], xp.asarray([-0.4,  8.]))
-        assert_allclose(res[1], 1.0666666666666667)
+        xp_assert_close(res[0], xp.asarray([-0.4,  8.]))
+        xp_assert_close(res[1], 1.0666666666666667)
 
     @skip_if_array_api
     def test_kmeans_and_kmeans2_random_seed(self):


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-19186 for gh-18668.

#### What does this implement/fix?
The new assertions `xp_assert_close` and `xp_assert_equal` are used in `cluster`, such that all of our array-API-converted code demonstrates the preferred methods of testing.

There are a few other changes in here, like changing `assert_equal(correspond(Z, y2), False)` to `assert not correspond(Z, y2)`, and some minor PEP-8 bits. I hope that that's okay, but please let me know if you'd like those removed.

#### Additional information
@mdhaber how does this look? `python dev.py test -s cluster -b all` passes for me, but there are a few tricky bits in here with dtypes, scalars and tolerances which could do with a look over. I think that I've covered everything, but there's a chance that I've missed something, or included an unwanted change.

cc: @tupui 