### PR TITLE
ENH: Add vectorized scalar minimization bracket finder

### DIFF
--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -9,10 +9,10 @@ from scipy import stats
 
 class TestBracketRoot:
     @pytest.mark.parametrize("seed", (615655101, 3141866013, 238075752))
-    @pytest.mark.parametrize("use_min", (False, True))
+    @pytest.mark.parametrize("use_xmin", (False, True))
     @pytest.mark.parametrize("other_side", (False, True))
     @pytest.mark.parametrize("fix_one_side", (False, True))
-    def test_nfev_expected(self, seed, use_min, other_side, fix_one_side):
+    def test_nfev_expected(self, seed, use_xmin, other_side, fix_one_side):
         # Property-based test to confirm that _bracket_root is behaving as
         # expected. The basic case is when root < a < b.
         # The number of times bracket expands (per side) can be found by
@@ -24,35 +24,35 @@ class TestBracketRoot:
         # Special cases like a < root < b are tested separately
 
         rng = np.random.default_rng(seed)
-        a, d, factor = rng.random(size=3) * [1e5, 10, 5]
+        xl0, d, factor = rng.random(size=3) * [1e5, 10, 5]
         factor = 1 + factor  # factor must be greater than 1
-        b = a + d  # b must be greater than a in basic case
+        xr0 = xl0 + d  # xr0 must be greater than a in basic case
 
         def f(x):
             f.count += 1
             return x  # root is 0
 
-        if use_min:
-            min = -rng.random()
-            n = np.ceil(np.log(-(a - min) / min) / np.log(factor))
-            l, u = min + (a - min)*factor**-n, min + (a - min)*factor**-(n - 1)
-            kwargs = dict(a=a, b=b, factor=factor, min=min)
+        if use_xmin:
+            xmin = -rng.random()
+            n = np.ceil(np.log(-(xl0 - xmin) / xmin) / np.log(factor))
+            l, u = xmin + (xl0 - xmin)*factor**-n, xmin + (xl0 - xmin)*factor**-(n - 1)
+            kwargs = dict(xl0=xl0, xr0=xr0, factor=factor, xmin=xmin)
         else:
-            n = np.ceil(np.log(b/d) / np.log(factor))
-            l, u = b - d*factor**n, b - d*factor**(n-1)
-            kwargs = dict(a=a, b=b, factor=factor)
+            n = np.ceil(np.log(xr0/d) / np.log(factor))
+            l, u = xr0 - d*factor**n, xr0 - d*factor**(n-1)
+            kwargs = dict(xl0=xl0, xr0=xr0, factor=factor)
 
         if other_side:
-            kwargs['a'], kwargs['b'] = -kwargs['b'], -kwargs['a']
+            kwargs['xl0'], kwargs['xr0'] = -kwargs['xr0'], -kwargs['xl0']
             l, u = -u, -l
-            if 'min' in kwargs:
-                kwargs['max'] = -kwargs.pop('min')
+            if 'xmin' in kwargs:
+                kwargs['xmax'] = -kwargs.pop('xmin')
 
         if fix_one_side:
             if other_side:
-                kwargs['min'] = -b
+                kwargs['xmin'] = -xr0
             else:
-                kwargs['max'] = b
+                kwargs['xmax'] = xr0
 
         f.count = 0
         res = _bracket_root(f, **kwargs)
@@ -90,13 +90,13 @@ class TestBracketRoot:
         return stats.norm.cdf(q) - p
 
     @pytest.mark.parametrize('p', [0.6, np.linspace(0.05, 0.95, 10)])
-    @pytest.mark.parametrize('min', [-5, None])
-    @pytest.mark.parametrize('max', [5, None])
+    @pytest.mark.parametrize('xmin', [-5, None])
+    @pytest.mark.parametrize('xmax', [5, None])
     @pytest.mark.parametrize('factor', [1.2, 2])
-    def test_basic(self, p, min, max, factor):
+    def test_basic(self, p, xmin, xmax, factor):
         # Test basic functionality to bracket root (distribution PPF)
-        res = _bracket_root(self.f, -0.01, 0.01, min=min, max=max,
-                                  factor=factor, args=(p,))
+        res = _bracket_root(self.f, -0.01, 0.01, xmin=xmin, xmax=xmax,
+                            factor=factor, args=(p,))
         assert_equal(-np.sign(res.fl), np.sign(res.fr))
 
     @pytest.mark.parametrize('shape', [tuple(), (12,), (3, 4), (3, 2, 2)])
@@ -108,10 +108,10 @@ class TestBracketRoot:
         maxiter = 10
 
         @np.vectorize
-        def bracket_root_single(a, b, min, max, factor, p):
-            return _bracket_root(self.f, a, b, min=min, max=max,
-                                       factor=factor, args=(p,),
-                                       maxiter=maxiter)
+        def bracket_root_single(xl0, xr0, xmin, xmax, factor, p):
+            return _bracket_root(self.f, xl0, xr0, xmin=xmin, xmax=xmax,
+                                 factor=factor, args=(p,),
+                                 maxiter=maxiter)
 
         def f(*args, **kwargs):
             f.f_evals += 1
@@ -119,16 +119,16 @@ class TestBracketRoot:
         f.f_evals = 0
 
         rng = np.random.default_rng(2348234)
-        a = -rng.random(size=shape)
-        b = rng.random(size=shape)
-        min, max = 1e3*a, 1e3*b
+        xl0 = -rng.random(size=shape)
+        xr0 = rng.random(size=shape)
+        xmin, xmax = 1e3*xl0, 1e3*xr0
         if shape:  # make some elements un
             i = rng.random(size=shape) > 0.5
-            min[i], max[i] = -np.inf, np.inf
+            xmin[i], xmax[i] = -np.inf, np.inf
         factor = rng.random(size=shape) + 1.5
-        res = _bracket_root(f, a, b, min=min, max=max, factor=factor,
-                                  args=args, maxiter=maxiter)
-        refs = bracket_root_single(a, b, min, max, factor, p).ravel()
+        res = _bracket_root(f, xl0, xr0, xmin=xmin, xmax=xmax, factor=factor,
+                            args=args, maxiter=maxiter)
+        refs = bracket_root_single(xl0, xr0, xmin, xmax, factor, p).ravel()
 
         attrs = ['xl', 'xr', 'fl', 'fr', 'success', 'nfev', 'nit']
         for attr in attrs:
@@ -160,10 +160,10 @@ class TestBracketRoot:
             return [funcs[j](x) for x, j in zip(xs, js)]
 
         args = (np.arange(4, dtype=np.int64),)
-        res = _bracket_root(f, a=[-1, -1, -1, -1], b=[1, 1, 1, 1],
-                                  min=[-np.inf, -1, -np.inf, -np.inf],
-                                  max=[np.inf, 1, np.inf, np.inf],
-                                  args=args, maxiter=3)
+        res = _bracket_root(f, xl0=[-1, -1, -1, -1], xr0=[1, 1, 1, 1],
+                            xmin=[-np.inf, -1, -np.inf, -np.inf],
+                            xmax=[np.inf, 1, np.inf, np.inf],
+                            args=args, maxiter=3)
 
         ref_flags = np.array([eim._ECONVERGED,
                               _ELIMITS,
@@ -172,20 +172,20 @@ class TestBracketRoot:
         assert_equal(res.status, ref_flags)
 
     @pytest.mark.parametrize("root", (0.622, [0.622, 0.623]))
-    @pytest.mark.parametrize('min', [-5, None])
-    @pytest.mark.parametrize('max', [5, None])
+    @pytest.mark.parametrize('xmin', [-5, None])
+    @pytest.mark.parametrize('xmax', [5, None])
     @pytest.mark.parametrize("dtype", (np.float16, np.float32, np.float64))
-    def test_dtype(self, root, min, max, dtype):
+    def test_dtype(self, root, xmin, xmax, dtype):
         # Test that dtypes are preserved
 
-        min = min if min is None else dtype(min)
-        max = max if max is None else dtype(max)
+        xmin = xmin if xmin is None else dtype(xmin)
+        xmax = xmax if xmax is None else dtype(xmax)
         root = dtype(root)
         def f(x, root):
             return ((x - root) ** 3).astype(dtype)
 
         bracket = np.asarray([-0.01, 0.01], dtype=dtype)
-        res = _bracket_root(f, *bracket, min=min, max=max, args=(root,))
+        res = _bracket_root(f, *bracket, xmin=xmin, xmax=xmax, args=(root,))
         assert np.all(res.success)
         assert res.xl.dtype == res.xr.dtype == dtype
         assert res.fl.dtype == res.fr.dtype == dtype
@@ -203,9 +203,9 @@ class TestBracketRoot:
         with pytest.raises(ValueError, match=message):
             _bracket_root(lambda x: x, -4, 'hello')
         with pytest.raises(ValueError, match=message):
-            _bracket_root(lambda x: x, -4, 4, min=np)
+            _bracket_root(lambda x: x, -4, 4, xmin=np)
         with pytest.raises(ValueError, match=message):
-            _bracket_root(lambda x: x, -4, 4, max=object())
+            _bracket_root(lambda x: x, -4, 4, xmax=object())
         with pytest.raises(ValueError, match=message):
             _bracket_root(lambda x: x, -4, 4, factor=sum)
 
@@ -213,13 +213,13 @@ class TestBracketRoot:
         with pytest.raises(ValueError, match=message):
             _bracket_root(lambda x: x, -4, 4, factor=0.5)
 
-        message = '`min <= a < b <= max` must be True'
+        message = '`xmin <= xl0 < xr0 <= xmax` must be True'
         with pytest.raises(ValueError, match=message):
             _bracket_root(lambda x: x, 4, -4)
         with pytest.raises(ValueError, match=message):
-            _bracket_root(lambda x: x, -4, 4, max=np.nan)
+            _bracket_root(lambda x: x, -4, 4, xmax=np.nan)
         with pytest.raises(ValueError, match=message):
-            _bracket_root(lambda x: x, -4, 4, min=10)
+            _bracket_root(lambda x: x, -4, 4, xmin=10)
 
         message = "shape mismatch: objects cannot be broadcast"
         # raised by `np.broadcast, but the traceback is readable IMO
@@ -286,25 +286,25 @@ class TestBracketRoot:
 
         # 3. bracket limit hits root exactly
         with np.errstate(over='ignore'):
-            res = _bracket_root(f, 5, 10, min=0)
+            res = _bracket_root(f, 5, 10, xmin=0)
         bracket = (res.xl, res.xr)
         assert_allclose(bracket[0], 0, atol=1e-15)
         with np.errstate(over='ignore'):
-            res = _bracket_root(f, -10, -5, max=0)
+            res = _bracket_root(f, -10, -5, xmax=0)
         bracket = (res.xl, res.xr)
         assert_allclose(bracket[1], 0, atol=1e-15)
 
         # 4. bracket not within min, max
         with np.errstate(over='ignore'):
-            res = _bracket_root(f, 5, 10, min=1)
+            res = _bracket_root(f, 5, 10, xmin=1)
         assert not res.success
 
 
 class TestBracketMinimum:
     def init_f(self):
-        def f(x, a, b):
+        def f(x, xl0, xr0):
             f.count += 1
-            return (x - a)**2 + b
+            return (x - xl0)**2 + xr0
         f.count = 0
         return f
 
@@ -318,11 +318,11 @@ class TestBracketMinimum:
         )
 
     def get_kwargs(
-            self, *, xl=None, xr=None, factor=None, xmin=None, xmax=None, args=()
+            self, *, xl0=None, xr0=None, factor=None, xmin=None, xmax=None, args=()
     ):
-        names = ("xl", "xr", "xmin", "xmax", "factor", "args")
+        names = ("xl0", "xr0", "xmin", "xmax", "factor", "args")
         return {
-            name: val for name, val in zip(names, (xl, xr, xmin, xmax, factor, args))
+            name: val for name, val in zip(names, (xl0, xr0, xmin, xmax, factor, args))
             if isinstance(val, np.ndarray) or np.isscalar(val)
             or val not in [None, ()]
         }
@@ -340,53 +340,53 @@ class TestBracketMinimum:
     def test_nfev_expected(self, seed, use_xmin, other_side):
         rng = np.random.default_rng(seed)
         args = (0, 0)  # f(x) = x^2 with minimum at 0
-        # xl, xm, xr are chosen such that the initial bracket is to
+        # xl0, xm0, xr0 are chosen such that the initial bracket is to
         # the right of the minimum, and the bracket will expand
         # downhill towards zero.
-        xl, d1, d2, factor = rng.random(size=4) * [1e5, 10, 10, 5]
-        xm = xl + d1
-        xr = xm + d2
+        xl0, d1, d2, factor = rng.random(size=4) * [1e5, 10, 10, 5]
+        xm0 = xl0 + d1
+        xr0 = xm0 + d2
         # Factor should be greater than one.
         factor += 1
 
         if use_xmin:
             xmin = -rng.random() * 5
-            n = int(np.ceil(np.log(-(xl - xmin) / xmin) / np.log(factor)))
-            lower = xmin + (xl - xmin)*factor**-n
-            middle = xmin + (xl - xmin)*factor**-(n-1)
-            upper = xmin + (xl - xmin)*factor**-(n-2) if n > 1 else xm
+            n = int(np.ceil(np.log(-(xl0 - xmin) / xmin) / np.log(factor)))
+            lower = xmin + (xl0 - xmin)*factor**-n
+            middle = xmin + (xl0 - xmin)*factor**-(n-1)
+            upper = xmin + (xl0 - xmin)*factor**-(n-2) if n > 1 else xm0
             # It may be the case the lower is below the minimum, but we still
             # don't have a valid bracket.
             if middle**2 > lower**2:
                 n += 1
                 lower, middle, upper = (
-                    xmin + (xl - xmin)*factor**-n, lower, middle
+                    xmin + (xl0 - xmin)*factor**-n, lower, middle
                 )
         else:
             xmin = None
-            n = int(np.ceil(np.log(xl / d1) / np.log(factor)))
-            lower = xl - d1*factor**n
-            middle = xl - d1*factor**(n-1) if n > 1 else xl
-            upper = xl - d1*factor**(n-2) if n > 1 else xm
+            n = int(np.ceil(np.log(xl0 / d1) / np.log(factor)))
+            lower = xl0 - d1*factor**n
+            middle = xl0 - d1*factor**(n-1) if n > 1 else xl0
+            upper = xl0 - d1*factor**(n-2) if n > 1 else xm0
             # It may be the case the lower is below the minimum, but we still
             # don't have a valid bracket.
             if middle**2 > lower**2:
                 n += 1
                 lower, middle, upper = (
-                    xl - d1*factor**n, lower, middle
+                    xl0 - d1*factor**n, lower, middle
                 )
         f = self.init_f()
 
         xmax = None
         if other_side:
-            xl, xm, xr = -xr, -xm, -xl
+            xl0, xm0, xr0 = -xr0, -xm0, -xl0
             xmin, xmax = None, -xmin if xmin is not None else None
             lower, middle, upper = -upper, -middle, -lower
 
         kwargs = self.get_kwargs(
-            xl=xl, xr=xr, xmin=xmin, xmax=xmax, factor=factor, args=args
+            xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, factor=factor, args=args
         )
-        result = _bracket_minimum(f, xm, **kwargs)
+        result = _bracket_minimum(f, xm0, **kwargs)
 
         # Check that `nfev` and `nit` have the correct relationship
         assert result.nfev == result.nit + 3
@@ -417,10 +417,10 @@ class TestBracketMinimum:
             return [funcs[j](x) for x, j in zip(xs, js)]
 
         args = (np.arange(4, dtype=np.int64),)
-        xl, xm, xr = np.full(4, -1.0), np.full(4, 0.0), np.full(4, 1.0)
-        result = _bracket_minimum(f, xm, xl=xl, xr=xr,
-                                        xmin=[-np.inf, -1.0, -np.inf, -np.inf],
-                                        args=args, maxiter=3)
+        xl0, xm0, xr0 = np.full(4, -1.0), np.full(4, 0.0), np.full(4, 1.0)
+        result = _bracket_minimum(f, xm0, xl0=xl0, xr0=xr0,
+                                  xmin=[-np.inf, -1.0, -np.inf, -np.inf],
+                                  args=args, maxiter=3)
 
         reference_flags = np.array([eim._ECONVERGED, _ELIMITS,
                                     eim._ECONVERR, eim._EVALUEERR])
@@ -438,9 +438,9 @@ class TestBracketMinimum:
         def f(x, minimum):
             return ((x - minimum)**2).astype(dtype)
 
-        xl, xm, xr = np.array([-0.01, 0.0, 0.01], dtype=dtype)
+        xl0, xm0, xr0 = np.array([-0.01, 0.0, 0.01], dtype=dtype)
         result = _bracket_minimum(
-            f, xm, xl=xl, xr=xr, xmin=xmin, xmax=xmax, args=(minimum, )
+            f, xm0, xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, args=(minimum, )
         )
         assert np.all(result.success)
         assert result.xl.dtype == result.xm.dtype == result.xr.dtype == dtype
@@ -450,13 +450,13 @@ class TestBracketMinimum:
 
         message = '`func` must be callable.'
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(None, -4, xl=4)
+            _bracket_minimum(None, -4, xl0=4)
 
         message = '...must be numeric and real.'
         with pytest.raises(ValueError, match=message):
             _bracket_minimum(lambda x: x**2, 4+1j)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xl='hello')
+            _bracket_minimum(lambda x: x**2, -4, xl0='hello')
         with pytest.raises(ValueError, match=message):
             _bracket_minimum(lambda x: x**2, -4, xmin=np)
         with pytest.raises(ValueError, match=message):
@@ -468,34 +468,34 @@ class TestBracketMinimum:
         with pytest.raises(ValueError, match=message):
             _bracket_minimum(lambda x: x, -4, factor=0.5)
 
-        message = '`xmin <= xl < xm < xr <= xmax` must be True'
+        message = '`xmin <= xl0 < xm0 < xr0 <= xmax` must be True'
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, 4, xl=6)
+            _bracket_minimum(lambda x: x**2, 4, xl0=6)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xr=-6)
+            _bracket_minimum(lambda x: x**2, -4, xr0=-6)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xl=-3, xr=-2)
+            _bracket_minimum(lambda x: x**2, -4, xl0=-3, xr0=-2)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xl=-6, xr=-5)
+            _bracket_minimum(lambda x: x**2, -4, xl0=-6, xr0=-5)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xl=-np.nan)
+            _bracket_minimum(lambda x: x**2, -4, xl0=-np.nan)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xr=np.nan)
+            _bracket_minimum(lambda x: x**2, -4, xr0=np.nan)
 
         message = "shape mismatch: objects cannot be broadcast"
         # raised by `np.broadcast, but the traceback is readable IMO
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, [-2, -3], xl=[-3, -4, -5])
+            _bracket_minimum(lambda x: x**2, [-2, -3], xl0=[-3, -4, -5])
 
         message = '`maxiter` must be a non-negative integer.'
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xr=4, maxiter=1.5)
+            _bracket_minimum(lambda x: x**2, -4, xr0=4, maxiter=1.5)
         with pytest.raises(ValueError, match=message):
-            _bracket_minimum(lambda x: x**2, -4, xr=4, maxiter=-1)
+            _bracket_minimum(lambda x: x**2, -4, xr0=4, maxiter=-1)
 
-    @pytest.mark.parametrize("xl", [0.0, None])
-    @pytest.mark.parametrize("xm", (0.05, 0.1, 0.15))
-    @pytest.mark.parametrize("xr", (0.2, 0.4, 0.6, None))
+    @pytest.mark.parametrize("xl0", [0.0, None])
+    @pytest.mark.parametrize("xm0", (0.05, 0.1, 0.15))
+    @pytest.mark.parametrize("xr0", (0.2, 0.4, 0.6, None))
     @pytest.mark.parametrize(
         "args",
         (
@@ -503,17 +503,17 @@ class TestBracketMinimum:
             (121.6, 0), (5764.1, 0), (-6.4, 0), (-12.9, 0), (-146.2, 0)
         )
     )
-    def test_scalar_no_limits(self, xl, xm, xr, args):
+    def test_scalar_no_limits(self, xl0, xm0, xr0, args):
         f = self.init_f()
-        kwargs = self.get_kwargs(xl=xl, xr=xr, args=args)
-        result = _bracket_minimum(f, xm, **kwargs)
+        kwargs = self.get_kwargs(xl0=xl0, xr0=xr0, args=args)
+        result = _bracket_minimum(f, xm0, **kwargs)
         self.assert_valid_bracket(result)
         assert result.status == 0
         assert result.success
         assert result.nfev == f.count
 
     @pytest.mark.parametrize(
-        "xl,xm,xr,xmin",
+        "xl0,xm0,xr0,xmin",
         (
             (0.5, 0.75, 1.0, 0.0),
             (1.0, 2.5, 4.0, 0.0),
@@ -530,17 +530,17 @@ class TestBracketMinimum:
             (0.0, 0.0), (1e-300, 0.0), (1e-20, 0.0), (0.1, 0.0), (0.2, 0.0), (0.4, 0.0)
         )
     )
-    def test_scalar_with_limit_left(self, xl, xm, xr, xmin, args):
+    def test_scalar_with_limit_left(self, xl0, xm0, xr0, xmin, args):
         f = self.init_f()
-        kwargs = self.get_kwargs(xl=xl, xr=xr, xmin=xmin, args=args)
-        result = _bracket_minimum(f, xm, **kwargs)
+        kwargs = self.get_kwargs(xl0=xl0, xr0=xr0, xmin=xmin, args=args)
+        result = _bracket_minimum(f, xm0, **kwargs)
         self.assert_valid_bracket(result)
         assert result.status == 0
         assert result.success
         assert result.nfev == f.count
 
     @pytest.mark.parametrize(
-        "xl,xm,xr,xmax",
+        "xl0,xm0,xr0,xmax",
         (
             (0.2, 0.3, 0.4, 1.0),
             (0.05, 0.075, 0.1, 1.0),
@@ -557,17 +557,17 @@ class TestBracketMinimum:
             (0.9999999999999999, 0.0), (0.9, 0.0), (0.7, 0.0), (0.5, 0.0)
         )
     )
-    def test_scalar_with_limit_right(self, xl, xm, xr, xmax, args):
+    def test_scalar_with_limit_right(self, xl0, xm0, xr0, xmax, args):
         f = self.init_f()
-        kwargs = self.get_kwargs(xl=xl, xr=xr, xmax=xmax, args=args)
-        result = _bracket_minimum(f, xm, **kwargs)
+        kwargs = self.get_kwargs(xl0=xl0, xr0=xr0, xmax=xmax, args=args)
+        result = _bracket_minimum(f, xm0, **kwargs)
         self.assert_valid_bracket(result)
         assert result.status == 0
         assert result.success
         assert result.nfev == f.count
 
     @pytest.mark.parametrize(
-        "xl,xm,xr,xmin,xmax,args",
+        "xl0,xm0,xr0,xmin,xmax,args",
         (
             (0.2, 0.3, 0.4, None, 1.0, (1.0, 0.0)),
             (1.4, 1.95, 2.5, 0.3, None, (0.3, 0.0)),
@@ -579,23 +579,23 @@ class TestBracketMinimum:
             (None, 4.5, None, -26.3, None, (-26.3, 0)),
         )
     )
-    def test_minima_at_boundary_point(self, xl, xm, xr, xmin, xmax, args):
+    def test_minima_at_boundary_point(self, xl0, xm0, xr0, xmin, xmax, args):
         f = self.init_f()
-        kwargs = self.get_kwargs(xr=xr, xmin=xmin, xmax=xmax, args=args)
-        result = _bracket_minimum(f, xm, **kwargs)
+        kwargs = self.get_kwargs(xr0=xr0, xmin=xmin, xmax=xmax, args=args)
+        result = _bracket_minimum(f, xm0, **kwargs)
         assert result.status == -1
         assert args[0] in (result.xl, result.xr)
         assert result.nfev == f.count
 
     @pytest.mark.parametrize(
-        "xm",
+        "xm0",
         (
             np.array([[0.55], [0.58]]),
             np.array([[0.55, 0.56], [0.57, 0.58]]),
         ),
     )
     @pytest.mark.parametrize(
-        "xl",
+        "xl0",
         (
             0.2,
             np.array([[0.2], [0.3]]),
@@ -604,7 +604,7 @@ class TestBracketMinimum:
         ),
     )
     @pytest.mark.parametrize(
-        "xr",
+        "xr0",
         (
             0.6,
             np.array([[0.6], [0.8]]),
@@ -631,10 +631,10 @@ class TestBracketMinimum:
             (np.array([[0.0], [-0.1]]), np.array([[0.0], [2.5]])),
         )
     )
-    def test_vectorized(self, xl, xm, xr, xmin, xmax, args):
+    def test_vectorized(self, xl0, xm0, xr0, xmin, xmax, args):
         f = self.init_f()
-        kwargs = self.get_kwargs(xl=xl, xr=xr, xmin=xmin, xmax=xmax, args=args)
-        result = _bracket_minimum(f, xm, **kwargs)
+        kwargs = self.get_kwargs(xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, args=args)
+        result = _bracket_minimum(f, xm0, **kwargs)
         self.assert_valid_bracket(result)
         result.nfev == f.count
 
@@ -647,16 +647,16 @@ class TestBracketMinimum:
             assert np.issubdtype(x.dtype, np.floating)
             return x ** 98 - 1
 
-        result = _bracket_minimum(f, -7, xr=5)
+        result = _bracket_minimum(f, -7, xr0=5)
         assert result.success
 
         # Test maxiter = 0. Should do nothing to bracket.
         def f(x):
             return x**2 - 10
 
-        xl, xm, xr = -3, -1, 2
-        result = _bracket_minimum(f, xm, xl=xl, xr=xr, maxiter=0)
-        assert_equal([result.xl, result.xm, result.xr], [xl, xm, xr])
+        xl0, xm0, xr0 = -3, -1, 2
+        result = _bracket_minimum(f, xm0, xl0=xl0, xr0=xr0, maxiter=0)
+        assert_equal([result.xl, result.xm, result.xr], [xl0, xm0, xr0])
 
         # Test scalar `args` (not in tuple)
         def f(x, c):
@@ -668,5 +668,5 @@ class TestBracketMinimum:
 
         # Initial bracket is valid.
         f = self.init_f()
-        result = _bracket_minimum(f, -0.2, xl=-1.0, xr=1.0, args=(0, 0))
+        result = _bracket_minimum(f, -0.2, xl0=-1.0, xr0=1.0, args=(0, 0))
         assert f.count == 3


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
I don't think there's an issue for this.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds a private vectorized `scalar_minimization` bracket finder, similar to the vectorized root bracket finder from gh-18348. The intent of this function is the same as [scipy.optimize.bracket](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.bracket.html). A bracket for the minima of a unimodal univariate function $f$ is a triple of points $x_l$, $x_m$, $x_r$, with $x_l < x_m < x_r$, such that

$$f(x_l) \geq f(x_m),\text{  }f(x_r) \geq f(x_m)$$

where at least one of these two inequalities is strict. Unlike `scipy.optimize.bracket`, this function is able to accept upper
and lower bounds on the endpoints of brackets. The algorithm was suggested to me by @mdhaber, who convinced me it is a sound approach. Quoting from the Notes section of the Docstring

    Given an initial trio of points `xl`, `xm`, `xr`, the algorithm checks if
    these points already give a valid bracket. If not, a new endpoint, `w` is
    chosen in the "downhill" direction, `xm` becomes the new opposite endpoint,
    and either `xl` or `xr` becomes the new middle point, depending on which
    direction is downhill. The algorithm repeats from here.

    The new endpoint `w` is chosen differently depending on whether or not a
    boundary `min` or `max` has been set in the downhill direction. Without
    loss of generality, suppose the downhill direction is to the right, so that
    ``f(xl) > f(xm) > f(xr)``. If there is no boundary to the right, then `w`
    is chosen to be ``xr + phi * (xr - xm)`` where `phi` is the golden ratio;
    so that step sizes increase in geometric proportion, with each step size
    equal to the sum of the two previous step sizes. If there is a boundary,
    `max` in this case, then `w` is chosen to be ``xr + (max - xr)/phi``, so
    that step sizes decrease in geometric proportion, slowing to a stop at
    `max`. This cautious approach ensures that a minima near but distinct from
    the boundary isn't missed.

Given a 
#### Additional information
<!--Any additional information you think is important.-->
This has been placed in `scipy.optimize._zeros_py.py` to avoid a circular import, since that is where most of the machinery used here lives. A more rightful home would be `scipy.optimize._optimize.py` where `scipy.optimize.bracket` lives. Since this is private, I don't think this is important just yet, but we should keep it in mind for the future. @mdhaber,  I think I finally get the details of how this machinery works.