### PR TITLE
MAINT, BLD: poetry loongarch shims

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ requires = [
     # now matches minimum supported version, keep here as separate requirement
     # to be able to sync more easily with oldest-supported-numpy
     # loongarch64 requires numpy>=1.22.0
-    "numpy==1.22.0; platform_machine=='loongarch64'",
+    "numpy==1.22.0; python_version<'3.11' and platform_machine=='loongarch64'",
 
     # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
     # built with vc142. 1.22.3 is the first version that has 32-bit Windows
     # wheels *and* was built with vc141. So use that:
-    "numpy==1.22.3; python_version=='3.9' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+    "numpy==1.22.3; python_version=='3.9' and platform_system=='Windows' and platform_python_implementation != 'PyPy' and platform_machine!='loongarch64'",
+    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy' and platform_machine!='loongarch64'",
 
     # default numpy requirements
     "numpy==1.21.6; python_version=='3.9' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",


### PR DESCRIPTION
(PR against maintenance branch, the issue doesn't really exist on `main`, or is at least a different situation there...)

* Fixes gh-19189
* Fixes gh-19437
* I was able to reproduce both using `poetry install` inside of a mock project (https://github.com/tylerjereddy/poetry-demo) locally pointing to our latest `maintenance/1.11.x` branch (fixing one of the issues cascades to the other)
* the changes in this patch allow the poetry version solving to pass locally; the basic idea was to bend over backwards to allow `loongarch` to be a special snowflake for Python up to `3.10` (the Windows combination can't happen anyway, as Ralf previously noted), and then to just let it follow the "defaults" at and beyond `3.11`
* at the time of writing I don't think there's much hope to test this automatically in CI; even locally, I experienced extraordinarly slow dependency resolution times per https://github.com/python-poetry/poetry/issues/2094, often many minutes long...

[skip cirrus]