### PR TITLE
Add documentation to explain behavior for transposing csr or csc arrays

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -800,6 +800,11 @@ class _spbase:
         -------
         p : `self` with the dimensions reversed.
 
+        Notes
+        -----
+        If `self` is a `csr_array` or a `csc_array`, then this will return a
+        `csc_array` or a `csr_array`, respectively.
+
         See Also
         --------
         numpy.transpose : NumPy's implementation of 'transpose' for ndarrays


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #19862

#### What does this implement/fix?
Adds documentation for the sparse ``transpose`` method explaining that for transposes of the ``csr_array`` and ``csc_array`` classes, a ``csc_array`` and a ``csr_array`` will be returned, respectively.
