### PR TITLE
BLD: update build dependency versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.14.0",
+    "meson-python>=0.15.0",
     "Cython>=0.29.35,!=3.0.3",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.14.0",
@@ -23,11 +23,18 @@ requires = [
     # default numpy requirements
     "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    "numpy>=1.26.0,<1.27; python_version=='3.12'",
+
+    # PyPy requirements; 1.25.0 was the first version to have pypy-3.9 wheels,
+    # and 1.25.0 also changed the C API target to 1.19.x, so no longer a need
+    # for an exact pin.
+    "numpy>=1.25.0; python_version>='3.9' and platform_python_implementation=='PyPy'",
+
     # For Python versions which aren't yet officially supported, we specify an
     # unpinned NumPy which allows source distributions to be used and allows
     # wheels to be used as soon as they become available.
-    "numpy>=1.26.0b1; python_version>='3.12'",
-    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
+    # Python 3.13 has known issues that are only fixed in numpy 2.0.0.dev0
+    "numpy>=2.0.0.dev0; python_version>='3.13'",
 ]
 
 [project]


### PR DESCRIPTION
The NumPy updates are regular ones; code comments explain. The meson-python update is useful because with 0.15.0, the dependency on setuptools for Python 3.12 disappears. Plus there are FreeBSD and PyPy fixes that may be relevant.