### PR TITLE
TST: fix more cases of fd leaks from np.load()

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1614,12 +1614,12 @@ class TestSmoothingSpline:
 
         """
         # load the data sample
-        data = np.load(data_file('gcvspl.npz'))
-        # data points
-        x = data['x']
-        y = data['y']
+        with np.load(data_file('gcvspl.npz')) as data:
+            # data points
+            x = data['x']
+            y = data['y']
 
-        y_GCVSPL = data['y_GCVSPL']
+            y_GCVSPL = data['y_GCVSPL']
         y_compr = make_smoothing_spline(x, y)(x)
 
         # such tolerance is explained by the fact that the spline is built

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -357,7 +357,8 @@ class TestBisplrep:
 
     def test_regression_1310(self):
         # Regression test for gh-1310
-        data = np.load(data_file('bug-1310.npz'))['data']
+        with np.load(data_file('bug-1310.npz')) as loaded_data:
+            data = loaded_data['data']
 
         # Shouldn't crash -- the input data triggers work array sizes
         # that caused previously some data to not be aligned on

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -129,12 +129,11 @@ def test_examples(dtype, irl):
     # PROPACK 2.1: http://sun.stanford.edu/~rmunk/PROPACK/
     relative_path = "propack_test_data.npz"
     filename = os.path.join(path_prefix, relative_path)
-    data = np.load(filename, allow_pickle=True)
-
-    if is_complex_type(dtype):
-        A = data['A_complex'].item().astype(dtype)
-    else:
-        A = data['A_real'].item().astype(dtype)
+    with np.load(filename, allow_pickle=True) as data:
+        if is_complex_type(dtype):
+            A = data['A_complex'].item().astype(dtype)
+        else:
+            A = data['A_real'].item().astype(dtype)
 
     k = 200
     u, s, vh, _ = _svdp(A, k, irl_mode=irl, random_state=0)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
n/a

#### What does this implement/fix?
Fix a few more cases of `np.load()` results not being closed. To confirm them, I've used the following hack:

```
from test.support.os_helper import fd_count

@pytest.fixture(autouse=True)
def fd_leak():
    before = fd_count()
    yield
    assert fd_count() == before
```

#### Additional information
Suggested in https://github.com/scipy/scipy/issues/19553#issuecomment-1883040331

With the hack, I'm seeing some more tests failing with possible fd leaks but I don't have the energy right now to try to confirm them better and/or figure out where they come from.