### PR TITLE
BUG: Restore the original behavior of 'trf' from least_squares to make x0 "sufficiently" feasible

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -822,7 +822,7 @@ def least_squares(
     ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol, method)
 
     if method == 'trf':
-        x0 = make_strictly_feasible(x0, lb, ub, rstep=0)
+        x0 = make_strictly_feasible(x0, lb, ub)
 
     def fun_wrapped(x):
         return np.atleast_1d(fun(x, *args, **kwargs))

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -268,7 +268,9 @@ def least_squares(
         arguments, as shown at the end of the Examples section.
     x0 : array_like with shape (n,) or float
         Initial guess on independent variables. If float, it will be treated
-        as a 1-D array with one element.
+        as a 1-D array with one element. When `method` is 'trf', the initial
+        guess might be slightly adjusted to lie sufficiently within the given
+        `bounds`.
     jac : {'2-point', '3-point', 'cs', callable}, optional
         Method of computing the Jacobian matrix (an m-by-n matrix, where
         element (i, j) is the partial derivative of f[i] with respect to


### PR DESCRIPTION
#### Reference issue
#19351

#### What does this implement/fix?
It restores the original behavior of 'trf' method of `least_squares` before the changes in #18896

The property that `x` is not too close to bounds (i.e. being interior point) is apparently required for the robust operation of 'trf'. The easiest solution is to restore the original code, because many other packages are already adjusted to its behavior and everything worked well in general.

#### Additional information
I haven't extended the docstring extensively (it's already large), besides mentioning that `x0` might be adjusted by 'trf'. Other than that I think it's expected from a user to realize than a numerical optimization simply executes iterations and checks for the convergence, it's not guaranteed or expected to find the "exact" solution in all cases. 