### PR TITLE
MAINT: stats.moment: rename parameter `moment` to `order`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4482,7 +4482,7 @@ class halfnorm_gen(rv_continuous):
         if fscale is not None:
             scale = fscale
         else:
-            scale = stats.moment(data, moment=2, center=loc)**0.5
+            scale = stats.moment(data, order=2, center=loc)**0.5
 
         return loc, scale
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -990,9 +990,9 @@ def moment(a, order=1, axis=0, nan_policy='propagate', *, center=None):
     Examples
     --------
     >>> from scipy.stats import moment
-    >>> moment([1, 2, 3, 4, 5], moment=1)
+    >>> moment([1, 2, 3, 4, 5], order=1)
     0.0
-    >>> moment([1, 2, 3, 4, 5], moment=2)
+    >>> moment([1, 2, 3, 4, 5], order=2)
     2.0
 
     """

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -920,7 +920,7 @@ def _moment_result_object(*args):
 #   returns it.
 # Currently this leads to a slight inconsistency: when the input array is
 # empty, there is no distinction between the `moment` function being called
-# with parameter `moments=1` and `moments=[1]`; the latter *should* produce
+# with parameter `order=1` and `order=[1]`; the latter *should* produce
 # the same as the former but with a singleton zeroth dimension.
 @_rename_parameter('moment', 'order')
 @_axis_nan_policy_factory(  # noqa: E302

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -887,9 +887,9 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
 
 def _moment_outputs(kwds):
-    moment = np.atleast_1d(kwds.get('moment', 1))
+    moment = np.atleast_1d(kwds.get('order', 1))
     if moment.size == 0:
-        raise ValueError("'moment' must be a scalar or a non-empty 1D "
+        raise ValueError("'order' must be a scalar or a non-empty 1D "
                          "list/array.")
     return len(moment)
 
@@ -922,11 +922,12 @@ def _moment_result_object(*args):
 # empty, there is no distinction between the `moment` function being called
 # with parameter `moments=1` and `moments=[1]`; the latter *should* produce
 # the same as the former but with a singleton zeroth dimension.
+@_rename_parameter('moment', 'order')
 @_axis_nan_policy_factory(  # noqa: E302
     _moment_result_object, n_samples=1, result_to_tuple=lambda x: (x,),
     n_outputs=_moment_outputs
 )
-def moment(a, moment=1, axis=0, nan_policy='propagate', *, center=None):
+def moment(a, order=1, axis=0, nan_policy='propagate', *, center=None):
     r"""Calculate the nth moment about the mean for a sample.
 
     A moment is a specific quantitative measure of the shape of a set of
@@ -937,7 +938,7 @@ def moment(a, moment=1, axis=0, nan_policy='propagate', *, center=None):
     ----------
     a : array_like
        Input array.
-    moment : int or array_like of ints, optional
+    order : int or array_like of ints, optional
        Order of central moment that is returned. Default is 1.
     axis : int or None, optional
        Axis along which the central moment is computed. Default is 0.
@@ -995,6 +996,7 @@ def moment(a, moment=1, axis=0, nan_policy='propagate', *, center=None):
     2.0
 
     """
+    moment = order  # parameter was renamed
     a, axis = _chk_asarray(a, axis)
 
     # for array_like moment input, return a value for each.

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -54,7 +54,7 @@ axis_nan_policy_cases = [
     (stats.kstat, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.kstatvar, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    (stats.moment, tuple(), dict(moment=[1, 2]), 1, 2, False, None),
+    (stats.moment, tuple(), dict(order=[1, 2]), 1, 2, False, None),
     (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
     (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
      unpack_ttest_result),

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1645,9 +1645,9 @@ class TestKstat:
         assert_allclose(moments, expected, rtol=1e-4)
 
         # test equivalence with `stats.moment`
-        m1 = stats.moment(data, moment=1)
-        m2 = stats.moment(data, moment=2)
-        m3 = stats.moment(data, moment=3)
+        m1 = stats.moment(data, order=1)
+        m2 = stats.moment(data, order=2)
+        m3 = stats.moment(data, order=3)
         assert_allclose((m1, m2, m3), expected[:-1], atol=0.02, rtol=1e-2)
 
     def test_empty_input(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3146,7 +3146,7 @@ class TestMoments:
             self._assert_equal(y, [], shape=(0,), dtype=np.float64)
             y = stats.moment([[]], axis=1)
             self._assert_equal(y, np.nan, shape=(1,), dtype=np.float64)
-            y = stats.moment([[]], moment=[0, 1], axis=0)
+            y = stats.moment([[]], order=[0, 1], axis=0)
             self._assert_equal(y, [], shape=(2, 0))
 
         x = np.arange(10.)
@@ -3157,21 +3157,21 @@ class TestMoments:
         assert_raises(ValueError, stats.moment, x, nan_policy='foobar')
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64, np.complex128])
-    @pytest.mark.parametrize('expect, moment', [(0, 1), (1, 0)])
-    def test_constant_moments(self, dtype, expect, moment):
+    @pytest.mark.parametrize('expect, order', [(0, 1), (1, 0)])
+    def test_constant_moments(self, dtype, expect, order):
         x = np.random.rand(5).astype(dtype)
-        y = stats.moment(x, moment=moment)
+        y = stats.moment(x, order=order)
         self._assert_equal(y, expect, dtype=dtype)
 
-        y = stats.moment(np.broadcast_to(x, (6, 5)), axis=0, moment=moment)
+        y = stats.moment(np.broadcast_to(x, (6, 5)), axis=0, order=order)
         self._assert_equal(y, expect, shape=(5,), dtype=dtype)
 
         y = stats.moment(np.broadcast_to(x, (1, 2, 3, 4, 5)), axis=2,
-                         moment=moment)
+                         order=order)
         self._assert_equal(y, expect, shape=(1, 2, 4, 5), dtype=dtype)
 
         y = stats.moment(np.broadcast_to(x, (1, 2, 3, 4, 5)), axis=None,
-                         moment=moment)
+                         order=order)
         self._assert_equal(y, expect, shape=(), dtype=dtype)
 
     def test_moment_propagate_nan(self):
@@ -3182,11 +3182,11 @@ class TestMoments:
         mm = stats.moment(a, 2, axis=1, nan_policy="propagate")
         np.testing.assert_allclose(mm, [1.25, np.nan], atol=1e-15)
 
-    def test_moment_empty_moment(self):
-        # tests moment with empty `moment` list
-        with pytest.raises(ValueError, match=r"'moment' must be a scalar or a"
+    def test_moment_empty_order(self):
+        # tests moment with empty `order` list
+        with pytest.raises(ValueError, match=r"'order' must be a scalar or a"
                                              r" non-empty 1D list/array."):
-            stats.moment([1, 2, 3, 4], moment=[])
+            stats.moment([1, 2, 3, 4], order=[])
 
     def test_skewness(self):
         # Scalar test case
@@ -3334,7 +3334,7 @@ def ttest_data_axis_strategy(draw):
         warnings.simplefilter("error")
         for axis in range(len(data.shape)):
             with contextlib.suppress(Exception):
-                var = stats.moment(data, moment=2, axis=axis)
+                var = stats.moment(data, order=2, axis=axis)
                 if np.all(var > 0) and np.all(np.isfinite(var)):
                     ok_axes.append(axis)
     # if there are no valid axes, tell hypothesis to try a different example

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3188,6 +3188,14 @@ class TestMoments:
                                              r" non-empty 1D list/array."):
             stats.moment([1, 2, 3, 4], order=[])
 
+    def test_rename_moment_order(self):
+        # Parameter 'order' was formerly known as 'moment'. The old name
+        # has not been deprecated, so it must continue to work.
+        x = np.arange(10)
+        res = stats.moment(x, moment=3)
+        ref = stats.moment(x, order=3)
+        np.testing.assert_equal(res, ref)
+
     def test_skewness(self):
         # Scalar test case
         y = stats.skew(self.scalar_testcase)


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
`stats.moment` has a parameter named `moment`. Given that the description is

> Order of central moment that is returned

and the name of the equivalent argument of [`scipy.stats.rv_generic.moment`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.moment.html) is `order`, 

<img width="766" alt="image" src="https://github.com/scipy/scipy/assets/6570539/633ac30d-0551-4fda-acdb-122a3a1e3337">

I think the name `order` would be more appropriate.

This PR renames the parameter in a way that maintains backward compatibility (i.e. use of keyword-argument 'moment' is still allowed as an alias).

#### Additional information

- This would need approval from the mailing list.
- We could consider deprecating use of kwarg `moment` instead of leaving it as an alias, but I am not necessarily pushing for it.
- I could refactor the code to actually use `order` instead of `moment`, but I chose instead to let `moment = order` at the top to minimize the diff.


