### PR TITLE
DOC:  Add example for `stats.hdquantiles`

### DIFF
--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -37,7 +37,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
     data : array_like
         Data array.
     prob : sequence, optional
-        Sequence of quantiles to compute.
+        Sequence of probabilities at which to compute the quantiles.
     axis : int or None, optional
         Axis along which to compute the quantiles. If None, use a flattened
         array.
@@ -63,14 +63,14 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
     >>> # Sample data
     >>> data = np.array([1.2, 2.5, 3.7, 4.0, 5.1, 6.3, 7.0, 8.2, 9.4])
 
-    >>> # Define quantiles to compute
-    >>> quantiles = [0.25, 0.5, 0.75]
+    >>> # Probabilities at which to compute quantiles
+    >>> probabilities = [0.25, 0.5, 0.75]
 
     >>> # Compute Harrell-Davis quantile estimates
-    >>> quantile_estimates = hdquantiles(data, prob=quantiles)
+    >>> quantile_estimates = hdquantiles(data, prob=probabilities)
 
     >>> # Display the quantile estimates
-    >>> for i, quantile in enumerate(quantiles):
+    >>> for i, quantile in enumerate(probabilities):
     ...     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
 
     25th percentile: 3.1505820231763066

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -71,7 +71,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
 
     >>> # Display the quantile estimates
     >>> for i, quantile in enumerate(quantiles):
-    >>>     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
+    ...     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
 
     25th percentile: 3.1505820231763066
     50th percentile: 5.194344084883956

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -55,6 +55,30 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
     --------
     hdquantiles_sd
 
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> from scipy.stats.mstats import hdquantiles
+
+    >>> # Sample data
+    >>> data = np.array([1.2, 2.5, 3.7, 4.0, 5.1, 6.3, 7.0, 8.2, 9.4])
+
+    >>> # Define quantiles to compute
+    >>> quantiles = [0.25, 0.5, 0.75]
+
+    >>> # Compute Harrell-Davis quantile estimates
+    >>> quantile_estimates = hdquantiles(data, prob=quantiles)
+
+    >>> # Display the quantile estimates
+    >>> for i, quantile in enumerate(quantiles):
+        >>> print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
+
+    25th percentile: 3.1505820231763066
+    50th percentile: 5.194344084883956
+    75th percentile: 7.430626414674935
+    ```
+
     """
     def _hd_1D(data,prob,var):
         "Computes the HD quantiles for a 1D array. Returns nan for invalid data."

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -72,12 +72,11 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
 
     >>> # Display the quantile estimates
     >>> for i, quantile in enumerate(quantiles):
-        >>> print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
+    >>>     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
 
     25th percentile: 3.1505820231763066
     50th percentile: 5.194344084883956
     75th percentile: 7.430626414674935
-    ```
 
     """
     def _hd_1D(data,prob,var):

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -59,16 +59,16 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
     --------
     >>> import numpy as np
     >>> from scipy.stats.mstats import hdquantiles
-
+    >>>
     >>> # Sample data
     >>> data = np.array([1.2, 2.5, 3.7, 4.0, 5.1, 6.3, 7.0, 8.2, 9.4])
-
+    >>>
     >>> # Probabilities at which to compute quantiles
     >>> probabilities = [0.25, 0.5, 0.75]
-
+    >>>
     >>> # Compute Harrell-Davis quantile estimates
     >>> quantile_estimates = hdquantiles(data, prob=probabilities)
-
+    >>>
     >>> # Display the quantile estimates
     >>> for i, quantile in enumerate(probabilities):
     ...     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -57,7 +57,6 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
 
     Examples
     --------
-    >>> import matplotlib.pyplot as plt
     >>> import numpy as np
     >>> from scipy.stats.mstats import hdquantiles
 

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -72,7 +72,6 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
     >>> # Display the quantile estimates
     >>> for i, quantile in enumerate(probabilities):
     ...     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
-
     25th percentile: 3.1505820231763066
     50th percentile: 5.194344084883956
     75th percentile: 7.430626414674935


### PR DESCRIPTION
#### Reference issue
Part of `DOC: Add "Examples" to docstrings` #7168 

#### What does this implement/fix?
Adds example for `stats.hdquantiles`

[skip actions] [skip cirrus]
