### PR TITLE
STY: special: use indent width of 4 in clang-format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,3 +28,7 @@ b9cb3d075dad2b1ee9c145f9e69192d6eeda4f1e
 81662226aac5c6b978825b381d2793b16d3b354f
 # Clean up for enabling line length check (gh-19609)
 fa9f13e6906e7d00510d593f7f982db30e4e4f14
+# Using clang-format with `special` C++ files (gh-19613)
+ecef3490da68a0c53ba543c618bab0c8e15dccee
+# Change to indent width of 4 in clang-format (gh-19660)
+852776a3fe0f3d08c0bed9174f6ac33f653a8677

--- a/scipy/special/special/.clang-format
+++ b/scipy/special/special/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 Standard: Cpp11
 UseTab: Never
-IndentWidth: 2
+IndentWidth: 4
 BreakBeforeBraces: Attach
 Cpp11BracedListStyle: true
 NamespaceIndentation: Inner

--- a/scipy/special/special/config.h
+++ b/scipy/special/special/config.h
@@ -61,10 +61,10 @@ class numeric_limits;
 
 template <>
 class numeric_limits<double> {
-public:
-  SPECFUN_HOST_DEVICE static constexpr double infinity() { return CUDART_INF; }
+  public:
+    SPECFUN_HOST_DEVICE static constexpr double infinity() { return CUDART_INF; }
 
-  SPECFUN_HOST_DEVICE static constexpr double quiet_NaN() { return CUDART_NAN; }
+    SPECFUN_HOST_DEVICE static constexpr double quiet_NaN() { return CUDART_NAN; }
 };
 
 } // namespace std
@@ -84,27 +84,27 @@ using complex = thrust::complex<T>;
 
 template <typename T>
 SPECFUN_HOST_DEVICE T abs(const complex<T> &z) {
-  return thrust::abs(z);
+    return thrust::abs(z);
 }
 
 template <typename T>
 SPECFUN_HOST_DEVICE complex<T> exp(const complex<T> &z) {
-  return thrust::exp(z);
+    return thrust::exp(z);
 }
 
 template <typename T>
 SPECFUN_HOST_DEVICE complex<T> log(const complex<T> &z) {
-  return thrust::log(z);
+    return thrust::log(z);
 }
 
 template <typename T>
 SPECFUN_HOST_DEVICE T norm(const complex<T> &z) {
-  return thrust::norm(z);
+    return thrust::norm(z);
 }
 
 template <typename T>
 SPECFUN_HOST_DEVICE complex<T> sqrt(const complex<T> &z) {
-  return thrust::sqrt(z);
+    return thrust::sqrt(z);
 }
 
 } // namespace std

--- a/scipy/special/special/error.h
+++ b/scipy/special/special/error.h
@@ -13,28 +13,28 @@ extern "C" {
 #endif
 
 typedef enum {
-  SF_ERROR_OK = 0,    /* no error */
-  SF_ERROR_SINGULAR,  /* singularity encountered */
-  SF_ERROR_UNDERFLOW, /* floating point underflow */
-  SF_ERROR_OVERFLOW,  /* floating point overflow */
-  SF_ERROR_SLOW,      /* too many iterations required */
-  SF_ERROR_LOSS,      /* loss of precision */
-  SF_ERROR_NO_RESULT, /* no result obtained */
-  SF_ERROR_DOMAIN,    /* out of domain */
-  SF_ERROR_ARG,       /* invalid input parameter */
-  SF_ERROR_OTHER,     /* unclassified error */
-  SF_ERROR__LAST
+    SF_ERROR_OK = 0,    /* no error */
+    SF_ERROR_SINGULAR,  /* singularity encountered */
+    SF_ERROR_UNDERFLOW, /* floating point underflow */
+    SF_ERROR_OVERFLOW,  /* floating point overflow */
+    SF_ERROR_SLOW,      /* too many iterations required */
+    SF_ERROR_LOSS,      /* loss of precision */
+    SF_ERROR_NO_RESULT, /* no result obtained */
+    SF_ERROR_DOMAIN,    /* out of domain */
+    SF_ERROR_ARG,       /* invalid input parameter */
+    SF_ERROR_OTHER,     /* unclassified error */
+    SF_ERROR__LAST
 } sf_error_t;
 
 #ifdef __cplusplus
 namespace special {
 
 #ifndef SP_SPECFUN_ERROR
-  SPECFUN_HOST_DEVICE inline void set_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
-    // nothing
-  }
+    SPECFUN_HOST_DEVICE inline void set_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
+        // nothing
+    }
 #else
-  void set_error(const char *func_name, sf_error_t code, const char *fmt, ...);
+    void set_error(const char *func_name, sf_error_t code, const char *fmt, ...);
 #endif
 } // namespace special
 

--- a/scipy/special/special/evalpoly.h
+++ b/scipy/special/special/evalpoly.h
@@ -19,24 +19,24 @@
 namespace special {
 
 SPECFUN_HOST_DEVICE inline std::complex<double> cevalpoly(const double *coeffs, int degree, std::complex<double> z) {
-  /* Evaluate a polynomial with real coefficients at a complex point.
-   *
-   * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
-   * efficient than Horner's method.
-   */
-  double a = coeffs[0];
-  double b = coeffs[1];
-  double r = 2 * z.real();
-  double s = std::norm(z);
-  double tmp;
+    /* Evaluate a polynomial with real coefficients at a complex point.
+     *
+     * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
+     * efficient than Horner's method.
+     */
+    double a = coeffs[0];
+    double b = coeffs[1];
+    double r = 2 * z.real();
+    double s = std::norm(z);
+    double tmp;
 
-  for (int j = 2; j < degree + 1; j++) {
-    tmp = b;
-    b = std::fma(-s, a, coeffs[j]);
-    a = std::fma(r, a, tmp);
-  }
+    for (int j = 2; j < degree + 1; j++) {
+        tmp = b;
+        b = std::fma(-s, a, coeffs[j]);
+        a = std::fma(r, a, tmp);
+    }
 
-  return z * a + b;
+    return z * a + b;
 }
 
 } // namespace special

--- a/scipy/special/special/lambertw.h
+++ b/scipy/special/special/lambertw.h
@@ -10,8 +10,10 @@
  * References:
  * [1] On the Lambert W function, Adv. Comp. Math. 5 (1996) 329-359,
  *     available online: https://web.archive.org/web/20230123211413/https://cs.uwaterloo.ca/research/tr/1993/03/W.pdf
- * [2] mpmath source code, https://github.com/mpmath/mpmath/blob/c5939823669e1bcce151d89261b802fe0d8978b4/mpmath/functions/functions.py#L435-L461
- * [3] https://web.archive.org/web/20230504171447/https://mpmath.org/doc/current/functions/powers.html#lambert-w-function
+ * [2] mpmath source code,
+ https://github.com/mpmath/mpmath/blob/c5939823669e1bcce151d89261b802fe0d8978b4/mpmath/functions/functions.py#L435-L461
+ * [3]
+ https://web.archive.org/web/20230504171447/https://mpmath.org/doc/current/functions/powers.html#lambert-w-function
  *
 
  * TODO: use a series expansion when extremely close to the branch point
@@ -28,111 +30,111 @@ constexpr double EXPN1 = 0.36787944117144232159553; // exp(-1)
 constexpr double OMEGA = 0.56714329040978387299997; // W(1, 0)
 
 namespace detail {
-  SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_branchpt(std::complex<double> z) {
-    // Series for W(z, 0) around the branch point; see 4.22 in [1].
-    double coeffs[] = {-1.0 / 3.0, 1.0, -1.0};
-    std::complex<double> p = std::sqrt(2.0 * (M_E * z + 1.0));
+    SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_branchpt(std::complex<double> z) {
+        // Series for W(z, 0) around the branch point; see 4.22 in [1].
+        double coeffs[] = {-1.0 / 3.0, 1.0, -1.0};
+        std::complex<double> p = std::sqrt(2.0 * (M_E * z + 1.0));
 
-    return cevalpoly(coeffs, 2, p);
-  }
+        return cevalpoly(coeffs, 2, p);
+    }
 
-  SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_pade0(std::complex<double> z) {
-    // (3, 2) Pade approximation for W(z, 0) around 0.
-    double num[] = {12.85106382978723404255, 12.34042553191489361902, 1.0};
-    double denom[] = {32.53191489361702127660, 14.34042553191489361702, 1.0};
+    SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_pade0(std::complex<double> z) {
+        // (3, 2) Pade approximation for W(z, 0) around 0.
+        double num[] = {12.85106382978723404255, 12.34042553191489361902, 1.0};
+        double denom[] = {32.53191489361702127660, 14.34042553191489361702, 1.0};
 
-    /* This only gets evaluated close to 0, so we don't need a more
-     * careful algorithm that avoids overflow in the numerator for
-     * large z. */
-    return z * cevalpoly(num, 2, z) / cevalpoly(denom, 2, z);
-  }
+        /* This only gets evaluated close to 0, so we don't need a more
+         * careful algorithm that avoids overflow in the numerator for
+         * large z. */
+        return z * cevalpoly(num, 2, z) / cevalpoly(denom, 2, z);
+    }
 
-  SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_asy(std::complex<double> z, long k) {
-    /* Compute the W function using the first two terms of the
-     * asymptotic series. See 4.20 in [1].
-     */
-    std::complex<double> w = std::log(z) + 2.0 * M_PI * k * std::complex<double>(0, 1);
-    return w - std::log(w);
-  }
+    SPECFUN_HOST_DEVICE inline std::complex<double> lambertw_asy(std::complex<double> z, long k) {
+        /* Compute the W function using the first two terms of the
+         * asymptotic series. See 4.20 in [1].
+         */
+        std::complex<double> w = std::log(z) + 2.0 * M_PI * k * std::complex<double>(0, 1);
+        return w - std::log(w);
+    }
 
 } // namespace detail
 
 SPECFUN_HOST_DEVICE inline std::complex<double> lambertw(std::complex<double> z, long k, double tol) {
-  double absz;
-  std::complex<double> w;
-  std::complex<double> ew, wew, wewz, wn;
+    double absz;
+    std::complex<double> w;
+    std::complex<double> ew, wew, wewz, wn;
 
-  if (std::isnan(z.real()) || std::isnan(z.imag())) {
-    return z;
-  }
-  if (z.real() == std::numeric_limits<double>::infinity()) {
-    return z + 2.0 * M_PI * k * std::complex<double>(0, 1);
-  }
-  if (z.real() == -std::numeric_limits<double>::infinity()) {
-    return -z + (2.0 * M_PI * k + M_PI) * std::complex<double>(0, 1);
-  }
-  if (z == 0.0) {
+    if (std::isnan(z.real()) || std::isnan(z.imag())) {
+        return z;
+    }
+    if (z.real() == std::numeric_limits<double>::infinity()) {
+        return z + 2.0 * M_PI * k * std::complex<double>(0, 1);
+    }
+    if (z.real() == -std::numeric_limits<double>::infinity()) {
+        return -z + (2.0 * M_PI * k + M_PI) * std::complex<double>(0, 1);
+    }
+    if (z == 0.0) {
+        if (k == 0) {
+            return z;
+        }
+        set_error("lambertw", SF_ERROR_SINGULAR, NULL);
+        return -std::numeric_limits<double>::infinity();
+    }
+    if (z == 1.0 && k == 0) {
+        // Split out this case because the asymptotic series blows up
+        return OMEGA;
+    }
+
+    absz = std::abs(z);
+    // Get an initial guess for Halley's method
     if (k == 0) {
-      return z;
-    }
-    set_error("lambertw", SF_ERROR_SINGULAR, NULL);
-    return -std::numeric_limits<double>::infinity();
-  }
-  if (z == 1.0 && k == 0) {
-    // Split out this case because the asymptotic series blows up
-    return OMEGA;
-  }
-
-  absz = std::abs(z);
-  // Get an initial guess for Halley's method
-  if (k == 0) {
-    if (std::abs(z + EXPN1) < 0.3) {
-      w = detail::lambertw_branchpt(z);
-    } else if (-1.0 < z.real() && z.real() < 1.5 && std::abs(z.imag()) < 1.0 &&
-               -2.5 * std::abs(z.imag()) - 0.2 < z.real()) {
-      /* Empirically determined decision boundary where the Pade
-       * approximation is more accurate. */
-      w = detail::lambertw_pade0(z);
+        if (std::abs(z + EXPN1) < 0.3) {
+            w = detail::lambertw_branchpt(z);
+        } else if (-1.0 < z.real() && z.real() < 1.5 && std::abs(z.imag()) < 1.0 &&
+                   -2.5 * std::abs(z.imag()) - 0.2 < z.real()) {
+            /* Empirically determined decision boundary where the Pade
+             * approximation is more accurate. */
+            w = detail::lambertw_pade0(z);
+        } else {
+            w = detail::lambertw_asy(z, k);
+        }
+    } else if (k == -1) {
+        if (absz <= EXPN1 && z.imag() == 0.0 && z.real() < 0.0) {
+            w = std::log(-z.real());
+        } else {
+            w = detail::lambertw_asy(z, k);
+        }
     } else {
-      w = detail::lambertw_asy(z, k);
+        w = detail::lambertw_asy(z, k);
     }
-  } else if (k == -1) {
-    if (absz <= EXPN1 && z.imag() == 0.0 && z.real() < 0.0) {
-      w = std::log(-z.real());
+
+    // Halley's method; see 5.9 in [1]
+    if (w.real() >= 0) {
+        // Rearrange the formula to avoid overflow in exp
+        for (int i = 0; i < 100; i++) {
+            ew = std::exp(-w);
+            wewz = w - z * ew;
+            wn = w - wewz / (w + 1.0 - (w + 2.0) * wewz / (2.0 * w + 2.0));
+            if (std::abs(wn - w) <= tol * std::abs(wn)) {
+                return wn;
+            }
+            w = wn;
+        }
     } else {
-      w = detail::lambertw_asy(z, k);
+        for (int i = 0; i < 100; i++) {
+            ew = std::exp(w);
+            wew = w * ew;
+            wewz = wew - z;
+            wn = w - wewz / (wew + ew - (w + 2.0) * wewz / (2.0 * w + 2.0));
+            if (std::abs(wn - w) <= tol * std::abs(wn)) {
+                return wn;
+            }
+            w = wn;
+        }
     }
-  } else {
-    w = detail::lambertw_asy(z, k);
-  }
 
-  // Halley's method; see 5.9 in [1]
-  if (w.real() >= 0) {
-    // Rearrange the formula to avoid overflow in exp
-    for (int i = 0; i < 100; i++) {
-      ew = std::exp(-w);
-      wewz = w - z * ew;
-      wn = w - wewz / (w + 1.0 - (w + 2.0) * wewz / (2.0 * w + 2.0));
-      if (std::abs(wn - w) <= tol * std::abs(wn)) {
-        return wn;
-      }
-      w = wn;
-    }
-  } else {
-    for (int i = 0; i < 100; i++) {
-      ew = std::exp(w);
-      wew = w * ew;
-      wewz = wew - z;
-      wn = w - wewz / (wew + ew - (w + 2.0) * wewz / (2.0 * w + 2.0));
-      if (std::abs(wn - w) <= tol * std::abs(wn)) {
-        return wn;
-      }
-      w = wn;
-    }
-  }
-
-  set_error("lambertw", SF_ERROR_SLOW, "iteration failed to converge: %g + %gj", z.real(), z.imag());
-  return std::complex<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+    set_error("lambertw", SF_ERROR_SLOW, "iteration failed to converge: %g + %gj", z.real(), z.imag());
+    return std::complex<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
 }
 
 } // namespace special


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/19613#issuecomment-1836503053
https://github.com/scipy/scipy/pull/19613#issuecomment-1837120479

#### What does this implement/fix?
- Changes from indent width 2 to 4 in the clang-format of `scipy/special/special`
- Adds `git blame` ignores for the style only changes

#### Additional information
<!--Any additional information you think is important.-->
