### PR TITLE
Returning NotImplemented in comparisons with sparse arrays

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -243,7 +243,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             all_true = self.__class__(np.ones(self.shape, dtype=np.bool_))
             return all_true - res
         else:
-            return False
+            return NotImplemented
 
     def __ne__(self, other):
         # Scalar other.
@@ -277,7 +277,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 other = other.asformat(self.format)
             return self._binopt(other, '_ne_')
         else:
-            return True
+            return NotImplemented
 
     def _inequality(self, other, op, op_name, bad_scalar_msg):
         # Scalar other.
@@ -311,7 +311,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             res = self._binopt(other, '_gt_' if op_name == '_le_' else '_lt_')
             return all_true - res
         else:
-            raise ValueError("Operands could not be compared.")
+            return NotImplemented
 
     def __lt__(self, other):
         return self._inequality(other, operator.lt, '_lt_',

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -235,22 +235,22 @@ class BinopTester_with_shape:
 class ComparisonTester:
     # Custom type to test comparison operations on sparse matrices.
     def __eq__(self, other):
-        return 'eq'
+        return "eq"
 
     def __ne__(self, other):
-        return 'ne'
+        return "ne"
 
     def __lt__(self, other):
-        return 'lt'
+        return "lt"
 
     def __le__(self, other):
-        return 'le'
+        return "le"
 
     def __gt__(self, other):
-        return 'gt'
+        return "gt"
 
     def __ge__(self, other):
-        return 'ge'
+        return "ge"
 
 
 #------------------------------------------------------------------------------

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -232,6 +232,26 @@ class BinopTester_with_shape:
     def __rmatmul__(self, mat):
         return "matrix on the left"
 
+class ComparisonTester:
+    # Custom type to test comparison operations on sparse matrices.
+    def __eq__(self, other):
+        return 'eq'
+
+    def __ne__(self, other):
+        return 'ne'
+
+    def __lt__(self, other):
+        return 'lt'
+
+    def __le__(self, other):
+        return 'le'
+
+    def __gt__(self, other):
+        return 'gt'
+
+    def __ge__(self, other):
+        return 'ge'
+
 
 #------------------------------------------------------------------------------
 # Generic tests
@@ -1642,6 +1662,16 @@ class _TestCommon:
 
         assert_equal(A @ B, "matrix on the left")
         assert_equal(B @ A, "matrix on the right")
+    
+    def test_comparisons_custom_type(self):
+        A = self.spcreator([[1], [2], [3]])
+        B = ComparisonTester()
+        assert_equal(A == B, "eq")
+        assert_equal(A != B, "ne")
+        assert_equal(A > B, "lt")
+        assert_equal(A >= B, "le")
+        assert_equal(A < B, "gt")
+        assert_equal(A <= B, "ge")
 
     def test_dot_scalar(self):
         M = self.spcreator(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue [#4819](https://github.com/scipy/scipy/issues/4819).

#### What does this implement/fix?
<!--Please explain your changes.-->
For the comparison operators: `__eq__, __ne__, __ge__, __gt__, __le__, and __lt__`, the sparse arrays (and matrices) will now return `NotImplemented` at the end of the function call when they don't recognize the other object in the comparison and hand over control.

As an example (used as unit test), in the present version of SciPy, the comparison methods of an instance of `A` are never called when comparing with a sparse array if the array is on the left hand side.

```py
class A:
    def __eq__(self, other): return 'eq'
    def __ne__(self, other): return 'ne'
    def __lt__(self, other): return 'lt'
    def __le__(self, other): return 'le'
    def __gt__(self, other): return 'gt'
    def __ge__(self, other): return 'ge'
x = sp.coo_array((1, 1))
a = A()
assert (x == a) == 'eq'
assert (x != a) == 'ne'
assert (x > a) == 'lt'
assert (x >= a) == 'le'
assert (x < a) == 'gt'
assert (x <= a) == 'ge'
```

Currently, all these assertions fail: `x == a` returns `False`, `x != a` returns `True`, and the rest raise a `ValueError`. This PR changes all these to return `NotImplemented` from the SciPy side such that custom classes may define their own behavior.