### PR TITLE
MAINT: Cumulative simpson follow-up comments

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -490,6 +490,8 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
     """
     y = np.asarray(y)
+    if y.shape[axis] == 0:
+        raise ValueError("At least one point is required along `axis`.")
     if x is None:
         d = dx
     else:
@@ -914,15 +916,19 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     Parameters
     ----------
     y : array_like
-        Values to integrate.
+        Values to integrate. Requires at least one point along `axis`. If two or fewer
+        points are provided along `axis`, Simpson's integration is not possible and the
+        result is calculated with `cumulative_trapezoid`.
     x : array_like, optional
-        The coordinate to integrate along. Must be monotonically increasing.
-        If None (default), use spacing `dx` between consecutive elements in 
-        `y`.
+        The coordinate to integrate along. Must have the same shape as `y` or
+        must be 1D with the same length as `y` along `axis`. `x` must also be
+        strictly increasing along `axis`.
+        If `x` is None (default), integration is performed using spacing `dx`
+        between consecutive elements in `y`.
     dx : scalar or array_like, optional
         Spacing between elements of `y`. Only used if `x` is None. Can either 
-        be a float, or an array with the same shape as `y`, but length 1 along
-        `axis`.
+        be a float, or an array with the same shape as `y`, but of length one along
+        `axis`. Default is 1.0.
     axis : int, optional
         Specifies the axis to integrate along. Default is -1 (last axis).
     initial : scalar or array_like, optional
@@ -930,7 +936,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         and add it to the rest of the result. Default is None, which means no
         value at ``x[0]`` is returned and `res` has one element less than `y`
         along the axis of integration. Can either be a float, or an array with
-        the same shape as `y`, but length 1 along `axis`.
+        the same shape as `y`, but of length one along `axis`.
 
     Returns
     -------
@@ -954,24 +960,22 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
 
     The composite Simpson's 1/3 method can be used to approximate the definite 
     integral of a sampled input function :math:`y(x)` [1]_. The method assumes 
-    a quadratic relationship over the interval containing any 3 consecutive 
+    a quadratic relationship over the interval containing any three consecutive
     sampled points.
 
     Consider three consecutive points: 
     :math:`(x_1, y_1), (x_2, y_2), (x_3, y_3)`.
-    where the widths of the 2 subintervals are:
-    :math:`h_1 = x_2 - x_1` and :math:`h_2 = x_3 - x_2`.
 
-    Assuming a quadratic relationship over the 3 points, the integral over 
+    Assuming a quadratic relationship over the three points, the integral over
     the subinterval between :math:`x_1` and :math:`x_2` is given by formula
     (8) of [2]_:
     
     .. math::
-        \int_{x_1}^{x_2} y(x) dx\ = \frac{x_2-x_1}{6}\left[\
+        \int_{x_1}^{x_2} y(x) dx\ &= \frac{x_2-x_1}{6}\left[\
         \left\{3-\frac{x_2-x_1}{x_3-x_1}\right\} y_1 + \
         \left\{3 + \frac{(x_2-x_1)^2}{(x_3-x_2)(x_3-x_1)} + \
-        \frac{x_2-x_1}{x_3-x_1}\right\} y_2 - \
-        \frac{(x_2-x_1)^2}{(x_3-x_2)(x_3-x_1)} y_3\right]
+        \frac{x_2-x_1}{x_3-x_1}\right\} y_2\\
+        - \frac{(x_2-x_1)^2}{(x_3-x_2)(x_3-x_1)} y_3\right]
 
     The integral between :math:`x_2` and :math:`x_3` is given by swapping
     appearances of :math:`x_1` and :math:`x_3`. The integral is estimated
@@ -979,8 +983,8 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     the final result.
     
     For samples that are equally spaced, the result is exact if the function
-    is a polynomial of order 3 or less [1]_ and the number of subintervals
-    is even. Otherwise, the integral is exact for polynomials of  order 2 or
+    is a polynomial of order three or less [1]_ and the number of subintervals
+    is even. Otherwise, the integral is exact for polynomials of order two or
     less. 
 
     References
@@ -1029,20 +1033,18 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     y = _ensure_float_array(y)
 
     # validate `axis` and standardize to work along the last axis
+    original_y = y
     original_shape = y.shape
     try:
         y = np.swapaxes(y, axis, -1)
     except IndexError as e:
         message = f"`axis={axis}` is not valid for `y` with `y.ndim={y.ndim}`."
         raise ValueError(message) from e
-
     if y.shape[-1] < 3:
-        raise ValueError(
-            "At least 3 points are required along the axis of integration "
-            "to use the composite Simpson's method."
-        )
+        res = cumulative_trapezoid(original_y, x, dx=dx, axis=axis, initial=None)
+        res = np.swapaxes(res, axis, -1)
 
-    if x is not None:
+    elif x is not None:
         x = _ensure_float_array(x)
         message = ("If given, shape of `x` must be the same as `y` or 1-D with "
                    "the same length as `y` along `axis`.")
@@ -1053,7 +1055,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         x = np.broadcast_to(x, y.shape) if x.ndim == 1 else np.swapaxes(x, axis, -1)
         dx = np.diff(x, axis=-1)
         if np.any(dx <= 0):
-            raise ValueError("Input x must be monotonically increasing.")
+            raise ValueError("Input x must be strictly increasing.")
         res = _cumulatively_sum_simpson_integrals(
             y, dx, _cumulative_simpson_unequal_intervals
         )


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Address follow-up comments from #18151 

#### What does this implement/fix?
This PR addresses follow-up comments on scipy.integrate.cumulative_simpson.
These include:
- Updating strategy to address input values of `y` of length < 3 along `axis`. This is now addressed by calling the existing `cumulative_trapezoid` function. This is consistent with the regular `integrate.simpson` function.
- Added unit test to address above case
- Minor documentation updates

#### Additional information
<!--Any additional information you think is important.-->
If possible, this is a PR for the maintenance/1.12.x branch
cc: @mdhaber 
