### PR TITLE
TST: test_rank shims in signal

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3325,16 +3325,16 @@ class TestVectorstrength:
 
 
 def cast_tf2sos(b, a):
-    """Convert TF2SOS, casting to complex128 and back to the original dtype."""
+    """Convert TF2SOS, casting to complex64 and back to the original dtype."""
     # tf2sos does not support all of the dtypes that we want to check, e.g.:
     #
-    #     TypeError: array type complex256 is unsupported in linalg
+    #     TypeError: array type complex128 is unsupported in linalg
     #
     # so let's cast, convert, and cast back -- should be fine for the
     # systems and precisions we are testing.
     dtype = np.asarray(b).dtype
-    b = np.array(b, np.complex128)
-    a = np.array(a, np.complex128)
+    b = np.array(b, np.complex64)
+    a = np.array(a, np.complex64)
     return tf2sos(b, a).astype(dtype)
 
 


### PR DESCRIPTION
* related to the MacOS ARM portion of gh-19605; tested the patch locally on that hardware with NumPy `main`

* the short version of it is that we have a testing-only shim function that needs even broader casting changes when NEP50 is active; I suppose one could argue
for an additional requirement that the shim only applies on platforms where we see the failure, though I haven't done that here at the moment

* the longer version is that I bisected the failure to:
```
197e61c6bbca7b35414f341f0596391ecf17a31f is the first bad commit
commit 197e61c6bbca7b35414f341f0596391ecf17a31f
Author: Sebastian Berg <sebastianb@nvidia.com>
Date:   Fri Jun 9 21:27:40 2023 +0200

    API: Switch to "weak" promotion state by default

 numpy/__init__.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
but didn't really see any obvious SciPy-side code paths related to these tests that was abusing scalar promotion; and indeed, we already have a custom shim function that mentions an identical error message, substituting `complex256` for `complex128`; so it seems NumPy is a little stricter here now...

* maybe good to ping @seberg on this one; I've been known to misunderstand NEP 50 stuff

[skip circle] [skip cirrus]