### PR TITLE
TST: signal: add missing assertion in test_filter_design.py

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4150,7 +4150,7 @@ class TestGammatone:
         fs = 16000
         ftypes = ['fir', 'iir']
         for ftype in ftypes:
-            # Create a gammatone filter centered at 1000 Hz
+            # Create a gammatone filter centered at 1000 Hz.
             b, a = gammatone(1000, ftype, fs=fs)
 
             # Calculate the frequency response.
@@ -4160,8 +4160,8 @@ class TestGammatone:
             # and corresponding frequency.
             response_max = np.max(np.abs(response))
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
-
-            # Assert values are close
+            
+          # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
             assert_allclose(response_max, 1, rtol=1e-2)
             assert_allclose(freq_hz, 1000, rtol=1e-2)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4150,7 +4150,7 @@ class TestGammatone:
         fs = 16000
         ftypes = ['fir', 'iir']
         for ftype in ftypes:
-            # Create a gammatone filter centered at 1000 Hz.
+            # Create a gammatone filter centered at 1000 Hz
             b, a = gammatone(1000, ftype, fs=fs)
 
             # Calculate the frequency response.
@@ -4161,9 +4161,9 @@ class TestGammatone:
             response_max = np.max(np.abs(response))
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
 
-            # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
-            assert response_max == pytest.approx(1, rel=1e-2)
-            assert freq_hz == pytest.approx(1000, rel=1e-2)
+            # Assert values are close
+        assert_allclose(response_max, 1, rtol=1e-2)  
+        assert_allclose(freq_hz, 1000, rtol=1e-2))
 
     # All built-in IIR filters are real, so should have perfectly
     # symmetrical poles and zeros. Then ba representation (using

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4162,8 +4162,8 @@ class TestGammatone:
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
 
             # Assert values are close
-        assert_allclose(response_max, 1, rtol=1e-2)  
-        assert_allclose(freq_hz, 1000, rtol=1e-2))
+            assert_allclose(response_max, 1, rtol=1e-2)
+            assert_allclose(freq_hz, 1000, rtol=1e-2)
 
     # All built-in IIR filters are real, so should have perfectly
     # symmetrical poles and zeros. Then ba representation (using

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4161,7 +4161,7 @@ class TestGammatone:
             response_max = np.max(np.abs(response))
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
             
-          # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
+            # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
             assert_allclose(response_max, 1, rtol=1e-2)
             assert_allclose(freq_hz, 1000, rtol=1e-2)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4160,7 +4160,7 @@ class TestGammatone:
             # and corresponding frequency.
             response_max = np.max(np.abs(response))
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
-            
+
             # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
             assert_allclose(response_max, 1, rtol=1e-2)
             assert_allclose(freq_hz, 1000, rtol=1e-2)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4162,8 +4162,8 @@ class TestGammatone:
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
 
             # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
-            response_max == pytest.approx(1, rel=1e-2)
-            freq_hz == pytest.approx(1000, rel=1e-2)
+            assert response_max == pytest.approx(1, rel=1e-2)
+            assert freq_hz == pytest.approx(1000, rel=1e-2)
 
     # All built-in IIR filters are real, so should have perfectly
     # symmetrical poles and zeros. Then ba representation (using


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes/Fixes #19398 

#### What does this implement/fix?
Use assert statements instead of comparisons
This will cause the test to fail if the assertions do not pass
No need to assign the comparison result, just assert **directly**

