### PR TITLE
DOC: use `np.copysign()` instead of `np.sign()`

### DIFF
--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -364,7 +364,7 @@ def null_space(A, rcond=None):
     >>> from scipy.linalg import null_space
     >>> A = np.array([[1, 1], [1, 1]])
     >>> ns = null_space(A)
-    >>> ns * np.sign(ns[0,0])  # Remove the sign ambiguity of the vector
+    >>> ns * np.copysign(1, ns[0,0])  # Remove the sign ambiguity of the vector
     array([[ 0.70710678],
            [-0.70710678]])
 


### PR DESCRIPTION
The basis vectors returned `scipy.linalg.null_space()` are guaranteed to be orthonormal, but whether they point in the "positive" or "negative" direction is arbitrary.  To remove this source of non-determinism, the 1D documentation example recommends multiplying the basis vector by the sign of its first element.

This seems like good advice, but there's a bug in the way it's implemented.  The issue is that `np.sign(0) == 0`, so if the first element of the basis vector happens to be zero, then the whole vector gets erased.  The solution is to use `np.copysign()`, which doesn't have this behavior (and which even handles -0 correctly).
