### PR TITLE
MAINT: simplify Nakagami mean calculation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7250,7 +7250,7 @@ class nakagami_gen(rv_continuous):
         return np.sqrt(1/nu * sc.gammainccinv(nu, p))
 
     def _stats(self, nu):
-        mu = sc.gamma(nu+0.5)/sc.gamma(nu)/np.sqrt(nu)
+        mu = sc.poch(nu, 0.5)/np.sqrt(nu)
         mu2 = 1.0-mu*mu
         g1 = mu * (1 - 4*nu*mu2) / 2.0 / nu / np.power(mu2, 1.5)
         g2 = -6*mu**4*nu + (8*nu-2)*mu**2-2*nu + 1

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9123,6 +9123,18 @@ class TestNakagami:
         assert np.isfinite(stats.nakagami._entropy(1e100))
         assert np.isfinite(stats.nakagami._entropy(1e-100))
 
+    @pytest.mark.parametrize("nu, ref",
+                             [(1e10, 0.9999999999875),
+                              (1e3, 0.9998750078173821)]
+                            )
+    def test_mean(self, nu, ref):
+        # reference values were computed with mpmath
+        # from mpmath import mp
+        # mp.dps = 500
+        # nu = mp.mpf(1e10)
+        # float(mp.rf(nu, mp.mpf(0.5))/mp.sqrt(nu))
+        assert_allclose(stats.nakagami.mean(nu), ref, rtol=1e-12)
+
     @pytest.mark.xfail(reason="Fit of nakagami not reliable, see gh-10908.")
     @pytest.mark.parametrize('nu', [1.6, 2.5, 3.9])
     @pytest.mark.parametrize('loc', [25.0, 10, 35])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9125,8 +9125,8 @@ class TestNakagami:
 
     @pytest.mark.parametrize("nu, ref",
                              [(1e10, 0.9999999999875),
-                              (1e3, 0.9998750078173821)]
-                            )
+                              (1e3, 0.9998750078173821),
+                              (1e-10, 1.772453850659802e-05)])
     def test_mean(self, nu, ref):
         # reference values were computed with mpmath
         # from mpmath import mp


### PR DESCRIPTION
#### Reference issue
`nakagami.stats` currently fails already for $\nu>200$ due to overflow in the computation of the mean involving a ratio of Gamma functions. 
The ratio of the Gamma functions can directly be computed using the Pochhammer symbol (`special.poch`) to avoid this:

$$
Poch(a, b)=\frac{\Gamma(a+b)}{\Gamma(a)}
$$

#### Additional information

<details><summary>Code</summary>
<p>

```python
import numpy as np
import matplotlib.pyplot as plt
from scipy.stats import nakagami
from scipy.special import poch

nu_range = np.logspace(-10, 20, 1000)

def nakagami_stats_pr(nu):
    mu = poch(nu, 0.5)/np.sqrt(nu)
    mu2 = 1.0-mu*mu # like main branch
    return mu, mu2

mean_pr, var_pr = nakagami_stats_pr(nu_range) #

mean, var = nakagami.stats(nu_range)
plt.loglog(nu_range, mean, label="mean main branch", ls="dashdot")
plt.loglog(nu_range, var, label="var main branch", ls="dashdot")
plt.loglog(nu_range, mean_pr, label="mean PR", ls="dotted")
plt.loglog(nu_range, var_pr, label="var PR", ls="dotted")
plt.legend()
plt.xlabel(r"$\nu$")
plt.title("Nakagami distribution moments")
plt.show()
```

</p>
</details> 

![image](https://github.com/scipy/scipy/assets/40656107/f534b3e5-8295-4fb3-88e8-ef97f3322e01)

Skew and kurtosis still fail relatively early but require more work to be improved. In case anyone is interested, Wolfram Alpha is for example able to provide asymptotic expansions.