### PR TITLE
MAINT: interpolate: fix build warning from `_ppoly.pyx`

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -181,7 +181,6 @@ def evaluate_nd(const double_or_complex[:,:,::1] c,
         # grab array pointers
         nxx[ip] = y.shape[0]
         xx[ip] = <double*>&y[0]
-        y = None
 
     if c.shape[1] != ntot:
         raise ValueError("xs and c have incompatible shapes")


### PR DESCRIPTION
This warning is new with GCC 12 (and a false positive, see discussion in [cython#5937](https://github.com/cython/cython/issues/5937)):

```
[6/7] Compiling C object scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/meson-generated__ppoly.c.o
In function '__Pyx_XCLEAR_MEMVIEW',
    inlined from '__pyx_pf_5scipy_11interpolate_6_ppoly_20evaluate_nd' at scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:22469:5,
    inlined from '__pyx_fuse_0__pyx_pw_5scipy_11interpolate_6_ppoly_21evaluate_nd' at scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:22135:13:
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:1577:46: warning: '__sync_fetch_and_sub_4' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
 1577 |     #define __pyx_atomic_decr_aligned(value) __sync_fetch_and_sub(value, 1)
      |                                              ^~~~~~~~~~~~~~~~~~~~
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:1604:13: note: in expansion of macro '__pyx_atomic_decr_aligned'
 1604 |             __pyx_atomic_decr_aligned(__pyx_get_slice_count_pointer(memview))
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:46077:29: note: in expansion of macro '__pyx_sub_acquisition_count'
46077 |     old_acquisition_count = __pyx_sub_acquisition_count(memview);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rgommers/mambaforge/envs/scipy-dev/include/python3.10/Python.h:74,
                 from scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:16:
/home/rgommers/mambaforge/envs/scipy-dev/include/python3.10/object.h: In function '__pyx_fuse_0__pyx_pw_5scipy_11interpolate_6_ppoly_21evaluate_nd':
/home/rgommers/mambaforge/envs/scipy-dev/include/python3.10/object.h:605:22: note: at offset 56 into destination object '_Py_NoneStruct' of size 16
  605 | PyAPI_DATA(PyObject) _Py_NoneStruct; /* Don't use this directly */
      |                      ^~~~~~~~~~~~~~
In function '__Pyx_XCLEAR_MEMVIEW',
    inlined from '__pyx_pf_5scipy_11interpolate_6_ppoly_22evaluate_nd' at scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:23624:5,
    inlined from '__pyx_fuse_1__pyx_pw_5scipy_11interpolate_6_ppoly_23evaluate_nd' at scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:23290:13:
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:1577:46: warning: '__sync_fetch_and_sub_4' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
 1577 |     #define __pyx_atomic_decr_aligned(value) __sync_fetch_and_sub(value, 1)
      |                                              ^~~~~~~~~~~~~~~~~~~~
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:1604:13: note: in expansion of macro '__pyx_atomic_decr_aligned'
 1604 |             __pyx_atomic_decr_aligned(__pyx_get_slice_count_pointer(memview))
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
scipy/interpolate/_ppoly.cpython-310-x86_64-linux-gnu.so.p/_ppoly.c:46077:29: note: in expansion of macro '__pyx_sub_acquisition_count'
46077 |     old_acquisition_count = __pyx_sub_acquisition_count(memview);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rgommers/mambaforge/envs/scipy-dev/include/python3.10/object.h: In function '__pyx_fuse_1__pyx_pw_5scipy_11interpolate_6_ppoly_23evaluate_nd':
/home/rgommers/mambaforge/envs/scipy-dev/include/python3.10/object.h:605:22: note: at offset 56 into destination object '_Py_NoneStruct' of size 16
  605 | PyAPI_DATA(PyObject) _Py_NoneStruct; /* Don't use this directly */
      |                      ^~~~~~~~~~~~~~
```

Avoiding use of `None`, which didn't seem to do anything anyway, avoids the warning being generated.
