### PR TITLE
TST: cluster: fix test_kmeans_and_kmeans2_random_seed

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -1,5 +1,6 @@
 import warnings
 import sys
+from copy import deepcopy
 
 import numpy as np
 from numpy.testing import (
@@ -404,13 +405,15 @@ class TestKMean:
         ]
 
         for seed in seed_list:
+            seed1 = deepcopy(seed)
+            seed2 = deepcopy(seed)
             # test for kmeans
-            res1, _ = kmeans(TESTDATA_2D, 2, seed=seed)
-            res2, _ = kmeans(TESTDATA_2D, 2, seed=seed)
-            assert_allclose(res1, res1)  # should be same results
+            res1, _ = kmeans(TESTDATA_2D, 2, seed=seed1)
+            res2, _ = kmeans(TESTDATA_2D, 2, seed=seed2)
+            assert_allclose(res1, res2)  # should be same results
 
             # test for kmeans2
             for minit in ["random", "points", "++"]:
-                res1, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed)
-                res2, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed)
-                assert_allclose(res1, res1)  # should be same results
+                res1, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed1)
+                res2, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed2)
+                assert_allclose(res1, res2)  # should be same results


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #19683 introduced in #13972

#### What does this implement/fix?
<!--Please explain your changes.-->
Fix wrong test comparison and using initialized seeds by a same value, not same seed.

#### Additional information
<!--Any additional information you think is important.-->
