### PR TITLE
MAINT: forward port 1.11.4 relnotes

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.11.3 (stable)",
+        "name": "1.11.4 (stable)",
+        "version":"1.11.4",
+        "url": "https://docs.scipy.org/doc/scipy-1.11.4/"
+    },
+    {
+        "name": "1.11.3",
         "version":"1.11.3",
         "url": "https://docs.scipy.org/doc/scipy-1.11.3/"
     },

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -9,6 +9,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
    :maxdepth: 1
 
    release/1.12.0-notes
+   release/1.11.4-notes
    release/1.11.3-notes
    release/1.11.2-notes
    release/1.11.1-notes

--- a/doc/source/release/1.11.4-notes.rst
+++ b/doc/source/release/1.11.4-notes.rst
@@ -1,0 +1,62 @@
+==========================
+SciPy 1.11.4 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.11.4 is a bug-fix release with no new features
+compared to 1.11.3.
+
+
+
+Authors
+=======
+* Name (commits)
+* Jake Bowhay (2)
+* Ralf Gommers (4)
+* Julien Jerphanion (2)
+* Nikolay Mayorov (2)
+* Melissa Weber Mendonça (1)
+* Tirth Patel (1)
+* Tyler Reddy (22)
+* Dan Schult (3)
+* Nicolas Vetsch (1) +
+
+A total of 9 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
+
+
+Issues closed for 1.11.4
+------------------------
+
+* `#19189 <https://github.com/scipy/scipy/issues/19189>`__: Contradiction in \`pyproject.toml\` requirements?
+* `#19228 <https://github.com/scipy/scipy/issues/19228>`__: Doc build fails with Python 3.11
+* `#19245 <https://github.com/scipy/scipy/issues/19245>`__: BUG: upcasting of indices dtype from DIA to COO/CSR/BSR arrays
+* `#19351 <https://github.com/scipy/scipy/issues/19351>`__: BUG: Regression in 1.11.3 can still fail for \`optimize.least_squares\`...
+* `#19357 <https://github.com/scipy/scipy/issues/19357>`__: BUG: build failure with Xcode 15 linker
+* `#19359 <https://github.com/scipy/scipy/issues/19359>`__: BUG: DiscreteAliasUrn construction fails with UNURANError for...
+* `#19387 <https://github.com/scipy/scipy/issues/19387>`__: BUG: problem importing libgfortran.5.dylib on macOS Sonoma
+* `#19403 <https://github.com/scipy/scipy/issues/19403>`__: BUG: scipy.sparse.lil_matrix division by complex number leads...
+* `#19437 <https://github.com/scipy/scipy/issues/19437>`__: BUG: can't install scipy on mac m1 with poetry due to incompatible...
+* `#19500 <https://github.com/scipy/scipy/issues/19500>`__: DOC: doc build failing
+* `#19513 <https://github.com/scipy/scipy/issues/19513>`__: BUG: Python version constraints in releases causes issues for...
+
+
+Pull requests for 1.11.4
+------------------------
+
+* `#19230 <https://github.com/scipy/scipy/pull/19230>`__: DOC, MAINT: workaround for py311 docs
+* `#19307 <https://github.com/scipy/scipy/pull/19307>`__: set idx_dtype in sparse dia_array.tocoo
+* `#19316 <https://github.com/scipy/scipy/pull/19316>`__: MAINT: Prep 1.11.4
+* `#19320 <https://github.com/scipy/scipy/pull/19320>`__: BLD: fix up version parsing issue in cythonize.py for setup.py...
+* `#19329 <https://github.com/scipy/scipy/pull/19329>`__: DOC: stats.chisquare: result object contains attribute 'statistic'
+* `#19335 <https://github.com/scipy/scipy/pull/19335>`__: BUG: fix pow method for sparrays with power zero
+* `#19364 <https://github.com/scipy/scipy/pull/19364>`__: MAINT, BUG: stats: update the UNU.RAN submodule with DAU fix
+* `#19379 <https://github.com/scipy/scipy/pull/19379>`__: BUG: Restore the original behavior of 'trf' from least_squares...
+* `#19400 <https://github.com/scipy/scipy/pull/19400>`__: BLD: use classic linker on macOS 14 (Sonoma), the new linker...
+* `#19408 <https://github.com/scipy/scipy/pull/19408>`__: BUG: Fix typecasting problem in scipy.sparse.lil_matrix truediv
+* `#19504 <https://github.com/scipy/scipy/pull/19504>`__: DOC, MAINT: Bump CircleCI Python version to 3.11
+* `#19517 <https://github.com/scipy/scipy/pull/19517>`__: MAINT, REL: unpin Python 1.11.x branch
+* `#19550 <https://github.com/scipy/scipy/pull/19550>`__: MAINT, BLD: poetry loongarch shims


### PR DESCRIPTION
* forward port SciPy `1.11.4` release notes + version switcher adjustment following the release yesterday

[skip cirrus] [skip actions]