### PR TITLE
MAINT: Avoid use of aligned_alloc in pocketfft on windows

### DIFF
--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -149,7 +149,7 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #endif
 #endif
 
-#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)) && (defined(__cpp_aligned_new) && __cpp_aligned_new >= 201606L)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   void *ptr = ::aligned_alloc(align,size);

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -149,7 +149,11 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #endif
 #endif
 
-#if __cplusplus >= 201703L && !defined(_MSVC_LANG)
+// MSVC does not provide the standard aligned allocation functions,
+// yet _still_ sets the feature test macro (__cpp_aligned_new)...
+// While there are replacement functions (_aligned_malloc & _aligned_free),
+// those produce crashes when used here, see GH-19726
+#if __cplusplus >= 201703L && !defined(_MSC_VER)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   void *ptr = ::aligned_alloc(align,size);

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -149,7 +149,7 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #endif
 #endif
 
-#if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)) && (defined(__cpp_aligned_new) && __cpp_aligned_new >= 201606L)
+#if __cplusplus >= 201703L && !defined(_MSVC_LANG)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   void *ptr = ::aligned_alloc(align,size);

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error This file is C++ and requires a C++ compiler.
 #endif
 
-#if !(__cplusplus >= 201103L || _MSVC_LANG+0L >= 201103L)
+#if !(__cplusplus >= 201103L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201103L))
 #error This file requires at least C++11 support.
 #endif
 

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -149,7 +149,7 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #endif
 #endif
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   void *ptr = ::aligned_alloc(align,size);

--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
@@ -9,7 +9,7 @@
 namespace fast_matrix_market {
 
 // MSVC does not define __cplusplus correctly by default; fall back to _MSVC_LANG if it exists
-#if __cplusplus >= 202002L || _MSVC_LANG+0L >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     // If available, use C++20 concepts for programmer clarity and better error messages.
     // If not using C++20 this shows what fast_matrix_market expects each template type to support.
 

--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
@@ -8,7 +8,8 @@
 
 namespace fast_matrix_market {
 
-#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+// MSVC does not define __cplusplus correctly by default; fall back to _MSVC_LANG if it exists
+#if __cplusplus >= 202002L || _MSVC_LANG+0L >= 202002L
     // If available, use C++20 concepts for programmer clarity and better error messages.
     // If not using C++20 this shows what fast_matrix_market expects each template type to support.
 

--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/array.hpp
@@ -8,7 +8,7 @@
 
 namespace fast_matrix_market {
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     // If available, use C++20 concepts for programmer clarity and better error messages.
     // If not using C++20 this shows what fast_matrix_market expects each template type to support.
 

--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/doublet.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/doublet.hpp
@@ -7,7 +7,7 @@
 #include "../fast_matrix_market.hpp"
 
 namespace fast_matrix_market {
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     // If available, use C++20 concepts for programmer clarity.
     // This shows what fast_matrix_market expects each template type to support.
 

--- a/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/triplet.hpp
+++ b/scipy/io/_fast_matrix_market/fast_matrix_market/include/fast_matrix_market/app/triplet.hpp
@@ -7,7 +7,7 @@
 #include "../fast_matrix_market.hpp"
 
 namespace fast_matrix_market {
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     // If available, use C++20 concepts for programmer clarity.
     // This shows what fast_matrix_market expects each template type to support.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

https://github.com/scipy/scipy/issues/19726

#### What does this implement/fix?

Fixes detection of cpp standard on MSVC platforms since it does not correctly define the value of `__cplusplus` without command line intervention

#### Additional information

N/A