### PR TITLE
ENH: sparse: Add min-max 1d support and tests

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -237,8 +237,7 @@ class _minmax_mixin:
 
     def _arg_min_or_max_axis(self, axis, argmin_or_argmax, compare):
         if self.shape[axis] == 0:
-            raise ValueError("Can't apply the operation along a zero-sized "
-                             "dimension.")
+            raise ValueError("Cannot apply the operation along a zero-sized dimension.")
 
         if axis < 0:
             axis += 2
@@ -287,7 +286,7 @@ class _minmax_mixin:
             return self._arg_min_or_max_axis(axis, argmin_or_argmax, compare)
 
         if 0 in self.shape:
-            raise ValueError("Can't apply the operation to an empty matrix.")
+            raise ValueError("Cannot apply the operation to an empty matrix.")
 
         if self.nnz == 0:
             return 0
@@ -301,7 +300,7 @@ class _minmax_mixin:
         num_col = mat.shape[-1]
 
         # If the min value is less than zero, or max is greater than zero,
-        # then we don't need to worry about implicit zeros.
+        # then we do not need to worry about implicit zeros.
         if compare(extreme_value, zero):
             # cast to Python int to avoid overflow and RuntimeError
             return int(mat.row[extreme_index]) * num_col + int(mat.col[extreme_index])

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -9,6 +9,7 @@ python_sources = [
   'test_csr.py',
   'test_extract.py',
   'test_matrix_io.py',
+  'test_minmax1d.py',
   'test_sparsetools.py',
   'test_spfuncs.py',
   'test_sputils.py'

--- a/scipy/sparse/tests/test_minmax1d.py
+++ b/scipy/sparse/tests/test_minmax1d.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from numpy.testing import assert_equal, assert_array_equal
 
-from scipy.sparse import coo_array  # , dok_array
+from scipy.sparse import coo_array
 from scipy.sparse._sputils import isscalarlike
 
 
@@ -16,7 +16,7 @@ def toarray(a):
     return a.toarray()
 
 
-formats_for_minmax = [coo_array]  # , dok_array]
+formats_for_minmax = [coo_array]
 
 
 @pytest.mark.parametrize("spcreator", formats_for_minmax)

--- a/scipy/sparse/tests/test_minmax1d.py
+++ b/scipy/sparse/tests/test_minmax1d.py
@@ -43,8 +43,10 @@ class Test_MinMaxMixin1D:
                 toarray(X.min(axis=axis)), D.min(axis=axis, keepdims=True)
             )
         for axis in [-2, 1]:
-            pytest.raises(ValueError, X.min, axis=axis)
-            pytest.raises(ValueError, X.max, axis=axis)
+            with pytest.raises(ValueError, match="axis out of range"):
+                X.min(axis=axis)
+            with pytest.raises(ValueError, match="axis out of range"):
+                X.max(axis=axis)
 
 
     def test_numpy_minmax(self, spcreator):
@@ -74,5 +76,7 @@ class Test_MinMaxMixin1D:
 
         for axis in [None, 0]:
             mat = spcreator(D6)
-            pytest.raises(ValueError, mat.argmax, axis=axis)
-            pytest.raises(ValueError, mat.argmin, axis=axis)
+            with pytest.raises(ValueError, match="to an empty matrix"):
+                mat.argmin(axis=axis)
+            with pytest.raises(ValueError, match="to an empty matrix"):
+                mat.argmax(axis=axis)

--- a/scipy/sparse/tests/test_minmax1d.py
+++ b/scipy/sparse/tests/test_minmax1d.py
@@ -1,0 +1,78 @@
+"""Test of min-max 1D features of sparse array classes"""
+
+import pytest
+
+import numpy as np
+
+from numpy.testing import assert_equal, assert_array_equal
+
+from scipy.sparse import coo_array  # , dok_array
+from scipy.sparse._sputils import isscalarlike
+
+
+def toarray(a):
+    if isinstance(a, np.ndarray) or isscalarlike(a):
+        return a
+    return a.toarray()
+
+
+formats_for_minmax = [coo_array]  # , dok_array]
+
+
+@pytest.mark.parametrize("spcreator", formats_for_minmax)
+class Test_MinMaxMixin1D:
+    def test_minmax(self, spcreator):
+        D = np.arange(5)
+        X = spcreator(D)
+
+        assert_equal(X.min(), 0)
+        assert_equal(X.max(), 4)
+        assert_equal((-X).min(), -4)
+        assert_equal((-X).max(), 0)
+
+
+    def test_minmax_axis(self, spcreator):
+        D = np.arange(50)
+        X = spcreator(D)
+
+        for axis in [0, -1]:
+            assert_array_equal(
+                toarray(X.max(axis=axis)), D.max(axis=axis, keepdims=True)
+            )
+            assert_array_equal(
+                toarray(X.min(axis=axis)), D.min(axis=axis, keepdims=True)
+            )
+        for axis in [-2, 1]:
+            pytest.raises(ValueError, X.min, axis=axis)
+            pytest.raises(ValueError, X.max, axis=axis)
+
+
+    def test_numpy_minmax(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+        assert_array_equal(np.min(datsp), np.min(dat))
+        assert_array_equal(np.max(datsp), np.max(dat))
+
+
+    def test_argmax(self, spcreator):
+        D1 = np.array([-1, 5, 2, 3])
+        D2 = np.array([0, 0, -1, -2])
+        D3 = np.array([-1, -2, -3, -4])
+        D4 = np.array([1, 2, 3, 4])
+        D5 = np.array([1, 2, 0, 0])
+
+        for D in [D1, D2, D3, D4, D5]:
+            mat = spcreator(D)
+
+            assert_equal(mat.argmax(), np.argmax(D))
+            assert_equal(mat.argmin(), np.argmin(D))
+
+            assert_equal(mat.argmax(axis=0), np.argmax(D, axis=0))
+            assert_equal(mat.argmin(axis=0), np.argmin(D, axis=0))
+
+        D6 = np.empty((0,))
+
+        for axis in [None, 0]:
+            mat = spcreator(D6)
+            pytest.raises(ValueError, mat.argmax, axis=axis)
+            pytest.raises(ValueError, mat.argmin, axis=axis)


### PR DESCRIPTION
This PR adds 1d support in the `_minmax_mixin` class providing min and max functionality. It is implemented in coo_array and is independent of the [PR for dok_array #19715 ](https://github.com/scipy/scipy/pull/19715).

This is much smaller than the coo-1d and dok-1d changes. Indeed, most of the new lines are in the tests.