### PR TITLE
MAINT/STY: fft: remove E501 (line length) lint ignore, `noqa` clean-up

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,5 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 49858c5fb2bf479b17a0bf42a7397d73f45f1b31
 # Line length clean up in odr (gh-19514)
 877f1cc34ad2147340684bcadfbf884d47f5a954
+# Line length clean up in fft (gh-19520)
+9d41d85c472438cf17211b843de7c770868d25a4

--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -84,7 +84,7 @@ def set_global_backend(backend, coerce=False, only=False, try_last=False):
     We can set the global fft backend:
 
     >>> from scipy.fft import fft, set_global_backend
-    >>> set_global_backend("scipy")  # Sets global backend. "scipy" is the default backend.
+    >>> set_global_backend("scipy")  # Sets global backend (default is "scipy").
     >>> fft([1])  # Calls the global backend
     array([1.+0.j])
     """
@@ -121,7 +121,9 @@ def register_backend(backend):
     ...          return NotImplemented
     >>> set_global_backend(NoopBackend())  # Set the invalid backend as global
     >>> register_backend("scipy")  # Register a new backend
-    >>> fft([1])  # The registered backend is called because the global backend returns `NotImplemented`
+    # The registered backend is called because
+    # the global backend returns `NotImplemented`
+    >>> fft([1])
     array([1.+0.j])
     >>> set_global_backend("scipy")  # Restore global backend to default
 

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -157,7 +157,8 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     >>> sp = fftshift(fft(np.sin(t)))
     >>> freq = fftshift(fftfreq(t.shape[-1]))
     >>> plt.plot(freq, sp.real, freq, sp.imag)
-    [<matplotlib.lines.Line2D object at 0x...>, <matplotlib.lines.Line2D object at 0x...>]
+    [<matplotlib.lines.Line2D object at 0x...>,
+     <matplotlib.lines.Line2D object at 0x...>]
     >>> plt.show()
 
     """

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -6,7 +6,9 @@ import contextlib
 
 import numpy as np
 # good_size is exposed (and used) from this import
-from .pypocketfft import good_size  # noqa: F401
+from .pypocketfft import good_size
+
+__all__ = ['good_size', 'set_workers', 'get_workers']
 
 _config = threading.local()
 _cpu_count = os.cpu_count()

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -27,7 +27,6 @@ target-version = "py39"
 "scipy/_lib/**" = ["E501"]
 "scipy/cluster/**" = ["E501"]
 "scipy/constants/**" = ["E501"]
-"scipy/fft/**" = ["E501"]
 "scipy/integrate/**" = ["E501"]
 "scipy/interpolate/**" = ["E501"]
 "scipy/io/**" = ["E501"]


### PR DESCRIPTION
#### Reference issue
Towards gh-19479.

#### What does this implement/fix?
- Follow-up to gh-19489 for `fft`.
- Clean up a `noqa` for unused import by introducing an `__all__`.

#### Additional information
I can add in a git blame ignore if wanted once this is ready.

cc @mdhaber @j-bowhay. Feel free to wait for gh-19497 if you don't want to test locally.