### PR TITLE
MAINT: make isinstance check in `stats._distn_infrastructure` more ro…

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -598,8 +598,8 @@ def argsreduce(cond, *args):
 
     # np.atleast_1d returns an array if only one argument, or a list of arrays
     # if more than one argument.
-    if not isinstance(newargs, list):
-        newargs = [newargs, ]
+    if not isinstance(newargs, (list, tuple)):
+        newargs = (newargs,)
 
     if np.all(cond):
         # broadcast arrays with cond


### PR DESCRIPTION
…bust

This check for a list return type from `atleast_1d` may fail if in NumPy 2.0 the return type will be tuple rather than list (xref https://github.com/numpy/numpy/pull/25570). Also, for PyTorch it's tuple, and in general tuple seems preferred here (due to immutability).

Checking for both list and tuple makes the code future-proof (also for array API support), and only costs a few tens of nanoseconds more (performance-wise this line doesn't matter). So it's useful to make the change now.