### PR TITLE
ENH: sparse: foundation for 1D arrays (add test suite, round up edge cases)

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -873,6 +873,8 @@ class _spbase:
         """Returns a copy of column j of the array, as an (m x 1) sparse
         array (column vector).
         """
+        if self.ndim == 1:
+            raise ValueError("getcol not provided for 1d arrays. Use indexing A[j]")
         # Subclasses should override this method for efficiency.
         # Post-multiply by a (n x 1) column vector 'a' containing all zeros
         # except for a_j = 1
@@ -884,8 +886,6 @@ class _spbase:
         col_selector = self._csc_container(([1], [[j], [0]]),
                                            shape=(N, 1), dtype=self.dtype)
         result = self @ col_selector
-        if self.ndim == 1:
-            return result.reshape(-1, 1)
         return result
 
     def _getrow(self, i):

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -885,9 +885,7 @@ class _spbase:
                                            shape=(N, 1), dtype=self.dtype)
         result = self @ col_selector
         if self.ndim == 1:
-            # only here to force col to be 2d ("as an (mx1) sparse array")
-            # should this be 1d? -- hard to know with name "getcol"
-            return result.reshape(1, 1)
+            return result.reshape(-1, 1)
         return result
 
     def _getrow(self, i):
@@ -1111,7 +1109,7 @@ class _spbase:
             ret = (self @ np.ones(self.shape, dtype=res_dtype)).astype(dtype)
 
             if out is not None:
-                if np.prod(np.array(out.shape)) != 1:
+                if any(dim != 1 for dim in out.shape):
                     raise ValueError("dimensions do not match")
                 out[...] = ret
             return ret

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -67,7 +67,7 @@ class _spbase:
 
     __array_priority__ = 10.1
     _format = 'und'  # undefined
-    
+
     @property
     def ndim(self) -> int:
         return len(self._shape)
@@ -157,7 +157,8 @@ class _spbase:
         """
         # If the shape already matches, don't bother doing an actual reshape
         # Otherwise, the default is to convert to COO and use its reshape
-        shape = check_shape(args, self.shape)
+        is_array = isinstance(self, sparray)
+        shape = check_shape(args, self.shape, allow_1d=is_array)
         order, copy = check_reshape_kwargs(kwargs)
         if shape == self.shape:
             if copy:
@@ -256,7 +257,7 @@ class _spbase:
 
     def __iter__(self):
         for r in range(self.shape[0]):
-            yield self[r, :]
+            yield self[r]
 
     def _getmaxprint(self):
         """Maximum number of elements to display when printed."""
@@ -586,7 +587,10 @@ class _spbase:
             if other.shape == (N,):
                 return self._mul_vector(other)
             elif other.shape == (N, 1):
-                return self._mul_vector(other.ravel()).reshape(M, 1)
+                result = self._mul_vector(other.ravel())
+                if self.ndim == 1:
+                    return result
+                return result.reshape(M, 1)
             elif other.ndim == 2 and other.shape[0] == N:
                 return self._mul_multivector(other)
 
@@ -595,7 +599,7 @@ class _spbase:
             return self._mul_scalar(other)
 
         if issparse(other):
-            if self.shape[1] != other.shape[0]:
+            if self.shape[-1] != other.shape[0]:
                 raise ValueError('dimension mismatch')
             if other.ndim == 1:
                 raise ValueError('Cannot yet multiply a 1d sparse array')
@@ -634,7 +638,7 @@ class _spbase:
             ##
             # dense 2D array or matrix ("multivector")
 
-            if other.shape[0] != self.shape[1]:
+            if other.shape[0] != N:
                 raise ValueError('dimension mismatch')
 
             result = self._mul_multivector(np.asarray(other))
@@ -872,29 +876,36 @@ class _spbase:
         # Subclasses should override this method for efficiency.
         # Post-multiply by a (n x 1) column vector 'a' containing all zeros
         # except for a_j = 1
-        n = self.shape[1]
+        N = self.shape[-1]
         if j < 0:
-            j += n
-        if j < 0 or j >= n:
+            j += N
+        if j < 0 or j >= N:
             raise IndexError("index out of bounds")
         col_selector = self._csc_container(([1], [[j], [0]]),
-                                           shape=(n, 1), dtype=self.dtype)
-        return self @ col_selector
+                                           shape=(N, 1), dtype=self.dtype)
+        result = self @ col_selector
+        if self.ndim == 1:
+            # only here to force col to be 2d ("as an (mx1) sparse array")
+            # should this be 1d? -- hard to know with name "getcol"
+            return result.reshape(1, 1)
+        return result
 
     def _getrow(self, i):
         """Returns a copy of row i of the array, as a (1 x n) sparse
         array (row vector).
         """
+        if self.ndim == 1:
+            raise ValueError("getrow not meaningful for a 1d array")
         # Subclasses should override this method for efficiency.
         # Pre-multiply by a (1 x m) row vector 'a' containing all zeros
         # except for a_i = 1
-        m = self.shape[0]
+        M = self.shape[0]
         if i < 0:
-            i += m
-        if i < 0 or i >= m:
+            i += M
+        if i < 0 or i >= M:
             raise IndexError("index out of bounds")
         row_selector = self._csr_container(([1], [[0], [i]]),
-                                           shape=(1, m), dtype=self.dtype)
+                                           shape=(1, M), dtype=self.dtype)
         return row_selector @ self
 
     # The following dunder methods cannot be implemented.
@@ -1091,18 +1102,29 @@ class _spbase:
         """
         validateaxis(axis)
 
+        # Mimic numpy's casting.
+        res_dtype = get_sum_dtype(self.dtype)
+
+        if self.ndim == 1:
+            if axis not in (None, -1, 0):
+                raise ValueError("axis must be None, -1 or 0")
+            ret = (self @ np.ones(self.shape, dtype=res_dtype)).astype(dtype)
+
+            if out is not None:
+                if np.prod(np.array(out.shape)) != 1:
+                    raise ValueError("dimensions do not match")
+                out[...] = ret
+            return ret
+
         # We use multiplication by a matrix of ones to achieve this.
         # For some sparse array formats more efficient methods are
         # possible -- these should override this function.
-        m, n = self.shape
-
-        # Mimic numpy's casting.
-        res_dtype = get_sum_dtype(self.dtype)
+        M, N = self.shape
 
         if axis is None:
             # sum over rows and columns
             return (
-                self @ self._ascontainer(np.ones((n, 1), dtype=res_dtype))
+                self @ self._ascontainer(np.ones((N, 1), dtype=res_dtype))
             ).sum(dtype=dtype, out=out)
 
         if axis < 0:
@@ -1112,12 +1134,12 @@ class _spbase:
         if axis == 0:
             # sum over columns
             ret = self._ascontainer(
-                np.ones((1, m), dtype=res_dtype)
+                np.ones((1, M), dtype=res_dtype)
             ) @ self
         else:
             # sum over rows
             ret = self @ self._ascontainer(
-                np.ones((n, 1), dtype=res_dtype)
+                np.ones((N, 1), dtype=res_dtype)
             )
 
         if out is not None and out.shape != ret.shape:
@@ -1162,14 +1184,11 @@ class _spbase:
         numpy.matrix.mean : NumPy's implementation of 'mean' for matrices
 
         """
-        def _is_integral(dtype):
-            return (np.issubdtype(dtype, np.integer) or
-                    np.issubdtype(dtype, np.bool_))
-
         validateaxis(axis)
 
         res_dtype = self.dtype.type
-        integral = _is_integral(self.dtype)
+        integral = (np.issubdtype(self.dtype, np.integer) or
+                    np.issubdtype(self.dtype, np.bool_))
 
         # output dtype
         if dtype is None:
@@ -1182,9 +1201,14 @@ class _spbase:
         inter_dtype = np.float64 if integral else res_dtype
         inter_self = self.astype(inter_dtype)
 
+        if self.ndim == 1:
+            if axis not in (None, -1, 0):
+                raise ValueError("axis must be None, -1 or 0")
+            res = inter_self / self.shape[-1]
+            return res.sum(dtype=res_dtype, out=out)
+
         if axis is None:
-            return (inter_self / np.array(
-                self.shape[0] * self.shape[1]))\
+            return (inter_self / (self.shape[0] * self.shape[1]))\
                 .sum(dtype=res_dtype, out=out)
 
         if axis < 0:

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -3,6 +3,7 @@ python_sources = [
   'test_array_api.py',
   'test_base.py',
   'test_coo.py',
+  'test_common1d.py',
   'test_construct.py',
   'test_deprecations.py',
   'test_csc.py',

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -32,11 +32,10 @@ def datsp_math_dtypes(dat1d):
 
 
 @pytest.mark.parametrize("spcreator", spcreators)
-class TestCommon1D:  # skip name check
+class TestCommon1D:
     """test common functionality shared by 1D sparse formats"""
 
-    def test_empty(self, spcreator):
-        # create empty matrices
+    def test_create_empty(self, spcreator):
         assert np.array_equal(spcreator((3,)).toarray(), np.zeros(3))
         assert np.array_equal(spcreator((3,)).nnz, 0)
         assert np.array_equal(spcreator((3,)).count_nonzero(), 0)
@@ -56,20 +55,20 @@ class TestCommon1D:  # skip name check
         assert np.array_equal(-A, (-spcreator(A)).toarray())
 
     def test_reshape_1d_tofrom_row_or_column(self, spcreator):
-        # add a dimension
+        # add a dimension 1d->2d
         x = spcreator([1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5])
         y = x.reshape(1, 12)
         desired = [[1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5]]
         assert np.array_equal(y.toarray(), desired)
 
-        # remove a size-1 dimension
+        # remove a size-1 dimension 2d->1d
         x = spcreator(desired)
         y = x.reshape(12)
         assert np.array_equal(y.toarray(), desired[0])
         y2 = x.reshape((12,))
         assert y.shape == y2.shape
 
-        # make a column 1d
+        # make a 2d column into 1d. 2d->1d
         y = x.T.reshape(12)
         assert np.array_equal(y.toarray(), desired[0])
 
@@ -102,7 +101,7 @@ class TestCommon1D:  # skip name check
                 assert np.allclose(dat.sum(axis=0), datsp.sum(axis=0))
                 assert np.allclose(dat.sum(axis=-1), datsp.sum(axis=-1))
 
-        # test out parameter
+        # test `out` parameter
         datsp.sum(axis=0, out=np.zeros(()))
 
     def test_sum_invalid_params(self, spcreator):
@@ -357,7 +356,7 @@ class TestCommon1D:  # skip name check
         dot_result = np.dot(Asp.toarray(), [1, 2, 3])
         assert np.allclose(Asp @ np.array([1, 2, 3]), dot_result)
         assert np.allclose(Asp @ [[1], [2], [3]], dot_result.T)
-        # Note that the result of Asp * x is dense if x has a singleton dimension.
+        # Note that the result of Asp @ x is dense if x has a singleton dimension.
 
     def test_rmatvec(self, spcreator, dat1d):
         M = spcreator(dat1d)
@@ -372,16 +371,15 @@ class TestCommon1D:  # skip name check
             assert np.array_equal(B.transpose().toarray(), A)
             assert np.array_equal(B.dtype, A.dtype)
 
-    def test_add_dense(self, spcreator, datsp_math_dtypes):
+    def test_add_dense_to_sparse(self, spcreator, datsp_math_dtypes):
         for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
-            # adding a dense matrix to a sparse matrix
             sum1 = dat + datsp
             assert np.array_equal(sum1, dat + dat)
             sum2 = datsp + dat
             assert np.array_equal(sum2, dat + dat)
 
-    # test that __iter__ is compatible with NumPy
     def test_iterator(self, spcreator):
+        # test that __iter__ is compatible with NumPy
         B = np.arange(5)
         A = spcreator(B)
 

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -1,0 +1,399 @@
+"""Test of 1D aspects of sparse array classes"""
+
+import pytest
+
+import numpy as np
+
+import scipy as sp
+from scipy.sparse._sputils import supported_dtypes, matrix
+from scipy._lib._util import ComplexWarning
+
+
+sup_complex = np.testing.suppress_warnings()
+sup_complex.filter(ComplexWarning)
+
+
+spcreators = [sp.sparse.coo_array]
+math_dtypes = [np.int64, np.float64, np.complex128]
+
+
+@pytest.fixture
+def dat1d():
+    return np.array([3, 0, 1, 0], 'd')
+
+
+@pytest.fixture
+def datsp_math_dtypes(dat1d):
+    dat_dtypes = {dtype: dat1d.astype(dtype) for dtype in math_dtypes}
+    return {
+        sp: [(dtype, dat, sp(dat)) for dtype, dat in dat_dtypes.items()]
+        for sp in spcreators
+    }
+
+
+@pytest.mark.parametrize("spcreator", spcreators)
+class TestCommon1D:  # skip name check
+    """test common functionality shared by 1D sparse formats"""
+
+    def test_empty(self, spcreator):
+        # create empty matrices
+        assert np.array_equal(spcreator((3,)).toarray(), np.zeros(3))
+        assert np.array_equal(spcreator((3,)).nnz, 0)
+        assert np.array_equal(spcreator((3,)).count_nonzero(), 0)
+
+    def test_invalid_shapes(self, spcreator):
+        with pytest.raises(ValueError, match='elements cannot be negative'):
+            spcreator((-3,))
+
+    def test_repr(self, spcreator, dat1d):
+        repr(spcreator(dat1d))
+
+    def test_str(self, spcreator, dat1d):
+        str(spcreator(dat1d))
+
+    def test_neg(self, spcreator):
+        A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
+        assert np.array_equal(-A, (-spcreator(A)).toarray())
+
+    def test_reshape_1d_tofrom_row_or_column(self, spcreator):
+        # add a dimension
+        x = spcreator([1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5])
+        y = x.reshape(1, 12)
+        desired = [[1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5]]
+        assert np.array_equal(y.toarray(), desired)
+
+        # remove a size-1 dimension
+        x = spcreator(desired)
+        y = x.reshape(12)
+        assert np.array_equal(y.toarray(), desired[0])
+        y2 = x.reshape((12,))
+        assert y.shape == y2.shape
+
+        # make a column 1d
+        y = x.T.reshape(12)
+        assert np.array_equal(y.toarray(), desired[0])
+
+    def test_reshape(self, spcreator):
+        x = spcreator([1, 0, 7, 0, 0, 0, 0, -3, 0, 0, 0, 5])
+        y = x.reshape((4, 3))
+        desired = [[1, 0, 7], [0, 0, 0], [0, -3, 0], [0, 0, 5]]
+        assert np.array_equal(y.toarray(), desired)
+
+        y = x.reshape((12,))
+        assert y is x
+
+        y = x.reshape(12)
+        assert np.array_equal(y.toarray(), x.toarray())
+
+    def test_sum(self, spcreator):
+        np.random.seed(1234)
+        dat_1 = np.array([0, 1, 2, 3, -4, 5, -6, 7, 9])
+        dat_2 = np.random.rand(5)
+        dat_3 = np.array([])
+        dat_4 = np.zeros((40,))
+        arrays = [dat_1, dat_2, dat_3, dat_4]
+
+        for dat in arrays:
+            datsp = spcreator(dat)
+            with np.errstate(over='ignore'):
+                assert np.isscalar(datsp.sum())
+                assert np.allclose(dat.sum(), datsp.sum())
+                assert np.allclose(dat.sum(axis=None), datsp.sum(axis=None))
+                assert np.allclose(dat.sum(axis=0), datsp.sum(axis=0))
+                assert np.allclose(dat.sum(axis=-1), datsp.sum(axis=-1))
+
+        # test out parameter
+        datsp.sum(axis=0, out=np.zeros(()))
+
+    def test_sum_invalid_params(self, spcreator):
+        out = np.zeros((3,))  # wrong size for out
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        with pytest.raises(ValueError, match='axis must be None, -1 or 0'):
+            datsp.sum(axis=1)
+        with pytest.raises(TypeError, match='Tuples are not accepted'):
+            datsp.sum(axis=(0, 1))
+        with pytest.raises(TypeError, match='axis must be an integer'):
+            datsp.sum(axis=1.5)
+        with pytest.raises(ValueError, match='dimensions do not match'):
+            datsp.sum(axis=0, out=out)
+
+    def test_numpy_sum(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        dat_sum = np.sum(dat)
+        datsp_sum = np.sum(datsp)
+
+        assert np.allclose(dat_sum, datsp_sum)
+
+    def test_mean(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        assert np.allclose(dat.mean(), datsp.mean())
+        assert np.isscalar(datsp.mean(axis=None))
+        assert np.allclose(dat.mean(axis=None), datsp.mean(axis=None))
+        assert np.allclose(dat.mean(axis=0), datsp.mean(axis=0))
+        assert np.allclose(dat.mean(axis=-1), datsp.mean(axis=-1))
+
+        with pytest.raises(ValueError, match='axis'):
+            datsp.mean(axis=1)
+        with pytest.raises(ValueError, match='axis'):
+            datsp.mean(axis=-2)
+
+    def test_mean_invalid_params(self, spcreator):
+        out = np.asarray(np.zeros((1, 3)))
+        dat = np.array([[0, 1, 2], [3, -4, 5], [-6, 7, 9]])
+
+        if spcreator._format == 'uni':
+            with pytest.raises(ValueError, match='zq'):
+                spcreator(dat)
+            return
+
+        datsp = spcreator(dat)
+        with pytest.raises(ValueError, match='axis out of range'):
+            datsp.mean(axis=3)
+        with pytest.raises(TypeError, match='Tuples are not accepted'):
+            datsp.mean(axis=(0, 1))
+        with pytest.raises(TypeError, match='axis must be an integer'):
+            datsp.mean(axis=1.5)
+        with pytest.raises(ValueError, match='dimensions do not match'):
+            datsp.mean(axis=1, out=out)
+
+    def test_sum_dtype(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        for dtype in supported_dtypes:
+            dat_sum = dat.sum(dtype=dtype)
+            datsp_sum = datsp.sum(dtype=dtype)
+
+            assert np.allclose(dat_sum, datsp_sum)
+            assert np.array_equal(dat_sum.dtype, datsp_sum.dtype)
+
+    def test_mean_dtype(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        for dtype in supported_dtypes:
+            dat_mean = dat.mean(dtype=dtype)
+            datsp_mean = datsp.mean(dtype=dtype)
+
+            assert np.allclose(dat_mean, datsp_mean)
+            assert np.array_equal(dat_mean.dtype, datsp_mean.dtype)
+
+    def test_mean_out(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        dat_out = np.array([0])
+        datsp_out = np.array([0])
+
+        dat.mean(out=dat_out, keepdims=True)
+        datsp.mean(out=datsp_out)
+        assert np.allclose(dat_out, datsp_out)
+
+        dat.mean(axis=0, out=dat_out, keepdims=True)
+        datsp.mean(axis=0, out=datsp_out)
+        assert np.allclose(dat_out, datsp_out)
+
+    def test_numpy_mean(self, spcreator):
+        dat = np.array([0, 1, 2])
+        datsp = spcreator(dat)
+
+        dat_mean = np.mean(dat)
+        datsp_mean = np.mean(datsp)
+
+        assert np.allclose(dat_mean, datsp_mean)
+        assert np.array_equal(dat_mean.dtype, datsp_mean.dtype)
+
+    @sup_complex
+    def test_from_array(self, spcreator):
+        A = np.array([2, 3, 4])
+        assert np.array_equal(spcreator(A).toarray(), A)
+
+        A = np.array([1.0 + 3j, 0, -1])
+        assert np.array_equal(spcreator(A).toarray(), A)
+        assert np.array_equal(spcreator(A, dtype='int16').toarray(), A.astype('int16'))
+
+    @sup_complex
+    def test_from_list(self, spcreator):
+        A = [2, 3, 4]
+        assert np.array_equal(spcreator(A).toarray(), A)
+
+        A = [1.0 + 3j, 0, -1]
+        assert np.array_equal(spcreator(A).toarray(), np.array(A))
+        assert np.array_equal(
+            spcreator(A, dtype='int16').toarray(), np.array(A).astype('int16')
+        )
+
+    @sup_complex
+    def test_from_sparse(self, spcreator):
+        D = np.array([1, 0, 0])
+        S = sp.sparse.coo_array(D)
+        assert np.array_equal(spcreator(S).toarray(), D)
+        S = spcreator(D)
+        assert np.array_equal(spcreator(S).toarray(), D)
+
+        D = np.array([1.0 + 3j, 0, -1])
+        S = sp.sparse.coo_array(D)
+        assert np.array_equal(spcreator(S).toarray(), D)
+        assert np.array_equal(spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+        S = spcreator(D)
+        assert np.array_equal(spcreator(S).toarray(), D)
+        assert np.array_equal(spcreator(S, dtype='int16').toarray(), D.astype('int16'))
+
+    def test_toarray(self, spcreator, dat1d):
+        datsp = spcreator(dat1d)
+        # Check C- or F-contiguous (default).
+        chk = datsp.toarray()
+        assert np.array_equal(chk, dat1d)
+        assert chk.flags.c_contiguous == chk.flags.f_contiguous
+
+        # Check C-contiguous (with arg).
+        chk = datsp.toarray(order='C')
+        assert np.array_equal(chk, dat1d)
+        assert chk.flags.c_contiguous
+        assert chk.flags.f_contiguous
+
+        # Check F-contiguous (with arg).
+        chk = datsp.toarray(order='F')
+        assert np.array_equal(chk, dat1d)
+        assert chk.flags.c_contiguous
+        assert chk.flags.f_contiguous
+
+        # Check with output arg.
+        out = np.zeros(datsp.shape, dtype=datsp.dtype)
+        datsp.toarray(out=out)
+        assert np.array_equal(out, dat1d)
+
+        # Check that things are fine when we don't initialize with zeros.
+        out[...] = 1.0
+        datsp.toarray(out=out)
+        assert np.array_equal(out, dat1d)
+
+        # np.dot does not work with sparse matrices (unless scalars)
+        # so this is testing whether dat1d matches datsp.toarray()
+        a = np.array([1.0, 2.0, 3.0, 4.0])
+        dense_dot_dense = np.dot(a, dat1d)
+        check = np.dot(a, datsp.toarray())
+        assert np.array_equal(dense_dot_dense, check)
+
+        b = np.array([1.0, 2.0, 3.0, 4.0])
+        dense_dot_dense = np.dot(dat1d, b)
+        check = np.dot(datsp.toarray(), b)
+        assert np.array_equal(dense_dot_dense, check)
+
+        # Check bool data works.
+        spbool = spcreator(dat1d, dtype=bool)
+        arrbool = dat1d.astype(bool)
+        assert np.array_equal(spbool.toarray(), arrbool)
+
+    def test_add(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            a = dat.copy()
+            a[0] = 2.0
+            b = datsp
+            c = b + a
+            assert np.array_equal(c, b.toarray() + a)
+
+            # test broadcasting
+            # Note: cant add nonzero scalar to sparray. Can add len 1 array
+            c = b + a[0:1]
+            assert np.array_equal(c, b.toarray() + a[0])
+
+    def test_radd(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            a = dat.copy()
+            a[0] = 2.0
+            b = datsp
+            c = a + b
+            assert np.array_equal(c, a + b.toarray())
+
+    def test_rsub(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
+            assert np.array_equal((dat - datsp), [0, 0, 0, 0])
+            assert np.array_equal((datsp - dat), [0, 0, 0, 0])
+            assert np.array_equal((0 - datsp).toarray(), -dat)
+
+            A = spcreator([1, -4, 0, 2], dtype='d')
+            assert np.array_equal((dat - A), dat - A.toarray())
+            assert np.array_equal((A - dat), A.toarray() - dat)
+            assert np.array_equal(A.toarray() - datsp, A.toarray() - dat)
+            assert np.array_equal(datsp - A.toarray(), dat - A.toarray())
+
+            # test broadcasting
+            assert np.array_equal(dat[:1] - datsp, dat[:1] - dat)
+
+    def test_matvec(self, spcreator):
+        A = np.array([2, 0, 3.0])
+        Asp = spcreator(A)
+        col = np.array([[1, 2, 3]]).T
+
+        assert np.allclose(Asp @ col, Asp.toarray() @ col)
+
+        assert (A @ np.array([1, 2, 3])).shape == ()
+        assert Asp @ np.array([1, 2, 3]) == 11
+        assert (Asp @ np.array([1, 2, 3])).shape == ()
+        assert (Asp @ np.array([[1], [2], [3]])).shape == ()
+        # check result type
+        assert isinstance(Asp @ matrix([[1, 2, 3]]).T, np.ndarray)
+        assert (Asp @ np.array([[1, 2, 3]]).T).shape == ()
+
+        # ensure exception is raised for improper dimensions
+        bad_vecs = [np.array([1, 2]), np.array([1, 2, 3, 4]), np.array([[1], [2]])]
+        for x in bad_vecs:
+            with pytest.raises(ValueError, match='dimension mismatch'):
+                Asp.__matmul__(x)
+
+        # The current relationship between sparse matrix products and array
+        # products is as follows:
+        dot_result = np.dot(Asp.toarray(), [1, 2, 3])
+        assert np.allclose(Asp @ np.array([1, 2, 3]), dot_result)
+        assert np.allclose(Asp @ [[1], [2], [3]], dot_result.T)
+        # Note that the result of Asp * x is dense if x has a singleton dimension.
+
+    def test_rmatvec(self, spcreator, dat1d):
+        M = spcreator(dat1d)
+        assert np.allclose([1, 2, 3, 4] @ M, np.dot([1, 2, 3, 4], M.toarray()))
+        row = np.array([[1, 2, 3, 4]])
+        assert np.allclose(row @ M, row @ M.toarray())
+
+    def test_transpose(self, spcreator, dat1d):
+        for A in [dat1d, np.array([])]:
+            B = spcreator(A)
+            assert np.array_equal(B.toarray(), A)
+            assert np.array_equal(B.transpose().toarray(), A)
+            assert np.array_equal(B.dtype, A.dtype)
+
+    def test_add_dense(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            # adding a dense matrix to a sparse matrix
+            sum1 = dat + datsp
+            assert np.array_equal(sum1, dat + dat)
+            sum2 = datsp + dat
+            assert np.array_equal(sum2, dat + dat)
+
+    # test that __iter__ is compatible with NumPy
+    def test_iterator(self, spcreator):
+        B = np.arange(5)
+        A = spcreator(B)
+
+        if A.format not in ['coo', 'dia', 'bsr']:
+            for x, y in zip(A, B):
+                assert np.array_equal(x, y)
+
+    def test_resize(self, spcreator):
+        # resize(shape) resizes the matrix in-place
+        D = np.array([1, 0, 3, 4])
+        S = spcreator(D)
+        assert S.resize((3,)) is None
+        assert np.array_equal(S.toarray(), [1, 0, 3])
+        S.resize((5,))
+        assert np.array_equal(S.toarray(), [1, 0, 3, 0, 0])


### PR DESCRIPTION
This PR splits the dok-1d PR #19715 into the part that is independent from dok (here in this PR) and the part that updates dok. 

Splitting (and merging this) allows other formats like the CSR format PR #19717 to build on the base without involving dok changes too. This should help review.

In this PR are changes to `_base.py` and a new test file `test_common1d.py` that is configured here to test `coo` format.
The tests in `test_common1d.py` are taken from `test_base`'s 2d tests for any tests that made sense with 1d inputs (avoiding tests for indexing, arithmetic, etc which hasn't been implemented in 1d yet). 