### PR TITLE
MAINT/DOC: stats: fix lint errors

### DIFF
--- a/doc/source/tutorial/stats/plots/qmc_plot_conv_mc.py
+++ b/doc/source/tutorial/stats/plots/qmc_plot_conv_mc.py
@@ -44,9 +44,11 @@ def conv_method(sampler, func, n_samples, n_conv, ref):
 sample_mc_rmse = []
 rng = np.random.default_rng()
 
+def sampler_mc(x):
+    return rng.random((x, case.dim))
+
 for ns in ns_gen:
     # Monte Carlo
-    sampler_mc = lambda x: rng.random((x, case.dim))
     conv_res = conv_method(sampler_mc, case.func, ns, n_conv, case.ref)
     sample_mc_rmse.append(conv_res)
 

--- a/doc/source/tutorial/stats/plots/qmc_plot_conv_mc_sobol.py
+++ b/doc/source/tutorial/stats/plots/qmc_plot_conv_mc_sobol.py
@@ -48,9 +48,11 @@ sample_mc_rmse = []
 sample_sobol_rmse = []
 rng = np.random.default_rng()
 
+def sampler_mc(x):
+    rng.random((x, case.dim))
+
 for ns in ns_gen:
     # Monte Carlo
-    sampler_mc = lambda x: rng.random((x, case.dim))
     conv_res = conv_method(sampler_mc, case.func, ns, n_conv, case.ref)
     sample_mc_rmse.append(conv_res)
 

--- a/doc/source/tutorial/stats/plots/qmc_plot_mc.py
+++ b/doc/source/tutorial/stats/plots/qmc_plot_mc.py
@@ -1,6 +1,4 @@
 """Multiple MC to show how it can be bad."""
-from scipy.stats import qmc
-from scipy.stats._qmc import check_random_state
 import numpy as np
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
#### Reference issue
Towards gh-19490.

#### What does this implement/fix?
Appeases the linter for all current errors related to `stats`, to stop potential future CI fails.

#### Additional information
Alternatively, we could use `noqa`, or even make the linter ignore these files, if that seems more appropriate.
