### PR TITLE
defect: sparse: 1d bool mask with wrong shape should raise IndexError

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -287,8 +287,8 @@ class IndexMixin:
 
 
 def _unpack_index(index) -> tuple[
-    int | slice | np.ndarray[np.bool_, np.int_],
-    int | slice | np.ndarray[np.bool_, np.int_]
+    int | slice | np.ndarray[np.bool_ | np.int_],
+    int | slice | np.ndarray[np.bool_ | np.int_]
 ]:
     """ Parse index. Always return a tuple of the form (row, col).
     Valid type for row/col is integer, slice, array of bool, or array of integers.

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -2,8 +2,13 @@
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from ._sputils import isintlike
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 INT_TYPES = (int, np.integer)
 
@@ -158,10 +163,10 @@ class IndexMixin:
         M, N = self.shape
 
         def _validate_bool_idx(
-            idx: np.ndarray[np.bool_],
+            idx: npt.NDArray[np.bool_],
             axis_size: int,
             axis_name: str
-        ) -> np.ndarray[np.int_]:
+        ) -> npt.NDArray[np.int_]:
             if len(idx) != axis_size:
                 raise IndexError(
                     f"boolean {axis_name} index has incorrect length: {len(idx)} "
@@ -289,8 +294,8 @@ class IndexMixin:
 
 
 def _unpack_index(index) -> tuple[
-    int | slice | np.ndarray[np.bool_ | np.int_],
-    int | slice | np.ndarray[np.bool_ | np.int_]
+    int | slice | npt.NDArray[np.bool_ | np.int_],
+    int | slice | npt.NDArray[np.bool_ | np.int_]
 ]:
     """ Parse index. Always return a tuple of the form (row, col).
     Valid type for row/col is integer, slice, array of bool, or array of integers.

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -1,5 +1,7 @@
 """Indexing mixin for sparse array/matrix classes.
 """
+from __future__ import annotations
+
 import numpy as np
 from ._sputils import isintlike
 

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -170,7 +170,7 @@ class IndexMixin:
             if len(idx) != axis_size:
                 raise IndexError(
                     f"boolean {axis_name} index has incorrect length: {len(idx)} "
-                    f" instead of {axis_size}"
+                    f"instead of {axis_size}"
                 )
             return _boolean_index_to_array(idx)
 

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -155,9 +155,16 @@ class IndexMixin:
             row, col = _unpack_index(key)
         M, N = self.shape
 
-        def _validate_bool_idx(idx: np.ndarray[np.bool_], axis_size: int, axis_name: str):
+        def _validate_bool_idx(
+            idx: np.ndarray[np.bool_],
+            axis_size: int,
+            axis_name: str
+        ) -> np.ndarray[np.int_]:
             if len(idx) != axis_size:
-                raise IndexError(f"boolean {axis_name} index has incorrect length: {len(idx)} instead of {axis_size}")
+                raise IndexError(
+                    f"boolean {axis_name} index has incorrect length: {len(idx)} "
+                    f" instead of {axis_size}"
+                )
             return _boolean_index_to_array(idx)
 
         if isintlike(row):
@@ -279,7 +286,10 @@ class IndexMixin:
         self._set_arrayXarray(row, col, x)
 
 
-def _unpack_index(index) -> tuple[int | slice | np.ndarray[np.bool_, np.int_], int | slice | np.ndarray[np.bool_, np.int_]]:
+def _unpack_index(index) -> tuple[
+    int | slice | np.ndarray[np.bool_, np.int_],
+    int | slice | np.ndarray[np.bool_, np.int_]
+]:
     """ Parse index. Always return a tuple of the form (row, col).
     Valid type for row/col is integer, slice, array of bool, or array of integers.
     """

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2982,6 +2982,29 @@ class _TestFancyIndexing:
         assert_raises(IndexError, S.__getitem__, (I_bad,J))
         assert_raises(IndexError, S.__getitem__, (I,J_bad))
 
+    def test_missized_masking(self):
+        np.random.seed(1234)  # make runs repeatable
+        rng = np.random.default_rng(1234)
+
+        B = asmatrix(arange(50).reshape(5,10))
+        A = self.spcreator(B)
+
+        row_long = rng.integers(2, size=6, dtype=bool)
+        row_short = rng.integers(2, size=4, dtype=bool)
+        col_long = rng.integers(2, size=12, dtype=bool)
+        col_short = rng.integers(2, size=8, dtype=bool)
+
+        assert_raises(IndexError, A.__getitem__, row_long)
+        assert_raises(IndexError, A.__getitem__, row_short)
+
+        for i, j in itertools.product(
+            (row_long, row_short, slice(None)),
+            (col_long, col_short, slice(None)),
+        ):
+            if isinstance(i, slice) and isinstance(j, slice):
+                continue
+            assert_raises(IndexError, A.__getitem__, (i, j))
+
     def test_fancy_indexing_boolean(self):
         np.random.seed(1234)  # make runs repeatable
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2983,16 +2983,22 @@ class _TestFancyIndexing:
         assert_raises(IndexError, S.__getitem__, (I,J_bad))
 
     def test_missized_masking(self):
-        np.random.seed(1234)  # make runs repeatable
         rng = np.random.default_rng(1234)
 
-        B = asmatrix(arange(50).reshape(5,10))
+        M, N = 5, 10
+
+        B = asmatrix(arange(M * N).reshape(M, N))
         A = self.spcreator(B)
 
-        row_long = rng.integers(2, size=6, dtype=bool)
-        row_short = rng.integers(2, size=4, dtype=bool)
-        col_long = rng.integers(2, size=12, dtype=bool)
-        col_short = rng.integers(2, size=8, dtype=bool)
+        def alternating_mask(size: int) -> np.ndarray[np.bool_]:
+            mask = np.zeros(size, dtype=bool)
+            mask[::2] = True
+            return mask
+
+        row_long = alternating_mask(M + 1)
+        row_short = alternating_mask(M - 1)
+        col_long = alternating_mask(N + 2)
+        col_short = alternating_mask(N - 2)
 
         assert_raises(IndexError, A.__getitem__, row_long)
         assert_raises(IndexError, A.__getitem__, row_short)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3009,7 +3009,7 @@ class _TestFancyIndexing:
         Z3 = np.zeros((6, 11), dtype=bool)
         Z3[-1,0] = True
 
-        assert_equal(A[Z1], np.array([]))
+        assert_raises(IndexError, A.__getitem__, Z1)
         assert_raises(IndexError, A.__getitem__, Z2)
         assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2994,8 +2994,16 @@ class _TestFancyIndexing:
         col_long = np.ones(N + 2, dtype=bool)
         col_short = np.ones(N - 2, dtype=bool)
 
-        assert_raises(IndexError, A.__getitem__, row_long)
-        assert_raises(IndexError, A.__getitem__, row_short)
+        with pytest.raises(
+            IndexError,
+            match=rf"boolean row index has incorrect length: {M + 1} instead of {M}"
+        ):
+            _ = A[row_long, :]
+        with pytest.raises(
+            IndexError,
+            match=rf"boolean row index has incorrect length: {M - 1} instead of {M}"
+        ):
+            _ = A[row_short, :]
 
         for i, j in itertools.product(
             (row_long, row_short, slice(None)),
@@ -3003,7 +3011,11 @@ class _TestFancyIndexing:
         ):
             if isinstance(i, slice) and isinstance(j, slice):
                 continue
-            assert_raises(IndexError, A.__getitem__, (i, j))
+            with pytest.raises(
+                IndexError,
+                match=r"boolean \w+ index has incorrect length"
+            ):
+                _ = A[i, j]
 
     def test_fancy_indexing_boolean(self):
         np.random.seed(1234)  # make runs repeatable

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2983,8 +2983,6 @@ class _TestFancyIndexing:
         assert_raises(IndexError, S.__getitem__, (I,J_bad))
 
     def test_missized_masking(self):
-        rng = np.random.default_rng(1234)
-
         M, N = 5, 10
 
         B = asmatrix(arange(M * N).reshape(M, N))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2988,15 +2988,11 @@ class _TestFancyIndexing:
         B = asmatrix(arange(M * N).reshape(M, N))
         A = self.spcreator(B)
 
-        def alternating_mask(size: int) -> np.ndarray[np.bool_]:
-            mask = np.zeros(size, dtype=bool)
-            mask[::2] = True
-            return mask
-
-        row_long = alternating_mask(M + 1)
-        row_short = alternating_mask(M - 1)
-        col_long = alternating_mask(N + 2)
-        col_short = alternating_mask(N - 2)
+        # Content of mask shouldn't matter, only its size
+        row_long = np.ones(M + 1, dtype=bool)
+        row_short = np.ones(M - 1, dtype=bool)
+        col_long = np.ones(N + 2, dtype=bool)
+        col_short = np.ones(N - 2, dtype=bool)
 
         assert_raises(IndexError, A.__getitem__, row_long)
         assert_raises(IndexError, A.__getitem__, row_short)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/19951

#### What does this implement/fix?
<!--Please explain your changes.-->

This causes an IndexError to be thrown when a malformed boolean index is passed. Previously this index was converted to integer indices before the length was validated.

This now throws an index error, like the equivalent numpy classes do.

Notably, this is also implemented for the old matrix classes, mostly since it was easier to do it that way, but also because the equivalent numpy classes also error here.

```python
np.matrix(np.arange(25).reshape(5, 5))[[True, False]]
```

```pytb
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 np.matrix(np.arange(25).reshape(5, 5))[[True, False]]

File /mnt/workspace/mambaforge/envs/scipy-dev/lib/python3.11/site-packages/numpy/matrixlib/defmatrix.py:194, in matrix.__getitem__(self, index)
    191 self._getitem = True
    193 try:
--> 194     out = N.ndarray.__getitem__(self, index)
    195 finally:
    196     self._getitem = False

IndexError: boolean index did not match indexed array along dimension 0; dimension is 5 but corresponding boolean dimension is 2
```

#### Additional information
<!--Any additional information you think is important.-->

* https://github.com/scipy/scipy/pull/19956

This PR builds on ^

The main addition here is adding checks for masking along one axis.