### PR TITLE
BLD: ensure the name of the installed `scipy` package is lower-case

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'SciPy',
+  'scipy',
   'c', 'cpp', 'cython',
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires = [
 ]
 
 [project]
-name = "SciPy"
+name = "scipy"
 version = "1.13.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`


### PR DESCRIPTION
Closes gh-19906. See that issue for details.
