### PR TITLE
CI/DEV: fix and simplify `label-globs` syntax

### DIFF
--- a/.github/label-globs.yml
+++ b/.github/label-globs.yml
@@ -4,109 +4,109 @@
 scipy.cluster:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/cluster/**/*
+    - scipy/cluster/**
 
 scipy.constants:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/constants/**/*
+    - scipy/constants/**
 
 scipy.fft:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/fft/**/*
+    - scipy/fft/**
 
 scipy.fftpack:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/fftpack/**/*
+    - scipy/fftpack/**
 
 scipy.integrate:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/integrate/**/*
+    - scipy/integrate/**
 
 scipy.interpolate:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/interpolate/**/*
+    - scipy/interpolate/**
 
 scipy.io:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/io/**/*
+    - scipy/io/**
 
 scipy._lib:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/_lib/**/*
+    - scipy/_lib/**
 
 scipy.linalg:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/linalg/**/*
+    - scipy/linalg/**
 
 scipy.misc:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/misc/**/*
+    - scipy/misc/**
 
 scipy.ndimage:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/ndimage/**/*
+    - scipy/ndimage/**
 
 scipy.odr:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/odr/**/*
+    - scipy/odr/**
 
 scipy.optimize:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/optimize/**/*
+    - scipy/optimize/**
 
 scipy.signal:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/signal/**/*
+    - scipy/signal/**
 
 scipy.sparse:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/sparse/**/*
+    - scipy/sparse/**
 
 scipy.sparse.csgraph:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/sparse/csgraph/**/*
+    - scipy/sparse/csgraph/**
 
 scipy.sparse.linalg:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/sparse/linalg/**/*
+    - scipy/sparse/linalg/**
 
 scipy.spatial:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/spatial/**/*
+    - scipy/spatial/**
 
 scipy.special:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/special/**/*
+    - scipy/special/**
 
 scipy.stats:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/stats/**/*
+    - scipy/stats/**
 
 Cython:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/**/*.pyx.*
-    - scipy/**/*.pxd.*
-    - scipy/**/*.pxi.*
+    - scipy/**/*.pyx*
+    - scipy/**/*.pxd*
+    - scipy/**/*.pxi*
     - scipy/**/_generate_pyx.py
 
 Fortran:
@@ -145,28 +145,28 @@ Meson:
 Documentation:
 - changed-files:
   - any-glob-to-any-file:
-    - doc/**/*
+    - doc/**
 
 CI:
 - changed-files:
   - any-glob-to-any-file:
-    - .circleci/**/*
-    - .github/workflows/**/*
-    - ci/**/*
+    - .circleci/**
+    - .github/workflows/**
+    - ci/**
     - .cirrus.star
 
 DX:
 - changed-files:
   - any-glob-to-any-file:
-    - doc/source/dev/**/*
+    - doc/source/dev/**
 
 BLD:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/_build_utils/**/*
+    - scipy/_build_utils/**
 
 uarray:
 - changed-files:
   - any-glob-to-any-file:
-    - scipy/_lib/_uarray/**/*
+    - scipy/_lib/_uarray/**
     - scipy/_lib/uarray.py


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
- The syntax was broken for Cython - `.pyx.in` files were matched, but `.pyx` files were not. https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html
- Also simplifies syntax where redundant characters were included.