### PR TITLE
WIP, BUG: spatial.distance.jensenshannon: handle subnormals

### DIFF
--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -365,8 +365,14 @@ jensenshannon_distance_double(const double *p, const double *q, const npy_intp n
         const double m_i = (p_i + q_i) / 2.0;
         if (p_i > 0.0)
             s += p_i * log(p_i / m_i);
-        if (q_i > 0.0)
-            s += q_i * log(q_i / m_i);
+        if (q_i > 0.0) {
+            if (fpclassify(q_i) == FP_SUBNORMAL) {
+                s += q_i;
+            }
+            else {
+                s += q_i * log(q_i / m_i);
+            }
+        }
     }
 
     return sqrt(s / 2.0);

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2241,3 +2241,17 @@ def test_gh_17703():
     actual = cdist(np.atleast_2d(arr_1),
                    np.atleast_2d(arr_2), metric='dice')
     assert_allclose(actual, expected)
+
+
+def test_gh_19436():
+    p = [0, 1]
+    q = [5e-324, 1]
+    actual = jensenshannon(p, q)
+    expected = jensenshannon(p, p)
+    x2 = cdist(np.atleast_2d(p),
+               np.atleast_2d(q),
+               metric="jensenshannon")
+    x3 = pdist([p, q], metric="jensenshannon")
+    assert_allclose(actual, expected)
+    assert_allclose(x2, expected)
+    assert_allclose(x3, expected)

--- a/scipy/special/_convex_analysis.pxd
+++ b/scipy/special/_convex_analysis.pxd
@@ -1,4 +1,5 @@
-from libc.math cimport log, fabs, expm1, log1p, isnan, NAN, INFINITY
+from libc.math cimport (log, fabs, expm1, log1p, isnan, NAN, INFINITY,
+                        fpclassify, FP_SUBNORMAL)
 
 cdef inline double entr(double x) noexcept nogil:
     if isnan(x):
@@ -27,6 +28,8 @@ cdef inline double rel_entr(double x, double y) noexcept nogil:
         return x * log(x / y)
     elif x == 0 and y >= 0:
         return 0
+    elif fpclassify(x) == FP_SUBNORMAL:
+        return x
     else:
         return INFINITY
 


### PR DESCRIPTION
* Fixes #19436

* this applies a bug fix + regression test for the above issue, on the assumption that we should treat subnormals fairly similar to zero itself, and applies a similar patch to the `cdist`/`pdist` code paths as well

* note, however, that I'm not operating from a place of deep expertise here and I can think of a number of things we might want to check/fix up (note below), though I'd probably argue this makes more sense than returning infinity for these cases

* some additional things it might make sense to do: check another reference/implementation, write a test with subnormals at the end of the vectors instead of just at the start, write a test with more than 1 subnormal per vector (and do we actually know exactly what we want in all these cases...)

[skip cirrus] [skip circle]
