### PR TITLE
MAINT: newton, make sure x0 is an inexact type

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -297,7 +297,10 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                              full_output)
 
     # Convert to float (don't use float(x0); this works also for complex x0)
-    x0 = np.asarray(x0)[()]
+    # Use np.asarray because we want x0 to be a numpy object, not a Python
+    # object. e.g. np.complex(1+1j) > 0 is possible, but (1 + 1j) > 0 raises
+    # a TypeError
+    x0 = np.asarray(x0)[()] * 1.0
     p0 = x0
     funcalls = 0
     if fprime is not None:

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -823,6 +823,20 @@ class TestNewton(TestScalarRootFinders):
         assert res.converged
         assert_allclose(res.root, 1)
 
+    @pytest.mark.parametrize('method', ['secant', 'newton'])
+    def test_int_x0_gh19280(self, method):
+        # Originally, `newton` ensured that only floats were passed to the
+        # callable. This was indadvertently changed by gh-17669. Check that
+        # it has been changed back.
+        def f(x):
+            # an integer raised to a negative integer power would fail
+            return x**-2 - 2
+
+        res = optimize.root_scalar(f, x0=1, method=method)
+        assert res.converged
+        assert_allclose(abs(res.root), 2**-0.5)
+        assert res.root.dtype == np.dtype(np.float64)
+
 
 def test_gh_5555():
     root = 0.1


### PR DESCRIPTION
Before this PR an integer `x0` passed to newton would not be coerced to an inexact type, which is what is typically needed for root finding. `np.asarray` doesn't coerce to an inexact type, it just makes sure something is in an array.