### PR TITLE
MAINT: git blame ignores for lint clean-ups

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -24,3 +24,7 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 05b872da4f498d923dbf5f5f38691b9a21580914
 # Clean up for UP lint rules (gh-19516)
 9cf72e4599e0a22902ef3bc1a42e645240b1734d
+# Clean up for B028 lint rule (gh-19623)
+81662226aac5c6b978825b381d2793b16d3b354f
+# Clean up for enabling line length check (gh-19609)
+fa9f13e6906e7d00510d593f7f982db30e4e4f14

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -3,6 +3,7 @@ line-length = 88
 # Enable Pyflakes `E` and `F` and PyUpgrade `UP` codes by default.
 # Also, `PGH004` which checks for blanket (non-specific) `noqa`s
 # and `B028` which checks that warnings include the `stacklevel` keyword.
+# `B028` added in gh-19623.
 select = ["E", "F", "PGH004", "UP", "B028"]
 ignore = ["E741"]
 exclude = ["scipy/datasets/_registry.py"]


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
git blame ignores for gh-19623 and gh-19609

#### Additional information
Also adds a comment so that the addition of `B028` to `lint.toml` can be traced despite not appearing in `git blame`.