### PR TITLE
DOC: update release version procedure

### DIFF
--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -116,8 +116,9 @@ and PRs under the Milestone for the release
 and that the release notes are up-to-date and included in the html docs.
 
 Then edit ``meson.build`` and ``tools/version_utils.py`` to get the correct version number (set
-``version:`` in the former, and ``ISRELEASED = True`` in the latter) and commit
-it with a message like ``REL: set version to <version-number>``.  Don't push
+``version:`` in the former, and ``ISRELEASED = True`` in the latter). It is
+also necessary to adjust the ``version`` in ``pyproject.toml``. Commit these
+changes with a message like ``REL: set version to <version-number>``.  Don't push
 this commit to the SciPy repo yet.
 
 Finally tag the release locally with ``git tag -s <v1.x.y>`` (the ``-s`` ensures


### PR DESCRIPTION
* we now need to adjust `version` in `pyproject.toml` in the release process, so update the release docs accordingly

* if you don't do this, the `sdist` will be incorrectly named (i.e., it might have `dev0` instead of `rc1`, etc.)

* there may be a way to unify to less sources of version truth, but for now documenting this seems easy enough compared to the risk of a release process refactor

[skip actions] [skip cirrus]