### PR TITLE
MAINT: fix use of `unique(..., return_inverse=True)`

### DIFF
--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -511,6 +511,7 @@ class RBFInterpolator:
             # neighborhood.
             yindices = np.sort(yindices, axis=1)
             yindices, inv = np.unique(yindices, return_inverse=True, axis=0)
+            inv = np.reshape(inv, (-1,))  # flatten, we need 1-D indices
             # `inv` tells us which neighborhood will be used by each evaluation
             # point. Now we find which evaluation points will be using each
             # neighborhood.

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -657,6 +657,7 @@ def _stats(input, labels=None, index=None, centered=False):
         # be 1-D, but it should be interpreted as the flattened N-D array of
         # label indices.
         unique_labels, new_labels = numpy.unique(labels, return_inverse=True)
+        new_labels = np.reshape(new_labels, (-1,))  # flatten, since it may be >1-D
         counts = numpy.bincount(new_labels)
         sums = numpy.bincount(new_labels, weights=input.ravel())
         if centered:


### PR DESCRIPTION
Code was written to expect a 1-D array with the inverse indices, and that got changed in NumPy in
https://github.com/numpy/numpy/pull/25553.

Closes gh-19867