### PR TITLE
MAINT: uarray CXX version hex cleanup

### DIFF
--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1775,8 +1775,8 @@ PyModuleDef uarray_module = {
 
 } // namespace
 
-PyMODINIT_FUNC
-PyInit__uarray(void) {
+
+PyMODINIT_FUNC PyInit__uarray(void) {
 
   auto m = py_ref::steal(PyModule_Create(&uarray_module));
   if (!m)

--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1775,18 +1775,7 @@ PyModuleDef uarray_module = {
 
 } // namespace
 
-// Can be removed when Python 3.9 is the lowest supported version,
-// see gh-16165 for details.
-#if (PY_VERSION_HEX < 0x03090000)
-#  if defined(WIN32) || defined(_WIN32)
-#    define MODULE_EXPORT __declspec(dllexport)
-#  else
-#    define MODULE_EXPORT __attribute__((visibility("default")))
-#  endif
-extern "C" MODULE_EXPORT PyObject *
-#else
 PyMODINIT_FUNC
-#endif
 PyInit__uarray(void) {
 
   auto m = py_ref::steal(PyModule_Create(&uarray_module));

--- a/scipy/_lib/_uarray/vectorcall.cxx
+++ b/scipy/_lib/_uarray/vectorcall.cxx
@@ -35,112 +35,6 @@ static PyObject * build_kwarg_dict(
   }
   return dict;
 }
-#elif (PY_VERSION_HEX < 0x03090000)
-// clang-format off
-
-static int is_method_descr(PyTypeObject* descr_tp) {
-    return (
-        (descr_tp->tp_flags & Q_Py_TPFLAGS_METHOD_DESCRIPTOR) != 0 ||
-        (descr_tp == &PyFunction_Type) ||
-        (descr_tp == &PyMethodDescr_Type));
-}
-
-/* The below code is derivative of CPython source, and is taken because
-_PyObject_GetMethod is not exported from shared objects.
-
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
-All Rights Reserved
-*/
-
-/* Specialized version of _PyObject_GenericGetAttrWithDict
-   specifically for the LOAD_METHOD opcode.
-
-   Return 1 if a method is found, 0 if it's a regular attribute
-   from __dict__ or something returned by using a descriptor
-   protocol.
-
-   `method` will point to the resolved attribute or NULL.  In the
-   latter case, an error will be set.
-*/
-static int _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
-{
-    PyTypeObject *tp = Py_TYPE(obj);
-    PyObject *descr;
-    descrgetfunc f = NULL;
-    PyObject **dictptr, *dict;
-    PyObject *attr;
-    int meth_found = 0;
-
-    assert(*method == NULL);
-
-    if (Py_TYPE(obj)->tp_getattro != PyObject_GenericGetAttr
-            || !PyUnicode_Check(name)) {
-        *method = PyObject_GetAttr(obj, name);
-        return 0;
-    }
-
-    if (tp->tp_dict == NULL && PyType_Ready(tp) < 0)
-        return 0;
-
-    descr = _PyType_Lookup(tp, name);
-    if (descr != NULL) {
-        Py_INCREF(descr);
-        if (is_method_descr(Py_TYPE(descr))) {
-            meth_found = 1;
-        } else {
-            f = Py_TYPE(descr)->tp_descr_get;
-            if (f != NULL && PyDescr_IsData(descr)) {
-                *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
-                Py_DECREF(descr);
-                return 0;
-            }
-        }
-    }
-
-    dictptr = _PyObject_GetDictPtr(obj);
-    if (dictptr != NULL && (dict = *dictptr) != NULL) {
-        Py_INCREF(dict);
-        attr = PyDict_GetItemWithError(dict, name);
-        if (attr != NULL) {
-            Py_INCREF(attr);
-            *method = attr;
-            Py_DECREF(dict);
-            Py_XDECREF(descr);
-            return 0;
-        }
-        else {
-            Py_DECREF(dict);
-            if (PyErr_Occurred()) {
-                Py_XDECREF(descr);
-                return 0;
-            }
-        }
-    }
-
-    if (meth_found) {
-        *method = descr;
-        return 1;
-    }
-
-    if (f != NULL) {
-        *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
-        Py_DECREF(descr);
-        return 0;
-    }
-
-    if (descr != NULL) {
-        *method = descr;
-        return 0;
-    }
-
-    PyErr_Format(PyExc_AttributeError,
-                 "'%.50s' object has no attribute '%U'",
-                 tp->tp_name, name);
-    return 0;
-}
-
-// clang-format on
 #endif /* PYPY_VERSION */
 
 
@@ -165,14 +59,8 @@ PyObject * Q_PyObject_Vectorcall(
   PyObject * ret = Q_PyObject_VectorcallDict(callable, args, nargs, dict);
   Py_XDECREF(dict);
   return ret;
-#elif (PY_VERSION_HEX >= 0x03090000)
-  return PyObject_Vectorcall(callable, args, nargsf, kwnames);
-#elif (PY_VERSION_HEX >= 0x03080000)
-  return _PyObject_Vectorcall(callable, args, nargsf, kwnames);
 #else
-  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
-  return _PyObject_FastCallKeywords(
-      callable, (PyObject **)args, nargs, kwnames);
+  return PyObject_Vectorcall(callable, args, nargsf, kwnames);
 #endif
 }
 
@@ -188,11 +76,8 @@ PyObject * Q_PyObject_VectorcallDict(
   PyObject * ret = PyObject_Call(callable, tuple, kwdict);
   Py_DECREF(tuple);
   return ret;
-#elif (PY_VERSION_HEX >= 0x03090000)
-  return PyObject_VectorcallDict(callable, args, nargsf, kwdict);
 #else
-  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
-  return _PyObject_FastCallDict(callable, (PyObject **)args, nargs, kwdict);
+  return PyObject_VectorcallDict(callable, args, nargsf, kwdict);
 #endif
 }
 
@@ -208,28 +93,7 @@ PyObject * Q_PyObject_VectorcallMethod(
       Q_PyObject_Vectorcall(callable, &args[1], nargsf - 1, kwnames);
   Py_DECREF(callable);
   return result;
-#elif (PY_VERSION_HEX >= 0x03090000)
-  return PyObject_VectorcallMethod(name, args, nargsf, kwnames);
 #else
-  /* Private CPython code for CALL_METHOD opcode */
-  PyObject * callable = NULL;
-  int unbound = _PyObject_GetMethod(args[0], name, &callable);
-  if (callable == NULL) {
-    return NULL;
-  }
-
-  if (unbound) {
-    /* We must remove PY_VECTORCALL_ARGUMENTS_OFFSET since
-     * that would be interpreted as allowing to change args[-1] */
-    nargsf &= ~Q_PY_VECTORCALL_ARGUMENTS_OFFSET;
-  } else {
-    /* Skip "self". We can keep PY_VECTORCALL_ARGUMENTS_OFFSET since
-     * args[-1] in the onward call is args[0] here. */
-    args++;
-    nargsf--;
-  }
-  PyObject * result = Q_PyObject_Vectorcall(callable, args, nargsf, kwnames);
-  Py_DECREF(callable);
-  return result;
+  return PyObject_VectorcallMethod(name, args, nargsf, kwnames);
 #endif
 }

--- a/scipy/_lib/_uarray/vectorcall.h
+++ b/scipy/_lib/_uarray/vectorcall.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 // True if python supports vectorcall on custom classes
-#if (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
+#if (!defined(PYPY_VERSION))
 #  define Q_HAS_VECTORCALL 1
 #else
 #  define Q_HAS_VECTORCALL 0
@@ -14,10 +14,8 @@ extern "C" {
 
 #if !Q_HAS_VECTORCALL
 #  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0
-#elif (PY_VERSION_HEX >= 0x03090000)
-#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
 #else
-#  define Q_Py_TPFLAGS_HAVE_VECTORCALL _Py_TPFLAGS_HAVE_VECTORCALL
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
 #endif
 
 #if !Q_HAS_VECTORCALL

--- a/scipy/_lib/_uarray/vectorcall.h
+++ b/scipy/_lib/_uarray/vectorcall.h
@@ -6,31 +6,16 @@ extern "C" {
 #endif
 
 // True if python supports vectorcall on custom classes
-#if (!defined(PYPY_VERSION))
-#  define Q_HAS_VECTORCALL 1
-#else
-#  define Q_HAS_VECTORCALL 0
-#endif
-
-#if !Q_HAS_VECTORCALL
+#ifdef PYPY_VERSION
 #  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0
-#else
-#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
-#endif
-
-#if !Q_HAS_VECTORCALL
 #  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR 0
-#else
-#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR Py_TPFLAGS_METHOD_DESCRIPTOR
-#endif
-
-#if !Q_HAS_VECTORCALL
 #  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET                                     \
     ((size_t)1 << (8 * sizeof(size_t) - 1))
 #else
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
+#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR Py_TPFLAGS_METHOD_DESCRIPTOR
 #  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET PY_VECTORCALL_ARGUMENTS_OFFSET
 #endif
-
 
 Py_ssize_t Q_PyVectorcall_NARGS(size_t n);
 

--- a/scipy/_lib/_uarray/vectorcall.h
+++ b/scipy/_lib/_uarray/vectorcall.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-// True if python supports vectorcall on custom classes
 #ifdef PYPY_VERSION
 #  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0
 #  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR 0


### PR DESCRIPTION
* I don't usually touch `uarray` stuff, but it looks like we can purge out ~150 lines of code
now that we no longer need these version hex checks?

[skip cirrus]