### PR TITLE
BLD: require Cython >=3.0.4, drop 0.29.X support

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - cython!=3.0.3
+  - cython>=3.0.4
   - compilers  # Currently unavailable for Windows. Comment out this line and download Rtools and add <path>\ucrt64\bin\ to your path: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
   - meson
   - meson-python

--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,7 @@ project(
   ],
 )
 
-# https://mesonbuild.com/Python-module.html
-py_mod = import('python')
-py3 = py_mod.find_installation(pure: false)
+py3 = import('python').find_installation(pure: false)
 py3_dep = py3.dependency()
 
 # Emit a warning for 32-bit Python installs on Windows; users are getting
@@ -50,8 +48,8 @@ elif cc.get_id() == 'msvc'
           'when building with MSVC')
   endif
 endif
-if not cy.version().version_compare('>=0.29.35')
-  error('SciPy requires Cython >= 0.29.35')
+if not cy.version().version_compare('>=3.0.4')
+  error('SciPy requires Cython >= 3.0.4')
 endif
 
 _global_c_args = cc.get_supported_arguments(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.15.0",
-    "Cython>=0.29.35,!=3.0.3",  # when updating version, also update check in meson.build
+    "Cython>=3.0.4",  # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.14.0",
 

--- a/scipy/_lib/_ccallback_c.pyx
+++ b/scipy/_lib/_ccallback_c.pyx
@@ -1,3 +1,5 @@
+# cython: show_performance_hints=False
+
 from cpython.pycapsule cimport (
     PyCapsule_CheckExact, PyCapsule_New, PyCapsule_SetContext, PyCapsule_GetName, PyCapsule_GetPointer,
     PyCapsule_GetContext


### PR DESCRIPTION
This will make maintenance a bit easier, and it's time; NumPy dropped Cython 0.29.X support months ago and this has gone fine.

This also fixes an annoying build warning that shows up twice, namely:

```
[5/7] Generating 'scipy/_lib/_ccallback_c.cpython-310-x86_64-linux-gnu.so.p/_ccallback_c.c'
performance hint: /home/rgommers/code/scipy/scipy/_lib/_ccallback_c.pyx:138:82: Exception check will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
```

The code is correct and not easy to change. It's only test code as well. The directive to silence the unhelpful hint was introduced in Cython 3.0.4, hence that's used as the new minimum version.