### PR TITLE
MAINT, REL: unpin Python 1.11.x branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.21.6,<1.28.0",
 ]


### PR DESCRIPTION
* this patch against our latest maintenance branch is related to gh-19513, and NumPy made a similar decision upstream in https://github.com/numpy/numpy/pull/24962

* the discussions surrounding this are pretty confusing, but it seems like we may need to do it for resolvers like those used by `poetry`...

* I suppose this increases the likelihood I have to do `1.11.4`, but it was looking somewhat likely anyway...

[skip cirrus] [skip circle]