### PR TITLE
MAINT: Fix/parametrize Rotation tests.

### DIFF
--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -688,7 +688,11 @@ def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
 def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([[45, 90, 35], [35, -90, 20], [35, 90, 25], [25, -90, 15]])
+    angles = np.array([
+        [45, 90, 35],
+        [35, -90, 20],
+        [35, 90, 25],
+        [25, -90, 15]])
 
     seq = "".join(seq_tuple)
     if intrinsic:
@@ -708,7 +712,11 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
 def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([[15, 0, 60], [35, 0, 75], [60, 180, 35], [15, -180, 25]])
+    angles = np.array([
+        [15, 0, 60],
+        [35, 0, 75],
+        [60, 180, 35],
+        [15, -180, 25]])
 
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -642,6 +642,8 @@ def test_as_euler_asymmetric_axes(seq_tuple, intrinsic):
 
     seq = "".join(seq_tuple)
     if intrinsic:
+        # Extrinsic rotation (wrt to global world at lower case
+        # intrinsinc (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles)
     angles_quat = rotation.as_euler(seq)
@@ -671,7 +673,8 @@ def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
     angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    # Extrinsic rotations
+    # Rotation of the form A/B/A are rotation around symmetric
+    # Axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         seq = seq.upper()
@@ -695,9 +698,10 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
         [35, 90, 25],
         [25, -90, 15]])
 
-    # Extrinsic rotations
     seq = "".join(seq_tuple)
     if intrinsic:
+        # Extrinsic rotation (wrt to global world at lower case
+        # Intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
     mat_expected = rotation.as_matrix()
@@ -720,8 +724,12 @@ def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
         [60, 180, 35],
         [15, -180, 25]])
 
+    # Rotation of the form A/B/A are rotation around symmetric
+    # Axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
+        # Extrinsic rotation (wrt to global world at lower case
+        # Intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
     mat_expected = rotation.as_matrix()
@@ -748,6 +756,8 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
 
     seq = "".join(seq_tuple)
     if intrinsic:
+        # Extrinsic rotation (wrt to global world at lower case
+        # Intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
 
     rot = Rotation.from_euler(seq, angles, degrees=True)
@@ -773,10 +783,12 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
 
     idx = angles[:, 1] == 0  # find problematic angles indices
 
-    # Extrinsic rotations
+    # Rotation of the form A/B/A are rotation around symmetric
+    # Axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
-        # Intrinsic rotations
+        # Extrinsinc rotation (wrt to global world at lower case
+        # Intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
 
     rot = Rotation.from_euler(seq, angles, degrees=True)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -642,7 +642,7 @@ def test_as_euler_asymmetric_axes(seq_tuple, intrinsic):
 
     seq = "".join(seq_tuple)
     if intrinsic:
-        # Extrinsic rotation (wrt to global world at lower case
+        # Extrinsic rotation (wrt to global world) at lower case
         # intrinsinc (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles)
@@ -700,7 +700,7 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
 
     seq = "".join(seq_tuple)
     if intrinsic:
-        # Extrinsic rotation (wrt to global world at lower case
+        # Extrinsic rotation (wrt to global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
@@ -728,7 +728,7 @@ def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     # Axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
-        # Extrinsic rotation (wrt to global world at lower case
+        # Extrinsic rotation (wrt to global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
@@ -786,7 +786,7 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
-        # Extrinsinc rotation (wrt to global world at lower case
+        # Extrinsinc rotation (wrt to global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -622,7 +622,9 @@ def test_from_euler_extrinsic_rotation_313():
     ]))
 
 
-def test_as_euler_asymmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_asymmetric_axes(seq_tuple, intrinsic):
     # helper function for mean error tests
     def test_stats(error, mean_max, rms_max):
         mean = np.mean(error, axis=0)
@@ -638,29 +640,22 @@ def test_as_euler_asymmetric_axes():
     angles[:, 1] = rnd.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    for seq_tuple in permutations('xyz'):
-        # Extrinsic rotations
-        seq = ''.join(seq_tuple)
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
-        test_stats(angles_quat - angles, 1e-15, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-14)
-
-        # Intrinsic rotations
+    seq = "".join(seq_tuple)
+    if intrinsic:
         seq = seq.upper()
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
-        test_stats(angles_quat - angles, 1e-15, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-14)
+    rotation = Rotation.from_euler(seq, angles)
+    angles_quat = rotation.as_euler(seq)
+    angles_mat = rotation._as_euler_from_matrix(seq)
+    assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
+    assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
+    test_stats(angles_quat - angles, 1e-15, 1e-14)
+    test_stats(angles_mat - angles, 1e-15, 1e-14)
 
 
-def test_as_euler_symmetric_axes():
+
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
     # helper function for mean error tests
     def test_stats(error, mean_max, rms_max):
         mean = np.mean(error, axis=0)
@@ -676,101 +671,61 @@ def test_as_euler_symmetric_axes():
     angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    for seq_tuple in permutations('xyz'):
-        # Extrinsic rotations
-        seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
-        test_stats(angles_quat - angles, 1e-16, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-13)
-
-        # Intrinsic rotations
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
         seq = seq.upper()
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
-        test_stats(angles_quat - angles, 1e-16, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-13)
+    rotation = Rotation.from_euler(seq, angles)
+    angles_quat = rotation.as_euler(seq)
+    angles_mat = rotation._as_euler_from_matrix(seq)
+    assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
+    assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
+    test_stats(angles_quat - angles, 1e-16, 1e-14)
+    test_stats(angles_mat - angles, 1e-15, 1e-13)
 
 
-def test_as_euler_degenerate_asymmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([
-        [45, 90, 35],
-        [35, -90, 20],
-        [35, 90, 25],
-        [25, -90, 15]])
+    angles = np.array([[45, 90, 35], [35, -90, 20], [35, 90, 25], [25, -90, 15]])
+
+    seq = "".join(seq_tuple)
+    if intrinsic:
+        seq = seq.upper()
+    rotation = Rotation.from_euler(seq, angles, degrees=True)
+    mat_expected = rotation.as_matrix()
 
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join(seq_tuple)
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+    mat_estimated = Rotation.from_euler(seq, angle_estimates, degrees=True).as_matrix()
 
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
-
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
+    assert_array_almost_equal(mat_expected, mat_estimated)
 
 
-def test_as_euler_degenerate_symmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([
-        [15, 0, 60],
-        [35, 0, 75],
-        [60, 180, 35],
-        [15, -180, 25]])
+    angles = np.array([[15, 0, 60], [35, 0, 75], [60, 180, 35], [15, -180, 25]])
+
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
+        seq = seq.upper()
+    rotation = Rotation.from_euler(seq, angles, degrees=True)
+    mat_expected = rotation.as_matrix()
 
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+    mat_estimated = Rotation.from_euler(seq, angle_estimates, degrees=True).as_matrix()
 
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
-
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
+    assert_array_almost_equal(mat_expected, mat_estimated)
 
 
-def test_as_euler_degenerate_compare_algorithms():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     # this test makes sure that both algorithms are doing the same choices
     # in degenerate cases
 
@@ -781,27 +736,20 @@ def test_as_euler_degenerate_compare_algorithms():
         [35, 90, 25],
         [25, -90, 15]])
 
-    with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join(seq_tuple)
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-            assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1],
-                            atol=0, rtol=1e-7)
+    seq = "".join(seq_tuple)
+    if intrinsic:
+        seq = seq.upper()
 
-            # Intrinsic rotations
-            seq = seq.upper()
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-            assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1],
-                            atol=0, rtol=1e-7)
+    rot = Rotation.from_euler(seq, angles, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_quat = rot.as_euler(seq, degrees=True)
+    assert_allclose(
+        estimates_matrix[:, [0, 2]], estimates_quat[:, [0, 2]], atol=0, rtol=1e-12
+    )
+    assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1], atol=0, rtol=1e-7)
+
     # symmetric axes
     # Absolute error tolerance must be looser to directly compare the results
     # from both algorithms, because of numerical loss of precision for the
@@ -815,35 +763,26 @@ def test_as_euler_degenerate_compare_algorithms():
 
     idx = angles[:, 1] == 0  # find problematic angles indices
 
+    # Extrinsic rotations
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
+        seq = seq.upper()
+    rot = Rotation.from_euler(seq, angles, degrees=True)
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
+        estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_quat = rot.as_euler(seq, degrees=True)
+    assert_allclose(
+        estimates_matrix[:, [0, 2]], estimates_quat[:, [0, 2]], atol=0, rtol=1e-12
+    )
 
-            assert_allclose(estimates_matrix[~idx, 1], estimates_quat[~idx, 1],
-                            atol=0, rtol=1e-7)
+    assert_allclose(
+        estimates_matrix[~idx, 1], estimates_quat[~idx, 1], atol=0, rtol=1e-7
+    )
 
-            assert_allclose(estimates_matrix[idx, 1], estimates_quat[idx, 1],
-                            atol=1e-6)  # problematic, angles[1] = 0
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-
-            assert_allclose(estimates_matrix[~idx, 1], estimates_quat[~idx, 1],
-                            atol=0, rtol=1e-7)
-
-            assert_allclose(estimates_matrix[idx, 1], estimates_quat[idx, 1],
-                            atol=1e-6)  # problematic, angles[1] = 0
+    assert_allclose(
+        estimates_matrix[idx, 1], estimates_quat[idx, 1], atol=1e-6
+    )  # problematic, angles[1] = 0
 
 
 def test_inv():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -671,6 +671,7 @@ def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
     angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
+    # Extrinsic rotations
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         seq = seq.upper()
@@ -694,6 +695,7 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
         [35, 90, 25],
         [25, -90, 15]])
 
+    # Extrinsic rotations
     seq = "".join(seq_tuple)
     if intrinsic:
         seq = seq.upper()
@@ -774,7 +776,9 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     # Extrinsic rotations
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
+        # Intrinsic rotations
         seq = seq.upper()
+
     rot = Rotation.from_euler(seq, angles, degrees=True)
     with pytest.warns(UserWarning, match="Gimbal lock"):
         estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -701,7 +701,7 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
     seq = "".join(seq_tuple)
     if intrinsic:
         # Extrinsic rotation (wrt to global world at lower case
-        # Intrinsic (WRT the object itself) lower case.
+        # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
     mat_expected = rotation.as_matrix()
@@ -729,7 +729,7 @@ def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         # Extrinsic rotation (wrt to global world at lower case
-        # Intrinsic (WRT the object itself) lower case.
+        # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
     mat_expected = rotation.as_matrix()
@@ -757,7 +757,7 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     seq = "".join(seq_tuple)
     if intrinsic:
         # Extrinsic rotation (wrt to global world at lower case
-        # Intrinsic (WRT the object itself) lower case.
+        # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
 
     rot = Rotation.from_euler(seq, angles, degrees=True)
@@ -783,12 +783,11 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
 
     idx = angles[:, 1] == 0  # find problematic angles indices
 
-    # Rotation of the form A/B/A are rotation around symmetric
-    # Axes
+    # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         # Extrinsinc rotation (wrt to global world at lower case
-        # Intrinsic (WRT the object itself) lower case.
+        # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
 
     rot = Rotation.from_euler(seq, angles, degrees=True)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -673,8 +673,7 @@ def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
     angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    # Rotation of the form A/B/A are rotation around symmetric
-    # Axes
+    # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         seq = seq.upper()
@@ -724,8 +723,7 @@ def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
         [60, 180, 35],
         [15, -180, 25]])
 
-    # Rotation of the form A/B/A are rotation around symmetric
-    # Axes
+    # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
         # Extrinsic rotation (wrt to global world) at lower case


### PR DESCRIPTION
The test were slightly incorrect in the sens that they were testing that at least one of the combination of angle/sequence/intrinsic-extrinsic angle where emitting a Gimbal Lock warning, instead of each of them.

The warning is now checked _only_ and on _all_ on the line that are supposed to emit such a warning.

And while I was at it I parametrized the tests, so each appear as a separate intem when running with pytest, and extended to all the parametrized test in case it ever have an issue somewhere.

In all of the `angles = np.array(...)` I have the impression that each one should emit a warning and that angle should likely also be a parameter, but it was starting to be a lot (maybe open an issue to parametrize angle?)

