### PR TITLE
DOC: stats.chisquare: result object contains attribute 'statistic'

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8118,7 +8118,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
             None or `f_obs` and `f_exp` are 1-D.
         pvalue : float or ndarray
             The p-value of the test.  The value is a float if `ddof` and the
-            return value `statistic` are scalars.
+            result attribute `statistic` are scalars.
 
     See Also
     --------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8113,12 +8113,12 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     res: Power_divergenceResult
         An object containing attributes:
 
-        chisq : float or ndarray
+        statistic : float or ndarray
             The chi-squared test statistic.  The value is a float if `axis` is
             None or `f_obs` and `f_exp` are 1-D.
         pvalue : float or ndarray
             The p-value of the test.  The value is a float if `ddof` and the
-            return value `chisq` are scalars.
+            return value `statistic` are scalars.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
[`scipy.stats.chisquare` documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.chisquare.html) says that the result object contains an attribute `chisq`, but the correct name of the attribute (since at least 2015) is `statistic`. 