### PR TITLE
MAINT: Minor fix to shim import of scipy.signal.

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -310,6 +310,7 @@ use the classes to create a reusable function instead.
 
 """
 import warnings
+import inspect
 
 from . import _sigtools, windows
 from ._waveforms import *
@@ -358,7 +359,7 @@ def deco(name):
 
     def wrapped(*args, **kwargs):
         warnings.warn(f"Importing {name} from 'scipy.signal' is deprecated "
-                      "and will raise an error in SciPy 1.13.0. Please use "
+                      "since SciPy 1.1.0 and will raise an error in SciPy 1.13.0. Please use "
                       f"'scipy.signal.windows.{name}' or the convenience "
                       "function 'scipy.signal.get_window' instead.",
                       DeprecationWarning, stacklevel=2)
@@ -366,6 +367,7 @@ def deco(name):
 
     wrapped.__name__ = name
     wrapped.__module__ = 'scipy.signal'
+    wrapped.__signature__ = inspect.signature(f)
     if hasattr(f, '__qualname__'):
         wrapped.__qualname__ = f.__qualname__
 
@@ -377,8 +379,9 @@ def deco(name):
         else:
             raise RuntimeError('dev error: badly formatted doc')
         spacing = ' ' * line.find('P')
-        lines.insert(li, ('{0}.. warning:: scipy.signal.{1} is deprecated,\n'
-                          '{0}             use scipy.signal.windows.{1} '
+        lines.insert(li, ('{0}.. warning:: `scipy.signal.{1}` is deprecated since\n'
+                          '{0}             SciPy 1.1.0 and will be removed in 1.13.0\n'
+                          '{0}             use `scipy.signal.windows.{1}`'
                           'instead.\n'.format(spacing, name)))
         wrapped.__doc__ = '\n'.join(lines)
 
@@ -394,4 +397,4 @@ __all__ = [s for s in dir() if not s.startswith('_') and s != "warnings"]
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
-del PytestTester
+del PytestTester, inspect

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -393,7 +393,9 @@ for name in deprecated_windows:
 
 del deprecated_windows, name, deco
 
-__all__ = [s for s in dir() if not s.startswith('_') and s != "warnings"]
+__all__ = [
+    s for s in dir() if not s.startswith("_") and s not in {"warnings", "inspect"}
+]
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -367,7 +367,7 @@ def deco(name):
 
     wrapped.__name__ = name
     wrapped.__module__ = 'scipy.signal'
-    wrapped.__signature__ = inspect.signature(f)
+    wrapped.__signature__ = inspect.signature(f)  # noqa: F821
     if hasattr(f, '__qualname__'):
         wrapped.__qualname__ = f.__qualname__
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -847,7 +847,7 @@ def test_not_needs_params():
 
 def test_deprecation():
     if dep_hann.__doc__ is not None:  # can be None with `-OO` mode
-        assert_('signal.hann is deprecated' in dep_hann.__doc__)
+        assert_('signal.hann` is deprecated' in dep_hann.__doc__)
         assert_('deprecated' not in windows.hann.__doc__)
 
 


### PR DESCRIPTION
1) Setting signature help tab completer and IPython `foo?` operator to
   show the real signature.

2) Use backticks in warning, in tools that would render such warning
   it would both render better and link to the right page.

3) Add version numbers. I think when it will be removed is not as
   useful as since when the new version is available.

I'm not sure why this does not use `functools.wrap`, but it's pretty old code from PR #7900
