### PR TITLE
MAINT: special: use faddeeva for real-valued erf and ndtr

### DIFF
--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -75,8 +75,15 @@ npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp)
 }
 
 /*
- * A wrapper for a normal CDF for complex argument
+ * A wrapper for a normal CDF for real & complex arguments
  */
+
+double faddeeva_ndtr_double(double x)
+{
+    x *= M_SQRT1_2;
+    return 0.5 * Faddeeva::erfc(-x);
+}
+
 
 npy_cdouble faddeeva_ndtr(npy_cdouble zp)
 {

--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -21,6 +21,11 @@ npy_cdouble faddeeva_erf(npy_cdouble zp)
     return npy_cpack(real(w), imag(w));
 }
 
+double faddeeva_erf_double(double x)
+{
+    return Faddeeva::erf(x);
+}
+
 double faddeeva_erfc(double x)
 {
     return Faddeeva::erfc(x);
@@ -80,6 +85,7 @@ npy_cdouble faddeeva_ndtr(npy_cdouble zp)
     complex<double> w = 0.5 * Faddeeva::erfc(-z);
     return npy_cpack(real(w), imag(w));
 }
+
 
 /*
  * Log of the CDF of the normal distribution for double x.

--- a/scipy/special/_faddeeva.h
+++ b/scipy/special/_faddeeva.h
@@ -20,6 +20,7 @@ EXTERN_C_START
 
 npy_cdouble faddeeva_w(npy_cdouble zp);
 npy_cdouble faddeeva_erf(npy_cdouble zp);
+double faddeeva_erf_double(double x);
 
 double faddeeva_erfc(double x);
 npy_cdouble faddeeva_erfc_complex(npy_cdouble zp);

--- a/scipy/special/_faddeeva.h
+++ b/scipy/special/_faddeeva.h
@@ -34,6 +34,7 @@ npy_cdouble faddeeva_erfi_complex(npy_cdouble zp);
 double faddeeva_dawsn(double zp);
 npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp);
 
+double faddeeva_ndtr_double(double x);
 npy_cdouble faddeeva_ndtr(npy_cdouble zp);
 
 double faddeeva_log_ndtr(double x);

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -419,18 +419,14 @@
     },
     "erf": {
         "_faddeeva.h++": {
+            "faddeeva_erf_double": "d->d",
             "faddeeva_erf": "D->D"
-        },
-        "cephes.h": {
-            "erf": "d->d"
         }
     },
     "erfc": {
         "_faddeeva.h++": {
+            "faddeeva_erfc": "d->d",
             "faddeeva_erfc_complex": "D->D"
-        },
-        "cephes.h": {
-            "erfc": "d->d"
         }
     },
     "erfcx": {

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1127,10 +1127,8 @@
     },
     "ndtr": {
         "_faddeeva.h++": {
+            "faddeeva_ndtr_double": "d->d",
             "faddeeva_ndtr": "D->D"
-        },
-        "cephes.h": {
-            "ndtr": "d->d"
         }
     },
     "ndtri": {

--- a/scipy/special/tests/test_cdft_asymptotic.py
+++ b/scipy/special/tests/test_cdft_asymptotic.py
@@ -19,7 +19,7 @@ def test_stdtr_vs_R_large_df():
              0.84134474606854292578]
     assert_allclose(res, res_R, rtol=2e-15)
     # last value should also agree with ndtr
-    assert_equal(res[3], ndtr(1.))
+    assert_allclose(res[3], ndtr(1.), atol=1.5e-16)
 
 
 def test_stdtrit_vs_R_large_df():

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -266,13 +266,13 @@ BOOST_TESTS = [
         data(ellipe_, 'ellint_e_data_ipp-ellint_e_data', 0, 1),
         data(ellipeinc_, 'ellint_e2_data_ipp-ellint_e2_data', (0,1), 2, rtol=1e-14),
 
-        data(erf, 'erf_data_ipp-erf_data', 0, 1),
+        data(erf, 'erf_data_ipp-erf_data', 0, 1, rtol=2e-14),
         data(erf, 'erf_data_ipp-erf_data', 0j, 1, rtol=1e-13),
         data(erfc, 'erf_data_ipp-erf_data', 0, 2, rtol=6e-15),
         data(erf, 'erf_large_data_ipp-erf_large_data', 0, 1),
         data(erf, 'erf_large_data_ipp-erf_large_data', 0j, 1),
         data(erfc, 'erf_large_data_ipp-erf_large_data', 0, 2, rtol=4e-14),
-        data(erf, 'erf_small_data_ipp-erf_small_data', 0, 1),
+        data(erf, 'erf_small_data_ipp-erf_small_data', 0, 1, rtol=3e-14),
         data(erf, 'erf_small_data_ipp-erf_small_data', 0j, 1, rtol=1e-13),
         data(erfc, 'erf_small_data_ipp-erf_small_data', 0, 2),
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3420,7 +3420,7 @@ class TestStudentT:
         t_meth_ref = getattr(t_dist_ref, methname)
         norm_meth = getattr(norm_dist, methname)
         res = t_meth(x)
-        assert_equal(res[df_infmask], norm_meth(x[df_infmask]))
+        assert_allclose(res[df_infmask], norm_meth(x[df_infmask]), atol=2e-16)
         assert_equal(res[~df_infmask], t_meth_ref(x[~df_infmask]))
 
     @pytest.mark.parametrize("df_infmask", [[0, 0], [1, 1], [0, 1],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

inspired by https://github.com/scipy/scipy/issues/19486

#### What does this implement/fix?
<!--Please explain your changes.-->

Route `erf` and `ndtr` calculations through faddeeva for real-valued arguments. Previously real-valued versions were from cephes and complex-valued versions were from faddeeva.

