### PR TITLE
BLD: propack: resolve missing return value warnings

### DIFF
--- a/scipy/sparse/linalg/_propack/cpropack.pyf
+++ b/scipy/sparse/linalg/_propack/cpropack.pyf
@@ -2,7 +2,7 @@
 
 python module __user__routines
     interface
-        function caprod(transa,m,n,x,y,cparm,iparm)
+        subroutine caprod(transa,m,n,x,y,cparm,iparm)
            character*1 :: transa
            integer intent(in) :: m
            integer intent(in) :: n
@@ -10,7 +10,7 @@ python module __user__routines
            complex precision depend(m,n),check(len(y)>=(transa[0] == 'n' ? m : n)),dimension((transa[0] == 'n' ? m : n)) :: y
            integer dimension(*) :: iparm
            complex dimension(*) :: cparm
-        end function caprod
+        end subroutine caprod
     end interface
 end python module __user__routines
 

--- a/scipy/sparse/linalg/_propack/dpropack.pyf
+++ b/scipy/sparse/linalg/_propack/dpropack.pyf
@@ -2,7 +2,7 @@
 
 python module __user__routines
     interface
-        function daprod(transa,m,n,x,y,dparm,iparm)
+        subroutine daprod(transa,m,n,x,y,dparm,iparm)
            character*1 :: transa
            integer intent(in) :: m
            integer intent(in) :: n
@@ -10,7 +10,7 @@ python module __user__routines
            double precision depend(m,n),check(len(y)>=(transa[0] == 'n' ? m : n)),dimension((transa[0] == 'n' ? m : n)) :: y
            integer dimension(*) :: iparm
            double precision dimension(*) :: dparm
-        end function daprod
+        end subroutine daprod
     end interface
 end python module __user__routines
 

--- a/scipy/sparse/linalg/_propack/spropack.pyf
+++ b/scipy/sparse/linalg/_propack/spropack.pyf
@@ -2,7 +2,7 @@
 
 python module __user__routines
     interface
-        function saprod(transa,m,n,x,y,dparm,iparm)
+        subroutine saprod(transa,m,n,x,y,dparm,iparm)
            character*1 :: transa
            integer intent(in) :: m
            integer intent(in) :: n
@@ -10,7 +10,7 @@ python module __user__routines
            real depend(m,n),check(len(y)>=(transa[0] == 'n' ? m : n)),dimension((transa[0] == 'n' ? m : n)) :: y
            integer dimension(*) :: iparm
            real dimension(*) :: dparm
-        end function saprod
+        end subroutine saprod
     end interface
 end python module __user__routines
 

--- a/scipy/sparse/linalg/_propack/zpropack.pyf
+++ b/scipy/sparse/linalg/_propack/zpropack.pyf
@@ -2,7 +2,7 @@
 
 python module __user__routines
     interface
-        function zaprod(transa,m,n,x,y,zparm,iparm)
+        subroutine zaprod(transa,m,n,x,y,zparm,iparm)
            character*1 :: transa
            integer intent(in) :: m
            integer intent(in) :: n
@@ -10,7 +10,7 @@ python module __user__routines
            complex*16 intent(in,out),dimension((transa[0] == 'n' ? m : n)) :: y
            integer dimension(*) :: iparm
            complex*16 dimension(*) :: zparm
-        end function zaprod
+        end subroutine zaprod
     end interface
 end python module __user__routines
 


### PR DESCRIPTION
This resolves a compiler-specific warning that I encountered at some point during my testing with either MSVC or the Intel compilers (don't remember which).