### PR TITLE
BUG: Make FMM classes `py::module_local` (fix for 1.12RC)

### DIFF
--- a/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
+++ b/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
@@ -196,7 +196,7 @@ PYBIND11_MODULE(_fmm_core, m) {
         }
     });
 
-    py::class_<fmm::matrix_market_header>(m, "header")
+    py::class_<fmm::matrix_market_header>(m, "header", py::module_local())
 #ifndef FMM_SCIPY_PRUNE
     .def(py::init<>())
     .def(py::init<int64_t, int64_t>())
@@ -225,7 +225,7 @@ PYBIND11_MODULE(_fmm_core, m) {
 #endif
     ///////////////////////////////
     // Read methods
-    py::class_<read_cursor>(m, "_read_cursor")
+    py::class_<read_cursor>(m, "_read_cursor", py::module_local())
     .def_readonly("header", &read_cursor::header)
     .def("close", &read_cursor::close);
 
@@ -237,7 +237,7 @@ PYBIND11_MODULE(_fmm_core, m) {
 
     ///////////////////////////////
     // Write methods
-    py::class_<write_cursor>(m, "_write_cursor")
+    py::class_<write_cursor>(m, "_write_cursor", py::module_local())
 #ifndef FMM_SCIPY_PRUNE
     .def_readwrite("header", &write_cursor::header)
 #endif


### PR DESCRIPTION
The `_fmm_core.so` C++ module (new in 1.12) exports three classes with pybind11 defaults. This makes them globals, which can clash with other modules exporting a class of the same name, causing an error like this one (seen with 1.12rc1):
```
ImportError: generic_type: type "header" is already registered!
```

This fixes the issue by making those classes `py::module_local()`.

This should be merged into both 1.12 branch and main, LMK if I should adjust the PR.