### PR TITLE
set idx_dtype in sparse dia_array.tocoo 

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -87,7 +87,7 @@ class _dia_base(_data_matrix):
             raise ValueError('offset array contains duplicate values')
 
     def __repr__(self):
-        format = _formats[self.getformat()][1]
+        format = _formats[self.format][1]
         return "<%dx%d sparse matrix of type '%s'\n" \
                "\twith %d stored elements (%d diagonals) in %s format>" % \
                (self.shape + (self.dtype.type, self.nnz, self.data.shape[0],
@@ -332,6 +332,11 @@ class _dia_base(_data_matrix):
         mask &= (self.data != 0)
         row = row[mask]
         col = np.tile(offset_inds, num_offsets)[mask.ravel()]
+        idx_dtype = self._get_index_dtype(
+            arrays=(self.offsets,), maxval=max(self.shape)
+        )
+        row = row.astype(idx_dtype, copy=False)
+        col = col.astype(idx_dtype, copy=False)
         data = self.data[mask]
         # Note: this cannot set has_canonical_format=True, because despite the
         # lack of duplicates, we do not generate sorted indices.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4928,6 +4928,7 @@ def cases_64bit():
         'test_large_dimensions_reshape': 'test actually requires 64-bit to work',
         'test_constructor_smallcol': 'test verifies int32 indexes',
         'test_constructor_largecol': 'test verifies int64 indexes',
+        'test_tocoo_tocsr_tocsc_gh19245': 'test verifies int32 indexes',
     }
 
     for cls in TEST_CLASSES:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4462,6 +4462,19 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         inds_are_sorted = np.all(np.diff(flat_inds) > 0)
         assert m.has_canonical_format == inds_are_sorted
 
+    def test_tocoo_tocsr_tocsc_gh19245(self):
+        # test index_dtype with tocoo, tocsr, tocsc
+        data = np.array([[1, 2, 3, 4]]).repeat(3, axis=0)
+        offsets = np.array([0, -1, 2], dtype=np.int32)
+        dia = sparse.dia_array((data, offsets), shape=(4, 4))
+
+        coo = dia.tocoo()
+        assert coo.col.dtype == np.int32
+        csr = dia.tocsr()
+        assert csr.indices.dtype == np.int32
+        csc = dia.tocsc()
+        assert csc.indices.dtype == np.int32
+
 
 TestDIA.init_class()
 


### PR DESCRIPTION
Fixes #19245 
(and the closed #19246 )

When sparse.dia_array converted to coo format it used the default index dtype. This PR implements the suggested fix in #19245 and adds a test to ensure that `tocoo()` sets the `idx_dtype` correctly to `np.int32` when appropriate.

This bug further impacted `tocsr()` because that conversion in turn used `tocoo()`. The added test checks tocoo, tocsr and tocsc. All now work.

Notes:  I changed one `.getformat()` to `.format` to avoid the deprecation warning on getformat. And I tested `tocsc` in addition to `tocoo` and `tocsr` because it was easy and fast and seemed natural, even though `tocsc` worked before this fix.  I can remove either of these changes if desired.
