### PR TITLE
CI: limit scipy-openblas32 wheel to 0.3.23.293.2

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython!=3.0.3 pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy-openblas32
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy "scipy-openblas32<=0.3.23.293.2"
         python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
 
     - name:  Prepare compiler cache

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython!=3.0.3 pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy "scipy-openblas32<=0.3.23.293.2"
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy "scipy-openblas32<=0.3.24.135"
         python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
 
     - name:  Prepare compiler cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis scipy-openblas32
+          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
 
       - name: Build
         run: |
@@ -80,7 +80,7 @@ jobs:
         run: |
           # 1.22.4 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis scipy-openblas32
+          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
 
       - name: Build
         run: |


### PR DESCRIPTION
I am working towards adding a `scipy_` prefix to all the openblas symbol names in the scipy-openblas wheels. This will allow using both the scipy-openblas wheels and another OpenBLAS library together in scipy, for instance if using a scipy compiled with the "regular" OpenBLAS together with a numpy compiled with the OpenBLAS wheels.

In order to do an ordered transition, first this PR freezes the current version of scipy-openblas32 used in CI here. Then I will release new scipy-openblas32 wheels with an updated `scipy-openblas.pc` file, that will define a new `-DBLAS_SYMBOL_PREFIX=scipy_` compile-time directive. Then I will come back to here and submit a new PR that reverts this one, and makes sure the use of BLAS_SYMBOL_PREFIX actually works.