### PR TITLE
MAINT: replace IOError alias with OSError

### DIFF
--- a/tools/ninjatracing.py
+++ b/tools/ninjatracing.py
@@ -128,7 +128,7 @@ def embed_time_trace(ninja_log_dir, target, pid, tid, options):
                 for time_trace_event in trace_to_dicts(target, trace, options,
                                                        pid, tid):
                     yield time_trace_event
-        except IOError:
+        except OSError:
             pass
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?

Since Python 3.3, IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including `IOError` (i.e. `assert IOError is OSError`).

This PR changes the old IOError alias to OSError.

<!--Please explain your changes.-->

#### Additional information

Similar to #14689.

<!--Any additional information you think is important.-->
