### PR TITLE
TST: Fix #19442 minimally

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -101,9 +101,9 @@ def test_MikotaPair():
 
 @pytest.mark.parametrize("n", [50])
 @pytest.mark.parametrize("m", [1, 2, 10])
-@pytest.mark.parametrize("Vdtype", REAL_DTYPES)
-@pytest.mark.parametrize("Bdtype", REAL_DTYPES)
-@pytest.mark.parametrize("BVdtype", REAL_DTYPES)
+@pytest.mark.parametrize("Vdtype", sorted(REAL_DTYPES, key=str))
+@pytest.mark.parametrize("Bdtype", sorted(REAL_DTYPES, key=str))
+@pytest.mark.parametrize("BVdtype", sorted(REAL_DTYPES, key=str))
 def test_b_orthonormalize(n, m, Vdtype, Bdtype, BVdtype):
     """Test B-orthonormalization by Cholesky with callable 'B'.
     The function '_b_orthonormalize' is key in LOBPCG but may


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes https://github.com/scipy/scipy/issues/19442.
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

This fixes https://github.com/scipy/scipy/issues/19442 minimally by parameterizing `test_b_orthonormalize` over a sorted-list version of the set `REAL_DVALUES`.

#### Additional information
<!--Any additional information you think is important.-->
As reported in https://github.com/scipy/scipy/issues/19442#issuecomment-1783523842, I tried paramet(e)rizing over `VDTYPES` instead, but the tests involving complex dtypes failed.

Future work could perhaps make this test pass with `VDTYPES`, and perhaps even add a test with complex dtypes having complex values, as suggested at the end of https://github.com/scipy/scipy/issues/19442#issuecomment-1783399099.