### PR TITLE
update openblas to 0.3.26

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -235,7 +235,7 @@ python_sources = [
   'special.pxd',
 ]
 
-if blas_name == 'scipy-openblas'
+if fs.exists('_distributor_init_local.py')
   python_sources += ['_distributor_init_local.py']
 endif
 

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -235,6 +235,7 @@ python_sources = [
   'special.pxd',
 ]
 
+fs = import('fs')
 if fs.exists('_distributor_init_local.py')
   python_sources += ['_distributor_init_local.py']
 endif
@@ -246,7 +247,6 @@ py3.install_sources(
 
 # Copy the main __init__.py and pxd files to the build dir.
 # Needed to trick Cython, it won't do a relative import outside a package
-fs = import('fs')
 #_cython_tree = declare_dependency(sources: [
 _cython_tree = [
   fs.copyfile('__init__.py'),

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -15,8 +15,7 @@ from urllib.error import HTTPError
 
 OPENBLAS_V = '0.3.26'
 OPENBLAS_LONG = 'v0.3.26'
-BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
-NIGHTLY_BASE_LOC = (
+BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'
 )
 
@@ -166,9 +165,8 @@ def setup_openblas(plat=get_plat(), ilp64=get_ilp64(), nightly=False):
     if not plat:
         raise ValueError('unknown platform')
     openblas_version = "HEAD" if nightly else OPENBLAS_LONG
-    base_loc = NIGHTLY_BASE_LOC if nightly else BASE_LOC
     typ = download_openblas(
-        tmp, plat, ilp64, openblas_version=openblas_version, base_loc=base_loc
+        tmp, plat, ilp64, openblas_version=openblas_version, base_loc=BASE_LOC
     )
     if not typ:
         return ''

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.21.dev'
-OPENBLAS_LONG = 'v0.3.20-571-g3dec11c6'
+OPENBLAS_V = '0.3.26'
+OPENBLAS_LONG = 'v0.3.26'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 NIGHTLY_BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'


### PR DESCRIPTION
Update the version of OpenBLAS to 0.3.26 like https://github.com/numpy/numpy/pull/25687

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

The change to the meson.build is to allow a prefix (`sicpy_`) for the symbols in the OpenBLAS shared object, which will minimize confusiong when mixing BLAS/LAPACK implementations.

#### Additional information
<!--Any additional information you think is important.-->
