### PR TITLE
BLD: stats: improve build config for `unuran_wrapper`

### DIFF
--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -1,3 +1,8 @@
+_unuran_pxd = [
+  fs.copyfile('__init__.py'),
+  fs.copyfile('unuran.pxd'),
+]
+
 unuran_sources = [
   '../../_lib/unuran/unuran/src/distr/cemp.c',
   '../../_lib/unuran/unuran/src/distr/condi.c',
@@ -208,9 +213,17 @@ unuran_defines = [
   '-DHAVE_DECL_HYPOT=1'
 ]
 
+# Cython pyx -> c generator with _lib_pxd dependency, because the unuran
+# code depends on _lib/_ccallback_c
+unuran_cython_gen = generator(cython,
+  arguments : cython_args,
+  output : '@BASENAME@.c',
+  depends : [_cython_tree, _lib_pxd, _stats_pxd, _unuran_pxd]
+)
+
 statlib = py3.extension_module('unuran_wrapper',
   [
-    unuran_wrap_pyx,
+    unuran_cython_gen.process('unuran_wrapper.pyx'),
     unuran_sources
   ],
   c_args: [unuran_defines, cython_c_args],
@@ -224,7 +237,6 @@ statlib = py3.extension_module('unuran_wrapper',
 
 py3.install_sources([
     '__init__.py',
-    'unuran.pxd',
     'unuran_wrapper.pyi',
   ],
   subdir: 'scipy/stats/_unuran'

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -2,7 +2,6 @@ _stats_pxd = [
   fs.copyfile('__init__.py'),
   fs.copyfile('_stats.pxd'),
   fs.copyfile('_biasedurn.pxd'),
-  fs.copyfile('_unuran/unuran.pxd'),
 ]
 
 stats_special_cython_gen = generator(cython,
@@ -119,8 +118,6 @@ nct_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
 skewnorm_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
 invgauss_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[10])
 
-# Extra dependency from _lib
-unuran_wrap_pyx = lib_cython_gen.process('_unuran/unuran_wrapper.pyx')
 
 biasedurn = py3.extension_module('_biasedurn',
   [


### PR DESCRIPTION
This problem was observed on PR 246 to
https://github.com/conda-forge/scipy-feedstock:

```
[1022/1628] Linking target scipy/stats/_unuran/unuran_wrapper.cp311-win_amd64.pyd
FAILED: scipy/stats/_unuran/unuran_wrapper.cp311-win_amd64.pyd
"clang.exe" @scipy/stats/_unuran/unuran_wrapper.cp311-win_amd64.pyd.rsp
clang: error: no such file or directory: 'C:bldscipy-split_1695543774951_h_envlibspython311.lib'
```

This was the only .pyx file which was processed with Cython in a different subdir from where the extension module was compiled.

Also it was missing a few build dependencies of `__init__.py` files.

_EDIT: this wasn't actually the problem in the conda-forge build (see https://github.com/conda-forge/scipy-feedstock/pull/253#issuecomment-1732545515), but is still a useful cleanup._