### PR TITLE
ENH: integrate._nsum: function for finite and infinite summation

### DIFF
--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -1062,11 +1062,7 @@ def _integral_bound(f, a, b, step, args, constants):
     n_steps = np.round(np.logspace(0, np.log10(maxterms), nfev, dtype=dtype))
     ks = a2 + n_steps * step2
     fks = f(ks, *args2)
-    if fks.size and np.all((fks < atol)[..., -1]):
-        nt = np.argmax(fks < atol, axis=-1)
-        nt = np.max(nt)
-    else:
-        nt = len(n_steps) - 1
+    nt = np.minimum(np.sum(fks > atol, axis=-1),  n_steps.shape[-1]-1)
     n_steps = n_steps[nt]
 
     # Directly evaluate the sum up to this term
@@ -1084,7 +1080,7 @@ def _integral_bound(f, a, b, step, args, constants):
     right = _tanhsinh(f, k, b, args=args, atol=atol, rtol=rtol, log=log)
 
     # Calculate the full estimate and error from the pieces
-    fk = fks[..., nt]
+    fk = fks[np.arange(len(fks)), nt]
     fb = f(b, *args)
     nfev += 1
     if log:

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -841,7 +841,7 @@ def _nsum(f, a, b, step=1, args=(), log=False, maxterms=int(2**20), atol=None,
         Real lower and upper limits of summed terms. Must be broadcastable.
         Elements of `b` may be infinite.
     args : tuple, optional
-        Additional positional arguments to be passed to `func`. Must be arrays
+        Additional positional arguments to be passed to `f`. Must be arrays
         broadcastable with `a` and `b`. If the callable to be summed
         requires arguments that are not broadcastable with `a` and `b`, wrap
         that callable with `f`. See Examples.
@@ -868,6 +868,7 @@ def _nsum(f, a, b, step=1, args=(), log=False, maxterms=int(2**20), atol=None,
         An instance of `scipy.optimize.OptimizeResult` with the following
         attributes. (The descriptions are written as though the values will be
         scalars; however, if `func` returns an array, the outputs will be
+
         arrays of the same shape.)
         success : bool
             ``True`` when the algorithm terminated successfully (status ``0``).
@@ -902,7 +903,7 @@ def _nsum(f, a, b, step=1, args=(), log=False, maxterms=int(2**20), atol=None,
     where :math:`\epsilon` is the requested absolute tolerance. If no absolute
     tolerance is specified, or if there is no :math:`c ≤ a + n` (where :math:`a`
     and :math:`n` represent `a` and `maxterms`, respectively) that satisfies
-    the tolerance, then :math:`c = a + n`. Then the infinite sum is approximated
+    the tolerance, we let :math:`c = a + n`. Then the infinite sum is approximated
     as
     
     .. math::
@@ -910,7 +911,7 @@ def _nsum(f, a, b, step=1, args=(), log=False, maxterms=int(2**20), atol=None,
         \sum_{k=a}^{c-1} f(k) + \int_c^\infty f(x) dx + f(c)/2
         
     and the reported error is :math:`f(c)/2` plus the error estimate of
-    integration.
+    numerical integration.
 
     References
     ----------
@@ -958,7 +959,6 @@ def _nsum(f, a, b, step=1, args=(), log=False, maxterms=int(2**20), atol=None,
     tmp = _nsum_iv(f, a, b, step, args, log, maxterms, atol, rtol)
     f, a, b, step, args, log, maxterms, atol, rtol = tmp
 
-    a, b, step = np.broadcast_arrays(a, b, step)
     tmp = _scalar_optimization_initialize(f, (a,), args, complex_ok=False)
     xs, fs, args, shape, dtype = tmp
 
@@ -1025,9 +1025,9 @@ def _direct(f, a, b, step, args, constants, inclusive=True):
     ks[i_nan] = np.nan
     fs = f(ks, *args2)
     fs[i_nan] = zero
-    nfev = max_steps-i_nan.sum(axis=-1)
+    nfev = max_steps - i_nan.sum(axis=-1)
     S = special.logsumexp(fs, axis=-1) if log else np.sum(fs, axis=-1)
-    E = np.real(S) + np.log(eps) if log else abs(eps * S)
+    E = np.real(S) + np.log(eps) if log else abs(eps) * S
     return S, E, nfev
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1541,7 +1541,7 @@ class TestNSum:
             return _nsum(lambda x: 1 / x**p, a, b, maxterms=maxterms)
 
         res = _nsum(f, a, b, maxterms=1000, args=(p,))
-        refs = _nsum_single(a, b, p, maxterms).ravel()
+        refs = _nsum_single(a, b, p, maxterms=1000).ravel()
 
         attrs = ['sum', 'error', 'success', 'status', 'nfev']
         for attr in attrs:

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1594,6 +1594,17 @@ class TestNSum:
         res = _nsum(self.f2, 1, np.inf, args=2)
         assert_allclose(res.sum, self.f1.ref)  # f1.ref is correct w/ args=2
 
+        # Test 0 size input
+        a = np.empty((3, 1, 1))  # arbitrary broadcastable shapes
+        b = np.empty((0, 1))  # could use Hypothesis
+        p = np.empty((4))  # but it's overkill
+        shape = np.broadcast_shapes(a.shape, b.shape, p.shape)
+        res = _nsum(self.f2, a, b, args=(p,))
+        assert res.sum.shape == shape
+        assert res.error.shape == shape
+        assert res.status.shape == shape
+        assert res.nfev.shape == shape
+
         # # Test NaNs
         # should skip both direct and integral methods if there are NaNs
         # a = [np.nan, 1, 1, 1]

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1583,6 +1583,14 @@ class TestNSum:
         res = _nsum(f, 1, np.inf, atol=1e-6)
         assert_equal(res.nfev, f.nfev)
 
+    def test_inclusive(self):
+        # There was an edge case off-by one bug when `_direct` was called with
+        # `inclusive=True`. Check that this is resolved.
+        res = _nsum(lambda k: 1 / k ** 2, [1, 4], np.inf, maxterms=500, atol=0.1)
+        ref = _nsum(lambda k: 1 / k ** 2, [1, 4], np.inf)
+        assert np.all(res.sum > (ref.sum - res.error))
+        assert np.all(res.sum < (ref.sum + res.error))
+
     def test_special_case(self):
         # test equal lower/upper limit
         f = self.f1

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1468,15 +1468,16 @@ class TestNSum:
 
         a = np.asarray([1, 5])[:, np.newaxis]
         b = np.asarray([20, 100, np.inf])[:, np.newaxis, np.newaxis]
+        # step = np.asarray([0.5, 1]).reshape((-1, 1, 1, 1))
         k = a + maxterms
-        direct = f(a + np.arange(maxterms)).sum(axis=-1, keepdims=True)  # direct contribution
+        direct = f(a + np.arange(maxterms)).sum(axis=-1, keepdims=True)  # partial sum
         integral = F(b) - F(k)  # integral approximation of remainder
         low = direct + integral + f(b)  # theoretical lower bound
         high = direct + integral + f(k)  # theoretical upper bound
-        ref_sum = (low + high)/2  # nsum uses average
-        ref_err = (high - low) / 2  # error assuming perfect quadrature
+        ref_sum = (low + high)/2  # _nsum uses average of the two
+        ref_err = (high - low) / 2  # error (assuming perfect quadrature)
 
-        # replace reference integrals by exact result where appropriate
+        # correct reference values where number of terms < maxterms
         a, b = np.broadcast_arrays(a, b)
         for i in np.ndindex(a.shape):
             ai, bi = a[i], b[i]

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1612,11 +1612,10 @@ class TestNSum:
         # Test 0 size input
         a = np.empty((3, 1, 1))  # arbitrary broadcastable shapes
         b = np.empty((0, 1))  # could use Hypothesis
-        p = np.empty((4))  # but it's overkill
+        p = np.empty(4)  # but it's overkill
         shape = np.broadcast_shapes(a.shape, b.shape, p.shape)
         res = _nsum(self.f2, a, b, args=(p,))
         assert res.sum.shape == shape
-        assert res.error.shape == shape
         assert res.status.shape == shape
         assert res.nfev.shape == shape
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1531,19 +1531,17 @@ class TestNSum:
         n = np.prod(shape)
 
         def f(x, p):
-            f.ncall += 1
             f.feval += 1 if (x.size == n or x.ndim <= 1) else x.shape[-1]
             return 1 / x ** p
 
-        f.ncall = 0
         f.feval = 0
 
         @np.vectorize
-        def _nsum_single(a, b, p):
-            return _nsum(lambda x: 1 / x**p, a, b, maxterms=1000)
+        def _nsum_single(a, b, p, maxterms):
+            return _nsum(lambda x: 1 / x**p, a, b, maxterms=maxterms)
 
         res = _nsum(f, a, b, maxterms=1000, args=(p,))
-        refs = _nsum_single(a, b, p).ravel()
+        refs = _nsum_single(a, b, p, maxterms).ravel()
 
         attrs = ['sum', 'error', 'success', 'status', 'nfev']
         for attr in attrs:

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1441,7 +1441,7 @@ class TestNSum:
         with pytest.raises(ValueError, match=message):
             _nsum(f, f.a, f.b, atol=np.inf, log=True)
 
-        message = '...must be a positive integer.'
+        message = '...must be a non-negative integer.'
         with pytest.raises(ValueError, match=message):
             _nsum(f, f.a, f.b, maxterms=3.5)
         with pytest.raises(ValueError, match=message):
@@ -1463,7 +1463,7 @@ class TestNSum:
         assert_equal(logres.status, 0)
         assert_equal(logres.success, True)
 
-    @pytest.mark.parametrize('maxterms', [1, 10, 20, 100])
+    @pytest.mark.parametrize('maxterms', [0, 1, 10, 20, 100])
     def test_integral(self, maxterms):
         # test precise behavior of integral approximation
         f = self.f1


### PR DESCRIPTION
#### Reference issue
gh-15928

#### What does this implement/fix?
Adds a private function for evaluating finite and infinite sums. The only interesting method (beside directly evaluating a finite sum) relies on the function to be monotone decreasing; it is based on the integral test for convergence. I've found this method to be very effective and reliable for the primary use case (distribution functions of discrete distributions); other methods (Richardson extrapolation, epsilon algorithm) can be added later if desired.

#### Additional information
```python3
import numpy as np
from scipy import special
from scipy.integrate._tanhsinh import _nsum

p = [1.1, 3]
b = np.asarray([10, np.inf])[:, np.newaxis]

res = _nsum(lambda k, p: 1 / k ** p, 1, b, maxterms=1000, atol=1e-6, args=(p,))
ref = special.zeta(p, 1) - special.zeta(p, b+1)
np.allclose(res.sum, ref)
print(res)
print('\nActual Error\n', res.sum - ref)
```
Output
```
 success: [[ True  True]
           [ True  True]]
  status: [[0 0]
           [0 0]]
     sum: [[ 2.680e+00  1.198e+00]
           [ 1.058e+01  1.202e+00]]
   error: [[ 5.951e-16  2.659e-16]
           [ 2.503e-04  4.967e-07]]
    nfev: [[  11   11]
           [1210  246]]
Actual Error
 [[-4.44089210e-16  0.00000000e+00]
 [-4.58092764e-08 -2.83374813e-09]]
```
(The documentation notes that `maxterms` only controls the number of terms when directly evaluating the sum or a portion of the sum; the total number of function evaluations can be a bit more if integration is used.)