### PR TITLE
TST: Remove some unnecessary tuple conversions

### DIFF
--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -164,8 +164,8 @@ def _check_laplacian_dtype(
 INT_DTYPES = {np.intc, np_long, np.longlong}
 REAL_DTYPES = {np.float32, np.float64, np.longdouble}
 COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
-# use sorted tuple to ensure fixed order of tests
-DTYPES = tuple(sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
+# use sorted list to ensure fixed order of tests
+DTYPES = sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -24,9 +24,9 @@ INT_DTYPES = {np.intc, np_long, np.longlong, np.uintc, np_ulong, np.ulonglong}
 # np.half is unsupported on many test systems so excluded
 REAL_DTYPES = {np.float32, np.float64, np.longdouble}
 COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
-# use sorted tuple to ensure fixed order of tests
-VDTYPES = tuple(sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
-MDTYPES = tuple(sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
+# use sorted list to ensure fixed order of tests
+VDTYPES = sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
+MDTYPES = sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
 
 
 def sign_align(A, B):

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -20,8 +20,8 @@ IMPRECISE = {np.single, np.csingle}
 REAL_DTYPES = {np.intc, np_long, np.longlong,
                np.float32, np.float64, np.longdouble}
 COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
-# use sorted tuple to ensure fixed order of tests
-DTYPES = tuple(sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str))
+# use sorted list to ensure fixed order of tests
+DTYPES = sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
 
 
 def estimated(func):


### PR DESCRIPTION
When we form a sorted list to use for parameterizing a test with consistent order, there is no need to then convert it into a tuple. Use the list directly.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Requested in https://github.com/scipy/scipy/issues/19442#issuecomment-1783687195.

#### What does this implement/fix?

This has no practical effect, but it slightly simplifies the test code.

#### Additional information
<!--Any additional information you think is important.-->

See also https://github.com/scipy/scipy/pull/19443.