### PR TITLE
CI: add '[lint only]', '[docs only]' skip tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             export git_log=$(git log --max-count=1 --pretty=format:"%B" | tr "\n" " ")
             echo "Got commit message:"
             echo "${git_log}"
-            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$git_log" == *"[skip circle]"* ]] || [[ "$git_log" == *"[circle skip]"* ]]); then
+            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$git_log" == *"[skip circle]"* ]] || [[ "$git_log" == *"[circle skip]"* ]] || [[ "$git_log" == *"[lint only]"* ]]); then
               echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
               circleci-agent step halt;
             fi

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -39,7 +39,7 @@ def main(ctx):
     if PR < 0:
         return []
 
-    if "[skip cirrus]" in dct["message"] or "[skip ci]" in dct["message"]:
+    if "[skip cirrus]" in dct["message"] or "[skip ci]" in dct["message"] or "[lint only]" in dct["message"] or "[docs only]" in dct["message"]:
         return []
 
     return fs.read("ci/cirrus_general_ci.yml")

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -21,9 +21,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    uses: ./.github/workflows/commit_message.yml
+
   pytorch_cpu:
     name: Linux PyTorch CPU
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -2,7 +2,9 @@ on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-22.04
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[skip circle]')  && github.event.context == 'ci/circleci: build_docs'"
+    if: >
+      github.repository == 'scipy/scipy'
+      && github.event.context == 'ci/circleci: build_docs'
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/commit_message.yml
+++ b/.github/workflows/commit_message.yml
@@ -1,0 +1,36 @@
+on:
+  workflow_call:
+    outputs:
+      message:
+        description: "Skip tag checker"
+        value: ${{ jobs.check_skip_tags.outputs.message }}
+
+permissions:
+   contents: read
+
+jobs:
+  check_skip_tags:
+    name: Check for skips
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.skip_check.outputs.message }}
+    steps:
+      - name: Checkout scipy
+        uses: actions/checkout@v3
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Check for skips
+        id: skip_check
+        # the lint workflow is not currently skipped with [docs only].
+        # this could be changed by adding a new job which uses this workflow to lint.yml
+        # and changing the output here based on the combination of tags (if desired).
+        run: |
+          set -xe
+          COMMIT_MSG=$(git log --no-merges -1)
+          RUN="1"
+          if [[ "$COMMIT_MSG" == *"[lint only]"* || "$COMMIT_MSG" == *"[docs only]"* ]]; then
+              RUN="0"
+          fi
+          echo "message=$RUN" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -21,10 +21,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    uses: ./.github/workflows/commit_message.yml
+
   test_meson:
     name: Meson build
-    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    # If using act to run CI locally the github object does not exist and
+    # the usual skipping should not be enforced
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -124,7 +132,10 @@ jobs:
   #################################################################################
   test_venv_install:
     name: Pip install into venv
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -180,7 +191,10 @@ jobs:
   python_debug:
     # also uses the vcs->sdist->wheel route.
     name: Python-debug & ATLAS
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-22.04  # provides python3.10-dbg
     steps:
       - uses: actions/checkout@v3
@@ -207,7 +221,10 @@ jobs:
   gcc8:
     # Purpose is to examine builds with oldest-supported gcc.
     name: Build with gcc-8
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-20.04  # 22.04 doesn't support gcc-8
     steps:
       - uses: actions/checkout@v3
@@ -255,7 +272,10 @@ jobs:
   prerelease_deps_coverage_64bit_blas:
     # TODO: re-enable ILP64 build.
     name: Prerelease deps, coverage, and 64-bit BLAS
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -324,7 +344,10 @@ jobs:
   #################################################################################
   linux_32bit:
     name: Linux - 32 bit
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-latest
     # I tried running directly in a container:, using the image: and options:
     # entries. Unfortunately at this time options: does not seem to listen to

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -19,10 +19,18 @@ concurrency:
 
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    uses: ./.github/workflows/commit_message.yml
+
   musllinux_x86_64:
+    needs: get_commit_message
     runs-on: ubuntu-latest
-    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    # If using act to run CI locally the github object does not exist and
+    # the usual skipping should not be enforced
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -21,10 +21,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    uses: ./.github/workflows/commit_message.yml
+
   test_meson:
     name: Meson build
-    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    # If using act to run CI locally the github object does not exist and
+    # the usual skipping should not be enforced
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,11 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_commit_message:
+    name: Get commit message
+    uses: ./.github/workflows/commit_message.yml
+
   test:
     name: cp310 (meson) fast
+    needs: get_commit_message
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -57,7 +64,10 @@ jobs:
   #############################################################################
   full_dev_py_min_numpy:
     name: cp39 (meson) full, dev.py, minimum numpy
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -95,7 +105,10 @@ jobs:
   full_build_sdist_wheel:
     # TODO: enable ILP64 once possible
     name: cp311 (build sdist + wheel), full, no pythran
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: windows-2019
     steps:
       - name: Checkout

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -80,17 +80,19 @@ Skipping CI can be achieved by adding a special text in the commit message:
 * ``[skip actions]``: will skip GitHub Actions
 * ``[skip circle]``: will skip CircleCI
 * ``[skip cirrus]``: will skip CirrusCI
+* ``[docs only]``: will skip *all but* the CircleCI checks and the linter
+* ``[lint only]``: will skip *all but* the linter
 * ``[skip ci]``: will skip *all* CI
 
 Of course, you can combine these to skip multiple workflows.
 
 This skip information should be placed on a new line. In this example, we
-just updated a ``.rst`` file in the documentation and ask to skip Cirrus and
-GitHub Actions' workflows::
+just updated a ``.rst`` file in the documentation and ask to skip all but the
+relevant docs checks (skip Cirrus and GitHub Actions' workflows)::
 
     DOC: improve QMCEngine examples.
 
-    [skip actions] [skip cirrus]
+    [docs only]
 
 Wheel builds
 ============


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/19491#issuecomment-1802656984 @mdhaber 

#### What does this implement/fix?
New '[lint only]' tag which will skip all CI workflows apart from `lint.yml`.

#### Additional information
This is my first time working on CI, sorry if I've missed anything obvious. This will obviously need to be documented as well.
