### PR TITLE
ENH: fft: GPU support for non-standard basic transforms

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -339,3 +339,7 @@ def cov(x, *, xp=None):
 
 def xp_unsupported_param_msg(param):
     return f'Providing {param!r} is only supported for numpy arrays.'
+
+
+def is_complex(x, xp):
+    return x.dtype in [xp.complex64, xp.complex128]

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -342,4 +342,4 @@ def xp_unsupported_param_msg(param):
 
 
 def is_complex(x, xp):
-    return x.dtype in [xp.complex64, xp.complex128]
+    return xp.isdtype(x.dtype, 'complex floating')

--- a/scipy/fft/_basic_backend.py
+++ b/scipy/fft/_basic_backend.py
@@ -1,4 +1,6 @@
-from scipy._lib._array_api import array_namespace, is_numpy, xp_unsupported_param_msg
+from scipy._lib._array_api import (
+    array_namespace, is_numpy, xp_unsupported_param_msg, is_complex
+)
 from . import _pocketfft
 import numpy as np
 
@@ -104,22 +106,12 @@ def ifftn(x, s=None, axes=None, norm=None,
 
 def fft2(x, s=None, axes=(-2, -1), norm=None,
          overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.fft2(x, s=s, axes=axes, norm=norm,
-                        overwrite_x=overwrite_x,
-                        workers=workers, plan=plan)
-    return xp.asarray(y)
+    return fftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
 
 
 def ifft2(x, s=None, axes=(-2, -1), norm=None,
           overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.ifft2(x, s=s, axes=axes, norm=norm,
-                         overwrite_x=overwrite_x,
-                         workers=workers, plan=plan)
-    return xp.asarray(y)
+    return ifftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
 
 
 def rfftn(x, s=None, axes=None, norm=None,
@@ -130,12 +122,7 @@ def rfftn(x, s=None, axes=None, norm=None,
 
 def rfft2(x, s=None, axes=(-2, -1), norm=None,
          overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.rfft2(x, s=s, axes=axes, norm=norm,
-                         overwrite_x=overwrite_x,
-                         workers=workers, plan=plan)
-    return xp.asarray(y)
+    return rfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
 
 
 def irfftn(x, s=None, axes=None, norm=None,
@@ -146,49 +133,46 @@ def irfftn(x, s=None, axes=None, norm=None,
 
 def irfft2(x, s=None, axes=(-2, -1), norm=None,
            overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.irfft2(x, s=s, axes=axes, norm=norm,
-                          overwrite_x=overwrite_x,
-                          workers=workers, plan=plan)
-    return xp.asarray(y)
+    return irfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
+
+
+def _swap_direction(norm):
+    if norm in (None, 'backward'):
+        norm = 'forward'
+    elif norm == 'forward':
+        norm = 'backward'
+    elif norm != 'ortho':
+        raise ValueError('Invalid norm value %s; should be "backward", '
+                         '"ortho", or "forward".' % norm)
+    return norm
 
 
 def hfftn(x, s=None, axes=None, norm=None,
           overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.hfftn(x, s=s, axes=axes, norm=norm,
-                         overwrite_x=overwrite_x,
-                         workers=workers, plan=plan)
-    return xp.asarray(y)
+    if is_complex(x, xp):
+        x = xp.conj(x)
+    return irfftn(x, s, axes, _swap_direction(norm),
+                  overwrite_x, workers, plan=plan)
 
 
 def hfft2(x, s=None, axes=(-2, -1), norm=None,
           overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.hfft2(x, s=s, axes=axes, norm=norm,
-                         overwrite_x=overwrite_x,
-                         workers=workers, plan=plan)
-    return xp.asarray(y)
+    if is_complex(x, xp):
+        x = xp.conj(x)
+    return irfftn(x, s, axes, _swap_direction(norm),
+                  overwrite_x, workers, plan=plan)
 
 
 def ihfftn(x, s=None, axes=None, norm=None,
            overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.ihfftn(x, s=s, axes=axes, norm=norm,
-                          overwrite_x=overwrite_x,
-                          workers=workers, plan=plan)
-    return xp.asarray(y)
-
+    return xp.conj(rfftn(x, s, axes, _swap_direction(norm),
+                         overwrite_x, workers, plan=plan))
 
 def ihfft2(x, s=None, axes=(-2, -1), norm=None,
            overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
-    x = np.asarray(x)
-    y = _pocketfft.ihfft2(x, s=s, axes=axes, norm=norm,
-                          overwrite_x=overwrite_x,
-                          workers=workers, plan=plan)
-    return xp.asarray(y)
+    return xp.conj(rfftn(x, s, axes, _swap_direction(norm),
+                         overwrite_x, workers, plan=plan))

--- a/scipy/fft/_basic_backend.py
+++ b/scipy/fft/_basic_backend.py
@@ -150,6 +150,8 @@ def _swap_direction(norm):
 def hfftn(x, s=None, axes=None, norm=None,
           overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
+    if is_numpy(xp):
+        return _pocketfft.hfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
     if is_complex(x, xp):
         x = xp.conj(x)
     return irfftn(x, s, axes, _swap_direction(norm),
@@ -158,21 +160,17 @@ def hfftn(x, s=None, axes=None, norm=None,
 
 def hfft2(x, s=None, axes=(-2, -1), norm=None,
           overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    if is_complex(x, xp):
-        x = xp.conj(x)
-    return irfftn(x, s, axes, _swap_direction(norm),
-                  overwrite_x, workers, plan=plan)
+    return hfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
 
 
 def ihfftn(x, s=None, axes=None, norm=None,
            overwrite_x=False, workers=None, *, plan=None):
     xp = array_namespace(x)
+    if is_numpy(xp):
+        return _pocketfft.ihfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)
     return xp.conj(rfftn(x, s, axes, _swap_direction(norm),
                          overwrite_x, workers, plan=plan))
 
 def ihfft2(x, s=None, axes=(-2, -1), norm=None,
            overwrite_x=False, workers=None, *, plan=None):
-    xp = array_namespace(x)
-    return xp.conj(rfftn(x, s, axes, _swap_direction(norm),
-                         overwrite_x, workers, plan=plan))
+    return ihfftn(x, s, axes, norm, overwrite_x, workers, plan=plan)

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -103,50 +103,6 @@ irfft = functools.partial(c2r, False)
 irfft.__name__ = 'irfft'
 
 
-def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
-         *, plan=None):
-    """
-    2-D discrete Fourier transform.
-    """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
-    return fftn(x, s, axes, norm, overwrite_x, workers)
-
-
-def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
-          *, plan=None):
-    """
-    2-D discrete inverse Fourier transform of real or complex sequence.
-    """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
-    return ifftn(x, s, axes, norm, overwrite_x, workers)
-
-
-def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
-          *, plan=None):
-    """
-    2-D discrete Fourier transform of a real sequence
-    """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
-    return rfftn(x, s, axes, norm, overwrite_x, workers)
-
-
-def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
-           *, plan=None):
-    """
-    2-D discrete inverse Fourier transform of a real sequence
-    """
-    if plan is not None:
-        raise NotImplementedError('Passing a precomputed plan is not yet '
-                                  'supported by scipy.fft functions')
-    return irfftn(x, s, axes, norm, overwrite_x, workers)
-
-
 def hfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False, workers=None,
           *, plan=None):
     """

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -737,6 +737,14 @@ class TestFftn:
         x = numpy.random.random((2,2,2))
         assert_allclose(fftn(x, axes=[]), x, atol=1e-7)
 
+    def test_regression_244(self):
+        """FFT returns wrong result with axes parameter."""
+        # fftn (and hence fft2) used to break when both axes and shape were used
+        x = numpy.ones((4, 4, 2))
+        y = fftn(x, s=(8, 8), axes=(-3, -2))
+        y_r = numpy.fft.fftn(x, s=(8, 8), axes=(-3, -2))
+        assert_allclose(y, y_r)
+
 
 class TestIfftn:
     dtype = None

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -6,7 +6,7 @@ from numpy.testing import (assert_, assert_equal, assert_array_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 from scipy.fft._pocketfft import (ifft, fft, fftn, ifftn,
-                                  rfft, irfft, rfftn, irfftn, fft2,
+                                  rfft, irfft, rfftn, irfftn,
                                   hfft, ihfft, hfftn, ihfftn)
 
 from numpy import (arange, array, asarray, zeros, dot, exp, pi,
@@ -456,24 +456,6 @@ class TestIRFFTSingle(_TestIRFFTBase):
         self.cdt = np.complex64
         self.rdt = np.float32
         self.ndec = 5
-
-
-class Testfft2:
-    def setup_method(self):
-        np.random.seed(1234)
-
-    def test_regression_244(self):
-        """FFT returns wrong result with axes parameter."""
-        # fftn (and hence fft2) used to break when both axes and shape were
-        # used
-        x = numpy.ones((4, 4, 2))
-        y = fft2(x, s=(8, 8), axes=(-3, -2))
-        y_r = numpy.fft.fftn(x, s=(8, 8), axes=(-3, -2))
-        assert_array_almost_equal(y, y_r)
-
-    def test_invalid_sizes(self):
-        assert_raises(ValueError, fft2, [[]])
-        assert_raises(ValueError, fft2, [[1, 1], [2, 2]], (4, -3))
 
 
 class TestFftnSingle:

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -9,7 +9,6 @@ from pytest import raises as assert_raises
 import scipy.fft as fft
 from scipy.conftest import (
     array_api_compatible,
-    skip_if_array_api_gpu,
     skip_if_array_api_backend
 )
 from scipy._lib._array_api import (
@@ -63,7 +62,6 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ifft(fft.fft(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_fft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -74,7 +72,6 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.fft2(x, norm="forward"), expect / (30 * 20))
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_ifft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -128,7 +125,6 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft(fft.rfft(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_rfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -139,7 +135,6 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.rfft2(x, norm="forward"), expect / (30 * 20))
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_irfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -191,7 +186,6 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ihfft(fft.hfft(x_herm, norm=norm), norm=norm), x_herm)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_hfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -199,7 +193,6 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfft2(fft.ihfft2(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_ihfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -212,7 +205,6 @@ class TestFFT1D:
         )
         xp_assert_close(fft.ihfft2(x, norm="forward"), expect * (30 * 20))
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_hfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -220,7 +212,6 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfftn(fft.ihfftn(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     @skip_if_array_api_backend('torch')
     def test_ihfftn(self, xp):
@@ -250,7 +241,6 @@ class TestFFT1D:
     def test_axes_standard(self, op, xp):
         self._check_axes(op, xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     @pytest.mark.parametrize("op", [fft.hfftn, fft.ihfftn])
     def test_axes_non_standard(self, op, xp):
@@ -276,7 +266,6 @@ class TestFFT1D:
                                          axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     @pytest.mark.parametrize("op", [fft.fft2, fft.ifft2,
                                     fft.rfft2, fft.irfft2,
@@ -412,37 +401,31 @@ class TestFFTThreadSafe:
                 err_msg='Function returned wrong value in multithreaded context'
             )
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_fft(self, xp):
         a = xp.ones(self.input_shape, dtype=xp.complex128)
         self._test_mtsame(fft.fft, a, xp=xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_ifft(self, xp):
         a = xp.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.ifft, a, xp=xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_rfft(self, xp):
         a = xp.ones(self.input_shape)
         self._test_mtsame(fft.rfft, a, xp=xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_irfft(self, xp):
         a = xp.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.irfft, a, xp=xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_hfft(self, xp):
         a = xp.ones(self.input_shape, dtype=xp.complex64)
         self._test_mtsame(fft.hfft, a, xp=xp)
 
-    @skip_if_array_api_gpu
     @array_api_compatible
     def test_ihfft(self, xp):
         a = xp.ones(self.input_shape)

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -350,7 +350,7 @@ class TestFFT1D:
         res_rfft = fft.irfft(fft.rfft(x))
         res_hfft = fft.hfft(fft.ihfft(x), x.shape[0])
         # Check both numerical results and exact dtype matches
-        rtol = {"float32": 1e-4, "float64": 1e-8}[dtype]
+        rtol = {"float32": 1.2e-4, "float64": 1e-8}[dtype]
         xp_assert_close(res_fft, x_complex, rtol=rtol, atol=0)
         xp_assert_close(res_rfft, x, rtol=rtol, atol=0)
         xp_assert_close(res_hfft, x, rtol=rtol, atol=0)

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -62,6 +62,8 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ifft(fft.fft(x, norm=norm), norm=norm), x)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_fft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -72,6 +74,8 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.fft2(x, norm="forward"), expect / (30 * 20))
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_ifft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -125,6 +129,8 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft(fft.rfft(x, norm=norm), norm=norm), x)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_rfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -135,6 +141,8 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.rfft2(x, norm="forward"), expect / (30 * 20))
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_irfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -186,6 +194,8 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ihfft(fft.hfft(x_herm, norm=norm), norm=norm), x_herm)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_hfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -193,6 +203,8 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfft2(fft.ihfft2(x, norm=norm), norm=norm), x)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_ihfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -205,6 +217,8 @@ class TestFFT1D:
         )
         xp_assert_close(fft.ihfft2(x, norm="forward"), expect * (30 * 20))
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_hfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -241,6 +255,8 @@ class TestFFT1D:
     def test_axes_standard(self, op, xp):
         self._check_axes(op, xp)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     @pytest.mark.parametrize("op", [fft.hfftn, fft.ihfftn])
     def test_axes_non_standard(self, op, xp):
@@ -266,6 +282,8 @@ class TestFFT1D:
                                          axes=a)
             xp_assert_close(op_tr, tr_op)
 
+    # torch.fft not yet implemented by array-api-compat
+    @skip_if_array_api_backend('torch')
     @array_api_compatible
     @pytest.mark.parametrize("op", [fft.fft2, fft.ifft2,
                                     fft.rfft2, fft.irfft2,


### PR DESCRIPTION
#### Reference issue
Towards gh-19257.

#### What does this implement/fix?
Following by example from CuPy (https://github.com/cupy/cupy/blob/main/cupyx/scipy/fft/_fft.py), the functions which are not part of the [array API standard extension](https://data-apis.org/array-api/latest/extensions/fourier_transform_functions.html) are written in terms of those which are, to enable GPU support.

#### Additional information
We have a new helper `is_complex` too. All `skip_if_array_api_gpu` markers have now been removed from `test_basic.py`.
