### PR TITLE
BUG: fix overflow in stats.boxcox_normmax when method='mle'

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1308,7 +1308,6 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         # Test if the optimal lambda causes overflow
         max_x = np.max(x, axis=0)
         istransinf = np.isinf(special.boxcox(max_x, res))
-        print(istransinf)
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
         if np.any(istransinf):
             warnings.warn(

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1319,7 +1319,8 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
             warnings.warn(
                 f"The optimal lambda is {res}, but the returned lambda is "
                 f"the constrained optimum to ensure that the maximum of the "
-                f"transformed data does not cause overflow in {dtype}."
+                f"transformed data does not cause overflow in {dtype}.",
+                stacklevel=2
             )
 
             # Return the constrained lambda to ensure the transformation

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1318,7 +1318,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         if np.any(istransinf):
             warnings.warn(
                 f"The optimal lambda is {res}, but the returned lambda is "
-                f"the constrained optimum to ensure that maximum of "
+                f"the constrained optimum to ensure that the maximum of the "
                 f"transformed data does not cause overflow in {dtype}."
             )
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1311,9 +1311,9 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
         if np.any(istransinf):
             warnings.warn(
-                f"The optimal lambda is {res}, but the returned lambda is"
-                " the constrained optimum to ensure that maximum of"
-                f" transformed data does not cause overflow in {dtype}."
+                f"The optimal lambda is {res}, but the returned lambda is "
+                f"the constrained optimum to ensure that maximum of "
+                f"transformed data does not cause overflow in {dtype}."
             )
 
             # Return the constrained lambda to ensure x^lambda

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1289,7 +1289,6 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
     optimfunc = methods[method]
 
-    x = np.asarray(x)
     try:
         res = optimfunc(x)
     except ValueError as e:
@@ -1306,6 +1305,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         raise ValueError(message)
     else:
         # Test if the optimal lambda causes overflow
+        x = np.asarray(x)
         max_x = np.max(x, axis=0)
         istransinf = np.isinf(special.boxcox(max_x, res))
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1990,6 +1990,20 @@ class TestBoxcox:
         with pytest.raises(ValueError, match=message):
             stats.boxcox_normmax(bad_x)
 
+    @pytest.mark.parametrize('x', [
+        # Attempt to trigger overflow in power expressions.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
+                  2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
+        # Attempt to trigger overflow with a large optimal lambda.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0]),
+        # Attempt to trigger overflow with large data.
+        np.array([2003.0e200, 1950.0e200, 1997.0e200, 2000.0e200, 2009.0e200])
+    ])
+    def test_overflow(self, x):
+        with pytest.warns(UserWarning, match="The optimal lambda is"):
+            xt_bc, lam_bc = stats.boxcox(x)
+            assert np.all(np.isfinite(xt_bc))
+
 
 class TestBoxcoxNormmax:
     def setup_method(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#18389 (overflow also happens in `boxcox`)

#### What does this implement/fix?
<!--Please explain your changes.-->

Code is inspired by https://github.com/scipy/scipy/pull/18852#issuecomment-1657858886 and #19016
1. Fix overflow in `stats.boxcox_normmax` when method='mle'
2. Adjust the output lambda to ensure that the transformed data is not infinite

#### Additional information
<!--Any additional information you think is important.-->
The Box-Cox transformation is $\phi(x)=(x^\lambda - 1)/\lambda$ for $\lambda\neq0$

Modify the variance formula since they don't affect the result
1. Remove the offset $1/\lambda$ #10072
2. Change the denominator to $|\lambda|$ (compute log)

Therefore,
$\text{Var}((x^\lambda - 1)/\lambda)=\text{Var}(x^\lambda /\lambda)=\text{Var}(x^\lambda /|\lambda|)$

Then, compute the log
$\log(x^\lambda /|\lambda|)=\lambda\log x - \log|\lambda|$

Finally, compute the log of the variance of transformed data using `_log_var`

~~To adjust the final $\lambda$, ensure $x^\lambda$ does not cause overflow, which is much simpler than the inverse of $\phi(x)$~~
~~So $\lambda^*=\log c / \log x$, $c$ is the maximum of floating point.~~

Use the exact approach to adjust the final lambda.
https://www.wolframalpha.com/input?i=solve+%28x%5El+-1%29+%2F+l+%3D+y+for+l