### PR TITLE
DEP: Adopt `*tol` deprecations also for `gcrotmk/lgmres/minres/tfqmr`

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1477,10 +1477,10 @@ class KrylovJacobian(Jacobian):
         return r
 
     def solve(self, rhs, tol=0):
-        if 'tol' in self.method_kw:
+        if 'rtol' in self.method_kw:
             sol, info = self.method(self.op, rhs, **self.method_kw)
         else:
-            sol, info = self.method(self.op, rhs, tol=tol, **self.method_kw)
+            sol, info = self.method(self.op, rhs, rtol=tol, **self.method_kw)
         return sol
 
     def update(self, x, f):

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -207,7 +207,8 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
 
         .. warning::
 
-           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
+           The default value for ``atol`` will be changed to ``0.0`` in
+           SciPy 1.14.0.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -245,8 +246,8 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `gcrotmk` keyword argument `tol` is deprecated in favor of `rtol`
-           and will be removed in SciPy 1.14.
+           `gcrotmk` keyword argument ``tol`` is deprecated in favor of
+           ``rtol`` and will be removed in SciPy 1.14.0.
 
     Returns
     -------

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2015, Pauli Virtanen <pav@iki.fi>
 # Distributed under the same license as SciPy.
 
-import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
 from scipy.linalg import (get_blas_funcs, qr, solve, svd, qr_insert, lstsq)
+from .iterative import _get_atol_rtol
 from scipy.sparse.linalg._isolve.utils import make_system
-from scipy._lib.deprecation import _deprecate_positional_args
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = ['gcrotmk']
@@ -183,9 +183,9 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
 
 
 @_deprecate_positional_args(version="1.14.0")
-def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
+def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
             m=20, k=None, CU=None, discard_C=False, truncate='oldest',
-            atol=None):
+            atol=None, rtol=1e-5):
     """
     Solve a matrix equation using flexible GCROT(m,k) algorithm.
 
@@ -200,14 +200,14 @@ def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : ndarray
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-        The default for ``atol`` is `tol`.
+    rtol, atol : float, optional
+        Parameters for the convergence test. For convergence,
+        ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
 
         .. warning::
 
-           The default value for `atol` will be changed in a future release.
-           For future compatibility, specify `atol` explicitly.
+           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -242,6 +242,11 @@ def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
         smallest singular values using the scheme discussed in [1,2].
         See [2]_ for detailed comparison.
         Default: 'oldest'
+    tol : float, optional, deprecated
+
+        .. deprecated:: 1.12.0
+           `gcrotmk` keyword argument `tol` is deprecated in favor of `rtol`
+           and will be removed in SciPy 1.14.
 
     Returns
     -------
@@ -287,12 +292,8 @@ def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
     if truncate not in ('oldest', 'smallest'):
         raise ValueError(f"Invalid value for 'truncate': {truncate!r}")
 
-    if atol is None:
-        warnings.warn("scipy.sparse.linalg.gcrotmk called without specifying `atol`. "
-                      "The default value will change in the future. To preserve "
-                      "current behavior, set ``atol=tol``.",
-                      category=DeprecationWarning, stacklevel=2)
-        atol = tol
+    # we call this to get the right atol/rtol and raise warnings as necessary
+    atol, rtol = _get_atol_rtol('gcrotmk', b, tol, atol, rtol)
 
     matvec = A.matvec
     psolve = M.matvec
@@ -385,7 +386,7 @@ def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
         beta = nrm2(r)
 
         # -- check stopping condition
-        beta_tol = max(atol, tol * b_norm)
+        beta_tol = max(atol, rtol * b_norm)
 
         if beta <= beta_tol and (j_outer > 0 or CU):
             # recompute residual to avoid rounding error
@@ -405,7 +406,7 @@ def gcrotmk(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
                                                r/beta,
                                                ml,
                                                rpsolve=psolve,
-                                               atol=max(atol, tol*b_norm)/beta,
+                                               atol=max(atol, rtol*b_norm)/beta,
                                                cs=cs)
             y *= beta
         except LinAlgError:

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -292,9 +292,6 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     if truncate not in ('oldest', 'smallest'):
         raise ValueError(f"Invalid value for 'truncate': {truncate!r}")
 
-    # we call this to get the right atol/rtol and raise warnings as necessary
-    atol, rtol = _get_atol_rtol('gcrotmk', b, tol, atol, rtol)
-
     matvec = A.matvec
     psolve = M.matvec
 
@@ -314,6 +311,10 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     axpy, dot, scal, nrm2 = get_blas_funcs(['axpy', 'dot', 'scal', 'nrm2'], (x, r))
 
     b_norm = nrm2(b)
+
+    # we call this to get the right atol/rtol and raise warnings as necessary
+    atol, rtol = _get_atol_rtol('gcrotmk', b_norm, tol, atol, rtol)
+
     if b_norm == 0:
         x = b
         return (postprocess(x), 0)

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -13,18 +13,17 @@ def _get_atol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
     A helper function to handle tolerance deprecations and normalization
     """
     if tol is not _NoValue:
-        msg = (f"'scipy.sparse.linalg.{name}' keyword argument 'tol' is "
-               "deprecated in favor of 'rtol' and will be removed in SciPy "
-               "v.1.14.0. Until then, if set, it will override 'rtol'.")
+        msg = (f"'scipy.sparse.linalg.{name}' keyword argument `tol` is "
+               "deprecated in favor of `rtol` and will be removed in SciPy "
+               "v1.14. Until then, if set, it will override `rtol`.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         rtol = float(tol) if tol is not None else rtol
 
     if atol == 'legacy':
-        warnings.warn("scipy.sparse.linalg.{name} called with `atol` set to "
-                      "string. This behavior is deprecated and atol parameter"
-                      " only excepts floats. In SciPy 1.14, this will result"
-                      " with an error.", category=DeprecationWarning,
-                      stacklevel=4)
+        msg = (f"'scipy.sparse.linalg.{name}' called with `atol='legacy'`. "
+               "This behavior is deprecated and will result in an error in "
+               "SciPy v1.14. To preserve current behaviour, set `atol=0.0`.")
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         atol = 0
 
     atol = max(float(atol), float(rtol) * float(np.linalg.norm(b)))

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -26,7 +26,7 @@ def _get_atol_rtol(name, b_norm, tol=_NoValue, atol=0., rtol=1e-5):
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         atol = 0
 
-    # this branch is only hit from gcrotmk/lgmres
+    # this branch is only hit from gcrotmk/lgmres/tfqmr
     if atol is None:
         msg = (f"'scipy.sparse.linalg.{name}' called without specifying "
                "`atol`. This behavior is deprecated and will result in an "

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -15,14 +15,14 @@ def _get_atol_rtol(name, b_norm, tol=_NoValue, atol=0., rtol=1e-5):
     if tol is not _NoValue:
         msg = (f"'scipy.sparse.linalg.{name}' keyword argument `tol` is "
                "deprecated in favor of `rtol` and will be removed in SciPy "
-               "v1.14. Until then, if set, it will override `rtol`.")
+               "v1.14.0. Until then, if set, it will override `rtol`.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         rtol = float(tol) if tol is not None else rtol
 
     if atol == 'legacy':
         msg = (f"'scipy.sparse.linalg.{name}' called with `atol='legacy'`. "
                "This behavior is deprecated and will result in an error in "
-               "SciPy v1.14. To preserve current behaviour, set `atol=0.0`.")
+               "SciPy v1.14.0. To preserve current behaviour, set `atol=0.0`.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         atol = 0
 
@@ -30,7 +30,7 @@ def _get_atol_rtol(name, b_norm, tol=_NoValue, atol=0., rtol=1e-5):
     if atol is None:
         msg = (f"'scipy.sparse.linalg.{name}' called without specifying "
                "`atol`. This behavior is deprecated and will result in an "
-               "error in SciPy v1.14. To preserve current behaviour, set "
+               "error in SciPy v1.14.0. To preserve current behaviour, set "
                "`atol=rtol`, or, to adopt the future default, set `atol=0.0`.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         atol = rtol
@@ -74,8 +74,8 @@ def bicg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `bicg` keyword argument `tol` is deprecated in favor of `rtol` and
-           will be removed in SciPy 1.14.0.
+           `bicg` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -203,8 +203,8 @@ def bicgstab(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `bicgstab` keyword argument `tol` is deprecated in favor of `rtol`
-           and will be removed in SciPy 1.14.0.
+           `bicgstab` keyword argument ``tol`` is deprecated in favor of
+           ``rtol`` and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -347,7 +347,7 @@ def cg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `cg` keyword argument `tol` is deprecated in favor of `rtol` and
+           `cg` keyword argument ``tol`` is deprecated in favor of ``rtol`` and
            will be removed in SciPy 1.14.0.
 
     Returns
@@ -461,8 +461,8 @@ def cgs(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `cgs` keyword argument `tol` is deprecated in favor of `rtol` and
-           will be removed in SciPy 1.14.0.
+           `cgs` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -635,13 +635,13 @@ def gmres(A, b, x0=None, *, tol=_NoValue, restart=None, maxiter=None, M=None,
     restrt : int, optional, deprecated
 
         .. deprecated:: 0.11.0
-           `gmres` keyword argument `restrt` is deprecated in favor of
-           `restart` and will be removed in SciPy 1.14.0.
+           `gmres` keyword argument ``restrt`` is deprecated in favor of
+           ``restart`` and will be removed in SciPy 1.14.0.
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `gmres` keyword argument `tol` is deprecated in favor of `rtol` and
-           will be removed in SciPy 1.14.0
+           `gmres` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0
 
     Returns
     -------
@@ -902,8 +902,8 @@ def qmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M1=None, M2=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `qmr` keyword argument `tol` is deprecated in favor of `rtol` and
-           will be removed in SciPy 1.14.0.
+           `qmr` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Returns
     -------

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -8,7 +8,7 @@ from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 __all__ = ['bicg', 'bicgstab', 'cg', 'cgs', 'gmres', 'qmr']
 
 
-def _get_atol_rtol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
+def _get_atol_rtol(name, b_norm, tol=_NoValue, atol=0., rtol=1e-5):
     """
     A helper function to handle tolerance deprecations and normalization
     """
@@ -35,7 +35,7 @@ def _get_atol_rtol(name, b, tol=_NoValue, atol=0., rtol=1e-5):
         warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
         atol = rtol
 
-    atol = max(float(atol), float(rtol) * float(np.linalg.norm(b)))
+    atol = max(float(atol), float(rtol) * float(b_norm))
 
     return atol, rtol
 
@@ -104,10 +104,10 @@ def bicg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('bicg', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
-
-    atol, _ = _get_atol_rtol('bicg', b, tol, atol, rtol)
 
     n = len(b)
     dotprod = np.vdot if np.iscomplexobj(x) else np.dot
@@ -237,10 +237,10 @@ def bicgstab(A, b, *, x0=None, tol=_NoValue, maxiter=None, M=None,
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('bicgstab', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
-
-    atol, _ = _get_atol_rtol('bicgstab', b, tol, atol, rtol)
 
     n = len(b)
 
@@ -380,10 +380,10 @@ def cg(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('cg', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
-
-    atol, _ = _get_atol_rtol('cg', b, tol, atol, rtol)
 
     n = len(b)
 
@@ -495,10 +495,10 @@ def cgs(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None, callback=None,
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('cgs', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
-
-    atol, _ = _get_atol_rtol('cgs', b, tol, atol, rtol)
 
     n = len(b)
 
@@ -723,6 +723,8 @@ def gmres(A, b, x0=None, *, tol=_NoValue, restart=None, maxiter=None, M=None,
     n = len(b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('gmres', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
 
@@ -736,8 +738,6 @@ def gmres(A, b, x0=None, *, tol=_NoValue, restart=None, maxiter=None, M=None,
     if restart is None:
         restart = 20
     restart = min(restart, n)
-
-    atol, _ = _get_atol_rtol('gmres', b, tol, atol, rtol)
 
     Mb_nrm2 = np.linalg.norm(psolve(b))
 
@@ -936,10 +936,10 @@ def qmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M1=None, M2=None,
     A, M, x, b, postprocess = make_system(A, None, x0, b)
     bnrm2 = np.linalg.norm(b)
 
+    atol, _ = _get_atol_rtol('qmr', bnrm2, tol, atol, rtol)
+
     if bnrm2 == 0:
         return postprocess(b), 0
-
-    atol, _ = _get_atol_rtol('qmr', b, tol, atol, rtol)
 
     if M1 is None and M2 is None:
         if hasattr(A_, 'psolve'):

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -42,7 +42,8 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
 
         .. warning::
 
-           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
+           The default value for ``atol`` will be changed to ``0.0`` in
+           SciPy 1.14.0.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -79,8 +80,8 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `lgmres` keyword argument `tol` is deprecated in favor of `rtol`
-           and will be removed in SciPy 1.14.
+           `lgmres` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Returns
     -------

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -135,9 +135,6 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     if not np.isfinite(b).all():
         raise ValueError("RHS must contain only finite numbers")
 
-    # we call this to get the right atol/rtol and raise warnings as necessary
-    atol, rtol = _get_atol_rtol('lgmres', b, tol, atol, rtol)
-
     matvec = A.matvec
     psolve = M.matvec
 
@@ -148,6 +145,10 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     nrm2 = get_blas_funcs('nrm2', [b])
 
     b_norm = nrm2(b)
+
+    # we call this to get the right atol/rtol and raise warnings as necessary
+    atol, rtol = _get_atol_rtol('lgmres', b_norm, tol, atol, rtol)
+
     if b_norm == 0:
         x = b
         return (postprocess(x), 0)

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2009, Pauli Virtanen <pav@iki.fi>
 # Distributed under the same license as SciPy.
 
-import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
 from scipy.linalg import get_blas_funcs
+from .iterative import _get_atol_rtol
 from .utils import make_system
-from scipy._lib.deprecation import _deprecate_positional_args
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 from ._gcrotmk import _fgmres
 
@@ -14,9 +14,9 @@ __all__ = ['lgmres']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
+def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
-           prepend_outer_v=False, atol=None):
+           prepend_outer_v=False, atol=None, rtol=1e-5):
     """
     Solve a matrix equation using the LGMRES algorithm.
 
@@ -35,14 +35,14 @@ def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : ndarray
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-        The default for ``atol`` is `tol`.
+    rtol, atol : float, optional
+        Parameters for the convergence test. For convergence,
+        ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
 
         .. warning::
 
-           The default value for `atol` will be changed in a future release.
-           For future compatibility, specify `atol` explicitly.
+           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -76,6 +76,11 @@ def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
     prepend_outer_v : bool, optional
         Whether to put outer_v augmentation vectors before Krylov iterates.
         In standard LGMRES, prepend_outer_v=False.
+    tol : float, optional, deprecated
+
+        .. deprecated:: 1.12.0
+           `lgmres` keyword argument `tol` is deprecated in favor of `rtol`
+           and will be removed in SciPy 1.14.
 
     Returns
     -------
@@ -130,12 +135,8 @@ def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
     if not np.isfinite(b).all():
         raise ValueError("RHS must contain only finite numbers")
 
-    if atol is None:
-        warnings.warn("scipy.sparse.linalg.lgmres called without specifying `atol`. "
-                      "The default value will change in the future. To preserve "
-                      "current behavior, set ``atol=tol``.",
-                      category=DeprecationWarning, stacklevel=2)
-        atol = tol
+    # we call this to get the right atol/rtol and raise warnings as necessary
+    atol, rtol = _get_atol_rtol('lgmres', b, tol, atol, rtol)
 
     matvec = A.matvec
     psolve = M.matvec
@@ -169,7 +170,7 @@ def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         # -- check stopping condition
         r_norm = nrm2(r_outer)
-        if r_norm <= max(atol, tol * b_norm):
+        if r_norm <= max(atol, rtol * b_norm):
             break
 
         # -- inner LGMRES iteration
@@ -183,7 +184,7 @@ def lgmres(A, b, x0=None, *, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         v0 = scal(1.0/inner_res_0, v0)
 
-        ptol = min(ptol_max_factor, max(atol, tol*b_norm)/r_norm)
+        ptol = min(ptol_max_factor, max(atol, rtol*b_norm)/r_norm)
 
         try:
             Q, R, B, vs, zs, y, pres = _fgmres(matvec,

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -69,7 +69,7 @@ def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `lgmres` keyword argument `tol` is deprecated in favor of `rtol`
+           `minres` keyword argument `tol` is deprecated in favor of `rtol`
            and will be removed in SciPy 1.14.
 
     Examples

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -48,7 +48,7 @@ def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
         Value to apply to the system ``(A - shift * I)x = b``. Default is 0.
     rtol : float
         Tolerance to achieve. The algorithm terminates when the relative
-        residual is below `rtol`.
+        residual is below ``rtol``.
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -69,8 +69,8 @@ def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `minres` keyword argument `tol` is deprecated in favor of `rtol`
-           and will be removed in SciPy 1.14.
+           `minres` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Examples
     --------

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -1,16 +1,17 @@
+import warnings
 from numpy import inner, zeros, inf, finfo
 from numpy.linalg import norm
 from math import sqrt
 
 from .utils import make_system
-from scipy._lib.deprecation import _deprecate_positional_args
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 __all__ = ['minres']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
-           M=None, callback=None, show=False, check=False):
+def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
+           M=None, callback=None, show=False, check=False, rtol=1e-5):
     """
     Use MINimum RESidual iteration to solve Ax=b
 
@@ -45,9 +46,9 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
         Starting guess for the solution.
     shift : float
         Value to apply to the system ``(A - shift * I)x = b``. Default is 0.
-    tol : float
+    rtol : float
         Tolerance to achieve. The algorithm terminates when the relative
-        residual is below `tol`.
+        residual is below `rtol`.
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -65,6 +66,11 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
     check : bool
         If ``True``, run additional input validation to check that `A` and
         `M` (if specified) are symmetric. Default is ``False``.
+    tol : float, optional, deprecated
+
+        .. deprecated:: 1.12.0
+           `lgmres` keyword argument `tol` is deprecated in favor of `rtol`
+           and will be removed in SciPy 1.14.
 
     Examples
     --------
@@ -93,6 +99,13 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
     """
     A, M, x, b, postprocess = make_system(A, M, x0, b)
 
+    if tol is not _NoValue:
+        msg = ("'scipy.sparse.linalg.minres' keyword argument `tol` is "
+               "deprecated in favor of `rtol` and will be removed in SciPy "
+               "v1.14. Until then, if set, it will override `rtol`.")
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
+        rtol = float(tol) if tol is not None else rtol
+
     matvec = A.matvec
     psolve = M.matvec
 
@@ -119,7 +132,7 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
     if show:
         print(first + 'Solution of symmetric Ax = b')
         print(first + f'n      =  {n:3g}     shift  =  {shift:23.14e}')
-        print(first + f'itnlim =  {maxiter:3g}     rtol   =  {tol:11.2e}')
+        print(first + f'itnlim =  {maxiter:3g}     rtol   =  {rtol:11.2e}')
         print()
 
     istop = 0
@@ -273,7 +286,7 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
         ynorm = norm(x)
         epsa = Anorm * eps
         epsx = Anorm * ynorm * eps
-        epsr = Anorm * ynorm * tol
+        epsr = Anorm * ynorm * rtol
         diag = gbar
 
         if diag == 0:
@@ -302,7 +315,7 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
         # In rare cases, istop is already -1 from above (Abar = const*I).
 
         if istop == 0:
-            t1 = 1 + test1      # These tests work if tol < eps
+            t1 = 1 + test1      # These tests work if rtol < eps
             t2 = 1 + test2
             if t2 <= 1:
                 istop = 2
@@ -317,9 +330,9 @@ def minres(A, b, x0=None, *, shift=0.0, tol=1e-5, maxiter=None,
                 istop = 3
             # if rnorm <= epsx   : istop = 2
             # if rnorm <= epsr   : istop = 1
-            if test2 <= tol:
+            if test2 <= rtol:
                 istop = 2
-            if test1 <= tol:
+            if test1 <= rtol:
                 istop = 1
 
         # See if it is time to print something.

--- a/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
@@ -37,7 +37,7 @@ def do_solve(**kw):
     count[0] = 0
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
-        x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), tol=1e-14, **kw)
+        x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), rtol=1e-14, **kw)
     count_0 = count[0]
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
@@ -91,7 +91,7 @@ class TestGCROTMK:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = gcrotmk(A, b, tol=0, maxiter=10)
+                x, info = gcrotmk(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -100,7 +100,7 @@ class TestGCROTMK:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = gcrotmk(A, b, tol=0, maxiter=10)
+                x, info = gcrotmk(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -111,7 +111,7 @@ class TestGCROTMK:
 
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x, info = gcrotmk(A, b, tol=0, maxiter=10)
+            x, info = gcrotmk(A, b, rtol=0, maxiter=10)
             assert_equal(info, 1)
 
     def test_truncate(self):
@@ -122,8 +122,8 @@ class TestGCROTMK:
         for truncate in ['oldest', 'smallest']:
             with suppress_warnings() as sup:
                 sup.filter(DeprecationWarning, ".*called without specifying.*")
-                x, info = gcrotmk(A, b, m=10, k=10, truncate=truncate, tol=1e-4,
-                                  maxiter=200)
+                x, info = gcrotmk(A, b, m=10, k=10, truncate=truncate,
+                                  rtol=1e-4, maxiter=200)
             assert_equal(info, 0)
             assert_allclose(A.dot(x) - b, 0, atol=1e-3)
 

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -27,9 +27,9 @@ _SOLVERS = [bicg, bicgstab, cg, cgs, gcrotmk, gmres, lgmres,
             minres, qmr, tfqmr]
 
 pytestmark = [
-    pytest.mark.filterwarnings("ignore:.* keyword argument 'tol'.*"),
-    pytest.mark.filterwarnings("ignore:.*called without specifying.*")
-    ]
+    # remove this once atol defaults to 0.0 for all methods
+    pytest.mark.filterwarnings("ignore:.*called without specifying.*"),
+]
 
 
 # create parametrized fixture for easy reuse in tests

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -228,7 +228,7 @@ def test_maxiter(case):
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
     A = case.A
-    tol = 1e-12
+    rtol = 1e-12
 
     b = case.b
     x0 = 0 * b
@@ -238,7 +238,7 @@ def test_maxiter(case):
     def callback(x):
         residuals.append(norm(b - case.A * x))
 
-    x, info = case.solver(A, b, x0=x0, tol=tol, maxiter=1, callback=callback)
+    x, info = case.solver(A, b, x0=x0, rtol=rtol, maxiter=1, callback=callback)
 
     assert len(residuals) == 1
     assert info == 1
@@ -248,19 +248,19 @@ def test_convergence(case):
     A = case.A
 
     if A.dtype.char in "dD":
-        tol = 1e-8
+        rtol = 1e-8
     else:
-        tol = 1e-2
+        rtol = 1e-2
 
     b = case.b
     x0 = 0 * b
 
-    x, info = case.solver(A, b, x0=x0, tol=tol)
+    x, info = case.solver(A, b, x0=x0, rtol=rtol)
 
     assert_array_equal(x0, 0 * b)  # ensure that x0 is not overwritten
     if case.convergence:
         assert info == 0
-        assert norm(A @ x - b) <= norm(b)*tol
+        assert norm(A @ x - b) <= norm(b) * rtol
     else:
         assert info != 0
         assert norm(A @ x - b) <= norm(b)
@@ -270,7 +270,7 @@ def test_precond_dummy(case):
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
 
-    tol = 1e-8
+    rtol = 1e-8
 
     def identity(b, which=None):
         """trivial preconditioner"""
@@ -291,19 +291,19 @@ def test_precond_dummy(case):
     precond = LinearOperator(A.shape, identity, rmatvec=identity)
 
     if case.solver is qmr:
-        x, info = case.solver(A, b, M1=precond, M2=precond, x0=x0, tol=tol)
+        x, info = case.solver(A, b, M1=precond, M2=precond, x0=x0, rtol=rtol)
     else:
-        x, info = case.solver(A, b, M=precond, x0=x0, tol=tol)
+        x, info = case.solver(A, b, M=precond, x0=x0, rtol=rtol)
     assert info == 0
-    assert norm(A @ x - b) <= norm(b)*tol
+    assert norm(A @ x - b) <= norm(b) * rtol
 
     A = aslinearoperator(A)
     A.psolve = identity
     A.rpsolve = identity
 
-    x, info = case.solver(A, b, x0=x0, tol=tol)
+    x, info = case.solver(A, b, x0=x0, rtol=rtol)
     assert info == 0
-    assert norm(A @ x - b) <= norm(b)*tol
+    assert norm(A @ x - b) <= norm(b) * rtol
 
 
 # Specific test for poisson1d and poisson2d cases
@@ -315,7 +315,7 @@ def test_precond_inverse(case):
         if solver in case.skip or solver is qmr:
             continue
 
-        tol = 1e-8
+        rtol = 1e-8
 
         def inverse(b, which=None):
             """inverse preconditioner"""
@@ -349,10 +349,10 @@ def test_precond_inverse(case):
 
         # Solve with preconditioner
         matvec_count = [0]
-        x, info = solver(A, b, M=precond, x0=x0, tol=tol)
+        x, info = solver(A, b, M=precond, x0=x0, rtol=rtol)
 
         assert info == 0
-        assert norm(case.A @ x - b) <= norm(b)*tol
+        assert norm(case.A @ x - b) <= norm(b) * rtol
 
         # Solution should be nearly instant
         assert matvec_count[0] <= 3
@@ -386,8 +386,8 @@ def test_atol(solver):
     M0 = M0 @ M0.T
     Ms = [None, 1e-6 * M0, 1e6 * M0]
 
-    for M, tol, atol in itertools.product(Ms, tols, tols):
-        if tol == 0 and atol == 0:
+    for M, rtol, atol in itertools.product(Ms, tols, tols):
+        if rtol == 0 and atol == 0:
             continue
 
         if solver is qmr:
@@ -396,14 +396,14 @@ def test_atol(solver):
                 M2 = aslinearoperator(np.eye(10))
             else:
                 M2 = None
-            x, info = solver(A, b, M1=M, M2=M2, tol=tol, atol=atol)
+            x, info = solver(A, b, M1=M, M2=M2, rtol=rtol, atol=atol)
         else:
-            x, info = solver(A, b, M=M, tol=tol, atol=atol)
+            x, info = solver(A, b, M=M, rtol=rtol, atol=atol)
 
         assert info == 0
         residual = A @ x - b
         err = np.linalg.norm(residual)
-        atol2 = tol * b_norm
+        atol2 = rtol * b_norm
         # Added 1.00025 fudge factor because of `err` exceeding `atol` just
         # very slightly on s390x (see gh-17839)
         assert err <= 1.00025 * max(atol, atol2)
@@ -418,24 +418,24 @@ def test_zero_rhs(solver):
     tols = np.r_[np.logspace(-10, 2, 7)]
 
     for tol in tols:
-        x, info = solver(A, b, tol=tol)
+        x, info = solver(A, b, rtol=tol)
         assert info == 0
         assert_allclose(x, 0., atol=1e-15)
 
-        x, info = solver(A, b, tol=tol, x0=ones(10))
+        x, info = solver(A, b, rtol=tol, x0=ones(10))
         assert info == 0
         assert_allclose(x, 0., atol=tol)
 
         if solver is not minres:
-            x, info = solver(A, b, tol=tol, atol=0, x0=ones(10))
+            x, info = solver(A, b, rtol=tol, atol=0, x0=ones(10))
             if info == 0:
                 assert_allclose(x, 0)
 
-            x, info = solver(A, b, tol=tol, atol=tol)
+            x, info = solver(A, b, rtol=tol, atol=tol)
             assert info == 0
             assert_allclose(x, 0, atol=1e-300)
 
-            x, info = solver(A, b, tol=tol, atol=0)
+            x, info = solver(A, b, rtol=tol, atol=0)
             assert info == 0
             assert_allclose(x, 0, atol=1e-300)
 
@@ -472,7 +472,7 @@ def test_maxiter_worsening(solver):
     slack_tol = 9
 
     for maxiter in range(1, 20):
-        x, info = solver(A, v, maxiter=maxiter, tol=1e-8, atol=0)
+        x, info = solver(A, v, maxiter=maxiter, rtol=1e-8, atol=0)
 
         if info == 0:
             assert norm(A @ x - v) <= 1e-8 * norm(v)
@@ -494,9 +494,9 @@ def test_x0_working(solver):
     x0 = rng.random(n)
 
     if solver is minres:
-        kw = dict(tol=1e-6)
+        kw = dict(rtol=1e-6)
     else:
-        kw = dict(atol=0, tol=1e-6)
+        kw = dict(atol=0, rtol=1e-6)
 
     x, info = solver(A, b, **kw)
     assert info == 0
@@ -513,12 +513,12 @@ def test_x0_equals_Mb(case):
     A = case.A
     b = case.b
     x0 = 'Mb'
-    tol = 1e-8
-    x, info = case.solver(A, b, x0=x0, tol=tol)
+    rtol = 1e-8
+    x, info = case.solver(A, b, x0=x0, rtol=rtol)
 
     assert_array_equal(x0, 'Mb')  # ensure that x0 is not overwritten
     assert info == 0
-    assert norm(A @ x - b) <= tol*norm(b)
+    assert norm(A @ x - b) <= rtol * norm(b)
 
 
 # Specific tfqmr test
@@ -589,10 +589,11 @@ class TestQMR:
         M1 = LinearOperator((n, n), matvec=L_solve, rmatvec=LT_solve)
         M2 = LinearOperator((n, n), matvec=U_solve, rmatvec=UT_solve)
 
-        x, info = qmr(A, b, tol=1e-8, maxiter=15, M1=M1, M2=M2)
+        rtol = 1e-8
+        x, info = qmr(A, b, rtol=rtol, maxiter=15, M1=M1, M2=M2)
 
         assert info == 0
-        assert norm(A @ x - b) <= 1e-8 * norm(b)
+        assert norm(A @ x - b) <= rtol * norm(b)
 
 
 class TestGMRES:
@@ -625,7 +626,7 @@ class TestGMRES:
         def callback(r):
             return store_residual(r, rvec)
 
-        x, flag = gmres(A, b, x0=zeros(A.shape[0]), tol=1e-16,
+        x, flag = gmres(A, b, x0=zeros(A.shape[0]), rtol=1e-16,
                         maxiter=maxiter, callback=callback)
 
         # Expected output from SciPy 1.0.0
@@ -635,7 +636,7 @@ class TestGMRES:
         M = 1e-3 * np.eye(A.shape[0])
         rvec = zeros(maxiter + 1)
         rvec[0] = 1.0
-        x, flag = gmres(A, b, M=M, tol=1e-16, maxiter=maxiter,
+        x, flag = gmres(A, b, M=M, rtol=1e-16, maxiter=maxiter,
                         callback=callback)
 
         # Expected output from SciPy 1.0.0
@@ -659,19 +660,19 @@ class TestGMRES:
 
         A = eye(2)
         b = ones(2)
-        x, info = gmres(A, b, tol=1e-5)
+        x, info = gmres(A, b, rtol=1e-5)
         assert np.linalg.norm(A @ x - b) <= 1e-5 * np.linalg.norm(b)
         assert_allclose(x, b, atol=0, rtol=1e-8)
 
         rndm = np.random.RandomState(12345)
         A = rndm.rand(30, 30)
         b = 1e-6 * ones(30)
-        x, info = gmres(A, b, tol=1e-7, restart=20)
+        x, info = gmres(A, b, rtol=1e-7, restart=20)
         assert np.linalg.norm(A @ x - b) > 1e-7
 
         A = eye(2)
         b = 1e-10 * ones(2)
-        x, info = gmres(A, b, tol=1e-8, atol=0)
+        x, info = gmres(A, b, rtol=1e-8, atol=0)
         assert np.linalg.norm(A @ x - b) <= 1e-8 * np.linalg.norm(b)
 
     def test_defective_precond_breakdown(self):
@@ -683,7 +684,7 @@ class TestGMRES:
         x = np.array([1, 0, 0])
         A = np.diag([2, 3, 4])
 
-        x, info = gmres(A, b, x0=x, M=M, tol=1e-15, atol=0)
+        x, info = gmres(A, b, x0=x, M=M, rtol=1e-15, atol=0)
 
         # Should not return nans, nor terminate with false success
         assert not np.isnan(x).any()
@@ -697,12 +698,13 @@ class TestGMRES:
         # Breakdown due to defective matrix
         A = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
         b = np.array([1, 0, 1])
-        x, info = gmres(A, b, tol=1e-8, atol=0)
+        rtol = 1e-8
+        x, info = gmres(A, b, rtol=rtol, atol=0)
 
         # Should not return nans, nor terminate with false success
         assert not np.isnan(x).any()
         if info == 0:
-            assert np.linalg.norm(A @ x - b) <= 1e-8 * np.linalg.norm(b)
+            assert np.linalg.norm(A @ x - b) <= rtol * np.linalg.norm(b)
 
         # The solution should be OK outside null space of A
         assert_allclose(A @ (A @ x), A @ b)
@@ -725,28 +727,28 @@ class TestGMRES:
 
         # 2 iterations is not enough to solve the problem
         cb_count = [0]
-        x, info = gmres(A, b, tol=1e-6, atol=0, callback=pr_norm_cb,
+        x, info = gmres(A, b, rtol=1e-6, atol=0, callback=pr_norm_cb,
                         maxiter=2, restart=50)
         assert info == 2
         assert cb_count[0] == 2
 
         # With `callback_type` specified, no warning should be raised
         cb_count = [0]
-        x, info = gmres(A, b, tol=1e-6, atol=0, callback=pr_norm_cb,
+        x, info = gmres(A, b, rtol=1e-6, atol=0, callback=pr_norm_cb,
                         maxiter=2, restart=50, callback_type='legacy')
         assert info == 2
         assert cb_count[0] == 2
 
         # 2 restart cycles is enough to solve the problem
         cb_count = [0]
-        x, info = gmres(A, b, tol=1e-6, atol=0, callback=pr_norm_cb,
+        x, info = gmres(A, b, rtol=1e-6, atol=0, callback=pr_norm_cb,
                         maxiter=2, restart=50, callback_type='pr_norm')
         assert info == 0
         assert cb_count[0] > 2
 
         # 2 restart cycles is enough to solve the problem
         cb_count = [0]
-        x, info = gmres(A, b, tol=1e-6, atol=0, callback=x_cb, maxiter=2,
+        x, info = gmres(A, b, rtol=1e-6, atol=0, callback=x_cb, maxiter=2,
                         restart=50, callback_type='x')
         assert info == 0
         assert cb_count[0] == 1
@@ -766,7 +768,7 @@ class TestGMRES:
             prev_r[0] = r
             count[0] += 1
 
-        x, info = gmres(A, b, tol=1e-6, atol=0, callback=x_cb, maxiter=20,
+        x, info = gmres(A, b, rtol=1e-6, atol=0, callback=x_cb, maxiter=20,
                         restart=10, callback_type='x')
         assert info == 20
         assert count[0] == 20

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -244,12 +244,6 @@ def test_maxiter(case):
     assert info == 1
 
 
-def assert_normclose(a, b, tol=1e-8):
-    residual = norm(a - b)
-    tolerance = tol * norm(b)
-    assert residual < tolerance
-
-
 def test_convergence(case):
     A = case.A
 
@@ -598,7 +592,7 @@ class TestQMR:
         x, info = qmr(A, b, tol=1e-8, maxiter=15, M1=M1, M2=M2)
 
         assert info == 0
-        assert_normclose(A @ x, b, tol=1e-8)
+        assert norm(A @ x - b) <= 1e-8 * norm(b)
 
 
 class TestGMRES:

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -40,7 +40,7 @@ def do_solve(**kw):
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
         x0, flag = lgmres(A, b, x0=zeros(A.shape[0]),
-                          inner_m=6, tol=1e-14, **kw)
+                          inner_m=6, rtol=1e-14, **kw)
     count_0 = count[0]
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
@@ -128,7 +128,7 @@ class TestLGMRES:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = lgmres(A, b, tol=0, maxiter=10)
+                x, info = lgmres(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -137,7 +137,7 @@ class TestLGMRES:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = lgmres(A, b, tol=0, maxiter=10)
+                x, info = lgmres(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -148,7 +148,7 @@ class TestLGMRES:
 
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x, info = lgmres(A, b, tol=0, maxiter=10)
+            x, info = lgmres(A, b, rtol=0, maxiter=10)
             assert_equal(info, 1)
 
     def test_breakdown_with_outer_v(self):

--- a/scipy/sparse/linalg/_isolve/tests/test_minres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_minres.py
@@ -1,9 +1,9 @@
 import numpy as np
+from numpy.linalg import norm
 from numpy.testing import assert_equal, assert_allclose, assert_
 from scipy.sparse.linalg._isolve import minres
 
 from pytest import raises as assert_raises
-from .test_iterative import assert_normclose
 
 
 def get_sample_problem():
@@ -22,7 +22,7 @@ def test_singular():
     b[0] = 0
     xp, info = minres(A, b)
     assert_equal(info, 0)
-    assert_normclose(A.dot(xp), b, tol=1e-5)
+    assert norm(A @ xp - b) <= 1e-5 * norm(b)
 
 
 def test_x0_is_used_by():
@@ -69,7 +69,7 @@ def test_minres_non_default_x0():
     b = np.random.randn(5)
     c = np.random.randn(5)
     x = minres(a, b, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    assert norm(a @ x - b) <= tol * norm(b)
 
 
 def test_minres_precond_non_default_x0():
@@ -82,7 +82,7 @@ def test_minres_precond_non_default_x0():
     m = np.random.randn(5, 5)
     m = np.dot(m, m.T)
     x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    assert norm(a @ x - b) <= tol * norm(b)
 
 
 def test_minres_precond_exact_x0():
@@ -94,4 +94,4 @@ def test_minres_precond_exact_x0():
     m = np.random.randn(10, 10)
     m = np.dot(m, m.T)
     x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    assert norm(a @ x - b) <= tol * norm(b)

--- a/scipy/sparse/linalg/_isolve/tests/test_minres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_minres.py
@@ -63,35 +63,35 @@ def test_asymmetric_fail():
 
 def test_minres_non_default_x0():
     np.random.seed(1234)
-    tol = 10**(-6)
+    rtol = 1e-6
     a = np.random.randn(5, 5)
     a = np.dot(a, a.T)
     b = np.random.randn(5)
     c = np.random.randn(5)
-    x = minres(a, b, x0=c, tol=tol)[0]
-    assert norm(a @ x - b) <= tol * norm(b)
+    x = minres(a, b, x0=c, rtol=rtol)[0]
+    assert norm(a @ x - b) <= rtol * norm(b)
 
 
 def test_minres_precond_non_default_x0():
     np.random.seed(12345)
-    tol = 10**(-6)
+    rtol = 1e-6
     a = np.random.randn(5, 5)
     a = np.dot(a, a.T)
     b = np.random.randn(5)
     c = np.random.randn(5)
     m = np.random.randn(5, 5)
     m = np.dot(m, m.T)
-    x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert norm(a @ x - b) <= tol * norm(b)
+    x = minres(a, b, M=m, x0=c, rtol=rtol)[0]
+    assert norm(a @ x - b) <= rtol * norm(b)
 
 
 def test_minres_precond_exact_x0():
     np.random.seed(1234)
-    tol = 10**(-6)
+    rtol = 1e-6
     a = np.eye(10)
     b = np.ones(10)
     c = np.ones(10)
     m = np.random.randn(10, 10)
     m = np.dot(m, m.T)
-    x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert norm(a @ x - b) <= tol * norm(b)
+    x = minres(a, b, M=m, x0=c, rtol=rtol)[0]
+    assert norm(a @ x - b) <= rtol * norm(b)

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -130,7 +130,8 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
     v = M.matvec(A.matvec(r))
     uhat = v
     d = theta = eta = 0.
-    rho = np.inner(rstar.conjugate(), r)
+    # at this point we know rstar == r, so rho is always real
+    rho = np.inner(rstar.conjugate(), r).real
     rhoLast = rho
     r0norm = np.sqrt(rho)
     tau = r0norm

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -31,7 +31,8 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
 
         .. warning::
 
-           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
+           The default value for ``atol`` will be changed to ``0.0`` in
+           SciPy 1.14.0.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -52,8 +53,8 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
     tol : float, optional, deprecated
 
         .. deprecated:: 1.12.0
-           `tfqmr` keyword argument `tol` is deprecated in favor of `rtol`
-           and will be removed in SciPy 1.14.
+           `tfqmr` keyword argument ``tol`` is deprecated in favor of ``rtol``
+           and will be removed in SciPy 1.14.0.
 
     Returns
     -------

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -1,14 +1,15 @@
 import numpy as np
+from .iterative import _get_atol_rtol
 from .utils import make_system
-from scipy._lib.deprecation import _deprecate_positional_args
+from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = ['tfqmr']
 
 
 @_deprecate_positional_args(version="1.14.0")
-def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
-          callback=None, atol=None, show=False):
+def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
+          callback=None, atol=None, rtol=1e-5, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
 
@@ -23,15 +24,14 @@ def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : {ndarray}
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b-Ax0), atol)``.
-        The default for `tol` is 1.0e-5.
-        The default for `atol` is ``tol * norm(b-Ax0)``.
+    rtol, atol : float, optional
+        Parameters for the convergence test. For convergence,
+        ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
 
         .. warning::
 
-           The default value for `atol` will be changed in a future release.
-           For future compatibility, specify `atol` explicitly.
+           The default value for ``atol`` will be changed to 0.0 in SciPy 1.14.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -49,6 +49,11 @@ def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
         Specify ``show = True`` to show the convergence, ``show = False`` is
         to close the output of the convergence.
         Default is `False`.
+    tol : float, optional, deprecated
+
+        .. deprecated:: 1.12.0
+           `tfqmr` keyword argument `tol` is deprecated in favor of `rtol`
+           and will be removed in SciPy 1.14.
 
     Returns
     -------
@@ -132,10 +137,8 @@ def tfqmr(A, b, x0=None, *, tol=1e-5, maxiter=None, M=None,
     if r0norm == 0:
         return (postprocess(x), 0)
 
-    if atol is None:
-        atol = tol * r0norm
-    else:
-        atol = max(atol, tol * r0norm)
+    # we call this to get the right atol and raise warnings as necessary
+    atol, _ = _get_atol_rtol('tfqmr', r0norm, tol, atol, rtol)
 
     for iter in range(maxiter):
         even = iter % 2 == 0


### PR DESCRIPTION
While #18488 solved most of #15738, it left out `gcrotmk` / `lgmres` / `minres` / `tfqmr`, which are defined differently (in python directly).

Make the deprecation work around tol/atol/rtol uniform for those functions, which otherwise have the same interface.

Marked as a backport because IMO the current status is quite broken (including some of the warning text, see first commit).

This is an alternative to #16050, which does a more aggressive switch (requiring float `atol` directly) that we didn't do for the other `scipy.sparse.linalg.*` functions.

Closes #15738
