### PR TITLE
DOC: Add version warning banner to documentation

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -7,6 +7,7 @@
     {
         "name": "1.12.0 (stable)",
         "version":"1.12.0",
+        "preferred": true,
         "url": "https://docs.scipy.org/doc/scipy-1.12.0/"
     },
     {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -215,6 +215,7 @@ html_theme_options = {
       "json_url": "https://scipy.github.io/devdocs/_static/version_switcher.json",
       "version_match": version,
   },
+  "show_version_warning_banner": True,
   "secondary_sidebar_items": ["page-toc"],
   # The service https://plausible.io is used to gather simple
   # and privacy-friendly analytics for the site. The dashboard can be accessed


### PR DESCRIPTION
#### Reference issue
--

#### What does this implement/fix?
This PR adds a warning banner to any versions of the docs that are not marked as "preferred". 

I've tried testing this locally but I think this is one of those cases where you can only see the end result when it's merged to main. In any case, from the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#version-warning-banners) it looks like this is all we need. The end-result would look something like the top-most banner in this page:

![Screenshot_20240124_184743](https://github.com/scipy/scipy/assets/3949932/75842ca3-8641-4f61-94ec-a82a705fe24c) 

I've set `stable` to be the preferred version, although this may not be what we want for the development docs (see #19699). 
