### PR TITLE
ENH: interpolate: add a QR solver to `make_lsq_spline`

### DIFF
--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -121,10 +121,10 @@ py3.extension_module('_rgi_cython',
 )
 
 _bspl = py3.extension_module('_bspl',
-  cython_gen.process('_bspl.pyx'),
-  c_args: cython_c_args,
+  cython_gen_cpp.process('_bspl.pyx'),
+  cpp_args: cython_cpp_args,
   include_directories: 'src/',
-  dependencies: np_dep,
+  dependencies: [lapack, np_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/interpolate'

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -1,3 +1,16 @@
+#include <iostream>
+#include <tuple>
+#include "../linalg/fortran_defs.h"
+
+#define DLARTG F_FUNC(dlartg, DLARTG)
+
+extern "C" {
+void DLARTG(double *f, double *g, double *cs, double *sn, double *r);
+}
+
+
+namespace fitpack {
+
 /*
  * B-spline evaluation routine.
  */
@@ -62,3 +75,328 @@ _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
         }
     }
 }
+
+
+/* TODO:
+ * 2. std::cout << array
+ * 4. rationalize explicit double vs templates
+ * 7. checks: contiguity etc: @ cython; y.shape[0] == m
+ * 8. complex
+ * 9. () or [] --- runtime penalty of a tuple?
+ * 10. flip boundscheck to False
+ */
+
+
+///////////// Bounds checking
+template<bool boundscheck> void _bcheck(ssize_t index, ssize_t size, ssize_t dim);
+
+template<>
+void _bcheck<true>(ssize_t index, ssize_t size, ssize_t dim) {
+    if (!((0 <= index) && (index < size))){
+        auto mesg = "Out of bounds with index = " + std::to_string(index) + " of size = ";
+        mesg = mesg + std::to_string(size) + " in dimension = " + std::to_string(dim);
+        throw(std::runtime_error(mesg) );
+    }
+}
+
+template<>
+void _bcheck<false>(ssize_t index, ssize_t size, ssize_t dim) { /* noop*/ }
+////////////////////////////
+
+
+template<typename T, bool boundscheck=true>
+struct Array1D
+{
+    T* data;
+    ssize_t nelem;
+    T& operator()(const ssize_t i) {
+        _bcheck<boundscheck>(i, nelem, 0);
+        return *(data + i);
+    }
+    Array1D(T *ptr, ssize_t num_elem) : data(ptr), nelem(num_elem) {};
+};
+
+
+
+template<typename T, bool boundscheck=true>
+struct Array2D
+{
+    T* data;
+    ssize_t nrows;
+    ssize_t ncols;
+    T& operator()(const ssize_t i, const ssize_t j) {
+        _bcheck<boundscheck>(i, nrows, 0);
+        _bcheck<boundscheck>(j, ncols, 1);
+        return *(data + ncols*i + j);
+    }
+    Array2D(T *ptr, ssize_t num_rows, ssize_t num_columns) : data(ptr), nrows(num_rows), ncols(num_columns) {};
+};
+
+
+// Flip boundschecking on/off here
+typedef Array2D<double, false> RealArray2D;
+typedef Array1D<double, false> RealArray1D;
+typedef Array1D<const double, false> ConstRealArray1D;
+typedef Array2D<const double, false> ConstRealArray2D;
+
+
+/*
+ *  Find an interval such that t[interval] <= xval < t[interval+1].
+ */
+inline
+ssize_t
+_find_interval(const double* tptr, ssize_t len_t,
+               int k,
+               double xval,
+               ssize_t prev_l,
+               int extrapolate)
+{
+    ConstRealArray1D t = ConstRealArray1D(tptr, len_t);
+
+    ssize_t n = t.nelem - k - 1;
+    double tb = t(k);
+    double te = t(n);
+
+    if (xval != xval) {
+        // nan
+        return -1;
+    }
+
+    if (((xval < tb) || (xval > te)) && !extrapolate) {
+        return -1;
+    }
+    ssize_t l = (k < prev_l) && (prev_l < n) ? prev_l : k;
+
+    // xval is in support, search for interval s.t. t[interval] <= xval < t[l+1]
+    while ((xval < t(l)) && (l != k)) {
+        l -= 1;
+    }
+
+    l += 1;
+    while ((xval >= t(l)) && (l != n)) {
+        l += 1;
+    }
+
+    return l-1;
+}
+
+
+/*
+ * Fill the (m, k+1) matrix of non-zero b-splines. A row gives b-splines
+ * which are non-zero at the corresponding value of `x`.
+ * Also for each row store the `offset`: with full matrices, the non-zero elements
+ * in row `i` start at `offset[i]`. IOW,
+ * A_full[i, offset[i]: offset[i] + k + 1] = A_packed[i, :].
+ *
+ * What we construct here is `A_packed` and `offset` arrays.
+ *
+ * We also take into account possible weights for each `x` value: they
+ * multiply the rows of the data matrix.
+ *
+ * To reconstruct the full dense matrix, `A_full`, we would need to know the
+ * number of its columns, `nc`. So we return it, too.
+ */
+inline void 
+data_matrix( /* inputs */
+            const double *xptr, ssize_t m,      // x, shape (m,)
+            const double *tptr, ssize_t len_t,  // t, shape (len_t,)
+            int k,
+            const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+            /* outputs */
+            double *Aptr,                       // A, shape(m, k+1)
+            ssize_t *offset_ptr,                // offset, shape (m,)
+            ssize_t *nc,                        // the number of coefficient
+            /* work array*/
+            double *wrk)                        // work, shape (2k+2)
+{
+    auto x = ConstRealArray1D(xptr, m);
+    auto t = ConstRealArray1D(tptr, len_t);
+    auto w = ConstRealArray1D(wptr, m);
+    auto A = RealArray2D(Aptr, m, k+1);
+    auto offset = Array1D<ssize_t, false>(offset_ptr, m);
+
+    ssize_t ind = k;
+    for (int i=0; i < m; ++i) { 
+        double xval = x(i);
+
+        // find the interval  
+        ind = _find_interval(t.data, len_t, k, xval, ind, 0);
+        if (ind < 0){
+            // should not happen here, validation is expected on the python side
+            throw std::runtime_error("find_interval: out of bounds with x = " + std::to_string(xval));
+        }
+        offset(i) = ind - k;
+
+        // compute non-zero b-splines
+        _deBoor_D(t.data, xval, k, ind, 0, wrk);
+
+        for (ssize_t j=0; j < k+1; ++j) {
+            A(i, j) = wrk[j] * w(i);
+        }
+    }
+
+    *nc = len_t - k - 1;
+}
+
+
+
+/*
+ * Linear algebra: banded QR via Givens transforms.
+ */
+template<typename T>
+inline
+std::tuple<T, T>
+fprota(T c, T s, T a, T b)
+{
+    return std::make_tuple(
+        c*a + s*b,
+       -s*a + c*b
+    );
+}
+
+
+
+/*
+    Solve the LSQ problem ||y - A@c||^2 via QR factorization.
+
+    QR factorization follows FITPACK: we reduce A row-by-row by Givens rotations.
+
+    To zero out the lower triangle, we use in the row `i` and column `j < i`,
+    the diagonal element in that column. That way, the sequence is
+    (here `[x]` are the pair of elements to Givens-rotate)
+
+     [x] x x x       x  x  x x      x  x  x x      x x  x  x      x x x x
+     [x] x x x  ->   0 [x] x x  ->  0 [x] x x  ->  0 x  x  x  ->  0 x x x
+      0  x x x       0 [x] x x      0  0  x x      0 0 [x] x      0 0 x x
+      0  x x x       0  x  x x      0 [x] x x      0 0 [x] x      0 0 0 x
+
+    The matrix A has a special structure: each row has at most (k+1) non-zeros, so
+    is encoded as a PackedMatrix instance.
+
+    On exit, the return matrix, also of shape (m, k+1), contains
+    elements of the upper triangular matrix `R[i, i: i + k + 1]`.
+    When we process the element (i, j), we store the rotated row in R[i, :],
+    and *shift it to the left*, so that the the diagonal element is always in the
+    zero-th place. This way, the process above becomes
+
+
+     [x] x x x       x  x x x       x  x x x       x  x x x      x x x x
+     [x] x x x  ->  [x] x x -  ->  [x] x x -   ->  x  x x -  ->  x x x -
+      x  x x -      [x] x x -       x  x - -      [x] x - -      x x - -
+      x  x x -       x  x x -      [x] x x -      [x] x - -      x - - -
+
+    The most confusing part is that when rotating the row `i` with a row `j`
+    above it, the offsets differ: for the upper row  `j`, `R[j, 0]` is the diagonal
+    element, while for the row `i`, `R[i, 0]` is the element being annihilated.
+
+    NB. This row-by-row Givens reduction process follows FITPACK:
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L112-L161
+    A possibly more efficient way could be to note that all data points which
+    lie between two knots all have the same offset: if `t[i] < x_1 .... x_s < t[i+1]`,
+    the `s-1` corresponding rows form an `(s-1, k+1)`-sized "block".
+    Then a blocked QR implementation could look like
+    https://people.sc.fsu.edu/~jburkardt/f77_src/band_qr/band_qr.f
+
+    The `startrow` optional argument accounts for the scenatio with a two-step
+    factorization. Namely, the preceding rows are assumend to be already
+    processed and are skipped.
+    This is to account for the scenario where we append new rows to an already
+    triangularized matrix.
+
+    This routine MODIFIES `a` & `y` in-place.
+*/
+void qr_reduce(double *aptr, const ssize_t m, const ssize_t nz, // a(m, nz), packed
+               ssize_t *offset,                                 // offset(m)
+               const ssize_t nc,                                // dense would be a(m, nc)
+               double *yptr, const ssize_t ydim1,               // y(m, ydim2)
+               const ssize_t startrow=1
+)
+{
+    auto R = RealArray2D(aptr, m, nz);
+    auto y = RealArray2D(yptr, m, ydim1);
+
+    for (ssize_t i=startrow; i < m; ++i) {
+        ssize_t oi = offset[i];
+        for (ssize_t j=oi; j < nc; ++j) {
+
+            // rotate only the lower diagonal
+            if (j >= std::min(i, nc)) {
+                break;
+            }
+
+            // in dense format: diag a1[j, j] vs a1[i, j]
+            double c, s, r;
+            DLARTG(&R(j, 0), &R(i, 0), &c, &s, &r);
+
+            // rotate l.h.s.
+            R(j, 0) = r;
+            for (ssize_t l=1; l < R.ncols; ++l) {
+                std::tie(R(j, l), R(i, l-1)) = fprota(c, s, R(j, l), R(i, l));
+            }
+            R(i, R.ncols-1) = 0.0;
+
+            // rotate r.h.s.
+            for (ssize_t l=0; l < y.ncols; ++l) {
+                std::tie(y(j, l), y(i, l)) = fprota(c, s, y(j, l), y(i, l));
+            }
+        }
+        if (i < nc) {
+            offset[i] = i;
+        }
+
+    } // for(i = ...
+}
+
+
+/*
+ * Back substitution solve of `R @ c = y` with an upper triangular R.
+ *
+ * R is in the 'packed' format:
+ *    1. Each row has at most `nz` non-zero elements, stored in a (m, nz) array
+ *    2. All non-zeros are consecutive.
+ * Since R is upper triangular, non-zeros in row `i` start at `i`. IOW,
+ * the 'offset' array is `np.arange(nc)`.
+ *
+ * If `R` were dense, it would have had shape `(m, nc)`. Since R is upper triangular,
+ * the first `nc` rows contain non-zeros; the last `m-nc` rows are all zeros
+ * (in fact, they may contain whatever, and are not referenced in the routine).
+ *
+ * `y` array is always two-dimensional, and has shape `(m, ydim2)`.
+ * IOW, if the original data is 1D, `y.shape == (m, 1)`.
+ *
+ * The output `c` array has the shape `(nc, ydim2)`.
+ */
+void fpback( /* inputs*/
+            const double *Rptr, ssize_t m, ssize_t nz,    // R(m, nz), packed
+            ssize_t nc,                                   // dense R would be (m, nc)
+            const double *yptr, ssize_t ydim2,            // y(m, ydim2)
+             /* output */
+            double *cptr)                                 // c(nc, ydim2)
+{
+    auto R = ConstRealArray2D(Rptr, m, nz);
+    auto y = ConstRealArray2D(yptr, m, ydim2);
+    auto c = RealArray2D(cptr, nc, ydim2);
+
+    // c[nc-1, ...] = y[nc-1] / R[nc-1, 0]
+    for (ssize_t l=0; l < ydim2; ++l) {
+        c(nc - 1, l) = y(nc - 1, l) / R(nc-1, 0); 
+    }
+
+    //for i in range(nc-2, -1, -1):
+    //    nel = min(nz, nc-i)
+    //    c[i, ...] = ( y[i] - (R[i, 1:nel, None] * c[i+1:i+nel, ...]).sum(axis=0) ) / R[i, 0]
+    for (ssize_t i=nc-2; i >= 0; --i) {
+        ssize_t nel = std::min(nz, nc - i);
+        for (ssize_t l=0; l < ydim2; ++l){
+            double ssum = y(i, l);
+            for (ssize_t j=1; j < nel; ++j) {
+                ssum -= R(i, j) * c(i + j, l);
+            }
+            ssum /= R(i, 0);
+            c(i, l) = ssum;
+        }
+    }
+}
+
+
+} // namespace fitpack

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -4,7 +4,6 @@
 #define PyInt_AsLong PyLong_AsLong
 
 static PyObject *fitpack_error;
-#include "__fitpack.h"
 
 #ifdef HAVE_ILP64
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1450,6 +1450,8 @@ def make_lsq_full_matrix(x, y, t, k=3):
     return c, (A, Y)
 
 
+parametrize_lsq_methods = pytest.mark.parametrize("method", ["norm-eq", "qr"])
+
 class TestLSQ:
     #
     # Test make_lsq_spline
@@ -1460,12 +1462,13 @@ class TestLSQ:
     y = np.random.random(n)
     t = _augknt(np.linspace(x[0], x[-1], 7), k)
 
-    def test_lstsq(self):
+    @parametrize_lsq_methods
+    def test_lstsq(self, method):
         # check LSQ construction vs a full matrix version
         x, y, t, k = self.x, self.y, self.t, self.k
 
         c0, AY = make_lsq_full_matrix(x, y, t, k)
-        b = make_lsq_spline(x, y, t, k)
+        b = make_lsq_spline(x, y, t, k, method=method)
 
         assert_allclose(b.c, c0)
         assert_equal(b.c.shape, (t.size - k - 1,))
@@ -1475,53 +1478,108 @@ class TestLSQ:
         c1, _, _, _ = np.linalg.lstsq(aa, y, rcond=-1)
         assert_allclose(b.c, c1)
 
-    def test_weights(self):
+    @parametrize_lsq_methods
+    def test_weights(self, method):
         # weights = 1 is same as None
         x, y, t, k = self.x, self.y, self.t, self.k
         w = np.ones_like(x)
 
-        b = make_lsq_spline(x, y, t, k)
-        b_w = make_lsq_spline(x, y, t, k, w=w)
+        b = make_lsq_spline(x, y, t, k, method=method)
+        b_w = make_lsq_spline(x, y, t, k, w=w, method=method)
 
         assert_allclose(b.t, b_w.t, atol=1e-14)
         assert_allclose(b.c, b_w.c, atol=1e-14)
         assert_equal(b.k, b_w.k)
 
-    def test_multiple_rhs(self):
+    def test_weights_same(self):
+        # both methods treat weights 
+        x, y, t, k = self.x, self.y, self.t, self.k
+        w = np.random.default_rng(1234).uniform(size=x.shape[0])
+
+        b_ne = make_lsq_spline(x, y, t, k, w=w, method="norm-eq")
+        b_qr = make_lsq_spline(x, y, t, k, w=w, method="qr")
+        b_no_w = make_lsq_spline(x, y, t, k, method="qr")
+
+        assert_allclose(b_ne.c, b_qr.c, atol=1e-14)
+        assert not np.allclose(b_no_w.c, b_qr.c, atol=1e-14)
+
+    @parametrize_lsq_methods
+    def test_multiple_rhs(self, method):
         x, t, k, n = self.x, self.t, self.k, self.n
         y = np.random.random(size=(n, 5, 6, 7))
 
-        b = make_lsq_spline(x, y, t, k)
+        b = make_lsq_spline(x, y, t, k, method=method)
         assert_equal(b.c.shape, (t.size-k-1, 5, 6, 7))
 
-    def test_complex(self):
+    @parametrize_lsq_methods
+    def test_multiple_rhs_2(self, method):
+        x, t, k, n = self.x, self.t, self.k, self.n
+        nrhs = 3
+        y = np.random.random(size=(n, nrhs))
+        b = make_lsq_spline(x, y, t, k, method=method)
+
+        bb = [make_lsq_spline(x, y[:, i], t, k, method=method)
+              for i in range(nrhs)]
+        coefs = np.vstack([bb[i].c for i in range(nrhs)]).T
+
+        assert_allclose(coefs, b.c, atol=1e-15)
+
+    def test_multiple_rhs_3(self):
+        x, t, k, n = self.x, self.t, self.k, self.n
+        nrhs = 3
+        y = np.random.random(size=(n, nrhs))
+        b_qr = make_lsq_spline(x, y, t, k, method="qr")
+        b_neq = make_lsq_spline(x, y, t, k, method="norm-eq")
+        assert_allclose(b_qr.c, b_neq.c, atol=1e-15)
+
+    @parametrize_lsq_methods
+    def test_complex(self, method):
+        if method == "qr":
+            pytest.xfail("method='qr' does not handle complex-valued `y` yet.")
+
         # cmplx-valued `y`
         x, t, k = self.x, self.t, self.k
         yc = self.y * (1. + 2.j)
 
-        b = make_lsq_spline(x, yc, t, k)
-        b_re = make_lsq_spline(x, yc.real, t, k)
-        b_im = make_lsq_spline(x, yc.imag, t, k)
+        b = make_lsq_spline(x, yc, t, k, method=method)
+        b_re = make_lsq_spline(x, yc.real, t, k, method=method)
+        b_im = make_lsq_spline(x, yc.imag, t, k, method=method)
 
         assert_allclose(b(x), b_re(x) + 1.j*b_im(x), atol=1e-15, rtol=1e-15)
 
-    def test_int_xy(self):
+    @parametrize_lsq_methods
+    def test_int_xy(self, method):
         x = np.arange(10).astype(int)
         y = np.arange(10).astype(int)
         t = _augknt(x, k=1)
         # Cython chokes on "buffer type mismatch"
-        make_lsq_spline(x, y, t, k=1)
+        make_lsq_spline(x, y, t, k=1, method=method)
 
-    def test_sliced_input(self):
+    @parametrize_lsq_methods
+    def test_f32_xy(self, method):
+        x = np.arange(10, dtype=np.float32)
+        y = np.arange(10, dtype=np.float32)
+        t = _augknt(x, k=1)
+        spl_f32 = make_lsq_spline(x, y, t, k=1, method=method)
+        spl_f64 = make_lsq_spline(
+            x.astype(float), y.astype(float), t.astype(float), k=1, method=method
+        )
+
+        x2 = (x[1:] + x[:-1]) / 2.0
+        assert_allclose(spl_f32(x2), spl_f64(x2), atol=1e-15)
+
+    @parametrize_lsq_methods
+    def test_sliced_input(self, method):
         # Cython code chokes on non C contiguous arrays
         xx = np.linspace(-1, 1, 100)
 
         x = xx[::3]
         y = xx[::3]
         t = _augknt(x, 1)
-        make_lsq_spline(x, y, t, k=1)
+        make_lsq_spline(x, y, t, k=1, method=method)
 
-    def test_checkfinite(self):
+    @parametrize_lsq_methods
+    def test_checkfinite(self, method):
         # check_finite defaults to True; nans and such trigger a ValueError
         x = np.arange(12).astype(float)
         y = x**2
@@ -1529,15 +1587,215 @@ class TestLSQ:
 
         for z in [np.nan, np.inf, -np.inf]:
             y[-1] = z
-            assert_raises(ValueError, make_lsq_spline, x, y, t)
+            assert_raises(ValueError, make_lsq_spline, x, y, t, method=method)
 
-    def test_read_only(self):
+    @parametrize_lsq_methods
+    def test_read_only(self, method):
         # Check that make_lsq_spline works with read only arrays
         x, y, t = self.x, self.y, self.t
         x.setflags(write=False)
         y.setflags(write=False)
         t.setflags(write=False)
-        make_lsq_spline(x=x, y=y, t=t)
+        make_lsq_spline(x=x, y=y, t=t, method=method)
+
+    @pytest.mark.parametrize('k', list(range(1, 7)))
+    def test_qr_vs_norm_eq(self, k):
+        # check that QR and normal eq solutions match
+        x, y = self.x, self.y
+        t = _augknt(np.linspace(x[0], x[-1], 7), k)
+        spl_norm_eq = make_lsq_spline(x, y, t, k=k, method='norm-eq')
+        spl_qr = make_lsq_spline(x, y, t, k=k, method='qr')
+
+        xx = (x[1:] + x[:-1]) / 2.0
+        assert_allclose(spl_norm_eq(xx), spl_qr(xx), atol=1e-15)
+
+    def test_duplicates(self):
+        # method="qr" can handle duplicated data points
+        x = np.repeat(self.x, 2)
+        y = np.repeat(self.y, 2)
+        spl_1 = make_lsq_spline(self.x, self.y, self.t, k=3, method='qr')
+        spl_2 = make_lsq_spline(x, y, self.t, k=3, method='qr')
+
+        xx = (x[1:] + x[:-1]) / 2.0
+        assert_allclose(spl_1(xx), spl_2(xx), atol=1e-15)
+
+
+def _qr_reduce_py(a_p, y, startrow=1):
+    """This is a python counterpart of the `_qr_reduce` routine,
+    defined in interpolate/src/__fitpack.h
+    """
+    from scipy.linalg.lapack import dlartg
+
+    # unpack the packed format
+    a = a_p.a
+    offset = a_p.offset
+    nc = a_p.nc
+
+    m, nz = a.shape
+
+    assert y.shape[0] == m
+    R = a.copy()
+    y1 = y.copy()
+
+    for i in range(startrow, m):
+        oi = offset[i]
+        for j in range(oi, nc):
+            # rotate only the lower diagonal
+            if j >= min(i, nc):
+                break
+
+            # In dense format: diag a1[j, j] vs a1[i, j]
+            c, s, r = dlartg(R[j, 0], R[i, 0])
+
+            # rotate l.h.s.
+            R[j, 0] = r
+            for l in range(1, nz):
+                R[j, l], R[i, l-1] = fprota(c, s, R[j, l], R[i, l])
+            R[i, -1] = 0.0
+
+            # rotate r.h.s.
+            for l in range(y1.shape[1]):
+                y1[j, l], y1[i, l] = fprota(c, s, y1[j, l], y1[i, l])
+
+    # convert to packed
+    offs = list(range(R.shape[0]))
+    R_p = _b.PackedMatrix(R, np.array(offs), nc)
+
+    return R_p, y1
+
+
+def fprota(c, s, a, b):
+    """Givens rotate [a, b].
+
+    [aa] = [ c s] @ [a]
+    [bb]   [-s c]   [b]
+
+    """
+    aa =  c*a + s*b
+    bb = -s*a + c*b
+    return aa, bb
+
+
+def fpback(R_p, y):
+    """Backsubsitution solve upper triangular banded `R @ c = y.`
+
+    `R` is in the "packed" format: `R[i, :]` is `a[i, i:i+k+1]`
+    """
+    R = R_p.a
+    _, nz = R.shape
+    nc = R_p.nc
+    assert y.shape[0] == R.shape[0]
+
+    c = np.zeros_like(y[:nc])
+    c[nc-1, ...] = y[nc-1] / R[nc-1, 0]
+    for i in range(nc-2, -1, -1):
+        nel = min(nz, nc-i)
+        # NB: broadcast R across trailing dimensions of `c`.
+        summ = (R[i, 1:nel, None] * c[i+1:i+nel, ...]).sum(axis=0)
+        c[i, ...] = ( y[i] - summ ) / R[i, 0]
+    return c
+
+
+class TestGivensQR:
+    # Test row-by-row QR factorization, used for the LSQ spline construction.
+    # This is implementation detail; still test it separately.
+    def _get_xyt(self, n):
+        k = 3
+        x = np.arange(n, dtype=float)
+        y = x**3 + 1/(1+x)
+        t = _not_a_knot(x, k)
+        return x, y, t, k
+
+    def test_vs_full(self):
+        n = 10
+        x, y, t, k = self._get_xyt(n)
+
+        # design matrix
+        a_csr = BSpline.design_matrix(x, t, k)
+
+        # dense QR
+        q, r = sl.qr(a_csr.todense())
+        qTy = q.T @ y
+
+        # prepare the PackedMatrix to factorize
+        # convert to "packed" format
+        m, nc = a_csr.shape
+        assert nc == t.shape[0] - k - 1
+
+        offset = a_csr.indices[::(k+1)]
+        offset = np.ascontiguousarray(offset, dtype=np.intp)
+        A = a_csr.data.reshape(m, k+1)
+
+        R = _b.PackedMatrix(A, offset, nc)
+        y_ = y[:, None]     # _qr_reduce requires `y` a 2D array
+        _bspl._qr_reduce(R, y_)         # modifies arguments in-place        
+
+        # signs may differ
+        assert_allclose(np.minimum(R.todense() + r,
+                                   R.todense() - r), 0, atol=1e-15)
+        assert_allclose(np.minimum(abs(qTy - y_[:, 0]),
+                                   abs(qTy + y_[:, 0])), 0, atol=2e-13)
+
+        # sign changes are consistent between Q and R:
+        c_full = sl.solve(r, qTy)
+        c_banded = _b.fpback(R, y_)
+        assert_allclose(c_full, c_banded[:, 0], atol=5e-13)
+
+    def test_py_vs_compiled(self):
+        # test _qr_reduce vs a python implementation
+        n = 10
+        x, y, t, k = self._get_xyt(n)
+
+        # design matrix
+        a_csr = BSpline.design_matrix(x, t, k)
+        m, nc = a_csr.shape
+        assert nc == t.shape[0] - k - 1
+
+        offset = a_csr.indices[::(k+1)]
+        offset = np.ascontiguousarray(offset, dtype=np.intp)
+        A = a_csr.data.reshape(m, k+1)
+
+        R = _b.PackedMatrix(A, offset, nc)
+        y_ = y[:, None]
+
+        RR, yy = _qr_reduce_py(R, y_)
+        _bspl._qr_reduce(R, y_)   # in-place
+
+        assert_allclose(RR.a, R.a, atol=1e-15)
+        assert_equal(RR.offset, R.offset)
+        assert RR.nc == R.nc
+        assert_allclose(yy, y_, atol=1e-15)
+
+    # Test C-level construction of the design matrix
+
+    def test_data_matrix(self):
+        n = 10
+        x, y, t, k = self._get_xyt(n)
+        w = np.arange(1, n+1, dtype=float)
+        A, offset, nc = _bspl._data_matrix(x, t, k, w)
+
+        m = x.shape[0]
+        a_csr = BSpline.design_matrix(x, t, k)
+        a_w = (a_csr * w[:, None]).tocsr()
+        A_ = a_w.data.reshape((m, k+1))
+        offset_ = a_w.indices[::(k+1)]
+
+        assert_allclose(A, A_, atol=1e-15)
+        assert_equal(offset, offset_)
+        assert nc == t.shape[0] - k - 1
+
+    def test_fpback(self):
+        n = 10
+        x, y, t, k = self._get_xyt(n)
+        y = np.c_[y, y**2]
+        A, offset, nc = _bspl._data_matrix(x, t, k, w=np.ones_like(x))
+        R = _b.PackedMatrix(A, offset, nc)
+        _bspl._qr_reduce(R, y)
+
+        c = fpback(R, y)
+        cc = _bspl._fpback(R, y)
+
+        assert_allclose(cc, c, atol=1e-14)
 
 
 def data_file(basename):


### PR DESCRIPTION
The strategy follows that of FITPACK: we reduce the observation matrix row by row via Givens rotations.

The user-visible change is that previously `make_lsq_spline` did not allow repeated `x` values (because it was using an explicit Cholesky factorization), and the QR process handles this case just fine.

<s>This is currently a WIP pure python prototype, which needs to be cythonized.</s>