### PR TITLE
DOC: outline workaround when precision losses occur in BFGS [skip cir…

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1457,7 +1457,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     ``Desired error not necessarily achieved due to precision loss``, then
     consider setting `gtol` to a higher value. This precision loss typically
     occurs when the (finite difference) numerical differentiation cannot provide
-    sufficient precision to ever satisfy the `gtol` termination criterion.
+    sufficient precision to satisfy the `gtol` termination criterion.
     This can happen when working in single precision and a callable jac is not
     provided. For single precision problems a `gtol` of 1e-3 seems to work.
     """

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1454,7 +1454,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
 
     If minimization doesn't complete successfully, with an error message of
-    `Desired error not necessarily achieved due to precision loss`, then
+    ``Desired error not necessarily achieved due to precision loss``, then
     consider setting `gtol` to a higher value. This precision loss typically
     occurs when the (finite difference) numerical differentiation cannot provide
     sufficient precision to ever satisfy the `gtol` termination criterion.

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1452,6 +1452,14 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     Notes
     -----
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
+
+    If minimization doesn't complete successfully, with an error message of
+    `Desired error not necessarily achieved due to precision loss`, then
+    consider setting `gtol` to a higher value. This precision loss typically
+    occurs when the (finite difference) numerical differentiation cannot provide
+    sufficient precision to ever satisfy the `gtol` termination criterion.
+    This can happen when working in single precision and a callable jac is not
+    provided.
     """
     _check_unknown_options(unknown_options)
     _check_positive_definite(hess_inv0)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1459,7 +1459,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     occurs when the (finite difference) numerical differentiation cannot provide
     sufficient precision to ever satisfy the `gtol` termination criterion.
     This can happen when working in single precision and a callable jac is not
-    provided.
+    provided. For single precision problems a `gtol` of 1e-3 seems to work.
     """
     _check_unknown_options(unknown_options)
     _check_positive_definite(hess_inv0)


### PR DESCRIPTION
This PR outlines what to do when `result.success is False` and `result.message == 'Desired error not necessarily achieved due to precision loss'` when using BFGS. This was reported in #19024. The reason this happens is the `gtol` termination criterion can be too small, so the minimisation loop never terminates. Eventually the linesearch reaches a point where it can't go any further because it recognises the precision in numerical differentiation means further iteration isn't possible, hence the reported message.

The solution is to relax the `gtol` convergence parameter.

For problems in double precision the default value of `gtol=1e-5` seems to work well.
For problems in single precision `gtol` may need to be relaxed to e.g. 1e-3.