### PR TITLE
MAINT: Translate binom to C++

### DIFF
--- a/scipy/special/_binom.h
+++ b/scipy/special/_binom.h
@@ -7,8 +7,6 @@
 #include "cephes.hh"
 
 
-using std::numeric_limits;
-
 namespace scipy {
     namespace special {
 
@@ -19,7 +17,7 @@ namespace scipy {
 		nx = std::floor(n);
 		if (n == nx) {
 		    // Undefined
-		    return numeric_limits<double>::quiet_NaN();
+		    return std::numeric_limits<double>::quiet_NaN();
 		}
 	    }
 

--- a/scipy/special/_binom.h
+++ b/scipy/special/_binom.h
@@ -74,9 +74,8 @@ namespace scipy {
 		kx = std::floor(k);
 		if (static_cast<int>(kx) == kx) {
 		    return 0;
-		} else {
-		    return num * std::sin(k*M_PI);
 		}
+		return num * std::sin(k*M_PI);
 	    }
 	    return 1/(n + 1)/cephes::beta(1 + n - k, 1 + k);
 	}

--- a/scipy/special/_binom.h
+++ b/scipy/special/_binom.h
@@ -16,7 +16,7 @@ namespace scipy {
 	    double kx, nx, num, den, dk, sgn;
 
 	    if (n < 0) {
-		nx = std::floor(k);
+		nx = std::floor(n);
 		if (n == nx) {
 		    // Undefined
 		    return numeric_limits<double>::quiet_NaN();
@@ -30,7 +30,7 @@ namespace scipy {
 		 *
 		 * This cannot be used for small nonzero n due to loss of
 		 * precision. */
-		nx = std::floor(k);
+		nx = std::floor(n);
 		if (nx == n && kx > nx/2 && nx > 0) {
 		    // Reduce kx by symmetry
 		    kx = nx - kx;
@@ -73,7 +73,7 @@ namespace scipy {
 		    }
 		    return num * std::sin((dk - n)*M_PI) * sgn;
 		}
-		kx = floor(k);
+		kx = std::floor(k);
 		if (static_cast<int>(kx) == kx) {
 		    return 0;
 		} else {

--- a/scipy/special/_binom.h
+++ b/scipy/special/_binom.h
@@ -1,0 +1,88 @@
+// Binomial coefficient
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include "cephes.hh"
+
+
+using std::numeric_limits;
+
+namespace scipy {
+    namespace special {
+
+	inline double binom(double n, double k) {
+	    double kx, nx, num, den, dk, sgn;
+
+	    if (n < 0) {
+		nx = std::floor(k);
+		if (n == nx) {
+		    // Undefined
+		    return numeric_limits<double>::quiet_NaN();
+		}
+	    }
+
+	    kx = std::floor(k);
+	    if (k == kx && (std::fabs(n) > 1E-8 || n == 0)) {
+		/* Integer case: use multiplication formula for less rounding
+		 * error for cases where the result is an integer.
+		 *
+		 * This cannot be used for small nonzero n due to loss of
+		 * precision. */
+		nx = std::floor(k);
+		if (nx == n && kx > nx/2 && nx > 0) {
+		    // Reduce kx by symmetry
+		    kx = nx - kx;
+		}
+
+		if (kx >= 0 && kx < 20) {
+		    num = 1.0;
+		    den = 1.0;
+		    for (int i = 1; i < 1 + static_cast<int>(kx); i++) {
+			num *= i + n - kx;
+			den *= i;
+			if (std::fabs(num) > 1E50) {
+			    num /= den;
+			    den = 1.0;
+			}
+		    }
+		    return num/den;
+		}
+	    }
+
+	    // general case
+	    if (n >= 1E10*k and k > 0) {
+		// avoid under/overflows intermediate results
+		return std::exp(-cephes::lbeta(1 + n - k, 1 + k)
+				- std::log(n + 1));
+	    }
+	    if (k > 1E8*std::fabs(n)) {
+		// avoid loss of precision
+		num = cephes::Gamma(1 + n) / std::fabs(k)
+		    + cephes::Gamma(1 + n) * n / (2*k*k); // + ...
+		num /= M_PI * std::pow(std::fabs(k), n);
+		if (k > 0) {
+		    kx = std::floor(k);
+		    if (static_cast<int>(kx) == kx) {
+			dk = k - kx;
+			sgn = (static_cast<int>(kx) % 2 == 0) ? 1 : -1;
+		    } else {
+			dk = k;
+			sgn = 1;
+		    }
+		    return num * std::sin((dk - n)*M_PI) * sgn;
+		}
+		kx = floor(k);
+		if (static_cast<int>(kx) == kx) {
+		    return 0;
+		} else {
+		    return num * std::sin(k*M_PI);
+		}
+	    }
+	    return 1/(n + 1)/cephes::beta(1 + n - k, 1 + k);
+	}
+
+    }
+}
+

--- a/scipy/special/_extra_special.h
+++ b/scipy/special/_extra_special.h
@@ -3,8 +3,12 @@
 #include <complex>
 #include <numpy/npy_math.h>
 
+#include "_binom.h"
 #include "_lambertw.h"
 
+inline double binom(double n, double k) {
+    return scipy::special::binom(n, k);
+}
 
 inline npy_cdouble lambertw_scalar(npy_cdouble zp, long k, double tol) {
     std::complex<double> z(npy_creal(zp), npy_cimag(zp));

--- a/scipy/special/cephes.hh
+++ b/scipy/special/cephes.hh
@@ -1,13 +1,23 @@
 #pragma once
 
-#include "cephes.h"
+/* Use this header to include functions from cephes in compiled special
+ * function kernels written in C++.
 
-/* cephes_names.h defines aliases airy -> cephes_airy etc.
+ * cephes_names.h defines aliases airy -> cephes_airy etc.
  * which causes trouble when one tries to use functions from cephes in the
  * same translation unit where boost is used, due to name clashes. We undef
  * all of these aliases and disambiguate the cephes functions by putting them
  * in a scipy::special::cephes namespace.
  */
+
+
+// Namespace the include to avoid polluting global namespace.
+namespace scipy {
+    namespace special {
+	namespace cephes {
+	    namespace cephes_internal {
+
+#include "cephes.h"
 
 #undef airy
 #undef bdtrc
@@ -118,22 +128,27 @@
 #undef kolmogc
 #undef kolmogci
 #undef owens_t
+	    }
+	}
+    }
+}
 
 
 namespace scipy {
     namespace special {
 	namespace cephes {
+	    // Functions are being added as needed.
 
 	    inline double beta(double a, double b) {
-		return ::cephes_beta(a, b);
+		return cephes_internal::cephes_beta(a, b);
 	    }
 
 	    inline double lbeta(double a, double b) {
-		return ::cephes_lbeta(a, b);
+		return cephes_internal::cephes_lbeta(a, b);
 	    }
 
 	    inline double Gamma(double x) {
-		return ::cephes_Gamma(x);
+		return cephes_internal::cephes_Gamma(x);
 	    }
 
 	}

--- a/scipy/special/cephes.hh
+++ b/scipy/special/cephes.hh
@@ -15,7 +15,7 @@
 namespace scipy {
     namespace special {
 	namespace cephes {
-	    namespace cephes_internal {
+	    namespace detail {
 
 #include "cephes.h"
 
@@ -140,15 +140,15 @@ namespace scipy {
 	    // Functions are being added as needed.
 
 	    inline double beta(double a, double b) {
-		return cephes_internal::cephes_beta(a, b);
+		return detail::cephes_beta(a, b);
 	    }
 
 	    inline double lbeta(double a, double b) {
-		return cephes_internal::cephes_lbeta(a, b);
+		return detail::cephes_lbeta(a, b);
 	    }
 
 	    inline double Gamma(double x) {
-		return cephes_internal::cephes_Gamma(x);
+		return detail::cephes_Gamma(x);
 	    }
 
 	}

--- a/scipy/special/cephes.hh
+++ b/scipy/special/cephes.hh
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "cephes.h"
+
+/* cephes_names.h defines aliases airy -> cephes_airy etc.
+ * which causes trouble when one tries to use functions from cephes in the
+ * same translation unit where boost is used, due to name clashes. We undef
+ * all of these aliases and disambiguate the cephes functions by putting them
+ * in a scipy::special::cephes namespace.
+ */
+
+#undef airy
+#undef bdtrc
+#undef bdtr
+#undef bdtri
+#undef besselpoly
+#undef beta
+#undef lbeta
+#undef btdtr
+#undef cbrt
+#undef chdtrc
+#undef chbevl
+#undef chdtr
+#undef chdtri
+#undef dawsn
+#undef ellie
+#undef ellik
+#undef ellpe
+#undef ellpj
+#undef ellpk
+#undef exp10
+#undef exp2
+#undef expn
+#undef fdtrc
+#undef fdtr
+#undef fdtri
+#undef fresnl
+#undef Gamma
+#undef lgam
+#undef lgam_sgn
+#undef gammasgn
+#undef gdtr
+#undef gdtrc
+#undef gdtri
+#undef hyp2f1
+#undef hyperg
+#undef i0
+#undef i0e
+#undef i1
+#undef i1e
+#undef igamc
+#undef igam
+#undef igami
+#undef incbet
+#undef incbi
+#undef iv
+#undef j0
+#undef y0
+#undef j1
+#undef y1
+#undef jn
+#undef jv
+#undef k0
+#undef k0e
+#undef k1
+#undef k1e
+#undef kn
+#undef nbdtrc
+#undef nbdtr
+#undef nbdtri
+#undef ndtr
+#undef erfc
+#undef erf
+#undef erfinv
+#undef erfcinv
+#undef ndtri
+#undef pdtrc
+#undef pdtr
+#undef pdtri
+#undef poch
+#undef psi
+#undef rgamma
+#undef riemann_zeta
+#undef round
+#undef shichi
+#undef sici
+#undef radian
+#undef sindg
+#undef sinpi
+#undef cosdg
+#undef cospi
+#undef sincos
+#undef spence
+#undef stdtr
+#undef stdtri
+#undef struve_h
+#undef struve_l
+#undef struve_power_series
+#undef struve_asymp_large_z
+#undef struve_bessel_series
+#undef yv
+#undef tandg
+#undef cotdg
+#undef log1p
+#undef expm1
+#undef cosm1
+#undef yn
+#undef zeta
+#undef zetac
+#undef smirnov
+#undef smirnovc
+#undef smirnovi
+#undef smirnovci
+#undef smirnovp
+#undef kolmogorov
+#undef kolmogi
+#undef kolmogp
+#undef kolmogc
+#undef kolmogci
+#undef owens_t
+
+
+namespace scipy {
+    namespace special {
+	namespace cephes {
+
+	    inline double beta(double a, double b) {
+		return ::cephes_beta(a, b);
+	    }
+
+	    inline double lbeta(double a, double b) {
+		return ::cephes_lbeta(a, b);
+	    }
+
+	    inline double Gamma(double x) {
+		return ::cephes_Gamma(x);
+	    }
+
+	}
+    }
+}

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -247,7 +247,7 @@
         }
     },
     "binom": {
-        "orthogonal_eval.pxd": {
+        "_extra_special.h++": {
             "binom": "dd->d"
         }
     },

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -374,6 +374,7 @@ py3.extension_module('_ufuncs_cxx',
   include_directories: ['../_lib/boost_math/include', '../_lib',
                         '../_build_utils/src'],
   link_args: version_link_args,
+    link_with: [cephes_lib],
   dependencies: [np_dep, ellint_dep],
   install: true,
   subdir: 'scipy/special'


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This PR closes no issues, but continues the work discussed in the RFC issue https://github.com/scipy/scipy/issues/19404.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR translates the real valued binomial coefficient function `binom` from Cython into C++. Again, the translation is as literal as possible.

#### Additional information
<!--Any additional information you think is important.-->
Since `binom` depends on `cephes` I needed to work out how to include `cephes` functions in C++ code. This was not immediately possible because `cephes` has a header `cephes_names.h` which defines aliases of the form `beta` -> `cephes_beta` etc. So far so good, but because of how they are implemented, the aliases bleed into all code in the same translation unit, for instance, expanding `expm1` when it appears in boost to `cephes_expm1`. Rather than trying to sort that out directly, I've created a new header `cephes.hh` for inclusion in C++ files, which puts cephes functions in the `scipy::special::cephes` namespace without a prefix in the name, and undefs all of the aliases

For now, I've kept the `binom` implementation within `orthogonal_eval.pxd` and it is still used internally there.

As is, this `binom` implementation is not header only because it depends on cephes. We'll need to discuss the possibility of making cephes or parts of cephes header only in the future. 

This PR should unblock the work that is stalled on gh-19287.

cc @izaid, @tirthasheshpatel, @rlucas7, @ilayn 
