### PR TITLE
MAINT: remove unused itertools-import in scipy.interpolate._interpolate

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -17,10 +17,6 @@ from . import _ppoly
 from .interpnd import _ndim_coords_from_arrays
 from ._bsplines import make_interp_spline, BSpline
 
-# even though this is a stdlib module, it got accidentally exposed in __all__
-# in the past. It is now deprecated and scheduled to be removed in SciPy 1.13.0
-import itertools  # noqa: F401
-
 
 def lagrange(x, w):
     r"""


### PR DESCRIPTION
I stumbled over this today, and wanted to double-check before we remove it.

AFAICT this couldn't have shown up in `from scipy.interpolate import *` due to the [presence](https://github.com/scipy/scipy/blame/main/scipy/interpolate/_interpolate.py#L1) of `__all__` in that module further up. I didn't test this at the time we [last](https://github.com/scipy/scipy/pull/18992#discussion_r1278997804) had this discussion, but I didn't manage to `itertools` to import (much less warn) through `scipy.interpolate`, neither in 1.11.4 nor on main.

I think we can just remove this now.