### PR TITLE
MAINT: SciPy 1.12.0 "final" backports/prep

### DIFF
--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.12.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.12.0 is not released yet!
-
 .. contents::
 
 SciPy 1.12.0 is the culmination of 6 months of hard work. It contains
@@ -327,7 +325,7 @@ Authors
 
 * Name (commits)
 * endolith (1)
-* h-vetinari (32)
+* h-vetinari (34)
 * Tom Adamczewski (3) +
 * Anudeep Adiraju (1) +
 * akeemlh (1)
@@ -373,7 +371,7 @@ Authors
 * Lukas Geiger (9) +
 * Artem Glebov (22) +
 * Caden Gobat (1)
-* Ralf Gommers (126)
+* Ralf Gommers (127)
 * Alexander Goscinski (2) +
 * Rohit Goswami (2) +
 * Olivier Grisel (1)
@@ -443,7 +441,7 @@ Authors
 * Bharat Raghunathan (1)
 * Chris Rapson (1) +
 * Matteo Raso (4)
-* Tyler Reddy (201)
+* Tyler Reddy (212)
 * Martin Reinecke (1)
 * Tilo Reneau-Cardoso (1) +
 * resting-dove (2) +
@@ -455,7 +453,7 @@ Authors
 * Masahiro Sakai (2) +
 * Omar Salman (14)
 * Andrej Savikin (1) +
-* Daniel Schmitz (54)
+* Daniel Schmitz (55)
 * Dan Schult (19)
 * Scott Shambaugh (9)
 * Sheila-nk (2) +
@@ -635,6 +633,7 @@ Issues closed for 1.12.0
 * `#19795 <https://github.com/scipy/scipy/issues/19795>`__: MAINT: need stable Pythran release for SciPy 1.12.0 RC2
 * `#19804 <https://github.com/scipy/scipy/issues/19804>`__: MAINT/TST: Warnings failing test suite with \`pytest 8\`
 * `#19852 <https://github.com/scipy/scipy/issues/19852>`__: CI, MAINT: Windows 3.11 CI failure with file access issue
+* `#19906 <https://github.com/scipy/scipy/issues/19906>`__: BUG: 1.12.0rc2 SciPy rather than scipy in \`pip list\` output
 
 ************************
 Pull requests for 1.12.0
@@ -1097,8 +1096,13 @@ Pull requests for 1.12.0
 * `#19761 <https://github.com/scipy/scipy/pull/19761>`__: MAINT: Avoid use of aligned_alloc in pocketfft on windows
 * `#19779 <https://github.com/scipy/scipy/pull/19779>`__: BUG: Fix \`nbinom.logcdf\` for invalid input
 * `#19785 <https://github.com/scipy/scipy/pull/19785>`__: BUG: support sparse Hessian in \`Newton-CG\`
+* `#19797 <https://github.com/scipy/scipy/pull/19797>`__: MAINT: 1.12.0rc2 prep
 * `#19800 <https://github.com/scipy/scipy/pull/19800>`__: TST: loosen tolerances for tests that fail otherwise on windows+MKL
 * `#19806 <https://github.com/scipy/scipy/pull/19806>`__: TST: fix compatibility with pytest 8
 * `#19830 <https://github.com/scipy/scipy/pull/19830>`__: REL: bump copyright to 2024
 * `#19842 <https://github.com/scipy/scipy/pull/19842>`__: TST: move reference data for test_real_transforms to a fixture
 * `#19859 <https://github.com/scipy/scipy/pull/19859>`__: BLD: improve scipy-openblas dependency check
+* `#19877 <https://github.com/scipy/scipy/pull/19877>`__: DOC: 1.12 release notes tweaks
+* `#19892 <https://github.com/scipy/scipy/pull/19892>`__: DEP: extend some announced deprecations due to out-of-band 1.13...
+* `#19903 <https://github.com/scipy/scipy/pull/19903>`__: DEP: reflect extended deprecations also in release notes
+* `#19910 <https://github.com/scipy/scipy/pull/19910>`__: BLD: ensure the name of the installed \`scipy\` package is lower-case

--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -102,8 +102,10 @@ New features
 
 `scipy.optimize` improvements
 =============================
+- `scipy.optimize.isotonic_regression` has been added to allow nonparametric isotonic
+  regression.
 - `scipy.optimize.nnls` is rewritten in Python and now implements the so-called
-  fnnls or fast nnls.
+  fnnls or fast nnls, making it more efficient for high-dimensional problems.
 - The result object of `scipy.optimize.root` and `scipy.optimize.root_scalar`
   now reports the method used.
 - The ``callback`` method of `scipy.optimize.differential_evolution` can now be
@@ -111,17 +113,17 @@ New features
   parameter. Also, the evolution ``strategy`` now accepts a callable for
   additional customization. The performance of ``differential_evolution`` has
   also been improved.
-- ``minimize`` method ``Newton-CG`` has been made slightly more efficient.
-- ``minimize`` method ``BFGS`` now accepts an initial estimate for the inverse
-  of the Hessian, which allows for more efficient workflows in some
+- `scipy.optimize.minimize` method ``Newton-CG`` now supports functions that
+  return sparse Hessian matrices/arrays for the ``hess`` parameter and is slightly
+  more efficient.
+- `scipy.optimize.minimize` method ``BFGS`` now accepts an initial estimate for the
+  inverse of the Hessian, which allows for more efficient workflows in some
   circumstances. The new parameter is ``hess_inv0``.
-- ``minimize`` methods ``CG``, ``Newton-CG``, and ``BFGS`` now accept parameters
-  ``c1`` and ``c2``, allowing specification of the Armijo and curvature rule
+- `scipy.optimize.minimize` methods ``CG``, ``Newton-CG``, and ``BFGS`` now accept
+  parameters ``c1`` and ``c2``, allowing specification of the Armijo and curvature rule
   parameters, respectively.
-- ``curve_fit`` performance has improved due to more efficient memoization
+- `scipy.optimize.curve_fit` performance has improved due to more efficient memoization
   of the callable function.
-- ``isotonic_regression`` has been added to allow nonparametric isotonic
-  regression.
 
 `scipy.signal` improvements
 ===========================
@@ -182,8 +184,10 @@ New features
   second kind. Both exact calculation and an asymptotic approximation
   (the default) are supported via ``exact=True`` and ``exact=False`` (the
   default) respectively.
--  Added `scipy.special.betaincc` for computation of the complementary incomplete Beta function and `scipy.special.betainccinv` for computation of its inverse.
-- Improved precision of `scipy.special.betainc` and `scipy.special.betaincinv`
+- Added `scipy.special.betaincc` for computation of the complementary
+  incomplete Beta function and `scipy.special.betainccinv` for computation of
+  its inverse.
+- Improved precision of `scipy.special.betainc` and `scipy.special.betaincinv`.
 - Experimental support added for alternative backends: functions
   `scipy.special.log_ndtr`, `scipy.special.ndtr`, `scipy.special.ndtri`, 
   `scipy.special.erf`, `scipy.special.erfc`, `scipy.special.i0`, 
@@ -225,19 +229,27 @@ New features
   `scipy.stats.kappa3`, `scipy.stats.loglaplace`, `scipy.stats.lognorm`,
   `scipy.stats.lomax`, `scipy.stats.pearson3`, `scipy.stats.rdist`, and
   `scipy.stats.pareto`.
-- The following functions now support parameters ``axis``, ``nan_policy``, and ``keep_dims``: `scipy.stats.entropy`, `scipy.stats.differential_entropy`, `scipy.stats.variation`, `scipy.stats.ansari`, `scipy.stats.bartlett`, `scipy.stats.levene`, `scipy.stats.fligner`, `scipy.stats.cirmean, `scipy.stats.circvar`, `scipy.stats.circstd`, `scipy.stats.tmean`, `scipy.stats.tvar`, `scipy.stats.tstd`, `scipy.stats.tmin`, `scipy.stats.tmax`, and `scipy.stats.tsem`.
+- The following functions now support parameters ``axis``, ``nan_policy``, and
+  ``keep_dims``: `scipy.stats.entropy`, `scipy.stats.differential_entropy`,
+  `scipy.stats.variation`, `scipy.stats.ansari`, `scipy.stats.bartlett`,
+  `scipy.stats.levene`, `scipy.stats.fligner`, `scipy.stats.circmean`,
+  `scipy.stats.circvar`, `scipy.stats.circstd`, `scipy.stats.tmean`,
+  `scipy.stats.tvar`, `scipy.stats.tstd`, `scipy.stats.tmin`, `scipy.stats.tmax`,
+  and `scipy.stats.tsem`.
 - The ``logpdf`` and ``fit`` methods of `scipy.stats.skewnorm` have been improved.
 - The beta negative binomial distribution is implemented as `scipy.stats.betanbinom`.
-- The speed of `scipy.stats.invwishart` ``rvs`` and ``logpdf`` have been improved.
-- A source of intermediate overflow in `scipy.stats.boxcox_normmax` with ``method='mle'`` has been eliminated, and the returned value of ``lmbda`` is constrained such that the transformed data will not overflow.
+- Improved performance of `scipy.stats.invwishart` ``rvs`` and ``logpdf``.
+- A source of intermediate overflow in `scipy.stats.boxcox_normmax` with
+  ``method='mle'`` has been eliminated, and the returned value of ``lmbda`` is
+  constrained such that the transformed data will not overflow.
 - `scipy.stats.nakagami` ``stats`` is more accurate and reliable.
 - A source of intermediate overflow in `scipy.norminvgauss.pdf` has been eliminated.
-- Added support for masked arrays to ``stats.circmean``, ``stats.circvar``,
-  ``stats.circstd``, and ``stats.entropy``.
-- ``dirichlet`` has gained a new covariance (``cov``) method.
-- Improved accuracy of ``multivariate_t`` entropy with large degrees of
-  freedom.
-- ``loggamma`` has an improved ``entropy`` method.
+- Added support for masked arrays to `scipy.stats.circmean`, `scipy.stats.circvar`,
+  `scipy.stats.circstd`, and `scipy.stats.entropy`.
+- `scipy.stats.dirichlet` has gained a new covariance (``cov``) method.
+- Improved accuracy of ``entropy`` method of `scipy.stats.multivariate_t` for large
+  degrees of freedom.
+- `scipy.stats.loggamma` has an improved ``entropy`` method.
 
 
 

--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -204,8 +204,6 @@ New features
   hypothesized value is the quantile associated with a specified probability.
   The ``confidence_interval`` method of the result object gives a confidence
   interval of the quantile.
-- `scipy.stats.wasserstein_distance` now computes the Wasserstein distance
-  in the multidimensional case.
 - `scipy.stats.sampling.FastGeneratorInversion` provides a convenient
   interface to fast random sampling via numerical inversion of distribution
   CDFs.
@@ -375,7 +373,7 @@ Authors
 * Alexander Goscinski (2) +
 * Rohit Goswami (2) +
 * Olivier Grisel (1)
-* Matt Haberland (243)
+* Matt Haberland (244)
 * Charles Harris (1)
 * harshilkamdar (1) +
 * Alon Hovav (2) +
@@ -441,7 +439,7 @@ Authors
 * Bharat Raghunathan (1)
 * Chris Rapson (1) +
 * Matteo Raso (4)
-* Tyler Reddy (212)
+* Tyler Reddy (215)
 * Martin Reinecke (1)
 * Tilo Reneau-Cardoso (1) +
 * resting-dove (2) +
@@ -1103,6 +1101,7 @@ Pull requests for 1.12.0
 * `#19842 <https://github.com/scipy/scipy/pull/19842>`__: TST: move reference data for test_real_transforms to a fixture
 * `#19859 <https://github.com/scipy/scipy/pull/19859>`__: BLD: improve scipy-openblas dependency check
 * `#19877 <https://github.com/scipy/scipy/pull/19877>`__: DOC: 1.12 release notes tweaks
+* `#19881 <https://github.com/scipy/scipy/pull/19881>`__: Revert "ENH: stats.wasserstein_distance: multivariate Wasserstein...
 * `#19892 <https://github.com/scipy/scipy/pull/19892>`__: DEP: extend some announced deprecations due to out-of-band 1.13...
 * `#19903 <https://github.com/scipy/scipy/pull/19903>`__: DEP: reflect extended deprecations also in release notes
 * `#19910 <https://github.com/scipy/scipy/pull/19910>`__: BLD: ensure the name of the installed \`scipy\` package is lower-case

--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -261,14 +261,14 @@ Deprecated features
   public namespace and warnings sharpened for private attributes that are not
   supposed to be imported at all.
 - `scipy.signal.cmplx_sort` has been deprecated and will be removed in
-  SciPy 1.14. A replacement you can use is provided in the deprecation message.
+  SciPy 1.15. A replacement you can use is provided in the deprecation message.
 - Values the the argument ``initial`` of `scipy.integrate.cumulative_trapezoid`
   other than ``0`` and ``None`` are now deprecated.
 - `scipy.stats.rvs_ratio_uniforms` is deprecated in favour of
   `scipy.stats.sampling.RatioUniforms`
 - `scipy.integrate.quadrature` and `scipy.integrate.romberg` have been
   deprecated due to accuracy issues and interface shortcomings. They will
-  be removed in SciPy 1.14. Please use `scipy.integrate.quad` instead.
+  be removed in SciPy 1.15. Please use `scipy.integrate.quad` instead.
 - Coinciding with upcoming changes to function signatures (e.g. removal of a
   deprecated keyword), we are deprecating positional use of keyword arguments
   for the affected functions, which will raise an error starting with

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'SciPy',
+  'scipy',
   'c', 'cpp', 'cython',
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.12.0rc2',
+  version: '1.12.0',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires = [
 ]
 
 [project]
-name = "SciPy"
+name = "scipy"
 version = "1.12.0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
 
 [project]
 name = "SciPy"
-version = "1.12.0rc2"
+version = "1.12.0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -58,7 +58,7 @@ def _sub_module_deprecation(*, sub_package, module, private_modules, all,
             f"`scipy.{sub_package}.{module}.{attribute}` is deprecated along with "
             f"the `scipy.{sub_package}.{module}` namespace. "
             f"`scipy.{sub_package}.{module}.{attribute}` will be removed "
-            f"in SciPy 1.13.0, and the `scipy.{sub_package}.{module}` namespace "
+            f"in SciPy 1.14.0, and the `scipy.{sub_package}.{module}` namespace "
             f"will be removed in SciPy 2.0.0."
         )
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -315,17 +315,17 @@ def vectorize1(func, args=(), vec_func=False):
 
 
 @_deprecated("`scipy.integrate.quadrature` is deprecated as of SciPy 1.12.0"
-             "and will be removed in SciPy 1.14.0. Please use"
+             "and will be removed in SciPy 1.15.0. Please use"
              "`scipy.integrate.quad` instead.")
 def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
                vec_func=True, miniter=1):
     """
+    Compute a definite integral using fixed-tolerance Gaussian quadrature.
+
     .. deprecated:: 1.12.0
 
           This function is deprecated as of SciPy 1.12.0 and will be removed
-          in SciPy 1.14.0. Please use `scipy.integrate.quad` instead.
-
-    Compute a definite integral using fixed-tolerance Gaussian quadrature.
+          in SciPy 1.15.0. Please use `scipy.integrate.quad` instead.
 
     Integrate `func` from `a` to `b` using Gaussian quadrature
     with absolute tolerance `tol`.
@@ -451,7 +451,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
         .. deprecated:: 1.12.0
             The option for non-zero inputs for `initial` will be deprecated in
-            SciPy 1.14.0. After this time, a ValueError will be raised if
+            SciPy 1.15.0. After this time, a ValueError will be raised if
             `initial` is not None or 0.
 
     Returns
@@ -522,7 +522,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
             warnings.warn(
                 "The option for values for `initial` other than None or 0 is "
                 "deprecated as of SciPy 1.12.0 and will raise a value error in"
-                " SciPy 1.14.0.",
+                " SciPy 1.15.0.",
                 DeprecationWarning, stacklevel=2
             )
         if not np.isscalar(initial):
@@ -1273,17 +1273,17 @@ def _printresmat(function, interval, resmat):
 
 
 @_deprecated("`scipy.integrate.romberg` is deprecated as of SciPy 1.12.0"
-             "and will be removed in SciPy 1.14.0. Please use"
+             "and will be removed in SciPy 1.15.0. Please use"
              "`scipy.integrate.quad` instead.")
 def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
             divmax=10, vec_func=False):
     """
+    Romberg integration of a callable function or method.
+
     .. deprecated:: 1.12.0
 
           This function is deprecated as of SciPy 1.12.0 and will be removed
-          in SciPy 1.14.0. Please use `scipy.integrate.quad` instead.
-
-    Romberg integration of a callable function or method.
+          in SciPy 1.15.0. Please use `scipy.integrate.quad` instead.
 
     Returns the integral of `function` (a function of one variable)
     over the interval (`a`, `b`).

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -97,7 +97,7 @@ def lagrange(x, w):
 
 
 dep_mesg = """\
-`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.13.0.
+`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.14.0.
 
 For legacy code, nearly bug-for-bug compatible replacements are
 `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -119,7 +119,7 @@ class interp2d:
     .. deprecated:: 1.10.0
 
         `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy
-        1.13.0.
+        1.14.0.
 
         For legacy code, nearly bug-for-bug compatible replacements are
         `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1498,7 +1498,7 @@ def order_filter(a, domain, rank):
     a = np.asarray(a)
     if a.dtype in [object, 'float128']:
         mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
         warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(a, domain, rank)
@@ -1576,7 +1576,7 @@ def medfilt(volume, kernel_size=None):
 
     if volume.dtype.char in ['O', 'g']:
         mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
         warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(volume, domain, order)
@@ -2463,8 +2463,8 @@ def hilbert2(x, N=None):
     return x
 
 
-_msg_cplx_sort="""cmplx_sort is deprecated in SciPy 1.12 and will be removed
-in SciPy 1.14. The exact equivalent for a numpy array argument is
+_msg_cplx_sort="""cmplx_sort was deprecated in SciPy 1.12 and will be removed
+in SciPy 1.15. The exact equivalent for a numpy array argument is
 >>> def cmplx_sort(p):
 ...    idx = np.argsort(abs(p))
 ...    return np.take(p, idx, 0), idx

--- a/scipy/signal/_wavelets.py
+++ b/scipy/signal/_wavelets.py
@@ -9,18 +9,18 @@ __all__ = ['daub', 'qmf', 'cascade', 'morlet', 'ricker', 'morlet2', 'cwt']
 
 
 _msg="""scipy.signal.%s is deprecated in SciPy 1.12 and will be removed
-in SciPy 1.14. We recommend using PyWavelets instead.
+in SciPy 1.15. We recommend using PyWavelets instead.
 """
 
 
 def daub(p):
     """
+    The coefficients for the FIR low-pass filter producing Daubechies wavelets.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.daub is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-    The coefficients for the FIR low-pass filter producing Daubechies wavelets.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     p>=1 gives the order of the zero at f=1/2.
     There are 2p filter coefficients.
@@ -91,13 +91,12 @@ def daub(p):
 
 def qmf(hk):
     """
+    Return high-pass qmf filter from low-pass
+
     .. deprecated:: 1.12.0
 
         scipy.signal.qmf is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return high-pass qmf filter from low-pass
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -119,13 +118,12 @@ def qmf(hk):
 
 def cascade(hk, J=7):
     """
+    Return (x, phi, psi) at dyadic points ``K/2**J`` from filter coefficients.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.cascade is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return (x, phi, psi) at dyadic points ``K/2**J`` from filter coefficients.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -233,12 +231,12 @@ def cascade(hk, J=7):
 
 def morlet(M, w=5.0, s=1.0, complete=True):
     """
+    Complex Morlet wavelet.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.morlet is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-    Complex Morlet wavelet.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Parameters
     ----------
@@ -317,13 +315,12 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
 def ricker(points, a):
     """
+    Return a Ricker wavelet, also known as the "Mexican hat wavelet".
+
     .. deprecated:: 1.12.0
 
         scipy.signal.ricker is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Return a Ricker wavelet, also known as the "Mexican hat wavelet".
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     It models the function:
 
@@ -375,13 +372,12 @@ def _ricker(points, a):
 
 def morlet2(M, s, w=5):
     """
+    Complex Morlet wavelet, designed to work with `cwt`.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.morlet2 is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Complex Morlet wavelet, designed to work with `cwt`.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Returns the complete version of morlet wavelet, normalised
     according to `s`::
@@ -462,13 +458,12 @@ def morlet2(M, s, w=5):
 
 def cwt(data, wavelet, widths, dtype=None, **kwargs):
     """
+    Continuous wavelet transform.
+
     .. deprecated:: 1.12.0
 
         scipy.signal.cwt is deprecated in SciPy 1.12 and will be removed
-        in SciPy 1.14. We recommend using PyWavelets instead.
-
-
-    Continuous wavelet transform.
+        in SciPy 1.15. We recommend using PyWavelets instead.
 
     Performs a continuous wavelet transform on `data`,
     using the `wavelet` function. A CWT performs a convolution

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -111,7 +111,7 @@ class _spbase:
                              " to be instantiated directly.")
         self.maxprint = maxprint
 
-    # Use this in 1.13.0 and later:
+    # Use this in 1.14.0 and later:
     #
     # @property
     # def shape(self):
@@ -313,11 +313,11 @@ class _spbase:
 
         .. deprecated:: 1.11.0
 
-            `.A` is deprecated and will be removed in v1.13.0.
+            `.A` is deprecated and will be removed in v1.14.0.
             Use `.toarray()` instead.
         """
         if isinstance(self, sparray):
-            message = ("`.A` is deprecated and will be removed in v1.13.0. "
+            message = ("`.A` is deprecated and will be removed in v1.14.0. "
                        "Use `.toarray()` instead.")
             warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.toarray()
@@ -333,11 +333,11 @@ class _spbase:
 
         .. deprecated:: 1.11.0
 
-            `.H` is deprecated and will be removed in v1.13.0.
+            `.H` is deprecated and will be removed in v1.14.0.
             Please use `.T.conjugate()` instead.
         """
         if isinstance(self, sparray):
-            message = ("`.H` is deprecated and will be removed in v1.13.0. "
+            message = ("`.H` is deprecated and will be removed in v1.14.0. "
                        "Please use `.T.conjugate()` instead.")
             warn(VisibleDeprecationWarning(message), stacklevel=2)
         return self.T.conjugate()
@@ -1312,7 +1312,7 @@ class _spbase:
 
 
     ## All methods below are deprecated and should be removed in
-    ## scipy 1.13.0
+    ## scipy 1.14.0
     ##
     ## Also uncomment the definition of shape above.
 
@@ -1320,11 +1320,11 @@ class _spbase:
         """Get shape of a sparse array/matrix.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.shape` instead.
         """
         msg = (
-            "`get_shape` is deprecated and will be removed in v1.13.0; "
+            "`get_shape` is deprecated and will be removed in v1.14.0; "
             "use `X.shape` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1335,11 +1335,11 @@ class _spbase:
         """See `reshape`.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.reshape` instead.
         """
         msg = (
-            "Shape assignment is deprecated and will be removed in v1.13.0; "
+            "Shape assignment is deprecated and will be removed in v1.14.0; "
             "use `reshape` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1354,7 +1354,7 @@ class _spbase:
         fset=set_shape,
         doc="""The shape of the array.
 
-Note that, starting in SciPy 1.13.0, this property will no longer be
+Note that, starting in SciPy 1.14.0, this property will no longer be
 settable. To change the array shape, use `X.reshape` instead.
 """
     )
@@ -1364,11 +1364,11 @@ settable. To change the array shape, use `X.reshape` instead.
 
         .. deprecated:: 1.11.0
            This method is for internal use only, and will be removed from the
-           public API in SciPy 1.13.0.
+           public API in SciPy 1.14.0.
         """
         msg = (
             "`asfptype` is an internal function, and is deprecated "
-            "as part of the public API. It will be removed in v1.13.0."
+            "as part of the public API. It will be removed in v1.14.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._asfptype()
@@ -1378,11 +1378,11 @@ settable. To change the array shape, use `X.reshape` instead.
 
         .. deprecated:: 1.11.0
            This method is for internal use only, and will be removed from the
-           public API in SciPy 1.13.0.
+           public API in SciPy 1.14.0.
         """
         msg = (
             "`getmaxprint` is an internal function, and is deprecated "
-            "as part of the public API. It will be removed in v1.13.0."
+            "as part of the public API. It will be removed in v1.14.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getmaxprint()
@@ -1391,11 +1391,11 @@ settable. To change the array shape, use `X.reshape` instead.
         """Sparse array/matrix storage format.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.format` instead.
         """
         msg = (
-            "`getformat` is deprecated and will be removed in v1.13.0; "
+            "`getformat` is deprecated and will be removed in v1.14.0; "
             "use `X.format` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1405,7 +1405,7 @@ settable. To change the array shape, use `X.reshape` instead.
         """Number of stored values, including explicit zeros.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0. Use `X.nnz`
+           This method will be removed in SciPy 1.14.0. Use `X.nnz`
            instead.  The `axis` argument will no longer be supported;
            please let us know if you still need this functionality.
 
@@ -1420,7 +1420,7 @@ settable. To change the array shape, use `X.reshape` instead.
         count_nonzero : Number of non-zero entries
         """
         msg = (
-            "`getnnz` is deprecated and will be removed in v1.13.0; "
+            "`getnnz` is deprecated and will be removed in v1.14.0; "
             "use `X.nnz` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1430,11 +1430,11 @@ settable. To change the array shape, use `X.reshape` instead.
         """Return the Hermitian transpose of this array/matrix.
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use `X.conj().T` instead.
         """
         msg = (
-            "`getH` is deprecated and will be removed in v1.13.0; "
+            "`getH` is deprecated and will be removed in v1.14.0; "
             "use `X.conj().T` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1445,11 +1445,11 @@ settable. To change the array shape, use `X.reshape` instead.
         array/matrix (column vector).
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use array/matrix indexing instead.
         """
         msg = (
-            "`getcol` is deprecated and will be removed in v1.13.0; "
+            "`getcol` is deprecated and will be removed in v1.14.0; "
             f"use `X[:, [{j}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
@@ -1460,17 +1460,17 @@ settable. To change the array shape, use `X.reshape` instead.
         array/matrix (row vector).
 
         .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.13.0.
+           This method will be removed in SciPy 1.14.0.
            Use array/matrix indexing instead.
         """
         msg = (
-            "`getrow` is deprecated and will be removed in v1.13.0; "
+            "`getrow` is deprecated and will be removed in v1.14.0; "
             f"use `X[[{i}]]` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self._getrow(i)
 
-    ## End 1.13.0 deprecated methods
+    ## End 1.14.0 deprecated methods
 
 
 class sparray:

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -7,7 +7,7 @@ def test_array_api_deprecations():
         [1,2,3],
         [4,0,6]
     ])
-    msg = "1.13.0"
+    msg = "1.14.0"
 
     with pytest.deprecated_call(match=msg):
         X.get_shape()

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -9,7 +9,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     .. deprecated:: 1.12.0
         `rvs_ratio_uniforms` is deprecated in favour of
         `scipy.stats.sampling.RatioUniforms` from version 1.12.0 and will
-        be removed in SciPy 1.14.0
+        be removed in SciPy 1.15.0
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
     warnings.warn("Please use `RatioUniforms` from the "
                   "`scipy.stats.sampling` namespace. The "
                   "`scipy.stats.rvs_ratio_uniforms` namespace is deprecated "
-                  "and will be removed in SciPy 1.14.0",
+                  "and will be removed in SciPy 1.15.0",
                   category=DeprecationWarning, stacklevel=2)
     gen = RatioUniforms(pdf, umax=umax, vmin=vmin, vmax=vmax,
                         c=c, random_state=random_state)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -34,12 +34,8 @@ from collections import namedtuple
 import numpy as np
 from numpy import array, asarray, ma
 
-from scipy import sparse
 from scipy.spatial.distance import cdist
-from scipy.spatial import distance_matrix
-
 from scipy.ndimage import _measurements
-from scipy.optimize import milp, LinearConstraint
 from scipy._lib._util import (check_random_state, MapWrapper, _get_nan,
                               rng_integers, _rename_parameter, _contains_nan,
                               AxisError)
@@ -4085,7 +4081,7 @@ def f_oneway(*samples, axis=0):
 
     # We haven't explicitly validated axis, but if it is bad, this call of
     # np.concatenate will raise np.exceptions.AxisError. The call will raise
-    # ValueError if the dimensions of all the arrays, except the axis 
+    # ValueError if the dimensions of all the arrays, except the axis
     # dimension, are not the same.
     alldata = np.concatenate(samples, axis=axis)
     bign = alldata.shape[axis]
@@ -9884,7 +9880,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-        * 'two-sided': the quantile associated with the probability `p` 
+        * 'two-sided': the quantile associated with the probability `p`
           is not `q`.
         * 'less': the quantile associated with the probability `p` is less
           than `q`.
@@ -10054,7 +10050,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
     As expected, the p-value is not below our threshold of 0.01, so
     we cannot reject the null hypothesis.
 
-    When testing data from the standard *normal* distribution, which has a 
+    When testing data from the standard *normal* distribution, which has a
     median of 0, we would expect the null hypothesis to be rejected.
 
     >>> rvs = stats.norm.rvs(size=100, random_state=rng)
@@ -10199,34 +10195,26 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
 
 def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
-    Compute the Wasserstein-1 distance between two discrete distributions.
+    Compute the first Wasserstein distance between two 1D distributions.
 
-    The Wasserstein distance, also called the Earth mover's distance or the
-    optimal transport distance, is a similarity metric between two probability
-    distributions. In the discrete case, the Wasserstein distance can be
-    understood as the cost of an optimal transport plan to convert one
-    distribution into the other. The cost is calculated as the product of the
-    amount of probability mass being moved and the distance it is being moved.
-    A brief and intuitive introduction can be found at [2]_.
+    This distance is also known as the earth mover's distance, since it can be
+    seen as the minimum amount of "work" required to transform :math:`u` into
+    :math:`v`, where "work" is measured as the amount of distribution weight
+    that must be moved, multiplied by the distance it has to be moved.
 
     .. versionadded:: 1.0.0
 
     Parameters
     ----------
-    u_values : 1d or 2d array_like
-        A sample from a probability distribution or the support (set of all
-        possible values) of a probability distribution. Each element along
-        axis 0 is an observation or possible value. If two-dimensional, axis
-        1 represents the dimensionality of the distribution; i.e., each row is
-        a vector observation or possible value.
-
-    v_values : 1d or 2d array_like
-        A sample from or the support of a second distribution.
-
-    u_weights, v_weights : 1d array_like, optional
-        Weights or counts corresponding with the sample or probability masses
-        corresponding with the support values. Sum of elements must be positive
-        and finite. If unspecified, each value is assigned the same weight.
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
 
     Returns
     -------
@@ -10235,9 +10223,8 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     Notes
     -----
-    Given two probability mass functions, :math:`u`
-    and :math:`v`, the first Wasserstein distance between the distributions
-    is:
+    The first Wasserstein distance between the distributions :math:`u` and
+    :math:`v` is:
 
     .. math::
 
@@ -10246,83 +10233,16 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     where :math:`\Gamma (u, v)` is the set of (probability) distributions on
     :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
-    :math:`v` on the first and second factors respectively. For a given value
-    :math:`x`, :math:`u(x)` gives the probability of :math:`u` at position
-    :math:`x`, and the same for :math:`v(x)`.
+    :math:`v` on the first and second factors respectively.
 
-    In the 1-dimensional case, let :math:`U` and :math:`V` denote the
-    respective CDFs of :math:`u` and :math:`v`, this distance also equals to:
+    If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and
+    :math:`v`, this distance also equals to:
 
     .. math::
 
         l_1(u, v) = \int_{-\infty}^{+\infty} |U-V|
 
-    See [3]_ for a proof of the equivalence of both definitions.
-
-    In the more general (higher dimensional) and discrete case, it is also
-    called the optimal transport problem or the Monge problem.
-    Let the finite point sets :math:`\{x_i\}` and :math:`\{y_j\}` denote
-    the support set of probability mass function :math:`u` and :math:`v`
-    respectively. The Monge problem can be expressed as follows,
-
-    Let :math:`\Gamma` denote the transport plan, :math:`D` denote the
-    distance matrix and,
-
-    .. math::
-
-        x = \text{vec}(\Gamma)          \\
-        c = \text{vec}(D)               \\
-        b = \begin{bmatrix}
-                u\\
-                v\\
-            \end{bmatrix}
-
-    The :math:`\text{vec}()` function denotes the Vectorization function
-    that transforms a matrix into a column vector by vertically stacking
-    the columns of the matrix.
-    The transport plan :math:`\Gamma` is a matrix :math:`[\gamma_{ij}]` in
-    which :math:`\gamma_{ij}` is a positive value representing the amount of
-    probability mass transported from :math:`u(x_i)` to :math:`v(y_i)`.
-    Summing over the rows of :math:`\Gamma` should give the source distribution
-    :math:`u` : :math:`\sum_j \gamma_{ij} = u(x_i)` holds for all :math:`i`
-    and summing over the columns of :math:`\Gamma` should give the target
-    distribution :math:`v`: :math:`\sum_i \gamma_{ij} = v(y_j)` holds for all
-    :math:`j`.
-    The distance matrix :math:`D` is a matrix :math:`[d_{ij}]`, in which
-    :math:`d_{ij} = d(x_i, y_j)`.
-
-    Given :math:`\Gamma`, :math:`D`, :math:`b`, the Monge problem can be
-    transformed into a linear programming problem by
-    taking :math:`A x = b` as constraints and :math:`z = c^T x` as minimization
-    target (sum of costs) , where matrix :math:`A` has the form
-
-    .. math::
-
-        \begin{array} {rrrr|rrrr|r|rrrr}
-            1 & 1 & \dots & 1 & 0 & 0 & \dots & 0 & \dots & 0 & 0 & \dots &
-                0 \cr
-            0 & 0 & \dots & 0 & 1 & 1 & \dots & 1 & \dots & 0 & 0 &\dots &
-                0 \cr
-            \vdots & \vdots & \ddots & \vdots & \vdots & \vdots & \ddots
-                & \vdots & \vdots & \vdots & \vdots & \ddots & \vdots  \cr
-            0 & 0 & \dots & 0 & 0 & 0 & \dots & 0 & \dots & 1 & 1 & \dots &
-                1 \cr \hline
-
-            1 & 0 & \dots & 0 & 1 & 0 & \dots & \dots & \dots & 1 & 0 & \dots &
-                0 \cr
-            0 & 1 & \dots & 0 & 0 & 1 & \dots & \dots & \dots & 0 & 1 & \dots &
-                0 \cr
-            \vdots & \vdots & \ddots & \vdots & \vdots & \vdots & \ddots &
-                \vdots & \vdots & \vdots & \vdots & \ddots & \vdots \cr
-            0 & 0 & \dots & 1 & 0 & 0 & \dots & 1 & \dots & 0 & 0 & \dots & 1
-        \end{array}
-
-    By solving the dual form of the above linear programming problem (with
-    solution :math:`y^*`), the Wasserstein distance :math:`l_1 (u, v)` can
-    be computed as :math:`b^T y^*`.
-
-    The above solution is inspired by Vincent Herrmann's blog [5]_ . For a
-    more thorough explanation, see [4]_ .
+    See [2]_ for a proof of the equivalence of both definitions.
 
     The input distributions can be empirical, therefore coming from samples
     whose values are effectively inputs of the function, or they can be seen as
@@ -10331,19 +10251,9 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     References
     ----------
-    .. [1] "Wasserstein metric",
-           https://en.wikipedia.org/wiki/Wasserstein_metric
-    .. [2] Lili Weng, "What is Wasserstein distance?", Lil'log,
-           https://lilianweng.github.io/posts/2017-08-20-gan/#what-is-
-           wasserstein-distance.
-    .. [3] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and
-           Related Families of Nonparametric Tests" (2015).
-           :arXiv:`1509.02237`.
-    .. [4] Peyré, Gabriel, and Marco Cuturi. "Computational optimal
-           transport." Center for Research in Economics and Statistics
-           Working Papers 2017-86 (2017).
-    .. [5] Hermann, Vincent. "Wasserstein GAN and the Kantorovich-Rubinstein
-           Duality". https://vincentherrmann.github.io/blog/wasserstein/.
+    .. [1] "Wasserstein metric", https://en.wikipedia.org/wiki/Wasserstein_metric
+    .. [2] Ramdas, Garcia, Cuturi "On Wasserstein Two Sample Testing and Related
+           Families of Nonparametric Tests" (2015). :arXiv:`1509.02237`.
 
     Examples
     --------
@@ -10356,69 +10266,8 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     ...                      [1.4, 0.9, 3.1, 7.2], [3.2, 3.5])
     4.0781331438047861
 
-    Compute the Wasserstein distance between two three-dimensional samples,
-    each with two observations.
-
-    >>> wasserstein_distance([[0, 2, 3], [1, 2, 5]], [[3, 2, 3], [4, 2, 5]])
-    3.0
-
-    Compute the Wasserstein distance between two two-dimensional distributions
-    with three and two weighted observations, respectively.
-
-    >>> wasserstein_distance([[0, 2.75], [2, 209.3], [0, 0]],
-    ...                      [[0.2, 0.322], [4.5, 25.1808]],
-    ...                      [0.4, 5.2, 0.114], [0.8, 1.5])
-    174.15840245217169
     """
-    m, n = len(u_values), len(v_values)
-    u_values = asarray(u_values)
-    v_values = asarray(v_values)
-
-    if u_values.ndim > 2 or v_values.ndim > 2:
-        raise ValueError('Invalid input values. The inputs must have either '
-                         'one or two dimensions.')
-    # if dimensions are not equal throw error
-    if u_values.ndim != v_values.ndim:
-        raise ValueError('Invalid input values. Dimensions of inputs must be '
-                         'equal.')
-    # if data is 1D then call the cdf_distance function
-    if u_values.ndim == 1 and v_values.ndim == 1:
-        return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
-
-    u_values, u_weights = _validate_distribution(u_values, u_weights)
-    v_values, v_weights = _validate_distribution(v_values, v_weights)
-    # if number of columns is not equal throw error
-    if u_values.shape[1] != v_values.shape[1]:
-        raise ValueError('Invalid input values. If two-dimensional, '
-                         '`u_values` and `v_values` must have the same '
-                         'number of columns.')
-
-    # if data contains np.inf then return inf or nan
-    if np.any(np.isinf(u_values)) ^ np.any(np.isinf(v_values)):
-        return np.inf
-    elif np.any(np.isinf(u_values)) and np.any(np.isinf(v_values)):
-        return np.nan
-
-    # create constraints
-    A_upper_part = sparse.block_diag((np.ones((1, n)), ) * m)
-    A_lower_part = sparse.hstack((sparse.eye(n), ) * m)
-    # sparse constraint matrix of size (m + n)*(m * n)
-    A = sparse.vstack((A_upper_part, A_lower_part))
-    A = sparse.coo_array(A)
-
-    # get cost matrix
-    D = distance_matrix(u_values, v_values, p=2)
-    cost = D.ravel()
-
-    # create the minimization target
-    p_u = np.full(m, 1/m) if u_weights is None else u_weights/np.sum(u_weights)
-    p_v = np.full(n, 1/n) if v_weights is None else v_weights/np.sum(v_weights)
-    b = np.concatenate((p_u, p_v), axis=0)
-
-    # solving LP
-    constraints = LinearConstraint(A=A.T, ub=cost)
-    opt_res = milp(c=-b, constraints=constraints, bounds=(-np.inf, np.inf))
-    return -opt_res.fun
+    return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
 
 
 def energy_distance(u_values, v_values, u_weights=None, v_weights=None):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7449,58 +7449,19 @@ class TestWassersteinDistance:
         assert_almost_equal(stats.wasserstein_distance(
             [0, 1, 2], [1, 2, 3]),
             1)
-    
-    def test_published_values(self):
-        # Compare against published values and manually computed results.
-        # The values and computed result are posted at James D. McCaffrey's blog,
-        # https://jamesmccaffrey.wordpress.com/2018/03/05/earth-mover-distance
-        # -wasserstein-metric-example-calculation/
-        u = [(1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1), (1,1),
-             (4,2), (6,1), (6,1)]
-        v = [(2,1), (2,1), (3,2), (3,2), (3,2), (5,1), (5,1), (5,1), (5,1), (5,1),
-             (5,1), (5,1), (7,1)]
-        
-        res = stats.wasserstein_distance(u, v)
-        # In original post, the author kept two decimal places for ease of calculation.
-        # This test uses the more precise value of distance to get the precise results.
-        # For comparison, please see the table and figure in the original blog post.
-        flow = np.array([2., 3., 5., 1., 1., 1.])
-        dist = np.array([1.00, 5**0.5, 4.00, 2**0.5, 1.00, 1.00])
-        ref = np.sum(flow * dist)/np.sum(flow)
-        assert_almost_equal(res, ref)
 
     def test_same_distribution(self):
-        # Any distribution moved to itself should have a Wasserstein distance
-        # of zero.
+        # Any distribution moved to itself should have a Wasserstein distance of
+        # zero.
         assert_equal(stats.wasserstein_distance([1, 2, 3], [2, 1, 3]), 0)
         assert_equal(
             stats.wasserstein_distance([1, 1, 1, 4], [4, 1],
                                        [1, 1, 1, 1], [1, 3]),
             0)
-    
-    @pytest.mark.parametrize('n_value', (4, 15, 35))
-    @pytest.mark.parametrize('ndim', (3, 4, 7))
-    @pytest.mark.parametrize('max_repeats', (5, 10))
-    def test_same_distribution_nD(self, ndim, n_value, max_repeats):
-        # Any distribution moved to itself should have a Wasserstein distance
-        # of zero.
-        rng = np.random.default_rng(363836384995579937222333)
-        repeats = rng.integers(1, max_repeats, size=n_value, dtype=int)
-
-        u_values = rng.random(size=(n_value, ndim))
-        v_values = np.repeat(u_values, repeats, axis=0)
-        v_weights = rng.random(np.sum(repeats))
-        range_repeat = np.repeat(np.arange(len(repeats)), repeats)
-        u_weights = np.bincount(range_repeat, weights=v_weights)
-        index = rng.permutation(len(v_weights))
-        v_values, v_weights = v_values[index], v_weights[index]
-
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_allclose(res, 0, atol=1e-15)
 
     def test_shift(self):
         # If the whole distribution is shifted by x, then the Wasserstein
-        # distance should be the norm of x.
+        # distance should be x.
         assert_almost_equal(stats.wasserstein_distance([0], [1]), 1)
         assert_almost_equal(stats.wasserstein_distance([-5], [5]), 10)
         assert_almost_equal(
@@ -7523,8 +7484,7 @@ class TestWassersteinDistance:
 
     def test_collapse(self):
         # Collapsing a distribution to a point distribution at zero is
-        # equivalent to taking the average of the absolute values of the
-        # values.
+        # equivalent to taking the average of the absolute values of the values.
         u = np.arange(-10, 30, 0.3)
         v = np.zeros_like(u)
         assert_almost_equal(
@@ -7537,47 +7497,12 @@ class TestWassersteinDistance:
             stats.wasserstein_distance(u, v, u_weights, v_weights),
             np.average(np.abs(u), weights=u_weights))
 
-    @pytest.mark.parametrize('nu', (8, 9, 38))
-    @pytest.mark.parametrize('nv', (8, 12, 17))
-    @pytest.mark.parametrize('ndim', (3, 5, 23))
-    def test_collapse_nD(self, nu, nv, ndim):
-        # test collapse for n dimensional values
-        # Collapsing a n-D distribution to a point distribution at zero
-        # is equivalent to taking the average of the norm of data.
-        rng = np.random.default_rng(38573488467338826109)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = np.zeros((nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = np.average(np.linalg.norm(u_values, axis=1), weights=u_weights)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
     def test_zero_weight(self):
         # Values with zero weight have no impact on the Wasserstein distance.
         assert_almost_equal(
             stats.wasserstein_distance([1, 2, 100000], [1, 1],
                                        [1, 1, 0], [1, 1]),
             stats.wasserstein_distance([1, 2], [1, 1], [1, 1], [1, 1]))
-
-    @pytest.mark.parametrize('nu', (8, 16, 32))
-    @pytest.mark.parametrize('nv', (8, 16, 32))
-    @pytest.mark.parametrize('ndim', (1, 2, 6))
-    def test_zero_weight_nD(self, nu, nv, ndim):
-        # Values with zero weight have no impact on the Wasserstein distance.
-        rng = np.random.default_rng(38573488467338826109)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        add_row, nrows = rng.integers(0, nu, size=2) 
-        add_value = rng.random(size=(nrows, ndim))
-        u_values = np.insert(u_values, add_row, add_value, axis=0)
-        u_weights = np.insert(u_weights, add_row, np.zeros(nrows), axis=0)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
 
     def test_inf_values(self):
         # Inf values can lead to an inf distance or trigger a RuntimeWarning
@@ -7596,72 +7521,6 @@ class TestWassersteinDistance:
             assert_equal(
                 stats.wasserstein_distance([1, 2, np.inf], [np.inf, 1]),
                 np.nan)
-        uv, vv, uw = [[1, 1], [2, 1]], [[np.inf, -np.inf]], [1, 1]
-        distance = stats.wasserstein_distance(uv, vv, uw)
-        assert_equal(distance, np.inf)
-        with np.errstate(invalid='ignore'):
-            uv, vv = [[np.inf, np.inf]], [[np.inf, -np.inf]]
-            distance = stats.wasserstein_distance(uv, vv)
-            assert_equal(distance, np.nan)
-
-    @pytest.mark.parametrize('nu', (10, 15, 20))
-    @pytest.mark.parametrize('nv', (10, 15, 20))
-    @pytest.mark.parametrize('ndim', (1, 3, 5))
-    def test_multi_dim_nD(self, nu, nv, ndim):
-        # Adding dimension on distributions do not affect the result
-        rng = np.random.default_rng(2736495738494849509)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        add_dim = rng.integers(0, ndim)
-        add_value = rng.random()
-
-        u_values = np.insert(u_values, add_dim, add_value, axis=1)
-        v_values = np.insert(v_values, add_dim, add_value, axis=1)
-        res = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
-    @pytest.mark.parametrize('nu', (7, 13, 19))
-    @pytest.mark.parametrize('nv', (7, 13, 19))
-    @pytest.mark.parametrize('ndim', (2, 4, 7))
-    def test_orthogonal_nD(self, nu, nv, ndim):
-        # orthogonal transformations do not affect the result of the 
-        # wasserstein_distance
-        rng = np.random.default_rng(34746837464536)
-        u_values = rng.random(size=(nu, ndim))
-        v_values = rng.random(size=(nv, ndim))
-        u_weights = rng.random(size=nu)
-        v_weights = rng.random(size=nv)
-        ref = stats.wasserstein_distance(u_values, v_values, u_weights, v_weights)
-
-        dist = stats.ortho_group(ndim)
-        transform = dist.rvs(random_state=rng)
-        shift = rng.random(size=ndim)
-        res = stats.wasserstein_distance(u_values @ transform + shift,
-                                         v_values @ transform + shift,
-                                         u_weights, v_weights)
-        assert_almost_equal(res, ref)
-
-    def test_error_code(self):
-        rng = np.random.default_rng(52473644737485644836320101)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. The inputs'):
-            u_values = rng.random(size=(4, 10, 15))
-            v_values = rng.random(size=(6, 2, 7))
-            _ = stats.wasserstein_distance(u_values, v_values)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. Dimensions'):
-            u_values = rng.random(size=(15,))
-            v_values = rng.random(size=(3, 15))
-            _ = stats.wasserstein_distance(u_values, v_values)
-        with pytest.raises(ValueError,
-                           match='Invalid input values. If two-dimensional'):
-            u_values = rng.random(size=(2, 10))
-            v_values = rng.random(size=(2, 2))
-            _ = stats.wasserstein_distance(u_values, v_values)
 
 
 class TestEnergyDistance:

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -6,9 +6,9 @@ import argparse
 MAJOR = 1
 MINOR = 12
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 def get_version_info(source_root):


### PR DESCRIPTION
- a few version changes to set us at `1.12.0` "unreleased" (the latter flag gets switched at the exact moment I do the release); delete the "is not released" disclaimer in the release notes
- update release notes after the backports

Backports included so far:

1. gh-19877
2. gh-19892
3. gh-19903
4. gh-19910 (manual resolution of merge conflict)
5. gh-19881

TODO:

- [x] known issue, maybe we let it slide since `pytest` RC (for now): https://github.com/scipy/scipy/issues/19847
- [x] need decision on this revert I think: https://github.com/scipy/scipy/pull/19881
- [x] 1 flush of the wheel builds in CI for testing when we're ready, before the final release process starts