### PR TITLE
DEP: deprecate special.sinc

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -335,6 +335,7 @@ for key in (
         'scipy.signal.morlet2 is deprecated',
         'scipy.signal.ricker is deprecated',
         'scipy.signal.cwt is deprecated',
+        'scipy.special.sinc is deprecated',
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -335,7 +335,7 @@ for key in (
         'scipy.signal.morlet2 is deprecated',
         'scipy.signal.ricker is deprecated',
         'scipy.signal.cwt is deprecated',
-        'scipy.special.sinc is deprecated',
+        '`scipy.special.sinc` is a deprecated alias',
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 from numpy.fft import irfft, fft, ifft
-from scipy.special import sinc
+from numpy import sinc
 from scipy.linalg import (toeplitz, hankel, solve, LinAlgError, LinAlgWarning,
                           lstsq)
 from scipy._lib.deprecation import _NoValue, _deprecate_positional_args

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -6,7 +6,7 @@ from pytest import raises as assert_raises
 import pytest
 
 from scipy.fft import fft
-from scipy.special import sinc
+from numpy import sinc
 from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
     firwin, firwin2, freqz, remez, firls, minimum_phase
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -110,10 +110,9 @@ def _nonneg_int_or_fail(n, var_name, strict=True):
 def sinc(x):
     r"""
     .. deprecated:: 1.12.0
-        scipy.special.sinc is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. As scipy.special.sinc is an alias of numpy.sinc,
-        we encourage using using numpy.sinc instead which returns the
-        same result.
+        `scipy.special.sinc` is a deprecated alias for `numpy.sinc` and will
+        be removed in SciPy 1.14. To silence this warning, use `numpy.sinc`
+        instead. Deprecated in SciPy 1.12.
 
     Return the normalized sinc function.
 
@@ -138,6 +137,10 @@ def sinc(x):
     -------
     out : ndarray
         ``sinc(x)``, which has the same shape as the input.
+
+    See Also
+    --------
+    numpy.sinc
 
     Notes
     -----
@@ -169,9 +172,10 @@ def sinc(x):
     >>> plt.xlabel("X")
     >>> plt.show()
     """
-    _depr_msg = ("scipy.special.sinc is deprecated in SciPy 1.12 and will be "
-                 "removed in SciPy 1.14. We recommend using numpy.sinc "
-                 "instead.")
+    _depr_msg = ("`scipy.special.sinc` is a deprecated alias for "
+                 "numpy.sinc` and will be removed in SciPy 1.14. To silence "
+                 "this warning, use `numpy.sinc` instead. Deprecated in "
+                 "SciPy 1.12.")
     warnings.warn(_depr_msg, DeprecationWarning, stacklevel=2)
     return np.sinc(x)
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -173,7 +173,7 @@ def sinc(x):
     >>> plt.show()
     """
     _depr_msg = ("`scipy.special.sinc` is a deprecated alias for "
-                 "numpy.sinc` and will be removed in SciPy 1.14. To silence "
+                 "`numpy.sinc` and will be removed in SciPy 1.14. To silence "
                  "this warning, use `numpy.sinc` instead. Deprecated in "
                  "SciPy 1.12.")
     warnings.warn(_depr_msg, DeprecationWarning, stacklevel=2)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -111,7 +111,9 @@ def sinc(x):
     r"""
     .. deprecated:: 1.12.0
         scipy.special.sinc is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using numpy.sinc instead.
+        in SciPy 1.14. As scipy.special.sinc is an alias of numpy.sinc,
+        we encourage using using numpy.sinc instead which returns the
+        same result.
 
     Return the normalized sinc function.
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -11,7 +11,6 @@ from heapq import heapify, heappop
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
                    extract, inexact, nan, zeros)
-from numpy import sinc as np_sinc
 from . import _ufuncs
 from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, hankel1, hankel2, yv, kv, poch, binom)
@@ -172,7 +171,7 @@ def sinc(x):
                  "removed in SciPy 1.14. We recommend using numpy.sinc "
                  "instead.")
     warnings.warn(_depr_msg, DeprecationWarning, stacklevel=2)
-    return np_sinc(x)
+    return np.sinc(x)
 
 
 def diric(x, n):

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -110,7 +110,6 @@ def _nonneg_int_or_fail(n, var_name, strict=True):
 
 def sinc(x):
     r"""
-
     .. deprecated:: 1.12.0
         scipy.special.sinc is deprecated in SciPy 1.12 and will be removed
         in SciPy 1.14. We recommend using numpy.sinc instead.

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -10,7 +10,8 @@ from collections import defaultdict
 from heapq import heapify, heappop
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
-                   extract, inexact, nan, zeros, sinc)
+                   extract, inexact, nan, zeros)
+from numpy import sinc as np_sinc
 from . import _ufuncs
 from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
                       psi, hankel1, hankel2, yv, kv, poch, binom)
@@ -105,6 +106,74 @@ def _nonneg_int_or_fail(n, var_name, strict=True):
     except (ValueError, TypeError) as err:
         raise err.__class__(f"{var_name} must be a non-negative integer") from err
     return n
+
+
+def sinc(x):
+    r"""
+
+    .. deprecated:: 1.12.0
+        scipy.special.sinc is deprecated in SciPy 1.12 and will be removed
+        in SciPy 1.14. We recommend using numpy.sinc instead.
+
+    Return the normalized sinc function.
+
+    The sinc function is equal to :math:`\sin(\pi x)/(\pi x)` for any argument
+    :math:`x\ne 0`. ``sinc(0)`` takes the limit value 1, making ``sinc`` not
+    only everywhere continuous but also infinitely differentiable.
+
+    .. note::
+
+        Note the normalization factor of ``pi`` used in the definition.
+        This is the most commonly used definition in signal processing.
+        Use ``sinc(x / np.pi)`` to obtain the unnormalized sinc function
+        :math:`\sin(x)/x` that is more common in mathematics.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array (possibly multi-dimensional) of values for which to calculate
+        ``sinc(x)``.
+
+    Returns
+    -------
+    out : ndarray
+        ``sinc(x)``, which has the same shape as the input.
+
+    Notes
+    -----
+    The name sinc is short for "sine cardinal" or "sinus cardinalis".
+
+    The sinc function is used in various signal processing applications,
+    including in anti-aliasing, in the construction of a Lanczos resampling
+    filter, and in interpolation.
+
+    For bandlimited interpolation of discrete-time signals, the ideal
+    interpolation kernel is proportional to the sinc function.
+
+    References
+    ----------
+    .. [1] Weisstein, Eric W. "Sinc Function." From MathWorld--A Wolfram Web
+           Resource. http://mathworld.wolfram.com/SincFunction.html
+    .. [2] Wikipedia, "Sinc function",
+           https://en.wikipedia.org/wiki/Sinc_function
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import sinc
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(-4, 4, 41)
+    >>> plt.plot(x, sinc(x))
+    >>> plt.title("Sinc Function")
+    >>> plt.ylabel("Amplitude")
+    >>> plt.xlabel("X")
+    >>> plt.show()
+    """
+    _depr_msg = ("scipy.special.sinc is deprecated in SciPy 1.12 and will be "
+                 "removed in SciPy 1.14. We recommend using numpy.sinc "
+                 "instead.")
+    warnings.warn(_depr_msg, DeprecationWarning, stacklevel=2)
+    return np_sinc(x)
 
 
 def diric(x, n):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1544,8 +1544,9 @@ class TestTrigonometric:
 
     def test_sinc(self):
         # the sinc implementation and more extensive sinc tests are in numpy
-        assert_array_equal(special.sinc([0]), 1)
-        assert_equal(special.sinc(0.0), 1.0)
+        with pytest.deprecated_call():
+            assert_array_equal(special.sinc([0]), 1)
+            assert_equal(special.sinc(0.0), 1.0)
 
     def test_sindg(self):
         sn = special.sindg(90)


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/17246

#### What does this implement/fix?
`special.sinc` is only an alias for `numpy.sinc`. It is deprecated here, pointing users to use numpy instead.

I did not know how to add the deprecation warning without the `sinc(x)=np.sinc(x)` dance including the copy of the docstring, thats why the diff looks bigger than expected.