### PR TITLE
ENH: improve `scipy.special.log_softmax` accuracy in edge cases by a factor of `2**126` to `2**1022`

### DIFF
--- a/scipy/special/tests/test_log_softmax.py
+++ b/scipy/special/tests/test_log_softmax.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -8,14 +9,6 @@ import scipy.special as sc
 
 @pytest.mark.parametrize('x, expected', [
     (np.array([1000, 1]), np.array([0, -999])),
-    # we shouldn't return zero on the smallest subnormal input
-    (np.array([-np.log(np.finfo(np.float32).smallest_subnormal), 0], dtype=np.float32),
-     np.array([float.fromhex('-0x1.00000p-149'), float.fromhex('-0x1.9d1dap+6')],
-              dtype=np.float32)),
-    (np.array([-np.log(np.finfo(np.float64).smallest_subnormal), 0], dtype=np.float64),
-     np.array([float.fromhex('-0x0.0000000000001p-1022'),
-               float.fromhex('-0x1.74385446d71c3p+9')],
-              dtype=np.float64)),
 
     # Expected value computed using mpmath (with mpmath.mp.dps = 200) and then
     # converted to float.
@@ -26,6 +19,26 @@ import scipy.special as sc
 ])
 def test_log_softmax(x, expected):
     assert_allclose(sc.log_softmax(x), expected, rtol=1e-13)
+
+
+@pytest.mark.parametrize('x, expected', [
+    # we shouldn't return zero on the smallest subnormal input
+    (np.array([-np.log(np.finfo(np.float32).smallest_subnormal), 0], dtype=np.float32),
+     np.array([float.fromhex('-0x1.00000p-149'), float.fromhex('-0x1.9d1dap+6')],
+              dtype=np.float32)),
+    (np.array([-np.log(np.finfo(np.float64).smallest_subnormal), 0], dtype=np.float64),
+     np.array([float.fromhex('-0x0.0000000000001p-1022'),
+               float.fromhex('-0x1.74385446d71c3p+9')],
+              dtype=np.float64)),
+])
+def test_log_softmax_use_atol_on_windows(x, expected):
+    # Windows has a bugged implementation of floating point arithmetic, see
+    # https://github.com/scipy/scipy/pull/19549#discussion_r1458551340
+    if os.name == 'nt':  # Check if the operating system is Windows
+        atol = np.finfo(x.dtype).smallest_subnormal
+        assert_allclose(sc.log_softmax(x), expected, atol=atol)
+    else:
+        assert_allclose(sc.log_softmax(x), expected, rtol=1e-13)
 
 
 @pytest.fixture

--- a/scipy/special/tests/test_log_softmax.py
+++ b/scipy/special/tests/test_log_softmax.py
@@ -8,6 +8,14 @@ import scipy.special as sc
 
 @pytest.mark.parametrize('x, expected', [
     (np.array([1000, 1]), np.array([0, -999])),
+    # we shouldn't return zero on the smallest subnormal input
+    (np.array([-np.log(np.finfo(np.float32).smallest_subnormal), 0], dtype=np.float32),
+     np.array([float.fromhex('-0x1.00000p-149'), float.fromhex('-0x1.9d1dap+6')],
+              dtype=np.float32)),
+    (np.array([-np.log(np.finfo(np.float64).smallest_subnormal), 0], dtype=np.float64),
+     np.array([float.fromhex('-0x0.0000000000001p-1022'),
+               float.fromhex('-0x1.74385446d71c3p+9')],
+              dtype=np.float64)),
 
     # Expected value computed using mpmath (with mpmath.mp.dps = 200) and then
     # converted to float.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #19521

#### What does this implement/fix?
By taking advantage of the fact that `x - x_max` is going to be 0 at the maximum and that `exp(0)` is 1, we can use `log1p` instead of `log` to increase the accuracy of `log_softmax` at the maximum index by a factor of about `2**126` (for float32) or about `2**1022` (for float64) when there is a single maximum value that is much larger than other values.  Most values should not be impacted.

#### Additional information
I've done some manual testing locally, but I'm not sure how to actually run all the tests, since `python dev.py test -v` fails with
<details><summary>fatal error: bits/timesize.h: No such file or directory</summary>

```
FAILED: scipy/stats/_stats_pythran.cpython-311-x86_64-linux-gnu.so.p/meson-generated_..__stats_pythran.cpp.o
/home/jgross/.local64/mambaforge/envs/scipy-dev/bin/x86_64-conda-linux-gnu-c++ -Iscipy/stats/_stats_pythran.cpython-311-x86_64-linux-gnu.so.p -Iscipy/stats -I../scipy/stats -I../../../../.local64/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/pythran -I../../../../.local64/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/numpy/core/include -I/usr/include -I/home/jgross/.local64/mambaforge/envs/scipy-dev/include/python3.11 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++14 -O2 -g -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /home/jgross/.local64/mambaforge/envs/scipy-dev/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /home/jgross/.local64/mambaforge/envs/scipy-dev/include -fPIC -DENABLE_PYTHON_MODULE -D__PYTHRAN__=3 -DPYTHRAN_BLAS_NONE -Wno-cpp -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-variable -Wno-int-in-bool-context -MD -MQ scipy/stats/_stats_pythran.cpython-311-x86_64-linux-gnu.so.p/meson-generated_..__stats_pythran.cpp.o -MF scipy/stats/_stats_pythran.cpython-311-x86_64-linux-gnu.so.p/meson-generated_..__stats_pythran.cpp.o.d -o scipy/stats/_stats_pythran.cpython-311-x86_64-linux-gnu.so.p/meson-generated_..__stats_pythran.cpp.o -c scipy/stats/_stats_pythran.cpp
In file included from /usr/include/features.h:392,
                 from /home/jgross/.local64/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.3.0/x86_64-conda-linux-gnu/bits/os_defines.h:39,
                 from /home/jgross/.local64/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.3.0/x86_64-conda-linux-gnu/bits/c++config.h:655,
                 from /home/jgross/.local64/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.3.0/type_traits:38,
                 from ../../../../.local64/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/pythran/pythonic/include/types/assignable.hpp:4,
                 from ../../../../.local64/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/pythran/pythonic/types/assignable.hpp:4,
                 from ../../../../.local64/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/pythran/pythonic/core.hpp:41,
                 from scipy/stats/_stats_pythran.cpp:1:
/usr/include/features-time64.h:21:10: fatal error: bits/timesize.h: No such file or directory
   21 | #include <bits/timesize.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```
</details>

So I'm relying on CI to run the tests that I added.