### PR TITLE
MAINT, BLD: more setup.py cleanups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,5 @@
 branch = True
 include = */scipy/*
 omit =
-    scipy/setup.py
-    scipy/*/setup.py
     scipy/signal/_max_len_seq_inner.py
 disable_warnings = include-ignored

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,6 @@
 
 # Build related files
 pyproject.toml  @rgommers
-setup.py  @rgommers @larsoner
 environment.yml  @rgommers
 meson*  @rgommers
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,13 +56,13 @@ _configtest.c
 
 # Python files #
 ################
-# setup.py working directory
+# build directory
 build
 # sphinx build directory
 doc/_build
 # cython files
 cythonize.dat
-# setup.py dist directory
+# sdist directory
 dist
 # Egg metadata
 *.egg-info

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -66,7 +66,6 @@ del _distributor_init
 
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
-# See setup.py for more details
 np_minversion = '1.22.4'
 np_maxversion = '9.9.99'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -397,9 +397,6 @@ def main():
         if options.outdir:
             # Used by Meson (options.outdir == scipy/sparse/sparsetools)
             outdir = os.path.join(os.getcwd(), options.outdir)
-        else:
-            # Used by setup.py
-            outdir = os.path.join(os.path.dirname(__file__), 'sparsetools')
 
         dst = os.path.join(outdir,
                            unit_name + '_impl.h')

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -91,8 +91,6 @@ if use_g77_abi
 endif
 foreach ele: elements
   # PROPACK integration is pretty much broken, see for example gh-15108.
-  # Note that in setup.py, adding `g77_abi_wrappers` is skipped for 32-bit
-  # architectures (stated reason: "it blows up").
   propack_lib = static_library('lib_' + ele[0],
     ele[1],
     fortran_args: [

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -91,6 +91,8 @@ if use_g77_abi
 endif
 foreach ele: elements
   # PROPACK integration is pretty much broken, see for example gh-15108.
+  # Note that in setup.py, adding `g77_abi_wrappers` was skipped for 32-bit
+  # architectures (stated reason: "it blows up").
   propack_lib = static_library('lib_' + ele[0],
     ele[1],
     fortran_args: [

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -159,7 +159,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     _boost_dir = pathlib.Path(__file__).resolve().parent.parent
-    if args.outdir:
+    if not args.outdir:
+        raise ValueError("A path to the output directory is required")
+    else:
         src_dir = pathlib.Path(args.outdir)
 
     # generate the PXD and PYX wrappers

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -3,7 +3,6 @@
 from typing import NamedTuple
 from warnings import warn
 from textwrap import dedent
-from shutil import copyfile
 import pathlib
 import argparse
 
@@ -162,16 +161,6 @@ if __name__ == '__main__':
     _boost_dir = pathlib.Path(__file__).resolve().parent.parent
     if args.outdir:
         src_dir = pathlib.Path(args.outdir)
-    else:
-        # We're using setup.py here, not Meson. Create target directory
-        src_dir = _boost_dir / 'src'
-        src_dir.mkdir(exist_ok=True, parents=True)
-
-    # copy contents of include into directory to satisfy Cython
-    # PXD include conditions
-    inc_dir = _boost_dir / 'include'
-    src = 'templated_pyufunc.pxd'
-    copyfile(inc_dir / src, src_dir / src)
 
     # generate the PXD and PYX wrappers
     _gen_func_defs_pxd(

--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -5,15 +5,11 @@ import os
 import argparse
 
 
-def make_boost(outdir, distutils_build=False):
+def make_boost(outdir):
     # Call code generator inside _boost directory
     code_gen = pathlib.Path(__file__).parent / '_boost/include/code_gen.py'
-    if distutils_build:
-        subprocess.run([sys.executable, str(code_gen), '-o', outdir,
-                        '--distutils-build', 'True'], check=True)
-    else:
-        subprocess.run([sys.executable, str(code_gen), '-o', outdir],
-                       check=True)
+    subprocess.run([sys.executable, str(code_gen), '-o', outdir],
+                   check=True)
 
 
 if __name__ == '__main__':
@@ -23,12 +19,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if not args.outdir:
-        # We're dealing with a distutils build here, write in-place:
-        outdir_abs = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))
-        outdir_abs_boost = outdir_abs / '_boost' / 'src'
-        if not os.path.exists(outdir_abs_boost):
-            os.makedirs(outdir_abs_boost)
-        make_boost(outdir_abs_boost, distutils_build=True)
+        raise ValueError("A path to the output directory is required")
     else:
         # Meson build
         srcdir_abs = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -2,6 +2,7 @@ _stats_pxd = [
   fs.copyfile('__init__.py'),
   fs.copyfile('_stats.pxd'),
   fs.copyfile('_biasedurn.pxd'),
+  fs.copyfile('_boost/include/templated_pyufunc.pxd'),
 ]
 
 stats_special_cython_gen = generator(cython,
@@ -81,12 +82,11 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
     'func_defs.pxd',  # 2 (S_B)
     'hypergeom_ufunc.pyx',  # 3 (S_B)
     'nbinom_ufunc.pyx',  # 4 (S_B)
-    'templated_pyufunc.pxd',  # 5 (S_B)
-    'ncf_ufunc.pyx',  # 6 (S_B)
-    'ncx2_ufunc.pyx',  # 7 (S_B)
-    'nct_ufunc.pyx',  # 8 (S_B)
-    'skewnorm_ufunc.pyx',  # 9 (S_B)
-    'invgauss_ufunc.pyx',  # 10 (S_B)
+    'ncf_ufunc.pyx',  # 5 (S_B)
+    'ncx2_ufunc.pyx',  # 6 (S_B)
+    'nct_ufunc.pyx',  # 7 (S_B)
+    'skewnorm_ufunc.pyx',  # 8 (S_B)
+    'invgauss_ufunc.pyx',  # 9 (S_B)
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
@@ -95,10 +95,6 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
     '_boost/include/code_gen.py',
     '_boost/include/gen_func_defs_pxd.py',
     '_boost/include/_info.py',
-    # TODO: once setup.py is gone, remove this .pxd file from here and from the
-    #       output of this custom_target, and stop copying it manually in
-    #       code_gen.py. Instead, use fs.copyfile at the top of this file.
-    '_boost/include/templated_pyufunc.pxd',
   ]
 )
 
@@ -121,11 +117,11 @@ beta_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[0])
 binom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[1])
 hypergeom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[3])
 nbinom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[4])
-ncf_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[6])
-ncx2_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[7])
-nct_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
-skewnorm_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
-invgauss_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[10])
+ncf_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[5])
+ncx2_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[6])
+nct_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[7])
+skewnorm_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
+invgauss_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
 
 
 biasedurn = py3.extension_module('_biasedurn',


### PR DESCRIPTION
* deal with the `setup.py`-related `TODO` comment in the `stats` build system surrounding `templated_pyufunc.pxd`, now that we no longer have `setup.py`

* remove `setup.py` handling from our coverage config (I think our coverage infrastructure is a bit dormant at the moment in any case)

* remove some stray comments/other configs related to `setup.py`

* I've avoided some potentially more complex cleanups for now, like `messagestream_config.h.in` (and yes, there are other places in the `meson` build system where we can cleanup, but I'm less confident to tackle those at this time)

[skip cirrus]