### PR TITLE
MAINT: `CODEOWNERS` syntax fix and changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,23 +14,28 @@
 
 # Build related files
 pyproject.toml  @rgommers
+tools/generate_requirements.py  @rgommers
+requirements/  @rgommers
 environment.yml  @rgommers
 meson*  @rgommers
 
+# Dev CLI
+dev.py  @rgommers
+
 # SciPy submodules (please keep in alphabetical order)
-scipy/fft/*  @peterbell10
-scipy/fftpack/*  @peterbell10
-scipy/linalg/*  @larsoner @ilayn
-scipy/integrate/* @steppi
-scipy/interpolate/*  @ev-br
-scipy/optimize/*  @andyfaff
-scipy/signal/*  @larsoner @ilayn
-scipy/sparse/*  @perimosocordiae
-scipy/spatial/*  @tylerjereddy @peterbell10
-scipy/special/*  @person142 @steppi
-scipy/stats/_distn_infrastructure  @andyfaff @ev-br
+scipy/fft/  @peterbell10
+scipy/fftpack/  @peterbell10
+scipy/linalg/  @larsoner @ilayn
+scipy/integrate/ @steppi
+scipy/interpolate/  @ev-br
+scipy/optimize/  @andyfaff
+scipy/signal/  @larsoner @ilayn
+scipy/sparse/  @perimosocordiae
+scipy/spatial/  @tylerjereddy @peterbell10
+scipy/special/  @person142 @steppi
+scipy/stats/_distn_infrastructure/  @andyfaff @ev-br
 scipy/stats/*distr*.py  @ev-br
-scipy/stats/_continuous_distns  @andyfaff
+scipy/stats/_continuous_distns/  @andyfaff
 scipy/stats/_covariance.py  @mdhaber
 scipy/stats/_hypothesis.py  @tupui
 scipy/stats/*qmc.*  @tupui
@@ -39,22 +44,22 @@ scipy/stats/_resampling.py  @mdhaber
 scipy/stats/*sobol*  @tupui
 scipy/stats/_sensitivity_analysis.py  @tupui
 scipy/stats/_survival.py  @tupui @mdhaber
-scipy/stats/.unuran/*  @tirthasheshpatel
+scipy/stats/.unuran/  @tirthasheshpatel
 
 # Testing infrastructure
-ci/*  @larsoner @andyfaff
+ci/  @larsoner @andyfaff
 tools/refguide_check.py  @ev-br
-tools/*  @larsoner @rgommers
+tools/  @larsoner @rgommers
 pytest.ini  @larsoner
-tox.ini  @larsoner
 .coveragerc  @larsoner
 benchmarks/asv.conf.json  @larsoner
 
 # CI config
-.circleci/*  @larsoner
-.github/*  @larsoner @andyfaff
+.circleci/  @larsoner
+.github/workflows/  @larsoner @andyfaff
+.cirrus.star  @larsoner @andyfaff
 
 # Doc
-doc_requirements.txt  @tupui
+requirements/doc.txt  @tupui
 doc/source/conf.py  @tupui
-doc/source/_static/*  @tupui
+doc/source/_static/  @tupui


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
- As per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file, our syntax isn't quite right. I noticed that sometimes reviews were not requested when nested files were modified, but top-level files remained the same. 99% sure this isn't deliberate but maybe I'm wrong.
- Also made some changes for things that are outdated and made some additions.

#### Additional information
I imagine there are other changes that would make sense as well, maybe this is a good opportunity to reconsider the entries. Or we can just go with these changes.