### PR TITLE
BUG:special:amos: Fix some mistakes in the AMOS C translation

### DIFF
--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -4056,9 +4056,8 @@ int amos_kscl(
     nz = n;
     if (ic == n) {
         nz = n-1;
-    } else {
-        nz = kk - 2;
     }
+
     for (int i = 0; i < nz; i++) { y[i] = 0.; }
     return nz;
 }

--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -4007,6 +4007,10 @@ int amos_kscl(
     if (n == 2) {
         return nz;
     }
+    if (nz == 0) {
+        return nz;
+    }
+
     fn = fnu + 1.;
     ck = fn*rz;
     s1 = cy[0];


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- related pr: https://github.com/scipy/scipy/pull/19587#discussion_r1460726081


#### What does this implement/fix?
<!--Please explain your changes.-->
1. Fixed missing return branch of `amos_kscl` function in C translation of amos code.
	See description below.
2. Remove extra `else` branch in `amos_kscl`.
	See my first comment for detailed description.

C translation:
https://github.com/scipy/scipy/blob/44b39e1e740795aa8cd4d69e88d6c0acb116eeac/scipy/special/_amos.c#L4007-L4011
ref: amos fortran code:  https://github.com/scipy/scipy/blob/e5f21298b62fb03732f000645d2caaa67aad8800/scipy/special/amos/zkscl.f#L52-L56


#### Additional information
<!--Any additional information you think is important.-->

- [ ] Add some test
Since this function is not exported, it is difficult to construct a test case to cover this bug.

Some shorter call paths from exported functions to `amos_kscl`.
```
amos_airy 
	-> amos_bknu -> amos_kscl

amos_besh, amos_besk
	-> amos_acon
	-> amos_bknu -> amos_kscl
```

<details>
<summary>full call graph</summary>


![amos](https://github.com/scipy/scipy/assets/5158738/79bda6b7-cb32-4f73-b486-d81f1cb07711)

</details>

It's a bit difficult to test this bug in python, but you can test it in C.
Add the following C code to _amos.c, compile it, and run it.
Then check the printout of the program.

<details>
<summary>C test code add to _amos.c</summary>

run with `gcc -g -o amos _amos.c -lm && ./amos`
```c
#include <stdio.h>
#define ARRAY_SIZE(x) ((sizeof x) / (sizeof *x))
int main () {
    int n = 5;
    double complex y[5] = { 0.0 };
    int y_size = ARRAY_SIZE(y);
    for (int i=0; i < y_size; i++) {
        y[i] = (i+1) + i*I;
    }
    double complex zr = 1e-9 + 0.0*I;
    double fnu = 2.0;
    double complex rz = 0.5 + 0.5*I;
    double ascle = 1e-30;
    double tol = 1e-15;
    double elim = 20.;

    printf("---- Input: y[%d] =\n", y_size);
    for (int i=0; i < n; i++) {
        printf( "  y[%d] = %g + %g*I\n",
            i, creal(y[i]), cimag(y[i]));
    }
    printf("zr = %g + %g*I;", creal(zr), cimag(zr));
    printf("  fnu=%g;  n=%d\n", fnu, n);
    printf("rz = %g + %g*I;", creal(rz), cimag(rz));
    printf("  ascle=%g;  tol=%g;  elim=%g\n",
        ascle, tol, elim);

    int nz = amos_kscl(zr,fnu,n,y,rz,&ascle,tol,elim);
    puts("---- Output");
    printf("nz=%d;  y[%d]=\n", nz, y_size);
    for (int i=0; i < y_size; i++) {
        printf( "  y[%d] = %g + %g*I\n",
            i, creal(y[i]), cimag(y[i]));
    }

    return 0;
}
#undef ARRAY_SIZE
```
</details>

<details>
<summary>C test code outout</summary>

master output (Without pr)
- `nz = 1`
```
$ gcc -O0 -g -o amos _amos.c -lm && ./amos
---- Input: y[5] =
  y[0] = 1 + 0*I
  y[1] = 2 + 1*I
  y[2] = 3 + 2*I
  y[3] = 4 + 3*I
  y[4] = 5 + 4*I
zr = 1e-09 + 0*I;  fnu=2;  n=5
rz = 0.5 + 0.5*I;  ascle=1e-30;  tol=1e-15;  elim=20
---- Output
nz=1;  y[5]=
  y[0] = 0 + 0*I
  y[1] = 2e+15 + 1e+15*I
  y[2] = 2.5e+15 + 4.5e+15*I
  y[3] = 4 + 3*I
  y[4] = 5 + 4*I
```

with pr
- `nz = 0`, and `y[]` outout also changed.
```
$ gcc -O0 -g -o amos _amos.c -lm && ./amos
---- Input: y[5] =
  y[0] = 1 + 0*I
  y[1] = 2 + 1*I
  y[2] = 3 + 2*I
  y[3] = 4 + 3*I
  y[4] = 5 + 4*I
zr = 1e-09 + 0*I;  fnu=2;  n=5
rz = 0.5 + 0.5*I;  ascle=1e-30;  tol=1e-15;  elim=20
---- Output
nz=0;  y[5]=
  y[0] = 1e+15 + 0*I
  y[1] = 2e+15 + 1e+15*I
  y[2] = 3 + 2*I
  y[3] = 4 + 3*I
  y[4] = 5 + 4*I
```
</details>
