### PR TITLE
MAINT: array types: restrict to boolean & numerical dtypes

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -37,9 +37,9 @@ def compliance_scipy(arrays):
     The following subclasses are not supported and raise and error:
     - `numpy.ma.MaskedArray`
     - `numpy.matrix`
-    - numpy arrays which do not have a boolean or numerical dtype
-    - Any array-like which is neither array API compatible nor coercible by numpy
-    - Any array-like which is coerced by numpy to an unsupported dtype
+    - NumPy arrays which do not have a boolean or numerical dtype
+    - Any array-like which is neither array API compatible nor coercible by NumPy
+    - Any array-like which is coerced by NumPy to an unsupported dtype
     """
     for i in range(len(arrays)):
         array = arrays[i]
@@ -57,7 +57,7 @@ def compliance_scipy(arrays):
                 array = np.asanyarray(array)
             except TypeError:
                 raise TypeError("An argument is neither array API compatible nor "
-                                "coercible by numpy.")
+                                "coercible by NumPy.")
             dtype = array.dtype
             if not (np.issubdtype(dtype, np.number) or np.issubdtype(dtype, np.bool_)):
                 message = (

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -44,9 +44,9 @@ def compliance_scipy(arrays):
     for i in range(len(arrays)):
         array = arrays[i]
         if isinstance(array, np.ma.MaskedArray):
-            raise TypeError("'numpy.ma.MaskedArray' arrays are not supported.")
+            raise TypeError("Inputs of type `numpy.ma.MaskedArray` are not supported.")
         elif isinstance(array, np.matrix):
-            raise TypeError("'numpy.matrix' arrays are not supported.")
+            raise TypeError("Inputs of type `numpy.matrix` are not supported.")
         if isinstance(array, (np.ndarray, np.generic)):
             dtype = array.dtype
             if not (np.issubdtype(dtype, np.number) or np.issubdtype(dtype, np.bool_)):

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -31,18 +31,19 @@ class TestArrayAPI:
 
     @pytest.mark.filterwarnings("ignore: the matrix subclass")
     def test_raises(self):
-        msg = "'numpy.ma.MaskedArray' are not supported"
+        msg = "'numpy.ma.MaskedArray' arrays are not supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace(np.ma.array(1), np.array(1))
 
-        msg = "'numpy.matrix' are not supported"
+        msg = "'numpy.matrix' arrays are not supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace(np.array(1), np.matrix(1))
 
-        msg = ("An argument was coerced to an object array, "
-               "but object arrays are not supported.")
+        msg = "only boolean and numerical dtypes are supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace([object()])
+        with pytest.raises(TypeError, match=msg):
+            array_namespace('abc')
 
     def test_array_likes(self):
         # should be no exceptions

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -31,11 +31,11 @@ class TestArrayAPI:
 
     @pytest.mark.filterwarnings("ignore: the matrix subclass")
     def test_raises(self):
-        msg = "'numpy.ma.MaskedArray' arrays are not supported"
+        msg = "of type `numpy.ma.MaskedArray` are not supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace(np.ma.array(1), np.array(1))
 
-        msg = "'numpy.matrix' arrays are not supported"
+        msg = "of type `numpy.matrix` are not supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace(np.array(1), np.matrix(1))
 


### PR DESCRIPTION
#### Reference issue
Closes gh-19276

#### What does this implement/fix?
- Restrict input dtypes to subdtypes of `np.number` and `np.bool_` when the `SCIPY_ARRAY_API` flag is set

#### Additional information
The other points in gh-19276 can be moved to gh-18972 as part of the wider validation overhaul.

cc @mdhaber @rgommers 