### PR TITLE
MAINT: Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "MAINT"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
This PR introduces a Dependabot configuration that will submit a single PR on a monthly basis to update GitHub action versions. The PR will batch all available action updates together.

If this merges, you can anticipate a single PR to be opened immediately to update e.g. `actions/checkout@v3` to `v4`.

#### Additional information
No additional info. I think that I followed the pre-PR checklist and followed the contributing guidelines, but please let me know if there's anything that needs to be addressed (for example, if I need to mark the commit as signed-off-by or something like that). Thanks!