### PR TITLE
BUG: Remove unnecessary incref on unrelated type

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -349,7 +349,6 @@ PyInit__superlu(void)
         return NULL;
     }
 
-    Py_INCREF(&PyArrayFlags_Type);
     if (PyDict_SetItemString(mdict, "SuperLU", (PyObject *) &SuperLUType)) {
         return NULL;
     }


### PR DESCRIPTION
I was removing it NumPy, because I don't see why we need the type public in the C-API.   That breaks SciPy, which breaks NumPy docs CI.
(Now, in principle, I guess we just shouldn't worry about the docs build failing for a while for such reasons, but...)
