### PR TITLE
MAINT: spatial: fix build warnings in `ckdtree` code

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1624,7 +1624,7 @@ cdef np.intp_t num_points(np.ndarray x, np.intp_t pdim) except -1:
         n *= x.shape[i]
     return n
 
-cdef np.ndarray broadcast_contiguous(object x, tuple shape, object dtype) except +:
+cdef np.ndarray broadcast_contiguous(object x, tuple shape, object dtype):
     """Broadcast ``x`` to ``shape`` and make contiguous, possibly by copying"""
     # Avoid copying if possible
     try:
@@ -1633,7 +1633,7 @@ cdef np.ndarray broadcast_contiguous(object x, tuple shape, object dtype) except
     except AttributeError:
         pass
 
-    # Assignment will broadcast automatically
+    # Assignment will broadcast automatically (may raise ValueError)
     cdef np.ndarray ret = np.empty(shape, dtype)
     ret[...] = x
     return ret

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -25,7 +25,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
     const double *data = self->raw_data;
     ckdtree_intp_t *indices = (intptr_t *)(self->raw_indices);
 
-    ckdtreenode new_node, *n, *root;
+    ckdtreenode new_node = {}, *n, *root;
     ckdtree_intp_t node_index, _less, _greater;
     ckdtree_intp_t i, j, p, d;
     double size, split, minval, maxval;


### PR DESCRIPTION
First warning:

```
[5/8] Compiling C++ object scipy/spatial/_ckdtree.cpython-310-x86_64-linux-gnu.so.p/ckdtree_src_build.cxx.o
In file included from /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/x86_64-conda-linux-gnu/bits/c++allocator.h:33,
                 from /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/allocator.h:46,
                 from /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/vector:61,
                 from ../scipy/spatial/ckdtree/src/ordered_pair.h:5,
                 from ../scipy/spatial/ckdtree/src/ckdtree_decl.h:19,
                 from ../scipy/spatial/ckdtree/src/build.cxx:1:
In member function 'void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = ckdtreenode; _Args = {const ckdtreenode&}; _Tp = ckdtreenode]',
    inlined from 'static void std::allocator_traits<std::allocator<_Tp1> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = ckdtreenode; _Args = {const ckdtreenode&}; _Tp = ckdtreenode]' at /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/alloc_traits.h:516:17,
    inlined from 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = ckdtreenode; _Alloc = std::allocator<ckdtreenode>]' at /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/stl_vector.h:1281:30,
    inlined from 'npy_intp build(ckdtree*, npy_intp, intptr_t, double*, double*, int, int)' at ../scipy/spatial/ckdtree/src/build.cxx:34:33:
/home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/new_allocator.h:175:11: warning: 'new_node' may be used uninitialized [-Wmaybe-uninitialized]
  175 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../scipy/spatial/ckdtree/src/build.cxx: In function 'npy_intp build(ckdtree*, npy_intp, intptr_t, double*, double*, int, int)':
../scipy/spatial/ckdtree/src/build.cxx:28:17: note: 'new_node' declared here
   28 |     ckdtreenode new_node, *n, *root;
      |                 ^~~~~~~~
In file included from /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/vector:64:
In member function 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = ckdtreenode; _Alloc = std::allocator<ckdtreenode>]',
    inlined from 'npy_intp build(ckdtree*, npy_intp, intptr_t, double*, double*, int, int)' at ../scipy/spatial/ckdtree/src/build.cxx:34:33:
/home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/stl_vector.h:1287:28: warning: 'new_node' may be used uninitialized [-Wmaybe-uninitialized]
 1287 |           _M_realloc_insert(end(), __x);
      |           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
In file included from /home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/vector:70:
/home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/vector.tcc: In function 'npy_intp build(ckdtree*, npy_intp, intptr_t, double*, double*, int, int)':
/home/rgommers/mambaforge/envs/scipy-dev/x86_64-conda-linux-gnu/include/c++/12.2.0/bits/vector.tcc:439:7: note: by argument 3 of type 'const ckdtreenode&' to 'void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {const ckdtreenode&}; _Tp = ckdtreenode; _Alloc = std::allocator<ckdtreenode>]' declared here
  439 |       vector<_Tp, _Alloc>::
      |       ^~~~~~~~~~~~~~~~~~~
../scipy/spatial/ckdtree/src/build.cxx:28:17: note: 'new_node' declared here
   28 |     ckdtreenode new_node, *n, *root;
      |                 ^~~~~~~~
```

Second warning:

```
[6/8] Generating 'scipy/spatial/_ckdtree.cpython-310-x86_64-linux-gnu.so.p/_ckdtree.cpp'
warning: /home/rgommers/code/scipy/scipy/spatial/_ckdtree.pyx:1627:5: Only extern functions can throw C++ exceptions.
```

This second one is due to the changes in Cython 3. This function is returning a Python object, and hence no `except` clause is needed at all anymore.