### PR TITLE
defect: sparse: bool mask with wrong shape should raise IndexError

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3009,7 +3009,7 @@ class _TestFancyIndexing:
         Z3 = np.zeros((6, 11), dtype=bool)
         Z3[-1,0] = True
 
-        assert_equal(A[Z1], np.array([]))
+        assert_raises(IndexError, A.__getitem__, Z1)
         assert_raises(IndexError, A.__getitem__, Z2)
         assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))


### PR DESCRIPTION
fixes #19951 

Indexing a sparse matrix (or array) with a boolean mask that has the wrong shape should raise an IndexError.

This case is handled in `_index,py`. This PR moves the first 7 lines of `_unpack_index` into the method `_validate_indices` before the only call made to the function (not method) `unpack_index` in the repo. These lines handle the case when the index is a single boolean array. I moved it into the method so it would have the shape of the array available to check against the shape of the index.

Based on a comment in the Issue, I will also check whether we need to fix this for a boolean array used for only one of the two dimensions being indexed.

There is a question as to whether this should be deprecated. There is a test in `test_base` that specifically tests the "feature" of not raising when no True entries lie outside the shape of the array being indexed. I don't see any tests of the case when the index is smaller than the array.
