### PR TITLE
MAINT: Remove remaining `numpy.int_` and filter `np.long` warning

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -39,9 +39,9 @@ if np.lib.NumpyVersion(np.__version__) >= "2.0.0.dev0":
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                action="ignore",
-                message=r".*In the future `np\.long` will be defined as.*",
-                category=FutureWarning,
+                "ignore",
+                r".*In the future `np\.long` will be defined as.*",
+                FutureWarning,
             )
             np_long = np.long  # type: ignore[attr-defined]
             np_ulong = np.ulong  # type: ignore[attr-defined]

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -37,8 +37,14 @@ np_ulong: type
 
 if np.lib.NumpyVersion(np.__version__) >= "2.0.0.dev0":
     try:
-        np_long = np.long  # type: ignore[attr-defined]
-        np_ulong = np.ulong  # type: ignore[attr-defined]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                message=".*In the future `np.long` will be defined as.*",
+                category=FutureWarning,
+            )
+            np_long = np.long  # type: ignore[attr-defined]
+            np_ulong = np.ulong  # type: ignore[attr-defined]
     except AttributeError:
             np_long = np.int_
             np_ulong = np.uint

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -40,7 +40,7 @@ if np.lib.NumpyVersion(np.__version__) >= "2.0.0.dev0":
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 action="ignore",
-                message=".*In the future `np.long` will be defined as.*",
+                message=r".*In the future `np\.long` will be defined as.*",
                 category=FutureWarning,
             )
             np_long = np.long  # type: ignore[attr-defined]

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -98,6 +98,7 @@ def test_warning_calls_filters(warning_calls):
         os.path.join('sparse', '__init__.py'),  # np.matrix pending-deprecation
         os.path.join('stats', '_discrete_distns.py'),  # gh-14901
         os.path.join('stats', '_continuous_distns.py'),
+        os.path.join('_lib', '_util.py'),  # gh-19341
     )
     bad_filters = [item for item in bad_filters if item.split(':')[0] not in
                    allowed_filters]

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1655,7 +1655,6 @@ def watershed_ift(input, markers, structure=None, output=None):
     integral_types = [numpy.int8,
                       numpy.int16,
                       numpy.int32,
-                      numpy.int_,
                       numpy.int64,
                       numpy.intc,
                       numpy.intp]

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -15,7 +15,7 @@ __all__ = ['compare_medians_ms',
 
 
 import numpy as np
-from numpy import float64, int_, ndarray
+from numpy import float64, ndarray
 
 import numpy.ma as ma
 from numpy.ma import MaskedArray
@@ -259,7 +259,7 @@ def mjci(data, prob=[0.25,0.5,0.75], axis=None):
     def _mjci_1D(data, p):
         data = np.sort(data.compressed())
         n = data.size
-        prob = (np.array(p) * n + 0.5).astype(int_)
+        prob = (np.array(p) * n + 0.5).astype(int)
         betacdf = beta.cdf
 
         mj = np.empty(len(prob), float64)

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -11,7 +11,7 @@ __all__ = [  # noqa: F822
     'idealfourths',
     'median_cihs','mjci','mquantiles_cimj',
     'rsh',
-    'trimmed_mean_ci', 'int_', 'ma', 'MaskedArray', 'mstats',
+    'trimmed_mean_ci', 'ma', 'MaskedArray', 'mstats',
     'norm', 'beta', 't', 'binom'
 ]
 


### PR DESCRIPTION
Hi @rgommers,

This is a follow-up PR for https://github.com/scipy/scipy/pull/19310.

I missed these two `int_`s because they were imported as `numpy.int_` instead of `np.int_`.