### PR TITLE
ENH: stats.kde: add `data_covariance` keyword argument

### DIFF
--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -604,3 +604,19 @@ def test_fewer_points_than_dimensions_gh17436():
     message = "Number of dimensions is greater than number of samples..."
     with pytest.raises(ValueError, match=message):
         stats.gaussian_kde(rvs)
+
+
+def test_data_covariance():
+    rng = np.random.default_rng(2046127537594925772)
+    rvs = rng.multivariate_normal(np.zeros(3), np.eye(3), size=10).T
+
+    message = "`data_covariance` must be a numerical array of shape..."
+    with pytest.raises(ValueError, match=message):
+        stats.gaussian_kde(rvs, data_covariance=[1, 2, 3])
+
+    cov = np.cov(rvs, rowvar=True, bias=False)
+    factor = rng.random()
+    kde1 = stats.gaussian_kde(rvs, bw_method=1)
+    kde2 = stats.gaussian_kde(rvs, bw_method=factor,
+                              data_covariance=cov/factor**2)
+    assert_allclose(kde1.pdf(rvs), kde2.pdf(rvs))


### PR DESCRIPTION
#### Reference issue
Closes gh-19250

#### What does this implement/fix?
This adds a `data_covariance` keyword argument to the initializer of `scipy.stats.kde`. This allows the user to pass the data covariance matrix if it is already known, avoiding redundant calculation, or to use a matrix other than the sample covariance (e.g. the identity, as in gh-19250).

#### Additional information
This needs an email to the mailing list before being merged.