### PR TITLE
BUG: stats._axis_nan_policy_factory: respect too_small when detecting empty inputs

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -380,7 +380,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
     if not callable(too_small):
         def is_too_small(samples, *ts_args, **ts_kwargs):
             for sample in samples:
-                if len(sample) <= too_small:
+                if sample.size <= too_small or len(sample) <= too_small:
                     return True
             return False
     else:
@@ -538,7 +538,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             # exceptions for empty input, so overriding it would break
             # backward compatibility.
             empty_output = _check_empty_inputs(samples, axis)
-            if empty_output is not None:
+            # only return empty output if zero sized input is too small.
+            if is_too_small(samples, kwds) and empty_output is not None:
                 res = [empty_output.copy() for i in range(n_out)]
                 res = _add_reduced_axes(res, reduced_axes, keepdims)
                 return tuple_to_result(*res)

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -128,9 +128,9 @@ def _broadcast_shapes_remove_axis(shapes, axis=None):
     return tuple(shape)
 
 
-def _broadcast_concatenate(arrays, axis):
+def _broadcast_concatenate(arrays, axis, paired=False):
     """Concatenate arrays along an axis with broadcasting."""
-    arrays = _broadcast_arrays(arrays, axis)
+    arrays = _broadcast_arrays(arrays, axis if not paired else None)
     res = np.concatenate(arrays, axis=axis)
     return res
 
@@ -378,7 +378,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             return res
 
     if not callable(too_small):
-        def is_too_small(samples, axis, *ts_args, **ts_kwargs):
+        def is_too_small(samples, *ts_args, axis=-1, **ts_kwargs):
             for sample in samples:
                 if sample.shape[axis] <= too_small:
                     return True
@@ -541,7 +541,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             # only return empty output if zero sized input is too small.
             if (
                 empty_output is not None
-                and (is_too_small(samples, -1, kwds) or empty_output.size == 0)
+                and (is_too_small(samples, kwds) or empty_output.size == 0)
             ):
                 res = [empty_output.copy() for i in range(n_out)]
                 res = _add_reduced_axes(res, reduced_axes, keepdims)
@@ -572,7 +572,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     samples = _remove_nans(samples, paired)
                     if sentinel:
                         samples = _remove_sentinel(samples, paired, sentinel)
-                    if is_too_small(samples, -1, kwds):
+                    if is_too_small(samples, kwds):
                         return np.full(n_out, NaN)
                     return result_to_tuple(hypotest_fun_out(*samples, **kwds))
 
@@ -586,7 +586,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     samples = np.split(x, split_indices)[:n_samp+n_kwd_samp]
                     if sentinel:
                         samples = _remove_sentinel(samples, paired, sentinel)
-                    if is_too_small(samples, -1, kwds):
+                    if is_too_small(samples, kwds):
                         return np.full(n_out, NaN)
                     return result_to_tuple(hypotest_fun_out(*samples, **kwds))
 
@@ -595,7 +595,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     samples = np.split(x, split_indices)[:n_samp+n_kwd_samp]
                     if sentinel:
                         samples = _remove_sentinel(samples, paired, sentinel)
-                    if is_too_small(samples, -1, kwds):
+                    if is_too_small(samples, kwds):
                         return np.full(n_out, NaN)
                     return result_to_tuple(hypotest_fun_out(*samples, **kwds))
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -154,9 +154,9 @@ def entropy(pk: np.typing.ArrayLike,
     return S
 
 
-def _differential_entropy_is_too_small(samples, kwargs):
+def _differential_entropy_is_too_small(samples, axis, kwargs):
     values = samples[0]
-    n = values.shape[-1]
+    n = values.shape[axis]
     window_length = kwargs.get("window_length",
                                math.floor(math.sqrt(n) + 0.5))
     if not 2 <= 2 * window_length < n:

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -114,6 +114,8 @@ inaccuracy_messages = {"Precision loss occurred in moment calculation",
 # For some functions, nan_policy='propagate' should not just return NaNs
 override_propagate_funcs = {stats.mode}
 
+# For some functions, empty arrays produce non-NaN results
+empty_special_case_funcs = {stats.entropy}
 
 def _mixed_data_generator(n_samples, n_repetitions, axis, rng,
                           paired=False):
@@ -691,6 +693,11 @@ def test_empty(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker):
                     sup.filter(RuntimeWarning, "invalid value encountered")
                     expected = np.mean(concat, axis=axis) * np.nan
 
+                if hypotest in empty_special_case_funcs:
+                    empty_val = hypotest(*([[]]*len(samples)), *args, **kwds)
+                    mask = np.isnan(expected)
+                    expected[mask] = empty_val
+
                 res = hypotest(*samples, *args, axis=axis, **kwds)
                 res = unpacker(res)
 
@@ -699,13 +706,14 @@ def test_empty(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker):
 
             except ValueError:
                 # confirm that the arrays truly are not broadcastable
-                assert not _check_arrays_broadcastable(samples, axis)
+                assert not _check_arrays_broadcastable(samples,
+                                                       None if paired else axis)
 
                 # confirm that _both_ `_broadcast_concatenate` and `hypotest`
                 # produce this information.
                 message = "Array shapes are incompatible for broadcasting."
                 with pytest.raises(ValueError, match=message):
-                    stats._stats_py._broadcast_concatenate(samples, axis)
+                    stats._stats_py._broadcast_concatenate(samples, axis, paired)
                 with pytest.raises(ValueError, match=message):
                     hypotest(*samples, *args, axis=axis, **kwds)
 


### PR DESCRIPTION
#### Reference issue

https://github.com/scipy/scipy/pull/19350#issuecomment-1758711603

#### What does this implement/fix?

Fix the decorator returning `nan` for `stats.entropy` when an empty input is passed.

#### Additional information

I think adding a test for this would be nice. Should we add a general test in the decorator itself or is it OK to add one for entropy only?