### PR TITLE
BLD: add float.h include to `_fpumode.c`, fixes Clang on Windows issue

### DIFF
--- a/scipy/_lib/_fpumode.c
+++ b/scipy/_lib/_fpumode.c
@@ -4,6 +4,7 @@
 
 
 #ifdef _MSC_VER
+#include <float.h>
 #pragma float_control(precise, on)
 #pragma fenv_access (on)
 #endif


### PR DESCRIPTION
Follow-up to gh-8918; the linked CPython code in the discussion on the issue that that PR closes has the same `<float.h>` include.

This upstreams a patch from https://github.com/conda-forge/scipy-feedstock/pull/246 (hat tip to @xhochy).