### PR TITLE
MAINT: scipy.stats: replace `_normtest_finish`/`_ttest_finish`/etc... with `_get_pvalue`

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -693,7 +693,7 @@ def _somers_d(A, alternative='two-sided'):
     with np.errstate(divide='ignore'):
         Z = (PA - QA)/(4*(S))**0.5
 
-    _, p = scipy.stats._stats_py._normtest_finish(Z, alternative)
+    p = scipy.stats._stats_py._get_pvalue(Z, distributions.norm, alternative)
 
     return d, p
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -16,7 +16,7 @@ from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
 from ._ansari_swilk_statistics import gscale, swilk
 from . import _stats_py
 from ._fit import FitResult
-from ._stats_py import find_repeats, _normtest_finish, SignificanceResult
+from ._stats_py import find_repeats, _get_pvalue, SignificanceResult
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic
@@ -2792,8 +2792,8 @@ def ansari(x, y, alternative='two-sided'):
     # Large values of AB indicate larger dispersion for the y sample.
     # This is opposite to the way we define the ratio of scales. see [1]_.
     z = (mnAB - AB) / sqrt(varAB)
-    z, pval = _normtest_finish(z, alternative)
-    return AnsariResult(AB, pval)
+    pvalue = _get_pvalue(z, distributions.norm, alternative)
+    return AnsariResult(AB[()], pvalue[()])
 
 
 BartlettResult = namedtuple('BartlettResult', ('statistic', 'pvalue'))
@@ -3824,7 +3824,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
         mnM = n * (N * N - 1.0) / 12
         varM = m * n * (N + 1.0) * (N + 2) * (N - 2) / 180
         z = (M - mnM) / sqrt(varM)
-    z, pval = _normtest_finish(z, alternative)
+    pval = _get_pvalue(z, distributions.norm, alternative)
 
     if res_shape == ():
         # Return scalars, not 0-D arrays
@@ -3833,7 +3833,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
     else:
         z.shape = res_shape
         pval.shape = res_shape
-    return SignificanceResult(z, pval)
+    return SignificanceResult(z[()], pval[()])
 
 
 WilcoxonResult = _make_tuple_bunch('WilcoxonResult', ['statistic', 'pvalue'])

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -88,6 +88,28 @@ def _chk_size(a, b):
     return (a, b, na)
 
 
+def _ttest_finish(df, t, alternative):
+    """Common code between all 3 t-test functions."""
+    # We use ``stdtr`` directly here to preserve masked arrays
+
+    if alternative == 'less':
+        pval = special.stdtr(df, t)
+    elif alternative == 'greater':
+        pval = special.stdtr(df, -t)
+    elif alternative == 'two-sided':
+        pval = special.stdtr(df, -np.abs(t))*2
+    else:
+        raise ValueError("alternative must be "
+                         "'less', 'greater' or 'two-sided'")
+
+    if t.ndim == 0:
+        t = t[()]
+    if pval.ndim == 0:
+        pval = pval[()]
+
+    return t, pval
+
+
 def argstoarray(*args):
     """
     Constructs a 2D array from a group of sequences.
@@ -672,7 +694,7 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate',
             # errors before taking the square root
             t = rs * np.sqrt((dof / ((rs+1.0) * (1.0-rs))).clip(0))
 
-        t, prob = scipy.stats._stats_py._ttest_finish(dof, t, alternative)
+        t, prob = _ttest_finish(dof, t, alternative)
 
         # For backwards compatibility, return scalars when comparing 2 columns
         if rs.shape == (2, 2):
@@ -890,12 +912,12 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto',
         var_s /= 18.
         var_s += (v1 + v2)
         z = (C-D)/np.sqrt(var_s)
-        _, prob = scipy.stats._stats_py._normtest_finish(z, alternative)
+        prob = scipy.stats._stats_py._get_pvalue(z, distributions.norm, alternative)
     else:
         raise ValueError("Unknown method "+str(method)+" specified, please "
                          "use auto, exact or asymptotic.")
 
-    res = scipy.stats._stats_py.SignificanceResult(tau, prob)
+    res = scipy.stats._stats_py.SignificanceResult(tau[()], prob[()])
     res.correlation = tau
     return res
 
@@ -1368,7 +1390,7 @@ def ttest_1samp(a, popmean, axis=0, alternative='two-sided'):
     with np.errstate(divide='ignore', invalid='ignore'):
         t = (x - popmean) / ma.sqrt(svar / n)
 
-    t, prob = scipy.stats._stats_py._ttest_finish(df, t, alternative)
+    t, prob = _ttest_finish(df, t, alternative)
     return Ttest_1sampResult(t, prob)
 
 
@@ -1452,7 +1474,7 @@ def ttest_ind(a, b, axis=0, equal_var=True, alternative='two-sided'):
     with np.errstate(divide='ignore', invalid='ignore'):
         t = (x1-x2) / denom
 
-    t, prob = scipy.stats._stats_py._ttest_finish(df, t, alternative)
+    t, prob = _ttest_finish(df, t, alternative)
     return Ttest_indResult(t, prob)
 
 
@@ -1513,7 +1535,7 @@ def ttest_rel(a, b, axis=0, alternative='two-sided'):
     with np.errstate(divide='ignore', invalid='ignore'):
         t = dm / denom
 
-    t, prob = scipy.stats._stats_py._ttest_finish(df, t, alternative)
+    t, prob = _ttest_finish(df, t, alternative)
     return Ttest_relResult(t, prob)
 
 
@@ -2957,8 +2979,9 @@ def skewtest(a, axis=0, alternative='two-sided'):
     alpha = ma.sqrt(2.0/(W2-1))
     y = ma.where(y == 0, 1, y)
     Z = delta*ma.log(y/alpha + ma.sqrt((y/alpha)**2+1))
+    pvalue = scipy.stats._stats_py._get_pvalue(Z, distributions.norm, alternative)
 
-    return SkewtestResult(*scipy.stats._stats_py._normtest_finish(Z, alternative))
+    return SkewtestResult(Z[()], pvalue[()])
 
 
 KurtosistestResult = namedtuple('KurtosistestResult', ('statistic', 'pvalue'))
@@ -3030,10 +3053,9 @@ def kurtosistest(a, axis=0, alternative='two-sided'):
     term2 = np.ma.where(denom > 0, ma.power((1-2.0/A)/denom, 1/3.0),
                         -ma.power(-(1-2.0/A)/denom, 1/3.0))
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))
+    pvalue = scipy.stats._stats_py._get_pvalue(Z, distributions.norm, alternative)
 
-    return KurtosistestResult(
-        *scipy.stats._stats_py._normtest_finish(Z, alternative)
-    )
+    return KurtosistestResult(Z[()], pvalue[()])
 
 
 NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -89,11 +89,25 @@ def _chk_size(a, b):
 
 
 def _ttest_finish(df, t, alternative):
-    # Light wrapper around _get_pvalue to preserve array masks
-    p = scipy.stats._stats_py._get_pvalue(t, distributions.t(df), alternative)
-    dft = df + t  # compute result mask, if there is one
-    p = np.ma.masked_array(p, mask=dft.mask) if hasattr(dft, 'mask') else p
-    return t[()], p[()]
+    """Common code between all 3 t-test functions."""
+    # We use ``stdtr`` directly here to preserve masked arrays
+
+    if alternative == 'less':
+        pval = special.stdtr(df, t)
+    elif alternative == 'greater':
+        pval = special.stdtr(df, -t)
+    elif alternative == 'two-sided':
+        pval = special.stdtr(df, -np.abs(t))*2
+    else:
+        raise ValueError("alternative must be "
+                         "'less', 'greater' or 'two-sided'")
+
+    if t.ndim == 0:
+        t = t[()]
+    if pval.ndim == 0:
+        pval = pval[()]
+
+    return t, pval
 
 
 def argstoarray(*args):

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -89,25 +89,11 @@ def _chk_size(a, b):
 
 
 def _ttest_finish(df, t, alternative):
-    """Common code between all 3 t-test functions."""
-    # We use ``stdtr`` directly here to preserve masked arrays
-
-    if alternative == 'less':
-        pval = special.stdtr(df, t)
-    elif alternative == 'greater':
-        pval = special.stdtr(df, -t)
-    elif alternative == 'two-sided':
-        pval = special.stdtr(df, -np.abs(t))*2
-    else:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
-
-    if t.ndim == 0:
-        t = t[()]
-    if pval.ndim == 0:
-        pval = pval[()]
-
-    return t, pval
+    # Light wrapper around _get_pvalue to preserve array masks
+    p = scipy.stats._stats_py._get_pvalue(t, distributions.t(df), alternative)
+    dft = df + t  # compute result mask, if there is one
+    p = np.ma.masked_array(p, mask=dft.mask) if hasattr(dft, 'mask') else p
+    return t[()], p[()]
 
 
 def argstoarray(*args):

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -1,6 +1,5 @@
 import warnings
 import numpy as np
-import scipy.stats._stats_py
 from . import distributions
 from .._lib._bunch import _make_tuple_bunch
 from ._stats_pythran import siegelslopes as siegelslopes_pythran

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -4,6 +4,7 @@ import scipy.stats._stats_py
 from . import distributions
 from .._lib._bunch import _make_tuple_bunch
 from ._stats_pythran import siegelslopes as siegelslopes_pythran
+from . import _mstats_basic
 
 __all__ = ['_find_repeats', 'linregress', 'theilslopes', 'siegelslopes']
 
@@ -194,7 +195,7 @@ def linregress(x, y=None, alternative='two-sided'):
         # n-2 degrees of freedom because 2 has been used up
         # to estimate the mean and standard deviation
         t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
-        t, prob = scipy.stats._stats_py._ttest_finish(df, t, alternative)
+        t, prob = _mstats_basic._ttest_finish(df, t, alternative)
 
         slope_stderr = np.sqrt((1 - r**2) * ssym / ssxm / df)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1394,22 +1394,22 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
 #####################################
 
 
-def _normtest_finish(z, alternative):
-    """Common code between all the normality-test functions."""
+def _get_pvalue(statistic, distribution, alternative, symmetric=True):
+    """Get p-value given the statistic, (continuous) distribution, and alternative"""
+
     if alternative == 'less':
-        prob = distributions.norm.cdf(z)
+        pvalue = distribution.cdf(statistic)
     elif alternative == 'greater':
-        prob = distributions.norm.sf(z)
+        pvalue = distribution.sf(statistic)
     elif alternative == 'two-sided':
-        prob = 2 * distributions.norm.sf(np.abs(z))
+        pvalue = 2 * (distribution.sf(np.abs(statistic)) if symmetric
+                      else np.minimum(distribution.cdf(statistic),
+                                      distribution.sf(statistic)))
     else:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
+        message = "`alternative` must be 'less', 'greater', or 'two-sided'."
+        raise ValueError(message)
 
-    if z.ndim == 0:
-        z = z[()]
-
-    return z, prob
+    return pvalue
 
 
 SkewtestResult = namedtuple('SkewtestResult', ('statistic', 'pvalue'))
@@ -1590,7 +1590,8 @@ def skewtest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     y = np.where(y == 0, 1, y)
     Z = delta * np.log(y / alpha + np.sqrt((y / alpha)**2 + 1))
 
-    return SkewtestResult(*_normtest_finish(Z, alternative))
+    pvalue = _get_pvalue(Z, distributions.norm, alternative)
+    return SkewtestResult(Z[()], pvalue[()])
 
 
 KurtosistestResult = namedtuple('KurtosistestResult', ('statistic', 'pvalue'))
@@ -1791,8 +1792,8 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
 
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))  # [1]_ Eq. 5
 
-    # zprob uses upper tail, so Z needs to be positive
-    return KurtosistestResult(*_normtest_finish(Z, alternative))
+    pvalue = _get_pvalue(Z, distributions.norm, alternative)
+    return KurtosistestResult(Z[()], pvalue[()])
 
 
 NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))
@@ -4795,17 +4796,9 @@ def pearsonr(x, y, *, alternative='two-sided', method=None):
     # hypothesis is the beta distribution on (-1, 1) with a = b = n/2 - 1.
     ab = n/2 - 1
     dist = stats.beta(ab, ab, loc=-1, scale=2)
-    if alternative == 'two-sided':
-        prob = 2*dist.sf(abs(r))
-    elif alternative == 'less':
-        prob = dist.cdf(r)
-    elif alternative == 'greater':
-        prob = dist.sf(r)
-    else:
-        raise ValueError('alternative must be one of '
-                         '["two-sided", "less", "greater"]')
+    pvalue = _get_pvalue(r, dist, alternative)
 
-    return PearsonRResult(statistic=r, pvalue=prob, n=n,
+    return PearsonRResult(statistic=r, pvalue=pvalue, n=n,
                           alternative=alternative, x=x, y=y)
 
 
@@ -5420,7 +5413,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         # errors before taking the square root
         t = rs * np.sqrt((dof/((rs+1.0)*(1.0-rs))).clip(0))
 
-    t, prob = _ttest_finish(dof, t, alternative)
+    prob = _get_pvalue(t, distributions.t(dof), alternative)
 
     # For backwards compatibility, return scalars when comparing 2 columns
     if rs.shape == (2, 2):
@@ -5878,7 +5871,7 @@ def kendalltau(x, y, *, initial_lexsort=_NoValue, nan_policy='propagate',
         var = ((m * (2*size + 5) - x1 - y1) / 18 +
                (2 * xtie * ytie) / m + x0 * y0 / (9 * m * (size - 2)))
         z = con_minus_dis / np.sqrt(var)
-        _, pvalue = _normtest_finish(z, alternative)
+        pvalue = _get_pvalue(z, distributions.norm, alternative)[()]
     else:
         raise ValueError(f"Unknown method {method} specified.  Use 'auto', "
                          "'exact' or 'asymptotic'.")
@@ -6870,8 +6863,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     denom = np.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):
-        t = np.divide(d, denom)
-    t, prob = _ttest_finish(df, t, alternative)
+        t = np.divide(d, denom)[()]
+    prob = _get_pvalue(t, distributions.t(df), alternative)
 
     # when nan_policy='omit', `df` can be different for different axis-slices
     df = np.broadcast_to(df, t.shape)[()]
@@ -6906,38 +6899,12 @@ def _t_confidence_interval(df, t, confidence_level, alternative):
 
     return low[()], high[()]
 
-
-def _ttest_finish(df, t, alternative):
-    """Common code between all 3 t-test functions."""
-    # We use ``stdtr`` directly here as it handles the case when ``nan``
-    # values are present in the data and masked arrays are passed
-    # while ``t.cdf`` emits runtime warnings. This way ``_ttest_finish``
-    # can be shared between the ``stats`` and ``mstats`` versions.
-
-    if alternative == 'less':
-        pval = special.stdtr(df, t)
-    elif alternative == 'greater':
-        pval = special.stdtr(df, -t)
-    elif alternative == 'two-sided':
-        pval = special.stdtr(df, -np.abs(t))*2
-    else:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
-
-    if t.ndim == 0:
-        t = t[()]
-    if pval.ndim == 0:
-        pval = pval[()]
-
-    return t, pval
-
-
 def _ttest_ind_from_stats(mean1, mean2, denom, df, alternative):
 
     d = mean1 - mean2
     with np.errstate(divide='ignore', invalid='ignore'):
-        t = np.divide(d, denom)
-    t, prob = _ttest_finish(df, t, alternative)
+        t = np.divide(d, denom)[()]
+    prob = _get_pvalue(t, distributions.t(df), alternative)
 
     return (t, prob)
 
@@ -7738,8 +7705,8 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
     denom = np.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):
-        t = np.divide(dm, denom)
-    t, prob = _ttest_finish(df, t, alternative)
+        t = np.divide(dm, denom)[()]
+    prob = _get_pvalue(t, distributions.t(df), alternative)
 
     # when nan_policy='omit', `df` can be different for different axis-slices
     df = np.broadcast_to(df, t.shape)[()]
@@ -9169,9 +9136,9 @@ def ranksums(x, y, alternative='two-sided'):
     s = np.sum(x, axis=0)
     expected = n1 * (n1+n2+1) / 2.0
     z = (s - expected) / np.sqrt(n1*n2*(n1+n2+1)/12.0)
-    z, prob = _normtest_finish(z, alternative)
+    pvalue = _get_pvalue(z, distributions.norm, alternative)
 
-    return RanksumsResult(z, prob)
+    return RanksumsResult(z[()], pvalue[()])
 
 
 KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -637,7 +637,7 @@ def logrank(
     difference between the two survival functions.
 
     """
-    # Input validation. `alternative` IV handled in `_normtest_finish` below.
+    # Input validation. `alternative` IV handled in `_get_pvalue` below.
     x = _iv_CensoredData(sample=x, param_name='x')
     y = _iv_CensoredData(sample=y, param_name='y')
 
@@ -680,8 +680,6 @@ def logrank(
     statistic = (n_died_x - sum_exp_deaths_x)/np.sqrt(sum_var)
 
     # Equivalent to chi2(df=1).sf(statistic**2) when alternative='two-sided'
-    _, pvalue = stats._stats_py._normtest_finish(
-        z=statistic, alternative=alternative
-    )
+    pvalue = stats._stats_py._get_pvalue(statistic, stats.norm, alternative)
 
     return LogRankResult(statistic=statistic, pvalue=pvalue)

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -682,4 +682,4 @@ def logrank(
     # Equivalent to chi2(df=1).sf(statistic**2) when alternative='two-sided'
     pvalue = stats._stats_py._get_pvalue(statistic, stats.norm, alternative)
 
-    return LogRankResult(statistic=statistic, pvalue=pvalue)
+    return LogRankResult(statistic=statistic[()], pvalue=pvalue[()])

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy import special, interpolate, stats
 from scipy.stats._censored_data import CensoredData
 from scipy.stats._common import ConfidenceInterval
+from scipy.stats import norm  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -680,6 +681,6 @@ def logrank(
     statistic = (n_died_x - sum_exp_deaths_x)/np.sqrt(sum_var)
 
     # Equivalent to chi2(df=1).sf(statistic**2) when alternative='two-sided'
-    pvalue = stats._stats_py._get_pvalue(statistic, stats.norm, alternative)
+    pvalue = stats._stats_py._get_pvalue(statistic, norm, alternative)
 
     return LogRankResult(statistic=statistic[()], pvalue=pvalue[()])

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -959,7 +959,7 @@ class TestSomersD(_TestPythranFunc):
         assert_equal(res.statistic, expected.statistic)
         assert_allclose(res.pvalue, expected.pvalue / 2)
 
-        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+        with pytest.raises(ValueError, match="`alternative` must be..."):
             stats.somersd(x1, x2, alternative="ekki-ekki")
 
     @pytest.mark.parametrize("positive_correlation", (False, True))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1318,7 +1318,7 @@ class TestMood:
         assert_allclose(p2, p1/2)
         assert_allclose(p3, 1 - p1/2)
 
-        with pytest.raises(ValueError, match="alternative must be..."):
+        with pytest.raises(ValueError, match="`alternative` must be..."):
             stats.mood(x, y, alternative='ekki-ekki')
 
     @pytest.mark.parametrize("alternative", ['two-sided', 'less', 'greater'])

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1164,7 +1164,7 @@ class TestNormalitytests:
 
     def test_bad_alternative(self):
         x = stats.norm.rvs(size=20, random_state=123)
-        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
+        msg = r"`alternative` must be..."
 
         with pytest.raises(ValueError, match=msg):
             mstats.skewtest(x, alternative='error')

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -296,7 +296,7 @@ class TestCorr:
 
         assert stat1 == stat2 == stat3
 
-        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+        with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
             mstats.spearmanr(x, y, alternative="ekki-ekki")
 
     @pytest.mark.skipif(platform.machine() == 'ppc64le',
@@ -1308,7 +1308,7 @@ class TestTtest_rel:
             assert_array_equal(p, np.array([np.nan, np.nan]))
 
     def test_bad_alternative(self):
-        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
+        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_ind([1, 2, 3], [4, 5, 6], alternative='foo')
 
@@ -1403,7 +1403,7 @@ class TestTtest_ind:
                                             equal_var=False), (np.nan, np.nan))
 
     def test_bad_alternative(self):
-        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
+        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_ind([1, 2, 3], [4, 5, 6], alternative='foo')
 
@@ -1473,7 +1473,7 @@ class TestTtest_1samp:
             assert_array_equal(p, (np.nan, np.nan))
 
     def test_bad_alternative(self):
-        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
+        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_1samp([1, 2, 3], 4, alternative='foo')
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -296,7 +296,7 @@ class TestCorr:
 
         assert stat1 == stat2 == stat3
 
-        with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
+        with pytest.raises(ValueError, match="alternative must be 'less'..."):
             mstats.spearmanr(x, y, alternative="ekki-ekki")
 
     @pytest.mark.skipif(platform.machine() == 'ppc64le',
@@ -1308,7 +1308,7 @@ class TestTtest_rel:
             assert_array_equal(p, np.array([np.nan, np.nan]))
 
     def test_bad_alternative(self):
-        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
+        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_ind([1, 2, 3], [4, 5, 6], alternative='foo')
 
@@ -1403,7 +1403,7 @@ class TestTtest_ind:
                                             equal_var=False), (np.nan, np.nan))
 
     def test_bad_alternative(self):
-        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
+        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_ind([1, 2, 3], [4, 5, 6], alternative='foo')
 
@@ -1473,7 +1473,7 @@ class TestTtest_1samp:
             assert_array_equal(p, (np.nan, np.nan))
 
     def test_bad_alternative(self):
-        msg = r"`alternative` must be 'less', 'greater', or 'two-sided'."
+        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
         with pytest.raises(ValueError, match=msg):
             mstats.ttest_1samp([1, 2, 3], 4, alternative='foo')
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1131,7 +1131,7 @@ class TestCorrSpearmanr2:
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1] / 2)
 
-        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+        with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
             stats.spearmanr(x1, x2, alternative="ekki-ekki")
 
     @pytest.mark.parametrize("alternative", ('two-sided', 'less', 'greater'))
@@ -1482,7 +1482,7 @@ class TestKendallTauAlternative:
         assert_equal(res[0], expected[0])
         assert_allclose(res[1], expected[1] / 2)
 
-        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+        with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
             stats.kendalltau(x1, x2, alternative="ekki-ekki")
 
     # There are a lot of special cases considered in the calculation of the
@@ -5853,7 +5853,7 @@ class TestRankSums:
         check_named_results(res, ('statistic', 'pvalue'))
 
     def test_input_validation(self):
-        with assert_raises(ValueError, match="alternative must be 'less'"):
+        with assert_raises(ValueError, match="`alternative` must be 'less'"):
             stats.ranksums(self.x, self.y, alternative='foobar')
 
 


### PR DESCRIPTION
#### What does this implement/fix?
`_normtest_finish`, `_ttest_finish`, and some other custom code in `stats` does the same job: given a statistic, null distribution, and `alternative`, get a p-value. This PR unifies the code, ensuring consistent input validation of `alternative`, streamlining future maintenance, and simplifying new hypothesis test development.

#### Additional information
~~WIP while I sort out some inconsistencies with masked arrays and assess where `[()]` should be added.~~ Done. `mstats` functions are already very inconsistent about whether they return masked or regular arrays (this doesn't change it), and I've gone ahead and added `[()]` pretty much everywhere it might be useful (since it is no longer done in `_get_pvalue`).

gh-19770 and gh-19744 will use this, too.