### PR TITLE
MAINT: special: fix meson deprecation warning

### DIFF
--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -428,21 +428,9 @@ special_cephes_sources = [
   'special/cephes/beta.h',
   'special/cephes/gamma.h'
 ]
+
 py3.install_sources(special_sources, subdir: 'scipy/special/special')
-foreach header: special_sources
-  fs.copyfile(header)
-endforeach
-
-
-foreach header: special_cephes_sources
-  configure_file(
-    input: header,
-    output: header.split('/')[-1],
-    copy: true,
-    install: true,
-    install_dir: py3.get_install_dir() / 'scipy/special/special/cephes'
-  )
-endforeach
+py3.install_sources(special_cephes_sources, subdir: 'scipy/special/special/cephes')
 
 python_sources = [
   '__init__.py',


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
gh-19681 introduced a deprecation warning into the build @steppi . This fixes that by replacing `configure_file` with `fs.copyfile`.

#### Additional information
`../scipy/special/meson.build:438: WARNING: Project targets '>= 1.1.0' but uses feature deprecated since '0.64.0': copy arg in configure_file. Use fs.copyfile instead`
