### PR TITLE
MAINT: fix a C++ build error with GCC 13

### DIFF
--- a/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
+++ b/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <fast_matrix_market/types.hpp>
+#include <cstdint>
 namespace fast_matrix_market {
     // Be able to set unsigned-integer field type. This type is only used by SciPy to represent uint64 values.
     field_type get_field_type([[maybe_unused]] const uint32_t* type) {


### PR DESCRIPTION
#### Reference issue

None

#### What does this implement/fix?

Compiling SciPy with GCC 13 gives the following error:

```
FAILED: scipy/io/_fast_matrix_market/_fmm_core.cpython-311-x86_64-linux-gnu.so.p/src__fmm_core.cpp.o 
ccache c++ -Iscipy/io/_fast_matrix_market/_fmm_core.cpython-311-x86_64-linux-gnu.so.p -Iscipy/io/_fast_matrix_market -I../scipy/io/_fast_matrix_market -I../scipy/io/_fast_matrix_market/fast_matrix_market/include -I../../virtualenvs/scipy-dev/lib/python3.11/site-packages/numpy/core/include -I../scipy/io/_fast_matrix_market/fast_matrix_market/dependencies/fast_float/include -Iscipy/io/_fast_matrix_market/fast_matrix_market/dependencies/ryu -I../scipy/io/_fast_matrix_market/fast_matrix_market/dependencies/ryu -I/usr/include/python3.11 -I/usr/local/google/home/tirthp/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/pybind11/include -I/usr/include/x86_64-linux-gnu/python3.11 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++17 -O2 -g -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -DFMM_SCIPY_PRUNE -DFMM_USE_FAST_FLOAT -DFMM_USE_RYU -DFMM_FROM_CHARS_INT_SUPPORTED -DFMM_TO_CHARS_INT_SUPPORTED -MD -MQ scipy/io/_fast_matrix_market/_fmm_core.cpython-311-x86_64-linux-gnu.so.p/src__fmm_core.cpp.o -MF scipy/io/_fast_matrix_market/_fmm_core.cpython-311-x86_64-linux-gnu.so.p/src__fmm_core.cpp.o.d -o scipy/io/_fast_matrix_market/_fmm_core.cpython-311-x86_64-linux-gnu.so.p/src__fmm_core.cpp.o -c ../scipy/io/_fast_matrix_market/src/_fmm_core.cpp
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:8:54: error: ‘uint32_t’ does not name a type
    8 |     field_type get_field_type([[maybe_unused]] const uint32_t* type) {
      |                                                      ^~~~~~~~
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:6:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    5 | #include <fast_matrix_market/types.hpp>
  +++ |+#include <cstdint>
    6 | namespace fast_matrix_market {
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:12:54: error: ‘uint64_t’ does not name a type
   12 |     field_type get_field_type([[maybe_unused]] const uint64_t* type) {
      |                                                      ^~~~~~~~
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:12:54: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:12:16: error: redefinition of ‘fast_matrix_market::field_type fast_matrix_market::get_field_type(const int*)’
   12 |     field_type get_field_type([[maybe_unused]] const uint64_t* type) {
      |                ^~~~~~~~~~~~~~
../scipy/io/_fast_matrix_market/src/_fmm_core.cpp:8:16: note: ‘fast_matrix_market::field_type fast_matrix_market::get_field_type(const int*)’ previously defined here
    8 |     field_type get_field_type([[maybe_unused]] const uint32_t* type) {
      |                ^~~~~~~~~~~~~~
[1282/1607] Generating scipy/linalg/flapack_module with a custom command
ninja: build stopped: subcommand failed.
Build failed!
```

This PR fixes the error by explicitly including the `<cstdint>` header.