### PR TITLE
MAINT:linalg:Adjust lwork/liwork changes OpenBLAS 0.3.26

### DIFF
--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -762,8 +762,8 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>=vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
-    integer optional,intent(in),depend(n),check(lwork>=max(1,26*n)||lwork==-1) :: lwork=max(26*n,1)
-    integer optional,intent(in),depend(n),check(liwork>=max(1,10*n)||liwork==-1):: liwork= max(1,10*n)
+    integer optional,intent(in),depend(n),check(lwork>=(n <= 1 ? 1 : max(1,26*n))||lwork==-1) :: lwork=max(26*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=(n <= 1 ? 1 : max(1,10*n))||liwork==-1):: liwork= max(1,10*n)
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)
@@ -832,9 +832,9 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
-    integer optional,intent(in),depend(n),check(lwork>=max(2*n,1)||lwork==-1) :: lwork=max(2*n,1)
-    integer optional,intent(in),depend(n),check(lrwork>=max(24*n,1)||lrwork==-1) :: lrwork=max(24*n,1)
-    integer optional,intent(in),depend(n),check(liwork>=max(1,10*n)||liwork==-1):: liwork= max(1,10*n)
+    integer optional,intent(in),depend(n),check(lwork>=(n <= 1 ? 1 : max(1,2*n))||lwork==-1) :: lwork=max(2*n,1)
+    integer optional,intent(in),depend(n),check(lrwork>=(n <= 1 ? 1 : max(1,24*n))||lrwork==-1) :: lrwork=max(24*n,1)
+    integer optional,intent(in),depend(n),check(liwork>=(n <= 1 ? 1 : max(1,10*n))||liwork==-1):: liwork= max(1,10*n)
 
     integer intent(hide),depend(a) :: n=shape(a,0)
     integer intent(hide),depend(n) :: lda=max(1,n)


### PR DESCRIPTION
Closes #19831 

See https://github.com/Reference-LAPACK/lapack/pull/942. The default values of `{l, li, lr}work` has changed for small `n`. This fixes our LAPACK wrappers. It looked like `evr` family is the one that got hit in our wrappers but if more we can use this template for them too.
