### PR TITLE
BUG: fix ValueError in stats.truncpareto

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9897,37 +9897,36 @@ class truncpareto_gen(rv_continuous):
         return self.a, c
 
     def _pdf(self, x, b, c):
-        return b * x**-(b+1) / (1 - c**-b)
+        return b * x**-(b+1) / (1 - 1/c**b)
 
     def _logpdf(self, x, b, c):
-        # return np.log(b) - np.log1p(-c**-b) - (b+1)*np.log(x)
         return np.log(b) - np.log(-np.expm1(-b*np.log(c))) - (b+1)*np.log(x)
 
     def _cdf(self, x, b, c):
-        return (1 - x**-b) / (1 - c**-b)
+        return (1 - x**-b) / (1 - 1/c**b)
 
     def _logcdf(self, x, b, c):
-        return np.log1p(-x**-b) - np.log1p(-c**-b)
+        return np.log1p(-x**-b) - np.log1p(-1/c**b)
 
     def _ppf(self, q, b, c):
-        return pow(1 - (1 - c**-b)*q, -1/b)
+        return pow(1 - (1 - 1/c**b)*q, -1/b)
 
     def _sf(self, x, b, c):
-        return (x**-b - c**-b) / (1 - c**-b)
+        return (x**-b - 1/c**b) / (1 - 1/c**b)
 
     def _logsf(self, x, b, c):
-        return np.log(x**-b - c**-b) - np.log1p(-c**-b)
+        return np.log(x**-b - 1/c**b) - np.log1p(-1/c**b)
 
     def _isf(self, q, b, c):
-        return pow(c**-b + (1 - c**-b)*q, -1/b)
+        return pow(1/c**b + (1 - 1/c**b)*q, -1/b)
 
     def _entropy(self, b, c):
-        return -(np.log(b/(1 - c**-b))
+        return -(np.log(b/(1 - 1/c**b))
                  + (b+1)*(np.log(c)/(c**b - 1) - 1/b))
 
     def _munp(self, n, b, c):
         if (n == b).all():
-            return b*np.log(c) / (1 - c**-b)
+            return b*np.log(c) / (1 - 1/c**b)
         else:
             return b / (b-n) * (c**b - c**n) / (c**b - 1)
 

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -110,6 +110,7 @@ distcont = [
     ['truncnorm', (-1.0978730080013919, 2.7306754109031979)],
     ['truncnorm', (0.1, 2.)],
     ['truncpareto', (1.8, 5.3)],
+    ['truncpareto', (2, 5)],
     ['truncweibull_min', (2.5, 0.25, 1.75)],
     ['tukeylambda', (3.1321477856738267,)],
     ['uniform', ()],


### PR DESCRIPTION
#### What does this implement/fix?

The methods `pdf`, `cdf`, `logcdf`, `ppf`, `sf`, `logsf`, `isf`, and moment all had expressions including `c**-b`, (`c`, `b` shape parameters). These triggered `ValueError` exceptions (integer raised to a negative integer power) when both shape parameters were integers (highlighted in the test case added to _distr_params), due to their promotion to numpy types. I replaced all of these by `1/c**b`, which takes care of the issue.

#### Additional information

The method entropy was not affected, but I modified it as well for consistency.
The expressions `x**-b` (`x` argument of the various statistical functions) are not a problem, as `x` is promoted to float in rv_continuous.

I had to `#include <cstdint>` in scipy/io/_fast_matrix_market/src/_fmm_core.cpp to be able to build (GCC 13.1.1, Fedora 38).
I suppose it is an issue coming from my system, and did not commit that change.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

