### PR TITLE
MAINT: fix BLD label typo

### DIFF
--- a/.github/label-globs.yml
+++ b/.github/label-globs.yml
@@ -160,7 +160,7 @@ DX:
   - any-glob-to-any-file:
     - doc/source/dev/**
 
-BLD:
+Build issues:
 - changed-files:
   - any-glob-to-any-file:
     - scipy/_build_utils/**


### PR DESCRIPTION
Fixes a typo from gh-19823.

The `BLD` label which was accidentally created should be deleted by a maintainer too.
