### PR TITLE
MAINT: remove `np.testing.suppress_warnings` that aren't in tests

### DIFF
--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -95,9 +95,12 @@ def test_warning_calls_filters(warning_calls):
         os.path.join('datasets', '_fetchers.py'),
         os.path.join('datasets', '__init__.py'),
         os.path.join('optimize', '_optimize.py'),
+        os.path.join('optimize', '_constraints.py'),
+        os.path.join('signal', '_ltisys.py'),
         os.path.join('sparse', '__init__.py'),  # np.matrix pending-deprecation
         os.path.join('stats', '_discrete_distns.py'),  # gh-14901
         os.path.join('stats', '_continuous_distns.py'),
+        os.path.join('stats', '_binned_statistic.py'),  # gh-19345
         os.path.join('_lib', '_util.py'),  # gh-19341
     )
     bad_filters = [item for item in bad_filters if item.split(':')[0] not in

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -1,12 +1,10 @@
 """Constraints definition for minimize."""
-import warnings
-
 import numpy as np
 from ._hessian_update_strategy import BFGS
 from ._differentiable_functions import (
     VectorFunction, LinearVectorFunction, IdentityVectorFunction)
 from ._optimize import OptimizeWarning
-from warnings import warn, catch_warnings, simplefilter
+from warnings import warn, catch_warnings, simplefilter, filterwarnings
 from scipy.sparse import issparse
 
 

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -1,11 +1,12 @@
 """Constraints definition for minimize."""
+import warnings
+
 import numpy as np
 from ._hessian_update_strategy import BFGS
 from ._differentiable_functions import (
     VectorFunction, LinearVectorFunction, IdentityVectorFunction)
 from ._optimize import OptimizeWarning
 from warnings import warn, catch_warnings, simplefilter
-from numpy.testing import suppress_warnings
 from scipy.sparse import issparse
 
 
@@ -386,8 +387,12 @@ class PreparedConstraint:
             How much the constraint is exceeded by, for each of the
             constraints specified by `PreparedConstraint.fun`.
         """
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning)
+        with catch_warnings():
+            # Ignore the following warning, it's not important when
+            # figuring out total violation
+            # UserWarning: delta_grad == 0.0. Check if the approximated
+            # function is linear
+            warnings.filterwarnings("ignore", "delta_grad", UserWarning)
             ev = self.fun.fun(np.asarray(x))
 
         excess_lb = np.maximum(self.bounds[0] - ev, 0)

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -392,7 +392,7 @@ class PreparedConstraint:
             # figuring out total violation
             # UserWarning: delta_grad == 0.0. Check if the approximated
             # function is linear
-            warnings.filterwarnings("ignore", "delta_grad", UserWarning)
+            filterwarnings("ignore", "delta_grad", UserWarning)
             ev = self.fun.fun(np.asarray(x))
 
         excess_lb = np.maximum(self.bounds[0] - ev, 0)

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -34,7 +34,6 @@ from ._lti_conversion import (tf2ss, abcd_normalize, ss2tf, zpk2ss, ss2zpk,
 
 import numpy
 import numpy as np
-from numpy.testing import suppress_warnings
 from numpy import (real, atleast_1d, squeeze, asarray, zeros,
                    dot, transpose, ones, zeros_like, linspace, nan_to_num)
 import copy
@@ -2385,10 +2384,12 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
     # Move the impulse in the input to the initial conditions, and then
     # solve using lsim2().
     ic = B + X0
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   "lsim2 is deprecated and will be removed from scipy 1.13. "
-                   "Use the feature-equivalent lsim function.")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "lsim2 is deprecated and will be removed from scipy 1.13",
+            DeprecationWarning
+        )
 
         Tr, Yr, Xr = lsim2(sys, T=T, X0=ic, **kwargs)
     return Tr, Yr
@@ -2554,10 +2555,12 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
         T = asarray(T)
     U = ones(T.shape, sys.A.dtype)
 
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   "lsim2 is deprecated and will be removed from scipy 1.13. "
-                   "Use the feature-equivalent lsim function.")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "lsim2 is deprecated and will be removed from scipy 1.13",
+            DeprecationWarning
+        )
         vals = lsim2(sys, U, T, X0=X0, **kwargs)
     return vals[0], vals[1]
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,6 +1,6 @@
 import builtins
+from warnings import catch_warnings, simplefilter
 import numpy as np
-from numpy.testing import suppress_warnings
 from operator import index
 from collections import namedtuple
 
@@ -646,8 +646,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
             i = np.argsort(values[vv])
             result[vv, binnumbers[i]] = values[vv, i]
     elif callable(statistic):
-        with np.errstate(invalid='ignore'), suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with np.errstate(invalid='ignore'), catch_warnings():
+            simplefilter("ignore", RuntimeWarning)
             try:
                 null = statistic([])
             except Exception:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2425,39 +2425,23 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
         def count(x):
             return np.count_nonzero(x, -1)
 
-        # Despite using masked_array to omit nan values from processing,
-        # the CI tests on "Azure pipelines" (but not on the other CI servers)
-        # emits warnings when there are nan values, contrarily to the purpose
-        # of masked_arrays. As a fix, we simply suppress the warnings.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "invalid value encountered in less",
-                RuntimeWarning
-            )
-            warnings.filterwarnings(
-                "ignore",
-                "invalid value encountered in greater",
-                RuntimeWarning
-            )
-
-            # Main computations/logic
-            if kind == 'rank':
-                left = count(a < score)
-                right = count(a <= score)
-                plus1 = left < right
-                perct = (left + right + plus1) * (50.0 / n)
-            elif kind == 'strict':
-                perct = count(a < score) * (100.0 / n)
-            elif kind == 'weak':
-                perct = count(a <= score) * (100.0 / n)
-            elif kind == 'mean':
-                left = count(a < score)
-                right = count(a <= score)
-                perct = (left + right) * (50.0 / n)
-            else:
-                raise ValueError(
-                    "kind can only be 'rank', 'strict', 'weak' or 'mean'")
+        # Main computations/logic
+        if kind == 'rank':
+            left = count(a < score)
+            right = count(a <= score)
+            plus1 = left < right
+            perct = (left + right + plus1) * (50.0 / n)
+        elif kind == 'strict':
+            perct = count(a < score) * (100.0 / n)
+        elif kind == 'weak':
+            perct = count(a <= score) * (100.0 / n)
+        elif kind == 'mean':
+            left = count(a < score)
+            right = count(a <= score)
+            perct = (left + right) * (50.0 / n)
+        else:
+            raise ValueError(
+                "kind can only be 'rank', 'strict', 'weak' or 'mean'")
 
     # Re-insert nan values
     perct = ma.filled(perct, np.nan)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -33,7 +33,6 @@ from collections import namedtuple
 
 import numpy as np
 from numpy import array, asarray, ma
-from numpy.testing import suppress_warnings
 
 from scipy import sparse
 from scipy.spatial.distance import cdist
@@ -2430,11 +2429,17 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
         # the CI tests on "Azure pipelines" (but not on the other CI servers)
         # emits warnings when there are nan values, contrarily to the purpose
         # of masked_arrays. As a fix, we simply suppress the warnings.
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning,
-                       "invalid value encountered in less")
-            sup.filter(RuntimeWarning,
-                       "invalid value encountered in greater")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "invalid value encountered in less",
+                RuntimeWarning
+            )
+            warnings.filterwarnings(
+                "ignore",
+                "invalid value encountered in greater",
+                RuntimeWarning
+            )
 
             # Main computations/logic
             if kind == 'rank':


### PR DESCRIPTION
This PR removes usages of `np.testing.suppress_warnings` that are in test files. 

Closes gh-19344