### PR TITLE
TST: bump tolerance of `test_al_mohy_higham_2012_experiment_1`

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -562,7 +562,7 @@ class TestFractionalMatrixPower:
         A_sqrtm, info = sqrtm(A, disp=False)
         A_rem_power = _matfuncs_inv_ssq._remainder_matrix_power(A, 0.5)
         A_power = fractional_matrix_power(A, 0.5)
-        assert_array_equal(A_rem_power, A_power)
+        assert_allclose(A_rem_power, A_power, rtol=1e-11)
         assert_allclose(A_sqrtm, A_power)
         assert_allclose(A_sqrtm, A_funm_sqrt)
 


### PR DESCRIPTION
This avoids a test failure that we see in CI in the musllinux job. From [this CI log](https://github.com/scipy/scipy/actions/runs/6485046189/job/17610274361?pr=19371):

```
_______ TestFractionalMatrixPower.test_al_mohy_higham_2012_experiment_1 ________
scipy/linalg/tests/test_matfuncs.py:565: in test_al_mohy_higham_2012_experiment_1
    assert_array_equal(A_rem_power, A_power)
        A          = array([[3.2346e-01, 3.0000e+04, 3.0000e+04, 3.0000e+04],
       [0.0000e+00, 3.0089e-01, 3.0000e+04, 3.0000e+04],
       [0.0000e+00, 0.0000e+00, 3.2210e-01, 3.0000e+04],
       [0.0000e+00, 0.0000e+00, 0.0000e+00, 3.0744e-01]])
        A_funm_sqrt = array([[ 5.68735439e-01,  2.68511676e+04, -6.35171101e+08,
         3.06962112e+13],
       [ 0.00000000e+00,  5.48534...45e-01,
         2.67376994e+04],
       [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
         5.54472723e-01]])
        A_power    = array([[ 5.68735439e-01,  2.68511676e+04, -6.35171101e+08,
         3.06962112e+13],
       [ 0.00000000e+00,  5.48534...45e-01,
         2.67376994e+04],
       [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
         5.54472723e-01]])
        A_rem_power = array([[ 5.68735439e-01,  2.68511676e+04, -6.35171101e+08,
         3.06962112e+13],
       [ 0.00000000e+00,  5.48534...45e-01,
         2.67376994e+04],
       [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
         5.54472723e-01]])
        A_sqrtm    = array([[ 5.68735439e-01,  2.68511676e+04, -6.35171101e+08,
         3.06962112e+13],
       [ 0.00000000e+00,  5.48534...45e-01,
         2.67376994e+04],
       [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
         5.54472723e-01]])
        info       = 1.7062881045522058e-10
        self       = <scipy.linalg.tests.test_matfuncs.TestFractionalMatrixPower object at 0x7f7f16d59030>
/opt/_internal/cpython-3.10.13/lib/python3.10/contextlib.py:79: in inner
    return func(*args, **kwds)
E   AssertionError:
E   Arrays are not equal
E
E   Mismatched elements: 7 / 16 (43.8%)
E   Max absolute difference: 111.140625
E   Max relative difference: 7.29361661e-12
E    x: array([[ 5.687354e-01,  2.685117e+04, -6.351711e+08,  3.069621e+13],
E          [ 0.000000e+00,  5.485344e-01,  2.687996e+04, -6.515628e+08],
E          [ 0.000000e+00,  0.000000e+00,  5.675385e-01,  2.673770e+04],
E          [ 0.000000e+00,  0.000000e+00,  0.000000e+00,  5.544727e-01]])
E    y: array([[ 5.687354e-01,  2.685117e+04, -6.351711e+08,  3.069621e+13],
E          [ 0.000000e+00,  5.485344e-01,  2.687996e+04, -6.515628e+08],
E          [ 0.000000e+00,  0.000000e+00,  5.675385e-01,  2.673770e+04],
E          [ 0.000000e+00,  0.000000e+00,  0.000000e+00,  5.544727e-01]])
```

The Cython code being called does a `schur` decomposition in one branch of the code, so it doesn't seem surprising that exact numerical equality didn't hold forever.