### PR TITLE
TST: special._sinpi/_cospi: skip failing `test_intermediate_overflow`

### DIFF
--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, suppress_warnings
 
@@ -29,6 +30,7 @@ def test_half_integer_real_part():
     assert_equal(res.real, 0.0)
 
 
+@pytest.mark.skip("Temporary skip while gh-19526 is being resolved")
 def test_intermediate_overlow():
     # Make sure we avoid overflow in situations where cosh/sinh would
     # overflow but the product with sin/cos would not

--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -42,14 +42,18 @@ def test_intermediate_overlow():
     with suppress_warnings() as sup:
         sup.filter(RuntimeWarning, "invalid value encountered in multiply")
         for p, std in zip(sinpi_pts, sinpi_std):
-            assert_allclose(sinpi(p), std)
+            res = sinpi(p)
+            assert_allclose(res.real, std.real)
+            assert_allclose(res.imag, std.imag)
 
     # Test for cosine, less interesting because cos(0) = 1.
     p = complex(0.5 + 1e-14, 227)
     std = complex(-8.113438309924894e+295, -np.inf)
     with suppress_warnings() as sup:
         sup.filter(RuntimeWarning, "invalid value encountered in multiply")
-        assert_allclose(cospi(p), std)
+        res = cospi(p)
+        assert_allclose(res.real, std.real)
+        assert_allclose(res.imag, std.imag)
 
 
 def test_zero_sign():


### PR DESCRIPTION
#### Reference issue
gh-19526

#### What does this implement/fix?
gh-19526 notes that `scipy.special.tests.test_trig.test_intermediate_overlow` is failing with latest NumPy. 
The first commit works around the NumPy change, but the second part of the test still fails because the imaginary part of `cospi(p)` is positive but it's supposed to be negative. (Is that OK?)
The second commit skips the test to make CI green while we resolve this issue.

#### Additional information
If this is merged, I'd suggest merging the commits separately so b121d4580541a61f33ca7f3b93103cc5586f9a92 can be reverted separately.