### PR TITLE
DOC: Add example for mstats.brunnermunzel

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3489,11 +3489,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     >>> import numpy as np
     >>> x1 = [1,2,np.nan,np.nan,1,1,1,1,1,1,2,4,1,1]
     >>> x2 = [3,3,4,3,1,2,3,1,1,5,4]
-    >>> w, p_value = brunnermunzel(x1, x2)
-    >>> w
-    1.4670611987757205
-    >>> p_value
-    0.15622840440238628
+    >>> brunnermunzel(x1, x2)
+    BrunnerMunzelResult(statistic=1.4723186918922935, pvalue=0.15479415300426624)
 
     """
     x = ma.asarray(x).compressed().view(ndarray)

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3490,7 +3490,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     >>> x1 = [1,2,np.nan,np.nan,1,1,1,1,1,1,2,4,1,1]
     >>> x2 = [3,3,4,3,1,2,3,1,1,5,4]
     >>> brunnermunzel(x1, x2)
-    BrunnerMunzelResult(statistic=1.4723186918922935, pvalue=0.15479415300426624)
+    BrunnerMunzelResult(statistic=1.4723186918922935, pvalue=0.15479415300426624)  # may vary
 
     """
     x = ma.asarray(x).compressed().view(ndarray)

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3489,7 +3489,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     >>> import numpy as np
     >>> x1 = [1,2,np.nan,np.nan,1,1,1,1,1,1,2,4,1,1]
     >>> x2 = [3,3,4,3,1,2,3,1,1,5,4]
-    >>> w, p_value = mstats.brunnermunzel(x1, x2)
+    >>> w, p_value = brunnermunzel(x1, x2)
     >>> w
     1.4670611987757205
     >>> p_value

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3442,9 +3442,17 @@ BrunnerMunzelResult = namedtuple('BrunnerMunzelResult', ('statistic', 'pvalue'))
 
 def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     """
-    Computes the Brunner-Munzel test on samples x and y
+    Compute the Brunner-Munzel test on samples x and y.
 
-    Missing values in `x` and/or `y` are discarded.
+    Any missing values in `x` and/or `y` are discarded.
+
+    The Brunner-Munzel test is a nonparametric test of the null hypothesis that
+    when values are taken one by one from each group, the probabilities of
+    getting large values in both groups are equal.
+    Unlike the Wilcoxon-Mann-Whitney's U test, this does not require the
+    assumption of equivariance of two groups. Note that this does not assume
+    the distributions are same. This test works on two independent samples,
+    which may have different sizes.
 
     Parameters
     ----------
@@ -3474,6 +3482,18 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     Notes
     -----
     For more details on `brunnermunzel`, see `scipy.stats.brunnermunzel`.
+
+    Examples
+    --------
+    >>> from scipy.stats.mstats import brunnermunzel
+    >>> import numpy as np
+    >>> x1 = [1,2,np.nan,np.nan,1,1,1,1,1,1,2,4,1,1]
+    >>> x2 = [3,3,4,3,1,2,3,1,1,5,4]
+    >>> w, p_value = mstats.brunnermunzel(x1, x2)
+    >>> w
+    1.4670611987757205
+    >>> p_value
+    0.15622840440238628
 
     """
     x = ma.asarray(x).compressed().view(ndarray)

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3487,8 +3487,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     --------
     >>> from scipy.stats.mstats import brunnermunzel
     >>> import numpy as np
-    >>> x1 = [1,2,np.nan,np.nan,1,1,1,1,1,1,2,4,1,1]
-    >>> x2 = [3,3,4,3,1,2,3,1,1,5,4]
+    >>> x1 = [1, 2, np.nan, np.nan, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1]
+    >>> x2 = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
     >>> brunnermunzel(x1, x2)
     BrunnerMunzelResult(statistic=1.4723186918922935, pvalue=0.15479415300426624)  # may vary
 


### PR DESCRIPTION
#### Reference issue
Towards #7168

#### What does this implement/fix?
Add an example to the docstring of brunnermunzel function on the mstats module. The example is the same as in the stats module, but with np.nan values.

If there's anything I need to take care of, please let me know.
