### PR TITLE
BLD:Add missing cstdin include in fast matrix market

### DIFF
--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/types.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/types.hpp
@@ -6,6 +6,7 @@
 
 #include <complex>
 #include <map>
+#include <cstdint>
 #include <string>
 
 namespace fast_matrix_market {


### PR DESCRIPTION
#### Reference issue
Closes #19577 

#### What does this implement/fix?
Similar to #19409 that causes a build error with the latest MinGw gcc 13 suite.
