### PR TITLE
MAINT: more NEP 50 shims

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -312,7 +312,7 @@ def _arg_wlen_as_expected(value):
         value = -1
     elif 1 < value:
         # Round up to a positive integer
-        if not np.can_cast(value, np.intp, "safe"):
+        if isinstance(value, float):
             value = math.ceil(value)
         value = np.intp(value)
     else:


### PR DESCRIPTION
* 3 test failures show up with latest NumPy: https://github.com/scipy/scipy/actions/runs/6632037087/job/18016857190?pr=19419

* almost certainly because of NEP50 adoption/changes: https://github.com/numpy/numpy/pull/23912

* it looks to me like the only special handling we need here is for floats, so `can_cast` may have been overkill anyway, although if you follow the control flow/docstrings, it gets a bit confusing with some things claiming to use `np.intp` and others Python `int`...

[skip cirrus] [skip circle]