### PR TITLE
MAINT: fft: clean up test-skips

### DIFF
--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -91,6 +91,7 @@ class TestFFT1D:
         xp_assert_close(expect * (30 * 20), fft.ifft2(x, norm="forward"))
 
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_fftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
@@ -102,6 +103,7 @@ class TestFFT1D:
         xp_assert_close(expect / (30 * 20 * 10), fft.fftn(x, norm="forward"))
 
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_ifftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
@@ -153,6 +155,7 @@ class TestFFT1D:
             xp_assert_close(x, fft.irfft2(fft.rfft2(x, norm=norm), norm=norm))
 
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_rfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -164,6 +167,7 @@ class TestFFT1D:
         xp_assert_close(expect / (30 * 20 * 10), fft.rfftn(x, norm="forward"))
 
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_irfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -238,6 +242,7 @@ class TestFFT1D:
 
     @skip_if_array_api_gpu
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_ihfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -483,6 +488,7 @@ def test_multiprocess(func):
 class TestIRFFTN:
 
     @array_api_compatible
+    # torch.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('torch')
     def test_not_last_axis_success(self, xp):
         ar, ai = np.random.random((2, 16, 8, 32))

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -4,15 +4,11 @@ import pytest
 
 from scipy.fft._fftlog import fht, ifht, fhtoffset
 from scipy.special import poch
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api_backend
-)
+
+from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close
 
 
-# https://github.com/pytorch/pytorch/issues/59786
-@skip_if_array_api_backend('torch')
 @array_api_compatible
 def test_fht_agrees_with_fftlog(xp):
     # check that fht numerically agrees with the output from Fortran FFTLog,
@@ -90,8 +86,6 @@ def test_fht_agrees_with_fftlog(xp):
     xp_assert_close(ours, theirs)
 
 
-# https://github.com/pytorch/pytorch/issues/59786
-@skip_if_array_api_backend('torch')
 @array_api_compatible
 @pytest.mark.parametrize('optimal', [True, False])
 @pytest.mark.parametrize('offset', [0.0, 1.0, -1.0])
@@ -113,8 +107,6 @@ def test_fht_identity(n, bias, offset, optimal, xp):
     xp_assert_close(a, a_)
 
 
-# https://github.com/pytorch/pytorch/issues/59786
-@skip_if_array_api_backend('torch')
 @array_api_compatible
 def test_fht_special_cases(xp):
     rng = np.random.RandomState(3491349965)
@@ -149,8 +141,6 @@ def test_fht_special_cases(xp):
         assert record, 'ifht did not warn about a singular transform'
 
 
-# https://github.com/pytorch/pytorch/issues/59786
-@skip_if_array_api_backend('torch')
 @array_api_compatible
 @pytest.mark.parametrize('n', [64, 63])
 def test_fht_exact(n, xp):


### PR DESCRIPTION
#### Reference issue
Towards gh-19257.

#### What does this implement/fix?
- Removes some unnecessary test skips which we forgot about.
- Adds brief descriptions to backend skips where they were missing.
