### PR TITLE
DOC: dev: update max line length to 88 characters

### DIFF
--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -4,7 +4,8 @@
 PEP8 and SciPy
 ==============
 
-All SciPy Python code should adhere to `PEP8`_ style guidelines. It’s so
+All SciPy Python code should adhere to `PEP8`_ style guidelines, with the exception
+that line length should be limited to 88 characters rather than 79. It's so
 important that some continuous integration tests on GitHub will fail due
 to certain PEP8 violations. Here are a few tips for ensuring PEP8
 compliance before pushing your code:

--- a/doc/source/dev/hacking.rst
+++ b/doc/source/dev/hacking.rst
@@ -83,7 +83,9 @@ tests, benchmarks, and correct code style.
 
 4. Code style
     Uniform code style makes it easier for others to read your code.
-    SciPy follows the standard Python style guideline, `PEP8`_.
+    SciPy follows the standard Python style guideline, `PEP8`_,
+    with the exception that the recommended maximum line length is 88 characters,
+    rather than PEP8's 79 characters.
 
     We provide a git pre-commit hook that can check each of your commits
     for proper style. Install it (once) by running the following from


### PR DESCRIPTION
#### Reference issue
[Mailing list discussion](https://mail.python.org/archives/list/scipy-dev@python.org/message/JDHHSQEADZUX4FGJ72OX6YSOOLYJ6M7R/)

#### What does this implement/fix?
The dev docs are updated to reflect that we differ from PEP8 in limiting line lengths to 88 characters, rather than 79.

#### Additional information
We don't actually test for any limit in CI at the moment, but informally people have settled on 88.
