### PR TITLE
DEP: deprecate complex dtypes in `PchipInterpolator` and `Akima1DInterpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import warnings
+
 import numpy as np
 
 from scipy.linalg import solve, solve_banded
@@ -239,6 +241,13 @@ class PchipInterpolator(CubicHermiteSpline):
 
     def __init__(self, x, y, axis=0, extrapolate=None):
         x, _, y, axis, _ = prepare_input(x, y, axis)
+        if np.iscomplexobj(y):
+            msg = ("`PchipInterpolator` only works with real values for `y`. "
+                   "Passing an array with a complex dtype for `y` is deprecated "
+                   "and will raise an error in SciPy 1.15.0. If you are trying to "
+                   "use the real components of the passed array, use `np.real` on "
+                   "the array before passing to `PchipInterpolator`.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
         xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
         dk = self._find_derivatives(xp, y)
         super().__init__(x, y, dk, axis=0, extrapolate=extrapolate)
@@ -484,6 +493,14 @@ class Akima1DInterpolator(CubicHermiteSpline):
         # Original implementation in MATLAB by N. Shamsundar (BSD licensed), see
         # https://www.mathworks.com/matlabcentral/fileexchange/1814-akima-interpolation
         x, dx, y, axis, _ = prepare_input(x, y, axis)
+
+        if np.iscomplexobj(y):
+            msg = ("`Akima1DInterpolator` only works with real values for `y`. "
+                   "Passing an array with a complex dtype for `y` is deprecated "
+                   "and will raise an error in SciPy 1.15.0. If you are trying to "
+                   "use the real components of the passed array, use `np.real` on "
+                   "the array before passing to `Akima1DInterpolator`.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
         # determine slopes between breakpoints
         m = np.empty((x.size + 3, ) + y.shape[1:])

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -342,6 +342,12 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
         A 1-D array of real values. `yi`'s length along the interpolation
         axis must be equal to the length of `xi`. If N-D array, use axis
         parameter to select correct axis.
+
+        .. deprecated:: 1.13.0
+            Complex data is deprecated and will raise an error in
+            SciPy 1.15.0. If you are trying to use the real components of
+            the passed array, use ``np.real`` on `yi`.
+
     x : scalar or array_like
         Of length M.
     der : int or list, optional

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -180,6 +180,12 @@ class PchipInterpolator(CubicHermiteSpline):
         A N-D array of real values. ``y``'s length along the interpolation
         axis must be equal to the length of ``x``. Use the ``axis``
         parameter to select the interpolation axis.
+
+        .. deprecated:: 1.13.0
+            Complex data is deprecated and will raise an error in SciPy 1.15.0.
+            If you are trying to use the real components of the passed array,
+            use ``np.real`` on ``y``.
+
     axis : int, optional
         Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
         to ``axis=0``.
@@ -397,6 +403,12 @@ class Akima1DInterpolator(CubicHermiteSpline):
         N-D array of real values. The length of ``y`` along the interpolation axis
         must be equal to the length of ``x``. Use the ``axis`` parameter to
         select the interpolation axis.
+
+        .. deprecated:: 1.13.0
+            Complex data is deprecated and will raise an error in SciPy 1.15.0.
+            If you are trying to use the real components of the passed array,
+            use ``np.real`` on ``y``.
+
     axis : int, optional
         Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
         to ``axis=0``.

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -68,10 +68,10 @@ class RegularGridInterpolator:
         accepted.
 
         .. deprecated:: 1.13.0
-            Complex data is deprecated with ``method="pchip"` and will raise an
+            Complex data is deprecated with ``method="pchip"`` and will raise an
             error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
             works with real values. If you are trying to use the real components of
-            the passed array, use `np.real` on `values`.
+            the passed array, use ``np.real`` on ``values``.
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear",
@@ -549,9 +549,10 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
         accepted.
 
         .. deprecated:: 1.13.0
-            Complex data is deprecated with method "pchip" and will raise an
+            Complex data is deprecated with ``method="pchip"`` and will raise an
             error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
-            works will real values.
+            works with real values. If you are trying to use the real components of
+            the passed array, use ``np.real`` on ``values``.
 
     xi : ndarray of shape (..., ndim)
         The coordinates to sample the gridded data at

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -1,6 +1,7 @@
 __all__ = ['RegularGridInterpolator', 'interpn']
 
 import itertools
+import warnings
 
 import numpy as np
 
@@ -63,8 +64,13 @@ class RegularGridInterpolator:
         strictly ascending or descending.
 
     values : array_like, shape (m1, ..., mn, ...)
-        The data on the regular grid in n dimensions. Complex data can be
-        acceptable.
+        The data on the regular grid in n dimensions. Complex data is
+        accepted.
+
+        .. deprecated:: 1.13.0
+            Complex data is deprecated with method "pchip" and will raise an
+            error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
+            works will real values.
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear",
@@ -243,6 +249,14 @@ class RegularGridInterpolator:
         self.fill_value = self._check_fill_value(self.values, fill_value)
         if self._descending_dimensions:
             self.values = np.flip(values, axis=self._descending_dimensions)
+        
+        if self.method == "pchip" and np.iscomplexobj(self.values):
+            msg = ("`PchipInterpolator` only works with real values. Passing "
+                   "complex-dtyped `values` with `method='pchip'` is deprecated "
+                   "and will raise an error in SciPy 1.15.0. If you are trying to "
+                   "use the real components of the passed array, use `np.real` on "
+                   "the array before passing to `RegularGridInterpolator`.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     def _check_dimensionality(self, grid, values):
         _check_dimensionality(grid, values)
@@ -530,8 +544,13 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
         strictly ascending or descending.
 
     values : array_like, shape (m1, ..., mn, ...)
-        The data on the regular grid in n dimensions. Complex data can be
-        acceptable.
+        The data on the regular grid in n dimensions. Complex data is
+        accepted.
+
+        .. deprecated:: 1.13.0
+            Complex data is deprecated with method "pchip" and will raise an
+            error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
+            works will real values.
 
     xi : ndarray of shape (..., ndim)
         The coordinates to sample the gridded data at

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -68,9 +68,10 @@ class RegularGridInterpolator:
         accepted.
 
         .. deprecated:: 1.13.0
-            Complex data is deprecated with method "pchip" and will raise an
+            Complex data is deprecated with ``method="pchip"` and will raise an
             error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
-            works will real values.
+            works with real values. If you are trying to use the real components of
+            the passed array, use `np.real` on `values`.
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear",

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1015,6 +1015,14 @@ class TestAkima1DInterpolator:
         with pytest.raises(NotImplementedError, match=match):
             Akima1DInterpolator(x, y, method="invalid")  # type: ignore
 
+    def test_complex(self):
+        # Complex-valued data deprecated
+        x = np.arange(0., 11.)
+        y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        y = y - 2j*y
+        with pytest.warns(DeprecationWarning):
+            Akima1DInterpolator(x, y)
+
 
 class TestPPolyCommon:
     # test basic functionality for PPoly and BPoly

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1020,7 +1020,7 @@ class TestAkima1DInterpolator:
         x = np.arange(0., 11.)
         y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
         y = y - 2j*y
-        with pytest.warns(DeprecationWarning):
+        with pytest.deprecated_call(match='complex'):
             Akima1DInterpolator(x, y)
 
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -143,7 +143,7 @@ def test_complex():
     x = [1, 2, 3, 4]
     y = [1, 2, 1j, 3]
 
-    for ip in [KroghInterpolator, BarycentricInterpolator, pchip, CubicSpline]:
+    for ip in [KroghInterpolator, BarycentricInterpolator, CubicSpline]:
         p = ip(x, y)
         assert_allclose(y, p(x))
 

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -121,6 +121,8 @@ class TestRegularGridInterpolator:
 
     @parametrize_rgi_interp_methods
     def test_complex(self, method):
+        if method == "pchip":
+            pytest.skip("pchip does not make sense for complex data")
         points, values = self._get_sample_4d_3()
         values = values - 2j*values
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
@@ -865,6 +867,17 @@ class TestInterpN:
         v2i = interpn(points, values.imag, sample, method=method)
         v2 = v2r + 1j*v2i
         assert_allclose(v1, v2)
+
+    def test_complex_pchip(self):
+        # Complex-valued data deprecated for pchip
+        x, y, values = self._sample_2d_data()
+        points = (x, y)
+        values = values - 2j*values
+
+        sample = np.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
+                           [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
+        with pytest.warns(DeprecationWarning):
+            interpn(points, values, sample, method='pchip')
 
     def test_complex_spline2fd(self):
         # Complex-valued data not supported by spline2fd

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -876,7 +876,7 @@ class TestInterpN:
 
         sample = np.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
                            [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
-        with pytest.warns(DeprecationWarning):
+        with pytest.deprecated_call(match='complex'):
             interpn(points, values, sample, method='pchip')
 
     def test_complex_spline2fd(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-19739

#### What does this implement/fix?
Warn on complex dtypes in `PchipInterpolator` and `Akima1DInterpolator`. Advise to use `np.real` if trying to use the real components.

#### Additional information
cc @j-bowhay @ev-br 