### PR TITLE
MAINT: enhance the configuration for the `pull-request-labeler` workflow

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
+    types: [opened]
 
 # Permissions needed for labelling Pull Requests automatically
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -7,8 +7,8 @@ on:
 jobs:
 
   label_pull_request:
-      # Permissions needed for labelling Pull Requests automatically
-      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    # Permissions needed for labelling Pull Requests automatically
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -7,6 +7,8 @@ on:
 jobs:
 
   label_pull_request:
+      # Permissions needed for labelling Pull Requests automatically
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -4,13 +4,13 @@ on:
 
 # Permissions needed for labelling Pull Requests automatically
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-permissions:
-   contents: read
-   pull-requests: write
 
 jobs:
 
   label_pull_request:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: thomasjpfan/labeler@v2.5.1

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -3,8 +3,6 @@ on:
   pull_request_target:
     types: [opened]
 
-# Permissions needed for labelling Pull Requests automatically
-# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 
 jobs:
 

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.5.1
+    - uses: actions/labeler@v5
       continue-on-error: true
       if: github.repository == 'scipy/scipy'
       with:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-19088

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR configures the pull request labeler workflow to run just once on a PR, i.e., at the time of its opening – with no subsequent runs on further synchronisation events or updates to said PR. The new release of [actions/labeler@v5](https://github.com/actions/labeler) has fixed a previous issue where the `sync-labels` input was not correctly configured (please see https://github.com/actions/labeler/issues/112). The permissions for the workflow have been moved to the job for security reasons, considering that this workflow will contain just a singleton job which needs those permissions.

#### Additional information
<!--Any additional information you think is important.-->

This PR uses the `pull_request_target` event and therefore might not run with the context of the changes here; however, I had tested and debugged my changes to see whether they will work and put together an explanation in a PR on my fork of SciPy: https://github.com/agriyakhetarpal/scipy/pull/2
