### PR TITLE
MAINT: stats.theilslopes: consistent promotion of `x` and `y`

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -321,11 +321,11 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
         raise ValueError("method must be either 'joint' or 'separate'."
                          f"'{method}' is invalid.")
     # We copy both x and y so we can use _find_repeats.
-    y = np.array(y).flatten()
+    y = np.array(y, dtype=float, copy=True).ravel()
     if x is None:
         x = np.arange(len(y), dtype=float)
     else:
-        x = np.array(x, dtype=float).flatten()
+        x = np.array(x, dtype=float, copy=True).ravel()
         if len(x) != len(y):
             raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1004,7 +1004,7 @@ class TestTheilslopes:
         rng = np.random.default_rng(2549824598234528)
         y = rng.integers(0, 255, size=10, dtype=np.uint8)
         res = stats.theilslopes(y, y)
-        np.testing.assert_allclose(res.slope,1)
+        np.testing.assert_allclose(res.slope, 1)
 
 
 def test_siegelslopes():

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -931,71 +931,80 @@ def test_linregress_identical_x():
         mstats.linregress(x, y)
 
 
-def test_theilslopes():
-    # Test for basic slope and intercept.
-    slope, intercept, lower, upper = mstats.theilslopes([0, 1, 1])
-    assert_almost_equal(slope, 0.5)
-    assert_almost_equal(intercept, 0.5)
+class TestTheilslopes:
+    def test_theilslopes(self):
+        # Test for basic slope and intercept.
+        slope, intercept, lower, upper = mstats.theilslopes([0, 1, 1])
+        assert_almost_equal(slope, 0.5)
+        assert_almost_equal(intercept, 0.5)
 
-    slope, intercept, lower, upper = mstats.theilslopes([0, 1, 1],
-                                                        method='joint')
-    assert_almost_equal(slope, 0.5)
-    assert_almost_equal(intercept, 0.0)
+        slope, intercept, lower, upper = mstats.theilslopes([0, 1, 1],
+                                                            method='joint')
+        assert_almost_equal(slope, 0.5)
+        assert_almost_equal(intercept, 0.0)
 
-    # Test for correct masking.
-    y = np.ma.array([0, 1, 100, 1], mask=[False, False, True, False])
-    slope, intercept, lower, upper = mstats.theilslopes(y)
-    assert_almost_equal(slope, 1./3)
-    assert_almost_equal(intercept, 2./3)
+        # Test for correct masking.
+        y = np.ma.array([0, 1, 100, 1], mask=[False, False, True, False])
+        slope, intercept, lower, upper = mstats.theilslopes(y)
+        assert_almost_equal(slope, 1./3)
+        assert_almost_equal(intercept, 2./3)
 
-    slope, intercept, lower, upper = mstats.theilslopes(y,
-                                                        method='joint')
-    assert_almost_equal(slope, 1./3)
-    assert_almost_equal(intercept, 0.0)
+        slope, intercept, lower, upper = mstats.theilslopes(y,
+                                                            method='joint')
+        assert_almost_equal(slope, 1./3)
+        assert_almost_equal(intercept, 0.0)
 
-    # Test of confidence intervals from example in Sen (1968).
-    x = [1, 2, 3, 4, 10, 12, 18]
-    y = [9, 15, 19, 20, 45, 55, 78]
-    slope, intercept, lower, upper = mstats.theilslopes(y, x, 0.07)
-    assert_almost_equal(slope, 4)
-    assert_almost_equal(intercept, 4.0)
-    assert_almost_equal(upper, 4.38, decimal=2)
-    assert_almost_equal(lower, 3.71, decimal=2)
+        # Test of confidence intervals from example in Sen (1968).
+        x = [1, 2, 3, 4, 10, 12, 18]
+        y = [9, 15, 19, 20, 45, 55, 78]
+        slope, intercept, lower, upper = mstats.theilslopes(y, x, 0.07)
+        assert_almost_equal(slope, 4)
+        assert_almost_equal(intercept, 4.0)
+        assert_almost_equal(upper, 4.38, decimal=2)
+        assert_almost_equal(lower, 3.71, decimal=2)
 
-    slope, intercept, lower, upper = mstats.theilslopes(y, x, 0.07,
-                                                        method='joint')
-    assert_almost_equal(slope, 4)
-    assert_almost_equal(intercept, 6.0)
-    assert_almost_equal(upper, 4.38, decimal=2)
-    assert_almost_equal(lower, 3.71, decimal=2)
-
-
-def test_theilslopes_warnings():
-    # Test `theilslopes` with degenerate input; see gh-15943
-    with pytest.warns(RuntimeWarning, match="All `x` coordinates are..."):
-        res = mstats.theilslopes([0, 1], [0, 0])
-        assert np.all(np.isnan(res))
-    with suppress_warnings() as sup:
-        sup.filter(RuntimeWarning, "invalid value encountered...")
-        res = mstats.theilslopes([0, 0, 0], [0, 1, 0])
-        assert_allclose(res, (0, 0, np.nan, np.nan))
+        slope, intercept, lower, upper = mstats.theilslopes(y, x, 0.07,
+                                                            method='joint')
+        assert_almost_equal(slope, 4)
+        assert_almost_equal(intercept, 6.0)
+        assert_almost_equal(upper, 4.38, decimal=2)
+        assert_almost_equal(lower, 3.71, decimal=2)
 
 
-def test_theilslopes_namedtuple_consistency():
-    """
-    Simple test to ensure tuple backwards-compatibility of the returned
-    TheilslopesResult object
-    """
-    y = [1, 2, 4]
-    x = [4, 6, 8]
-    slope, intercept, low_slope, high_slope = mstats.theilslopes(y, x)
-    result = mstats.theilslopes(y, x)
+    def test_theilslopes_warnings(self):
+        # Test `theilslopes` with degenerate input; see gh-15943
+        with pytest.warns(RuntimeWarning, match="All `x` coordinates are..."):
+            res = mstats.theilslopes([0, 1], [0, 0])
+            assert np.all(np.isnan(res))
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered...")
+            res = mstats.theilslopes([0, 0, 0], [0, 1, 0])
+            assert_allclose(res, (0, 0, np.nan, np.nan))
 
-    # note all four returned values are distinct here
-    assert_equal(slope, result.slope)
-    assert_equal(intercept, result.intercept)
-    assert_equal(low_slope, result.low_slope)
-    assert_equal(high_slope, result.high_slope)
+
+    def test_theilslopes_namedtuple_consistency(self):
+        """
+        Simple test to ensure tuple backwards-compatibility of the returned
+        TheilslopesResult object
+        """
+        y = [1, 2, 4]
+        x = [4, 6, 8]
+        slope, intercept, low_slope, high_slope = mstats.theilslopes(y, x)
+        result = mstats.theilslopes(y, x)
+
+        # note all four returned values are distinct here
+        assert_equal(slope, result.slope)
+        assert_equal(intercept, result.intercept)
+        assert_equal(low_slope, result.low_slope)
+        assert_equal(high_slope, result.high_slope)
+
+    def test_gh19678_uint8(self):
+        # `theilslopes` returned unexpected results when `y` was an unsigned type.
+        # Check that this is resolved.
+        rng = np.random.default_rng(2549824598234528)
+        y = rng.integers(0, 255, size=10, dtype=np.uint8)
+        res = stats.theilslopes(y, y)
+        np.testing.assert_allclose(res.slope,1)
 
 
 def test_siegelslopes():


### PR DESCRIPTION
#### Reference issue
Closes gh-19678

#### What does this implement/fix?
`stats.theilslopes` did not respect the dtype of user input `x`, always promoting it to `float` before performing calculations.  Even when `x` was not provided, it created `x` with `float` dtype. However, it respected the dtype of user-provided `y` to a fault, even allowing it to remain an unsigned integer type. This led to the unexpected results in gh-19678.

It is a known issue that `stats` does not have a consistent policy for respecting input dtype when performing calculations (gh-14651). That is a much larger issue, so I don't address it here. This PR takes the simple route: promote `y` just like `x`. 

#### Additional information
Please select "Hide whitespace" when reviewing the diff; I just gathered all the `theilslopes` tests into a class.