### PR TITLE
ENH: enable approximation for factorialk 

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2817,7 +2817,7 @@ def _range_prod(lo, hi, k=1):
         return hi
 
 
-def _exact_factorialx_array(n, k=1):
+def _factorialx_array_exact(n, k=1):
     """
     Exact computation of factorial for an array.
 
@@ -2972,7 +2972,7 @@ def factorial(n, exact=False):
         raise ValueError(msg)
 
     if exact:
-        return _exact_factorialx_array(n)
+        return _factorialx_array_exact(n, k=1)
     # exact=False case
     res = _ufuncs._factorial(n)
     if isinstance(n, np.ndarray):
@@ -3049,7 +3049,7 @@ def factorial2(n, exact=False):
     if not np.issubdtype(n.dtype, np.integer):
         raise ValueError("factorial2 does not support non-integral arrays")
     if exact:
-        return _exact_factorialx_array(n, k=2)
+        return _factorialx_array_exact(n, k=2)
     # approximation
     vals = zeros(n.shape)
     cond = (n >= 0)
@@ -3179,7 +3179,7 @@ def factorialk(n, k, exact=None):
         msg = "factorialk does not support non-integral arrays!"
         raise ValueError(msg + helpmsg)
     if exact:
-        return _exact_factorialx_array(n, k=k)
+        return _factorialx_array_exact(n, k=k)
     # approximation
     vals = zeros(n.shape)
     cond = (n >= 0)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2929,7 +2929,9 @@ def _factorialx_approx_core(n, k):
     # factor dependent on residue r (for `r=0` it's 1, so we skip `r=0`
     # below and thus also avoid evaluating `max(r, 1)`)
     def corr(k, r): return np.power(k, -r / k) / gamma(r / k + 1) * r
-    for r in range(1, k):
+    for r in np.unique(n_mod_k):
+        if r == 0:
+            continue
         result[n_mod_k == r] *= corr(k, r)
     return result
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2093,14 +2093,14 @@ class TestFactorialFunctions:
     def test_factorialx_scalar_return_type(self, exact):
         assert np.isscalar(special.factorial(1, exact=exact))
         assert np.isscalar(special.factorial2(1, exact=exact))
-        assert np.isscalar(special.factorialk(1, 3, exact=True))
+        assert np.isscalar(special.factorialk(1, 3, exact=exact))
 
     @pytest.mark.parametrize("n", [-1, -2, -3])
     @pytest.mark.parametrize("exact", [True, False])
     def test_factorialx_negative(self, exact, n):
         assert_equal(special.factorial(n, exact=exact), 0)
         assert_equal(special.factorial2(n, exact=exact), 0)
-        assert_equal(special.factorialk(n, 3, exact=True), 0)
+        assert_equal(special.factorialk(n, 3, exact=exact), 0)
 
     @pytest.mark.parametrize("exact", [True, False])
     def test_factorialx_negative_array(self, exact):
@@ -2110,7 +2110,7 @@ class TestFactorialFunctions:
                     [0, 0, 1, 1])
         assert_func(special.factorial2([-5, -4, 0, 1], exact=exact),
                     [0, 0, 1, 1])
-        assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=True),
+        assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=exact),
                     [0, 0, 1, 1])
 
     @pytest.mark.parametrize("exact", [True, False])
@@ -2120,7 +2120,7 @@ class TestFactorialFunctions:
         # scalar
         assert special.factorial(content, exact=exact) is np.nan
         assert special.factorial2(content, exact=exact) is np.nan
-        assert special.factorialk(content, 3, exact=True) is np.nan
+        assert special.factorialk(content, 3, exact=exact) is np.nan
         # array-like (initializes np.array with default dtype)
         if content is not np.nan:
             # None causes object dtype, which is not supported; as is datetime
@@ -2135,7 +2135,7 @@ class TestFactorialFunctions:
         with pytest.raises(ValueError, match="factorial2 does not support.*"):
             special.factorial2([content], exact=exact)
         with pytest.raises(ValueError, match="factorialk does not support.*"):
-            special.factorialk([content], 3, exact=True)
+            special.factorialk([content], 3, exact=exact)
         # array-case also tested in test_factorial{,2,k}_corner_cases
 
     @pytest.mark.parametrize("levels", range(1, 5))
@@ -2162,13 +2162,13 @@ class TestFactorialFunctions:
 
         n = np.array(_nest_me([5, 25], k=levels))
         exp_nucleus = {1: [120, math.factorial(25)],
-                       # correctness of factorial2() is tested elsewhere
+                       # correctness of factorial{2,k}() is tested elsewhere
                        2: [15, special.factorial2(25, exact=True)],
-                       3: [10, special.factorialk(25, 3)]}
+                       3: [10, special.factorialk(25, 3, exact=True)]}
 
         _check(special.factorial(n, exact=exact), exp_nucleus[1])
         _check(special.factorial2(n, exact=exact), exp_nucleus[2])
-        _check(special.factorialk(n, 3, exact=True), exp_nucleus[3])
+        _check(special.factorialk(n, 3, exact=exact), exp_nucleus[3])
 
     @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("dim", range(0, 5))
@@ -2179,7 +2179,7 @@ class TestFactorialFunctions:
                         np.array(exp[1], ndmin=dim))
         assert_allclose(special.factorial2(n, exact=exact),
                         np.array(exp[2], ndmin=dim))
-        assert_allclose(special.factorialk(n, 3, exact=True),
+        assert_allclose(special.factorialk(n, 3, exact=exact),
                         np.array(exp[3], ndmin=dim))
 
     @pytest.mark.parametrize("exact", [True, False])
@@ -2198,7 +2198,7 @@ class TestFactorialFunctions:
                     np.array(exp_nucleus[1], ndmin=level))
         assert_func(special.factorial2(n, exact=exact),
                     np.array(exp_nucleus[2], ndmin=level))
-        assert_func(special.factorialk(n, 3, exact=True),
+        assert_func(special.factorialk(n, 3, exact=exact),
                     np.array(exp_nucleus[3], ndmin=level))
 
     # note that n=170 is the last integer such that factorial(n) fits float64
@@ -2377,6 +2377,20 @@ class TestFactorialFunctions:
             with pytest.raises(ValueError, match="factorial2 does not*"):
                 special.factorial2(n, exact=exact)
 
+    @pytest.mark.parametrize("k", range(1, 5))
+    # note that n=170 is the last integer such that factorial(n) fits float64;
+    # use odd increment to make sure both odd & even numbers are tested
+    @pytest.mark.parametrize('n', range(170, 20, -29))
+    def test_factorialk_accuracy(self, n, k):
+        # Compare exact=True vs False, i.e. that the accuracy of the
+        # approximation is better than the specified tolerance.
+
+        # need to cast exact result to float due to numpy/numpy#21220
+        assert_allclose(float(special.factorialk(n, k=k, exact=True)),
+                        special.factorialk(n, k=k, exact=False))
+        assert_allclose(special.factorialk([n], k=k, exact=True).astype(float),
+                        special.factorialk([n], k=k, exact=False))
+
     @pytest.mark.parametrize('k', list(range(1, 5)) + [10, 20])
     @pytest.mark.parametrize('n',
                              list(range(0, 22)) + list(range(22, 100, 11)))
@@ -2390,68 +2404,78 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorialk(n, k, True))
         assert_array_equal(correct, special.factorialk([n], k, True)[0])
 
-        # exact=False not yet supported
-        # assert_allclose(float(correct), special.factorialk(n, k, False))
-        # assert_allclose(float(correct), special.factorialk([n], k, False)[0])
+        assert_allclose(float(correct), special.factorialk(n, k, False))
+        assert_allclose(float(correct), special.factorialk([n], k, False)[0])
 
     @pytest.mark.parametrize("dtype", [np.int64, np.float64,
                                        np.complex128, object])
+    @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("dim", range(0, 5))
     # test empty & non-empty arrays, with nans and mixed
     @pytest.mark.parametrize("content", [[], [1], [np.nan], [np.nan, 1]],
                              ids=["[]", "[1]", "[NaN]", "[NaN, 1]"])
-    def test_factorialk_array_corner_cases(self, content, dim, dtype):
+    def test_factorialk_array_corner_cases(self, content, dim, exact, dtype):
         if dtype == np.int64 and any(np.isnan(x) for x in content):
             pytest.skip("impossible combination")
         # np.array(x, ndim=0) will not be 0-dim. unless x is too
         content = content if (dim > 0 or len(content) != 1) else content[0]
-        n = np.array(content, ndmin=dim, dtype=dtype)
+        n = np.array(content, ndmin=dim, dtype=dtype if exact else np.float64)
         if np.issubdtype(n.dtype, np.integer) or (not content):
             # no error; expected result is identical to n
-            assert_equal(special.factorialk(n, 3), n)
+            assert_equal(special.factorialk(n, 3, exact=exact), n)
         else:
             with pytest.raises(ValueError, match="factorialk does not*"):
-                special.factorialk(n, 3)
+                special.factorialk(n, 3, exact=exact)
 
-    @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("exact", [True, False, None])
     @pytest.mark.parametrize("k", range(1, 5))
     @pytest.mark.parametrize("n", [1, 1.1, 2 + 2j, np.nan, None],
                              ids=["1", "1.1", "2+2j", "NaN", "None"])
     def test_factorialk_scalar_corner_cases(self, n, k, exact):
-        if not exact:
-            with pytest.raises(NotImplementedError):
-                special.factorialk(n, k=k, exact=exact)
-        elif n is None or n is np.nan or np.issubdtype(type(n), np.integer):
-            # no error
-            result = special.factorial2(n, exact=exact)
+        if n is None or n is np.nan or np.issubdtype(type(n), np.integer):
+            if exact is None:
+                with pytest.deprecated_call(match="factorialk will default.*"):
+                    result = special.factorialk(n, k=k, exact=exact)
+            else:
+                # no error
+                result = special.factorialk(n, k=k, exact=exact)
+
             nan_cond = n is np.nan or n is None
-            expected = np.nan if nan_cond else special.factorialk(n, k=k)
+            # factorialk(1, k) == 1 for all k
+            expected = np.nan if nan_cond else 1
             assert_equal(result, expected)
         else:
             with pytest.raises(ValueError, match="factorialk does not*"):
-                special.factorialk(n, k=k, exact=exact)
+                with suppress_warnings() as sup:
+                    sup.filter(DeprecationWarning, "factorialk will default")
+                    special.factorialk(n, k=k, exact=exact)
 
     @pytest.mark.parametrize("k", [0, 1.1, np.nan, "1"])
     def test_factorialk_raises_k(self, k):
         with pytest.raises(ValueError, match="k must be a positive integer*"):
             special.factorialk(1, k)
 
+    @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("k", range(1, 12))
-    def test_factorialk_dtype(self, k):
-        if k in _FACTORIALK_LIMITS_64BITS.keys():
+    def test_factorialk_dtype(self, k, exact):
+        kw = {"k": k, "exact": exact}
+        if exact and k in _FACTORIALK_LIMITS_64BITS.keys():
             n = np.array([_FACTORIALK_LIMITS_32BITS[k]])
-            assert_equal(special.factorialk(n, k).dtype, np_long)
-            assert_equal(special.factorialk(n + 1, k).dtype, np.int64)
+            assert_equal(special.factorialk(n, **kw).dtype, np_long)
+            assert_equal(special.factorialk(n + 1, **kw).dtype, np.int64)
             # assert maximality of limits for given dtype
-            assert special.factorialk(n + 1, k) > np.iinfo(np.int32).max
+            assert special.factorialk(n + 1, **kw) > np.iinfo(np.int32).max
 
             n = np.array([_FACTORIALK_LIMITS_64BITS[k]])
-            assert_equal(special.factorialk(n, k).dtype, np.int64)
-            assert_equal(special.factorialk(n + 1, k).dtype, object)
-            assert special.factorialk(n + 1, k) > np.iinfo(np.int64).max
+            assert_equal(special.factorialk(n, **kw).dtype, np.int64)
+            assert_equal(special.factorialk(n + 1, **kw).dtype, object)
+            assert special.factorialk(n + 1, **kw) > np.iinfo(np.int64).max
         else:
-            # for k >= 10, we always return object
-            assert_equal(special.factorialk(np.array([1]), k).dtype, object)
+            n = np.array([_FACTORIALK_LIMITS_64BITS.get(k, 1)])
+            # for exact=True and k >= 10, we always return object;
+            # for exact=False it's always float
+            dtype = object if exact else np.float64
+            assert_equal(special.factorialk(n, **kw).dtype, dtype)
 
     def test_factorial_mixed_nan_inputs(self):
         x = np.array([np.nan, 1, 2, 3, np.nan])


### PR DESCRIPTION
Follow-up to https://github.com/scipy/scipy/pull/15841, preparation for further work towards https://github.com/scipy/scipy/issues/18409 (otherwise the API for factorialk would be very strange), and preparing to make `exact=` have the same default across all factorial* functions.

Based on #19703 and a draft until that's merged (although I can separate the PRs if desired), until then only the last commit is relevant.