### PR TITLE
DEP: extend some announced deprecations due to out-of-band 1.13 release

### DIFF
--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -58,7 +58,7 @@ def _sub_module_deprecation(*, sub_package, module, private_modules, all,
             f"`scipy.{sub_package}.{module}.{attribute}` is deprecated along with "
             f"the `scipy.{sub_package}.{module}` namespace. "
             f"`scipy.{sub_package}.{module}.{attribute}` will be removed "
-            f"in SciPy 1.13.0, and the `scipy.{sub_package}.{module}` namespace "
+            f"in SciPy 1.14.0, and the `scipy.{sub_package}.{module}` namespace "
             f"will be removed in SciPy 2.0.0."
         )
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -315,17 +315,17 @@ def vectorize1(func, args=(), vec_func=False):
 
 
 @_deprecated("`scipy.integrate.quadrature` is deprecated as of SciPy 1.12.0"
-             "and will be removed in SciPy 1.14.0. Please use"
+             "and will be removed in SciPy 1.15.0. Please use"
              "`scipy.integrate.quad` instead.")
 def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
                vec_func=True, miniter=1):
     """
+    Compute a definite integral using fixed-tolerance Gaussian quadrature.
+
     .. deprecated:: 1.12.0
 
           This function is deprecated as of SciPy 1.12.0 and will be removed
-          in SciPy 1.14.0. Please use `scipy.integrate.quad` instead.
-
-    Compute a definite integral using fixed-tolerance Gaussian quadrature.
+          in SciPy 1.15.0. Please use `scipy.integrate.quad` instead.
 
     Integrate `func` from `a` to `b` using Gaussian quadrature
     with absolute tolerance `tol`.
@@ -451,7 +451,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
         .. deprecated:: 1.12.0
             The option for non-zero inputs for `initial` will be deprecated in
-            SciPy 1.14.0. After this time, a ValueError will be raised if
+            SciPy 1.15.0. After this time, a ValueError will be raised if
             `initial` is not None or 0.
 
     Returns
@@ -522,7 +522,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
             warnings.warn(
                 "The option for values for `initial` other than None or 0 is "
                 "deprecated as of SciPy 1.12.0 and will raise a value error in"
-                " SciPy 1.14.0.",
+                " SciPy 1.15.0.",
                 DeprecationWarning, stacklevel=2
             )
         if not np.isscalar(initial):
@@ -1273,17 +1273,17 @@ def _printresmat(function, interval, resmat):
 
 
 @_deprecated("`scipy.integrate.romberg` is deprecated as of SciPy 1.12.0"
-             "and will be removed in SciPy 1.14.0. Please use"
+             "and will be removed in SciPy 1.15.0. Please use"
              "`scipy.integrate.quad` instead.")
 def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
             divmax=10, vec_func=False):
     """
+    Romberg integration of a callable function or method.
+
     .. deprecated:: 1.12.0
 
           This function is deprecated as of SciPy 1.12.0 and will be removed
-          in SciPy 1.14.0. Please use `scipy.integrate.quad` instead.
-
-    Romberg integration of a callable function or method.
+          in SciPy 1.15.0. Please use `scipy.integrate.quad` instead.
 
     Returns the integral of `function` (a function of one variable)
     over the interval (`a`, `b`).

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -93,7 +93,7 @@ def lagrange(x, w):
 
 
 dep_mesg = """\
-`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.13.0.
+`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.14.0.
 
 For legacy code, nearly bug-for-bug compatible replacements are
 `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -115,7 +115,7 @@ class interp2d:
     .. deprecated:: 1.10.0
 
         `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy
-        1.13.0.
+        1.14.0.
 
         For legacy code, nearly bug-for-bug compatible replacements are
         `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1498,7 +1498,7 @@ def order_filter(a, domain, rank):
     a = np.asarray(a)
     if a.dtype in [object, 'float128']:
         mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
         warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(a, domain, rank)
@@ -1576,7 +1576,7 @@ def medfilt(volume, kernel_size=None):
 
     if volume.dtype.char in ['O', 'g']:
         mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
         warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(volume, domain, order)
@@ -2463,8 +2463,8 @@ def hilbert2(x, N=None):
     return x
 
 
-_msg_cplx_sort="""cmplx_sort is deprecated in SciPy 1.12 and will be removed
-in SciPy 1.14. The exact equivalent for a numpy array argument is
+_msg_cplx_sort="""cmplx_sort was deprecated in SciPy 1.12 and will be removed
+in SciPy 1.15. The exact equivalent for a numpy array argument is
 >>> def cmplx_sort(p):
 ...    idx = np.argsort(abs(p))
 ...    return np.take(p, idx, 0), idx

--- a/scipy/signal/_wavelets.py
+++ b/scipy/signal/_wavelets.py
@@ -9,18 +9,18 @@ __all__ = ['daub', 'qmf', 'cascade', 'morlet', 'ricker', 'morlet2', 'cwt']
 
 
 _msg="""scipy.signal.%s is deprecated in SciPy 1.12 and will be removed
-in SciPy 1.14. We recommend using PyWavelets instead.
+in SciPy 1.15. We recommend using PyWavelets instead.
 """
 
 
 def daub(p):
     """
+    The coefficients for the FIR low-pass filter producing Daubechies wavelets.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.daub is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-    The coefficients for the FIR low-pass filter producing Daubechies wavelets.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     p>=1 gives the order of the zero at f=1/2.
     There are 2p filter coefficients.
@@ -91,13 +91,12 @@ def daub(p):
 
 def qmf(hk):
     """
+    Return high-pass qmf filter from low-pass
+
     .. deprecated:: 1.12.0
 
         scipy.signal.qmf is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return high-pass qmf filter from low-pass
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -119,13 +118,12 @@ def qmf(hk):
 
 def cascade(hk, J=7):
     """
+    Return (x, phi, psi) at dyadic points ``K/2**J`` from filter coefficients.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.cascade is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return (x, phi, psi) at dyadic points ``K/2**J`` from filter coefficients.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -233,12 +231,12 @@ def cascade(hk, J=7):
 
 def morlet(M, w=5.0, s=1.0, complete=True):
     """
+    Complex Morlet wavelet.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.morlet is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-    Complex Morlet wavelet.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -317,13 +315,12 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
 def ricker(points, a):
     """
+    Return a Ricker wavelet, also known as the "Mexican hat wavelet".
+
     .. deprecated:: 1.12.0
 
         scipy.signal.ricker is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return a Ricker wavelet, also known as the "Mexican hat wavelet".
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     It models the function:
 
@@ -375,13 +372,12 @@ def _ricker(points, a):
 
 def morlet2(M, s, w=5):
     """
+    Complex Morlet wavelet, designed to work with `cwt`.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.morlet2 is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Complex Morlet wavelet, designed to work with `cwt`.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Returns the complete version of morlet wavelet, normalised
     according to `s`::
@@ -462,13 +458,12 @@ def morlet2(M, s, w=5):
 
 def cwt(data, wavelet, widths, dtype=None, **kwargs):
     """
+    Continuous wavelet transform.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.cwt is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Continuous wavelet transform.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Performs a continuous wavelet transform on `data`,
     using the `wavelet` function. A CWT performs a convolution

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -119,7 +119,7 @@ class _spbase:
                              " to be instantiated directly.")
         self.maxprint = maxprint
 
-    # Use this in 1.13.0 and later:
+    # Use this in 1.14.0 and later:
     #
     # @property
     # def shape(self):
@@ -321,11 +321,11 @@ class _spbase:
 
         .. deprecated:: 1.11.0
 
-            `.A` is deprecated and will be removed in v1.13.0.
+            `.A` is deprecated and will be removed in v1.14.0.
             Use `.toarray()` instead.
         """
         if isinstance(self, sparray):
-            message = ("`.A` is deprecated and will be removed in v1.13.0. "
+            message = ("`.A` is deprecated and will be removed in v1.14.0. "
                        "Use `.toarray()` instead.")
             warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.toarray()
@@ -341,11 +341,11 @@ class _spbase:
 
         .. deprecated:: 1.11.0
 
-            `.H` is deprecated and will be removed in v1.13.0.
+            `.H` is deprecated and will be removed in v1.14.0.
             Please use `.T.conjugate()` instead.
         """
         if isinstance(self, sparray):
-            message = ("`.H` is deprecated and will be removed in v1.13.0. "
+            message = ("`.H` is deprecated and will be removed in v1.14.0. "
                        "Please use `.T.conjugate()` instead.")
             warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.T.conjugate()
@@ -1330,7 +1330,7 @@ class _spbase:
 
 
     ## All methods below are deprecated and should be removed in
-    ## scipy 1.13.0
+    ## scipy 1.14.0
     ##
     ## Also uncomment the definition of shape above.
 
@@ -1338,11 +1338,11 @@ class _spbase:
         """Get shape of a sparse array/matrix.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.shape` instead.
         """
         msg = (
-            "`get_shape` is deprecated and will be removed in v1.13.0; "
+            "`get_shape` is deprecated and will be removed in v1.14.0; "
             "use `X.shape` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1353,11 +1353,11 @@ class _spbase:
         """See `reshape`.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.reshape` instead.
         """
         msg = (
-            "Shape assignment is deprecated and will be removed in v1.13.0; "
+            "Shape assignment is deprecated and will be removed in v1.14.0; "
             "use `reshape` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1372,7 +1372,7 @@ class _spbase:
         fset=set_shape,
         doc="""The shape of the array.
 
-Note that, starting in SciPy 1.13.0, this property will no longer be
+Note that, starting in SciPy 1.14.0, this property will no longer be
 settable. To change the array shape, use `X.reshape` instead.
 """
     )
@@ -1382,11 +1382,11 @@ settable. To change the array shape, use `X.reshape` instead.
 
         .. deprecated:: 1.11.0
            This method is for internal use only, and will be removed from the
-           public API in SciPy 1.13.0.
+           public API in SciPy 1.14.0.
         """
         msg = (
             "`asfptype` is an internal function, and is deprecated "
-            "as part of the public API. It will be removed in v1.13.0."
+            "as part of the public API. It will be removed in v1.14.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._asfptype()
@@ -1396,11 +1396,11 @@ settable. To change the array shape, use `X.reshape` instead.
 
         .. deprecated:: 1.11.0
            This method is for internal use only, and will be removed from the
-           public API in SciPy 1.13.0.
+           public API in SciPy 1.14.0.
         """
         msg = (
             "`getmaxprint` is an internal function, and is deprecated "
-            "as part of the public API. It will be removed in v1.13.0."
+            "as part of the public API. It will be removed in v1.14.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getmaxprint()
@@ -1409,11 +1409,11 @@ settable. To change the array shape, use `X.reshape` instead.
         """Sparse array/matrix storage format.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.format` instead.
         """
         msg = (
-            "`getformat` is deprecated and will be removed in v1.13.0; "
+            "`getformat` is deprecated and will be removed in v1.14.0; "
             "use `X.format` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1423,7 +1423,7 @@ settable. To change the array shape, use `X.reshape` instead.
         """Number of stored values, including explicit zeros.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0. Use `X.nnz`
+           This method will be removed in SciPy 1.14.0. Use `X.nnz`
            instead.  The `axis` argument will no longer be supported;
            please let us know if you still need this functionality.
 
@@ -1438,7 +1438,7 @@ settable. To change the array shape, use `X.reshape` instead.
         count_nonzero : Number of non-zero entries
         """
         msg = (
-            "`getnnz` is deprecated and will be removed in v1.13.0; "
+            "`getnnz` is deprecated and will be removed in v1.14.0; "
             "use `X.nnz` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1448,11 +1448,11 @@ settable. To change the array shape, use `X.reshape` instead.
         """Return the Hermitian transpose of this array/matrix.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.conj().T` instead.
         """
         msg = (
-            "`getH` is deprecated and will be removed in v1.13.0; "
+            "`getH` is deprecated and will be removed in v1.14.0; "
             "use `X.conj().T` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1463,11 +1463,11 @@ settable. To change the array shape, use `X.reshape` instead.
         array/matrix (column vector).
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use array/matrix indexing instead.
         """
         msg = (
-            "`getcol` is deprecated and will be removed in v1.13.0; "
+            "`getcol` is deprecated and will be removed in v1.14.0; "
             f"use `X[:, [{j}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1478,17 +1478,17 @@ settable. To change the array shape, use `X.reshape` instead.
         array/matrix (row vector).
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use array/matrix indexing instead.
         """
         msg = (
-            "`getrow` is deprecated and will be removed in v1.13.0; "
+            "`getrow` is deprecated and will be removed in v1.14.0; "
             f"use `X[[{i}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getrow(i)
 
-    ## End 1.13.0 deprecated methods
+    ## End 1.14.0 deprecated methods
 
 
 class sparray:

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -7,7 +7,7 @@ def test_array_api_deprecations():
         [1,2,3],
         [4,0,6]
     ])
-    msg = "1.13.0"
+    msg = "1.14.0"
 
     with pytest.deprecated_call(match=msg):
         X.get_shape()

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -9,7 +9,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     .. deprecated:: 1.12.0
         `rvs_ratio_uniforms` is deprecated in favour of
         `scipy.stats.sampling.RatioUniforms` from version 1.12.0 and will
-        be removed in SciPy 1.14.0
+        be removed in SciPy 1.15.0
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     warnings.warn("Please use `RatioUniforms` from the "
                   "`scipy.stats.sampling` namespace. The "
                   "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated "
-                  "and will be removed in SciPy 1.14.0",
+                  "and will be removed in SciPy 1.15.0",
                   category=DeprecationWarning, stacklevel=2)
     gen = RatioUniforms(pdf, umax=umax, vmin=vmin, vmax=vmax,
                         c=c, random_state=random_state)


### PR DESCRIPTION
Implement the [plan](https://github.com/scipy/scipy/issues/15765#issuecomment-1892941618) to delay some deprecations, due to the out-of-band release of 1.13 that was not accounted for when these deprecation warnings were written.

I've also moved the deprecation sections away from the top line of docstrings, because that is read/displayed by lots of tooling (e.g. IDEs), and should still contain the description of the function (even though we want to place the deprecation warning prominently).