### PR TITLE
BLD: avoid fast-math for oneAPI compilers, fix up handling of `special` headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,18 +96,18 @@ endif
 # is actually needed, everything else shouldn't be there).
 _intel_cflags = []
 _intel_fflags = []
-if cc.get_id() == 'intel'
+if cc.get_id() in ['intel', 'intel-llvm']
   _intel_cflags += cc.get_supported_arguments('-fp-model=strict')
-elif cc.get_id() == 'intel-cl'
+elif cc.get_id() in ['intel-cl', 'intel-llvm-cl']
   _intel_cflags += cc.get_supported_arguments('/fp:strict')
 endif
-if ff.get_id() == 'intel'
+if ff.get_id() in ['intel', 'intel-llvm']
   _intel_fflags = ff.get_supported_arguments('-fp-model=strict')
   minus0_arg = ['-assume', 'minus0']
   if ff.has_multi_arguments(minus0_arg)
     _intel_fflags += minus0_arg
   endif
-elif ff.get_id() == 'intel-cl'
+elif ff.get_id() in ['intel-cl', 'intel-llvm-cl']
   # Intel Fortran on Windows does things differently, so deal with that
   # (also specify dynamic linking and the right name mangling)
   _intel_fflags = ff.get_supported_arguments(

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -478,24 +478,17 @@ foreach npz_file: npz_files
 endforeach
 
 
+# Headers for special functions in `special` library (temporary name) are
+# included in both build and install dirs for development purposes. Not public!
 special_sources = [
   'special/config.h',
   'special/error.h',
   'special/evalpoly.h',
   'special/lambertw.h'
 ]
-
-# Headers for special functions in special library are included
-# in build folder for development purposes.
-# special is a temporary working name.
+py3.install_sources(special_sources, subdir: 'scipy/special/special')
 foreach header: special_sources
-  configure_file(
-    input: header,
-    output: header.split('/')[-1],
-    copy: true,
-    install: true,
-    install_dir: py3.get_install_dir() / 'scipy/special/special'
-  )
+  fs.copyfile(header)
 endforeach
 
 python_sources = [


### PR DESCRIPTION
Using fast-math is undesirable and also leads to hundreds of build warnings. We did this already for `icc`/`ifort`, but the new `icx`/`ifx` compilers are completely different and have separate IDs in Meson.

The second commit avoids use of a deprecated Meson feature. That may be removed and hence break the build, so is important to backport.