### PR TITLE
MAINT, BUG: stats: update the UNU.RAN submodule with DAU fix

### DIFF
--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -294,12 +294,12 @@ def test_with_scipy_distribution():
     check_discr_samples(rng, pv, dist.stats())
 
 
-def check_cont_samples(rng, dist, mv_ex):
+def check_cont_samples(rng, dist, mv_ex, rtol=1e-7, atol=1e-1):
     rvs = rng.rvs(100000)
     mv = rvs.mean(), rvs.var()
     # test the moments only if the variance is finite
     if np.isfinite(mv_ex[1]):
-        assert_allclose(mv, mv_ex, rtol=1e-7, atol=1e-1)
+        assert_allclose(mv, mv_ex, rtol=rtol, atol=atol)
     # Cramer Von Mises test for goodness-of-fit
     rvs = rng.rvs(500)
     dist.cdf = np.vectorize(dist.cdf)
@@ -307,11 +307,11 @@ def check_cont_samples(rng, dist, mv_ex):
     assert pval > 0.1
 
 
-def check_discr_samples(rng, pv, mv_ex):
+def check_discr_samples(rng, pv, mv_ex, rtol=1e-3, atol=1e-1):
     rvs = rng.rvs(100000)
     # test if the first few moments match
     mv = rvs.mean(), rvs.var()
-    assert_allclose(mv, mv_ex, rtol=1e-2, atol=1e-1)
+    assert_allclose(mv, mv_ex, rtol=rtol, atol=atol)
     # normalize
     pv = pv / pv.sum()
     # chi-squared test for goodness-of-fit
@@ -743,7 +743,8 @@ class TestDiscreteAliasUrn:
         pv = special.softmax(np.ones((1533,)))
         rng = DiscreteAliasUrn(pv, random_state=42)
         # check the correctness
-        check_discr_samples(rng, pv, (1532 / 2, (1532**2 - 1) / 12))
+        check_discr_samples(rng, pv, (1532 / 2, (1532**2 - 1) / 12),
+                            rtol=5e-3)
 
 
 class TestNumericalInversePolynomial:

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -311,7 +311,7 @@ def check_discr_samples(rng, pv, mv_ex):
     rvs = rng.rvs(100000)
     # test if the first few moments match
     mv = rvs.mean(), rvs.var()
-    assert_allclose(mv, mv_ex, rtol=1e-3, atol=1e-1)
+    assert_allclose(mv, mv_ex, rtol=1e-2, atol=1e-1)
     # normalize
     pv = pv / pv.sum()
     # chi-squared test for goodness-of-fit
@@ -738,6 +738,12 @@ class TestDiscreteAliasUrn:
 
         with pytest.raises(ValueError, match=msg):
             DiscreteAliasUrn(dist)
+
+    def test_gh19359(self):
+        pv = special.softmax(np.ones((1533,)))
+        rng = DiscreteAliasUrn(pv, random_state=42)
+        # check the correctness
+        check_discr_samples(rng, pv, (1532 / 2, (1532**2 - 1) / 12))
 
 
 class TestNumericalInversePolynomial:


### PR DESCRIPTION
#### Reference issue

Closes #19359 

#### What does this implement/fix?

Updates the UNU.RAN submodule that includes a fix for the DAU method setup failure for certain probability vectors.
