### PR TITLE
MAINT: sparse.linalg: change `LinearOperator` exception message

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -590,7 +590,11 @@ class _CustomLinearOperator(LinearOperator):
             return super()._matmat(X)
 
     def _matvec(self, x):
-        return self.__matvec_impl(x)
+        if self.__matvec_impl is not None:
+            return self.__matvec_impl(x)
+        else:
+            raise TypeError("Tthis LinearOperator doesn't implement `rmatvec` nor `adjoint`,"
+                " and hence multiplying with it on the right-hand side is not supported.")
 
     def _rmatvec(self, x):
         func = self.__rmatvec_impl

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -593,7 +593,7 @@ class _CustomLinearOperator(LinearOperator):
         if self.__matvec_impl is not None:
             return self.__matvec_impl(x)
         else:
-            raise TypeError("Tthis LinearOperator doesn't implement `rmatvec` nor `adjoint`,"
+            raise TypeError("This LinearOperator doesn't implement `rmatvec` nor `adjoint`,"
                 " and hence multiplying with it on the right-hand side is not supported.")
 
     def _rmatvec(self, x):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes: #18140 
#### What does this implement/fix?
Changed exception message when multiplying LinearOperator from the right 
#### Additional information
<!--Any additional information you think is important.-->
