### PR TITLE
MAINT: sparse: update tests to switch to format and toarray from get_format() and .A, .H

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -809,7 +809,7 @@ class _TestCommon:
                     n = min(len(d), len(v))
                     assert_array_equal(d[:n], v[:n], err_msg="%s %d" % (msg, r))
                 # check that sparse setdiag worked
-                assert_array_equal(b.A, a, err_msg="%s %d" % (msg, r))
+                assert_array_equal(b.toarray(), a, err_msg="%s %d" % (msg, r))
 
         # comprehensive test
         np.random.seed(1234)
@@ -2398,7 +2398,7 @@ class _TestSlicing:
         E = matrix([[1, 2, 1], [4, 0, 0], [0, 0, 0], [0, 0, 1]])
         F = self.spcreator(E)
         assert_array_equal(E[1, 1:3], F[1, 1:3].toarray())
-        assert_array_equal(E[2, -2:], F[2, -2:].A)
+        assert_array_equal(E[2, -2:], F[2, -2:].toarray())
 
         # The following should raise exceptions:
         assert_raises(IndexError, A.__getitem__, (slice(None), 11))
@@ -2643,15 +2643,15 @@ class _TestSlicingAssign:
 
             A = B / 10
             B[0,:] = A[0,:]
-            assert_array_equal(A[0,:].A, B[0,:].A)
+            assert_array_equal(A[0,:].toarray(), B[0,:].toarray())
 
             A = B / 10
             B[:,:] = A[:1,:1]
-            assert_array_equal(np.zeros((4,3)) + A[0,0], B.A)
+            assert_array_equal(np.zeros((4,3)) + A[0,0], B.toarray())
 
             A = B / 10
             B[:-1,0] = A[0,:].T
-            assert_array_equal(A[0,:].A.T, B[:-1,0].A)
+            assert_array_equal(A[0,:].toarray().T, B[:-1,0].toarray())
 
     def test_slice_assignment(self):
         B = self.spcreator((4,3))
@@ -3689,7 +3689,7 @@ class TestCSR(sparse_test_class()):
         assert_array_equal(bsp.indices,[1,0,1])
         assert_array_equal(bsp.indptr,[0,1,2,3])
         assert_equal(bsp.getnnz(),3)
-        assert_equal(bsp.getformat(),'csr')
+        assert_equal(bsp.format,'csr')
         assert_array_equal(bsp.toarray(), b)
 
     def test_constructor2(self):
@@ -3941,7 +3941,7 @@ class TestCSC(sparse_test_class()):
         assert_array_equal(bsp.indptr,[0,1,2,3,4])
         assert_equal(bsp.getnnz(),4)
         assert_equal(bsp.shape,b.shape)
-        assert_equal(bsp.getformat(),'csc')
+        assert_equal(bsp.format,'csc')
 
     def test_constructor2(self):
         b = zeros((6,6),'d')
@@ -4081,7 +4081,7 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
         A[5,6] = 20
         D = A*A.T
         E = A*A.H
-        assert_array_equal(D.A, E.A)
+        assert_array_equal(D.toarray(), E.toarray())
 
     def test_add_nonzero(self):
         A = self.spcreator((3,2))
@@ -4189,7 +4189,7 @@ class TestLIL(sparse_test_class(minmax=False)):
         if platform.machine() != 'ppc64le':
             assert_array_equal(A @ A.T, (B * B.T).toarray())
 
-        assert_array_equal(A @ A.conjugate().T, (B * B.H).toarray())
+        assert_array_equal(A @ A.conjugate().T, (B * B.conjugate().T).toarray())
 
     def test_scalar_mul(self):
         x = lil_matrix((3, 3))
@@ -4246,7 +4246,7 @@ class TestLIL(sparse_test_class(minmax=False)):
         B[8, 9] = 50
         C = B.tocsr()
         D = lil_matrix(C)
-        assert_array_equal(C.A, D.A)
+        assert_array_equal(C.toarray(), D.toarray())
 
     def test_fancy_indexing_lil(self):
         M = asmatrix(arange(25).reshape(5, 5))
@@ -4362,17 +4362,17 @@ class TestCOO(sparse_test_class(getset=False,
     def test_todia_all_zeros(self):
         zeros = [[0, 0]]
         dia = coo_matrix(zeros).todia()
-        assert_array_equal(dia.A, zeros)
+        assert_array_equal(dia.toarray(), zeros)
 
     def test_sum_duplicates(self):
         coo = coo_matrix((4,3))
         coo.sum_duplicates()
         coo = coo_matrix(([1,2], ([1,0], [1,0])))
         coo.sum_duplicates()
-        assert_array_equal(coo.A, [[2,0],[0,1]])
+        assert_array_equal(coo.toarray(), [[2,0],[0,1]])
         coo = coo_matrix(([1,2], ([1,1], [1,1])))
         coo.sum_duplicates()
-        assert_array_equal(coo.A, [[0,0],[0,3]])
+        assert_array_equal(coo.toarray(), [[0,0],[0,3]])
         assert_array_equal(coo.row, [1])
         assert_array_equal(coo.col, [1])
         assert_array_equal(coo.data, [3])
@@ -4380,7 +4380,7 @@ class TestCOO(sparse_test_class(getset=False,
     def test_todok_duplicates(self):
         coo = coo_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
         dok = coo.todok()
-        assert_array_equal(dok.A, coo.A)
+        assert_array_equal(dok.toarray(), coo.toarray())
 
     def test_eliminate_zeros(self):
         data = array([1, 0, 0, 0, 2, 0, 3, 0])
@@ -4390,7 +4390,7 @@ class TestCOO(sparse_test_class(getset=False,
         bsp = asp.copy()
         asp.eliminate_zeros()
         assert_((asp.data != 0).all())
-        assert_array_equal(asp.A, bsp.A)
+        assert_array_equal(asp.toarray(), bsp.toarray())
 
     def test_reshape_copy(self):
         arr = [[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]]
@@ -4667,18 +4667,18 @@ class TestBSR(sparse_test_class(getset=False,
                       [3, 0, 0, 0]])
         S = self.spcreator(D, blocksize=(1, 2))
         assert_(S.resize((3, 2)) is None)
-        assert_array_equal(S.A, [[1, 0],
+        assert_array_equal(S.toarray(), [[1, 0],
                                  [2, 0],
                                  [3, 0]])
         S.resize((2, 2))
-        assert_array_equal(S.A, [[1, 0],
+        assert_array_equal(S.toarray(), [[1, 0],
                                  [2, 0]])
         S.resize((3, 2))
-        assert_array_equal(S.A, [[1, 0],
+        assert_array_equal(S.toarray(), [[1, 0],
                                  [2, 0],
                                  [0, 0]])
         S.resize((3, 4))
-        assert_array_equal(S.A, [[1, 0, 0, 0],
+        assert_array_equal(S.toarray(), [[1, 0, 0, 0],
                                  [2, 0, 0, 0],
                                  [0, 0, 0, 0]])
         assert_raises(ValueError, S.resize, (2, 3))
@@ -4767,7 +4767,7 @@ class _NonCanonicalMixin:
         construct = super().spcreator
         M = construct(D, **kwargs)
 
-        zero_pos = (M.A == 0).nonzero()
+        zero_pos = (M.toarray() == 0).nonzero()
         has_zeros = (zero_pos[0].size > 0)
         if has_zeros:
             k = zero_pos[0].size//2
@@ -4790,7 +4790,7 @@ class _NonCanonicalMixin:
             rtol = 1e-05
         else:
             rtol = 1e-07
-        assert_allclose(NC.A, M.A, rtol=rtol)
+        assert_allclose(NC.toarray(), M.toarray(), rtol=rtol)
 
         # check that at least one explicit zero
         if has_zeros:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4668,19 +4668,19 @@ class TestBSR(sparse_test_class(getset=False,
         S = self.spcreator(D, blocksize=(1, 2))
         assert_(S.resize((3, 2)) is None)
         assert_array_equal(S.toarray(), [[1, 0],
-                                 [2, 0],
-                                 [3, 0]])
+                                         [2, 0],
+                                         [3, 0]])
         S.resize((2, 2))
         assert_array_equal(S.toarray(), [[1, 0],
-                                 [2, 0]])
+                                         [2, 0]])
         S.resize((3, 2))
         assert_array_equal(S.toarray(), [[1, 0],
-                                 [2, 0],
-                                 [0, 0]])
+                                         [2, 0],
+                                         [0, 0]])
         S.resize((3, 4))
         assert_array_equal(S.toarray(), [[1, 0, 0, 0],
-                                 [2, 0, 0, 0],
-                                 [0, 0, 0, 0]])
+                                         [2, 0, 0, 0],
+                                         [0, 0, 0, 0]])
         assert_raises(ValueError, S.resize, (2, 3))
 
     @pytest.mark.xfail(run=False, reason='BSR does not have a __setitem__')

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -53,19 +53,19 @@ def test_csc_getcol():
       0, (0, 6))])
 def test_csc_empty_slices(matrix_input, axis, expected_shape):
     # see gh-11127 for related discussion
-    slice_1 = matrix_input.A.shape[0] - 1
+    slice_1 = matrix_input.toarray().shape[0] - 1
     slice_2 = slice_1
     slice_3 = slice_2 - 1
 
     if axis == 0:
-        actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
-        actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+        actual_shape_1 = matrix_input[slice_1:slice_2, :].toarray().shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, :].toarray().shape
     elif axis == 1:
-        actual_shape_1 = matrix_input[:, slice_1:slice_2].A.shape
-        actual_shape_2 = matrix_input[:, slice_1:slice_3].A.shape
+        actual_shape_1 = matrix_input[:, slice_1:slice_2].toarray().shape
+        actual_shape_2 = matrix_input[:, slice_1:slice_3].toarray().shape
     elif axis == 'both':
-        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].A.shape
-        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].A.shape
+        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].toarray().shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].toarray().shape
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -76,19 +76,19 @@ def test_csr_getcol():
       0, (0, 5))])
 def test_csr_empty_slices(matrix_input, axis, expected_shape):
     # see gh-11127 for related discussion
-    slice_1 = matrix_input.A.shape[0] - 1
+    slice_1 = matrix_input.toarray().shape[0] - 1
     slice_2 = slice_1
     slice_3 = slice_2 - 1
 
     if axis == 0:
-        actual_shape_1 = matrix_input[slice_1:slice_2, :].A.shape
-        actual_shape_2 = matrix_input[slice_1:slice_3, :].A.shape
+        actual_shape_1 = matrix_input[slice_1:slice_2, :].toarray().shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, :].toarray().shape
     elif axis == 1:
-        actual_shape_1 = matrix_input[:, slice_1:slice_2].A.shape
-        actual_shape_2 = matrix_input[:, slice_1:slice_3].A.shape
+        actual_shape_1 = matrix_input[:, slice_1:slice_2].toarray().shape
+        actual_shape_2 = matrix_input[:, slice_1:slice_3].toarray().shape
     elif axis == 'both':
-        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].A.shape
-        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].A.shape
+        actual_shape_1 = matrix_input[slice_1:slice_2, slice_1:slice_2].toarray().shape
+        actual_shape_2 = matrix_input[slice_1:slice_3, slice_1:slice_3].toarray().shape
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2


### PR DESCRIPTION
The changes `spA.get_format()` -> `spA.format` and `spA.A` -> `spA.toarray()` bring our sparse tests closer to the array syntax, replacing some of these matrix based idioms in the tests. It's a small step toward leaving the `np.matrix` api, but its a step (and doesn't affect users -- this is only the tests).

This concern was [raised in the 1d coo array](https://github.com/scipy/scipy/pull/18530#discussion_r1314282239) PR #18530 but is really separate from that PR. So for simplicity it's on its own here.