### PR TITLE
MAINT/STY: fftpack: remove E501 (line length) lint ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,5 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 79099da5aefd2f76092b999823e45a6519e41005
 # Line length clean up in misc (gh-19491)
 8870c5d01a6f91a737db4642343ef997a63c8584
+# Line length clean up in fftpack (gh-19503)
+39787f146137b0ec9d31907989c6f104ba7eed76

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -157,7 +157,10 @@ class TestSingleFFT(_TestFFTBase):
         self.cdt = np.complex64
         self.rdt = np.float32
 
-    @pytest.mark.xfail(run=False, reason="single-precision FFT implementation is partially disabled, until accuracy issues with large prime powers are resolved")
+    reason = ("single-precision FFT implementation is partially disabled, "
+              "until accuracy issues with large prime powers are resolved")
+
+    @pytest.mark.xfail(run=False, reason=reason)
     def test_notice(self):
         pass
 

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -29,7 +29,6 @@ target-version = "py39"
 "scipy/cluster/**" = ["E501"]
 "scipy/constants/**" = ["E501"]
 "scipy/fft/**" = ["E501"]
-"scipy/fftpack/**" = ["E501"]
 "scipy/integrate/**" = ["E501"]
 "scipy/interpolate/**" = ["E501"]
 "scipy/io/**" = ["E501"]


### PR DESCRIPTION
#### Reference issue
Towards gh-19479.

#### What does this implement/fix?
Follow-up to gh-19489 for `fftpack`.

#### Additional information
cc @mdhaber @j-bowhay. Feel free to wait for gh-19497 if you don't want to test locally.