### PR TITLE
MAINT: Mark in `.gitignore` the directories instead of their content  as ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *~
 *$
 *.bak
-.idea/*
+.idea/
 *.kdev4
 *.org
 .project
@@ -85,8 +85,8 @@ pip-wheel-metadata
 #########
 .mesonpy-native-file.ini
 installdir/
-build-install/*
-.mesonpy/*
+build-install/
+.mesonpy/
 
 # doit
 ######
@@ -103,17 +103,17 @@ build-install/*
 
 # pytest cache #
 ################
-.cache/*
-.pytest_cache/*
+.cache/
+.pytest_cache/
 
 # mypy cache #
 ##############
-.mypy_cache/*
+.mypy_cache/
 
 # linter #
 ##########
-.ruff_cache/*
-.pre-commit-workdir/*
+.ruff_cache/
+.pre-commit-workdir/
 
 # Patches #
 ###########


### PR DESCRIPTION
This is a small improvement in the spirit of resolving #18900: This PR marks the directories instead of their content to be ignored, so they will be displayed as ignored by PyCharm and others.  This is possible since those directories themselves are not controlled by Git.

A use case arises when trying to rebuild SciPy with a non-empty `build-install` directory (as happened [here](https://github.com/scipy/scipy/issues/14740#issuecomment-1818882894)). If the directory is marked as ignored, the user knows that it can be deleted without breaking the source tree.

[skip actions] [skip cirrus]