### PR TITLE
DEP: non-integers in `factorial(..., exact=True)`: deprecate for scalars and execute deprecation for arrays

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2949,8 +2949,10 @@ def factorial(n, exact=False):
             return 0
         elif exact and np.issubdtype(type(n), np.integer):
             return math.factorial(n)
-        # we do not raise for non-integers with exact=True due to
-        # historical reasons, though deprecation would be possible
+        elif exact:
+            msg = ("Non-integer values of `n` together with `exact=True` are "
+                   "deprecated. Either ensure integer `n` or use `exact=False`.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return _ufuncs._factorial(n)
 
     # arrays & array-likes

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2965,26 +2965,13 @@ def factorial(n, exact=False):
             "Permitted data types are integers and floating point numbers"
         )
     if exact and not np.issubdtype(n.dtype, np.integer):
-        # legacy behaviour is to support mixed integers/NaNs;
-        # deprecate this for exact=True
-        n_flt = n[~np.isnan(n)]
-        if np.allclose(n_flt, n_flt.astype(np.int64)):
-            warnings.warn(
-                "Non-integer arrays (e.g. due to presence of NaNs) "
-                "together with exact=True are deprecated. Either ensure "
-                "that the the array has integer dtype or use exact=False.",
-                DeprecationWarning,
-                stacklevel=2
-            )
-        else:
-            msg = ("factorial with exact=True does not "
-                   "support non-integral arrays")
-            raise ValueError(msg)
+        msg = ("factorial with `exact=True` does not "
+               "support non-integral arrays")
+        raise ValueError(msg)
 
     if exact:
         return _exact_factorialx_array(n)
-    # we do not raise for non-integers with exact=True due to
-    # historical reasons, though deprecation would be possible
+    # exact=False case
     res = _ufuncs._factorial(n)
     if isinstance(n, np.ndarray):
         # _ufuncs._factorial does not maintain 0-dim arrays

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2286,14 +2286,12 @@ class TestFactorialFunctions:
             assert_equal(x, y)
 
         if result is not None:
+            # keep 0-dim.; otherwise n.ravel().ndim==1, even if n.ndim==0
+            n_flat = n.ravel() if n.ndim else n
+            ref = special.factorial(n_flat, exact=exact) if n.size else []
             # expected result is empty if and only if n is empty,
             # and has the same dtype & dimension as n
-            with suppress_warnings() as sup:
-                sup.filter(DeprecationWarning)
-                # keep 0-dim.; otherwise n.ravel().ndim==1, even if n.ndim==0
-                n_flat = n.ravel() if n.ndim else n
-                r = special.factorial(n_flat, exact=exact) if n.size else []
-            expected = np.array(r, ndmin=dim, dtype=dtype)
+            expected = np.array(ref, ndmin=dim, dtype=dtype)
             assert_really_equal(result, expected)
 
     @pytest.mark.parametrize("exact", [True, False])

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2127,9 +2127,8 @@ class TestFactorialFunctions:
             with pytest.raises(ValueError, match="Unsupported datatype.*"):
                 special.factorial([content], exact=exact)
         elif exact:
-            # cannot use `is np.nan` see https://stackoverflow.com/a/52124109
-            with pytest.warns(DeprecationWarning, match="Non-integer array.*"):
-                assert np.isnan(special.factorial([content], exact=exact)[0])
+            with pytest.raises(ValueError, match="factorial with `exact=Tr.*"):
+                special.factorial([content], exact=exact)
         else:
             assert np.isnan(special.factorial([content], exact=exact)[0])
         # factorial{2,k} don't support array case due to dtype constraints
@@ -2270,18 +2269,8 @@ class TestFactorialFunctions:
                   or np.issubdtype(n.dtype, np.floating)):
             with pytest.raises(ValueError, match="Unsupported datatype*"):
                 special.factorial(n, exact=exact)
-        elif (exact and not np.issubdtype(n.dtype, np.integer) and n.size and
-              np.allclose(n[~np.isnan(n)], n[~np.isnan(n)].astype(np.int64))):
-            # using integers but in array with wrong dtype (e.g. due to NaNs)
-            with pytest.warns(DeprecationWarning, match="Non-integer array.*"):
-                result = special.factorial(n, exact=exact)
-                # expected dtype is integer, unless there are NaNs
-                if np.any(np.isnan(n)):
-                    dtype = np.dtype(np.float64)
-                else:
-                    dtype = np.dtype(int)
         elif exact and not np.issubdtype(n.dtype, np.integer):
-            with pytest.raises(ValueError, match="factorial with exact=.*"):
+            with pytest.raises(ValueError, match="factorial with `exact=.*"):
                 special.factorial(n, exact=exact)
         else:
             # no error
@@ -2462,8 +2451,8 @@ class TestFactorialFunctions:
         x = np.array([np.nan, 1, 2, 3, np.nan])
         expected = np.array([np.nan, 1, 2, 6, np.nan])
         assert_equal(special.factorial(x, exact=False), expected)
-        with pytest.warns(DeprecationWarning, match=r"Non-integer array.*"):
-            assert_equal(special.factorial(x, exact=True), expected)
+        with pytest.raises(ValueError, match="factorial with `exact=True.*"):
+            special.factorial(x, exact=True)
 
 
 class TestFresnel:


### PR DESCRIPTION
Follow-up to #15841