### PR TITLE
MAINT: Prefer `np.fill_diagonal` over `diag_indices`

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -467,7 +467,7 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
         # xGEBAL does not remove the diagonals before scaling. Also
         # to avoid destroying the Symplectic structure, we follow Ref.3
         M = np.abs(H) + np.abs(J)
-        M[np.diag_indices_from(M)] = 0.
+        np.fill_diagonal(M, 0.)
         _, (sca, _) = matrix_balance(M, separate=1, permute=0)
         # do we need to bother?
         if not np.allclose(sca, np.ones_like(sca)):
@@ -673,7 +673,7 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
         # xGEBAL does not remove the diagonals before scaling. Also
         # to avoid destroying the Symplectic structure, we follow Ref.3
         M = np.abs(H) + np.abs(J)
-        M[np.diag_indices_from(M)] = 0.
+        np.fill_diagonal(M, 0.)
         _, (sca, _) = matrix_balance(M, separate=1, permute=0)
         # do we need to bother?
         if not np.allclose(sca, np.ones_like(sca)):


### PR DESCRIPTION
#### What does this implement/fix?

`np.fill_diagonal` internally uses a faster implementation that never constructs the indices and uses simple slicing (ref [numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.fill_diagonal.html))