### PR TITLE
MAINT: special: array types: fix warning when not in array API mode

### DIFF
--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -17,7 +17,7 @@ def test_dispatch_to_unrecognize_library():
     x = [1, 2, 3]
     res = f(xp.asarray(x))
     ref = xp.asarray(special.ndtr(np.asarray(x)))
-    xp_assert_close(res, ref)
+    xp_assert_close(res, ref, xp=xp)
 
 
 @array_api_compatible


### PR DESCRIPTION
#### Reference issue
<details>
<summary>Example CI log</summary>

```
_____________________ test_dispatch_to_unrecognize_library _____________________
[gw0] linux -- Python 3.12.1 /opt/hostedtoolcache/Python/3.12.1/x64/bin/python
scipy/special/tests/test_support_alternative_backends.py:20: in test_dispatch_to_unrecognize_library
    xp_assert_close(res, ref)
        f          = <function get_array_special_func.<locals>.f at 0x7f0712c4a7a0>
        ref        = Array([0.84134475, 0.97724987, 0.9986501 ], dtype=np.array_api.float64)
        res        = Array([0.84134475, 0.97724987, 0.9986501 ], dtype=np.array_api.float64)
        x          = [1, 2, 3]
        xp         = <module 'numpy.array_api' from '/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/numpy/array_api/__init__.py'>
scipy/_lib/_array_api.py:286: in xp_assert_close
    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
        actual     = Array([0.84134475, 0.97724987, 0.9986501 ], dtype=np.array_api.float64)
        atol       = 0
        check_dtype = True
        check_namespace = True
        check_shape = True
        desired    = Array([0.84134475, 0.97724987, 0.9986501 ], dtype=np.array_api.float64)
        err_msg    = ''
        rtol       = 1e-07
        xp         = <module 'scipy._lib.array_api_compat.numpy' from '/home/runner/work/scipy/scipy/build-install/lib/python3.12/site-packages/scipy/_lib/array_api_compat/numpy/__init__.py'>
scipy/_lib/_array_api.py:219: in _strict_check
    assert actual.dtype == desired.dtype, _msg
        _msg       = 'dtypes do not match.\nActual: {actual.dtype}\nDesired: {desired.dtype}'
        actual     = Array([0.84134475, 0.97724987, 0.9986501 ], dtype=np.array_api.float64)
        check_dtype = True
        check_namespace = True
        check_shape = True
        desired    = array([0.84134475, 0.97724987, 0.9986501 ])
        xp         = <module 'scipy._lib.array_api_compat.numpy' from '/home/runner/work/scipy/scipy/build-install/lib/python3.12/site-packages/scipy/_lib/array_api_compat/numpy/__init__.py'>
/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/numpy/array_api/_dtypes.py:24: in __eq__
    warnings.warn(
E   UserWarning: You are comparing a numpy.array_api dtype against a NumPy native dtype object, but you probably don't want to do this. numpy.array_api dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
        other      = dtype('float64')
        self       = np.array_api.float64
```

</details>

#### What does this implement/fix?
The greater strictness introduced by numpy/numpy#25370 caught that one of our tests, which tests passing `numpy.array_api` as an argument to `get_array_special_func`, plays up when array API mode is _not_ enabled, since `array_namespace` returns `array_api_compat.numpy` regardless of the input type (thanks @asmeurer !).

#### Additional information
I think the simplest fix here is just to let the assertion know which backend we're using. I can't check locally without installing a NumPy nightly so I'll let CI do it for me.

An alternative is to skip this test whenever we are not in array API mode. That might be preferable.