### PR TITLE
ENH: Use `np.dot` to speedup `spatial.distance.hamming`

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -746,7 +746,9 @@ def hamming(u, v, w=None):
         w = _validate_weights(w)
         if w.shape != u.shape:
             raise ValueError("'w' should have the same length as 'u' and 'v'.")
-    return np.average(u_ne_v, weights=w)
+        w /= w.sum()
+        return np.dot(u_ne_v, w)
+    return np.mean(u_ne_v)
 
 
 def jaccard(u, v, w=None):


### PR DESCRIPTION
#### What does this implement/fix?
This PR changes the implementation of `spatial.distance.hamming` to rely on dot products for computing the weighted distance as a follow up to #19583. This reduces the runtime of weighted `spatial.distance.hamming` by **~1.8 x**.

#### Additional information

I briefly benchmarked this using
```python
The above numbers where measured using the script below.

import numpy as np
import scipy.spatial

x = np.random.normal(size=512)
y = np.random.normal(size=512)
w = np.random.uniform(size=512)

%timeit scipy.spatial.distance.hamming(x, y, w)
# main: 20 µs ± 1.06 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# this PR: 11.2 µs ± 195 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```