### PR TITLE
BLD: set default `cpp_std` to `c++17`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project(
     'buildtype=debugoptimized',
     'b_ndebug=if-release',
     'c_std=c99',
-    'cpp_std=c++14',
+    'cpp_std=c++17',
     'fortran_std=legacy',
     'blas=openblas',
     'lapack=openblas'

--- a/scipy/io/_fast_matrix_market/meson.build
+++ b/scipy/io/_fast_matrix_market/meson.build
@@ -27,7 +27,6 @@ py3.extension_module('_fmm_core',
     'src/_fmm_core_write_coo_32.cpp',
     'src/_fmm_core_write_coo_64.cpp',
   ],
-  override_options: ['cpp_std=c++17'],
   cpp_args: [
     '-DFMM_SCIPY_PRUNE',
     '-DFMM_USE_FAST_FLOAT',


### PR DESCRIPTION
#### Reference issue
Closes gh-19726. The last action item apart from gh-15533 which is tracked there.

#### What does this implement/fix?
Changes the default `cpp_std` from `c++14` to `c++17`.

#### Additional information
Do we need to update https://docs.scipy.org/doc/scipy/dev/toolchain.html#c-language-standards?

cc @h-vetinari @rgommers 