### PR TITLE
MAINT/STY: `scipyoptdoc.py`: remove E501 (line length) lint ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,5 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 8870c5d01a6f91a737db4642343ef997a63c8584
 # Line length clean up in fftpack (gh-19503)
 39787f146137b0ec9d31907989c6f104ba7eed76
+# Line length clean up in `scipyoptdoc.py` (gh-19505)
+49858c5fb2bf479b17a0bf42a7397d73f45f1b31

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -60,7 +60,8 @@ class ScipyOptimizeInterfaceDomain(PythonDomain):
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)
         self.directives = dict(self.directives)
-        self.directives['function'] = wrap_mangling_directive(self.directives['function'])
+        function_directive = self.directives['function']
+        self.directives['function'] = wrap_mangling_directive(function_directive)
 
 
 BLURB = """
@@ -80,7 +81,7 @@ def wrap_mangling_directive(base_directive):
             # Implementation function
             impl_name = self.options['impl']
             impl_obj = _import_object(impl_name)
-            impl_args, impl_varargs, impl_keywords, impl_defaults = getfullargspec_no_self(impl_obj)[:4]
+            impl_args, _, _, impl_defaults = getfullargspec_no_self(impl_obj)[:4]
 
             # Format signature taking implementation into account
             args = list(args)
@@ -105,7 +106,7 @@ def wrap_mangling_directive(base_directive):
                 if opt_name in args:
                     continue
                 if j >= len(impl_args) - len(impl_defaults):
-                    options.append((opt_name, impl_defaults[len(impl_defaults) - (len(impl_args) - j)]))
+                    options.append((opt_name, impl_defaults[-len(impl_args) + j]))
                 else:
                     options.append((opt_name, None))
             set_default('options', dict(options))

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -24,7 +24,6 @@ target-version = "py39"
 "scipy/optimize/_linprog_ip.py" = ["F401"]
 # E501 (line length) ignores
 "benchmarks/benchmarks/**" = ["E501"]
-"doc/source/scipyoptdoc.py" = ["E501"]
 "scipy/_lib/**" = ["E501"]
 "scipy/cluster/**" = ["E501"]
 "scipy/constants/**" = ["E501"]


### PR DESCRIPTION
#### Reference issue
Towards gh-19479.

#### What does this implement/fix?
Follow-up to gh-19489 for `scipyoptdoc.py`.

#### Additional information
I can add in a git blame ignore if wanted once this is ready.

cc @mdhaber @j-bowhay. Feel free to wait for gh-19497 if you don't want to test locally.