### PR TITLE
ENH: stats.yeojohnson: improve bounds

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2291,7 +2291,7 @@ class TestYeojohnson:
         # Attempt to trigger overflow with a large optimal lambda.
         np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0]),
         # Attempt to trigger overflow with large data.
-        np.array([2003.0e200, 1950.0e200, 1997.0e200, 2000.0e200, 2009.0e200])
+        np.array([2003.0e300, 1950.0e300, 1997.0e300, 2000.0e300, 2009.0e300])
     ])
     def test_overflow(self, x):
         # non-regression test for gh-18389
@@ -2316,7 +2316,7 @@ class TestYeojohnson:
                   2009.0, 1980.0, 1999.0, 2007.0, 1991.0]),
         np.array([2003.0, 1950.0, 1997.0, 2000.0, 2009.0])
     ])
-    @pytest.mark.parametrize('scale', [1, 1e-12, 1e-32, 1e-150, 1e32, 1e200])
+    @pytest.mark.parametrize('scale', [1, 1e-12, 1e-32, 1e-147, 1e32, 1e300])
     @pytest.mark.parametrize('sign', [1, -1])
     def test_overflow_underflow_signed_data(self, x, scale, sign):
         # non-regression test for gh-18389


### PR DESCRIPTION
#### Reference issue
This is a follow-up improvement to #18852, which addressed under- and overflow in the Yeo-Johnson transform.

#### What does this implement/fix?
As [suggested](https://github.com/scipy/scipy/pull/18852#pullrequestreview-1531164724) by @mdhaber, this PR implements an exact* formula to determine the lower and upper bounds on lambda in the Yeo-Johnson transform to avoid underflow and overflow (on the given input data, but also on unknown future input).

Important notes about this PR:
1. This PR further increases the search space for lambda relative to the comparatively conservative bounds introduced by #18852.
2. Overflow can now be avoided for input data up to 1e303 (which is close to double precision's maximum of 1e308), up from about 1e200.
3. Underflow can unfortunately only be avoided for input data up to 1e-150, which is not an improvement over the current state. The reason for this is that other parts of Scipy, specifically the implementation of Brent's method in `scipy.optimize.fminbound`, are not equipped to deal with extremely small (or large) input data.
4. Instead of optimising over lambda directly, this PR optimizes over $λ' := \textrm{tanh}(λ)$. This is done because the increased search space for lambda (1) is sufficiently large that the implementation of Brent's method overflows. By optimising over the transformed lambda, we avoid that overflow.
5. *Under- and overflow can appear in two places: as the result of the Yeo-Johnson transform itself ($((1 + x) ^ λ - 1) / λ$), and in its numerator ($(1 + x) ^ λ - 1$). Overflow can be avoided by constraining lambda to an interval, but to avoid underflow a more complex constraint on lambda would need to be imposed in general. For that reason, underflow cannot be entirely avoided. Right now, the implementation accepts that underflow could in theory still occur in the numerator.