### PR TITLE
DOC: add `fft` to list of array API supporting modules

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -95,6 +95,7 @@ variable is set:
 
 - ``scipy.cluster.hierarchy``
 - ``scipy.cluster.vq``
+- ``scipy.fft``
 
 
 Implementation notes


### PR DESCRIPTION
#### Reference issue
Towards gh-19257.

#### What does this implement/fix?
`scipy.fft` joins `scipy.cluster.hierarchy` and `scipy.cluster.vq` on the list of modules which support the array API standard.
