### PR TITLE
BUG: support sparse Hessian in `Newton-CG`

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -38,7 +38,6 @@ from ._linesearch import (line_search_wolfe1, line_search_wolfe2,
                           line_search_wolfe2 as line_search,
                           LineSearchWarning)
 from ._numdiff import approx_derivative
-from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._util import MapWrapper, check_random_state
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
@@ -2179,11 +2178,9 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                     Ap = fhess_p(xk, psupi, *args)
                     hcalls += 1
             else:
-                if isinstance(A, HessianUpdateStrategy):
-                    # if hess was supplied as a HessianUpdateStrategy
-                    Ap = A.dot(psupi)
-                else:
-                    Ap = np.dot(A, psupi)
+                # hess was supplied as a callable or hessian update strategy, so
+                # A is a dense numpy array or sparse matrix
+                Ap = A.dot(psupi)
             # check curvature
             Ap = asarray(Ap).squeeze()  # get rid of matrices...
             curv = np.dot(psupi, Ap)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3130,22 +3130,24 @@ def test_gh12594():
     assert_allclose(res.x, ref.x)
 
 
+@pytest.mark.parametrize('method', ['Newton-CG', 'trust-constr'])
 @pytest.mark.parametrize('sparse_type', [coo_matrix, csc_matrix, csr_matrix,
                                          coo_array, csr_array, csc_array])
-def test_gh8792(sparse_type):
+def test_sparse_hessian(method, sparse_type):
     # gh-8792 reported an error for minimization with `newton_cg` when `hess`
     # returns a sparse matrix. Check that results are the same whether `hess`
-    # returns a dense or sparse matrix.
+    # returns a dense or sparse matrix for optimization methods that accept
+    # sparse Hessian matrices.
 
     def sparse_rosen_hess(x):
         return sparse_type(rosen_hess(x))
 
     x0 = [2., 2.]
 
-    res_sparse = optimize.minimize(rosen, x0, method="Newton-CG",
-                          jac=rosen_der, hess=sparse_rosen_hess)
-    res_dense = optimize.minimize(rosen, x0, method="Newton-CG",
-                          jac=rosen_der, hess=rosen_hess)
+    res_sparse = optimize.minimize(rosen, x0, method=method,
+                                   jac=rosen_der, hess=sparse_rosen_hess)
+    res_dense = optimize.minimize(rosen, x0, method=method,
+                                  jac=rosen_der, hess=rosen_hess)
 
     assert_allclose(res_dense.fun, res_sparse.fun)
     assert_allclose(res_dense.x, res_sparse.x)


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/8792

#### What does this implement/fix?
The `Newton-CG` optimizer does not handle hessian callables that return sparse matrices/arrays so far. This is fixed here.
