### PR TITLE
MAINT: interpolate/RGI: avoid unnecessary validation of data size

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -321,8 +321,8 @@ class RegularGridInterpolator:
         >>> interp([[1.5, 1.3], [0.3, 4.5]], method='linear')
         array([ 4.7, 24.3])
         """
-        is_method_changed = self.method != method
         method = self.method if method is None else method
+        is_method_changed = self.method != method
         if method not in self._ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
 


### PR DESCRIPTION
RegularGridInterpolator allows changing the interpolation method  at call site; if it is changed, data sizes need re-validation for  a new method (cubics require at least four points and so on).
    
At the call site, `__call__(..., method=None)` means that the interpolation method is the same as self.method and thus there is no need to re-validate self.values.
Take this into account and avoid re-validation if `method is None`
