### PR TITLE
MAINT: logsumexp: properly handle complex sign

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -40,11 +40,13 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     res : ndarray
         The result, ``np.log(np.sum(np.exp(a)))`` calculated in a numerically
         more stable way. If `b` is given then ``np.log(np.sum(b*np.exp(a)))``
-        is returned.
+        is returned. If ``return_sign`` is True, ``res`` contians the log of
+        the absolute value of the argument.
     sgn : ndarray
         If return_sign is True, this will be an array of floating-point
-        numbers matching res and +1, 0, or -1 depending on the sign
-        of the result. For complex input, sgn will be a complex phase.
+        numbers matching res containing +1, 0, -1 (for real-valued inputs)
+        or a complex phase (for complex inputs). This gives the sign of the
+        argument of the logarithm in ``res``.
         If return_sign is False, only one result is returned.
 
     See Also

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -98,10 +98,9 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
             a = a + 0.  # promote to at least float
             a[b == 0] = -np.inf
 
-    if np.issubdtype(a.dtype, np.complexfloating):
-      a_max = np.amax(abs(a), axis=axis, keepdims=True)
-    else:
-      a_max = np.amax(a, axis=axis, keepdims=True)
+    # Scale by real part for complex inputs, because this affects
+    # the magnitude of the exponential.
+    a_max = np.amax(a.real, axis=axis, keepdims=True)
 
     if a_max.ndim > 0:
         a_max[~np.isfinite(a_max)] = 0

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -121,7 +121,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
         if return_sign:
             # For complex, use the numpy>=2.0 convention for sign.
             if np.issubdtype(s.dtype, np.complexfloating):
-                sgn = np.where(s == 0, 0, s / abs(s))
+                sgn = s / np.where(s == 0, 1, abs(s))
             else:
                 sgn = np.sign(s)
             s = abs(s)

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -40,14 +40,14 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     res : ndarray
         The result, ``np.log(np.sum(np.exp(a)))`` calculated in a numerically
         more stable way. If `b` is given then ``np.log(np.sum(b*np.exp(a)))``
-        is returned. If ``return_sign`` is True, ``res`` contians the log of
+        is returned. If ``return_sign`` is True, ``res`` contains the log of
         the absolute value of the argument.
     sgn : ndarray
-        If return_sign is True, this will be an array of floating-point
+        If ``return_sign`` is True, this will be an array of floating-point
         numbers matching res containing +1, 0, -1 (for real-valued inputs)
         or a complex phase (for complex inputs). This gives the sign of the
         argument of the logarithm in ``res``.
-        If return_sign is False, only one result is returned.
+        If ``return_sign`` is False, only one result is returned.
 
     See Also
     --------

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -124,7 +124,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
                 sgn = np.where(s == 0, 0, s / abs(s))
             else:
                 sgn = np.sign(s)
-            s = abs(s).astype(s.dtype)
+            s = abs(s)
         out = np.log(s)
 
     if not keepdims:

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -120,7 +120,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
         s = np.sum(tmp, axis=axis, keepdims=keepdims)
         if return_sign:
             # For complex, use the numpy>=2.0 convention for sign.
-            if np.issubdtype(s, np.complexfloating):
+            if np.issubdtype(s.dtype, np.complexfloating):
                 sgn = np.where(s == 0, 0, s / abs(s))
             else:
                 sgn = np.sign(s)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -115,6 +115,19 @@ def test_logsumexp_sign_shape():
     assert_equal(r.shape, (1,3))
 
 
+def test_logsumexp_complex_sign():
+    a = np.array([1 + 1j, 2 - 1j, -2 + 3j])
+
+    r, s = logsumexp(a, return_sign=True)
+
+    expected_sumexp = np.exp(a).sum()
+    # This is the numpy>=2.0 convention for np.sign
+    expected_sign = expected_sumexp / abs(expected_sumexp)
+
+    assert_allclose(s, expected_sign)
+    assert_allclose(s * np.exp(r), expected_sumexp)
+
+
 def test_logsumexp_shape():
     a = np.ones((1, 2, 3, 4))
     b = np.ones_like(a)


### PR DESCRIPTION
Fixes #19854

I opted to have `logsumexp` return a sign that matches the convention of `np.sign` for whichever numpy version is installed.