### PR TITLE
ENH: Fit skewnorms with MLE more robustly

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9221,6 +9221,8 @@ class skewnorm_gen(rv_continuous):
         shape parameter ``a`` will be infinite.
         \n\n""")
     def fit(self, data, *args, **kwds):
+        if kwds.pop("superfit", False):
+            return super().fit(data, *args, **kwds)
         if isinstance(data, CensoredData):
             if data.num_censored() == 0:
                 data = data._uncensor()

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3867,6 +3867,16 @@ class TestSkewNorm:
         a7m, loc7m, scale7m = stats.skewnorm.fit(-rvs, method='mm')
         assert_allclose([a7m, loc7m, scale7m], [-a7p, -loc7p, scale7p])
 
+        # test that MLE is resistant to finding the wrong local optimum (see gh-19332)
+        a_correct, loc_correct, scale_correct = -1.60957, 2.2990, 2.46210
+        for n in range(8):
+            rvs = np.array([-5, -1, n / 100_000] + 12 * [1] + [5])
+            a8, loc8, scale8 = stats.skewnorm.fit(rvs)
+            assert_allclose(
+                (a8, loc8, scale8), (a_correct, loc_correct, scale_correct), atol=1e-4
+            )
+
+
 class TestExpon:
     def test_zero(self):
         assert_equal(stats.expon.pdf(0), 1)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -33,7 +33,7 @@ from scipy.special import xlogy, polygamma, entr
 from scipy.stats._distr_params import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
 from scipy.stats._continuous_distns import FitDataError, _argus_phi
-from scipy.optimize import root, fmin
+from scipy.optimize import root, fmin, differential_evolution
 from itertools import product
 
 # python -OO strips docstrings
@@ -3867,14 +3867,29 @@ class TestSkewNorm:
         a7m, loc7m, scale7m = stats.skewnorm.fit(-rvs, method='mm')
         assert_allclose([a7m, loc7m, scale7m], [-a7p, -loc7p, scale7p])
 
-        # test that MLE is resistant to finding the wrong local optimum (see gh-19332)
-        a_correct, loc_correct, scale_correct = -1.60957, 2.2990, 2.46210
-        for n in range(8):
-            rvs = np.array([-5, -1, n / 100_000] + 12 * [1] + [5])
-            a8, loc8, scale8 = stats.skewnorm.fit(rvs)
-            assert_allclose(
-                (a8, loc8, scale8), (a_correct, loc_correct, scale_correct), atol=1e-4
-            )
+    def test_fit_gh19332(self):
+        # When the skewness of the data was high, `skewnorm.fit` fell back on
+        # generic `fit` behavior with a bad guess of the skewness parameter.
+        # Test that this is improved; `skewnorm.fit` is now better at finding
+        # the global optimum when the sample is highly skewed. See gh-19332.
+        x = np.array([-5, -1, 1 / 100_000] + 12 * [1] + [5])
+
+        params = stats.skewnorm.fit(x)
+        res = stats.skewnorm.nnlf(params, x)
+
+        # Compare overridden fit against generic fit
+        params_super = stats.skewnorm.fit(x, superfit=True)
+        ref = stats.skewnorm.nnlf(params_super, x)
+        assert res < ref - 0.5
+
+        # Compare overridden fit against stats.fit
+        rng = np.random.default_rng(9842356982345693637)
+        bounds = {'a': (-5, 5), 'loc': (-10, 10), 'scale': (1e-16, 10)}
+        def optimizer(fun, bounds):
+            return differential_evolution(fun, bounds, seed=rng)
+
+        fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
+        np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
 
 class TestExpon:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3877,7 +3877,9 @@ class TestSkewNorm:
         params = stats.skewnorm.fit(x)
         res = stats.skewnorm.nnlf(params, x)
 
-        # Compare overridden fit against generic fit
+        # Compare overridden fit against generic fit.
+        # res should be about 32.01, and generic fit is worse at 32.64.
+        # In case the generic fit improves, remove this assertion (see gh-19333).
         params_super = stats.skewnorm.fit(x, superfit=True)
         ref = stats.skewnorm.nnlf(params_super, x)
         assert res < ref - 0.5


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-19332

#### What does this implement/fix?
Improves the initial guess to the MLE optimizer in the case when the skew of the data exceeds the maximum skew of the skewnorm distribution.

In this case, MoM can't provide a valid initial guess. Instead of balking and calling `rv_continuous.fit` with the default skew `a=0`, clip the skew value to a large feasible number (`0.99` where the max is ~`0.995`) so that we can continue with a reasonable initial guess.

For a more detailed explanation, please see gh-19332.