### PR TITLE
MAINT: replace io.open alias with built-in open

### DIFF
--- a/tools/authors.py
+++ b/tools/authors.py
@@ -17,7 +17,6 @@ import argparse
 import re
 import sys
 import os
-import io
 import subprocess
 import collections
 
@@ -149,7 +148,7 @@ This list of names is automatically generated, and may not be fully complete.
 def load_name_map(filename):
     name_map = {}
 
-    with io.open(filename, 'r', encoding='utf-8') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if line.startswith(u"#") or not line:

--- a/tools/wheels/check_license.py
+++ b/tools/wheels/check_license.py
@@ -9,7 +9,6 @@ distribution.
 """
 import os
 import sys
-import io
 import re
 import argparse
 
@@ -37,7 +36,7 @@ def main():
 
     # Check license text
     license_txt = os.path.join(os.path.dirname(mod.__file__), "LICENSE.txt")
-    with io.open(license_txt, "r", encoding="utf-8") as f:
+    with open(license_txt, "r", encoding="utf-8") as f:
         text = f.read()
 
     ok = check_text(text)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In Python 3, [`io.open`](https://docs.python.org/3/library/io.html#io.open) is an alias for the builtin [`open`](https://docs.python.org/3.12/library/functions.html#open) function.

This PR changes the outdated `io.open` alias to `open`.

#### Additional information
<!--Any additional information you think is important.-->
