### PR TITLE
WIP: integrate.solve_ivp: allow y to be N-D

### DIFF
--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -242,7 +242,7 @@ class OdeSolution:
         ys = np.hstack(ys)
         ys = ys[:, reverse]
         if self.yshape is not None:
-            ys = ys.reshape(self.yshape + (-1,))
+            ys = ys.reshape(self.yshape + ys.shape[1:])
 
         return ys
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -158,7 +158,7 @@ class OdeSolution:
     t_min, t_max : float
         Time range of the interpolation.
     """
-    def __init__(self, ts, interpolants, alt_segment=False):
+    def __init__(self, ts, interpolants, alt_segment=False, yshape=None):
         ts = np.asarray(ts)
         d = np.diff(ts)
         # The first case covers integration on zero segment.
@@ -172,6 +172,7 @@ class OdeSolution:
                              "don't match.")
 
         self.ts = ts
+        self.yshape = yshape
         self.interpolants = interpolants
         if ts[-1] >= ts[0]:
             self.t_min = ts[0]
@@ -240,6 +241,8 @@ class OdeSolution:
 
         ys = np.hstack(ys)
         ys = ys[:, reverse]
+        if self.yshape is not None:
+            ys = ys.reshape(self.yshape + (-1,))
 
         return ys
 

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -743,7 +743,12 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
 
     if t_events is not None:
         t_events = [np.asarray(te) for te in t_events]
-        y_events = [np.asarray(ye).reshape(shape0 + (-1,)) for ye in y_events]
+        if len(shape0) > 1:
+            for i, _ in enumerate(y_events):
+                ye = np.asarray(y_events[i])
+                y_events[i] = ye.reshape(ye.shape[:-1] + shape0)
+        else:
+            y_events = [np.asarray(ye) for ye in y_events]
 
     if t_eval is None:
         ts = np.array(ts)
@@ -751,7 +756,10 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     elif ts:
         ts = np.hstack(ts)
         ys = np.hstack(ys)
-    ys = ys.reshape(shape0 + (-1,))
+
+    if len(shape0) > 1 and len(ys):
+        ys = np.asarray(ys)
+        ys = ys.reshape(shape0 + ys.shape[1:])
 
     if dense_output:
         if t_eval is None:


### PR DESCRIPTION
#### Reference issue
Closes gh-19630

#### What does this implement/fix?
gh-19630 asks for `solve_ivp` to work with N-D `y`. I've seen this come up in this and other contexts (e.g. `optimize.minimize`) before (including two stack overflow posts this month), and I figured that it's worth it if it only takes a few minutes to implement. 

#### Additional information
We'll see after adding tests whether anything tricky comes up. Just thought I'd get the gist out there.)
