### PR TITLE
ENH: Add ability to silence Gimbal Lock warnings for rotations.

### DIFF
--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -688,7 +688,11 @@ def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
 def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([[45, 90, 35], [35, -90, 20], [35, 90, 25], [25, -90, 15]])
+    angles = np.array([
+        [45, 90, 35],
+        [35, -90, 20],
+        [35, 90, 25],
+        [25, -90, 15]])
 
     seq = "".join(seq_tuple)
     if intrinsic:
@@ -708,7 +712,11 @@ def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
 def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([[15, 0, 60], [35, 0, 75], [60, 180, 35], [15, -180, 25]])
+    angles = np.array([
+        [15, 0, 60],
+        [35, 0, 75],
+        [60, 180, 35],
+        [15, -180, 25]])
 
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -622,7 +622,9 @@ def test_from_euler_extrinsic_rotation_313():
     ]))
 
 
-def test_as_euler_asymmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_asymmetric_axes(seq_tuple, intrinsic):
     # helper function for mean error tests
     def test_stats(error, mean_max, rms_max):
         mean = np.mean(error, axis=0)
@@ -638,29 +640,22 @@ def test_as_euler_asymmetric_axes():
     angles[:, 1] = rnd.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    for seq_tuple in permutations('xyz'):
-        # Extrinsic rotations
-        seq = ''.join(seq_tuple)
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
-        test_stats(angles_quat - angles, 1e-15, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-14)
-
-        # Intrinsic rotations
+    seq = "".join(seq_tuple)
+    if intrinsic:
         seq = seq.upper()
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
-        test_stats(angles_quat - angles, 1e-15, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-14)
+    rotation = Rotation.from_euler(seq, angles)
+    angles_quat = rotation.as_euler(seq)
+    angles_mat = rotation._as_euler_from_matrix(seq)
+    assert_allclose(angles, angles_quat, atol=0, rtol=1e-12)
+    assert_allclose(angles, angles_mat, atol=0, rtol=1e-12)
+    test_stats(angles_quat - angles, 1e-15, 1e-14)
+    test_stats(angles_mat - angles, 1e-15, 1e-14)
 
 
-def test_as_euler_symmetric_axes():
+
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_symmetric_axes(seq_tuple, intrinsic):
     # helper function for mean error tests
     def test_stats(error, mean_max, rms_max):
         mean = np.mean(error, axis=0)
@@ -676,101 +671,61 @@ def test_as_euler_symmetric_axes():
     angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
     angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
-    for seq_tuple in permutations('xyz'):
-        # Extrinsic rotations
-        seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
-        test_stats(angles_quat - angles, 1e-16, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-13)
-
-        # Intrinsic rotations
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
         seq = seq.upper()
-        rotation = Rotation.from_euler(seq, angles)
-        angles_quat = rotation.as_euler(seq)
-        angles_mat = rotation._as_euler_from_matrix(seq)
-        assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
-        assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
-        test_stats(angles_quat - angles, 1e-16, 1e-14)
-        test_stats(angles_mat - angles, 1e-15, 1e-13)
+    rotation = Rotation.from_euler(seq, angles)
+    angles_quat = rotation.as_euler(seq)
+    angles_mat = rotation._as_euler_from_matrix(seq)
+    assert_allclose(angles, angles_quat, atol=0, rtol=1e-13)
+    assert_allclose(angles, angles_mat, atol=0, rtol=1e-9)
+    test_stats(angles_quat - angles, 1e-16, 1e-14)
+    test_stats(angles_mat - angles, 1e-15, 1e-13)
 
 
-def test_as_euler_degenerate_asymmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_asymmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([
-        [45, 90, 35],
-        [35, -90, 20],
-        [35, 90, 25],
-        [25, -90, 15]])
+    angles = np.array([[45, 90, 35], [35, -90, 20], [35, 90, 25], [25, -90, 15]])
+
+    seq = "".join(seq_tuple)
+    if intrinsic:
+        seq = seq.upper()
+    rotation = Rotation.from_euler(seq, angles, degrees=True)
+    mat_expected = rotation.as_matrix()
 
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join(seq_tuple)
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+    mat_estimated = Rotation.from_euler(seq, angle_estimates, degrees=True).as_matrix()
 
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
-
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
+    assert_array_almost_equal(mat_expected, mat_estimated)
 
 
-def test_as_euler_degenerate_symmetric_axes():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_symmetric_axes(seq_tuple, intrinsic):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality
-    angles = np.array([
-        [15, 0, 60],
-        [35, 0, 75],
-        [60, 180, 35],
-        [15, -180, 25]])
+    angles = np.array([[15, 0, 60], [35, 0, 75], [60, 180, 35], [15, -180, 25]])
+
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
+        seq = seq.upper()
+    rotation = Rotation.from_euler(seq, angles, degrees=True)
+    mat_expected = rotation.as_matrix()
 
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
+        angle_estimates = rotation.as_euler(seq, degrees=True)
+    mat_estimated = Rotation.from_euler(seq, angle_estimates, degrees=True).as_matrix()
 
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rotation = Rotation.from_euler(seq, angles, degrees=True)
-            mat_expected = rotation.as_matrix()
-
-            angle_estimates = rotation.as_euler(seq, degrees=True)
-            mat_estimated = Rotation.from_euler(
-                seq, angle_estimates, degrees=True
-                ).as_matrix()
-
-            assert_array_almost_equal(mat_expected, mat_estimated)
+    assert_array_almost_equal(mat_expected, mat_estimated)
 
 
-def test_as_euler_degenerate_compare_algorithms():
+@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("intrinsic", (False, True))
+def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     # this test makes sure that both algorithms are doing the same choices
     # in degenerate cases
 
@@ -781,27 +736,20 @@ def test_as_euler_degenerate_compare_algorithms():
         [35, 90, 25],
         [25, -90, 15]])
 
-    with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join(seq_tuple)
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-            assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1],
-                            atol=0, rtol=1e-7)
+    seq = "".join(seq_tuple)
+    if intrinsic:
+        seq = seq.upper()
 
-            # Intrinsic rotations
-            seq = seq.upper()
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-            assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1],
-                            atol=0, rtol=1e-7)
+    rot = Rotation.from_euler(seq, angles, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_quat = rot.as_euler(seq, degrees=True)
+    assert_allclose(
+        estimates_matrix[:, [0, 2]], estimates_quat[:, [0, 2]], atol=0, rtol=1e-12
+    )
+    assert_allclose(estimates_matrix[:, 1], estimates_quat[:, 1], atol=0, rtol=1e-7)
+
     # symmetric axes
     # Absolute error tolerance must be looser to directly compare the results
     # from both algorithms, because of numerical loss of precision for the
@@ -815,35 +763,26 @@ def test_as_euler_degenerate_compare_algorithms():
 
     idx = angles[:, 1] == 0  # find problematic angles indices
 
+    # Extrinsic rotations
+    seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
+    if intrinsic:
+        seq = seq.upper()
+    rot = Rotation.from_euler(seq, angles, degrees=True)
     with pytest.warns(UserWarning, match="Gimbal lock"):
-        for seq_tuple in permutations('xyz'):
-            # Extrinsic rotations
-            seq = ''.join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
+        estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
+    with pytest.warns(UserWarning, match="Gimbal lock"):
+        estimates_quat = rot.as_euler(seq, degrees=True)
+    assert_allclose(
+        estimates_matrix[:, [0, 2]], estimates_quat[:, [0, 2]], atol=0, rtol=1e-12
+    )
 
-            assert_allclose(estimates_matrix[~idx, 1], estimates_quat[~idx, 1],
-                            atol=0, rtol=1e-7)
+    assert_allclose(
+        estimates_matrix[~idx, 1], estimates_quat[~idx, 1], atol=0, rtol=1e-7
+    )
 
-            assert_allclose(estimates_matrix[idx, 1], estimates_quat[idx, 1],
-                            atol=1e-6)  # problematic, angles[1] = 0
-
-            # Intrinsic rotations
-            seq = seq.upper()
-            rot = Rotation.from_euler(seq, angles, degrees=True)
-            estimates_matrix = rot._as_euler_from_matrix(seq, degrees=True)
-            estimates_quat = rot.as_euler(seq, degrees=True)
-            assert_allclose(estimates_matrix[:, [0, 2]],
-                            estimates_quat[:, [0, 2]], atol=0, rtol=1e-12)
-
-            assert_allclose(estimates_matrix[~idx, 1], estimates_quat[~idx, 1],
-                            atol=0, rtol=1e-7)
-
-            assert_allclose(estimates_matrix[idx, 1], estimates_quat[idx, 1],
-                            atol=1e-6)  # problematic, angles[1] = 0
+    assert_allclose(
+        estimates_matrix[idx, 1], estimates_quat[idx, 1], atol=1e-6
+    )  # problematic, angles[1] = 0
 
 
 def test_inv():


### PR DESCRIPTION
This is on top of #19302 which introduce only a test refactor to make this one much easier to read.  You may want to look at the last commit on its own when reviewing the tests.

Therefore opening only as draft for now.

----

While it is possible to silence warnings with `catch_warnings()` context manager and a filter the approach has a few drawbacks:

1) The warnings are still emitted, which can have a perf impact
2) Using catch_warnings hits this bug `python/cpython#73858` that may reset a bunch of other warnings.

I also slightly refactor the code by moving the warning 1 level up into `_compute_euler` in the stack and having the core function not emit the warnings, but return a tuple of (data, was_there_a_gimbal_lock). This in particular also emit the warnings only once per function call instead of once per gimbal lock.

Another possibility would be to move the warning one more level up into `as_euler(...)` which is the only public method that uses `_compute_euler(...)`. The other one being `_as_euler_from_matrix(...)`, whcih is private and only use in tests. If I can to that, then I think it might be ok to not add the `gimbal_lock_ok` keyword and just tell users to reach for the private `_compute_euler`, and discard the warning flag.

We could also return a boolean array of whcich rotations are Gimbal Locked. I don't know if that would be useful.

Closes #19306