### PR TITLE
TST: skip RGI(..., method="pchip" for complex values)

### DIFF
--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -850,6 +850,9 @@ class TestInterpN:
 
     @parametrize_rgi_interp_methods
     def test_complex(self, method):
+        if method == "pchip":
+            pytest.skip("pchip does not make sense for complex data")
+
         x, y, values = self._sample_2d_data()
         points = (x, y)
         values = values - 2j*values


### PR DESCRIPTION
PchipInterpolator is nonlinear in data, hence does not guarantee that `pchip(x, y) == pchip(x, y.real) + 1j*pchip(x, y.imag)`
The test was passing by chance.

cross-ref gh-19739 which exposed the problem with this test. Note that this PR only  closes gh-19739 if we declare that we don't care that pchip(complex-valued y) returns nonsense.
Otherwise, there is discussion to follow up in  gh-19739.

Also cc @tylerjereddy : may want to backport this patch to improve compatibility of SciPy 1.12 and NumPy 2.0 --- the latter may contain the change to `np.sign` which exposes the issue in the test this PR removes. 