### PR TITLE
Revert "ENH: stats.wasserstein_distance: multivariate Wasserstein distance/EMD

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -34,12 +34,8 @@ from collections import namedtuple
 import numpy as np
 from numpy import array, asarray, ma
 
-from scipy import sparse
 from scipy.spatial.distance import cdist
-from scipy.spatial import distance_matrix
-
 from scipy.ndimage import _measurements
-from scipy.optimize import milp, LinearConstraint
 from scipy._lib._util import (check_random_state, MapWrapper, _get_nan,
                               rng_integers, _rename_parameter, _contains_nan,
                               AxisError)
@@ -4075,7 +4071,7 @@ def f_oneway(*samples, axis=0):
 
     # We haven't explicitly validated axis, but if it is bad, this call of
     # np.concatenate will raise np.exceptions.AxisError. The call will raise
-    # ValueError if the dimensions of all the arrays, except the axis 
+    # ValueError if the dimensions of all the arrays, except the axis
     # dimension, are not the same.
     alldata = np.concatenate(samples, axis=axis)
     bign = alldata.shape[axis]
@@ -9874,7 +9870,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-        * 'two-sided': the quantile associated with the probability `p` 
+        * 'two-sided': the quantile associated with the probability `p`
           is not `q`.
         * 'less': the quantile associated with the probability `p` is less
           than `q`.
@@ -10044,7 +10040,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
     As expected, the p-value is not below our threshold of 0.01, so
     we cannot reject the null hypothesis.
 
-    When testing data from the standard *normal* distribution, which has a 
+    When testing data from the standard *normal* distribution, which has a
     median of 0, we would expect the null hypothesis to be rejected.
 
     >>> rvs = stats.norm.rvs(size=100, random_state=rng)
@@ -10189,34 +10185,26 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
 
 def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
-    Compute the Wasserstein-1 distance between two discrete distributions.
+    Compute the first Wasserstein distance between two 1D distributions.
 
-    The Wasserstein distance, also called the Earth mover's distance or the
-    optimal transport distance, is a similarity metric between two probability
-    distributions. In the discrete case, the Wasserstein distance can be
-    understood as the cost of an optimal transport plan to convert one
-    distribution into the other. The cost is calculated as the product of the
-    amount of probability mass being moved and the distance it is being moved.
-    A brief and intuitive introduction can be found at [2]_.
+    This distance is also known as the earth mover's distance, since it can be
+    seen as the minimum amount of "work" required to transform :math:`u` into
+    :math:`v`, where "work" is measured as the amount of distribution weight
+    that must be moved, multiplied by the distance it has to be moved.
 
     .. versionadded:: 1.0.0
 
     Parameters
     ----------
-    u_values : 1d or 2d array_like
-        A sample from a probability distribution or the support (set of all
-        possible values) of a probability distribution. Each element along
-        axis 0 is an observation or possible value. If two-dimensional, axis
-        1 represents the dimensionality of the distribution; i.e., each row is
-        a vector observation or possible value.
-
-    v_values : 1d or 2d array_like
-        A sample from or the support of a second distribution.
-
-    u_weights, v_weights : 1d array_like, optional
-        Weights or counts corresponding with the sample or probability masses
-        corresponding with the support values. Sum of elements must be positive
-        and finite. If unspecified, each value is assigned the same weight.
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
 
     Returns
     -------
@@ -10225,9 +10213,8 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     Notes
     -----
-    Given two probability mass functions, :math:`u`
-    and :math:`v`, the first Wasserstein distance between the distributions
-    is:
+    The first Wasserstein distance between the distributions :math:`u` and
+    :math:`v` is:
 
     .. math::
 
@@ -10236,83 +10223,16 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     where :math:`\Gamma (u, v)` is the set of (probability) distributions on
     :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
-    :math:`v` on the first and second factors respectively. For a given value
-    :math:`x`, :math:`u(x)` gives the probability of :math:`u` at position
-    :math:`x`, and the same for :math:`v(x)`.
+    :math:`v` on the first and second factors respectively.
 
-    In the 1-dimensional case, let :math:`U` and :math:`V` denote the
-    respective CDFs of :math:`u` and :math:`v`, this distance also equals to:
+    If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and
+    :math:`v`, this distance also equals to:
 
     .. math::
 
         l_1(u, v) = \int_{-\infty}^{+\infty} |U-V|
 
-    See [3]_ for a proof of the equivalence of both definitions.
-
-    In the more general (higher dimensional) and discrete case, it is also
-    called the optimal transport problem or the Monge problem.
-    Let the finite point sets :math:`\{x_i\}` and :math:`\{y_j\}` denote
-    the support set of probability mass function :math:`u` and :math:`v`
-    respectively. The Monge problem can be expressed as follows,
-
-    Let :math:`\Gamma` denote the transport plan, :math:`D` denote the
-    distance matrix and,
-
-    .. math::
-
-        x = \text{vec}(\Gamma)          \\
-        c = \text{vec}(D)               \\
-        b = \begin{bmatrix}
-                u\\
-                v\\
-            \end{bmatrix}
-
-    The :math:`\text{vec}()` function denotes the Vectorization function
-    that transforms a matrix into a column vector by vertically stacking
-    the columns of the matrix.
-    The transport plan :math:`\Gamma` is a matrix :math:`[\gamma_{ij}]` in
-    which :math:`\gamma_{ij}` is a positive value representing the amount of
-    probability mass transported from :math:`u(x_i)` to :math:`v(y_i)`.
-    Summing over the rows of :math:`\Gamma` should give the source distribution
-    :math:`u` : :math:`\sum_j \gamma_{ij} = u(x_i)` holds for all :math:`i`
-    and summing over the columns of :math:`\Gamma` should give the target
-    distribution :math:`v`: :math:`\sum_i \gamma_{ij} = v(y_j)` holds for all
-    :math:`j`.
-    The distance matrix :math:`D` is a matrix :math:`[d_{ij}]`, in which
-    :math:`d_{ij} = d(x_i, y_j)`.
-
-    Given :math:`\Gamma`, :math:`D`, :math:`b`, the Monge problem can be
-    transformed into a linear programming problem by
-    taking :math:`A x = b` as constraints and :math:`z = c^T x` as minimization
-    target (sum of costs) , where matrix :math:`A` has the form
-
-    .. math::
-
-        \begin{array} {rrrr|rrrr|r|rrrr}
-            1 & 1 & \dots & 1 & 0 & 0 & \dots & 0 & \dots & 0 & 0 & \dots &
-                0 \cr
-            0 & 0 & \dots & 0 & 1 & 1 & \dots & 1 & \dots & 0 & 0 &\dots &
-                0 \cr
-            \vdots & \vdots & \ddots & \vdots & \vdots & \vdots & \ddots
-                & \vdots & \vdots & \vdots & \vdots & \ddots & \vdots  \cr
-            0 & 0 & \dots & 0 & 0 & 0 & \dots & 0 & \dots & 1 & 1 & \dots &
-                1 \cr \hline
-
-            1 & 0 & \dots & 0 & 1 & 0 & \dots & \dots & \dots & 1 & 0 & \dots &
-                0 \cr
-            0 & 1 & \dots & 0 & 0 & 1 & \dots & \dots & \dots & 0 & 1 & \dots &
-                0 \cr
-            \vdots & \vdots & \ddots & \vdots & \vdots & \vdots & \ddots &
-                \vdots & \vdots & \vdots & \vdots & \ddots & \vdots \cr
-            0 & 0 & \dots & 1 & 0 & 0 & \dots & 1 & \dots & 0 & 0 & \dots & 1
-        \end{array}
-
-    By solving the dual form of the above linear programming problem (with
-    solution :math:`y^*`), the Wasserstein distance :math:`l_1 (u, v)` can
-    be computed as :math:`b^T y^*`.
-
-    The above solution is inspired by Vincent Herrmann's blog [5]_ . For a
-    more thorough explanation, see [4]_ .
+    See [2]_ for a proof of the equivalence of both definitions.
 
     The input distributions can be empirical, therefore coming from samples
     whose values are effectively inputs of the function, or they can be seen as
@@ -10321,19 +10241,9 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     References
     ----------
-    .. [1] "Wasserstein metric",
-           https://en.wikipedia.org/wiki/Wasserstein_metric
-    .. [2] Lili Weng, "What is Wasserstein distance?", Lil'log,
-           https://lilianweng.github.io/posts/2017-08-20-gan/#what-is-
-           wasserstein-distance.
-    .. [3] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and
-           Related Families of Nonparametric Tests" (2015).
-           :arXiv:`1509.02237`.
-    .. [4] Peyré, Gabriel, and Marco Cuturi. "Computational optimal
-           transport." Center for Research in Economics and Statistics
-           Working Papers 2017-86 (2017).
-    .. [5] Hermann, Vincent. "Wasserstein GAN and the Kantorovich-Rubinstein
-           Duality". https://vincentherrmann.github.io/blog/wasserstein/.
+    .. [1] "Wasserstein metric", https://en.wikipedia.org/wiki/Wasserstein_metric
+    .. [2] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and Related
+           Families of Nonparametric Tests" (2015). :arXiv:`1509.02237`.
 
     Examples
     --------
@@ -10346,69 +10256,8 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     ...                      [1.4, 0.9, 3.1, 7.2], [3.2, 3.5])
     4.0781331438047861
 
-    Compute the Wasserstein distance between two three-dimensional samples,
-    each with two observations.
-
-    >>> wasserstein_distance([[0, 2, 3], [1, 2, 5]], [[3, 2, 3], [4, 2, 5]])
-    3.0
-
-    Compute the Wasserstein distance between two two-dimensional distributions
-    with three and two weighted observations, respectively.
-
-    >>> wasserstein_distance([[0, 2.75], [2, 209.3], [0, 0]],
-    ...                      [[0.2, 0.322], [4.5, 25.1808]],
-    ...                      [0.4, 5.2, 0.114], [0.8, 1.5])
-    174.15840245217169
     """
-    m, n = len(u_values), len(v_values)
-    u_values = asarray(u_values)
-    v_values = asarray(v_values)
-
-    if u_values.ndim > 2 or v_values.ndim > 2:
-        raise ValueError('Invalid input values. The inputs must have either '
-                         'one or two dimensions.')
-    # if dimensions are not equal throw error
-    if u_values.ndim != v_values.ndim:
-        raise ValueError('Invalid input values. Dimensions of inputs must be '
-                         'equal.')
-    # if data is 1D then call the cdf_distance function
-    if u_values.ndim == 1 and v_values.ndim == 1:
-        return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
-
-    u_values, u_weights = _validate_distribution(u_values, u_weights)
-    v_values, v_weights = _validate_distribution(v_values, v_weights)
-    # if number of columns is not equal throw error
-    if u_values.shape[1] != v_values.shape[1]:
-        raise ValueError('Invalid input values. If two-dimensional, '
-                         '`u_values` and `v_values` must have the same '
-                         'number of columns.')
-
-    # if data contains np.inf then return inf or nan
-    if np.any(np.isinf(u_values)) ^ np.any(np.isinf(v_values)):
-        return np.inf
-    elif np.any(np.isinf(u_values)) and np.any(np.isinf(v_values)):
-        return np.nan
-
-    # create constraints
-    A_upper_part = sparse.block_diag((np.ones((1, n)), ) * m)
-    A_lower_part = sparse.hstack((sparse.eye(n), ) * m)
-    # sparse constraint matrix of size (m + n)*(m * n)
-    A = sparse.vstack((A_upper_part, A_lower_part))
-    A = sparse.coo_array(A)
-
-    # get cost matrix
-    D = distance_matrix(u_values, v_values, p=2)
-    cost = D.ravel()
-
-    # create the minimization target
-    p_u = np.full(m, 1/m) if u_weights is None else u_weights/np.sum(u_weights)
-    p_v = np.full(n, 1/n) if v_weights is None else v_weights/np.sum(v_weights)
-    b = np.concatenate((p_u, p_v), axis=0)
-
-    # solving LP
-    constraints = LinearConstraint(A=A.T, ub=cost)
-    opt_res = milp(c=-b, constraints=constraints, bounds=(-np.inf, np.inf))
-    return -opt_res.fun
+    return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
 
 
 def energy_distance(u_values, v_values, u_weights=None, v_weights=None):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7450,57 +7450,18 @@ class TestWassersteinDistance:
             [0, 1, 2], [1, 2, 3]),
             1)
 
-    def test_published_values(self):
-        # Compare against published values and manually computed results.
-        # The values and computed result are posted at James D. McCaffrey's blog,
-        # https://jamesmccaffrey.wordpress.com/2018/03/05/earth-mover-distance
-        # -wasserstein-metric-example-calculation/
-        u = [(1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1),
-             (4,2), (6,1), (6,1)]
-        v = [(2,1), (2,1), (3,2), (3,2), (3,2), (5,1), (5,1), (5,1), (5,1), (5,1),
-             (5,1), (5,1), (7,1)]
-
-        res = stats.wasserstein_distance(u, v)
-        # In original post, the author kept two decimal places for ease of calculation.
-        # This test uses the more precise value of distance to get the precise results.
-        # For comparison, please see the table and figure in the original blog post.
-        flow = np.array([2., 3., 5., 1., 1., 1.])
-        dist = np.array([1.00, 5**0.5, 4.00, 2**0.5, 1.00, 1.00])
-        ref = np.sum(flow * dist)/np.sum(flow)
-        assert_almost_equal(res, ref)
-
     def test_same_distribution(self):
-        # Any distribution moved to itself should have a Wasserstein distance
-        # of zero.
+        # Any distribution moved to itself should have a Wasserstein distance of
+        # zero.
         assert_equal(stats.wasserstein_distance([1, 2, 3], [2, 1, 3]), 0)
         assert_equal(
             stats.wasserstein_distance([1, 1, 1, 4], [4, 1],
                                        [1, 1, 1, 1], [1, 3]),
             0)
 
-    @pytest.mark.parametrize('n_value', (4, 15, 35))
-    @pytest.mark.parametrize('ndim', (3, 4, 7))
-    @pytest.mark.parametrize('max_repeats', (5, 10))
-    def test_same_distribution_nD(self, ndim, n_value, max_repeats):
-        # Any distribution moved to itself should have a Wasserstein distance
-        # of zero.
-        rng = np.random.default_rng(363836384995579937222333)
-        repeats = rng.integers(1, max_repeats, size=n_value, dtype=int)
-
-        u_values = rng.random(size=(n_value, ndim))
-        v_values = np.repeat(u_values, repeats, axis=0)
-        v_weights = rng.random(np.sum(repeats))
-        range_repeat = np.repeat(np.arange(len(repeats)), repeats)
-        u_weights = np.bincount(range_repeat, weights=v_weights)
-        index = rng.permutation(len(v_weights))
-        v_values, v_weights = v_values[index], v_weights[index]
-
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_allclose(res, 0, atol=1e-15)
-
     def test_shift(self):
         # If the whole distribution is shifted by x, then the Wasserstein
-        # distance should be the norm of x.
+        # distance should be x.
         assert_almost_equal(stats.wasserstein_distance([0], [1]), 1)
         assert_almost_equal(stats.wasserstein_distance([-5], [5]), 10)
         assert_almost_equal(
@@ -7523,8 +7484,7 @@ class TestWassersteinDistance:
 
     def test_collapse(self):
         # Collapsing a distribution to a point distribution at zero is
-        # equivalent to taking the average of the absolute values of the
-        # values.
+        # equivalent to taking the average of the absolute values of the values.
         u = np.arange(-10, 30, 0.3)
         v = np.zeros_like(u)
         assert_almost_equal(
@@ -7537,47 +7497,12 @@ class TestWassersteinDistance:
             stats.wasserstein_distance(u, v, u_weights, v_weights),
             np.average(np.abs(u), weights=u_weights))
 
-    @pytest.mark.parametrize('nu', (8, 9, 38))
-    @pytest.mark.parametrize('nv', (8, 12, 17))
-    @pytest.mark.parametrize('ndim', (3, 5, 23))
-    def test_collapse_nD(self, nu, nv, ndim):
-        # test collapse for n dimensional values
-        # Collapsing a n-D distribution to a point distribution at zero
-        # is equivalent to taking the average of the norm of data.
-        rng = np.random.default_rng(38573488467338826109)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = np.zeros((nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = np.average(np.linalg.norm(u_values, axis=1), weights=u_weights)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
     def test_zero_weight(self):
         # Values with zero weight have no impact on the Wasserstein distance.
         assert_almost_equal(
             stats.wasserstein_distance([1, 2, 100000], [1, 1],
                                        [1, 1, 0], [1, 1]),
             stats.wasserstein_distance([1, 2], [1, 1], [1, 1], [1, 1]))
-
-    @pytest.mark.parametrize('nu', (8, 16, 32))
-    @pytest.mark.parametrize('nv', (8, 16, 32))
-    @pytest.mark.parametrize('ndim', (1, 2, 6))
-    def test_zero_weight_nD(self, nu, nv, ndim):
-        # Values with zero weight have no impact on the Wasserstein distance.
-        rng = np.random.default_rng(38573488467338826109)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        add_row, nrows = rng.integers(0, nu, size=2)
-        add_value = rng.random(size=(nrows, ndim))
-        u_values = np.insert(u_values, add_row, add_value, axis=0)
-        u_weights = np.insert(u_weights, add_row, np.zeros(nrows), axis=0)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
 
     def test_inf_values(self):
         # Inf values can lead to an inf distance or trigger a RuntimeWarning
@@ -7596,72 +7521,6 @@ class TestWassersteinDistance:
             assert_equal(
                 stats.wasserstein_distance([1, 2, np.inf], [np.inf, 1]),
                 np.nan)
-        uv, vv, uw = [[1, 1], [2, 1]], [[np.inf, -np.inf]], [1, 1]
-        distance = stats.wasserstein_distance(uv, vv, uw)
-        assert_equal(distance, np.inf)
-        with np.errstate(invalid='ignore'):
-            uv, vv = [[np.inf, np.inf]], [[np.inf, -np.inf]]
-            distance = stats.wasserstein_distance(uv, vv)
-            assert_equal(distance, np.nan)
-
-    @pytest.mark.parametrize('nu', (10, 15, 20))
-    @pytest.mark.parametrize('nv', (10, 15, 20))
-    @pytest.mark.parametrize('ndim', (1, 3, 5))
-    def test_multi_dim_nD(self, nu, nv, ndim):
-        # Adding dimension on distributions do not affect the result
-        rng = np.random.default_rng(2736495738494849509)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        add_dim = rng.integers(0, ndim)
-        add_value = rng.random()
-
-        u_values = np.insert(u_values, add_dim, add_value, axis=1)
-        v_values = np.insert(v_values, add_dim, add_value, axis=1)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
-    @pytest.mark.parametrize('nu', (7, 13, 19))
-    @pytest.mark.parametrize('nv', (7, 13, 19))
-    @pytest.mark.parametrize('ndim', (2, 4, 7))
-    def test_orthogonal_nD(self, nu, nv, ndim):
-        # orthogonal transformations do not affect the result of the
-        # wasserstein_distance
-        rng = np.random.default_rng(34746837464536)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        dist = stats.ortho_group(ndim)
-        transform = dist.rvs(random_state=rng)
-        shift = rng.random(size=ndim)
-        res = stats.wasserstein_distance(u_values @ transform + shift,
-                                         v_values @ transform + shift,
-                                         u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
-    def test_error_code(self):
-        rng = np.random.default_rng(52473644737485644836320101)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. The inputs'):
-            u_values = rng.random(size=(4, 10, 15))
-            v_values = rng.random(size=(6, 2, 7))
-            _ = stats.wasserstein_distance(u_values, v_values)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. Dimensions'):
-            u_values = rng.random(size=(15,))
-            v_values = rng.random(size=(3, 15))
-            _ = stats.wasserstein_distance(u_values, v_values)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. If two-dimensional'):
-            u_values = rng.random(size=(2, 10))
-            v_values = rng.random(size=(2, 2))
-            _ = stats.wasserstein_distance(u_values, v_values)
 
 
 class TestEnergyDistance:


### PR DESCRIPTION
#### Reference issue
Reverts gh-17473

#### What does this implement/fix?
gh-17473 added support for multivariate Wasserstein distance to `scipy.stats.wasserstein_distance`. There is not a problem with the feature, but I'd like to think twice about adding it to the existing function because it complicates support for an `axis` argument (vectorized calculation over 1D slices) and [different norms](https://github.com/scipy/scipy/issues/19727#issuecomment-1891131325) (e.g. $p=\infty$). If the algorithms and capabilities are going to be totally different for 1D and N-D, it might make sense to create a separate function for the N-D case.

#### Additional information
In the interest of time, I've just done a wholesale revert, even though some improvements to the documentation might be relevant. After this is backported to 1.12.0, we can revert this revert, move what needs to be moved to the new interface, and hopefully release N-D support in 1.13.0.