### PR TITLE
DOC: Added examples for correlation, num_obs_dm, num_obs_y functions.

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -630,7 +630,7 @@ def correlation(u, v, w=None, centered=True):
 
     Using a weighting array, the correlation can be calculated as:
 
-    >>> correlation([1, 0, 1],[1, 1, 0], [0.9, 0.1, 0.1])
+    >>> correlation([1, 0, 1], [1, 1, 0], w=[0.9, 0.1, 0.1])
     1.1
 
     If centering is not needed, the correlation can be calculated as:

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -635,7 +635,7 @@ def correlation(u, v, w=None, centered=True):
 
     If centering is not needed, the correlation can be calculated as:
 
-    >>> correlation([1, 0, 1], [1, 1, 0], centered = False)
+    >>> correlation([1, 0, 1], [1, 1, 0], centered=False)
     0.5
     """
     u = _validate_vector(u)
@@ -2624,7 +2624,7 @@ def num_obs_dm(d):
     to a square redundant distance matrix d.
     
     >>> from scipy.spatial.distance import num_obs_dm
-    >>> d = [[0, 100, 200],[100, 0, 150],[200, 150, 0]]
+    >>> d = [[0, 100, 200], [100, 0, 150], [200, 150, 0]]
     >>> num_obs_dm(d)
     3
     """

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2632,6 +2632,7 @@ def num_obs_dm(d):
     is_valid_dm(d, tol=np.inf, throw=True, name='d')
     return d.shape[0]
 
+
 def num_obs_y(Y):
     """
     Return the number of original observations that correspond to a

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -625,7 +625,7 @@ def correlation(u, v, w=None, centered=True):
     Find the correlation between two arrays.
 
     >>> from scipy.spatial.distance import correlation
-    >>> correlation([1, 0, 1],[1, 1, 0])
+    >>> correlation([1, 0, 1], [1, 1, 0])
     1.5
 
     Using a weighting array, the correlation can be calculated as:

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -620,6 +620,23 @@ def correlation(u, v, w=None, centered=True):
     correlation : double
         The correlation distance between 1-D array `u` and `v`.
 
+    Examples
+    --------
+    Find the correlation between two arrays.
+
+    >>> from scipy.spatial.distance import correlation
+    >>> correlation([1, 0, 1],[1, 1, 0])
+    1.5
+
+    Using a weighting array, the correlation can be calculated as:
+
+    >>> correlation([1, 0, 1],[1, 1, 0], [0.9, 0.1, 0.1])
+    1.1
+
+    If centering is not needed, the correlation can be calculated as:
+
+    >>> correlation([1, 0, 1], [1, 1, 0], centered = False)
+    0.5
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
@@ -2601,10 +2618,16 @@ def num_obs_dm(d):
     num_obs_dm : int
         The number of observations in the redundant distance matrix.
 
+    Examples
+    --------
+    Find the number of original observations corresponding
+    to a square redundant distance matrix d.
+    
+    >>> from scipy.spatial.distance import num_obs_dm
+    >>> d = [[0, 100, 200],[100, 0, 150],[200, 150, 0]]
+    >>> num_obs_dm(d)
+    3
     """
-    d = np.asarray(d, order='c')
-    is_valid_dm(d, tol=np.inf, throw=True, name='d')
-    return d.shape[0]
 
 
 def num_obs_y(Y):
@@ -2622,6 +2645,15 @@ def num_obs_y(Y):
     n : int
         The number of observations in the condensed distance matrix `Y`.
 
+    Examples
+    --------
+    Find the number of original observations corresponding to a
+    condensed distance matrix Y.
+    
+    >>> from scipy.spatial.distance import num_obs_y
+    >>> Y = [1, 2, 3.5, 7, 10, 4]
+    >>> num_obs_y(Y)
+    4
     """
     Y = np.asarray(Y, order='c')
     is_valid_y(Y, throw=True, name='Y')

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2628,7 +2628,9 @@ def num_obs_dm(d):
     >>> num_obs_dm(d)
     3
     """
-
+    d = np.asarray(d, order='c')
+    is_valid_dm(d, tol=np.inf, throw=True, name='d')
+    return d.shape[0]
 
 def num_obs_y(Y):
     """


### PR DESCRIPTION
Reference issue
DOC: Add "Examples" to docstrings https://github.com/scipy/scipy/issues/7168

What does this implement/fix?
Added examples for correlation, num_obs_dm, num_obs_y functions.

Additional information
[skip actions] [skip cirrus]
