### PR TITLE
MNT: use int instead of long in cython code

### DIFF
--- a/scipy/_lib/_ccallback_c.pyx
+++ b/scipy/_lib/_ccallback_c.pyx
@@ -61,7 +61,7 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
     elif context_obj is None:
         context = NULL
     else:
-        context = PyLong_AsVoidPtr(long(context_obj))
+        context = PyLong_AsVoidPtr(int(context_obj))
 
     if PyCapsule_CheckExact(func_obj):
         capsule_name = PyCapsule_GetName(func_obj)
@@ -73,7 +73,7 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
         if name == NULL:
             name = capsule_name
     else:
-        func = PyLong_AsVoidPtr(long(func_obj))
+        func = PyLong_AsVoidPtr(int(func_obj))
 
     if name == NULL:
         name_copy = name


### PR DESCRIPTION
https://github.com/cython/cython/pull/5830 /
d7e95912b6ed7d20e190fbf1aecb9f2a997d479 in cython removed long as a valid type in favor of int.
