### PR TITLE
CI: undo cython==0.29.35 pin for the 32-bit Linux job, remove `!=3.0.3`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: setup Python venv
           command: |
-            pip install numpy cython!=3.0.3 pybind11 pythran ninja meson
+            pip install numpy cython pybind11 pythran ninja meson
             pip install -r doc_requirements.txt
             pip install "myst-nb<1.0.0"
             pip install mpmath gmpy2 "asv>=0.6.0" click rich-click doit pydevtool pooch threadpoolctl

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython!=3.0.3 pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
 
     - name: Install PyTorch CPU
       run: |

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -64,13 +64,13 @@ jobs:
     - name: Install Python packages
       if: matrix.python-version == '3.10'
       run: |
-        python -m pip install numpy cython!=3.0.3 pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
 
     - name: Install Python packages from repositories
       if: matrix.python-version == '3.12-dev'
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
-        python -m pip install ninja cython!=3.0.3 pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
+        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd
         python -m pip install git+https://github.com/mesonbuild/meson.git
 
@@ -175,7 +175,7 @@ jobs:
         # Install build dependencies. Use meson-python from its main branch,
         # most convenient to test in this job because we're using pip without
         # build isolation here.
-        python -m pip install numpy pybind11 pythran cython!=3.0.3 pytest ninja hypothesis
+        python -m pip install numpy pybind11 pythran cython pytest ninja hypothesis
         python -m pip install git+https://github.com/mesonbuild/meson-python.git
         # Non-isolated build, so we use dependencies installed inside the source tree
         python -m pip install -U pip  # need pip >=23 for `--config-settings`
@@ -247,7 +247,7 @@ jobs:
         run: |
           pip install "numpy==1.22.4" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython!=3.0.3
+          pip install build meson-python ninja pythran pybind11 cython
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout hypothesis
 
@@ -305,7 +305,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install cython!=3.0.3 pythran ninja meson-python pybind11 click rich_click pydevtool
+        python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy "scipy-openblas32<=0.3.24.135"
         python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
 
@@ -370,6 +370,6 @@ jobs:
         python3.9 -m venv test && \
         source test/bin/activate && \
         python -m pip install doit click rich_click pydevtool meson ninja && \
-        python -m pip install numpy==1.22.4 cython==0.29.35 pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis && \
+        python -m pip install numpy==1.22.4 cython pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py build && \
         LD_LIBRARY_PATH=/usr/local/lib python dev.py test"

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -67,7 +67,7 @@ jobs:
         source test_env/bin/activate
         cd $GITHUB_WORKSPACE
 
-        python -m pip install cython!=3.0.3 numpy
+        python -m pip install cython numpy
         # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install meson ninja pybind11 pythran pytest hypothesis
         python -m pip install click rich_click doit pydevtool pooch

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -134,9 +134,9 @@ jobs:
           #  numpy2.0 wheels available on PyPI. Also remove/comment out the
           # PIP_NO_BUILD_ISOLATION and PIP_EXTRA_INDEX_URL from CIBW_ENVIRONMENT
           # (also for _MACOS and _WINDOWS below)
-          CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-          CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+          CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+          CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja; bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
           # Allow pip to find install nightly wheels if necessary
           # Setting PIP_NO_BUILD_ISOLATION=false makes pip use build-isolation.
           CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=false PIP_PRE=1 PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
+          pip install numpy==1.22.4 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
 
       - name: Build
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: |
           # 1.22.4 is currently the oldest numpy usable on cp3.9 according
           # to pyproject.toml
-          python -m pip install numpy==1.22.4 cython!=3.0.3 pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
+          python -m pip install numpy==1.22.4 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis "scipy-openblas32<=0.3.23.293.2"
 
       - name: Build
         run: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          python -m pip install build delvewheel numpy cython!=3.0.3 pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis
+          python -m pip install build delvewheel numpy cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis
 
       - name: Build
         run: |

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -69,7 +69,7 @@ linux_aarch64_test_task:
     echo "PATH=$PATH" >> $CIRRUS_ENV
     echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
-    python -m pip install meson ninja numpy cython!=3.0.3 pybind11 pythran
+    python -m pip install meson ninja numpy cython pybind11 pythran
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch pytest-xdist hypothesis
     
@@ -129,7 +129,7 @@ macos_arm64_test_task:
     source test_env/bin/activate
     cd $_CWD
 
-    python -m pip install meson ninja numpy cython!=3.0.3 pybind11 pythran
+    python -m pip install meson ninja numpy cython pybind11 pythran
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch pytest-xdist hypothesis
     

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -31,7 +31,7 @@ cirrus_wheels_linux_aarch64_task:
     CIBW_PRERELEASE_PYTHONS: True
     # TODO remove the CIBW_BEFORE_BUILD_LINUX line once there are numpy2.0 wheels available on PyPI.
     # Also remove/comment out PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
-    CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+    CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
     CIBW_ENVIRONMENT: >
       PIP_PRE=1
       PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
@@ -68,7 +68,7 @@ cirrus_wheels_macos_arm64_task:
       PIP_NO_BUILD_ISOLATION=false
     # TODO remove the following line once there are numpy2.0 wheels available on PyPI.
     # Also remove PIP_NO_BUILD_ISOLATION, PIP_EXTRA_INDEX_URL flags.
-    CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython!=3.0.3 pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+    CIBW_BEFORE_BUILD_MACOS: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
     PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
     # assumes that the cmake config is in /usr/local/lib/cmake
     CMAKE_PREFIX_PATH: /opt/arm64-builds/


### PR DESCRIPTION
We're at Cython 3.0.6 now and the relevant upstream bugs have been fixed. We no longer need the `!=3.0.3` condition in CI jobs, because that version will never be installed anymore. We only keep it for now in `pyproject.toml` and in `environment.yml`, because there it is still useful information for downstream redistributors.