### PR TITLE
TST: linalg: Test Cython LAPACK complex ladiv

### DIFF
--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -446,6 +446,12 @@ def _test_slamch(cmach):
     # must be passed as a part of the function call.
     cdef char* cmach_char = cmach_bytes
     return slamch(cmach_char)
+
+cpdef double complex _test_zladiv(double complex zx, double complex zy) noexcept nogil:
+    return zladiv(&zx, &zy)
+
+cpdef float complex _test_cladiv(float complex cx, float complex cy) noexcept nogil:
+    return cladiv(&cx, &cy)
 """
 
 

--- a/scipy/linalg/tests/test_cython_lapack.py
+++ b/scipy/linalg/tests/test_cython_lapack.py
@@ -15,3 +15,8 @@ class TestLamch:
             assert_allclose(cython_lapack._test_dlamch(c),
                             lapack.dlamch(c))
 
+    def test_complex_ladiv(self):
+        cx = .5 + 1.j
+        cy = .875 + 2.j
+        assert_allclose(cython_lapack._test_zladiv(cy, cx), 1.95+0.1j)
+        assert_allclose(cython_lapack._test_cladiv(cy, cx), 1.95+0.1j)


### PR DESCRIPTION
In my experience, modifying the BLAS/LAPACK interface often causes functions with complex return values to have inconsistent behavior across platforms. With ILP64 support and other changes slated for the near future, this PR completes test coverage of these functions by adding tests for `[c/d]ladiv` on top of the existing tests for `[c/z]dot[c/u]`.
