### PR TITLE
ENH: stats.mannwhitneyu: speed improvement, memory reduction, and `PermutationMethod` support

### DIFF
--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -320,10 +320,9 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
         * ``'auto'``: chooses ``'exact'`` when the size of one of the samples
           is less than or equal to 8 and there are no ties;
           chooses ``'asymptotic'`` otherwise.
-
-        `method` may also be an instance of `stats.PermutationMethod`, in which
-        case the p-value is computed using `scipy.stats.permutation_test` with
-        the provided configuration options and other appropriate settings.
+        * `scipy.stats.PermutationMethod` instance. In this case, the p-value
+          is computed using`scipy.stats.permutation_test` with the provided
+          configuration options and other appropriate settings.
 
     Returns
     -------
@@ -515,7 +514,7 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
     elif method == "asymptotic":
         z = _get_mwu_z(U, n1, n2, ranks, continuity=use_continuity)
         p = stats.norm.sf(z)
-    else:
+    else:  # `PermutationMethod` instance (already validated)
         def statistic(x, y, axis):
             return mannwhitneyu(x, y, use_continuity=use_continuity,
                                 alternative=alternative, axis=axis,

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -81,7 +81,7 @@ class _MWU:
             cdfs = np.asarray(self.cdf(kc, m, n))
             cdfs[i] = 1. - cdfs[i] + self.pmf(kc[i], m, n)
         else:
-            cdfs = self.cdf(kc, m, n)
+            cdfs = np.asarray(self.cdf(kc, m, n))
         return cdfs[()]
 
     def _resize_fmnks(self, m, n, k):

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -308,7 +308,7 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
         see [5] section 5.1.
     axis : int, optional
         Axis along which to perform the test. Default is 0.
-    method : {'auto', 'asymptotic', 'exact'} or `stats.PermutationMethod`, optional
+    method : {'auto', 'asymptotic', 'exact'} or `PermutationMethod` instance, optional
         Selects the method used to calculate the *p*-value.
         Default is 'auto'. The following options are available.
 
@@ -320,8 +320,8 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
         * ``'auto'``: chooses ``'exact'`` when the size of one of the samples
           is less than or equal to 8 and there are no ties;
           chooses ``'asymptotic'`` otherwise.
-        * `scipy.stats.PermutationMethod` instance. In this case, the p-value
-          is computed using`scipy.stats.permutation_test` with the provided
+        * `PermutationMethod` instance. In this case, the p-value
+          is computed using `permutation_test` with the provided
           configuration options and other appropriate settings.
 
     Returns
@@ -350,7 +350,7 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
     Note that the exact method is *not* corrected for ties, but
     `mannwhitneyu` will not raise errors or warnings if there are ties in the
     data. If there are ties and either samples is small (fewer than ~10
-    observations), consider passing an instance of `stats.PermutationMethod`
+    observations), consider passing an instance of `PermutationMethod`
     as the `method` to perform a permutation test.
 
     The Mann-Whitney U test is a non-parametric version of the t-test for

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -488,7 +488,7 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
         U, f = np.maximum(U1, U2), 2  # multiply SF by two for two-sided test
 
     if method == "exact":
-        p = _mwu_state.sf(U.astype(int), n1, n2)
+        p = _mwu_state.sf(U.astype(int), min(n1, n2), max(n1, n2))
     elif method == "asymptotic":
         z = _get_mwu_z(U, n1, n2, ranks, continuity=use_continuity)
         p = stats.norm.sf(z)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -634,6 +634,18 @@ class TestMannWhitneyU:
         stats.mannwhitneyu(0*x, y, method='exact', alternative='greater')
         assert shape == _mwu_state._fmnks.shape
 
+    @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
+    def test_permutation_method(self, alternative):
+        rng = np.random.default_rng(7600451795963068007)
+        x = rng.random(size=(2, 5))
+        y = rng.random(size=(2, 6))
+        res = stats.mannwhitneyu(x, y, method=stats.PermutationMethod(),
+                                 alternative=alternative, axis=1)
+        res2 = stats.mannwhitneyu(x, y, method='exact',
+                                  alternative=alternative, axis=1)
+        assert_allclose(res.statistic, res2.statistic, rtol=1e-15)
+        assert_allclose(res.pvalue, res2.pvalue, rtol=1e-15)
+
     def teardown_method(self):
         _mwu_state._recursive = None
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -620,9 +620,9 @@ class TestMannWhitneyU:
         _mwu_state._fmnks = -np.ones((1, 1, 1))  # reset cache
         stats.mannwhitneyu(x, y, method='exact')
         shape = _mwu_state._fmnks.shape
-        assert shape[0] < shape[1]
+        assert shape[0] <= 6 and shape[1] <= 12  # one more than sizes
         stats.mannwhitneyu(y, x, method='exact')
-        assert shape == _mwu_state._fmnks.shape
+        assert shape == _mwu_state._fmnks.shape  # unchanged when sizes are reversed
 
         # Also, we weren't exploiting the symmmetry of the null distribution
         # to its full potential. Ensure that the null distribution is not

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -609,6 +609,19 @@ class TestMannWhitneyU:
                            method="asymptotic")
         assert_allclose(res, expected, rtol=1e-12)
 
+    def test_gh19692_smaller_table(self):
+        # In gh-19692, we noted that the shape of the cache used in calculating
+        # p-values was dependent on the order of the inputs because the sample
+        # sizes n1 and n2 changed. This was indicative of unnecessary cache
+        # growth and redundant calculation. Check that this is resolved.
+        rng = np.random.default_rng(7600451795963068007)
+        x = rng.random(size=5)
+        y = rng.random(size=11)
+        stats.mannwhitneyu(x, y, method='exact')
+        shape = _mwu_state._fmnks.shape
+        stats.mannwhitneyu(y, x, method='exact')
+        assert shape == _mwu_state._fmnks.shape
+
     def teardown_method(self):
         _mwu_state._recursive = None
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -617,9 +617,21 @@ class TestMannWhitneyU:
         rng = np.random.default_rng(7600451795963068007)
         x = rng.random(size=5)
         y = rng.random(size=11)
+        _mwu_state._fmnks = -np.ones((1, 1, 1))  # reset cache
         stats.mannwhitneyu(x, y, method='exact')
         shape = _mwu_state._fmnks.shape
+        assert shape[0] < shape[1]
         stats.mannwhitneyu(y, x, method='exact')
+        assert shape == _mwu_state._fmnks.shape
+
+        # Also, we weren't exploiting the symmmetry of the null distribution
+        # to its full potential. Ensure that the null distribution is not
+        # evaluated explicitly for `k > m*n/2`.
+        _mwu_state._fmnks = -np.ones((1, 1, 1))  # reset cache
+        stats.mannwhitneyu(x, 0*y, method='exact', alternative='greater')
+        shape = _mwu_state._fmnks.shape
+        assert shape[-1] == 1  # k is smallest possible
+        stats.mannwhitneyu(0*x, y, method='exact', alternative='greater')
         assert shape == _mwu_state._fmnks.shape
 
     def teardown_method(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-19692

#### What does this implement/fix?
gh-19692 reported high memory consumption in the `stats.mannwhitneyu` p-value calculation. Several improvements were suggested in https://github.com/scipy/scipy/issues/19692#issuecomment-1863311504. This implements most of those improvement ideas.

#### Additional information
Before this PR, both of these calls would have been slow, and memory consumption would have increased during the second call. Now, second call is very fast, and it doesn't increase memory usage.

```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(2549824598234528)
x = rng.random(size=30)
y = rng.random(size=120)
stats.mannwhitneyu(x, y, method='exact')
# second call is fast because cache can be reused even when
# sample sizes are reversed
stats.mannwhitneyu(y, x, method='exact')
```

Before this PR, this call would have been very slow because the p-value computation required summing all elements of the null distribution PDF. Now, by exploiting the symmetry of the null distribution, only one element of the null distribution PDF needs to be calculated.

```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(2549824598234528)
x = rng.random(size=30)
y = rng.random(size=120)
stats.mannwhitneyu(0*x, y, method='exact', alternative='greater')
```

Finally, this PR adds support for `method` being an instance of `PermutationMethod`. This can p-values to be estimated accurately in cases where both `asymptotic` and `exact` would not be acceptable (e.g. small samples with ties, one sample very large with the other very small):
```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(2549824598234528)
rng = np.random.default_rng(2549824598234528)
x = rng.random(size=5)
y = rng.random(size=6)
stats.mannwhitneyu(x, y, method='exact')
# MannwhitneyuResult(statistic=9.0, pvalue=0.32900432900432897)
stats.mannwhitneyu(x, y, method=stats.PermutationMethod())
# MannwhitneyuResult(statistic=9.0, pvalue=0.329004329004329)

x[1] = x[2]  # introduce a tie
stats.mannwhitneyu(x, y, method='exact')
# MannwhitneyuResult(statistic=12.0, pvalue=0.6623376623376623)
stats.mannwhitneyu(x, y, method=stats.PermutationMethod())
# MannwhitneyuResult(statistic=12.0, pvalue=0.6277056277056277)
```