### PR TITLE
DOC: Add `fft` to list of submodules in tutorial

### DIFF
--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -25,7 +25,8 @@ Subpackage          Description
 ==================  ======================================================
 `cluster`           Clustering algorithms
 `constants`         Physical and mathematical constants
-`fftpack`           Fast Fourier Transform routines
+`fft`               Discrete Fourier transforms
+`fftpack`           Fast Fourier Transform routines (legacy)
 `integrate`         Integration and ordinary differential equation solvers
 `interpolate`       Interpolation and smoothing splines
 `io`                Input and Output


### PR DESCRIPTION
Hello!

I made a quick look at the first good issues and found that one, is it as minimal as it looks? 
Is there a local documentation built along when I run `python dev.py test -v ` ?

I'd be happy to contribute, please let me know

#### Reference issue
Closes #19835 

#### What does this implement/fix?

In [scipy/doc/source/tutorial/index.rst](https://github.com/scipy/scipy/blob/e7c6a0d1ce504c528ab00d19ddac6bdb1ae1cb36/doc/source/tutorial/index.rst?plain=1#L17-L41) :

- Add `fft` module to the list of scipy submodules
- Add legacy mention to `fftpack`

