### PR TITLE
DEV/CI: use scipy-openblas32 wheels in dev.py and some CI jobs

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -276,10 +276,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache gfortran
 
-        # Install OpenBLAS a la cibuildwheel.
-        chmod +x tools/wheels/cibw_before_build_linux.sh
-        sudo tools/wheels/cibw_before_build_linux.sh --nightly .       
-
     - name: Caching Python dependencies
       uses: actions/cache@v3
       id: cache
@@ -289,13 +285,9 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install cython!=3.0.3
-        python -m pip install ninja meson meson-python wheel click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-        python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd
-        # Use pytest-xdist<4.0 due to https://github.com/pytest-dev/pytest-cov/issues/557
-        # can update once pytest-cov>4.0 and remove warning filtering in pytest.ini
-        python -m pip install --pre --upgrade pytest pytest-cov "pytest-xdist<4.0" pybind11 mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
+        python -m pip install cython!=3.0.3 pythran ninja meson-python pybind11 click rich_click pydevtool
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy-openblas32
+        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
 
     - name:  Prepare compiler cache
       id:    prep-ccache
@@ -318,7 +310,7 @@ jobs:
 
     - name: Build and install SciPy
       run: |
-        python dev.py build --gcov
+        python dev.py build --gcov --use-scipy-openblas
 
     - name: Ccache performance
       shell: bash -l {0}
@@ -326,8 +318,6 @@ jobs:
 
     - name: Test SciPy
       run: |
-        export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
         export OPENBLAS_NUM_THREADS=1
         python dev.py test -j2 --mode full -- --cov --cov-report term-missing 
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,29 +40,15 @@ jobs:
           choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
-      - name: show-gfortran
-        run: |
-          gcc --version
-          gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
-      - name: Install OpenBLAS
-        shell: bash
-        run: |
-          # same OpenBLAS install method as cibuildwheel
-          set -xe
-          bash tools/wheels/cibw_before_build_win.sh .
-          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
+          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis scipy-openblas32
+
       - name: Build
         run: |
           echo "SCIPY_USE_PROPACK=1" >> $env:GITHUB_ENV
-          python dev.py build --win-cp-openblas
-          # Necessary because GitHub Actions checks out the repo to D:\ while OpenBLAS
-          # got installed to C:\ higher up. The copying with `--win-cp-openblas` fails
-          # when things are split over drives.
-          cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
-          python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
+          python dev.py build --use-scipy-openblas
+
       - name: Test
         run: |
           python dev.py test -j2
@@ -90,25 +76,15 @@ jobs:
           choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
-      - name: Install OpenBLAS
-        shell: bash
-        run: |
-          set -xe
-          bash tools/wheels/cibw_before_build_win.sh .
-          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
-
       - name: pip-packages
         run: |
           # 1.22.4 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
+          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis scipy-openblas32
 
       - name: Build
         run: |
-          python dev.py build --win-cp-openblas
-          # Copy OpenBLAS DLL, write distributor-init (see first job in this file for why)
-          cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
-          python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
+          python dev.py build --use-scipy-openblas
 
       - name: Test
         run: |
@@ -142,6 +118,7 @@ jobs:
       - name: Install OpenBLAS
         shell: bash
         run: |
+          # Keep this using the OpenBLAS tarballs for now, as long as we use those for wheel builds
           set -xe
           bash tools/wheels/cibw_before_build_win.sh .
           echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,8 @@ benchmarks/results
 benchmarks/scipy
 benchmarks/html
 benchmarks/scipy-benchmarks
+.openblas
+scipy/_distributor_init_local.py
 scipy/__config__.py
 scipy/_lib/_ccallback_c.c
 scipy/_lib/messagestream.c

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,7 +13,6 @@ filterwarnings =
     ignore:'contextfunction' is renamed to 'pass_context'
     ignore:.*The distutils.* is deprecated.*:DeprecationWarning
     ignore:\s*.*numpy.distutils.*:DeprecationWarning
-    ignore:.*The --rsyncdir command line argument.*:DeprecationWarning
     ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning
     ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning
     ignore:.*In the future `np.long` will be defined as.*:FutureWarning

--- a/scipy/_distributor_init.py
+++ b/scipy/_distributor_init.py
@@ -1,10 +1,18 @@
 """ Distributor init file
 
-Distributors: you can add custom code here to support particular distributions
-of SciPy.
+Distributors: you can replace the contents of this file with your own custom
+code to support particular distributions of SciPy.
 
-For example, this is a good place to put any checks for hardware requirements.
+For example, this is a good place to put any checks for hardware requirements
+or BLAS/LAPACK library initialization.
 
-The SciPy standard source distribution will not put code in this file, so you
-can safely replace this file with your own version.
+The SciPy standard source distribution will not put code in this file beyond
+the try-except import of `_distributor_init_local` (which is not part of a
+standard source distribution), so you can safely replace this file with your
+own version.
 """
+
+try:
+    from . import _distributor_init_local  # noqa: F401
+except ImportError:
+    pass

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -153,6 +153,16 @@ fortranobject_dep = declare_dependency(
 # https://github.com/mesonbuild/meson/issues/2835
 blas_name = get_option('blas')
 lapack_name = get_option('lapack')
+
+# First try scipy-openblas, and if found don't look for cblas or lapack, we
+# know what's inside the scipy-openblas wheels already.
+if blas_name == 'openblas' or blas_name == 'auto'
+  blas = dependency('scipy-openblas', required: false)
+  if blas.found()
+    blas_name = 'scipy-openblas'
+  endif
+endif
+
 # pkg-config uses a lower-case name while CMake uses a capitalized name, so try
 # that too to make the fallback detection with CMake work
 if blas_name == 'openblas'
@@ -171,7 +181,11 @@ else
   cblas = []
 endif
 
-if lapack_name == 'openblas'
+if 'mkl' in blas.name() or blas.name() == 'accelerate' or blas_name == 'scipy-openblas'
+  # For these libraries we know that they contain LAPACK, and it's desirable to
+  # use that - no need to run the full detection twice.
+  lapack = blas
+elif lapack_name == 'openblas'
   lapack = dependency(['openblas', 'OpenBLAS'])
 else
   lapack = dependency(lapack_name)
@@ -225,6 +239,10 @@ python_sources = [
   'optimize.pxd',
   'special.pxd',
 ]
+
+if blas_name == 'scipy-openblas'
+  python_sources += ['_distributor_init_local.py']
+endif
 
 py3.install_sources(
   python_sources,


### PR DESCRIPTION
Addresses most of gh-19269. The newer OpenBLAS version seems to hang on 32-bit Linux in `scipy.cluster` tests, I'll open an issue for that. Switching over the wheel build jobs will be a follow-up to this PR, to not do too much at once.

The `dev.py` usage is slightly more polished than what `numpy` has, because there is no need to set `PKG_CONFIG_PATH` - that's taken care of from within `dev.py`. To use this locally:
```bash
$ pip install scipy-openblas32
$ python dev.py build --use-scipy-openblas   # in a clean env, not with an already configured build dir
```
After that, you can use all the `dev.py` commands without having to pass `--use-scipy-openblas` again (until you do `git clean -xdf` of course).

In CI, this gets rid of having to deal with manually locating the OpenBLAS shared library, something copying it over, putting it on `LD_LIBRARY_PATH`, etc.