### PR TITLE
MAINT/TST: ignore backend import errors when not in array API mode

### DIFF
--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -13,6 +13,8 @@ import pytest
 
 import scipy
 
+from scipy.conftest import xp_available_backends
+
 
 def test_dir_testing():
     """Assert that output of dir has only one "testing/tester"
@@ -212,16 +214,33 @@ SKIP_LIST = [
 ]
 
 
+# XXX: this test does more than it says on the tin - in using `pkgutil.walk_packages`,
+# it will raise if it encounters any exceptions which are not of type `ImportError` or
+# handled by `ignore_errors` while attempting to import each discovered package.
+# For now, `ignore_errors` only ignores what is necessary, but this could be expanded -
+# for example, to all errors from private modules or git subpackages - if desired.
 def test_all_modules_are_expected():
     """
     Test that we don't add anything that looks like a new public module by
     accident.  Check is based on filenames.
     """
 
+    def ignore_errors(name):
+        # if versions of other array libraries are installed which are incompatible
+        # with the installed NumPy version, there can be errors on importing
+        # `array_api_compat`. This should only raise if SciPy is configured with
+        # that library as an available backend.
+        for backend, dir_name in {'cupy': 'cupy', 'pytorch': 'torch'}.items():
+            path = f'array_api_compat.{dir_name}'
+            if path in name and backend not in xp_available_backends:
+                return
+        raise
+
     modnames = []
-    for _, modname, ispkg in pkgutil.walk_packages(path=scipy.__path__,
-                                                   prefix=scipy.__name__ + '.',
-                                                   onerror=None):
+
+    for _, modname, _ in pkgutil.walk_packages(path=scipy.__path__,
+                                               prefix=scipy.__name__ + '.',
+                                               onerror=ignore_errors):
         if is_unexpected(modname) and modname not in SKIP_LIST:
             # We have a name that is new.  If that's on purpose, add it to
             # PUBLIC_MODULES.  We don't expect to have to add anything to


### PR DESCRIPTION
#### Reference issue
Closes gh-19754

#### What does this implement/fix?
Handles the error seen in the linked issue. Errors relating to incompatible backend versions should not be occurring unless both backends are configured as available for use.

#### Additional information
@tylerjereddy could you test when you get round to it? I have been struggling to get an environment set up with NumPy 2.0dev so have been unable to test.

I've added a comment which explains that this test does more than what it says on the tin by finding these errors.