### PR TITLE
MAINT: simplify `t.logpdf`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7545,29 +7545,15 @@ class t_gen(rv_continuous):
 
     def _logpdf(self, x, df):
 
-        def regular_formula(x, df):
-            return (sc.gammaln((df + 1)/2) - sc.gammaln(df/2)
-                    - (0.5 * np.log(df*np.pi))
+        def t_logpdf(x, df):
+            return (np.log(sc.poch(0.5 * df, 0.5))
+                    - 0.5 * (np.log(df) + np.log(np.pi))
                     - (df + 1)/2*np.log1p(x * x/df))
-
-        def asymptotic_formula(x, df):
-            return (- 0.5 * (1 + np.log(2 * np.pi)) + df/2 * np.log1p(1/df)
-                    + 1/6 * (df + 1)**-1. - 1/45*(df + 1)**-3.
-                    - 1/6 * df**-1. + 1/45*df**-3.
-                    - (df + 1)/2 * np.log1p(x*x/df))
 
         def norm_logpdf(x, df):
             return norm._logpdf(x)
 
-        return _lazyselect(
-            ((df == np.inf),
-             (df >= 200) & np.isfinite(df),
-             (df < 200)),
-            (norm_logpdf,
-             asymptotic_formula,
-             regular_formula),
-            (x, df, )
-        )
+        return _lazywhere(df == np.inf, (x, df, ), f=norm_logpdf, f2=t_logpdf)
 
     def _cdf(self, x, df):
         return sc.stdtr(df, x)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3464,7 +3464,7 @@ class TestStudentT:
                       -50.918938533204674, -1.8378770664093456]
         pdf_ref = [0.24197072451914334, 0,
                    7.69459862670642e-23, 0.15915494309189535]
-        assert_allclose(stats.t.logpdf(x, df), logpdf_ref, rtol=1e-15)
+        assert_allclose(stats.t.logpdf(x, df), logpdf_ref, rtol=1e-14)
         assert_allclose(stats.t.pdf(x, df), pdf_ref, rtol=1e-14)
 
 


### PR DESCRIPTION
#### What does this implement/fix?
In #18433 I had implemented an asymptotic expansion to increasethe precision of the `logpdf` method of the student t distribution for high degrees of freedom. Turned out that this was not necessary actually, `special.poch` comes again to the rescue. This simplifies the code, eliminates a branch and slightly improves performance at the expense of a very minor decrease of accuracy for extreme high degrees of freedom.