### PR TITLE
MAINT: fix some small array API support issues

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -196,15 +196,15 @@ def copy(x, *, xp=None):
 
 
 def is_numpy(xp):
-    return xp.__name__ == 'scipy._lib.array_api_compat.numpy'
+    return xp.__name__ in ('numpy', 'scipy._lib.array_api_compat.numpy')
 
 
 def is_cupy(xp):
-    return xp.__name__ == 'scipy._lib.array_api_compat.cupy'
+    return xp.__name__ in ('cupy', 'scipy._lib.array_api_compat.cupy')
 
 
 def is_torch(xp):
-    return xp.__name__ == 'scipy._lib.array_api_compat.torch'
+    return xp.__name__ in ('torch', 'scipy._lib.array_api_compat.torch')
 
 
 def _strict_check(actual, desired, xp,

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -209,6 +209,7 @@ def is_torch(xp):
 
 def _strict_check(actual, desired, xp,
                   check_namespace=True, check_dtype=True, check_shape=True):
+    __tracebackhide__ = True  # Hide traceback for py.test
     if check_namespace:
         _assert_matching_namespace(actual, desired)
 
@@ -228,6 +229,7 @@ def _strict_check(actual, desired, xp,
 
 
 def _assert_matching_namespace(actual, desired):
+    __tracebackhide__ = True  # Hide traceback for py.test
     actual = actual if isinstance(actual, tuple) else (actual,)
     desired_space = array_namespace(desired)
     for arr in actual:
@@ -239,6 +241,7 @@ def _assert_matching_namespace(actual, desired):
 
 
 def _check_scalar(actual, desired, xp):
+    __tracebackhide__ = True  # Hide traceback for py.test
     # Shape check alone is sufficient unless desired.shape == (). Also,
     # only NumPy distinguishes between scalars and arrays.
     if desired.shape != () or not is_numpy(xp):
@@ -264,6 +267,7 @@ def _check_scalar(actual, desired, xp):
 
 def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
                     check_shape=True, err_msg='', xp=None):
+    __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
@@ -281,6 +285,7 @@ def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
 
 def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_namespace=True,
                     check_dtype=True, check_shape=True, err_msg='', xp=None):
+    __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
@@ -298,6 +303,7 @@ def xp_assert_close(actual, desired, rtol=1e-07, atol=0, check_namespace=True,
 
 def xp_assert_less(actual, desired, check_namespace=True, check_dtype=True,
                    check_shape=True, err_msg='', verbose=True, xp=None):
+    __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -121,7 +121,8 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
         raise ValueError("Exactly one of `fillvalue` or `f2` must be given.")
 
     args = xp.broadcast_arrays(cond, *arrays)
-    cond, arrays = xp.astype(args[0], bool, copy=False), args[1:]
+    bool_dtype = xp.asarray([True]).dtype  # numpy 1.xx doesn't have `bool`
+    cond, arrays = xp.astype(args[0], bool_dtype, copy=False), args[1:]
 
     temp1 = xp.asarray(f(*(arr[cond] for arr in arrays)))
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -163,7 +163,7 @@ def _warning(s):
 def int_floor(arr, xp):
     # numpy.array_api is strict about not allowing `int()` on a float array.
     # That's typically not needed, here it is - so explicitly convert
-    return int(xp.astype(arr, xp.int64))
+    return int(xp.astype(xp.asarray(arr), xp.int64))
 
 
 def single(y):

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -517,7 +517,9 @@ def _kpoints(data, k, rng, xp):
 
     """
     idx = rng.choice(data.shape[0], size=int(k), replace=False)
-    return data[idx, ...]
+    # convert to array with default integer dtype (avoids numpy#25607)
+    idx = xp.asarray(idx, dtype=xp.asarray([1]).dtype)
+    return xp.take(data, idx, axis=0)
 
 
 def _krandinit(data, k, rng, xp):
@@ -805,12 +807,12 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
             rng = check_random_state(seed)
             code_book = init_meth(data, code_book, rng, xp)
 
+    data = np.asarray(data)
+    code_book = np.asarray(code_book)
     for i in range(iter):
         # Compute the nearest neighbor for each obs using the current code book
         label = vq(data, code_book, check_finite=check_finite)[0]
         # Update the code book by computing centroids
-        data = np.asarray(data)
-        label = np.asarray(label)
         new_code_book, has_members = _vq.update_cluster_means(data, label, nc)
         if not has_members.all():
             miss_meth()


### PR DESCRIPTION
These surfaced with the more strict reference implementation in https://github.com/numpy/numpy/pull/25370 and with the addition of a `__array_namespace__` method to `numpy.ndarray` for NumPy 2.0 (which caused the `is_numpy` utility function to be wrong). Even if the `is_numpy` issue is also handled by a change in array-api-compat, this still seems like a logical change to make; if `x.__name__` is `'numpy'` then `is_numpy(x)` should return True.

Further changes:
- improved tracebacks for test functions in `_lib/_array_api.py`
- update the `array-ap-compat` submodule to 1.4.1, in order to support NumPy `main`/2.0