### PR TITLE
DOC: remove unused parameter in spline_filter docstring

### DIFF
--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -142,9 +142,6 @@ def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     %(input)s
     order : int, optional
         The order of the spline, default is 3.
-    axis : int, optional
-        The axis along which the spline filter is applied. Default is the last
-        axis.
     output : ndarray or dtype, optional
         The array in which to place the output, or the dtype of the returned
         array. Default is ``numpy.float64``.

--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -69,7 +69,7 @@ _mode_reflect_doc = (
 
 _mode_interp_constant_doc = (
 """mode : {'reflect', 'grid-mirror', 'constant', 'grid-constant', 'nearest', \
-           'mirror', 'grid-wrap', 'wrap'}, optional
+'mirror', 'grid-wrap', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended
     beyond its boundaries. Default is 'constant'. Behavior for each valid
     value is as follows (see additional plots and details on


### PR DESCRIPTION
Axis is not a parameter of the function

DOC: fix line break in spline_filter and spline_filter_1d

Leading spaces in _mode_interp_constant_doc leads to unwanted whitespaces in final docstring

[skip actions] [skip cirrus] [skip ci]
