### PR TITLE
TST: consolidate array API test skip decorators

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -223,25 +223,57 @@ The following pytest markers are available:
 
 * ``array_api_compatible -> xp``: use a parametrisation to run a test on
   multiple array backends.
-* ``skip_if_array_api``: don't run a test if ``SCIPY_ARRAY_API`` is on.
-* ``skip_if_array_api_gpu``: don't run a test if GPU is involved (also applies
-  to PyTorch's MPS mode).
-* ``skip_if_array_api_backend(backend, reason=None)``: don't run a test for a
-  specific backend
+* ``skip_if_array_api(*backends, reasons=None, np_only=False, cpu_only=False)``:
+  skip certain backends and/or devices. ``np_only`` skips tests for all backends
+  other than the default NumPy backend.
+  ``@pytest.mark.usefixtures("skip_if_array_api")`` must be used alongside this
+  marker for the skipping to apply.
 
-The following is an example using the main decorator responsible of the
-namespace parametrization::
+The following is an example using the markers::
 
   from scipy.conftest import array_api_compatible
   ...
+  @pytest.mark.skip_if_array_api(np_only=True,
+                                 reasons=['skip reason'])
+  @pytest.mark.usefixtures("skip_if_array_api")
   @array_api_compatible
-  def test_toto(self, xp):
+  def test_toto1(self, xp):
+      a = xp.asarray([1, 2, 3])
+      b = xp.asarray([0, 2, 5])
+      toto(a, b)
+  ...
+  @pytest.mark.skip_if_array_api('numpy.array_api', 'cupy',
+                                 reasons=['skip reason 1',
+                                          'skip reason 2',])
+  @pytest.mark.usefixtures("skip_if_array_api")
+  @array_api_compatible
+  def test_toto2(self, xp):
       a = xp.asarray([1, 2, 3])
       b = xp.asarray([0, 2, 5])
       toto(a, b)
 
-Then ``dev.py`` can be used with he new option ``-b`` or
-``--array-api-backend``::
+Passing a custom reason to ``reasons`` when ``cpu_only=True`` is unsupported
+since ``cpu_only=True`` can be used alongside passing ``backends``. Also,
+the reason for using ``cpu_only`` is likely just that compiled code is used
+in the function(s) being tested.
+
+When every test function in a file has been updated for array API
+compatibility, one can reduce verbosity by telling ``pytest`` to apply the
+markers to every test function using ``pytestmark``::
+
+    from scipy.conftest import array_api_compatible
+    
+    pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+    skip_if_array_api = pytest.mark.skip_if_array_api
+    ...
+    @skip_if_array_api(np_only=True, reasons=['skip reason'])
+    def test_toto1(self, xp):
+        a = xp.asarray([1, 2, 3])
+        b = xp.asarray([0, 2, 5])
+        toto(a, b)
+
+After applying these markers, ``dev.py test`` can be used with the new option
+``-b`` or ``--array-api-backend``::
 
   python dev.py test -b numpy -b pytorch -s cluster
 

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -226,8 +226,8 @@ The following pytest markers are available:
 * ``skip_if_array_api``: don't run a test if ``SCIPY_ARRAY_API`` is on.
 * ``skip_if_array_api_gpu``: don't run a test if GPU is involved (also applies
   to PyTorch's MPS mode).
-* ``skip_if_array_api_backend(backend)``: don't run a test for a specific
-  backend
+* ``skip_if_array_api_backend(backend, reason=None)``: don't run a test for a
+  specific backend
 
 The following is an example using the main decorator responsible of the
 namespace parametrization::

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -102,7 +102,7 @@ def array_namespace(*arrays):
     1. Check for the global switch: SCIPY_ARRAY_API. This can also be accessed
        dynamically through ``_GLOBAL_CONFIG['SCIPY_ARRAY_API']``.
     2. `compliance_scipy` raise exceptions on known-bad subclasses. See
-       it's definition for more details.
+       its definition for more details.
 
     When the global switch is False, it defaults to the `numpy` namespace.
     In that case, there is no compliance check. This is a convenience to

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -305,6 +305,12 @@ class TestLeaders:
                    reasons=['`is_isomorphic` only supports NumPy backend'])
 class TestIsIsomorphic:
 
+    @skip_if_array_api(np_only=True,
+                       reasons=['array-likes only supported for NumPy backend'])
+    def test_array_like(self, xp):
+        assert is_isomorphic([1, 1, 1], [2, 2, 2])
+        assert is_isomorphic([], [])
+
     def test_is_isomorphic_1(self, xp):
         # Tests is_isomorphic on test case #1 (one flat cluster, different labellings)
         a = xp.asarray([1, 1, 1])

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -47,13 +47,8 @@ from scipy.cluster.hierarchy import (
     _order_cluster_tree, _hierarchy, _LINKAGE_METHODS)
 from scipy.spatial.distance import pdist
 from scipy.cluster._hierarchy import Heap
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api,
-    skip_if_array_api_gpu,
-    skip_if_array_api_backend,
-)
-from scipy._lib._array_api import xp_assert_close
+from scipy.conftest import array_api_compatible
+from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 
 from . import hierarchy_test_data
 
@@ -71,10 +66,13 @@ except Exception:
     have_matplotlib = False
 
 
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+skip_if_array_api = pytest.mark.skip_if_array_api
+
+
 class TestLinkage:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_linkage_non_finite_elements_in_distance_matrix(self, xp):
         # Tests linkage(Y) where Y contains a non-finite element (e.g. NaN or Inf).
         # Exception expected.
@@ -82,13 +80,13 @@ class TestLinkage:
         y[0] = xp.nan
         assert_raises(ValueError, linkage, y)
 
-    def test_linkage_empty_distance_matrix(self):
+    @skip_if_array_api(cpu_only=True)
+    def test_linkage_empty_distance_matrix(self, xp):
         # Tests linkage(Y) where Y is a 0x4 linkage matrix. Exception expected.
-        y = np.zeros((0,))
+        y = xp.zeros((0,))
         assert_raises(ValueError, linkage, y)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_linkage_tdist(self, xp):
         for method in ['single', 'complete', 'average', 'weighted']:
             self.check_linkage_tdist(method, xp)
@@ -99,8 +97,7 @@ class TestLinkage:
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_' + method)
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_linkage_X(self, xp):
         for method in ['centroid', 'median', 'ward']:
             self.check_linkage_q(method, xp)
@@ -116,8 +113,7 @@ class TestLinkage:
         Z = linkage(xp.asarray(y), method)
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_compare_with_trivial(self, xp):
         rng = np.random.RandomState(0)
         n = 20
@@ -129,14 +125,14 @@ class TestLinkage:
             Z = linkage(xp.asarray(d), method)
             xp_assert_close(Z, xp.asarray(Z_trivial), rtol=1e-14, atol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_optimal_leaf_ordering(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), optimal_ordering=True)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_single_olo')
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestLinkageTies:
 
     _expectations = {
@@ -156,8 +152,6 @@ class TestLinkageTies:
                           [2, 3, 2.44948974, 3]]),
     }
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_linkage_ties(self, xp):
         for method in ['single', 'complete', 'average', 'weighted',
                        'centroid', 'median', 'ward']:
@@ -170,10 +164,9 @@ class TestLinkageTies:
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestInconsistent:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_inconsistent_tdist(self, xp):
         for depth in hierarchy_test_data.inconsistent_ytdist:
             self.check_inconsistent_tdist(depth, xp)
@@ -184,10 +177,9 @@ class TestInconsistent:
                         xp.asarray(hierarchy_test_data.inconsistent_ytdist[depth]))
 
 
+@skip_if_array_api(cpu_only=True)
 class TestCopheneticDistance:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_linkage_cophenet_tdist_Z(self, xp):
         # Tests cophenet(Z) on tdist data set.
         expectedM = xp.asarray([268, 295, 255, 255, 295, 295, 268, 268, 295, 295,
@@ -196,8 +188,6 @@ class TestCopheneticDistance:
         M = cophenet(Z)
         xp_assert_close(M, xp.asarray(expectedM, dtype=xp.float64), atol=1e-10)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_linkage_cophenet_tdist_Z_Y(self, xp):
         # Tests cophenet(Z, Y) on tdist data set.
         Z = xp.asarray(hierarchy_test_data.linkage_ytdist_single)
@@ -211,15 +201,13 @@ class TestCopheneticDistance:
 
 class TestMLabLinkageConversion:
 
-    @skip_if_array_api
-    def test_mlab_linkage_conversion_empty(self):
+    def test_mlab_linkage_conversion_empty(self, xp):
         # Tests from/to_mlab_linkage on empty linkage array.
-        X = np.asarray([])
-        assert_equal(from_mlab_linkage([]), X)
-        assert_equal(to_mlab_linkage([]), X)
+        X = xp.asarray([], dtype=xp.float64)
+        xp_assert_equal(from_mlab_linkage(X), X)
+        xp_assert_equal(to_mlab_linkage(X), X)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_mlab_linkage_conversion_single_row(self, xp):
         # Tests from/to_mlab_linkage on linkage array with single row.
         Z = xp.asarray([[0., 1., 3., 2.]])
@@ -229,8 +217,7 @@ class TestMLabLinkageConversion:
         xp_assert_close(to_mlab_linkage(Z), xp.asarray(Zm, dtype=xp.float64),
                         rtol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_mlab_linkage_conversion_multiple_rows(self, xp):
         # Tests from/to_mlab_linkage on linkage array with multiple rows.
         Zm = xp.asarray([[3, 6, 138], [4, 5, 219],
@@ -246,10 +233,9 @@ class TestMLabLinkageConversion:
                         rtol=1e-15)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestFcluster:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_fclusterdata(self, xp):
         for t in hierarchy_test_data.fcluster_inconsistent:
             self.check_fclusterdata(t, 'inconsistent', xp)
@@ -265,8 +251,6 @@ class TestFcluster:
         T = fclusterdata(X, criterion=criterion, t=t)
         assert_(is_isomorphic(T, expectedT))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_fcluster(self, xp):
         for t in hierarchy_test_data.fcluster_inconsistent:
             self.check_fcluster(t, 'inconsistent', xp)
@@ -282,8 +266,6 @@ class TestFcluster:
         T = fcluster(Z, criterion=criterion, t=t)
         assert_(is_isomorphic(T, expectedT))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_fcluster_monocrit(self, xp):
         for t in hierarchy_test_data.fcluster_distance:
             self.check_fcluster_monocrit(t, xp)
@@ -303,10 +285,9 @@ class TestFcluster:
         assert_(is_isomorphic(T, expectedT))
 
 
+@skip_if_array_api(cpu_only=True)
 class TestLeaders:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_leaders_single(self, xp):
         # Tests leaders using a flat clustering generated by single linkage.
         X = hierarchy_test_data.Q_X
@@ -320,81 +301,75 @@ class TestLeaders:
         assert_allclose(np.concatenate(L), np.concatenate(Lright), rtol=1e-15)
 
 
+@skip_if_array_api(np_only=True,
+                   reasons=['`is_isomorphic` only supports NumPy backend'])
 class TestIsIsomorphic:
 
-    @skip_if_array_api
-    def test_is_isomorphic_1(self):
+    def test_is_isomorphic_1(self, xp):
         # Tests is_isomorphic on test case #1 (one flat cluster, different labellings)
-        a = [1, 1, 1]
-        b = [2, 2, 2]
-        assert_(is_isomorphic(a, b))
-        assert_(is_isomorphic(b, a))
+        a = xp.asarray([1, 1, 1])
+        b = xp.asarray([2, 2, 2])
+        assert is_isomorphic(a, b)
+        assert is_isomorphic(b, a)
 
-    @skip_if_array_api
-    def test_is_isomorphic_2(self):
+    def test_is_isomorphic_2(self, xp):
         # Tests is_isomorphic on test case #2 (two flat clusters, different labelings)
-        a = np.asarray([1, 7, 1])
-        b = np.asarray([2, 3, 2])
-        assert_(is_isomorphic(a, b))
-        assert_(is_isomorphic(b, a))
+        a = xp.asarray([1, 7, 1])
+        b = xp.asarray([2, 3, 2])
+        assert is_isomorphic(a, b)
+        assert is_isomorphic(b, a)
 
-    @skip_if_array_api
-    def test_is_isomorphic_3(self):
+    def test_is_isomorphic_3(self, xp):
         # Tests is_isomorphic on test case #3 (no flat clusters)
-        a = np.asarray([])
-        b = np.asarray([])
-        assert_(is_isomorphic(a, b))
+        a = xp.asarray([])
+        b = xp.asarray([])
+        assert is_isomorphic(a, b)
 
-    @skip_if_array_api
-    def test_is_isomorphic_4A(self):
+    def test_is_isomorphic_4A(self, xp):
         # Tests is_isomorphic on test case #4A
         # (3 flat clusters, different labelings, isomorphic)
-        a = np.asarray([1, 2, 3])
-        b = np.asarray([1, 3, 2])
-        assert_(is_isomorphic(a, b))
-        assert_(is_isomorphic(b, a))
+        a = xp.asarray([1, 2, 3])
+        b = xp.asarray([1, 3, 2])
+        assert is_isomorphic(a, b)
+        assert is_isomorphic(b, a)
 
-    @skip_if_array_api
-    def test_is_isomorphic_4B(self):
+    def test_is_isomorphic_4B(self, xp):
         # Tests is_isomorphic on test case #4B
         # (3 flat clusters, different labelings, nonisomorphic)
-        a = np.asarray([1, 2, 3, 3])
-        b = np.asarray([1, 3, 2, 3])
-        assert_(is_isomorphic(a, b) is False)
-        assert_(is_isomorphic(b, a) is False)
+        a = xp.asarray([1, 2, 3, 3])
+        b = xp.asarray([1, 3, 2, 3])
+        assert is_isomorphic(a, b) is False
+        assert is_isomorphic(b, a) is False
 
-    @skip_if_array_api
-    def test_is_isomorphic_4C(self):
+    def test_is_isomorphic_4C(self, xp):
         # Tests is_isomorphic on test case #4C
         # (3 flat clusters, different labelings, isomorphic)
-        a = np.asarray([7, 2, 3])
-        b = np.asarray([6, 3, 2])
-        assert_(is_isomorphic(a, b))
-        assert_(is_isomorphic(b, a))
+        a = xp.asarray([7, 2, 3])
+        b = xp.asarray([6, 3, 2])
+        assert is_isomorphic(a, b)
+        assert is_isomorphic(b, a)
 
-    @skip_if_array_api
-    def test_is_isomorphic_5(self):
+    def test_is_isomorphic_5(self, xp):
         # Tests is_isomorphic on test case #5 (1000 observations, 2/3/5 random
         # clusters, random permutation of the labeling).
         for nc in [2, 3, 5]:
-            self.help_is_isomorphic_randperm(1000, nc)
+            self.help_is_isomorphic_randperm(1000, nc, xp=xp)
 
-    @skip_if_array_api
-    def test_is_isomorphic_6(self):
+    def test_is_isomorphic_6(self, xp):
         # Tests is_isomorphic on test case #5A (1000 observations, 2/3/5 random
         # clusters, random permutation of the labeling, slightly
         # nonisomorphic.)
         for nc in [2, 3, 5]:
-            self.help_is_isomorphic_randperm(1000, nc, True, 5)
+            self.help_is_isomorphic_randperm(1000, nc, True, 5, xp=xp)
 
-    @skip_if_array_api
-    def test_is_isomorphic_7(self):
+    def test_is_isomorphic_7(self, xp):
         # Regression test for gh-6271
-        a = np.asarray([1, 2, 3])
-        b = np.asarray([1, 1, 1])
-        assert_(not is_isomorphic(a, b))
+        a = xp.asarray([1, 2, 3])
+        b = xp.asarray([1, 1, 1])
+        assert not is_isomorphic(a, b)
 
-    def help_is_isomorphic_randperm(self, nobs, nclusters, noniso=False, nerrors=0):
+    def help_is_isomorphic_randperm(self, nobs, nclusters, noniso=False, nerrors=0,
+                                    *, xp):
         for k in range(3):
             a = (np.random.rand(nobs) * nclusters).astype(int)
             b = np.zeros(a.size, dtype=int)
@@ -405,14 +380,15 @@ class TestIsIsomorphic:
                 Q = np.random.permutation(nobs)
                 b[Q[0:nerrors]] += 1
                 b[Q[0:nerrors]] %= nclusters
-            assert_(is_isomorphic(a, b) == (not noniso))
-            assert_(is_isomorphic(b, a) == (not noniso))
+            a = xp.asarray(a)
+            b = xp.asarray(b)
+            assert is_isomorphic(a, b) == (not noniso)
+            assert is_isomorphic(b, a) == (not noniso)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestIsValidLinkage:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_various_size(self, xp):
         for nrow, ncol, valid in [(2, 5, False), (2, 3, False),
                                   (1, 4, True), (2, 4, True)]:
@@ -427,8 +403,6 @@ class TestIsValidLinkage:
         if not valid:
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_int_type(self, xp):
         # Tests is_valid_linkage(Z) with integer type.
         Z = xp.asarray([[0, 1, 3.0, 2],
@@ -436,16 +410,12 @@ class TestIsValidLinkage:
         assert_(is_valid_linkage(Z) is False)
         assert_raises(TypeError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_empty(self, xp):
         # Tests is_valid_linkage(Z) with empty linkage.
         Z = xp.zeros((0, 4), dtype=xp.float64)
         assert_(is_valid_linkage(Z) is False)
         assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_4_and_up(self, xp):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3).
@@ -455,8 +425,6 @@ class TestIsValidLinkage:
             Z = linkage(y)
             assert_(is_valid_linkage(Z) is True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_4_and_up_neg_index_left(self, xp):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative indices (left).
@@ -468,8 +436,6 @@ class TestIsValidLinkage:
             assert_(is_valid_linkage(Z) is False)
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_4_and_up_neg_index_right(self, xp):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative indices (right).
@@ -481,8 +447,6 @@ class TestIsValidLinkage:
             assert_(is_valid_linkage(Z) is False)
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_4_and_up_neg_dist(self, xp):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative distances.
@@ -494,8 +458,6 @@ class TestIsValidLinkage:
             assert_(is_valid_linkage(Z) is False)
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_linkage_4_and_up_neg_counts(self, xp):
         # Tests is_valid_linkage(Z) on linkage on observation sets between
         # sizes 4 and 15 (step size 3) with negative counts.
@@ -508,10 +470,9 @@ class TestIsValidLinkage:
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestIsValidInconsistent:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_int_type(self, xp):
         # Tests is_valid_im(R) with integer type.
         R = xp.asarray([[0, 1, 3.0, 2],
@@ -519,8 +480,6 @@ class TestIsValidInconsistent:
         assert_(is_valid_im(R) is False)
         assert_raises(TypeError, is_valid_im, R, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_various_size(self, xp):
         for nrow, ncol, valid in [(2, 5, False), (2, 3, False),
                                   (1, 4, True), (2, 4, True)]:
@@ -535,16 +494,12 @@ class TestIsValidInconsistent:
         if not valid:
             assert_raises(ValueError, is_valid_im, R, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_empty(self, xp):
         # Tests is_valid_im(R) with empty inconsistency matrix.
         R = xp.zeros((0, 4), dtype=xp.float64)
         assert_(is_valid_im(R) is False)
         assert_raises(ValueError, is_valid_im, R, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_4_and_up(self, xp):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3).
@@ -555,8 +510,6 @@ class TestIsValidInconsistent:
             R = inconsistent(Z)
             assert_(is_valid_im(R) is True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_4_and_up_neg_index_left(self, xp):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link height means.
@@ -569,8 +522,6 @@ class TestIsValidInconsistent:
             assert_(is_valid_im(R) is False)
             assert_raises(ValueError, is_valid_im, R, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_4_and_up_neg_index_right(self, xp):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link height standard deviations.
@@ -583,8 +534,6 @@ class TestIsValidInconsistent:
             assert_(is_valid_im(R) is False)
             assert_raises(ValueError, is_valid_im, R, throw=True)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_valid_im_4_and_up_neg_dist(self, xp):
         # Tests is_valid_im(R) on im on observation sets between sizes 4 and 15
         # (step size 3) with negative link counts.
@@ -600,28 +549,24 @@ class TestIsValidInconsistent:
 
 class TestNumObsLinkage:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_num_obs_linkage_empty(self, xp):
         # Tests num_obs_linkage(Z) with empty linkage.
         Z = xp.zeros((0, 4), dtype=xp.float64)
         assert_raises(ValueError, num_obs_linkage, Z)
 
-    @array_api_compatible
     def test_num_obs_linkage_1x4(self, xp):
         # Tests num_obs_linkage(Z) on linkage over 2 observations.
         Z = xp.asarray([[0, 1, 3.0, 2]], dtype=xp.float64)
         assert_equal(num_obs_linkage(Z), 2)
 
-    @array_api_compatible
     def test_num_obs_linkage_2x4(self, xp):
         # Tests num_obs_linkage(Z) on linkage over 3 observations.
         Z = xp.asarray([[0, 1, 3.0, 2],
                         [3, 2, 4.0, 3]], dtype=xp.float64)
         assert_equal(num_obs_linkage(Z), 3)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_num_obs_linkage_4_and_up(self, xp):
         # Tests num_obs_linkage(Z) on linkage on observation sets between sizes
         # 4 and 15 (step size 3).
@@ -632,18 +577,15 @@ class TestNumObsLinkage:
             assert_equal(num_obs_linkage(Z), i)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestLeavesList:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_leaves_list_1x4(self, xp):
         # Tests leaves_list(Z) on a 1x4 linkage.
         Z = xp.asarray([[0, 1, 3.0, 2]], dtype=xp.float64)
         to_tree(Z)
         assert_allclose(leaves_list(Z), [0, 1], rtol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_leaves_list_2x4(self, xp):
         # Tests leaves_list(Z) on a 2x4 linkage.
         Z = xp.asarray([[0, 1, 3.0, 2],
@@ -651,8 +593,6 @@ class TestLeavesList:
         to_tree(Z)
         assert_allclose(leaves_list(Z), [0, 1, 2], rtol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_leaves_list_Q(self, xp):
         for method in ['single', 'complete', 'average', 'weighted', 'centroid',
                        'median', 'ward']:
@@ -665,8 +605,6 @@ class TestLeavesList:
         node = to_tree(Z)
         assert_allclose(node.pre_order(), leaves_list(Z), rtol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_Q_subtree_pre_order(self, xp):
         # Tests that pre_order() works when called on sub-trees.
         X = xp.asarray(hierarchy_test_data.Q_X)
@@ -677,18 +615,15 @@ class TestLeavesList:
                         rtol=1e-15)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestCorrespond:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_correspond_empty(self, xp):
         # Tests correspond(Z, y) with empty linkage and condensed distance matrix.
         y = xp.zeros((0,), dtype=xp.float64)
         Z = xp.zeros((0,4), dtype=xp.float64)
         assert_raises(ValueError, correspond, Z, y)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_correspond_2_and_up(self, xp):
         # Tests correspond(Z, y) on linkage and CDMs over observation sets of
         # different sizes.
@@ -703,8 +638,6 @@ class TestCorrespond:
             Z = linkage(y)
             assert_(correspond(Z, y))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_correspond_4_and_up(self, xp):
         # Tests correspond(Z, y) on linkage and CDMs over observation sets of
         # different sizes. Correspondence should be false.
@@ -719,8 +652,6 @@ class TestCorrespond:
             assert not correspond(Z, y2)
             assert not correspond(Z2, y)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_correspond_4_and_up_2(self, xp):
         # Tests correspond(Z, y) on linkage and CDMs over observation sets of
         # different sizes. Correspondence should be false.
@@ -735,8 +666,6 @@ class TestCorrespond:
             assert not correspond(Z, y2)
             assert not correspond(Z2, y)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_num_obs_linkage_multi_matrix(self, xp):
         # Tests num_obs_linkage with observation matrices of multiple sizes.
         for n in range(2, 10):
@@ -747,40 +676,31 @@ class TestCorrespond:
             assert_equal(num_obs_linkage(Z), n)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestIsMonotonic:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_empty(self, xp):
         # Tests is_monotonic(Z) on an empty linkage.
         Z = xp.zeros((0, 4), dtype=xp.float64)
         assert_raises(ValueError, is_monotonic, Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_1x4(self, xp):
         # Tests is_monotonic(Z) on 1x4 linkage. Expecting True.
         Z = xp.asarray([[0, 1, 0.3, 2]], dtype=xp.float64)
         assert is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_2x4_T(self, xp):
         # Tests is_monotonic(Z) on 2x4 linkage. Expecting True.
         Z = xp.asarray([[0, 1, 0.3, 2],
                         [2, 3, 0.4, 3]], dtype=xp.float64)
         assert is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_2x4_F(self, xp):
         # Tests is_monotonic(Z) on 2x4 linkage. Expecting False.
         Z = xp.asarray([[0, 1, 0.4, 2],
                         [2, 3, 0.3, 3]], dtype=xp.float64)
         assert not is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_3x4_T(self, xp):
         # Tests is_monotonic(Z) on 3x4 linkage. Expecting True.
         Z = xp.asarray([[0, 1, 0.3, 2],
@@ -788,8 +708,6 @@ class TestIsMonotonic:
                         [4, 5, 0.6, 4]], dtype=xp.float64)
         assert is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_3x4_F1(self, xp):
         # Tests is_monotonic(Z) on 3x4 linkage (case 1). Expecting False.
         Z = xp.asarray([[0, 1, 0.3, 2],
@@ -797,8 +715,6 @@ class TestIsMonotonic:
                         [4, 5, 0.6, 4]], dtype=xp.float64)
         assert not is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_3x4_F2(self, xp):
         # Tests is_monotonic(Z) on 3x4 linkage (case 2). Expecting False.
         Z = xp.asarray([[0, 1, 0.8, 2],
@@ -806,8 +722,6 @@ class TestIsMonotonic:
                         [4, 5, 0.6, 4]], dtype=xp.float64)
         assert not is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_3x4_F3(self, xp):
         # Tests is_monotonic(Z) on 3x4 linkage (case 3). Expecting False
         Z = xp.asarray([[0, 1, 0.3, 2],
@@ -815,16 +729,12 @@ class TestIsMonotonic:
                         [4, 5, 0.2, 4]], dtype=xp.float64)
         assert not is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_tdist_linkage1(self, xp):
         # Tests is_monotonic(Z) on clustering generated by single linkage on
         # tdist data set. Expecting True.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
         assert is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_tdist_linkage2(self, xp):
         # Tests is_monotonic(Z) on clustering generated by single linkage on
         # tdist data set. Perturbing. Expecting False.
@@ -832,8 +742,6 @@ class TestIsMonotonic:
         Z[2,2] = 0.0
         assert not is_monotonic(Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_is_monotonic_Q_linkage(self, xp):
         # Tests is_monotonic(Z) on clustering generated by single linkage on
         # Q data set. Expecting True.
@@ -842,17 +750,14 @@ class TestIsMonotonic:
         assert is_monotonic(Z)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestMaxDists:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_maxdists_empty_linkage(self, xp):
         # Tests maxdists(Z) on empty linkage. Expecting exception.
         Z = xp.zeros((0, 4), dtype=xp.float64)
         assert_raises(ValueError, maxdists, Z)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_maxdists_one_cluster_linkage(self, xp):
         # Tests maxdists(Z) on linkage with one cluster.
         Z = xp.asarray([[0, 1, 0.3, 4]], dtype=xp.float64)
@@ -860,8 +765,6 @@ class TestMaxDists:
         expectedMD = calculate_maximum_distances(Z, xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_maxdists_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             self.check_maxdists_Q_linkage(method, xp)
@@ -877,15 +780,13 @@ class TestMaxDists:
 
 class TestMaxInconsts:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxinconsts_empty_linkage(self, xp):
         # Tests maxinconsts(Z, R) on empty linkage. Expecting exception.
         Z = xp.zeros((0, 4), dtype=xp.float64)
         R = xp.zeros((0, 4), dtype=xp.float64)
         assert_raises(ValueError, maxinconsts, Z, R)
 
-    @array_api_compatible
     def test_maxinconsts_difrow_linkage(self, xp):
         # Tests maxinconsts(Z, R) on linkage and inconsistency matrices with
         # different numbers of clusters. Expecting exception.
@@ -894,8 +795,7 @@ class TestMaxInconsts:
         R = xp.asarray(R)
         assert_raises(ValueError, maxinconsts, Z, R)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxinconsts_one_cluster_linkage(self, xp):
         # Tests maxinconsts(Z, R) on linkage with one cluster.
         Z = xp.asarray([[0, 1, 0.3, 4]], dtype=xp.float64)
@@ -904,8 +804,7 @@ class TestMaxInconsts:
         expectedMD = calculate_maximum_inconsistencies(Z, R, xp=xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxinconsts_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             self.check_maxinconsts_Q_linkage(method, xp)
@@ -922,7 +821,6 @@ class TestMaxInconsts:
 
 class TestMaxRStat:
 
-    @array_api_compatible
     def test_maxRstat_invalid_index(self, xp):
         for i in [3.3, -1, 4]:
             self.check_maxRstat_invalid_index(i, xp)
@@ -936,8 +834,7 @@ class TestMaxRStat:
         else:
             assert_raises(TypeError, maxRstat, Z, R, i)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxRstat_empty_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_empty_linkage(i, xp)
@@ -948,7 +845,6 @@ class TestMaxRStat:
         R = xp.zeros((0, 4), dtype=xp.float64)
         assert_raises(ValueError, maxRstat, Z, R, i)
 
-    @array_api_compatible
     def test_maxRstat_difrow_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_difrow_linkage(i, xp)
@@ -961,8 +857,7 @@ class TestMaxRStat:
         R = xp.asarray(R)
         assert_raises(ValueError, maxRstat, Z, R, i)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxRstat_one_cluster_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_one_cluster_linkage(i, xp)
@@ -975,8 +870,7 @@ class TestMaxRStat:
         expectedMD = calculate_maximum_inconsistencies(Z, R, 1, xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_maxRstat_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             for i in range(4):
@@ -992,10 +886,9 @@ class TestMaxRStat:
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
 
+@skip_if_array_api(cpu_only=True)
 class TestDendrogram:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_dendrogram_single_linkage_tdist(self, xp):
         # Tests dendrogram calculation on single linkage of the tdist data set.
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
@@ -1003,14 +896,10 @@ class TestDendrogram:
         leaves = R["leaves"]
         assert_equal(leaves, [2, 5, 1, 0, 3, 4])
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_valid_orientation(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_labels_as_array_or_list(self, xp):
         # test for gh-12418
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
@@ -1019,8 +908,6 @@ class TestDendrogram:
         result2 = dendrogram(Z, labels=list(labels), no_plot=True)
         assert result1 == result2
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_valid_label_size(self, xp):
         link = xp.asarray([
@@ -1041,8 +928,6 @@ class TestDendrogram:
 
         plt.close()
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_plot(self, xp):
         for orientation in ['top', 'bottom', 'left', 'right']:
@@ -1110,8 +995,6 @@ class TestDendrogram:
         R2['dcoord'] = np.asarray(R2['dcoord'])
         assert_equal(R2, expected)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_truncate_mode(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
@@ -1144,8 +1027,6 @@ class TestDendrogram:
                          'leaves_color_list': ['C1', 'C1', 'C0', 'C0', 'C0'],
                          })
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_dendrogram_colors(self, xp):
         # Tests dendrogram plots with alternate colors
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
@@ -1161,8 +1042,6 @@ class TestDendrogram:
         # reset color palette (global list)
         set_link_color_palette(None)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_dendrogram_leaf_colors_zero_dist(self, xp):
         # tests that the colors of leafs are correct for tree
         # with two identical points
@@ -1178,8 +1057,6 @@ class TestDendrogram:
         colors = d["leaves_color_list"]
         assert_equal(colors, exp_colors)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_dendrogram_leaf_colors(self, xp):
         # tests that the colors are correct for a tree
         # with two near points ((0, 0, 1.1) and (0, 0, 1))
@@ -1233,29 +1110,25 @@ def calculate_maximum_inconsistencies(Z, R, k=3, xp=np):
     return B
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 def test_unsupported_uncondensed_distance_matrix_linkage_warning(xp):
     assert_warns(ClusterWarning, linkage, xp.asarray([[0, 1], [1, 0]]))
 
 
-@array_api_compatible
 def test_euclidean_linkage_value_error(xp):
     for method in scipy.cluster.hierarchy._EUCLIDEAN_METHODS:
         assert_raises(ValueError, linkage, xp.asarray([[1, 1], [1, 1]]),
                       method=method, metric='cityblock')
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 def test_2x2_linkage(xp):
     Z1 = linkage(xp.asarray([1]), method='single', metric='euclidean')
     Z2 = linkage(xp.asarray([[0, 1], [0, 0]]), method='single', metric='euclidean')
     xp_assert_close(Z1, Z2, rtol=1e-15)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 def test_node_compare(xp):
     np.random.seed(23)
     nobs = 50
@@ -1269,9 +1142,7 @@ def test_node_compare(xp):
     assert_(tree.get_right() != tree.get_left())
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
-@skip_if_array_api_backend('array_api_strict')
+@skip_if_array_api(np_only=True, reasons=['`cut_tree` uses non-standard indexing'])
 def test_cut_tree(xp):
     np.random.seed(23)
     nobs = 50
@@ -1300,8 +1171,7 @@ def test_cut_tree(xp):
                     cut_tree(Z, height=[10, 5]), rtol=1e-15)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 def test_optimal_leaf_ordering(xp):
     # test with the distance vector y
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.ytdist)),
@@ -1316,9 +1186,9 @@ def test_optimal_leaf_ordering(xp):
     xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
-@skip_if_array_api
-def test_Heap():
-    values = np.array([2, -1, 0, -1.5, 3])
+@skip_if_array_api(np_only=True, reasons=['`Heap` only supports NumPy backend'])
+def test_Heap(xp):
+    values = xp.asarray([2, -1, 0, -1.5, 3])
     heap = Heap(values)
 
     pair = heap.get_min()

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 from numpy.testing import (
-    assert_array_equal, assert_allclose, assert_equal, assert_, suppress_warnings
+    assert_array_equal, assert_equal, assert_, suppress_warnings
 )
 import pytest
 from pytest import raises as assert_raises
@@ -12,16 +12,15 @@ from pytest import raises as assert_raises
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, vq, whiten,
                               ClusterError, _krandinit)
 from scipy.cluster import _vq
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api,
-    skip_if_array_api_gpu
-)
+from scipy.conftest import array_api_compatible
 from scipy.sparse._sputils import matrix
 
 from scipy._lib._array_api import (
     SCIPY_ARRAY_API, copy, cov, xp_assert_close, xp_assert_equal
 )
+
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+skip_if_array_api = pytest.mark.skip_if_array_api
 
 TESTDATA_2D = np.array([
     -2.2, 1.17, -1.63, 1.69, -2.04, 4.38, -3.09, 0.95, -1.7, 4.79, -1.68, 0.68,
@@ -81,7 +80,6 @@ LABEL1 = np.array([0, 1, 2, 2, 2, 2, 1, 2, 1, 1, 1])
 
 class TestWhiten:
 
-    @array_api_compatible
     def test_whiten(self, xp):
         desired = xp.asarray([[5.08738849, 2.97091878],
                             [3.19909255, 0.69660580],
@@ -96,7 +94,6 @@ class TestWhiten:
                           [0.45067590, 0.45464607]])
         xp_assert_close(whiten(obs), desired, rtol=1e-5)
 
-    @array_api_compatible
     def test_whiten_zero_std(self, xp):
         desired = xp.asarray([[0., 1.0, 2.86666544],
                               [0., 1.0, 1.32460034],
@@ -113,7 +110,6 @@ class TestWhiten:
             assert_equal(len(w), 1)
             assert_(issubclass(w[-1].category, RuntimeWarning))
 
-    @array_api_compatible
     def test_whiten_not_finite(self, xp):
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
         for tp in arrays:
@@ -128,8 +124,7 @@ class TestWhiten:
 
 class TestVq:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_py_vq(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
@@ -139,16 +134,16 @@ class TestVq:
             xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64),
                             check_dtype=False)
 
-    @skip_if_array_api
-    def test_vq(self):
+    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    def test_vq(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
-        for tp in [np.asarray, matrix]:
+        arrays = [xp.asarray] if SCIPY_ARRAY_API else [np.asarray, matrix]
+        for tp in arrays:
             label1, dist = _vq.vq(tp(X), tp(initc))
             assert_array_equal(label1, LABEL1)
-            tlabel1, tdist = vq(tp(X), tp(initc))
+            _, _ = vq(tp(X), tp(initc))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_vq_1d(self, xp):
         # Test special rank 1 vq algo, python implementation.
         data = X[:, 0]
@@ -161,19 +156,18 @@ class TestVq:
         xp_assert_equal(ta, xp.asarray(a, dtype=xp.int64), check_dtype=False)
         xp_assert_equal(tb, xp.asarray(b))
 
-    @skip_if_array_api
-    def test__vq_sametype(self):
-        a = np.array([1.0, 2.0], dtype=np.float64)
-        b = a.astype(np.float32)
+    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    def test__vq_sametype(self, xp):
+        a = xp.asarray([1.0, 2.0], dtype=xp.float64)
+        b = a.astype(xp.float32)
         assert_raises(TypeError, _vq.vq, a, b)
 
-    @skip_if_array_api
-    def test__vq_invalid_type(self):
-        a = np.array([1, 2], dtype=int)
+    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    def test__vq_invalid_type(self, xp):
+        a = xp.asarray([1, 2], dtype=int)
         assert_raises(TypeError, _vq.vq, a, a)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_vq_large_nfeat(self, xp):
         X = np.random.rand(20, 20)
         code_book = np.random.rand(3, 20)
@@ -197,8 +191,7 @@ class TestVq:
         # codes1.dtype varies between int32 and int64 over platforms
         xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64), check_dtype=False)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
+    @skip_if_array_api(cpu_only=True)
     def test_vq_large_features(self, xp):
         X = np.random.rand(10, 5) * 1000000
         code_book = np.random.rand(2, 5) * 1000000
@@ -214,10 +207,9 @@ class TestVq:
 
 # Whole class skipped on GPU for now;
 # once pdist/cdist are hooked up for CuPy, more tests will work
+@skip_if_array_api(cpu_only=True)
 class TestKMean:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_large_features(self, xp):
         # Generate a data set with large values, and run kmeans on it to
         # (regression for 1077).
@@ -233,10 +225,8 @@ class TestKMean:
         data[:x.shape[0]] = x
         data[x.shape[0]:] = y
 
-        kmeans(xp.asarray(data), xp.asarray(2))
+        kmeans(xp.asarray(data), 2)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans_simple(self, xp):
         np.random.seed(54321)
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
@@ -245,8 +235,6 @@ class TestKMean:
             code1 = kmeans(tp(X), tp(initc), iter=1)[0]
             xp_assert_close(code1, xp.asarray(CODET2))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans_lost_cluster(self, xp):
         # This will cause kmeans to have a cluster with no points.
         data = xp.asarray(TESTDATA_2D)
@@ -263,8 +251,6 @@ class TestKMean:
 
         assert_raises(ClusterError, kmeans2, data, initk, missing='raise')
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_simple(self, xp):
         np.random.seed(12345678)
         initc = xp.asarray(np.concatenate([[X[0]], [X[1]], [X[2]]]))
@@ -276,8 +262,6 @@ class TestKMean:
             xp_assert_close(code1, xp.asarray(CODET1))
             xp_assert_close(code2, xp.asarray(CODET2))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_rank1(self, xp):
         data = xp.asarray(TESTDATA_2D)
         data1 = data[:, 0]
@@ -287,28 +271,22 @@ class TestKMean:
         kmeans2(data1, code, iter=1)[0]
         kmeans2(data1, code, iter=2)[0]
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_rank1_2(self, xp):
         data = xp.asarray(TESTDATA_2D)
         data1 = data[:, 0]
-        kmeans2(data1, xp.asarray(2), iter=1)
+        kmeans2(data1, 2, iter=1)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_high_dim(self, xp):
         # test kmeans2 when the number of dimensions exceeds the number
         # of input points
         data = xp.asarray(TESTDATA_2D)
         data = xp.reshape(data, (20, 20))[:10, :]
-        kmeans2(data, xp.asarray(2))
+        kmeans2(data, 2)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_init(self, xp):
         np.random.seed(12345)
         data = xp.asarray(TESTDATA_2D)
-        k = xp.asarray(3)
+        k = 3
 
         kmeans2(data, k, minit='points')
         kmeans2(data[:, :1], k, minit='points')  # special case (1-D)
@@ -322,8 +300,6 @@ class TestKMean:
             kmeans2(data, k, minit='random')
             kmeans2(data[:, :1], k, minit='random')  # special case (1-D)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='Fails with MemoryError in Wine.')
     def test_krandinit(self, xp):
@@ -338,40 +314,31 @@ class TestKMean:
             init_cov = cov(init.T)
             xp_assert_close(orig_cov, init_cov, atol=1e-2)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_empty(self, xp):
         # Regression test for gh-1032.
-        assert_raises(ValueError, kmeans2, xp.asarray([]), xp.asarray(2))
+        assert_raises(ValueError, kmeans2, xp.asarray([]), 2)
 
-    @skip_if_array_api
-    def test_kmeans_0k(self):
+    def test_kmeans_0k(self, xp):
         # Regression test for gh-1073: fail when k arg is 0.
-        assert_raises(ValueError, kmeans, X, 0)
-        assert_raises(ValueError, kmeans2, X, 0)
-        assert_raises(ValueError, kmeans2, X, np.array([]))
+        assert_raises(ValueError, kmeans, xp.asarray(X), 0)
+        assert_raises(ValueError, kmeans2, xp.asarray(X), 0)
+        assert_raises(ValueError, kmeans2, xp.asarray(X), xp.asarray([]))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans_large_thres(self, xp):
         # Regression test for gh-1774
         x = xp.asarray([1, 2, 3, 4, 10], dtype=xp.float64)
-        res = kmeans(x, xp.asarray(1), thresh=1e16)
+        res = kmeans(x, 1, thresh=1e16)
         xp_assert_close(res[0], xp.asarray([4.], dtype=xp.float64))
         xp_assert_close(res[1], xp.asarray(2.3999999999999999, dtype=xp.float64)[()])
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_kpp_low_dim(self, xp):
         # Regression test for gh-11462
         prev_res = xp.asarray([[-1.95266667, 0.898],
                                [-3.153375, 3.3945]], dtype=xp.float64)
         np.random.seed(42)
-        res, _ = kmeans2(xp.asarray(TESTDATA_2D), xp.asarray(2), minit='++')
+        res, _ = kmeans2(xp.asarray(TESTDATA_2D), 2, minit='++')
         xp_assert_close(res, prev_res)
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans2_kpp_high_dim(self, xp):
         # Regression test for gh-11462
         n_dim = 100
@@ -385,11 +352,9 @@ class TestKMean:
         ])
 
         data = xp.asarray(data)
-        res, _ = kmeans2(data, xp.asarray(2), minit='++')
+        res, _ = kmeans2(data, 2, minit='++')
         xp_assert_equal(xp.sign(res), xp.sign(xp.asarray(centers)))
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans_diff_convergence(self, xp):
         # Regression test for gh-8727
         obs = xp.asarray([-3, -1, 0, 1, 1, 8], dtype=xp.float64)
@@ -397,8 +362,6 @@ class TestKMean:
         xp_assert_close(res[0], xp.asarray([-0.4,  8.], dtype=xp.float64))
         xp_assert_close(res[1], xp.asarray(1.0666666666666667, dtype=xp.float64)[()])
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_kmeans_and_kmeans2_random_seed(self, xp):
 
         seed_list = [
@@ -412,10 +375,9 @@ class TestKMean:
             # test for kmeans
             res1, _ = kmeans(data, 2, seed=seed1)
             res2, _ = kmeans(data, 2, seed=seed2)
-            assert_allclose(res1, res2)  # should be same results
-
+            xp_assert_close(res1, res2, xp=xp)  # should be same results
             # test for kmeans2
             for minit in ["random", "points", "++"]:
                 res1, _ = kmeans2(data, 2, minit=minit, seed=seed1)
                 res2, _ = kmeans2(data, 2, minit=minit, seed=seed2)
-                assert_allclose(res1, res2)  # should be same results
+                xp_assert_close(res1, res2, xp=xp)  # should be same results

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -183,11 +183,10 @@ def skip_if_array_api_gpu(func):
     return wrapped
 
 
-def skip_if_array_api_backend(backend):
-    def wrapper(func):
-        reason = (
-            f"do not run with Array API backend: {backend}"
-        )
+def skip_if_array_api_backend(backend, reason=None):
+    def wrapper(func, reason=reason):
+        if reason is None:
+            reason = f"do not run with Array API backend: {backend}"
         # method gets there as a function so we cannot use inspect.ismethod
         if '.' in func.__qualname__:
             @wraps(func)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -3,7 +3,6 @@ import json
 import os
 import warnings
 import tempfile
-from functools import wraps
 
 import numpy as np
 import numpy.testing as npt

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -161,7 +161,7 @@ def skip_if_array_api(xp, request):
     Parameters
     ----------
     *backends : tuple
-        Backends to skip, e.g. ``("numpy.array_api", "torch")``.
+        Backends to skip, e.g. ``("array_api_strict", "torch")``.
         These are overriden when ``np_only`` is ``True``, and are not
         necessary to provide for non-CPU backends when ``cpu_only`` is ``True``.
     reasons : list, optional

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -28,6 +28,9 @@ def pytest_configure(config):
     except Exception:
         config.addinivalue_line(
             "markers", 'timeout: mark a test for a non-default timeout')
+    config.addinivalue_line("markers",
+        "skip_if_array_api(*backends, reasons=None, np_only=False, cpu_only=False): "
+        "mark the desired skip configuration for the `skip_if_array_api` fixture.")
 
 
 def _get_mark(item, name):
@@ -149,61 +152,64 @@ if 'cupy' in xp_available_backends:
 
 array_api_compatible = pytest.mark.parametrize("xp", xp_available_backends.values())
 
-skip_if_array_api = pytest.mark.skipif(
-    SCIPY_ARRAY_API,
-    reason="do not run with Array API on",
-)
 
+@pytest.fixture
+def skip_if_array_api(xp, request):
+    """
+    Skip based on the ``skip_if_array_api`` marker.
 
-def skip_if_array_api_gpu(func):
-    reason = "do not run with Array API on and not on CPU"
-    # method gets there as a function so we cannot use inspect.ismethod
-    if '.' in func.__qualname__:
-        @wraps(func)
-        def wrapped(self, *args, **kwargs):
-            xp = kwargs["xp"]
-            if SCIPY_ARRAY_API and SCIPY_DEVICE != 'cpu':
-                if xp.__name__ == 'cupy':
+    Parameters
+    ----------
+    *backends : tuple
+        Backends to skip, e.g. ``("numpy.array_api", "torch")``.
+        These are overriden when ``np_only`` is ``True``, and are not
+        necessary to provide for non-CPU backends when ``cpu_only`` is ``True``.
+    reasons : list, optional
+        A list of reasons for each skip. When ``np_only`` is ``True``,
+        this should be a singleton list. Otherwise, this should be a list
+        of reasons, one for each corresponding backend in ``backends``.
+        If unprovided, default reasons are used. Note that it is not possible
+        to specify a custom reason with ``cpu_only``. Default: ``None``.
+    np_only : bool, optional
+        When ``True``, the test is skipped for all backends other
+        than the default NumPy backend. There is no need to provide
+        any ``backends`` in this case. To specify a reason, pass a
+        singleton list to ``reasons``. Default: ``False``.
+    cpu_only : bool, optional
+        When ``True``, the test is skipped on non-CPU devices.
+        There is no need to provide any ``backends`` in this case,
+        but any ``backends`` will also be skipped on the CPU.
+        Default: ``False``.
+    """
+    if "skip_if_array_api" not in request.keywords:
+        return
+    backends = request.keywords["skip_if_array_api"].args
+    kwargs = request.keywords["skip_if_array_api"].kwargs
+    np_only = kwargs.get("np_only", False)
+    cpu_only = kwargs.get("cpu_only", False)
+    if np_only:
+        reasons = kwargs.get("reasons", ["do not run with non-NumPy backends."])
+        reason = reasons[0]
+        if xp.__name__ != 'numpy':
+            pytest.skip(reason=reason)
+        return
+    if cpu_only:
+        reason = "do not run with `SCIPY_ARRAY_API` set and not on CPU"
+        if SCIPY_ARRAY_API and SCIPY_DEVICE != 'cpu':
+            if xp.__name__ == 'cupy':
+                pytest.skip(reason=reason)
+            elif xp.__name__ == 'torch':
+                if 'cpu' not in torch.empty(0).device.type:
                     pytest.skip(reason=reason)
-                elif xp.__name__ == 'torch':
-                    if 'cpu' not in torch.empty(0).device.type:
-                        pytest.skip(reason=reason)
-            return func(self, *args, **kwargs)
-    else:
-        @wraps(func)
-        def wrapped(*args, **kwargs):
-            xp = kwargs["xp"]
-            if SCIPY_ARRAY_API and SCIPY_DEVICE != 'cpu':
-                if xp.__name__ == 'cupy':
-                    pytest.skip(reason=reason)
-                elif xp.__name__ == 'torch':
-                    if 'cpu' not in torch.empty(0).device.type:
-                        pytest.skip(reason=reason)
-            return func(*args, **kwargs)
-    return wrapped
-
-
-def skip_if_array_api_backend(backend, reason=None):
-    def wrapper(func, reason=reason):
-        if reason is None:
-            reason = f"do not run with Array API backend: {backend}"
-        # method gets there as a function so we cannot use inspect.ismethod
-        if '.' in func.__qualname__:
-            @wraps(func)
-            def wrapped(self, *args, **kwargs):
-                xp = kwargs["xp"]
-                if xp.__name__ == backend:
-                    pytest.skip(reason=reason)
-                return func(self, *args, **kwargs)
-        else:
-            @wraps(func)
-            def wrapped(*args, **kwargs):
-                xp = kwargs["xp"]
-                if xp.__name__ == backend:
-                    pytest.skip(reason=reason)
-                return func(*args, **kwargs)
-        return wrapped
-    return wrapper
+    if backends is not None:
+        reasons = kwargs.get("reasons", False)
+        for i, backend in enumerate(backends):
+            if xp.__name__ == backend:
+                if not reasons:
+                    reason = f"do not run with array API backend: {backend}"
+                else:
+                    reason = reasons[i]
+                pytest.skip(reason=reason)
 
 
 # Following the approach of NumPy's conftest.py...

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -7,13 +7,13 @@ from numpy.random import random
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from pytest import raises as assert_raises
 import scipy.fft as fft
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api_backend
-)
+from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     array_namespace, size, xp_assert_close, xp_assert_equal
 )
+
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+skip_if_array_api = pytest.mark.skip_if_array_api
 
 
 # Expected input dtypes. Note that `scipy.fft` is more flexible for numpy,
@@ -43,7 +43,6 @@ def fft1(x):
 
 class TestFFTShift:
 
-    @array_api_compatible
     def test_fft_n(self, xp):
         x = xp.asarray([1, 2, 3], dtype=xp.complex128)
         if xp.__name__ == 'torch':
@@ -54,7 +53,6 @@ class TestFFTShift:
 
 class TestFFT1D:
 
-    @array_api_compatible
     def test_identity(self, xp):
         maxlen = 512
         x = xp.asarray(random(maxlen) + 1j*random(maxlen))
@@ -63,7 +61,6 @@ class TestFFT1D:
             xp_assert_close(fft.ifft(fft.fft(x[0:i])), x[0:i], rtol=1e-9, atol=0)
             xp_assert_close(fft.irfft(fft.rfft(xr[0:i]), i), xr[0:i], rtol=1e-9, atol=0)
 
-    @array_api_compatible
     def test_fft(self, xp):
         x = random(30) + 1j*random(30)
         expect = xp.asarray(fft1(x))
@@ -74,16 +71,14 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30, dtype=xp.float64)),)
         xp_assert_close(fft.fft(x, norm="forward"), expect / 30)
 
-    @array_api_compatible
     def test_ifft(self, xp):
         x = xp.asarray(random(30) + 1j*random(30))
         xp_assert_close(fft.ifft(fft.fft(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ifft(fft.fft(x, norm=norm), norm=norm), x)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_fft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
         expect = fft.fft(fft.fft(x, axis=1), axis=0)
@@ -93,9 +88,8 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.fft2(x, norm="forward"), expect / (30 * 20))
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ifft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
         expect = fft.ifft(fft.ifft(x, axis=1), axis=0)
@@ -105,9 +99,8 @@ class TestFFT1D:
                         expect * xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.ifft2(x, norm="forward"), expect * (30 * 20))
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_fftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
         expect = fft.fft(fft.fft(fft.fft(x, axis=2), axis=1), axis=0)
@@ -117,9 +110,8 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20 * 10, dtype=xp.float64)))
         xp_assert_close(fft.fftn(x, norm="forward"), expect / (30 * 20 * 10))
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ifftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
         expect = fft.ifft(fft.ifft(fft.ifft(x, axis=2), axis=1), axis=0)
@@ -131,7 +123,6 @@ class TestFFT1D:
         )
         xp_assert_close(fft.ifftn(x, norm="forward"), expect * (30 * 20 * 10))
 
-    @array_api_compatible
     def test_rfft(self, xp):
         x = xp.asarray(random(29), dtype=xp.float64)
         for n in [size(x), 2*size(x)]:
@@ -144,16 +135,14 @@ class TestFFT1D:
                 fft.rfft(x, n=n) / xp.sqrt(xp.asarray(n, dtype=xp.float64))
             )
 
-    @array_api_compatible
     def test_irfft(self, xp):
         x = xp.asarray(random(30))
         xp_assert_close(fft.irfft(fft.rfft(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft(fft.rfft(x, norm=norm), norm=norm), x)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_rfft2(self, xp):
         x = xp.asarray(random((30, 20)), dtype=xp.float64)
         expect = fft.fft2(xp.asarray(x, dtype=xp.complex128))[:, :11]
@@ -163,18 +152,16 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.rfft2(x, norm="forward"), expect / (30 * 20))
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_irfft2(self, xp):
         x = xp.asarray(random((30, 20)))
         xp_assert_close(fft.irfft2(fft.rfft2(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft2(fft.rfft2(x, norm=norm), norm=norm), x)
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_rfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)), dtype=xp.float64)
         expect = fft.fftn(xp.asarray(x, dtype=xp.complex128))[:, :, :6]
@@ -184,16 +171,14 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20 * 10, dtype=xp.float64)))
         xp_assert_close(fft.rfftn(x, norm="forward"), expect / (30 * 20 * 10))
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_irfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
         xp_assert_close(fft.irfftn(fft.rfftn(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfftn(fft.rfftn(x, norm=norm), norm=norm), x)
 
-    @array_api_compatible
     def test_hfft(self, xp):
         x = random(14) + 1j*random(14)
         x_herm = np.concatenate((random(1), x, random(1)))
@@ -207,7 +192,6 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30, dtype=xp.float64)))
         xp_assert_close(fft.hfft(x_herm, norm="forward"), expect / 30)
 
-    @array_api_compatible
     def test_ihfft(self, xp):
         x = random(14) + 1j*random(14)
         x_herm = np.concatenate((random(1), x, random(1)))
@@ -218,18 +202,16 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ihfft(fft.hfft(x_herm, norm=norm), norm=norm), x_herm)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_hfft2(self, xp):
         x = xp.asarray(random((30, 20)))
         xp_assert_close(fft.hfft2(fft.ihfft2(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfft2(fft.ihfft2(x, norm=norm), norm=norm), x)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ihfft2(self, xp):
         x = xp.asarray(random((30, 20)), dtype=xp.float64)
         expect = fft.ifft2(xp.asarray(x, dtype=xp.complex128))[:, :11]
@@ -241,18 +223,16 @@ class TestFFT1D:
         )
         xp_assert_close(fft.ihfft2(x, norm="forward"), expect * (30 * 20))
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_hfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
         xp_assert_close(fft.hfftn(fft.ihfftn(x)), x)
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfftn(fft.ihfftn(x, norm=norm), norm=norm), x)
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ihfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)), dtype=xp.float64)
         expect = fft.ifftn(xp.asarray(x, dtype=xp.complex128))[:, :, :6]
@@ -274,23 +254,20 @@ class TestFFT1D:
             tr_op = xp_test.permute_dims(op(x, axes=a), axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fftn, fft.ifftn, fft.rfftn, fft.irfftn])
     def test_axes_standard(self, op, xp):
         self._check_axes(op, xp)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.hfftn, fft.ihfftn])
     def test_axes_non_standard(self, op, xp):
         self._check_axes(op, xp)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fftn, fft.ifftn,
                                     fft.rfftn, fft.irfftn])
     def test_axes_subset_with_shape_standard(self, op, xp):
@@ -309,9 +286,8 @@ class TestFFT1D:
                                          axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
+    @skip_if_array_api('torch',
+                       reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fft2, fft.ifft2,
                                     fft.rfft2, fft.irfft2,
                                     fft.hfft2, fft.ihfft2,
@@ -330,7 +306,6 @@ class TestFFT1D:
             tr_op = xp_test.permute_dims(op(x, s=shape[:2], axes=a[:2]), axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    @array_api_compatible
     def test_all_1d_norm_preserving(self, xp):
         # verify that round-trip transforms are norm-preserving
         x = xp.asarray(random(30), dtype=xp.float64)
@@ -354,6 +329,7 @@ class TestFFT1D:
                     tmp = back(tmp, n=n, norm=norm)
                     xp_assert_close(xp_test.linalg.vector_norm(tmp), x_norm)
 
+    @skip_if_array_api(np_only=True)
     @pytest.mark.parametrize("dtype", [np.float16, np.longdouble])
     def test_dtypes_nonstandard(self, dtype):
         x = random(30).astype(dtype)
@@ -371,7 +347,6 @@ class TestFFT1D:
         assert res_rfft.dtype == np.result_type(np.float32, x.dtype)
         assert res_hfft.dtype == np.result_type(np.float32, x.dtype)
 
-    @array_api_compatible
     @pytest.mark.parametrize("dtype", ["float32", "float64"])
     def test_dtypes_real(self, dtype, xp):
         x = xp.asarray(random(30), dtype=getattr(xp, dtype))
@@ -383,7 +358,6 @@ class TestFFT1D:
         xp_assert_close(res_rfft, x, rtol=rtol, atol=0)
         xp_assert_close(res_hfft, x, rtol=rtol, atol=0)
 
-    @array_api_compatible
     @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
     def test_dtypes_complex(self, dtype, xp):
         x = xp.asarray(random(30), dtype=getattr(xp, dtype))
@@ -393,6 +367,7 @@ class TestFFT1D:
         rtol = {"complex64": 1.2e-4, "complex128": 1e-8}[dtype]
         xp_assert_close(res_fft, x, rtol=rtol, atol=0)
 
+@skip_if_array_api(np_only=True)
 @pytest.mark.parametrize(
         "dtype",
         [np.float32, np.float64, np.longdouble,
@@ -456,37 +431,32 @@ class TestFFTThreadSafe:
                 err_msg='Function returned wrong value in multithreaded context'
             )
 
-    @array_api_compatible
     def test_fft(self, xp):
         a = xp.ones(self.input_shape, dtype=xp.complex128)
         self._test_mtsame(fft.fft, a, xp=xp)
 
-    @array_api_compatible
     def test_ifft(self, xp):
         a = xp.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.ifft, a, xp=xp)
 
-    @array_api_compatible
     def test_rfft(self, xp):
         a = xp.ones(self.input_shape)
         self._test_mtsame(fft.rfft, a, xp=xp)
 
-    @array_api_compatible
     def test_irfft(self, xp):
         a = xp.full(self.input_shape, 1+0j)
         self._test_mtsame(fft.irfft, a, xp=xp)
 
-    @array_api_compatible
     def test_hfft(self, xp):
         a = xp.ones(self.input_shape, dtype=xp.complex64)
         self._test_mtsame(fft.hfft, a, xp=xp)
 
-    @array_api_compatible
     def test_ihfft(self, xp):
         a = xp.ones(self.input_shape)
         self._test_mtsame(fft.ihfft, a, xp=xp)
 
 
+@skip_if_array_api(np_only=True)
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)
@@ -499,11 +469,10 @@ def test_multiprocess(func):
         assert_allclose(x, expect)
 
 
+@skip_if_array_api('torch',
+                   reasons=['torch.fft not yet implemented by array-api-compat'])
 class TestIRFFTN:
 
-    @array_api_compatible
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
     def test_not_last_axis_success(self, xp):
         ar, ai = np.random.random((2, 16, 8, 32))
         a = ar + 1j*ai
@@ -515,9 +484,8 @@ class TestIRFFTN:
         fft.irfftn(a, axes=axes)
 
 
-# torch.fft not yet implemented by array-api-compat
-@skip_if_array_api_backend('torch')
-@array_api_compatible
+@skip_if_array_api('torch',
+                   reasons=['torch.fft not yet implemented by array-api-compat'])
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft,
                                   fft.fftn, fft.ifftn,
                                   fft.rfftn, fft.irfftn, fft.hfft, fft.ihfft])

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -8,8 +8,9 @@ from scipy.special import poch
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close
 
+pytestmark = array_api_compatible
 
-@array_api_compatible
+
 def test_fht_agrees_with_fftlog(xp):
     # check that fht numerically agrees with the output from Fortran FFTLog,
     # the results were generated with the provided `fftlogtest` program,
@@ -86,7 +87,6 @@ def test_fht_agrees_with_fftlog(xp):
     xp_assert_close(ours, theirs)
 
 
-@array_api_compatible
 @pytest.mark.parametrize('optimal', [True, False])
 @pytest.mark.parametrize('offset', [0.0, 1.0, -1.0])
 @pytest.mark.parametrize('bias', [0, 0.1, -0.1])
@@ -107,7 +107,6 @@ def test_fht_identity(n, bias, offset, optimal, xp):
     xp_assert_close(a_, a)
 
 
-@array_api_compatible
 def test_fht_special_cases(xp):
     rng = np.random.RandomState(3491349965)
 
@@ -141,7 +140,6 @@ def test_fht_special_cases(xp):
         assert record, 'ifht did not warn about a singular transform'
 
 
-@array_api_compatible
 @pytest.mark.parametrize('n', [64, 63])
 def test_fht_exact(n, xp):
     rng = np.random.RandomState(3491349965)

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -10,13 +10,12 @@ from pytest import raises as assert_raises
 import pytest
 import numpy as np
 import sys
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api_gpu,
-    skip_if_array_api_backend
-)
+from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close, SCIPY_DEVICE
 from scipy import fft
+
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+skip_if_array_api = pytest.mark.skip_if_array_api
 
 _5_smooth_numbers = [
     2, 3, 4, 5, 6, 8, 9, 10,
@@ -52,6 +51,7 @@ def _assert_n_smooth(x, n):
            f'x={x_orig} is not {n}-smooth, remainder={x}'
 
 
+@skip_if_array_api(np_only=True)
 class TestNextFastLen:
 
     def test_next_fast_len(self):
@@ -126,10 +126,9 @@ class TestNextFastLen:
         assert next_fast_len(target=7, real=False) == 7
 
 
+@skip_if_array_api(cpu_only=True)
 class Test_init_nd_shape_and_axes:
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_py_0d_defaults(self, xp):
         x = xp.asarray(4)
         shape = None
@@ -143,8 +142,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_0d_defaults(self, xp):
         x = xp.asarray(7.)
         shape = None
@@ -158,8 +155,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_py_1d_defaults(self, xp):
         x = xp.asarray([1, 2, 3])
         shape = None
@@ -173,8 +168,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_1d_defaults(self, xp):
         x = xp.arange(0, 1, .1)
         shape = None
@@ -188,8 +181,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_py_2d_defaults(self, xp):
         x = xp.asarray([[1, 2, 3, 4],
                         [5, 6, 7, 8]])
@@ -204,8 +195,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_2d_defaults(self, xp):
         x = xp.arange(0, 1, .1)
         x = xp.reshape(x, (5, 2))
@@ -220,8 +209,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_5d_defaults(self, xp):
         x = xp.zeros([6, 2, 5, 3, 4])
         shape = None
@@ -235,8 +222,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_5d_set_shape(self, xp):
         x = xp.zeros([6, 2, 5, 3, 4])
         shape = [10, -1, -1, 1, 4]
@@ -250,8 +235,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_5d_set_axes(self, xp):
         x = xp.zeros([6, 2, 5, 3, 4])
         shape = None
@@ -265,8 +248,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_xp_5d_set_shape_axes(self, xp):
         x = xp.zeros([6, 2, 5, 3, 4])
         shape = [10, -1, 2]
@@ -280,8 +261,6 @@ class Test_init_nd_shape_and_axes:
         assert shape_res == shape_expected
         assert axes_res == axes_expected
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_shape_axes_subset(self, xp):
         x = xp.zeros((2, 3, 4, 5))
         shape, axes = _init_nd_shape_and_axes(x, shape=(5, 5, 5), axes=None)
@@ -289,8 +268,6 @@ class Test_init_nd_shape_and_axes:
         assert shape == (5, 5, 5)
         assert axes == [1, 2, 3]
 
-    @skip_if_array_api_gpu
-    @array_api_compatible
     def test_errors(self, xp):
         x = xp.zeros(1)
         with assert_raises(ValueError, match="axes must be a scalar or "
@@ -338,11 +315,10 @@ class Test_init_nd_shape_and_axes:
             _init_nd_shape_and_axes(x, shape=-2, axes=None)
 
 
+@skip_if_array_api('torch',
+                   reasons=['torch.fft not yet implemented by array-api-compat'])
 class TestFFTShift:
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
     def test_definition(self, xp):
         x = xp.asarray([0., 1, 2, 3, 4, -4, -3, -2, -1])
         y = xp.asarray([-4., -3, -2, -1, 0, 1, 2, 3, 4])
@@ -353,17 +329,11 @@ class TestFFTShift:
         xp_assert_close(fft.fftshift(x), y)
         xp_assert_close(fft.ifftshift(y), x)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
     def test_inverse(self, xp):
         for n in [1, 4, 9, 100, 211]:
             x = xp.asarray(np.random.random((n,)))
             xp_assert_close(fft.ifftshift(fft.fftshift(x)), x)
 
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
     def test_axes_keyword(self, xp):
         freqs = xp.asarray([[0., 1, 2], [3, 4, -4], [-3, -2, -1]])
         shifted = xp.asarray([[-1., -3, -2], [2, 0, 1], [-4, 3, 4]])
@@ -375,9 +345,6 @@ class TestFFTShift:
         xp_assert_close(fft.fftshift(freqs), shifted)
         xp_assert_close(fft.ifftshift(shifted), freqs)
     
-    # torch.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('torch')
-    @array_api_compatible
     def test_uneven_dims(self, xp):
         """ Test 2D input, which has uneven dimension sizes """
         freqs = xp.asarray([
@@ -424,13 +391,11 @@ class TestFFTShift:
         xp_assert_close(fft.ifftshift(shift_dim_both), freqs)
 
 
+@skip_if_array_api('array_api_strict', 'cupy',
+                   reasons=['fft not yet implemented by array-api-strict',
+                            'cupy.fft not yet implemented by array-api-compat'])
 class TestFFTFreq:
 
-    # fft not yet implemented by array-api-strict
-    @skip_if_array_api_backend('array_api_strict')
-    # cupy.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('cupy')
-    @array_api_compatible
     def test_definition(self, xp):
         device = SCIPY_DEVICE
         try:
@@ -454,13 +419,11 @@ class TestFFTFreq:
         xp_assert_close(y, x2)
 
 
+@skip_if_array_api('array_api_strict', 'cupy',
+                   reasons=['fft not yet implemented by array-api-strict',
+                            'cupy.fft not yet implemented by array-api-compat'])
 class TestRFFTFreq:
 
-    # fft not yet implemented by array-api-strict
-    @skip_if_array_api_backend('array_api_strict')
-    # cupy.fft not yet implemented by array-api-compat
-    @skip_if_array_api_backend('cupy')
-    @array_api_compatible
     def test_definition(self, xp):
         device = SCIPY_DEVICE
         try:

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -5,11 +5,11 @@ import pytest
 from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
 import scipy.fft as fft
 from scipy import fftpack
-from scipy.conftest import (
-    array_api_compatible,
-    skip_if_array_api_gpu
-)
+from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import copy, xp_assert_close
+
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
+skip_if_array_api = pytest.mark.skip_if_array_api
 
 import math
 SQRT_2 = math.sqrt(2)
@@ -19,8 +19,7 @@ SQRT_2 = math.sqrt(2)
 # fftpack/test_real_transforms.py
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("n", [2, 3, 4, 5, 10, 16])
@@ -43,6 +42,8 @@ def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize, xp):
     xp_assert_close(z2, x)
 
 
+@skip_if_array_api(np_only=True,
+                   reasons=['`overwrite_x` only supported for NumPy backend.'])
 @pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
@@ -67,8 +68,7 @@ def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
         assert_allclose(z, x_orig, rtol=1e-6, atol=1e-6)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("shape, axes",
@@ -115,6 +115,8 @@ def test_identity_nd(forward, backward, type, shape, axes, norm,
     xp_assert_close(z2, x)
 
 
+@skip_if_array_api(np_only=True,
+                   reasons=['`overwrite_x` only supported for NumPy backend.'])
 @pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("shape, axes",
@@ -148,8 +150,7 @@ def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
         assert_array_equal(y, y_orig)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("func", ['dct', 'dst', 'dctn', 'dstn'])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
@@ -162,8 +163,7 @@ def test_fftpack_equivalience(func, type, norm, xp):
     xp_assert_close(fft_res, fftpack_res)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("func", [dct, dst, dctn, dstn])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 def test_orthogonalize_default(func, type, xp):
@@ -180,8 +180,7 @@ def test_orthogonalize_default(func, type, xp):
         xp_assert_close(a, b)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func, type", [
     (dct, 4), (dst, 1), (dst, 4)])
@@ -193,8 +192,7 @@ def test_orthogonalize_noop(func, type, norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 def test_orthogonalize_dct1(norm, xp):
     x = xp.asarray(np.random.rand(100))
@@ -211,8 +209,7 @@ def test_orthogonalize_dct1(norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst2(func, norm, xp):
@@ -224,8 +221,7 @@ def test_orthogonalize_dcst2(func, norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api_gpu
-@array_api_compatible
+@skip_if_array_api(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst3(func, norm, xp):

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
+import math
 
 from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
 import scipy.fft as fft
@@ -11,7 +12,6 @@ from scipy._lib._array_api import copy, xp_assert_close
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
 skip_if_array_api = pytest.mark.skip_if_array_api
 
-import math
 SQRT_2 = math.sqrt(2)
 
 # scipy.fft wraps the fftpack versions but with normalized inverse transforms.


### PR DESCRIPTION
#### Reference issue
Closes gh-19181, towards gh-18866.

#### What does this implement/fix?
- Consolidates the array API test-skip infrastructure into a single `pytest` fixture and marker.

#### Additional information
- Also makes some minor improvements to some tests in `cluster`.
