### PR TITLE
MAINT: lint: enable UP rules

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -22,3 +22,5 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 664a42c9a7945a0a47f876baa6d27fb4c31c6847
 # Unused noqa clean up (gh-19529)
 05b872da4f498d923dbf5f5f38691b9a21580914
+# Clean up for UP lint rules (gh-19516)
+9cf72e4599e0a22902ef3bc1a42e645240b1734d

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -136,7 +136,7 @@ def run_monitored_proc(code):
         if ret is not None:
             break
 
-        with open('/proc/%d/status' % process.pid, 'r') as f:
+        with open('/proc/%d/status' % process.pid) as f:
             procdata = f.read()
 
         m = re.search(r'VmRSS:\s*(\d+)\s*kB', procdata, re.S | re.I)

--- a/benchmarks/benchmarks/cython_special.py
+++ b/benchmarks/benchmarks/cython_special.py
@@ -59,8 +59,8 @@ class _CythonSpecialMeta(type):
 
 class CythonSpecial(metaclass=_CythonSpecialMeta):
     def setup(self, name, args, N, api):
-        self.py_func = getattr(cython_special, '_bench_{}_py'.format(name))
-        self.cy_func = getattr(cython_special, '_bench_{}_cy'.format(name))
+        self.py_func = getattr(cython_special, f'_bench_{name}_py')
+        self.cy_func = getattr(cython_special, f'_bench_{name}_cy')
         m = re.match('^(.*)_[dDl]+$', name)
         self.np_func = getattr(special, m.group(1))
 

--- a/benchmarks/benchmarks/go_benchmark_functions/__init__.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ==============================================================================
 `go_benchmark_functions` --  Problems for testing global optimization routines

--- a/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import abs, asarray
 
@@ -62,7 +61,7 @@ class Benchmark:
         self.custom_bounds = None
 
     def __str__(self):
-        return '{0} ({1} dimensions)'.format(self.__class__.__name__, self.N)
+        return f'{self.__class__.__name__} ({self.N} dimensions)'
 
     def __repr__(self):
         return self.__class__.__name__

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, cos, exp, pi, prod, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, cos, exp, log, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import (abs, asarray, cos, exp, floor, pi, sign, sin, sqrt, sum,
                    size, tril, isnan, atleast_2d, repeat)
@@ -214,7 +213,7 @@ class Cola(Benchmark):
         yj = repeat(yi, size(yi, 1), axis=0)
         yi = yi.T
 
-        inner = (sqrt(((xi - xj) ** 2 + (yi - yj) ** 2)) - self.d) ** 2
+        inner = (sqrt((xi - xj) ** 2 + (yi - yj) ** 2) - self.d) ** 2
         inner = tril(inner, -1)
         return sum(sum(inner, axis=1))
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import abs, cos, exp, arange, pi, sin, sqrt, sum, zeros, tanh
 from numpy.testing import assert_almost_equal

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, asarray, cos, exp, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .go_benchmark import Benchmark
 
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import abs, sin, cos, exp, floor, log, arange, prod, sqrt, sum
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import abs, arctan2, asarray, cos, exp, arange, pi, sin, sqrt, sum
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import sin, sum
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import sum, asarray, arange, exp
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import asarray, atleast_2d, arange, sin, sqrt, prod, sum, round
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import sum, cos, exp, pi, arange, sin
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import (abs, asarray, cos, exp, log, arange, pi, prod, sin, sqrt,
                    sum, tan)
 from .go_benchmark import Benchmark, safe_import
@@ -328,8 +327,8 @@ class Mishra03(Benchmark):
     def fun(self, x, *args):
         self.nfev += 1
 
-        return ((0.01 * (x[0] + x[1])
-                + sqrt(abs(cos(sqrt(abs(x[0] ** 2 + x[1] ** 2)))))))
+        return (0.01 * (x[0] + x[1])
+                + sqrt(abs(cos(sqrt(abs(x[0] ** 2 + x[1] ** 2))))))
 
 
 class Mishra04(Benchmark):
@@ -368,8 +367,8 @@ class Mishra04(Benchmark):
     def fun(self, x, *args):
         self.nfev += 1
 
-        return ((0.01 * (x[0] + x[1])
-                + sqrt(abs(sin(sqrt(abs(x[0] ** 2 + x[1] ** 2)))))))
+        return (0.01 * (x[0] + x[1])
+                + sqrt(abs(sin(sqrt(abs(x[0] ** 2 + x[1] ** 2))))))
 
 
 class Mishra05(Benchmark):

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import cos, sqrt, sin, abs
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import sum, cos, exp, pi, asarray
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import (abs, sum, sin, cos, sqrt, log, prod, where, pi, exp, arange,
                    floor, log10, atleast_2d, zeros)
 from .go_benchmark import Benchmark
@@ -345,7 +344,7 @@ class PermFunction01(Benchmark):
         k = atleast_2d(arange(self.N) + 1).T
         j = atleast_2d(arange(self.N) + 1)
         s = (j ** k + b) * ((x / j) ** k - 1)
-        return sum((sum(s, axis=1) ** 2))
+        return sum(sum(s, axis=1) ** 2)
 
 
 class PermFunction02(Benchmark):
@@ -394,7 +393,7 @@ class PermFunction02(Benchmark):
         k = atleast_2d(arange(self.N) + 1).T
         j = atleast_2d(arange(self.N) + 1)
         s = (j + b) * (x ** k - (1. / j) ** k)
-        return sum((sum(s, axis=1) ** 2))
+        return sum(sum(s, axis=1) ** 2)
 
 
 class Pinter(Benchmark):

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, sum, arange, sqrt
 
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, sum, sin, cos, asarray, arange, pi, exp, log, sqrt
 from scipy.optimize import rosen
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import (abs, asarray, cos, floor, arange, pi, prod, roll, sin,
                    sqrt, sum, repeat, atleast_2d, tril)
 from numpy.random import uniform
@@ -168,7 +167,7 @@ class Schaffer02(Benchmark):
     def fun(self, x, *args):
         self.nfev += 1
 
-        num = sin((x[0] ** 2 - x[1] ** 2)) ** 2 - 0.5
+        num = sin(x[0] ** 2 - x[1] ** 2) ** 2 - 0.5
         den = (1 + 0.001 * (x[0] ** 2 + x[1] ** 2)) ** 2
         return 0.5 + num / den
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, asarray, cos, exp, arange, pi, sin, sum, atleast_2d
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, sin, cos, pi, sqrt
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import sum, cos, sin, log
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import atleast_2d, arange, sum, cos, exp, pi
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy import abs, sum, sin, cos, pi, exp, arange, prod, sqrt
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, sum, cos, pi
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import abs, sum, sign, arange
 from .go_benchmark import Benchmark
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_univariate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from numpy import cos, exp, log, pi, sin, sqrt
 
 from .go_benchmark import Benchmark

--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -62,10 +62,10 @@ class MemUsage(Benchmark):
         savemat(self.filename, dict(x=x), do_compression=compressed, oned_as='row')
         del x
 
-        code = """
+        code = f"""
         from scipy.io import loadmat
-        loadmat('%s')
-        """ % (self.filename,)
+        loadmat('{self.filename}')
+        """
         time, peak_mem = run_monitored(code)
 
         return peak_mem / size

--- a/benchmarks/benchmarks/linprog_benchmark_files/__init__.py
+++ b/benchmarks/benchmarks/linprog_benchmark_files/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ==============================================================================
 `` --  Problems for testing linear programming routines

--- a/benchmarks/benchmarks/lsq_problems.py
+++ b/benchmarks/benchmarks/lsq_problems.py
@@ -480,7 +480,7 @@ def extract_lsq_problems():
                 hasattr(problem_class, 'INITIAL_GUESSES')):
             for i, x0 in enumerate(problem_class.INITIAL_GUESSES):
                 if len(problem_class.INITIAL_GUESSES) > 1:
-                    key_name = "{0}_{1}".format(name, i)
+                    key_name = f"{name}_{i}"
                 else:
                     key_name = name
                 problems[key_name] = problem_class(x0)

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -520,7 +520,7 @@ class BenchGlobal(Benchmark):
             raise NotImplementedError("skipped")
 
         # load json backing file
-        with open(self.dump_fn, 'r') as f:
+        with open(self.dump_fn) as f:
             self.results = json.load(f)
 
     def teardown(self, name, ret_value, solver):

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -345,7 +345,7 @@ class NullSlice(Benchmark):
         X = coo_matrix((data, (row, col)), shape=(n, k))
         X.sum_duplicates()
         X = X.asformat(format)
-        with open('{}-{}.pck'.format(density, format), 'wb') as f:
+        with open(f'{density}-{format}.pck', 'wb') as f:
             pickle.dump(X, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     def setup_cache(self):
@@ -357,7 +357,7 @@ class NullSlice(Benchmark):
 
     def setup(self, density, format):
         # Unpickling is faster than computing the random matrix...
-        with open('{}-{}.pck'.format(density, format), 'rb') as f:
+        with open(f'{density}-{format}.pck', 'rb') as f:
             self.X = pickle.load(f)
 
     def time_getrow(self, density, format):

--- a/dev.py
+++ b/dev.py
@@ -561,8 +561,8 @@ class Build(Task):
                         log_size = os.stat(log_filename).st_size
                         if log_size > last_log_size:
                             elapsed = datetime.datetime.now() - start_time
-                            print("    ... installation in progress ({} "
-                                  "elapsed)".format(elapsed))
+                            print(f"    ... installation in progress ({elapsed} "
+                                  "elapsed)")
                             last_blip = time.time()
                             last_log_size = log_size
 
@@ -611,11 +611,11 @@ class Build(Task):
             raise RuntimeError(f"'pip install {module_name} first")
 
         local = os.path.join(basedir, "scipy", "_distributor_init_local.py")
-        with open(local, "wt", encoding="utf8") as fid:
+        with open(local, "w", encoding="utf8") as fid:
             fid.write(f"import {module_name}\n")
 
         os.makedirs(openblas_dir, exist_ok=True)
-        with open(pkg_config_fname, "wt", encoding="utf8") as fid:
+        with open(pkg_config_fname, "w", encoding="utf8") as fid:
             fid.write(openblas.get_pkg_config().replace("\\", "/"))
 
     @classmethod
@@ -837,8 +837,7 @@ class Bench(Task):
             for a in extra_argv:
                 bench_args.extend(['--bench', ' '.join(str(x) for x in a)])
             if not args.compare:
-                print("Running benchmarks for Scipy version %s at %s"
-                      % (version, mod_path))
+                print(f"Running benchmarks for Scipy version {version} at {mod_path}")
                 cmd = ['asv', 'run', '--dry-run', '--show-stderr',
                        '--python=same', '--quick'] + bench_args
                 retval = cls.run_asv(dirs, cmd)
@@ -936,7 +935,7 @@ def task_check_test_name():
 
 
 @cli.cls_cmd('lint')
-class Lint():
+class Lint:
     """:dash: Run linter on modified files and check for
     disallowed Unicode characters and possibly-invalid test names."""
     def run():

--- a/doc/source/doi_role.py
+++ b/doc/source/doi_role.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     doilinks
     ~~~~~~~~

--- a/doc/source/tutorial/examples/plot_interp_grid.py
+++ b/doc/source/tutorial/examples/plot_interp_grid.py
@@ -44,7 +44,7 @@ for ax, order in zip(axes, orders):
     yc = np.tile(np.arange(starty, starty + order + 1)[np.newaxis, :],
                  (order + 1, 1)).ravel()
     ax.plot(xc, -yc, 'ko')
-    ax.set_title("Interpolation (order = {})".format(order),
+    ax.set_title(f"Interpolation (order = {order})",
                  fontdict=dict(size=16, weight='bold'))
 
     # set limits and ticks for 0, 0 voxel at upper left

--- a/scipy/_build_utils/system_info.py
+++ b/scipy/_build_utils/system_info.py
@@ -30,8 +30,7 @@ def combine_dict(*dicts, **kw):
                 elif value == old_value:
                     continue
 
-                raise ValueError("Conflicting configuration dicts: {!r} {!r}"
-                                 "".format(new_dict, d))
+                raise ValueError(f"Conflicting configuration dicts: {new_dict!r} {d!r}")
             else:
                 new_dict[key] = value
 

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -414,8 +414,7 @@ class NumpyDocString(Mapping):
                 filename = inspect.getsourcefile(self._obj)
             except TypeError:
                 filename = None
-            msg = msg + (" in the docstring of %s in %s."
-                         % (self._obj, filename))
+            msg = msg + (f" in the docstring of {self._obj} in {filename}.")
         if error:
             raise ValueError(msg)
         else:

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -209,8 +209,7 @@ def check_free_memory(free_mb):
         if mem_free is None:
             pytest.skip("Could not determine available memory; set SCIPY_AVAILABLE_MEM "
                         "variable to free memory in MB to run the test.")
-        msg = '{} MB memory required, but {} MB available'.format(
-            free_mb, mem_free/1e6)
+        msg = f'{free_mb} MB memory required, but {mem_free/1e6} MB available'
 
     if mem_free < free_mb * 1e6:
         pytest.skip(msg)

--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -40,9 +40,9 @@ __all__ = [
     "_SetBackendContext",
 ]
 
-ArgumentExtractorType = typing.Callable[..., typing.Tuple["Dispatchable", ...]]
+ArgumentExtractorType = typing.Callable[..., tuple["Dispatchable", ...]]
 ArgumentReplacerType = typing.Callable[
-    [typing.Tuple, typing.Dict, typing.Tuple], typing.Tuple[typing.Tuple, typing.Dict]
+    [tuple, dict, tuple], tuple[tuple, dict]
 ]
 
 def unpickle_function(mod_name, qname, self_):
@@ -440,9 +440,7 @@ class Dispatchable:
         return (self.type, self.value)[index]
 
     def __str__(self):
-        return "<{}: type={!r}, value={!r}>".format(
-            type(self).__name__, self.type, self.value
-        )
+        return f"<{type(self).__name__}: type={self.type!r}, value={self.value!r}>"
 
     __repr__ = __str__
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,6 @@ from typing import (
     Optional,
     Union,
     TYPE_CHECKING,
-    Type,
     TypeVar,
 )
 
@@ -19,9 +18,9 @@ import numpy as np
 from scipy._lib._array_api import array_namespace
 
 
-AxisError: Type[Exception]
-ComplexWarning: Type[Warning]
-VisibleDeprecationWarning: Type[Warning]
+AxisError: type[Exception]
+ComplexWarning: type[Warning]
+VisibleDeprecationWarning: type[Warning]
 
 if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
     from numpy.exceptions import (
@@ -68,7 +67,7 @@ if TYPE_CHECKING:
 try:
     from numpy.random import Generator as Generator
 except ImportError:
-    class Generator():  # type: ignore[no-redef]
+    class Generator:  # type: ignore[no-redef]
         pass
 
 

--- a/scipy/_lib/decorator.py
+++ b/scipy/_lib/decorator.py
@@ -221,8 +221,8 @@ def decorator(caller, _func=None):
     if inspect.isclass(caller):
         name = caller.__name__.lower()
         callerfunc = get_init(caller)
-        doc = 'decorator({}) converts functions/generators into ' \
-            'factories of {} objects'.format(caller.__name__, caller.__name__)
+        doc = (f'decorator({caller.__name__}) converts functions/generators into ' 
+               f'factories of {caller.__name__} objects')
     elif inspect.isfunction(caller):
         if caller.__name__ == '<lambda>':
             name = '_lambda_'

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -146,8 +146,7 @@ def deprecate_cython_api(module, routine_name, new_name=None, message=None):
     if new_name is None:
         depdoc = "`%s` is deprecated!" % old_name
     else:
-        depdoc = "`%s` is deprecated, use `%s` instead!" % \
-                 (old_name, new_name)
+        depdoc = f"`{old_name}` is deprecated, use `{new_name}` instead!"
 
     if message is not None:
         depdoc += "\n" + message

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -276,7 +276,7 @@ def test_all_modules_are_expected_2():
 
     if unexpected_members:
         raise AssertionError("Found unexpected object(s) that look like "
-                             "modules: {}".format(unexpected_members))
+                             f"modules: {unexpected_members}")
 
 
 def test_api_importable():
@@ -301,7 +301,7 @@ def test_api_importable():
 
     if module_names:
         raise AssertionError("Modules in the public API that cannot be "
-                             "imported: {}".format(module_names))
+                             f"imported: {module_names}")
 
     with warnings.catch_warnings(record=True):
         warnings.filterwarnings('always', category=DeprecationWarning)
@@ -313,7 +313,7 @@ def test_api_importable():
     if module_names:
         raise AssertionError("Modules that are not really public but looked "
                              "public and can not be imported: "
-                             "{}".format(module_names))
+                             f"{module_names}")
 
 
 @pytest.mark.parametrize(("module_name", "correct_module"),

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1104,19 +1104,19 @@ class ClusterNode:
     def __lt__(self, node):
         if not isinstance(node, ClusterNode):
             raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+                             f"to type {type(node)}")
         return self.dist < node.dist
 
     def __gt__(self, node):
         if not isinstance(node, ClusterNode):
             raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+                             f"to type {type(node)}")
         return self.dist > node.dist
 
     def __eq__(self, node):
         if not isinstance(node, ClusterNode):
             raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+                             f"to type {type(node)}")
         return self.dist == node.dist
 
     def get_id(self):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -98,8 +98,8 @@ def check_fpu_mode(request):
     new_mode = get_fpu_mode()
 
     if old_mode != new_mode:
-        warnings.warn("FPU mode changed from {:#x} to {:#x} during "
-                      "the test".format(old_mode, new_mode),
+        warnings.warn(f"FPU mode changed from {old_mode:#x} to {new_mode:#x} during "
+                      "the test",
                       category=FPUModeChangeWarning, stacklevel=0)
 
 

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1567,8 +1567,7 @@ class ConstantWarning(DeprecationWarning):
 
 def _check_obsolete(key: str) -> None:
     if key in _obsolete_constants and key not in _aliases:
-        warnings.warn("Constant '{}' is not in current {} data set".format(
-            key, _current_codata), ConstantWarning)
+        warnings.warn(f"Constant '{key}' is not in current {_current_codata} data set", ConstantWarning)
 
 
 def value(key: str) -> float:

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -23,8 +23,8 @@ def c2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
         tmp, copied = _fix_shape_1d(tmp, n, axis)
         overwrite_x = overwrite_x or copied
     elif tmp.shape[axis] < 1:
-        raise ValueError("invalid number of data points ({}) specified"
-                         .format(tmp.shape[axis]))
+        message = f"invalid number of data points ({tmp.shape[axis]}) specified"
+        raise ValueError(message)
 
     out = (tmp if overwrite_x and tmp.dtype.kind == 'c' else None)
 
@@ -55,8 +55,7 @@ def r2c(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
     if n is not None:
         tmp, _ = _fix_shape_1d(tmp, n, axis)
     elif tmp.shape[axis] < 1:
-        raise ValueError("invalid number of data points ({}) specified"
-                         .format(tmp.shape[axis]))
+        raise ValueError(f"invalid number of data points ({tmp.shape[axis]}) specified")
 
     # Note: overwrite_x is not utilised
     return pfft.r2c(tmp, (axis,), forward, norm, None, workers)
@@ -88,8 +87,7 @@ def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
     if n is None:
         n = (tmp.shape[axis] - 1) * 2
         if n < 1:
-            raise ValueError("Invalid number of data points ({}) specified"
-                             .format(n))
+            raise ValueError(f"Invalid number of data points ({n}) specified")
     else:
         tmp, _ = _fix_shape_1d(tmp, (n//2) + 1, axis)
 
@@ -240,8 +238,7 @@ def r2r_fftpack(forward, x, n=None, axis=-1, norm=None, overwrite_x=False):
         tmp, copied = _fix_shape_1d(tmp, n, axis)
         overwrite_x = overwrite_x or copied
     elif tmp.shape[axis] < 1:
-        raise ValueError("invalid number of data points ({}) specified"
-                         .format(tmp.shape[axis]))
+        raise ValueError(f"invalid number of data points ({tmp.shape[axis]}) specified")
 
     out = (tmp if overwrite_x else None)
 

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -34,8 +34,7 @@ def _iterable_of_int(x, name=None):
         x = [operator.index(a) for a in x]
     except TypeError as e:
         name = name or "value"
-        raise ValueError("{} must be a scalar or iterable of integers"
-                         .format(name)) from e
+        raise ValueError(f"{name} must be a scalar or iterable of integers") from e
 
     return x
 
@@ -168,8 +167,8 @@ def _workers(workers):
         if workers >= -_cpu_count:
             workers += 1 + _cpu_count
         else:
-            raise ValueError("workers value out of range; got {}, must not be"
-                             " less than {}".format(workers, -_cpu_count))
+            raise ValueError(f"workers value out of range; got {workers}, must not be"
+                             f" less than {-_cpu_count}")
     elif workers == 0:
         raise ValueError("workers must not be zero")
 

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -31,8 +31,7 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
         tmp, copied = _fix_shape_1d(tmp, n, axis)
         overwrite_x = overwrite_x or copied
     elif tmp.shape[axis] < 1:
-        raise ValueError("invalid number of data points ({}) specified"
-                         .format(tmp.shape[axis]))
+        raise ValueError(f"invalid number of data points ({tmp.shape[axis]}) specified")
 
     out = (tmp if overwrite_x else None)
 

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -334,8 +334,7 @@ class _TestRFFTBase:
                 return getattr(self.data, item)
             except AttributeError as e:
                 raise AttributeError("'MockSeries' object "
-                                      "has no attribute '{attr}'".
-                                      format(attr=item)) from e
+                                      f"has no attribute '{item}'") from e
 
     def test_non_ndarray_with_dtype(self):
         x = np.array([1., 2., 3., 4., 5.])

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,5 +1,5 @@
 from os.path import join, dirname
-from typing import Callable, Dict, Tuple, Union, Type
+from typing import Callable, Union
 
 import numpy as np
 from numpy.testing import (
@@ -195,8 +195,8 @@ def test_complex(transform, dtype):
     assert_array_almost_equal(x, y)
 
 
-DecMapType = Dict[
-    Tuple[Callable[..., np.ndarray], Union[Type[np.floating], Type[int]], int],
+DecMapType = dict[
+    tuple[Callable[..., np.ndarray], Union[type[np.floating], type[int]], int],
     int,
 ]
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -294,8 +294,7 @@ class _TestRFFTBase:
                 return getattr(self.data, item)
             except AttributeError as e:
                 raise AttributeError("'MockSeries' object "
-                                      "has no attribute '{attr}'".
-                                      format(attr=item)) from e
+                                      f"has no attribute '{item}'") from e
 
     def test_non_ndarray_with_dtype(self):
         x = np.array([1., 2., 3., 4., 5.])

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -1014,8 +1014,8 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     if y.ndim != 2:
         raise ValueError("`y` must be 2 dimensional.")
     if y.shape[1] != x.shape[0]:
-        raise ValueError("`y` is expected to have {} columns, but actually "
-                         "has {}.".format(x.shape[0], y.shape[1]))
+        raise ValueError(f"`y` is expected to have {x.shape[0]} columns, but actually "
+                         f"has {y.shape[1]}.")
 
     if p is None:
         p = np.array([])
@@ -1037,8 +1037,8 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     if S is not None:
         S = np.asarray(S, dtype=dtype)
         if S.shape != (n, n):
-            raise ValueError("`S` is expected to have shape {}, "
-                             "but actually has {}".format((n, n), S.shape))
+            raise ValueError(f"`S` is expected to have shape {(n, n)}, "
+                             f"but actually has {S.shape}")
 
         # Compute I - S^+ S to impose necessary boundary conditions.
         B = np.identity(n) - np.dot(pinv(S), S)
@@ -1062,13 +1062,13 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
 
     f = fun_wrapped(x, y, p)
     if f.shape != y.shape:
-        raise ValueError("`fun` return is expected to have shape {}, "
-                         "but actually has {}.".format(y.shape, f.shape))
+        raise ValueError(f"`fun` return is expected to have shape {y.shape}, "
+                         f"but actually has {f.shape}.")
 
     bc_res = bc_wrapped(y[:, 0], y[:, -1], p)
     if bc_res.shape != (n + k,):
-        raise ValueError("`bc` return is expected to have shape {}, "
-                         "but actually has {}.".format((n + k,), bc_res.shape))
+        raise ValueError(f"`bc` return is expected to have shape {(n + k,)}, "
+                         f"but actually has {bc_res.shape}.")
 
     status = 0
     iteration = 0
@@ -1129,27 +1129,23 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
 
     if verbose > 0:
         if status == 0:
-            print("Solved in {} iterations, number of nodes {}. \n"
-                  "Maximum relative residual: {:.2e} \n"
-                  "Maximum boundary residual: {:.2e}"
-                  .format(iteration, x.shape[0], max_rms_res, max_bc_res))
+            print(f"Solved in {iteration} iterations, number of nodes {x.shape[0]}. \n"
+                  f"Maximum relative residual: {max_rms_res:.2e} \n"
+                  f"Maximum boundary residual: {max_bc_res:.2e}")
         elif status == 1:
-            print("Number of nodes is exceeded after iteration {}. \n"
-                  "Maximum relative residual: {:.2e} \n"
-                  "Maximum boundary residual: {:.2e}"
-                  .format(iteration, max_rms_res, max_bc_res))
+            print(f"Number of nodes is exceeded after iteration {iteration}. \n"
+                  f"Maximum relative residual: {max_rms_res:.2e} \n"
+                  f"Maximum boundary residual: {max_bc_res:.2e}")
         elif status == 2:
             print("Singular Jacobian encountered when solving the collocation "
-                  "system on iteration {}. \n"
-                  "Maximum relative residual: {:.2e} \n"
-                  "Maximum boundary residual: {:.2e}"
-                  .format(iteration, max_rms_res, max_bc_res))
+                  f"system on iteration {iteration}. \n"
+                  f"Maximum relative residual: {max_rms_res:.2e} \n"
+                  f"Maximum boundary residual: {max_bc_res:.2e}")
         elif status == 3:
             print("The solver was unable to satisfy boundary conditions "
-                  "tolerance on iteration {}. \n"
-                  "Maximum relative residual: {:.2e} \n"
-                  "Maximum boundary residual: {:.2e}"
-                  .format(iteration, max_rms_res, max_bc_res))
+                  f"tolerance on iteration {iteration}. \n"
+                  f"Maximum relative residual: {max_rms_res:.2e} \n"
+                  f"Maximum boundary residual: {max_bc_res:.2e}")
 
     if p.size == 0:
         p = None

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -566,8 +566,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     """
     if method not in METHODS and not (
             inspect.isclass(method) and issubclass(method, OdeSolver)):
-        raise ValueError("`method` must be one of {} or OdeSolver class."
-                         .format(METHODS))
+        raise ValueError(f"`method` must be one of {METHODS} or OdeSolver class.")
 
     t0, tf = map(float, t_span)
 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -531,9 +531,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
                     msg = ("All break points in 'points' must lie within the"
                            " integration limits.")
                 elif len(points) >= limit:
-                    msg = ("Number of break points ({:d})"
-                           " must be less than subinterval"
-                           " limit ({:d})").format(len(points), limit)
+                    msg = (f"Number of break points ({len(points):d}) "
+                           f"must be less than subinterval limit ({limit:d})")
 
         else:
             if maxp1 < 1:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1291,8 +1291,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         raise ValueError("First and last points does not match while "
                          "periodic case expected")
     if x.size != y.shape[0]:
-        raise ValueError('Shapes of x {} and y {} are incompatible'
-                         .format(x.shape, y.shape))
+        raise ValueError(f'Shapes of x {x.shape} and y {y.shape} are incompatible')
     if np.any(x[1:] == x[:-1]):
         raise ValueError("Expect x to not have duplicates")
     if x.ndim != 1 or np.any(x[1:] < x[:-1]):
@@ -1371,7 +1370,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     if nt - n != nleft + nright:
         raise ValueError("The number of derivatives at boundaries does not "
-                         "match: expected {}, got {}+{}".format(nt-n, nleft, nright))
+                         f"match: expected {nt-n}, got {nleft}+{nright}")
 
     # bail out if the `y` array is zero-sized
     if y.size == 0:
@@ -1544,13 +1543,11 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     if t.ndim != 1 or np.any(t[1:] - t[:-1] < 0):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
     if x.size != y.shape[0]:
-        raise ValueError('Shapes of x {} and y {} are incompatible'
-                         .format(x.shape, y.shape))
+        raise ValueError(f'Shapes of x {x.shape} and y {y.shape} are incompatible')
     if k > 0 and np.any((x < t[k]) | (x > t[-k])):
         raise ValueError('Out of bounds w/ x = %s.' % x)
     if x.size != w.size:
-        raise ValueError('Shapes of x {} and w {} are incompatible'
-                         .format(x.shape, w.shape))
+        raise ValueError(f'Shapes of x {x.shape} and w {w.shape} are incompatible')
 
     # number of coefficients
     n = t.size - k - 1

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -45,8 +45,8 @@ def prepare_input(x, y, axis, dydx=None):
     if x.shape[0] < 2:
         raise ValueError("`x` must contain at least 2 elements.")
     if x.shape[0] != y.shape[axis]:
-        raise ValueError("The length of `y` along `axis`={} doesn't "
-                         "match the length of `x`".format(axis))
+        raise ValueError(f"The length of `y` along `axis`={axis} doesn't "
+                         "match the length of `x`")
 
     if not np.all(np.isfinite(x)):
         raise ValueError("`x` must contain only finite values.")
@@ -811,9 +811,9 @@ class CubicSpline(CubicHermiteSpline):
             if bc_type == 'periodic':
                 if not np.allclose(y[0], y[-1], rtol=1e-15, atol=1e-15):
                     raise ValueError(
-                        "The first and last `y` point along axis {} must "
+                        f"The first and last `y` point along axis {axis} must "
                         "be identical (within machine precision) when "
-                        "bc_type='periodic'.".format(axis))
+                        "bc_type='periodic'.")
 
             bc_type = (bc_type, bc_type)
 

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -744,8 +744,8 @@ def splder(tck, n=1):
     t, c, k = tck
 
     if n > k:
-        raise ValueError(("Order of derivative (n = {!r}) must be <= "
-                          "order of spline (k = {!r})").format(n, tck[2]))
+        raise ValueError(f"Order of derivative (n = {n!r}) must be <= "
+                         f"order of spline (k = {tck[2]!r})")
 
     # Extra axes for the trailing dims of the `c` array:
     sh = (slice(None),) + ((None,)*len(c.shape[1:]))

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -345,8 +345,7 @@ class interp2d:
             any_out_of_bounds_y = np.any(out_of_bounds_y)
 
         if self.bounds_error and (any_out_of_bounds_x or any_out_of_bounds_y):
-            raise ValueError("Values out of range; x must be in %r, y in %r"
-                             % ((self.x_min, self.x_max),
+            raise ValueError("Values out of range; x must be in {!r}, y in {!r}".format((self.x_min, self.x_max),
                                 (self.y_min, self.y_max)))
 
         z = _fitpack_py.bisplev(x, y, self.tck, dx, dy)
@@ -376,9 +375,8 @@ def _check_broadcast_up_to(arr_from, shape_to, name):
                 arr_from = np.ones(shape_to, arr_from.dtype) * arr_from
             return arr_from.ravel()
     # at least one check failed
-    raise ValueError('%s argument must be able to broadcast up '
-                     'to shape %s but had shape %s'
-                     % (name, shape_to, shape_from))
+    raise ValueError(f'{name} argument must be able to broadcast up '
+                     f'to shape {shape_to} but had shape {shape_from}')
 
 
 def _do_extrapolate(fill_value):
@@ -790,14 +788,12 @@ class interp1d(_Interpolator1D):
 
         if self.bounds_error and below_bounds.any():
             below_bounds_value = x_new[np.argmax(below_bounds)]
-            raise ValueError("A value ({}) in x_new is below "
-                             "the interpolation range's minimum value ({})."
-                             .format(below_bounds_value, self.x[0]))
+            raise ValueError(f"A value ({below_bounds_value}) in x_new is below "
+                             f"the interpolation range's minimum value ({self.x[0]}).")
         if self.bounds_error and above_bounds.any():
             above_bounds_value = x_new[np.argmax(above_bounds)]
-            raise ValueError("A value ({}) in x_new is above "
-                             "the interpolation range's maximum value ({})."
-                             .format(above_bounds_value, self.x[-1]))
+            raise ValueError(f"A value ({above_bounds_value}) in x_new is above "
+                             f"the interpolation range's maximum value ({self.x[-1]}).")
 
         # !! Should we emit a warning if some values are out of bounds?
         # !! matlab does not.
@@ -823,8 +819,7 @@ class _PPolyBase:
                              "2-dimensional.")
 
         if not (0 <= axis < self.c.ndim - 1):
-            raise ValueError("axis=%s must be between 0 and %s" %
-                             (axis, self.c.ndim-1))
+            raise ValueError(f"axis={axis} must be between 0 and {self.c.ndim-1}")
 
         self.axis = axis
         if axis != 0:
@@ -914,8 +909,7 @@ class _PPolyBase:
         if x.ndim != 1:
             raise ValueError("invalid dimensions for x")
         if x.shape[0] != c.shape[1]:
-            raise ValueError("Shapes of x {} and c {} are incompatible"
-                             .format(x.shape, c.shape))
+            raise ValueError(f"Shapes of x {x.shape} and c {c.shape} are incompatible")
         if c.shape[2:] != self.c.shape[2:] or c.ndim != self.c.ndim:
             raise ValueError("Shapes of c {} and self.c {} are incompatible"
                              .format(c.shape, self.c.shape))

--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -79,7 +79,7 @@ class _TextToBytesWrapper(io.BufferedReader):
     """
 
     def __init__(self, text_io_buffer, encoding=None, errors=None, **kwargs):
-        super(_TextToBytesWrapper, self).__init__(text_io_buffer, **kwargs)
+        super().__init__(text_io_buffer, **kwargs)
         self.encoding = encoding or text_io_buffer.encoding or 'utf-8'
         self.errors = errors or text_io_buffer.errors or 'strict'
 
@@ -107,7 +107,7 @@ class _TextToBytesWrapper(io.BufferedReader):
         if offset == 0 and whence == 0 or \
            offset == 0 and whence == 2:
             # seek to start or end is ok
-            super(_TextToBytesWrapper, self).seek(offset, whence)
+            super().seek(offset, whence)
         else:
             # Drop any other seek
             # In this application this may happen when pystreambuf seeks during sync(), which can happen when closing

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -257,8 +257,8 @@ class FortranFile:
 
         num_blocks, remainder = divmod(first_size, block_size)
         if remainder != 0:
-            raise ValueError('Size obtained ({}) is not a multiple of the '
-                             'dtypes given ({}).'.format(first_size, block_size))
+            raise ValueError(f'Size obtained ({first_size}) is not a multiple of the '
+                             f'dtypes given ({block_size}).')
 
         if len(dtypes) != 1 and first_size != block_size:
             # Fortran does not write mixed type array items in interleaved order,

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -242,13 +242,13 @@ class HBInfo:
         values_format = parser.parse(values_format_str)
         if isinstance(values_format, ExpFormat):
             if mxtype.value_type not in ["real", "complex"]:
-                raise ValueError("Inconsistency between matrix type {} and "
-                                 "value type {}".format(mxtype, values_format))
+                raise ValueError(f"Inconsistency between matrix type {mxtype} and "
+                                 f"value type {values_format}")
             values_dtype = np.float64
         elif isinstance(values_format, IntFormat):
             if mxtype.value_type not in ["integer"]:
-                raise ValueError("Inconsistency between matrix type {} and "
-                                 "value type {}".format(mxtype, values_format))
+                raise ValueError(f"Inconsistency between matrix type {mxtype} and "
+                                 f"value type {values_format}")
             # XXX: fortran int -> dtype association ?
             values_dtype = int
         else:
@@ -415,8 +415,7 @@ class HBMatrixType:
                self._q2f_storage[self.storage]
 
     def __repr__(self):
-        return "HBMatrixType(%s, %s, %s)" % \
-               (self.value_type, self.structure, self.storage)
+        return f"HBMatrixType({self.value_type}, {self.structure}, {self.storage})"
 
 
 class HBFile:

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -289,8 +289,7 @@ class MMFile:
     @classmethod
     def _validate_format(self, format):
         if format not in self.FORMAT_VALUES:
-            raise ValueError('unknown format type %s, must be one of %s' %
-                             (format, self.FORMAT_VALUES))
+            raise ValueError(f'unknown format type {format}, must be one of {self.FORMAT_VALUES}')
 
     # field values
     FIELD_INTEGER = 'integer'
@@ -304,8 +303,7 @@ class MMFile:
     @classmethod
     def _validate_field(self, field):
         if field not in self.FIELD_VALUES:
-            raise ValueError('unknown field type %s, must be one of %s' %
-                             (field, self.FIELD_VALUES))
+            raise ValueError(f'unknown field type {field}, must be one of {self.FIELD_VALUES}')
 
     # symmetry values
     SYMMETRY_GENERAL = 'general'
@@ -318,8 +316,7 @@ class MMFile:
     @classmethod
     def _validate_symmetry(self, symmetry):
         if symmetry not in self.SYMMETRY_VALUES:
-            raise ValueError('unknown symmetry type %s, must be one of %s' %
-                             (symmetry, self.SYMMETRY_VALUES))
+            raise ValueError(f'unknown symmetry type {symmetry}, must be one of {self.SYMMETRY_VALUES}')
 
     DTYPES_BY_FIELD = {FIELD_INTEGER: 'intp',
                        FIELD_UNSIGNED: 'uint64',

--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -156,8 +156,7 @@ class NominalAttribute(Attribute):
         elif data_str == '?':
             return data_str
         else:
-            raise ValueError("{} value not in {}".format(str(data_str),
-                                                     str(self.values)))
+            raise ValueError(f"{str(data_str)} value not in {str(self.values)}")
 
     def __str__(self):
         msg = self.name + ",{"
@@ -453,8 +452,7 @@ def workaround_csv_sniffer_bug_last_field(sniff_line, dialect, delimiters):
         space = bool(m[n])
 
         dq_regexp = re.compile(
-            r"((%(delim)s)|^)\W*%(quote)s[^%(delim)s\n]*%(quote)s[^%(delim)s\n]*%(quote)s\W*((%(delim)s)|$)" %
-            {'delim': re.escape(delim), 'quote': quote}, re.MULTILINE
+            rf"(({re.escape(delim)})|^)\W*{quote}[^{re.escape(delim)}\n]*{quote}[^{re.escape(delim)}\n]*{quote}\W*(({re.escape(delim)})|$)", re.MULTILINE
         )
 
         doublequote = bool(dq_regexp.search(sniff_line))

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -330,8 +330,7 @@ class MatFile5Reader(MatFileReader):
                 res = self.read_var_array(hdr, process)
             except MatReadError as err:
                 warnings.warn(
-                    'Unreadable variable "%s", because "%s"' %
-                    (name, err),
+                    f'Unreadable variable "{name}", because "{err}"',
                     Warning, stacklevel=2)
                 res = "Read error: %s" % err
             self.mat_stream.seek(next_position)
@@ -652,8 +651,7 @@ class VarWriter5:
         # Try to convert things that aren't arrays
         narr = to_writeable(arr)
         if narr is None:
-            raise TypeError('Could not convert %s (type %s) to array'
-                            % (arr, type(arr)))
+            raise TypeError(f'Could not convert {arr} (type {type(arr)}) to array')
         if isinstance(narr, MatlabObject):
             self.write_object(narr)
         elif isinstance(narr, MatlabFunction):
@@ -845,8 +843,7 @@ class MatFile5Writer:
     def write_file_header(self):
         # write header
         hdr = np.zeros((), NDT_FILE_HDR)
-        hdr['description'] = 'MATLAB 5.0 MAT-file Platform: %s, Created on: %s' \
-            % (os.name,time.asctime())
+        hdr['description'] = f'MATLAB 5.0 MAT-file Platform: {os.name}, Created on: {time.asctime()}'
         hdr['version'] = 0x0100
         hdr['endian_test'] = np.ndarray(shape=(),
                                       dtype='S2',

--- a/scipy/io/matlab/_miobase.py
+++ b/scipy/io/matlab/_miobase.py
@@ -246,7 +246,7 @@ def _get_matfile_version(fileobj):
     ret = (maj_val, min_val)
     if maj_val in (1, 2):
         return ret
-    raise ValueError('Unknown mat file type, version %s, %s' % ret)
+    raise ValueError('Unknown mat file type, version {}, {}'.format(*ret))
 
 
 def matdims(arr, oned_as='column'):

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -260,8 +260,7 @@ def _check_level(label, expected, actual):
         return
     # Check types are as expected
     assert_(types_compatible(expected, actual),
-            "Expected type %s, got %s at %s" %
-            (type(expected), type(actual), label))
+            f"Expected type {type(expected)}, got {type(actual)} at {label}")
     # A field in a record array may not be an ndarray
     # A scalar from a record array will be type np.void
     if not isinstance(expected,
@@ -270,9 +269,7 @@ def _check_level(label, expected, actual):
         return
     # This is an ndarray-like thing
     assert_(expected.shape == actual.shape,
-            msg='Expected shape {}, got {} at {}'.format(expected.shape,
-                                                     actual.shape,
-                                                     label))
+            msg=f'Expected shape {expected.shape}, got {actual.shape} at {label}')
     ex_dtype = expected.dtype
     if ex_dtype.hasobject:  # array of objects
         if isinstance(expected, MatlabObject):

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -658,9 +658,8 @@ def read(filename, mmap=False):
                 if data_chunk_received:
                     # End of file but data successfully read
                     warnings.warn(
-                        "Reached EOF prematurely; finished at {:d} bytes, "
-                        "expected {:d} bytes from header."
-                        .format(fid.tell(), file_size),
+                        f"Reached EOF prematurely; finished at {fid.tell():d} bytes, "
+                        f"expected {file_size:d} bytes from header.",
                         WavFileWarning, stacklevel=2)
                     break
                 else:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -39,8 +39,7 @@ lapack_cast_dict = {x: ''.join([y for y in 'fdFD' if np.can_cast(x, y)])
 def _solve_check(n, info, lamch=None, rcond=None):
     """ Check arguments during the different steps of the solution phase """
     if info < 0:
-        raise ValueError('LAPACK reported an illegal value in {}-th argument'
-                         '.'.format(-info))
+        raise ValueError(f'LAPACK reported an illegal value in {-info}-th argument.')
     elif 0 < info:
         raise LinAlgError('Matrix is singular.')
 
@@ -48,8 +47,8 @@ def _solve_check(n, info, lamch=None, rcond=None):
         return
     E = lamch('E')
     if rcond < E:
-        warn('Ill-conditioned matrix (rcond={:.6g}): '
-             'result may not be accurate.'.format(rcond),
+        warn(f'Ill-conditioned matrix (rcond={rcond:.6g}): '
+             'result may not be accurate.',
              LinAlgWarning, stacklevel=3)
 
 
@@ -178,8 +177,7 @@ def solve(a, b, lower=False, overwrite_a=False,
         b_is_1D = True
 
     if assume_a not in ('gen', 'sym', 'her', 'pos'):
-        raise ValueError('{} is not a recognized matrix structure'
-                         ''.format(assume_a))
+        raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     # for a real matrix, describe it as "symmetric", not "hermitian"
     # (lapack doesn't know what to do with real hermitian matrices)
@@ -340,8 +338,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
-        raise ValueError('shapes of a {} and b {} are incompatible'
-                         .format(a1.shape, b1.shape))
+        raise ValueError(f'shapes of a {a1.shape} and b {b1.shape} are incompatible')
     overwrite_b = overwrite_b or _datacopied(b1, b)
 
     trans = {'N': 0, 'T': 1, 'C': 2}.get(trans, trans)
@@ -859,8 +856,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
     b = np.atleast_1d(b)
     nb = _get_axis_len("b", b, baxis)
     if nc != nb:
-        raise ValueError('Shapes of c {} and b {} are incompatible'
-                         .format(c.shape, b.shape))
+        raise ValueError(f'Shapes of c {c.shape} and b {b.shape} are incompatible')
 
     fc = np.fft.fft(np.moveaxis(c, caxis, -1), axis=-1)
     abs_fc = np.abs(fc)
@@ -1236,7 +1232,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         nrhs = 1
     if m != b1.shape[0]:
         raise ValueError('Shape mismatch: a and b should have the same number'
-                         ' of rows ({} != {}).'.format(m, b1.shape[0]))
+                         f' of rows ({m} != {b1.shape[0]}).')
     if m == 0 or n == 0:  # Zero-sized problem, confuses LAPACK
         x = np.zeros((n,) + b1.shape[1:], dtype=np.common_type(a1, b1))
         if n == 0:
@@ -1673,9 +1669,8 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     if info < 0:
         raise ValueError('xGEBAL exited with the internal error '
-                         '"illegal value in argument number {}.". See '
-                         'LAPACK documentation for the xGEBAL error codes.'
-                         ''.format(-info))
+                         f'"illegal value in argument number {-info}.". See '
+                         'LAPACK documentation for the xGEBAL error codes.')
 
     # Separate the permutations from the scalings and then convert to int
     scaling = np.ones_like(ps, dtype=float)

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -475,8 +475,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
             raise ValueError('expected square "b" matrix')
 
         if b1.shape != a1.shape:
-            raise ValueError("wrong b dimensions {}, should "
-                             "be {}".format(b1.shape, a1.shape))
+            raise ValueError(f"wrong b dimensions {b1.shape}, should be {a1.shape}")
 
         if type not in [1, 2, 3]:
             raise ValueError('"type" keyword only accepts 1, 2, and 3.')
@@ -502,8 +501,8 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         lo, hi = (int(x) for x in subset_by_index)
         if not (0 <= lo <= hi < n):
             raise ValueError('Requested eigenvalue indices are not valid. '
-                             'Valid range is [0, {}] and start <= end, but '
-                             'start={}, end={} is given'.format(n-1, lo, hi))
+                             f'Valid range is [0, {n-1}] and start <= end, but '
+                             f'start={lo}, end={hi} is given')
         # fortran is 1-indexed
         drv_args.update({'range': 'I', 'il': lo + 1, 'iu': hi + 1})
 
@@ -512,7 +511,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         if not (-inf <= lo < hi <= inf):
             raise ValueError('Requested eigenvalue bounds are not valid. '
                              'Valid range is (-inf, inf) and low < high, but '
-                             'low={}, high={} is given'.format(lo, hi))
+                             f'low={lo}, high={hi} is given')
 
         drv_args.update({'range': 'V', 'vl': lo, 'vu': hi})
 
@@ -523,16 +522,13 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     # first early exit on incompatible choice
     if driver:
         if b is None and (driver in ["gv", "gvd", "gvx"]):
-            raise ValueError('{} requires input b array to be supplied '
-                             'for generalized eigenvalue problems.'
-                             ''.format(driver))
+            raise ValueError(f'{driver} requires input b array to be supplied '
+                             'for generalized eigenvalue problems.')
         if (b is not None) and (driver in ['ev', 'evd', 'evr', 'evx']):
-            raise ValueError('"{}" does not accept input b array '
-                             'for standard eigenvalue problems.'
-                             ''.format(driver))
+            raise ValueError(f'"{driver}" does not accept input b array '
+                             'for standard eigenvalue problems.')
         if subset and (driver in ["ev", "evd", "gv", "gvd"]):
-            raise ValueError('"{}" cannot compute subsets of eigenvalues'
-                             ''.format(driver))
+            raise ValueError(f'"{driver}" cannot compute subsets of eigenvalues')
 
     # Default driver is evr and gvd
     else:
@@ -593,10 +589,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
             raise LinAlgError('Illegal value in argument {} of internal {}'
                               ''.format(-info, drv.typecode + pfx + driver))
         elif info > n:
-            raise LinAlgError('The leading minor of order {} of B is not '
+            raise LinAlgError(f'The leading minor of order {info-n} of B is not '
                               'positive definite. The factorization of B '
                               'could not be completed and no eigenvalues '
-                              'or eigenvectors were computed.'.format(info-n))
+                              'or eigenvectors were computed.')
         else:
             drv_err = {'ev': 'The algorithm failed to converge; {} '
                              'off-diagonal elements of an intermediate '
@@ -649,8 +645,7 @@ def _check_select(select, select_range, max_ev, max_len):
         else:  # 2 (index)
             if sr.dtype.char.lower() not in 'hilqp':
                 raise ValueError('when using select="i", select_range must '
-                                 'contain integers, got dtype %s (%s)'
-                                 % (sr.dtype, sr.dtype.char))
+                                 f'contain integers, got dtype {sr.dtype} ({sr.dtype.char})')
             # translate Python (0 ... N-1) into Fortran (1 ... N) with + 1
             il, iu = sr + 1
             if min(il, iu) < 1 or max(il, iu) > max_len:
@@ -1304,16 +1299,14 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         if check.dtype.char in 'GFD':  # complex
             raise TypeError('Only real arrays currently supported')
     if d.size != e.size + 1:
-        raise ValueError('d (%s) must have one more element than e (%s)'
-                         % (d.size, e.size))
+        raise ValueError(f'd ({d.size}) must have one more element than e ({e.size})')
     select, vl, vu, il, iu, _ = _check_select(
         select, select_range, 0, d.size)
     if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be str')
     drivers = ('auto', 'stemr', 'sterf', 'stebz', 'stev')
     if lapack_driver not in drivers:
-        raise ValueError('lapack_driver must be one of %s, got %s'
-                         % (drivers, lapack_driver))
+        raise ValueError(f'lapack_driver must be one of {drivers}, got {lapack_driver}')
     if lapack_driver == 'auto':
         lapack_driver = 'stemr' if select == 0 else 'stebz'
     func, = get_lapack_funcs((lapack_driver,), (d, e))

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -19,12 +19,11 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
 
     # Dimension check
     if a1.ndim != 2:
-        raise ValueError('Input array needs to be 2D but received '
-                         'a {}d-array.'.format(a1.ndim))
+        raise ValueError(f'Input array needs to be 2D but received a {a1.ndim}d-array.')
     # Squareness check
     if a1.shape[0] != a1.shape[1]:
         raise ValueError('Input array is expected to be square but has '
-                         'the shape: {}.'.format(a1.shape))
+                         f'the shape: {a1.shape}.')
 
     # Quick return for square empty array
     if a1.size == 0:
@@ -37,8 +36,8 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
         raise LinAlgError("%d-th leading minor of the array is not positive "
                           "definite" % info)
     if info < 0:
-        raise ValueError('LAPACK reported an illegal value in {}-th argument'
-                         'on entry to "POTRF".'.format(-info))
+        raise ValueError(f'LAPACK reported an illegal value in {-info}-th argument'
+                         'on entry to "POTRF".')
     return c, lower
 
 
@@ -202,8 +201,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     if c.ndim != 2 or c.shape[0] != c.shape[1]:
         raise ValueError("The factored matrix c is not square.")
     if c.shape[1] != b1.shape[0]:
-        raise ValueError("incompatible dimensions ({} and {})"
-                         .format(c.shape, b1.shape))
+        raise ValueError(f"incompatible dimensions ({c.shape} and {b1.shape})")
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
 

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -113,14 +113,12 @@ def cossin(X, p=None, q=None, separate=False,
         X = _asarray_validated(X, check_finite=True)
         if not np.equal(*X.shape):
             raise ValueError("Cosine Sine decomposition only supports square"
-                             " matrices, got {}".format(X.shape))
+                             f" matrices, got {X.shape}")
         m = X.shape[0]
         if p >= m or p <= 0:
-            raise ValueError("invalid p={}, 0<p<{} must hold"
-                             .format(p, X.shape[0]))
+            raise ValueError(f"invalid p={p}, 0<p<{X.shape[0]} must hold")
         if q >= m or q <= 0:
-            raise ValueError("invalid q={}, 0<q<{} must hold"
-                             .format(q, X.shape[0]))
+            raise ValueError(f"invalid q={q}, 0<q<{X.shape[0]} must hold")
 
         x11, x12, x21, x22 = X[:p, :q], X[:p, q:], X[p:, :q], X[p:, q:]
     elif not isinstance(X, Iterable):
@@ -129,7 +127,7 @@ def cossin(X, p=None, q=None, separate=False,
     else:
         if len(X) != 4:
             raise ValueError("When p and q are None, exactly four arrays"
-                             " should be in X, got {}".format(len(X)))
+                             f" should be in X, got {len(X)}")
 
         x11, x12, x21, x22 = (np.atleast_2d(x) for x in X)
         for name, block in zip(["x11", "x12", "x21", "x22"],
@@ -140,12 +138,12 @@ def cossin(X, p=None, q=None, separate=False,
         mmp, mmq = x22.shape
 
         if x12.shape != (p, mmq):
-            raise ValueError("Invalid x12 dimensions: desired {}, "
-                             "got {}".format((p, mmq), x12.shape))
+            raise ValueError(f"Invalid x12 dimensions: desired {(p, mmq)}, "
+                             f"got {x12.shape}")
 
         if x21.shape != (mmp, q):
-            raise ValueError("Invalid x21 dimensions: desired {}, "
-                             "got {}".format((mmp, q), x21.shape))
+            raise ValueError(f"Invalid x21 dimensions: desired {(mmp, q)}, "
+                             f"got {x21.shape}")
 
         if p + mmp != q + mmq:
             raise ValueError("The subblocks have compatible sizes but "
@@ -172,8 +170,7 @@ def cossin(X, p=None, q=None, separate=False,
 
     method_name = csd.typecode + driver
     if info < 0:
-        raise ValueError('illegal value in argument {} of internal {}'
-                         .format(-info, method_name))
+        raise ValueError(f'illegal value in argument {-info} of internal {method_name}')
     if info > 0:
         raise LinAlgError(f"{method_name} did not converge: {info}")
 

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -144,9 +144,9 @@ def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     ldu, piv, info = solver(a, lwork=lwork, lower=lower,
                             overwrite_a=overwrite_a)
     if info < 0:
-        raise ValueError('{} exited with the internal error "illegal value '
-                         'in argument number {}". See LAPACK documentation '
-                         'for the error codes.'.format(s.upper(), -info))
+        raise ValueError(f'{s.upper()} exited with the internal error "illegal value '
+                         f'in argument number {-info}". See LAPACK documentation '
+                         'for the error codes.')
 
     swap_arr, pivot_arr = _ldl_sanitize_ipiv(piv, lower=lower)
     d, lu = _ldl_get_d_and_l(ldu, pivot_arr, lower=lower, hermitian=hermitian)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -177,8 +177,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         b1 = asarray(b)
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if lu.shape[0] != b1.shape[0]:
-        raise ValueError("Shapes of lu {} and b {} are incompatible"
-                         .format(lu.shape, b1.shape))
+        raise ValueError(f"Shapes of lu {lu.shape} and b {b1.shape} are incompatible")
 
     getrs, = get_lapack_funcs(('getrs',), (lu, b1))
     x, info = getrs(lu, piv, b1, trans=trans, overwrite_b=overwrite_b)

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -254,7 +254,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     """
     if mode not in ['left', 'right']:
         raise ValueError("Mode argument can only be 'left' or 'right' but "
-                         "not '{}'".format(mode))
+                         f"not '{mode}'")
     c = numpy.asarray_chkfinite(c)
     if c.ndim < 2:
         onedim = True
@@ -270,11 +270,11 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     if mode == 'left':
         if c.shape[0] != min(M, N + overwrite_c*(M-N)):
             raise ValueError('Array shapes are not compatible for Q @ c'
-                             ' operation: {} vs {}'.format(a.shape, c.shape))
+                             f' operation: {a.shape} vs {c.shape}')
     else:
         if M != c.shape[1]:
             raise ValueError('Array shapes are not compatible for c @ Q'
-                             ' operation: {} vs {}'.format(c.shape, a.shape))
+                             f' operation: {c.shape} vs {a.shape}')
 
     raw = qr(a, overwrite_a, None, "raw", pivoting)
     Q, tau = raw[0]

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -127,7 +127,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     elif info > 0 and info <= a_n:
         warnings.warn("The QZ iteration failed. (a,b) are not in Schur "
                       "form, but ALPHAR(j), ALPHAI(j), and BETA(j) should be "
-                      "correct for J={},...,N".format(info-1), LinAlgWarning,
+                      f"correct for J={info-1},...,N", LinAlgWarning,
                       stacklevel=3)
     elif info == a_n+1:
         raise LinAlgError("Something other than QZ iteration failed")

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -166,8 +166,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
 
     info = result[-1]
     if info < 0:
-        raise ValueError('illegal value in {}-th argument of internal gees'
-                         ''.format(-info))
+        raise ValueError(f'illegal value in {-info}-th argument of internal gees')
     elif info == a1.shape[0] + 1:
         raise LinAlgError('Eigenvalues could not be separated for reordering.')
     elif info == a1.shape[0] + 2:
@@ -277,8 +276,7 @@ def rsf2csf(T, Z, check_finite=True):
             raise ValueError("Input '{}' must be square.".format('ZT'[ind]))
 
     if T.shape[0] != Z.shape[0]:
-        raise ValueError("Input array shapes must match: Z: {} vs. T: {}"
-                         "".format(Z.shape, T.shape))
+        raise ValueError(f"Input array shapes must match: Z: {Z.shape} vs. T: {T.shape}")
     N = T.shape[0]
     t = _commonType(Z, T, array([3.0], 'F'))
     Z, T = _castCopy(t, Z, T)

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -114,8 +114,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be a string')
     if lapack_driver not in ('gesdd', 'gesvd'):
-        raise ValueError('lapack_driver must be "gesdd" or "gesvd", not "%s"'
-                         % (lapack_driver,))
+        raise ValueError(f'lapack_driver must be "gesdd" or "gesvd", not "{lapack_driver}"')
     funcs = (lapack_driver, lapack_driver + '_lwork')
     gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,), ilp64='preferred')
 
@@ -474,7 +473,7 @@ def subspace_angles(A, B):
         raise ValueError(f'expected 2D array, got shape {B.shape}')
     if len(B) != len(QA):
         raise ValueError('A and B must have the same number of rows, got '
-                         '{} and {}'.format(QA.shape[0], B.shape[0]))
+                         f'{QA.shape[0]} and {B.shape[0]}')
     QB = orth(B)
     del B
 

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -82,8 +82,7 @@ def orthogonal_procrustes(A, B, check_finite=True):
     if A.ndim != 2:
         raise ValueError('expected ndim to be 2, but observed %s' % A.ndim)
     if A.shape != B.shape:
-        raise ValueError('the shapes of A and B differ ({} vs {})'.format(
-            A.shape, B.shape))
+        raise ValueError(f'the shapes of A and B differ ({A.shape} vs {B.shape})')
     # Be clever with transposes, with the intention to save memory.
     u, w, vt = svd(B.T.dot(A).T)
     R = u.dot(vt)

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -186,9 +186,8 @@ def solve_continuous_lyapunov(a, q):
 
     if info < 0:
         raise ValueError('?TRSYL exited with the internal error '
-                         '"illegal value in argument number {}.". See '
-                         'LAPACK documentation for the ?TRSYL error codes.'
-                         ''.format(-info))
+                         f'"illegal value in argument number {-info}.". See '
+                         'LAPACK documentation for the ?TRSYL error codes.')
     elif info == 1:
         warnings.warn('Input "a" has an eigenvalue pair whose sum is '
                       'very close to or exactly zero. The solution is '

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1049,7 +1049,7 @@ def dft(n, scale=None):
     """
     if scale not in [None, 'sqrtn', 'n']:
         raise ValueError("scale must be None, 'sqrtn', or 'n'; "
-                         "{!r} is not valid.".format(scale))
+                         f"{scale!r} is not valid.")
 
     omegas = np.exp(-2j * np.pi * np.arange(n) / n).reshape(-1, 1)
     m = omegas ** np.arange(n)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -921,8 +921,8 @@ def svd(A, eps_or_k, rand=True):
         else:
             k = int(eps_or_k)
             if k > min(A.shape):
-                raise ValueError("Approximation rank {} exceeds min(A.shape) = "
-                                 " {} ".format(k, min(A.shape)))
+                raise ValueError(f"Approximation rank {k} exceeds min(A.shape) = "
+                                 f" {min(A.shape)} ")
             if rand:
                 if real:
                     U, V, S = _backend.iddr_asvd(A, k)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -784,8 +784,8 @@ class TestSolve:
             if assume_a == 'her' and not is_complex:
                 continue
 
-            err_msg = ("Failed for size: {}, assume_a: {},"
-                       "dtype: {}".format(size, assume_a, dtype))
+            err_msg = (f"Failed for size: {size}, assume_a: {assume_a},"
+                       f"dtype: {dtype}")
 
             a = np.random.randn(size, size).astype(dtype)
             b = np.random.randn(size).astype(dtype)
@@ -1207,8 +1207,8 @@ class TestLstsq:
                                         overwrite_b=overwrite)
                             x = out[0]
                             r = out[2]
-                            assert_(r == n, 'expected efficient rank {}, '
-                                    'got {}'.format(n, r))
+                            assert_(r == n, f'expected efficient rank {n}, '
+                                    f'got {r}')
                             if dtype is np.float32:
                                 assert_allclose(
                                           dot(a, x), b,
@@ -1243,8 +1243,8 @@ class TestLstsq:
                                         overwrite_b=overwrite)
                             x = out[0]
                             r = out[2]
-                            assert_(r == n, 'expected efficient rank {}, '
-                                    'got {}'.format(n, r))
+                            assert_(r == n, f'expected efficient rank {n}, '
+                                    f'got {r}')
                             if dtype is np.complex64:
                                 assert_allclose(
                                           dot(a, x), b,
@@ -1278,8 +1278,8 @@ class TestLstsq:
                                         overwrite_b=overwrite)
                             x = out[0]
                             r = out[2]
-                            assert_(r == m, 'expected efficient rank {}, '
-                                    'got {}'.format(m, r))
+                            assert_(r == m, f'expected efficient rank {m}, '
+                                    f'got {r}')
                             assert_allclose(
                                           x, direct_lstsq(a, b, cmplx=0),
                                           rtol=25 * _eps_cast(a1.dtype),
@@ -1308,8 +1308,8 @@ class TestLstsq:
                                         overwrite_b=overwrite)
                             x = out[0]
                             r = out[2]
-                            assert_(r == m, 'expected efficient rank {}, '
-                                    'got {}'.format(m, r))
+                            assert_(r == m, f'expected efficient rank {m}, '
+                                    f'got {r}')
                             assert_allclose(
                                       x, direct_lstsq(a, b, cmplx=1),
                                       rtol=25 * _eps_cast(a1.dtype),

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1408,8 +1408,7 @@ def test_sfrk_hfrk():
             A = A + A.T + n*eye(n)
 
         prefix = 's'if ind < 2 else 'h'
-        trttf, tfttr, shfrk = get_lapack_funcs(('trttf', 'tfttr', '{}frk'
-                                                ''.format(prefix)),
+        trttf, tfttr, shfrk = get_lapack_funcs(('trttf', 'tfttr', f'{prefix}frk'),
                                                dtype=dtype)
 
         Afp, _ = trttf(A)
@@ -2229,8 +2228,7 @@ def test_pttrf_pttrs_errors_singular_nonSPD(ddtype, dtype):
     e[0] = 0
     _d, _e, info = pttrf(d, e)
     assert_equal(_d[info - 1], 0,
-                 "?pttrf: _d[info-1] is {}, not the illegal value :0."
-                 .format(_d[info - 1]))
+                 f"?pttrf: _d[info-1] is {_d[info - 1]}, not the illegal value :0.")
 
     # test with non-spd matrix
     d = generate_random_dtype_array((n,), ddtype)
@@ -2498,8 +2496,7 @@ def test_standard_eigh_lworks(pfx, driver):
         _compute_lwork(sc_dlw, n, lower=1)
         _compute_lwork(dz_dlw, n, lower=1)
     except Exception as e:
-        pytest.fail("{}_lwork raised unexpected exception: {}"
-                    "".format(pfx+driver, e))
+        pytest.fail(f"{pfx+driver}_lwork raised unexpected exception: {e}")
 
 
 @pytest.mark.parametrize("driver", ['gv', 'gvx'])
@@ -2514,8 +2511,7 @@ def test_generalized_eigh_lworks(pfx, driver):
         _compute_lwork(sc_dlw, n, uplo="L")
         _compute_lwork(dz_dlw, n, uplo="L")
     except Exception as e:
-        pytest.fail("{}_lwork raised unexpected exception: {}"
-                    "".format(pfx+driver, e))
+        pytest.fail(f"{pfx+driver}_lwork raised unexpected exception: {e}")
 
 
 @pytest.mark.parametrize("dtype_", DTYPES)

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -519,9 +519,8 @@ def labeled_comprehension(input, labels, index, func, out_dtype, default, pass_p
 
     index = numpy.atleast_1d(index)
     if np.any(index.astype(labels.dtype).astype(index.dtype) != index):
-        raise ValueError("Cannot convert index values from <%s> to <%s> "
-                            "(labels' type) without loss of precision" %
-                            (index.dtype, labels.dtype))
+        raise ValueError(f"Cannot convert index values from <{index.dtype}> to "
+                         f"<{labels.dtype}> (labels' type) without loss of precision")
 
     index = index.astype(labels.dtype)
 

--- a/scipy/ndimage/tests/__init__.py
+++ b/scipy/ndimage/tests/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Type 
 import numpy
 
 # list of numarray data types

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -261,9 +261,8 @@ class Data:
         self.x = _conv(x)
 
         if not isinstance(self.x, numpy.ndarray):
-            raise ValueError(("Expected an 'ndarray' of data for 'x', "
-                              "but instead got data of type '{name}'").format(
-                    name=type(self.x).__name__))
+            raise ValueError("Expected an 'ndarray' of data for 'x', "
+                             f"but instead got data of type '{type(self.x).__name__}'")
 
         self.y = _conv(y)
         self.we = _conv(we)
@@ -375,9 +374,8 @@ class RealData(Data):
         self.x = _conv(x)
 
         if not isinstance(self.x, numpy.ndarray):
-            raise ValueError(("Expected an 'ndarray' of data for 'x', "
-                              "but instead got data of type '{name}'").format(
-                    name=type(self.x).__name__))
+            raise ValueError("Expected an 'ndarray' of data for 'x', "
+                              f"but instead got data of type '{type(self.x).__name__}'")
 
         self.y = _conv(y)
         self.sx = _conv(sx)

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -319,14 +319,12 @@ class VectorFunction:
                  finite_diff_rel_step, finite_diff_jac_sparsity,
                  finite_diff_bounds, sparse_jacobian):
         if not callable(jac) and jac not in FD_METHODS:
-            raise ValueError("`jac` must be either callable or one of {}."
-                             .format(FD_METHODS))
+            raise ValueError(f"`jac` must be either callable or one of {FD_METHODS}.")
 
         if not (callable(hess) or hess in FD_METHODS
                 or isinstance(hess, HessianUpdateStrategy)):
             raise ValueError("`hess` must be either callable,"
-                             "HessianUpdateStrategy or one of {}."
-                             .format(FD_METHODS))
+                             f"HessianUpdateStrategy or one of {FD_METHODS}.")
 
         if jac in FD_METHODS and hess in FD_METHODS:
             raise ValueError("Whenever the Jacobian is estimated via "

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -219,13 +219,13 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-9):
     # The selected pivot should never lead to a pivot value less than the tol.
     if np.isclose(pivval, tol, atol=0, rtol=1e4):
         message = (
-            "The pivot operation produces a pivot value of:{: .1e}, "
+            f"The pivot operation produces a pivot value of:{pivval: .1e}, "
             "which is only slightly greater than the specified "
-            "tolerance{: .1e}. This may lead to issues regarding the "
+            f"tolerance{tol: .1e}. This may lead to issues regarding the "
             "numerical stability of the simplex method. "
             "Removing redundant constraints, changing the pivot strategy "
             "via Bland's rule or increasing the tolerance may "
-            "help reduce the issue.".format(pivval, tol))
+            "help reduce the issue.")
         warn(message, OptimizeWarning, stacklevel=5)
 
 

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -444,7 +444,7 @@ def _clean_inputs(lp):
         # Do not try to handle multidimensional bounds input
         raise ValueError(
             "Invalid input for linprog: provide a 2-D array for bounds, "
-            "not a {:d}-D array.".format(len(bsh)))
+            f"not a {len(bsh):d}-D array.")
     elif np.all(bsh == (n_x, 2)):
         # Regular N x 2 array
         bounds_clean = bounds_conv
@@ -456,12 +456,12 @@ def _clean_inputs(lp):
     elif np.all(bsh == (2, n_x)):
         # Reject a 2 x N array
         raise ValueError(
-            "Invalid input for linprog: provide a {:d} x 2 array for bounds, "
-            "not a 2 x {:d} array.".format(n_x, n_x))
+            f"Invalid input for linprog: provide a {n_x:d} x 2 array for bounds, "
+            f"not a 2 x {n_x:d} array.")
     else:
         raise ValueError(
             "Invalid input for linprog: unable to interpret bounds with this "
-            "dimension tuple: {}.".format(bsh))
+            f"dimension tuple: {bsh}.")
 
     # The process above creates nan-s where the input specified None
     # Convert the nan-s in the 1st column to -np.inf and in the 2nd column

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -583,8 +583,7 @@ def print_iteration_linear(iteration, cost, cost_reduction, step_norm,
     else:
         step_norm = f"{step_norm:^15.2e}"
 
-    print("{:^15}{:^15.4e}{}{}{:^15.2e}".format(
-        iteration, cost, cost_reduction, step_norm, optimality))
+    print(f"{iteration:^15}{cost:^15.4e}{cost_reduction}{step_norm}{optimality:^15.2e}")
 
 
 # Simple helper functions.

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -108,9 +108,8 @@ def check_tolerance(ftol, xtol, gtol, method):
         if tol is None:
             tol = 0
         elif tol < EPS:
-            warn("Setting `{}` below the machine epsilon ({:.2e}) effectively "
-                 "disables the corresponding termination condition."
-                 .format(name, EPS))
+            warn(f"Setting `{name}` below the machine epsilon ({EPS:.2e}) effectively "
+                 "disables the corresponding termination condition.")
         return tol
 
     ftol = check(ftol, "ftol")
@@ -119,10 +118,10 @@ def check_tolerance(ftol, xtol, gtol, method):
 
     if method == "lm" and (ftol < EPS or xtol < EPS or gtol < EPS):
         raise ValueError("All tolerances must be higher than machine epsilon "
-                         "({:.2e}) for method 'lm'.".format(EPS))
+                         f"({EPS:.2e}) for method 'lm'.")
     elif ftol < EPS and xtol < EPS and gtol < EPS:
         raise ValueError("At least one of the tolerances must be higher than "
-                         "machine epsilon ({:.2e}).".format(EPS))
+                         f"machine epsilon ({EPS:.2e}).")
 
     return ftol, xtol, gtol
 
@@ -833,7 +832,7 @@ def least_squares(
 
     if f0.ndim != 1:
         raise ValueError("`fun` must return at most 1-d array_like. "
-                         "f0.shape: {}".format(f0.shape))
+                         f"f0.shape: {f0.shape}")
 
     if not np.all(np.isfinite(f0)):
         raise ValueError("Residuals are not finite in the initial point.")
@@ -883,8 +882,8 @@ def least_squares(
                                  "`jac_sparsity`.")
 
             if jac != '2-point':
-                warn("jac='{}' works equivalently to '2-point' "
-                     "for method='lm'.".format(jac))
+                warn(f"jac='{jac}' works equivalently to '2-point' "
+                     "for method='lm'.")
 
             J0 = jac_wrapped = None
         else:
@@ -908,8 +907,9 @@ def least_squares(
     if J0 is not None:
         if J0.shape != (m, n):
             raise ValueError(
-                "The return value of `jac` has wrong shape: expected {}, "
-                "actual {}.".format((m, n), J0.shape))
+                f"The return value of `jac` has wrong shape: expected {(m, n)}, "
+                f"actual {J0.shape}."
+            )
 
         if not isinstance(J0, np.ndarray):
             if method == 'lm':

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -332,8 +332,7 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
 
         if verbose > 0:
             print(termination_message)
-            print("Final cost {:.4e}, first-order optimality {:.2e}"
-                  .format(cost, g_norm))
+            print(f"Final cost {cost:.4e}, first-order optimality {g_norm:.2e}")
 
         return OptimizeResult(
             x=x_lsq, fun=r, cost=cost, optimality=g_norm,
@@ -353,9 +352,8 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
 
     if verbose > 0:
         print(res.message)
-        print("Number of iterations {}, initial cost {:.4e}, "
-              "final cost {:.4e}, first-order optimality {:.2e}."
-              .format(res.nit, res.initial_cost, res.cost, res.optimality))
+        print(f"Number of iterations {res.nit}, initial cost {res.initial_cost:.4e}, "
+              f"final cost {res.cost:.4e}, first-order optimality {res.optimality:.2e}.")
 
     del res.initial_cost
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -32,8 +32,8 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs,
             if len(output_shape) > 1:
                 if output_shape[1] == 1:
                     return shape(res)
-            msg = "{}: there is a mismatch between the input and output " \
-                  "shape of the '{}' argument".format(checker, argname)
+            msg = f"{checker}: there is a mismatch between the input and output " \
+                  f"shape of the '{argname}' argument"
             func_name = getattr(thefunc, '__name__', None)
             if func_name:
                 msg += " '%s'." % func_name
@@ -449,9 +449,9 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=False,
               2: ["The relative error between two consecutive "
                   "iterates is at most %f" % xtol, None],
               3: ["Both actual and predicted relative reductions in "
-                  "the sum of squares\n  are at most {:f} and the "
+                  f"the sum of squares\n  are at most {ftol:f} and the "
                   "relative error between two consecutive "
-                  "iterates is at \n  most {:f}".format(ftol, xtol), None],
+                  f"iterates is at \n  most {xtol:f}", None],
               4: ["The cosine of the angle between func(x) and any "
                   "column of the\n  Jacobian is at most %f in "
                   "absolute value" % gtol, None],

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1199,8 +1199,8 @@ def check_grad(func, grad, x0, *args, epsilon=_epsilon,
         vars = x0
         analytical_grad = grad(x0, *args)
     else:
-        raise ValueError("{} is not a valid string for "
-                         "``direction`` argument".format(direction))
+        raise ValueError(f"{direction} is not a valid string for "
+                         "``direction`` argument")
 
     return np.sqrt(np.sum(np.abs(
         (analytical_grad - approx_fprime(vars, _func, step, *_args))**2

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -464,7 +464,7 @@ def shgo(
         shc.find_lowest_vertex()
         shc.break_routine = True
         shc.fail_routine(mes="Failed to find a feasible minimizer point. "
-                             "Lowest sampling point = {}".format(shc.f_lowest))
+                             f"Lowest sampling point = {shc.f_lowest}")
         shc.res.fun = shc.f_lowest
         shc.res.x = shc.x_lowest
         shc.res.nfev = shc.fn
@@ -1332,12 +1332,10 @@ class SHGO:
             return self.LMC[x_min].lres
 
         if self.callback is not None:
-            logging.info('Callback for '
-                  'minimizer starting at {}:'.format(x_min))
+            logging.info(f'Callback for minimizer starting at {x_min}:')
 
         if self.disp:
-            logging.info('Starting '
-                  'minimization at {}...'.format(x_min))
+            logging.info(f'Starting minimization at {x_min}...')
 
         if self.sampling_method == 'simplicial':
             x_min_t = tuple(x_min)

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -120,7 +120,7 @@ class Complex:
         # Domains
         self.domain = domain
         if domain is None:
-            self.bounds = [(float(0), float(1.0)), ] * dim
+            self.bounds = [(0.0, 1.0), ] * dim
         else:
             self.bounds = domain
         self.symmetry = symmetry

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -484,9 +484,7 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
             warnings.warn(msg, RuntimeWarning)
     elif failures.any():
         all_or_some = 'all' if failures.all() else 'some'
-        msg = '{:s} failed to converge after {:d} iterations'.format(
-            all_or_some, maxiter
-        )
+        msg = f'{all_or_some:s} failed to converge after {maxiter:d} iterations'
         if failures.all():
             raise RuntimeError(msg)
         warnings.warn(msg, RuntimeWarning)
@@ -1148,7 +1146,7 @@ class TOMS748Solver:
 
         if np.sign(fb) * np.sign(fa) > 0:
             raise ValueError("f(a) and f(b) must have different signs, but "
-                             "f({:e})={:e}, f({:e})={:e} ".format(a, fa, b, fb))
+                             f"f({a:e})={fa:e}, f({b:e})={fb:e} ")
         self.fab[:] = [fa, fb]
 
         return _EINPROGRESS, sum(self.ab) / 2.0

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -64,8 +64,7 @@ def _assert_success(res, desired_fun=None, desired_x=None,
     # desired_fun: desired objective function value or None
     # desired_x: desired solution or None
     if not res.success:
-        msg = "linprog status {}, message: {}".format(res.status,
-                                                        res.message)
+        msg = f"linprog status {res.status}, message: {res.message}"
         raise AssertionError(msg)
 
     assert_equal(res.status, 0)
@@ -2211,7 +2210,7 @@ class TestLinprogHiGHSIPM(LinprogHiGHSTests):
 ###################################
 
 
-class TestLinprogHiGHSMIP():
+class TestLinprogHiGHSMIP:
     method = "highs"
     options = {}
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1478,9 +1478,7 @@ class TestOptimizeSimple(CheckOptimize):
             res = optimize.minimize(f, x0, jac=g, method=method,
                                     options=options)
 
-            err_msg = "{} {}: {}: {}".format(method, scale,
-                                                 first_step_size,
-                                                 res)
+            err_msg = f"{method} {scale}: {first_step_size}: {res}"
 
             assert res.success, err_msg
             assert_allclose(res.x, [1.0], err_msg=err_msg)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -325,7 +325,7 @@ class Test2opt(QAPCommonTests):
             )
 
 
-class TestQAPOnce():
+class TestQAPOnce:
     def setup_method(self):
         np.random.seed(0)
 

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -523,7 +523,7 @@ class TestSLSQP:
 
     def test_nested_minimization(self):
 
-        class NestedProblem():
+        class NestedProblem:
 
             def __init__(self):
                 self.F_outer_count = 0

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -1289,7 +1289,7 @@ def test_maxiter_int_check_gh10236(method):
         method(f1, 0.0, 1.0, maxiter=72.45)
 
 
-class TestDifferentiate():
+class TestDifferentiate:
 
     def f(self, x):
         return stats.norm().cdf(x)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1544,8 +1544,7 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
 
     valid_pairings = ['nearest', 'keep_odd', 'minimal']
     if pairing not in valid_pairings:
-        raise ValueError('pairing must be one of %s, not %s'
-                         % (valid_pairings, pairing))
+        raise ValueError(f'pairing must be one of {valid_pairings}, not {pairing}')
 
     if analog and pairing != 'minimal':
         raise ValueError('for analog zpk2sos conversion, '
@@ -2382,8 +2381,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     if wp.shape[0] != ws.shape[0] or wp.shape not in [(1,), (2,)]:
         raise ValueError("wp and ws must have one or two elements each, and"
-                         "the same shape, got %s and %s"
-                         % (wp.shape, ws.shape))
+                         f"the same shape, got {wp.shape} and {ws.shape}")
 
     if any(wp <= 0) or any(ws <= 0):
         raise ValueError("Values for wp, ws must be greater than 0")
@@ -2394,7 +2392,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
                 raise ValueError("Values for wp, ws must be less than 1")
         elif any(wp >= fs/2) or any(ws >= fs/2):
             raise ValueError("Values for wp, ws must be less than fs/2"
-                             " (fs={} -> fs/2={})".format(fs, fs/2))
+                             f" (fs={fs} -> fs/2={fs/2})")
 
     if wp.shape[0] == 2:
         if not ((ws[0] < wp[0] and wp[1] < ws[1]) or
@@ -5300,8 +5298,8 @@ def iircomb(w0, Q, ftype='notch', fs=2.0, *, pass_zero=False):
     # Check for invalid cutoff frequency or filter type
     ftype = ftype.lower()
     if not 0 < w0 < fs / 2:
-        raise ValueError("w0 must be between 0 and {}"
-                         " (nyquist), but given {}.".format(fs / 2, w0))
+        raise ValueError(f"w0 must be between 0 and {fs / 2}"
+                         f" (nyquist), but given {w0}.")
     if ftype not in ('notch', 'peak'):
         raise ValueError('ftype must be either notch or peak.')
 
@@ -5468,8 +5466,8 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
     ftype = ftype.lower()
     filter_types = ['fir', 'iir']
     if not 0 < freq < fs / 2:
-        raise ValueError("The frequency must be between 0 and {}"
-                         " (nyquist), but given {}.".format(fs / 2, freq))
+        raise ValueError(f"The frequency must be between 0 and {fs / 2}"
+                         f" (nyquist), but given {freq}.")
     if ftype not in filter_types:
         raise ValueError('ftype must be either fir or iir.')
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -424,28 +424,24 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
             if pass_zero == 'lowpass':
                 if cutoff.size != 1:
                     raise ValueError('cutoff must have one element if '
-                                     'pass_zero=="lowpass", got %s'
-                                     % (cutoff.shape,))
+                                     f'pass_zero=="lowpass", got {cutoff.shape}')
             elif cutoff.size <= 1:
                 raise ValueError('cutoff must have at least two elements if '
-                                 'pass_zero=="bandstop", got %s'
-                                 % (cutoff.shape,))
+                                 f'pass_zero=="bandstop", got {cutoff.shape}')
             pass_zero = True
         elif pass_zero in ('bandpass', 'highpass'):
             if pass_zero == 'highpass':
                 if cutoff.size != 1:
                     raise ValueError('cutoff must have one element if '
-                                     'pass_zero=="highpass", got %s'
-                                     % (cutoff.shape,))
+                                     f'pass_zero=="highpass", got {cutoff.shape}')
             elif cutoff.size <= 1:
                 raise ValueError('cutoff must have at least two elements if '
-                                 'pass_zero=="bandpass", got %s'
-                                 % (cutoff.shape,))
+                                 f'pass_zero=="bandpass", got {cutoff.shape}')
             pass_zero = False
         else:
             raise ValueError('pass_zero must be True, False, "bandpass", '
                              '"lowpass", "highpass", or "bandstop", got '
-                             '{}'.format(pass_zero))
+                             f'{pass_zero}')
     pass_zero = bool(operator.index(pass_zero))  # ensure bool-like
 
     pass_nyquist = bool(cutoff.size & 1) ^ pass_zero
@@ -663,7 +659,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming', nyq=_NoValue,
         if (d <= 0).any():
             raise ValueError("freq cannot contain numbers that are too close "
                              "(within eps * (fs/2): "
-                             "{}) to a repeated value".format(eps))
+                             f"{eps}) to a repeated value")
 
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)
@@ -1021,9 +1017,8 @@ def firls(numtaps, bands, desired, *, weight=None, nyq=_NoValue, fs=None):
     # check remaining params
     desired = np.asarray(desired).flatten()
     if bands.size != desired.size:
-        raise ValueError("desired must have one entry per frequency, got %s "
-                         "gains for %s frequencies."
-                         % (desired.size, bands.size))
+        raise ValueError("desired must have one entry per frequency, got {} "
+                         "gains for {} frequencies.".format(desired.size, bands.size))
     desired.shape = (-1, 2)
     if (np.diff(bands) <= 0).any() or (np.diff(bands[:, 0]) < 0).any():
         raise ValueError("bands must be monotonically nondecreasing and have "
@@ -1037,7 +1032,7 @@ def firls(numtaps, bands, desired, *, weight=None, nyq=_NoValue, fs=None):
     weight = np.asarray(weight).flatten()
     if len(weight) != len(desired):
         raise ValueError("weight must be the same size as the number of "
-                         "band pairs ({}).".format(len(bands)))
+                         f"band pairs ({len(bands)}).")
     if (weight < 0).any():
         raise ValueError("weight must be non-negative.")
 
@@ -1260,8 +1255,7 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
                       'fail', RuntimeWarning)
     if not isinstance(method, str) or method not in \
             ('homomorphic', 'hilbert',):
-        raise ValueError('method must be "homomorphic" or "hilbert", got %r'
-                         % (method,))
+        raise ValueError(f'method must be "homomorphic" or "hilbert", got {method!r}')
     if n_fft is None:
         n_fft = 2 ** int(np.ceil(np.log2(2 * (len(h) - 1) / 0.01)))
     n_fft = int(n_fft)

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1450,8 +1450,7 @@ class StateSpace(LinearTimeInvariant):
         if isinstance(other, StateSpace):
             # Disallow mix of discrete and continuous systems.
             if type(other) is not type(self):
-                raise TypeError('Cannot add {} and {}'.format(type(self),
-                                                              type(other)))
+                raise TypeError(f'Cannot add {type(self)} and {type(other)}')
 
             if self.dt != other.dt:
                 raise TypeError('Cannot add systems with different `dt`.')
@@ -1481,8 +1480,7 @@ class StateSpace(LinearTimeInvariant):
                 d = self.D + other
             else:
                 raise ValueError("Cannot add systems with incompatible "
-                                 "dimensions ({} and {})"
-                                 .format(self.D.shape, other.shape))
+                                 f"dimensions ({self.D.shape} and {other.shape})")
 
         common_dtype = np.result_type(a.dtype, b.dtype, c.dtype, d.dtype)
         return StateSpace(np.asarray(a, dtype=common_dtype),

--- a/scipy/signal/_max_len_seq.py
+++ b/scipy/signal/_max_len_seq.py
@@ -106,8 +106,8 @@ def max_len_seq(nbits, state=None, length=None, taps=None):
     if taps is None:
         if nbits not in _mls_taps:
             known_taps = np.array(list(_mls_taps.keys()))
-            raise ValueError('nbits must be between %s and %s if taps is None'
-                             % (known_taps.min(), known_taps.max()))
+            raise ValueError(f'nbits must be between {known_taps.min()} and '
+                             f'{known_taps.max()} if taps is None')
         taps = np.array(_mls_taps[nbits], taps_dtype)
     else:
         taps = np.unique(np.array(taps, taps_dtype))[::-1]

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -316,8 +316,7 @@ def _arg_wlen_as_expected(value):
             value = math.ceil(value)
         value = np.intp(value)
     else:
-        raise ValueError('`wlen` must be larger than 1, was {}'
-                         .format(value))
+        raise ValueError(f'`wlen` must be larger than 1, was {value}')
     return value
 
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 # Linter does not allow to import ``Generator`` from ``typing`` module:
 from collections.abc import Generator
 from functools import cache, lru_cache, partial
-from typing import Callable, get_args, Literal, Union
+from typing import Callable, get_args, Literal
 
 import numpy as np
 
@@ -357,7 +357,7 @@ class ShortTimeFFT:
                    phase_shift=phase_shift)
 
     @classmethod
-    def from_window(cls, win_param: Union[str, tuple, float],
+    def from_window(cls, win_param: str | tuple | float,
                     fs: float, nperseg: int, noverlap: int, *,
                     symmetric_win: bool = False,
                     fft_mode: FFT_MODE_TYPE = 'onesided',
@@ -796,8 +796,7 @@ class ShortTimeFFT:
                                  padding=padding, axis=axis)
 
     def stft_detrend(self, x: np.ndarray,
-                     detr: Union[Callable[[np.ndarray], np.ndarray],
-                                 Literal['linear', 'constant'], None],
+                     detr: Callable[[np.ndarray], np.ndarray] | Literal['linear', 'constant'] | None,
                      p0: int | None = None, p1: int | None = None, *,
                      k_offset: int = 0, padding: PAD_TYPE = 'zeros',
                      axis: int = -1) \
@@ -848,8 +847,7 @@ class ShortTimeFFT:
         return S
 
     def spectrogram(self, x: np.ndarray, y: np.ndarray | None = None,
-                    detr: Union[Callable[[np.ndarray], np.ndarray],
-                                Literal['linear', 'constant'], None] = None, *,
+                    detr: Callable[[np.ndarray], np.ndarray] | Literal['linear', 'constant'] | None = None, *,
                     p0: int | None = None, p1: int | None = None,
                     k_offset: int = 0, padding: PAD_TYPE = 'zeros',
                     axis: int = -1) \

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -447,7 +447,7 @@ def _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False):
     if not all(s1[a] == s2[a] or s1[a] == 1 or s2[a] == 1
                for a in range(in1.ndim) if a not in axes):
         raise ValueError("incompatible shapes for in1 and in2:"
-                         " {} and {}".format(s1, s2))
+                         f" {s1} and {s2}")
 
     # Check that input sizes are compatible with 'valid' mode.
     if _inputs_swap_needed(mode, s1, s2, axes=axes):
@@ -1030,7 +1030,7 @@ def _conv_ops(x_shape, h_shape, mode):
         out_shape = x_shape
     else:
         raise ValueError("Acceptable mode flags are 'valid',"
-                         " 'same', or 'full', not mode={}".format(mode))
+                         f" 'same', or 'full', not mode={mode}")
 
     s1, s2 = x_shape, h_shape
     if len(x_shape) == 1:
@@ -2120,8 +2120,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
                         strides[k] = 0
                     else:
                         raise ValueError('Unexpected shape for zi: expected '
-                                         '%s, found %s.' %
-                                         (expected_shape, zi.shape))
+                                         f'{expected_shape}, found {zi.shape}.')
                 zi = np.lib.stride_tricks.as_strided(zi, expected_shape,
                                                      strides)
             inputs.append(zi)
@@ -3132,7 +3131,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
 
     if domain not in ('time', 'freq'):
         raise ValueError("Acceptable domain flags are 'time' or"
-                         " 'freq', not domain={}".format(domain))
+                         f" 'freq', not domain={domain}")
 
     x = np.asarray(x)
     Nx = x.shape[axis]

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -605,8 +605,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
             elif average == 'mean':
                 Pxy = Pxy.mean(axis=-1)
             else:
-                raise ValueError('average must be "median" or "mean", got %s'
-                                 % (average,))
+                raise ValueError(f'average must be "median" or "mean", got {average}')
         else:
             Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 
@@ -759,8 +758,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
     """
     modelist = ['psd', 'complex', 'magnitude', 'angle', 'phase']
     if mode not in modelist:
-        raise ValueError('unknown value for mode {}, must be one of {}'
-                         .format(mode, modelist))
+        raise ValueError(f'unknown value for mode {mode}, must be one of {modelist}')
 
     # need to set default for nperseg before setting default for noverlap below
     window, nperseg = _triage_segments(window, nperseg,
@@ -2043,9 +2041,8 @@ def _triage_segments(window, nperseg, input_length):
         if nperseg is None:
             nperseg = 256  # then change to default
         if nperseg > input_length:
-            warnings.warn('nperseg = {0:d} is greater than input length '
-                          ' = {1:d}, using nperseg = {1:d}'
-                          .format(nperseg, input_length))
+            warnings.warn(f'nperseg = {nperseg:d} is greater than input length '
+                          f' = {input_length:d}, using nperseg = {input_length:d}')
             nperseg = input_length
         win = get_window(window, nperseg)
     else:

--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -258,8 +258,7 @@ def _csd_wrapper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
             elif average == 'mean':
                 Pxy = Pxy.mean(axis=-1)
             else:
-                raise ValueError('average must be "median" or "mean", got %s'
-                                 % (average,))
+                raise ValueError(f'average must be "median" or "mean", got {average}')
         else:
             Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -44,8 +44,7 @@ class TestFirwin:
         for freq, expected in expected_response:
             actual = abs(np.sum(h*np.exp(-1.j*np.pi*m*freq)))
             mse = abs(actual-expected)**2
-            assert_(mse < tol, 'response not as expected, mse=%g > %g'
-               % (mse, tol))
+            assert_(mse < tol, f'response not as expected, mse={mse:g} > {tol:g}')
 
     def test_response(self):
         N = 51

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2558,7 +2558,7 @@ class TestDecimate:
         rate = 120
         rates_to = [15, 20, 30, 40]  # q = 8, 6, 4, 3
 
-        t_tot = int(100)  # Need to let antialiasing filters settle
+        t_tot = 100  # Need to let antialiasing filters settle
         t = np.arange(rate*t_tot+1) / float(rate)
 
         # Sinusoids at 0.8*nyquist, windowed to avoid edge artifacts

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2014,8 +2014,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
         norm = 'approximate' if Kmax is None else 2
     known_norms = (2, 'approximate', 'subsample')
     if norm not in known_norms:
-        raise ValueError('norm must be one of %s, got %s'
-                         % (known_norms, norm))
+        raise ValueError(f'norm must be one of {known_norms}, got {norm}')
     if Kmax is None:
         singleton = True
         Kmax = 1

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -367,7 +367,7 @@ class _spbase:
         # helper function, outputs "(i,j)  v"
         def tostr(row, col, data):
             triples = zip(list(zip(row, col)), data)
-            return '\n'.join([('  %s\t%s' % t) for t in triples])
+            return '\n'.join([('  {}\t{}'.format(*t)) for t in triples])
 
         if self.nnz > maxprint:
             half = maxprint // 2

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -83,8 +83,8 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                 self.data = getdata(data, copy=copy, dtype=dtype)
                 if self.data.ndim != 3:
                     raise ValueError(
-                        'BSR data must be 3-dimensional, got shape={}'.format(
-                            self.data.shape,))
+                        f'BSR data must be 3-dimensional, got shape={self.data.shape}'
+                    )
                 if blocksize is not None:
                     if not isshape(blocksize):
                         raise ValueError(f'invalid blocksize={blocksize}')

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -70,16 +70,15 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                     self.data = np.array(data, copy=copy, dtype=dtype)
                 else:
-                    raise ValueError("unrecognized {}_matrix "
-                                     "constructor usage".format(self.format))
+                    raise ValueError(f"unrecognized {self.format}_matrix "
+                                     "constructor usage")
 
         else:
             # must be dense
             try:
                 arg1 = np.asarray(arg1)
             except Exception as e:
-                raise ValueError("unrecognized {}_matrix constructor usage"
-                                 "".format(self.format)) from e
+                raise ValueError(f"unrecognized {self.format}_matrix constructor usage") from e
             self._set_self(self.__class__(
                 self._coo_container(arg1, dtype=dtype)
             ))
@@ -150,11 +149,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # index arrays should have integer data types
         if self.indptr.dtype.kind != 'i':
-            warn("indptr array has non-integer dtype ({})"
-                 "".format(self.indptr.dtype.name), stacklevel=3)
+            warn(f"indptr array has non-integer dtype ({self.indptr.dtype.name})", stacklevel=3)
         if self.indices.dtype.kind != 'i':
-            warn("indices array has non-integer dtype ({})"
-                 "".format(self.indices.dtype.name), stacklevel=3)
+            warn(f"indices array has non-integer dtype ({self.indices.dtype.name})", stacklevel=3)
 
         # check array shapes
         for x in [self.data.ndim, self.indices.ndim, self.indptr.ndim]:
@@ -181,11 +178,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # check format validity (more expensive)
             if self.nnz > 0:
                 if self.indices.max() >= minor_dim:
-                    raise ValueError("{} index values must be < {}"
-                                     "".format(minor_name, minor_dim))
+                    raise ValueError(f"{minor_name} index values must be < {minor_dim}")
                 if self.indices.min() < 0:
-                    raise ValueError("{} index values must be >= 0"
-                                     "".format(minor_name))
+                    raise ValueError(f"{minor_name} index values must be >= 0")
                 if np.diff(self.indptr).min() < 0:
                     raise ValueError("index pointer values must form a "
                                      "non-decreasing sequence")
@@ -348,8 +343,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def _add_dense(self, other):
         if other.shape != self.shape:
-            raise ValueError('Incompatible shapes ({} and {})'
-                             .format(self.shape, other.shape))
+            raise ValueError(f'Incompatible shapes ({self.shape} and {other.shape})')
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         order = self._swap('CF')[0]
         result = np.array(other, dtype=dtype, order=order, copy=True)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -82,8 +82,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 self._shape = check_shape(M.shape)
                 if shape is not None:
                     if check_shape(shape) != self._shape:
-                        raise ValueError('inconsistent shapes: %s != %s' %
-                                         (shape, self._shape))
+                        raise ValueError(f'inconsistent shapes: {shape} != {self._shape}')
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
                 row, col = M.nonzero()
                 self.row = row.astype(index_dtype, copy=False)
@@ -468,8 +467,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     def _add_dense(self, other):
         if other.shape != self.shape:
-            raise ValueError('Incompatible shapes ({} and {})'
-                             .format(self.shape, other.shape))
+            raise ValueError(f'Incompatible shapes ({self.shape} and {other.shape})')
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -149,8 +149,8 @@ for npfunc in _ufuncs_with_fixed_point_at_zero:
             result = op(self._deduped_data())
             return self._with_data(result, copy=True)
 
-        method.__doc__ = ("Element-wise {}.\n\n"
-                          "See `numpy.{}` for more information.".format(name, name))
+        method.__doc__ = (f"Element-wise {name}.\n\n"
+                          f"See `numpy.{name}` for more information.")
         method.__name__ = name
 
         return method

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -424,7 +424,7 @@ def main():
     method_struct = """\nstatic struct PyMethodDef sparsetools_methods[] = {"""
     for name in names:
         method_struct += """
-        {"%(name)s", (PyCFunction)%(name)s_method, METH_VARARGS, NULL},""" % dict(name=name)
+        {{"{name}", (PyCFunction){name}_method, METH_VARARGS, NULL}},""".format(**dict(name=name))
     method_struct += """
         {NULL, NULL, 0, NULL}
     };"""

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -148,4 +148,4 @@ def load_npz(file):
             return cls((loaded['data'], (loaded['row'], loaded['col'])), shape=loaded['shape'])
         else:
             raise NotImplementedError('Load is not implemented for '
-                                      'sparse matrix of format {}.'.format(matrix_format))
+                                      f'sparse matrix of format {matrix_format}.')

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -112,9 +112,8 @@ def _get_umf_family(A):
         family = _families[(f_type, i_type)]
 
     except KeyError as e:
-        msg = 'only float64 or complex128 matrices with int32 or int64' \
-            ' indices are supported! (got: matrix: %s, indices: %s)' \
-            % (f_type, i_type)
+        msg = ('only float64 or complex128 matrices with int32 or int64 '
+               f'indices are supported! (got: matrix: {f_type}, indices: {i_type})')
         raise ValueError(msg) from e
 
     # See gh-8278. Considered converting only if
@@ -254,8 +253,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         raise ValueError(f"matrix must be square (has shape {(M, N)})")
 
     if M != b.shape[0]:
-        raise ValueError("matrix - rhs dimension mismatch (%s - %s)"
-                         % (A.shape, b.shape[0]))
+        raise ValueError(f"matrix - rhs dimension mismatch ({A.shape} - {b.shape[0]})")
 
     use_umfpack = use_umfpack and useUmfpack
 
@@ -687,7 +685,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         raise ValueError(
             'The size of the dimensions of A must be equal to '
             'the size of the first dimension of b but the shape of A is '
-            '{} and the shape of b is {}.'.format(A.shape, b.shape))
+            f'{A.shape} and the shape of b is {b.shape}.'
+        )
 
     # Init x as (a copy of) b.
     x_dtype = np.result_type(A.data, b, np.float64)
@@ -696,8 +695,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
             x = b
         else:
             raise ValueError(
-                'Cannot overwrite b (dtype {}) with result '
-                'of type {}.'.format(b.dtype, x_dtype))
+                f'Cannot overwrite b (dtype {b.dtype}) with result '
+                f'of type {x_dtype}.'
+            )
     else:
         x = b.astype(x_dtype, copy=True)
 

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1257,8 +1257,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:
         if M.shape != A.shape:
-            raise ValueError('wrong M dimensions %s, should be %s'
-                             % (M.shape, A.shape))
+            raise ValueError(f'wrong M dimensions {M.shape}, should be {A.shape}')
         if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
             warnings.warn('M does not have the same type precision as A. '
                           'This may adversely affect ARPACK convergence')
@@ -1585,8 +1584,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:
         if M.shape != A.shape:
-            raise ValueError('wrong M dimensions %s, should be %s'
-                             % (M.shape, A.shape))
+            raise ValueError(f'wrong M dimensions {M.shape}, should be {A.shape}')
         if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
             warnings.warn('M does not have the same type precision as A. '
                           'This may adversely affect ARPACK convergence')

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -838,7 +838,7 @@ class SVDSCommonTests:
 # --- Perform tests with each solver ---
 
 
-class Test_SVDS_once():
+class Test_SVDS_once:
     @pytest.mark.parametrize("solver", ['ekki', object])
     def test_svds_input_validation_solver(self, solver):
         message = "solver must be one of"

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -164,7 +164,7 @@ def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
         if tau * np.sqrt(iter+1) < atol:
             if (show):
                 print("TFQMR: Linear solve converged due to reach TOL "
-                      "iterations {}".format(iter+1))
+                      f"iterations {iter+1}")
             return (postprocess(x), 0)
 
         if (not even):
@@ -182,5 +182,5 @@ def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
 
     if (show):
         print("TFQMR: Linear solve not converged due to reach MAXIT "
-              "iterations {}".format(iter+1))
+              f"iterations {iter+1}")
     return (postprocess(x), maxiter)

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -136,8 +136,7 @@ def norm(x, ord=None, axis=None):
     if len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
-            raise ValueError('Invalid axis %r for an array with shape %r' %
-                             (axis, x.shape))
+            raise ValueError(f'Invalid axis {axis!r} for an array with shape {x.shape!r}')
         if row_axis % nd == col_axis % nd:
             raise ValueError('Duplicate axes given.')
         if ord == 2:
@@ -163,8 +162,7 @@ def norm(x, ord=None, axis=None):
     elif len(axis) == 1:
         a, = axis
         if not (-nd <= a < nd):
-            raise ValueError('Invalid axis %r for an array with shape %r' %
-                             (axis, x.shape))
+            raise ValueError(f'Invalid axis {axis!r} for an array with shape {x.shape!r}')
         if ord == np.inf:
             M = abs(x).max(axis=a)
         elif ord == -np.inf:

--- a/scipy/spatial/_ckdtree.pyi
+++ b/scipy/spatial/_ckdtree.pyi
@@ -1,11 +1,9 @@
+from __future__ import annotations
 from typing import (
     Any,
     Generic,
-    Optional,
     overload,
-    Tuple,
     TypeVar,
-    Union,
 )
 
 import numpy as np
@@ -19,19 +17,9 @@ _BoxType = TypeVar("_BoxType", None, npt.NDArray[np.float64])
 
 # Copied from `numpy.typing._scalar_like._ScalarLike`
 # TODO: Expand with 0D arrays once we have shape support
-_ArrayLike0D = Union[
-    bool,
-    int,
-    float,
-    complex,
-    str,
-    bytes,
-    np.generic,
-]
-_WeightType = Union[
-    npt.ArrayLike,
-    Tuple[Optional[npt.ArrayLike], Optional[npt.ArrayLike]],
-]
+_ArrayLike0D = bool | int | float | complex | str | bytes | np.generic
+
+_WeightType = npt.ArrayLike | tuple[npt.ArrayLike | None, npt.ArrayLike | None]
 
 class cKDTreeNode:
     @property

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2479,21 +2479,18 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
         else:
             if not (D - D.T <= tol).all():
                 if name:
-                    raise ValueError(('Distance matrix \'%s\' must be '
-                                      'symmetric within tolerance %5.5f.')
-                                     % (name, tol))
+                    raise ValueError(f'Distance matrix \'{name}\' must be '
+                                     f'symmetric within tolerance {tol:5.5f}.')
                 else:
-                    raise ValueError('Distance matrix must be symmetric within'
-                                     ' tolerance %5.5f.' % tol)
+                    raise ValueError('Distance matrix must be symmetric within '
+                                     'tolerance %5.5f.' % tol)
             if not (D[range(0, s[0]), range(0, s[0])] <= tol).all():
                 if name:
-                    raise ValueError(('Distance matrix \'%s\' diagonal must be'
-                                      ' close to zero within tolerance %5.5f.')
-                                     % (name, tol))
+                    raise ValueError(f'Distance matrix \'{name}\' diagonal must be '
+                                     f'close to zero within tolerance {tol:5.5f}.')
                 else:
-                    raise ValueError(('Distance matrix \'%s\' diagonal must be'
-                                      ' close to zero within tolerance %5.5f.')
-                                     % tol)
+                    raise ValueError(('Distance matrix \'{}\' diagonal must be close '
+                                      'to zero within tolerance {:5.5f}.').format(*tol))
     except Exception as e:
         if throw:
             raise

--- a/scipy/spatial/distance.pyi
+++ b/scipy/spatial/distance.pyi
@@ -1,12 +1,12 @@
-from typing import (overload, Any, Union, SupportsFloat,
-                    Literal, Protocol, SupportsIndex)
+from __future__ import annotations
+from typing import (overload, Any, SupportsFloat, Literal, Protocol, SupportsIndex)
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 # Anything that can be parsed by `np.float64.__init__` and is thus
 # compatible with `ndarray.__setitem__` (for a float64 array)
-_FloatValue = Union[None, str, bytes, SupportsFloat, SupportsIndex]
+_FloatValue = None | str | bytes | SupportsFloat | SupportsIndex
 
 class _MetricCallback1(Protocol):
     def __call__(
@@ -20,7 +20,7 @@ class _MetricCallback2(Protocol):
 
 # TODO: Use a single protocol with a parameter specification variable
 # once available (PEP 612)
-_MetricCallback = Union[_MetricCallback1, _MetricCallback2]
+_MetricCallback = _MetricCallback1 | _MetricCallback2
 
 _MetricKind = Literal[
     'braycurtis',

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1808,7 +1808,7 @@ class TestIsValidDM:
     def test_is_valid_dm_improper_shape_1D_E(self):
         D = np.zeros((5,), dtype=np.float64)
         with pytest.raises(ValueError):
-            is_valid_dm_throw((D))
+            is_valid_dm_throw(D)
 
     def test_is_valid_dm_improper_shape_1D_F(self):
         D = np.zeros((5,), dtype=np.float64)
@@ -1817,7 +1817,7 @@ class TestIsValidDM:
     def test_is_valid_dm_improper_shape_3D_E(self):
         D = np.zeros((3, 3, 3), dtype=np.float64)
         with pytest.raises(ValueError):
-            is_valid_dm_throw((D))
+            is_valid_dm_throw(D)
 
     def test_is_valid_dm_improper_shape_3D_F(self):
         D = np.zeros((3, 3, 3), dtype=np.float64)
@@ -1829,7 +1829,7 @@ class TestIsValidDM:
         for i in range(0, 5):
             D[i, i] = 2.0
         with pytest.raises(ValueError):
-            is_valid_dm_throw((D))
+            is_valid_dm_throw(D)
 
     def test_is_valid_dm_nonzero_diagonal_F(self):
         y = np.random.rand(10)
@@ -1843,7 +1843,7 @@ class TestIsValidDM:
         D = squareform(y)
         D[1, 3] = D[3, 1] + 1
         with pytest.raises(ValueError):
-            is_valid_dm_throw((D))
+            is_valid_dm_throw(D)
 
     def test_is_valid_dm_asymmetric_F(self):
         y = np.random.rand(10)
@@ -1888,7 +1888,7 @@ class TestIsValidY:
     def test_is_valid_y_improper_shape_2D_E(self):
         y = np.zeros((3, 3,), dtype=np.float64)
         with pytest.raises(ValueError):
-            is_valid_y_throw((y))
+            is_valid_y_throw(y)
 
     def test_is_valid_y_improper_shape_2D_F(self):
         y = np.zeros((3, 3,), dtype=np.float64)
@@ -1897,7 +1897,7 @@ class TestIsValidY:
     def test_is_valid_y_improper_shape_3D_E(self):
         y = np.zeros((3, 3, 3), dtype=np.float64)
         with pytest.raises(ValueError):
-            is_valid_y_throw((y))
+            is_valid_y_throw(y)
 
     def test_is_valid_y_improper_shape_3D_F(self):
         y = np.zeros((3, 3, 3), dtype=np.float64)

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -997,8 +997,7 @@ class TestVoronoi:
                 try:
                     return vertex_map[x]
                 except KeyError as e:
-                    raise AssertionError("incremental result has spurious vertex at %r"
-                                         % (objx.vertices[x],)) from e
+                    raise AssertionError(f"incremental result has spurious vertex at {objx.vertices[x]!r}") from e
 
             def simplified(x):
                 items = set(map(sorted_tuple, x))

--- a/scipy/spatial/transform/_rotation.pyi
+++ b/scipy/spatial/transform/_rotation.pyi
@@ -1,11 +1,12 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Union, Sequence
+from typing import TYPE_CHECKING
+from collections.abc import Sequence
 import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-_IntegerType = Union[int, np.integer]
+_IntegerType = int | np.integer
 
 
 class Rotation:

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -75,7 +75,6 @@ from stat import ST_MTIME
 import argparse
 import re
 import textwrap
-from typing import List
 
 import numpy
 
@@ -1407,7 +1406,7 @@ def generate_fused_funcs(modname, ufunc_fn_prefix, fused_funcs):
         f.write("\n\n".join(bench_aux))
 
 
-def generate_ufuncs_type_stubs(module_name: str, ufuncs: List[Ufunc]):
+def generate_ufuncs_type_stubs(module_name: str, ufuncs: list[Ufunc]):
     stubs, module_all = [], []
     for ufunc in ufuncs:
         stubs.append(f'{ufunc.name}: np.ufunc')

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -431,8 +431,7 @@ def mp_assert_allclose(res, std, atol=0, rtol=1e-17):
     if nfail > 0:
         ndigits = int(abs(np.log10(rtol)))
         msg = [""]
-        msg.append("Bad results ({} out of {}) for the following points:"
-                   .format(nfail, k + 1))
+        msg.append(f"Bad results ({nfail} out of {k + 1}) for the following points:")
         for k, resval, stdval in failures:
             resrep = mpmath.nstr(resval, ndigits, min_fixed=0, max_fixed=0)
             stdrep = mpmath.nstr(stdval, ndigits, min_fixed=0, max_fixed=0)
@@ -441,6 +440,5 @@ def mp_assert_allclose(res, std, atol=0, rtol=1e-17):
             else:
                 rdiff = mpmath.fabs((resval - stdval)/stdval)
                 rdiff = mpmath.nstr(rdiff, 3)
-            msg.append("{}: {} != {} (rdiff {})".format(k, resrep, stdrep,
-                                                        rdiff))
+            msg.append(f"{k}: {resrep} != {stdrep} (rdiff {rdiff})")
         assert_(False, "\n".join(msg))

--- a/scipy/special/_orthogonal.pyi
+++ b/scipy/special/_orthogonal.pyi
@@ -1,29 +1,20 @@
+from __future__ import annotations
 from typing import (
     Any,
     Callable,
     Literal,
     Optional,
     overload,
-    Tuple,
-    Union,
 )
 
 import numpy
 
-_IntegerType = Union[int, numpy.integer]
-_FloatingType = Union[float, numpy.floating]
-_PointsAndWeights = Tuple[numpy.ndarray, numpy.ndarray]
-_PointsAndWeightsAndMu = Tuple[numpy.ndarray, numpy.ndarray, float]
+_IntegerType = int | numpy.integer
+_FloatingType = float | numpy.floating
+_PointsAndWeights = tuple[numpy.ndarray, numpy.ndarray]
+_PointsAndWeightsAndMu = tuple[numpy.ndarray, numpy.ndarray, float]
 
-_ArrayLike0D = Union[
-    bool,
-    int,
-    float,
-    complex,
-    str,
-    bytes,
-    numpy.generic,
-]
+_ArrayLike0D = bool | int | float | complex | str | bytes | numpy.generic
 
 __all__ = [
     'legendre',
@@ -287,7 +278,7 @@ class orthopoly1d(numpy.poly1d):
             hn: float = ...,
             kn: float = ...,
             wfunc = Optional[Callable[[float], float]],
-            limits = Optional[Tuple[float, float]],
+            limits = tuple[float, float] | None,
             monic: bool = ...,
             eval_func: numpy.ufunc = ...,
     ) -> None: ...

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -99,8 +99,7 @@ def multigammaln(a, d):
     if not np.isscalar(d) or (np.floor(d) != d):
         raise ValueError("d should be a positive integer (dimension)")
     if np.any(a <= 0.5 * (d - 1)):
-        raise ValueError("condition a (%f) > 0.5 * (d-1) (%f) not met"
-                         % (a, 0.5 * (d-1)))
+        raise ValueError(f"condition a ({a:f}) > 0.5 * (d-1) ({0.5 * (d-1):f}) not met")
 
     res = (d * (d-1) * 0.25) * np.log(np.pi)
     res += np.sum(loggam([(a - (j - 1.)/2) for j in range(1, d+1)]), axis=0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -99,8 +99,8 @@ class TestCephes:
         def binom_int(n, k):
             n = int(n)
             k = int(k)
-            num = int(1)
-            den = int(1)
+            num = 1
+            den = 1
             for i in range(1, k+1):
                 num *= i + n - k
                 den *= i

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -1,7 +1,7 @@
 """Test how the ufuncs in special handle nan inputs.
 
 """
-from typing import Callable, Dict
+from typing import Callable
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_, suppress_warnings
@@ -9,9 +9,9 @@ import pytest
 import scipy.special as sc
 
 
-KNOWNFAILURES: Dict[str, Callable] = {}
+KNOWNFAILURES: dict[str, Callable] = {}
 
-POSTPROCESSING: Dict[str, Callable] = {}
+POSTPROCESSING: dict[str, Callable] = {}
 
 
 def _get_ufuncs():

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -601,9 +601,8 @@ class FitDataError(ValueError):
     def __init__(self, distr, lower, upper):
         self.args = (
             "Invalid values in `data`.  Maximum likelihood "
-            "estimation with {distr!r} requires that {lower!r} < "
-            "(x - loc)/scale  < {upper!r} for each x in `data`.".format(
-                distr=distr, lower=lower, upper=upper),
+            f"estimation with {distr!r} requires that {lower!r} < "
+            f"(x - loc)/scale  < {upper!r} for each x in `data`.",
         )
 
 
@@ -3491,10 +3490,9 @@ class erlang_gen(gamma_gen):
         if not allint:
             # An Erlang distribution shouldn't really have a non-integer
             # shape parameter, so warn the user.
-            warnings.warn(
-                'The shape parameter of the erlang distribution '
-                'has been given a non-integer value {!r}.'.format(a),
-                RuntimeWarning)
+            message = ('The shape parameter of the erlang distribution '
+                       f'has been given a non-integer value {a!r}.')
+            warnings.warn(message, RuntimeWarning)
         return a > 0
 
     def _shape_info(self):
@@ -5056,8 +5054,8 @@ class geninvgauss_gen(rv_continuous):
 
                 if (simulated == 0) and (i*N >= 50000):
                     msg = ("Not a single random variate could be generated "
-                           "in {} attempts. Sampling does not appear to "
-                           "work for the provided parameters.".format(i*N))
+                           f"in {i*N} attempts. Sampling does not appear to "
+                           "work for the provided parameters.")
                     raise RuntimeError(msg)
                 i += 1
         else:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -812,8 +812,7 @@ class rv_generic:
                 self.__doc__ = doccer.docformat(self.__doc__, tempdict)
             except TypeError as e:
                 raise Exception("Unable to construct docstring for "
-                                "distribution \"%s\": %s" %
-                                (self.name, repr(e))) from e
+                                f"distribution \"{self.name}\": {repr(e)}") from e
 
         # correct for empty shapes
         self.__doc__ = self.__doc__.replace('(, ', '(').replace(', )', ')')

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -100,7 +100,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
     nx, ny = len(x), len(y)
     if (nx < 5) or (ny < 5):
         raise ValueError('x and y should have at least 5 elements, but len(x) '
-                         '= {} and len(y) = {}.'.format(nx, ny))
+                         f'= {nx} and len(y) = {ny}.')
     if not np.isfinite(x).all():
         raise ValueError('x must not contain nonfinite values.')
     if not np.isfinite(y).all():

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4313,8 +4313,8 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
 
     ties_options = ['below', 'above', 'ignore']
     if ties not in ties_options:
-        raise ValueError("invalid 'ties' option '{}'; 'ties' must be one "
-                         "of: {}".format(ties, str(ties_options)[1:-1]))
+        raise ValueError(f"invalid 'ties' option '{ties}'; 'ties' must be one "
+                         f"of: {str(ties_options)[1:-1]}")
 
     data = [np.asarray(sample) for sample in samples]
 

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -84,7 +84,7 @@ def _chk_size(a, b):
     (na, nb) = (a.size, b.size)
     if na != nb:
         raise ValueError("The size of the input array should match!"
-                         " ({} <> {})".format(na, nb))
+                         f" ({na} <> {nb})")
     return (a, b, na)
 
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1457,7 +1457,7 @@ def _dirichlet_check_parameters(alpha):
         raise ValueError("All parameters must be greater than 0")
     elif alpha.ndim != 1:
         raise ValueError("Parameter vector 'a' must be one dimensional, "
-                         "but a.shape = {}.".format(alpha.shape))
+                         f"but a.shape = {alpha.shape}.")
     return alpha
 
 
@@ -1467,8 +1467,8 @@ def _dirichlet_check_input(alpha, x):
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
         raise ValueError("Vector 'x' must have either the same number "
                          "of entries as, or one entry fewer than, "
-                         "parameter vector 'a', but alpha.shape = {} "
-                         "and x.shape = {}.".format(alpha.shape, x.shape))
+                         f"parameter vector 'a', but alpha.shape = {alpha.shape} "
+                         f"and x.shape = {x.shape}.")
 
     if x.shape[0] != alpha.shape[0]:
         xk = np.array([1 - np.sum(x, 0)])
@@ -2061,7 +2061,7 @@ class wishart_gen(multi_rv_generic):
         # Now we have 3-dim array; should have shape [dim, dim, *]
         if not x.shape[0:2] == (dim, dim):
             raise ValueError('Quantiles have incompatible dimensions: should'
-                             ' be {}, got {}.'.format((dim, dim), x.shape[0:2]))
+                             f' be {(dim, dim)}, got {x.shape[0:2]}.')
 
         return x
 

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -319,7 +319,7 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
     """
     if method not in ['joint', 'separate']:
         raise ValueError("method must be either 'joint' or 'separate'."
-                         "'{}' is invalid.".format(method))
+                         f"'{method}' is invalid.")
     # We copy both x and y so we can use _find_repeats.
     y = np.array(y).flatten()
     if x is None:
@@ -327,8 +327,7 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
     else:
         x = np.array(x, dtype=float).flatten()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" %
-                             (len(y), len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 
     # Compute sorted slopes only when deltax > 0
     deltax = x[:, np.newaxis] - x
@@ -493,8 +492,7 @@ def siegelslopes(y, x=None, method="hierarchical"):
     else:
         x = np.asarray(x, dtype=float).ravel()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" %
-                             (len(y), len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
     dtype = np.result_type(x, y, np.float32)  # use at least float32
     y, x = y.astype(dtype), x.astype(dtype)
     medslope, medinter = siegelslopes_pythran(y, x, method)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5369,8 +5369,8 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
     """
     if axis is not None and axis > 1:
         raise ValueError("spearmanr only handles 1-D or 2-D arrays, "
-                         "supplied axis argument {}, please use only "
-                         "values 0, 1 or None for axis".format(axis))
+                         f"supplied axis argument {axis}, please use only "
+                         "values 0, 1 or None for axis")
 
     a, axisout = _chk_asarray(a, axis)
     if a.ndim > 2:
@@ -6050,7 +6050,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     if x.size != y.size:
         raise ValueError("All inputs to `weightedtau` must be "
                          "of the same size, "
-                         "found x-size {} and y-size {}".format(x.size, y.size))
+                         f"found x-size {x.size} and y-size {y.size}")
     if not x.size:
         # Return NaN if arrays are empty
         res = SignificanceResult(np.nan, np.nan)
@@ -6090,7 +6090,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         if rank.size != x.size:
             raise ValueError(
                 "All inputs to `weightedtau` must be of the same size, "
-                "found x-size {} and rank-size {}".format(x.size, rank.size)
+                f"found x-size {x.size} and rank-size {rank.size}"
             )
 
     tau = _weightedrankedtau(x, y, rank, weigher, additive)
@@ -6389,13 +6389,11 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     if x.ndim == 1:
         x = x[:, np.newaxis]
     elif x.ndim != 2:
-        raise ValueError("Expected a 2-D array `x`, found shape "
-                         "{}".format(x.shape))
+        raise ValueError(f"Expected a 2-D array `x`, found shape {x.shape}")
     if y.ndim == 1:
         y = y[:, np.newaxis]
     elif y.ndim != 2:
-        raise ValueError("Expected a 2-D array `y`, found shape "
-                         "{}".format(y.shape))
+        raise ValueError(f"Expected a 2-D array `y`, found shape {y.shape}")
 
     nx, px = x.shape
     ny, py = y.shape
@@ -7983,8 +7981,8 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     if isinstance(lambda_, str):
         if lambda_ not in _power_div_lambda_names:
             names = repr(list(_power_div_lambda_names.keys()))[1:-1]
-            raise ValueError("invalid string for lambda_: {!r}. "
-                             "Valid strings are {}".format(lambda_, names))
+            raise ValueError(f"invalid string for lambda_: {lambda_!r}. "
+                             f"Valid strings are {names}")
         lambda_ = _power_div_lambda_names[lambda_]
     elif lambda_ is None:
         lambda_ = 1
@@ -9364,7 +9362,7 @@ def friedmanchisquare(*samples):
     k = len(samples)
     if k < 3:
         raise ValueError('At least 3 sets of samples must be given '
-                         'for Friedman test, got {}.'.format(k))
+                         f'for Friedman test, got {k}.')
 
     n = len(samples[0])
     for i in range(1, k):

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -1,12 +1,12 @@
+from __future__ import annotations
 import numpy as np
-from typing import (Union, overload, Callable, NamedTuple,
-                    Protocol)
+from typing import (overload, Callable, NamedTuple, Protocol)
 import numpy.typing as npt
 from scipy._lib._util import SeedType
 import scipy.stats as stats
 
 
-ArrayLike0D = Union[bool, int, float, complex, str, bytes, np.generic]
+ArrayLike0D = bool | int | float | complex | str | bytes | np.generic
 
 
 __all__: list[str]

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -338,7 +338,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
         # the exception message.
         zeropos = list(zip(*np.nonzero(expected == 0)))[0]
         raise ValueError("The internally computed table of expected "
-                         "frequencies has a zero element at {}.".format(zeropos))
+                         f"frequencies has a zero element at {zeropos}.")
 
     # The degrees of freedom
     dof = expected.size - sum(expected.shape) + expected.ndim - 1

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1130,7 +1130,7 @@ def test_array_like_input(dtype):
     # Check that `_axis_nan_policy`-decorated functions work with custom
     # containers that are coercible to numeric arrays
 
-    class ArrLike():
+    class ArrLike:
         def __init__(self, x):
             self._x = x
 

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -303,8 +303,7 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
     chis, pval = stats.chisquare(np.array(freq), len(rvs)*distmass)
 
     npt.assert_(pval > alpha,
-                'chisquare - test for %s at arg = %s with pval = %s' %
-                (msg, str(arg), str(pval)))
+                f'chisquare - test for {msg} at arg = {str(arg)} with pval = {str(pval)}')
 
 
 def check_scale_docstring(distfn):

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -344,7 +344,7 @@ class TestZipfian:
                         [mean, var, skew, kurtosis])
 
 
-class TestNCH():
+class TestNCH:
     np.random.seed(2)  # seeds 0 and 1 had some xl = xu; randint failed
     shape = (2, 4, 3)
     max_m = 100

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5267,14 +5267,15 @@ class TestLevyStable:
                   (subdata2['relerr'] >= rtol) |
                   np.isnan(p)
                 ]
+                message = (
+                    f"pdf test {ix} failed with method '{default_method}' "
+                    f"[platform: {platform_desc}]\n{failures.dtype.names}\n{failures}"
+                )
                 assert_allclose(
                     p,
                     subdata['p'],
                     rtol,
-                    err_msg="pdf test %s failed with method '%s'"
-                            " [platform: %s]\n%s\n%s" %
-                    (ix, default_method, platform_desc, failures.dtype.names,
-                        failures),
+                    err_msg=message,
                     verbose=False
                 )
 
@@ -5417,8 +5418,7 @@ class TestLevyStable:
                     p,
                     subdata['p'],
                     rtol,
-                    err_msg="cdf test %s failed with method '%s'\n%s\n%s" %
-                    (ix, default_method, failures.dtype.names, failures),
+                    err_msg=f"cdf test {ix} failed with method '{default_method}'\n{failures.dtype.names}\n{failures}",
                     verbose=False
                 )
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1066,7 +1066,7 @@ def test_plotting_positions():
     assert_array_almost_equal(pos.data, np.array([0.25, 0.5, 0.75]))
 
 
-class TestNormalitytests():
+class TestNormalitytests:
 
     def test_vs_nonmasked(self):
         x = np.array((-2, -1, 0, 1, 2, 3)*4)**2
@@ -1161,7 +1161,7 @@ class TestNormalitytests():
             mstats.kurtosistest(x, alternative='error')
 
 
-class TestFOneway():
+class TestFOneway:
     def test_result_attributes(self):
         a = np.array([655, 788], dtype=np.uint16)
         b = np.array([789, 772], dtype=np.uint16)
@@ -1170,7 +1170,7 @@ class TestFOneway():
         check_named_results(res, attributes, ma=True)
 
 
-class TestMannwhitneyu():
+class TestMannwhitneyu:
     # data from gh-1428
     x = np.array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
                   1., 1., 1., 1., 1., 1., 1., 2., 1., 1., 1., 1., 1., 1.,
@@ -1219,7 +1219,7 @@ class TestMannwhitneyu():
         assert_allclose(res1.pvalue, res2.pvalue)
 
 
-class TestKruskal():
+class TestKruskal:
     def test_result_attributes(self):
         x = [1, 3, 5, 7, 9]
         y = [2, 4, 6, 8, 10]
@@ -1230,7 +1230,7 @@ class TestKruskal():
 
 
 # TODO: for all ttest functions, add tests with masked array inputs
-class TestTtest_rel():
+class TestTtest_rel:
     def test_vs_nonmasked(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
@@ -1321,7 +1321,7 @@ class TestTtest_rel():
         assert_allclose(p, p_ex, rtol=1e-14)
 
 
-class TestTtest_ind():
+class TestTtest_ind:
     def test_vs_nonmasked(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
@@ -1415,7 +1415,7 @@ class TestTtest_ind():
         assert_allclose(p, p_ex, rtol=1e-14)
 
 
-class TestTtest_1samp():
+class TestTtest_1samp:
     def test_vs_nonmasked(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]

--- a/scipy/stats/tests/test_sensitivity_analysis.py
+++ b/scipy/stats/tests/test_sensitivity_analysis.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less
 import pytest
@@ -189,7 +187,7 @@ class TestSobolIndices:
 
         def jansen_sobol_typed(
             f_A: np.ndarray, f_B: np.ndarray, f_AB: np.ndarray
-        ) -> Tuple[np.ndarray, np.ndarray]:
+        ) -> tuple[np.ndarray, np.ndarray]:
             return jansen_sobol(f_A, f_B, f_AB)
 
         _ = sobol_indices(

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2472,7 +2472,7 @@ class TestMode:
     def test_raise_non_numeric_gh18254(self):
         message = "Argument `a` is not recognized as numeric."
 
-        class ArrLike():
+        class ArrLike:
             def __init__(self, x):
                 self._x = x
 
@@ -4721,7 +4721,7 @@ def test_ttest_ind():
     assert_allclose(p, converter(tr, pr, 'greater'), rtol=1e-14)
 
 
-class Test_ttest_ind_permutations():
+class Test_ttest_ind_permutations:
     N = 20
 
     # data for most tests
@@ -8076,7 +8076,7 @@ class TestMGCStat:
         assert_equal(res.stat, res.statistic)
 
 
-class TestQuantileTest():
+class TestQuantileTest:
     r""" Test the non-parametric quantile test,
     including the computation of confidence intervals
     """

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -104,7 +104,7 @@ def main():
         n_authors = list(new_authors)
         n_authors.sort(key=name_key)
         # Print some empty lines to separate
-        stdout_b.write(("\n\n").encode('utf-8'))
+        stdout_b.write(b"\n\n")
         for author in n_authors:
             stdout_b.write(("- %s\n" % author).encode('utf-8'))
         # return for early exit so we only print new authors
@@ -129,9 +129,9 @@ Authors
         author_clean = author.strip('@')
 
         if author in all_authors:
-            stdout_b.write((f"* {author_clean} ({count})\n").encode('utf-8'))
+            stdout_b.write((f"* {author_clean} ({count})\n").encode())
         else:
-            stdout_b.write((f"* {author_clean} ({count}) +\n").encode('utf-8'))
+            stdout_b.write((f"* {author_clean} ({count}) +\n").encode())
 
     stdout_b.write(("""
 A total of %(count)d people contributed to this release.
@@ -140,14 +140,14 @@ This list of names is automatically generated, and may not be fully complete.
 
 """ % dict(count=len(authors))).encode('utf-8'))
 
-    stdout_b.write(("\nNOTE: Check this list manually! It is automatically generated "
-                    "and some names\n      may be missing.\n").encode('utf-8'))
+    stdout_b.write(b"\nNOTE: Check this list manually! It is automatically generated "
+                   b"and some names\n      may be missing.\n")
 
 
 def load_name_map(filename):
     name_map = {}
 
-    with open(filename, 'r', encoding='utf-8') as f:
+    with open(filename, encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if line.startswith("#") or not line:
@@ -155,7 +155,7 @@ def load_name_map(filename):
 
             m = re.match(r'^(.*?)\s*<(.*?)>(.*?)\s*<(.*?)>\s*$', line)
             if not m:
-                print("Invalid line in .mailmap: '{!r}'".format(line), file=sys.stderr)
+                print(f"Invalid line in .mailmap: '{line!r}'", file=sys.stderr)
                 sys.exit(1)
 
             new_name = m.group(1).strip()

--- a/tools/check_test_name.py
+++ b/tools/check_test_name.py
@@ -32,7 +32,7 @@ import ast
 import os
 from pathlib import Path
 import sys
-from typing import Iterator, Sequence
+from collections.abc import Iterator, Sequence
 import itertools
 
 PRAGMA = "# skip name check"

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -176,9 +176,8 @@ def expand_sub(substr, names):
             elif num == numsubs:
                 rules[r] = rule
             else:
-                print("Mismatch in number of replacements (base <%s=%s>)"
-                      " for <%s=%s>. Ignoring." %
-                      (base_rule, ','.join(rules[base_rule]), r, thelist))
+                print("Mismatch in number of replacements (base <{}={}>) "
+                      "for <{}={}>. Ignoring.".format(base_rule, ','.join(rules[base_rule]), r, thelist))
     if not rules:
         return substr
 

--- a/tools/gh_lists.py
+++ b/tools/gh_lists.py
@@ -61,17 +61,17 @@ def main():
             print(msg)
         print()
 
-    msg = "Issues closed for {0}".format(args.milestone)
+    msg = f"Issues closed for {args.milestone}"
     print_list(msg, issues)
 
-    msg = "Pull requests for {0}".format(args.milestone)
+    msg = f"Pull requests for {args.milestone}"
     print_list(msg, prs)
 
     return 0
 
 
 def get_milestones(getter, project):
-    url = "https://api.github.com/repos/{project}/milestones".format(project=project)
+    url = f"https://api.github.com/repos/{project}/milestones"
     data = getter.get(url)
 
     milestones = {}
@@ -110,9 +110,9 @@ class CachedGet:
 
         self.filename = filename
         if os.path.isfile(filename):
-            print("[gh_lists] using {0} as cache (remove it if you want fresh data)".format(filename),
+            print(f"[gh_lists] using {filename} as cache (remove it if you want fresh data)",
                   file=sys.stderr)
-            with open(filename, 'r', encoding='utf-8') as f:
+            with open(filename, encoding='utf-8') as f:
                 self.cache = json.load(f)
         else:
             self.cache = {}
@@ -159,7 +159,7 @@ class GithubGet:
               file=sys.stderr, flush=True)
         print("Access token: ", file=sys.stderr, end='', flush=True)
         token = input()
-        self.headers['Authorization'] = 'token {0}'.format(token.strip())
+        self.headers['Authorization'] = f'token {token.strip()}'
 
     def urlopen(self, url, auth=None):
         assert url.startswith('https://')
@@ -181,7 +181,7 @@ class GithubGet:
                 s = self.ratelimit_reset + 5 - time.time()
                 if s <= 0:
                     break
-                print("[gh_lists] rate limit exceeded: waiting until {0} ({1} s remaining)".format(
+                print("[gh_lists] rate limit exceeded: waiting until {} ({} s remaining)".format(
                          datetime.datetime.fromtimestamp(self.ratelimit_reset).strftime('%Y-%m-%d %H:%M:%S'),
                          int(s)),
                       file=sys.stderr, flush=True)

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -1,7 +1,7 @@
 line-length = 88
 
 # Enable Pyflakes `E` and `F` codes by default.
-select = ["E", "F", "PGH004"]
+select = ["E", "F", "PGH004", "UP"]
 ignore = ["E741"]
 exclude = ["scipy/datasets/_registry.py"]
 

--- a/tools/ninjatracing.py
+++ b/tools/ninjatracing.py
@@ -124,10 +124,8 @@ def embed_time_trace(ninja_log_dir, target, pid, tid, options):
         o_path = os.path.join(ninja_log_dir, t)
         json_trace_path = os.path.splitext(o_path)[0] + '.json'
         try:
-            with open(json_trace_path, 'r') as trace:
-                for time_trace_event in trace_to_dicts(target, trace, options,
-                                                       pid, tid):
-                    yield time_trace_event
+            with open(json_trace_path) as trace:
+                yield from trace_to_dicts(target, trace, options, pid, tid)
         except OSError:
             pass
 
@@ -151,9 +149,7 @@ def log_to_dicts(log, pid, options):
                 ninja_log_dir = os.path.dirname(log.name)
             except AttributeError:
                 continue
-            for time_trace in embed_time_trace(ninja_log_dir, target, pid,
-                                               tid, options):
-                yield time_trace
+            yield from embed_time_trace(ninja_log_dir, target, pid, tid, options)
 
 
 def main(argv):
@@ -177,7 +173,7 @@ def main(argv):
 
     entries = []
     for pid, log_file in enumerate(options.logfiles):
-        with open(log_file, 'r') as log:
+        with open(log_file) as log:
             entries += list(log_to_dicts(log, pid, vars(options)))
     json.dump(entries, sys.stdout)
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -334,7 +334,7 @@ def validate_rst_syntax(text, name, dots=True):
     if text is None:
         if dots:
             output_dot('E')
-        return False, "ERROR: %s: no documentation" % (name,)
+        return False, f"ERROR: {name}: no documentation"
 
     ok_unknown_items = set([
         'mod', 'currentmodule', 'autosummary', 'data', 'legacy',
@@ -423,7 +423,7 @@ def check_rest(module, names, dots=True):
         obj = getattr(module, name, None)
 
         if obj is None:
-            results.append((full_name, False, "%s has no docstring" % (full_name,)))
+            results.append((full_name, False, f"{full_name} has no docstring"))
             continue
         elif isinstance(obj, skip_types):
             continue

--- a/tools/refguide_summaries.py
+++ b/tools/refguide_summaries.py
@@ -54,7 +54,7 @@ def main():
     module = importlib.import_module('scipy.' + args.module)
 
     fnew = []
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         line = f.readline()
         while line:
             if '.. autosummary::' in line:

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -97,7 +97,7 @@ def git_version(cwd):
         # commit history. This gives the commit count since the previous branch
         # point from the current branch (assuming a full `git clone`, it may be
         # less if `--depth` was used - commonly the default in CI):
-        prev_version_tag = '^v{}.{}.0'.format(MAJOR, MINOR - 2)
+        prev_version_tag = f'^v{MAJOR}.{MINOR - 2}.0'
         out = _minimal_ext_cmd(['git', '--git-dir', git_dir,
                                 'rev-list', 'HEAD', prev_version_tag,
                                 '--count'])

--- a/tools/wheels/check_license.py
+++ b/tools/wheels/check_license.py
@@ -36,14 +36,14 @@ def main():
 
     # Check license text
     license_txt = os.path.join(os.path.dirname(mod.__file__), "LICENSE.txt")
-    with open(license_txt, "r", encoding="utf-8") as f:
+    with open(license_txt, encoding="utf-8") as f:
         text = f.read()
 
     ok = check_text(text)
     if not ok:
         print(
-            "ERROR: License text {} does not contain expected "
-            "text fragments\n".format(license_txt)
+            f"ERROR: License text {license_txt} does not contain expected "
+            "text fragments\n"
         )
         print(text)
         sys.exit(1)

--- a/tools/write_release_and_log.py
+++ b/tools/write_release_and_log.py
@@ -70,7 +70,7 @@ def compute_md5(idirs):
         fn_updated = os.path.join("release", fn)
         with open(fn_updated, 'rb') as f:
             m = md5(f.read())
-        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(fn)))
+        checksums.append(f'{m.hexdigest()}  {os.path.basename(fn)}')
     return checksums
 
 
@@ -83,7 +83,7 @@ def compute_sha256(idirs):
         fn_updated = os.path.join("release", fn)
         with open(fn_updated, 'rb') as f:
             m = sha256(f.read())
-        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(fn)))
+        checksums.append(f'{m.hexdigest()}  {os.path.basename(fn)}')
 
     return checksums
 
@@ -119,7 +119,7 @@ SHA256
 
 def write_log_task(filename='Changelog'):
     st = subprocess.Popen(
-        ['git', 'log', '%s..%s' % (LOG_START, LOG_END)],
+        ['git', 'log', f'{LOG_START}..{LOG_END}'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = st.communicate()
     if not st.returncode == 0:


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/18353#issuecomment-1808711017

#### What does this implement/fix?
- The UP rules are enabled in the linter
- All existing violations are cleaned up

Quoting @stefanv :

> The [Ruff PyUpgrade rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up) ensure that SciPy uses modern Python constructs that work with all support Python versions.
> While the linter only runs on files touched in any given PR, we have the option to apply these rules wholesale each time we drop support for another version of Python.
> This keeps our code current, at low cost to maintainers.

#### Additional information
The vast majority of these changes were made automatically by Ruff's `--fix`, with the rest (changing from `Union` typing and to `yield from`) made by me.

Due to the automatic fixes, further (minor) style cleanups are possible here, but I don't know if they're worth the effort (or worth delaying this PR for).

The blame ignore will be added once this is ready.