### PR TITLE
MAINT fix more `-Wdeprecate-non-prototype` warnings

### DIFF
--- a/scipy/signal/_bspline_util.c.in
+++ b/scipy/signal/_bspline_util.c.in
@@ -23,10 +23,7 @@
 #endif
 
 void
-compute_root_from_lambda(lambda, r, omega)
-     double lambda;
-     double *r;
-     double *omega;
+compute_root_from_lambda(double lambda, double *r, double *omega)
 {
     double xi;
     double tmp, tmp2;


### PR DESCRIPTION
These are the last ones except for a couple that come from f2py and a bunch from SuperLU - these are best fixed upstream first and then pulled in.