### PR TITLE
MAINT: update pocketfft git submodule location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,4 @@
 	url = https://github.com/data-apis/array-api-compat.git
 [submodule "scipy/_lib/pocketfft"]
 	path = scipy/_lib/pocketfft
-	url = https://github.com/mreineck/pocketfft
+	url = https://github.com/scipy/pocketfft


### PR DESCRIPTION
Point it at our own fork, for future-proofing. That fork will be a mirror of the upstream repo. See discussion on gh-19882 for context.