### PR TITLE
MAINT: lint: enable `stacklevel` warnings check

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1400,7 +1400,7 @@ def _cpu_count_affinity(os_cpu_count):
             warnings.warn(
                 "Failed to inspect CPU affinity constraints on this system. "
                 "Please install psutil or explicitly set LOKY_MAX_CPU_COUNT.",
-                stacklevel=2
+                stacklevel=4
             )
 
     # This can happen for platforms that do not implement any kind of CPU

--- a/dev.py
+++ b/dev.py
@@ -1327,7 +1327,8 @@ def cpu_count(only_physical_cores=False):
             f"following reason:\n{exception}\n"
             "Returning the number of logical cores instead. You can "
             "silence this warning by setting LOKY_MAX_CPU_COUNT to "
-            "the number of cores you want to use."
+            "the number of cores you want to use.",
+            stacklevel=2
         )
         traceback.print_tb(exception.__traceback__)
 
@@ -1398,7 +1399,8 @@ def _cpu_count_affinity(os_cpu_count):
             # havoc, typically on CI workers.
             warnings.warn(
                 "Failed to inspect CPU affinity constraints on this system. "
-                "Please install psutil or explicitly set LOKY_MAX_CPU_COUNT."
+                "Please install psutil or explicitly set LOKY_MAX_CPU_COUNT.",
+                stacklevel=2
             )
 
     # This can happen for platforms that do not implement any kind of CPU

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -74,7 +74,7 @@ if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
     warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
                   f" is required for this version of SciPy (detected "
                   f"version {__numpy_version__})",
-                  UserWarning)
+                  UserWarning, stacklevel=2)
 del _pep440
 
 

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -418,7 +418,7 @@ class NumpyDocString(Mapping):
         if error:
             raise ValueError(msg)
         else:
-            warn(msg, stacklevel=2)
+            warn(msg, stacklevel=3)
 
     # string conversion routines
 

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -418,7 +418,7 @@ class NumpyDocString(Mapping):
         if error:
             raise ValueError(msg)
         else:
-            warn(msg)
+            warn(msg, stacklevel=2)
 
     # string conversion routines
 

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -101,7 +101,8 @@ class PytestTester:
             else:
                 import warnings
                 warnings.warn('Could not run tests in parallel because '
-                              'pytest-xdist plugin is not available.')
+                              'pytest-xdist plugin is not available.',
+                              stacklevel=2)
 
         pytest_args += ['--pyargs'] + list(tests)
 

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -139,7 +139,7 @@ def whiten(obs, check_finite=True):
         std_dev[zero_std_mask] = 1.0
         warnings.warn("Some columns have standard deviation zero. "
                       "The values of these columns will not change.",
-                      RuntimeWarning)
+                      RuntimeWarning, stacklevel=2)
     return obs / std_dev
 
 
@@ -622,7 +622,8 @@ _valid_init_meth = {'random': _krandinit, 'points': _kpoints, '++': _kpp}
 def _missing_warn():
     """Print a warning when called."""
     warnings.warn("One of the clusters is empty. "
-                  "Re-run kmeans with a different initialization.")
+                  "Re-run kmeans with a different initialization.",
+                  stacklevel=2)
 
 
 def _missing_raise():
@@ -794,7 +795,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
             raise ValueError("Cannot ask kmeans2 for %d clusters"
                              " (k was %s)" % (nc, code_book))
         elif nc != code_book:
-            warnings.warn("k was not an integer, was converted.")
+            warnings.warn("k was not an integer, was converted.", stacklevel=2)
 
         try:
             init_meth = _valid_init_meth[minit]

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -623,7 +623,7 @@ def _missing_warn():
     """Print a warning when called."""
     warnings.warn("One of the clusters is empty. "
                   "Re-run kmeans with a different initialization.",
-                  stacklevel=2)
+                  stacklevel=3)
 
 
 def _missing_raise():

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1568,7 +1568,7 @@ class ConstantWarning(DeprecationWarning):
 def _check_obsolete(key: str) -> None:
     if key in _obsolete_constants and key not in _aliases:
         warnings.warn(f"Constant '{key}' is not in current {_current_codata} data set",
-                      ConstantWarning, stacklevel=2)
+                      ConstantWarning, stacklevel=3)
 
 
 def value(key: str) -> float:

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1567,7 +1567,8 @@ class ConstantWarning(DeprecationWarning):
 
 def _check_obsolete(key: str) -> None:
     if key in _obsolete_constants and key not in _aliases:
-        warnings.warn(f"Constant '{key}' is not in current {_current_codata} data set", ConstantWarning)
+        warnings.warn(f"Constant '{key}' is not in current {_current_codata} data set",
+                      ConstantWarning, stacklevel=2)
 
 
 def value(key: str) -> float:

--- a/scipy/fft/_fftlog_backend.py
+++ b/scipy/fft/_fftlog_backend.py
@@ -102,12 +102,12 @@ def fhtcoeff(n, dln, mu, offset=0.0, bias=0.0, inverse=False):
 
     # check for singular transform or singular inverse transform
     if np.isinf(u[0]) and not inverse:
-        warn('singular transform; consider changing the bias')
+        warn('singular transform; consider changing the bias', stacklevel=2)
         # fix coefficient to obtain (potentially correct) transform anyway
         u = copy(u)
         u[0] = 0
     elif u[0] == 0 and inverse:
-        warn('singular inverse transform; consider changing the bias')
+        warn('singular inverse transform; consider changing the bias', stacklevel=2)
         # fix coefficient to obtain (potentially correct) inverse anyway
         u = copy(u)
         u[0] = np.inf

--- a/scipy/fft/_fftlog_backend.py
+++ b/scipy/fft/_fftlog_backend.py
@@ -102,12 +102,12 @@ def fhtcoeff(n, dln, mu, offset=0.0, bias=0.0, inverse=False):
 
     # check for singular transform or singular inverse transform
     if np.isinf(u[0]) and not inverse:
-        warn('singular transform; consider changing the bias', stacklevel=2)
+        warn('singular transform; consider changing the bias', stacklevel=3)
         # fix coefficient to obtain (potentially correct) transform anyway
         u = copy(u)
         u[0] = 0
     elif u[0] == 0 and inverse:
-        warn('singular inverse transform; consider changing the bias', stacklevel=2)
+        warn('singular inverse transform; consider changing the bias', stacklevel=3)
         # fix coefficient to obtain (potentially correct) inverse anyway
         u = copy(u)
         u[0] = np.inf

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -1025,7 +1025,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         raise ValueError("`p` must be 1 dimensional.")
 
     if tol < 100 * EPS:
-        warn(f"`tol` is too low, setting to {100 * EPS:.2e}")
+        warn(f"`tol` is too low, setting to {100 * EPS:.2e}", stacklevel=2)
         tol = 100 * EPS
 
     if verbose not in [0, 1, 2]:

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -37,7 +37,8 @@ def warn_extraneous(extraneous):
     """
     if extraneous:
         warn("The following arguments have no effect for a chosen solver: {}."
-             .format(", ".join(f"`{x}`" for x in extraneous)))
+             .format(", ".join(f"`{x}`" for x in extraneous)),
+             stacklevel=2)
 
 
 def validate_tol(rtol, atol, n):
@@ -45,7 +46,8 @@ def validate_tol(rtol, atol, n):
 
     if np.any(rtol < 100 * EPS):
         warn("At least one element of `rtol` is too small. "
-             f"Setting `rtol = np.maximum(rtol, {100 * EPS})`.")
+             f"Setting `rtol = np.maximum(rtol, {100 * EPS})`.",
+             stacklevel=2)
         rtol = np.maximum(rtol, 100 * EPS)
 
     atol = np.asarray(atol)

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -38,7 +38,7 @@ def warn_extraneous(extraneous):
     if extraneous:
         warn("The following arguments have no effect for a chosen solver: {}."
              .format(", ".join(f"`{x}`" for x in extraneous)),
-             stacklevel=2)
+             stacklevel=3)
 
 
 def validate_tol(rtol, atol, n):
@@ -47,7 +47,7 @@ def validate_tol(rtol, atol, n):
     if np.any(rtol < 100 * EPS):
         warn("At least one element of `rtol` is too small. "
              f"Setting `rtol = np.maximum(rtol, {100 * EPS})`.",
-             stacklevel=2)
+             stacklevel=3)
         rtol = np.maximum(rtol, 100 * EPS)
 
     atol = np.asarray(atol)

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -385,7 +385,7 @@ class ode:
             # FIXME: this really should be raise an exception. Will that break
             # any code?
             message = f'No integrator name match with {name!r} or is not available.'
-            warnings.warn(message, stacklevel=3)
+            warnings.warn(message, stacklevel=2)
         else:
             self._integrator = integrator(**integrator_params)
             if not len(self._y):

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -385,7 +385,7 @@ class ode:
             # FIXME: this really should be raise an exception. Will that break
             # any code?
             message = f'No integrator name match with {name!r} or is not available.'
-            warnings.warn(message, stacklevel=2)
+            warnings.warn(message, stacklevel=3)
         else:
             self._integrator = integrator(**integrator_params)
             if not len(self._y):

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -384,8 +384,8 @@ class ode:
         if integrator is None:
             # FIXME: this really should be raise an exception. Will that break
             # any code?
-            warnings.warn('No integrator name match with %r or is not '
-                          'available.' % name)
+            message = f'No integrator name match with {name!r} or is not available.'
+            warnings.warn(message, stacklevel=2)
         else:
             self._integrator = integrator(**integrator_params)
             if not len(self._y):
@@ -1009,7 +1009,8 @@ class vode(IntegratorBase):
         if istate < 0:
             unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
-                          self.messages.get(istate, unexpected_istate_msg)))
+                          self.messages.get(istate, unexpected_istate_msg)),
+                          stacklevel=2)
             self.success = 0
         else:
             self.call_args[3] = 2  # upgrade istate from 1 to 2
@@ -1177,7 +1178,8 @@ class dopri5(IntegratorBase):
         if istate < 0:
             unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
-                          self.messages.get(istate, unexpected_istate_msg)))
+                          self.messages.get(istate, unexpected_istate_msg)),
+                          stacklevel=2)
             self.success = 0
         return y, x
 
@@ -1346,7 +1348,8 @@ class lsoda(IntegratorBase):
         if istate < 0:
             unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
-                          self.messages.get(istate, unexpected_istate_msg)))
+                          self.messages.get(istate, unexpected_istate_msg)),
+                          stacklevel=2)
             self.success = 0
         else:
             self.call_args[3] = 2  # upgrade istate from 1 to 2

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -246,10 +246,10 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
                              int(bool(tfirst)))
     if output[-1] < 0:
         warning_msg = _msgs[output[-1]] + " Run with full_output = 1 to get quantitative information."
-        warnings.warn(warning_msg, ODEintWarning)
+        warnings.warn(warning_msg, ODEintWarning, stacklevel=2)
     elif printmessg:
         warning_msg = _msgs[output[-1]]
-        warnings.warn(warning_msg, ODEintWarning)
+        warnings.warn(warning_msg, ODEintWarning, stacklevel=2)
 
     if full_output:
         output[1]['message'] = _msgs[output[-1]]

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -393,7 +393,8 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     else:
         warnings.warn(
             "maxiter (%d) exceeded. Latest difference = %e" % (maxiter, err),
-            AccuracyWarning)
+            AccuracyWarning, stacklevel=2
+        )
     return val, err
 
 
@@ -1117,7 +1118,7 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
     else:
         warnings.warn(
             "divmax (%d) exceeded. Latest difference = %e" % (divmax, err),
-            AccuracyWarning)
+            AccuracyWarning, stacklevel=2)
 
     if show:
         _printresmat(vfunc, interval, resmat)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -310,7 +310,7 @@ class UnivariateSpline:
             if ier == 1:
                 self._set_class(LSQUnivariateSpline)
             message = _curfit_messages.get(ier, 'ier=%s' % (ier))
-            warnings.warn(message, stacklevel=2)
+            warnings.warn(message, stacklevel=3)
 
     def _set_class(self, cls):
         self._spline_class = cls
@@ -347,7 +347,7 @@ class UnivariateSpline:
         if data[6] == -1:
             warnings.warn('smoothing factor unchanged for'
                           'LSQ spline with fixed knots',
-                          stacklevel=2)
+                          stacklevel=3)
             return
         args = data[:6] + (s,) + data[7:]
         data = dfitpack.fpcurf1(*args)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -310,7 +310,7 @@ class UnivariateSpline:
             if ier == 1:
                 self._set_class(LSQUnivariateSpline)
             message = _curfit_messages.get(ier, 'ier=%s' % (ier))
-            warnings.warn(message)
+            warnings.warn(message, stacklevel=2)
 
     def _set_class(self, cls):
         self._spline_class = cls
@@ -346,7 +346,8 @@ class UnivariateSpline:
         data = self._data
         if data[6] == -1:
             warnings.warn('smoothing factor unchanged for'
-                          'LSQ spline with fixed knots')
+                          'LSQ spline with fixed knots',
+                          stacklevel=2)
             return
         args = data[:6] + (s,) + data[7:]
         data = dfitpack.fpcurf1(*args)
@@ -1416,7 +1417,7 @@ class SmoothBivariateSpline(BivariateSpline):
             pass
         else:
             message = _surfit_messages.get(ier, 'ier=%s' % (ier))
-            warnings.warn(message)
+            warnings.warn(message, stacklevel=2)
 
         self.fp = fp
         self.tck = tx[:nx], ty[:ny], c[:(nx-kx-1)*(ny-ky-1)]
@@ -1516,7 +1517,7 @@ class LSQBivariateSpline(BivariateSpline):
                 message = _surfit_messages.get(-3) % (deficiency)
             else:
                 message = _surfit_messages.get(ier, 'ier=%s' % (ier))
-            warnings.warn(message)
+            warnings.warn(message, stacklevel=2)
         self.fp = fp
         self.tck = tx1[:nx], ty1[:ny], c
         self.degrees = kx, ky

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -347,7 +347,7 @@ class UnivariateSpline:
         if data[6] == -1:
             warnings.warn('smoothing factor unchanged for'
                           'LSQ spline with fixed knots',
-                          stacklevel=3)
+                          stacklevel=2)
             return
         args = data[:6] + (s,) + data[7:]
         data = dfitpack.fpcurf1(*args)

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -118,7 +118,8 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
             if x[i][0] != x[i][-1]:
                 if not quiet:
                     warnings.warn(RuntimeWarning('Setting x[%d][%d]=x[%d][0]' %
-                                                 (i, m, i)))
+                                                 (i, m, i)),
+                                  stacklevel=2)
                 x[i][-1] = x[i][0]
     if not 0 < idim < 11:
         raise TypeError('0 < idim < 11 must hold')
@@ -188,10 +189,11 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     if ier <= 0 and not quiet:
         warnings.warn(RuntimeWarning(_iermess[ier][0] +
                                      "\tk=%d n=%d m=%d fp=%f s=%f" %
-                                     (k, len(t), m, fp, s)))
+                                     (k, len(t), m, fp, s)),
+                      stacklevel=2)
     if ier > 0 and not full_output:
         if ier in [1, 2, 3]:
-            warnings.warn(RuntimeWarning(_iermess[ier][0]))
+            warnings.warn(RuntimeWarning(_iermess[ier][0]), stacklevel=2)
         else:
             try:
                 raise _iermess[ier][1](_iermess[ier][0])
@@ -279,10 +281,10 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     if ier <= 0 and not quiet:
         _mess = (_iermess[ier][0] + "\tk=%d n=%d m=%d fp=%f s=%f" %
                  (k, len(t), m, fp, s))
-        warnings.warn(RuntimeWarning(_mess))
+        warnings.warn(RuntimeWarning(_mess), stacklevel=2)
     if ier > 0 and not full_output:
         if ier in [1, 2, 3]:
-            warnings.warn(RuntimeWarning(_iermess[ier][0]))
+            warnings.warn(RuntimeWarning(_iermess[ier][0]), stacklevel=2)
         else:
             try:
                 raise _iermess[ier][1](_iermess[ier][0])
@@ -374,7 +376,8 @@ def sproot(tck, mest=10):
         if ier == 0:
             return z[:m]
         if ier == 1:
-            warnings.warn(RuntimeWarning("The number of zeros exceeds mest"))
+            warnings.warn(RuntimeWarning("The number of zeros exceeds mest"),
+                          stacklevel=2)
             return z[:m]
         raise TypeError("Unknown error")
 
@@ -586,12 +589,12 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
         _mess = (_iermess2[ierm][0] +
                  "\tkx,ky=%d,%d nx,ny=%d,%d m=%d fp=%f s=%f" %
                  (kx, ky, len(tx), len(ty), m, fp, s))
-        warnings.warn(RuntimeWarning(_mess))
+        warnings.warn(RuntimeWarning(_mess), stacklevel=2)
     if ierm > 0 and not full_output:
         if ier in [1, 2, 3, 4, 5]:
             _mess = ("\n\tkx,ky=%d,%d nx,ny=%d,%d m=%d fp=%f s=%f" %
                      (kx, ky, len(tx), len(ty), m, fp, s))
-            warnings.warn(RuntimeWarning(_iermess2[ierm][0] + _mess))
+            warnings.warn(RuntimeWarning(_iermess2[ierm][0] + _mess), stacklevel=2)
         else:
             try:
                 raise _iermess2[ierm][1](_iermess2[ierm][0])

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -346,10 +346,10 @@ class RBFInterpolator:
                 warnings.warn(
                     f"`degree` should not be below {min_degree} when `kernel` "
                     f"is '{kernel}'. The interpolant may not be uniquely "
-                    "solvable, and the smoothing parameter may have an "
-                    "unintuitive effect.",
-                    UserWarning
-                    )
+                    f"solvable, and the smoothing parameter may have an "
+                    f"unintuitive effect.",
+                    UserWarning, stacklevel=2
+                )
 
         if neighbors is None:
             nobs = ny

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -112,7 +112,7 @@ class FortranFile:
 
         header_dtype = np.dtype(header_dtype)
         if header_dtype.kind != 'u':
-            warnings.warn("Given a dtype which is not unsigned.")
+            warnings.warn("Given a dtype which is not unsigned.", stacklevel=2)
 
         if mode not in 'rw' or len(mode) != 1:
             raise ValueError('mode must be either r or w')

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -221,7 +221,8 @@ class HBInfo:
         if key is None:
             key = "|No Key"
         if len(key) > 8:
-            warnings.warn("key is > 8 characters (key is %s)" % key, LineOverflow)
+            warnings.warn("key is > 8 characters (key is %s)" % key,
+                          LineOverflow, stacklevel=2)
 
         self.total_nlines = total_nlines
         self.pointer_nlines = pointer_nlines

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -222,7 +222,7 @@ class HBInfo:
             key = "|No Key"
         if len(key) > 8:
             warnings.warn("key is > 8 characters (key is %s)" % key,
-                          LineOverflow, stacklevel=2)
+                          LineOverflow, stacklevel=3)
 
         self.total_nlines = total_nlines
         self.pointer_nlines = pointer_nlines

--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -277,7 +277,7 @@ def _read_array(f, typecode, array_desc):
             nbytes = _read_int32(f)
             if nbytes != array_desc['nbytes']:
                 warnings.warn("Not able to verify number of bytes from header",
-                              stacklevel=2)
+                              stacklevel=3)
 
         # Read bytes as numpy array
         array = np.frombuffer(f.read(array_desc['nbytes']),
@@ -406,11 +406,11 @@ def _read_record(f):
 
     elif record['rectype'] == "UNKNOWN":
 
-        warnings.warn("Skipping UNKNOWN record", stacklevel=2)
+        warnings.warn("Skipping UNKNOWN record", stacklevel=3)
 
     elif record['rectype'] == "SYSTEM_VARIABLE":
 
-        warnings.warn("Skipping SYSTEM_VARIABLE record", stacklevel=2)
+        warnings.warn("Skipping SYSTEM_VARIABLE record", stacklevel=3)
 
     else:
 
@@ -462,7 +462,7 @@ def _read_arraydesc(f):
 
     elif arraydesc['arrstart'] == 18:
 
-        warnings.warn("Using experimental 64-bit array read", stacklevel=2)
+        warnings.warn("Using experimental 64-bit array read", stacklevel=3)
 
         _skip_bytes(f, 8)
 
@@ -575,7 +575,7 @@ def _replace_heap(variable, heap):
                 else:
                     warnings.warn("Variable referenced by pointer not found "
                                   "in heap: variable will be set to None",
-                                  stacklevel=2)
+                                  stacklevel=3)
                     variable = None
 
         replace, new = _replace_heap(variable, heap)

--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -276,7 +276,8 @@ def _read_array(f, typecode, array_desc):
         if typecode == 1:
             nbytes = _read_int32(f)
             if nbytes != array_desc['nbytes']:
-                warnings.warn("Not able to verify number of bytes from header")
+                warnings.warn("Not able to verify number of bytes from header",
+                              stacklevel=2)
 
         # Read bytes as numpy array
         array = np.frombuffer(f.read(array_desc['nbytes']),
@@ -405,16 +406,15 @@ def _read_record(f):
 
     elif record['rectype'] == "UNKNOWN":
 
-        warnings.warn("Skipping UNKNOWN record")
+        warnings.warn("Skipping UNKNOWN record", stacklevel=2)
 
     elif record['rectype'] == "SYSTEM_VARIABLE":
 
-        warnings.warn("Skipping SYSTEM_VARIABLE record")
+        warnings.warn("Skipping SYSTEM_VARIABLE record", stacklevel=2)
 
     else:
 
-        raise Exception("record['rectype']=%s not implemented" %
-                                                            record['rectype'])
+        raise Exception(f"record['rectype']={record['rectype']} not implemented")
 
     f.seek(nextrec)
 
@@ -462,7 +462,7 @@ def _read_arraydesc(f):
 
     elif arraydesc['arrstart'] == 18:
 
-        warnings.warn("Using experimental 64-bit array read")
+        warnings.warn("Using experimental 64-bit array read", stacklevel=2)
 
         _skip_bytes(f, 8)
 
@@ -574,7 +574,8 @@ def _replace_heap(variable, heap):
                     variable = heap[variable.index]
                 else:
                     warnings.warn("Variable referenced by pointer not found "
-                                  "in heap: variable will be set to None")
+                                  "in heap: variable will be set to None",
+                                  stacklevel=2)
                     variable = None
 
         replace, new = _replace_heap(variable, heap)

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -303,13 +303,14 @@ class netcdf_file:
                     else:
                         # we cannot close self._mm, since self._mm_buf is
                         # alive and there may still be arrays referring to it
-                        warnings.warn((
+                        warnings.warn(
                             "Cannot close a netcdf_file opened with mmap=True, when "
                             "netcdf_variables or arrays referring to its data still exist. "
                             "All data arrays obtained from such files refer directly to "
                             "data on disk, and must be copied before the file can be cleanly "
-                            "closed. (See netcdf_file docstring for more information on mmap.)"
-                        ), category=RuntimeWarning)
+                            "closed. (See netcdf_file docstring for more information on mmap.)",
+                            category=RuntimeWarning, stacklevel=2
+                        )
                 self._mm = None
                 self.fp.close()
     __del__ = close

--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -119,7 +119,7 @@ class VarReader4:
         if M not in (0, 1):
             warnings.warn("We do not support byte ordering '%s'; returned "
                           "data may be corrupt" % order_codes[M],
-                          UserWarning, stacklevel=2)
+                          UserWarning, stacklevel=3)
         O, rest = divmod(rest, 100)  # unused, should be 0
         if O != 0:
             raise ValueError('O in MOPT integer should be 0, wrong format?')

--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -119,7 +119,7 @@ class VarReader4:
         if M not in (0, 1):
             warnings.warn("We do not support byte ordering '%s'; returned "
                           "data may be corrupt" % order_codes[M],
-                          UserWarning)
+                          UserWarning, stacklevel=2)
         O, rest = divmod(rest, 100)  # unused, should be 0
         if O != 0:
             raise ValueError('O in MOPT integer should be 0, wrong format?')

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -824,7 +824,7 @@ def _logm_force_nonsingular_triangular_matrix(T, inplace=False):
     abs_diag = np.absolute(np.diag(T))
     if np.any(abs_diag == 0):
         exact_singularity_msg = 'The logm input matrix is exactly singular.'
-        warnings.warn(exact_singularity_msg, LogmExactlySingularWarning, stacklevel=2)
+        warnings.warn(exact_singularity_msg, LogmExactlySingularWarning, stacklevel=3)
         if not inplace:
             T = T.copy()
         n = T.shape[0]
@@ -833,7 +833,7 @@ def _logm_force_nonsingular_triangular_matrix(T, inplace=False):
                 T[i, i] = tri_eps
     elif np.any(abs_diag < tri_eps):
         near_singularity_msg = 'The logm input matrix may be nearly singular.'
-        warnings.warn(near_singularity_msg, LogmNearlySingularWarning, stacklevel=2)
+        warnings.warn(near_singularity_msg, LogmNearlySingularWarning, stacklevel=3)
     return T
 
 

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -824,7 +824,7 @@ def _logm_force_nonsingular_triangular_matrix(T, inplace=False):
     abs_diag = np.absolute(np.diag(T))
     if np.any(abs_diag == 0):
         exact_singularity_msg = 'The logm input matrix is exactly singular.'
-        warnings.warn(exact_singularity_msg, LogmExactlySingularWarning)
+        warnings.warn(exact_singularity_msg, LogmExactlySingularWarning, stacklevel=2)
         if not inplace:
             T = T.copy()
         n = T.shape[0]
@@ -833,7 +833,7 @@ def _logm_force_nonsingular_triangular_matrix(T, inplace=False):
                 T[i, i] = tri_eps
     elif np.any(abs_diag < tri_eps):
         near_singularity_msg = 'The logm input matrix may be nearly singular.'
-        warnings.warn(near_singularity_msg, LogmNearlySingularWarning)
+        warnings.warn(near_singularity_msg, LogmNearlySingularWarning, stacklevel=2)
     return T
 
 

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -192,7 +192,7 @@ def solve_continuous_lyapunov(a, q):
         warnings.warn('Input "a" has an eigenvalue pair whose sum is '
                       'very close to or exactly zero. The solution is '
                       'obtained via perturbing the coefficients.',
-                      RuntimeWarning)
+                      RuntimeWarning, stacklevel=2)
     y *= scale
 
     return u.dot(y).dot(u.conj().T)

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -619,7 +619,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         warnings.warn(
             "The behavior of affine_transform with a 1-D "
             "array supplied for the matrix parameter has changed in "
-            "SciPy 0.18.0."
+            "SciPy 0.18.0.",
+            stacklevel=2
         )
         _nd_image.zoom_shift(filtered, matrix, offset/matrix, output, order,
                              mode, cval, npad, False)
@@ -848,7 +849,8 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         if suggest_mode is not None:
             warnings.warn(
                 ("It is recommended to use mode = {} instead of {} when "
-                 "grid_mode is True.").format(suggest_mode, mode)
+                 "grid_mode is True.").format(suggest_mode, mode),
+                stacklevel=2
             )
     mode = _ni_support._extend_mode_to_code(mode)
 

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -83,7 +83,7 @@ def _get_output(output, input, shape=None, complex_output=False):
     elif isinstance(output, (type, numpy.dtype)):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
         if complex_output and numpy.dtype(output).kind != 'c':
-            warnings.warn("promoting specified output dtype to complex")
+            warnings.warn("promoting specified output dtype to complex", stacklevel=2)
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -83,7 +83,7 @@ def _get_output(output, input, shape=None, complex_output=False):
     elif isinstance(output, (type, numpy.dtype)):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
         if complex_output and numpy.dtype(output).kind != 'c':
-            warnings.warn("promoting specified output dtype to complex", stacklevel=2)
+            warnings.warn("promoting specified output dtype to complex", stacklevel=3)
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -871,7 +871,7 @@ class ODR:
         if self.data.x.size == 0:
             warn("Empty data detected for ODR instance. "
                  "Do not expect any fitting to occur",
-                 OdrWarning, stacklevel=2)
+                 OdrWarning, stacklevel=3)
 
     def _gen_work(self):
         """ Generate a suitable work array if one does not already exist.

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -869,9 +869,9 @@ class ODR:
                 "delta0 is not a %s-shaped array" % repr(self.data.x.shape))
 
         if self.data.x.size == 0:
-            warn(("Empty data detected for ODR instance. "
-                  "Do not expect any fitting to occur"),
-                 OdrWarning)
+            warn("Empty data detected for ODR instance. "
+                 "Do not expect any fitting to occur",
+                 OdrWarning, stacklevel=2)
 
     def _gen_work(self):
         """ Generate a suitable work array if one does not already exist.

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -459,7 +459,8 @@ def new_constraint_to_old(con, x0):
                 con.keep_feasible):
             warn("Constraint options `finite_diff_jac_sparsity`, "
                  "`finite_diff_rel_step`, `keep_feasible`, and `hess`"
-                 "are ignored by this method.", OptimizeWarning)
+                 "are ignored by this method.",
+                 OptimizeWarning, stacklevel=2)
 
         fun = con.fun
         if callable(con.jac):
@@ -469,8 +470,8 @@ def new_constraint_to_old(con, x0):
 
     else:  # LinearConstraint
         if np.any(con.keep_feasible):
-            warn("Constraint option `keep_feasible` is ignored by this "
-                 "method.", OptimizeWarning)
+            warn("Constraint option `keep_feasible` is ignored by this method.",
+                 OptimizeWarning, stacklevel=2)
 
         A = con.A
         if issparse(A):
@@ -492,7 +493,8 @@ def new_constraint_to_old(con, x0):
 
     if np.any(i_unbounded):
         warn("At least one constraint is unbounded above and below. Such "
-             "constraints are ignored.", OptimizeWarning)
+             "constraints are ignored.",
+             OptimizeWarning, stacklevel=2)
 
     ceq = []
     if np.any(i_eq):
@@ -540,7 +542,8 @@ def new_constraint_to_old(con, x0):
         warn("Equality and inequality constraints are specified in the same "
              "element of the constraint list. For efficient use with this "
              "method, equality and inequality constraints should be specified "
-             "in separate elements of the constraint list. ", OptimizeWarning)
+             "in separate elements of the constraint list. ",
+             OptimizeWarning, stacklevel=2)
     return old_constraints
 
 

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -460,7 +460,7 @@ def new_constraint_to_old(con, x0):
             warn("Constraint options `finite_diff_jac_sparsity`, "
                  "`finite_diff_rel_step`, `keep_feasible`, and `hess`"
                  "are ignored by this method.",
-                 OptimizeWarning, stacklevel=2)
+                 OptimizeWarning, stacklevel=3)
 
         fun = con.fun
         if callable(con.jac):
@@ -471,7 +471,7 @@ def new_constraint_to_old(con, x0):
     else:  # LinearConstraint
         if np.any(con.keep_feasible):
             warn("Constraint option `keep_feasible` is ignored by this method.",
-                 OptimizeWarning, stacklevel=2)
+                 OptimizeWarning, stacklevel=3)
 
         A = con.A
         if issparse(A):
@@ -494,7 +494,7 @@ def new_constraint_to_old(con, x0):
     if np.any(i_unbounded):
         warn("At least one constraint is unbounded above and below. Such "
              "constraints are ignored.",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
 
     ceq = []
     if np.any(i_eq):
@@ -543,7 +543,7 @@ def new_constraint_to_old(con, x0):
              "element of the constraint list. For efficient use with this "
              "method, equality and inequality constraints should be specified "
              "in separate elements of the constraint list. ",
-             OptimizeWarning, stacklevel=2)
+             OptimizeWarning, stacklevel=3)
     return old_constraints
 
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1216,10 +1216,11 @@ class DifferentialEvolutionSolver:
 
                 constr_violation = self._constraint_violation_fn(DE_result.x)
                 if np.any(constr_violation > 0.):
-                    warnings.warn("differential evolution didn't find a"
-                                  " solution satisfying the constraints,"
-                                  " attempting to polish from the least"
-                                  " infeasible solution", UserWarning)
+                    warnings.warn("differential evolution didn't find a "
+                                  "solution satisfying the constraints, "
+                                  "attempting to polish from the least "
+                                  "infeasible solution",
+                                  UserWarning, stacklevel=2)
             if self.disp:
                 print(f"Polishing solution with '{polish_method}'")
             result = minimize(self.func,

--- a/scipy/optimize/_hessian_update_strategy.py
+++ b/scipy/optimize/_hessian_update_strategy.py
@@ -183,7 +183,8 @@ class FullHessianUpdateStrategy(HessianUpdateStrategy):
                  'function is linear. If the function is linear '
                  'better results can be obtained by defining the '
                  'Hessian as zero instead of using quasi-Newton '
-                 'approximations.', UserWarning)
+                 'approximations.',
+                 UserWarning, stacklevel=2)
             return
         if self.first_iteration:
             # Get user specific scale

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -315,7 +315,8 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
             extra_condition2, maxiter=maxiter)
 
     if derphi_star is None:
-        warn('The line search algorithm did not converge', LineSearchWarning)
+        warn('The line search algorithm did not converge',
+             LineSearchWarning, stacklevel=2)
     else:
         # derphi_star is a number (derphi) -- so use the most recently
         # calculated gradient used in computing it derphi = gfk*pk
@@ -427,7 +428,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
                 msg = "The line search algorithm could not find a solution " + \
                       "less than or equal to amax: %s" % amax
 
-            warn(msg, LineSearchWarning)
+            warn(msg, LineSearchWarning, stacklevel=2)
             break
 
         not_first_iteration = i > 0
@@ -468,7 +469,8 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
         alpha_star = alpha1
         phi_star = phi_a1
         derphi_star = None
-        warn('The line search algorithm did not converge', LineSearchWarning)
+        warn('The line search algorithm did not converge',
+             LineSearchWarning, stacklevel=2)
 
     return alpha_star, phi_star, phi0, derphi_star
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -614,13 +614,13 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     if x0 is not None and meth != "revised simplex":
         warning_message = "x0 is used only when method is 'revised simplex'. "
-        warn(warning_message, OptimizeWarning)
+        warn(warning_message, OptimizeWarning, stacklevel=2)
 
     if np.any(integrality) and not meth == "highs":
         integrality = None
         warning_message = ("Only `method='highs'` supports integer "
                            "constraints. Ignoring `integrality`.")
-        warn(warning_message, OptimizeWarning)
+        warn(warning_message, OptimizeWarning, stacklevel=2)
     elif np.any(integrality):
         integrality = np.broadcast_to(integrality, np.shape(c))
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -109,7 +109,8 @@ def check_tolerance(ftol, xtol, gtol, method):
             tol = 0
         elif tol < EPS:
             warn(f"Setting `{name}` below the machine epsilon ({EPS:.2e}) effectively "
-                 "disables the corresponding termination condition.")
+                 f"disables the corresponding termination condition.",
+                 stacklevel=2)
         return tol
 
     ftol = check(ftol, "ftol")
@@ -882,8 +883,8 @@ def least_squares(
                                  "`jac_sparsity`.")
 
             if jac != '2-point':
-                warn(f"jac='{jac}' works equivalently to '2-point' "
-                     "for method='lm'.")
+                warn(f"jac='{jac}' works equivalently to '2-point' for method='lm'.",
+                     stacklevel=2)
 
             J0 = jac_wrapped = None
         else:
@@ -944,7 +945,8 @@ def least_squares(
     elif method == 'dogbox':
         if tr_solver == 'lsmr' and 'regularize' in tr_options:
             warn("The keyword 'regularize' in `tr_options` is not relevant "
-                 "for 'dogbox' method.")
+                 "for 'dogbox' method.",
+                 stacklevel=2)
             tr_options = tr_options.copy()
             del tr_options['regularize']
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -110,7 +110,7 @@ def check_tolerance(ftol, xtol, gtol, method):
         elif tol < EPS:
             warn(f"Setting `{name}` below the machine epsilon ({EPS:.2e}) effectively "
                  f"disables the corresponding termination condition.",
-                 stacklevel=2)
+                 stacklevel=3)
         return tol
 
     ftol = check(ftol, "ftol")

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -558,32 +558,33 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     # - jac
     if meth in ('nelder-mead', 'powell', 'cobyla') and bool(jac):
         warn('Method %s does not use gradient information (jac).' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
     # - hess
     if meth not in ('newton-cg', 'dogleg', 'trust-ncg', 'trust-constr',
                     'trust-krylov', 'trust-exact', '_custom') and hess is not None:
         warn('Method %s does not use Hessian information (hess).' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
     # - hessp
     if meth not in ('newton-cg', 'trust-ncg', 'trust-constr',
                     'trust-krylov', '_custom') \
        and hessp is not None:
         warn('Method %s does not use Hessian-vector product '
-             'information (hessp).' % method, RuntimeWarning)
+             'information (hessp).' % method,
+             RuntimeWarning, stacklevel=2)
     # - constraints or bounds
     if (meth not in ('cobyla', 'slsqp', 'trust-constr', '_custom') and
             np.any(constraints)):
         warn('Method %s cannot handle constraints.' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
     if meth not in ('nelder-mead', 'powell', 'l-bfgs-b', 'cobyla', 'slsqp',
                     'tnc', 'trust-constr', '_custom') and bounds is not None:
         warn('Method %s cannot handle bounds.' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
     # - return_all
     if (meth in ('l-bfgs-b', 'tnc', 'cobyla', 'slsqp') and
             options.get('return_all', False)):
         warn('Method %s does not support the return_all option.' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
 
     # check gradient vector
     if callable(jac):
@@ -917,7 +918,8 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         options = dict(options)
         if meth == 'bounded' and 'xatol' not in options:
             warn("Method 'bounded' does not support relative tolerance in x; "
-                 "defaulting to absolute tolerance.", RuntimeWarning)
+                 "defaulting to absolute tolerance.",
+                 RuntimeWarning, stacklevel=2)
             options['xatol'] = tol
         elif meth == '_custom':
             options.setdefault('tol', tol)

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -178,7 +178,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
         elif status == 1:
             pass
         elif status in [2, 3, 4, 5]:
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
         else:
             raise TypeError(msg)
         return res['x']
@@ -496,7 +496,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=False,
         return (retval[0], cov_x) + retval[1:-1] + (errors[info][0], info)
     else:
         if info in LEASTSQ_FAILURE:
-            warnings.warn(errors[info][0], RuntimeWarning)
+            warnings.warn(errors[info][0], RuntimeWarning, stacklevel=2)
         elif info == 0:
             raise errors[info][1](errors[info][0])
         return retval[0], info
@@ -1020,7 +1020,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
     if warn_cov:
         warnings.warn('Covariance of the parameters could not be estimated',
-                      category=OptimizeWarning)
+                      category=OptimizeWarning, stacklevel=2)
 
     if full_output:
         return popt, pcov, infodict, errmsg, ier

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -423,7 +423,7 @@ def _check_clip_x(x, bounds):
     if (x < bounds[0]).any() or (x > bounds[1]).any():
         warnings.warn("Values in x were outside bounds during a "
                       "minimize step, clipping to bounds",
-                      RuntimeWarning, stacklevel=2)
+                      RuntimeWarning, stacklevel=3)
         x = np.clip(x, bounds[0], bounds[1])
         return x
 
@@ -861,7 +861,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         if (lower_bound > upper_bound).any():
             raise ValueError(
                 "Nelder Mead - one of the lower bounds is greater than an upper bound.",
-                stacklevel=2
+                stacklevel=3
             )
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -290,7 +290,7 @@ def _check_unknown_options(unknown_options):
         # Stack level 4: this is called from _minimize_*, which is
         # called from another function in SciPy. Level 4 is the first
         # level in user code.
-        warnings.warn("Unknown solver options: %s" % msg, OptimizeWarning, 4)
+        warnings.warn("Unknown solver options: %s" % msg, OptimizeWarning, stacklevel=4)
 
 
 def is_finite_scalar(x):
@@ -422,7 +422,8 @@ def _clip_x_for_func(func, bounds):
 def _check_clip_x(x, bounds):
     if (x < bounds[0]).any() or (x > bounds[1]).any():
         warnings.warn("Values in x were outside bounds during a "
-                      "minimize step, clipping to bounds", RuntimeWarning)
+                      "minimize step, clipping to bounds",
+                      RuntimeWarning, stacklevel=2)
         x = np.clip(x, bounds[0], bounds[1])
         return x
 
@@ -858,10 +859,13 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         lower_bound, upper_bound = bounds.lb, bounds.ub
         # check bounds
         if (lower_bound > upper_bound).any():
-            raise ValueError("Nelder Mead - one of the lower bounds is greater than an upper bound.")
+            raise ValueError(
+                "Nelder Mead - one of the lower bounds is greater than an upper bound.",
+                stacklevel=2
+            )
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",
-                          OptimizeWarning, 3)
+                          OptimizeWarning, stacklevel=3)
 
     if bounds is not None:
         x0 = np.clip(x0, lower_bound, upper_bound)
@@ -1016,12 +1020,12 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         warnflag = 1
         msg = _status_message['maxfev']
         if disp:
-            warnings.warn(msg, RuntimeWarning, 3)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
     elif iterations >= maxiter:
         warnflag = 2
         msg = _status_message['maxiter']
         if disp:
-            warnings.warn(msg, RuntimeWarning, 3)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
     else:
         msg = _status_message['success']
         if disp:
@@ -3566,7 +3570,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         if np.linalg.matrix_rank(direc) != direc.shape[0]:
             warnings.warn("direc input is not full rank, some parameters may "
                           "not be optimized",
-                          OptimizeWarning, 3)
+                          OptimizeWarning, stacklevel=3)
 
     if bounds is None:
         # don't make these arrays of all +/- inf. because
@@ -3579,7 +3583,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         lower_bound, upper_bound = bounds.lb, bounds.ub
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",
-                          OptimizeWarning, 3)
+                          OptimizeWarning, stacklevel=3)
 
     fval = squeeze(func(x))
     x1 = x.copy()
@@ -3950,10 +3954,9 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
             success = res[-1] == 0
         if not success:
             if disp:
-                warnings.warn(
-                    "Either final optimization did not succeed "
-                    "or `finish` does not return `statuscode` as its last "
-                    "argument.", RuntimeWarning, 2)
+                warnings.warn("Either final optimization did not succeed or `finish` "
+                              "does not return `statuscode` as its last argument.",
+                              RuntimeWarning, stacklevel=2)
 
     if full_output:
         return xmin, Jmin, grid, Jout

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -208,7 +208,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
 
     if callback is not None and meth in ('hybr', 'lm'):
         warn('Method %s does not accept callback.' % method,
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
 
     # fun also returns the Jacobian
     if not callable(jac) and meth in ('hybr', 'lm'):
@@ -255,7 +255,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
 def _warn_jac_unused(jac, method):
     if jac is not None:
         warn(f'Method {method} does not use the jacobian (jac).',
-             RuntimeWarning)
+             RuntimeWarning, stacklevel=2)
 
 
 def _root_leastsq(fun, x0, args=(), jac=None,

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -954,7 +954,7 @@ class SHGO:
                     warnings.warn(
                         f"A much lower value than expected f* = {self.f_min_true} "
                         f"was found f_lowest = {self.f_lowest}",
-                        stacklevel=2
+                        stacklevel=3
                     )
             if pe <= self.f_tol:
                 self.stop_global = True

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -951,10 +951,11 @@ class SHGO:
                 self.stop_global = True
                 # 2if (pe - self.f_tol) <= abs(1.0 / abs(self.f_min_true)):
                 if abs(pe) >= 2 * self.f_tol:
-                    warnings.warn("A much lower value than expected f* =" +
-                                  f" {self.f_min_true} than" +
-                                  " the was found f_lowest =" +
-                                  f"{self.f_lowest} ")
+                    warnings.warn(
+                        f"A much lower value than expected f* = {self.f_min_true} "
+                        f"was found f_lowest = {self.f_lowest}",
+                        stacklevel=2
+                    )
             if pe <= self.f_tol:
                 self.stop_global = True
 

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -283,7 +283,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         if warnflag == 0:
             print(status_messages[warnflag])
         else:
-            warnings.warn(status_messages[warnflag], RuntimeWarning, 3)
+            warnings.warn(status_messages[warnflag], RuntimeWarning, stacklevel=3)
         print("         Current function value: %f" % m.fun)
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -379,7 +379,7 @@ def projections(A, method=None, orth_tol=1e-12, max_refin=3, tol=1e-15):
             warnings.warn("Only accepts 'NormalEquation' option when "
                           "scikit-sparse is available. Using "
                           "'AugmentedSystem' option instead.",
-                          ImportWarning, stacklevel=2)
+                          ImportWarning, stacklevel=3)
             method = 'AugmentedSystem'
     else:
         if method is None:

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -102,7 +102,7 @@ def augmented_system_projections(A, m, n, orth_tol, max_refin, tol):
     except RuntimeError:
         warn("Singular Jacobian matrix. Using dense SVD decomposition to "
              "perform the factorizations.",
-             stacklevel=2)
+             stacklevel=3)
         return svd_factorization_projections(A.toarray(),
                                              m, n, orth_tol,
                                              max_refin, tol)
@@ -181,7 +181,7 @@ def qr_factorization_projections(A, m, n, orth_tol, max_refin, tol):
     if np.linalg.norm(R[-1, :], np.inf) < tol:
         warn('Singular Jacobian matrix. Using SVD decomposition to ' +
              'perform the factorizations.',
-             stacklevel=2)
+             stacklevel=3)
         return svd_factorization_projections(A, m, n,
                                              orth_tol,
                                              max_refin,

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -101,7 +101,8 @@ def augmented_system_projections(A, m, n, orth_tol, max_refin, tol):
         solve = scipy.sparse.linalg.factorized(K)
     except RuntimeError:
         warn("Singular Jacobian matrix. Using dense SVD decomposition to "
-             "perform the factorizations.")
+             "perform the factorizations.",
+             stacklevel=2)
         return svd_factorization_projections(A.toarray(),
                                              m, n, orth_tol,
                                              max_refin, tol)
@@ -179,7 +180,8 @@ def qr_factorization_projections(A, m, n, orth_tol, max_refin, tol):
 
     if np.linalg.norm(R[-1, :], np.inf) < tol:
         warn('Singular Jacobian matrix. Using SVD decomposition to ' +
-             'perform the factorizations.')
+             'perform the factorizations.',
+             stacklevel=2)
         return svd_factorization_projections(A, m, n,
                                              orth_tol,
                                              max_refin,
@@ -374,10 +376,10 @@ def projections(A, method=None, orth_tol=1e-12, max_refin=3, tol=1e-15):
         if method not in ("NormalEquation", "AugmentedSystem"):
             raise ValueError("Method not allowed for sparse matrix.")
         if method == "NormalEquation" and not sksparse_available:
-            warnings.warn(("Only accepts 'NormalEquation' option when"
-                           " scikit-sparse is available. Using "
-                           "'AugmentedSystem' option instead."),
-                          ImportWarning)
+            warnings.warn("Only accepts 'NormalEquation' option when "
+                          "scikit-sparse is available. Using "
+                          "'AugmentedSystem' option instead.",
+                          ImportWarning, stacklevel=2)
             method = 'AugmentedSystem'
     else:
         if method is None:

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -475,18 +475,18 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
                 rms = np.sqrt(
                     sum((p1[zero_der_nz_dp] - p[zero_der_nz_dp]) ** 2)
                 )
-                warnings.warn(f'RMS of {rms:g} reached', RuntimeWarning, stacklevel=2)
+                warnings.warn(f'RMS of {rms:g} reached', RuntimeWarning, stacklevel=3)
         # Newton or Halley warnings
         else:
             all_or_some = 'all' if zero_der.all() else 'some'
             msg = f'{all_or_some:s} derivatives were zero'
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
     elif failures.any():
         all_or_some = 'all' if failures.all() else 'some'
         msg = f'{all_or_some:s} failed to converge after {maxiter:d} iterations'
         if failures.all():
             raise RuntimeError(msg)
-        warnings.warn(msg, RuntimeWarning, stacklevel=2)
+        warnings.warn(msg, RuntimeWarning, stacklevel=3)
 
     if full_output:
         result = namedtuple('result', ('root', 'converged', 'zero_der'))
@@ -1101,7 +1101,7 @@ class TOMS748Solver:
         # Noisily replace a high value of k with self._K_MAX
         if self.k > self._K_MAX:
             msg = "toms748: Overriding k: ->%d" % self._K_MAX
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
             self.k = self._K_MAX
 
     def _callf(self, x, error=True):

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -323,7 +323,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                         " Failed to converge after %d iterations, value is %s."
                         % (itr + 1, p0))
                     raise RuntimeError(msg)
-                warnings.warn(msg, RuntimeWarning)
+                warnings.warn(msg, RuntimeWarning, stacklevel=2)
                 return _results_select(
                     full_output, (p0, funcalls, itr + 1, _ECONVERR), method)
             newton_step = fval / fder
@@ -371,7 +371,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                             " Failed to converge after %d iterations, value is %s."
                             % (itr + 1, p1))
                         raise RuntimeError(msg)
-                    warnings.warn(msg, RuntimeWarning)
+                    warnings.warn(msg, RuntimeWarning, stacklevel=2)
                 p = (p1 + p0) / 2.0
                 return _results_select(
                     full_output, (p, funcalls, itr + 1, _ECONVERR), method)
@@ -475,19 +475,18 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
                 rms = np.sqrt(
                     sum((p1[zero_der_nz_dp] - p[zero_der_nz_dp]) ** 2)
                 )
-                warnings.warn(
-                    f'RMS of {rms:g} reached', RuntimeWarning)
+                warnings.warn(f'RMS of {rms:g} reached', RuntimeWarning, stacklevel=2)
         # Newton or Halley warnings
         else:
             all_or_some = 'all' if zero_der.all() else 'some'
             msg = f'{all_or_some:s} derivatives were zero'
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
     elif failures.any():
         all_or_some = 'all' if failures.all() else 'some'
         msg = f'{all_or_some:s} failed to converge after {maxiter:d} iterations'
         if failures.all():
             raise RuntimeError(msg)
-        warnings.warn(msg, RuntimeWarning)
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     if full_output:
         result = namedtuple('result', ('root', 'converged', 'zero_der'))
@@ -1102,7 +1101,7 @@ class TOMS748Solver:
         # Noisily replace a high value of k with self._K_MAX
         if self.k > self._K_MAX:
             msg = "toms748: Overriding k: ->%d" % self._K_MAX
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
             self.k = self._K_MAX
 
     def _callf(self, x, error=True):

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1800,7 +1800,8 @@ def normalize(b, a):
     # Trim leading zeros of numerator
     if leading_zeros > 0:
         warnings.warn("Badly conditioned filter coefficients (numerator): the "
-                      "results may be meaningless", BadCoefficients)
+                      "results may be meaningless",
+                      BadCoefficients, stacklevel=2)
         # Make sure at least one column remains
         if leading_zeros == num.shape[1]:
             leading_zeros -= 1
@@ -3962,7 +3963,7 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
     except ZeroDivisionError:
         W0 = 1.0
         warnings.warn("Order is zero...check input parameters.",
-                      RuntimeWarning, 2)
+                      RuntimeWarning, stacklevel=2)
 
     # now convert this frequency back from lowpass prototype
     # to the original analog filter
@@ -5505,9 +5506,9 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
     elif ftype == 'iir':
         # Raise warning if order and/or numtaps is passed
         if order is not None:
-            warnings.warn('order is not used for IIR gammatone filter.')
+            warnings.warn('order is not used for IIR gammatone filter.', stacklevel=2)
         if numtaps is not None:
-            warnings.warn('numtaps is not used for IIR gammatone filter.')
+            warnings.warn('numtaps is not used for IIR gammatone filter.', stacklevel=2)
 
         # Gammatone impulse response settings
         T = 1./fs

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1251,8 +1251,8 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
         raise ValueError('h must be 1-D and at least 2 samples long')
     n_half = len(h) // 2
     if not np.allclose(h[-n_half:][::-1], h[:n_half]):
-        warnings.warn('h does not appear to by symmetric, conversion may '
-                      'fail', RuntimeWarning)
+        warnings.warn('h does not appear to by symmetric, conversion may fail',
+                      RuntimeWarning, stacklevel=2)
     if not isinstance(method, str) or method not in \
             ('homomorphic', 'hilbert',):
         raise ValueError(f'method must be "homomorphic" or "hilbert", got {method!r}')

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1562,7 +1562,8 @@ def medfilt(volume, kernel_size=None):
             raise ValueError("Each element of kernel_size should be odd.")
     if any(k > s for k, s in zip(kernel_size, volume.shape)):
         warnings.warn('kernel_size exceeds volume extent: the volume will be '
-                      'zero-padded.')
+                      'zero-padded.',
+                      stacklevel=2)
 
     domain = np.ones(kernel_size, dtype=volume.dtype)
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1896,7 +1896,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         if np.iscomplexobj(x):
             sides = 'twosided'
             warnings.warn('Input data is complex, switching to return_onesided=False',
-                          stacklevel=2)
+                          stacklevel=3)
         else:
             sides = 'onesided'
             if not same_data:
@@ -1904,7 +1904,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
                     sides = 'twosided'
                     warnings.warn('Input data is complex, switching to '
                                   'return_onesided=False',
-                                  stacklevel=2)
+                                  stacklevel=3)
     else:
         sides = 'twosided'
 
@@ -2045,7 +2045,7 @@ def _triage_segments(window, nperseg, input_length):
         if nperseg > input_length:
             warnings.warn(f'nperseg = {nperseg:d} is greater than input length '
                           f' = {input_length:d}, using nperseg = {input_length:d}',
-                          stacklevel=2)
+                          stacklevel=3)
             nperseg = input_length
         win = get_window(window, nperseg)
     else:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1518,7 +1518,8 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if np.sum(norm > 1e-10) != len(norm):
         warnings.warn(
             "NOLA condition failed, STFT may not be invertible."
-            + (" Possibly due to missing boundary" if not boundary else "")
+            + (" Possibly due to missing boundary" if not boundary else ""),
+            stacklevel=2
         )
     x /= np.where(norm > 1e-10, norm, 1.0)
 
@@ -1894,15 +1895,16 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     if return_onesided:
         if np.iscomplexobj(x):
             sides = 'twosided'
-            warnings.warn('Input data is complex, switching to '
-                          'return_onesided=False')
+            warnings.warn('Input data is complex, switching to return_onesided=False',
+                          stacklevel=2)
         else:
             sides = 'onesided'
             if not same_data:
                 if np.iscomplexobj(y):
                     sides = 'twosided'
                     warnings.warn('Input data is complex, switching to '
-                                  'return_onesided=False')
+                                  'return_onesided=False',
+                                  stacklevel=2)
     else:
         sides = 'twosided'
 
@@ -2042,7 +2044,8 @@ def _triage_segments(window, nperseg, input_length):
             nperseg = 256  # then change to default
         if nperseg > input_length:
             warnings.warn(f'nperseg = {nperseg:d} is greater than input length '
-                          f' = {input_length:d}, using nperseg = {input_length:d}')
+                          f' = {input_length:d}, using nperseg = {input_length:d}',
+                          stacklevel=2)
             nperseg = input_length
         win = get_window(window, nperseg)
     else:

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1545,7 +1545,8 @@ def chebwin(M, at, sym=True):
                       "the equivalent noise bandwidth of a Chebyshev window "
                       "does not grow monotonically with increasing sidelobe "
                       "attenuation when the attenuation is smaller than "
-                      "about 45 dB.")
+                      "about 45 dB.",
+                      stacklevel=2)
     if _len_guards(M):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -317,10 +317,9 @@ class _spbase:
             Use `.toarray()` instead.
         """
         if isinstance(self, sparray):
-            warn(VisibleDeprecationWarning(
-                "`.A` is deprecated and will be removed in v1.13.0. "
-                "Use `.toarray()` instead."
-            ))
+            message = ("`.A` is deprecated and will be removed in v1.13.0. "
+                       "Use `.toarray()` instead.")
+            warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.toarray()
 
     @property
@@ -338,10 +337,9 @@ class _spbase:
             Please use `.T.conjugate()` instead.
         """
         if isinstance(self, sparray):
-            warn(VisibleDeprecationWarning(
-                "`.H` is deprecated and will be removed in v1.13.0. "
-                "Please use `.T.conjugate()` instead."
-            ))
+            message = ("`.H` is deprecated and will be removed in v1.13.0. "
+                       "Please use `.T.conjugate()` instead.")
+            warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.T.conjugate()
 
     @property

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -148,11 +148,11 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
         # index arrays should have integer data types
         if self.indptr.dtype.kind != 'i':
-            warn("indptr array has non-integer dtype (%s)"
-                    % self.indptr.dtype.name)
+            warn(f"indptr array has non-integer dtype ({self.indptr.dtype.name})",
+                 stacklevel=2)
         if self.indices.dtype.kind != 'i':
-            warn("indices array has non-integer dtype (%s)"
-                    % self.indices.dtype.name)
+            warn(f"indices array has non-integer dtype ({self.indices.dtype.name})",
+                 stacklevel=2)
 
         # check array shapes
         if self.indices.ndim != 1 or self.indptr.ndim != 1:

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -285,7 +285,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if 0 == other and op_name in ('_le_', '_ge_'):
                 raise NotImplementedError(" >= and <= don't work with 0.")
             elif op(0, other):
-                warn(bad_scalar_msg, SparseEfficiencyWarning)
+                warn(bad_scalar_msg, SparseEfficiencyWarning, stacklevel=2)
                 other_arr = np.empty(self.shape, dtype=np.result_type(other))
                 other_arr.fill(other)
                 other_arr = self.__class__(other_arr)
@@ -306,7 +306,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return self._binopt(other, op_name)
 
             warn("Comparing sparse matrices using >= and <= is inefficient, "
-                 "using <, >, or !=, instead.", SparseEfficiencyWarning)
+                 "using <, >, or !=, instead.",
+                 SparseEfficiencyWarning, stacklevel=2)
             all_true = self.__class__(np.ones(self.shape, dtype=np.bool_))
             res = self._binopt(other, '_gt_' if op_name == '_le_' else '_lt_')
             return all_true - res

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -285,7 +285,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if 0 == other and op_name in ('_le_', '_ge_'):
                 raise NotImplementedError(" >= and <= don't work with 0.")
             elif op(0, other):
-                warn(bad_scalar_msg, SparseEfficiencyWarning, stacklevel=2)
+                warn(bad_scalar_msg, SparseEfficiencyWarning, stacklevel=3)
                 other_arr = np.empty(self.shape, dtype=np.result_type(other))
                 other_arr.fill(other)
                 other_arr = self.__class__(other_arr)
@@ -307,7 +307,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
             warn("Comparing sparse matrices using >= and <= is inefficient, "
                  "using <, >, or !=, instead.",
-                 SparseEfficiencyWarning, stacklevel=2)
+                 SparseEfficiencyWarning, stacklevel=3)
             all_true = self.__class__(np.ones(self.shape, dtype=np.bool_))
             res = self._binopt(other, '_gt_' if op_name == '_le_' else '_lt_')
             return all_true - res

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -167,11 +167,11 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         # index arrays should have integer data types
         if self.row.dtype.kind != 'i':
-            warn("row index array has non-integer dtype (%s)  "
-                    % self.row.dtype.name)
+            warn(f"row index array has non-integer dtype ({self.row.dtype.name})",
+                 stacklevel=2)
         if self.col.dtype.kind != 'i':
-            warn("col index array has non-integer dtype (%s) "
-                    % self.col.dtype.name)
+            warn(f"col index array has non-integer dtype ({self.col.dtype.name})",
+                 stacklevel=2)
 
         idx_dtype = self._get_index_dtype((self.row, self.col), maxval=max(self.shape))
         self.row = np.asarray(self.row, dtype=idx_dtype)
@@ -328,7 +328,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if len(diags) > 100:
             # probably undesired, should todia() have a maxdiags parameter?
             warn("Constructing a DIA matrix with %d diagonals "
-                 "is inefficient" % len(diags), SparseEfficiencyWarning)
+                 "is inefficient" % len(diags),
+                 SparseEfficiencyWarning, stacklevel=2)
 
         #initialize and fill in data array
         if self.data.size == 0:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -168,10 +168,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
         # index arrays should have integer data types
         if self.row.dtype.kind != 'i':
             warn(f"row index array has non-integer dtype ({self.row.dtype.name})",
-                 stacklevel=2)
+                 stacklevel=3)
         if self.col.dtype.kind != 'i':
             warn(f"col index array has non-integer dtype ({self.col.dtype.name})",
-                 stacklevel=2)
+                 stacklevel=3)
 
         idx_dtype = self._get_index_dtype((self.row, self.col), maxval=max(self.shape))
         self.row = np.asarray(self.row, dtype=idx_dtype)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -230,7 +230,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_matrix(A)
         warn('spsolve requires A be CSC or CSR matrix format',
-                SparseEfficiencyWarning)
+             SparseEfficiencyWarning, stacklevel=2)
 
     # b is a vector only if b have shape (n,) or (n, 1)
     b_is_sparse = issparse(b) or is_pydata_spmatrix(b)
@@ -292,7 +292,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
                                     b, flag, options=options)
             if info != 0:
-                warn("Matrix is exactly singular", MatrixRankWarning)
+                warn("Matrix is exactly singular", MatrixRankWarning, stacklevel=2)
                 x.fill(np.nan)
             if b_is_vector:
                 x = x.ravel()
@@ -302,7 +302,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
             if not (b.format == "csc" or is_pydata_spmatrix(b)):
                 warn('spsolve is more efficient when sparse b '
-                     'is in the CSC matrix format', SparseEfficiencyWarning)
+                     'is in the CSC matrix format',
+                     SparseEfficiencyWarning, stacklevel=2)
                 b = csc_matrix(b)
 
             # Create a sparse output matrix by repeatedly applying
@@ -411,7 +412,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
-        warn('splu converted its input to CSC format', SparseEfficiencyWarning)
+        warn('splu converted its input to CSC format',
+             SparseEfficiencyWarning, stacklevel=2)
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -506,7 +508,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
         warn('spilu converted its input to CSC format',
-             SparseEfficiencyWarning)
+             SparseEfficiencyWarning, stacklevel=2)
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -574,7 +576,7 @@ def factorized(A):
         if not (issparse(A) and A.format == "csc"):
             A = csc_matrix(A)
             warn('splu converted its input to CSC format',
-                 SparseEfficiencyWarning)
+                 SparseEfficiencyWarning, stacklevel=2)
 
         A = A._asfptype()  # upcast to a floating point format
 
@@ -664,7 +666,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
     # Check the input for correct type and format.
     if not (issparse(A) and A.format == "csr"):
         warn('CSR matrix format is required. Converting to CSR matrix.',
-             SparseEfficiencyWarning)
+             SparseEfficiencyWarning, stacklevel=2)
         A = csr_matrix(A)
     elif not overwrite_A:
         A = A.copy()

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1260,7 +1260,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
             raise ValueError(f'wrong M dimensions {M.shape}, should be {A.shape}')
         if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
             warnings.warn('M does not have the same type precision as A. '
-                          'This may adversely affect ARPACK convergence')
+                          'This may adversely affect ARPACK convergence',
+                          stacklevel=2)
 
     n = A.shape[0]
 
@@ -1270,7 +1271,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     if k >= n - 1:
         warnings.warn("k >= N - 1 for N * N square matrix. "
                       "Attempting to use scipy.linalg.eig instead.",
-                      RuntimeWarning)
+                      RuntimeWarning, stacklevel=2)
 
         if issparse(A):
             raise TypeError("Cannot use scipy.linalg.eig for sparse A with "
@@ -1587,7 +1588,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
             raise ValueError(f'wrong M dimensions {M.shape}, should be {A.shape}')
         if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
             warnings.warn('M does not have the same type precision as A. '
-                          'This may adversely affect ARPACK convergence')
+                          'This may adversely affect ARPACK convergence',
+                          stacklevel=2)
 
     n = A.shape[0]
 
@@ -1597,7 +1599,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     if k >= n:
         warnings.warn("k >= N for N * N square matrix. "
                       "Attempting to use scipy.linalg.eigh instead.",
-                      RuntimeWarning)
+                      RuntimeWarning, stacklevel=2)
 
         if issparse(A):
             raise TypeError("Cannot use scipy.linalg.eigh for sparse A with "

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -217,9 +217,10 @@ def geometric_slerp(
     # diameter of 2 within tolerance means antipodes, which is a problem
     # for all unit n-spheres (even the 0-sphere would have an ambiguous path)
     if np.allclose(coord_dist, 2.0, rtol=0, atol=tol):
-        warnings.warn("start and end are antipodes"
-                      " using the specified tolerance;"
-                      " this may cause ambiguous slerp paths")
+        warnings.warn("start and end are antipodes "
+                      "using the specified tolerance; "
+                      "this may cause ambiguous slerp paths",
+                      stacklevel=2)
 
     t = np.asarray(t, dtype=np.float64)
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2508,7 +2508,7 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
         if throw:
             raise
         if warning:
-            warnings.warn(str(e))
+            warnings.warn(str(e), stacklevel=2)
         valid = False
     return valid
 
@@ -2588,7 +2588,7 @@ def is_valid_y(y, warning=False, throw=False, name=None):
         if throw:
             raise
         if warning:
-            warnings.warn(str(e))
+            warnings.warn(str(e), stacklevel=2)
         valid = False
     return valid
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -360,7 +360,8 @@ def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg
             # when some combination of arguments makes weighting impossible,
             #  this is the desired response
             if not silent:
-                warnings.warn(f"{fn.__name__} NotImplemented weights: {e}")
+                warnings.warn(f"{fn.__name__} NotImplemented weights: {e}",
+                              stacklevel=2)
         return result
     return wrapped
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -361,7 +361,7 @@ def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg
             #  this is the desired response
             if not silent:
                 warnings.warn(f"{fn.__name__} NotImplemented weights: {e}",
-                              stacklevel=2)
+                              stacklevel=3)
         return result
     return wrapped
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1635,7 +1635,7 @@ def mathieu_even_coef(m, q):
         qm = 17.0 + 3.1*sqrt(q) - .126*q + .0037*sqrt(q)*q
     km = int(qm + 0.5*m)
     if km > 251:
-        warnings.warn("Too many predicted coefficients.", RuntimeWarning, 2)
+        warnings.warn("Too many predicted coefficients.", RuntimeWarning, stacklevel=2)
     kd = 1
     m = int(floor(m))
     if m % 2:
@@ -1692,7 +1692,7 @@ def mathieu_odd_coef(m, q):
         qm = 17.0 + 3.1*sqrt(q) - .126*q + .0037*sqrt(q)*q
     km = int(qm + 0.5*m)
     if km > 251:
-        warnings.warn("Too many predicted coefficients.", RuntimeWarning, 2)
+        warnings.warn("Too many predicted coefficients.", RuntimeWarning, stacklevel=2)
     kd = 4
     m = int(floor(m))
     if m % 2:

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -98,7 +98,8 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
 
         if has_NPY_FLOAT16:
             warn('Boost stats NPY_FLOAT16 ufunc generation not '
-                 'currently not supported!')
+                 'currently not supported!',
+                 stacklevel=2)
 
         # Generate ufuncs for each method
         for ii, m in enumerate(methods):

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -99,7 +99,7 @@ def _ufunc_gen(scipy_dist: str, types: list, ctor_args: tuple,
         if has_NPY_FLOAT16:
             warn('Boost stats NPY_FLOAT16 ufunc generation not '
                  'currently not supported!',
-                 stacklevel=2)
+                 stacklevel=3)
 
         # Generate ufuncs for each method
         for ii, m in enumerate(methods):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3492,7 +3492,7 @@ class erlang_gen(gamma_gen):
             # shape parameter, so warn the user.
             message = ('The shape parameter of the erlang distribution '
                        f'has been given a non-integer value {a!r}.')
-            warnings.warn(message, RuntimeWarning, stacklevel=2)
+            warnings.warn(message, RuntimeWarning, stacklevel=3)
         return a > 0
 
     def _shape_info(self):
@@ -3836,7 +3836,7 @@ class genhyperbolic_gen(rv_continuous):
         if np.isnan(intgrl):
             msg = ("Infinite values encountered in scipy.special.kve. "
                    "Values replaced by NaN to avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
         return max(0.0, min(1.0, intgrl))
 
     def _cdf(self, x, p, a, b):
@@ -4875,7 +4875,7 @@ class geninvgauss_gen(rv_continuous):
         if np.isnan(z).any():
             msg = ("Infinite values encountered in scipy.special.kve(p, b). "
                    "Values replaced by NaN to avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
         return z
 
     def _pdf(self, x, p, b):
@@ -5126,7 +5126,7 @@ class geninvgauss_gen(rv_continuous):
             msg = ("Infinite values encountered in the moment calculation "
                    "involving scipy.special.kve. Values replaced by NaN to "
                    "avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
             m = np.full_like(num, np.nan, dtype=np.float64)
             m[~inf_vals] = num[~inf_vals] / denom[~inf_vals]
         else:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3492,7 +3492,7 @@ class erlang_gen(gamma_gen):
             # shape parameter, so warn the user.
             message = ('The shape parameter of the erlang distribution '
                        f'has been given a non-integer value {a!r}.')
-            warnings.warn(message, RuntimeWarning)
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
         return a > 0
 
     def _shape_info(self):
@@ -3836,7 +3836,7 @@ class genhyperbolic_gen(rv_continuous):
         if np.isnan(intgrl):
             msg = ("Infinite values encountered in scipy.special.kve. "
                    "Values replaced by NaN to avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
         return max(0.0, min(1.0, intgrl))
 
     def _cdf(self, x, p, a, b):
@@ -4875,7 +4875,7 @@ class geninvgauss_gen(rv_continuous):
         if np.isnan(z).any():
             msg = ("Infinite values encountered in scipy.special.kve(p, b). "
                    "Values replaced by NaN to avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
         return z
 
     def _pdf(self, x, p, b):
@@ -5126,7 +5126,7 @@ class geninvgauss_gen(rv_continuous):
             msg = ("Infinite values encountered in the moment calculation "
                    "involving scipy.special.kve. Values replaced by NaN to "
                    "avoid incorrect results.")
-            warnings.warn(msg, RuntimeWarning)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
             m = np.full_like(num, np.nan, dtype=np.float64)
             m[~inf_vals] = num[~inf_vals] / denom[~inf_vals]
         else:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3803,7 +3803,8 @@ def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,
         if abs(delta) < tolerance * x.size:
             break
         if count > maxcount:
-            warnings.warn('expect(): sum did not converge', RuntimeWarning)
+            warnings.warn('expect(): sum did not converge',
+                          RuntimeWarning, stacklevel=2)
             return tot
 
     # iterate over [lb, x0)
@@ -3814,7 +3815,8 @@ def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,
         if abs(delta) < tolerance * x.size:
             break
         if count > maxcount:
-            warnings.warn('expect(): sum did not converge', RuntimeWarning)
+            warnings.warn('expect(): sum did not converge',
+                          RuntimeWarning, stacklevel=2)
             break
 
     return tot

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3804,7 +3804,7 @@ def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,
             break
         if count > maxcount:
             warnings.warn('expect(): sum did not converge',
-                          RuntimeWarning, stacklevel=2)
+                          RuntimeWarning, stacklevel=3)
             return tot
 
     # iterate over [lb, x0)
@@ -3816,7 +3816,7 @@ def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,
             break
         if count > maxcount:
             warnings.warn('expect(): sum did not converge',
-                          RuntimeWarning, stacklevel=2)
+                          RuntimeWarning, stacklevel=3)
             break
 
     return tot

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -130,7 +130,8 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
     if r < 2*len(t):
         warnings.warn('Estimated covariance matrix does not have full rank. '
                       'This indicates a bad choice of the input t and the '
-                      'test might not be consistent.')  # see p. 183 in [1]_
+                      'test might not be consistent.', # see p. 183 in [1]_
+                      stacklevel=2)
 
     # compute test statistic w distributed asympt. as chisquare with df=r
     g_diff = np.mean(gx, axis=0) - np.mean(gy, axis=0)

--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -393,7 +393,7 @@ class gaussian_kde:
         if inform:
             msg = ('An integral in _mvn.mvnun requires more points than %s' %
                    (self.d * 1000))
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
         return value
 

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -953,7 +953,7 @@ class levy_stable_gen(rv_continuous):
                 warnings.warn(
                     "Density calculations experimental for FFT method."
                     + " Use combination of piecewise and dni methods instead.",
-                    RuntimeWarning,
+                    RuntimeWarning, stacklevel=2,
                 )
                 _alpha, _beta = pair
                 _x = data_subset[:, (0,)]
@@ -1093,7 +1093,7 @@ class levy_stable_gen(rv_continuous):
                 warnings.warn(
                     "Cumulative density calculations experimental for FFT"
                     + " method. Use piecewise method instead.",
-                    RuntimeWarning,
+                    RuntimeWarning, stacklevel=2,
                 )
                 _alpha, _beta = pair
                 _x = data_subset[:, (0,)]

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -953,7 +953,7 @@ class levy_stable_gen(rv_continuous):
                 warnings.warn(
                     "Density calculations experimental for FFT method."
                     + " Use combination of piecewise and dni methods instead.",
-                    RuntimeWarning, stacklevel=2,
+                    RuntimeWarning, stacklevel=3,
                 )
                 _alpha, _beta = pair
                 _x = data_subset[:, (0,)]
@@ -1093,7 +1093,7 @@ class levy_stable_gen(rv_continuous):
                 warnings.warn(
                     "Cumulative density calculations experimental for FFT"
                     + " method. Use piecewise method instead.",
-                    RuntimeWarning, stacklevel=2,
+                    RuntimeWarning, stacklevel=3,
                 )
                 _alpha, _beta = pair
                 _x = data_subset[:, (0,)]

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2752,7 +2752,7 @@ def ansari(x, y, alternative='two-sided'):
     repeats = (len(uxy) != len(xy))
     exact = ((m < 55) and (n < 55) and not repeats)
     if repeats and (m < 55 or n < 55):
-        warnings.warn("Ties preclude use of exact statistic.")
+        warnings.warn("Ties preclude use of exact statistic.", stacklevel=2)
     if exact:
         if alternative == 'two-sided':
             pval = 2.0 * np.minimum(_abw_state.cdf(AB, n, m),
@@ -4106,7 +4106,8 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     if n_zero > 0 and mode == "exact":
         mode = "approx"
         warnings.warn("Exact p-value calculation does not work if there are "
-                      "zeros. Switching to normal approximation.")
+                      "zeros. Switching to normal approximation.",
+                      stacklevel=2)
 
     if mode == "approx":
         if zero_method in ["wilcox", "pratt"]:
@@ -4119,7 +4120,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
 
     count = len(d)
     if count < 10 and mode == "approx":
-        warnings.warn("Sample size too small for normal approximation.")
+        warnings.warn("Sample size too small for normal approximation.", stacklevel=2)
 
     r = _stats_py.rankdata(abs(d))
     r_plus = np.sum((d > 0) * r)

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3008,8 +3008,9 @@ def kurtosistest(a, axis=0, alternative='two-sided'):
             " were given." % np.min(n))
     if np.min(n) < 20:
         warnings.warn(
-            "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %
-            np.min(n))
+            "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" % np.min(n),
+            stacklevel=2,
+        )
 
     b2 = kurtosis(a, axis, fisher=False)
     E = 3.0*(n-1) / (n+1)

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -97,7 +97,7 @@ def _percentile_along_axis(theta_hat_b, alpha):
                 " This problem is known to occur when the distribution"
                 " is degenerate or the statistic is np.min."
             )
-            warnings.warn(DegenerateDataWarning(msg), stacklevel=2)
+            warnings.warn(DegenerateDataWarning(msg), stacklevel=3)
             percentiles[indices] = np.nan
         else:
             theta_hat_b_i = theta_hat_b[indices]

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -97,7 +97,7 @@ def _percentile_along_axis(theta_hat_b, alpha):
                 " This problem is known to occur when the distribution"
                 " is degenerate or the statistic is np.min."
             )
-            warnings.warn(DegenerateDataWarning(msg))
+            warnings.warn(DegenerateDataWarning(msg), stacklevel=2)
             percentiles[indices] = np.nan
         else:
             theta_hat_b_i = theta_hat_b[indices]

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2500,7 +2500,7 @@ def _histogram(a, numbins=10, defaultlimits=None, weights=None,
                        if defaultlimits[0] > v or v > defaultlimits[1]])
     if extrapoints > 0 and printextras:
         warnings.warn("Points outside given histogram range = %s" % extrapoints,
-                      stacklevel=2,)
+                      stacklevel=3,)
 
     return HistogramResult(hist, defaultlimits[0], binsize, extrapoints)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1784,7 +1784,8 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
             " were given." % int(n))
     if n < 20:
         warnings.warn("kurtosistest only valid for n>=20 ... continuing "
-                      "anyway, n=%i" % int(n))
+                      "anyway, n=%i" % int(n),
+                      stacklevel=2)
     b2 = kurtosis(a, axis, fisher=False)
 
     E = 3.0*(n-1) / (n+1)
@@ -1800,9 +1801,9 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     term2 = np.sign(denom) * np.where(denom == 0.0, np.nan,
                                       np.power((1-2.0/A)/np.abs(denom), 1/3.0))
     if np.any(denom == 0):
-        msg = "Test statistic not defined in some cases due to division by " \
-              "zero. Return nan in that case..."
-        warnings.warn(msg, RuntimeWarning)
+        msg = ("Test statistic not defined in some cases due to division by "
+               "zero. Return nan in that case...")
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))  # [1]_ Eq. 5
 
@@ -2498,8 +2499,8 @@ def _histogram(a, numbins=10, defaultlimits=None, weights=None,
     extrapoints = len([v for v in a
                        if defaultlimits[0] > v or v > defaultlimits[1]])
     if extrapoints > 0 and printextras:
-        warnings.warn("Points outside given histogram range = %s"
-                      % extrapoints)
+        warnings.warn("Points outside given histogram range = %s" % extrapoints,
+                      stacklevel=2,)
 
     return HistogramResult(hist, defaultlimits[0], binsize, extrapoints)
 
@@ -4091,15 +4092,15 @@ def f_oneway(*samples, axis=0):
     # Check this after forming alldata, so shape errors are detected
     # and reported before checking for 0 length inputs.
     if any(sample.shape[axis] == 0 for sample in samples):
-        warnings.warn(stats.DegenerateDataWarning('at least one input '
-                                                  'has length 0'))
+        msg = 'at least one input has length 0'
+        warnings.warn(stats.DegenerateDataWarning(msg), stacklevel=2)
         return _create_f_oneway_nan_result(alldata.shape, axis)
 
     # Must have at least one group with length greater than 1.
     if all(sample.shape[axis] == 1 for sample in samples):
         msg = ('all input arrays have length 1.  f_oneway requires that at '
                'least one input has length greater than 1.')
-        warnings.warn(stats.DegenerateDataWarning(msg))
+        warnings.warn(stats.DegenerateDataWarning(msg), stacklevel=2)
         return _create_f_oneway_nan_result(alldata.shape, axis)
 
     # Check if all values within each group are identical, and if the common
@@ -4123,9 +4124,9 @@ def f_oneway(*samples, axis=0):
     # the same (e.g. [[3, 3, 3], [5, 5, 5, 5], [4, 4, 4]]).
     all_const = is_const.all(axis=axis)
     if all_const.any():
-        msg = ("Each of the input arrays is constant;"
+        msg = ("Each of the input arrays is constant; "
                "the F statistic is not defined or infinite")
-        warnings.warn(stats.ConstantInputWarning(msg))
+        warnings.warn(stats.ConstantInputWarning(msg), stacklevel=2)
 
     # all_same_const is True if all the values in the groups along the axis=0
     # slice are the same (e.g. [[3, 3, 3], [3, 3, 3, 3], [3, 3, 3]]).
@@ -4270,7 +4271,7 @@ def alexandergovern(*samples, nan_policy='propagate'):
 
     if np.any([(sample == sample[0]).all() for sample in samples]):
         msg = "An input array is constant; the statistic is not defined."
-        warnings.warn(stats.ConstantInputWarning(msg))
+        warnings.warn(stats.ConstantInputWarning(msg), stacklevel=2)
         return AlexanderGovernResult(np.nan, np.nan)
 
     # The following formula numbers reference the equation described on
@@ -4739,7 +4740,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None):
     if (x == x[0]).all() or (y == y[0]).all():
         msg = ("An input array is constant; the correlation coefficient "
                "is not defined.")
-        warnings.warn(stats.ConstantInputWarning(msg))
+        warnings.warn(stats.ConstantInputWarning(msg), stacklevel=2)
         result = PearsonRResult(statistic=np.nan, pvalue=np.nan, n=n,
                                 alternative=alternative, x=x, y=y)
         return result
@@ -4805,7 +4806,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None):
         # might result in large errors in r.
         msg = ("An input array is nearly constant; the computed "
                "correlation coefficient may be inaccurate.")
-        warnings.warn(stats.NearConstantInputWarning(msg))
+        warnings.warn(stats.NearConstantInputWarning(msg), stacklevel=2)
 
     r = np.dot(xm/normxm, ym/normym)
 
@@ -5403,7 +5404,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         if (a[:, 0][0] == a[:, 0]).all() or (a[:, 1][0] == a[:, 1]).all():
             # If an input is constant, the correlation coefficient
             # is not defined.
-            warnings.warn(stats.ConstantInputWarning(warn_msg))
+            warnings.warn(stats.ConstantInputWarning(warn_msg), stacklevel=2)
             res = SignificanceResult(np.nan, np.nan)
             res.correlation = np.nan
             return res
@@ -5411,7 +5412,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         if (a[0, :][0] == a[0, :]).all() or (a[1, :][0] == a[1, :]).all():
             # If an input is constant, the correlation coefficient
             # is not defined.
-            warnings.warn(stats.ConstantInputWarning(warn_msg))
+            warnings.warn(stats.ConstantInputWarning(warn_msg), stacklevel=2)
             res = SignificanceResult(np.nan, np.nan)
             res.correlation = np.nan
             return res
@@ -6434,7 +6435,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
         msg = ("The number of replications is low (under 1000), and p-value "
                "calculations may be unreliable. Use the p-value result, with "
                "caution!")
-        warnings.warn(msg, RuntimeWarning)
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     if is_twosamp:
         if compute_distance is None:
@@ -9518,7 +9519,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
             message = ("p-value cannot be estimated with `distribution='t' "
                        "because degrees of freedom parameter is undefined "
                        "(0/0). Try using `distribution='normal'")
-            warnings.warn(message, RuntimeWarning)
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
 
         p = distributions.t.cdf(wbfn, df)
     elif distribution == "normal":

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -1,6 +1,8 @@
 line-length = 88
 
-# Enable Pyflakes `E` and `F` codes by default.
+# Enable Pyflakes `E` and `F` and PyUpgrade `UP` codes by default.
+# Also, `PGH004` which checks for blanket (non-specific) `noqa`s
+# and `B028` which checks that warnings include the `stacklevel` keyword.
 select = ["E", "F", "PGH004", "UP", "B028"]
 ignore = ["E741"]
 exclude = ["scipy/datasets/_registry.py"]

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -1,7 +1,7 @@
 line-length = 88
 
 # Enable Pyflakes `E` and `F` codes by default.
-select = ["E", "F", "PGH004", "UP"]
+select = ["E", "F", "PGH004", "UP", "B028"]
 ignore = ["E741"]
 exclude = ["scipy/datasets/_registry.py"]
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/19604#issuecomment-1836467622 @mdhaber 

#### What does this implement/fix?
- Enable rule `B028` which checks that warnings have an explicit `stacklevel` which is not equal to `1`.

#### Additional information
163 violations right now, will clean them up when I have time.