### PR TITLE
MAINT:special:Add more noexcept to Cython signatures

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -1076,7 +1076,7 @@ class FusedFunc(Func):
         for n, (intype, _) in enumerate(self.intypes):
             callvars.append(f"{intype} {self.invars[n]}")
         (outtype, _) = self.outtypes[0]
-        dec = "cpdef {} {}({}) nogil".format(outtype, self.name, ", ".join(callvars))
+        dec = f'cpdef {outtype} {self.name}({", ".join(callvars)}) noexcept nogil'
         head.append(dec + ":")
         head.append(tab + f'"""{self.doc}"""')
 


### PR DESCRIPTION

#### What does this implement/fix?
With the new Cython, we started to get a lot of performance hint warnings from scipy.special

```
[104/258] Generating 'scipy\\special\\cython_special.cp310-win_amd64.pyd.p\\cython_special.c'
performance hint: scipy\special\cython_special.pyx:1874:6: Exception check on 'betainc' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:1886:6: Exception check on 'betaincc' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:1898:6: Exception check on 'betaincinv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:1910:6: Exception check on 'betainccinv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2002:6: Exception check on 'dawsn' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2046:6: Exception check on 'elliprc' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2058:6: Exception check on 'elliprd' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2070:6: Exception check on 'elliprf' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2082:6: Exception check on 'elliprg' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2094:6: Exception check on 'elliprj' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2110:6: Exception check on 'erf' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2122:6: Exception check on 'erfc' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2134:6: Exception check on 'erfcx' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2146:6: Exception check on 'erfi' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2158:6: Exception check on 'erfinv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2174:6: Exception check on 'eval_chebyc' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2188:6: Exception check on 'eval_chebys' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2202:6: Exception check on 'eval_chebyt' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2216:6: Exception check on 'eval_chebyu' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2230:6: Exception check on 'eval_gegenbauer' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2244:6: Exception check on 'eval_genlaguerre' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2266:6: Exception check on 'eval_jacobi' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2280:6: Exception check on 'eval_laguerre' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2294:6: Exception check on 'eval_legendre' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2308:6: Exception check on 'eval_sh_chebyt' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2322:6: Exception check on 'eval_sh_chebyu' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2336:6: Exception check on 'eval_sh_jacobi' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2350:6: Exception check on 'eval_sh_legendre' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2364:6: Exception check on 'exp1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2384:6: Exception check on 'expi' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2396:6: Exception check on 'expit' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2412:6: Exception check on 'expm1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2477:6: Exception check on 'gamma' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2533:6: Exception check on 'hankel1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2537:6: Exception check on 'hankel1e' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2541:6: Exception check on 'hankel2' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2545:6: Exception check on 'hankel2e' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2553:6: Exception check on 'hyp0f1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2565:6: Exception check on 'hyp1f1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2577:6: Exception check on 'hyp2f1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2681:6: Exception check on 'iv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2693:6: Exception check on 'ive' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2713:6: Exception check on 'jv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2725:6: Exception check on 'jve' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2810:6: Exception check on 'kv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2822:6: Exception check on 'kve' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2834:6: Exception check on 'log1p' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2846:6: Exception check on 'log_expit' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2862:6: Exception check on 'log_ndtr' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2874:6: Exception check on 'loggamma' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:2886:6: Exception check on 'logit' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3077:6: Exception check on 'ndtr' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3224:6: Exception check on 'powm1' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3304:6: Exception check on 'psi' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3324:6: Exception check on 'rgamma' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3402:6: Exception check on 'spence' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3414:6: Exception check on 'sph_harm' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3447:6: Exception check on 'wofz' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3451:6: Exception check on 'wrightomega' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3463:6: Exception check on 'xlog1py' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3475:6: Exception check on 'xlogy' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3504:6: Exception check on 'yv' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
performance hint: scipy\special\cython_special.pyx:3516:6: Exception check on 'yve' will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
```
and so on. This is an attempt to see whether they get silenced
