### PR TITLE
MAINT: bump project version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
 
 [project]
 name = "SciPy"
-version = "1.12.0.dev0"
+version = "1.13.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}


### PR DESCRIPTION
* if you do i.e., `pip install -v .` on latest SciPy `main` branch, the version string reported via `pip list` (for example) will be wrong, so fix that here

* I guess as `pyproject.toml` gains more (meta)data I need to be more careful

[skip cirrus] [skip circle]