### PR TITLE
BUG:io:Skip arr_to_chars call for single code points

### DIFF
--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -546,7 +546,8 @@ class VarWriter4:
             self.write_bytes(arr)
 
     def write_char(self, arr, name):
-        arr = arr_to_chars(arr)
+        if arr.dtype.type == np.str_ and arr.dtype.itemsize != np.dtype('U1').itemsize:
+            arr = arr_to_chars(arr)
         arr = arr_to_2d(arr, self.oned_as)
         dims = arr.shape
         self.write_header(

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1327,3 +1327,13 @@ def test_gh_17992(tmp_path):
             new_dict)
     assert_allclose(new_dict["data"][0][0], array_one)
     assert_allclose(new_dict["data"][0][1], array_two)
+
+
+def test_gh_19659(tmp_path):
+    d = {
+        "char_array": np.array([list("char"), list("char")], dtype="U1"),
+        "string_array": np.array(["string", "string"]),
+        }
+    outfile = tmp_path / "tmp.mat"
+    # should not error:
+    savemat(outfile, d, format="4")


### PR DESCRIPTION
When an array of unicode strings is passed to `write_char()` that has only single code points (i.e. dtype("<U1")), skip the conversion call to `arr_to_chars()` as it is already a char array. The function `arr_to_chars` would otherwise increase the number of dimensions resulting in a subsequent exception.

#### Reference issue
Closes #19659 

#### Additional information
One could insert a test case for it, but it would be more involved since there is no unit test for the file `scipy/io/matlab/_mio4.py`. Also, since the patched function `write_char()` is a member function, I guess one has to mock the writer/come up with a test object.

In any case, the reproducing code example stated in the issue could serve as a part of a test case which could be improved by another test for the `np.bytes_` datatype.