### PR TITLE
MAINT: hypothesis: document minimum required version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ test = [
     "threadpoolctl",
     "scikit-umfpack",
     "pooch",
-    "hypothesis",
+    "hypothesis>=6.30",
 ]
 doc = [
     "sphinx!=4.1.0",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,4 @@ mpmath
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch
-hypothesis
+hypothesis>=6.30


### PR DESCRIPTION
I had an old version of hypothesis installed and found that it didn't work with scipy. Scipy uses the `allow_subnormal` argument to `from_dtype`, which wasn't added until hypothesis 6.30: https://hypothesis.readthedocs.io/en/latest/changes.html#v6-30-0. For older versions of hypothesis, I see the following error:
```
TypeError: from_dtype() got an unexpected keyword argument 'allow_subnormal'
```