### PR TITLE
DOC: add example for `ndimage.shift`

### DIFF
--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -662,6 +662,10 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     shift : ndarray
         The shifted input.
 
+    See Also
+    --------
+    affine_transform : Affine transformations
+
     Notes
     -----
     For complex-valued `input`, this function shifts the real and imaginary
@@ -670,6 +674,37 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     .. versionadded:: 1.6.0
         Complex-valued support added.
 
+    Examples
+    --------
+    Import the necessary modules and an exemplary image.
+
+    >>> from scipy.ndimage import shift
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import datasets
+    >>> image = datasets.ascent()
+
+    Shift the image vertically by 20 pixels.
+
+    >>> image_shifted_vertically = shift(image, (20, 0))
+
+    Shift the image vertically by -200 pixels and horizontally by 100 pixels.
+
+    >>> image_shifted_both_directions = shift(image, (-200, 100))
+
+    Plot the original and the shifted images.
+
+    >>> fig, axes = plt.subplots(3, 1, figsize=(4, 12))
+    >>> plt.gray()  # show the filtered result in grayscale
+    >>> top, middle, bottom = axes
+    >>> for ax in axes:
+    ...     ax.set_axis_off()  # remove coordinate system
+    >>> top.imshow(image)
+    >>> top.set_title("Original image")
+    >>> middle.imshow(image_shifted_vertically)
+    >>> middle.set_title("Vertically shifted image")
+    >>> bottom.imshow(image_shifted_both_directions)
+    >>> bottom.set_title("Image shifted in both directions")
+    >>> fig.tight_layout()
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')


### PR DESCRIPTION
#### Reference issue
Part of #7168

#### What does this implement/fix?
Adds examples for `ndimage.shift`.

#### Additional information
Only 6 functions without examples left in `ndimage` after this PR.