### PR TITLE
DEP: signal: remove scipy.signal.{bspline,quadratic,cubic}

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -300,7 +300,7 @@ fftconvolve, convolve2d, correlate2d, and sepfir2d.) Eliminate the overlap with
 convolution and correlation, put the implementation somewhere, and use that
 consistently throughout SciPy.
 
-*B-splines*: (Relevant functions are bspline, cubic, quadratic, gauss_spline,
+*B-splines*: (Relevant functions are gauss_spline,
 cspline1d, qspline1d, cspline2d, qspline2d, cspline1d_eval, and spline_filter.)
 Move the good stuff to `interpolate` (with appropriate API changes to match how
 things are done in `interpolate`), and eliminate any duplication.

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -25,9 +25,6 @@ B-splines
 .. autosummary::
    :toctree: generated/
 
-   bspline        -- B-spline basis function of order n.
-   cubic          -- B-spline basis function of order 3.
-   quadratic      -- B-spline basis function of order 2.
    gauss_spline   -- Gaussian approximation to the B-spline basis function.
    cspline1d      -- Coefficients for 1-D cubic (3rd order) B-spline.
    qspline1d      -- Coefficients for 1-D quadratic (2nd order) B-spline.

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -1,20 +1,14 @@
-import warnings
-
-from numpy import (logical_and, asarray, pi, zeros_like,
-                   piecewise, array, arctan2, tan, ones, arange, floor,
-                   r_, atleast_1d)
-from numpy import (sqrt, exp, greater, less, cos, add, sin, less_equal,
-                   greater_equal)
+from numpy import (asarray, pi, zeros_like,
+                   array, arctan2, tan, ones, arange, floor,
+                   r_, atleast_1d, sqrt, exp, greater, cos, add, sin)
 
 # From splinemodule.c
 from ._spline import cspline2d, sepfir2d
 from ._signaltools import lfilter, sosfilt, lfiltic
 
-from scipy.special import comb
-from scipy._lib._util import float_factorial
 from scipy.interpolate import BSpline
 
-__all__ = ['spline_filter', 'bspline', 'gauss_spline', 'cubic', 'quadratic',
+__all__ = ['spline_filter', 'gauss_spline',
            'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval']
 
 
@@ -77,152 +71,6 @@ def spline_filter(Iin, lmbda=5.0):
 _splinefunc_cache = {}
 
 
-def _bspline_piecefunctions(order):
-    """Returns the function defined over the left-side pieces for a bspline of
-    a given order.
-
-    The 0th piece is the first one less than 0. The last piece is a function
-    identical to 0 (returned as the constant 0). (There are order//2 + 2 total
-    pieces).
-
-    Also returns the condition functions that when evaluated return boolean
-    arrays for use with `numpy.piecewise`.
-    """
-    try:
-        return _splinefunc_cache[order]
-    except KeyError:
-        pass
-
-    def condfuncgen(num, val1, val2):
-        if num == 0:
-            return lambda x: logical_and(less_equal(x, val1),
-                                         greater_equal(x, val2))
-        elif num == 2:
-            return lambda x: less_equal(x, val2)
-        else:
-            return lambda x: logical_and(less(x, val1),
-                                         greater_equal(x, val2))
-
-    last = order // 2 + 2
-    if order % 2:
-        startbound = -1.0
-    else:
-        startbound = -0.5
-    condfuncs = [condfuncgen(0, 0, startbound)]
-    bound = startbound
-    for num in range(1, last - 1):
-        condfuncs.append(condfuncgen(1, bound, bound - 1))
-        bound = bound - 1
-    condfuncs.append(condfuncgen(2, 0, -(order + 1) / 2.0))
-
-    # final value of bound is used in piecefuncgen below
-
-    # the functions to evaluate are taken from the left-hand side
-    #  in the general expression derived from the central difference
-    #  operator (because they involve fewer terms).
-
-    fval = float_factorial(order)
-
-    def piecefuncgen(num):
-        Mk = order // 2 - num
-        if (Mk < 0):
-            return 0  # final function is 0
-        coeffs = [(1 - 2 * (k % 2)) * float(comb(order + 1, k, exact=1)) / fval
-                  for k in range(Mk + 1)]
-        shifts = [-bound - k for k in range(Mk + 1)]
-
-        def thefunc(x):
-            res = 0.0
-            for k in range(Mk + 1):
-                res += coeffs[k] * (x + shifts[k]) ** order
-            return res
-        return thefunc
-
-    funclist = [piecefuncgen(k) for k in range(last)]
-
-    _splinefunc_cache[order] = (funclist, condfuncs)
-
-    return funclist, condfuncs
-
-
-msg_bspline = """`scipy.signal.bspline` is deprecated in SciPy 1.11 and will be
-removed in SciPy 1.13.
-
-The exact equivalent (for a float array `x`) is
-
->>> from scipy.interpolate import BSpline
->>> knots = np.arange(-(n+1)/2, (n+3)/2)
->>> out = BSpline.basis_element(knots)(x)
->>> out[(x < knots[0]) | (x > knots[-1])] = 0.0
-"""
-
-
-def bspline(x, n):
-    """
-    .. deprecated:: 1.11.0
-
-        `scipy.signal.bspline` is deprecated in SciPy 1.11 and will be
-        removed in SciPy 1.13.
-
-        The exact equivalent (for a float array `x`) is::
-
-            >>> import numpy as np
-            >>> from scipy.interpolate import BSpline
-            >>> knots = np.arange(-(n+1)/2, (n+3)/2)
-            >>> out = BSpline.basis_element(knots)(x)
-            >>> out[(x < knots[0]) | (x > knots[-1])] = 0.0
-
-    B-spline basis function of order n.
-
-    Parameters
-    ----------
-    x : array_like
-        a knot vector
-    n : int
-        The order of the spline. Must be non-negative, i.e., n >= 0
-
-    Returns
-    -------
-    res : ndarray
-        B-spline basis function values
-
-    See Also
-    --------
-    cubic : A cubic B-spline.
-    quadratic : A quadratic B-spline.
-
-    Notes
-    -----
-    Uses numpy.piecewise and automatic function-generator.
-
-    Examples
-    --------
-    We can calculate B-Spline basis function of several orders:
-
-    >>> import numpy as np
-    >>> from scipy.signal import bspline, cubic, quadratic
-    >>> bspline(0.0, 1)
-    1
-
-    >>> knots = [-1.0, 0.0, -1.0]
-    >>> bspline(knots, 2)
-    array([0.125, 0.75, 0.125])
-
-    >>> np.array_equal(bspline(knots, 2), quadratic(knots))
-    True
-
-    >>> np.array_equal(bspline(knots, 3), cubic(knots))
-    True
-
-    """
-    warnings.warn(msg_bspline, DeprecationWarning, stacklevel=2)
-
-    ax = -abs(asarray(x, dtype=float))
-    # number of pieces on the left-side is (n+1)/2
-    funclist, condfuncs = _bspline_piecefunctions(n)
-    condlist = [func(ax) for func in condfuncs]
-    return piecewise(ax, condlist, funclist)
-
 def gauss_spline(x, n):
     r"""Gaussian approximation to B-spline basis function of order n.
 
@@ -262,96 +110,15 @@ def gauss_spline(x, n):
     distribution:
 
     >>> import numpy as np
-    >>> from scipy.signal import gauss_spline, bspline
+    >>> from scipy.signal import gauss_spline
     >>> knots = np.array([-1.0, 0.0, -1.0])
     >>> gauss_spline(knots, 3)
     array([0.15418033, 0.6909883, 0.15418033])  # may vary
-
-    >>> bspline(knots, 3)
-    array([0.16666667, 0.66666667, 0.16666667])  # may vary
 
     """
     x = asarray(x)
     signsq = (n + 1) / 12.0
     return 1 / sqrt(2 * pi * signsq) * exp(-x ** 2 / 2 / signsq)
-
-
-msg_cubic = """`scipy.signal.cubic` is deprecated in SciPy 1.11 and will be
-removed in SciPy 1.13.
-
-The exact equivalent (for a float array `x`) is
-
->>> from scipy.interpolate import BSpline
->>> out = BSpline.basis_element([-2, -1, 0, 1, 2])(x)
->>> out[(x < -2 | (x > 2)] = 0.0
-"""
-
-
-def cubic(x):
-    """
-    .. deprecated:: 1.11.0
-
-        `scipy.signal.cubic` is deprecated in SciPy 1.11 and will be
-        removed in SciPy 1.13.
-
-        The exact equivalent (for a float array `x`) is::
-
-            >>> from scipy.interpolate import BSpline
-            >>> out = BSpline.basis_element([-2, -1, 0, 1, 2])(x)
-            >>> out[(x < -2 | (x > 2)] = 0.0
-
-    A cubic B-spline.
-
-    This is a special case of `bspline`, and equivalent to ``bspline(x, 3)``.
-
-    Parameters
-    ----------
-    x : array_like
-        a knot vector
-
-    Returns
-    -------
-    res : ndarray
-        Cubic B-spline basis function values
-
-    See Also
-    --------
-    bspline : B-spline basis function of order n
-    quadratic : A quadratic B-spline.
-
-    Examples
-    --------
-    We can calculate B-Spline basis function of several orders:
-
-    >>> import numpy as np
-    >>> from scipy.signal import bspline, cubic, quadratic
-    >>> bspline(0.0, 1)
-    1
-
-    >>> knots = [-1.0, 0.0, -1.0]
-    >>> bspline(knots, 2)
-    array([0.125, 0.75, 0.125])
-
-    >>> np.array_equal(bspline(knots, 2), quadratic(knots))
-    True
-
-    >>> np.array_equal(bspline(knots, 3), cubic(knots))
-    True
-
-    """
-    warnings.warn(msg_cubic, DeprecationWarning, stacklevel=2)
-
-    ax = abs(asarray(x, dtype=float))
-    res = zeros_like(ax)
-    cond1 = less(ax, 1)
-    if cond1.any():
-        ax1 = ax[cond1]
-        res[cond1] = 2.0 / 3 - 1.0 / 2 * ax1 ** 2 * (2 - ax1)
-    cond2 = ~cond1 & less(ax, 2)
-    if cond2.any():
-        ax2 = ax[cond2]
-        res[cond2] = 1.0 / 6 * (2 - ax2) ** 3
-    return res
 
 
 def _cubic(x):
@@ -360,84 +127,6 @@ def _cubic(x):
     out = b(x)
     out[(x < -2) | (x > 2)] = 0
     return out
-
-
-msg_quadratic = """`scipy.signal.quadratic` is deprecated in SciPy 1.11 and
-will be removed in SciPy 1.13.
-
-The exact equivalent (for a float array `x`) is
-
->>> from scipy.interpolate import BSpline
->>> out = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5])(x)
->>> out[(x < -1.5 | (x > 1.5)] = 0.0
-"""
-
-
-def quadratic(x):
-    """
-    .. deprecated:: 1.11.0
-
-        `scipy.signal.quadratic` is deprecated in SciPy 1.11 and
-        will be removed in SciPy 1.13.
-
-        The exact equivalent (for a float array `x`) is::
-
-            >>> from scipy.interpolate import BSpline
-            >>> out = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5])(x)
-            >>> out[(x < -1.5 | (x > 1.5)] = 0.0
-
-    A quadratic B-spline.
-
-    This is a special case of `bspline`, and equivalent to ``bspline(x, 2)``.
-
-    Parameters
-    ----------
-    x : array_like
-        a knot vector
-
-    Returns
-    -------
-    res : ndarray
-        Quadratic B-spline basis function values
-
-    See Also
-    --------
-    bspline : B-spline basis function of order n
-    cubic : A cubic B-spline.
-
-    Examples
-    --------
-    We can calculate B-Spline basis function of several orders:
-
-    >>> import numpy as np
-    >>> from scipy.signal import bspline, cubic, quadratic
-    >>> bspline(0.0, 1)
-    1
-
-    >>> knots = [-1.0, 0.0, -1.0]
-    >>> bspline(knots, 2)
-    array([0.125, 0.75, 0.125])
-
-    >>> np.array_equal(bspline(knots, 2), quadratic(knots))
-    True
-
-    >>> np.array_equal(bspline(knots, 3), cubic(knots))
-    True
-
-    """
-    warnings.warn(msg_quadratic, DeprecationWarning, stacklevel=2)
-
-    ax = abs(asarray(x, dtype=float))
-    res = zeros_like(ax)
-    cond1 = less(ax, 0.5)
-    if cond1.any():
-        ax1 = ax[cond1]
-        res[cond1] = 0.75 - ax1 ** 2
-    cond2 = ~cond1 & less(ax, 1.5)
-    if cond2.any():
-        ax2 = ax[cond2]
-        res[cond2] = (ax2 - 1.5) ** 2 / 2.0
-    return res
 
 
 def _quadratic(x):

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -7,10 +7,9 @@ from scipy._lib.deprecation import _sub_module_deprecation
 __all__ = [  # noqa: F822
     'spline_filter', 'gauss_spline',
     'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval',
-    'logical_and', 'zeros_like', 'piecewise', 'array', 'arctan2',
-    'tan', 'arange', 'floor', 'exp', 'greater', 'less', 'add',
-    'less_equal', 'greater_equal', 'cspline2d', 'sepfir2d', 'comb',
-    'float_factorial'
+    'zeros_like', 'array', 'arctan2',
+    'tan', 'arange', 'floor', 'exp', 'greater', 'add',
+    'cspline2d', 'sepfir2d'
 ]
 
 

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -5,7 +5,7 @@
 from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
-    'spline_filter', 'bspline', 'gauss_spline', 'cubic', 'quadratic',
+    'spline_filter', 'gauss_spline',
     'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval',
     'logical_and', 'zeros_like', 'piecewise', 'array', 'arctan2',
     'tan', 'arange', 'floor', 'exp', 'greater', 'less', 'add',

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_allclose, assert_array_equal,
-                           assert_almost_equal, suppress_warnings)
+                           assert_almost_equal)
 import pytest
 from pytest import raises
 
@@ -65,27 +65,6 @@ class TestBSplines:
         assert_allclose(bsp.spline_filter(data_array_real, 0),
                         result_array_real)
 
-    def test_bspline(self):
-        # Verify with theoretical results at integer points up to order 5
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
-            assert_allclose(bsp.bspline([-1, 0, 1], 0),
-                            array([0, 1, 0]))
-            assert_allclose(bsp.bspline([-1, 0, 1], 1),
-                            array([0, 1, 0]))
-            assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 2),
-                            array([0, 1, 6, 1, 0])/8.)
-            assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 3),
-                            array([0, 1, 4, 1, 0])/6.)
-            assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 4),
-                            array([0, 1, 76, 230, 76, 1, 0])/384.)
-            assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
-                            array([0, 1, 26, 66, 26, 1, 0]) / 120.)
-            # Compare with SciPy 1.1.0
-            np.random.seed(12458)
-            assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
-                            array([[0.73694695]]))
-
     def test_gauss_spline(self):
         np.random.seed(12459)
         assert_almost_equal(bsp.gauss_spline(0, 0), 1.381976597885342)
@@ -96,22 +75,6 @@ class TestBSplines:
         knots = [-1.0, 0.0, -1.0]
         assert_almost_equal(bsp.gauss_spline(knots, 3),
                             array([0.15418033, 0.6909883, 0.15418033]))
-
-    def test_cubic(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
-            np.random.seed(12460)
-            # Verify with theoretical results at integer points (see docstring)
-            assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
-                            array([0, 1, 4, 1, 0])/6.)
-
-    def test_quadratic(self):
-        np.random.seed(12461)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
-            # Verify correct results at integer points
-            assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
-                            array([0, 1, 6, 1, 0])/8.)
 
     def test_cspline1d(self):
         np.random.seed(12462)

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -117,9 +117,6 @@ DOCTEST_SKIPLIST = set([
     'scipy.linalg.LinAlgError',
     'scipy.optimize.show_options',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
-    'scipy.signal.bspline',
-    'scipy.signal.cubic',
-    'scipy.signal.quadratic',
 ])
 
 # these names are not required to be present in ALL despite being in


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #17455
#### What does this implement/fix?
<!--Please explain your changes.-->
Acts the roadmap item (https://docs.scipy.org/doc/scipy/dev/roadmap-detailed.html#scipy-roadmap-detailed)

> B-splines: (Relevant functions are bspline, cubic, quadratic, gauss_spline, cspline1d, qspline1d, cspline2d, qspline2d, 
> cspline1d_eval, and spline_filter.) Move the good stuff to interpolate (with appropriate API changes to match how 
> things are done in interpolate), and eliminate any duplication.

signal.{bspline,quadratic,cubic} have been deprecated for two releases so should  be good to remove
#### Additional information
<!--Any additional information you think is important.-->
