### PR TITLE
DOC, MAINT: fix make dist in rel process

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -75,7 +75,7 @@ dist:
 	install -d build
 	rm -rf build/env
 	$(PYTHON) -mvenv --system-site-packages build/env
-	$(CURDIR)/build/env/bin/python -mpip install -r ../doc_requirements.txt
+	$(CURDIR)/build/env/bin/python -mpip install -r ../requirements/doc.txt
 	$(CURDIR)/build/env/bin/python -mpip install ..
 	make PYTHON="$(CURDIR)/build/env/bin/python" doc-dist
 


### PR DESCRIPTION
* gh-19750 broke the `make dist` doc building used in the release process, so fixing it here

[skip actions] [skip cirrus]

(there's probably no point in flushing circle here either, but `make dist` was successful after and failing before the patch locally)