### PR TITLE
CI: fix pre-release job by correct version pin for scipy-openblas32

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -306,8 +306,11 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy "scipy-openblas32<=0.3.24.135"
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
+        # TODO: once the scipy_ symbol prefix issue is fixed, install
+        # scipy-openblas32 from the pre-releases bucket again (see gh-19640)
+        python -m pip install "scipy-openblas32<=0.3.23.293.2"
 
     - name:  Prepare compiler cache
       id:    prep-ccache


### PR DESCRIPTION
Closes gh-19640

This just passed on my fork ([CI log](https://github.com/rgommers/scipy/actions/runs/7143188498/job/19454105895)), so skipping CI here.