### PR TITLE
DOC: Small documentation and docstring corrections for `ShortTimeFFT`

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1174,7 +1174,7 @@ Note that an inverse STFT does not necessarily exist for all windows and hop siz
 window :math:`w[m]` the hop size :math:`h` must be small enough to ensure that
 every sample of :math:`x[k]` is touched by a non-zero value of at least one
 window slice. This is sometimes referred as the "non-zero overlap condition"
-(see :func:`check_NOLA <scipy.signal.check_NOLA>`). Some more details are
+(see :func:`~scipy.signal.check_NOLA`). Some more details are
 given in the subsection :ref:`tutorial_stft_dual_win`.
 
 .. _tutorial_stft_sliding_win:
@@ -1258,8 +1258,7 @@ will be sketched out in the following:
 Since the STFT given in Eq. :math:numref:`eq_dSTFT` is a linear mapping in
 :math:`x[k]`, it can be expressed in vector-matrix notation. This allows us to
 express the inverse via the formal solution of the linear least squares method
-(as in :func:`lstsq <scipy.linalg.lstsq>`), which leads to a beautiful and
-simple result.
+(as in :func:`~scipy.linalg.lstsq`), which leads to a beautiful and simple result.
 
 We begin by reformulating the windowing of Eq. :math:numref:`eq_STFT_windowing`
 
@@ -1463,8 +1462,7 @@ with a negative slope:
     >>> f0, Sz0 = fftshift(f0_u), fftshift(Sz0_u, axes=0)
     ...
     >>> # New STFT:
-    >>> SFT = ShortTimeFFT.from_window(win, fs, nperseg, noverlap,
-    ...                                fft_mode='centered',
+    >>> SFT = ShortTimeFFT.from_window(win, fs, nperseg, noverlap, fft_mode='centered',
     ...                                scale_to='magnitude', phase_shift=None)
     >>> Sz1 = SFT.stft(z)
     ...
@@ -1472,16 +1470,16 @@ with a negative slope:
     >>> fig1, axx = plt.subplots(2, 1, sharex='all', sharey='all',
     ...                          figsize=(6., 5.))  # enlarge figure a bit
     >>> t_lo, t_hi, f_lo, f_hi = SFT.extent(N, center_bins=True)
-    >>> t_str0 = r"Legacy stft() produces $%d\times%d$ points" % Sz0.T.shape
-    >>> t_str1 = r"ShortTimeFFT produces $%d\times%d$ points" % Sz1.T.shape
-    >>> _ = axx[0].set(title=t_str0, xlim=(t_lo, t_hi), ylim=(f_lo, f_hi))
-    >>> _ = axx[1].set(title=t_str1, xlabel="Time $t$ in seconds " +
-    ...                rf"($\Delta t= %g\,$s)" % SFT.delta_t)
+    >>> axx[0].set_title(r"Legacy stft() produces $%d\times%d$ points" % Sz0.T.shape)
+    >>> axx[0].set_xlim(t_lo, t_hi)
+    >>> axx[0].set_ylim(f_lo, f_hi)
+    >>> axx[1].set_title(r"ShortTimeFFT produces $%d\times%d$ points" % Sz1.T.shape)
+    >>> axx[1].set_xlabel(rf"Time $t$ in seconds ($\Delta t= {SFT.delta_t:g}\,$s)")
     ...
-    >>> # Calculate extent of plot with centered bins since imshow
-    ... # does not interpolate by default:
-    ... dt2 = (nperseg-noverlap) / fs  / 2 # equals SFT.delta_t / 2
-    >>> df2 = fs / nperseg / 2 # equals SFT.delta_f / 2
+    >>> # Calculate extent of plot with centered bins since
+    >>> # imshow does not interpolate by default:
+    >>> dt2 = (nperseg-noverlap) / fs / 2  # equals SFT.delta_t / 2
+    >>> df2 = fs / nperseg / 2  # equals SFT.delta_f / 2
     >>> extent0 = (-dt2, t0[-1] + dt2, f0[0] - df2, f0[-1] - df2)
     >>> extent1 = SFT.extent(N, center_bins=True)
     ...
@@ -1489,8 +1487,8 @@ with a negative slope:
     >>> im1a = axx[0].imshow(abs(Sz0), extent=extent0, **kw)
     >>> im1b = axx[1].imshow(abs(Sz1), extent=extent1, **kw)
     >>> fig1.colorbar(im1b, ax=axx, label="Magnitude $|S_z(t, f)|$")
-    >>> _ = fig1.supylabel(rf"Frequency $f$ in Hertz ($\Delta f = %g\,$Hz)" %
-    ...                    SFT.delta_f)
+    >>> _ = fig1.supylabel(r"Frequency $f$ in Hertz ($\Delta f = %g\,$Hz)" %
+    ...                    SFT.delta_f, x=0.08, y=0.5, fontsize='medium')
     >>> plt.show()
 
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -274,7 +274,7 @@ Spectral analysis
    welch          -- Compute a periodogram using Welch's method.
    csd            -- Compute the cross spectral density, using Welch's method.
    coherence      -- Compute the magnitude squared coherence, using Welch's method.
-   spectrogram    -- Compute the spectrogram.
+   spectrogram    -- Compute the spectrogram (legacy).
    lombscargle    -- Computes the Lomb-Scargle periodogram.
    vectorstrength -- Computes the vector strength.
    ShortTimeFFT   -- Interface for calculating the \

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -529,14 +529,14 @@ class ShortTimeFFT:
 
         'twosided':
             Two-sided FFT, where values for the negative frequencies are in
-            upper half of the array. Corresponds to :func:`scipy.fft.fft()`.
+            upper half of the array. Corresponds to :func:`~scipy.fft.fft()`.
         'centered':
             Two-sided FFT with the values being ordered along monotonically
             increasing frequencies. Corresponds to applying
-            :func:`scipy.fft.fftshift()` to :func:`scipy.fft.fft()`.
+            :func:`~scipy.fft.fftshift()` to :func:`~scipy.fft.fft()`.
         'onesided':
             Calculates only values for non-negative frequency values.
-            Corresponds to :func:`scipy.fft.rfft()`.
+            Corresponds to :func:`~scipy.fft.rfft()`.
         'onesided2X':
             Like `onesided`, but the non-zero frequencies are doubled if
             `scaling` is set to 'magnitude' or multiplied by ``sqrt(2)`` if
@@ -613,8 +613,8 @@ class ShortTimeFFT:
         If not ``None``, the FFTs can be either interpreted as a magnitude or
         a power spectral density spectrum.
 
-        The window function can be scaled by calling the `scale_to()` method,
-        or it is set by the initializer parameter `scale_to`.
+        The window function can be scaled by calling the `scale_to` method,
+        or it is set by the initializer parameter ``scale_to``.
 
         See Also
         --------
@@ -1628,7 +1628,7 @@ class ShortTimeFFT:
         """Return minimum and maximum values time-frequency values.
 
         A tuple with four floats  ``(t0, t1, f0, f1)`` for 'tf' and
-        ``(f0, f1, t0, t1)`` for 'ft') is returned describing the corners
+        ``(f0, f1, t0, t1)`` for 'ft' is returned describing the corners
         of the time-frequency domain of the `~ShortTimeFFT.stft`.
         That tuple can be passed to `matplotlib.pyplot.imshow` as a parameter
         with the same name.

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -615,7 +615,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):
-    """Compute a spectrogram with consecutive Fourier transforms.
+    """Compute a spectrogram with consecutive Fourier transforms (legacy function).
 
     Spectrograms can be used as a way of visualizing the change of a
     nonstationary signal's frequency content over time.
@@ -1047,7 +1047,7 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
 def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
          detrend=False, return_onesided=True, boundary='zeros', padded=True,
          axis=-1, scaling='spectrum'):
-    r"""Compute the Short Time Fourier Transform (STFT).
+    r"""Compute the Short Time Fourier Transform (legacy function).
 
     STFTs can be used as a way of quantifying the change of a
     nonstationary signal's frequency and phase content over time.
@@ -1238,7 +1238,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
 def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
           input_onesided=True, boundary=True, time_axis=-1, freq_axis=-2,
           scaling='spectrum'):
-    r"""Perform the inverse Short Time Fourier transform (iSTFT).
+    r"""Perform the inverse Short Time Fourier transform (legacy function).
 
     .. legacy:: function
 


### PR DESCRIPTION
* Marked function `stft()`, `istft()` and `spectrogram()` as legacy in docstrings. This is a helpful clarification in the [function list](https://scipy.github.io/devdocs/reference/signal.html#spectral-analysis) of the API reference.
* Beautified the Python code example in `signal.rst` a little bit
* A few small fixes in `signal.rst` and `_short_time_fft.py`

[skip actions] [skip cirrus]