### PR TITLE
ENH: Add faster inverse-Wishart rvs and logpdf

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2634,7 +2634,7 @@ class invwishart_gen(wishart_gen):
     .. [1] M.L. Eaton, "Multivariate Statistics: A Vector Space Approach",
            Wiley, 1983.
     .. [2] S.D. Axen, "Efficiently generating inverse-Wishart matrices and
-           their Cholesky factors", arXiv preprint arXiv:2310.15884. 2023.
+           their Cholesky factors", :arXiv:`2310.15884v1`. 2023.
     .. [3] Gupta, M. and Srivastava, S. "Parametric Bayesian Estimation of
            Differential Entropy and Relative Entropy". Entropy 12, 818 - 843.
            2010.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2627,6 +2627,10 @@ class invwishart_gen(wishart_gen):
     inverse Gamma distribution with parameters shape = :math:`\frac{\nu}{2}`
     and scale = :math:`\frac{1}{2}`.
 
+    Instead of inverting a randomly generated Wishart matrix as described in [2],
+    here the algorithm in [4] is used to directly generate a random inverse-Wishart
+    matrix without inversion.
+
     .. versionadded:: 0.16.0
 
     References
@@ -2639,6 +2643,8 @@ class invwishart_gen(wishart_gen):
     .. [3] Gupta, M. and Srivastava, S. "Parametric Bayesian Estimation of
            Differential Entropy and Relative Entropy". Entropy 12, 818 - 843.
            2010.
+    .. [4] S.D. Axen, "Efficiently generating inverse-Wishart matrices and
+           their Cholesky factors", :arXiv:`2310.15884v1`. 2023.
 
     Examples
     --------

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2710,10 +2710,14 @@ class invwishart_gen(wishart_gen):
         log_det_x = np.empty(x.shape[-1])
         tr_scale_x_inv = np.empty(x.shape[-1])
         trsm = get_blas_funcs(('trsm'), (x,))
-        for i in range(x.shape[-1]):
-            Cx, log_det_x[i] = self._cholesky_logdet(x[:, :, i])
-            A = trsm(1., Cx, C, side=0, lower=True)
-            tr_scale_x_inv[i] = np.linalg.norm(A)**2
+        if dim > 1:
+            for i in range(x.shape[-1]):
+                Cx, log_det_x[i] = self._cholesky_logdet(x[:, :, i])
+                A = trsm(1., Cx, C, side=0, lower=True)
+                tr_scale_x_inv[i] = np.linalg.norm(A)**2
+        else:
+            log_det_x[:] = np.log(x[0, 0])
+            tr_scale_x_inv[:] = C[0, 0]**2 / x[0, 0]
 
         # Log PDF
         out = ((0.5 * df * log_det_scale - 0.5 * tr_scale_x_inv) -

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2685,7 +2685,7 @@ class invwishart_gen(wishart_gen):
         """
         return invwishart_frozen(df, scale, seed)
 
-    def _logpdf(self, x, dim, df, scale, log_det_scale, C):
+    def _logpdf(self, x, dim, df, log_det_scale, C):
         """Log of the inverse Wishart probability density function.
 
         Parameters
@@ -2697,8 +2697,6 @@ class invwishart_gen(wishart_gen):
             Dimension of the scale matrix
         df : int
             Degrees of freedom
-        scale : ndarray
-            Scale matrix
         log_det_scale : float
             Logarithm of the determinant of the scale matrix
         C : ndarray
@@ -2748,7 +2746,7 @@ class invwishart_gen(wishart_gen):
         dim, df, scale = self._process_parameters(df, scale)
         x = self._process_quantiles(x, dim)
         C, log_det_scale = self._cholesky_logdet(scale)
-        out = self._logpdf(x, dim, df, scale, log_det_scale, C)
+        out = self._logpdf(x, dim, df, log_det_scale, C)
         return _squeeze_output(out)
 
     def pdf(self, x, df, scale):
@@ -3064,7 +3062,7 @@ class invwishart_frozen(multi_rv_frozen):
 
     def logpdf(self, x):
         x = self._dist._process_quantiles(x, self.dim)
-        out = self._dist._logpdf(x, self.dim, self.df, self.scale,
+        out = self._dist._logpdf(x, self.dim, self.df,
                                  self.log_det_scale, self.C)
         return _squeeze_output(out)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2706,14 +2706,14 @@ class invwishart_gen(wishart_gen):
         """
         # Retrieve tr(scale x^{-1})
         log_det_x = np.empty(x.shape[-1])
-        tr_inv_scale_x = np.empty(x.shape[-1])
+        tr_scale_x_inv = np.empty(x.shape[-1])
         for i in range(x.shape[-1]):
             Cx, log_det_x[i] = self._cholesky_logdet(x[:, :, i])
             A = scipy.linalg.solve_triangular(Cx, C, lower=True)
-            tr_inv_scale_x[i] = np.linalg.norm(A)**2
+            tr_scale_x_inv[i] = np.linalg.norm(A)**2
 
         # Log PDF
-        out = ((0.5 * df * log_det_scale - 0.5 * tr_inv_scale_x) -
+        out = ((0.5 * df * log_det_scale - 0.5 * tr_scale_x_inv) -
                (0.5 * df * dim * _LOG_2 + 0.5 * (df + dim + 1) * log_det_x) -
                multigammaln(0.5*df, dim))
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3011,8 +3011,7 @@ class invwishart_gen(wishart_gen):
         dim, df, scale = self._process_parameters(df, scale)
 
         # Cholesky decomposition of scale
-        C, _ = scipy.linalg.cho_factor(scale, lower=True)
-        C = np.tril(C)
+        C = scipy.linalg.cholesky(scale, lower=True)
 
         out = self._rvs(n, shape, dim, df, C, random_state)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2633,8 +2633,9 @@ class invwishart_gen(wishart_gen):
     ----------
     .. [1] M.L. Eaton, "Multivariate Statistics: A Vector Space Approach",
            Wiley, 1983.
-    .. [2] S.D. Axen, "Efficiently generating inverse-Wishart matrices and
-           their Cholesky factors", :arXiv:`2310.15884v1`. 2023.
+    .. [2] M.C. Jones, "Generating Inverse Wishart Matrices", Communications
+           in Statistics - Simulation and Computation, vol. 14.2, pp.511-514,
+           1985.
     .. [3] Gupta, M. and Srivastava, S. "Parametric Bayesian Estimation of
            Differential Entropy and Relative Entropy". Entropy 12, 818 - 843.
            2010.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2709,9 +2709,10 @@ class invwishart_gen(wishart_gen):
         # Retrieve tr(scale x^{-1})
         log_det_x = np.empty(x.shape[-1])
         tr_scale_x_inv = np.empty(x.shape[-1])
+        trsm = get_blas_funcs(('trsm'), (x,))
         for i in range(x.shape[-1]):
             Cx, log_det_x[i] = self._cholesky_logdet(x[:, :, i])
-            A = scipy.linalg.solve_triangular(Cx, C, lower=True)
+            A = trsm(1., Cx, C, side=0, lower=True)
             tr_scale_x_inv[i] = np.linalg.norm(A)**2
 
         # Log PDF

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2696,9 +2696,8 @@ class invwishart_gen(wishart_gen):
     ----------
     .. [1] M.L. Eaton, "Multivariate Statistics: A Vector Space Approach",
            Wiley, 1983.
-    .. [2] M.C. Jones, "Generating Inverse Wishart Matrices", Communications
-           in Statistics - Simulation and Computation, vol. 14.2, pp.511-514,
-           1985.
+    .. [2] S.D. Axen, "Efficiently generating inverse-Wishart matrices and
+           their Cholesky factors", arXiv preprint arXiv:2310.15884. 2023.
     .. [3] Gupta, M. and Srivastava, S. "Parametric Bayesian Estimation of
            Differential Entropy and Relative Entropy". Entropy 12, 818 - 843.
            2010.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2558,69 +2558,6 @@ for name in ['logpdf', 'pdf', 'mean', 'mode', 'var', 'rvs', 'entropy']:
     method.__doc__ = doccer.docformat(method.__doc__, wishart_docdict_params)
 
 
-def _cho_inv_batch(a, check_finite=True):
-    """
-    Invert the matrices a_i, using a Cholesky factorization of A, where
-    a_i resides in the last two dimensions of a and the other indices describe
-    the index i.
-
-    Overwrites the data in a.
-
-    Parameters
-    ----------
-    a : array
-        Array of matrices to invert, where the matrices themselves are stored
-        in the last two dimensions.
-    check_finite : bool, optional
-        Whether to check that the input matrices contain only finite numbers.
-        Disabling may give a performance gain, but may result in problems
-        (crashes, non-termination) if the inputs do contain infinities or NaNs.
-
-    Returns
-    -------
-    x : array
-        Array of inverses of the matrices ``a_i``.
-
-    See Also
-    --------
-    scipy.linalg.cholesky : Cholesky factorization of a matrix
-
-    """
-    if check_finite:
-        a1 = asarray_chkfinite(a)
-    else:
-        a1 = asarray(a)
-    if len(a1.shape) < 2 or a1.shape[-2] != a1.shape[-1]:
-        raise ValueError('expected square matrix in last two dimensions')
-
-    potrf, potri = get_lapack_funcs(('potrf', 'potri'), (a1,))
-
-    triu_rows, triu_cols = np.triu_indices(a.shape[-2], k=1)
-    for index in np.ndindex(a1.shape[:-2]):
-
-        # Cholesky decomposition
-        a1[index], info = potrf(a1[index], lower=True, overwrite_a=False,
-                                clean=False)
-        if info > 0:
-            raise LinAlgError("%d-th leading minor not positive definite"
-                              % info)
-        if info < 0:
-            raise ValueError('illegal value in %d-th argument of internal'
-                             ' potrf' % -info)
-        # Inversion
-        a1[index], info = potri(a1[index], lower=True, overwrite_c=False)
-        if info > 0:
-            raise LinAlgError("the inverse could not be computed")
-        if info < 0:
-            raise ValueError('illegal value in %d-th argument of internal'
-                             ' potrf' % -info)
-
-        # Make symmetric (dpotri only fills in the lower triangle)
-        a1[index][triu_rows, triu_cols] = a1[index][triu_cols, triu_rows]
-
-    return a1
-
-
 class invwishart_gen(wishart_gen):
     r"""An inverse Wishart random variable.
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2909,6 +2909,14 @@ class invwishart_gen(wishart_gen):
             If `seed` is already a ``Generator`` or ``RandomState`` instance
             then that instance is used.
 
+        Returns
+        -------
+        A : ndarray
+            Random variates of shape (`shape`) + (``dim``, ``dim``).
+            Each slice `A[..., :, :]` is lower-triangular, and its
+            inverse is the lower Cholesky factor of a draw from
+            `invwishart(df, np.eye(dim))`.
+
         Notes
         -----
         As this function does no argument checking, it should not be

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3,14 +3,12 @@
 #
 import math
 import numpy as np
-from numpy import asarray_chkfinite, asarray
 import scipy.linalg
 from scipy._lib import doccer
 from scipy.special import (gammaln, psi, multigammaln, xlogy, entr, betaln,
                            ive, loggamma)
 from scipy._lib._util import check_random_state, _lazywhere
 from scipy.linalg.blas import drot, get_blas_funcs
-from scipy.linalg._misc import LinAlgError
 from ._continuous_distns import norm
 from ._discrete_distns import binom
 from . import _mvn, _covariance, _rcont

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -18,7 +18,6 @@ import numpy as np
 import scipy.linalg
 from scipy.stats._multivariate import (_PSD,
                                        _lnB,
-                                       _cho_inv_batch,
                                        multivariate_normal_frozen)
 from scipy.stats import (multivariate_normal, multivariate_hypergeom,
                          matrix_normal, special_ortho_group, ortho_group,
@@ -1900,23 +1899,6 @@ class TestInvwishart:
         max_diff = norm.ppf(1 - fail_rate / 2)
         idx = np.triu_indices(dim)
         assert np.allclose((Xmean_est[idx] - Xmean_exp[idx]) / Xmean_std[idx], 0, atol=max_diff)
-
-    def test_cho_inv_batch(self):
-        """Regression test for gh-8844."""
-        a0 = np.array([[2, 1, 0, 0.5],
-                       [1, 2, 0.5, 0.5],
-                       [0, 0.5, 3, 1],
-                       [0.5, 0.5, 1, 2]])
-        a1 = np.array([[2, -1, 0, 0.5],
-                       [-1, 2, 0.5, 0.5],
-                       [0, 0.5, 3, 1],
-                       [0.5, 0.5, 1, 4]])
-        a = np.array([a0, a1])
-        ainv = a.copy()
-        _cho_inv_batch(ainv)
-        ident = np.eye(4)
-        assert_allclose(a[0].dot(ainv[0]), ident, atol=1e-15)
-        assert_allclose(a[1].dot(ainv[1]), ident, atol=1e-15)
 
     def test_logpdf_4x4(self):
         """Regression test for gh-8844."""

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1787,7 +1787,7 @@ class TestInvwishart:
             # entropy
             assert_allclose(iw.entropy(), ig.entropy())
 
-    def test_wishart_invwishart_2D_rvs(self):
+    def test_wishart_2D_rvs(self):
         dim = 3
         df = 10
 
@@ -1796,19 +1796,14 @@ class TestInvwishart:
         scale[0,1] = 0.5
         scale[1,0] = 0.5
 
-        # Construct frozen Wishart and inverse Wishart random variables
+        # Construct frozen Wishart random variables
         w = wishart(df, scale)
-        iw = invwishart(df, scale)
 
         # Get the generated random variables from a known seed
         np.random.seed(248042)
         w_rvs = wishart.rvs(df, scale)
         np.random.seed(248042)
         frozen_w_rvs = w.rvs()
-        np.random.seed(248042)
-        iw_rvs = invwishart.rvs(df, scale)
-        np.random.seed(248042)
-        frozen_iw_rvs = iw.rvs()
 
         # Manually calculate what it should be, based on the Bartlett (1933)
         # decomposition of a Wishart into D A A' D', where D is the Cholesky
@@ -1832,19 +1827,9 @@ class TestInvwishart:
         DA = D.dot(A)
         manual_w_rvs = np.dot(DA, DA.T)
 
-        # inverse Wishart random variate
-        # Supposing that the inverse wishart has scale matrix `scale`, then the
-        # random variate is the inverse of a random variate drawn from a Wishart
-        # distribution with scale matrix `inv_scale = np.linalg.inv(scale)`
-        iD = np.linalg.cholesky(np.linalg.inv(scale))
-        iDA = iD.dot(A)
-        manual_iw_rvs = np.linalg.inv(np.dot(iDA, iDA.T))
-
         # Test for equality
         assert_allclose(w_rvs, manual_w_rvs)
         assert_allclose(frozen_w_rvs, manual_w_rvs)
-        assert_allclose(iw_rvs, manual_iw_rvs)
-        assert_allclose(frozen_iw_rvs, manual_iw_rvs)
 
     def test_cho_inv_batch(self):
         """Regression test for gh-8844."""

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1877,6 +1877,30 @@ class TestInvwishart:
         assert_allclose(iw_rvs, manual_iw_rvs)
         assert_allclose(frozen_iw_rvs, manual_iw_rvs)
 
+    def test_sample_mean(self):
+        """Test that sample mean consistent with known mean."""
+        # Construct an arbitrary positive definite scale matrix
+        dim = 5
+        df = 10
+        sample_size = 10_000
+        scale = np.diag(np.arange(dim) + 1)
+        scale[np.tril_indices(dim, k=-1)] = np.arange(dim * (dim - 1) / 2)
+        scale = np.dot(scale.T, scale)
+
+        dist = invwishart(df, scale)
+        Xmean_exp = dist.mean()
+        Xvar_exp = dist.var()
+        Xmean_std = (Xvar_exp / sample_size)**0.5  # asymptotic SE of mean estimate
+
+        X = dist.rvs(size=sample_size, random_state=1234)
+        Xmean_est = X.mean(axis=0)
+
+        fail_rate = 0.01
+        fail_rate = 1 - (1 - fail_rate) ** (dim*(dim + 1)//2)  # correct for multiple tests
+        max_diff = norm.ppf(1 - fail_rate / 2)
+        idx = np.triu_indices(dim)
+        assert np.allclose((Xmean_est[idx] - Xmean_exp[idx]) / Xmean_std[idx], 0, atol=max_diff)
+
     def test_cho_inv_batch(self):
         """Regression test for gh-8844."""
         a0 = np.array([[2, 1, 0, 0.5],


### PR DESCRIPTION
This PR updates inverse-Wishart sampling to use the faster algorithm described in Algorithm 5 of https://arxiv.org/abs/2310.15884. It additionally updates the `logpdf` method to a faster version using the transform used in Theorem 3.2 of the same paper. 

#### Reference issue
Closes #19432 

#### What does this implement/fix?
The new `rvs` implementation eliminates one dense product, one `chol_solve`, and one `cholesky` factorization. The new `logpdf` implementation replaces an inversion via Cholesky solve, a matrix product, and a trace with a triangular solve and an l2-norm.

#### Additional information
The new `rvs` implementation was benchmarked in https://github.com/scipy/scipy/issues/19432#issuecomment-1780106406 is 1.7x faster than the old algorithm. I benchmarked the new `logpdf` implementation with the following code and saw a 2x speedup:

<details>

```python
import timeit
import numpy as np
from scipy.stats import invwishart

# Seed for reproducibility
random_seed = 42
np.random.seed(random_seed)

# Define the parameters for the inverse Wishart distribution
dim = 100  # dim
df = dim   # degrees of freedom

def rand_pd_mat(dim):
    _, R = np.linalg.qr(np.random.normal(size=(dim, dim)))
    return R.T @ R

scale = rand_pd_mat(dim)
n_samples = 10
x = np.moveaxis(invwishart.rvs(df=df, scale=scale, size=n_samples), [0, 1, 2], [2, 0, 1])

def logpdfs():
    invwishart.logpdf(x, df, scale)

# Time the function
number_of_evals = 10
total_time = timeit.repeat(logpdfs, repeat=100, number=number_of_evals)
min_time_per_run = min(total_time) / number_of_evals
print(f"min time per run: {min_time_per_run}")
```
old: 0.012830740000936203
new: 0.0061246897996170445

</details> 

cc @ilayn, since this involves some LAPACK calls. 