### PR TITLE
CI: avoid using Cython 3.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,9 @@ jobs:
       - run:
           name: setup Python venv
           command: |
-            pip install cython
-            pip install numpy==1.23.5
+            pip install numpy==1.23.5 cython!=3.0.3 pybind11 pythran ninja meson
             pip install -r doc_requirements.txt
-            pip install mpmath gmpy2 "asv>=0.6.0" pythran ninja meson click rich-click doit pydevtool pooch threadpoolctl
-            pip install pybind11
+            pip install mpmath gmpy2 "asv>=0.6.0" click rich-click doit pydevtool pooch threadpoolctl
             # extra benchmark deps
             pip install pyfftw cffi pytest
 

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython!=3.0.3 pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
 
     - name: Install PyTorch CPU
       run: |

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -56,13 +56,13 @@ jobs:
     - name: Install Python packages
       if: matrix.python-version == '3.10'
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython!=3.0.3 pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
 
     - name: Install Python packages from repositories
       if: matrix.python-version == '3.12-dev'
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
-        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
+        python -m pip install ninja cython!=3.0.3 pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd
         python -m pip install git+https://github.com/mesonbuild/meson.git
 
@@ -164,7 +164,7 @@ jobs:
         # Install build dependencies. Use meson-python from its main branch,
         # most convenient to test in this job because we're using pip without
         # build isolation here.
-        python -m pip install numpy pybind11 pythran cython pytest ninja hypothesis
+        python -m pip install numpy pybind11 pythran cython!=3.0.3 pytest ninja hypothesis
         python -m pip install git+https://github.com/mesonbuild/meson-python.git
         # Non-isolated build, so we use dependencies installed inside the source tree
         python -m pip install -U pip  # need pip >=23 for `--config-settings`
@@ -230,7 +230,7 @@ jobs:
         run: |
           pip install "numpy==1.22.4" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython wheel
+          pip install build meson-python ninja pythran pybind11 cython!=3.0.3
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout hypothesis
 
@@ -289,7 +289,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install "Cython>=3.0.0b3"
+        python -m pip install cython!=3.0.3
         python -m pip install ninja meson meson-python wheel click rich_click pydevtool
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -59,7 +59,7 @@ jobs:
         source test_env/bin/activate
         cd $GITHUB_WORKSPACE
 
-        python -m pip install cython numpy
+        python -m pip install cython!=3.0.3 numpy
         # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install meson ninja pybind11 pythran pytest hypothesis
         python -m pip install click rich_click doit pydevtool pooch

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -134,9 +134,9 @@ jobs:
           #  numpy2.0 wheels available on PyPI. Also remove/comment out the
           # PIP_NO_BUILD_ISOLATION and PIP_EXTRA_INDEX_URL from CIBW_ENVIRONMENT
           # (also for _MACOS and _WINDOWS below)
-          CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-          CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+          CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+          CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
           # Allow pip to find install nightly wheels if necessary
           # Setting PIP_NO_BUILD_ISOLATION=false makes pip use build-isolation.
           CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=false PIP_PRE=1 PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.4 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
+          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
       - name: Install OpenBLAS
         shell: bash
         run: |
@@ -101,7 +101,7 @@ jobs:
         run: |
           # 1.22.4 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.4 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
+          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
 
       - name: Build
         run: |
@@ -148,7 +148,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          python -m pip install build delvewheel numpy cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis
+          python -m pip install build delvewheel numpy cython!=3.0.3 pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis
 
       - name: Build
         run: |

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -66,7 +66,7 @@ linux_aarch64_test_task:
     echo "PATH=$PATH" >> $CIRRUS_ENV
     echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
-    python -m pip install meson ninja numpy cython pybind11 pythran cython
+    python -m pip install meson ninja numpy cython!=3.0.3 pybind11 pythran
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch pytest-xdist hypothesis
     
@@ -126,7 +126,7 @@ macos_arm64_test_task:
     source test_env/bin/activate
     cd $_CWD
 
-    python -m pip install meson ninja numpy cython pybind11 pythran cython
+    python -m pip install meson ninja numpy cython!=3.0.3 pybind11 pythran
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch pytest-xdist hypothesis
     

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -31,7 +31,7 @@ cirrus_wheels_linux_aarch64_task:
     CIBW_PRERELEASE_PYTHONS: True
     # TODO remove the CIBW_BEFORE_BUILD_LINUX line once there are numpy2.0 wheels available on PyPI.
     # Also remove/comment out PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
-    CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+    CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
     CIBW_ENVIRONMENT: >
       PIP_PRE=1
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
@@ -68,7 +68,7 @@ cirrus_wheels_macos_arm64_task:
       PIP_NO_BUILD_ISOLATION=false
     # TODO remove the following line once there are numpy2.0 wheels available on PyPI.
     # Also remove PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
-    CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+    CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - cython
+  - cython!=3.0.3
   - compilers  # Currently unavailable for Windows. Comment out this line and download Rtools and add <path>\ucrt64\bin\ to your path: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
   - meson
   - meson-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.14.0",
-    "Cython>=0.29.35",  # when updating version, also update check in meson.build
+    "Cython>=0.29.35,!=3.0.3",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.14.0",
 


### PR DESCRIPTION
Closes gh-19352

Also a few very minor cleanups; combining some `pip install` calls and removing an install of `wheel` that we no longer need.