### PR TITLE
ENH: sparse: speedup csr/csc setdiag by converting to coo

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -32,7 +32,9 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                 arg1 = arg1.copy()
             else:
                 arg1 = arg1.tobsr(blocksize=blocksize)
-            self._set_self(arg1)
+            self.indptr, self.indices, self.data, self._shape = (
+                arg1.indptr, arg1.indices, arg1.data, arg1._shape
+            )
 
         elif isinstance(arg1,tuple):
             if isshape(arg1):
@@ -60,10 +62,10 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
             elif len(arg1) == 2:
                 # (data,(row,col)) format
-                self._set_self(
-                    self._coo_container(arg1, dtype=dtype, shape=shape).tobsr(
-                        blocksize=blocksize
-                    )
+                coo = self._coo_container(arg1, dtype=dtype, shape=shape)
+                bsr = coo.tobsr(blocksize=blocksize)
+                self.indptr, self.indices, self.data, self._shape = (
+                    bsr.indptr, bsr.indices, bsr.data, bsr._shape
                 )
 
             elif len(arg1) == 3:
@@ -106,7 +108,9 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
             arg1 = self._coo_container(
                 arg1, dtype=dtype
             ).tobsr(blocksize=blocksize)
-            self._set_self(arg1)
+            self.indptr, self.indices, self.data, self._shape = (
+                arg1.indptr, arg1.indices, arg1.data, arg1._shape
+            )
 
         if shape is not None:
             self._shape = check_shape(shape)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -50,10 +50,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             else:
                 if len(arg1) == 2:
                     # (data, ij) format
-                    other = self.__class__(
-                        self._coo_container(arg1, shape=shape, dtype=dtype)
-                    )
-                    self._set_self(other)
+                    coo = self._coo_container(arg1, shape=shape, dtype=dtype)
+                    arrays = coo._coo_to_compressed(self._swap)
+                    self.indptr, self.indices, self.data, self._shape = arrays
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
                     (data, indices, indptr) = arg1
@@ -69,8 +68,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
                     if not copy:
                         copy = copy_if_needed
-                    self.indices = np.array(indices, copy=copy,
-                                            dtype=idx_dtype)
+                    self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                     self.data = np.array(data, copy=copy, dtype=dtype)
                 else:
@@ -84,9 +82,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 msg = f"unrecognized {self.format}_matrix constructor usage"
                 raise ValueError(msg) from e
-            self._set_self(self.__class__(
-                self._coo_container(arg1, dtype=dtype)
-            ))
+            coo = self._coo_container(arg1, dtype=dtype)
+            arrays = coo._coo_to_compressed(self._swap)
+            self.indptr, self.indices, self.data, self._shape = arrays
 
         # Read matrix dimensions given, if any
         if shape is not None:
@@ -100,8 +98,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 except Exception as e:
                     raise ValueError('unable to infer matrix dimensions') from e
                 else:
-                    self._shape = check_shape(self._swap((major_dim,
-                                                          minor_dim)))
+                    self._shape = check_shape(self._swap((major_dim, minor_dim)))
 
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
@@ -860,31 +857,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if 0 in self.shape:
             return
 
-        M, N = self.shape
-        broadcast = (values.ndim == 0)
-
-        if k < 0:
-            if broadcast:
-                max_index = min(M + k, N)
-            else:
-                max_index = min(M + k, N, len(values))
-            i = np.arange(max_index, dtype=self.indices.dtype)
-            j = np.arange(max_index, dtype=self.indices.dtype)
-            i -= k
-
-        else:
-            if broadcast:
-                max_index = min(M, N - k)
-            else:
-                max_index = min(M, N - k, len(values))
-            i = np.arange(max_index, dtype=self.indices.dtype)
-            j = np.arange(max_index, dtype=self.indices.dtype)
-            j += k
-
-        if not broadcast:
-            values = values[:len(i)]
-
-        self[i, j] = values
+        coo = self.tocoo()
+        coo._setdiag(values, k)
+        arrays = coo._coo_to_compressed(self._swap)
+        self.indptr, self.indices, self.data, _ = arrays
 
     def _prepare_indices(self, i, j):
         M, N = self._swap(self.shape)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -32,7 +32,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 arg1 = arg1.copy()
             else:
                 arg1 = arg1.asformat(self.format)
-            self._set_self(arg1)
+            self.indptr, self.indices, self.data, self._shape = (
+                arg1.indptr, arg1.indices, arg1.data, arg1._shape
+            )
 
         elif isinstance(arg1, tuple):
             if isshape(arg1):
@@ -121,17 +123,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             raise ValueError('axis out of bounds')
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
-
-    def _set_self(self, other, copy=False):
-        """take the member variables of other and assign them to self"""
-
-        if copy:
-            other = other.copy()
-
-        self.data = other.data
-        self.indices = other.indices
-        self.indptr = other.indptr
-        self._shape = check_shape(other.shape)
 
     def check_format(self, full_check=True):
         """Check whether the array/matrix respects the CSR or CSC format.

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -894,6 +894,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         mask = (offsets <= -1)
         # Boundary between csc and convert to coo
+        # The value 0.001 is justified in gh-19962#issuecomment-1920499678
         if mask.sum() < self.nnz * 0.001:
             # create new entries
             i = i[mask]

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -353,9 +353,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
         M, N = swap(self.shape)
         major, minor = swap(self.coords)
         nnz = len(major)
+        # convert idx_dtype intc to int32 for pythran.
+        # tested in scipy/optimize/tests/test__numdiff.py::test_group_columns
+        idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, M, N))
+        major = major.astype(idx_dtype, copy=False)
+        minor = minor.astype(idx_dtype, copy=False)
 
-        indptr = np.empty(M + 1, dtype=major.dtype)
-        indices = np.empty_like(minor)
+        indptr = np.empty(M + 1, dtype=idx_dtype)
+        indices = np.empty_like(minor, dtype=idx_dtype)
         data = np.empty_like(self.data, dtype=self.dtype)
 
         coo_tocsr(M, N, nnz, major, minor, self.data, indptr, indices, data)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -14,7 +14,7 @@ from ._matrix import spmatrix
 from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from ._base import issparse, SparseEfficiencyWarning, _spbase, sparray
 from ._data import _data_matrix, _minmax_mixin
-from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
+from ._sputils import (upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index, get_index_dtype,
                        check_shape, check_reshape_kwargs)
 
@@ -307,19 +307,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if self.nnz == 0:
             return self._csc_container(self.shape, dtype=self.dtype)
         else:
-            M,N = self.shape
-            idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, M))
-            row = self.row.astype(idx_dtype, copy=False)
-            col = self.col.astype(idx_dtype, copy=False)
+            from ._csc import csc_array
+            indptr, indices, data, shape = self._coo_to_compressed(csc_array._swap)
 
-            indptr = np.empty(N + 1, dtype=idx_dtype)
-            indices = np.empty_like(row, dtype=idx_dtype)
-            data = np.empty_like(self.data, dtype=upcast(self.dtype))
-
-            coo_tocsr(N, M, self.nnz, col, row, self.data,
-                      indptr, indices, data)
-
-            x = self._csc_container((data, indices, indptr), shape=self.shape)
+            x = self._csc_container((data, indices, indptr), shape=shape)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
@@ -349,27 +340,18 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if self.nnz == 0:
             return self._csr_container(self.shape, dtype=self.dtype)
         else:
-            M,N = self.shape
-            idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, N))
-            row = self.row.astype(idx_dtype, copy=False)
-            col = self.col.astype(idx_dtype, copy=False)
-
-            indptr = np.empty(M + 1, dtype=idx_dtype)
-            indices = np.empty_like(col, dtype=idx_dtype)
-            data = np.empty_like(self.data, dtype=upcast(self.dtype))
-
-            coo_tocsr(M, N, self.nnz, row, col, self.data,
-                      indptr, indices, data)
+            from ._csr import csr_array
+            indptr, indices, data, shape = self._coo_to_compressed(csr_array._swap)
 
             x = self._csr_container((data, indices, indptr), shape=self.shape)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
 
-    def _coo_to_compressed(self, swap):  #major_dim, minor_dim, major, minor, data):
-        """convert (shape, (row, col), data) to (indptr, indices, data)"""
+    def _coo_to_compressed(self, swap):
+        """convert (shape, coords, data) to (indptr, indices, data, shape)"""
         M, N = swap(self.shape)
-        major, minor = swap(self.indices)
+        major, minor = swap(self.coords)
         nnz = len(major)
 
         indptr = np.empty(M + 1, dtype=major.dtype)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -366,6 +366,19 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 x.sum_duplicates()
             return x
 
+    def _coo_to_compressed(self, swap):  #major_dim, minor_dim, major, minor, data):
+        """convert (shape, (row, col), data) to (indptr, indices, data)"""
+        M, N = swap(self.shape)
+        major, minor = swap(self.indices)
+        nnz = len(major)
+
+        indptr = np.empty(M + 1, dtype=major.dtype)
+        indices = np.empty_like(minor)
+        data = np.empty_like(self.data, dtype=self.dtype)
+
+        coo_tocsr(M, N, nnz, major, minor, self.data, indptr, indices, data)
+        return indptr, indices, data, self.shape
+
     def tocoo(self, copy=False):
         if copy:
             return self.copy()

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -355,7 +355,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         nnz = len(major)
         # convert idx_dtype intc to int32 for pythran.
         # tested in scipy/optimize/tests/test__numdiff.py::test_group_columns
-        idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, M, N))
+        idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, N))
         major = major.astype(idx_dtype, copy=False)
         minor = minor.astype(idx_dtype, copy=False)
 

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -139,7 +139,8 @@ class _csc_base(_cs_matrix):
 
     # these functions are used by the parent class (_cs_matrix)
     # to remove redundancy between csc_array and csr_matrix
-    def _swap(self, x):
+    @staticmethod
+    def _swap(x):
         """swap the members of x if this is a column-oriented matrix
         """
         return x[1], x[0]

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -114,7 +114,8 @@ class _csr_base(_cs_matrix):
 
     # these functions are used by the parent class (_cs_matrix)
     # to remove redundancy between csc_matrix and csr_array
-    def _swap(self, x):
+    @staticmethod
+    def _swap(x):
         """swap the members of x if this is a column-oriented matrix
         """
         return x


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes gh-19943

#### What does this implement/fix?
Implement setdiag for compressed format that avoids index value setting by converting to coo format, calling setdiag, and then converting back.

The return conversion took two steps -- converting to csr/csc and then updating the data on self. By creating a private convenience function to shortcut the tocsr/tocsc function, we avoid one of those steps. This also helps a few places in `_compressed.__init__` where we convert to coo and back again. We can avoid some of the input checking.

#### Additional information
Some crude benchmarks. New code is 5-125 times faster. All have linear dependence on nnz. The convert-to-coo version has three curves on top of each other with a lower slope.  Below is the picture with just the convert-to-coo curves to show that they do increase, just at a lower slope.

![cross_branch](https://github.com/scipy/scipy/assets/915037/acf0b06c-12f0-41c3-a992-098dde62cdb5)

![new_code](https://github.com/scipy/scipy/assets/915037/fb187969-eb98-49ce-beb4-9a61de31b185)

[Edit -- legend in the second plot should indicate the new branch -- not `main`]
<!--Any additional information you think is important.-->
