### PR TITLE
MAINT: fix remaining lint errors

### DIFF
--- a/benchmarks/benchmarks/integrate.py
+++ b/benchmarks/benchmarks/integrate.py
@@ -12,8 +12,11 @@ with safe_import() as exc:
     from scipy import LowLevelCallable
     from_cython = LowLevelCallable.from_cython
 if exc.error:
-    LowLevelCallable = lambda func, data: (func, data)
-    from_cython = lambda *a: a
+    def LowLevelCallable(func, data):
+        return (func, data)
+
+    def from_cython(*a):
+        return a
 
 with safe_import() as exc:
     import cffi

--- a/scipy/_lib/_bunch.py
+++ b/scipy/_lib/_bunch.py
@@ -9,7 +9,7 @@ def _validate_names(typename, field_names, extra_field_names):
     among field_names + extra_field_names.
     """
     for name in [typename] + field_names + extra_field_names:
-        if type(name) is not str:
+        if not isinstance(name, str):
             raise TypeError('typename and all field names must be strings')
         if not name.isidentifier():
             raise ValueError('typename and all field names must be valid '

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -15,7 +15,7 @@ DATA_PATH = path.join(path.dirname(__file__), 'data')
 def assert_identical(a, b):
     """Assert whether value AND type are the same"""
     assert_equal(a, b)
-    if type(b) is str:
+    if isinstance(b, str):
         assert_equal(type(a), type(b))
     else:
         assert_equal(np.asarray(a).dtype.type, np.asarray(b).dtype.type)

--- a/scipy/ndimage/tests/test_datatypes.py
+++ b/scipy/ndimage/tests/test_datatypes.py
@@ -1,7 +1,5 @@
 """ Testing data types for ndimage calls
 """
-import sys
-
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
 import pytest


### PR DESCRIPTION
#### Reference issue
Towards gh-19490.

#### What does this implement/fix?
Appeases the linter for all current errors not covered by gh-19507 and gh-19508, to stop potential CI fails.

#### Additional information
Alternatively, we could use `noqa`, or even make the linter ignore these files, if that seems more appropriate.
