### PR TITLE
ENH: stats: add support for masked arrays, `nan_policy`, and `keepdims` to `entropy`

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -13,6 +13,15 @@ from ._axis_nan_policy import _axis_nan_policy_factory
 __all__ = ['entropy', 'differential_entropy']
 
 
+@_axis_nan_policy_factory(
+    lambda x: x,
+    n_samples=lambda kwgs: (
+        2 if ("qk" in kwgs and kwgs["qk"] is not None)
+        else 1
+    ),
+    n_outputs=1, result_to_tuple=lambda x: (x,), paired=True,
+    too_small=-1  # entropy doesn't have too small inputs
+)
 def entropy(pk: np.typing.ArrayLike,
             qk: np.typing.ArrayLike | None = None,
             base: float | None = None,

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -64,7 +64,9 @@ axis_nan_policy_cases = [
     (_get_ttest_ci(stats.ttest_ind), tuple(), dict(), 2, 2, False, None),
     (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count)),
     (stats.differential_entropy, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    (stats.variation, tuple(), dict(), 1, 1, False, lambda x: (x,))
+    (stats.variation, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.entropy, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.entropy, tuple(), dict(), 2, 1, True, lambda x: (x,))
 ]
 
 # If the message is one of those expected, put nans in

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -100,7 +100,7 @@ class TestEntropy:
     def test_entropy_shape_mismatch(self):
         x = np.random.rand(10, 1, 12)
         y = np.random.rand(11, 2)
-        message = "shape mismatch: objects cannot be broadcast"
+        message = "Array shapes are incompatible for broadcasting."
         with pytest.raises(ValueError, match=message):
             stats.entropy(x, y)
 


### PR DESCRIPTION
#### Reference issue

Towards https://github.com/scipy/scipy/issues/14651

#### What does this implement/fix?

This PR adds support for ~~`axis` tuples~~ masked arrays, `nan_policy`, and `keepdims` to `scipy.stats.entropy`.
