### PR TITLE
ENH: stats.rankdata: vectorize calculation

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10797,7 +10797,6 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     array([ 2.,  3.,  4., nan,  1., nan])
 
     """
-    method = str(method).lower()
     methods = ('average', 'min', 'max', 'dense', 'ordinal')
     if method not in methods:
         raise ValueError(f'unknown method "{method}"')
@@ -10860,15 +10859,14 @@ def _rankdata(x, method, return_ties=False):
     counts = np.diff(indices, append=y.size)
 
     # Compute `'min'`, `'max'`, and `'mid'` ranks of unique elements
-    match method:
-        case 'min':
-            ranks = ordinal_ranks[i]
-        case 'max':
-            ranks = ordinal_ranks[i] + counts - 1
-        case 'average':
-            ranks = ordinal_ranks[i] + (counts - 1)/2
-        case 'dense':
-            ranks = np.cumsum(i, axis=-1)[i]
+    if method == 'min':
+        ranks = ordinal_ranks[i]
+    elif method == 'max':
+        ranks = ordinal_ranks[i] + counts - 1
+    elif method == 'average':
+        ranks = ordinal_ranks[i] + (counts - 1)/2
+    elif method == 'dense':
+        ranks = np.cumsum(i, axis=-1)[i]
 
     ranks = np.repeat(ranks, counts).reshape(shape)
     ranks = _order_ranks(ranks, j)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10797,66 +10797,87 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     array([ 2.,  3.,  4., nan,  1., nan])
 
     """
-    if method not in ('average', 'min', 'max', 'dense', 'ordinal'):
+    method = str(method).lower()
+    methods = ('average', 'min', 'max', 'dense', 'ordinal')
+    if method not in methods:
         raise ValueError(f'unknown method "{method}"')
 
-    a = np.asarray(a)
+    x = np.asarray(a)
 
-    if axis is not None:
-        if a.size == 0:
-            # The return values of `normalize_axis_index` are ignored.  The
-            # call validates `axis`, even though we won't use it.
-            normalize_axis_index(axis, a.ndim)
-            if method == 'average':
-                dt = np.dtype(np.float64)
-            else:
-                dt = np.dtype(int)
-            return np.empty(a.shape, dtype=dt)
-        return np.apply_along_axis(rankdata, axis, a, method,
-                                   nan_policy=nan_policy)
+    if x.size == 0:
+        dtype = float if method == 'average' else int
+        return np.empty(x.shape, dtype=dtype)
 
-    arr = np.ravel(a)
-    contains_nan, nan_policy = _contains_nan(arr, nan_policy)
-    nan_indexes = None
+    if axis is None:
+        x = x.ravel()
+        axis = -1
+
+    contains_nan, nan_policy = _contains_nan(x, nan_policy)
+
+    x = np.swapaxes(x, axis, -1)
+    ranks = _rankdata(x, method)
+
     if contains_nan:
-        if nan_policy == 'omit':
-            nan_indexes = np.isnan(arr)
-        if nan_policy == 'propagate':
-            return np.full_like(arr, np.nan)
+        i_nan = (np.isnan(x) if nan_policy == 'omit'
+                 else np.isnan(x).any(axis=-1))
+        ranks = ranks.astype(float, copy=False)
+        ranks[i_nan] = np.nan
 
-    algo = 'mergesort' if method == 'ordinal' else 'quicksort'
-    sorter = np.argsort(arr, kind=algo)
+    ranks = np.swapaxes(ranks, axis, -1)
+    return ranks
 
-    inv = np.empty(sorter.size, dtype=np.intp)
-    inv[sorter] = np.arange(sorter.size, dtype=np.intp)
 
+def _order_ranks(ranks, j):
+    # Reorder ascending order `ranks` according to `j`
+    ordered_ranks = np.empty(j.shape, dtype=ranks.dtype)
+    np.put_along_axis(ordered_ranks, j, ranks, axis=-1)
+    return ordered_ranks
+
+
+def _rankdata(x, method, return_ties=False):
+    # Rank data `x` by desired `method`; `return_ties` if desired
+
+    shape = x.shape
+
+    # Get sort order
+    kind = 'mergesort' if method == 'ordinal' else 'quicksort'
+    j = np.argsort(x, axis=-1, kind=kind)
+    ordinal_ranks = np.broadcast_to(np.arange(1, shape[-1]+1, dtype=int), shape)
+
+    # Ordinal ranks is very easy because ties don't matter. We're done.
     if method == 'ordinal':
-        result = inv + 1
-    else:
-        arr = arr[sorter]
-        obs = np.r_[True, arr[1:] != arr[:-1]]
-        dense = obs.cumsum()[inv]
+        return _order_ranks(ordinal_ranks, j)  # never return ties
 
-        if method == 'dense':
-            result = dense
-        else:
-            # cumulative counts of each unique value
-            count = np.r_[np.nonzero(obs)[0], len(obs)]
+    # Sort array
+    y = np.take_along_axis(x, j, axis=-1)
+    # Logical indices of unique elements
+    i = np.concatenate([np.ones(shape[:-1] + (1,), dtype=np.bool_),
+                       y[..., :-1] != y[..., 1:]], axis=-1)
 
-            if method == 'max':
-                result = count[dense]
+    # Integer indices of unique elements
+    indices = np.arange(y.size)[i.ravel()]
+    # Counts of unique elements
+    counts = np.diff(indices, append=y.size)
 
-            if method == 'min':
-                result = count[dense - 1] + 1
+    # Compute `'min'`, `'max'`, and `'mid'` ranks of unique elements
+    match method:
+        case 'min':
+            ranks = ordinal_ranks[i]
+        case 'max':
+            ranks = ordinal_ranks[i] + counts - 1
+        case 'average':
+            ranks = ordinal_ranks[i] + (counts - 1)/2
+        case 'dense':
+            ranks = np.cumsum(i, axis=-1)[i]
 
-            if method == 'average':
-                result = .5 * (count[dense] + count[dense - 1] + 1)
+    ranks = np.repeat(ranks, counts).reshape(shape)
+    ranks = _order_ranks(ranks, j)
 
-    if nan_indexes is not None:
-        result = result.astype('float64')
-        result[nan_indexes] = np.nan
-
-    return result
+    if return_ties:
+        t = np.zeros(shape, dtype=float)
+        t[i] = counts
+        return ranks, t
+    return ranks
 
 
 def expectile(a, alpha=0.5, *, weights=None):


### PR DESCRIPTION
#### Reference issue
gh-19770
gh-19749

#### What does this implement/fix?
`stats.rankdata` implemented `axis` by looping over slices; this vectorizes the calculation. It will be useful for the referenced PRs.

#### Additional information
This PR version tends to be a little faster for both small and large 1D arrays and considerably faster with multidimensional arrays over an axis. It can be a little slower for `nan_policy='propagate'` right now because it calculates the ranks in all slices before replacing slices with NaNs, but there is a simple fix for that if we think it's important.

This will immediately speed up `rankdata` and many hypothesis tests that depend on it. It also opens the door to further improvements in these hypothesis tests because `_rankdata` can also return tie counts, which many of these tests need.

<details>

```
import numpy as np
from scipy import stats
rng = np.random.default_rng(435984535)

# shape = (100)
shape = (100, 100)
axis = -1

x = rng.integers(0, 5, size=shape)
# %timeit stats.rankdata(x, axis=-1)
# pr   1d: 31.3 µs ± 442 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# main 1d: 37.2 µs ± 233 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# pr   2d: 369 µs ± 4.1 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# main 2d: 2.58 ms ± 8.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

y = x.copy().astype(float)
i = rng.random(size=shape)
y[i < 0.3] = np.nan
# %timeit stats.rankdata(y, axis=-1, nan_policy='omit')
# pr   1d: 40.1 µs ± 122 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# main 1d: 46.9 µs ± 586 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# pr   2d: 526 µs ± 6.29 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# main 2d: 3.59 ms ± 28.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

z = rng.normal(size=shape)
# %timeit stats.rankdata(z, axis=-1)
# pr   1d: 38.9 µs ± 57.7 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# main 1d: 44.8 µs ± 104 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# pr   2d: 604 µs ± 10.7 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# main 2d: 3.47 ms ± 23.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
</details>