### PR TITLE
MAINT: get rid of more Python 2 left-overs

### DIFF
--- a/tools/authors.py
+++ b/tools/authors.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding:utf-8 -*-
 """
 List the authors who contributed within a given revision interval::
 

--- a/tools/gh_lists.py
+++ b/tools/gh_lists.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- encoding:utf-8 -*-
 """
 gh_lists.py MILESTONE
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?

Get rid of a couple `# -*- encoding:utf-8 -*`.

#### Additional information

These might have been previously skipped because of the missing space after the colon.