### PR TITLE
MAINT: more SciPy windows int shims

### DIFF
--- a/scipy/interpolate/_rgi_cython.pyx
+++ b/scipy/interpolate/_rgi_cython.pyx
@@ -17,7 +17,7 @@ np.import_array()
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 def evaluate_linear_2d(double_or_complex[:, :] values, # cannot declare as ::1
-                       const long[:, :] indices,       # unless prior
+                       const np.intp_t[:, :] indices,       # unless prior
                        double[:, :] norm_distances,    # np.ascontiguousarray
                        tuple grid not None,
                        double_or_complex[:] out):
@@ -87,7 +87,7 @@ def find_indices(tuple grid not None, const double[:, :] xi):
         int index = 0
 
         # Indices of relevant edges between which xi are situated
-        long[:,::1] indices = np.empty_like(xi, dtype=int)
+        np.intp_t[:,::1] indices = np.empty_like(xi, dtype=np.intp)
 
         # Distances to lower edge in unity units
         double[:,::1] norm_distances = np.zeros_like(xi, dtype=float)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2844,7 +2844,7 @@ def _exact_factorialx_array(n, k=1):
             # e.g. k=3: 26!!! > np.iinfo(np.int32).max
             dt = np.int64
         else:
-            dt = np.int_
+            dt = np.dtype("long")
     else:
         # for k >= 10, we always use object
         dt = object

--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -1,3 +1,4 @@
+import numpy as np
 from ._ufuncs import (_spherical_jn, _spherical_yn, _spherical_in,
                       _spherical_kn, _spherical_jn_d, _spherical_yn_d,
                       _spherical_in_d, _spherical_kn_d)
@@ -84,6 +85,7 @@ def spherical_jn(n, z, derivative=False):
     >>> plt.show()
 
     """
+    n = np.asarray(n, dtype=np.dtype("long"))
     if derivative:
         return _spherical_jn_d(n, z)
     else:
@@ -171,6 +173,7 @@ def spherical_yn(n, z, derivative=False):
     >>> plt.show()
 
     """
+    n = np.asarray(n, dtype=np.dtype("long"))
     if derivative:
         return _spherical_yn_d(n, z)
     else:
@@ -257,6 +260,7 @@ def spherical_in(n, z, derivative=False):
     >>> plt.show()
 
     """
+    n = np.asarray(n, dtype=np.dtype("long"))
     if derivative:
         return _spherical_in_d(n, z)
     else:
@@ -343,6 +347,7 @@ def spherical_kn(n, z, derivative=False):
     >>> plt.show()
 
     """
+    n = np.asarray(n, dtype=np.dtype("long"))
     if derivative:
         return _spherical_kn_d(n, z)
     else:

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -278,7 +278,7 @@ def verify_gauss_quad(root_func, eval_func, weight_func, a, b, N,
     # this test is copied from numpy's TestGauss in test_hermite.py
     x, w, mu = root_func(N, True)
 
-    n = np.arange(N)
+    n = np.arange(N, dtype=np.dtype("long"))
     v = eval_func(n[:,np.newaxis], x)
     vv = np.dot(v*w, v.T)
     vd = 1 / np.sqrt(vv.diagonal())

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -8,7 +8,7 @@ from scipy.special._testutils import FuncData
 
 
 def test_eval_chebyt():
-    n = np.arange(0, 10000, 7)
+    n = np.arange(0, 10000, 7, dtype=np.dtype("long"))
     x = 2*np.random.rand() - 1
     v1 = np.cos(n*np.arccos(x))
     v2 = _ufuncs.eval_chebyt(n, x)
@@ -61,7 +61,7 @@ class TestPolys:
         dataset = np.concatenate(dataset, axis=0)
 
         def polyfunc(*p):
-            p = (p[0].astype(int),) + p[1:]
+            p = (p[0].astype(np.dtype("long")),) + p[1:]
             return func(*p)
 
         with np.errstate(all='raise'):


### PR DESCRIPTION
* fixes another 120 test failures on SciPy `main` built against NumPy `main` on Windows, while still passing full suite on that platform with NumPy
`1.26.x` (334 fails -> 214 fails now)

* related to gh-19605, mostly dealing with recent changes to integer type handling on NumPy `main` (64-bit default on Windows now)

* `_spherical_bessel` changes preserve the use of old-school `long` explicitly because changing special ufunc signatures to accommodate fused types, or even just to change to a forced `int64_t`, looks way messier for now

* `_rgi_cython` had some `long` swapped to `intp` for indexing, because it seemed to work, and there was at least one comment suggesting that we do that eventually anyway...

* `test_orthogonal_eval` was adjusted to use the old-school `long` type as well, though I didn't check that this was the most optimal solution

* a number of other similar integer-related changes...

[skip cirrus] [skip circle]