### PR TITLE
MAINT: array API: rename `arg_err_msg` and move to `_lib`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -335,3 +335,7 @@ def cov(x, *, xp=None):
     c /= fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
+
+
+def xp_unsupported_param_msg(param):
+    return f'Providing {param!r} is only supported for numpy arrays.'

--- a/scipy/fft/_basic_backend.py
+++ b/scipy/fft/_basic_backend.py
@@ -1,17 +1,13 @@
-from scipy._lib._array_api import array_namespace, is_numpy
+from scipy._lib._array_api import array_namespace, is_numpy, xp_unsupported_param_msg
 from . import _pocketfft
 import numpy as np
 
 
-def arg_err_msg(param):
-    return f'Providing {param!r} is only supported for numpy arrays.'
-
-
 def _validate_fft_args(workers, plan, norm):
     if workers is not None:
-        raise ValueError(arg_err_msg("workers"))
+        raise ValueError(xp_unsupported_param_msg("workers"))
     if plan is not None:
-        raise ValueError(arg_err_msg("plan"))
+        raise ValueError(xp_unsupported_param_msg("plan"))
     if norm is None:
         norm = 'backward'
     return norm


### PR DESCRIPTION
#### Reference issue
Towards gh-19257.

#### What does this implement/fix?
`arg_err_msg` is renamed to `xp_unsupported_param_msg` and moved to `_lib._array_api.py` for use in other submodules.

#### Additional information
We want to use this in gh-19260.

Please suggest a better name if you have one! This one is a bit long.
