### PR TITLE
ENH: sparse: single-pass CSR matrix binops

### DIFF
--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -803,14 +803,12 @@ bool csr_binop_csr_canonical(const I n_row, const I n_col,
         I A_end = Ap[i+1];
         I B_end = Bp[i+1];
 
-        // for checking if matrices are canonical
-        I A_j_prev, B_j_prev;
-        I A_pos_start = A_pos;
-        I B_pos_start = B_pos;
-
         // Check if row pointers are canonical
-        if (Ap[i] > Ap[i+1] || Bp[i] > Bp[i+1])
-            return false;
+        if (A_pos > A_end || B_pos > B_end) return false;
+
+        // for checking if column indices are canonical
+        I A_j_prev = Aj[A_pos] - 1;
+        I B_j_prev = Bj[B_pos] - 1;
 
         //while not finished with either row
         while(A_pos < A_end && B_pos < B_end){
@@ -818,9 +816,7 @@ bool csr_binop_csr_canonical(const I n_row, const I n_col,
             I B_j = Bj[B_pos];
 
             // check if matrices are canonical
-            if ((A_pos != A_pos_start && !(A_j_prev < A_j)) ||
-                (B_pos != B_pos_start && !(B_j_prev < B_j)))
-                return false;
+            if (A_j_prev >= A_j || B_j_prev >= B_j) return false;
             A_j_prev = A_j;
             B_j_prev = B_j;
 
@@ -858,8 +854,7 @@ bool csr_binop_csr_canonical(const I n_row, const I n_col,
             I A_j = Aj[A_pos];
 
             // check if matrices are canonical
-            if (A_pos != A_pos_start && !(A_j_prev < A_j))
-                return false;
+            if (A_j_prev >= A_j) return false;
             A_j_prev = A_j;
 
             T result = op(Ax[A_pos],0);
@@ -874,8 +869,7 @@ bool csr_binop_csr_canonical(const I n_row, const I n_col,
             I B_j = Bj[B_pos];
 
             // check if matrices are canonical
-            if (B_pos != B_pos_start && !(B_j_prev < B_j))
-                return false;
+            if (B_j_prev >= B_j) return false;
             B_j_prev = B_j;
 
             T result = op(0,Bx[B_pos]);

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -818,7 +818,8 @@ bool csr_binop_csr_canonical(const I n_row, const I n_col,
             I B_j = Bj[B_pos];
 
             // check if matrices are canonical
-            if (A_pos != A_pos_start && (!(A_j_prev < A_j) || !(B_j_prev < B_j)))
+            if ((A_pos != A_pos_start && !(A_j_prev < A_j)) ||
+                (B_pos != B_pos_start && !(B_j_prev < B_j)))
                 return false;
             A_j_prev = A_j;
             B_j_prev = B_j;


### PR DESCRIPTION
#### Reference issue
No issue, saw this optimization opportunity while working in this file.

#### What does this implement/fix?

The CSR elementwise binary operators have two implementations: one for canonical form (no duplicate elements, elements in order) and another for general.

Previous behavior first checks both operands then selects the appropriate implementation. However this check requires a full scan of both operands. The canonical form binop operation itself is also a single scan of both operands, so the form check adds an extra scan. Binops are a memory bandwidth-bound operation.

This PR merges the format check with the canonical form implementation. In other words, merges `csr_has_canonical_format()` into `csr_binop_csr_canonical()`.

New behavior is to optimistically execute the canonical implementation with a fallback to the general if the operands are not canonical, eliminating one full memory scan of both operands.

#### Impact
Expect a 25% to 45% speedup on large matrices.

See attached a synthetic `bench_sparse_add.py` script which benchmarks elementwise add runtime on random and Poisson 2d matrices of increasing nnz:

|   | main | this PR | Speedup |
|---|------|---------|---------|
| random-50,000 | 0.00028791697695851326 | 0.00015637511387467384| 1.84    
| poisson-49,600 | 0.0001479999627918005 | 0.00010145897977054119| 1.46    
| random-500,000 | 0.001349416095763445 | 0.0009573330171406269| 1.41    
| poisson-498,016 | 0.0014221249148249626 | 0.0010420831385999918| 1.36    
| random-5,000,000 | 0.014241500059142709 | 0.011061792029067874| 1.29    
| poisson-4,996,000 | 0.015750708989799023 | 0.010916250059381127| 1.44    
| random-50,000,000 | 0.15272545884363353 | 0.11954350001178682| 1.28    
| poisson-49,978,572 | 0.16468741605058312 | 0.1213894160464406| 1.36 

try yourself: `python dev.py python bench_sparse_add.py`

[bench_sparse_add.py.txt](https://github.com/scipy/scipy/files/13774324/bench_sparse_add.py.txt)
