### PR TITLE
BUG: cluster.kmeans*: array types: accept `int`s for k

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -397,8 +397,9 @@ class TestKMean:
         xp_assert_close(res[0], xp.asarray([-0.4,  8.], dtype=xp.float64))
         xp_assert_close(res[1], xp.asarray(1.0666666666666667, dtype=xp.float64)[()])
 
-    @skip_if_array_api
-    def test_kmeans_and_kmeans2_random_seed(self):
+    @skip_if_array_api_gpu
+    @array_api_compatible
+    def test_kmeans_and_kmeans2_random_seed(self, xp):
 
         seed_list = [
             1234, np.random.RandomState(1234), np.random.default_rng(1234)
@@ -407,13 +408,14 @@ class TestKMean:
         for seed in seed_list:
             seed1 = deepcopy(seed)
             seed2 = deepcopy(seed)
+            data = xp.asarray(TESTDATA_2D)
             # test for kmeans
-            res1, _ = kmeans(TESTDATA_2D, 2, seed=seed1)
-            res2, _ = kmeans(TESTDATA_2D, 2, seed=seed2)
+            res1, _ = kmeans(data, 2, seed=seed1)
+            res2, _ = kmeans(data, 2, seed=seed2)
             assert_allclose(res1, res2)  # should be same results
 
             # test for kmeans2
             for minit in ["random", "points", "++"]:
-                res1, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed1)
-                res2, _ = kmeans2(TESTDATA_2D, 2, minit=minit, seed=seed2)
+                res1, _ = kmeans2(data, 2, minit=minit, seed=seed1)
+                res2, _ = kmeans2(data, 2, minit=minit, seed=seed2)
                 assert_allclose(res1, res2)  # should be same results

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -462,7 +462,10 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
     >>> plt.show()
 
     """
-    xp = array_namespace(obs, k_or_guess)
+    if isinstance(k_or_guess, int):
+        xp = array_namespace(obs)
+    else:
+        xp = array_namespace(obs, k_or_guess)
     obs = _asarray(obs, xp=xp, check_finite=check_finite)
     guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite)
     if iter < 1:
@@ -768,7 +771,10 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
     except KeyError as e:
         raise ValueError(f"Unknown missing method {missing!r}") from e
 
-    xp = array_namespace(data, k)
+    if isinstance(k, int):
+        xp = array_namespace(data)
+    else:
+        xp = array_namespace(data, k)
     data = _asarray(data, xp=xp, check_finite=check_finite)
     code_book = copy(k, xp=xp)
     if data.ndim == 1:


### PR DESCRIPTION
#### Reference issue
None, but this unblocks gh-19682.

#### What does this implement/fix?
The `k_or_guess` / `k` parameters are documented to accept `int`s as well as `ndarray`s, but they do not accept `int`s for alternative backends. That is fixed here.

#### Additional information
The alternative is to strictly require arrays (as we currently do), even for a single integer, but that seems wrong to me.

The first commit removes a skip from a test, which fails before and passes after the second commit.