### PR TITLE
MAINT: fix -Wdeprecated-non-prototype warnings in Cephes code

### DIFF
--- a/scipy/special/cephes/airy.c
+++ b/scipy/special/cephes/airy.c
@@ -253,8 +253,7 @@ static double APGD[11] = {
     5.79912514929147598821E-9,
 };
 
-int airy(x, ai, aip, bi, bip)
-double x, *ai, *aip, *bi, *bip;
+int airy(double x, double *ai, double *aip, double *bi, double *bip)
 {
     double z, zz, t, f, g, uf, ug, k, zeta, theta;
     int domflg;

--- a/scipy/special/cephes/btdtr.c
+++ b/scipy/special/cephes/btdtr.c
@@ -52,8 +52,7 @@
 
 #include "mconf.h"
 
-double btdtr(a, b, x)
-double a, b, x;
+double btdtr(double a, double b, double x)
 {
 
     return (incbet(a, b, x));

--- a/scipy/special/cephes/chdtr.c
+++ b/scipy/special/cephes/chdtr.c
@@ -150,8 +150,7 @@
 
 #include "mconf.h"
 
-double chdtrc(df, x)
-double df, x;
+double chdtrc(double df, double x)
 {
 
     if (x < 0.0)
@@ -161,8 +160,7 @@ double df, x;
 
 
 
-double chdtr(df, x)
-double df, x;
+double chdtr(double df, double x)
 {
 
     if ((x < 0.0)) {		/* || (df < 1.0) ) */
@@ -174,8 +172,7 @@ double df, x;
 
 
 
-double chdtri(df, y)
-double df, y;
+double chdtri(double df, double y)
 {
     double x;
 

--- a/scipy/special/cephes/dawsn.c
+++ b/scipy/special/cephes/dawsn.c
@@ -124,8 +124,7 @@ static double CD[5] = {
 
 extern double MACHEP;
 
-double dawsn(xx)
-double xx;
+double dawsn(double xx)
 {
     double x, y;
     int sign;

--- a/scipy/special/cephes/ellpe.c
+++ b/scipy/special/cephes/ellpe.c
@@ -92,8 +92,7 @@ static double Q[] = {
     2.49999999999888314361E-1
 };
 
-double ellpe(x)
-double x;
+double ellpe(double x)
 {
     x = 1.0 - x;
     if (x <= 0.0) {

--- a/scipy/special/cephes/ellpk.c
+++ b/scipy/special/cephes/ellpk.c
@@ -94,8 +94,7 @@ static double C1 = 1.3862943611198906188E0;	/* log(4) */
 
 extern double MACHEP;
 
-double ellpk(x)
-double x;
+double ellpk(double x)
 {
 
     if (x < 0.0) {

--- a/scipy/special/cephes/fresnl.c
+++ b/scipy/special/cephes/fresnl.c
@@ -159,8 +159,7 @@ static double gd[11] = {
 
 extern double MACHEP;
 
-int fresnl(xxa, ssa, cca)
-double xxa, *ssa, *cca;
+int fresnl(double xxa, double *ssa, double *cca)
 {
     double f, g, cc, ss, c, s, t, u;
     double x, x2;

--- a/scipy/special/cephes/gdtr.c
+++ b/scipy/special/cephes/gdtr.c
@@ -96,10 +96,9 @@
  */
 
 #include "mconf.h"
-double gdtri(double, double, double);
 
-double gdtr(a, b, x)
-double a, b, x;
+
+double gdtr(double a, double b, double x)
 {
 
     if (x < 0.0) {
@@ -110,8 +109,7 @@ double a, b, x;
 }
 
 
-double gdtrc(a, b, x)
-double a, b, x;
+double gdtrc(double a, double b, double x)
 {
 
     if (x < 0.0) {
@@ -122,8 +120,7 @@ double a, b, x;
 }
 
 
-double gdtri(a, b, y)
-double a, b, y;
+double gdtri(double a, double b, double y)
 {
 
     if ((y < 0.0) || (y > 1.0) || (a <= 0.0) || (b < 0.0)) {

--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -85,8 +85,8 @@ static double hyp2f1ra(double a, double b, double c, double x,
 		       double *loss);
 static double hyp2f1_neg_c_equal_bc(double a, double b, double x);
 
-double hyp2f1(a, b, c, x)
-double a, b, c, x;
+
+double hyp2f1(double a, double b, double c, double x)
 {
     double d, d1, d2, e;
     double p, q, r, s, y, ax;

--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -58,8 +58,6 @@
  * A "singularity" message is printed on overflow or
  * in cases not addressed (such as x < -1).
  */
-
-/*                                                      hyp2f1  */
 
 
 /*
@@ -79,12 +77,272 @@
 
 extern double MACHEP;
 
-static double hyt2f1(double a, double b, double c, double x, double *loss);
-static double hys2f1(double a, double b, double c, double x, double *loss);
-static double hyp2f1ra(double a, double b, double c, double x,
-		       double *loss);
-static double hyp2f1_neg_c_equal_bc(double a, double b, double x);
 
+/* hys2f1 and hyp2f1ra depend on each other, so we need this prototype */
+static double hyp2f1ra(double a, double b, double c, double x, double *loss);
+
+
+/* Defining power series expansion of Gauss hypergeometric function */
+/* The `loss` parameter estimates loss of significance */
+static double hys2f1(double a, double b, double c, double x, double *loss)
+{
+    double f, g, h, k, m, s, u, umax;
+    int i;
+    int ib, intflag = 0;
+
+    if (fabs(b) > fabs(a)) {
+	/* Ensure that |a| > |b| ... */
+	f = b;
+	b = a;
+	a = f;
+    }
+
+    ib = round(b);
+
+    if (fabs(b - ib) < EPS && ib <= 0 && fabs(b) < fabs(a)) {
+	/* .. except when `b` is a smaller negative integer */
+	f = b;
+	b = a;
+	a = f;
+	intflag = 1;
+    }
+
+    if ((fabs(a) > fabs(c) + 1 || intflag) && fabs(c - a) > 2 && fabs(a) > 2) {
+	/* |a| >> |c| implies that large cancellation error is to be expected.
+	 *
+	 * We try to reduce it with the recurrence relations
+	 */
+	return hyp2f1ra(a, b, c, x, loss);
+    }
+
+    i = 0;
+    umax = 0.0;
+    f = a;
+    g = b;
+    h = c;
+    s = 1.0;
+    u = 1.0;
+    k = 0.0;
+    do {
+	if (fabs(h) < EPS) {
+	    *loss = 1.0;
+	    return INFINITY;
+	}
+	m = k + 1.0;
+	u = u * ((f + k) * (g + k) * x / ((h + k) * m));
+	s += u;
+	k = fabs(u);		/* remember largest term summed */
+	if (k > umax)
+	    umax = k;
+	k = m;
+	if (++i > MAX_ITERATIONS) {	/* should never happen */
+	    *loss = 1.0;
+	    return (s);
+	}
+    }
+    while (s == 0 || fabs(u / s) > MACHEP);
+
+    /* return estimated relative error */
+    *loss = (MACHEP * umax) / fabs(s) + (MACHEP * i);
+
+    return (s);
+}
+
+
+/* Apply transformations for |x| near 1 then call the power series */
+static double hyt2f1(double a, double b, double c, double x, double *loss)
+{
+    double p, q, r, s, t, y, w, d, err, err1;
+    double ax, id, d1, d2, e, y1;
+    int i, aid, sign;
+
+    int ia, ib, neg_int_a = 0, neg_int_b = 0;
+
+    ia = round(a);
+    ib = round(b);
+
+    if (a <= 0 && fabs(a - ia) < EPS) {	/* a is a negative integer */
+	neg_int_a = 1;
+    }
+
+    if (b <= 0 && fabs(b - ib) < EPS) {	/* b is a negative integer */
+	neg_int_b = 1;
+    }
+
+    err = 0.0;
+    s = 1.0 - x;
+    if (x < -0.5 && !(neg_int_a || neg_int_b)) {
+	if (b > a)
+	    y = pow(s, -a) * hys2f1(a, c - b, c, -x / s, &err);
+
+	else
+	    y = pow(s, -b) * hys2f1(c - a, b, c, -x / s, &err);
+
+	goto done;
+    }
+
+    d = c - a - b;
+    id = round(d);		/* nearest integer to d */
+
+    if (x > 0.9 && !(neg_int_a || neg_int_b)) {
+	if (fabs(d - id) > EPS) {
+	    int sgngam;
+
+	    /* test for integer c-a-b */
+	    /* Try the power series first */
+	    y = hys2f1(a, b, c, x, &err);
+	    if (err < ETHRESH)
+		goto done;
+	    /* If power series fails, then apply AMS55 #15.3.6 */
+	    q = hys2f1(a, b, 1.0 - d, s, &err);
+            sign = 1;
+            w = lgam_sgn(d, &sgngam);
+            sign *= sgngam;
+            w -= lgam_sgn(c-a, &sgngam);
+            sign *= sgngam;
+            w -= lgam_sgn(c-b, &sgngam);
+            sign *= sgngam;
+	    q *= sign * exp(w);
+	    r = pow(s, d) * hys2f1(c - a, c - b, d + 1.0, s, &err1);
+            sign = 1;
+            w = lgam_sgn(-d, &sgngam);
+            sign *= sgngam;
+            w -= lgam_sgn(a, &sgngam);
+            sign *= sgngam;
+            w -= lgam_sgn(b, &sgngam);
+            sign *= sgngam;
+	    r *= sign * exp(w);
+	    y = q + r;
+
+	    q = fabs(q);	/* estimate cancellation error */
+	    r = fabs(r);
+	    if (q > r)
+		r = q;
+	    err += err1 + (MACHEP * r) / y;
+
+	    y *= gamma(c);
+	    goto done;
+	}
+	else {
+	    /* Psi function expansion, AMS55 #15.3.10, #15.3.11, #15.3.12
+	     *
+	     * Although AMS55 does not explicitly state it, this expansion fails
+	     * for negative integer a or b, since the psi and Gamma functions
+	     * involved have poles.
+	     */
+
+	    if (id >= 0.0) {
+		e = d;
+		d1 = d;
+		d2 = 0.0;
+		aid = id;
+	    }
+	    else {
+		e = -d;
+		d1 = 0.0;
+		d2 = d;
+		aid = -id;
+	    }
+
+	    ax = log(s);
+
+	    /* sum for t = 0 */
+	    y = psi(1.0) + psi(1.0 + e) - psi(a + d1) - psi(b + d1) - ax;
+	    y /= gamma(e + 1.0);
+
+	    p = (a + d1) * (b + d1) * s / gamma(e + 2.0);	/* Poch for t=1 */
+	    t = 1.0;
+	    do {
+		r = psi(1.0 + t) + psi(1.0 + t + e) - psi(a + t + d1)
+		    - psi(b + t + d1) - ax;
+		q = p * r;
+		y += q;
+		p *= s * (a + t + d1) / (t + 1.0);
+		p *= (b + t + d1) / (t + 1.0 + e);
+		t += 1.0;
+		if (t > MAX_ITERATIONS) {	/* should never happen */
+		    sf_error("hyp2f1", SF_ERROR_SLOW, NULL);
+		    *loss = 1.0;
+		    return NAN;
+		}
+	    }
+	    while (y == 0 || fabs(q / y) > EPS);
+
+	    if (id == 0.0) {
+		y *= gamma(c) / (gamma(a) * gamma(b));
+		goto psidon;
+	    }
+
+	    y1 = 1.0;
+
+	    if (aid == 1)
+		goto nosum;
+
+	    t = 0.0;
+	    p = 1.0;
+	    for (i = 1; i < aid; i++) {
+		r = 1.0 - e + t;
+		p *= s * (a + t + d2) * (b + t + d2) / r;
+		t += 1.0;
+		p /= t;
+		y1 += p;
+	    }
+	  nosum:
+	    p = gamma(c);
+	    y1 *= gamma(e) * p / (gamma(a + d1) * gamma(b + d1));
+
+	    y *= p / (gamma(a + d2) * gamma(b + d2));
+	    if ((aid & 1) != 0)
+		y = -y;
+
+	    q = pow(s, id);	/* s to the id power */
+	    if (id > 0.0)
+		y *= q;
+	    else
+		y1 *= q;
+
+	    y += y1;
+	  psidon:
+	    goto done;
+	}
+
+    }
+
+    /* Use defining power series if no special cases */
+    y = hys2f1(a, b, c, x, &err);
+
+  done:
+    *loss = err;
+    return (y);
+}
+
+
+/*
+    15.4.2 Abramowitz & Stegun.
+*/
+static double hyp2f1_neg_c_equal_bc(double a, double b, double x)
+{
+    double k;
+    double collector = 1;
+    double sum = 1;
+    double collector_max = 1;
+
+    if (!(fabs(b) < 1e5)) {
+        return NAN;
+    }
+
+    for (k = 1; k <= -b; k++) {
+        collector *= (a + k - 1)*x/k;
+        collector_max = fmax(fabs(collector), collector_max);
+        sum += collector;
+    }
+
+    if (1e-16 * (1 + collector_max/fabs(sum)) > 1e-7) {
+        return NAN;
+    }
+
+    return sum;
+}
 
 double hyp2f1(double a, double b, double c, double x)
 {
@@ -274,255 +532,6 @@ double hyp2f1(double a, double b, double c, double x)
 }
 
 
-
-
-
-
-/* Apply transformations for |x| near 1
- * then call the power series
- */
-static double hyt2f1(a, b, c, x, loss)
-double a, b, c, x;
-double *loss;
-{
-    double p, q, r, s, t, y, w, d, err, err1;
-    double ax, id, d1, d2, e, y1;
-    int i, aid, sign;
-
-    int ia, ib, neg_int_a = 0, neg_int_b = 0;
-
-    ia = round(a);
-    ib = round(b);
-
-    if (a <= 0 && fabs(a - ia) < EPS) {	/* a is a negative integer */
-	neg_int_a = 1;
-    }
-
-    if (b <= 0 && fabs(b - ib) < EPS) {	/* b is a negative integer */
-	neg_int_b = 1;
-    }
-
-    err = 0.0;
-    s = 1.0 - x;
-    if (x < -0.5 && !(neg_int_a || neg_int_b)) {
-	if (b > a)
-	    y = pow(s, -a) * hys2f1(a, c - b, c, -x / s, &err);
-
-	else
-	    y = pow(s, -b) * hys2f1(c - a, b, c, -x / s, &err);
-
-	goto done;
-    }
-
-    d = c - a - b;
-    id = round(d);		/* nearest integer to d */
-
-    if (x > 0.9 && !(neg_int_a || neg_int_b)) {
-	if (fabs(d - id) > EPS) {
-	    int sgngam;
-
-	    /* test for integer c-a-b */
-	    /* Try the power series first */
-	    y = hys2f1(a, b, c, x, &err);
-	    if (err < ETHRESH)
-		goto done;
-	    /* If power series fails, then apply AMS55 #15.3.6 */
-	    q = hys2f1(a, b, 1.0 - d, s, &err);
-            sign = 1;
-            w = lgam_sgn(d, &sgngam);
-            sign *= sgngam;
-            w -= lgam_sgn(c-a, &sgngam);
-            sign *= sgngam;
-            w -= lgam_sgn(c-b, &sgngam);
-            sign *= sgngam;
-	    q *= sign * exp(w);
-	    r = pow(s, d) * hys2f1(c - a, c - b, d + 1.0, s, &err1);
-            sign = 1;
-            w = lgam_sgn(-d, &sgngam);
-            sign *= sgngam;
-            w -= lgam_sgn(a, &sgngam);
-            sign *= sgngam;
-            w -= lgam_sgn(b, &sgngam);
-            sign *= sgngam;
-	    r *= sign * exp(w);
-	    y = q + r;
-
-	    q = fabs(q);	/* estimate cancellation error */
-	    r = fabs(r);
-	    if (q > r)
-		r = q;
-	    err += err1 + (MACHEP * r) / y;
-
-	    y *= gamma(c);
-	    goto done;
-	}
-	else {
-	    /* Psi function expansion, AMS55 #15.3.10, #15.3.11, #15.3.12
-	     *
-	     * Although AMS55 does not explicitly state it, this expansion fails
-	     * for negative integer a or b, since the psi and Gamma functions
-	     * involved have poles.
-	     */
-
-	    if (id >= 0.0) {
-		e = d;
-		d1 = d;
-		d2 = 0.0;
-		aid = id;
-	    }
-	    else {
-		e = -d;
-		d1 = 0.0;
-		d2 = d;
-		aid = -id;
-	    }
-
-	    ax = log(s);
-
-	    /* sum for t = 0 */
-	    y = psi(1.0) + psi(1.0 + e) - psi(a + d1) - psi(b + d1) - ax;
-	    y /= gamma(e + 1.0);
-
-	    p = (a + d1) * (b + d1) * s / gamma(e + 2.0);	/* Poch for t=1 */
-	    t = 1.0;
-	    do {
-		r = psi(1.0 + t) + psi(1.0 + t + e) - psi(a + t + d1)
-		    - psi(b + t + d1) - ax;
-		q = p * r;
-		y += q;
-		p *= s * (a + t + d1) / (t + 1.0);
-		p *= (b + t + d1) / (t + 1.0 + e);
-		t += 1.0;
-		if (t > MAX_ITERATIONS) {	/* should never happen */
-		    sf_error("hyp2f1", SF_ERROR_SLOW, NULL);
-		    *loss = 1.0;
-		    return NAN;
-		}
-	    }
-	    while (y == 0 || fabs(q / y) > EPS);
-
-	    if (id == 0.0) {
-		y *= gamma(c) / (gamma(a) * gamma(b));
-		goto psidon;
-	    }
-
-	    y1 = 1.0;
-
-	    if (aid == 1)
-		goto nosum;
-
-	    t = 0.0;
-	    p = 1.0;
-	    for (i = 1; i < aid; i++) {
-		r = 1.0 - e + t;
-		p *= s * (a + t + d2) * (b + t + d2) / r;
-		t += 1.0;
-		p /= t;
-		y1 += p;
-	    }
-	  nosum:
-	    p = gamma(c);
-	    y1 *= gamma(e) * p / (gamma(a + d1) * gamma(b + d1));
-
-	    y *= p / (gamma(a + d2) * gamma(b + d2));
-	    if ((aid & 1) != 0)
-		y = -y;
-
-	    q = pow(s, id);	/* s to the id power */
-	    if (id > 0.0)
-		y *= q;
-	    else
-		y1 *= q;
-
-	    y += y1;
-	  psidon:
-	    goto done;
-	}
-
-    }
-
-    /* Use defining power series if no special cases */
-    y = hys2f1(a, b, c, x, &err);
-
-  done:
-    *loss = err;
-    return (y);
-}
-
-
-
-
-
-/* Defining power series expansion of Gauss hypergeometric function */
-
-static double hys2f1(a, b, c, x, loss)
-double a, b, c, x;
-double *loss;			/* estimates loss of significance */
-{
-    double f, g, h, k, m, s, u, umax;
-    int i;
-    int ib, intflag = 0;
-
-    if (fabs(b) > fabs(a)) {
-	/* Ensure that |a| > |b| ... */
-	f = b;
-	b = a;
-	a = f;
-    }
-
-    ib = round(b);
-
-    if (fabs(b - ib) < EPS && ib <= 0 && fabs(b) < fabs(a)) {
-	/* .. except when `b` is a smaller negative integer */
-	f = b;
-	b = a;
-	a = f;
-	intflag = 1;
-    }
-
-    if ((fabs(a) > fabs(c) + 1 || intflag) && fabs(c - a) > 2
-	&& fabs(a) > 2) {
-	/* |a| >> |c| implies that large cancellation error is to be expected.
-	 *
-	 * We try to reduce it with the recurrence relations
-	 */
-	return hyp2f1ra(a, b, c, x, loss);
-    }
-
-    i = 0;
-    umax = 0.0;
-    f = a;
-    g = b;
-    h = c;
-    s = 1.0;
-    u = 1.0;
-    k = 0.0;
-    do {
-	if (fabs(h) < EPS) {
-	    *loss = 1.0;
-	    return INFINITY;
-	}
-	m = k + 1.0;
-	u = u * ((f + k) * (g + k) * x / ((h + k) * m));
-	s += u;
-	k = fabs(u);		/* remember largest term summed */
-	if (k > umax)
-	    umax = k;
-	k = m;
-	if (++i > MAX_ITERATIONS) {	/* should never happen */
-	    *loss = 1.0;
-	    return (s);
-	}
-    }
-    while (s == 0 || fabs(u / s) > MACHEP);
-
-    /* return estimated relative error */
-    *loss = (MACHEP * umax) / fabs(s) + (MACHEP * i);
-
-    return (s);
-}
-
-
 /*
  * Evaluate hypergeometric function by two-term recurrence in `a`.
  *
@@ -532,8 +541,7 @@ double *loss;			/* estimates loss of significance */
  *
  * AMS55 #15.2.10
  */
-static double hyp2f1ra(double a, double b, double c, double x,
-		       double *loss)
+static double hyp2f1ra(double a, double b, double c, double x, double *loss)
 {
     double f2, f1, f0;
     int n;
@@ -594,32 +602,4 @@ static double hyp2f1ra(double a, double b, double c, double x,
     }
 
     return f0;
-}
-
-
-/*
-    15.4.2 Abramowitz & Stegun.
-*/
-static double hyp2f1_neg_c_equal_bc(double a, double b, double x)
-{
-    double k;
-    double collector = 1;
-    double sum = 1;
-    double collector_max = 1;
-
-    if (!(fabs(b) < 1e5)) {
-        return NAN;
-    }
-
-    for (k = 1; k <= -b; k++) {
-        collector *= (a + k - 1)*x/k;
-        collector_max = fmax(fabs(collector), collector_max);
-        sum += collector;
-    }
-
-    if (1e-16 * (1 + collector_max/fabs(sum)) > 1e-7) {
-        return NAN;
-    }
-
-    return sum;
 }

--- a/scipy/special/cephes/i0.c
+++ b/scipy/special/cephes/i0.c
@@ -146,8 +146,7 @@ static double B[] = {
     8.04490411014108831608E-1
 };
 
-double i0(x)
-double x;
+double i0(double x)
 {
     double y;
 
@@ -165,8 +164,7 @@ double x;
 
 
 
-double i0e(x)
-double x;
+double i0e(double x)
 {
     double y;
 

--- a/scipy/special/cephes/i1.c
+++ b/scipy/special/cephes/i1.c
@@ -147,8 +147,7 @@ static double B[] = {
     7.78576235018280120474E-1
 };
 
-double i1(x)
-double x;
+double i1(double x)
 {
     double y, z;
 
@@ -167,8 +166,7 @@ double x;
 
 /*                                                     i1e()   */
 
-double i1e(x)
-double x;
+double i1e(double x)
 {
     double y, z;
 

--- a/scipy/special/cephes/incbet.c
+++ b/scipy/special/cephes/incbet.c
@@ -68,12 +68,219 @@ extern double MACHEP, MINLOG, MAXLOG;
 static double big = 4.503599627370496e15;
 static double biginv = 2.22044604925031308085e-16;
 
-static double incbcf(double a, double b, double x);
-static double incbd(double a, double b, double x);
-static double pseries(double a, double b, double x);
 
-double incbet(aa, bb, xx)
-double aa, bb, xx;
+/* Power series for incomplete beta integral.
+ * Use when b*x is small and x not too close to 1.  */
+
+static double pseries(double a, double b, double x)
+{
+    double s, t, u, v, n, t1, z, ai;
+
+    ai = 1.0 / a;
+    u = (1.0 - b) * x;
+    v = u / (a + 1.0);
+    t1 = v;
+    t = u;
+    n = 2.0;
+    s = 0.0;
+    z = MACHEP * ai;
+    while (fabs(v) > z) {
+	u = (n - b) * x / n;
+	t *= u;
+	v = t / (a + n);
+	s += v;
+	n += 1.0;
+    }
+    s += t1;
+    s += ai;
+
+    u = a * log(x);
+    if ((a + b) < MAXGAM && fabs(u) < MAXLOG) {
+        t = 1.0 / beta(a, b);
+	s = s * t * pow(x, a);
+    }
+    else {
+	t = -lbeta(a,b) + u + log(s);
+	if (t < MINLOG)
+	    s = 0.0;
+	else
+	    s = exp(t);
+    }
+    return (s);
+}
+
+
+/* Continued fraction expansion #1 for incomplete beta integral */
+
+static double incbcf(double a, double b, double x)
+{
+    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
+    double k1, k2, k3, k4, k5, k6, k7, k8;
+    double r, t, ans, thresh;
+    int n;
+
+    k1 = a;
+    k2 = a + b;
+    k3 = a;
+    k4 = a + 1.0;
+    k5 = 1.0;
+    k6 = b - 1.0;
+    k7 = k4;
+    k8 = a + 2.0;
+
+    pkm2 = 0.0;
+    qkm2 = 1.0;
+    pkm1 = 1.0;
+    qkm1 = 1.0;
+    ans = 1.0;
+    r = 1.0;
+    n = 0;
+    thresh = 3.0 * MACHEP;
+    do {
+
+	xk = -(x * k1 * k2) / (k3 * k4);
+	pk = pkm1 + pkm2 * xk;
+	qk = qkm1 + qkm2 * xk;
+	pkm2 = pkm1;
+	pkm1 = pk;
+	qkm2 = qkm1;
+	qkm1 = qk;
+
+	xk = (x * k5 * k6) / (k7 * k8);
+	pk = pkm1 + pkm2 * xk;
+	qk = qkm1 + qkm2 * xk;
+	pkm2 = pkm1;
+	pkm1 = pk;
+	qkm2 = qkm1;
+	qkm1 = qk;
+
+	if (qk != 0)
+	    r = pk / qk;
+	if (r != 0) {
+	    t = fabs((ans - r) / r);
+	    ans = r;
+	}
+	else
+	    t = 1.0;
+
+	if (t < thresh)
+	    goto cdone;
+
+	k1 += 1.0;
+	k2 += 1.0;
+	k3 += 2.0;
+	k4 += 2.0;
+	k5 += 1.0;
+	k6 -= 1.0;
+	k7 += 2.0;
+	k8 += 2.0;
+
+	if ((fabs(qk) + fabs(pk)) > big) {
+	    pkm2 *= biginv;
+	    pkm1 *= biginv;
+	    qkm2 *= biginv;
+	    qkm1 *= biginv;
+	}
+	if ((fabs(qk) < biginv) || (fabs(pk) < biginv)) {
+	    pkm2 *= big;
+	    pkm1 *= big;
+	    qkm2 *= big;
+	    qkm1 *= big;
+	}
+    }
+    while (++n < 300);
+
+  cdone:
+    return (ans);
+}
+
+
+/* Continued fraction expansion #2 for incomplete beta integral */
+
+static double incbd(double a, double b, double x)
+{
+    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
+    double k1, k2, k3, k4, k5, k6, k7, k8;
+    double r, t, ans, z, thresh;
+    int n;
+
+    k1 = a;
+    k2 = b - 1.0;
+    k3 = a;
+    k4 = a + 1.0;
+    k5 = 1.0;
+    k6 = a + b;
+    k7 = a + 1.0;;
+    k8 = a + 2.0;
+
+    pkm2 = 0.0;
+    qkm2 = 1.0;
+    pkm1 = 1.0;
+    qkm1 = 1.0;
+    z = x / (1.0 - x);
+    ans = 1.0;
+    r = 1.0;
+    n = 0;
+    thresh = 3.0 * MACHEP;
+    do {
+
+	xk = -(z * k1 * k2) / (k3 * k4);
+	pk = pkm1 + pkm2 * xk;
+	qk = qkm1 + qkm2 * xk;
+	pkm2 = pkm1;
+	pkm1 = pk;
+	qkm2 = qkm1;
+	qkm1 = qk;
+
+	xk = (z * k5 * k6) / (k7 * k8);
+	pk = pkm1 + pkm2 * xk;
+	qk = qkm1 + qkm2 * xk;
+	pkm2 = pkm1;
+	pkm1 = pk;
+	qkm2 = qkm1;
+	qkm1 = qk;
+
+	if (qk != 0)
+	    r = pk / qk;
+	if (r != 0) {
+	    t = fabs((ans - r) / r);
+	    ans = r;
+	}
+	else
+	    t = 1.0;
+
+	if (t < thresh)
+	    goto cdone;
+
+	k1 += 1.0;
+	k2 -= 1.0;
+	k3 += 2.0;
+	k4 += 2.0;
+	k5 += 1.0;
+	k6 += 1.0;
+	k7 += 2.0;
+	k8 += 2.0;
+
+	if ((fabs(qk) + fabs(pk)) > big) {
+	    pkm2 *= biginv;
+	    pkm1 *= biginv;
+	    qkm2 *= biginv;
+	    qkm1 *= biginv;
+	}
+	if ((fabs(qk) < biginv) || (fabs(pk) < biginv)) {
+	    pkm2 *= big;
+	    pkm1 *= big;
+	    qkm2 *= big;
+	    qkm1 *= big;
+	}
+    }
+    while (++n < 300);
+  cdone:
+    return (ans);
+}
+
+
+double incbet(double aa, double bb, double xx)
 {
     double a, b, t, x, xc, w, y;
     int flag;
@@ -158,219 +365,5 @@ double aa, bb, xx;
     }
     return (t);
 }
-
-/* Continued fraction expansion #1
- * for incomplete beta integral
- */
 
-static double incbcf(a, b, x)
-double a, b, x;
-{
-    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
-    double k1, k2, k3, k4, k5, k6, k7, k8;
-    double r, t, ans, thresh;
-    int n;
 
-    k1 = a;
-    k2 = a + b;
-    k3 = a;
-    k4 = a + 1.0;
-    k5 = 1.0;
-    k6 = b - 1.0;
-    k7 = k4;
-    k8 = a + 2.0;
-
-    pkm2 = 0.0;
-    qkm2 = 1.0;
-    pkm1 = 1.0;
-    qkm1 = 1.0;
-    ans = 1.0;
-    r = 1.0;
-    n = 0;
-    thresh = 3.0 * MACHEP;
-    do {
-
-	xk = -(x * k1 * k2) / (k3 * k4);
-	pk = pkm1 + pkm2 * xk;
-	qk = qkm1 + qkm2 * xk;
-	pkm2 = pkm1;
-	pkm1 = pk;
-	qkm2 = qkm1;
-	qkm1 = qk;
-
-	xk = (x * k5 * k6) / (k7 * k8);
-	pk = pkm1 + pkm2 * xk;
-	qk = qkm1 + qkm2 * xk;
-	pkm2 = pkm1;
-	pkm1 = pk;
-	qkm2 = qkm1;
-	qkm1 = qk;
-
-	if (qk != 0)
-	    r = pk / qk;
-	if (r != 0) {
-	    t = fabs((ans - r) / r);
-	    ans = r;
-	}
-	else
-	    t = 1.0;
-
-	if (t < thresh)
-	    goto cdone;
-
-	k1 += 1.0;
-	k2 += 1.0;
-	k3 += 2.0;
-	k4 += 2.0;
-	k5 += 1.0;
-	k6 -= 1.0;
-	k7 += 2.0;
-	k8 += 2.0;
-
-	if ((fabs(qk) + fabs(pk)) > big) {
-	    pkm2 *= biginv;
-	    pkm1 *= biginv;
-	    qkm2 *= biginv;
-	    qkm1 *= biginv;
-	}
-	if ((fabs(qk) < biginv) || (fabs(pk) < biginv)) {
-	    pkm2 *= big;
-	    pkm1 *= big;
-	    qkm2 *= big;
-	    qkm1 *= big;
-	}
-    }
-    while (++n < 300);
-
-  cdone:
-    return (ans);
-}
-
-
-/* Continued fraction expansion #2
- * for incomplete beta integral
- */
-
-static double incbd(a, b, x)
-double a, b, x;
-{
-    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
-    double k1, k2, k3, k4, k5, k6, k7, k8;
-    double r, t, ans, z, thresh;
-    int n;
-
-    k1 = a;
-    k2 = b - 1.0;
-    k3 = a;
-    k4 = a + 1.0;
-    k5 = 1.0;
-    k6 = a + b;
-    k7 = a + 1.0;;
-    k8 = a + 2.0;
-
-    pkm2 = 0.0;
-    qkm2 = 1.0;
-    pkm1 = 1.0;
-    qkm1 = 1.0;
-    z = x / (1.0 - x);
-    ans = 1.0;
-    r = 1.0;
-    n = 0;
-    thresh = 3.0 * MACHEP;
-    do {
-
-	xk = -(z * k1 * k2) / (k3 * k4);
-	pk = pkm1 + pkm2 * xk;
-	qk = qkm1 + qkm2 * xk;
-	pkm2 = pkm1;
-	pkm1 = pk;
-	qkm2 = qkm1;
-	qkm1 = qk;
-
-	xk = (z * k5 * k6) / (k7 * k8);
-	pk = pkm1 + pkm2 * xk;
-	qk = qkm1 + qkm2 * xk;
-	pkm2 = pkm1;
-	pkm1 = pk;
-	qkm2 = qkm1;
-	qkm1 = qk;
-
-	if (qk != 0)
-	    r = pk / qk;
-	if (r != 0) {
-	    t = fabs((ans - r) / r);
-	    ans = r;
-	}
-	else
-	    t = 1.0;
-
-	if (t < thresh)
-	    goto cdone;
-
-	k1 += 1.0;
-	k2 -= 1.0;
-	k3 += 2.0;
-	k4 += 2.0;
-	k5 += 1.0;
-	k6 += 1.0;
-	k7 += 2.0;
-	k8 += 2.0;
-
-	if ((fabs(qk) + fabs(pk)) > big) {
-	    pkm2 *= biginv;
-	    pkm1 *= biginv;
-	    qkm2 *= biginv;
-	    qkm1 *= biginv;
-	}
-	if ((fabs(qk) < biginv) || (fabs(pk) < biginv)) {
-	    pkm2 *= big;
-	    pkm1 *= big;
-	    qkm2 *= big;
-	    qkm1 *= big;
-	}
-    }
-    while (++n < 300);
-  cdone:
-    return (ans);
-}
-
-/* Power series for incomplete beta integral.
- * Use when b*x is small and x not too close to 1.  */
-
-static double pseries(a, b, x)
-double a, b, x;
-{
-    double s, t, u, v, n, t1, z, ai;
-
-    ai = 1.0 / a;
-    u = (1.0 - b) * x;
-    v = u / (a + 1.0);
-    t1 = v;
-    t = u;
-    n = 2.0;
-    s = 0.0;
-    z = MACHEP * ai;
-    while (fabs(v) > z) {
-	u = (n - b) * x / n;
-	t *= u;
-	v = t / (a + n);
-	s += v;
-	n += 1.0;
-    }
-    s += t1;
-    s += ai;
-
-    u = a * log(x);
-    if ((a + b) < MAXGAM && fabs(u) < MAXLOG) {
-        t = 1.0 / beta(a, b);
-	s = s * t * pow(x, a);
-    }
-    else {
-	t = -lbeta(a,b) + u + log(s);
-	if (t < MINLOG)
-	    s = 0.0;
-	else
-	    s = exp(t);
-    }
-    return (s);
-}

--- a/scipy/special/cephes/incbi.c
+++ b/scipy/special/cephes/incbi.c
@@ -48,8 +48,7 @@
 
 extern double MACHEP, MAXLOG, MINLOG;
 
-double incbi(aa, bb, yy0)
-double aa, bb, yy0;
+double incbi(double aa, double bb, double yy0)
 {
     double a, b, y0, d, y, x, x0, x1, lgm, yp, di, dithresh, yl, yh, xt;
     int i, rflg, dir, nflg;

--- a/scipy/special/cephes/j0.c
+++ b/scipy/special/cephes/j0.c
@@ -182,8 +182,7 @@ static double RQ[8] = {
 
 extern double SQ2OPI;
 
-double j0(x)
-double x;
+double j0(double x)
 {
     double w, z, p, q, xn;
 
@@ -218,8 +217,7 @@ double x;
  * = 0.073804295108687225.
  */
 
-double y0(x)
-double x;
+double y0(double x)
 {
     double w, z, p, q, xn;
 

--- a/scipy/special/cephes/j1.c
+++ b/scipy/special/cephes/j1.c
@@ -171,8 +171,7 @@ static double Z2 = 4.92184563216946036703E1;
 
 extern double THPIO4, SQ2OPI;
 
-double j1(x)
-double x;
+double j1(double x)
 {
     double w, z, p, q, xn;
 
@@ -197,8 +196,7 @@ double x;
 }
 
 
-double y1(x)
-double x;
+double y1(double x)
 {
     double w, z, p, q, xn;
 

--- a/scipy/special/cephes/k0.c
+++ b/scipy/special/cephes/k0.c
@@ -128,8 +128,7 @@ static double B[] = {
     2.44030308206595545468E0
 };
 
-double k0(x)
-double x;
+double k0(double x)
 {
     double y, z;
 
@@ -155,8 +154,7 @@ double x;
 
 
 
-double k0e(x)
-double x;
+double k0e(double x)
 {
     double y;
 

--- a/scipy/special/cephes/k1.c
+++ b/scipy/special/cephes/k1.c
@@ -130,8 +130,7 @@ static double B[] = {
 
 extern double MINLOG;
 
-double k1(x)
-double x;
+double k1(double x)
 {
     double y, z;
 
@@ -157,8 +156,7 @@ double x;
 
 
 
-double k1e(x)
-double x;
+double k1e(double x)
 {
     double y;
 

--- a/scipy/special/cephes/kn.c
+++ b/scipy/special/cephes/kn.c
@@ -83,9 +83,7 @@
 #define MAXFAC 31
 extern double MACHEP, MAXLOG;
 
-double kn(nn, x)
-int nn;
-double x;
+double kn(int nn, double x)
 {
     double k, kf, nk1f, nkf, zn, t, s, z0, z;
     double ans, fn, pn, pk, zmn, tlg, tox;

--- a/scipy/special/cephes/nbdtr.c
+++ b/scipy/special/cephes/nbdtr.c
@@ -152,9 +152,7 @@
 
 #include "mconf.h"
 
-double nbdtrc(k, n, p)
-int k, n;
-double p;
+double nbdtrc(int k, int n, double p)
 {
     double dk, dn;
 
@@ -173,9 +171,7 @@ double p;
 
 
 
-double nbdtr(k, n, p)
-int k, n;
-double p;
+double nbdtr(int k, int n, double p)
 {
     double dk, dn;
 
@@ -193,9 +189,7 @@ double p;
 
 
 
-double nbdtri(k, n, p)
-int k, n;
-double p;
+double nbdtri(int k, int n, double p)
 {
     double dk, dn, w;
 

--- a/scipy/special/cephes/ndtri.c
+++ b/scipy/special/cephes/ndtri.c
@@ -131,8 +131,7 @@ static double Q2[8] = {
     6.79019408009981274425E-9,
 };
 
-double ndtri(y0)
-double y0;
+double ndtri(double y0)
 {
     double x, y, z, y2, x0, x1;
     int code;

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -159,9 +159,7 @@ double pdtr(double k, double m)
 }
 
 
-double pdtri(k, y)
-int k;
-double y;
+double pdtri(int k, double y)
 {
     double v;
 

--- a/scipy/special/cephes/rgamma.c
+++ b/scipy/special/cephes/rgamma.c
@@ -74,8 +74,7 @@ static char name[] = "rgamma";
 extern double MAXLOG;
 
 
-double rgamma(x)
-double x;
+double rgamma(double x)
 {
     double w, y, z;
     int sign;

--- a/scipy/special/cephes/shichi.c
+++ b/scipy/special/cephes/shichi.c
@@ -171,9 +171,7 @@ static double hyp3f0(double a1, double a2, double a3, double z);
 
 extern double MACHEP;
 
-int shichi(x, si, ci)
-double x;
-double *si, *ci;
+int shichi(double x, double *si, double *ci)
 {
     double k, z, c, s, a, b;
     short sign;

--- a/scipy/special/cephes/sici.c
+++ b/scipy/special/cephes/sici.c
@@ -186,9 +186,7 @@ static double GD8[] = {
 extern double MACHEP;
 
 
-int sici(x, si, ci)
-double x;
-double *si, *ci;
+int sici(double x, double *si, double *ci)
 {
     double z, c, s, f, g;
     short sign;

--- a/scipy/special/cephes/sindg.c
+++ b/scipy/special/cephes/sindg.c
@@ -98,8 +98,7 @@ static double coscof[] = {
 static double PI180 = 1.74532925199432957692E-2;	/* pi/180 */
 static double lossth = 1.0e14;
 
-double sindg(x)
-double x;
+double sindg(double x)
 {
     double y, z, zz;
     int j, sign;
@@ -154,8 +153,7 @@ double x;
 }
 
 
-double cosdg(x)
-double x;
+double cosdg(double x)
 {
     double y, z, zz;
     int j, sign;
@@ -215,8 +213,7 @@ double x;
 static double P64800 =
     4.848136811095359935899141023579479759563533023727e-6;
 
-double radian(d, m, s)
-double d, m, s;
+double radian(double d, double m, double s)
 {
     return (((d * 60.0 + m) * 60.0 + s) * P64800);
 }

--- a/scipy/special/cephes/spence.c
+++ b/scipy/special/cephes/spence.c
@@ -74,8 +74,7 @@ static double B[8] = {
 
 extern double MACHEP;
 
-double spence(x)
-double x;
+double spence(double x)
 {
     double w, y, z;
     int flag;

--- a/scipy/special/cephes/stdtr.c
+++ b/scipy/special/cephes/stdtr.c
@@ -89,9 +89,7 @@
 
 extern double MACHEP;
 
-double stdtr(k, t)
-int k;
-double t;
+double stdtr(int k, double t)
 {
     double x, rk, z, f, tz, p, xsqk;
     int j;
@@ -169,9 +167,7 @@ double t;
     return (p);
 }
 
-double stdtri(k, p)
-int k;
-double p;
+double stdtri(int k, double p)
 {
     double t, rk, z;
     int rflg;

--- a/scipy/special/cephes/yn.c
+++ b/scipy/special/cephes/yn.c
@@ -54,9 +54,7 @@
 #include "mconf.h"
 extern double MAXLOG;
 
-double yn(n, x)
-int n;
-double x;
+double yn(int n, double x)
 {
     double an, anm1, anm2, r;
     int k, sign;

--- a/scipy/special/cephes/zeta.c
+++ b/scipy/special/cephes/zeta.c
@@ -86,8 +86,7 @@ static double A[] = {
 /* 30 Nov 86 -- error in third coefficient fixed */
 
 
-double zeta(x, q)
-double x, q;
+double zeta(double x, double q)
 {
     int i;
     double a, b, k, s, t, w;


### PR DESCRIPTION
This starts showing up with Clang 15. Example warning (there are a lot of them):
```
[95/1601] Compiling C object scipy/special/libcephes.a.p/cephes_kn.c.o
../scipy/special/cephes/kn.c:86:8: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
double kn(nn, x)
       ^
```

The last three commits are for the three files (`incbet.c`, `hyperg.c` and `hyp2f1.c`) that required reordering functions within the files in order to remove function prototypes, ensuring that if one function calls another, the function being called is defined higher up in the file. Functions in those files are only reordered, without functional or style changes.

There are a few warnings left for other submodules, but `special` was the main offended here. I'll do the other ones in a separate PR.