### PR TITLE
ENH: sparse: Add DOK support for 1d (without indexing)

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -407,7 +407,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             coords = zip(*self.coords)
 
-        dok._update(zip(coords, self.data))
+        dok._dict = dict(zip(coords, self.data))
         return dok
 
     todok.__doc__ = _spbase.todok.__doc__

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -399,12 +399,15 @@ class _coo_base(_data_matrix, _minmax_mixin):
     todia.__doc__ = _spbase.todia.__doc__
 
     def todok(self, copy=False):
-        if self.ndim != 2:
-            raise ValueError("Cannot convert a 1d sparse array to dok format")
         self.sum_duplicates()
-        dok = self._dok_container((self.shape), dtype=self.dtype)
-        dok._update(zip(zip(self.row,self.col),self.data))
+        dok = self._dok_container(self.shape, dtype=self.dtype)
+        # ensure that 1d indices are not tuples
+        if self.ndim == 1:
+            indices = self.indices[0]
+        else:
+            indices = zip(*self.indices)
 
+        dok._update(zip(indices, self.data))
         return dok
 
     todok.__doc__ = _spbase.todok.__doc__

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -401,13 +401,13 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def todok(self, copy=False):
         self.sum_duplicates()
         dok = self._dok_container(self.shape, dtype=self.dtype)
-        # ensure that 1d indices are not tuples
+        # ensure that 1d coordinates are not tuples
         if self.ndim == 1:
-            indices = self.indices[0]
+            coords = self.coords[0]
         else:
-            indices = zip(*self.indices)
+            coords = zip(*self.coords)
 
-        dok._update(zip(indices, self.data))
+        dok._update(zip(coords, self.data))
         return dok
 
     todok.__doc__ = _spbase.todok.__doc__

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -335,7 +335,7 @@ class _dok_base(_spbase, IndexMixin, dict):
             else:  # elif self.ndim == 1:
                 # this works for 2d too, but maybe subtle differences?
                 o_coo = other.tocoo()
-                o_coo_data = zip(zip(*o_coo.indices), o_coo.data)
+                o_coo_data = zip(zip(*o_coo.coords), o_coo.data)
                 if self.ndim == 1:
                     o_coo_data = ((k[0], v) for k, v in o_coo_data)
                 with np.errstate(over='ignore'):
@@ -374,14 +374,14 @@ class _dok_base(_spbase, IndexMixin, dict):
     def _matmul_vector(self, other):
         res_dtype = upcast(self.dtype, other.dtype)
 
-        # vector * vector
+        # vector @ vector
         if self.ndim == 1:
             if issparse(other):
                 if other.format == "dok":
                     shared_keys = self.keys() & other.keys()
                 else:
                     o_coo = other.tocoo()
-                    shared_keys = self.keys() & o_coo.indices[0]
+                    shared_keys = self.keys() & o_coo.coords[0]
                 arr = np.array([self._dict[k] * other._dict[k] for k in shared_keys])
                 return arr.sum(dtype=res_dtype)
             elif isdense(other):
@@ -513,8 +513,8 @@ class _dok_base(_spbase, IndexMixin, dict):
         data = np.fromiter(self.values(), dtype=self.dtype, count=nnz)
         # handle 1d keys specially b/c not a tuple
         inds = zip(*self.keys()) if self.ndim > 1 else (self.keys(),)
-        indices = tuple(np.fromiter(ix, dtype=idx_dtype, count=nnz) for ix in inds)
-        A = self._coo_container((data, indices), shape=self.shape, dtype=self.dtype)
+        coords = tuple(np.fromiter(ix, dtype=idx_dtype, count=nnz) for ix in inds)
+        A = self._coo_container((data, coords), shape=self.shape, dtype=self.dtype)
         A.has_canonical_format = True
         return A
 

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -59,9 +59,7 @@ class _dok_base(_spbase, IndexMixin, dict):
 
     def update(self, val):
         # Prevent direct usage of update
-        raise NotImplementedError(
-            "Direct modification to dok_array element is not allowed."
-        )
+        raise NotImplementedError("Direct update to DOK sparse format is not allowed.")
 
     def _getnnz(self, axis=None):
         if axis is not None:

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -161,11 +161,13 @@ def test_1d_row_and_col():
         res.row = [1, 2, 3]
 
 
-def test_1d_tocsc_tocsr_todia_todok():
+def test_1d_toformats():
     res = coo_array([1, -2, -3])
-    for f in [res.tocsc, res.tocsr, res.todok, res.todia]:
+    for f in [res.tocsc, res.tocsr, res.todia, res.tolil, res.tobsr]:
         with pytest.raises(ValueError, match='Cannot convert'):
             f()
+    for f in [res.tocoo, res.todok]:
+        assert np.array_equal(f().toarray(), res.toarray())
 
 
 @pytest.mark.parametrize('arg', [1, 2, 4, 5, 8])


### PR DESCRIPTION
This PR adds DOK support for 1d with a small footprint to ease review.
I've removed any support for indexing beyond integer indices. That will be a separate PR.

The new test file `test_common1d.py` has tests taken from `test_base.py` revamped for 1d. In this PR many are skipped as not relevant for this limited dok 1d support. I can remove the skipped tests if that is preferred. Similarly I could move away from test classes toward parametrized functions if that is preferred.

Notes:
- _`getcol` and `_getrow` are still returning 2d row/col objects -- as stated in the doc_string.  It's not clear what to return in the 1d case for these methods. And I'm not sure what the long term plan is for `getrow` and `getcol` or the relationship between them and their private partners discussed here. 
- `__add__` currently converted to `csc` and adds when the format does not match. Changing to `coo` and then using that datastructure to construct a dok result is implemented here. I've left commented out code that could handle 1d separately from 2d and keep the old `csc` behavior.  I need to change this to remove the comments, or remove the tocoo approach. 
- `__radd__` is a duplicate of `__add__` so why keep it? Please check if I've missed something -- especially if we should leave it. I left it as just calling `__add__` in case there is a subtlety that occurs if you remove it.
- `resize` works within 1d and within 2d. But raises an exception if asked to resize from 1d to 2d or vice versa.
- `astype` on `_spbase` uses `tocsr` so I added an overwrite version to make it work without converting. This works for 1d or 2d. So as written it changes the code run for 2d to convert the dtype of the dok array. I could call the super() version for 2d if preferred.

This PR builds on #18530 and that should be merged first.

Feedback is welcome.