### PR TITLE
ENH: Use `np.dot` to speedup `spatial.distance.correlation`

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -105,6 +105,7 @@ __all__ = [
 ]
 
 
+import math
 import warnings
 import numpy as np
 import dataclasses
@@ -637,9 +638,9 @@ def correlation(u, v, w=None, centered=True):
     uv = np.dot(u, vw)
     uu = np.dot(u, uw)
     vv = np.dot(v, vw)
-    dist = 1.0 - uv / np.sqrt(uu * vv)
+    dist = 1.0 - uv / math.sqrt(uu * vv)
     # Return absolute value to avoid small negative value due to rounding
-    return np.abs(dist)
+    return abs(dist)
 
 
 def cosine(u, v, w=None):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -628,9 +628,15 @@ def correlation(u, v, w=None, centered=True):
         vmu = np.average(v, weights=w)
         u = u - umu
         v = v - vmu
-    uv = np.average(u * v, weights=w)
-    uu = np.average(np.square(u), weights=w)
-    vv = np.average(np.square(v), weights=w)
+    if w is not None:
+        w /= w.sum()
+        vw = v * w
+        uw = u * w
+    else:
+        vw, uw = v, u
+    uv = np.dot(u, vw)
+    uu = np.dot(u, uw)
+    vv = np.dot(v, vw)
     dist = 1.0 - uv / np.sqrt(uu * vv)
     # Return absolute value to avoid small negative value due to rounding
     return np.abs(dist)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -624,13 +624,17 @@ def correlation(u, v, w=None, centered=True):
     v = _validate_vector(v)
     if w is not None:
         w = _validate_weights(w)
+        w /= w.sum()
     if centered:
-        umu = np.average(u, weights=w)
-        vmu = np.average(v, weights=w)
+        if w is not None:
+            umu = np.dot(u, w)
+            vmu = np.dot(v, w)
+        else:
+            umu = np.mean(u)
+            vmu = np.mean(v)
         u = u - umu
         v = v - vmu
     if w is not None:
-        w /= w.sum()
         vw = v * w
         uw = u * w
     else:


### PR DESCRIPTION
#### What does this implement/fix?
This PR changes the implementation of `spatial.distance.correlation` to rely on dot products for computing the distance (7e85a8894dca17e3c70747265f090ff620f90a60). 77f135df810351e959cbb06054a019b9ade4896f switches to builtin math operations when working on scalars as they have less overhead compared to numpy.

Overall this reduces the runtime of `spatial.distance.cosine` by **~6 x** and the weighted version by **~3.5 x** 🚀 

#### Additional information

The above numbers where measured using the script below.

```python
import numpy as np
import scipy.spatial

x = np.random.normal(size=512)
y = np.random.normal(size=512)
w = np.random.uniform(size=512)

%timeit scipy.spatial.distance.cosine(x, y)
# main: 19.2 µs ± 358 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# this PR: 3.15 µs ± 54.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

%timeit scipy.spatial.distance.cosine(x, y, w)
# main: 46.6 µs ± 1.79 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# this PR: 13.6 µs ± 530 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

%timeit scipy.spatial.distance.correlation(x, y)
# main: 34.1 µs ± 326 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# this PR: 14.2 µs ± 168 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

%timeit scipy.spatial.distance.correlation(x, y, w)
# main: 71.3 µs ± 2.42 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# this PR: 17.7 µs ± 89 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Here are the results of the `XdistWeighted` (`Xdist` doesn't show a difference since it uses C code instead):
```
spatial.XdistWeighted.time_cdist (main)    spatial.XdistWeighted.time_cdist (this PR)
============ ============ =============    ============ ============= =============
--                     metric              --                      metric
------------ --------------------------    ------------ ---------------------------
 num_points     cosine     correlation      num_points      cosine     correlation
============ ============ =============    ============ ============= =============
     10       3.99±0.1ms    6.37±0.2ms          10       1.38±0.1ms   1.54±0.07ms
     20       16.5±0.2ms     25.7±1ms           20       5.40±0.5ms    6.14±0.2ms
    100        420±20ms      652±30ms          100        134±10ms      154±20ms
============ ============ =============    ============ ============= =============


spatial.XdistWeighted.time_pdist (main)    spatial.XdistWeighted.time_pdist (this PR)
============ ============= =============   ============ ============= =============
--                      metric             --                      metric
------------ ---------------------------   ------------ ---------------------------
 num_points      cosine     correlation     num_points      cosine     correlation
============ ============= =============   ============ ============= =============
     10       1.99±0.08ms    3.13±0.5ms         10       635±100μs      707±50μs
     20        7.97±0.3ms   11.9±0.03ms         20       2.56±0.1ms    3.07±0.2ms
    100         208±10ms      313±10ms         100        61.8±2ms      79.9±4ms
============ ============= =============   ============ ============= =============

```