### PR TITLE
TST: Test number of iterations for 'trf' convergence when initialized close to bounds

### DIFF
--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -923,5 +923,6 @@ def test_gh_19351():
     # Check that the optimization is terminated as converged in less than 400
     # function evaluations. When make_strictly_feasible is called with
     # rstep=0 the number of function evaluations goes higher than 400.
-    result = least_squares(fun, x0, bounds=bounds, max_nfev=400)
+    result = least_squares(fun, x0, bounds=bounds, max_nfev=500)
     assert result.success
+    assert result.nfev < 400


### PR DESCRIPTION
#### Reference issue
 #19351

#### What does this implement/fix?
Includes the code from #19351 as a test. 

#### Additional information
The issue with the `rstep=0` is probably not as bad. In this example it only results in a higher number of iterations (not passing through default settings of curve_fit/least_squares which causes the reported exception).

But I still think it's a right call to keep the parameter intact as not to disturb existing packages and maintainers. The complaint in #18793 is not completely invalid, but it's not worth it to adjust the behavior to only slightly improve that particular case IMO. Again, from the algorithm perspective, the returned solution in that case is valid.

![image](https://github.com/scipy/scipy/assets/7074023/3108de79-0156-46fe-b353-a47ec5c09eed)

