### PR TITLE
defect: sparse: 1d array row attribute should raise.

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1047,7 +1047,7 @@ def block_diag(mats, format=None, dtype=None):
         if issparse(a):
             a = a.tocoo()
             nrows, ncols = a._shape_as_2d
-            row.append(a.row_as_2d + r_idx)
+            row.append(a._row_as_2d + r_idx)
             col.append(a.col + c_idx)
             data.append(a.data)
         else:

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1047,7 +1047,7 @@ def block_diag(mats, format=None, dtype=None):
         if issparse(a):
             a = a.tocoo()
             nrows, ncols = a._shape_as_2d
-            row.append(a.row + r_idx)
+            row.append(a.row_as_2d + r_idx)
             col.append(a.col + c_idx)
             data.append(a.data)
         else:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -96,7 +96,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         self._check()
 
     @property
-    def row_as_2d(self):
+    def _row_as_2d(self):
         return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
 
     @property
@@ -273,7 +273,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         # This handles both 0D and 1D cases correctly regardless of the
         # original shape.
         M, N = self._shape_as_2d
-        coo_todense(M, N, self.nnz, self.row_as_2d, self.col, self.data,
+        coo_todense(M, N, self.nnz, self._row_as_2d, self.col, self.data,
                     B.ravel('A'), fortran)
         # Note: reshape() doesn't copy here, but does return a new array (view).
         return B.reshape(self.shape)
@@ -532,7 +532,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)
         M, N = self._shape_as_2d
-        coo_todense(M, N, self.nnz, self.row_as_2d, self.col, self.data,
+        coo_todense(M, N, self.nnz, self._row_as_2d, self.col, self.data,
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -96,9 +96,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
         self._check()
 
     @property
-    def row(self):
+    def row_as_2d(self):
         return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
 
+    @property
+    def row(self):
+        if self.ndim > 1:
+            return self.indices[-2]
+        raise ValueError('1d sparse arrays have no row attribute. Only `col`')
 
     @row.setter
     def row(self, new_row):
@@ -268,7 +273,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         # This handles both 0D and 1D cases correctly regardless of the
         # original shape.
         M, N = self._shape_as_2d
-        coo_todense(M, N, self.nnz, self.row, self.col, self.data,
+        coo_todense(M, N, self.nnz, self.row_as_2d, self.col, self.data,
                     B.ravel('A'), fortran)
         # Note: reshape() doesn't copy here, but does return a new array (view).
         return B.reshape(self.shape)
@@ -527,7 +532,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)
         M, N = self._shape_as_2d
-        coo_todense(M, N, self.nnz, self.row, self.col, self.data,
+        coo_todense(M, N, self.nnz, self.row_as_2d, self.col, self.data,
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -295,28 +295,28 @@ class _minmax_mixin:
         mat = self.tocoo()
         # Convert to canonical form: no duplicates, sorted indices.
         mat.sum_duplicates()
-        extreme_index = argmin_or_argmax(mat.data)
-        extreme_value = mat.data[extreme_index]
+        extreme_idx = argmin_or_argmax(mat.data)
+        extreme_value = mat.data[extreme_idx]
         num_col = mat.shape[-1]
 
         # If the min value is less than zero, or max is greater than zero,
         # then we do not need to worry about implicit zeros.
         if compare(extreme_value, zero):
             # cast to Python int to avoid overflow and RuntimeError
-            return int(mat.row[extreme_index]) * num_col + int(mat.col[extreme_index])
+            return int(mat.row_as_2d[extreme_idx]) * num_col + int(mat.col[extreme_idx])
 
         # Cheap test for the rare case where we have no implicit zeros.
         size = np.prod(self.shape)
         if size == mat.nnz:
-            return int(mat.row[extreme_index]) * num_col + int(mat.col[extreme_index])
+            return int(mat.row_as_2d[extreme_idx]) * num_col + int(mat.col[extreme_idx])
 
         # At this stage, any implicit zero could be the min or max value.
         # After sum_duplicates(), the `row` and `col` arrays are guaranteed to
         # be sorted in C-order, which means the linearized indices are sorted.
-        linear_indices = mat.row * num_col + mat.col
+        linear_indices = mat.row_as_2d * num_col + mat.col
         first_implicit_zero_index = _find_missing_index(linear_indices, size)
         if extreme_value == zero:
-            return min(first_implicit_zero_index, extreme_index)
+            return min(first_implicit_zero_index, extreme_idx)
         return first_implicit_zero_index
 
     def max(self, axis=None, out=None):

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -297,23 +297,23 @@ class _minmax_mixin:
         mat.sum_duplicates()
         extreme_idx = argmin_or_argmax(mat.data)
         extreme_value = mat.data[extreme_idx]
-        num_col = mat.shape[-1]
+        n_col = mat.shape[-1]
 
         # If the min value is less than zero, or max is greater than zero,
         # then we do not need to worry about implicit zeros.
         if compare(extreme_value, zero):
             # cast to Python int to avoid overflow and RuntimeError
-            return int(mat.row_as_2d[extreme_idx]) * num_col + int(mat.col[extreme_idx])
+            return int(mat._row_as_2d[extreme_idx]) * n_col + int(mat.col[extreme_idx])
 
         # Cheap test for the rare case where we have no implicit zeros.
         size = np.prod(self.shape)
         if size == mat.nnz:
-            return int(mat.row_as_2d[extreme_idx]) * num_col + int(mat.col[extreme_idx])
+            return int(mat._row_as_2d[extreme_idx]) * n_col + int(mat.col[extreme_idx])
 
         # At this stage, any implicit zero could be the min or max value.
         # After sum_duplicates(), the `row` and `col` arrays are guaranteed to
         # be sorted in C-order, which means the linearized indices are sorted.
-        linear_indices = mat.row_as_2d * num_col + mat.col
+        linear_indices = mat._row_as_2d * n_col + mat.col
         first_implicit_zero_index = _find_missing_index(linear_indices, size)
         if extreme_value == zero:
             return min(first_implicit_zero_index, extreme_idx)

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -148,13 +148,13 @@ def test_transpose_with_axis():
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
     assert np.array_equal(res.col, np.array([0, 1, 2]))
-    assert np.array_equal(res.row_as_2d, np.zeros_like(res.col))
-    assert res.row_as_2d.dtype == res.col.dtype
+    assert np.array_equal(res._row_as_2d, np.zeros_like(res.col))
+    assert res._row_as_2d.dtype == res.col.dtype
 
     res.col = [1, 2, 3]
     assert len(res.indices) == 1
     assert np.array_equal(res.col, np.array([1, 2, 3]))
-    assert res.row_as_2d.dtype == res.col.dtype
+    assert res._row_as_2d.dtype == res.col.dtype
 
     with pytest.raises(ValueError, match="1d sparse arrays have no row attribute"):
         res.row
@@ -219,7 +219,7 @@ def test_eliminate_zeros():
     assert arr1d.count_nonzero() == 1
     assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
     assert np.array_equal(arr1d.col, np.array([1]))
-    assert np.array_equal(arr1d.row_as_2d, np.array([0]))
+    assert np.array_equal(arr1d._row_as_2d, np.array([0]))
     with pytest.raises(ValueError, match="1d sparse arrays have no row attribute"):
         arr1d.row
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -148,14 +148,16 @@ def test_transpose_with_axis():
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
     assert np.array_equal(res.col, np.array([0, 1, 2]))
-    assert np.array_equal(res.row, np.zeros_like(res.col))
-    assert res.row.dtype == res.col.dtype
+    assert np.array_equal(res.row_as_2d, np.zeros_like(res.col))
+    assert res.row_as_2d.dtype == res.col.dtype
 
     res.col = [1, 2, 3]
     assert len(res.indices) == 1
     assert np.array_equal(res.col, np.array([1, 2, 3]))
-    assert res.row.dtype == res.col.dtype
+    assert res.row_as_2d.dtype == res.col.dtype
 
+    with pytest.raises(ValueError, match="1d sparse arrays have no row attribute"):
+        res.row
     with pytest.raises(ValueError, match="cannot set row attribute"):
         res.row = [1, 2, 3]
 
@@ -217,7 +219,9 @@ def test_eliminate_zeros():
     assert arr1d.count_nonzero() == 1
     assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
     assert np.array_equal(arr1d.col, np.array([1]))
-    assert np.array_equal(arr1d.row, np.array([0]))
+    assert np.array_equal(arr1d.row_as_2d, np.array([0]))
+    with pytest.raises(ValueError, match="1d sparse arrays have no row attribute"):
+        arr1d.row
 
 
 def test_1d_add_dense():


### PR DESCRIPTION
This is an attempt to address a concern raised in #18530 and scikit-learn/scikit-learn#28047.

The property `row` cannot be treated as a mutable array for 1d coo_arrays. We currently have `row` construct a row of zeros to mimic what the row would be like if the object was a 2d-array. But changing the result does not update the array's indices the way it does for a 2d-array. The use-case is to change the type of the indices `A.row` and `A.col`.

This potential confusion -- changing the type or value of `A.row` can be done, but doesn't affect the array object -- is here eliminated by raising on `A.row` for 1d sparse arrays. This is justified because the array has no row indices. `A.col` holds the indices of the explicit values of the array. But `A.row` is not well defined.

There are, of course, times when you want to treat the object as a 2d-array, e.g. when calling `sparsetools` 2d functionality with a 1d-array input. It can be treated as a 2d-array with 1 row of zeros. For cases where this is desired this PR creates a property `_row_as_2d`, to match `_shape_as_2d`. This new non-mutable property returns `np.zeros_like(self.col)`.

The discussion at the end of #18530 about handling of `row` can continue here with some example code to look at. Suggestions for better ways to handle it (or other PRs) are welcome.