### PR TITLE
DEP: linalg: remove tri{,u,l}

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -48,8 +48,6 @@ Basics
    pinvh - Pseudo-inverse of hermitian matrix
    kron - Kronecker product of two arrays
    khatri_rao - Khatri-Rao product of two arrays
-   tril - Construct a lower-triangular matrix from a given matrix
-   triu - Construct an upper-triangular matrix from a given matrix
    orthogonal_procrustes - Solve an orthogonal Procrustes problem
    matrix_balance - Balance matrix entries with a similarity transformation
    subspace_angles - Compute the subspace angles between two matrices
@@ -179,7 +177,6 @@ Special Matrices
    pascal - Pascal matrix
    invpascal - Inverse Pascal matrix
    toeplitz - Toeplitz matrix
-   tri - Construct a matrix filled with ones at and below a given diagonal
 
 Low-level routines
 ==================

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1,10 +1,9 @@
 import math
-import warnings
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-__all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
+__all__ = ['toeplitz', 'circulant', 'hankel',
            'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
            'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
            'fiedler', 'fiedler_companion', 'convolution_matrix']
@@ -13,146 +12,6 @@ __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
 # -----------------------------------------------------------------------------
 #  matrix construction functions
 # -----------------------------------------------------------------------------
-
-#
-# *Note*: tri{,u,l} is implemented in NumPy, but an important bug was fixed in
-# 2.0.0.dev-1af2f3, the following tri{,u,l} definitions are here for backwards
-# compatibility.
-
-def tri(N, M=None, k=0, dtype=None):
-    """
-    .. deprecated:: 1.11.0
-        `tri` is deprecated in favour of `numpy.tri` and will be removed in
-        SciPy 1.13.0.    
-    
-    Construct (N, M) matrix filled with ones at and below the kth diagonal.
-
-    The matrix has A[i,j] == 1 for j <= i + k
-
-    Parameters
-    ----------
-    N : int
-        The size of the first dimension of the matrix.
-    M : int or None, optional
-        The size of the second dimension of the matrix. If `M` is None,
-        `M = N` is assumed.
-    k : int, optional
-        Number of subdiagonal below which matrix is filled with ones.
-        `k` = 0 is the main diagonal, `k` < 0 subdiagonal and `k` > 0
-        superdiagonal.
-    dtype : dtype, optional
-        Data type of the matrix.
-
-    Returns
-    -------
-    tri : (N, M) ndarray
-        Tri matrix.
-
-    Examples
-    --------
-    >>> from scipy.linalg import tri
-    >>> tri(3, 5, 2, dtype=int)
-    array([[1, 1, 1, 0, 0],
-           [1, 1, 1, 1, 0],
-           [1, 1, 1, 1, 1]])
-    >>> tri(3, 5, -1, dtype=int)
-    array([[0, 0, 0, 0, 0],
-           [1, 0, 0, 0, 0],
-           [1, 1, 0, 0, 0]])
-
-    """
-    warnings.warn("'tri'/'tril/'triu' are deprecated as of SciPy 1.11.0 and "
-                  "will be removed in v1.13.0. Please use "
-                  "numpy.(tri/tril/triu) instead.",
-                  DeprecationWarning, stacklevel=2)
-    
-    if M is None:
-        M = N
-    if isinstance(M, str):
-        # pearu: any objections to remove this feature?
-        #       As tri(N,'d') is equivalent to tri(N,dtype='d')
-        dtype = M
-        M = N
-    m = np.greater_equal.outer(np.arange(k, N+k), np.arange(M))
-    if dtype is None:
-        return m
-    else:
-        return m.astype(dtype)
-
-
-def tril(m, k=0):
-    """
-    .. deprecated:: 1.11.0
-        `tril` is deprecated in favour of `numpy.tril` and will be removed in
-        SciPy 1.13.0.
-
-    Make a copy of a matrix with elements above the kth diagonal zeroed.
-
-    Parameters
-    ----------
-    m : array_like
-        Matrix whose elements to return
-    k : int, optional
-        Diagonal above which to zero elements.
-        `k` == 0 is the main diagonal, `k` < 0 subdiagonal and
-        `k` > 0 superdiagonal.
-
-    Returns
-    -------
-    tril : ndarray
-        Return is the same shape and type as `m`.
-
-    Examples
-    --------
-    >>> from scipy.linalg import tril
-    >>> tril([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], -1)
-    array([[ 0,  0,  0],
-           [ 4,  0,  0],
-           [ 7,  8,  0],
-           [10, 11, 12]])
-
-    """
-    m = np.asarray(m)
-    out = tri(m.shape[0], m.shape[1], k=k, dtype=m.dtype.char) * m
-    return out
-
-
-def triu(m, k=0):
-    """
-    .. deprecated:: 1.11.0
-        `tril` is deprecated in favour of `numpy.triu` and will be removed in
-        SciPy 1.13.0.
-
-    Make a copy of a matrix with elements below the kth diagonal zeroed.
-
-    Parameters
-    ----------
-    m : array_like
-        Matrix whose elements to return
-    k : int, optional
-        Diagonal below which to zero elements.
-        `k` == 0 is the main diagonal, `k` < 0 subdiagonal and
-        `k` > 0 superdiagonal.
-
-    Returns
-    -------
-    triu : ndarray
-        Return matrix with zeroed elements below the kth diagonal and has
-        same shape and type as `m`.
-
-    Examples
-    --------
-    >>> from scipy.linalg import triu
-    >>> triu([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], -1)
-    array([[ 1,  2,  3],
-           [ 4,  5,  6],
-           [ 0,  8,  9],
-           [ 0,  0, 12]])
-
-    """
-    m = np.asarray(m)
-    out = (1 - tri(m.shape[0], m.shape[1], k - 1, m.dtype.char)) * m
-    return out
 
 
 def toeplitz(c, r=None):

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -5,7 +5,7 @@
 from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
-    'tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
+    'toeplitz', 'circulant', 'hankel',
     'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
     'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
     'fiedler', 'fiedler_companion', 'convolution_matrix', 'as_strided'

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy import arange, add, array, eye, copy, sqrt
+from numpy import arange, array, eye, copy, sqrt
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose)
 from pytest import raises as assert_raises
@@ -8,114 +8,11 @@ from pytest import raises as assert_raises
 from scipy.fft import fft
 from scipy.special import comb
 from scipy.linalg import (toeplitz, hankel, circulant, hadamard, leslie, dft,
-                          companion, tri, triu, tril, kron, block_diag,
+                          companion, kron, block_diag,
                           helmert, hilbert, invhilbert, pascal, invpascal,
                           fiedler, fiedler_companion, eigvals,
                           convolution_matrix)
 from numpy.linalg import cond
-
-
-def get_mat(n):
-    data = arange(n)
-    data = add.outer(data, data)
-    return data
-
-dep_filter = np.testing.suppress_warnings()
-dep_filter.filter(DeprecationWarning, "'tri'/'tril/'triu'")
-
-@dep_filter
-class TestTri:
-    def test_basic(self):
-        assert_equal(tri(4), array([[1, 0, 0, 0],
-                                    [1, 1, 0, 0],
-                                    [1, 1, 1, 0],
-                                    [1, 1, 1, 1]]))
-        assert_equal(tri(4, dtype='f'), array([[1, 0, 0, 0],
-                                               [1, 1, 0, 0],
-                                               [1, 1, 1, 0],
-                                               [1, 1, 1, 1]], 'f'))
-
-    def test_diag(self):
-        assert_equal(tri(4, k=1), array([[1, 1, 0, 0],
-                                         [1, 1, 1, 0],
-                                         [1, 1, 1, 1],
-                                         [1, 1, 1, 1]]))
-        assert_equal(tri(4, k=-1), array([[0, 0, 0, 0],
-                                          [1, 0, 0, 0],
-                                          [1, 1, 0, 0],
-                                          [1, 1, 1, 0]]))
-
-    def test_2d(self):
-        assert_equal(tri(4, 3), array([[1, 0, 0],
-                                       [1, 1, 0],
-                                       [1, 1, 1],
-                                       [1, 1, 1]]))
-        assert_equal(tri(3, 4), array([[1, 0, 0, 0],
-                                       [1, 1, 0, 0],
-                                       [1, 1, 1, 0]]))
-
-    def test_diag2d(self):
-        assert_equal(tri(3, 4, k=2), array([[1, 1, 1, 0],
-                                            [1, 1, 1, 1],
-                                            [1, 1, 1, 1]]))
-        assert_equal(tri(4, 3, k=-2), array([[0, 0, 0],
-                                             [0, 0, 0],
-                                             [1, 0, 0],
-                                             [1, 1, 0]]))
-
-
-@dep_filter
-class TestTril:
-    def test_basic(self):
-        a = (100*get_mat(5)).astype('l')
-        b = a.copy()
-        for k in range(5):
-            for l in range(k+1, 5):
-                b[k, l] = 0
-        assert_equal(tril(a), b)
-
-    def test_diag(self):
-        a = (100*get_mat(5)).astype('f')
-        b = a.copy()
-        for k in range(5):
-            for l in range(k+3, 5):
-                b[k, l] = 0
-        assert_equal(tril(a, k=2), b)
-        b = a.copy()
-        for k in range(5):
-            for l in range(max((k-1, 0)), 5):
-                b[k, l] = 0
-        assert_equal(tril(a, k=-2), b)
-
-
-@dep_filter
-class TestTriu:
-    def test_basic(self):
-        a = (100*get_mat(5)).astype('l')
-        b = a.copy()
-        for k in range(5):
-            for l in range(k+1, 5):
-                b[l, k] = 0
-        assert_equal(triu(a), b)
-
-    def test_diag(self):
-        a = (100*get_mat(5)).astype('f')
-        b = a.copy()
-        for k in range(5):
-            for l in range(max((k-1, 0)), 5):
-                b[l, k] = 0
-        assert_equal(triu(a, k=2), b)
-        b = a.copy()
-        for k in range(5):
-            for l in range(k+3, 5):
-                b[l, k] = 0
-        assert_equal(triu(a, k=-2), b)
-
-
-@pytest.mark.parametrize("func", [tri, tril, triu])
-def test_special_matrices_deprecation(func):
-    with pytest.warns(DeprecationWarning, match="'tri'/'tril/'triu'"):
-        func(np.array([[1]]))
 
 
 class TestToeplitz:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #18021
#### What does this implement/fix?
<!--Please explain your changes.-->
tri{,u,l} have been deprecated in favour of their numpy alternative for the last two releases so should be good to remove
#### Additional information
<!--Any additional information you think is important.-->
