### PR TITLE
MAINT: replicate FITPACK's `fpchec` routine in python

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2076,7 +2076,7 @@ def fpcheck(x, t, k):
 
     # check condition no 1
     # c      1) k+1 <= n-k-1 <= m
-    if (nk1 < k + 1) or (nk1 > m):
+    if not (k + 1 <= nk1 <= m):
         raise ValueError(f"Need k+1 <= n-k-1 <= m. Got {m = }, {n = } and {k = }.")
 
     # check condition no 2
@@ -2110,7 +2110,7 @@ def fpcheck(x, t, k):
         raise ValueError(mesg)
 
     m = x.shape[0]
-    i = 0
+    m = x.shape[0]
     l = k+1
     nk3 = n - k - 3
     if nk3 < 2:
@@ -2119,12 +2119,11 @@ def fpcheck(x, t, k):
         tj = t[j]
         l += 1
         tl = t[l]
-        while True:
-            i += 1
-            if i >= m-1:
-                raise ValueError(mesg)
-            if x[i] > tj:
-                break
+        i = np.argmax(x > tj)
+        if i >= m-1:
+            raise ValueError(mesg)
+        if x[i] >= tl:
+            raise ValueError(mesg)
         if x[i] >= tl:
             raise ValueError(mesg)
     return

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2035,3 +2035,96 @@ def make_smoothing_spline(x, y, w=None, lam=None):
                c[-1] * (2 * t[-4] - t[-5] - t[-6]) + c[-2]]
 
     return BSpline.construct_fast(t, c_, 3)
+
+
+########################
+#  FITPACK look-alikes #
+########################
+
+def fpcheck(x, t, k):
+    """ Check consistency of the data vector `x` and the knot vector `t`.
+
+    Return None if inputs are consistent, raises a ValueError otherwise.
+    """
+    # This routine is a clone of the `fpchec` Fortran routine, 
+    # https://github.com/scipy/scipy/blob/main/scipy/interpolate/fitpack/fpchec.f
+    # which carries the following comment:
+    #
+    # subroutine fpchec verifies the number and the position of the knots
+    #  t(j),j=1,2,...,n of a spline of degree k, in relation to the number
+    #  and the position of the data points x(i),i=1,2,...,m. if all of the
+    #  following conditions are fulfilled, the error parameter ier is set
+    #  to zero. if one of the conditions is violated ier is set to ten.
+    #      1) k+1 <= n-k-1 <= m
+    #      2) t(1) <= t(2) <= ... <= t(k+1)
+    #         t(n-k) <= t(n-k+1) <= ... <= t(n)
+    #      3) t(k+1) < t(k+2) < ... < t(n-k)
+    #      4) t(k+1) <= x(i) <= t(n-k)
+    #      5) the conditions specified by schoenberg and whitney must hold
+    #         for at least one subset of data points, i.e. there must be a
+    #         subset of data points y(j) such that
+    #             t(j) < y(j) < t(j+k+1), j=1,2,...,n-k-1
+    x = np.asarray(x)
+    t = np.asarray(t)
+
+    if x.ndim != 1 or t.ndim != 1:
+        raise ValueError(f"Expect `x` and `t` be 1D sequences. Got {x = } and {t = }")
+
+    m = x.shape[0]
+    n = t.shape[0]
+    nk1 = n - k - 1
+
+    # check condition no 1
+    # c      1) k+1 <= n-k-1 <= m
+    if (nk1 < k + 1) or (nk1 > m):
+        raise ValueError(f"Need k+1 <= n-k-1 <= m. Got {m = }, {n = } and {k = }.")
+
+    # check condition no 2
+    # c      2) t(1) <= t(2) <= ... <= t(k+1)
+    # c         t(n-k) <= t(n-k+1) <= ... <= t(n)
+    if (t[:k+1] > t[1:k+2]).any():
+        raise ValueError(f"First k knots must be ordered; got {t = }.")
+
+    if (t[nk1:] < t[nk1-1:-1]).any():
+        raise ValueError(f"Last k knots must be ordered; got {t = }.")
+
+    # c  check condition no 3
+    # c      3) t(k+1) < t(k+2) < ... < t(n-k)
+    if (t[k+1:n-k] <= t[k:n-k-1]).any():
+        raise ValueError(f"Internal knots must be distinct. Got {t = }.")
+
+    # c  check condition no 4
+    # c      4) t(k+1) <= x(i) <= t(n-k)
+    # NB: FITPACK's fpchec only checks x[0] & x[-1], so we follow.
+    if (x[0] < t[k]) or (x[-1] > t[n-k-1]):
+        raise ValueError(f"Out of bounds: {x = } and {t = }.")
+
+    # c  check condition no 5
+    # c      5) the conditions specified by schoenberg and whitney must hold
+    # c         for at least one subset of data points, i.e. there must be a
+    # c         subset of data points y(j) such that
+    # c             t(j) < y(j) < t(j+k+1), j=1,2,...,n-k-1
+    mesg = f"Schoenberg-Whitney condition is violated with {t = } and {x =}."
+
+    if (x[0] >= t[k+1]) or (x[-1] <= t[n-k-2]):
+        raise ValueError(mesg)
+
+    m = x.shape[0]
+    i = 0
+    l = k+1
+    nk3 = n - k - 3
+    if nk3 < 2:
+        return
+    for j in range(1, nk3+1):
+        tj = t[j]
+        l += 1
+        tl = t[l]
+        while True:
+            i += 1
+            if i >= m-1:
+                raise ValueError(mesg)
+            if x[i] > tj:
+                break
+        if x[i] >= tl:
+            raise ValueError(mesg)
+    return

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2124,6 +2124,4 @@ def fpcheck(x, t, k):
             raise ValueError(mesg)
         if x[i] >= tl:
             raise ValueError(mesg)
-        if x[i] >= tl:
-            raise ValueError(mesg)
     return

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2110,7 +2110,6 @@ def fpcheck(x, t, k):
         raise ValueError(mesg)
 
     m = x.shape[0]
-    m = x.shape[0]
     l = k+1
     nk3 = n - k - 3
     if nk3 < 2:

--- a/scipy/interpolate/fitpack/fpchec.f
+++ b/scipy/interpolate/fitpack/fpchec.f
@@ -29,22 +29,24 @@ c  ..
       nk2 = nk1+1
       ier = 10
 c  check condition no 1
-      if(nk1.lt.k1 .or. nk1.gt.m) go to 80
+      if(nk1.lt.k1 .or. nk1.gt.m)then; ier=10; go to 80; endif
 c  check condition no 2
       j = n
       do 20 i=1,k
-        if(t(i).gt.t(i+1)) go to 80
-        if(t(j).lt.t(j-1)) go to 80
+        if(t(i).gt.t(i+1))then; ier=20; go to 80; endif
+        if(t(j).lt.t(j-1))then; ier=20; go to 80; endif
         j = j-1
   20  continue
 c  check condition no 3
       do 30 i=k2,nk2
-        if(t(i).le.t(i-1)) go to 80
+        if(t(i).le.t(i-1))then; ier=30; go to 80; endif
   30  continue
 c  check condition no 4
-      if(x(1).lt.t(k1) .or. x(m).gt.t(nk2)) go to 80
+      if(x(1).lt.t(k1) .or. x(m).gt.t(nk2))then; ier=40; go to 80;
+      endif
 c  check condition no 5
-      if(x(1).ge.t(k2) .or. x(m).le.t(nk1)) go to 80
+      if(x(1).ge.t(k2) .or. x(m).le.t(nk1))then; ier=50; go to 80;
+      endif
       i = 1
       l = k2
       nk3 = nk1-1
@@ -54,9 +56,9 @@ c  check condition no 5
         l = l+1
         tl = t(l)
   40    i = i+1
-        if(i.ge.m) go to 80
+        if(i.ge.m)then; ier=50; go to 80; endif
         if(x(i).le.tj) go to 40
-        if(x(i).ge.tl) go to 80
+        if(x(i).ge.tl)then; ier=50; go to 80; endif
   60  continue
   70  ier = 0
   80  return

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -20,6 +20,9 @@ from scipy.interpolate._bsplines import (_not_a_knot, _augknt,
 import scipy.interpolate._fitpack_impl as _impl
 from scipy._lib._util import AxisError
 
+from scipy.interpolate import dfitpack
+from scipy.interpolate import _bsplines as _b
+
 
 class TestBSpline:
 
@@ -2159,3 +2162,146 @@ class TestNdBSpline:
         bspl3_ = NdBSpline(t3, c3, k=3)
 
         assert bspl3((1, 2, 3)) == bspl3_((1, 2, 3))
+
+
+class TestFpchec:
+    # https://github.com/scipy/scipy/blob/main/scipy/interpolate/fitpack/fpchec.f
+    def test_condition_1(self):
+        # c      1) k+1 <= n-k-1 <= m
+        k = 3
+        n  = 2*(k + 1) - 1    # not OK
+        m = n + 11            # OK
+        t = np.arange(n)
+        x = np.arange(m)
+
+        assert dfitpack.fpchec(x, t, k) == 10
+        with pytest.raises(ValueError, match="Need k+1*"):
+            _b.fpcheck(x, t, k)
+
+        n = 2*(k+1) + 1   # OK
+        m = n - k - 2     # not OK
+        t = np.arange(n)
+        x = np.arange(m)
+
+        assert dfitpack.fpchec(x, t, k) == 10
+        with pytest.raises(ValueError, match="Need k+1*"):
+            _b.fpcheck(x, t, k)
+
+    def test_condition_2(self):
+        # c      2) t(1) <= t(2) <= ... <= t(k+1)
+        # c         t(n-k) <= t(n-k+1) <= ... <= t(n)
+        k = 3
+        t = [0]*(k+1) + [2] + [5]*(k+1)   # this is OK
+        x = [1, 2, 3, 4, 4.5]
+
+        assert dfitpack.fpchec(x, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None    # does not raise
+
+        tt = t.copy()
+        tt[-1] = tt[0]   # not OK
+        assert dfitpack.fpchec(x, tt, k) == 20
+        with pytest.raises(ValueError, match="Last k knots*"):
+            _b.fpcheck(x, tt, k)
+
+        tt = t.copy()
+        tt[0] = tt[-1]   # not OK
+        assert dfitpack.fpchec(x, tt, k) == 20
+        with pytest.raises(ValueError, match="First k knots*"):
+            _b.fpcheck(x, tt, k)
+
+    def test_condition_3(self):
+        # c      3) t(k+1) < t(k+2) < ... < t(n-k)
+        k = 3
+        t = [0]*(k+1) + [2, 3] + [5]*(k+1)   # this is OK
+        x = [1, 2, 3, 3.5, 4, 4.5]
+        assert dfitpack.fpchec(x, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None
+
+        t = [0]*(k+1) + [2, 2] + [5]*(k+1)   # this is not OK
+        assert dfitpack.fpchec(x, t, k) == 30
+        with pytest.raises(ValueError, match="Internal knots*"):
+            _b.fpcheck(x, t, k)
+
+    def test_condition_4(self):
+        # c      4) t(k+1) <= x(i) <= t(n-k)
+        # NB: FITPACK's fpchec only checks x[0] & x[-1], so we follow.
+        k = 3
+        t = [0]*(k+1) + [5]*(k+1)
+        x = [1, 2, 3, 3.5, 4, 4.5]      # this is OK
+        assert dfitpack.fpchec(x, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None
+
+        xx = x.copy()
+        xx[0] = t[0]    # still OK
+        assert dfitpack.fpchec(xx, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None
+
+        xx = x.copy()
+        xx[0] = t[0] - 1    # not OK
+        assert dfitpack.fpchec(xx, t, k) == 40
+        with pytest.raises(ValueError, match="Out of bounds*"):
+            _b.fpcheck(xx, t, k)
+
+        xx = x.copy()
+        xx[-1] = t[-1] + 1    # not OK
+        assert dfitpack.fpchec(xx, t, k) == 40
+        with pytest.raises(ValueError, match="Out of bounds*"):
+            _b.fpcheck(xx, t, k)
+
+    # ### Test the S-W condition (no 5)
+    # c      5) the conditions specified by schoenberg and whitney must hold
+    # c         for at least one subset of data points, i.e. there must be a
+    # c         subset of data points y(j) such that
+    # c             t(j) < y(j) < t(j+k+1), j=1,2,...,n-k-1
+    def test_condition_5_x1xm(self):
+        # x(1).ge.t(k2) .or. x(m).le.t(nk1)
+        k = 1
+        t = [0, 0, 1, 2, 2]
+        x = [1.1, 1.1, 1.1]
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
+
+        x = [0.5, 0.5, 0.5]
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
+
+    def test_condition_5_k1(self):
+        # special case nk3 (== n - k - 2) < 2
+        k = 1
+        t = [0, 0, 1, 1]
+        x = [0.5, 0.6]
+        assert dfitpack.fpchec(x, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None
+
+    def test_condition_5_1(self):
+        # basically, there can't be an interval of t[j]..t[j+k+1] with no x
+        k = 3
+        t = [0]*(k+1) + [2] + [5]*(k+1)
+        x = [3]*5
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
+
+        t = [0]*(k+1) + [2] + [5]*(k+1)
+        x = [1]*5
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
+
+    def test_condition_5_2(self):
+        # same as _5_1, only the empty interval is in the middle
+        k = 3
+        t = [0]*(k+1) + [2, 3] + [5]*(k+1)
+        x = [1.1]*5 + [4]
+
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
+
+        # and this one is OK
+        x = [1.1]*4 + [4, 4]
+        assert dfitpack.fpchec(x, t, k) == 0
+        assert _b.fpcheck(x, t, k) is None
+

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2166,6 +2166,18 @@ class TestNdBSpline:
 
 class TestFpchec:
     # https://github.com/scipy/scipy/blob/main/scipy/interpolate/fitpack/fpchec.f
+
+    def test_1D_x_t(self):
+        k = 1
+        t = np.arange(12).reshape(2, 6)
+        x = np.arange(12)
+
+        with pytest.raises(ValueError, match="1D sequence"):
+            _b.fpcheck(x, t, k)
+
+        with pytest.raises(ValueError, match="1D sequence"):
+            _b.fpcheck(t, x, k)
+
     def test_condition_1(self):
         # c      1) k+1 <= n-k-1 <= m
         k = 3
@@ -2304,4 +2316,14 @@ class TestFpchec:
         x = [1.1]*4 + [4, 4]
         assert dfitpack.fpchec(x, t, k) == 0
         assert _b.fpcheck(x, t, k) is None
+
+    def test_condition_5_3(self):
+        # similar to _5_2, covers a different failure branch
+        k = 1
+        t = [0, 0, 2, 3, 4, 5, 6, 7, 7]
+        x = [1, 1, 1, 5.2, 5.2, 5.2, 6.5]
+
+        assert dfitpack.fpchec(x, t, k) == 50
+        with pytest.raises(ValueError, match="Schoenberg-Whitney*"):
+            _b.fpcheck(x, t, k)
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

cross-ref https://github.com/scipy/scipy/issues/9850, which this PR does not close just yet.

#### What does this implement/fix?
<!--Please explain your changes.-->

Add a pure python version of FITPACK's `fpchec` routine which checks consistency of the input data array `x` and the knot vector `t` for spline fitting. 

While at it, make the Fortran routine error codes more granular: `fpchec` checks five conditions, so make it return five different error codes instead of just one (previously `ier=10` meant "one of pre-condition is violated, go figure which one").

#### Additional information
<!--Any additional information you think is important.-->

Better granularity of error reporting was requested in gh-9850. Addressing that issue is a byproduct of this PR though. The main reason for tweaking the FOrtran returns is to verify the python port by checking that the error code from Fortran corresponds to the error raised from python. 

This PR is a part of a larger rework, https://github.com/users/ev-br/projects/1/views/1, and is only split off into a separate PR to keep the diff sizes manageable.