### PR TITLE
BLD: require `pythran>=0.14.0`

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
         python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
-        python -m pip install git+https://github.com/serge-sans-paille/pythran.git@e3babfd
+        python -m pip install git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install git+https://github.com/mesonbuild/meson.git
 
     - name:  Prepare compiler cache

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,9 @@ tempita = files('scipy/_build_utils/tempita.py')
 use_pythran = get_option('use-pythran')
 if use_pythran
   pythran = find_program('pythran', native: true)
+  if not pythran.version().version_compare('>=0.14.0')
+    error('SciPy requires pythran >= 0.14.0')
+  endif
   # xsimd is unvendored from pythran by conda-forge, and due to a compiler
   # activation bug the default <prefix>/include/ may not be visible (see
   # gh-15698). Hence look for xsimd explicitly.


### PR DESCRIPTION
#### Reference issue
Closes gh-19733

#### What does this implement/fix?
The minimum version for `pythran` is set as `0.14.0` in `pyproject.toml`, but nothing stops you from building with a lesser version, whereas e.g. the minimum bound for `Cython` is enforced.

#### Additional information
I've checked locally that the error is triggered when trying to build with `pythran=0.13.1`, then goes away after `mamba install pythran=0.14.0`.

cc @rgommers 