### PR TITLE
DOC/MAINT: fft: fix signature for next_fast_len

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,4 +1,5 @@
 from functools import update_wrapper, lru_cache
+import inspect
 
 from ._pocketfft import helper as _helper
 
@@ -67,8 +68,10 @@ def next_fast_len(target, real=False):
 
 # Directly wrap the c-function good_size but take the docstring etc., from the
 # next_fast_len function above
+_sig = inspect.signature(next_fast_len)
 next_fast_len = update_wrapper(lru_cache(_helper.good_size), next_fast_len)
 next_fast_len.__wrapped__ = _helper.good_size
+next_fast_len.__signature__ = _sig
 
 
 def _init_nd_shape_and_axes(x, shape, axes):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes: #19448
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds the missing signature to the wrapper function so the appears in the docs and so that `next_fast_len?` etc works
#### Additional information
<!--Any additional information you think is important.-->
