### PR TITLE
MAINT: Add warning filter for `numpy.core` rename

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ filterwarnings =
     ignore:\s*.*numpy.distutils.*:DeprecationWarning
     ignore:.*The --rsyncdir command line argument.*:DeprecationWarning
     ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning
+    ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning


### PR DESCRIPTION
Hi! 
`numpy.core` is being renamed to `numpy._core` in https://github.com/numpy/numpy/pull/24634 PR. 
It doesn't have a direct impact on scipy, but it has on pybind11 (In a nutshell, pybind11 imports from `core` [here](https://github.com/pybind/pybind11/blob/5891867ee4ad1d671e0f54c5fb30f62d1322d8d0/include/pybind11/numpy.h#L266)). 

Due to this fact pypocketfft, which includes `<pybind11/numpy.h>` in its build process, emits a warning when executing pypocketfft functions (only in the test suite, when calling directly the private module - I checked it locally). 

Pytest turns these warnings in errors, hence this change (`numpy.array_api` warnings were also hidden this way).
