### PR TITLE
BUG:special:amos: Fix exit path in `amos_asyi`

### DIFF
--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -1020,7 +1020,7 @@ int amos_asyi(
     double complex ak1, ck, cs1, cs2, cz, dk, ez, p1, rz, s2;
     double aa, acz, aez, ak, arg, arm, atol, az, bb, bk, dfnu;
     double dnu2, fdn, rtr1, s, sgn, sqk, x, yy;
-    int ib, il, inu, j, jl, k, koded, m, nn;
+    int ib, il, inu, jl, k, koded, m, nn;
     int flag_for_break;
     double pi = 3.14159265358979324;
     double rpi = 0.159154943091895336; /* (1 / pi) */

--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -1021,6 +1021,7 @@ int amos_asyi(
     double aa, acz, aez, ak, arg, arm, atol, az, bb, bk, dfnu;
     double dnu2, fdn, rtr1, s, sgn, sqk, x, yy;
     int ib, il, inu, j, jl, k, koded, m, nn;
+    int flag_for_break;
     double pi = 3.14159265358979324;
     double rpi = 0.159154943091895336; /* (1 / pi) */
     int nz = 0;
@@ -1076,7 +1077,8 @@ int amos_asyi(
             aa = 1.;
             bb = aez;
             dk = ez;
-            j = 1;
+
+            flag_for_break = 0;
             for (int j = 1; j < (jl+1); j++)
             {
                 ck *= sqk / dk;
@@ -1088,9 +1090,12 @@ int amos_asyi(
                 bb += aez;
                 ak += 8.;
                 sqk -= ak;
-                if (aa <= atol) { break; }
+                if (aa <= atol) {
+                    flag_for_break = 1;
+                    break; 
+                }
             }
-            if ((j == jl) && (aa > atol)) { return -2; }
+            if (0 == flag_for_break) { return -2; }
 
             /* 50 */
             s2 = cs1;

--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -1115,7 +1115,10 @@ int amos_asyi(
         if (koded == 0) { return nz; }
         ck = cexp(cz);
         for (int i = 0; i < (nn + 1); i++) { y[i] *= ck; }
+        /* 90 */
+        return nz;
     }
+    /* 100 */
     return -1;
 }
 

--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -1020,8 +1020,7 @@ int amos_asyi(
     double complex ak1, ck, cs1, cs2, cz, dk, ez, p1, rz, s2;
     double aa, acz, aez, ak, arg, arm, atol, az, bb, bk, dfnu;
     double dnu2, fdn, rtr1, s, sgn, sqk, x, yy;
-    int ib, il, inu, jl, k, koded, m, nn;
-    int flag_for_break;
+    int ib, il, inu, j, jl, k, koded, m, nn;
     double pi = 3.14159265358979324;
     double rpi = 0.159154943091895336; /* (1 / pi) */
     int nz = 0;
@@ -1077,9 +1076,8 @@ int amos_asyi(
             aa = 1.;
             bb = aez;
             dk = ez;
-
-            flag_for_break = 0;
-            for (int j = 1; j < (jl+1); j++)
+            j = 1;
+            for (j = 1; j < (jl+1); j++)
             {
                 ck *= sqk / dk;
                 cs2 += ck;
@@ -1090,12 +1088,9 @@ int amos_asyi(
                 bb += aez;
                 ak += 8.;
                 sqk -= ak;
-                if (aa <= atol) {
-                    flag_for_break = 1;
-                    break; 
-                }
+                if (aa <= atol) { break; }
             }
-            if (0 == flag_for_break) { return -2; }
+            if ((j == (jl+1)) && (aa > atol)) { return -2; }
 
             /* 50 */
             s2 = cs1;


### PR DESCRIPTION
#### Reference issue
xref: #19587  cc @ilayn 

#### What does this implement/fix?
- Fixed an issue where a return branch in `amos_asyi` was always false

#### Additional information
<!--Any additional information you think is important.-->

C:
https://github.com/scipy/scipy/blob/b882f1b7ebe55e534f29a8d68a54e4ecd30aeb1a/scipy/special/_amos.c#L1078-L1095

The value of the first expression, `(j == jl)`, on line 1093 is independent of how the `for` loop exits.
Because the `for` loop introduces a new variable scope, modifying the loop variable `j` used by for does not affect the `j` variable of the same name outside `for`.

So in fact there is always `j==1`.

My modification introduces a new flag to check if you're exiting from `break`, and if so, continue the function.
Otherwise, it returns an error code.

There are a number of ways to fix this, perhaps using `aa > atol` directly as a judgment condition for exiting the function would work without introducing a new variable, I'm not sure.

Fortran:
https://github.com/scipy/scipy/blob/e5f21298b62fb03732f000645d2caaa67aad8800/scipy/special/amos/zasyi.f#L99-L117
https://github.com/scipy/scipy/blob/e5f21298b62fb03732f000645d2caaa67aad8800/scipy/special/amos/zasyi.f#L162-L164
