### PR TITLE
BUG: Fix typecasting problem in scipy.sparse.lil_matrix truediv

### DIFF
--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -290,7 +290,6 @@ class _lil_base(_spbase, IndexMixin):
             new_dtype = np.result_type(self.dtype, np.array(other).dtype)
             if new_dtype != self.dtype:
                 new.data = new.data.astype(new_dtype)
-                new.dtype = new_dtype
             # Divide every element by this scalar
             for j, rowvals in enumerate(new.data):
                 new.data[j] = [val/other for val in rowvals]

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -287,6 +287,10 @@ class _lil_base(_spbase, IndexMixin):
     def __truediv__(self, other):           # self / other
         if isscalarlike(other):
             new = self.copy()
+            new_dtype = np.result_type(self.dtype, np.array(other).dtype)
+            if new_dtype != self.dtype:
+                new.data = new.data.astype(new_dtype)
+                new.dtype = new_dtype
             # Divide every element by this scalar
             for j, rowvals in enumerate(new.data):
                 new.data[j] = [val/other for val in rowvals]

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -287,9 +287,7 @@ class _lil_base(_spbase, IndexMixin):
     def __truediv__(self, other):           # self / other
         if isscalarlike(other):
             new = self.copy()
-            new_dtype = np.result_type(self.dtype, np.array(other).dtype)
-            if new_dtype != self.dtype:
-                new.data = new.data.astype(new_dtype)
+            new.dtype = np.result_type(self, other)
             # Divide every element by this scalar
             for j, rowvals in enumerate(new.data):
                 new.data[j] = [val/other for val in rowvals]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4201,13 +4201,13 @@ class TestLIL(sparse_test_class(minmax=False)):
         x = x*0
         assert_equal(x[0, 0], 0)
 
-    def test_lil_divide_scalar(self):
+    def test_truediv_scalar(self):
         A = self.spcreator((3, 2))
         A[0, 1] = -10
         A[2, 0] = 20
 
-        assert_array_equal((A/1j).toarray(), A.toarray()/1j)
-        assert_array_equal((A/9).toarray(), A.toarray()/9)
+        assert_array_equal((A / 1j).toarray(), A.toarray() / 1j)
+        assert_array_equal((A / 9).toarray(), A.toarray() / 9)
 
     def test_inplace_ops(self):
         A = lil_matrix([[0, 2, 3], [4, 0, 6]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4201,6 +4201,14 @@ class TestLIL(sparse_test_class(minmax=False)):
         x = x*0
         assert_equal(x[0, 0], 0)
 
+    def test_lil_divide_scalar(self):
+        A = self.spcreator((3, 2))
+        A[0, 1] = -10
+        A[2, 0] = 20
+
+        assert_array_equal((A/1j).toarray(), A.toarray()/1j)
+        assert_array_equal((A/9).toarray(), A.toarray()/9)
+
     def test_inplace_ops(self):
         A = lil_matrix([[0, 2, 3], [4, 0, 6]])
         B = lil_matrix([[0, 1, 0], [0, 2, 3]])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #19403 

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes the inconsistent behavior I observed when dividing a `scipy.sparse.lil_matrix` by a scalar of differing type. Now the resulting `dtype` is checked and adjusted if necessary.

