### PR TITLE
BUG: interpolate/ndbspline: fix OOB access for len(tx) != len(ty) in tensor product splines

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -483,6 +483,7 @@ def _make_design_matrix(const double[::1] x,
 @cython.nonecheck(False)
 def evaluate_ndbspline(const double[:, ::1] xi,
                        const double[:, ::1] t,
+                       const long[::1] len_t,
                        long[::1] k,
                        int[::1] nu,
                        bint extrapolate,
@@ -499,8 +500,13 @@ def evaluate_ndbspline(const double[:, ::1] xi,
         xi : ndarray, shape(npoints, ndim)
             ``npoints`` values to evaluate the spline at, each value is
             a point in an ``ndim``-dimensional space.
-        t : tuple, len(ndim)
-            Tuple of knots for each dimension.
+        t : ndarray, shape(ndim, max_len_t)
+            Array of knots for each dimension.
+            This array packs the tuple of knot arrays per dimension into a single
+            2D array. The array is ragged (knot lengths may differ), hence
+            the real knots in dimension ``d`` are ``t[d, :len_t[d]]``.
+        len_t : ndarray, 1D, shape (ndim,)
+            Lengths of the knot arrays, per dimension.
         k : tuple of ints, len(ndim)
             Spline degrees in each dimension.
         nu : ndarray of ints, shape(ndim,)
@@ -612,7 +618,7 @@ def evaluate_ndbspline(const double[:, ::1] xi,
                 # For each point, iterate over the dimensions
                 out_of_bounds = 0
                 for d in range(ndim):
-                    td = t[d]
+                    td = t[d, :len_t[d]]
                     xd = xv[d]
                     kd = k[d]
 

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -174,6 +174,7 @@ class NdBSpline:
         _t.fill(np.nan)
         for d in range(ndim):
             _t[d, :len(self.t[d])] = self.t[d]
+        len_t = np.asarray(len_t)
 
         # tabulate the flat indices for iterating over the (k+1)**ndim subarray
         shape = tuple(kd + 1 for kd in self.k)
@@ -194,6 +195,7 @@ class NdBSpline:
 
         _bspl.evaluate_ndbspline(xi,
                                  _t,
+                                 len_t,
                                  _k,
                                  nu,
                                  extrapolate,

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -10,7 +10,7 @@ import pytest
 from scipy.interpolate import (
         BSpline, BPoly, PPoly, make_interp_spline, make_lsq_spline, _bspl,
         splev, splrep, splprep, splder, splantider, sproot, splint, insert,
-        CubicSpline, NdBSpline, make_smoothing_spline
+        CubicSpline, NdBSpline, make_smoothing_spline, RegularGridInterpolator,
 )
 import scipy.linalg as sl
 
@@ -1944,6 +1944,26 @@ class TestNdBSpline:
         assert_allclose(bspl2(xi),
                         [bspl2_0(xp) for xp in xi], atol=1e-14)
 
+    def test_tx_neq_ty(self):
+        # 2D separable spline w/ len(tx) != len(ty)
+        x = np.arange(6)
+        y = np.arange(7) + 1.5
+
+        spl_x = make_interp_spline(x, x**3, k=3)
+        spl_y = make_interp_spline(y, y**2 + 2*y, k=3)
+        cc = spl_x.c[:, None] * spl_y.c[None, :]
+        bspl = NdBSpline((spl_x.t, spl_y.t), cc, (spl_x.k, spl_y.k))
+
+        values = (x**3)[:, None] * (y**2 + 2*y)[None, :]
+        rgi = RegularGridInterpolator((x, y), values)
+
+        xi = [(a, b) for a, b in itertools.product(x, y)]
+        bxi = bspl(xi)
+
+        assert not np.isnan(bxi).any()
+        assert_allclose(bxi, rgi(xi), atol=1e-14)
+        assert_allclose(bxi.reshape(values.shape), values, atol=1e-14)
+
     def make_3d_case(self):
         # make a 3D separable spline
         x = np.arange(6)
@@ -2127,7 +2147,6 @@ class TestNdBSpline:
 
         assert_allclose(bspl2(xi),
                         [bspl2_0(xp) for xp in xi], atol=1e-14)
-
 
     def test_readonly(self):
         t3, c3, k = self.make_3d_case()


### PR DESCRIPTION
To be able to release the GIL, we pack the tuple of 1D knot arrays into a 2D array. Since the lengths of knot arrays for different dimensions may differ, the 2D array has dimensions (ndim, max_length), with extra elements filled with NaNs.

The actual lengths of knot arrays need to be known to the interval search routine, which finds for a given `x`, the index `i` such that `t[i] <= x < x[i+1]`. Otherwise these extra nans confuse the interval search routine, leading to OOB access down the line.

