### PR TITLE
DOC: stats.logrank: fix typo that affect survival curves in manual

### DIFF
--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -615,7 +615,7 @@ def logrank(
     >>> ecdf_x = stats.ecdf(x)
     >>> ecdf_x.sf.plot(ax, label='Astrocytoma')
     >>> ecdf_y = stats.ecdf(y)
-    >>> ecdf_x.sf.plot(ax, label='Glioblastoma')
+    >>> ecdf_y.sf.plot(ax, label='Glioblastoma')
     >>> ax.set_xlabel('Time to death (weeks)')
     >>> ax.set_ylabel('Empirical SF')
     >>> plt.legend()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Due to typo, the survival curves here ( https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.logrank.html#rdb7ee857e622-2 ) only have 1 curve of "Astrocytoma" group.
#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
