### PR TITLE
DOC: Change default for bounds in scipy.optimize.linprog

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -168,7 +168,7 @@ def linprog_terse_callback(res):
 
 
 def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
-            bounds=None, method='highs', callback=None,
+            bounds=(0, None), method='highs', callback=None,
             options=None, x0=None, integrality=None):
     r"""
     Linear programming: minimize a linear objective function subject to linear


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #18902 

#### What does this implement/fix?
Changes the default value of `bounds` in the function signature from `None` to `(0,  None)`. It would not cause any issues since `bounds` is expecting a `(min, max)` tuple anyways as referenced by documentation. 

This provides clarity to the reader as described by @TiloRC . 

#### Additional information
I ran the tests in the main branch and issue branch which gave the same results. Also, first issue :)
