### PR TITLE
TST: stats: fix a few issues with non-reproducible seeding

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -147,7 +147,7 @@ class TestVonMises:
 
     def test_vonmises_rvs_gh4598(self):
         # check that random variates wrap around as discussed in gh-4598
-        seed = abs(hash('von_mises_rvs'))
+        seed = 30899520
         rng1 = np.random.default_rng(seed)
         rng2 = np.random.default_rng(seed)
         rng3 = np.random.default_rng(seed)

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -212,7 +212,7 @@ class TestRankData:
     @pytest.mark.parametrize('method', methods)
     def test_nan_policy_omit_3d(self, axis, method):
         shape = (20, 21, 22)
-        rng = np.random.default_rng(abs(hash('falafel')))
+        rng = np.random.RandomState(23983242)
 
         a = rng.random(size=shape)
         i = rng.random(size=shape) < 0.4

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4404,7 +4404,7 @@ class TestKSTwoSamples:
     def test_warnings_gh_14019(self):
         # Check that RuntimeWarning is raised when method='auto' and exact
         # p-value calculation fails. See gh-14019.
-        rng = np.random.default_rng(abs(hash('test_warnings_gh_14019')))
+        rng = np.random.RandomState(seed=23493549)
         # random samples of the same size as in the issue
         data1 = rng.random(size=881) + 0.5
         data2 = rng.random(size=369)
@@ -5898,7 +5898,7 @@ class TestJarqueBera:
         assert_raises(ValueError, stats.jarque_bera, [])
 
     def test_axis(self):
-        rng = np.random.default_rng(abs(hash('JarqueBera')))
+        rng = np.random.RandomState(seed=122398129)
         x = rng.random(size=(2, 45))
 
         assert_equal(stats.jarque_bera(x, axis=None),


### PR DESCRIPTION
The use of `hash('a_descriptive_string')` is cute, but unfortunately hashes are not reproducible at all. This resulted in a hard to debug failure in gh-19797 (see https://github.com/scipy/scipy/pull/19797#issuecomment-1888863426). So remove all usages of `hash()`, and also use `np.random.RandomState` for good measure since that has more stability guarantees than `np.random.default_rng`.

