### PR TITLE
MAINT: make import of `array_api_compat` nicer

### DIFF
--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -124,31 +124,55 @@ py3.install_sources(
   subdir: 'scipy/_lib'
 )
 
-python_sources = [
-  'array_api_compat/array_api_compat/__init__.py',
-  'array_api_compat/array_api_compat/_internal.py',
-  'array_api_compat/array_api_compat/common/__init__.py',
-  'array_api_compat/array_api_compat/common/_aliases.py',
-  'array_api_compat/array_api_compat/common/_helpers.py',
-  'array_api_compat/array_api_compat/common/_linalg.py',
-  'array_api_compat/array_api_compat/common/_typing.py',
-  'array_api_compat/array_api_compat/cupy/__init__.py',
-  'array_api_compat/array_api_compat/cupy/_aliases.py',
-  'array_api_compat/array_api_compat/cupy/_typing.py',
-  'array_api_compat/array_api_compat/cupy/linalg.py',
-  'array_api_compat/array_api_compat/numpy/__init__.py',
-  'array_api_compat/array_api_compat/numpy/_aliases.py',
-  'array_api_compat/array_api_compat/numpy/_typing.py',
-  'array_api_compat/array_api_compat/numpy/linalg.py',
-  'array_api_compat/array_api_compat/torch/__init__.py',
-  'array_api_compat/array_api_compat/torch/_aliases.py',
-  'array_api_compat/array_api_compat/torch/linalg.py',
-]
+# `array_api_compat` install to simplify import path;
+# should be updated whenever new files are added to `array_api_compat`
 
 py3.install_sources(
-  python_sources,
-  preserve_path: true,
-  subdir: 'scipy/_lib'
+  [
+    'array_api_compat/array_api_compat/__init__.py',
+    'array_api_compat/array_api_compat/_internal.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat',
+)
+
+py3.install_sources(
+  [
+    'array_api_compat/array_api_compat/common/__init__.py',
+    'array_api_compat/array_api_compat/common/_aliases.py',
+    'array_api_compat/array_api_compat/common/_helpers.py',
+    'array_api_compat/array_api_compat/common/_linalg.py',
+    'array_api_compat/array_api_compat/common/_typing.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/common',
+)
+
+py3.install_sources(
+  [
+    'array_api_compat/array_api_compat/cupy/__init__.py',
+    'array_api_compat/array_api_compat/cupy/_aliases.py',
+    'array_api_compat/array_api_compat/cupy/_typing.py',
+    'array_api_compat/array_api_compat/cupy/linalg.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/cupy',
+)
+
+py3.install_sources(
+  [
+    'array_api_compat/array_api_compat/numpy/__init__.py',
+    'array_api_compat/array_api_compat/numpy/_aliases.py',
+    'array_api_compat/array_api_compat/numpy/_typing.py',
+    'array_api_compat/array_api_compat/numpy/linalg.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/numpy',
+)
+
+py3.install_sources(
+  [
+    'array_api_compat/array_api_compat/torch/__init__.py',
+    'array_api_compat/array_api_compat/torch/_aliases.py',
+    'array_api_compat/array_api_compat/torch/linalg.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/torch',
 )
 
 subdir('_uarray')

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -5,7 +5,7 @@ from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, as_xparray, copy, xp_assert_equal, is_numpy
 )
-import scipy._lib.array_api_compat.array_api_compat.numpy as np_compat
+import scipy._lib.array_api_compat.numpy as np_compat
 
 
 @pytest.mark.skipif(not _GLOBAL_CONFIG["SCIPY_ARRAY_API"],

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -12,7 +12,7 @@ from ._ufuncs import (
     gammaln, gammainc, gammaincc, logit, expit)  # noqa: F401
 
 _SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
-array_api_compat_prefix = "scipy._lib.array_api_compat.array_api_compat"
+array_api_compat_prefix = "scipy._lib.array_api_compat"
 
 
 def get_array_special_func(f_name, xp, n_array_args):

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -7,7 +7,7 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
 from scipy.conftest import array_api_compatible
 from scipy import special
 from scipy._lib._array_api import xp_assert_close
-from scipy._lib.array_api_compat.array_api_compat import numpy as np
+from scipy._lib.array_api_compat import numpy as np
 import numpy.array_api as np_array_api
 
 


### PR DESCRIPTION
#### Reference issue
Towards gh-18866

#### What does this implement/fix?
- Changes the import from e.g. `from scipy._lib.array_api_compat.array_api_compat import numpy` to just `from scipy._lib.array_api_compat import numpy`
- Uses the new import

#### Additional information
@rgommers is there a nicer way to do this? See https://github.com/mesonbuild/meson/issues/12601 for why I've used `install_data`.

- Also moves from `np.testing.assert_` to `assert` in the `xp` assertions since we're cleaning up imports
