### PR TITLE
MAINT: special: remove use of `numpy.math` from `_cdflib.pyx`

### DIFF
--- a/scipy/special/_cdflib.pyx
+++ b/scipy/special/_cdflib.pyx
@@ -7,8 +7,7 @@
 import numpy as np
 cimport numpy as cnp
 cnp.import_array()
-from libc.math cimport sin, tan, log, exp, sqrt, floor
-from numpy.math cimport INFINITY, PI
+from libc.math cimport sin, tan, log, exp, sqrt, floor, INFINITY, pi as PI
 
 cdef double[3] spmpar = [np.finfo(np.float64).eps,
                          np.finfo(np.float64).tiny,

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -168,11 +168,11 @@ py3.extension_module('_specfun',
   subdir: 'scipy/special'
 )
 
-cdflib_c = cython_gen.process('_cdflib.pyx')
-
 py3.extension_module('_cdflib',
-  cdflib_c,
+  cython_gen.process('_cdflib.pyx'),
+  c_args: cython_c_args,
   dependencies: [np_dep],
+  link_args: version_link_args,
   install: true,
   subdir: 'scipy/special'
 )


### PR DESCRIPTION
This Cython module should not be used, since it's likely to be deprecated and we cleaned up all instances of it a while back. It is not necessary here (symbols are in `libc.math` too).

Also fix some issues with the build definition for the `special._cdflib` extension.