### PR TITLE
BLD: fix "Failed to guess install tag" in meson-log.txt, add explicit tags

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -23,7 +23,8 @@ cython_linalg = custom_target('cython_linalg',
   # TODO - we only want to install the .pxd files! See comments for
   #        `pxd_files` further down.
   install: true,
-  install_dir: py3.get_install_dir() / 'scipy/linalg'
+  install_dir: py3.get_install_dir() / 'scipy/linalg',
+  install_tag: 'devel'
 )
 
 # This dummy custom target is only needed to establish a dependency on

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -228,7 +228,8 @@ generate_version = custom_target(
   output: 'version.py',
   input: '../tools/version_utils.py',
   command: [py3, '@INPUT@', '--source-root', '@SOURCE_ROOT@'],
-  install_dir: scipy_dir
+  install_dir: scipy_dir,
+  install_tag: 'python-runtime',
 )
 
 python_sources = [
@@ -479,6 +480,7 @@ configure_file(
   output: '__config__.py',
   configuration : conf_data,
   install_dir: scipy_dir,
+  install_tag: 'python-runtime',
 )
 
 # Ordering of subdirs: special and linalg come first, because other submodules

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -302,7 +302,8 @@ cython_special = custom_target('cython_special',
   input: ['_generate_pyx.py', 'functions.json', '_add_newdocs.py'],
   command: [py3, '@INPUT0@', '-o', '@OUTDIR@'],
   install: true,
-  install_dir: py3.get_install_dir() / 'scipy/special'
+  install_dir: py3.get_install_dir() / 'scipy/special',
+  install_tag: 'devel',
 )
 
 # Only needed to establish a dependency; see comments in linalg/meson.build
@@ -473,7 +474,8 @@ foreach npz_file: npz_files
       '--use-timestamp', npz_file[2], '-o', '@OUTDIR@'
     ],
     install: true,
-    install_dir: py3.get_install_dir() / 'scipy/special/tests/data'
+    install_dir: py3.get_install_dir() / 'scipy/special/tests/data',
+    install_tag: 'python-runtime',
   )
 endforeach
 


### PR DESCRIPTION
This removed about ~40 lines from `meson-log.txt`. For `custom_target`, `configure_file` and other such generic calls, Meson can't know what install tags to add automatically, hence it adds a warning to the build log and adds a "dummy" tag. These aren't really needed for Python packaging, but it's possible that Linux distros could want to use tags. Either way, best to get it right.

The warnings looked like:
```
Failed to guess install tag for /__w/scipy/scipy/build-install/lib64/python3.12/site-packages/scipy/version.py
Failed to guess install tag for /__w/scipy/scipy/build-install/lib64/python3.12/site-packages/scipy/special/_ufuncs.pyx
Failed to guess install tag for /__w/scipy/scipy/build-install/lib64/python3.12/site-packages/scipy/special/_ufuncs_defs.h
```

Fix is similar to the one for NumPy in https://github.com/numpy/numpy/pull/24883.
