### PR TITLE
MAINT: stats: fix `differential_entropy` too small error behavior

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -157,8 +157,7 @@ def _differential_entropy_is_too_small(samples, kwargs):
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,),
-    too_small=_differential_entropy_is_too_small,
-    override={"nan_propagation": False}
+    too_small=_differential_entropy_is_too_small
 )
 def differential_entropy(
     values: np.typing.ArrayLike,

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -48,10 +48,6 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
         but it is recommended to use ``ddof=1`` to ensure that the sample
         standard deviation is computed as the square root of the unbiased
         sample variance.
-    keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in the
-        result as dimensions with size one. With this option, the result
-        will broadcast correctly against the input array.
 
     Returns
     -------


### PR DESCRIPTION
#### Reference issue

Follow-up of #19303

#### What does this implement/fix?

https://github.com/scipy/scipy/pull/19303#discussion_r1342240306

#### Additional information

Also removed the `keepdims` docs from the `scipy.stats.variation` since we removed the parameter. The decorator should generate the docstring so this change shouldn't have any effect.