### PR TITLE
DOC, MAINT: Bump CircleCI Python version to 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
           command: |
             pip install numpy cython!=3.0.3 pybind11 pythran ninja meson
             pip install -r doc_requirements.txt
+            pip install "myst-nb<1.0.0"
             pip install mpmath gmpy2 "asv>=0.6.0" click rich-click doit pydevtool pooch threadpoolctl
             # extra benchmark deps
             pip install pyfftw cffi pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/python:3.9
+    - image: cimg/python:3.11
   working_directory: ~/repo
 
 commands:
@@ -115,7 +115,7 @@ jobs:
           name: build docs
           no_output_timeout: 25m
           command: |
-            export PYTHONPATH=$PWD/build-install/lib/python3.9/site-packages
+            export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             python dev.py --no-build doc -j2
 
       - store_artifacts:
@@ -142,7 +142,7 @@ jobs:
           name: run asv
           no_output_timeout: 30m
           command: |
-            export PYTHONPATH=$PWD/build-install/lib/python3.9/site-packages
+            export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             cd benchmarks
             asv machine --machine CircleCI
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
@@ -170,7 +170,7 @@ jobs:
           no_output_timeout: 25m
           command: |
             sudo apt-get install -y wamerican-small
-            export PYTHONPATH=$PWD/build-install/lib/python3.9/site-packages
+            export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             python dev.py --no-build refguide-check
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: setup Python venv
           command: |
-            pip install numpy==1.23.5 cython!=3.0.3 pybind11 pythran ninja meson
+            pip install numpy cython!=3.0.3 pybind11 pythran ninja meson
             pip install -r doc_requirements.txt
             pip install mpmath gmpy2 "asv>=0.6.0" click rich-click doit pydevtool pooch threadpoolctl
             # extra benchmark deps


### PR DESCRIPTION


#### Reference issue
This is an attempt to fix the docs build - locally I also built the docs successfully with Python 3.10, FYI.

#### What does this implement/fix?
Fixes #19500 