### PR TITLE
ENH: stats.monte_carlo_test: account for inexact calculation of statistic

### DIFF
--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1009,6 +1009,24 @@ class TestMonteCarloHypothesisTest:
         assert_allclose(res.statistic, ref.statistic)
         assert_allclose(res.pvalue, ref.pvalue, atol=1e-2)
 
+    def test_finite_precision_statistic(self):
+        # Some statistics return numerically distinct values when the values
+        # should be equal in theory. Test that `monte_carlo_test` accounts
+        # for this in some way.
+        rng = np.random.default_rng(2549824598234528)
+        n_resamples = 9999
+        def rvs(size):
+            return 1. * stats.bernoulli(p=0.333).rvs(size=size, random_state=rng)
+
+        x = rvs(100)
+        res = stats.monte_carlo_test(x, rvs, np.var, alternative='less',
+                                     n_resamples=n_resamples)
+        # show that having a tolerance matters
+        c0 = np.sum(res.null_distribution <= res.statistic)
+        c1 = np.sum(res.null_distribution <= res.statistic*(1+1e-15))
+        assert c0 != c1
+        assert res.pvalue == (c1 + 1)/(n_resamples + 1)
+
 
 class TestPermutationTest:
 

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1009,6 +1009,7 @@ class TestMonteCarloHypothesisTest:
         assert_allclose(res.statistic, ref.statistic)
         assert_allclose(res.pvalue, ref.pvalue, atol=1e-2)
 
+    @pytest.mark.xfail_on_32bit("Statistic may not depend on sample order on 32-bit")
     def test_finite_precision_statistic(self):
         # Some statistics return numerically distinct values when the values
         # should be equal in theory. Test that `monte_carlo_test` accounts


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-15869

#### What does this implement/fix?
In `monte_carlo_test`, elements of the null distribution may differ from the observed value of the test statistic due to numerical noise. In some cases, this can lead to much larger errors in the p-value. This PR accounts for this problem by performing the comparison with a tolerance.

#### Additional information
We should discuss whether there should be an absolute tolerance and whether the absolute and relative tolerances should be exposed as options.

This also needs to be done for `bootstrap`, but I think that will be a little more involved.