### PR TITLE
MAINT: Cleanup expired ndarray methods

### DIFF
--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -618,7 +618,7 @@ def _replace_heap(variable, heap):
                 replace, new = _replace_heap(variable.item(iv), heap)
 
                 if replace:
-                    variable.itemset(iv, new)
+                    variable.reshape(-1)[iv] = new
 
         return False, variable
 

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -935,7 +935,7 @@ class netcdf_variable:
             # of NumPy still supported by scipy contains the fix for #1622.
             raise RuntimeError("variable is not writeable")
 
-        self.data.itemset(value)
+        self.data[:] = value
 
     def typecode(self):
         """

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -533,7 +533,7 @@ class VarWriter5:
             mdtype = NP_TO_MTYPES[arr.dtype.str[1:]]
         # Array needs to be in native byte order
         if arr.dtype.byteorder == swapped_code:
-            arr = arr.byteswap().newbyteorder()
+            arr = arr.byteswap().view(arr.dtype.newbyteorder())
         byte_count = arr.size*arr.itemsize
         if byte_count <= 4:
             self.write_smalldata_element(arr, mdtype, byte_count)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -919,9 +919,11 @@ def test_write_opposite_endian():
     int_arr = np.arange(6).reshape((2, 3))
     uni_arr = np.array(['hello', 'world'], dtype='U')
     stream = BytesIO()
-    savemat(stream, {'floats': float_arr.byteswap().newbyteorder(),
-                            'ints': int_arr.byteswap().newbyteorder(),
-                            'uni_arr': uni_arr.byteswap().newbyteorder()})
+    savemat(stream, {
+        'floats': float_arr.byteswap().view(float_arr.dtype.newbyteorder()),
+        'ints': int_arr.byteswap().view(int_arr.dtype.newbyteorder()),
+        'uni_arr': uni_arr.byteswap().view(uni_arr.dtype.newbyteorder()),
+    })
     rdr = MatFile5Reader(stream)
     d = rdr.get_variables()
     assert_array_equal(d['floats'], float_arr)


### PR DESCRIPTION
Hi!
This PR reflects changes introduced in https://github.com/numpy/numpy/pull/24682.