### PR TITLE
defect: sparse: set writeable flag to False for 1d coo_array `row` property returned ndarray

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -97,7 +97,11 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     @property
     def row(self):
-        return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
+        if self.ndim > 1:
+            return self.indices[-2]
+        result = np.zeros_like(self.col)
+        result.setflags(write=False)
+        return result
 
 
     @row.setter

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -150,6 +150,7 @@ def test_1d_row_and_col():
     assert np.array_equal(res.col, np.array([0, 1, 2]))
     assert np.array_equal(res.row, np.zeros_like(res.col))
     assert res.row.dtype == res.col.dtype
+    assert res.row.flags.writeable is False
 
     res.col = [1, 2, 3]
     assert len(res.indices) == 1


### PR DESCRIPTION
1d `coo_array` has a property `A.row` which creates and returns `np.zeros_like(self.col)`. In 1d, rows are only a construct to make them play nice with 2d oriented code.  The property makes `A.row` look like A would look if it was a 2d row vector.

But for 1d, changing the `A.row` array does not change the coo_array at all -- unlike in the 2d case where changing the row values change the index values. To make this more obvious and hopefully reduce confusion, we decided to set the returned array's `writeable` flag to `False`.  That way a user who tries to change the values in the array will raise an exception because it is read-only.

This PR sets the writeable flag of the returned `zeros_like` array to `False`, and adds a test of this. 


