### PR TITLE
ENH: sparse: Add 1d support to dok format and update coo-1d code. Add tests.

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -353,7 +353,7 @@ class _spbase:
     def imag(self):
         return self._imag()
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         _, format_name = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
         shape_str = 'x'.join(str(x) for x in self.shape)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -67,7 +67,10 @@ class _spbase:
 
     __array_priority__ = 10.1
     _format = 'und'  # undefined
-    ndim = 2
+    
+    @property
+    def ndim(self) -> int:
+        return len(self._shape)
 
     @property
     def _bsr_container(self):
@@ -350,7 +353,7 @@ class _spbase:
     def imag(self):
         return self._imag()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         _, format_name = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
         shape_str = 'x'.join(str(x) for x in self.shape)
@@ -568,7 +571,11 @@ class _spbase:
         # This method has to be different from `__matmul__` because it is also
         # called by sparse matrix classes.
 
-        M, N = self.shape
+        # Currently matrix multiplication is only supported
+        # for 2D arrays. Hence we unpacked and use only the
+        # two last axes' lengths.
+        N = self.shape[-1]
+        M = self.shape[-2] if self.ndim > 1 else 1
 
         if other.__class__ is np.ndarray:
             # Fast path for the most common case

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -597,8 +597,7 @@ class _spbase:
         # Currently matrix multiplication is only supported
         # for 2D arrays. Hence we unpacked and use only the
         # two last axes' lengths.
-        N = self.shape[-1]
-        M = self.shape[-2] if self.ndim > 1 else 1
+        M, N = self._shape_as_2d
 
         if other.__class__ is np.ndarray:
             # Fast path for the most common case

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -157,13 +157,27 @@ class _spbase:
         """
         # If the shape already matches, don't bother doing an actual reshape
         # Otherwise, the default is to convert to COO and use its reshape
-        shape = check_shape(args, self.shape)
+        is_array = isinstance(self, sparray)
+        shape = check_shape(args, self.shape, allow_1d=is_array)
         order, copy = check_reshape_kwargs(kwargs)
         if shape == self.shape:
             if copy:
                 return self.copy()
             else:
                 return self
+
+#        if is_array:
+#            # speedup common 1d<->2d cases
+#            if len(shape) == self.ndim + 1 and 1 in shape:
+#                # remove one dimension
+#                new = self.tocsr(copy=copy)
+#                new._shape = shape
+#                return new
+#            if len(shape) == self.ndim - 1 and 1 in self.shape:
+#                # add one dimension
+#                new = (self if self.shape[0] == 1 else self.T).tocsr(copy=copy)
+#                new._shape = shape
+#                return new
 
         return self.tocoo(copy=copy).reshape(shape, order=order, copy=False)
 
@@ -255,8 +269,12 @@ class _spbase:
                             'point format' % self.dtype.name)
 
     def __iter__(self):
-        for r in range(self.shape[0]):
-            yield self[r, :]
+        if self.ndim == 1:
+            for r in range(self.shape[0]):
+                yield self[r]
+        else:
+            for r in range(self.shape[0]):
+                yield self[r, :]
 
     def _getmaxprint(self):
         """Maximum number of elements to display when printed."""
@@ -587,7 +605,10 @@ class _spbase:
             if other.shape == (N,):
                 return self._mul_vector(other)
             elif other.shape == (N, 1):
-                return self._mul_vector(other.ravel()).reshape(M, 1)
+                result = self._mul_vector(other.ravel())
+                if M == 1:
+                    return result
+                return result.reshape(M, 1)
             elif other.ndim == 2 and other.shape[0] == N:
                 return self._mul_multivector(other)
 
@@ -596,7 +617,7 @@ class _spbase:
             return self._mul_scalar(other)
 
         if issparse(other):
-            if self.shape[1] != other.shape[0]:
+            if self.shape[-1] != other.shape[0]:
                 raise ValueError('dimension mismatch')
             return self._mul_sparse_matrix(other)
 
@@ -633,7 +654,7 @@ class _spbase:
             ##
             # dense 2D array or matrix ("multivector")
 
-            if other.shape[0] != self.shape[1]:
+            if other.shape[0] != N:
                 raise ValueError('dimension mismatch')
 
             result = self._mul_multivector(np.asarray(other))
@@ -866,29 +887,33 @@ class _spbase:
         # Subclasses should override this method for efficiency.
         # Post-multiply by a (n x 1) column vector 'a' containing all zeros
         # except for a_j = 1
-        n = self.shape[1]
+        N = self.shape[-1]
         if j < 0:
-            j += n
-        if j < 0 or j >= n:
+            j += N
+        if j < 0 or j >= N:
             raise IndexError("index out of bounds")
         col_selector = self._csc_container(([1], [[j], [0]]),
-                                           shape=(n, 1), dtype=self.dtype)
+                                           shape=(N, 1), dtype=self.dtype)
+        if self.ndim == 1:
+            return (self @ col_selector).reshape(1, 1)
         return self @ col_selector
 
     def _getrow(self, i):
         """Returns a copy of row i of the array, as a (1 x n) sparse
         array (row vector).
         """
+        if self.ndim == 1:
+            return self.reshape(1, self.shape[0])
         # Subclasses should override this method for efficiency.
         # Pre-multiply by a (1 x m) row vector 'a' containing all zeros
         # except for a_i = 1
-        m = self.shape[0]
+        M = self.shape[0]
         if i < 0:
-            i += m
-        if i < 0 or i >= m:
+            i += M
+        if i < 0 or i >= M:
             raise IndexError("index out of bounds")
         row_selector = self._csr_container(([1], [[0], [i]]),
-                                           shape=(1, m), dtype=self.dtype)
+                                           shape=(1, M), dtype=self.dtype)
         return row_selector @ self
 
     # The following dunder methods cannot be implemented.
@@ -1085,18 +1110,29 @@ class _spbase:
         """
         validateaxis(axis)
 
+        # Mimic numpy's casting.
+        res_dtype = get_sum_dtype(self.dtype)
+
+        if self.ndim == 1:
+            if axis not in (None, -1, 0):
+                raise ValueError("axis must be None, -1 or 0")
+            ret = (self @ np.ones(self.shape, dtype=res_dtype)).astype(dtype)
+
+            if out is not None:
+                if np.prod(np.array(out.shape)) != 1:
+                    raise ValueError("dimensions do not match")
+                out[...] = ret
+            return ret
+
         # We use multiplication by a matrix of ones to achieve this.
         # For some sparse array formats more efficient methods are
         # possible -- these should override this function.
-        m, n = self.shape
-
-        # Mimic numpy's casting.
-        res_dtype = get_sum_dtype(self.dtype)
+        M, N = self.shape
 
         if axis is None:
             # sum over rows and columns
             return (
-                self @ self._ascontainer(np.ones((n, 1), dtype=res_dtype))
+                self @ self._ascontainer(np.ones((N, 1), dtype=res_dtype))
             ).sum(dtype=dtype, out=out)
 
         if axis < 0:
@@ -1106,12 +1142,12 @@ class _spbase:
         if axis == 0:
             # sum over columns
             ret = self._ascontainer(
-                np.ones((1, m), dtype=res_dtype)
+                np.ones((1, M), dtype=res_dtype)
             ) @ self
         else:
             # sum over rows
             ret = self @ self._ascontainer(
-                np.ones((n, 1), dtype=res_dtype)
+                np.ones((N, 1), dtype=res_dtype)
             )
 
         if out is not None and out.shape != ret.shape:
@@ -1156,14 +1192,11 @@ class _spbase:
         numpy.matrix.mean : NumPy's implementation of 'mean' for matrices
 
         """
-        def _is_integral(dtype):
-            return (np.issubdtype(dtype, np.integer) or
-                    np.issubdtype(dtype, np.bool_))
-
         validateaxis(axis)
 
         res_dtype = self.dtype.type
-        integral = _is_integral(self.dtype)
+        integral = (np.issubdtype(self.dtype, np.integer) or
+                    np.issubdtype(self.dtype, np.bool_))
 
         # output dtype
         if dtype is None:
@@ -1175,6 +1208,12 @@ class _spbase:
         # intermediate dtype for summation
         inter_dtype = np.float64 if integral else res_dtype
         inter_self = self.astype(inter_dtype)
+
+        if self.ndim == 1:
+            if axis not in (None, -1, 0):
+                raise ValueError("axis must be None, -1 or 0")
+            res = inter_self / np.array(self.shape[0])
+            return res.sum(dtype=res_dtype, out=out)
 
         if axis is None:
             return (inter_self / np.array(

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -73,6 +73,11 @@ class _spbase:
         return len(self._shape)
 
     @property
+    def _shape_as_2d(self):
+        s = self._shape
+        return (1, s[-1]) if len(s) == 1 else s
+
+    @property
     def _bsr_container(self):
         from ._bsr import bsr_array
         return bsr_array

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1043,7 +1043,7 @@ def block_diag(mats, format=None, dtype=None):
     c_idx = 0
     for a in mats:
         if isinstance(a, (list, numbers.Number)):
-            a = coo_array(a)
+            a = coo_array(np.atleast_2d(a))
         nrows, ncols = a.shape
         if issparse(a):
             a = a.tocoo()

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -129,21 +129,20 @@ class _coo_base(_data_matrix, _minmax_mixin):
             else:
                 return self
 
-        if self.ndim == 1:
-            new_indices = np.unravel_index(self.indices[0], shape, order=order)
-        else:
-            flat_indices = _ravel_indices(self.indices, self.shape, order=order)
-            if len(shape) == 1:
-                new_indices = (flat_indices,)
+        # When reducing the number of dimensions, we need to be careful about
+        # index overflow. This is why we can't simply call
+        # `np.ravel_multi_index()` followed by `np.unravel_index()` here.
+        flat_indices = _ravel_indices(self.indices, self.shape, order=order)
+        if len(shape) == 2:
+            if order == 'C':
+                new_indices = divmod(flat_indices, shape[1])
             else:
-                if order == 'C':
-                    new_indices = divmod(flat_indices, shape[1])
-                elif order == 'F':
-                    new_indices = divmod(flat_indices, shape[0])[::-1]
-                # else: already checked in _ravel_indices
+                new_indices = divmod(flat_indices, shape[0])[::-1]
+        else:
+            new_indices = np.unravel_index(flat_indices, shape, order=order)
 
         # Handle copy here rather than passing on to the constructor so that no
-        # copy will be made of new_row and new_col regardless
+        # copy will be made of `new_indices` regardless.
         if copy:
             new_data = self.data.copy()
         else:
@@ -578,6 +577,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
 def _ravel_indices(indices, shape, order='C'):
     """Like np.ravel_multi_index, but avoids some overflow issues."""
+    if len(indices) == 1:
+        return indices[0]
     # Handle overflow as in https://github.com/scipy/scipy/pull/9132
     if len(indices) == 2:
         nrows, ncols = shape
@@ -592,8 +593,6 @@ def _ravel_indices(indices, shape, order='C'):
             return np.multiply(nrows, col, dtype=idx_dtype) + row
         else:
             raise ValueError("'order' must be 'C' or 'F'")
-    if len(indices) == 1:
-        return indices[0]
     return np.ravel_multi_index(indices, shape, order=order)
 
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -99,17 +99,15 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     @property
     def row(self):
-        if self.ndim > 1:
-            return self.indices[0]
-        return np.zeros(self.nnz, dtype=self.indices[0].dtype)
+        return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
 
 
     @row.setter
     def row(self, new_row):
         if self.ndim < 2:
             raise ValueError('cannot set row attribute of a 1-dimensional sparse array')
-        new_row = np.asarray(new_row, dtype=self.indices[0].dtype)
-        self.indices = (new_row,) + self.indices[1:]
+        new_row = np.asarray(new_row, dtype=self.indices[-2].dtype)
+        self.indices = self.indices[:-2] + (new_row,) + self.indices[-1:]
 
     @property
     def col(self):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -24,73 +24,71 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
+        is_array = isinstance(self, sparray)
 
         if isinstance(arg1, tuple):
-            if isshape(arg1):
-                M, N = arg1
-                self._shape = check_shape((M, N))
-                idx_dtype = self._get_index_dtype(maxval=max(M, N))
+            if isshape(arg1, allow_ndim=is_array):
+                self._shape = check_shape(arg1, allow_ndim=is_array)
+                idx_dtype = self._get_index_dtype(maxval=max(self._shape))
                 data_dtype = getdtype(dtype, default=float)
-                self.row = np.array([], dtype=idx_dtype)
-                self.col = np.array([], dtype=idx_dtype)
+                self.indices = tuple(np.array([], dtype=idx_dtype)
+                                     for _ in range(len(self._shape)))
                 self.data = np.array([], dtype=data_dtype)
                 self.has_canonical_format = True
             else:
                 try:
-                    obj, (row, col) = arg1
+                    obj, indices = arg1
                 except (TypeError, ValueError) as e:
                     raise TypeError('invalid input format') from e
 
                 if shape is None:
-                    if len(row) == 0 or len(col) == 0:
+                    if any(len(idx) == 0 for idx in indices):
                         raise ValueError('cannot infer dimensions from zero '
                                          'sized index arrays')
-                    M = operator.index(np.max(row)) + 1
-                    N = operator.index(np.max(col)) + 1
-                    self._shape = check_shape((M, N))
-                else:
-                    # Use 2 steps to ensure shape has length 2.
-                    M, N = shape
-                    self._shape = check_shape((M, N))
+                    shape = tuple(operator.index(np.max(idx)) + 1
+                                  for idx in indices)
+                self._shape = check_shape(shape, allow_ndim=is_array)
 
-                idx_dtype = self._get_index_dtype((row, col),
+                idx_dtype = self._get_index_dtype(indices,
                                                   maxval=max(self.shape),
                                                   check_contents=True)
-                self.row = np.array(row, copy=copy, dtype=idx_dtype)
-                self.col = np.array(col, copy=copy, dtype=idx_dtype)
+                self.indices = tuple(np.array(idx, copy=copy, dtype=idx_dtype)
+                                     for idx in indices)
                 self.data = getdata(obj, copy=copy, dtype=dtype)
                 self.has_canonical_format = False
         else:
             if issparse(arg1):
                 if arg1.format == self.format and copy:
-                    self.row = arg1.row.copy()
-                    self.col = arg1.col.copy()
+                    self.indices = tuple(idx.copy() for idx in arg1.indices)
                     self.data = arg1.data.copy()
-                    self._shape = check_shape(arg1.shape)
+                    self._shape = check_shape(arg1.shape,
+                                              allow_ndim=is_array)
+                    self.has_canonical_format = arg1.has_canonical_format
                 else:
                     coo = arg1.tocoo()
-                    self.row = coo.row
-                    self.col = coo.col
+                    self.indices = tuple(coo.indices)
                     self.data = coo.data
-                    self._shape = check_shape(coo.shape)
-                self.has_canonical_format = False
+                    self._shape = check_shape(coo.shape,
+                                              allow_ndim=is_array)
+                    self.has_canonical_format = False
             else:
-                #dense argument
-                M = np.atleast_2d(np.asarray(arg1))
+                # dense argument
+                M = np.asarray(arg1)
+                if not is_array:
+                    M = np.atleast_2d(M)
+                    if M.ndim != 2:
+                        raise TypeError('expected dimension <= 2 array or matrix')
 
-                if M.ndim != 2:
-                    raise TypeError('expected dimension <= 2 array or matrix')
-
-                self._shape = check_shape(M.shape)
+                self._shape = check_shape(M.shape, allow_ndim=is_array)
                 if shape is not None:
-                    if check_shape(shape) != self._shape:
+                    if check_shape(shape, allow_ndim=is_array) != self._shape:
                         message = f'inconsistent shapes: {shape} != {self._shape}'
                         raise ValueError(message)
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
-                row, col = M.nonzero()
-                self.row = row.astype(index_dtype, copy=False)
-                self.col = col.astype(index_dtype, copy=False)
-                self.data = M[self.row, self.col]
+                indices = M.nonzero()
+                self.indices = tuple(idx.astype(index_dtype, copy=False)
+                                     for idx in indices)
+                self.data = M[indices]
                 self.has_canonical_format = True
 
         if dtype is not None:
@@ -98,8 +96,29 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         self._check()
 
+    @property
+    def row(self):
+        return self.indices[0]
+
+    @row.setter
+    def row(self, new_row):
+        new_row = np.asarray(new_row, dtype=self.indices[0].dtype)
+        self.indices = (new_row,) + self.indices[1:]
+
+    @property
+    def col(self):
+        return self.indices[1] if self.ndim > 1 else np.zeros_like(self.row)
+
+    @col.setter
+    def col(self, new_col):
+        if self.ndim < 2:
+            raise ValueError('cannot set col attribute of a 1-dimensional sparse array')
+        new_col = np.asarray(new_col, dtype=self.indices[1].dtype)
+        self.indices = self.indices[:1] + (new_col,) + self.indices[2:]
+
     def reshape(self, *args, **kwargs):
-        shape = check_shape(args, self.shape)
+        is_array = isinstance(self, sparray)
+        shape = check_shape(args, self.shape, allow_ndim=is_array)
         order, copy = check_reshape_kwargs(kwargs)
 
         # Return early if reshape is not required
@@ -109,25 +128,9 @@ class _coo_base(_data_matrix, _minmax_mixin):
             else:
                 return self
 
-        nrows, ncols = self.shape
-
-        if order == 'C':
-            # Upcast to avoid overflows: the coo_array constructor
-            # below will downcast the results to a smaller dtype, if
-            # possible.
-            maxval = (ncols * max(0, nrows - 1) + max(0, ncols - 1))
-            dtype = self._get_index_dtype(maxval=maxval)
-
-            flat_indices = np.multiply(ncols, self.row, dtype=dtype) + self.col
-            new_row, new_col = divmod(flat_indices, shape[1])
-        elif order == 'F':
-            maxval = (nrows * max(0, ncols - 1) + max(0, nrows - 1))
-            dtype = self._get_index_dtype(maxval=maxval)
-
-            flat_indices = np.multiply(nrows, self.col, dtype=dtype) + self.row
-            new_col, new_row = divmod(flat_indices, shape[0])
-        else:
-            raise ValueError("'order' must be 'C' or 'F'")
+        # TODO: Handle overflow as in https://github.com/scipy/scipy/pull/9132
+        flat_indices = np.ravel_multi_index(self.indices, self.shape, order=order)
+        new_indices = np.unravel_index(flat_indices, shape, order=order)
 
         # Handle copy here rather than passing on to the constructor so that no
         # copy will be made of new_row and new_col regardless
@@ -136,85 +139,110 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             new_data = self.data
 
-        return self.__class__((new_data, (new_row, new_col)),
-                              shape=shape, copy=False)
+        return self.__class__((new_data, new_indices), shape=shape, copy=False)
 
     reshape.__doc__ = _spbase.reshape.__doc__
 
     def _getnnz(self, axis=None):
-        if axis is None:
+        if axis is None or (axis == 0 and self.ndim == 1):
             nnz = len(self.data)
-            if nnz != len(self.row) or nnz != len(self.col):
-                raise ValueError('row, column, and data array must all be the '
+            if any(len(idx) != nnz for idx in self.indices):
+                raise ValueError('all index and data arrays must have the '
                                  'same length')
 
-            if self.data.ndim != 1 or self.row.ndim != 1 or \
-                    self.col.ndim != 1:
+            if self.data.ndim != 1 or any(idx.ndim != 1 for idx in self.indices):
                 raise ValueError('row, column, and data arrays must be 1-D')
 
             return int(nnz)
 
         if axis < 0:
-            axis += 2
-        if axis == 0:
-            return np.bincount(downcast_intp_index(self.col),
-                               minlength=self.shape[1])
-        elif axis == 1:
-            return np.bincount(downcast_intp_index(self.row),
-                               minlength=self.shape[0])
-        else:
+            axis += self.ndim
+        if axis >= self.ndim:
             raise ValueError('axis out of bounds')
+        if self.ndim > 2:
+            raise NotImplementedError('per-axis nnz for COO arrays with >2 '
+                                      'dimensions is not supported')
+        return np.bincount(downcast_intp_index(self.indices[1 - axis]),
+                           minlength=self.shape[1 - axis])
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
     def _check(self):
         """ Checks data structure for consistency """
+        if self.ndim != len(self.indices):
+            raise ValueError('mismatching number of index arrays for shape; '
+                             f'got {len(self.indices)}, expected {self.ndim}')
 
         # index arrays should have integer data types
-        if self.row.dtype.kind != 'i':
-            warn(f"row index array has non-integer dtype ({self.row.dtype.name})",
-                 stacklevel=3)
-        if self.col.dtype.kind != 'i':
-            warn(f"col index array has non-integer dtype ({self.col.dtype.name})",
-                 stacklevel=3)
+        for i, idx in enumerate(self.indices):
+            if idx.dtype.kind != 'i':
+                warn(f'index array {i} has non-integer dtype ({idx.dtype.name}) ')
 
-        idx_dtype = self._get_index_dtype((self.row, self.col), maxval=max(self.shape))
-        self.row = np.asarray(self.row, dtype=idx_dtype)
-        self.col = np.asarray(self.col, dtype=idx_dtype)
+        idx_dtype = self._get_index_dtype(self.indices, maxval=max(self.shape))
+        self.indices = tuple(np.asarray(idx, dtype=idx_dtype)
+                             for idx in self.indices)
         self.data = to_native(self.data)
 
         if self.nnz > 0:
-            if self.row.max() >= self.shape[0]:
-                raise ValueError('row index exceeds matrix dimensions')
-            if self.col.max() >= self.shape[1]:
-                raise ValueError('column index exceeds matrix dimensions')
-            if self.row.min() < 0:
-                raise ValueError('negative row index found')
-            if self.col.min() < 0:
-                raise ValueError('negative column index found')
+            for i, idx in enumerate(self.indices):
+                if idx.max() >= self.shape[i]:
+                    raise ValueError(f'axis {i} index {idx.max()} exceeds '
+                                     f'matrix dimension {self.shape[i]}')
+                if idx.min() < 0:
+                    raise ValueError(f'negative axis {i} index: {idx.min()}')
 
     def transpose(self, axes=None, copy=False):
-        if axes is not None and axes != (1, 0):
-            raise ValueError("Sparse array/matrices do not support "
-                              "an 'axes' parameter because swapping "
-                              "dimensions is the only logical permutation.")
+        if axes is None:
+            axes = range(self.ndim)[::-1]
+        elif isinstance(self, sparray):
+            if len(axes) != self.ndim:
+                raise ValueError("axes don't match matrix dimensions")
+            if len(set(axes)) != self.ndim:
+                raise ValueError("repeated axis in transpose")
+        elif axes != (1, 0):
+            raise ValueError("Sparse matrices do not support an 'axes' "
+                             "parameter because swapping dimensions is the "
+                             "only logical permutation.")
 
-        M, N = self.shape
-        return self.__class__((self.data, (self.col, self.row)),
-                              shape=(N, M), copy=copy)
+        permuted_shape = tuple(self._shape[i] for i in axes)
+        permuted_indices = tuple(self.indices[i] for i in axes)
+        return self.__class__((self.data, permuted_indices),
+                              shape=permuted_shape, copy=copy)
 
     transpose.__doc__ = _spbase.transpose.__doc__
 
-    def resize(self, *shape):
-        shape = check_shape(shape)
-        new_M, new_N = shape
-        M, N = self.shape
+    def resize(self, *shape) -> None:
+        is_array = isinstance(self, sparray)
+        shape = check_shape(shape, allow_ndim=is_array)
 
-        if new_M < M or new_N < N:
-            mask = np.logical_and(self.row < new_M, self.col < new_N)
+        # Check for added dimensions.
+        if len(shape) > self.ndim:
+            flat_indices = np.ravel_multi_index(self.indices, self.shape)
+            max_size = np.prod(shape)
+            self.indices = np.unravel_index(flat_indices[:max_size], shape)
+            self.data = self.data[:max_size]
+            self._shape = shape
+            return
+
+        # Check for removed dimensions.
+        if len(shape) < self.ndim:
+            tmp_shape = (
+                self._shape[:len(shape) - 1]  # Original shape without last axis
+                + (-1,)  # Last axis is used to flatten the array
+                + (1,) * (self.ndim - len(shape))  # Pad with ones
+            )
+            tmp = self.reshape(tmp_shape)
+            self.indices = tmp.indices[:len(shape)]
+            self._shape = tmp.shape[:len(shape)]
+
+        # Handle truncation of existing dimensions.
+        is_truncating = any(old > new for old, new in zip(self.shape, shape))
+        if is_truncating:
+            mask = np.logical_and.reduce([
+                idx < size for idx, size in zip(self.indices, shape)
+            ])
             if not mask.all():
-                self.row = self.row[mask]
-                self.col = self.col[mask]
+                self.indices = tuple(idx[mask] for idx in self.indices)
                 self.data = self.data[mask]
 
         self._shape = shape
@@ -226,10 +254,17 @@ class _coo_base(_data_matrix, _minmax_mixin):
         fortran = int(B.flags.f_contiguous)
         if not fortran and not B.flags.c_contiguous:
             raise ValueError("Output array must be C or F contiguous")
-        M,N = self.shape
+        if self.ndim > 2:
+            raise ValueError("Cannot densify higher-rank sparse array")
+        # This handles both 0D and 1D cases correctly regardless of the
+        # original shape.
+        M, N, *_ = self.shape + (1, 1)
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     B.ravel('A'), fortran)
-        return B
+        # Note: reshape() doesn't copy here, but does return a new array (view).
+        return B.reshape(self.shape)
+
+    toarray.__doc__ = _spbase.toarray.__doc__
 
     toarray.__doc__ = _spbase.toarray.__doc__
 
@@ -253,6 +288,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
                [0, 0, 0, 1]])
 
         """
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to csc format")
         if self.nnz == 0:
             return self._csc_container(self.shape, dtype=self.dtype)
         else:
@@ -295,6 +332,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
                [0, 0, 0, 1]])
 
         """
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to csr format")
         if self.nnz == 0:
             return self._csr_container(self.shape, dtype=self.dtype)
         else:
@@ -326,6 +365,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     tocoo.__doc__ = _spbase.tocoo.__doc__
 
     def todia(self, copy=False):
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to dia format")
         self.sum_duplicates()
         ks = self.col - self.row  # the diagonal for each nonzero
         diags, diag_idx = np.unique(ks, return_inverse=True)
@@ -348,6 +389,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     todia.__doc__ = _spbase.todia.__doc__
 
     def todok(self, copy=False):
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to dok format")
         self.sum_duplicates()
         dok = self._dok_container((self.shape), dtype=self.dtype)
         dok._update(zip(zip(self.row,self.col),self.data))
@@ -357,6 +400,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     todok.__doc__ = _spbase.todok.__doc__
 
     def diagonal(self, k=0):
+        if self.ndim != 2:
+            raise ValueError("diagonal requires two dimensions")
         rows, cols = self.shape
         if k <= -rows or k >= cols:
             return np.empty(0, dtype=self.data.dtype)
@@ -368,9 +413,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
             row = self.row[diag_mask]
             data = self.data[diag_mask]
         else:
-            row, _, data = self._sum_duplicates(self.row[diag_mask],
-                                                self.col[diag_mask],
-                                                self.data[diag_mask])
+            inds = tuple(idx[diag_mask] for idx in self.indices)
+            (row, _), data = self._sum_duplicates(inds, self.data[diag_mask])
         diag[row + min(k, 0)] = data
 
         return diag
@@ -378,6 +422,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     diagonal.__doc__ = _data_matrix.diagonal.__doc__
 
     def _setdiag(self, values, k):
+        if self.ndim != 2:
+            raise ValueError("setting a diagonal requires two dimensions")
         M, N = self.shape
         if values.ndim and not len(values):
             return
@@ -408,54 +454,51 @@ class _coo_base(_data_matrix, _minmax_mixin):
             new_data[:] = values
 
         # Update the internal structure.
-        self.row = np.concatenate((self.row[keep], new_row))
-        self.col = np.concatenate((self.col[keep], new_col))
+        self.indices = (np.concatenate((self.row[keep], new_row)),
+                        np.concatenate((self.col[keep], new_col)))
         self.data = np.concatenate((self.data[keep], new_data))
         self.has_canonical_format = False
 
     # needed by _data_matrix
-    def _with_data(self,data,copy=True):
+    def _with_data(self, data, copy=True):
         """Returns a matrix with the same sparsity structure as self,
-        but with different data.  By default the index arrays
-        (i.e. .row and .col) are copied.
+        but with different data. By default the index arrays are copied.
         """
         if copy:
-            return self.__class__((data, (self.row.copy(), self.col.copy())),
-                                   shape=self.shape, dtype=data.dtype)
+            indices = tuple(idx.copy() for idx in self.indices)
         else:
-            return self.__class__((data, (self.row, self.col)),
-                                   shape=self.shape, dtype=data.dtype)
+            indices = self.indices
+        return self.__class__((data, indices), shape=self.shape, dtype=data.dtype)
 
-    def sum_duplicates(self):
+    def sum_duplicates(self) -> None:
         """Eliminate duplicate entries by adding them together
 
         This is an *in place* operation
         """
         if self.has_canonical_format:
             return
-        summed = self._sum_duplicates(self.row, self.col, self.data)
-        self.row, self.col, self.data = summed
+        summed = self._sum_duplicates(self.indices, self.data)
+        self.indices, self.data = summed
         self.has_canonical_format = True
 
-    def _sum_duplicates(self, row, col, data):
-        # Assumes (data, row, col) not in canonical format.
+    def _sum_duplicates(self, indices, data):
+        # Assumes indices not in canonical format.
         if len(data) == 0:
-            return row, col, data
+            return indices, data
         # Sort indices w.r.t. rows, then cols. This corresponds to C-order,
         # which we rely on for argmin/argmax to return the first index in the
         # same way that numpy does (in the case of ties).
-        order = np.lexsort((col, row))
-        row = row[order]
-        col = col[order]
+        order = np.lexsort(indices[::-1])
+        indices = tuple(idx[order] for idx in indices)
         data = data[order]
-        unique_mask = ((row[1:] != row[:-1]) |
-                       (col[1:] != col[:-1]))
+        unique_mask = np.logical_or.reduce([
+            idx[1:] != idx[:-1] for idx in indices
+        ])
         unique_mask = np.append(True, unique_mask)
-        row = row[unique_mask]
-        col = col[unique_mask]
+        indices = tuple(idx[unique_mask] for idx in indices)
         unique_inds, = np.nonzero(unique_mask)
         data = np.add.reduceat(data, unique_inds, dtype=self.dtype)
-        return row, col, data
+        return indices, data
 
     def eliminate_zeros(self):
         """Remove zero entries from the array/matrix
@@ -464,8 +507,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         """
         mask = self.data != 0
         self.data = self.data[mask]
-        self.row = self.row[mask]
-        self.col = self.col[mask]
+        self.indices = tuple(idx[mask] for idx in self.indices)
 
     #######################
     # Arithmetic handlers #
@@ -477,23 +519,50 @@ class _coo_base(_data_matrix, _minmax_mixin):
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)
-        M, N = self.shape
+        M = self.shape[0]
+        N = self.shape[1] if self.ndim > 1 else 1
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)
 
     def _mul_vector(self, other):
-        #output array
-        result = np.zeros(self.shape[0], dtype=upcast_char(self.dtype.char,
-                                                            other.dtype.char))
-        coo_matvec(self.nnz, self.row, self.col, self.data, other, result)
+        result_shape = self.shape[0] if self.ndim > 1 else 1
+        result = np.zeros(result_shape,
+                          dtype=upcast_char(self.dtype.char, other.dtype.char))
+
+        if self.ndim == 2:
+            col = self.col
+            row = self.row
+        elif self.ndim == 1:
+            col = self.indices[0]
+            row = np.zeros_like(col)
+        else:
+            raise NotImplementedError(
+                f"coo_matvec not implemented for ndim={self.ndim}")
+
+        coo_matvec(self.nnz, row, col, self.data, other, result)
+        # Array semantics return a scalar here, not a single-element array.
+        if isinstance(self, sparray) and result_shape == 1:
+            return result[0]
         return result
 
     def _mul_multivector(self, other):
-        result = np.zeros((other.shape[1], self.shape[0]),
-                          dtype=upcast_char(self.dtype.char, other.dtype.char))
-        for i, col in enumerate(other.T):
-            coo_matvec(self.nnz, self.row, self.col, self.data, col, result[i])
+        result_dtype = upcast_char(self.dtype.char, other.dtype.char)
+        if self.ndim == 2:
+            result_shape = (other.shape[1], self.shape[0])
+            col = self.col
+            row = self.row
+        elif self.ndim == 1:
+            result_shape = (other.shape[1],)
+            col = self.indices[0]
+            row = np.zeros_like(col)
+        else:
+            raise NotImplementedError(
+                f"coo_matvec not implemented for ndim={self.ndim}")
+
+        result = np.zeros(result_shape, dtype=result_dtype)
+        for i, other_col in enumerate(other.T):
+            coo_matvec(self.nnz, row, col, self.data, other_col, result[i:i + 1])
         return result.T.view(type=type(other))
 
 
@@ -532,40 +601,37 @@ class coo_array(_coo_base, sparray):
 
     This can be instantiated in several ways:
         coo_array(D)
-            where D is a 2-D ndarray
+            where D is an ndarray
 
         coo_array(S)
             with another sparse array or matrix S (equivalent to S.tocoo())
 
-        coo_array((M, N), [dtype])
-            to construct an empty array with shape (M, N)
+        coo_array(shape, [dtype])
+            to construct an empty sparse array with shape `shape`
             dtype is optional, defaulting to dtype='d'.
 
-        coo_array((data, (i, j)), [shape=(M, N)])
-            to construct from three arrays:
-                1. data[:]   the entries of the array, in any order
-                2. i[:]      the row indices of the array entries
-                3. j[:]      the column indices of the array entries
+        coo_array((data, indices), [shape])
+            to construct from existing data and index arrays:
+                1. data[:]       the entries of the sparse array, in any order
+                2. indices[i][:] the axis-i indices of the data entries
 
-            Where ``A[i[k], j[k]] = data[k]``.  When shape is not
-            specified, it is inferred from the index arrays
+            Where ``A[indices] = data``, and indices is a tuple of index arrays.
+            When shape is not specified, it is inferred from the index arrays.
 
     Attributes
     ----------
     dtype : dtype
-        Data type of the array
-    shape : 2-tuple
-        Shape of the array
+        Data type of the sparse array
+    shape : tuple of integers
+        Shape of the sparse array
     ndim : int
-        Number of dimensions (this is always 2)
+        Number of dimensions of the sparse array
     nnz
     size
     data
-        COO format data array of the array
-    row
-        COO format row index array of the array
-    col
-        COO format column index array of the array
+        COO format data array of the sparse array
+    indices
+        COO format tuple of index arrays
     has_canonical_format : bool
         Whether the matrix has sorted indices and no duplicates
     format
@@ -603,7 +669,7 @@ class coo_array(_coo_base, sparray):
     Examples
     --------
 
-    >>> # Constructing an empty array
+    >>> # Constructing an empty sparse array
     >>> import numpy as np
     >>> from scipy.sparse import coo_array
     >>> coo_array((3, 4), dtype=np.int8).toarray()
@@ -611,7 +677,7 @@ class coo_array(_coo_base, sparray):
            [0, 0, 0, 0],
            [0, 0, 0, 0]], dtype=int8)
 
-    >>> # Constructing an array using ijv format
+    >>> # Constructing a sparse array using ijv format
     >>> row  = np.array([0, 3, 1, 0])
     >>> col  = np.array([0, 3, 1, 2])
     >>> data = np.array([4, 5, 7, 9])
@@ -621,7 +687,7 @@ class coo_array(_coo_base, sparray):
            [0, 0, 0, 0],
            [0, 0, 0, 5]])
 
-    >>> # Constructing an array with duplicate indices
+    >>> # Constructing a sparse array with duplicate indices
     >>> row  = np.array([0, 0, 1, 3, 1, 0, 0])
     >>> col  = np.array([0, 2, 1, 3, 1, 0, 0])
     >>> data = np.array([1, 1, 1, 1, 1, 1, 1])
@@ -751,3 +817,9 @@ class coo_matrix(spmatrix, _coo_base):
 
     """
 
+    def __setstate__(self, state):
+        if 'indices' not in state:
+            # For retro-compatibility with the previous attributes
+            # storing nnz coordinates for 2D COO matrix.
+            state['indices'] = (state.pop('row'), state.pop('col'))
+        self.__dict__.update(state)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -74,22 +74,22 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     self.has_canonical_format = False
             else:
                 # dense argument
-                A = np.asarray(arg1)
+                M = np.asarray(arg1)
                 if not is_array:
-                    A = np.atleast_2d(A)
-                    if A.ndim != 2:
+                    M = np.atleast_2d(M)
+                    if M.ndim != 2:
                         raise TypeError('expected dimension <= 2 array or matrix')
 
-                self._shape = check_shape(A.shape, allow_ndim=is_array)
+                self._shape = check_shape(M.shape, allow_ndim=is_array)
                 if shape is not None:
                     if check_shape(shape, allow_ndim=is_array) != self._shape:
                         message = f'inconsistent shapes: {shape} != {self._shape}'
                         raise ValueError(message)
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
-                indices = A.nonzero()
+                indices = M.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
                                      for idx in indices)
-                self.data = A[indices]
+                self.data = M[indices]
                 self.has_canonical_format = True
 
         if dtype is not None:
@@ -303,7 +303,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             M,N = self.shape
             idx_dtype = self._get_index_dtype(
-                (self.col, self.row), maxval=max(self.nnz, *self.shape)
+                (self.col, self.row), maxval=max(self.nnz, M)
             )
             row = self.row.astype(idx_dtype, copy=False)
             col = self.col.astype(idx_dtype, copy=False)
@@ -347,7 +347,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             M,N = self.shape
             idx_dtype = self._get_index_dtype(
-                (self.row, self.col), maxval=max(self.nnz, *self.shape)
+                (self.row, self.col), maxval=max(self.nnz, N)
             )
             row = self.row.astype(idx_dtype, copy=False)
             col = self.col.astype(idx_dtype, copy=False)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -98,7 +98,6 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def row(self):
         return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
 
-
     @row.setter
     def row(self, new_row):
         if self.ndim < 2:
@@ -394,12 +393,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
     todia.__doc__ = _spbase.todia.__doc__
 
     def todok(self, copy=False):
-        if self.ndim != 2:
-            raise ValueError("Cannot convert a 1d sparse array to dok format")
         self.sum_duplicates()
-        dok = self._dok_container((self.shape), dtype=self.dtype)
-        dok._update(zip(zip(self.row,self.col),self.data))
-
+        dok = self._dok_container(self.shape, dtype=self.dtype)
+        # ensure that 1d indices are not tuples
+        if self.ndim == 1:
+            indices = self.indices[0]
+        else:
+            indices = zip(*self.indices)
+        dok._update(zip(indices, self.data))
         return dok
 
     todok.__doc__ = _spbase.todok.__doc__

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -28,8 +28,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
         is_array = isinstance(self, sparray)
 
         if isinstance(arg1, tuple):
-            if isshape(arg1, allow_ndim=is_array):
-                self._shape = check_shape(arg1, allow_ndim=is_array)
+            if isshape(arg1, allow_1d=is_array):
+                self._shape = check_shape(arg1, allow_1d=is_array)
                 idx_dtype = self._get_index_dtype(maxval=max(self._shape))
                 data_dtype = getdtype(dtype, default=float)
                 self.indices = tuple(np.array([], dtype=idx_dtype)
@@ -48,7 +48,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                                          'sized index arrays')
                     shape = tuple(operator.index(np.max(idx)) + 1
                                   for idx in indices)
-                self._shape = check_shape(shape, allow_ndim=is_array)
+                self._shape = check_shape(shape, allow_1d=is_array)
 
                 idx_dtype = self._get_index_dtype(indices,
                                                   maxval=max(self.shape),
@@ -62,15 +62,13 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 if arg1.format == self.format and copy:
                     self.indices = tuple(idx.copy() for idx in arg1.indices)
                     self.data = arg1.data.copy()
-                    self._shape = check_shape(arg1.shape,
-                                              allow_ndim=is_array)
+                    self._shape = check_shape(arg1.shape, allow_1d=is_array)
                     self.has_canonical_format = arg1.has_canonical_format
                 else:
                     coo = arg1.tocoo()
                     self.indices = tuple(coo.indices)
                     self.data = coo.data
-                    self._shape = check_shape(coo.shape,
-                                              allow_ndim=is_array)
+                    self._shape = check_shape(coo.shape, allow_1d=is_array)
                     self.has_canonical_format = False
             else:
                 # dense argument
@@ -80,11 +78,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     if M.ndim != 2:
                         raise TypeError('expected dimension <= 2 array or matrix')
 
-                self._shape = check_shape(M.shape, allow_ndim=is_array)
+                self._shape = check_shape(M.shape, allow_1d=is_array)
                 if shape is not None:
-                    if check_shape(shape, allow_ndim=is_array) != self._shape:
-                        message = f'inconsistent shapes: {shape} != {self._shape}'
-                        raise ValueError(message)
+                    if check_shape(shape, allow_1d=is_array) != self._shape:
+                        raise ValueError(f'inconsistent shapes: {shape} != {self._shape}')
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
                 indices = M.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
@@ -120,7 +117,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     def reshape(self, *args, **kwargs):
         is_array = isinstance(self, sparray)
-        shape = check_shape(args, self.shape, allow_ndim=is_array)
+        shape = check_shape(args, self.shape, allow_1d=is_array)
         order, copy = check_reshape_kwargs(kwargs)
 
         # Return early if reshape is not required
@@ -223,7 +220,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     def resize(self, *shape) -> None:
         is_array = isinstance(self, sparray)
-        shape = check_shape(shape, allow_ndim=is_array)
+        shape = check_shape(shape, allow_1d=is_array)
 
         # Check for added dimensions.
         if len(shape) > self.ndim:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -74,22 +74,22 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     self.has_canonical_format = False
             else:
                 # dense argument
-                M = np.asarray(arg1)
+                A = np.asarray(arg1)
                 if not is_array:
-                    M = np.atleast_2d(M)
-                    if M.ndim != 2:
+                    A = np.atleast_2d(A)
+                    if A.ndim != 2:
                         raise TypeError('expected dimension <= 2 array or matrix')
 
-                self._shape = check_shape(M.shape, allow_ndim=is_array)
+                self._shape = check_shape(A.shape, allow_ndim=is_array)
                 if shape is not None:
                     if check_shape(shape, allow_ndim=is_array) != self._shape:
                         message = f'inconsistent shapes: {shape} != {self._shape}'
                         raise ValueError(message)
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
-                indices = M.nonzero()
+                indices = A.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
                                      for idx in indices)
-                self.data = M[indices]
+                self.data = A[indices]
                 self.has_canonical_format = True
 
         if dtype is not None:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -81,7 +81,9 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 self._shape = check_shape(M.shape, allow_1d=is_array)
                 if shape is not None:
                     if check_shape(shape, allow_1d=is_array) != self._shape:
-                        raise ValueError(f'inconsistent shapes: {shape} != {self._shape}')
+                        raise ValueError(
+                            f'inconsistent shapes: {shape} != {self._shape}'
+                        )
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
                 indices = M.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
@@ -182,7 +184,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
         # index arrays should have integer data types
         for i, idx in enumerate(self.indices):
             if idx.dtype.kind != 'i':
-                warn(f'index array {i} has non-integer dtype ({idx.dtype.name}) ')
+                warn(f'index array {i} has non-integer dtype ({idx.dtype.name})',
+                     stacklevel=2)
 
         idx_dtype = self._get_index_dtype(self.indices, maxval=max(self.shape))
         self.indices = tuple(np.asarray(idx, dtype=idx_dtype)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -268,7 +268,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             raise ValueError("Cannot densify higher-rank sparse array")
         # This handles both 0D and 1D cases correctly regardless of the
         # original shape.
-        *_, M, N = (1, 1) + self.shape
+        M, N = self._shape_as_2d
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     B.ravel('A'), fortran)
         # Note: reshape() doesn't copy here, but does return a new array (view).
@@ -527,8 +527,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)
-        M = self.shape[0] if self.ndim > 1 else 1
-        N = self.shape[-1]
+        M, N = self._shape_as_2d
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -162,7 +162,8 @@ class _dok_base(_spbase, IndexMixin):
             else:
                 new_idx = np.unravel_index(np.arange(len(dok_vals)), idx.shape)
                 new_idx = new_idx[0] if len(new_idx) == 1 else zip(*new_idx)
-                for i, v in zip(new_idx, dok_vals, strict=True):
+                # zip could use 'strict=True' With Python 3.10+
+                for i, v in zip(new_idx, dok_vals):  # , strict=True):
                     if v:
                         new_dok._dict[i] = v
         return new_dok

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -19,23 +19,25 @@ class _dok_base(_spbase, IndexMixin):
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _spbase.__init__(self)
-        self._dict = {}
+        self._dict = sd = {}
 
         self.dtype = getdtype(dtype, default=float)
-        if isinstance(arg1, tuple) and isshape(arg1):  # (M,N)
-            M, N = arg1
-            self._shape = check_shape((M, N))
+        is_array = isinstance(self, sparray)
+        if isinstance(arg1, tuple):
+            if isshape(arg1, allow_1d=is_array):
+                self._shape = check_shape(arg1, allow_1d=is_array)
         elif issparse(arg1):  # Sparse ctor
-            if arg1.format == self.format and copy:
-                arg1 = arg1.copy()
+            if arg1.format == self.format:
+                if copy:
+                    arg1 = arg1.copy()
             else:
                 arg1 = arg1.todok()
 
             if dtype is not None:
                 arg1 = arg1.astype(dtype, copy=False)
 
-            self._dict.update(arg1)
-            self._shape = check_shape(arg1.shape)
+            sd.update(arg1._dict)
+            self._shape = check_shape(arg1.shape, allow_1d=is_array)
             self.dtype = arg1.dtype
         else:  # Dense ctor
             try:
@@ -43,13 +45,19 @@ class _dok_base(_spbase, IndexMixin):
             except Exception as e:
                 raise TypeError('Invalid input format.') from e
 
-            if len(arg1.shape) != 2:
+            if arg1.ndim > 2:
                 raise TypeError('Expected rank <=2 dense array or matrix.')
 
-            d = self._coo_container(arg1, dtype=dtype).todok()
-            self._dict.update(d)
-            self._shape = check_shape(arg1.shape)
-            self.dtype = d.dtype
+            if arg1.ndim == 1:
+                if dtype is not None:
+                    arg1 = arg1.astype(dtype)
+                sd.update((i, v) for i, v in enumerate(arg1.ravel()) if v != 0)
+                self.dtype = arg1.dtype
+            else:
+                d = self._coo_container(arg1, dtype=dtype).todok()
+                sd.update(d._dict.items())
+                self.dtype = d.dtype
+            self._shape = check_shape(arg1.shape, allow_1d=is_array)
 
     def update(self, val):
         # Prevent direct usage of update
@@ -59,7 +67,8 @@ class _dok_base(_spbase, IndexMixin):
     def _update(self, data):
         """An update method for dict data defined for direct access to
         `dok_array` data. Main purpose is to be used for efficient conversion
-        from other _spbase classes. Has no checking if `data` is valid."""
+        from other _spbase classes. Has no checking if `data` is valid.
+        Be acreful to use int for 1d-array and tuple for 2d."""
         return self._dict.update(data)
 
     def _getnnz(self, axis=None):
@@ -69,7 +78,7 @@ class _dok_base(_spbase, IndexMixin):
         return len(self._dict)
 
     def count_nonzero(self):
-        return sum(x != 0 for x in self.values())
+        return sum(x != 0 for x in self._dict.values())
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
     count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
@@ -102,18 +111,52 @@ class _dok_base(_spbase, IndexMixin):
         return self._dict.values()
 
     def get(self, key, default=0.):
-        """This overrides the dict.get method, providing type checking
-        but otherwise equivalent functionality.
-        """
+        """This provides dict.get method functionality with type checking"""
+        if key in self._dict:
+            return self._dict.get(key, default)
+        if isintlike(key) and self.ndim == 1:
+            key = (key,)
+        if self.ndim != len(key):
+            raise IndexError(f'Index {key} length needs to match self.shape')
         try:
-            i, j = key
-            assert isintlike(i) and isintlike(j)
+            for i in key:
+                assert isintlike(i)
         except (AssertionError, TypeError, ValueError) as e:
-            raise IndexError('Index must be a pair of integers.') from e
-        if (i < 0 or i >= self.shape[0] or j < 0 or j >= self.shape[1]):
+            raise IndexError('Index must be or consist of integers.') from e
+        key = tuple(i + M if i < 0 else i for i, M in zip(key, self.shape))
+        if any(i < 0 or i >= M for i, M in zip(key, self.shape)):
             raise IndexError('Index out of bounds.')
         return self._dict.get(key, default)
 
+    # 1D get methods
+    def _get_int(self, idx):
+        return self._dict.get(idx, self.dtype.type(0))
+
+    def _get_slice(self, idx):
+        i_range = range(*idx.indices(self.shape[0]))
+        return self._get_array(list(i_range))
+
+    def _get_array(self, idx):
+        idx = np.asarray(idx)
+        if len(idx.shape) == 0:
+            val = self._dict.get(int(idx), self.dtype.type(0))
+            return np.array(val, stype=self.dtype)
+        new_dok = self._dok_container(idx.shape, dtype=self.dtype)
+        dok_vals = [self._dict.get(i, 0) for i in idx.ravel()]
+        if dok_vals:
+            if len(idx.shape) == 1:
+                for i, v in enumerate(dok_vals):
+                    if v:
+                        new_dok._dict[i] = v
+            else:
+                new_idx = np.unravel_index(np.arange(len(dok_vals)), idx.shape)
+                new_idx = new_idx[0] if len(new_idx) == 1 else zip(*new_idx)
+                for i, v in zip(new_idx, dok_vals, strict=True):
+                    if v:
+                        new_dok._dict[i] = v
+        return new_dok
+
+    # 2D get methods
     def _get_intXint(self, row, col):
         return self._dict.get((row, col), self.dtype.type(0))
 
@@ -184,6 +227,37 @@ class _dok_base(_spbase, IndexMixin):
                 newdok._dict[key] = v
         return newdok
 
+    # 1D set methods
+    def _set_int(self, idx, x):
+        if x:
+            self._dict[idx] = x
+        elif idx in self._dict:
+            del self._dict[idx]
+
+    def _set_slice(self, idx, x):
+        i_range = range(*idx.indices(self.shape[0]))
+        x = x.ravel()
+        for i, v in zip(i_range, x):
+            if v:
+                self._dict[i] = v
+            elif i in self._dict:
+                del self._dict[i]
+
+    def _set_array(self, idx, x):
+        idx_set = idx.ravel()
+        x_set = x.ravel()
+        if len(idx_set) != len(x_set):
+            if len(x_set) == 1:
+                x_set = np.array([x_set[0]] * len(idx_set), dtype=self.dtype)
+            else:
+                raise ValueError("Need len(index)==len(data) or len(data)==1")
+        for i, v in zip(idx_set, x_set):
+            if v:
+                self._dict[i] = v
+            elif i in self._dict:
+                del self._dict[i]
+
+    # 2D set methods
     def _set_intXint(self, row, col, x):
         key = (row, col)
         if x:
@@ -208,26 +282,35 @@ class _dok_base(_spbase, IndexMixin):
             res_dtype = upcast_scalar(self.dtype, other)
             new = self._dok_container(self.shape, dtype=res_dtype)
             # Add this scalar to every element.
-            M, N = self.shape
-            for key in itertools.product(range(M), range(N)):
+            if self.ndim == 1:
+                keys = range(self.shape[0])
+            else:
+                keys = itertools.product(*map(range, self.shape))
+            for key in keys:
                 aij = self._dict.get(key, 0) + other
                 if aij:
                     new[key] = aij
-            # new.dtype.char = self.dtype.char
         elif issparse(other):
+            if other.shape != self.shape:
+                raise ValueError("Matrix dimensions are not equal.")
+            res_dtype = upcast(self.dtype, other.dtype)
+            new = self._dok_container(self.shape, dtype=res_dtype)
+            new._dict.update(self._dict)
             if other.format == "dok":
-                if other.shape != self.shape:
-                    raise ValueError("Matrix dimensions are not equal.")
-                # We could alternatively set the dimensions to the largest of
-                # the two matrices to be summed.  Would this be a good idea?
-                res_dtype = upcast(self.dtype, other.dtype)
-                new = self._dok_container(self.shape, dtype=res_dtype)
-                new._dict.update(self._dict)
                 with np.errstate(over='ignore'):
-                    new._dict.update((k, new[k] + other[k]) for k in other.keys())
+                    new._dict.update(
+                        (k, new[k] + o_value) for k, o_value in other.items()
+                    )
             else:
-                csc = self.tocsc()
-                new = csc + other
+                o_coo = other.tocoo()
+                if other.ndim == 1:
+                    o_coo_data = zip(o_coo.indices[0], o_coo.data)
+                else:
+                    o_coo_data = zip(zip(*o_coo.indices), o_coo.data)
+                with np.errstate(over='ignore'):
+                    new._dict.update(
+                        (k, new[k] + o_value) for k, o_value in o_coo_data
+                    )
         elif isdense(other):
             new = self.todense() + other
         else:
@@ -235,35 +318,14 @@ class _dok_base(_spbase, IndexMixin):
         return new
 
     def __radd__(self, other):
-        if isscalarlike(other):
-            new = self._dok_container(self.shape, dtype=self.dtype)
-            M, N = self.shape
-            for key in itertools.product(range(M), range(N)):
-                aij = self._dict.get(key, 0) + other
-                if aij:
-                    new[key] = aij
-        elif issparse(other):
-            if other.format == "dok":
-                if other.shape != self.shape:
-                    raise ValueError("Matrix dimensions are not equal.")
-                new = self._dok_container(self.shape, dtype=self.dtype)
-                new._dict.update(self._dict)
-                new._dict.update((k, self[k] + other[k]) for k in other)
-            else:
-                csc = self.tocsc()
-                new = csc + other
-        elif isdense(other):
-            new = other + self.todense()
-        else:
-            return NotImplemented
-        return new
+        return self + other  # addition is commutative
 
     def __neg__(self):
         if self.dtype.kind == 'b':
             raise NotImplementedError('Negating a sparse boolean matrix is not'
                                       ' supported.')
         new = self._dok_container(self.shape, dtype=self.dtype)
-        new._dict.update((k, -self[k]) for k in self.keys())
+        new._dict.update((k, -v) for k, v in self.items())
         return new
 
     def _mul_scalar(self, other):
@@ -274,19 +336,53 @@ class _dok_base(_spbase, IndexMixin):
         return new
 
     def _mul_vector(self, other):
+        sd = self._dict
+        res_dtype = upcast(self.dtype, other.dtype)
+        # vector * vector
+        if self.ndim == 1:
+            if issparse(other):
+                if other.format == "dok":
+                    shared_keys = sd.keys() & other._dict.keys()
+                else:
+                    o_coo = other.tocoo()
+                    shared_keys = sd.keys() & o_coo.indices[0]
+                return np.array([sd[k] * other._dict[k] for k in shared_keys]).sum(dtype=res_dtype)
+            elif isdense(other):
+                return np.array([other[k] * v for k, v in sd.items()]).sum(dtype=res_dtype)
+
         # matrix * vector
-        result = np.zeros(self.shape[0], dtype=upcast(self.dtype, other.dtype))
-        for (i, j), v in self.items():
+        result = np.zeros(self.shape[0], dtype=res_dtype)
+        for (i, j), v in sd.items():
             result[i] += v * other[j]
         return result
 
     def _mul_multivector(self, other):
-        # matrix * multivector
-        result_shape = (self.shape[0], other.shape[1])
         result_dtype = upcast(self.dtype, other.dtype)
-        result = np.zeros(result_shape, dtype=result_dtype)
-        for (i, j), v in self.items():
-            result[i,:] += v * other[j,:]
+        # vector * multivector
+        if self.ndim == 1:
+            if other.ndim == 1:
+                result_shape = ()
+                result = np.zeros(result_shape, dtype=result_dtype)
+                for j, v in self._dict.items():
+                    result += v * other[j]
+            else:
+                result_shape = (other.shape[1],)
+                result = np.zeros(result_shape, dtype=result_dtype)
+                for j, v in self._dict.items():
+                    result[:] += v * other[j,:]
+            return result
+
+        # matrix * multivector
+        if other.ndim == 1:
+            result_shape = (self.shape[0],)
+            result = np.zeros(result_shape, dtype=result_dtype)
+            for (i, j), v in self.items():
+                result[i] += v * other[j]
+        else:
+            result_shape = (self.shape[0], other.shape[1])
+            result = np.zeros(result_shape, dtype=result_dtype)
+            for (i, j), v in self.items():
+                result[i,:] += v * other[j,:]
         return result
 
     def __imul__(self, other):
@@ -299,7 +395,7 @@ class _dok_base(_spbase, IndexMixin):
         if isscalarlike(other):
             res_dtype = upcast_scalar(self.dtype, other)
             new = self._dok_container(self.shape, dtype=res_dtype)
-            new._dict.update(((k, v / other) for k, v in self.items()))
+            new._dict.update(((k, v / other) for k, v in self._dict.items()))
             return new
         return self.tocsr() / other
 
@@ -316,8 +412,11 @@ class _dok_base(_spbase, IndexMixin):
         return dict.__reduce__(self)
 
     def transpose(self, axes=None, copy=False):
+        if self.ndim == 1:
+            return self.copy()
+
         if axes is not None and axes != (1, 0):
-            raise ValueError("Sparse arrays/matrices do not support "
+            raise ValueError("Sparse matrices do not support "
                              "an 'axes' parameter because swapping "
                              "dimensions is the only logical permutation.")
 
@@ -331,6 +430,9 @@ class _dok_base(_spbase, IndexMixin):
 
     def conjtransp(self):
         """Return the conjugate transpose."""
+        if self.ndim == 1:
+            raise NotImplementedError
+
         M, N = self.shape
         new = self._dok_container((N, M), dtype=self.dtype)
         new._dict.update((((right, left), np.conj(val))
@@ -345,15 +447,21 @@ class _dok_base(_spbase, IndexMixin):
     copy.__doc__ = _spbase.copy.__doc__
 
     def tocoo(self, copy=False):
-        if self.nnz == 0:
+        nnz = self.nnz
+        sd = self._dict
+        if nnz == 0:
             return self._coo_container(self.shape, dtype=self.dtype)
 
         idx_dtype = self._get_index_dtype(maxval=max(self.shape))
-        data = np.fromiter(self.values(), dtype=self.dtype, count=self.nnz)
-        row = np.fromiter((i for i, _ in self.keys()), dtype=idx_dtype, count=self.nnz)
-        col = np.fromiter((j for _, j in self.keys()), dtype=idx_dtype, count=self.nnz)
+        data = np.fromiter(sd.values(), dtype=self.dtype, count=nnz)
+        if self.ndim == 1:
+            indices = (np.fromiter(sd, dtype = idx_dtype, count=nnz),)
+        else:
+            row = np.fromiter((i for i, _ in sd), dtype=idx_dtype, count=nnz)
+            col = np.fromiter((j for _, j in sd), dtype=idx_dtype, count=nnz)
+            indices = (row, col)
         A = self._coo_container(
-            (data, (row, col)), shape=self.shape, dtype=self.dtype
+            (data, indices), shape=self.shape, dtype=self.dtype
         )
         A.has_canonical_format = True
         return A
@@ -368,12 +476,30 @@ class _dok_base(_spbase, IndexMixin):
     todok.__doc__ = _spbase.todok.__doc__
 
     def tocsc(self, copy=False):
+        if self.ndim ==1:
+            raise NotImplementedError("tocsr() not valid for 1d sparse array")
         return self.tocoo(copy=False).tocsc(copy=copy)
 
     tocsc.__doc__ = _spbase.tocsc.__doc__
 
+    def eliminate_zeros(self):
+        self._dict = {k: v for k, v in self._dict.items() if v != 0}
+
     def resize(self, *shape):
-        shape = check_shape(shape)
+        is_array = isinstance(self, sparray)
+        shape = check_shape(shape, allow_1d=is_array)
+        if len(shape) != len(self.shape):
+            # TODO implement resize across dimensions
+            raise NotImplementedError
+
+        if self.ndim == 1:
+            newM = shape[0]
+            for i in list(self._dict):
+                if i >= newM:
+                    del self._dict[i]
+            self._shape = shape
+            return
+
         newM, newN = shape
         M, N = self.shape
         if newM < M or newN < N:
@@ -384,6 +510,17 @@ class _dok_base(_spbase, IndexMixin):
         self._shape = shape
 
     resize.__doc__ = _spbase.resize.__doc__
+
+    def astype(self, dtype, casting='unsafe', copy=True):
+        dtype = np.dtype(dtype)
+        if self.dtype != dtype:
+            result = self._dok_container(self.shape, dtype=dtype)
+            data = np.array(list(self._dict.values()), dtype=dtype)
+            result._update(zip(self._dict, data))
+            return result
+        elif copy:
+            return self.copy()
+        return self
 
 
 def isspmatrix_dok(x):

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -184,12 +184,9 @@ class IndexMixin:
         # single boolean matrix
         if ((issparse(key) or isinstance(key, np.ndarray)) and
                 key.ndim == self.ndim and key.dtype.kind == 'b'):
-            for keyN, N in zip(key.shape, self._shape):
-                if keyN > N:
-                    raise IndexError("index shape bigger than indexed array")
+            if key.shape != self._shape:
+                raise IndexError("index shape doesn't match array shape")
             idx = key.nonzero()
-            if self.ndim == 1 and len(idx) > 1:
-                idx = (idx[1],)
             index = [self._asindices(ix, N) for N, ix in zip(self.shape, idx)]
             return tuple(index)
 
@@ -350,7 +347,7 @@ def _unpack_index(index, desired_shape):
 
             # Replace the Ellipsis object with 0, 1, or 2 null-slices as needed.
             i, = ellipsis_indices
-            num_slices = max(0, 3 - len(index))
+            num_slices = max(0, desired_ndim + 1 - len(index))
             index = index[:i] + (slice(None),) * num_slices + index[i + 1:]
 
         # pad tuples

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -236,14 +236,14 @@ def isintlike(x) -> bool:
     return True
 
 
-def isshape(x, nonneg=False, allow_ndim=False) -> bool:
+def isshape(x, nonneg=False, *, allow_1d=False) -> bool:
     """Is x a valid tuple of dimensions?
 
     If nonneg, also checks that the dimensions are non-negative.
-    If allow_ndim, shapes of any dimensionality are allowed.
+    If allow_1d, shapes of length 1 or 2 are allowed.
     """
     ndim = len(x)
-    if not allow_ndim and ndim != 2:
+    if ndim != 2 and not (allow_1d and ndim == 1):
         return False
     for d in x:
         if not isintlike(d):
@@ -292,7 +292,7 @@ def validateaxis(axis) -> None:
         raise ValueError("axis out of range")
 
 
-def check_shape(args, current_shape=None, allow_ndim=False) -> tuple[int, ...]:
+def check_shape(args, current_shape=None, *, allow_1d=False) -> tuple[int, ...]:
     """Imitate numpy.matrix handling of shape arguments
 
     Parameters
@@ -302,8 +302,8 @@ def check_shape(args, current_shape=None, allow_ndim=False) -> tuple[int, ...]:
     current_shape : tuple, optional
         The current shape of the sparse array or matrix.
         If None (default), the current shape will be inferred from args.
-    allow_ndim : bool, optional
-        If True, then n-D arrays are accepted.
+    allow_1d : bool, optional
+        If True, then 1-D or 2-D arrays are accepted.
         If False (default), then only 2-D arrays are accepted and an error is
         raised otherwise.
 
@@ -326,9 +326,13 @@ def check_shape(args, current_shape=None, allow_ndim=False) -> tuple[int, ...]:
         new_shape = tuple(operator.index(arg) for arg in args)
 
     if current_shape is None:
-        if not allow_ndim and len(new_shape) != 2:
+        if allow_1d:
+            if len(new_shape) not in (1, 2):
+                raise ValueError('shape must be a 1- or 2-tuple of positive '
+                                 'integers')
+        elif len(new_shape) != 2:
             raise ValueError('shape must be a 2-tuple of positive integers')
-        elif any(d < 0 for d in new_shape):
+        if any(d < 0 for d in new_shape):
             raise ValueError("'shape' elements cannot be negative")
     else:
         # Check the current size only if needed
@@ -353,7 +357,7 @@ def check_shape(args, current_shape=None, allow_ndim=False) -> tuple[int, ...]:
         else:
             raise ValueError('can only specify one unknown dimension')
 
-    if not allow_ndim and len(new_shape) != 2:
+    if len(new_shape) != 2 and not (allow_1d and len(new_shape) == 1):
         raise ValueError('matrix shape must be two-dimensional')
 
     return new_shape

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -292,8 +292,26 @@ def validateaxis(axis) -> None:
         raise ValueError("axis out of range")
 
 
-def check_shape(args, current_shape=None):
-    """Imitate numpy.matrix handling of shape arguments"""
+def check_shape(args, current_shape=None, allow_ndim=False) -> tuple[int, ...]:
+    """Imitate numpy.matrix handling of shape arguments
+
+    Parameters
+    ----------
+    args : array_like
+        Data structures providing information about the shape of the sparse array.
+    current_shape : tuple, optional
+        The current shape of the sparse array or matrix.
+        If None (default), the current shape will be inferred from args.
+    allow_ndim : bool, optional
+        If True, then n-D arrays are accepted.
+        If False (default), then only 2-D arrays are accepted and an error is
+        raised otherwise.
+
+    Returns
+    -------
+    new_shape: tuple
+        The new shape after validation.
+    """
     if len(args) == 0:
         raise TypeError("function missing 1 required positional argument: "
                         "'shape'")
@@ -308,7 +326,7 @@ def check_shape(args, current_shape=None):
         new_shape = tuple(operator.index(arg) for arg in args)
 
     if current_shape is None:
-        if len(new_shape) != 2:
+        if not allow_ndim and len(new_shape) != 2:
             raise ValueError('shape must be a 2-tuple of positive integers')
         elif any(d < 0 for d in new_shape):
             raise ValueError("'shape' elements cannot be negative")
@@ -335,7 +353,7 @@ def check_shape(args, current_shape=None):
         else:
             raise ValueError('can only specify one unknown dimension')
 
-    if len(new_shape) != 2:
+    if not allow_ndim and len(new_shape) != 2:
         raise ValueError('matrix shape must be two-dimensional')
 
     return new_shape

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -3,6 +3,7 @@ python_sources = [
   'test_array_api.py',
   'test_base.py',
   'test_coo.py',
+  'test_common1d.py',
   'test_construct.py',
   'test_deprecations.py',
   'test_csc.py',

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -2,6 +2,7 @@ python_sources = [
   '__init__.py',
   'test_array_api.py',
   'test_base.py',
+  'test_coo.py',
   'test_construct.py',
   'test_deprecations.py',
   'test_csc.py',

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3016,16 +3016,6 @@ class _TestFancyIndexing:
         assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
 
-        L = [True, False, True, True, False]
-        assert_equal(B[L], toarray(A[L]))
-        LL = [L + L] * 5  # 5x10 list of lists
-        assert_equal(B[LL], toarray(A[LL]))
-
-        assert_raises(IndexError, A.__getitem__, [[L]])
-        assert_raises(IndexError, B.__getitem__, [[L]])
-        assert_raises(IndexError, A.__getitem__, [[[L]]])
-        assert_raises(IndexError, B.__getitem__, [[[L]]])
-
     def test_fancy_indexing_sparse_boolean(self):
         np.random.seed(1234)  # make runs repeatable
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3002,6 +3002,7 @@ class _TestFancyIndexing:
                       False, False, False, False, False])
 
         assert_equal(toarray(A[I, J]), B[I, J])
+        assert_equal(toarray(A[I]), B[I])
 
         Z1 = np.zeros((6, 11), dtype=bool)
         Z2 = np.zeros((6, 11), dtype=bool)
@@ -3009,10 +3010,21 @@ class _TestFancyIndexing:
         Z3 = np.zeros((6, 11), dtype=bool)
         Z3[-1,0] = True
 
-        assert_equal(A[Z1], np.array([]))
+        # This used to be: assert_equal(A[Z1], np.array([]))
+        assert_raises(IndexError, A.__getitem__, Z1)
         assert_raises(IndexError, A.__getitem__, Z2)
         assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
+
+        L = [True, False, True, True, False]
+        assert_equal(B[L], toarray(A[L]))
+        LL = [L + L] * 5  # 5x10 list of lists
+        assert_equal(B[LL], toarray(A[LL]))
+
+        assert_raises(IndexError, A.__getitem__, [[L]])
+        assert_raises(IndexError, B.__getitem__, [[L]])
+        assert_raises(IndexError, A.__getitem__, [[[L]]])
+        assert_raises(IndexError, B.__getitem__, [[[L]]])
 
     def test_fancy_indexing_sparse_boolean(self):
         np.random.seed(1234)  # make runs repeatable

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -15,10 +15,11 @@ from scipy.sparse import (coo_array, csr_array, csc_array,
                           dok_array, sparray, issparse,
                           SparseEfficiencyWarning)
 from scipy.sparse._sputils import supported_dtypes, isscalarlike, matrix
+from scipy._lib._util import ComplexWarning
 
 
 sup_complex = suppress_warnings()
-sup_complex.filter(np.ComplexWarning)
+sup_complex.filter(ComplexWarning)
 
 
 def assert_array_equal_dtype(x, y, **kwargs):
@@ -1026,11 +1027,10 @@ class _SlicingAndFancy1D:
 
 
         # [[[1],[2]]]
-        assert_equal(A[[[1], [3]]].toarray(), B[[[1], [3]]])
-        assert_equal(
-            A[[[-1], [-3], [-2]]].toarray(),
-            B[[[-1], [-3], [-2]]]
-        )
+        ind = np.array([[1], [3]])
+        assert_equal(A[ind].toarray(), B[ind])
+        ind = np.array([[-1], [-3], [-2]])
+        assert_equal(A[ind].toarray(), B[ind])
 
         # [[1,2]]
         assert_equal(A[[1, 3]].toarray(), B[[1, 3]])

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -22,7 +22,7 @@ sup_complex = suppress_warnings()
 sup_complex.filter(ComplexWarning)
 
 
-def assert_array_equal_dtype(x, y, **kwargs):
+def assert_array_equal_dtype(x, y, **kwargs):  # skip name check
     assert_(x.dtype == y.dtype)
     assert_array_equal(x, y, **kwargs)
 
@@ -42,7 +42,7 @@ class _Common1D:
     # Some sparse and dense matrices with data for every supported dtype.
     # This set union is a workaround for numpy#6295, which means that
     # two np.int64 dtypes don't hash to the same value.
-    math_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int64, np.float64, np.complex128]
     checked_dtypes = set(supported_dtypes).union(math_dtypes)
     dat_dtypes = {}
     for dtype in checked_dtypes:
@@ -759,7 +759,7 @@ class _Common1D:
         assert_array_equal(S.toarray(), [1, 0, 3, 0, 0])
 
 
-class _GetSet1D:
+class _GetSet1D:  # skip name check
     def test_getelement(self):
         D = np.array([4,3,0])
         A = self.spcreator(D)
@@ -1259,7 +1259,7 @@ class TestCOO1D(_Common1D, _MinMaxMixin1D):
 #        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
 
 
-#class TestCSR1D(_Common1D, _MinMaxMixin1D, _SlicingAndFancy1D):
+#class TestCSR1D(_Common1D, _MinMaxMixin1D, _GetSet1D, _SlicingAndFancy1D):
 #    spcreator = csr_array
 #    datsp = spcreator(_Common1D.dat1d)
 #    datsp_dtypes = {}

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -318,10 +318,14 @@ class _Common1D:
         D = np.array([1.0 + 3j, 0, -1])
         S = coo_array(D)
         assert_array_equal(self.spcreator(S).toarray(), D)
-        assert_array_equal(self.spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+        assert_array_equal(
+            self.spcreator(S, dtype='int16').toarray(), D.astype('int16')
+        )
         S = self.spcreator(D)
         assert_array_equal(self.spcreator(S).toarray(), D)
-        assert_array_equal(self.spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+        assert_array_equal(
+            self.spcreator(S, dtype='int16').toarray(), D.astype('int16')
+        )
 
     def test_toarray(self):
         # Check C- or F-contiguous (default).
@@ -771,8 +775,10 @@ class _GetSet1D:
         dtype = np.float64
         A = self.spcreator((12,), dtype=dtype)
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             A[0] = dtype(0)
             A[np.array(6)] = dtype(4.0)  # scalar index
             A[1] = dtype(3)
@@ -884,8 +890,10 @@ class _SlicingAndFancy1D:
         A = self.spcreator((5,))
         B = np.zeros((5,))
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+               "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             for C in [A, B]:
                 C[0:1] = 1
                 C[2:0] = 4
@@ -900,8 +908,10 @@ class _SlicingAndFancy1D:
         for idx in [slice(3), slice(None, 10, 4), slice(5, -2)]:
             A = self.spcreator(shape)
             with suppress_warnings() as sup:
-                sup.filter(SparseEfficiencyWarning,
-                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                sup.filter(
+                    SparseEfficiencyWarning,
+                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                )
                 A[idx] = 1
             B = np.zeros(shape)
             B[idx] = 1
@@ -912,8 +922,10 @@ class _SlicingAndFancy1D:
         # Tests whether a row of one lil_matrix can be assigned to another.
         B = self.spcreator((5,))
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+               "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             B[0] = 2
             B[1] = 0
             B[2] = 3
@@ -939,8 +951,10 @@ class _SlicingAndFancy1D:
         block = [2, 1]
 
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+               "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             B[0] = 5
             B[2] = 7
             B[:] = B+B
@@ -959,8 +973,10 @@ class _SlicingAndFancy1D:
                   np.array(-1), np.int8(-3)]
 
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+               "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             for j, a in enumerate(slices):
                 A[a] = j
                 B[a] = j
@@ -1090,7 +1106,9 @@ class _SlicingAndFancy1D:
     ############################
     def test_bad_index_assign(self):
         A = self.spcreator(np.zeros(5))
-        pytest.raises((IndexError, ValueError, TypeError), A.__setitem__, "foo", 2)
+        pytest.raises(
+            (IndexError, ValueError, TypeError), A.__setitem__, "foo", 2
+        )
 
     def test_fancy_indexing_set(self):
         M = (5,)
@@ -1101,8 +1119,10 @@ class _SlicingAndFancy1D:
             A = self.spcreator(M)
             B = np.zeros(M)
             with suppress_warnings() as sup:
-                sup.filter(SparseEfficiencyWarning,
-                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                sup.filter(
+                    SparseEfficiencyWarning,
+                   "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                )
                 B[j] = 1
                 with check_remains_sorted(A):
                     A[j] = 1
@@ -1117,8 +1137,10 @@ class _SlicingAndFancy1D:
         i2 = np.array(i0)
 
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+               "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+            )
             with check_remains_sorted(A):
                 A[i0] = B[i0]
                 pytest.raises(IndexError, B.__getitem__, i1)

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -1,0 +1,1254 @@
+"""Test of 1D aspects of sparse array classes"""
+
+import contextlib
+import operator
+import pytest
+
+import numpy as np
+from numpy import array
+
+from numpy.testing import (assert_equal, assert_array_equal,
+        assert_array_almost_equal, assert_almost_equal, assert_,
+        assert_allclose,suppress_warnings)
+
+from scipy.sparse import (coo_array, csr_array, csc_array,
+                          dok_array, sparray, issparse,
+                          SparseEfficiencyWarning)
+from scipy.sparse._sputils import supported_dtypes, isscalarlike, matrix
+
+
+sup_complex = suppress_warnings()
+sup_complex.filter(np.ComplexWarning)
+
+
+def assert_array_equal_dtype(x, y, **kwargs):
+    assert_(x.dtype == y.dtype)
+    assert_array_equal(x, y, **kwargs)
+
+
+def toarray(a):
+    if isinstance(a, np.ndarray) or isscalarlike(a):
+        return a
+    return a.toarray()
+
+
+class _Common1D:
+    """test common functionality shared by 1D sparse formats"""
+
+    # Canonical data.
+    dat1d = np.array([3, 0, 1, 0], 'd')
+
+    # Some sparse and dense matrices with data for every supported dtype.
+    # This set union is a workaround for numpy#6295, which means that
+    # two np.int64 dtypes don't hash to the same value.
+    math_dtypes = [np.int_, np.float_, np.complex_]
+    checked_dtypes = set(supported_dtypes).union(math_dtypes)
+    dat_dtypes = {}
+    for dtype in checked_dtypes:
+        dat_dtypes[dtype] = dat1d.astype(dtype)
+
+    def test_class_vars(self):
+        # Check that the original data is equivalent to the
+        # corresponding dat_dtypes & datsp_dtypes.
+        assert_equal(self.dat1d, self.dat_dtypes[np.float64])
+        assert_equal(self.datsp.toarray(),
+                     self.datsp_dtypes[np.float64].toarray())
+
+    def test_empty(self):
+        # create empty matrices
+        assert_equal(self.spcreator((3,)).toarray(), np.zeros(3))
+        assert_equal(self.spcreator((3,)).nnz, 0)
+        assert_equal(self.spcreator((3,)).count_nonzero(), 0)
+
+    def test_invalid_shapes(self):
+        pytest.raises(ValueError, self.spcreator, (-3,))
+
+    def test_repr(self):
+        repr(self.datsp)
+
+    def test_str(self):
+        str(self.datsp)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_empty_arithmetic(self):
+        # Test manipulating empty matrices. Fails in SciPy SVN <= r1768
+        shape = (5,)
+        for mytype in [np.dtype('int32'), np.dtype('float32'),
+                np.dtype('float64'), np.dtype('complex64'),
+                np.dtype('complex128')]:
+            a = self.spcreator(shape, dtype=mytype)
+            b = a + a
+            c = 2 * a
+            d = a @ a.tocsc()
+            e = a @ a.tocsr()
+            f = a @ a.tocoo()
+            for m in [a,b,c,d,e,f]:
+                assert_equal(toarray(m), a.toarray()@a.toarray())
+                assert_equal(m.dtype, mytype)
+                assert_equal(toarray(m).dtype, mytype)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_abs(self):
+        A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
+        assert_equal(abs(A), abs(self.spcreator(A)).toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_round(self):
+        decimal = 1
+        A = np.array([-1.35, 0.56, 17.25, -5.98], 'd')
+        assert_equal(np.around(A, decimals=decimal),
+                     round(self.spcreator(A), ndigits=decimal).toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_elementwise_power(self):
+        A = np.array([-4, -3, -2, -1, 0, 1, 2, 3, 4], 'd')
+        assert_equal(np.power(A, 2), self.spcreator(A).power(2).toarray())
+
+        #it's element-wise power function, input has to be a scalar
+        pytest.raises(NotImplementedError, self.spcreator(A).power, A)
+
+    def test_neg(self):
+        A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
+        assert_equal(-A, (-self.spcreator(A)).toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_real(self):
+        D = np.array([1 + 3j, 2 - 4j])
+        A = self.spcreator(D)
+        assert_equal(A.real.toarray(), D.real)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_imag(self):
+        D = np.array([1 + 3j, 2 - 4j])
+        A = self.spcreator(D)
+        assert_equal(A.imag.toarray(), D.imag)
+
+    def test_reshape_1d_tofrom_row_or_column(self):
+        # add a dimension
+        x = self.spcreator([1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5])
+        y = x.reshape(1, 12)
+        desired = [[1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5]]
+        assert_array_equal(y.toarray(), desired)
+
+        # remove a size-1 dimension
+        x = self.spcreator(desired)
+        y = x.reshape(12)
+        assert_array_equal(y.toarray(), desired[0])
+        y2 = x.reshape((12,))
+        assert_equal(y.shape, y2.shape)
+
+        # make a column 1d
+        y = x.T.reshape(12)
+        assert_array_equal(y.toarray(), desired[0])
+
+    def test_reshape(self):
+        x = self.spcreator([1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5])
+        y = x.reshape((4, 3))
+        desired = [[1, 0, 7], [0, 0, 0], [0, -3, 0], [0, 0, 5]]
+        assert_array_equal(y.toarray(), desired)
+
+        y = x.reshape((12,))
+        assert_(y is x)
+
+        y = x.reshape(12)
+        assert_array_equal(y.toarray(), x.toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_getrowcol(self):
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            assert_array_equal(self.datsp.getrow(0).toarray(), self.dat1d[None, :])
+            assert_array_equal(self.datsp.getrow(-1).toarray(), self.dat1d[None, :])
+            assert_array_equal(self.datsp.getcol(2).toarray(), self.dat1d[None, [2]])
+            assert_array_equal(self.datsp.getcol(-2).toarray(), self.dat1d[None, [-2]])
+
+    def test_sum(self):
+        np.random.seed(1234)
+        dat_1 = np.array([0, 1, 2, 3, -4, 5, -6, 7, 9])
+        dat_2 = np.random.rand(5)
+        dat_3 = np.array([])
+        dat_4 = np.zeros((40, ))
+        matrices = [dat_1, dat_2, dat_3, dat_4]
+
+        for m in matrices:
+            dat = np.array(m)
+            datsp = self.spcreator(dat)
+            with np.errstate(over='ignore'):
+                assert_(np.isscalar(datsp.sum()))
+                assert_array_almost_equal(dat.sum(), datsp.sum())
+                assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
+                assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
+                assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
+
+        # test out parameter
+        datsp.sum(axis=0, out=np.zeros(()))
+
+    def test_sum_invalid_params(self):
+        out = np.zeros((3,))  # wrong size for out
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        pytest.raises(ValueError, datsp.sum, axis=1)
+        pytest.raises(TypeError, datsp.sum, axis=(0, 1))
+        pytest.raises(TypeError, datsp.sum, axis=1.5)
+        pytest.raises(ValueError, datsp.sum, axis=0, out=out)
+
+    def test_numpy_sum(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        dat_sum = np.sum(dat)
+        datsp_sum = np.sum(datsp)
+
+        assert_array_almost_equal(dat_sum, datsp_sum)
+
+    def test_mean(self):
+        keepdims = not isinstance(self, sparray)
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        assert_array_almost_equal(dat.mean(), datsp.mean())
+        assert_(np.isscalar(datsp.mean(axis=None)))
+        assert_array_almost_equal(
+            dat.mean(axis=None, keepdims=keepdims), datsp.mean(axis=None)
+        )
+        assert_array_almost_equal(
+            dat.mean(axis=0, keepdims=keepdims), datsp.mean(axis=0)
+        )
+        assert_array_almost_equal(
+            dat.mean(axis=-1, keepdims=keepdims), datsp.mean(axis=-1)
+        )
+
+        with pytest.raises(ValueError, match='axis'):
+            datsp.mean(axis=1)
+        with pytest.raises(ValueError, match='axis'):
+            datsp.mean(axis=-2)
+
+    def test_mean_invalid_params(self):
+        out = np.asarray(np.zeros((1, 3)))
+        dat = np.array([[0, 1, 2],
+                     [3, -4, 5],
+                     [-6, 7, 9]])
+
+        if self.spcreator._format == 'uni':
+            pytest.raises(ValueError, self.spcreator, dat)
+            return
+
+        datsp = self.spcreator(dat)
+        pytest.raises(ValueError, datsp.mean, axis=3)
+        pytest.raises(TypeError, datsp.mean, axis=(0, 1))
+        pytest.raises(TypeError, datsp.mean, axis=1.5)
+        pytest.raises(ValueError, datsp.mean, axis=1, out=out)
+
+    def test_sum_dtype(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        for dtype in self.checked_dtypes:
+            dat_sum = dat.sum(dtype=dtype)
+            datsp_sum = datsp.sum(dtype=dtype)
+
+            assert_array_almost_equal(dat_sum, datsp_sum)
+            assert_equal(dat_sum.dtype, datsp_sum.dtype)
+
+    def test_mean_dtype(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        for dtype in self.checked_dtypes:
+            dat_mean = dat.mean(dtype=dtype)
+            datsp_mean = datsp.mean(dtype=dtype)
+
+            assert_array_almost_equal(dat_mean, datsp_mean)
+            assert_equal(dat_mean.dtype, datsp_mean.dtype)
+
+    def test_mean_out(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        dat_out = np.array([0])
+        datsp_out = np.array([0])
+
+        dat.mean(out=dat_out, keepdims=True)
+        datsp.mean(out=datsp_out)
+        assert_array_almost_equal(dat_out, datsp_out)
+
+        dat.mean(axis=0, out=dat_out, keepdims=True)
+        datsp.mean(axis=0, out=datsp_out)
+        assert_array_almost_equal(dat_out, datsp_out)
+
+    def test_numpy_mean(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+
+        dat_mean = np.mean(dat)
+        datsp_mean = np.mean(datsp)
+
+        assert_array_almost_equal(dat_mean, datsp_mean)
+        assert_equal(dat_mean.dtype, datsp_mean.dtype)
+
+    @sup_complex
+    def test_from_array(self):
+        A = np.array([2,3,4])
+        assert_array_equal(self.spcreator(A).toarray(), A)
+
+        A = np.array([1.0 + 3j, 0, -1])
+        assert_array_equal(self.spcreator(A).toarray(), A)
+        assert_array_equal(self.spcreator(A, dtype='int16').toarray(),A.astype('int16'))
+
+    @sup_complex
+    def test_from_list(self):
+        A = [2,3,4]
+        assert_array_equal(self.spcreator(A).toarray(), A)
+
+        A = [1.0 + 3j, 0, -1]
+        assert_array_equal(self.spcreator(A).toarray(), np.array(A))
+        assert_array_equal(
+            self.spcreator(A, dtype='int16').toarray(), np.array(A).astype('int16')
+        )
+
+    @sup_complex
+    def test_from_sparse(self):
+        D = np.array([1,0,0])
+        S = coo_array(D)
+        assert_array_equal(self.spcreator(S).toarray(), D)
+        S = self.spcreator(D)
+        assert_array_equal(self.spcreator(S).toarray(), D)
+
+        D = np.array([1.0 + 3j, 0, -1])
+        S = coo_array(D)
+        assert_array_equal(self.spcreator(S).toarray(), D)
+        assert_array_equal(self.spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+        S = self.spcreator(D)
+        assert_array_equal(self.spcreator(S).toarray(), D)
+        assert_array_equal(self.spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+
+    def test_toarray(self):
+        # Check C- or F-contiguous (default).
+        dat = np.asarray(self.dat1d)
+        chk = self.datsp.toarray()
+        assert_array_equal(chk, dat)
+        assert_(chk.flags.c_contiguous == chk.flags.f_contiguous)
+        # Check C-contiguous (with arg).
+        chk = self.datsp.toarray(order='C')
+        assert_array_equal(chk, dat)
+        assert_(chk.flags.c_contiguous)
+        assert_(chk.flags.f_contiguous)
+        # Check F-contiguous (with arg).
+        chk = self.datsp.toarray(order='F')
+        assert_array_equal(chk, dat)
+        assert_(chk.flags.c_contiguous)
+        assert_(chk.flags.f_contiguous)
+
+        # Check with output arg.
+        out = np.zeros(self.datsp.shape, dtype=self.datsp.dtype)
+        self.datsp.toarray(out=out)
+        assert_array_equal(chk, dat)
+        # Check that things are fine when we don't initialize with zeros.
+        out[...] = 1.
+        self.datsp.toarray(out=out)
+        assert_array_equal(chk, dat)
+        a = np.array([1., 2., 3., 4.])
+        dense_dot_dense = np.dot(a, dat)
+        check = np.dot(a, self.datsp.toarray())
+        assert_array_equal(dense_dot_dense, check)
+        b = np.array([1., 2., 3., 4.])
+        dense_dot_dense = np.dot(dat, b)
+        check2 = np.dot(self.datsp.toarray(), b)
+        assert_array_equal(dense_dot_dense, check2)
+
+        # Check bool data works.
+        spbool = self.spcreator(dat, dtype=bool)
+        arrbool = dat.astype(bool)
+        assert_array_equal(spbool.toarray(), arrbool)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_mul_scalar(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            assert_array_equal(dat*2, (datsp*2).toarray())
+            assert_array_equal(dat*17.3, (datsp*17.3).toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_rmul_scalar(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            assert_array_equal(2*dat, (2*datsp).toarray())
+            assert_array_equal(17.3*dat, (17.3*datsp).toarray())
+
+    def test_add(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            a = dat.copy()
+            a[0] = 2.0
+            b = datsp
+            c = b + a
+            assert_array_equal(c, b.toarray() + a)
+
+            # test broadcasting
+            # Note: cdnt add nonzero scalar to sparray. Can add len 1 array
+            c = b + a[0:1]
+            assert_array_equal(c, b.toarray() + a[0])
+
+    def test_radd(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            a = dat.copy()
+            a[0] = 2.0
+            b = datsp
+            c = a + b
+            assert_array_equal(c, a + b.toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_sub(self):
+        for dtype in self.math_dtypes:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            assert_array_equal((datsp - datsp).toarray(), np.zeros(4))
+            assert_array_equal((datsp - 0).toarray(), dat)
+
+            A = self.spcreator([1, -4, 0, 2], dtype='d')
+            assert_array_equal((datsp - A).toarray(), dat - A.toarray())
+            assert_array_equal((A - datsp).toarray(), A.toarray() - dat)
+
+            # test broadcasting
+            assert_array_equal(datsp.toarray() - dat[0], dat - dat[0])
+
+    def test_rsub(self):
+        for dtype in self.math_dtypes:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            assert_array_equal((dat - datsp),[0,0,0,0])
+            assert_array_equal((datsp - dat),[0,0,0,0])
+            assert_array_equal((0 - datsp).toarray(), -dat)
+
+            A = self.spcreator([1, -4, 0, 2], dtype='d')
+            assert_array_equal((dat - A), dat - A.toarray())
+            assert_array_equal((A - dat), A.toarray() - dat)
+            assert_array_equal(A.toarray() - datsp, A.toarray() - dat)
+            assert_array_equal(datsp - A.toarray(), dat - A.toarray())
+
+            # test broadcasting
+            assert_array_equal(dat[:1] - datsp, dat[:1] - dat)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_add0(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            # Adding 0 to a sparse matrix
+            assert_array_equal((datsp + 0).toarray(), dat)
+            # use sum (which takes 0 as a starting value)
+            sumS = sum([k * datsp for k in range(1, 3)])
+            sumD = sum([k * dat for k in range(1, 3)])
+            assert_almost_equal(sumS.toarray(), sumD)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_elementwise_multiply(self):
+        # real/real
+        A = np.array([4,0,9])
+        B = np.array([0,7,-1])
+        Asp = self.spcreator(A)
+        Bsp = self.spcreator(B)
+        assert_almost_equal(Asp.multiply(Bsp).toarray(), A*B)  # sparse/sparse
+        assert_almost_equal(Asp.multiply(B).toarray(), A*B)  # sparse/dense
+
+        # complex/complex
+        C = np.array([1-2j,0+5j,-1+0j])
+        D = np.array([5+2j,7-3j,-2+1j])
+        Csp = self.spcreator(C)
+        Dsp = self.spcreator(D)
+        assert_almost_equal(Csp.multiply(Dsp).toarray(), C*D)  # sparse/sparse
+        assert_almost_equal(Csp.multiply(D).toarray(), C*D)  # sparse/dense
+
+        # real/complex
+        assert_almost_equal(Asp.multiply(Dsp).toarray(), A*D)  # sparse/sparse
+        assert_almost_equal(Asp.multiply(D).toarray(), A*D)  # sparse/dense
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_elementwise_multiply_broadcast(self):
+        A = np.array([4])
+        B = np.array([[-9]])
+        C = np.array([1,-1,0])
+        D = np.array([[7,9,-9]])
+        E = np.array([[3],[2],[1]])
+        F = np.array([[8,6,3],[-4,3,2],[6,6,6]])
+        G = [1, 2, 3]
+        H = np.ones((3, 4))
+        J = H.T
+        K = np.array([[0]])
+        L = np.array([[[1,2],[0,1]]])
+
+        # Some arrays can't be cast as spmatrices (A,C,L) so leave
+        # them out.
+        Asp = self.spcreator(A)
+        Csp = self.spcreator(C)
+        Gsp = self.spcreator(G)
+        # 2d arrays
+        creator = self.spcreator if Asp.format != 'uni' else csr_array
+        Bsp = creator(B)
+        Dsp = creator(D)
+        Esp = creator(E)
+        Fsp = creator(F)
+        Hsp = creator(H)
+        Hspp = creator(H[0,None])
+        Jsp = creator(J)
+        Jspp = creator(J[:,0,None])
+        Ksp = creator(K)
+
+        matrices = [A, B, C, D, E, F, G, H, J, K, L]
+        spmatrices = [Asp, Bsp, Csp, Dsp, Esp, Fsp, Gsp, Hsp, Hspp, Jsp, Jspp, Ksp]
+        sp1dmatrices = [Asp, Csp, Gsp]
+
+        # sparse/sparse
+        for i in sp1dmatrices:
+            for j in spmatrices:
+                try:
+                    dense_mult = i.toarray() * j.toarray()
+                except ValueError:
+                    pytest.raises(ValueError, i.multiply, j)
+                    continue
+                sp_mult = i.multiply(j)
+                assert_almost_equal(sp_mult.toarray(), dense_mult)
+
+        # sparse/dense
+        for i in sp1dmatrices:
+            for j in matrices:
+                try:
+                    dense_mult = i.toarray() * j
+                except TypeError:
+                    continue
+                except ValueError:
+                    pytest.raises(ValueError, i.multiply, j)
+                    continue
+                sp_mult = i.multiply(j)
+                if issparse(sp_mult):
+                    assert_almost_equal(sp_mult.toarray(), dense_mult)
+                else:
+                    assert_almost_equal(sp_mult, dense_mult)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_elementwise_divide(self):
+        expected = [1, np.nan, 1, np.nan]
+        assert_array_equal(self.datsp / self.datsp, expected)
+
+        denom = self.spcreator([1, 0, 0, 4],dtype='d')
+        expected = [3, np.nan, np.inf, 0]
+        assert_array_equal(toarray(self.datsp / denom), expected)
+
+        # complex
+        A = np.array([1-2j, 0+5j, -1+0j])
+        B = np.array([5+2j, 7-3j, -2+1j])
+        Asp = self.spcreator(A)
+        Bsp = self.spcreator(B)
+        assert_almost_equal(toarray(Asp / Bsp), A/B)
+
+        # integer
+        A = np.array([1, 2, 3])
+        B = np.array([0, 1, 2])
+        Asp = self.spcreator(A)
+        Bsp = self.spcreator(B)
+        with np.errstate(divide='ignore'):
+            assert_array_equal(toarray(Asp / Bsp), A / B)
+
+        # mismatching sparsity patterns
+        A = np.array([0, 1])
+        B = np.array([1, 0])
+        Asp = self.spcreator(A)
+        Bsp = self.spcreator(B)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            assert_array_equal(array(toarray(Asp / Bsp)), A / B)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_pow(self):
+        A = np.array([1, 0, 2, 0])
+        B = self.spcreator(A)
+
+        # unusual exponents
+        with pytest.raises(ValueError, match='negative integer powers'):
+            B ** -1
+        with pytest.raises(NotImplementedError, match='zero power'):
+            B ** 0
+
+        for exponent in [1, 2, 3, 2.2]:
+            ret_sp = B**exponent
+            ret_np = A**exponent
+            assert_array_equal(ret_sp.toarray(), ret_np)
+            assert_equal(ret_sp.dtype, ret_np.dtype)
+
+    def test_rmatvec(self):
+        M = self.datsp
+        assert_array_almost_equal([1,2,3,4] @ M, np.dot([1,2,3,4], M.toarray()))
+        row = np.array([[1,2,3,4]])
+        assert_array_almost_equal(row @ M, row @ M.toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_dot_scalar(self):
+        M = self.datsp
+        scalar = 10
+        actual = M.dot(scalar)
+        expected = M * scalar
+
+        assert_allclose(actual.toarray(), expected.toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_matmul(self):
+        M = self.spcreator([2,0,3.0])
+        creator = self.spcreator if M.format != 'uni' else csr_array
+        B = creator(array([[0,1],[1,0],[0,2]],'d'))
+        col = np.array([[1,2,3]]).T
+
+        matmul = operator.matmul
+        # check matrix-vector
+        assert_array_almost_equal(matmul(M, col), M.toarray() @ col)
+
+        # check matrix-matrix
+        assert_array_almost_equal(matmul(M, B).toarray(), (M @ B).toarray())
+        assert_array_almost_equal(matmul(M.toarray(), B), (M @ B).toarray())
+        assert_array_almost_equal(matmul(M, B.toarray()), (M @ B).toarray())
+
+        # check error on matrix-scalar
+        pytest.raises(ValueError, matmul, M, 1)
+        pytest.raises(ValueError, matmul, 1, M)
+
+    def test_matvec(self):
+        A = np.array([2,0,3.0])
+        Asp = self.spcreator(A)
+        col = np.array([[1,2,3]]).T
+
+        assert_array_almost_equal(Asp @ col, Asp.toarray() @ col)
+
+        assert_equal((A @ np.array([1,2,3])).shape,())
+        assert Asp @ np.array([1,2,3]) == 11
+        assert_equal((Asp @ np.array([1,2,3])).shape,())
+        assert_equal((Asp @ np.array([[1],[2],[3]])).shape,())
+        # check result type
+        assert isinstance(Asp @ matrix([[1,2,3]]).T, np.ndarray)
+
+        # ensure exception is raised for improper dimensions
+        bad_vecs = [array([1,2]), np.array([1,2,3,4]), array([[1],[2]]),
+                    matrix([1,2,3]), matrix([[1],[2]])]
+        for x in bad_vecs:
+            pytest.raises(ValueError, Asp.__matmul__, x)
+
+        # The current relationship between sparse matrix products and array
+        # products is as follows:
+        dot_result = np.dot(Asp.toarray(),[1,2,3])
+        assert_array_almost_equal(Asp@array([1,2,3]), dot_result)
+        assert_array_almost_equal(Asp@[[1],[2],[3]], dot_result.T)
+        # Note that the result of Asp * x is dense if x has a singleton dimension.
+
+    def test_transpose(self):
+        dat_1 = self.dat1d
+        dat_2 = np.array([])
+        matrices = [dat_1, dat_2]
+
+        for dtype in self.checked_dtypes:
+            for j in range(len(matrices)):
+                dat = np.array(matrices[j], dtype=dtype)
+                datsp = self.spcreator(dat)
+
+                a = datsp.transpose()
+                b = dat.transpose()
+
+                assert_array_equal(a.toarray(), b)
+                assert_array_equal(a.transpose().toarray(), dat)
+                assert_equal(a.dtype, b.dtype)
+
+    def test_add_dense(self):
+        for dtype in self.math_dtypes:
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            # adding a dense matrix to a sparse matrix
+            sum1 = dat + datsp
+            assert_array_equal(sum1, dat + dat)
+            sum2 = datsp + dat
+            assert_array_equal(sum2, dat + dat)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_sub_dense(self):
+        # subtracting a dense matrix to/from a sparse matrix
+        for dtype in self.math_dtypes:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            # Manually add to avoid upcasting from scalar
+            # multiplication.
+            sum1 = (dat + dat + dat) - datsp
+            assert_array_equal(sum1, dat + dat)
+            sum2 = (datsp + datsp + datsp) - dat
+            assert_array_equal(sum2, dat + dat)
+
+    # test that __iter__ is compatible with NumPy matrix
+    def test_iterator(self):
+        B = np.arange(5)
+        A = self.spcreator(B)
+
+        if A.format not in ['coo', 'dia', 'bsr']:
+            for x, y in zip(A, B):
+                assert_equal(x, y)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_size_zero_matrix_arithmetic(self):
+        # Test basic matrix arithmetic with shapes like (0,0), (10,0),
+        # (0, 3), etc.
+        mat = np.array([])
+        a = mat.reshape(0)
+        d = mat.reshape((1, 0))
+        f = np.ones([5, 5])
+
+        asp = self.spcreator(a)
+        creator = self.spcreator if asp.format != 'uni' else csr_array
+        dsp = creator(d)
+        # bad shape for addition
+        pytest.raises(ValueError, asp.__add__, dsp)
+
+        # matrix product.
+        assert_equal(asp.dot(asp), np.dot(a, a))
+
+        # bad matrix products
+        pytest.raises(ValueError, asp.dot, f)
+
+        # elemente-wise multiplication
+        assert_array_equal(asp.multiply(asp).toarray(), np.multiply(a, a))
+
+        assert_array_equal(asp.multiply(a).toarray(), np.multiply(a, a))
+
+        assert_array_equal(asp.multiply(6).toarray(), np.multiply(a, 6))
+
+        # bad element-wise multiplication
+        pytest.raises(ValueError, asp.multiply, f)
+
+        # Addition
+        assert_array_equal(asp.__add__(asp).toarray(), a.__add__(a))
+
+    def test_resize(self):
+        # resize(shape) resizes the matrix in-place
+        D = np.array([1, 0, 3, 4])
+        S = self.spcreator(D)
+        assert_(S.resize((3,)) is None)
+        assert_array_equal(S.toarray(), [1, 0, 3])
+        S.resize((5,))
+        assert_array_equal(S.toarray(), [1, 0, 3, 0, 0])
+
+
+class _GetSet1D:
+    def test_getelement(self):
+        D = np.array([4,3,0])
+        A = self.spcreator(D)
+        N = D.shape[0]
+
+        for j in range(-N, N):
+            assert_equal(A[j], D[j])
+        assert_array_equal(A[()].toarray(), D[()])
+        for ij in [(0,3),(3,),3,-4]:
+            pytest.raises((IndexError, TypeError), A.__getitem__, ij)
+
+
+    def test_setelement(self):
+        dtype = np.float64
+        A = self.spcreator((12,), dtype=dtype)
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            A[0] = dtype(0)
+            A[np.array(6)] = dtype(4.0)  # scalar index
+            A[1] = dtype(3)
+            A[8] = dtype(9.0)
+            A[-9,] = dtype(8)
+            A[-2] = dtype(7)
+            A[np.array(8)] = dtype(2.0)  # overwrite with scalar index
+            A[1,] = dtype(5)  # overwrite with 1-tuple index 
+            A[5] = 9
+
+            assert_array_equal(A.toarray(), [0, 5, 0, 8, 0, 9, 4, 0, 2, 0, 7, 0])
+
+        for ij in [(13,),13,-14]:
+            pytest.raises(IndexError, A.__setitem__, ij, 123.0)
+
+        for v in [(), (0, 3), [1,2,3], np.array([1,2,3])]:
+            pytest.raises(ValueError, A.__setitem__, 0, v)
+
+
+@contextlib.contextmanager
+def check_remains_sorted(X):
+    """Checks that sorted indices property is retained through an operation
+    """
+    if not hasattr(X, 'has_sorted_indices') or not X.has_sorted_indices:
+        yield
+        return
+    yield
+    indices = X.indices.copy()
+    X.has_sorted_indices = False
+    X.sort_indices()
+    assert_array_equal(indices, X.indices,
+                       'Expected sorted indices, found unsorted')
+
+
+class _SlicingAndFancy1D:
+    ####################
+    #  1d Slice as index
+    ####################
+    def test_dtype_preservation(self):
+        assert_equal(self.spcreator((10,), dtype=np.int16)[1:5].dtype, np.int16)
+        assert_equal(self.spcreator((6,), dtype=np.int32)[0:0:2].dtype, np.int32)
+        assert_equal(self.spcreator((6,), dtype=np.int64)[:].dtype, np.int64)
+
+    def test_get_1d_slice(self):
+        B = np.arange(50.)
+        A = self.spcreator(B)
+        assert_array_equal(B[:], A[:].toarray())
+        assert_array_equal(B[2:5], A[2:5].toarray())
+
+        C = np.array([4, 0, 6, 0, 0, 0, 0, 0, 1])
+        D = self.spcreator(C)
+        assert_array_equal(C[1:3], D[1:3].toarray())
+
+        # Now test slicing when a row contains only zeros
+        E = np.array([0, 0, 0, 0, 0])
+        F = self.spcreator(E)
+        assert_array_equal(E[1:3], F[1:3].toarray())
+        assert_array_equal(E[-2:], F[-2:].toarray())
+        assert_array_equal(E[:], F[:].toarray())
+        assert_array_equal(E[slice(None)], F[slice(None)].toarray())
+
+    def test_slicing_idx_slice(self):
+        B = np.arange(50)
+        A = self.spcreator(B)
+
+        # [i]
+        assert_equal(A[2], B[2])
+        assert_equal(A[-1], B[-1])
+        assert_equal(A[array(-2)], B[-2])
+
+        # [1:2]
+        assert_equal(A[:].toarray(), B[:])
+        assert_equal(A[5:-2].toarray(), B[5:-2])
+        assert_equal(A[5:12:3].toarray(), B[5:12:3])
+
+        # int8 slice
+        s = slice(np.int8(2), np.int8(4), None)
+        assert_equal(A[s].toarray(), B[2:4])
+
+        # np.s_
+        s_ = np.s_
+        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
+                  s_[15:20], s_[3:2],
+                  s_[8:3:-1], s_[4::-2], s_[:5:-1],
+                  0, 1, s_[:], s_[1:5], -1, -2, -5,
+                  np.array(-1), np.int8(-3)]
+
+        for j, a in enumerate(slices):
+            x = A[a]
+            y = B[a]
+            if y.shape == ():
+                assert_equal(x, y, repr(a))
+            else:
+                if x.size == 0 and y.size == 0:
+                    pass
+                else:
+                    assert_array_equal(x.toarray(), y, repr(a))
+
+    def test_ellipsis_1d_slicing(self):
+        B = np.arange(50)
+        A = self.spcreator(B)
+        assert_array_equal(A[...].toarray(), B[...])
+        assert_array_equal(A[...,].toarray(), B[...,])
+
+    ##########################
+    #  Assignment with Slicing
+    ##########################
+    def test_slice_scalar_assign(self):
+        A = self.spcreator((5,))
+        B = np.zeros((5,))
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            for C in [A, B]:
+                C[0:1] = 1
+                C[2:0] = 4
+                C[2:3] = 9
+                C[3:] = 1
+                C[3::-1] = 9
+        assert_array_equal(A.toarray(), B)
+
+    def test_slice_assign_2(self):
+        shape = (10,)
+
+        for idx in [slice(3), slice(None, 10, 4), slice(5, -2)]:
+            A = self.spcreator(shape)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                A[idx] = 1
+            B = np.zeros(shape)
+            B[idx] = 1
+            msg = f"idx={idx!r}"
+            assert_array_almost_equal(A.toarray(), B, err_msg=msg)
+
+    def test_self_self_assignment(self):
+        # Tests whether a row of one lil_matrix can be assigned to another.
+        B = self.spcreator((5,))
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            B[0] = 2
+            B[1] = 0
+            B[2] = 3
+            B[3] = 10
+
+            A = B / 10
+            B[:] = A[:]
+            assert_array_equal(A[:].toarray(), B[:].toarray())
+            B.eliminate_zeros()
+
+            A = B / 10
+            B[:] = A[:1]
+            assert_array_equal(np.zeros((5,)) + A[0], B.toarray())
+
+            A = B / 10
+            B[:-1] = A[1:]
+            assert_array_equal(A[1:].toarray(), B[:-1].toarray())
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_slice_assignment(self):
+        B = self.spcreator((4,))
+        expected = np.array([10, 0, 14, 0])
+        block = [2, 1]
+
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            B[0] = 5
+            B[2] = 7
+            B[:] = B+B
+            assert_array_equal(B.toarray(), expected)
+
+            B[:2] = csc_array(block)
+            assert_array_equal(B.toarray()[:2], block)
+
+    def test_set_slice(self):
+        A = self.spcreator((5,))
+        B = np.zeros(5, float)
+        s_ = np.s_
+        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
+                  s_[8:3:-1], s_[4::-2], s_[:5:-1],
+                  0, 1, s_[:], s_[1:5], -1, -2, -5,
+                  np.array(-1), np.int8(-3)]
+
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            for j, a in enumerate(slices):
+                A[a] = j
+                B[a] = j
+                assert_array_equal(A.toarray(), B, repr(a))
+
+            A[1:10:2] = range(1, 5, 2)
+            B[1:10:2] = range(1, 5, 2)
+            assert_array_equal(A.toarray(), B)
+
+        # The next commands should raise exceptions
+        toobig = list(range(100))
+        pytest.raises(ValueError, A.__setitem__, 0, toobig)
+        pytest.raises(ValueError, A.__setitem__, slice(None), toobig)
+
+    def test_assign_empty(self):
+        A = self.spcreator(np.ones(3))
+        B = self.spcreator((2,))
+        A[:2] = B
+        assert_array_equal(A.toarray(), [0, 0, 1])
+
+    ####################
+    #  1d Fancy Indexing
+    ####################
+    def test_dtype_preservation_empty_index(self):
+        A = self.spcreator((2,), dtype=np.int16)
+        assert_equal(A[[False, False]].dtype, np.int16)
+        assert_equal(A[[]].dtype, np.int16)
+
+    def test_bad_index(self):
+        A = self.spcreator(np.zeros(5))
+        pytest.raises((IndexError, ValueError, TypeError), A.__getitem__, "foo")
+        pytest.raises((IndexError, ValueError, TypeError), A.__getitem__, (2, "foo"))
+
+    def test_fancy_indexing(self):
+        B = np.arange(50)
+        A = self.spcreator(B)
+
+        # [i]
+        assert_equal(A[[3]].toarray(), B[[3]])
+
+        # [array]
+        assert_equal(A[[1, 3]].toarray(), B[[1, 3]])
+        assert_equal(A[[2, -5]].toarray(), B[[2, -5]])
+        assert_equal(A[array(-1)], B[-1])
+        assert_equal(A[array([-1, 2])].toarray(), B[[-1, 2]])
+        assert_equal(A[array(5)], B[array(5)])
+
+
+        # [[[1],[2]]]
+        assert_equal(A[[[1], [3]]].toarray(), B[[[1], [3]]])
+        assert_equal(
+            A[[[-1], [-3], [-2]]].toarray(),
+            B[[[-1], [-3], [-2]]]
+        )
+
+        # [[1,2]]
+        assert_equal(A[[1, 3]].toarray(), B[[1, 3]])
+        assert_equal(A[[-1, -3]].toarray(), B[[-1, -3]])
+        assert_equal(A[array([-1, -3])].toarray(), B[[-1, -3]])
+
+        # [[1,2]][[1,2]]
+        assert_equal(A[[1, 5, 2, 8]][[1, 3]].toarray(),
+                     B[[1, 5, 2, 8]][[1, 3]])
+        assert_equal(A[[-1, -5, 2, 8]][[1, -4]].toarray(),
+                     B[[-1, -5, 2, 8]][[1, -4]])
+
+    def test_fancy_indexing_boolean(self):
+        np.random.seed(1234)  # make runs repeatable
+
+        B = np.arange(50)
+        A = self.spcreator(B)
+
+        I = np.array(np.random.randint(0, 2, size=50), dtype=bool)
+
+        assert_equal(toarray(A[I]), B[I])
+        assert_equal(toarray(A[B > 9]), B[B > 9])
+
+        Z1 = np.zeros(51, dtype=bool)
+        Z2 = np.zeros(51, dtype=bool)
+        Z2[-1] = True
+        Z3 = np.zeros(51, dtype=bool)
+        Z3[0] = True
+
+        pytest.raises(IndexError, A.__getitem__, Z1)
+        pytest.raises(IndexError, A.__getitem__, Z2)
+        pytest.raises(IndexError, A.__getitem__, Z3)
+
+    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
+    def test_fancy_indexing_sparse_boolean(self):
+        np.random.seed(1234)  # make runs repeatable
+
+        B = np.arange(20)
+        A = self.spcreator(B)
+
+        X = np.array(np.random.randint(0, 2, size=20), dtype=bool)
+        Xsp = csr_array(X)
+
+        assert_equal(toarray(A[Xsp]), B[X])
+        assert_equal(toarray(A[A > 9]), B[B > 9])
+
+        Y = np.array(np.random.randint(0, 2, size=60), dtype=bool)
+
+        Ysp = csr_array(Y)
+
+        pytest.raises(IndexError, A.__getitem__, Ysp)
+        pytest.raises((IndexError, ValueError), A.__getitem__, (Xsp, 1))
+
+    def test_fancy_indexing_seq_assign(self):
+        mat = self.spcreator(np.array([1, 0]))
+        pytest.raises(ValueError, mat.__setitem__, 0, np.array([1,2]))
+
+    def test_fancy_indexing_empty(self):
+        B = np.arange(50)
+        B[3:9] = 0
+        B[30] = 0
+        A = self.spcreator(B)
+
+        K = np.array([False] * 50)
+        assert_equal(toarray(A[K]), B[K])
+        K = np.array([], dtype=int)
+        assert_equal(toarray(A[K]), B[K])
+        J = np.array([0, 1, 2, 3, 4], dtype=int)
+        assert_equal(toarray(A[J]), B[J])
+
+    ############################
+    #  1d Fancy Index Assignment
+    ############################
+    def test_bad_index_assign(self):
+        A = self.spcreator(np.zeros(5))
+        pytest.raises((IndexError, ValueError, TypeError), A.__setitem__, "foo", 2)
+
+    def test_fancy_indexing_set(self):
+        M = (5,)
+
+        # [1:2]
+        for j in [[2, 3, 4], slice(None, 10, 4), np.arange(3),
+                     slice(5, -2), slice(2, 5)]:
+            A = self.spcreator(M)
+            B = np.zeros(M)
+            with suppress_warnings() as sup:
+                sup.filter(SparseEfficiencyWarning,
+                           "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+                B[j] = 1
+                with check_remains_sorted(A):
+                    A[j] = 1
+            assert_array_almost_equal(A.toarray(), B)
+
+    def test_sequence_assignment(self):
+        A = self.spcreator((4,))
+        B = self.spcreator((3,))
+
+        i0 = [0,1,2]
+        i1 = (0,1,2)
+        i2 = np.array(i0)
+
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning,
+                       "Changing the sparsity structure of a cs[cr]_matrix is expensive")
+            with check_remains_sorted(A):
+                A[i0] = B[i0]
+                pytest.raises(IndexError, B.__getitem__, i1)
+                A[i2] = B[i2]
+            assert_array_equal(A[:3].toarray(), B.toarray())
+            assert A.shape == (4,)
+
+            # slice
+            A = self.spcreator((4,))
+            with check_remains_sorted(A):
+                A[1:3] = [10,20]
+            assert_array_equal(A.toarray(), [0, 10, 20, 0])
+
+            # array
+            A = self.spcreator((4,))
+            B = np.zeros(4)
+            with check_remains_sorted(A):
+                for C in [A, B]:
+                    C[[0,1,2]] = [4,5,6]
+            assert_array_equal(A.toarray(), B)
+
+    def test_fancy_assign_empty(self):
+        B = np.arange(50)
+        B[2] = 0
+        B[[3, 6]] = 0
+        A = self.spcreator(B)
+
+        K = np.array([False] * 50)
+        A[K] = 42
+        assert_equal(A.toarray(), B)
+
+        K = np.array([], dtype=int)
+        A[K] = 42
+        assert_equal(A.toarray(), B)
+
+
+class _MinMaxMixin1D:
+    def test_minmax(self):
+        D = np.arange(5)
+        X = self.spcreator(D)
+
+        assert_equal(X.min(), 0)
+        assert_equal(X.max(), 4)
+        assert_equal((-X).min(), -4)
+        assert_equal((-X).max(), 0)
+
+
+    def test_minmax_axis(self):
+        D = np.arange(50)
+        X = self.spcreator(D)
+
+        for axis in [0, -1]:
+            assert_array_equal(
+                toarray(X.max(axis=axis)), D.max(axis=axis, keepdims=True)
+            )
+            assert_array_equal(
+                toarray(X.min(axis=axis)), D.min(axis=axis, keepdims=True)
+            )
+        for axis in [-2, 1]:
+            pytest.raises(ValueError, X.min, axis=axis)
+            pytest.raises(ValueError, X.max, axis=axis)
+
+
+    def test_numpy_minmax(self):
+        dat = np.array([0, 1, 2])
+        datsp = self.spcreator(dat)
+        assert_array_equal(np.min(datsp), np.min(dat))
+        assert_array_equal(np.max(datsp), np.max(dat))
+
+
+    def test_argmax(self):
+        D1 = np.array([-1, 5, 2, 3])
+        D2 = np.array([0, 0, -1, -2])
+        D3 = np.array([-1, -2, -3, -4])
+        D4 = np.array([1, 2, 3, 4])
+        D5 = np.array([1, 2, 0, 0])
+
+        for D in [D1, D2, D3, D4, D5]:
+            mat = self.spcreator(D)
+
+            assert_equal(mat.argmax(), np.argmax(D))
+            assert_equal(mat.argmin(), np.argmin(D))
+
+            assert_equal(mat.argmax(axis=0), np.argmax(D, axis=0))
+            assert_equal(mat.argmin(axis=0), np.argmin(D, axis=0))
+
+        D6 = np.empty((0,))
+
+        for axis in [None, 0]:
+            mat = self.spcreator(D6)
+            pytest.raises(ValueError, mat.argmax, axis=axis)
+            pytest.raises(ValueError, mat.argmin, axis=axis)
+
+
+class TestCOO1D(_Common1D, _MinMaxMixin1D):
+    spcreator = coo_array
+    datsp = spcreator(_Common1D.dat1d)
+    datsp_dtypes = {}
+    for dtype in _Common1D.checked_dtypes:
+        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
+
+
+#class TestUNI1D(_Common1D, _MinMaxMixin1D):
+#    spcreator = uni_array
+#    datsp = spcreator(_Common1D.dat1d)
+#    datsp_dtypes = {}
+#    for dtype in _Common1D.checked_dtypes:
+#        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
+
+
+#class TestCSC1D(_Common1D, _MinMaxMixin1D, _GetSet1D, _SlicingAndFancy1D):
+#    spcreator = csc_array
+#    datsp = spcreator(_Common1D.dat1d)
+#    datsp_dtypes = {}
+#    for dtype in _Common1D.checked_dtypes:
+#        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
+
+
+#class TestCSR1D(_Common1D, _MinMaxMixin1D, _SlicingAndFancy1D):
+#    spcreator = csr_array
+#    datsp = spcreator(_Common1D.dat1d)
+#    datsp_dtypes = {}
+#    for dtype in _Common1D.checked_dtypes:
+#        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
+
+
+class TestDOK1D(_Common1D, _SlicingAndFancy1D):
+    spcreator = dok_array
+    datsp = spcreator(_Common1D.dat1d)
+    datsp_dtypes = {}
+    for dtype in _Common1D.checked_dtypes:
+        datsp_dtypes[dtype] = spcreator(_Common1D.dat1d.astype(dtype))
+

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -83,7 +83,7 @@ def test_1d_tuple_constructor_with_shape():
 
 def test_non_subscriptability():
     coo_2d = coo_array((2, 2))
-    
+
     with pytest.raises(TypeError,
                         match="'coo_array' object does not support item assignment"):
         coo_2d[0, 0] = 1
@@ -95,7 +95,7 @@ def test_non_subscriptability():
 def test_reshape():
     arr1d = coo_array([1, 0, 3])
     assert arr1d.shape == (3,)
-    
+
     col_vec = arr1d.reshape((3, 1))
     assert col_vec.shape == (3, 1)
     assert np.array_equal(col_vec.toarray(), np.array([[1], [0], [3]]))
@@ -184,7 +184,7 @@ def test_1d_tocsc_tocsr_todia_todok():
 def test_1d_resize(arg: int):
     den = np.array([1, -2, -3])
     res = coo_array(den)
-    den.resize(arg)
+    den.resize(arg, refcheck=False)
     res.resize(arg)
     assert res.shape == den.shape
     assert np.array_equal(res.toarray(), den)
@@ -195,7 +195,7 @@ def test_1d_to_2d_resize(arg: tuple[int, int]):
     den = np.array([1, 0, 3])
     res = coo_array(den)
 
-    den.resize(arg)
+    den.resize(arg, refcheck=False)
     res.resize(arg)
     assert res.shape == den.shape
     assert np.array_equal(res.toarray(), den)
@@ -205,7 +205,7 @@ def test_1d_to_2d_resize(arg: tuple[int, int]):
 def test_2d_to_1d_resize(arg: int):
     den = np.array([[1, 0, 3], [4, 0, 0]])
     res = coo_array(den)
-    den.resize(arg)
+    den.resize(arg, refcheck=False)
     res.resize(arg)
     assert res.shape == den.shape
     assert np.array_equal(res.toarray(), den)
@@ -256,7 +256,7 @@ def test_1d_mul_vector():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
     res = coo_array(den_a) @ den_b
-    assert type(res) == type(exp)
+    assert np.ndim(res) == 0
     assert np.array_equal(res, exp)
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -12,11 +12,8 @@ def test_shape_constructor():
     assert empty2d.shape == (3, 2)
     assert np.array_equal(empty2d.toarray(), np.zeros((3, 2)))
 
-    empty3d = coo_array((3, 2, 2))
-    assert empty3d.shape == (3, 2, 2)
-    with pytest.raises(ValueError,
-                       match='Cannot densify higher-rank sparse array'):
-        empty3d.toarray()
+    with pytest.raises(TypeError, match='invalid input format'):
+        coo_array((3, 2, 2))
 
 
 def test_dense_constructor():
@@ -28,8 +25,8 @@ def test_dense_constructor():
     assert res2d.shape == (2, 3)
     assert np.array_equal(res2d.toarray(), np.array([[1, 2, 3], [4, 5, 6]]))
 
-    res3d = coo_array([[[3]], [[4]]])
-    assert res3d.shape == (2, 1, 1)
+    with pytest.raises(ValueError, match='shape must be a 1- or 2-tuple'):
+        coo_array([[[3]], [[4]]])
 
 
 def test_dense_constructor_with_shape():
@@ -41,8 +38,8 @@ def test_dense_constructor_with_shape():
     assert res2d.shape == (2, 3)
     assert np.array_equal(res2d.toarray(), np.array([[1, 2, 3], [4, 5, 6]]))
 
-    res3d = coo_array([[[3]], [[4]]], shape=(2, 1, 1))
-    assert res3d.shape == (2, 1, 1)
+    with pytest.raises(ValueError, match='shape must be a 1- or 2-tuple'):
+        coo_array([[[3]], [[4]]], shape=(2, 1, 1))
 
 
 def test_dense_constructor_with_inconsistent_shape():
@@ -121,10 +118,6 @@ def test_nnz():
     assert arr2d.shape == (2, 3)
     assert arr2d.nnz == 3
 
-    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]])
-    assert arr3d.shape == (1, 2, 3)
-    assert arr3d.nnz == 2
-
 
 def test_transpose():
     arr1d = coo_array([1, 0, 3]).T
@@ -135,9 +128,6 @@ def test_transpose():
     assert arr2d.shape == (3, 2)
     assert np.array_equal(arr2d.toarray(), np.array([[1, 0], [2, 0], [0, 3]]))
 
-    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]]).T
-    assert arr3d.shape == (3, 2, 1)
-
 
 def test_transpose_with_axis():
     arr1d = coo_array([1, 0, 3]).transpose(axes=(0,))
@@ -147,9 +137,6 @@ def test_transpose_with_axis():
     arr2d = coo_array([[1, 2, 0], [0, 0, 3]]).transpose(axes=(0, 1))
     assert arr2d.shape == (2, 3)
     assert np.array_equal(arr2d.toarray(), np.array([[1, 2, 0], [0, 0, 3]]))
-
-    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]]).transpose(axes=(1, 0, 2))
-    assert arr3d.shape == (2, 1, 3)
 
     with pytest.raises(ValueError, match="axes don't match matrix dimensions"):
         coo_array([1, 0, 3]).transpose(axes=(0, 1))

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -160,11 +160,13 @@ def test_1d_row_and_col():
         res.row = [1, 2, 3]
 
 
-def test_1d_tocsc_tocsr_todia_todok():
+def test_1d_toformats():
     res = coo_array([1, -2, -3])
-    for f in [res.tocsc, res.tocsr, res.todok, res.todia]:
+    for f in [res.tocsc, res.tocsr, res.todia, res.tolil, res.tobsr]:
         with pytest.raises(ValueError, match='Cannot convert'):
             f()
+    for f in [res.tocoo, res.todok]:
+        assert np.array_equal(f().toarray(), res.toarray())
 
 
 @pytest.mark.parametrize('arg', [1, 2, 4, 5, 8])

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -160,17 +160,17 @@ def test_transpose_with_axis():
 
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
-    assert np.array_equal(res.row, np.array([0, 1, 2]))
-    assert np.array_equal(res.col, np.zeros_like(res.row))
+    assert np.array_equal(res.col, np.array([0, 1, 2]))
+    assert np.array_equal(res.row, np.zeros_like(res.row))
     assert res.row.dtype == res.col.dtype
 
-    res.row = [1, 2, 3]
+    res.col = [1, 2, 3]
     assert len(res.indices) == 1
-    assert np.array_equal(res.row, np.array([1, 2, 3]))
+    assert np.array_equal(res.col, np.array([1, 2, 3]))
     assert res.row.dtype == res.col.dtype
 
-    with pytest.raises(ValueError, match="cannot set col attribute"):
-        res.col = [1, 2, 3]
+    with pytest.raises(ValueError, match="cannot set row attribute"):
+        res.row = [1, 2, 3]
 
 
 def test_1d_tocsc_tocsr_todia_todok():
@@ -229,7 +229,8 @@ def test_eliminate_zeros():
     assert arr1d.nnz == 1
     assert arr1d.count_nonzero() == 1
     assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
-    assert np.array_equal(arr1d.row, np.array([1]))
+    assert np.array_equal(arr1d.col, np.array([1]))
+    assert np.array_equal(arr1d.row, np.array([0]))
 
 
 def test_1d_add_dense():
@@ -237,7 +238,7 @@ def test_1d_add_dense():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a + den_b
     res = coo_array(den_a) + den_b
-    assert type(res) == type(exp)
+    assert isinstance(res, np.ndarray)
     assert np.array_equal(res, exp)
 
 
@@ -256,6 +257,7 @@ def test_1d_mul_vector():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
     res = coo_array(den_a) @ den_b
+    assert isinstance(res, np.int_)
     assert np.ndim(res) == 0
     assert np.array_equal(res, exp)
 
@@ -265,7 +267,7 @@ def test_1d_mul_multivector():
     other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
     exp = den @ other
     res = coo_array(den) @ other
-    assert type(res) == type(exp)
+    assert isinstance(res, np.ndarray)
     assert np.array_equal(res, exp)
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -161,7 +161,7 @@ def test_transpose_with_axis():
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
     assert np.array_equal(res.col, np.array([0, 1, 2]))
-    assert np.array_equal(res.row, np.zeros_like(res.row))
+    assert np.array_equal(res.row, np.zeros_like(res.col))
     assert res.row.dtype == res.col.dtype
 
     res.col = [1, 2, 3]
@@ -238,7 +238,7 @@ def test_1d_add_dense():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a + den_b
     res = coo_array(den_a) + den_b
-    assert isinstance(res, np.ndarray)
+    assert type(res) == type(exp)
     assert np.array_equal(res, exp)
 
 
@@ -257,7 +257,6 @@ def test_1d_mul_vector():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
     res = coo_array(den_a) @ den_b
-    assert isinstance(res, np.int_)
     assert np.ndim(res) == 0
     assert np.array_equal(res, exp)
 
@@ -267,7 +266,7 @@ def test_1d_mul_multivector():
     other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
     exp = den @ other
     res = coo_array(den) @ other
-    assert isinstance(res, np.ndarray)
+    assert type(res) == type(exp)
     assert np.array_equal(res, exp)
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1,0 +1,283 @@
+import numpy as np
+import pytest
+from scipy.sparse import coo_array
+
+
+def test_shape_constructor():
+    empty1d = coo_array((3,))
+    assert empty1d.shape == (3,)
+    assert np.array_equal(empty1d.toarray(), np.zeros((3,)))
+
+    empty2d = coo_array((3, 2))
+    assert empty2d.shape == (3, 2)
+    assert np.array_equal(empty2d.toarray(), np.zeros((3, 2)))
+
+    empty3d = coo_array((3, 2, 2))
+    assert empty3d.shape == (3, 2, 2)
+    with pytest.raises(ValueError,
+                       match='Cannot densify higher-rank sparse array'):
+        empty3d.toarray()
+
+
+def test_dense_constructor():
+    res1d = coo_array([1, 2, 3])
+    assert res1d.shape == (3,)
+    assert np.array_equal(res1d.toarray(), np.array([1, 2, 3]))
+
+    res2d = coo_array([[1, 2, 3], [4, 5, 6]])
+    assert res2d.shape == (2, 3)
+    assert np.array_equal(res2d.toarray(), np.array([[1, 2, 3], [4, 5, 6]]))
+
+    res3d = coo_array([[[3]], [[4]]])
+    assert res3d.shape == (2, 1, 1)
+
+
+def test_dense_constructor_with_shape():
+    res1d = coo_array([1, 2, 3], shape=(3,))
+    assert res1d.shape == (3,)
+    assert np.array_equal(res1d.toarray(), np.array([1, 2, 3]))
+
+    res2d = coo_array([[1, 2, 3], [4, 5, 6]], shape=(2, 3))
+    assert res2d.shape == (2, 3)
+    assert np.array_equal(res2d.toarray(), np.array([[1, 2, 3], [4, 5, 6]]))
+
+    res3d = coo_array([[[3]], [[4]]], shape=(2, 1, 1))
+    assert res3d.shape == (2, 1, 1)
+
+
+def test_dense_constructor_with_inconsistent_shape():
+    with pytest.raises(ValueError, match='inconsistent shapes'):
+        coo_array([1, 2, 3], shape=(4,))
+
+    with pytest.raises(ValueError, match='inconsistent shapes'):
+        coo_array([1, 2, 3], shape=(3, 1))
+
+    with pytest.raises(ValueError, match='inconsistent shapes'):
+        coo_array([[1, 2, 3]], shape=(3,))
+
+    with pytest.raises(ValueError,
+                       match='axis 0 index 2 exceeds matrix dimension 2'):
+        coo_array(([1], ([2],)), shape=(2,))
+
+    with pytest.raises(ValueError, match='negative axis 0 index: -1'):
+        coo_array(([1], ([-1],)))
+
+
+def test_1d_sparse_constructor():
+    empty1d = coo_array((3,))
+    res = coo_array(empty1d)
+    assert res.shape == (3,)
+    assert np.array_equal(res.toarray(), np.zeros((3,)))
+
+
+def test_1d_tuple_constructor():
+    res = coo_array(([9,8], ([1,2],)))
+    assert res.shape == (3,)
+    assert np.array_equal(res.toarray(), np.array([0, 9, 8]))
+
+
+def test_1d_tuple_constructor_with_shape():
+    res = coo_array(([9,8], ([1,2],)), shape=(4,))
+    assert res.shape == (4,)
+    assert np.array_equal(res.toarray(), np.array([0, 9, 8, 0]))
+
+def test_non_subscriptability():
+    coo_2d = coo_array((2, 2))
+    
+    with pytest.raises(TypeError,
+                        match="'coo_array' object does not support item assignment"):
+        coo_2d[0, 0] = 1
+
+    with pytest.raises(TypeError,
+                       match="'coo_array' object is not subscriptable"):
+        coo_2d[0, :]
+
+def test_reshape():
+    arr1d = coo_array([1, 0, 3])
+    assert arr1d.shape == (3,)
+    
+    col_vec = arr1d.reshape((3, 1))
+    assert col_vec.shape == (3, 1)
+    assert np.array_equal(col_vec.toarray(), np.array([[1], [0], [3]]))
+
+    row_vec = arr1d.reshape((1, 3))
+    assert row_vec.shape == (1, 3)
+    assert np.array_equal(row_vec.toarray(), np.array([[1, 0, 3]]))
+
+    arr2d = coo_array([[1, 2, 0], [0, 0, 3]])
+    assert arr2d.shape == (2, 3)
+
+    flat = arr2d.reshape((6,))
+    assert flat.shape == (6,)
+    assert np.array_equal(flat.toarray(), np.array([1, 2, 0, 0, 0, 3]))
+
+
+def test_nnz():
+    arr1d = coo_array([1, 0, 3])
+    assert arr1d.shape == (3,)
+    assert arr1d.nnz == 2
+
+    arr2d = coo_array([[1, 2, 0], [0, 0, 3]])
+    assert arr2d.shape == (2, 3)
+    assert arr2d.nnz == 3
+
+    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]])
+    assert arr3d.shape == (1, 2, 3)
+    assert arr3d.nnz == 2
+
+
+def test_transpose():
+    arr1d = coo_array([1, 0, 3]).T
+    assert arr1d.shape == (3,)
+    assert np.array_equal(arr1d.toarray(), np.array([1, 0, 3]))
+
+    arr2d = coo_array([[1, 2, 0], [0, 0, 3]]).T
+    assert arr2d.shape == (3, 2)
+    assert np.array_equal(arr2d.toarray(), np.array([[1, 0], [2, 0], [0, 3]]))
+
+    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]]).T
+    assert arr3d.shape == (3, 2, 1)
+
+
+def test_transpose_with_axis():
+    arr1d = coo_array([1, 0, 3]).transpose(axes=(0,))
+    assert arr1d.shape == (3,)
+    assert np.array_equal(arr1d.toarray(), np.array([1, 0, 3]))
+
+    arr2d = coo_array([[1, 2, 0], [0, 0, 3]]).transpose(axes=(0, 1))
+    assert arr2d.shape == (2, 3)
+    assert np.array_equal(arr2d.toarray(), np.array([[1, 2, 0], [0, 0, 3]]))
+
+    arr3d = coo_array([[[1, 2, 0], [0, 0, 0]]]).transpose(axes=(1, 0, 2))
+    assert arr3d.shape == (2, 1, 3)
+
+    with pytest.raises(ValueError, match="axes don't match matrix dimensions"):
+        coo_array([1, 0, 3]).transpose(axes=(0, 1))
+
+    with pytest.raises(ValueError, match="repeated axis in transpose"):
+        coo_array([[1, 2, 0], [0, 0, 3]]).transpose(axes=(1, 1))
+
+
+def test_1d_row_and_col():
+    res = coo_array([1, -2, -3])
+    assert np.array_equal(res.row, np.array([0, 1, 2]))
+    assert np.array_equal(res.col, np.zeros_like(res.row))
+    assert res.row.dtype == res.col.dtype
+
+    res.row = [1, 2, 3]
+    assert len(res.indices) == 1
+    assert np.array_equal(res.row, np.array([1, 2, 3]))
+    assert res.row.dtype == res.col.dtype
+
+    with pytest.raises(ValueError, match="cannot set col attribute"):
+        res.col = [1, 2, 3]
+
+
+def test_1d_tocsc_tocsr_todia_todok():
+    res = coo_array([1, -2, -3])
+    for f in [res.tocsc, res.tocsr, res.todok, res.todia]:
+        with pytest.raises(ValueError, match='Cannot convert'):
+            f()
+
+
+@pytest.mark.parametrize('arg', [1, 2, 4, 5, 8])
+def test_1d_resize(arg: int):
+    den = np.array([1, -2, -3])
+    res = coo_array(den)
+    den.resize(arg)
+    res.resize(arg)
+    assert res.shape == den.shape
+    assert np.array_equal(res.toarray(), den)
+
+
+@pytest.mark.parametrize('arg', zip([1, 2, 3, 4], [1, 2, 3, 4]))
+def test_1d_to_2d_resize(arg: tuple[int, int]):
+    den = np.array([1, 0, 3])
+    res = coo_array(den)
+
+    den.resize(arg)
+    res.resize(arg)
+    assert res.shape == den.shape
+    assert np.array_equal(res.toarray(), den)
+
+
+@pytest.mark.parametrize('arg', [1, 4, 6, 8])
+def test_2d_to_1d_resize(arg: int):
+    den = np.array([[1, 0, 3], [4, 0, 0]])
+    res = coo_array(den)
+    den.resize(arg)
+    res.resize(arg)
+    assert res.shape == den.shape
+    assert np.array_equal(res.toarray(), den)
+
+
+def test_sum_duplicates():
+    arr1d = coo_array(([2, 2, 2], ([1, 0, 1],)))
+    assert arr1d.nnz == 3
+    assert np.array_equal(arr1d.toarray(), np.array([2, 4]))
+    arr1d.sum_duplicates()
+    assert arr1d.nnz == 2
+    assert np.array_equal(arr1d.toarray(), np.array([2, 4]))
+
+
+def test_eliminate_zeros():
+    arr1d = coo_array(([0, 0, 1], ([1, 0, 1],)))
+    assert arr1d.nnz == 3
+    assert arr1d.count_nonzero() == 1
+    assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
+    arr1d.eliminate_zeros()
+    assert arr1d.nnz == 1
+    assert arr1d.count_nonzero() == 1
+    assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
+    assert np.array_equal(arr1d.row, np.array([1]))
+
+
+def test_1d_add_dense():
+    den_a = np.array([0, -2, -3, 0])
+    den_b = np.array([0, 1, 2, 3])
+    exp = den_a + den_b
+    res = coo_array(den_a) + den_b
+    assert type(res) == type(exp)
+    assert np.array_equal(res, exp)
+
+
+def test_1d_add_sparse():
+    den_a = np.array([0, -2, -3, 0])
+    den_b = np.array([0, 1, 2, 3])
+    # Currently this routes through CSR format, so 1d sparse addition
+    # isn't supported.
+    with pytest.raises(ValueError,
+                       match='Cannot convert a 1d sparse array'):
+        coo_array(den_a) + coo_array(den_b)
+
+
+def test_1d_mul_vector():
+    den_a = np.array([0, -2, -3, 0])
+    den_b = np.array([0, 1, 2, 3])
+    exp = den_a @ den_b
+    res = coo_array(den_a) @ den_b
+    assert type(res) == type(exp)
+    assert np.array_equal(res, exp)
+
+
+def test_1d_mul_multivector():
+    den = np.array([0, -2, -3, 0])
+    other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
+    exp = den @ other
+    res = coo_array(den) @ other
+    assert type(res) == type(exp)
+    assert np.array_equal(res, exp)
+
+
+def test_2d_mul_multivector():
+    den = np.array([[0, 1, 2, 3], [3, 2, 1, 0]])
+    arr2d = coo_array(den)
+    exp = den @ den.T
+    res = arr2d @ arr2d.T
+    assert np.array_equal(res.toarray(), exp)
+
+
+def test_1d_diagonal():
+    den = np.array([0, -2, -3, 0])
+    with pytest.raises(ValueError, match='diagonal requires two dimensions'):
+        coo_array(den).diagonal()

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -67,13 +67,13 @@ class TestSparseUtils:
         assert_equal(sputils.isshape((-1, 2), nonneg=True),False)
         assert_equal(sputils.isshape((2, -1), nonneg=True),False)
 
-        assert_equal(sputils.isshape((1.5, 2), allow_ndim=True), False)
-        assert_equal(sputils.isshape(([2], 2), allow_ndim=True), False)
-        assert_equal(sputils.isshape((2, 2, -2), nonneg=True, allow_ndim=True),
+        assert_equal(sputils.isshape((1.5, 2), allow_1d=True), False)
+        assert_equal(sputils.isshape(([2], 2), allow_1d=True), False)
+        assert_equal(sputils.isshape((2, 2, -2), nonneg=True, allow_1d=True),
                      False)
-        assert_equal(sputils.isshape((2,), allow_ndim=True), True)
-        assert_equal(sputils.isshape((2, 2,), allow_ndim=True), True)
-        assert_equal(sputils.isshape((2, 2, 2), allow_ndim=True), True)
+        assert_equal(sputils.isshape((2,), allow_1d=True), True)
+        assert_equal(sputils.isshape((2, 2,), allow_1d=True), True)
+        assert_equal(sputils.isshape((2, 2, 2), allow_1d=True), False)
 
     def test_issequence(self):
         assert_equal(sputils.issequence((1,)), True)


### PR DESCRIPTION
This PR builds on the 1d COO work in #18530. It is intended to be reviewed after that PR is merged,
but I'm submitting it in draft form now to get CI-info and receive preliminary feedback.

Main goals:
- adds a module `test_common1d.py` for testing base/common activity with 1d arrays
- adds 1d support for: 
    - 1d min_max for `coo_array`. That means `_minmax_mixin` now supports 1d and 2d.
    - 1d format `dok_array`. That means `IndexMixin` now supports 1d and 2d.

Items of note:
- `_index.py`: Biggest change is refactoring `validate_indices`.
  - Inlined four helper functions: two short `maybe_boolean_index` and `_boolean_index_to_array`
    and two longer `check_ellipsis` and the recursive (max_depth 3) `_first_element_bool`.
    I also moved parts of `_unpack_indices` into the main function: handling a solo boolean
    matrix and a solo Ellipsis in the main function now.
  - Tempted to inline `_unpack_indices`. With 1d, it needs self.shape anyway. But I resisted
    because it makes the main function pretty long.
  - [Edit: resolved conflicts]~~The upcoming SciPy PR #18541 removes indexing support for multiple ellipsis. It will impact this code.~~
  - Current code raises an IndexError for a sparse index on one axis. Seems fixable, but not this PR.
  - The current behavior for first level boolean i.e. `A[True]` is not tested and doesn't
    seem to align with NumPy behavior, though the numpy behavior is strange too. I didn't
    try to make them the same here. But I could work at it if that's needed.

- `_dok.py`: has mostly straightforward `shape`-handling changes.
    The `__init__` method has the most changes. I added `astype` to avoid `tocsr()` and back again.

- `tests/test_base.py`:  [In fancy_indexing_boolean](https://github.com/scipy/scipy/blob/e00a5948a9dddd81954d2039d71e7b0ffe8a36bc/scipy/sparse/tests/test_base.py#L3012) one test makes sure we conflict with Numpy behavior.
    It requires that no error is raised when the index is larger than the array so long as only False
    values lie outside the valid boundaries. This example shows the difference.
    ```python
    A = np.array([[1,2], [0,1]])
    B = np.array([[True, False, False],[True, False, False],[False, False, False]])

    Asp = sp.sparse.csr_array(A)
    Bsp = sp.sparse.csr_array(B)

    Asp[Bsp]  # No exception raised!!
    A[B]     # Numpy does raise an IndexError. shapes must match.
    ```
    It is easily fixable, so I put in code that raises an IndexError with the same message as numpy.
    I'm sure this is what we want, but how dangerous is the change? Does it need a deprecation cycle
    even though it currently does the wrong thing?  (Probably not too many people use an array
    for indexing that is bigger than the array itself, but you never know).

    I added a few tests in that fancy_indexing_boolean method -- with no measurable time impact.

- `_base.py`: has more changes than I expected. Updating `iter` and `reshape`. Also, we need to fix
    matmul to return scalars or 1d arrays when appropriate. That's more for the future but some done here.

- `_data.py`: has changes to make min/max stuff work.
- `_coo.py`: update todok() to work with 1d.
- `tests/test_coo.py`: update todok() to work with 1d.
- `tests/test_common1d.py`: Most of these tests were taken from methods in test_base.py
  and refactored to act on 1d arrays. A few were pretty tricky -- like `test_empty_arithmetic`
  and `test_size_zero_matrix_arithmetic`. The TestCOO1D class is a straight-forward subclass
  rather than an instance as is done in test_base.py. I can change that if needed.