### PR TITLE
DOC: Brenth Comment Correction in scipy.optimize._zero_py.py

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -823,7 +823,7 @@ def brenth(f, a, b, args=(),
     between the arguments a and b that uses hyperbolic extrapolation instead of
     inverse quadratic extrapolation. Bus & Dekker (1975) guarantee convergence
     for this method, claiming that the upper bound of function evaluations here
-    is 4 or 5 times lesser than that for bisection.
+    is 4 or 5 times that of bisection.
     f(a) and f(b) cannot have the same signs. Generally, on a par with the
     brent routine, but not as heavily tested. It is a safe version of the
     secant method that uses hyperbolic extrapolation.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->
Corrected scipy.optimize.brenth function's docs to match what was stated in abstract of paper that was cited for the fact. 

Brenth has upper bound of 4 to 5 times that of bisection's function evaluations, not 4 to 5 times less than that of bisection.

Current documentation is an incorrect representation of the method's comparison to brentq.

#### Additional information
<!--Any additional information you think is important.-->
Paper link: https://dl.acm.org/doi/pdf/10.1145/355656.355659
