### PR TITLE
DOC: Clarify integration error bound in `integrate` tutorial

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -48,8 +48,8 @@ function, method, or class instance). Notice the use of a lambda-
 function in this case as the argument. The next two arguments are the
 limits of integration. The return value is a tuple, with the first
 element holding the estimated value of the integral and the second
-element holding an upper bound on the error. Notice, that in this
-case, the true value of this integral is
+element holding an estimate of the absolute integration error. 
+Notice, that in this case, the true value of this integral is
 
 .. math::
 
@@ -63,7 +63,7 @@ where
 
 is the Fresnel sine integral. Note that the numerically-computed integral is
 within :math:`1.04\times10^{-11}` of the exact result --- well below the
-reported error bound.
+reported error estimate.
 
 
 If the function to integrate takes additional parameters, they can be provided


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
The integration tutorial states that `quad` and other integration routines return an upper bound on the integration error.
This first led me to believe that the actual value of the integral is guaranteed to be within the error bound from the estimated integral value. My change clarifies this by replacing "upper bound on the error" with "estimated error bound". 

#### Additional information
<!--Any additional information you think is important.-->
