### PR TITLE
ENH: add `axis` tuple, `nan_policy`, and `keepdims` to `differential_entropy`

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import math
 import numpy as np
 from scipy import special
+from ._axis_nan_policy import _axis_nan_policy_factory
 
 __all__ = ['entropy', 'differential_entropy']
 
@@ -143,7 +144,9 @@ def entropy(pk: np.typing.ArrayLike,
         S /= np.log(base)
     return S
 
-
+@_axis_nan_policy_factory(
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+)
 def differential_entropy(
     values: np.typing.ArrayLike,
     *,

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -144,8 +144,21 @@ def entropy(pk: np.typing.ArrayLike,
         S /= np.log(base)
     return S
 
+
+def _differential_entropy_is_too_small(samples, kwargs):
+    values = samples[0]
+    n = values.shape[-1]
+    window_length = kwargs.get("window_length",
+                               math.floor(math.sqrt(n) + 0.5))
+    if not 2 <= 2 * window_length < n:
+        return True
+    return False
+
+
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,),
+    too_small=_differential_entropy_is_too_small,
+    override={"nan_propagation": False}
 )
 def differential_entropy(
     values: np.typing.ArrayLike,

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -62,7 +62,8 @@ axis_nan_policy_cases = [
     (_get_ttest_ci(stats.ttest_1samp), (0,), dict(), 1, 2, False, None),
     (_get_ttest_ci(stats.ttest_rel), tuple(), dict(), 2, 2, True, None),
     (_get_ttest_ci(stats.ttest_ind), tuple(), dict(), 2, 2, False, None),
-    (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count))
+    (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count)),
+    (stats.differential_entropy, tuple(), dict(), 1, 1, False, lambda x: (x,))
 ]
 
 # If the message is one of those expected, put nans in
@@ -82,7 +83,10 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "zero-size array to reduction operation maximum",
                       "`x` and `y` must be of nonzero size.",
                       "The exact distribution of the Wilcoxon test",
-                      "Data input must not be empty"}
+                      "Data input must not be empty",
+                      "Window length (0) must be positive and less",
+                      "Window length (1) must be positive and less",
+                      "Window length (2) must be positive and less"}
 
 # If the message is one of these, results of the function may be inaccurate,
 # but NaNs are not to be placed

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -63,7 +63,7 @@ axis_nan_policy_cases = [
     (_get_ttest_ci(stats.ttest_rel), tuple(), dict(), 2, 2, True, None),
     (_get_ttest_ci(stats.ttest_ind), tuple(), dict(), 2, 2, False, None),
     (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count)),
-    (stats.differential_entropy, tuple(), dict(), 1, 1, False, lambda x: (x,))
+    (stats.differential_entropy, tuple(), dict(), 1, 1, False, lambda x: (x,)),
 ]
 
 # If the message is one of those expected, put nans in
@@ -86,7 +86,7 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "Data input must not be empty",
                       "Window length (0) must be positive and less",
                       "Window length (1) must be positive and less",
-                      "Window length (2) must be positive and less"}
+                      "Window length (2) must be positive and less",}
 
 # If the message is one of these, results of the function may be inaccurate,
 # but NaNs are not to be placed


### PR DESCRIPTION
#### Reference issue

Towards #14651

#### What does this implement/fix?

This PR adds support for `axis` tuples, `nan_policy`, and `keepdims` to `scipy.stats.differential_entropy`.

#### Additional information

`differential_entropy` throws a `ValueError` when the size of the input array (on `axis` dimension) is less than or equal to twice the value of the `window_length` argument. Since it didn't handle `nan`s before, the function treated them just like any other value (and didn't error out). But the decorator now removes the `nan`s when `nan_policy="omit"` (and the function errors out). The behavior is also different when `nan_policy="propagate"` but that can be fixed by passing `override={"nan_propagation": False}` (will also add a test for it).

Here's an example for both the cases:

```python
import numpy as np
from scipy import stats

# NaN policy "propagate" case
stats.differential_entropy([np.nan])  # outputs np.nan
stats.differential_entropy([np.nan], _no_deco=True)  # ValueError
# Can be fixed by override={"nan_propagation": False}

# NaN policy "omit" case
stats.differential_entropy([np.nan]*4 + [0.1], nan_policy="omit")  # ValueError
stats.differential_entropy([np.nan]*4 + [0.1])  # np.nan
# The tests say that, for this case, we must output `np.nan` since the
# input is too small.
#  1. Is that intuitive in this case? I think a ValueError might be more appropriate.
#  2. We will need to convert the "too_small" argument to a callable to achieve nan output.
```

@mdhaber How do you think `nan_policy="omit"` case should be resolved? One option is to allow callable `too_small` argument in the decorator and let the decorator return `nan` instead of raising the error. Or keep the behavior of raising the ValueError and exempt the function from the test.