### PR TITLE
CI: add labeler based on issue/PR titles

### DIFF
--- a/.github/label-globs.yml
+++ b/.github/label-globs.yml
@@ -1,3 +1,6 @@
+# This file contains globs for automatically adding labels based on changed files,
+# for use with https://github.com/actions/labeler.
+
 scipy.cluster:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# This file contains regexes for automatically adding labels based on issue/PR titles,
+# for use with https://github.com/github/issue-labeler.
+
+array types:
+  - 'array types'
+
+Benchmarks:
+  - 'BENCH'
+
+Build issues:
+  - 'BLD'
+
+CI:
+  - 'CI'
+
+defect:
+  - '(BUG|FIX)'
+
+deprecated:
+  - 'DEP'
+
+Documentation:
+  - 'DOC'
+
+DX:
+  - 'DEV'
+
+enhancement:
+  - 'ENH'
+
+maintenance:
+  - '(MAINT|TST)'
+
+query:
+  - '(Q|q)uery'
+
+RFC:
+  - 'RFC'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,25 +1,18 @@
-name: "Pull Request Labeler"
+name: "Issue Labeler"
 on:
-  pull_request_target:
+  issues:
     types: [opened]
 
 jobs:
-  label_pull_request:
-    # Permissions needed for labelling Pull Requests automatically
+  label_issue:
+    # Permissions needed for labelling issues automatically
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
-    # label based on changed files
-    - uses: actions/labeler@v5
-      continue-on-error: true
-      if: github.repository == 'scipy/scipy'
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: ".github/label-globs.yml"
-    # label based on PR title
+    # label based on issue title
     - uses: github/issue-labeler@v3.3
       if: github.repository == 'scipy/scipy'
       with:


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/17116#issuecomment-1582279070 @j-bowhay 

#### What does this implement/fix?
- Adds a labeler to automatically add labels based on acronyms in issue/PR titles (e.g. 'MAINT' -> 'maintenance')

#### Additional information
I've convinced myself that this works over at https://github.com/lucascolley/scipy/pull/9.
