### PR TITLE
DOC: Fix documentation of callback function signature of scipy.optimize.minimize

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -202,7 +202,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         All methods except TNC, SLSQP, and COBYLA support a callable with
         the signature:
 
-            ``callback(OptimizeResult: intermediate_result)``
+            ``callback(intermediate_result: OptimizeResult)``
 
         where ``intermediate_result`` is a keyword parameter containing an
         `OptimizeResult` with attributes ``x`` and ``fun``, the present values


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

One of the possible signature of the `callback` function of `scipy.optimize.minimize` is documented as `callback(OptimizeResult: intermediate_result)`, but the argument and its type seems to be swapped.

#### Additional information
<!--Any additional information you think is important.-->
