### PR TITLE
DOC: Rst don't like list without blanklines.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5425,9 +5425,11 @@ class jf_skew_t_gen(rv_continuous):
 
     def _munp(self, n, a, b):
         """Returns the n-th moment(s) where all the following hold:
-            - n >= 0
-            - a > n / 2
-            - b > n / 2
+
+        - n >= 0
+        - a > n / 2
+        - b > n / 2
+
         The result is np.nan in all other cases.
         """
         def nth_moment(n_k, a_k, b_k):


### PR DESCRIPTION
It does not matter much as this is not rendered in the docs. But still if something try to parse all the docstrings of all the function of scipy it fails.

You can https://stsewd.dev/tree-sitter-rst/ to parse the docstring and see how it fails.

And yes you want to not indent as otherwise it becomes a block quote.

[ci skip]