### PR TITLE
MAINT: Make use of sf_error conditional on flag in scipy::special C++ library

### DIFF
--- a/scipy/special/_lambertw.h
+++ b/scipy/special/_lambertw.h
@@ -27,7 +27,7 @@
 #include <limits>
 
 #include "_evalpoly.h"
-#include "sf_error.h"
+#include "error.h"
 
 using namespace std::complex_literals;
 
@@ -96,7 +96,7 @@ namespace scipy {
 		if (k == 0) {
 		    return z;
 		}
-		sf_error("lambertw", SF_ERROR_SINGULAR, NULL);
+		set_error("lambertw", SF_ERROR_SINGULAR, NULL);
 		return -numeric_limits<double>::infinity();
 	    }
 	    if (z == 1.0 && k == 0) {
@@ -152,7 +152,7 @@ namespace scipy {
 		}
 	    }
 	    
-	    sf_error("lambertw", SF_ERROR_SLOW,
+	    set_error("lambertw", SF_ERROR_SLOW,
 		     "iteration failed to converge: %g + %gj", z.real(), z.imag());
 	    return std::complex<double>(numeric_limits<double>::quiet_NaN(),
 					numeric_limits<double>::quiet_NaN());

--- a/scipy/special/error.h
+++ b/scipy/special/error.h
@@ -4,7 +4,7 @@
 namespace scipy {
     namespace special {
 #ifndef SP_SPECFUN_ERROR
-        void set_error(const char *func_name, int code, const char *fmt, ...) {
+        inline void set_error(const char *func_name, int code, const char *fmt, ...) {
             // nothing
         }
 #else

--- a/scipy/special/error.h
+++ b/scipy/special/error.h
@@ -1,14 +1,36 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+typedef enum {
+    SF_ERROR_OK = 0,      /* no error */
+    SF_ERROR_SINGULAR,    /* singularity encountered */
+    SF_ERROR_UNDERFLOW,   /* floating point underflow */
+    SF_ERROR_OVERFLOW,    /* floating point overflow */
+    SF_ERROR_SLOW,        /* too many iterations required */
+    SF_ERROR_LOSS,        /* loss of precision */
+    SF_ERROR_NO_RESULT,   /* no result obtained */
+    SF_ERROR_DOMAIN,      /* out of domain */
+    SF_ERROR_ARG,         /* invalid input parameter */
+    SF_ERROR_OTHER,       /* unclassified error */
+    SF_ERROR__LAST
+} sf_error_t;
+
+
+#ifdef __cplusplus
 namespace scipy {
     namespace special {
 #ifndef SP_SPECFUN_ERROR
-        inline void set_error(const char *func_name, int code, const char *fmt, ...) {
+        inline void set_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
             // nothing
         }
 #else
-        void set_error(const char *func_name, int code, const char *fmt, ...);
+        void set_error(const char *func_name, sf_error_t code, const char *fmt, ...);
 #endif
     }
 }
+
+} // closes extern "C"
+#endif

--- a/scipy/special/error.h
+++ b/scipy/special/error.h
@@ -1,0 +1,14 @@
+#pragma once
+
+
+namespace scipy {
+    namespace special {
+#ifndef SP_SPECFUN_ERROR
+        void set_error(const char *func_name, int code, const char *fmt, ...) {
+            // nothing
+        }
+#else
+        void set_error(const char *func_name, int code, const char *fmt, ...);
+#endif
+    }
+}

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -366,11 +366,18 @@ ellint_files = [
 
 ellint_dep = declare_dependency(sources: ellint_files)
 
+ufuncs_cxx_cpp_args = [
+  cython_cpp_args,
+  '-DBOOST_MATH_STANDALONE=1',
+  '-DCYTHON_EXTERN_C=extern "C"',
+  '-DSP_SPECFUN_ERROR', # For error handling in special functions.
+]
+
 py3.extension_module('_ufuncs_cxx',
   [ufuncs_cxx_sources,
     uf_cython_gen_cpp.process(cython_special[2]),  # _ufuncs_cxx.pyx
     ],
-  cpp_args: [cython_cpp_args, '-DBOOST_MATH_STANDALONE=1', '-DCYTHON_EXTERN_C=extern "C"'],
+  cpp_args: ufuncs_cxx_cpp_args,
   include_directories: ['../_lib/boost_math/include', '../_lib',
                         '../_build_utils/src'],
   link_args: version_link_args,

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -49,14 +49,16 @@ sf_action_t sf_error_get_action(sf_error_t code)
 }
 
 
-void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
+void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list ap)
 {
+    /* Internal function which takes a va_list instead of variadic args.
+     * Makes this easier to wrap in error handling used in scipy::special C++
+     * namespace for special function kernels provided by SciPy. */
     PyGILState_STATE save;
     PyObject *scipy_special = NULL;
     char msg[2048], info[1024];
     static PyObject *py_SpecialFunctionWarning = NULL;
     sf_action_t action;
-    va_list ap;
 
     if ((int)code < 0 || (int)code >= 10) {
 	code = SF_ERROR_OTHER;
@@ -71,9 +73,7 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
     }
 
     if (fmt != NULL && fmt[0] != '\0') {
-        va_start(ap, fmt);
         PyOS_vsnprintf(info, 1024, fmt, ap);
-        va_end(ap);
         PyOS_snprintf(msg, 2048, "scipy.special/%s: (%s) %s",
                       func_name, sf_error_messages[(int)code], info);
     }
@@ -136,6 +136,14 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
 #else
 	;
 #endif
+}
+
+
+void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    sf_error_v(func_name, code, fmt, ap);
+    va_end(ap);
 }
 
 

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -3,29 +3,30 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-#include "sf_error.h"
+#include "error.h"
+// #include "sf_error.h"
 
 extern "C" {
 #include "sf_error.c"
 }
 
 
-namespace scipy {
-    namespace special {
-	void set_error(const char *func_name, int code, const char *fmt, ...) {
-	    /* Definition of error handling for scipy::special C++ library of special
-	     * functions used in SciPy.
-	     *
-	     * The arg "code" must take an int that is a valid value for enum sf_error_t.
-	     * See sf_error.h for the definition of this enum.
-	     *
-	     * Other packages making use of this library can supply their own implementation. 
-	     */
-	    va_list ap;
-	    va_start(ap, fmt);
-	    // Version of sf_error that takes va_list instead of variadic args.
-	    sf_error_v(func_name, static_cast<sf_error_t>(code), fmt, ap);
-	    va_end(ap);
-	}
-    }
+#ifdef SP_SPECFUN_ERROR
+void scipy::special::set_error(const char *func_name, sf_error_t code,
+			       const char *fmt, ...) {
+    /* Definition of error handling for scipy::special C++ library of special
+     * functions used in SciPy.
+     *
+     * The arg "code" must take an int that is a valid value for enum sf_error_t.
+     * See sf_error.h for the definition of this enum.
+     *
+     * Other packages making use of this library can supply their own implementation. 
+     */
+    va_list ap;
+    va_start(ap, fmt);
+    // Version of sf_error that takes va_list instead of variadic args.
+    sf_error_v(func_name, code, fmt, ap);
+    va_end(ap);
 }
+#endif
+

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -8,3 +8,24 @@
 extern "C" {
 #include "sf_error.c"
 }
+
+
+namespace scipy {
+    namespace special {
+	void set_error(const char *func_name, int code, const char *fmt, ...) {
+	    /* Definition of error handling for scipy::special C++ library of special
+	     * functions used in SciPy.
+	     *
+	     * The arg "code" must take an int that is a valid value for enum sf_error_t.
+	     * See sf_error.h for the definition of this enum.
+	     *
+	     * Other packages making use of this library can supply their own implementation. 
+	     */
+	    va_list ap;
+	    va_start(ap, fmt);
+	    // Version of sf_error that takes va_list instead of variadic args.
+	    sf_error_v(func_name, static_cast<sf_error_t>(code), fmt, ap);
+	    va_end(ap);
+	}
+    }
+}

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -17,8 +17,7 @@ void scipy::special::set_error(const char *func_name, sf_error_t code,
     /* Definition of error handling for scipy::special C++ library of special
      * functions used in SciPy.
      *
-     * The arg "code" must take an int that is a valid value for enum sf_error_t.
-     * See sf_error.h for the definition of this enum.
+     * See error.h for info on valid codes in enum sf_error_t.
      *
      * Other packages making use of this library can supply their own implementation. 
      */

--- a/scipy/special/sf_error.h
+++ b/scipy/special/sf_error.h
@@ -1,23 +1,12 @@
 #ifndef SF_ERROR_H_
 #define SF_ERROR_H_
 
+#include "error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef enum {
-    SF_ERROR_OK = 0,      /* no error */
-    SF_ERROR_SINGULAR,    /* singularity encountered */
-    SF_ERROR_UNDERFLOW,   /* floating point underflow */
-    SF_ERROR_OVERFLOW,    /* floating point overflow */
-    SF_ERROR_SLOW,        /* too many iterations required */
-    SF_ERROR_LOSS,        /* loss of precision */
-    SF_ERROR_NO_RESULT,   /* no result obtained */
-    SF_ERROR_DOMAIN,      /* out of domain */
-    SF_ERROR_ARG,         /* invalid input parameter */
-    SF_ERROR_OTHER,       /* unclassified error */
-    SF_ERROR__LAST         
-} sf_error_t;
 
 typedef enum {
     SF_ERROR_IGNORE = 0,  /* Ignore errors */

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -104,6 +104,14 @@ def test_errstate_cpp_basic():
     assert_equal(olderr, sc.geterr())
 
 
+def test_errstate_cpp_scipy_special():
+    olderr = sc.geterr()
+    with sc.errstate(singular='raise'):
+        with assert_raises(sc.SpecialFunctionError):
+            sc.lambertw(0, 1)
+    assert_equal(olderr, sc.geterr())
+
+
 def test_errstate():
     for category, error_code in _sf_error_code_map.items():
         for action in _sf_error_actions:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-19480
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR implements conditional use of `sf_error` in C++ code in the `scipy::special` namespace, following the suggestions made by @izaid in gh-19480.

#### Additional information
<!--Any additional information you think is important.-->
There is a compile time flag, `SP_SF_ERROR` which enables use of a user supplied implementation of a function `scipy::special::set_error`. The default behavior if the flag is not set is for this function to be a no-op. We define our own implementation in `scipy/special/sf_error.cc` which wraps the function `sf_error` that we've been using internally in `special`.

One slight complication is that `sf_error` has the signature

```C
void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...);
```

where the variadic args are for arguments to be passed with the format string `fmt` to the printing function in the Python
C API, `PyOS_vsnprintf`. In order to maintain this signature in the wrapper, I had to create a function I called `sf_error_v` with signature 

```C
void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list ap);
```

which takes a `va_list` instead of variadic args. This function is called by `sf_error` and also by `scipy::special::set_error`.


In `meson.build`, I've made it so the option `-DSP_SPECFUN_ERROR` is always supplied, unconditionally. Maybe this should be made conditional for testing purposes? I've verified that it works locally as expected at least, and `scipy/special/test_sf_error.py` confirms that error handling works as expected when `-DSP_SPECFUN_ERROR` is set.