### PR TITLE
BLD: simplify pythran version requirement in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -135,10 +135,7 @@ tempita = files('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')
 if use_pythran
-  pythran = find_program('pythran', native: true)
-  if not pythran.version().version_compare('>=0.14.0')
-    error('SciPy requires pythran >= 0.14.0')
-  endif
+  pythran = find_program('pythran', native: true, version: '>=0.14.0')
   # xsimd is unvendored from pythran by conda-forge, and due to a compiler
   # activation bug the default <prefix>/include/ may not be visible (see
   # gh-15698). Hence look for xsimd explicitly.


### PR DESCRIPTION
For a find_program() invocation, the version check can be inlined into the lookup. This is different from cc / cython, where version_compare is used because the list of project languages is internally responsible for finding the compiler object and doesn't have a side channel for compiler-versions-per-compiler-id.

Follow-up for #19738