### PR TITLE
MAINT: bs4 deprecation shim

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -50,7 +50,7 @@ def get_wheel_names(version):
     index_url = f"{STAGING_URL}/files"
     index_html = http.request('GET', index_url)
     soup = BeautifulSoup(index_html.data, 'html.parser')
-    return soup.findAll(text=tmpl)
+    return soup.findAll(string=tmpl)
 
 
 def download_wheels(version, wheelhouse):


### PR DESCRIPTION
* deals with the following deprecation warnings I've been seeing during the release process for a long time now:

```
/home/treddy/github_projects/scipy/tools/download-wheels.py:53: DeprecationWarning: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.
  return soup.findAll(text=tmpl)
```

* looks like it comes from `beautifulsoup4` HTML parsing lib, which is not developed on GitHub, so I kind of gave up on finding the link to where the deprecation decision was made

* skipping CI since we don't flush the release tools in CI, but I did check that this command works locally, with less noise now: `python tools/download-wheels.py 1.12.0rc1 -w /home/treddy/github_projects/scipy/release/installers`

[ci skip] [skip circle]