### PR TITLE
MAINT: simplify chi distribution mean calculation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1467,7 +1467,8 @@ class chi_gen(rv_continuous):
         return np.sqrt(2*sc.gammainccinv(.5*df, q))
 
     def _stats(self, df):
-        mu = np.sqrt(2)*np.exp(sc.gammaln(df/2.0+0.5)-sc.gammaln(df/2.0))
+        # poch(df/2, 1/2) = gamma(df/2 + 1/2) / gamma(df/2)
+        mu = np.sqrt(2) * sc.poch(0.5 * df, 0.5)
         mu2 = df - mu*mu
         g1 = (2*mu**3.0 + mu*(1-2*df))/np.asarray(np.power(mu2, 1.5))
         g2 = 2*df*(1.0-df)-6*mu**4 + 4*mu**2 * (2*df-1)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -487,9 +487,18 @@ class TestChi:
         x = stats.chi.isf(self.CHI_SF_10_4, 4)
         assert_allclose(x, 10, rtol=1e-15)
 
-    def test_mean(self):
-        x = stats.chi.mean(df=1000)
-        assert_allclose(x, self.CHI_MEAN_1000, rtol=1e-12)
+    # reference value for 1e14 was computed via mpmath
+    # from mpmath import mp
+    # mp.dps = 500
+    # df = mp.mpf(1e20)
+    # float(mp.rf(mp.mpf(0.5) * df, mp.mpf(0.5)) * mp.sqrt(2.))
+
+    @pytest.mark.parametrize('df, ref',
+                             [(1e3, CHI_MEAN_1000),
+                              (1e14, 9999999.999999976)]
+                            ) 
+    def test_mean(self, df, ref):
+        assert_allclose(stats.chi.mean(df), ref, rtol=1e-12)
 
     # Entropy references values were computed with the following mpmath code
     # from mpmath import mp

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -490,7 +490,7 @@ class TestChi:
     # reference value for 1e14 was computed via mpmath
     # from mpmath import mp
     # mp.dps = 500
-    # df = mp.mpf(1e20)
+    # df = mp.mpf(1e14)
     # float(mp.rf(mp.mpf(0.5) * df, mp.mpf(0.5)) * mp.sqrt(2.))
 
     @pytest.mark.parametrize('df, ref',


### PR DESCRIPTION
#### Reference issue
No direct issue, similar to #19635.

#### What does this implement/fix?
Replaces a gamma ratio via `gammaln` by a call to `special.poch`. This simplfies the code and increases the range/precision of `chi.stats`

#### Additional information

<details><summary>Code</summary>
<p>

```python

import numpy as np
from scipy.stats import chi
from scipy.special import poch
import matplotlib.pyplot as plt

dfs = np.logspace(0, 25, 10000)

def _stats_pr(df):
    mu = np.sqrt(2) * poch(0.5 * df, 0.5)  # only difference
    mu2 = df - mu*mu
    return mu, mu2

mean, var = chi.stats(dfs)
mean_pr, var_pr = _stats_pr(dfs)

plt.loglog(dfs, mean, label="mean main branch", ls="dashdot")
plt.loglog(dfs, var, label="var main branch", ls="dashdot", alpha=0.3)
plt.loglog(dfs, mean_pr, label="mean PR", ls="dotted")
plt.loglog(dfs, var_pr, label="var PR", ls="dotted", alpha=0.3)
plt.legend()
plt.ylim(0, 1e20)
plt.xlabel(r"$df$")
plt.title("Chi distribution moments")
plt.show()
``` 

</p>
</details> 

![image](https://github.com/scipy/scipy/assets/40656107/58658b29-3166-41a3-8354-852840a17db5)

