### PR TITLE
API: Enable `pydata/sparse` input for csgraph module

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -219,7 +219,7 @@ jobs:
 
   #################################################################################
   gcc8:
-    # Purpose is to examine builds with oldest-supported gcc.
+    # Purpose is to examine builds with oldest-supported gcc and test with pydata/sparse.
     name: Build with gcc-8
     needs: get_commit_message
     if: >
@@ -250,6 +250,7 @@ jobs:
           pip install build meson-python ninja pythran pybind11 cython
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout hypothesis
+          pip install sparse
 
       - name: Build wheel and install
         run: |
@@ -271,7 +272,7 @@ jobs:
   #################################################################################
   prerelease_deps_coverage_64bit_blas:
     # TODO: re-enable ILP64 build.
-    name: Prerelease deps, coverage, and 64-bit BLAS
+    name: Prerelease deps, coverage and 64-bit BLAS
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,5 @@ filterwarnings =
     ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning
     ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning
     ignore:.*In the future `np.long` will be defined as.*:FutureWarning
+# Ignore DeprecationWarning from sparse (fixed in the main branch)
+    ignore:.*coords should be an ndarray.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,5 +17,3 @@ filterwarnings =
     ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning
     ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning
     ignore:.*In the future `np.long` will be defined as.*:FutureWarning
-# Ignore DeprecationWarning from sparse (fixed in the main branch)
-    ignore:.*coords should be an ndarray.*:DeprecationWarning

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -2,6 +2,7 @@
 """
 
 import sys
+from typing import Any, Literal, Optional, Union
 import operator
 import numpy as np
 from math import prod
@@ -386,6 +387,22 @@ def is_pydata_spmatrix(m) -> bool:
     """
     base_cls = getattr(sys.modules.get('sparse'), 'SparseArray', None)
     return base_cls is not None and isinstance(m, base_cls)
+
+
+def convert_pydata_sparse_to_scipy(
+    arg: Any, target_format: Optional[Literal["csc", "csr"]] = None
+) -> Union[Any, "sp.spmatrix"]:
+    """
+    Convert a pydata/sparse array to scipy sparse matrix,
+    pass through anything else.
+    """
+    if is_pydata_spmatrix(arg):
+        arg = arg.to_scipy_sparse()
+        if target_format is not None:
+            arg = arg.asformat(target_format)
+        elif arg.format not in ("csc", "csr"):
+            arg = arg.tocsc()
+    return arg
 
 
 ###############################################################################

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -3,7 +3,7 @@
 import numpy as np
 
 from scipy.sparse import csr_matrix, issparse
-from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy, is_pydata_spmatrix
 
 cimport numpy as np
 
@@ -225,6 +225,9 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     modifying the capacities of the new graph appropriately.
 
     """
+    is_pydata_sparse = is_pydata_spmatrix(csgraph)
+    if is_pydata_sparse:
+        pydata_sparse_cls = csgraph.__class__
     csgraph = convert_pydata_sparse_to_scipy(csgraph, target_format="csr")
     if not (issparse(csgraph) and csgraph.format == "csr"):
         raise TypeError("graph must be in CSR format")
@@ -265,6 +268,8 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     flow_array = np.asarray(flow)
     flow_matrix = csr_matrix((flow_array, m.indices, m.indptr),
                              shape=m.shape)
+    if is_pydata_sparse:
+        flow_matrix = pydata_sparse_cls.from_scipy_sparse(flow_matrix)
     source_flow = flow_array[m.indptr[source]:m.indptr[source + 1]]
     return MaximumFlowResult(source_flow.sum(), flow_matrix)
 

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -3,6 +3,7 @@
 import numpy as np
 
 from scipy.sparse import csr_matrix, issparse
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 
 cimport numpy as np
 
@@ -224,6 +225,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     modifying the capacities of the new graph appropriately.
 
     """
+    csgraph = convert_pydata_sparse_to_scipy(csgraph, target_format="csr")
     if not (issparse(csgraph) and csgraph.format == "csr"):
         raise TypeError("graph must be in CSR format")
     if not issubclass(csgraph.dtype.type, np.integer):

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -5,6 +5,7 @@ Laplacian of a compressed-sparse graph
 import numpy as np
 from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 
 
 ###############################################################################
@@ -329,6 +330,7 @@ def laplacian(
     in the middle by deleting a single edge.
     Both determined partitions are optimal.
     """
+    csgraph = convert_pydata_sparse_to_scipy(csgraph)
     if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
         raise ValueError('csgraph must be a square matrix or array')
 

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -5,7 +5,7 @@ Laplacian of a compressed-sparse graph
 import numpy as np
 from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator
-from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy, is_pydata_spmatrix
 
 
 ###############################################################################
@@ -330,7 +330,10 @@ def laplacian(
     in the middle by deleting a single edge.
     Both determined partitions are optimal.
     """
-    csgraph = convert_pydata_sparse_to_scipy(csgraph)
+    is_pydata_sparse = is_pydata_spmatrix(csgraph)
+    if is_pydata_sparse:
+        pydata_sparse_cls = csgraph.__class__
+        csgraph = convert_pydata_sparse_to_scipy(csgraph)
     if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
         raise ValueError('csgraph must be a square matrix or array')
 
@@ -362,6 +365,8 @@ def laplacian(
         dtype=dtype,
         symmetrized=symmetrized,
     )
+    if is_pydata_sparse:
+        lap = pydata_sparse_cls.from_scipy_sparse(lap)
     if return_diag:
         return lap, d
     return lap

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -7,6 +7,7 @@ from libc.math cimport INFINITY
 
 
 from scipy.sparse import issparse
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 
 np.import_array()
 
@@ -133,6 +134,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
      [2 0 0 3]]
 
     """
+    graph = convert_pydata_sparse_to_scipy(graph)
     if not issparse(graph):
         raise TypeError("graph must be sparse")
     if graph.format not in ("csr", "csc", "coo"):
@@ -450,6 +452,7 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
     28.0
 
     """
+    biadjacency_matrix = convert_pydata_sparse_to_scipy(biadjacency_matrix)
     if not issparse(biadjacency_matrix):
         raise TypeError("graph must be sparse")
     if biadjacency_matrix.format not in ("csr", "csc", "coo"):

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -7,6 +7,7 @@ cimport cython
 
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph._validation import validate_graph
+from scipy.sparse._sputils import is_pydata_spmatrix
 
 np.import_array()
 
@@ -93,6 +94,9 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     """
     global NULL_IDX
     
+    is_pydata_sparse = is_pydata_spmatrix(csgraph)
+    if is_pydata_sparse:
+        pydata_sparse_cls = csgraph.__class__
     csgraph = validate_graph(csgraph, True, DTYPE, dense_output=False,
                              copy_if_sparse=not overwrite)
     cdef int N = csgraph.shape[0]
@@ -115,6 +119,8 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     sp_tree = csr_matrix((data, indices, indptr), (N, N))
     sp_tree.eliminate_zeros()
 
+    if is_pydata_sparse:
+        sp_tree = pydata_sparse_cls.from_scipy_sparse(sp_tree)
     return sp_tree
 
 

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -6,6 +6,7 @@ import numpy as np
 cimport numpy as np
 from warnings import warn
 from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 from . import maximum_bipartite_matching
 
 np.import_array()
@@ -68,6 +69,7 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     array([3, 2, 1, 0], dtype=int32)
     
     """
+    graph = convert_pydata_sparse_to_scipy(graph)
     if not issparse(graph):
         raise TypeError("Input graph must be sparse")
     if graph.format not in ("csc", "csr"):
@@ -226,7 +228,8 @@ def structural_rank(graph):
     4
 
     """
-    if not issparse:
+    graph = convert_pydata_sparse_to_scipy(graph)
+    if not issparse(graph):
         raise TypeError('Input must be a sparse matrix')
     if graph.format != "csr":
         if graph.format not in ("csc", "coo"):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -16,6 +16,7 @@ cimport numpy as np
 
 from scipy.sparse import csr_matrix, issparse
 from scipy.sparse.csgraph._validation import validate_graph
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 
 cimport cython
 
@@ -169,6 +170,7 @@ def shortest_path(csgraph, method='auto',
     if method == 'auto':
         # guess fastest method based on number of nodes and edges
         N = csgraph.shape[0]
+        csgraph = convert_pydata_sparse_to_scipy(csgraph)
         is_sparse = issparse(csgraph)
         if is_sparse:
             Nk = csgraph.nnz

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -1,7 +1,10 @@
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
-from ._tools import csgraph_to_dense, csgraph_from_dense,\
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
+from scipy.sparse.csgraph._tools import (
+    csgraph_to_dense, csgraph_from_dense,
     csgraph_masked_from_dense, csgraph_from_masked
+)
 
 DTYPE = np.float64
 
@@ -14,6 +17,8 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
     """Routine for validation and conversion of csgraph inputs"""
     if not (csr_output or dense_output):
         raise ValueError("Internal: dense or csr output must be true")
+
+    csgraph = convert_pydata_sparse_to_scipy(csgraph)
 
     # if undirected and csc storage, then transposing in-place
     # is quicker than later converting to csr.

--- a/scipy/sparse/csgraph/tests/meson.build
+++ b/scipy/sparse/csgraph/tests/meson.build
@@ -5,6 +5,7 @@ python_sources = [
   'test_flow.py',
   'test_graph_laplacian.py',
   'test_matching.py',
+  'test_pydata_sparse.py',
   'test_reordering.py',
   'test_shortest_path.py',
   'test_spanning_tree.py',

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -41,6 +41,26 @@ def graphs(sparse_cls):
     return A_dense, A_sparse
 
 
+@pytest.mark.parametrize(
+    "func",
+    [
+        spgraph.shortest_path,
+        spgraph.dijkstra,
+        spgraph.floyd_warshall,
+        spgraph.bellman_ford,
+        spgraph.johnson,
+        spgraph.reverse_cuthill_mckee,
+        spgraph.maximum_bipartite_matching,
+        spgraph.structural_rank,
+    ]
+)
+def test_csgraph_equiv(func, graphs):
+    A_dense, A_sparse = graphs
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+    assert_equal(actual, desired)
+
+
 def test_connected_components(graphs):
     A_dense, A_sparse = graphs
     func = spgraph.connected_components
@@ -54,62 +74,15 @@ def test_connected_components(graphs):
 
 def test_laplacian(graphs):
     A_dense, A_sparse = graphs
+    sparse_cls = type(A_sparse)
     func = spgraph.laplacian
 
     actual = func(A_sparse)
     desired = func(sp.csc_matrix(A_dense))
 
-    assert_equal(actual.toarray(), desired.toarray())
+    assert isinstance(actual, sparse_cls)
 
-
-def test_shortest_path(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.shortest_path
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
-
-
-def test_dijkstra(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.dijkstra
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
-
-
-def test_floyd_warshall(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.floyd_warshall
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
-
-
-def test_bellman_ford(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.bellman_ford
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
-
-
-def test_johnson(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.johnson
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
+    assert_equal(actual.todense(), desired.todense())
 
 
 @pytest.mark.parametrize(
@@ -129,52 +102,41 @@ def test_order_search(graphs, func):
 )
 def test_tree_search(graphs, func):
     A_dense, A_sparse = graphs
+    sparse_cls = type(A_sparse)
 
     actual = func(A_sparse, 0)
     desired = func(sp.csc_matrix(A_dense), 0)
 
-    assert_equal(actual.toarray(), desired.toarray())
+    assert isinstance(actual, sparse_cls)
+
+    assert_equal(actual.todense(), desired.todense())
 
 
 def test_minimum_spanning_tree(graphs):
     A_dense, A_sparse = graphs
+    sparse_cls = type(A_sparse)
     func = spgraph.minimum_spanning_tree
 
     actual = func(A_sparse)
     desired = func(sp.csc_matrix(A_dense))
 
-    assert_equal(actual.toarray(), desired.toarray())
+    assert isinstance(actual, sparse_cls)
 
-
-def test_reverse_cuthill_mckee(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.reverse_cuthill_mckee
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
+    assert_equal(actual.todense(), desired.todense())
 
 
 def test_maximum_flow(graphs):
     A_dense, A_sparse = graphs
+    sparse_cls = type(A_sparse)
     func = spgraph.maximum_flow
 
     actual = func(A_sparse, 0, 2)
     desired = func(sp.csr_matrix(A_dense), 0, 2)
 
     assert actual.flow_value == desired.flow_value
-    assert_equal(actual.flow.toarray(), desired.flow.toarray())
+    assert isinstance(actual.flow, sparse_cls)
 
-
-def test_maximum_bipartite_matching(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.maximum_bipartite_matching
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert_equal(actual, desired)
+    assert_equal(actual.flow.todense(), desired.flow.todense())
 
 
 def test_min_weight_full_bipartite_matching(graphs):
@@ -185,13 +147,3 @@ def test_min_weight_full_bipartite_matching(graphs):
     desired = func(sp.csc_matrix(A_dense)[0:2, 1:3])
 
     assert_equal(actual, desired)
-
-
-def test_structural_rank(graphs):
-    A_dense, A_sparse = graphs
-    func = spgraph.structural_rank
-
-    actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
-
-    assert actual == desired

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -1,0 +1,197 @@
+import pytest
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.csgraph as spgraph
+
+from numpy.testing import assert_equal
+
+try:
+    import sparse
+except Exception:
+    sparse = None
+
+pytestmark = pytest.mark.skipif(sparse is None,
+                                reason="pydata/sparse not installed")
+
+
+msg = "pydata/sparse (0.15.1) does not implement necessary operations"
+
+
+sparse_params = (pytest.param("COO"),
+                 pytest.param("DOK", marks=[pytest.mark.xfail(reason=msg)]))
+
+
+@pytest.fixture(params=sparse_params)
+def sparse_cls(request):
+    return getattr(sparse, request.param)
+
+
+@pytest.fixture
+def graphs(sparse_cls):
+    graph = [
+        [0, 1, 1, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 0],
+    ]
+    A_dense = np.array(graph)
+    A_sparse = sparse_cls(A_dense)
+    return A_dense, A_sparse
+
+
+def test_connected_components(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.connected_components
+
+    actual_comp, actual_labels = func(A_sparse)
+    desired_comp, desired_labels, = func(sp.csc_matrix(A_dense))
+
+    assert actual_comp == desired_comp
+    assert_equal(actual_labels, desired_labels)
+
+
+def test_laplacian(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.laplacian
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual.toarray(), desired.toarray())
+
+
+def test_shortest_path(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.shortest_path
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_dijkstra(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.dijkstra
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_floyd_warshall(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.floyd_warshall
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_bellman_ford(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.bellman_ford
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_johnson(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.johnson
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+@pytest.mark.parametrize(
+    "func", [spgraph.breadth_first_order, spgraph.depth_first_order]
+)
+def test_order_search(graphs, func):
+    A_dense, A_sparse = graphs
+
+    actual = func(A_sparse, 0)
+    desired = func(sp.csc_matrix(A_dense), 0)
+
+    assert_equal(actual, desired)
+
+
+@pytest.mark.parametrize(
+    "func", [spgraph.breadth_first_tree, spgraph.depth_first_tree]
+)
+def test_tree_search(graphs, func):
+    A_dense, A_sparse = graphs
+
+    actual = func(A_sparse, 0)
+    desired = func(sp.csc_matrix(A_dense), 0)
+
+    assert_equal(actual.toarray(), desired.toarray())
+
+
+def test_minimum_spanning_tree(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.minimum_spanning_tree
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual.toarray(), desired.toarray())
+
+
+def test_reverse_cuthill_mckee(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.reverse_cuthill_mckee
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_maximum_flow(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.maximum_flow
+
+    actual = func(A_sparse, 0, 2)
+    desired = func(sp.csr_matrix(A_dense), 0, 2)
+
+    assert actual.flow_value == desired.flow_value
+    assert_equal(actual.flow.toarray(), desired.flow.toarray())
+
+
+def test_maximum_bipartite_matching(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.maximum_bipartite_matching
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert_equal(actual, desired)
+
+
+def test_min_weight_full_bipartite_matching(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.min_weight_full_bipartite_matching
+
+    actual = func(A_sparse[0:2, 1:3])
+    desired = func(sp.csc_matrix(A_dense)[0:2, 1:3])
+
+    assert_equal(actual, desired)
+
+
+def test_structural_rank(graphs):
+    A_dense, A_sparse = graphs
+    func = spgraph.structural_rank
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    assert actual == desired

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -223,6 +223,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     >>> np.allclose(A.dot(x).toarray(), B.toarray())
     True
     """
+    is_pydata_sparse = is_pydata_spmatrix(b)
+    pydata_sparse_cls = b.__class__ if is_pydata_sparse else None
     A = convert_pydata_sparse_to_scipy(A)
     b = convert_pydata_sparse_to_scipy(b)
 
@@ -328,8 +330,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             x = A.__class__((sparse_data, (sparse_row, sparse_col)),
                            shape=b.shape, dtype=A.dtype)
 
-            if is_pydata_spmatrix(b):
-                x = b.__class__(x)
+            if is_pydata_sparse:
+                x = pydata_sparse_cls.from_scipy_sparse(x)
 
     return x
 
@@ -404,7 +406,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     if is_pydata_spmatrix(A):
         def csc_construct_func(*a, cls=type(A)):
-            return cls(csc_matrix(*a))
+            return cls.from_scipy_sparse(csc_matrix(*a))
         A = A.to_scipy_sparse().tocsc()
     else:
         csc_construct_func = csc_matrix
@@ -499,7 +501,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
 
     if is_pydata_spmatrix(A):
         def csc_construct_func(*a, cls=type(A)):
-            return cls(csc_matrix(*a))
+            return cls.from_scipy_sparse(csc_matrix(*a))
         A = A.to_scipy_sparse().tocsc()
     else:
         csc_construct_func = csc_matrix

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse,
                           SparseEfficiencyWarning, csc_matrix, csr_matrix)
-from scipy.sparse._sputils import is_pydata_spmatrix
+from scipy.sparse._sputils import is_pydata_spmatrix, convert_pydata_sparse_to_scipy
 from scipy.linalg import LinAlgError
 import copy
 
@@ -223,9 +223,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     >>> np.allclose(A.dot(x).toarray(), B.toarray())
     True
     """
-
-    if is_pydata_spmatrix(A):
-        A = A.to_scipy_sparse().tocsc()
+    A = convert_pydata_sparse_to_scipy(A)
+    b = convert_pydata_sparse_to_scipy(b)
 
     if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_matrix(A)
@@ -233,7 +232,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
              SparseEfficiencyWarning, stacklevel=2)
 
     # b is a vector only if b have shape (n,) or (n, 1)
-    b_is_sparse = issparse(b) or is_pydata_spmatrix(b)
+    b_is_sparse = issparse(b)
     if not b_is_sparse:
         b = asarray(b)
     b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(sparse is None,
                                 reason="pydata/sparse not installed")
 
 
-msg = "pydata/sparse (0.8) does not implement necessary operations"
+msg = "pydata/sparse (0.15.1) does not implement necessary operations"
 
 
 sparse_params = (pytest.param("COO"),
@@ -72,7 +72,7 @@ def test_lsmr(matrices):
     A_dense, A_sparse, b = matrices
     res0 = splin.lsmr(A_dense, b)
     res = splin.lsmr(A_sparse, b)
-    assert_allclose(res[0], res0[0], atol=1.8e-5)
+    assert_allclose(res[0], res0[0], atol=1e-3)
 
 
 # test issue 17012
@@ -158,7 +158,7 @@ def test_spsolve(matrices):
     x0 = splin.spsolve(sp.csc_matrix(A_dense),
                        sp.csc_matrix(A_dense))
     x = splin.spsolve(A_sparse, A_sparse)
-    assert isinstance(x, type(A_sparse))
+    assert isinstance(x, sp.csc_matrix)
     assert_allclose(x.toarray(), x0.toarray())
 
 
@@ -176,9 +176,9 @@ def test_splu(matrices):
     Pc = sparse_cls(sp.csc_matrix((np.ones(n), (np.arange(n), lu.perm_c))))
     A2 = Pr.T @ lu.L @ lu.U @ Pc.T
 
-    assert_allclose(A2.toarray(), A_sparse.toarray())
+    assert_allclose(A2.todense(), A_sparse.todense())
 
-    z = lu.solve(A_sparse.toarray())
+    z = lu.solve(A_sparse.todense())
     assert_allclose(z, np.eye(n), atol=1e-10)
 
 
@@ -191,7 +191,7 @@ def test_spilu(matrices):
     assert isinstance(lu.L, sparse_cls)
     assert isinstance(lu.U, sparse_cls)
 
-    z = lu.solve(A_sparse.toarray())
+    z = lu.solve(A_sparse.todense())
     assert_allclose(z, np.eye(len(b)), atol=1e-3)
 
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -158,8 +158,8 @@ def test_spsolve(matrices):
     x0 = splin.spsolve(sp.csc_matrix(A_dense),
                        sp.csc_matrix(A_dense))
     x = splin.spsolve(A_sparse, A_sparse)
-    assert isinstance(x, sp.csc_matrix)
-    assert_allclose(x.toarray(), x0.toarray())
+    assert isinstance(x, type(A_sparse))
+    assert_allclose(x.todense(), x0.todense())
 
 
 def test_splu(matrices):
@@ -172,8 +172,10 @@ def test_splu(matrices):
     assert isinstance(lu.L, sparse_cls)
     assert isinstance(lu.U, sparse_cls)
 
-    Pr = sparse_cls(sp.csc_matrix((np.ones(n), (lu.perm_r, np.arange(n)))))
-    Pc = sparse_cls(sp.csc_matrix((np.ones(n), (np.arange(n), lu.perm_c))))
+    _Pr_scipy = sp.csc_matrix((np.ones(n), (lu.perm_r, np.arange(n))))
+    _Pc_scipy = sp.csc_matrix((np.ones(n), (np.arange(n), lu.perm_c)))
+    Pr = sparse_cls.from_scipy_sparse(_Pr_scipy)
+    Pc = sparse_cls.from_scipy_sparse(_Pc_scipy)
     A2 = Pr.T @ lu.L @ lu.U @ Pc.T
 
     assert_allclose(A2.todense(), A_sparse.todense())
@@ -214,14 +216,14 @@ def test_inv(matrices):
     A_dense, A_sparse, b = matrices
     x0 = splin.inv(sp.csc_matrix(A_dense))
     x = splin.inv(A_sparse)
-    assert_allclose(x.toarray(), x0.toarray())
+    assert_allclose(x.todense(), x0.todense())
 
 
 def test_expm(matrices):
     A_dense, A_sparse, b = matrices
     x0 = splin.expm(sp.csc_matrix(A_dense))
     x = splin.expm(A_sparse)
-    assert_allclose(x.toarray(), x0.toarray())
+    assert_allclose(x.todense(), x0.todense())
 
 
 def test_expm_multiply(matrices):


### PR DESCRIPTION
Hi!
This PR adds simple support for `pydata/sparse` inputs to `scipy.sparse.csgraph`, similarly to `scipy.sparse.linalg`, where `pydata/sparse` is supported. 

Here, for now, by "support" I mean converting to `scipy` sparse format. 