### PR TITLE
DEP: signal: remove ability to import window functions from signal namespace

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -309,8 +309,6 @@ repeatedly generate the same chirp signal with every call.  In these cases,
 use the classes to create a reusable function instead.
 
 """
-import warnings
-import inspect
 
 from . import _sigtools, windows
 from ._waveforms import *
@@ -345,58 +343,10 @@ from . import (
     spectral, signaltools, waveforms, wavelets, spline
 )
 
-# deal with * -> windows.* doc-only soft-deprecation
-deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
-                      'nuttall', 'blackmanharris', 'flattop', 'bartlett',
-                      'barthann', 'hamming', 'kaiser', 'gaussian',
-                      'general_gaussian', 'chebwin', 'cosine',
-                      'hann', 'exponential', 'tukey')
-
-
-def deco(name):
-    f = getattr(windows, name)
-    # Add deprecation to docstring
-
-    def wrapped(*args, **kwargs):
-        warnings.warn(f"Importing {name} from 'scipy.signal' is deprecated "
-                      f"since SciPy 1.1.0 and will raise an error in SciPy 1.13.0. "
-                      f"Please use 'scipy.signal.windows.{name}' or the convenience "
-                      f"function 'scipy.signal.get_window' instead.",
-                      DeprecationWarning, stacklevel=2)
-        return f(*args, **kwargs)
-
-    wrapped.__name__ = name
-    wrapped.__module__ = 'scipy.signal'
-    wrapped.__signature__ = inspect.signature(f)  # noqa: F821
-    if hasattr(f, '__qualname__'):
-        wrapped.__qualname__ = f.__qualname__
-
-    if f.__doc__:
-        lines = f.__doc__.splitlines()
-        for li, line in enumerate(lines):
-            if line.strip() == 'Parameters':
-                break
-        else:
-            raise RuntimeError('dev error: badly formatted doc')
-        spacing = ' ' * line.find('P')
-        lines.insert(li, ('{0}.. warning:: `scipy.signal.{1}` is deprecated since\n'
-                          '{0}             SciPy 1.1.0 and will be removed in 1.13.0\n'
-                          '{0}             use `scipy.signal.windows.{1}`'
-                          'instead.\n'.format(spacing, name)))
-        wrapped.__doc__ = '\n'.join(lines)
-
-    return wrapped
-
-
-for name in deprecated_windows:
-    locals()[name] = deco(name)
-
-del deprecated_windows, name, deco
-
 __all__ = [
-    s for s in dir() if not s.startswith("_") and s not in {"warnings", "inspect"}
+    s for s in dir() if not s.startswith("_")
 ]
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
-del PytestTester, inspect
+del PytestTester

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -1,17 +1,13 @@
-import pickle
-
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose,
                            assert_equal, assert_, assert_array_less,
                            suppress_warnings)
-import pytest
 from pytest import raises as assert_raises
 
 from scipy.fft import fft
-from scipy.signal import windows, get_window, resample, hann as dep_hann
-from scipy import signal
+from scipy.signal import windows, get_window, resample
 
 
 window_funcs = [
@@ -39,15 +35,6 @@ window_funcs = [
     ('lanczos', ()),
     ]
 
-@pytest.mark.parametrize(["method", "args"], window_funcs)
-def test_deprecated_import(method, args):
-    if method in ('taylor', 'lanczos', 'dpss'):
-        pytest.skip("Deprecation test not applicable")
-    func = getattr(signal, method)
-    msg = f"Importing {method}"
-    with pytest.deprecated_call(match=msg):
-        func(1, *args)
-        
 
 class TestBartHann:
 
@@ -843,17 +830,6 @@ def test_not_needs_params():
                    ]:
         win = get_window(winstr, 7)
         assert_equal(len(win), 7)
-
-
-def test_deprecation():
-    if dep_hann.__doc__ is not None:  # can be None with `-OO` mode
-        assert_('signal.hann` is deprecated' in dep_hann.__doc__)
-        assert_('deprecated' not in windows.hann.__doc__)
-
-
-def test_deprecated_pickleable():
-    dep_hann2 = pickle.loads(pickle.dumps(dep_hann))
-    assert_(dep_hann2 is dep_hann)
 
 
 def test_symmetric():


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #18489 
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes the ability to import window functions from the main signal namespace as this has been deprecated for the last two releases and doc deprecated for ages
#### Additional information
<!--Any additional information you think is important.-->
