### PR TITLE
MAINT: spatial: Change error message in KDTree to be more informative.

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -554,7 +554,7 @@ cdef class cKDTree:
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
         if data.ndim != 2:
-            raise ValueError("data must be 2 dimensions")
+            raise ValueError("data must be of shape (n, m), where there are n points of dimension m")
 
         if not np.isfinite(data).all():
             raise ValueError("data must be finite, check for nan or inf values")

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -554,7 +554,8 @@ cdef class cKDTree:
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
         if data.ndim != 2:
-            raise ValueError("data must be of shape (n, m), where there are n points of dimension m")
+            raise ValueError("data must be of shape (n, m), where there are"
+                             "n points of dimension m")
 
         if not np.isfinite(data).all():
             raise ValueError("data must be finite, check for nan or inf values")


### PR DESCRIPTION
#### Reference issue
Closes #19188

#### What does this implement/fix?
Based on the discussion in #19188, change the error message when calling KDTree with an invalid data array to make it clearer that data should be a 2D array, but the data _in_ the array can be any dimension (1D, 2D, ...).

#### Additional information
I'm not sure if this is exactly what the people involved had in mind, but it's a quick and simple fix.
