### PR TITLE
MAINT: forward port 1.12.0 relnotes

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.11.4 (stable)",
+        "name": "1.12.0 (stable)",
+        "version":"1.12.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.12.0/"
+    },
+    {
+        "name": "1.11.4",
         "version":"1.11.4",
         "url": "https://docs.scipy.org/doc/scipy-1.11.4/"
     },

--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.12.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.12.0 is not released yet!
-
 .. contents::
 
 SciPy 1.12.0 is the culmination of 6 months of hard work. It contains
@@ -28,8 +26,9 @@ Highlights of this release
 - Experimental support for the array API standard has been added to part of
   `scipy.special`, and to all of `scipy.fft` and `scipy.cluster`. There are
   likely to be bugs and early feedback for usage with CuPy arrays, PyTorch
-  tensors, and other array API compatible libraries is appreciated.
-- A new class, ``ShortTimeFFT```, provides a more versatile implementation of the
+  tensors, and other array API compatible libraries is appreciated. Use the
+  ``SCIPY_ARRAY_API`` environment variable for testing.
+- A new class, ``ShortTimeFFT``, provides a more versatile implementation of the
   short-time Fourier transform (STFT), its inverse (ISTFT) as well as the (cross-)
   spectrogram. It utilizes an improved algorithm for calculating the ISTFT.
 - Several new constructors have been added for sparse arrays, and many operations
@@ -81,7 +80,7 @@ New features
   and knot vectors. This way it generalizes ``BSpline`` for 1D data to N-D, and
   parallels ``NdPPoly`` (which represents N-D tensor product polynomials).
   Evaluations exploit the localized nature of b-splines.
-- ``NeastNDInterpolator.__call__`` accepts ``**query_options``, which are
+- ``NearestNDInterpolator.__call__`` accepts ``**query_options``, which are
   passed through to the ``KDTree.query`` call to find nearest neighbors. This
   allows, for instance, to limit the neighbor search distance and parallelize
   the query using the ``workers`` keyword.
@@ -205,8 +204,6 @@ New features
   hypothesized value is the quantile associated with a specified probability.
   The ``confidence_interval`` method of the result object gives a confidence
   interval of the quantile.
-- `scipy.stats.wasserstein_distance` now computes the Wasserstein distance
-  in the multidimensional case.
 - `scipy.stats.sampling.FastGeneratorInversion` provides a convenient
   interface to fast random sampling via numerical inversion of distribution
   CDFs.
@@ -326,7 +323,7 @@ Authors
 
 * Name (commits)
 * endolith (1)
-* h-vetinari (29)
+* h-vetinari (34)
 * Tom Adamczewski (3) +
 * Anudeep Adiraju (1) +
 * akeemlh (1)
@@ -340,17 +337,20 @@ Authors
 * Ben Beasley (3) +
 * Doron Behar (1)
 * Peter Bell (1)
+* Sebastian Berg (1)
 * Ben Boeckel (1) +
-* Jake Bowhay (100)
+* David Boetius (1) +
+* Matt Borland (1)
+* Jake Bowhay (103)
 * Larry Bradley (1) +
 * Dietrich Brunn (5)
-* Evgeni Burovski (101)
+* Evgeni Burovski (102)
 * Matthias Bussonnier (18)
-* CJ Carey (4)
+* CJ Carey (6)
 * Colin Carroll (1) +
 * Aadya Chinubhai (1) +
 * Luca Citi (1)
-* Lucas Colley (136) +
+* Lucas Colley (141) +
 * com3dian (1) +
 * Anirudh Dagar (4)
 * Danni (1) +
@@ -360,19 +360,20 @@ Authors
 * drestebon (1) +
 * Thomas Duvernay (1)
 * elbarso (1) +
+* emilfrost (2) +
 * Paul Estano (8) +
 * Evandro (2)
 * Franz Király (1) +
 * Nikita Furin (1) +
 * gabrielthomsen (1) +
-* Lukas Geiger (8) +
+* Lukas Geiger (9) +
 * Artem Glebov (22) +
 * Caden Gobat (1)
-* Ralf Gommers (120)
+* Ralf Gommers (127)
 * Alexander Goscinski (2) +
 * Rohit Goswami (2) +
 * Olivier Grisel (1)
-* Matt Haberland (238)
+* Matt Haberland (244)
 * Charles Harris (1)
 * harshilkamdar (1) +
 * Alon Hovav (2) +
@@ -380,6 +381,7 @@ Authors
 * Romain Jacob (1) +
 * jcwhitehead (1) +
 * Julien Jerphanion (13)
+* He Jia (1)
 * JohnWT (1) +
 * jokasimr (1) +
 * Evan W Jones (1)
@@ -404,7 +406,7 @@ Authors
 * Thomas Loke (4) +
 * Malte Londschien (1) +
 * Christian Lorentzen (6)
-* Adam Lugowski (9) +
+* Adam Lugowski (10) +
 * lutefiskhotdish (1)
 * mainak33 (1) +
 * Ben Mares (11) +
@@ -413,6 +415,7 @@ Authors
 * Nikolay Mayorov (4)
 * Nicholas McKibben (1)
 * Melissa Weber Mendonça (7)
+* Michał Górny (1)
 * Kat Mistberg (2) +
 * mkiffer (1) +
 * mocquin (1) +
@@ -421,12 +424,12 @@ Authors
 * Roberto Pastor Muela (3) +
 * Bijay Nayak (1) +
 * Andrew Nelson (105)
-* Praveer Nidamaluri (1) +
+* Praveer Nidamaluri (3) +
 * Lysandros Nikolaou (2)
 * Dimitri Papadopoulos Orfanos (7)
 * Pablo Rodríguez Pérez (1) +
 * Dimitri Papadopoulos (2)
-* Tirth Patel (13)
+* Tirth Patel (14)
 * Kyle Paterson (1) +
 * Paul (4) +
 * Yann Pellegrini (2) +
@@ -436,7 +439,7 @@ Authors
 * Bharat Raghunathan (1)
 * Chris Rapson (1) +
 * Matteo Raso (4)
-* Tyler Reddy (161)
+* Tyler Reddy (215)
 * Martin Reinecke (1)
 * Tilo Reneau-Cardoso (1) +
 * resting-dove (2) +
@@ -448,8 +451,8 @@ Authors
 * Masahiro Sakai (2) +
 * Omar Salman (14)
 * Andrej Savikin (1) +
-* Daniel Schmitz (50)
-* Dan Schult (18)
+* Daniel Schmitz (55)
+* Dan Schult (19)
 * Scott Shambaugh (9)
 * Sheila-nk (2) +
 * Mauro Silberberg (3) +
@@ -476,14 +479,14 @@ Authors
 * Warren Weckesser (7)
 * Bernhard M. Wiedemann (4)
 * Levi John Wolf (1)
-* Xuefeng Xu (3) +
+* Xuefeng Xu (4) +
 * Rory Yorke (2)
 * YoussefAli1 (1) +
 * Irwin Zaid (4) +
 * Jinzhe Zeng (1) +
 * JIMMY ZHAO (1) +
 
-A total of 157 people contributed to this release.
+A total of 163 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -500,6 +503,7 @@ Issues closed for 1.12.0
 * `#5022 <https://github.com/scipy/scipy/issues/5022>`__: bicg returns last iterate, not the smallest-residue vector
 * `#6198 <https://github.com/scipy/scipy/issues/6198>`__: callback for Krylov methods
 * `#7241 <https://github.com/scipy/scipy/issues/7241>`__: ENH: Implement Chandrupatla's algorithm for root finding (simpler/faster...
+* `#8792 <https://github.com/scipy/scipy/issues/8792>`__: Newton-CG throws error when Hessian is a \`scipy.sparse\` class
 * `#9527 <https://github.com/scipy/scipy/issues/9527>`__: Anderson-Darling ksamples can not estimate p-values beyond given...
 * `#11516 <https://github.com/scipy/scipy/issues/11516>`__: Recommend ccache for benchmarks in contributor documentation
 * `#12017 <https://github.com/scipy/scipy/issues/12017>`__: Expose FACTOR parameter instead of using magic number in scipy.optimize.nnls
@@ -509,8 +513,8 @@ Issues closed for 1.12.0
 * `#13437 <https://github.com/scipy/scipy/issues/13437>`__: DOC: Add example as to how to use solve_ivp to solve complex...
 * `#14037 <https://github.com/scipy/scipy/issues/14037>`__: ENH: other quality metrics for random sampling
 * `#14480 <https://github.com/scipy/scipy/issues/14480>`__: LSODA implementation of dense output yields incorrect result
-* `#15533 <https://github.com/scipy/scipy/issues/15533>`__: BUG: test failure with MKL in presence of AVX512-capable processor
 * `#15676 <https://github.com/scipy/scipy/issues/15676>`__: ENH: Implement \`multivariate_normal.fit\`
+* `#15738 <https://github.com/scipy/scipy/issues/15738>`__: DEP: change default of atol in \`scipy.sparse.linalg.\*\`
 * `#16729 <https://github.com/scipy/scipy/issues/16729>`__: _fitpack / dfitpack duplication
 * `#16880 <https://github.com/scipy/scipy/issues/16880>`__: ENH: Add Rotation.align_vector
 * `#17290 <https://github.com/scipy/scipy/issues/17290>`__: ENH: multi dimensional wasserstein/earth mover distance in Scipy
@@ -611,6 +615,7 @@ Issues closed for 1.12.0
 * `#19448 <https://github.com/scipy/scipy/issues/19448>`__: DOC:fft: next_fast_len signature is empty in docs
 * `#19490 <https://github.com/scipy/scipy/issues/19490>`__: MAINT: lint: fail inventory
 * `#19544 <https://github.com/scipy/scipy/issues/19544>`__: DOC/MAINT: refguide-check errors
+* `#19553 <https://github.com/scipy/scipy/issues/19553>`__: BUG: Test suite leaks file descriptors (\`OSError: [Errno 24]...
 * `#19565 <https://github.com/scipy/scipy/issues/19565>`__: DOC/DX: \`meson-python\` missing from 'required build dependencies'
 * `#19568 <https://github.com/scipy/scipy/issues/19568>`__: DOC/DX: \`cd scipy\` missing from 'Building from source'
 * `#19575 <https://github.com/scipy/scipy/issues/19575>`__: BUG: scipy.ndimage.watershed_ift cost data type is too small...
@@ -621,6 +626,12 @@ Issues closed for 1.12.0
 * `#19620 <https://github.com/scipy/scipy/issues/19620>`__: _lib: Test error in test_warning_calls_filters because of a Python...
 * `#19636 <https://github.com/scipy/scipy/issues/19636>`__: DOC: issue in documentation for the callback argument in scipy.optimize.minimize
 * `#19640 <https://github.com/scipy/scipy/issues/19640>`__: CI, MAINT: pre-release job failures with scipy-openblas32
+* `#19726 <https://github.com/scipy/scipy/issues/19726>`__: BUG: 1.12.0rc1: build failure on windows due to macro collision...
+* `#19747 <https://github.com/scipy/scipy/issues/19747>`__: BUG: Invalid \`IndexError\` from \`scipy.stats.nbinom.logcdf\`
+* `#19795 <https://github.com/scipy/scipy/issues/19795>`__: MAINT: need stable Pythran release for SciPy 1.12.0 RC2
+* `#19804 <https://github.com/scipy/scipy/issues/19804>`__: MAINT/TST: Warnings failing test suite with \`pytest 8\`
+* `#19852 <https://github.com/scipy/scipy/issues/19852>`__: CI, MAINT: Windows 3.11 CI failure with file access issue
+* `#19906 <https://github.com/scipy/scipy/issues/19906>`__: BUG: 1.12.0rc2 SciPy rather than scipy in \`pip list\` output
 
 ************************
 Pull requests for 1.12.0
@@ -1060,6 +1071,7 @@ Pull requests for 1.12.0
 * `#19623 <https://github.com/scipy/scipy/pull/19623>`__: MAINT: lint: enable \`stacklevel\` warnings check
 * `#19624 <https://github.com/scipy/scipy/pull/19624>`__: MAINT/TST: _lib: use value instead of deprecated s
 * `#19626 <https://github.com/scipy/scipy/pull/19626>`__: MAINT: more SciPy windows int shims
+* `#19628 <https://github.com/scipy/scipy/pull/19628>`__: DOC: 1.12.0 release notes
 * `#19635 <https://github.com/scipy/scipy/pull/19635>`__: MAINT: simplify Nakagami mean calculation
 * `#19637 <https://github.com/scipy/scipy/pull/19637>`__: DOC: Clarify integration error bound in \`integrate\` tutorial
 * `#19648 <https://github.com/scipy/scipy/pull/19648>`__: MAINT: simplify chi distribution mean calculation
@@ -1068,3 +1080,28 @@ Pull requests for 1.12.0
 * `#19658 <https://github.com/scipy/scipy/pull/19658>`__: MAINT: git blame ignores for lint clean-ups
 * `#19660 <https://github.com/scipy/scipy/pull/19660>`__: STY: special: use indent width of 4 in clang-format
 * `#19661 <https://github.com/scipy/scipy/pull/19661>`__: CI: fix pre-release job by correct version pin for scipy-openblas32
+* `#19670 <https://github.com/scipy/scipy/pull/19670>`__: MAINT: version bounds for 1.12.0rc1
+* `#19677 <https://github.com/scipy/scipy/pull/19677>`__: DOC: array types: mention partial support in \`special\`
+* `#19686 <https://github.com/scipy/scipy/pull/19686>`__: TST: fix incorrect signal.sosfilt tests
+* `#19690 <https://github.com/scipy/scipy/pull/19690>`__: BLD: avoid fast-math for oneAPI compilers, fix up handling of...
+* `#19691 <https://github.com/scipy/scipy/pull/19691>`__: BUG: fix negative overflow in stats.boxcox_normmax
+* `#19693 <https://github.com/scipy/scipy/pull/19693>`__: BUG: Prevent mutation of \`w\` parameter in \`spatial.distance.\*\`
+* `#19702 <https://github.com/scipy/scipy/pull/19702>`__: DEP: Adopt \`\*tol\` deprecations also for \`gcrotmk/lgmres/minres/tfqmr\`
+* `#19709 <https://github.com/scipy/scipy/pull/19709>`__: MAINT: Cumulative simpson follow-up comments
+* `#19735 <https://github.com/scipy/scipy/pull/19735>`__: DOC: update release notes with all deprecations for 1.12 release
+* `#19748 <https://github.com/scipy/scipy/pull/19748>`__: TST: skip RGI(..., method="pchip" for complex values)
+* `#19751 <https://github.com/scipy/scipy/pull/19751>`__: BUG: Make FMM classes \`py::module_local\` (fix for 1.12RC)
+* `#19761 <https://github.com/scipy/scipy/pull/19761>`__: MAINT: Avoid use of aligned_alloc in pocketfft on windows
+* `#19779 <https://github.com/scipy/scipy/pull/19779>`__: BUG: Fix \`nbinom.logcdf\` for invalid input
+* `#19785 <https://github.com/scipy/scipy/pull/19785>`__: BUG: support sparse Hessian in \`Newton-CG\`
+* `#19797 <https://github.com/scipy/scipy/pull/19797>`__: MAINT: 1.12.0rc2 prep
+* `#19800 <https://github.com/scipy/scipy/pull/19800>`__: TST: loosen tolerances for tests that fail otherwise on windows+MKL
+* `#19806 <https://github.com/scipy/scipy/pull/19806>`__: TST: fix compatibility with pytest 8
+* `#19830 <https://github.com/scipy/scipy/pull/19830>`__: REL: bump copyright to 2024
+* `#19842 <https://github.com/scipy/scipy/pull/19842>`__: TST: move reference data for test_real_transforms to a fixture
+* `#19859 <https://github.com/scipy/scipy/pull/19859>`__: BLD: improve scipy-openblas dependency check
+* `#19877 <https://github.com/scipy/scipy/pull/19877>`__: DOC: 1.12 release notes tweaks
+* `#19881 <https://github.com/scipy/scipy/pull/19881>`__: Revert "ENH: stats.wasserstein_distance: multivariate Wasserstein...
+* `#19892 <https://github.com/scipy/scipy/pull/19892>`__: DEP: extend some announced deprecations due to out-of-band 1.13...
+* `#19903 <https://github.com/scipy/scipy/pull/19903>`__: DEP: reflect extended deprecations also in release notes
+* `#19910 <https://github.com/scipy/scipy/pull/19910>`__: BLD: ensure the name of the installed \`scipy\` package is lower-case


### PR DESCRIPTION
* forward port SciPy `1.12.0` release notes following the "final" release this afternoon, and adjust the docs version switcher

[docs only]