### PR TITLE
TST: skip test_bootstrap_against_theory

### DIFF
--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -161,6 +161,7 @@ def test_bootstrap_vectorized(method, axis, paired):
     assert_equal(res2.standard_error.shape, result_shape)
 
 
+@pytest.mark.xfail_on_32bit("MemoryError with BCa observed in CI")
 @pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
 def test_bootstrap_against_theory(method):
     # based on https://www.statology.org/confidence-intervals-python/


### PR DESCRIPTION
* skip `test_bootstrap_against_theory()` on 32-bit architecture because it is failing fairly frequently in CI with a memory error; I thought about placing a more granular skip on just the `BCa` parameter, which is the case that actually fails, but since many tests in this module already have the broad 32-bit skip I figured I'd just do that with an explanation for now

* one drawback to using our in-house `xfail_on_32bit` construct as done here is that we can't set `run=False`, which I might be inclined to do, since `MemoryError` subclasses aren't guaranteed to be safe to recover from, but it doesn't seem to actually cause a crash...

[skip cirrus] [skip circle]

Example fails:
https://github.com/scipy/scipy/actions/runs/6788568241/job/18453856177?pr=19466
https://github.com/scipy/scipy/actions/runs/6803327498/job/18498407424?pr=19496