### PR TITLE
ENH: add `BSpline.insert_knot` method

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -236,17 +236,17 @@ def insert(double xval,
 # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/insert.f
 # which carries the following comment:
 #
-# c  subroutine insert inserts a new knot x into a spline function s(x)
-# c  of degree k and calculates the b-spline representation of s(x) with
-# c  respect to the new set of knots. in addition, if iopt.ne.0, s(x)
-# c  will be considered as a periodic spline with period per=t(n-k)-t(k+1)
-# c  satisfying the boundary constraints
-# c       t(i+n-2*k-1) = t(i)+per  ,i=1,2,...,2*k+1
-# c       c(i+n-2*k-1) = c(i)      ,i=1,2,...,k
-# c  in that case, the knots and b-spline coefficients returned will also
-# c  satisfy these boundary constraints, i.e.
-# c       tt(i+nn-2*k-1) = tt(i)+per  ,i=1,2,...,2*k+1
-# c       cc(i+nn-2*k-1) = cc(i)      ,i=1,2,...,k
+# subroutine insert inserts a new knot x into a spline function s(x)
+# of degree k and calculates the b-spline representation of s(x) with
+# respect to the new set of knots. in addition, if iopt.ne.0, s(x)
+# will be considered as a periodic spline with period per=t(n-k)-t(k+1)
+# satisfying the boundary constraints
+#      t(i+n-2*k-1) = t(i)+per  ,i=1,2,...,2*k+1
+#      c(i+n-2*k-1) = c(i)      ,i=1,2,...,k
+# in that case, the knots and b-spline coefficients returned will also
+# satisfy these boundary constraints, i.e.
+#      tt(i+nn-2*k-1) = tt(i)+per  ,i=1,2,...,2*k+1
+#      cc(i+nn-2*k-1) = cc(i)      ,i=1,2,...,k
     cdef:
         int interval, i
 
@@ -277,7 +277,7 @@ def insert(double xval,
 
     for i in range(interval, interval-k, -1):
         fac = (xval - tt[i]) / (tt[i+k+1] - tt[i])
-        cc[i] = fac*c[i, ...] + (1. - fac)*c[i-1, ...]
+        cc[i, ...] = fac*c[i, ...] + (1. - fac)*c[i-1, ...]
 
     cc[:interval - k+1, ...] = c[:interval - k+1, ...]
 

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -227,20 +227,45 @@ def insert(double xval,
            const double[::1] t,
            const double_or_complex[:, ::1] c,
            int k,
+           bint periodic=False
         ):
     """Insert a single knot at `xval`.
     """
+#
+# This is a port of the FORTRAN `insert` routine by P. Dierckx,
+# https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/insert.f
+# which carries the following comment:
+#
+# c  subroutine insert inserts a new knot x into a spline function s(x)
+# c  of degree k and calculates the b-spline representation of s(x) with
+# c  respect to the new set of knots. in addition, if iopt.ne.0, s(x)
+# c  will be considered as a periodic spline with period per=t(n-k)-t(k+1)
+# c  satisfying the boundary constraints
+# c       t(i+n-2*k-1) = t(i)+per  ,i=1,2,...,2*k+1
+# c       c(i+n-2*k-1) = c(i)      ,i=1,2,...,k
+# c  in that case, the knots and b-spline coefficients returned will also
+# c  satisfy these boundary constraints, i.e.
+# c       tt(i+nn-2*k-1) = tt(i)+per  ,i=1,2,...,2*k+1
+# c       cc(i+nn-2*k-1) = cc(i)      ,i=1,2,...,k
     cdef:
         int interval, i
 
     interval = find_interval(t, k, xval, k, False)
     if interval < 0:
-        raise ValueError("cannot happen.")
+        # extrapolated values are guarded for in BSpline.insert_knot
+        raise ValueError(f"Cannot insert the knot at {xval}.")
 
     # super edge case: a knot with multiplicity > k+1
     # see https://github.com/scipy/scipy/commit/037204c3e91
     if t[interval] == t[interval + k + 1]:
         interval -= 1
+
+    if periodic:
+        if (interval + 1 <= 2*k) and (interval + 1 >= t.shape[0] - 2*k):
+            # in case of a periodic spline (iopt.ne.0) there must be
+            # either at least k interior knots t(j) satisfying t(k+1)<t(j)<=x
+            # or at least k interior knots t(j) satisfying x<=t(j)<t(n-k)            
+            raise ValueError("Not enough internal knots.")
 
     # knots
     tt = np.r_[t[:interval+1], xval, t[interval+1:]]
@@ -248,13 +273,30 @@ def insert(double xval,
     cc = np.zeros((c.shape[0]+1, c.shape[1]))
 
     # coefficients
-    cc[interval+1:] = c[interval:]
+    cc[interval+1:, ...] = c[interval:, ...]
 
     for i in range(interval, interval-k, -1):
         fac = (xval - tt[i]) / (tt[i+k+1] - tt[i])
         cc[i] = fac*c[i, ...] + (1. - fac)*c[i-1, ...]
 
-    cc[:interval - k+1] = c[:interval - k+1]
+    cc[:interval - k+1, ...] = c[:interval - k+1, ...]
+
+    if periodic:
+        # c   incorporate the boundary conditions for a periodic spline.
+        n = tt.shape[0]
+        nk = n - k - 1
+        n2k = n - 2*k - 1
+        T = tt[nk] - tt[k]   # period
+
+        if interval >= nk - k:
+            # adjust the left-hand boundary knots & coefs
+            tt[:k] = tt[nk - k:nk] - T
+            cc[:k, ...] = cc[n2k:n2k + k, ...]
+
+        if interval <= 2*k-1:
+            # adjust the right-hand boundary knots & coefs
+            tt[n-k:] = tt[k+1:k+1+k] + T
+            cc[n2k:n2k + k, ...] = cc[:k, ...]
 
     return tt, cc
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -845,11 +845,7 @@ class BSpline:
         -------
         spl : BSpline object
             A new BSpline object with the new knot inserted.
-
         """
-        if self.extrapolate == "periodic":
-            # XXX: implement
-            raise NotImplementedError()
         if x < self.t[self.k] or x > self.t[-self.k-1]:
             raise ValueError(f"Cannot insert a knot at {x}.")
         if m <= 0:
@@ -863,7 +859,7 @@ class BSpline:
         cc = cc.reshape(-1, num_extra)
 
         for _ in range(m):
-            tt, cc = _bspl.insert(x, tt, cc, self.k)
+            tt, cc = _bspl.insert(x, tt, cc, self.k, self.extrapolate == "periodic")
 
         return self.construct_fast(
             tt, cc.reshape((-1,) + extradim), self.k, self.extrapolate, self.axis

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -859,6 +859,10 @@ class BSpline:
         ``t(k+1)<t(j)<=x`` or at least k interior knots t(j) satisfying
         ``x<=t(j)<t(n-k)``.
 
+        This routine is functionally equivalent to `scipy.interpolate.insert`.
+
+        .. versionadded:: 1.13
+
         References
         ----------
         .. [1] W. Boehm, "Inserting new knots into b-spline curves.",
@@ -867,6 +871,9 @@ class BSpline:
         .. [2] P. Dierckx, "Curve and surface fitting with splines, Monographs on
             Numerical Analysis", Oxford University Press, 1993.
 
+        See Also
+        --------
+        scipy.interpolate.insert
 
         Examples
         --------

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -834,17 +834,64 @@ class BSpline:
     def insert_knot(self, x, m=1):
         """Insert a new knot at `x` of multiplicity `m`.
 
+        Given the knots and coefficients of a B-spline representation, create a
+        new B-spline with a knot inserted `m` times at point `x`.
+
         Parameters
         ----------
         x : float
             The position of the new knot
         m : int, optional
-            The multiplicity of the new knot. Default is 1.
+            The number of times to insert the given knot (its multiplicity).
+            Default is 1.
 
         Returns
         -------
         spl : BSpline object
             A new BSpline object with the new knot inserted.
+
+        Notes
+        -----
+        Based on algorithms from [1]_ and [2]_.
+
+        In case of a periodic spline (``self.extrapolate == "periodic"``)
+        there must be either at least k interior knots t(j) satisfying
+        ``t(k+1)<t(j)<=x`` or at least k interior knots t(j) satisfying
+        ``x<=t(j)<t(n-k)``.
+
+        References
+        ----------
+        .. [1] W. Boehm, "Inserting new knots into b-spline curves.",
+            Computer Aided Design, 12, p.199-201, 1980.
+            :doi:`10.1016/0010-4485(80)90154-2`.
+        .. [2] P. Dierckx, "Curve and surface fitting with splines, Monographs on
+            Numerical Analysis", Oxford University Press, 1993.
+
+
+        Examples
+        --------
+        You can insert knots into a B-spline:
+
+        >>> import numpy as np
+        >>> from scipy.interpolate import BSpline, make_interp_spline
+        >>> x = np.linspace(0, 10, 5)
+        >>> y = np.sin(x)
+        >>> spl = make_interp_spline(x, y, k=3)
+        >>> spl.t
+        array([ 0.,  0.,  0.,  0.,  5., 10., 10., 10., 10.])
+
+        Insert a single knot
+
+        >>> spl_1 = spl.insert_knot(3)
+        >>> spl_1.t
+        array([ 0.,  0.,  0.,  0.,  3.,  5., 10., 10., 10., 10.])
+
+        Insert a multiple knot
+
+        >>> spl_2 = spl.insert_knot(8, m=3)
+        >>> spl_2.t
+        array([ 0.,  0.,  0.,  0.,  5.,  8.,  8.,  8., 10., 10., 10., 10.])
+
         """
         if x < self.t[self.k] or x > self.t[-self.k-1]:
             raise ValueError(f"Cannot insert a knot at {x}.")

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -581,8 +581,8 @@ def insert(x, tck, m=1, per=0):
 
     Parameters
     ----------
-    x (u) : array_like
-        A 1-D point at which to insert a new knot(s).  If `tck` was returned
+    x (u) : float
+        A knot value at which to insert a new knot.  If `tck` was returned
         from ``splprep``, then the parameter values, u should be given.
     tck : a `BSpline` instance or a tuple
         If tuple, then it is expected to be a tuple (t,c,k) containing

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -610,7 +610,12 @@ def insert(x, tck, m=1, per=0):
     Based on algorithms from [1]_ and [2]_.
 
     Manipulating the tck-tuples directly is not recommended. In new code,
-    prefer using the `BSpline` objects.
+    prefer using the `BSpline` objects, in particular `BSpline.insert_knot`
+    method.
+
+    See Also
+    --------
+    BSpline.insert_knot
 
     References
     ----------


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Add a `BSpline.insert_knot` method to parallel the module-level `insert` routine. The latter is a wrapper around FITPACK, and the new routine has a small cython snippet instead.

This can be further optimized, especially for multiple knots: ATM `m > 1` incurs `m` allocations, each being linear in data. However for the first version let's keep it simple, and optimize on a user request.

<s>To get feature-completeness, still need to port FITPACK's handling of periodic boundary conditions.</s> this is done now.

#### Additional information
<!--Any additional information you think is important.-->

This PR only adds functionality, and does not remove anything Fortran, not just yet.