### PR TITLE
MAINT/DOC/BENCH: optimize: fix linter errors

### DIFF
--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
@@ -175,12 +175,19 @@ class Zimmerman(Benchmark):
         self.fglob = 0.0
 
     def fun(self, x, *args):
-        self.nfev += 1
+        def Zh1(x):
+            return 9.0 - x[0] - x[1]
 
-        Zh1 = lambda x: 9.0 - x[0] - x[1]
-        Zh2 = lambda x: (x[0] - 3.0) ** 2.0 + (x[1] - 2.0) ** 2.0 - 16.0
-        Zh3 = lambda x: x[0] * x[1] - 14.0
-        Zp = lambda x: 100.0 * (1.0 + x)
+        def Zh2(x):
+            return (x[0] - 3.0) ** 2.0 + (x[1] - 2.0) ** 2.0 - 16.0
+
+        def Zh3(x):
+            return x[0] * x[1] - 14.0
+
+        def Zp(x):
+            return 100.0 * (1.0 + x)
+
+        self.nfev += 1
 
         return max(Zh1(x),
                    Zp(Zh2(x)) * sign(Zh2(x)),

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
 from numpy import cos, exp, log, pi, sin, sqrt
 
-from .go_benchmark import Benchmark, safe_import
-
-with safe_import():
-    try:
-        from scipy.special import factorial  # new
-    except ImportError:
-        from scipy.misc import factorial  # old
+from .go_benchmark import Benchmark
 
 
 #-----------------------------------------------------------------------

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -387,8 +387,12 @@ class BenchSmoothUnbounded(Benchmark):
         return b
 
     def run_sin_1d(self, methods=None):
-        fun = lambda x: np.sin(x[0])
-        der = lambda x: np.array([np.cos(x[0])])
+        def fun(x):
+            return np.sin(x[0])
+
+        def der(x):
+            return np.array([np.cos(x[0])])
+
         b = _BenchOptimizers("1d sin function",
                              fun=fun, der=der, hess=None)
         for i in range(10):

--- a/benchmarks/benchmarks/tests/test_go_benchmark_functions.py
+++ b/benchmarks/benchmarks/tests/test_go_benchmark_functions.py
@@ -46,7 +46,7 @@ class TestGoBenchmarkFunctions:
 
             f = klass()
             # should result in an attribute error if it doesn't exist
-            val = f.fglob
+            _ = f.fglob
 
     def test_bounds_access_subscriptable(self):
         # In Python 2 zip returns a list which is subscriptable
@@ -56,7 +56,7 @@ class TestGoBenchmarkFunctions:
                 continue
 
             f = klass()
-            bounds = f.bounds[0]
+            _ = f.bounds[0]
 
     def test_redimension(self):
         # check that problems can be redimensioned, use LJ for this.

--- a/doc/source/tutorial/examples/newton_krylov_preconditioning.py
+++ b/doc/source/tutorial/examples/newton_krylov_preconditioning.py
@@ -1,4 +1,3 @@
-import numpy as np
 from scipy.optimize import root
 from scipy.sparse import spdiags, kron
 from scipy.sparse.linalg import spilu, LinearOperator

--- a/doc/source/tutorial/examples/optimize_global_2.py
+++ b/doc/source/tutorial/examples/optimize_global_2.py
@@ -1,6 +1,5 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 
 def eggholder(x):
     return (-(x[1] + 47) * np.sin(np.sqrt(abs(x[0]/2 + (x[1]  + 47))))


### PR DESCRIPTION
#### Reference issue
Towards gh-19490.

#### What does this implement/fix?
Appeases the linter for all current errors related to `optimize`, to stop potential future CI fails.

#### Additional information
Alternatively, we could use `noqa`, or even make the linter ignore these files, if that seems more appropriate.
