### PR TITLE
ENH: optimize.shgo: add specific logger

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -18,6 +18,8 @@ from scipy.optimize._shgo_lib._complex import Complex
 
 __all__ = ['shgo']
 
+logger = logging.getLogger('scipy.optimize.shgo')
+
 
 def shgo(
     func, bounds, args=(), constraints=None, n=100, iters=1, callback=None,
@@ -496,7 +498,7 @@ def shgo(
         shc.iterate_all()
 
     if not shc.break_routine:
-        logging.getLogger('scipy.optimize.shgo').info(
+        logger.info(
             "Successfully completed construction of complex."
         )
 
@@ -530,8 +532,6 @@ class SHGO:
                  iters=None, callback=None, minimizer_kwargs=None,
                  options=None, sampling_method='simplicial', workers=1):
         from scipy.stats import qmc
-
-        self.logger = logging.getLogger('scipy.optimize.shgo')
 
         # Input checks
         methods = ['halton', 'sobol', 'simplicial']
@@ -869,7 +869,7 @@ class SHGO:
         processing time) has been met.
 
         """
-        self.logger.info('Splitting first generation')
+        logger.info('Splitting first generation')
 
         while not self.stop_global:
             if self.break_routine:
@@ -893,7 +893,7 @@ class SHGO:
         Construct the minimizer pool, map the minimizers to local minima
         and sort the results into a global return object.
         """
-        self.logger.info('Searching for minimizer pool...')
+        logger.info('Searching for minimizer pool...')
 
         self.minimizers()
 
@@ -911,7 +911,7 @@ class SHGO:
         else:
             self.find_lowest_vertex()
 
-        self.logger.info("Minimiser pool = SHGO.X_min = %s", self.X_min)
+        logger.info("Minimiser pool = SHGO.X_min = %s", self.X_min)
 
     def find_lowest_vertex(self):
         # Find the lowest objective function value on one of
@@ -919,7 +919,7 @@ class SHGO:
         self.f_lowest = np.inf
         for x in self.HC.V.cache:
             if self.HC.V[x].f < self.f_lowest:
-                self.logger.info('self.HC.V[x].f = %f', self.HC.V[x].f)
+                logger.info('self.HC.V[x].f = %f', self.HC.V[x].f)
                 self.f_lowest = self.HC.V[x].f
                 self.x_lowest = self.HC.V[x].x_a
         for lmc in self.LMC.cache:
@@ -934,7 +934,7 @@ class SHGO:
     # Stopping criteria functions:
     def finite_iterations(self):
         mi = min(x for x in [self.iters, self.maxiter] if x is not None)
-        self.logger.info('Iterations done = %d / %d', self.iters_done, mi)
+        logger.info('Iterations done = %d / %d', self.iters_done, mi)
         if self.iters is not None:
             if self.iters_done >= (self.iters):
                 self.stop_global = True
@@ -946,7 +946,7 @@ class SHGO:
 
     def finite_fev(self):
         # Finite function evals in the feasible domain
-        self.logger.info(
+        logger.info(
             'Function evaluations done = %d / %d', self.fn, self.maxfev
         )
         if self.fn >= self.maxfev:
@@ -955,7 +955,7 @@ class SHGO:
 
     def finite_ev(self):
         # Finite evaluations including infeasible sampling points
-        self.logger.info(
+        logger.info(
             'Sampling evaluations done = %d / %d', self.n_sampled, self.maxev
         )
         if self.n_sampled >= self.maxev:
@@ -963,7 +963,7 @@ class SHGO:
 
     def finite_time(self) -> None:
         elapsed_time: float = time.time() - self.init
-        self.logger.info('Time elapsed = %f / %f', elapsed_time, self.maxtime)
+        logger.info('Time elapsed = %f / %f', elapsed_time, self.maxtime)
         if elapsed_time >= self.maxtime:
             self.stop_global = True
 
@@ -976,8 +976,8 @@ class SHGO:
         """
         # If no minimizer has been found use the lowest sampling value
         self.find_lowest_vertex()
-        self.logger.info('Lowest function evaluation = %f', self.f_lowest)
-        self.logger.info('Specified minimum = %f', self.f_min_true)
+        logger.info('Lowest function evaluation = %f', self.f_lowest)
+        logger.info('Specified minimum = %f', self.f_min_true)
         # If no feasible point was return from test
         if self.f_lowest is None:
             return self.stop_global
@@ -1013,7 +1013,7 @@ class SHGO:
         self.hgr = self.LMC.size
         if self.hgrd <= self.minhgrd:
             self.stop_global = True
-        self.logger.info(
+        logger.info(
             'Current homology growth = %d  (minimum growth = %d)',
             self.hgrd,
             self.minhgrd
@@ -1062,7 +1062,7 @@ class SHGO:
         Note: called with ``self.iterate_complex()`` after class initiation
         """
         # Iterate the complex
-        self.logger.info('Constructing and refining simplicial complex graph '
+        logger.info('Constructing and refining simplicial complex graph '
                          'structure')
         if self.n is None:
             self.HC.refine_all()
@@ -1071,7 +1071,7 @@ class SHGO:
             self.HC.refine(self.n)
             self.n_sampled += self.n
 
-        self.logger.info('Triangulation completed, evaluating all constraints '
+        logger.info('Triangulation completed, evaluating all constraints '
                          'and objective function values.')
 
         # Re-add minimisers to complex
@@ -1093,7 +1093,7 @@ class SHGO:
 
         # Evaluate all constraints and functions
         self.HC.V.process_pools()
-        self.logger.info('Evaluations completed.')
+        logger.info('Evaluations completed.')
 
         # feasible sampling points counted by the triangulation.py routines
         self.fn = self.HC.V.nfev
@@ -1109,9 +1109,9 @@ class SHGO:
         self.sampled_surface(infty_cons_sampl=self.infty_cons_sampl)
 
         # Add sampled points to a triangulation, construct self.Tri
-        self.logger.info('self.n = %d', self.n)
-        self.logger.info('self.nc = %d', self.nc)
-        self.logger.info('Constructing and refining simplicial complex graph '
+        logger.info('self.n = %d', self.n)
+        logger.info('self.nc = %d', self.nc)
+        logger.info('Constructing and refining simplicial complex graph '
                          'structure from sampling points.')
 
         if self.dim < 2:
@@ -1131,7 +1131,7 @@ class SHGO:
                 self.delaunay_triangulation(n_prc=self.n_prc)
             self.n_prc = self.C.shape[0]
 
-        self.logger.info('Triangulation completed, evaluating all '
+        logger.info('Triangulation completed, evaluating all '
                          'constraints and objective function values.')
 
         if hasattr(self, 'Tri'):
@@ -1139,12 +1139,12 @@ class SHGO:
 
         # Process all pools
         # Evaluate all constraints and functions
-        self.logger.info('Triangulation completed, evaluating all constraints '
+        logger.info('Triangulation completed, evaluating all constraints '
                          'and objective function values.')
 
         # Evaluate all constraints and functions
         self.HC.V.process_pools()
-        self.logger.info('Evaluations completed.')
+        logger.info('Evaluations completed.')
 
         # feasible sampling points counted by the triangulation.py routines
         self.fn = self.HC.V.nfev
@@ -1168,20 +1168,20 @@ class SHGO:
                 continue
 
             if self.HC.V[x].minimiser():
-                self.logger.info('=' * 60)
-                self.logger.info('v.x = %s is minimizer', self.HC.V[x].x_a)
-                self.logger.info('v.f = %s is minimizer', self.HC.V[x].f)
-                self.logger.info('=' * 30)
+                logger.info('=' * 60)
+                logger.info('v.x = %s is minimizer', self.HC.V[x].x_a)
+                logger.info('v.f = %s is minimizer', self.HC.V[x].f)
+                logger.info('=' * 30)
 
                 if self.HC.V[x] not in self.minimizer_pool:
                     self.minimizer_pool.append(self.HC.V[x])
 
-                self.logger.info('Neighbors:')
-                self.logger.info('=' * 30)
+                logger.info('Neighbors:')
+                logger.info('=' * 30)
                 for vn in self.HC.V[x].nn:
-                    self.logger.info('x = %s || f = %s', vn.x, vn.f)
+                    logger.info('x = %s || f = %s', vn.x, vn.f)
 
-                self.logger.info('=' * 60)
+                logger.info('=' * 60)
         self.minimizer_pool_F = []
         self.X_min = []
         # normalized tuple in the Vertex cache
@@ -1315,8 +1315,8 @@ class SHGO:
                 if (x_i > v_min.x_a[i]) and (x_i < cbounds[i][1]):
                     cbounds[i][1] = x_i
 
-        self.logger.info('cbounds found for v_min.x_a = %s', v_min.x_a)
-        self.logger.info('cbounds = %s', cbounds)
+        logger.info('cbounds found for v_min.x_a = %s', v_min.x_a)
+        logger.info('cbounds = %s', cbounds)
 
         return cbounds
 
@@ -1357,16 +1357,16 @@ class SHGO:
             object.
         """
         # Use minima maps if vertex was already run
-        self.logger.info('Vertex minimiser maps = %s', self.LMC.v_maps)
+        logger.info('Vertex minimiser maps = %s', self.LMC.v_maps)
 
         if self.LMC[x_min].lres is not None:
-            self.logger.info('Found self.LMC[x_min].lres = %s', self.LMC[x_min].lres)
+            logger.info('Found self.LMC[x_min].lres = %s', self.LMC[x_min].lres)
             return self.LMC[x_min].lres
 
         if self.callback is not None:
-            self.logger.info('Callback for minimizer starting at %s:', x_min)
+            logger.info('Callback for minimizer starting at %s:', x_min)
 
-        self.logger.info('Starting minimization at %s...', x_min)
+        logger.info('Starting minimization at %s...', x_min)
 
         if self.sampling_method == 'simplicial':
             x_min_t = tuple(x_min)
@@ -1376,22 +1376,22 @@ class SHGO:
             g_bounds = self.construct_lcb_simplicial(self.HC.V[x_min_t_norm])
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
-                self.logger.info(self.minimizer_kwargs['bounds'])
+                logger.info(self.minimizer_kwargs['bounds'])
 
         else:
             g_bounds = self.construct_lcb_delaunay(x_min, ind=ind)
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
-                self.logger.info(self.minimizer_kwargs['bounds'])
+                logger.info(self.minimizer_kwargs['bounds'])
 
         if 'bounds' in self.minimizer_kwargs:
-            self.logger.info('bounds in kwarg:')
-            self.logger.info(self.minimizer_kwargs['bounds'])
+            logger.info('bounds in kwarg:')
+            logger.info(self.minimizer_kwargs['bounds'])
 
         # Local minimization using scipy.optimize.minimize:
         lres = minimize(self.func, x_min, **self.minimizer_kwargs)
 
-        self.logger.info('lres = %s', lres)
+        logger.info('lres = %s', lres)
 
         # Local function evals for all minimizers
         self.res.nlfev += lres.nfev
@@ -1452,7 +1452,7 @@ class SHGO:
         requires more objective function evaluations.
         """
         # Generate sampling points
-        self.logger.info('Generating sampling points')
+        logger.info('Generating sampling points')
         self.sampling(self.nc, self.dim)
         if len(self.LMC.xl_maps) > 0:
             self.C = np.vstack((self.C, np.array(self.LMC.xl_maps)))
@@ -1504,7 +1504,7 @@ class SHGO:
                                     + 'feasible set. Increasing sampling '
                                     + 'size.')
                 # sampling correctly for both 1-D and >1-D cases
-                self.logger.info(self.res.message)
+                logger.info(self.res.message)
 
     def sorted_samples(self):  # Validated
         """Find indexes of the sorted sampling points"""
@@ -1524,7 +1524,7 @@ class SHGO:
                                             )
             except spatial.QhullError:
                 if str(sys.exc_info()[1])[:6] == 'QH6239':
-                    self.logger.warning('QH6239 Qhull precision error detected, '
+                    logger.warning('QH6239 Qhull precision error detected, '
                                     'this usually occurs when no bounds are '
                                     'specified, Qhull can only run with '
                                     'handling cocircular/cospherical points'

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -203,48 +203,7 @@ def shgo(
 
         * disp : bool (L)
             Set to True to print convergence messages. This setting applies
-            mainly to compiled subroutines used during optimization. The
-            native Python code is mainly set up to log messages using the
-            standard ``logging`` library to the logger named
-            "scipy.optimize.shgo". By default warnings and errors will be
-            printed to ``sys.stderr`` while information and debug log messages
-            are hidden.
-            To change the logging level from the default
-            ``logging.WARNING`` you may anywhere in your code change the
-            logger through e.g.
-
-            >>> import logging
-            ...
-            >>> logger = logging.getLogger('scipy.optimize.shgo')
-            ...
-            >>> # set the logging level to DEBUG
-            >>> logger.setLevel(logging.DEBUG)
-            ...
-            >>> # Add a handler which outputs log messages to the console.
-            >>> # In order to write log messages to file use
-            >>> # logging.FileHandler instead.
-            >>> ch = logging.StreamHandler()
-            ...
-            >>> # Use the standard format for logging output.
-            >>> # Alternatively specify other desired format.
-            >>> formatter = logging.Formatter(logging.BASIC_FORMAT)
-            ...
-            >>> ch.setFormatter(formatter)
-            >>> logger.addHandler(ch)
-
-            Note that the organization of the loggers is hierachical. The
-            "scipy.optimize.shgo" logger is the child of "scipy.optimize" which
-            is the child of "scipy". Changes made to one logger propagates down
-            the hierarchy, meaning that setting the logging level of "scipy"
-            will affect the logging level of "scipy.optimize.shgo" unless the
-            latter is also explicitly modified.
-            See e.g.
-            https://docs.python.org/3/howto/logging.html#configuring-logging
-            for further information on formats, writing to file, and the
-            available logging levels.
-
-            .. versionchanged:: 1.12.1
-                Using the 'scipy.optimize.shgo' logger instead of root.
+            mainly to compiled subroutines used during optimization.
 
     sampling_method : str or function, optional
         Current built in sampling method options are ``halton``, ``sobol`` and
@@ -322,6 +281,9 @@ def shgo(
 
     The ``halton`` and ``sobol`` method points are generated using
     `scipy.stats.qmc`. Any other QMC method could be used.
+
+    The Python code of this optimizer is set up to log messages using the
+    standard ``logging`` library to the logger named "scipy.optimize.shgo".
 
     References
     ----------

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -200,7 +200,46 @@ def shgo(
         Feedback:
 
         * disp : bool (L)
-            Set to True to print convergence messages.
+            Set to True to print convergence messages. This setting applies
+            mainly to compiled subroutines used during optimization. The
+            native Python code is mainly set up to log messages using the
+            standard ``logging`` library to the logger named
+            "scipy.optimize.shgo". By default warnings and errors will be
+            printed to ``sys.stderr`` while information and debug log messages
+            are hidden.
+            To change the logging level from the default
+            ``logging.WARNING`` you may anywhere in your code change the
+            logger through e.g.
+
+            >>> import logging
+            ...
+            >>> logger = logging.getLogger('scipy.optimize.shgo')
+            ...
+            >>> # set the logging level to DEBUG
+            >>> logger.setLevel(logging.DEBUG)
+            ...
+            >>> # Add a handler which outputs log messages to the console.
+            >>> # In order to write log messages to file use
+            >>> # logging.FileHandler instead.
+            >>> ch = logging.StreamHandler()
+            ...
+            >>> # Use the standard format for logging output.
+            >>> # Alternatively specify other desired format.
+            >>> formatter = logging.Formatter(logging.BASIC_FORMAT)
+            ...
+            >>> ch.setFormatter(formatter)
+            >>> logger.addHandler(ch)
+
+            Note that the organization of the loggers is hierachical. The
+            "scipy.optimize.shgo" logger is the child of "scipy.optimize" which
+            is the child of "scipy". Changes made to one logger propagates down
+            the hierarchy, meaning that setting the logging level of "scipy"
+            will affect the logging level of "scipy.optimize.shgo" unless the
+            latter is also explicitly modified.
+            See e.g.
+            https://docs.python.org/3/howto/logging.html#configuring-logging
+            for further information on formats, writing to file, and the
+            available logging levels.
 
     sampling_method : str or function, optional
         Current built in sampling method options are ``halton``, ``sobol`` and
@@ -454,8 +493,9 @@ def shgo(
         shc.iterate_all()
 
     if not shc.break_routine:
-        if shc.disp:
-            logging.info("Successfully completed construction of complex.")
+        logging.getLogger('scipy.optimize.shgo').info(
+            "Successfully completed construction of complex."
+        )
 
     # Test post iterations success
     if len(shc.LMC.xl_maps) == 0:
@@ -487,6 +527,9 @@ class SHGO:
                  iters=None, callback=None, minimizer_kwargs=None,
                  options=None, sampling_method='simplicial', workers=1):
         from scipy.stats import qmc
+
+        self.logger = logging.getLogger('scipy.optimize.shgo')
+
         # Input checks
         methods = ['halton', 'sobol', 'simplicial']
         if isinstance(sampling_method, str) and sampling_method not in methods:
@@ -823,8 +866,7 @@ class SHGO:
         processing time) has been met.
 
         """
-        if self.disp:
-            logging.info('Splitting first generation')
+        self.logger.info('Splitting first generation')
 
         while not self.stop_global:
             if self.break_routine:
@@ -848,8 +890,7 @@ class SHGO:
         Construct the minimizer pool, map the minimizers to local minima
         and sort the results into a global return object.
         """
-        if self.disp:
-            logging.info('Searching for minimizer pool...')
+        self.logger.info('Searching for minimizer pool...')
 
         self.minimizers()
 
@@ -867,8 +908,7 @@ class SHGO:
         else:
             self.find_lowest_vertex()
 
-        if self.disp:
-            logging.info(f"Minimiser pool = SHGO.X_min = {self.X_min}")
+        self.logger.info(f"Minimiser pool = SHGO.X_min = {self.X_min}")
 
     def find_lowest_vertex(self):
         # Find the lowest objective function value on one of
@@ -876,8 +916,7 @@ class SHGO:
         self.f_lowest = np.inf
         for x in self.HC.V.cache:
             if self.HC.V[x].f < self.f_lowest:
-                if self.disp:
-                    logging.info(f'self.HC.V[x].f = {self.HC.V[x].f}')
+                self.logger.info(f'self.HC.V[x].f = {self.HC.V[x].f}')
                 self.f_lowest = self.HC.V[x].f
                 self.x_lowest = self.HC.V[x].x_a
         for lmc in self.LMC.cache:
@@ -892,8 +931,7 @@ class SHGO:
     # Stopping criteria functions:
     def finite_iterations(self):
         mi = min(x for x in [self.iters, self.maxiter] if x is not None)
-        if self.disp:
-            logging.info(f'Iterations done = {self.iters_done} / {mi}')
+        self.logger.info(f'Iterations done = {self.iters_done} / {mi}')
         if self.iters is not None:
             if self.iters_done >= (self.iters):
                 self.stop_global = True
@@ -905,23 +943,20 @@ class SHGO:
 
     def finite_fev(self):
         # Finite function evals in the feasible domain
-        if self.disp:
-            logging.info(f'Function evaluations done = {self.fn} / {self.maxfev}')
+        self.logger.info(f'Function evaluations done = {self.fn} / {self.maxfev}')
         if self.fn >= self.maxfev:
             self.stop_global = True
         return self.stop_global
 
     def finite_ev(self):
         # Finite evaluations including infeasible sampling points
-        if self.disp:
-            logging.info(f'Sampling evaluations done = {self.n_sampled} '
+        self.logger.info(f'Sampling evaluations done = {self.n_sampled} '
                          f'/ {self.maxev}')
         if self.n_sampled >= self.maxev:
             self.stop_global = True
 
     def finite_time(self):
-        if self.disp:
-            logging.info(f'Time elapsed = {time.time() - self.init} '
+        self.logger.info(f'Time elapsed = {time.time() - self.init} '
                          f'/ {self.maxtime}')
         if (time.time() - self.init) >= self.maxtime:
             self.stop_global = True
@@ -935,9 +970,8 @@ class SHGO:
         """
         # If no minimizer has been found use the lowest sampling value
         self.find_lowest_vertex()
-        if self.disp:
-            logging.info(f'Lowest function evaluation = {self.f_lowest}')
-            logging.info(f'Specified minimum = {self.f_min_true}')
+        self.logger.info(f'Lowest function evaluation = {self.f_lowest}')
+        self.logger.info(f'Specified minimum = {self.f_min_true}')
         # If no feasible point was return from test
         if self.f_lowest is None:
             return self.stop_global
@@ -973,8 +1007,7 @@ class SHGO:
         self.hgr = self.LMC.size
         if self.hgrd <= self.minhgrd:
             self.stop_global = True
-        if self.disp:
-            logging.info(f'Current homology growth = {self.hgrd} '
+        self.logger.info(f'Current homology growth = {self.hgrd} '
                          f' (minimum growth = {self.minhgrd})')
         return self.stop_global
 
@@ -1020,8 +1053,7 @@ class SHGO:
         Note: called with ``self.iterate_complex()`` after class initiation
         """
         # Iterate the complex
-        if self.disp:
-            logging.info('Constructing and refining simplicial complex graph '
+        self.logger.info('Constructing and refining simplicial complex graph '
                          'structure')
         if self.n is None:
             self.HC.refine_all()
@@ -1030,8 +1062,7 @@ class SHGO:
             self.HC.refine(self.n)
             self.n_sampled += self.n
 
-        if self.disp:
-            logging.info('Triangulation completed, evaluating all constraints '
+        self.logger.info('Triangulation completed, evaluating all constraints '
                          'and objective function values.')
 
         # Re-add minimisers to complex
@@ -1053,8 +1084,7 @@ class SHGO:
 
         # Evaluate all constraints and functions
         self.HC.V.process_pools()
-        if self.disp:
-            logging.info('Evaluations completed.')
+        self.logger.info('Evaluations completed.')
 
         # feasible sampling points counted by the triangulation.py routines
         self.fn = self.HC.V.nfev
@@ -1070,10 +1100,9 @@ class SHGO:
         self.sampled_surface(infty_cons_sampl=self.infty_cons_sampl)
 
         # Add sampled points to a triangulation, construct self.Tri
-        if self.disp:
-            logging.info(f'self.n = {self.n}')
-            logging.info(f'self.nc = {self.nc}')
-            logging.info('Constructing and refining simplicial complex graph '
+        self.logger.info(f'self.n = {self.n}')
+        self.logger.info(f'self.nc = {self.nc}')
+        self.logger.info('Constructing and refining simplicial complex graph '
                          'structure from sampling points.')
 
         if self.dim < 2:
@@ -1093,8 +1122,7 @@ class SHGO:
                 self.delaunay_triangulation(n_prc=self.n_prc)
             self.n_prc = self.C.shape[0]
 
-        if self.disp:
-            logging.info('Triangulation completed, evaluating all '
+        self.logger.info('Triangulation completed, evaluating all '
                          'constraints and objective function values.')
 
         if hasattr(self, 'Tri'):
@@ -1102,14 +1130,12 @@ class SHGO:
 
         # Process all pools
         # Evaluate all constraints and functions
-        if self.disp:
-            logging.info('Triangulation completed, evaluating all constraints '
+        self.logger.info('Triangulation completed, evaluating all constraints '
                          'and objective function values.')
 
         # Evaluate all constraints and functions
         self.HC.V.process_pools()
-        if self.disp:
-            logging.info('Evaluations completed.')
+        self.logger.info('Evaluations completed.')
 
         # feasible sampling points counted by the triangulation.py routines
         self.fn = self.HC.V.nfev
@@ -1133,22 +1159,20 @@ class SHGO:
                 continue
 
             if self.HC.V[x].minimiser():
-                if self.disp:
-                    logging.info('=' * 60)
-                    logging.info(f'v.x = {self.HC.V[x].x_a} is minimizer')
-                    logging.info(f'v.f = {self.HC.V[x].f} is minimizer')
-                    logging.info('=' * 30)
+                self.logger.info('=' * 60)
+                self.logger.info(f'v.x = {self.HC.V[x].x_a} is minimizer')
+                self.logger.info(f'v.f = {self.HC.V[x].f} is minimizer')
+                self.logger.info('=' * 30)
 
                 if self.HC.V[x] not in self.minimizer_pool:
                     self.minimizer_pool.append(self.HC.V[x])
 
-                if self.disp:
-                    logging.info('Neighbors:')
-                    logging.info('=' * 30)
-                    for vn in self.HC.V[x].nn:
-                        logging.info(f'x = {vn.x} || f = {vn.f}')
+                self.logger.info('Neighbors:')
+                self.logger.info('=' * 30)
+                for vn in self.HC.V[x].nn:
+                    self.logger.info(f'x = {vn.x} || f = {vn.f}')
 
-                    logging.info('=' * 60)
+                self.logger.info('=' * 60)
         self.minimizer_pool_F = []
         self.X_min = []
         # normalized tuple in the Vertex cache
@@ -1282,9 +1306,8 @@ class SHGO:
                 if (x_i > v_min.x_a[i]) and (x_i < cbounds[i][1]):
                     cbounds[i][1] = x_i
 
-        if self.disp:
-            logging.info(f'cbounds found for v_min.x_a = {v_min.x_a}')
-            logging.info(f'cbounds = {cbounds}')
+        self.logger.info(f'cbounds found for v_min.x_a = {v_min.x_a}')
+        self.logger.info(f'cbounds = {cbounds}')
 
         return cbounds
 
@@ -1325,19 +1348,17 @@ class SHGO:
             object.
         """
         # Use minima maps if vertex was already run
-        if self.disp:
-            logging.info(f'Vertex minimiser maps = {self.LMC.v_maps}')
+        self.logger.info(f'Vertex minimiser maps = {self.LMC.v_maps}')
 
         if self.LMC[x_min].lres is not None:
-            logging.info(f'Found self.LMC[x_min].lres = '
+            self.logger.info(f'Found self.LMC[x_min].lres = '
                          f'{self.LMC[x_min].lres}')
             return self.LMC[x_min].lres
 
         if self.callback is not None:
-            logging.info(f'Callback for minimizer starting at {x_min}:')
+            self.logger.info(f'Callback for minimizer starting at {x_min}:')
 
-        if self.disp:
-            logging.info(f'Starting minimization at {x_min}...')
+        self.logger.info(f'Starting minimization at {x_min}...')
 
         if self.sampling_method == 'simplicial':
             x_min_t = tuple(x_min)
@@ -1347,23 +1368,22 @@ class SHGO:
             g_bounds = self.construct_lcb_simplicial(self.HC.V[x_min_t_norm])
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
-                logging.info(self.minimizer_kwargs['bounds'])
+                self.logger.info(self.minimizer_kwargs['bounds'])
 
         else:
             g_bounds = self.construct_lcb_delaunay(x_min, ind=ind)
             if 'bounds' in self.min_solver_args:
                 self.minimizer_kwargs['bounds'] = g_bounds
-                logging.info(self.minimizer_kwargs['bounds'])
+                self.logger.info(self.minimizer_kwargs['bounds'])
 
-        if self.disp and 'bounds' in self.minimizer_kwargs:
-            logging.info('bounds in kwarg:')
-            logging.info(self.minimizer_kwargs['bounds'])
+        if 'bounds' in self.minimizer_kwargs:
+            self.logger.info('bounds in kwarg:')
+            self.logger.info(self.minimizer_kwargs['bounds'])
 
         # Local minimization using scipy.optimize.minimize:
         lres = minimize(self.func, x_min, **self.minimizer_kwargs)
 
-        if self.disp:
-            logging.info(f'lres = {lres}')
+        self.logger.info(f'lres = {lres}')
 
         # Local function evals for all minimizers
         self.res.nlfev += lres.nfev
@@ -1424,8 +1444,7 @@ class SHGO:
         requires more objective function evaluations.
         """
         # Generate sampling points
-        if self.disp:
-            logging.info('Generating sampling points')
+        self.logger.info('Generating sampling points')
         self.sampling(self.nc, self.dim)
         if len(self.LMC.xl_maps) > 0:
             self.C = np.vstack((self.C, np.array(self.LMC.xl_maps)))
@@ -1477,8 +1496,7 @@ class SHGO:
                                     + 'feasible set. Increasing sampling '
                                     + 'size.')
                 # sampling correctly for both 1-D and >1-D cases
-                if self.disp:
-                    logging.info(self.res.message)
+                self.logger.info(self.res.message)
 
     def sorted_samples(self):  # Validated
         """Find indexes of the sorted sampling points"""
@@ -1498,7 +1516,7 @@ class SHGO:
                                             )
             except spatial.QhullError:
                 if str(sys.exc_info()[1])[:6] == 'QH6239':
-                    logging.warning('QH6239 Qhull precision error detected, '
+                    self.logger.warning('QH6239 Qhull precision error detected, '
                                     'this usually occurs when no bounds are '
                                     'specified, Qhull can only run with '
                                     'handling cocircular/cospherical points'

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -421,14 +421,14 @@ class Complex:
                     if (self.bounds[symmetry[i]] is not
                             self.bounds[symmetry[j]]):
                         logging.getLogger('scipy.optimize.shgo').warning(
-                            f"Variable {i} was specified as "
-                            f"symmetetric to variable {j}, however"
-                            f", the bounds {i} ="
-                            f" {self.bounds[symmetry[i]]} and {j}"
-                            f" ="
-                            f" {self.bounds[symmetry[j]]} do not "
-                            f"match, the mismatch was ignored in "
-                            f"the initial triangulation."
+                            "Variable %d was specified as symmetric to"
+                            " variable %d, however, the bounds"
+                            " %d = %s and %d = %s do not match,"
+                            " the mismatch was ignored in "
+                            "the initial triangulation.",
+                            i, j,
+                            i, self.bounds[symmetry[i]],
+                            j, self.bounds[symmetry[j]]
                         )
                         cbounds[i] = self.bounds[symmetry[j]]
 

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -9,6 +9,8 @@ import numpy
 
 from ._vertex import (VertexCacheField, VertexCacheIndex)
 
+logger = logging.getLogger('scipy.optimize.shgo')
+
 
 class Complex:
     """
@@ -420,7 +422,7 @@ class Complex:
                     cbounds[i] = [self.bounds[symmetry[i]][1]]
                     if (self.bounds[symmetry[i]] is not
                             self.bounds[symmetry[j]]):
-                        logging.getLogger('scipy.optimize.shgo').warning(
+                        logger.warning(
                             "Variable %d was specified as symmetric to"
                             " variable %d, however, the bounds"
                             " %d = %s and %d = %s do not match,"

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -420,14 +420,16 @@ class Complex:
                     cbounds[i] = [self.bounds[symmetry[i]][1]]
                     if (self.bounds[symmetry[i]] is not
                             self.bounds[symmetry[j]]):
-                        logging.warning(f"Variable {i} was specified as "
-                                        f"symmetetric to variable {j}, however"
-                                        f", the bounds {i} ="
-                                        f" {self.bounds[symmetry[i]]} and {j}"
-                                        f" ="
-                                        f" {self.bounds[symmetry[j]]} do not "
-                                        f"match, the mismatch was ignored in "
-                                        f"the initial triangulation.")
+                        logging.getLogger('scipy.optimize.shgo').warning(
+                            f"Variable {i} was specified as "
+                            f"symmetetric to variable {j}, however"
+                            f", the bounds {i} ="
+                            f" {self.bounds[symmetry[i]]} and {j}"
+                            f" ="
+                            f" {self.bounds[symmetry[j]]} do not "
+                            f"match, the mismatch was ignored in "
+                            f"the initial triangulation."
+                        )
                         cbounds[i] = self.bounds[symmetry[j]]
 
         if n is None:

--- a/scipy/optimize/_shgo_lib/_vertex.py
+++ b/scipy/optimize/_shgo_lib/_vertex.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from scipy._lib._util import MapWrapper
 
+logger = logging.getLogger('scipy.optimize.shgo')
+
 
 class VertexBase(ABC):
     """
@@ -238,7 +240,7 @@ class VertexCacheIndex(VertexCacheBase):
         except KeyError:
             self.index += 1
             xval = self.Vertex(x, index=self.index)
-            logging.getLogger('scipy.optimize.shgo').info(
+            logger.info(
                 "New generated vertex at x = %s", x
             )
             self.cache[x] = xval
@@ -352,9 +354,7 @@ class VertexCacheField(VertexCacheBase):
             # TODO: logging
             # Left commented out during rewriting of log statements since the
             # linter complains that the class has no attribute x_a.
-            # logging.getLogger('scipy.optimize.shgo').warning(
-                # "Field function not found at x = %s", self.x_a
-            # )
+            # logger.warning("Field function not found at x = %s", self.x_a)
         if np.isnan(v.f):
             v.f = np.inf
 

--- a/scipy/optimize/_shgo_lib/_vertex.py
+++ b/scipy/optimize/_shgo_lib/_vertex.py
@@ -1,3 +1,4 @@
+import logging
 import collections
 from abc import ABC, abstractmethod
 
@@ -237,9 +238,9 @@ class VertexCacheIndex(VertexCacheBase):
         except KeyError:
             self.index += 1
             xval = self.Vertex(x, index=self.index)
-            # logging.info("New generated vertex at x = {}".format(x))
-            # NOTE: Surprisingly high performance increase if logging
-            # is commented out
+            logging.getLogger('scipy.optimize.shgo').info(
+                "New generated vertex at x = %s", x
+            )
             self.cache[x] = xval
             return self.cache[x]
 
@@ -348,7 +349,12 @@ class VertexCacheField(VertexCacheBase):
             self.nfev += 1
         except AttributeError:
             v.f = np.inf
-            # logging.warning(f"Field function not found at x = {self.x_a}")
+            # TODO: logging
+            # Left commented out during rewriting of log statements since the
+            # linter complains that the class has no attribute x_a.
+            # logging.getLogger('scipy.optimize.shgo').warning(
+                # "Field function not found at x = %s", self.x_a
+            # )
         if np.isnan(v.f):
             v.f = np.inf
 

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -319,7 +319,7 @@ def run_test(test, args=(), test_atol=1e-5, n=100, iters=None,
                sampling_method=sampling_method, workers=workers)
 
     print(f'res = {res}')
-    logging.info(f'res = {res}')
+    logging.getLogger('scipy.optimize.tests.shgo').info(f'res = {res}')
     if test.expected_x is not None:
         numpy.testing.assert_allclose(res.x, test.expected_x,
                                       rtol=test_atol,
@@ -674,8 +674,9 @@ class TestShgoArguments:
             minimizer_kwargs = {'method': solver,
                                 'jac': jac,
                                 'hess': hess}
-            logging.info(f"Solver = {solver}")
-            logging.info("=" * 100)
+            logger = logging.getLogger('scipy.optimize.tests.shgo')
+            logger.info(f"Solver = {solver}")
+            logger.info("=" * 100)
             run_test(test1_1, n=100, test_atol=1e-3,
                      minimizer_kwargs=minimizer_kwargs,
                      sampling_method='sobol')

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -13,6 +13,8 @@ from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
 from scipy.optimize._constraints import new_constraint_to_old
 from scipy.optimize._shgo import SHGO
 
+logger = logging.getLogger('scipy.optimize.tests.shgo')
+
 
 class StructTestFunction:
     def __init__(self, bounds, expected_x, expected_fun=None,
@@ -319,7 +321,7 @@ def run_test(test, args=(), test_atol=1e-5, n=100, iters=None,
                sampling_method=sampling_method, workers=workers)
 
     print(f'res = {res}')
-    logging.getLogger('scipy.optimize.tests.shgo').info(f'res = {res}')
+    logger.info('res = %s', res)
     if test.expected_x is not None:
         numpy.testing.assert_allclose(res.x, test.expected_x,
                                       rtol=test_atol,
@@ -674,8 +676,7 @@ class TestShgoArguments:
             minimizer_kwargs = {'method': solver,
                                 'jac': jac,
                                 'hess': hess}
-            logger = logging.getLogger('scipy.optimize.tests.shgo')
-            logger.info(f"Solver = {solver}")
+            logger.info("Solver = %s", solver)
             logger.info("=" * 100)
             run_test(test1_1, n=100, test_atol=1e-3,
                      minimizer_kwargs=minimizer_kwargs,


### PR DESCRIPTION
#### Using the `logging` library

I would like to commend the use of the `logging` library to log messages in SHGO. It seems to me a very good practice which allows the user much flexibilty and useful insight for development and debugging. I have implemented a few changes which enhance the flexibilty on the user's end.


#### Specific SHGO logger

Set up the `scipy.optimize.shgo` solver to log messages to a logger named "scipy.optimize.shgo" instead of the "root" logger. This provides the end user more flexibility in setting up a logging system in their application. When logging to the "root" logger, any changes to the logging level will affect all other loggers in the system as they all inherit settings from "root". Thus the loggers from different libraries, as well as the user's own code, may conflict.

Previously, all the log statements were hidden behind conditional statements using the 'disp' option passed as argument to the `shgo` function. Thus to see the log statements the user had to both set this option to `True` as well as set the logging level of the "root" logger. I have removed this conditional such that setting the logging level of the "scipy.optimize.shgo" logger is sufficient to configure the log messages. I have edited the docstring to illustrate the use.
Removing these conditional statements incur a performance cost which is remedied by a change in the formatting of the log messages.


#### Formatting of log messages

Change the log messages to use lazy formatting rather than f-strings. With the new formatting log messages will not be created unless they are actually going to be logged. This gives a performance improvement for messages that ultimately are not logged. (Running a simple test of the time required to log the elements of a NumPy array with five elements showed that formatting with f-strings takes 45-50 times as long as lazy formatting on my desktop.)

The combined changes in this PR result in practically indistinguishable execution times on my desktop for the benchmarking and test suites (the change is within 1% for the benchmarking suite; I see greater variation between individual runs caused by other processes on the computer).


#### Logging in SciPy

This system of logging could well be extended to the rest of the Python code in SciPy, but I could not find discussions of this elsewhere. The loggers are arranged in a namespace such that "scipy.optimize.shgo" is the child of "scipy.optimize" which is the child of "scipy". Configurations made for a logger automatically affect its children. Thus loggers for different parts of the code base may be set up in the "scipy" namespace and be configured all together, in groups, or individually depending on the user's desires.