### PR TITLE
MAINT: qmc permutations win type

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -780,6 +780,7 @@ def van_der_corput(
         else:
             permutations = np.asarray(permutations)
 
+        permutations = permutations.astype(np.int64)
         return _cy_van_der_corput_scrambled(n, base, start_index,
                                             permutations, workers)
 

--- a/scipy/stats/_qmc_cy.pyx
+++ b/scipy/stats/_qmc_cy.pyx
@@ -393,7 +393,7 @@ cdef _cy_van_der_corput_threaded_loop(Py_ssize_t istart,
 def _cy_van_der_corput_scrambled(Py_ssize_t n,
                                  long base,
                                  long start_index,
-                                 long[:,::1] permutations,
+                                 np.int64_t[:,::1] permutations,
                                  unsigned int workers):
     sequence = np.zeros(n)
 
@@ -427,7 +427,7 @@ cdef _cy_van_der_corput_scrambled_loop(Py_ssize_t istart,
                                        Py_ssize_t istop,
                                        long base,
                                        long start_index,
-                                       long[:,::1] permutations,
+                                       np.int64_t[:,::1] permutations,
                                        double[::1] sequence_view):
 
     cdef:


### PR DESCRIPTION
* Related to gh-19605, probably default integer type changing to `int64` on Windows on NumPy `main`.

* this patch fixes 116 test failures for SciPy with NumPy `main` on Windows; the full Windows suite still passes for SciPy with NumPy `1.26.2` on this branch as well (there are other failures left to fix, but easier for me to do in pieces because my Windows box is pretty slow, etc.)

[skip cirrus] [skip circle]

Alternative solutions might be to use a fused type in Cython so that old NumPy can still use the smaller integer on occasion, or to coerce the use of a smaller integer type. That said, if the distinction was really important, I'd kind of hope the test suite would catch (though this is slightly optimistic if it only matters for i.e., performance/mem footprint).