### PR TITLE
BUG: Correct handling of inf support in binomial

### DIFF
--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -1,6 +1,6 @@
 from . cimport sf_error
 
-from libc.math cimport NAN, isnan, isinf
+from libc.math cimport NAN, isnan, isinf, isfinite
 cdef extern from "cephes.h" nogil:
     double ndtr(double a)
     double ndtri(double y0)
@@ -126,7 +126,7 @@ cdef inline double bdtrik(double p, double xn, double pr) noexcept nogil:
         int status
         char *argnames[5]
 
-    if isnan(p) or isnan(xn) or isnan(pr):
+    if isnan(p) or not isfinite(xn) or isnan(pr):
       return NAN
 
     argnames[0] = "p"
@@ -330,7 +330,7 @@ cdef inline double nbdtrik(double p, double xn, double pr) noexcept nogil:
         int status = 10
         char *argnames[5]
 
-    if isnan(p) or isnan(xn) or isnan(pr):
+    if isnan(p) or not isfinite(xn) or isnan(pr):
       return NAN
 
     argnames[0] = "p"

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -491,3 +491,13 @@ def test_stdtr_stdtrit_neg_inf():
     # -inf was treated as +inf and values from the normal were returned
     assert np.all(np.isnan(sp.stdtr(-np.inf, [-np.inf, -1.0, 0.0, 1.0, np.inf])))
     assert np.all(np.isnan(sp.stdtrit(-np.inf, [0.0, 0.25, 0.5, 0.75, 1.0])))
+
+
+def test_bdtrik_nbdtrik_inf():
+    y = np.array(
+        [np.nan,-np.inf,-10.0, -1.0, 0.0, .00001, .5, 0.9999, 1.0, 10.0, np.inf])
+    y = y[:,None]
+    p = np.atleast_2d(
+        [np.nan, -np.inf, -10.0, -1.0, 0.0, .00001, .5, 1.0, np.inf])
+    assert np.all(np.isnan(sp.bdtrik(y, np.inf, p)))
+    assert np.all(np.isnan(sp.nbdtrik(y, np.inf, p)))


### PR DESCRIPTION
Return NaN when support is infinite for special binomial distribution Avoids corner case with infinite hang f(0.0, inf, 1.0)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


#### What does this implement/fix?
Changes return value when number of events is infinite to be consistently NaN
Avoids an infinite hang in the case of bdtrik(0.0, inf, 1.0)

#### Additional information
Edge case catching when testing results from cython port.
