### PR TITLE
CI: fix prerelease job to use numpy 2.0, and add a second job to test ABI compat

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -279,7 +279,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        # Both use numpy 2.0-dev at build time; 3.9 job then downgrades to
+        # lowest supported NumPy version in order to test ABI compatibility.
+        python-version: ['3.9', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -343,10 +345,15 @@ jobs:
       shell: bash -l {0}
       run: ccache -s
 
+    - name: Downgrade NumPy from 2.0-dev to lowest supported
+      if: matrix.python-version == '3.9'
+      run: |
+        python -m pip install "numpy==1.22.4"
+
     - name: Test SciPy
       run: |
         export OPENBLAS_NUM_THREADS=1
-        python dev.py test -j2 --mode full -- --cov --cov-report term-missing 
+        python dev.py --no-build test -j2 --mode full -- --cov --cov-report term-missing
 
   #################################################################################
   linux_32bit:

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -306,11 +306,15 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch matplotlib hypothesis
+        # Note: matplotlib not installed here to avoid issues around numpy 2.0
+        # (it can be put back after matplotlib has made a 2.0-compatible
+        # release on PyPI.
+        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
         # TODO: once the scipy_ symbol prefix issue is fixed, install
         # scipy-openblas32 from the pre-releases bucket again (see gh-19640)
         python -m pip install "scipy-openblas32<=0.3.23.293.2"
+        # Install numpy last, to ensure we get 2.0.0-dev (avoid possible <2.0 constraints).
+        python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
     - name:  Prepare compiler cache
       id:    prep-ccache

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1563,7 +1563,7 @@ class TestButtord:
         assert "gstop should be larger than 0.0" in str(exc_info.value)
 
     def test_runtime_warnings(self):
-        msg = "Order is zero.*|divide by zero encountered in divide"
+        msg = "Order is zero.*|divide by zero encountered"
         with pytest.warns(RuntimeWarning, match=msg):
             buttord(0.0, 1.0, 3, 60)
 


### PR DESCRIPTION
Closes gh-19846

The new job added is the same as the old job, except that it builds against numpy 2.0-dev, then downgrades numpy to 1.22.4, and then runs the tests. This will surface potential issues with ABI compatibility. We may not need that job forever, but it'll be useful insurance during the 2.0 release period.