### PR TITLE
CI: debugging aids for cirrus clone [skip actions][skip circle]

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -19,6 +19,9 @@ modified_clone: &MODIFIED_CLONE
       # However, if you do a PR against a maintenance branch we will want to
       # merge the PR into the maintenance branch, not main
       git checkout $CIRRUS_BASE_BRANCH
+    
+      # visualise the last 10 commits to aid git clone debugging.
+      git log -n10 --oneline
 
       # alpine git package needs default user.name and user.email to be set before a merge
       git -c user.email="you@example.com" merge --no-commit pull/$CIRRUS_PR


### PR DESCRIPTION
Prints out the last 10 commits during the cirrus clone step, to aid with debugging.