### PR TITLE
BUG: fix negative overflow in stats.boxcox_normmax

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1314,7 +1314,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
     else:
         # Test if the optimal lambda causes overflow
         x = np.asarray(x)
-        x_treme = np.max(x, axis=0) if res > 0 else np.min(x, axis=0)
+        x_treme = np.max(x, axis=0) if np.any(res > 0) else np.min(x, axis=0)
         istransinf = np.isinf(special.boxcox(x_treme, res))
         dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
         if np.any(istransinf):

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1320,8 +1320,11 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
 
         sign_lmbm1 = np.sign(res - 1)
         x_treme = np.max(x) if np.any(sign_lmbm1) else np.min(x)
+
+        # There are two conditions of overflow to check
+        # 1. x>1, lmb>1; 2. x<1, lmb<1
         mask = False
-        if np.any((x_treme - 1) * sign_lmbm1):
+        if np.any((x_treme - 1) * sign_lmbm1 > 0):
             mask = special.boxcox(x_treme, res) * sign_lmbm1 > ymax
 
         if np.any(mask):

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1319,7 +1319,7 @@ def boxcox_normmax(x, brack=None, method='pearsonr', optimizer=None):
         ymax = np.finfo(dtype).max / 10000
 
         sign_lmbm1 = np.sign(res - 1)
-        x_treme = np.max(x) if np.any(sign_lmbm1) else np.min(x)
+        x_treme = np.max(x) if np.any(sign_lmbm1 > 0) else np.min(x)
 
         # There are two conditions of overflow to check
         # 1. x>1, lmb>1; 2. x<1, lmb<1

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2073,7 +2073,7 @@ class TestBoxcoxNormmax:
         ymax = np.finfo(np.float64).max / 10000
         x_treme = np.max(x) if lmbda > 0 else np.min(x)
         y_extreme = special.boxcox(x_treme, lmbda)
-        assert_allclose(y_extreme, ymax * np.sign(lmbda))
+        assert_allclose(y_extreme, ymax * np.sign(lmbda), rtol=2e-1)
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1989,6 +1989,20 @@ class TestBoxcox:
         with pytest.raises(ValueError, match=message):
             stats.boxcox_normmax(bad_x)
 
+    @pytest.mark.parametrize('x', [
+        # Attempt to trigger overflow in power expressions.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
+                  2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
+        # Attempt to trigger overflow with a large optimal lambda.
+        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0]),
+        # Attempt to trigger overflow with large data.
+        np.array([2003.0e200, 1950.0e200, 1997.0e200, 2000.0e200, 2009.0e200])
+    ])
+    def test_overflow(self, x):
+        with pytest.warns(UserWarning, match="The optimal lambda is"):
+            xt_bc, lam_bc = stats.boxcox(x)
+            assert np.all(np.isfinite(xt_bc))
+
 
 class TestBoxcoxNormmax:
     def setup_method(self):
@@ -2071,10 +2085,9 @@ class TestBoxcoxNormmax:
         assert np.isfinite(special.boxcox(x, lmbda)).all()
         # 10000 is safety factor used in boxcox_normmax
         ymax = np.finfo(np.float64).max / 10000
-        sign_lmbm1 = np.sign(lmbda - 1)
-        x_treme = np.max(x) if sign_lmbm1 > 0 else np.min(x)
+        x_treme = np.max(x) if lmbda > 0 else np.min(x)
         y_extreme = special.boxcox(x_treme, lmbda)
-        assert_allclose(y_extreme, ymax * sign_lmbm1)
+        assert_allclose(y_extreme, ymax * np.sign(lmbda))
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -15,7 +15,7 @@ from numpy.testing import (assert_array_equal, assert_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 import re
-from scipy import optimize, stats, special
+from scipy import optimize, stats
 from scipy.stats._morestats import _abw_state, _get_As_weibull, _Avals_weibull
 from .common_tests import check_named_results
 from .._hypotests import _get_wilcoxon_distr, _get_wilcoxon_distr2

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2071,9 +2071,10 @@ class TestBoxcoxNormmax:
         assert np.isfinite(special.boxcox(x, lmbda)).all()
         # 10000 is safety factor used in boxcox_normmax
         ymax = np.finfo(np.float64).max / 10000
-        x_treme = np.max(x) if lmbda > 0 else np.min(x)
+        sign_lmbm1 = np.sign(lmbda - 1)
+        x_treme = np.max(x) if sign_lmbm1 > 0 else np.min(x)
         y_extreme = special.boxcox(x_treme, lmbda)
-        assert_allclose(y_extreme, ymax * np.sign(lmbda), rtol=2e-1)
+        assert_allclose(y_extreme, ymax * sign_lmbm1)
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1990,12 +1990,11 @@ class TestBoxcox:
             stats.boxcox_normmax(bad_x)
 
     @pytest.mark.parametrize('x', [
-        # Attempt to trigger overflow in power expressions.
-        np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0,
-                  2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
-        # Attempt to trigger overflow with a large optimal lambda.
+        # negative overflow
+        np.array([0.50000471, 0.50004979, 0.50005902, 0.50009312, 0.50001632]),
+        # positive overflow
         np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0]),
-        # Attempt to trigger overflow with large data.
+        # positive overflow
         np.array([2003.0e200, 1950.0e200, 1997.0e200, 2000.0e200, 2009.0e200])
     ])
     def test_overflow(self, x):
@@ -2074,20 +2073,6 @@ class TestBoxcoxNormmax:
 
             stats.boxcox_normmax(self.x, brack=(-2.0, 2.0),
                                  optimizer=optimizer)
-
-    @pytest.mark.parametrize(
-        'x', ([2003.0, 1950.0, 1997.0, 2000.0, 2009.0],
-              [0.50000471, 0.50004979, 0.50005902, 0.50009312, 0.50001632]))
-    def test_overflow(self, x):
-        message = "The optimal lambda is..."
-        with pytest.warns(UserWarning, match=message):
-            lmbda = stats.boxcox_normmax(x, method='mle')
-        assert np.isfinite(special.boxcox(x, lmbda)).all()
-        # 10000 is safety factor used in boxcox_normmax
-        ymax = np.finfo(np.float64).max / 10000
-        x_treme = np.max(x) if lmbda > 0 else np.min(x)
-        y_extreme = special.boxcox(x_treme, lmbda)
-        assert_allclose(y_extreme, ymax * np.sign(lmbda))
 
 
 class TestBoxcoxNormplot:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -15,8 +15,7 @@ from numpy.testing import (assert_array_equal, assert_almost_equal,
 import pytest
 from pytest import raises as assert_raises
 import re
-from scipy import optimize
-from scipy import stats
+from scipy import optimize, stats, special
 from scipy.stats._morestats import _abw_state, _get_As_weibull, _Avals_weibull
 from .common_tests import check_named_results
 from .._hypotests import _get_wilcoxon_distr, _get_wilcoxon_distr2
@@ -2075,6 +2074,20 @@ class TestBoxcoxNormmax:
 
             stats.boxcox_normmax(self.x, brack=(-2.0, 2.0),
                                  optimizer=optimizer)
+
+    @pytest.mark.parametrize(
+        'x', ([2003.0, 1950.0, 1997.0, 2000.0, 2009.0],
+              [0.50000471, 0.50004979, 0.50005902, 0.50009312, 0.50001632]))
+    def test_overflow(self, x):
+        message = "The optimal lambda is..."
+        with pytest.warns(UserWarning, match=message):
+            lmbda = stats.boxcox_normmax(x, method='mle')
+        assert np.isfinite(special.boxcox(x, lmbda)).all()
+        # 10000 is safety factor used in boxcox_normmax
+        ymax = np.finfo(np.float64).max / 10000
+        x_treme = np.max(x) if lmbda > 0 else np.min(x)
+        y_extreme = special.boxcox(x_treme, lmbda)
+        assert_allclose(y_extreme, ymax * np.sign(lmbda))
 
 
 class TestBoxcoxNormplot:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Follow up #19604 (The prior fix positive overflow, this fix negative overflow)
Towards #19016

#### What does this implement/fix?
<!--Please explain your changes.-->

Negative overflow https://github.com/scipy/scipy/pull/19631#issuecomment-1847524240

There are two cases to check, see https://github.com/scipy/scipy/pull/19631#issuecomment-1846976320 for more detail.
- When `xmax` > 1 and `lmb` > 1, check if `BC(xmax)` > `ymax`
- When `xmin` < 1 and `lmb` < 0, check if `BC(xmin)` < `-ymax`

#### Additional information
<!--Any additional information you think is important.-->

The second check is improved from `xmin` < 1 and `lmb` < 1 to `xmin` < 1 and `lmb` < 0
See https://github.com/scipy/scipy/pull/19631#issuecomment-1847150161 for explanation and 

```python
from scipy.special import boxcox
print(boxcox(np.finfo(np.float64).smallest_normal, 0))
# -708.3964185322641
```
