### PR TITLE
BUG: Correct handling of -inf in special stdr funcs

### DIFF
--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -601,7 +601,7 @@ cdef inline double stdtr(double df, double t) noexcept nogil:
     argnames[0] = "t"
     argnames[1] = "df"
 
-    if isinf(df):
+    if isinf(df) and df > 0:
         return NAN if isnan(t) else ndtr(t)
 
     if isnan(df) or isnan(t):
@@ -636,7 +636,7 @@ cdef inline double stdtrit(double df, double p) noexcept nogil:
         int status = 10
         char *argnames[3]
 
-    if isinf(df):
+    if isinf(df) and df > 0:
         return NAN if isnan(p) else ndtri(p)
 
     if isnan(p) or isnan(df):

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -485,3 +485,9 @@ def test_nctdtrinc_gh19896():
                -3.086951096691082]
     actual = sp.nctdtrinc(dfarr, parr, tarr)
     assert_allclose(actual, desired, rtol=2e-12, atol=0.0)
+
+
+def test_stdtr_stdtrit_neg_inf():
+    # -inf was treated as +inf and values from the normal were returned
+    assert np.all(np.isnan(sp.stdtr(-np.inf, [-np.inf, -1.0, 0.0, 1.0, np.inf])))
+    assert np.all(np.isnan(sp.stdtrit(-np.inf, [0.0, 0.25, 0.5, 0.75, 1.0])))


### PR DESCRIPTION
Ensure that -inf returns nan rather than the value from a normal

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Changes inf check from any inf to only positive inf.  -inf is not passed to function to get the correct result of `nan`

#### Additional information
This is a mistake in the code since it does not have a shortcut test for negative values of df first.
