### PR TITLE
BUG: Use uint32 for cost in NI_WatershedElement

### DIFF
--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -204,7 +204,7 @@ break
 typedef struct {
     npy_intp index;
     void *next, *prev;
-    npy_uint16 cost;
+    npy_uint32 cost;
     npy_uint8 done;
 } NI_WatershedElement;
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1390,3 +1390,14 @@ class TestWatershedIft:
         expected = [[1, 1],
                     [1, 1]]
         assert_array_almost_equal(out, expected)
+
+    def test_watershed_ift09(self):
+        # Test large cost. See gh-19575
+        data = np.array([[(1 << 16) - 1, 0],
+                         [0, 0]], np.uint16)
+        markers = np.array([[1, 0],
+                            [0, 0]], np.int8)
+        out = ndimage.watershed_ift(data, markers)
+        expected = [[1, 1],
+                    [1, 1]]
+        assert_array_almost_equal(out, expected)

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1,9 +1,15 @@
 import os.path
 
 import numpy as np
-from numpy.testing import (assert_, assert_array_almost_equal, assert_equal,
-                           assert_almost_equal, assert_array_equal,
-                           suppress_warnings)
+from numpy.testing import (
+    assert_,
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    suppress_warnings,
+)
 from pytest import raises as assert_raises
 
 import scipy.ndimage as ndimage
@@ -1393,11 +1399,11 @@ class TestWatershedIft:
 
     def test_watershed_ift09(self):
         # Test large cost. See gh-19575
-        data = np.array([[(1 << 16) - 1, 0],
+        data = np.array([[np.iinfo(np.uint16).max, 0],
                          [0, 0]], np.uint16)
         markers = np.array([[1, 0],
                             [0, 0]], np.int8)
         out = ndimage.watershed_ift(data, markers)
         expected = [[1, 1],
                     [1, 1]]
-        assert_array_almost_equal(out, expected)
+        assert_allclose(out, expected)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #19575

#### What does this implement/fix?
Use larger data type for the cost.

#### Additional information
<!--Any additional information you think is important.-->
