### PR TITLE
BUG: Prevent mutation of `w` parameter in `spatial.distance.*`

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -626,7 +626,7 @@ def correlation(u, v, w=None, centered=True):
     v = _validate_vector(v)
     if w is not None:
         w = _validate_weights(w)
-        w /= w.sum()
+        w = w / w.sum()
     if centered:
         if w is not None:
             umu = np.dot(u, w)
@@ -748,7 +748,7 @@ def hamming(u, v, w=None):
         w = _validate_weights(w)
         if w.shape != u.shape:
             raise ValueError("'w' should have the same length as 'u' and 'v'.")
-        w /= w.sum()
+        w = w / w.sum()
         return np.dot(u_ne_v, w)
     return np.mean(u_ne_v)
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -47,6 +47,8 @@ from numpy.testing import (verbose, assert_,
                            break_cycles, IS_PYPY)
 import pytest
 
+import scipy.spatial.distance
+
 from scipy.spatial.distance import (
     squareform, pdist, cdist, num_obs_y, num_obs_dm, is_valid_dm, is_valid_y,
     _validate_vector, _METRICS_NAMES)
@@ -2250,3 +2252,11 @@ def test_gh_17703():
     actual = cdist(np.atleast_2d(arr_1),
                    np.atleast_2d(arr_2), metric='dice')
     assert_allclose(actual, expected)
+
+
+def test_immutable_input(metric):
+    if metric in ("jensenshannon", "mahalanobis", "seuclidean"):
+        pytest.skip("not applicable")
+    x = np.arange(10, dtype=np.float64)
+    x.setflags(write=False)
+    getattr(scipy.spatial.distance, metric)(x, x, w=x)


### PR DESCRIPTION
#### What does this implement/fix?
#19583 and #19589 introduced a bug where the `w` parameter to `spatial.distance.hamming` and `spatial.distance.correlation` was mutated. I was under the impression that `_validate_weights` would return a copy which obviously isn't the case, sorry about that. This PR fixes this.

