### PR TITLE
BUG: fix pow method for sparrays with power zero

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -115,15 +115,17 @@ class _data_matrix(_spbase):
 
         Raises
         ------
-        ValueError : if n is a zero scalar
+        NotImplementedError : if n is a zero scalar
             If zero power is desired, special case it to use
             `np.ones(A.shape, dtype=A.dtype)`
         """
         if not isscalarlike(n):
             raise NotImplementedError("input is not scalar")
         if not n:
-            raise NotImplementedError("zero power makes all ones (dense).\n"
-                "Use `np.ones(A.shape, dtype=A.dtype)` for this case.")
+            raise NotImplementedError(
+                "n=0 is not supported as it would densify the matrix.\n"
+                "Use `np.ones(A.shape, dtype=A.dtype)` for this case."
+            )
 
         data = self._deduped_data()
         if dtype is not None:

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -123,7 +123,7 @@ class _data_matrix(_spbase):
             raise NotImplementedError("input is not scalar")
         if not n:
             raise NotImplementedError(
-                "n=0 is not supported as it would densify the matrix.\n"
+                "zero power is not supported as it would densify the matrix.\n"
                 "Use `np.ones(A.shape, dtype=A.dtype)` for this case."
             )
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -107,12 +107,23 @@ class _data_matrix(_spbase):
 
         Parameters
         ----------
-        n : n is a scalar
+        n : scalar
+            n is a non-zero scalar (nonzero avoids dense ones creation)
+            If zero power is desired, special case it to use `np.ones`
 
         dtype : If dtype is not specified, the current dtype will be preserved.
+
+        Raises
+        ------
+        ValueError : if n is a zero scalar
+            If zero power is desired, special case it to use
+            `np.ones(A.shape, dtype=A.dtype)`
         """
         if not isscalarlike(n):
             raise NotImplementedError("input is not scalar")
+        if not n:
+            raise ValueError("zero power makes all ones (dense).\n"
+                "Use `np.ones(A.shape, dtype=A.dtype)` for this case.")
 
         data = self._deduped_data()
         if dtype is not None:

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -122,7 +122,7 @@ class _data_matrix(_spbase):
         if not isscalarlike(n):
             raise NotImplementedError("input is not scalar")
         if not n:
-            raise ValueError("zero power makes all ones (dense).\n"
+            raise NotImplementedError("zero power makes all ones (dense).\n"
                 "Use `np.ones(A.shape, dtype=A.dtype)` for this case.")
 
         data = self._deduped_data()

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -140,10 +140,16 @@ def test_matmul(A):
     assert np.all((A @ A.T).todense() == A.dot(A.T).todense())
 
 
-@parametrize_square_sparrays
-def test_pow(B):
-    assert isinstance((B**0), scipy.sparse.sparray), "Expected array, got matrix"
-    assert isinstance((B**2), scipy.sparse.sparray), "Expected array, got matrix"
+@parametrize_sparrays
+def test_power_operator(A):
+    assert isinstance((A**2), scipy.sparse.sparray), "Expected array, got matrix"
+
+    # https://github.com/scipy/scipy/issues/15948
+    npt.assert_equal((A**2).todense(), (A.todense())**2)
+
+    # power of zero is all ones (dense) so helpful msg exception
+    with pytest.raises(ValueError):
+        A**0
 
 
 @parametrize_sparrays
@@ -344,12 +350,6 @@ def test_spilu():
     ])
     LU = spla.spilu(X)
     npt.assert_allclose(LU.solve(np.array([1, 2, 3, 4])), [1, 0, 0, 0])
-
-
-@parametrize_sparrays
-def test_power_operator(A):
-    # https://github.com/scipy/scipy/issues/15948
-    npt.assert_equal((A**2).todense(), (A.todense())**2)
 
 
 @pytest.mark.parametrize(

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -148,7 +148,7 @@ def test_power_operator(A):
     npt.assert_equal((A**2).todense(), (A.todense())**2)
 
     # power of zero is all ones (dense) so helpful msg exception
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="zero power"):
         A**0
 
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -148,7 +148,7 @@ def test_power_operator(A):
     npt.assert_equal((A**2).todense(), (A.todense())**2)
 
     # power of zero is all ones (dense) so helpful msg exception
-    with pytest.raises(ValueError, match="zero power"):
+    with pytest.raises(NotImplementedError, match="zero power"):
         A**0
 
 


### PR DESCRIPTION
Even after the fix #16430 fixed #15948 so the sparse array ** operator matches numpy **, they don't match when the power is `0`. The result of `A ** 0` is `np.ones(A.shape)` for a ndarray, but sparse arrays set `A ** 0` to ones only for originally non-zero values.  Thus 
```python
A = sp.sparse.csr_array([[0,2,-3]])
result = (A ** 0).toarray()         # => np.array([[0, 1, 1]])

np.array([[0, 2, -3]] ** 0  #  =>  np.array([[1, 1, 1]])
```

`A**0` should mean every entry is `1`, not just the originally non-zero entries. So the current return values are incorrect for sparse arrays (BUG).

Furthermore, this means the nonzero structure of `A**x` changes in a discontinuous fashion near x=0. There is a question then as to whether this method should return a sparse array with all entries 1, or switch to a dense array, or raise an exception with a workaround described.

This PR implements raising a `ValueError` when `n` is a zero valued scalar. The message (and doc_string description of `n`) says if they want to compute `A**n` for `n==0`, they should special case that value to use `np.ones(A.shape, dtype=A.dtype)`

If they really meant to do this, I'm thinking they could use something like:
```python
result = A ** x if x else np.ones(A.shape, dtype=A.dtype)
```
And we could make our function do that too, but I think it might surprise people who don't expect conversion to a dense matrix.  Either way, the current return value of a matrix with some 1 and some 0 values is wrong and doesn't match numpy results.
