### PR TITLE
DOC: update Building from source docs for editable installs

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -379,29 +379,33 @@ interface is self-documenting, so please see ``python dev.py --help`` and
 .. admonition:: IDE support & editable installs
 
     While the ``dev.py`` interface is our recommended way of working on SciPy,
-    it has one limitation: because of the custom install location, setting
-    breakpoints inside an IDE or debugger does not work as expected. This will
-    only work with an *in-place build* (or "editable install").
+    it has one limitation: because of the custom install location, SciPy
+    installed using ``dev.py`` will not be recognized automatically within an
+    IDE (e.g., for running a script via a "run" button, or setting breakpoints
+    visually). This will work better with an *in-place build* (or "editable
+    install").
 
     Editable installs are supported. It is important to understand that **you
-    must use either an editable install or dev.py, but not both**. If you use
-    editable installs, you can use ``pytest`` and other development tools
-    directly instead of using ``dev.py``.
+    may use either an editable install or dev.py in a given repository clone,
+    but not both**. If you use editable installs, you have to use ``pytest``
+    and other development tools directly instead of using ``dev.py``.
 
     To use an editable install, ensure you start from a clean repository (run
-    ``git clean -xdf`` if you've built with ``dev.py`` before) and have all dependencies set up correctly as described higher up on this page. Then do::
+    ``git clean -xdf`` if you've built with ``dev.py`` before) and have all
+    dependencies set up correctly as described higher up on this page. Then
+    do::
 
         # Note: the --no-build-isolation is important! meson-python will
-        # auto-rebuild each time Scipy is imported by the Python interpreter.
+        # auto-rebuild each time SciPy is imported by the Python interpreter.
         pip install -e . --no-build-isolation
 
         # To run the tests for, e.g., the `scipy.linalg` module:
         pytest scipy/linalg
 
     When making changes to SciPy code, including to compiled code, there is no
-    need to manually rebuild. When you run ``git clean -xdf``, which removes
-    the built extension modules, remember to also uninstall SciPy with ``pip
-    uninstall scipy``.
+    need to manually rebuild or reinstall. When you run ``git clean -xdf``,
+    which removes the built extension modules, remember to also uninstall SciPy
+    with ``pip uninstall scipy``.
 
     See the meson-python_ documentation on editable installs for more details
     on how things work under the hood.

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -246,7 +246,7 @@ Building from source to use SciPy
       mamba env create -f environment.yml
 
       # Or, install only the required build dependencies
-      mamba install python numpy cython pythran pybind11 compilers openblas pkg-config
+      mamba install python numpy cython pythran pybind11 compilers openblas meson-python pkg-config
 
       # To build the latest stable release:
       pip install scipy --no-build-isolation --no-binary scipy
@@ -353,7 +353,7 @@ virtual environments:
     PyPI with::
 
        # Build dependencies
-       python -m pip install numpy cython pythran pybind11 meson ninja pydevtool rich-click
+       python -m pip install numpy cython pythran pybind11 meson-python ninja pydevtool rich-click
 
        # Test and optional runtime dependencies
        python -m pip install pytest pytest-xdist pytest-timeout pooch threadpoolctl asv gmpy2 mpmath hypothesis

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -376,6 +376,37 @@ interface is self-documenting, so please see ``python dev.py --help`` and
 ``python dev.py <subcommand> --help`` for detailed guidance.
 
 
+.. admonition:: IDE support & editable installs
+
+    While the ``dev.py`` interface is our recommended way of working on SciPy,
+    it has one limitation: because of the custom install location, setting
+    breakpoints inside an IDE or debugger does not work as expected. This will
+    only work with an *in-place build* (or "editable install").
+
+    Editable installs are supported. It is important to understand that **you
+    must use either an editable install or dev.py, but not both**. If you use
+    editable installs, you can use ``pytest`` and other development tools
+    directly instead of using ``dev.py``.
+
+    To use an editable install, ensure you start from a clean repository (run
+    ``git clean -xdf`` if you've built with ``dev.py`` before) and have all dependencies set up correctly as described higher up on this page. Then do::
+
+        # Note: the --no-build-isolation is important! meson-python will
+        # auto-rebuild each time Scipy is imported by the Python interpreter.
+        pip install -e . --no-build-isolation
+
+        # To run the tests for, e.g., the `scipy.linalg` module:
+        pytest scipy/linalg
+
+    When making changes to SciPy code, including to compiled code, there is no
+    need to manually rebuild. When you run ``git clean -xdf``, which removes
+    the built extension modules, remember to also uninstall SciPy with ``pip
+    uninstall scipy``.
+
+    See the meson-python_ documentation on editable installs for more details
+    on how things work under the hood.
+
+
 Customizing builds
 ------------------
 
@@ -400,3 +431,4 @@ Background information
 
 
 .. _Mambaforge: https://github.com/conda-forge/miniforge#mambaforge
+.. _meson-python: https://mesonbuild.com/meson-python/


### PR DESCRIPTION
This has been quite stable for some months, so it's time to add this as an option to the docs.

Also fixes a small issue with `meson-python` missing from listed dependencies.
    
Closes gh-18900
Closes gh-19565
