### PR TITLE
MAINT: silence doc test warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -335,6 +335,7 @@ for key in (
         'scipy.signal.morlet2 is deprecated',
         'scipy.signal.ricker is deprecated',
         'scipy.signal.cwt is deprecated',
+        'numpy.core.numeric is deprecated',
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 


### PR DESCRIPTION
#### What does this implement/fix?
Recently, I have seen the array API CI job failing due to a deprecation warning (see [example](https://github.com/scipy/scipy/actions/runs/6593096394/job/17915021307?pr=19416)):

![image](https://github.com/scipy/scipy/assets/40656107/1839fc99-f855-4ea7-b4d4-16de6c0f1f6a)

Try to fix it here by filterning this warning like other deperecation warnings.
