### PR TITLE
BLD: improve scipy-openblas dependency check

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -151,7 +151,7 @@ lapack_name = get_option('lapack')
 # First try scipy-openblas, and if found don't look for cblas or lapack, we
 # know what's inside the scipy-openblas wheels already.
 if blas_name == 'openblas' or blas_name == 'auto'
-  blas = dependency('scipy-openblas', required: false)
+  blas = dependency('scipy-openblas', method: 'pkg-config', required: false)
   if blas.found()
     blas_name = 'scipy-openblas'
   endif
@@ -161,7 +161,7 @@ endif
 # that too to make the fallback detection with CMake work
 if blas_name == 'openblas'
   blas = dependency(['openblas', 'OpenBLAS'])
-else
+elif blas_name != 'scipy-openblas'  # if so, we found it already
   blas = dependency(blas_name)
 endif
 if blas_name == 'blas'


### PR DESCRIPTION
This avoids looking for scipy-openblas with CMake (which we never want), and avoids looking for it twice (that was an oversight). As a result, we should be robust to whatever is the underlying problem of the CI failures reported in gh-19852 are.

Closes gh-19852