### PR TITLE
DOC: doc shim for eig normalization

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -161,8 +161,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         multiplicity. The shape is (M,) unless
         ``homogeneous_eigvals=True``.
     vl : (M, M) double or complex ndarray
-        The normalized left eigenvector corresponding to the eigenvalue
+        The left eigenvector corresponding to the eigenvalue
         ``w[i]`` is the column ``vl[:,i]``. Only returned if ``left=True``.
+        The left eigenvector is not normalized.
     vr : (M, M) double or complex ndarray
         The normalized right eigenvector corresponding to the eigenvalue
         ``w[i]`` is the column ``vr[:,i]``.  Only returned if ``right=True``.


### PR DESCRIPTION
* this is a documentation shim to at least temporarily avoid the confusion in gh-11550, as discussed in the comments at gh-15340

* perhaps the clearer wording will motivate folks to come to a consensus about whether a behavior change is justified at some point in the future, but that almost certainly won't be decided before branching in early December

[skip cirrus] [skip actions]