### PR TITLE
ENH: SphericalVoronoi sort faster

### DIFF
--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -20,16 +20,18 @@ __all__ = ['sort_vertices_of_regions']
 
 
 @cython.boundscheck(False)
-def sort_vertices_of_regions(int[:,::1] simplices, regions):
-    cdef np.npy_intp n, k, s, i
+def sort_vertices_of_regions(int[:,::1] simplices, list regions):
+    cdef np.npy_intp n, k, s, i, max_len
     cdef np.npy_intp num_regions = len(regions)
     cdef np.npy_intp current_simplex, current_vertex
     cdef np.npy_intp remaining_size
     cdef np.npy_intp[:] remaining
     cdef np.ndarray[np.intp_t, ndim=1] sorted_vertices
-    sorted_vertices = np.empty(max([len(region) for region
-                               in regions]),
-                               dtype=np.intp)
+
+    max_len = 0
+    for region in regions:
+        max_len = max(max_len, len(region))
+    sorted_vertices = np.empty(max_len, dtype=np.intp)
 
     for n in range(num_regions):
         remaining = np.asarray(regions[n][:])

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -26,9 +26,10 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
     cdef np.npy_intp current_simplex, current_vertex
     cdef np.npy_intp remaining_size
     cdef np.npy_intp[:] remaining
-    cdef np.npy_intp[:] sorted_vertices = np.empty(max([len(region) for region
-                                                   in regions]),
-                                                   dtype=np.intp)
+    cdef np.ndarray[np.intp_t, ndim=1] sorted_vertices
+    sorted_vertices = np.empty(max([len(region) for region
+                               in regions]),
+                               dtype=np.intp)
 
     for n in range(num_regions):
         remaining = np.asarray(regions[n][:])
@@ -53,4 +54,4 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
                 if s != n and s != current_vertex:
                     current_vertex = s
                     break
-        regions[n] = list(np.asarray(sorted_vertices[:remaining_size]))
+        regions[n] = list(sorted_vertices[:remaining_size])


### PR DESCRIPTION
* avoid a large number of memoryview->ndarray conversions in the `sort_vertices_of_regions` loop

* `asv continuous -e -b ".*SphericalVor.*" main treddy_sph_vor_sort_faster`

```
| Change   | Before [5dc8a79e] <main>   | After [a0350aee] <treddy_sph_vor_sort_faster>   |   Ratio | Benchmark (Parameter)                                                 |
|----------|----------------------------|-------------------------------------------------|---------|-----------------------------------------------------------------------|
| -        | 12.4±0.02ms                | 10.9±0.1ms                                      |    0.88 | spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(10000) |
| -        | 1.23±0ms                   | 1.07±0ms                                        |    0.87 | spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(1000)  |
| -        | 6.17±0.01ms                | 5.33±0.04ms                                     |    0.86 | spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(5000)  |
| -        | 122±4μs                    | 104±1μs                                         |    0.85 | spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(100)   |
| -        | 11.9±0.02μs                | 10.0±0.08μs                                     |    0.84 | spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(10)    |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

[skip cirrus] [skip circle]
