### PR TITLE
MAINT: stats: fix editable install issue in `qmc` and MPL-related issue in test

### DIFF
--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -1,9 +1,10 @@
 # cython: language_level=3
 # cython: cdivision=True
+import importlib.resources
+
 cimport cython
 cimport numpy as cnp
 
-import os
 import numpy as np
 
 cnp.import_array()
@@ -140,8 +141,11 @@ def _initialize_direction_numbers(poly, vinit, dtype):
         np.savez_compressed("./_sobol_direction_numbers", vinit=vs, poly=poly)
 
     """
-    dns = np.load(os.path.join(os.path.dirname(__file__),
-                  "_sobol_direction_numbers.npz"))
+    _curdir = importlib.resources.files("scipy.stats")
+    _npzfile = _curdir.joinpath("_sobol_direction_numbers.npz")
+    with importlib.resources.as_file(_npzfile) as f:
+        dns = np.load(f)
+
     dns_poly = dns["poly"].astype(dtype)
     dns_vinit = dns["vinit"].astype(dtype)
     poly[...] = dns_poly

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -987,6 +987,10 @@ class TestFitResult:
             with pytest.raises(ValueError, match=message):
                 res.plot(plot_type='llama')
         except (ModuleNotFoundError, ImportError):
-            message = r"matplotlib must be installed to use method `plot`."
-            with pytest.raises(ModuleNotFoundError, match=message):
-                res.plot(plot_type='llama')
+            # Avoid trying to call MPL with numpy 2.0-dev, because that fails
+            # too often due to ABI mismatches and is hard to avoid. This test
+            # will work fine again once MPL has done a 2.0-compatible release.
+            if not np.__version__.startswith('2.0.0.dev0'):
+                message = r"matplotlib must be installed to use method `plot`."
+                with pytest.raises(ModuleNotFoundError, match=message):
+                    res.plot(plot_type='llama')

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -382,9 +382,13 @@ class TestSurvival:
             import matplotlib.pyplot as plt  # noqa: F401
             res.sf.plot()  # no other errors occur
         except (ModuleNotFoundError, ImportError):
-            message = r"matplotlib must be installed to use method `plot`."
-            with pytest.raises(ModuleNotFoundError, match=message):
-                res.sf.plot()
+            # Avoid trying to call MPL with numpy 2.0-dev, because that fails
+            # too often due to ABI mismatches and is hard to avoid. This test
+            # will work fine again once MPL has done a 2.0-compatible release.
+            if not np.__version__.startswith('2.0.0.dev0'):
+                message = r"matplotlib must be installed to use method `plot`."
+                with pytest.raises(ModuleNotFoundError, match=message):
+                    res.sf.plot()
 
 
 class TestLogRank:


### PR DESCRIPTION
This makes the full test suite pass with editable installs and numpy 2.0-dev installed (without a matching `matplotlib` build, which is a pain to do).