### PR TITLE
DOC: sparse: update sparse portion of roadmap.rst and roadmap-detailed.rst

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -328,36 +328,39 @@ The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point).
 
-What we want is sparse arrays, that act like ``numpy.ndarray``. In SciPy
-``1.8.0`` a new set of classes (``csr_array`` et al.) was added.
-Construction functions for arrays were added in ``1.12.0``. Support for
-1-D array is expected in ``1.13.0``.
+What we want is sparse arrays, that act like ``numpy.ndarray``. Initial
+support for a new set of classes (``csr_array`` et al.) was added in SciPy
+``1.8.0`` and stabilized in ``1.12.0`` when construction functions for
+arrays were added. Support for 1-D array is expected in ``1.13.0``.
 
 Next steps toward sparse array support:
 
-- Extend sparse array api to 1-D arrays.
-    - support for coo, csr and dok formats.
-    - csr 1d support (using sparsetools) for min-max, indexing, arithmetic
+- Extend sparse array API to 1-D arrays.
+    - Support for COO, CSR and DOK formats.
+    - CSR 1D support for min-max, indexing, arithmetic.
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs
-  further examination. NetworkX, Scikit-learn and scikit-image are in
+  further examination. NetworkX, scikit-learn and scikit-image are in
   progress or have completed conversion to sparse arrays.
 - After sparse array code is mature (~1 release cycle?) add deprecation
   warnings for sparse matrix.
-- Work with numpy on deprecation/removal of numpy matrix.
+- Work with Numpy on deprecation/removal of ``numpy.matrix``.
 - Deprecate and then remove sparse matrix in favor of sparse array.
-- Start api shift of construction function names (`diags`, `block`, etc.)
+- Start API shift of construction function names (``diags``, ``block``, etc.)
     - Note: as a whole, the construction functions undergo two name shifts.
       Once to move from matrix creation to new functions for array creation
-      (i.e. `eye` -> `eye_array`). Then a second move to change names to match
-      the array_api name (i.e. `eye_array` to `eye`) after sparse matrices are removed.
-- add construction function names matching array_api names.
-- deprecate the transition construction function names.
+      (i.e. ``eye`` -> ``eye_array``). Then a second move to change names to match
+      the ``array_api`` name (i.e. ``eye_array`` to ``eye``) after sparse matrices are
+      removed. We will keep the ``*_array`` versions for a long time as
+      (maybe hidden) aliases.
+- Add construction function names matching ``array_api`` names.
+- Deprecate the transition construction function names.
 
 An alternative (more ambitious, and unclear if it will materialize)
 plan is being worked on in https://github.com/pydata/sparse.
-To support that effort the plan in Scipy is to further support ``pydata/sparse``
-in ``scipy.sparse.linalg`` and add ``scipy.sparse.csgraph`` after that.
+To support that effort the plan in Scipy is that support for ``pydata/sparse``
+in ``scipy.sparse.linalg`` and ``scipy.sparse.csgraph`` is mostly complete.
+We aim to support PyData Sparse in all functions that accept sparse arrays.
 
 Regarding the different sparse matrix formats: there are a lot of them.  These
 should be kept, but improvements/optimizations should go into CSR/CSC, which

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -328,7 +328,7 @@ The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point).
 
-What we want is sparse arrays, that act like ``numpy.ndarray``. Initial
+What we want is sparse arrays that act like ``numpy.ndarray``. Initial
 support for a new set of classes (``csr_array`` et al.) was added in SciPy
 ``1.8.0`` and stabilized in ``1.12.0`` when construction functions for
 arrays were added. Support for 1-D array is expected in ``1.13.0``.
@@ -344,7 +344,7 @@ Next steps toward sparse array support:
   progress or have completed conversion to sparse arrays.
 - After sparse array code is mature (~1 release cycle?) add deprecation
   warnings for sparse matrix.
-- Work with Numpy on deprecation/removal of ``numpy.matrix``.
+- Work with NumPy on deprecation/removal of ``numpy.matrix``.
 - Deprecate and then remove sparse matrix in favor of sparse array.
 - Start API shift of construction function names (``diags``, ``block``, etc.)
     - Note: as a whole, the construction functions undergo two name shifts.
@@ -358,9 +358,9 @@ Next steps toward sparse array support:
 
 An alternative (more ambitious, and unclear if it will materialize)
 plan is being worked on in https://github.com/pydata/sparse.
-To support that effort the plan in Scipy is that support for ``pydata/sparse``
-in ``scipy.sparse.linalg`` and ``scipy.sparse.csgraph`` is mostly complete.
-We aim to support PyData Sparse in all functions that accept sparse arrays.
+To support that effort we aim to support PyData Sparse in all functions that
+accept sparse arrays.  Support for ``pydata/sparse`` in ``scipy.sparse.linalg``
+and ``scipy.sparse.csgraph`` is mostly complete.
 
 Regarding the different sparse matrix formats: there are a lot of them.  These
 should be kept, but improvements/optimizations should go into CSR/CSC, which
@@ -478,7 +478,7 @@ improvements will help SciPy better serve this role.
 - Improve the core calculations provided by SciPy's probability distributions
   so they can robustly handle wide ranges of parameter values.  Specifically,
   replace many of the PDF and CDF methods from the Fortran library CDFLIB
-  used in scipy.special with Boost implementations as in
+  used in ``scipy.special`` with Boost implementations as in
   `gh-13328 <https://github.com/scipy/scipy/pull/13328>`__.
 
 In addition, we should:

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -334,15 +334,14 @@ Construction functions for arrays were added in ``1.12.0``. Support for
 1-D array is expected in ``1.13.0``.
 
 Next steps toward sparse array support:
+
 - Extend sparse array api to 1-D arrays.
     - support for coo, csr and dok formats.
     - csr 1d support (using sparsetools) for min-max, indexing, arithmetic
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs
-  further examination.
-    - networkx is already migrated
-    - sklearn is [in progress 27090](https://github.com/scikit-learn/scikit-learn/issues/27090)
-    - scikit-image [preparation in 6261](https://github.com/scikit-image/scikit-image/pull/6261)
+  further examination. NetworkX, Scikit-learn and scikit-image are in
+  progress or have completed conversion to sparse arrays.
 - After sparse array code is mature (~1 release cycle?) add deprecation
   warnings for sparse matrix.
 - Work with numpy on deprecation/removal of numpy matrix.
@@ -357,9 +356,8 @@ Next steps toward sparse array support:
 
 An alternative (more ambitious, and unclear if it will materialize)
 plan is being worked on in https://github.com/pydata/sparse.
-To support that effort the plan in Scipy is to
-- Further support ``pydata/sparse`` in ``scipy.sparse.linalg`` and
-  add ``scipy.sparse.csgraph`` after that.
+To support that effort the plan in Scipy is to further support ``pydata/sparse``
+in ``scipy.sparse.linalg`` and add ``scipy.sparse.csgraph`` after that.
 
 Regarding the different sparse matrix formats: there are a lot of them.  These
 should be kept, but improvements/optimizations should go into CSR/CSC, which

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -329,26 +329,42 @@ is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point).
 
 What we want is sparse arrays, that act like ``numpy.ndarray``. In SciPy
-``1.8.0`` a new set of classes (``csr_array`` et al.) has been added - these
-need testing in the real world, as well as a few extra features like 1-D array
-support.
-An alternative (more ambitious, and unclear if it will materialize at this
-point) plan is being worked on in https://github.com/pydata/sparse.  The
-tentative plan for that was/is:
+``1.8.0`` a new set of classes (``csr_array`` et al.) was added.
+Construction functions for arrays were added in ``1.12.0``. Support for
+1-D array is expected in ``1.13.0``.
 
-- Start depending on ``pydata/sparse`` once it's feature-complete enough (it
-  still needs a CSC/CSR equivalent) and okay performance-wise.
-- Add support for ``pydata/sparse`` to ``scipy.sparse.linalg`` (and perhaps to
-  ``scipy.sparse.csgraph`` after that).
-- Indicate in the documentation that for new code users should prefer
-  ``pydata/sparse`` over sparse matrices.
-- When NumPy deprecates ``numpy.matrix``, vendor that or maintain it as a
-  stand-alone package.
+Next steps toward sparse array support:
+- Extend sparse array api to 1-D arrays.
+    - support for coo, csr and dok formats.
+    - csr 1d support (using sparsetools) for min-max, indexing, arithmetic
+- Help other libraries convert to sparse arrays from sparse matrices.
+  Create transition guide and helpful scripts to flag code that needs
+  further examination.
+    - networkx is already migrated
+    - sklearn is [in progress 27090](https://github.com/scikit-learn/scikit-learn/issues/27090)
+    - scikit-image [preparation in 6261](https://github.com/scikit-image/scikit-image/pull/6261)
+- After sparse array code is mature (~1 release cycle?) add deprecation
+  warnings for sparse matrix.
+- Work with numpy on deprecation/removal of numpy matrix.
+- Deprecate and then remove sparse matrix in favor of sparse array.
+- Start api shift of construction function names (`diags`, `block`, etc.)
+    - Note: as a whole, the construction functions undergo two name shifts.
+      Once to move from matrix creation to new functions for array creation
+      (i.e. `eye` -> `eye_array`). Then a second move to change names to match
+      the array_api name (i.e. `eye_array` to `eye`) after sparse matrices are removed.
+- add construction function names matching array_api names.
+- deprecate the transition construction function names.
+
+An alternative (more ambitious, and unclear if it will materialize)
+plan is being worked on in https://github.com/pydata/sparse.
+To support that effort the plan in Scipy is to
+- Further support ``pydata/sparse`` in ``scipy.sparse.linalg`` and
+  add ``scipy.sparse.csgraph`` after that.
 
 Regarding the different sparse matrix formats: there are a lot of them.  These
 should be kept, but improvements/optimizations should go into CSR/CSC, which
-are the preferred formats.  LIL may be the exception, it's inherently
-inefficient.  It could be dropped if DOK is extended to support all the
+are the preferred formats. LIL may be the exception, it's inherently
+inefficient. It could be dropped if DOK is extended to support all the
 operations LIL currently provides.
 
 

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -79,8 +79,8 @@ Implement sparse arrays in addition to sparse matrices
 
 The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
-some point). What we want is sparse *arrays* that act like ``numpy.ndarray``.
-(See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_.)
+some point). What we want is sparse *arrays* that act like ``numpy.ndarray``
+(See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_).
 Sparse arrays have largely been implemented in scipy/sparse at this time. Some
 functionality is still being completed. The future plan is:
 

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -84,10 +84,10 @@ Sparse arrays have largely been implemented in scipy/sparse at this time. Some
 functionality is still being completed. The future plan is:
 
 - Provide a feature-complete sparse array api (including 1d-array).
-  - Extend sparse array api to 1d arrays:
-    - coo, csr and dok formats.
-    - the csr 1d format uses 2d csr sparsetools to do 1d things:
-      indexing/min-max/arithmetic.
+    - Extend sparse array api to 1d arrays:
+        - coo, csr and dok formats.
+        - the csr 1d format uses 2d csr sparsetools to do 1d things like
+          indexing/min-max/arithmetic.
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs changing.
 - Deprecate and then remove sparse matrix in favor of sparse array.

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -79,13 +79,16 @@ Implement sparse arrays in addition to sparse matrices
 
 The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
-some point).  What we want is sparse *arrays* that act like ``numpy.ndarray``.
-This is being worked on in https://github.com/pydata/sparse, which is quite far
-along.  The tentative plan is:
+some point). What we want is sparse *arrays* that act like ``numpy.ndarray``.
+Sparse arrays have largely been implemented in scipy/sparse at this time. Some
+functionality is still being completed. The future plan is:
 
-- Start depending on ``pydata/sparse`` once it's feature-complete enough (it
-  still needs a CSC/CSR equivalent) and okay performance-wise.
-- Indicate in the documentation that for new code users should prefer
-  ``pydata/sparse`` over sparse matrices.
-- When NumPy deprecates ``numpy.matrix``, vendor that or maintain it as a
-  stand-alone package.
+- Provide a feature-complete sparse array api (including 1d-array).
+  - Extend sparse array api to 1d arrays:
+    - coo, csr and dok formats.
+    - the csr 1d format uses 2d csr sparsetools to do 1d things:
+      indexing/min-max/arithmetic.
+- Help other libraries convert to sparse arrays from sparse matrices.
+  Create transition guide and helpful scripts to flag code that needs changing.
+- Deprecate and then remove sparse matrix in favor of sparse array.
+- Work with numpy on deprecation/removal of numpy matrix.

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -80,15 +80,16 @@ Implement sparse arrays in addition to sparse matrices
 The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point). What we want is sparse *arrays* that act like ``numpy.ndarray``.
+(See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_.)
 Sparse arrays have largely been implemented in scipy/sparse at this time. Some
 functionality is still being completed. The future plan is:
 
-- Provide a feature-complete sparse array api (including 1d-array).
-    - Extend sparse array api to 1d arrays:
-        - coo, csr and dok formats.
-        - the csr 1d format uses 2d csr sparsetools to do 1d things like
+- Provide a feature-complete sparse array API (including 1D-array).
+    - Extend sparse array API to 1D arrays:
+        - COO, CSR and DOK formats.
+        - The CSR 1D format uses 2D CSR code to do 1D things like
           indexing/min-max/arithmetic.
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs changing.
-- Deprecate and then remove sparse matrix in favor of sparse array.
-- Work with numpy on deprecation/removal of numpy matrix.
+- Deprecate and then remove "sparse matrix" in favor of "sparse array".
+- Work with Numpy on deprecation/removal of ``numpy.matrix``.

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -81,7 +81,7 @@ The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point). What we want is sparse *arrays* that act like ``numpy.ndarray``
 (See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_).
-Sparse arrays have largely been implemented in ``scipy/sparse`` at this time.
+Sparse arrays have largely been implemented in ``scipy.sparse`` at this time.
 Some functionality is still being completed. The future plan is:
 
 - Provide a feature-complete sparse array API (including 1D-array).

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -81,8 +81,8 @@ The sparse matrix formats are mostly feature-complete, however the main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point). What we want is sparse *arrays* that act like ``numpy.ndarray``
 (See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_).
-Sparse arrays have largely been implemented in scipy/sparse at this time. Some
-functionality is still being completed. The future plan is:
+Sparse arrays have largely been implemented in ``scipy/sparse`` at this time.
+Some functionality is still being completed. The future plan is:
 
 - Provide a feature-complete sparse array API (including 1D-array).
     - Extend sparse array API to 1D arrays:
@@ -92,4 +92,4 @@ functionality is still being completed. The future plan is:
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs changing.
 - Deprecate and then remove "sparse matrix" in favor of "sparse array".
-- Work with Numpy on deprecation/removal of ``numpy.matrix``.
+- Work with NumPy on deprecation/removal of ``numpy.matrix``.


### PR DESCRIPTION
Enough progress has been made on sparse arrays, and enough time has passed since the roadmap was adjusted. So it's time to update the sparse portion of the SciPy Roadmap.  

This PR updates the `roadmap.rst` and `roadmap-detailed.rst` to reflect the path toward supporting sparse array data structures in scipy-sparse. It also includes the steps to help heavy-user libraries to sparse arrays from sparse matrices, and to provide helpful transition guides and scripts for smaller libraries.

This same information was posted to the scipy-dev mailing list. But I expect some conversation here as well. Let us know your reactions and thoughts on this plan to move from matrices to arrays.