### PR TITLE
BUG:special:amos: Fix typo in `amos_mlri`

### DIFF
--- a/scipy/special/_amos.c
+++ b/scipy/special/_amos.c
@@ -3866,7 +3866,7 @@ int amos_mlri(
                 tst *= sqrt(rho / (rho*rho - 1.0));
                 itime = 2;
             }
-            if (i == 80) {
+            if (k == 80) {
                 /* Exhausted loop without break */
                 return -2;
             }


### PR DESCRIPTION
#### Reference issue
xref: #19587  cc @ilayn 

#### What does this implement/fix?
- Fixed a typo in a variable name in the `amos_mlri` function.

#### Additional information
You may want to examine the loop variable `k` instead of `i`.
https://github.com/scipy/scipy/blob/b882f1b7ebe55e534f29a8d68a54e4ecd30aeb1a/scipy/special/_amos.c#L3850-L3869