### PR TITLE
MAINT/STY: `conftest.py`: remove E501 (line length) lint ignore

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -47,7 +47,8 @@ def pytest_runtest_setup(item):
         except ValueError:
             v = False
         if not v:
-            pytest.skip("very slow test; set environment variable SCIPY_XSLOW=1 to run it")
+            pytest.skip("very slow test; "
+                        "set environment variable SCIPY_XSLOW=1 to run it")
     mark = _get_mark(item, 'xfail_on_32bit')
     if mark is not None and np.intp(0).itemsize < 8:
         pytest.xfail(f'Fails on our 32-bit test platform(s): {mark.args[0]}')

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -27,7 +27,6 @@ target-version = "py39"
 "doc/source/scipyoptdoc.py" = ["E501"]
 "scipy/_lib/**" = ["E501"]
 "scipy/cluster/**" = ["E501"]
-"scipy/conftest.py" = ["E501"]
 "scipy/constants/**" = ["E501"]
 "scipy/fft/**" = ["E501"]
 "scipy/fftpack/**" = ["E501"]


### PR DESCRIPTION
#### Reference issue
Towards gh-19479.

#### What does this implement/fix?
Follow-up to gh-19489 for `conftest.py`.

#### Additional information
I'll add the blame-ignore once this looks ready.