### PR TITLE
MAINT: NumPy int type shims

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -289,7 +289,7 @@ def _colloc(const double[::1] x, const double[::1] t, int k, double[::1, :] ab,
 def _handle_lhs_derivatives(const double[::1]t, int k, double xval,
                             double[::1, :] ab,
                             int kl, int ku,
-                            const cnp.int_t[::1] deriv_ords,
+                            const cnp.npy_long[::1] deriv_ords,
                             int offset=0):
     """ Fill in the entries of the collocation matrix corresponding to known
     derivatives at xval.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1384,10 +1384,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     _bspl._colloc(x, t, k, ab, offset=nleft)
     if nleft > 0:
         _bspl._handle_lhs_derivatives(t, k, x[0], ab, kl, ku,
-                                      deriv_l_ords.astype(int))
+                                      deriv_l_ords.astype(np.dtype("long")))
     if nright > 0:
         _bspl._handle_lhs_derivatives(t, k, x[-1], ab, kl, ku,
-                                      deriv_r_ords.astype(int),
+                                      deriv_r_ords.astype(np.dtype("long")),
                                       offset=nt-nright)
 
     # set up the RHS: values to interpolate (+ derivative values, if any)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1383,9 +1383,11 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     ab = np.zeros((2*kl + ku + 1, nt), dtype=np.float64, order='F')
     _bspl._colloc(x, t, k, ab, offset=nleft)
     if nleft > 0:
-        _bspl._handle_lhs_derivatives(t, k, x[0], ab, kl, ku, deriv_l_ords)
+        _bspl._handle_lhs_derivatives(t, k, x[0], ab, kl, ku,
+                                      deriv_l_ords.astype(int))
     if nright > 0:
-        _bspl._handle_lhs_derivatives(t, k, x[-1], ab, kl, ku, deriv_r_ords,
+        _bspl._handle_lhs_derivatives(t, k, x[-1], ab, kl, ku,
+                                      deriv_r_ords.astype(int),
                                       offset=nt-nright)
 
     # set up the RHS: values to interpolate (+ derivative values, if any)

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -207,7 +207,7 @@ cpdef _label(np.ndarray input,
         ("Shapes must match for input and output,"
          "{} != {}".format((<object> input).shape, (<object> output).shape))
 
-    structure = np.asanyarray(structure, dtype=int).copy()
+    structure = np.asanyarray(structure, dtype=np.bool_).copy()
     assert input.ndim == structure.ndim, \
         ("Structuring element must have same "
          "# of dimensions as input, "

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -326,9 +326,9 @@ cpdef _label(np.ndarray input,
                 # Take neighbor labels
                 PyArray_ITER_RESET(itstruct)
                 for ni in range(num_neighbors):
-                    neighbor_use_prev = (<np.int_t *> PyArray_ITER_DATA(itstruct))[0]
-                    neighbor_use_adjacent = (<np.int_t *> (<char *> PyArray_ITER_DATA(itstruct) + ss))[0]
-                    neighbor_use_next = (<np.int_t *> (<char *> PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
+                    neighbor_use_prev = (<np.npy_long *> PyArray_ITER_DATA(itstruct))[0]
+                    neighbor_use_adjacent = (<np.npy_long *> (<char *> PyArray_ITER_DATA(itstruct) + ss))[0]
+                    neighbor_use_next = (<np.npy_long *> (<char *> PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
                     if not (neighbor_use_prev or
                             neighbor_use_adjacent or
                             neighbor_use_next):

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -326,9 +326,9 @@ cpdef _label(np.ndarray input,
                 # Take neighbor labels
                 PyArray_ITER_RESET(itstruct)
                 for ni in range(num_neighbors):
-                    neighbor_use_prev = (<np.npy_long *> PyArray_ITER_DATA(itstruct))[0]
-                    neighbor_use_adjacent = (<np.npy_long *> (<char *> PyArray_ITER_DATA(itstruct) + ss))[0]
-                    neighbor_use_next = (<np.npy_long *> (<char *> PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
+                    neighbor_use_prev = (<np.npy_bool *> PyArray_ITER_DATA(itstruct))[0]
+                    neighbor_use_adjacent = (<np.npy_bool *> (<char *> PyArray_ITER_DATA(itstruct) + ss))[0]
+                    neighbor_use_next = (<np.npy_bool *> (<char *> PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
                     if not (neighbor_use_prev or
                             neighbor_use_adjacent or
                             neighbor_use_next):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2416,7 +2416,7 @@ class MultinomialQMC:
             base_draws = self.engine.random(self.n_trials).ravel()
             p_cumulative = np.empty_like(self.pvals, dtype=float)
             _fill_p_cumulative(np.array(self.pvals, dtype=float), p_cumulative)
-            sample_ = np.zeros_like(self.pvals, dtype=int)
+            sample_ = np.zeros_like(self.pvals, dtype=np.intp)
             _categorize(base_draws, p_cumulative, sample_)
             sample[i] = sample_
         return sample

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -406,7 +406,7 @@ cpdef void _fill_p_cumulative(cnp.float_t[::1] p,
 @cython.wraparound(False)
 cpdef void _categorize(cnp.float_t[::1] draws,
                        cnp.float_t[::1] p_cumulative,
-                       cnp.npy_long[::1] result) noexcept nogil:
+                       cnp.intp_t[::1] result) noexcept nogil:
     cdef int i
     cdef int n_p = p_cumulative.shape[0]
     for i in range(draws.shape[0]):

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -406,7 +406,7 @@ cpdef void _fill_p_cumulative(cnp.float_t[::1] p,
 @cython.wraparound(False)
 cpdef void _categorize(cnp.float_t[::1] draws,
                        cnp.float_t[::1] p_cumulative,
-                       cnp.int_t[::1] result) noexcept nogil:
+                       cnp.npy_long[::1] result) noexcept nogil:
     cdef int i
     cdef int n_p = p_cumulative.shape[0]
     for i in range(draws.shape[0]):


### PR DESCRIPTION
* related to gh-19462 (a few build/test issues with latest NumPy `main`)

* `_categorize()` Cython function was only ever called with a NumPy array input with `dtype=int` for its `result` argument, so I think that makes switching to `npy_long` safe there

* I applied a similar fix with less confidence to `_handle_lhs_derivatives()` and `_label()` (leaning on the test suite...)

* checking if CI is happy on Windows may be helpful here, though I don't think we actually flush CI with bleeding edge NumPy on Windows? (I only checked on my x86_64 Linux box at work..)

[skip cirrus] [skip circle]