### PR TITLE
DOC, CI: refguide may vary locs

### DIFF
--- a/doc/source/tutorial/arpack.rst
+++ b/doc/source/tutorial/arpack.rst
@@ -292,7 +292,7 @@ same first derivative to an input signal:
     >>> evals_all_imag[-4:]
     array([-0.95105652, 0.95105652, -0.98768834, 0.98768834])
     >>> evals_large_imag
-    array([0.95105652, -0.95105652, 0.98768834, -0.98768834])
+    array([0.95105652, -0.95105652, 0.98768834, -0.98768834]) # may vary
 
 Note that the eigenvalues of this operator are all imaginary. Moreover,
 the keyword ``which='LI'`` of :func:`scipy.sparse.linalg.eigs` produces

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -94,8 +94,8 @@ code block for the example parameters ``a=0.5`` and ``b=1``.
     ...	               args=(0.5, 1.), options={'xatol': 1e-8, 'disp': True})
     Optimization terminated successfully.
              Current function value: 1.000000
-             Iterations: 319
-             Function evaluations: 525
+             Iterations: 319 # may vary
+             Function evaluations: 525 # may vary
 
     >>> print(res.x)
     [1.         1.         1.         1.         0.99999999]


### PR DESCRIPTION
* add `# may vary` to two doc examples in attempt to repair refguide-check circleCI fails like this
one:
https://app.circleci.com/pipelines/github/scipy/scipy/23372/workflows/09f8210c-c813-44a7-88ec-7377cb1882d8/jobs/78647

* I actually see completely different issues with refguide locally, so wasn't able to repro + fix what we see in the CI locally

[skip cirrus] [skip actions]