### PR TITLE
BUG: stats: fix build failure due to incorrect Boost policies usage

### DIFF
--- a/scipy/stats/_boost/include/func_defs.hpp
+++ b/scipy/stats/_boost/include/func_defs.hpp
@@ -11,12 +11,6 @@ typedef boost::math::policies::policy<
     boost::math::policies::discrete_quantile<
         boost::math::policies::integer_round_up > > Policy;
 
-// Run user_error function when evaluation_errors and overflow_errors are encountered
-typedef boost::math::policies::policy<
-    boost::math::policies::evaluation_error<boost::math::policies::user_error>,
-    boost::math::policies::overflow_error<boost::math::policies::user_error> > user_error_policy;
-BOOST_MATH_DECLARE_SPECIAL_FUNCTIONS(user_error_policy)
-
 
 // Raise a RuntimeWarning making users aware that something went wrong during
 // evaluation of the function, but return the best guess

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -91,7 +91,16 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
-  depends: _stats_pxd
+  depends: _stats_pxd,
+  depend_files: [
+    '_boost/include/code_gen.py',
+    '_boost/include/gen_func_defs_pxd.py',
+    '_boost/include/_info.py',
+    # TODO: once setup.py is gone, remove this .pxd file from here and from the
+    #       output of this custom_target, and stop copying it manually in
+    #       code_gen.py. Instead, use fs.copyfile at the top of this file.
+    '_boost/include/templated_pyufunc.pxd',
+  ]
 )
 
 # Only needed to establish a dependency; see comments in linalg/meson.build


### PR DESCRIPTION
Removes use of `BOOST_MATH_DECLARE_SPECIAL_FUNCTIONS`. This macro must not be used in the global scope, as pointed out in https://github.com/conda-forge/scipy-feedstock/pull/246#issuecomment-1731603386. Rather, it should be used in a separate namespace (see, e.g., `boost_math/example/policy_eg_9.cpp`). It caused compilation errors with Clang on Windows in https://github.com/conda-forge/scipy-feedstock/pull/246.
    
This bit of code also did not seem necessary, given that these compile flags in `stats/_boost/meson.build` should already achieve the same effect:
```
'-DBOOST_MATH_EVALUATION_ERROR_POLICY=user_error',
'-DBOOST_MATH_OVERFLOW_ERROR_POLICY=user_error',
```
    
That the custom error handling in `func_defs.hpp` is still used can be verified by running for example after modifying the `user_evaluation_error` handler:
```
python dev.py test -t scipy.stats.tests.test_distributions -- -k test_boost_eval_issue_14606
```

Also fix the build dependencies for the Boost Cython wrappers. Code generation with a Python script that reads other files is something that Meson cannot handle automatically.

EDIT: this came in with gh-14618.