### PR TITLE
ENH: interpolate: replicate `splrep` and `splprep` in Python

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -80,6 +80,9 @@ Tensor product polynomials:
    make_interp_spline
    make_lsq_spline
    make_smoothing_spline
+   generate_knots
+   make_splrep
+   make_splprep
 
 Functional interface to FITPACK routines:
 
@@ -189,6 +192,7 @@ from ._cubic import *
 from ._ndgriddata import *
 
 from ._bsplines import *
+from ._fitpack_repro import generate_knots, make_splrep, make_splprep
 
 from ._pade import *
 

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -437,7 +437,8 @@ def _make_design_matrix(const double[::1] x,
                         const double[::1] t,
                         int k,
                         bint extrapolate,
-                        int32_or_int64[::1] indices):
+                        int32_or_int64[::1] indices,
+                        int nu=0):
     """
     Returns a design matrix in CSR format.
 
@@ -481,7 +482,7 @@ def _make_design_matrix(const double[::1] x,
         # extrapolate=False and out of bound values are already dealt with in
         # design_matrix
         ind = find_interval(t, k, xval, ind, extrapolate)
-        _deBoor_D(&t[0], xval, k, ind, 0, &work[0])
+        _deBoor_D(&t[0], xval, k, ind, nu, &work[0])
 
         # data[(k + 1) * i : (k + 1) * (i + 1)] = work[:k + 1]
         # indices[(k + 1) * i : (k + 1) * (i + 1)] = np.arange(ind - k, ind + 1)

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -856,7 +856,6 @@ def _colloc_nd(const double[:, ::1] xvals, tuple t not None, const npy_int32[::1
     return np.asarray(csr_data), np.asarray(csr_indices), csr_indptr
 
 
-
 # ---------------------------
 # wrappers for fitpack repro
 # ---------------------------

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -13,8 +13,40 @@ from libc.math cimport NAN
 
 cnp.import_array()
 
-cdef extern from "src/__fitpack.h":
-    void _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) nogil
+cdef extern from "src/__fitpack.h" namespace "fitpack":
+    void _deBoor_D(const double *t, double x, int k, int ell, int m, double *result
+    ) noexcept nogil
+    ssize_t _find_interval(const double* tptr, ssize_t len_t,
+                           int k,
+                           double xval,
+                           ssize_t prev_l,
+                           int extrapolate
+    ) noexcept nogil
+    void qr_reduce(double *aptr, const ssize_t m, const ssize_t nz,    # a
+                   ssize_t *offset,
+                   const ssize_t nc,
+                   double *yptr, const ssize_t ydim1,                  # y
+                   const ssize_t startrow
+    ) except+ nogil
+    void data_matrix(const double *xptr, ssize_t m,
+                       const double *tptr, ssize_t len_t,
+                       int k,
+                       const double *wptr,
+                       double *Aptr,    # outputs
+                       ssize_t *offset_ptr,
+                       Py_ssize_t *nc,
+                       double *wrk
+    ) except+ nogil
+    void fpback(const double *Rptr, ssize_t m, ssize_t nz,
+                ssize_t nc,
+                const double *yptr, ssize_t ydim2,
+                double *cptr
+    ) except+ nogil
+    double fpknot(const double *x_ptr, ssize_t m,
+                  const double *t_ptr, ssize_t len_t,
+                  int k,
+                  const double *residuals_ptr
+    ) except+ nogil
 
 
 ctypedef fused int32_or_int64:
@@ -58,37 +90,14 @@ cdef inline int find_interval(const double[::1] t,
         Suitable interval or -1 if xval was nan.
 
     """
-    cdef:
-        int l
-        int n = t.shape[0] - k - 1
-        double tb = t[k]
-        double te = t[n]
-
-    if xval != xval:
-        # nan
-        return -1
-
-    if ((xval < tb) or (xval > te)) and not extrapolate:
-        return -1
-
-    l = prev_l if k < prev_l < n else k
-
-    # xval is in support, search for interval s.t. t[interval] <= xval < t[l+1]
-    while(xval < t[l] and l != k):
-        l -= 1
-
-    l += 1
-    while(xval >= t[l] and l != n):
-        l += 1
-
-    return l-1
+    return _find_interval(&t[0], t.shape[0], k, xval, prev_l, extrapolate)
 
 
 # NB: a python wrapper for find_interval. The leading underscore signals
 # it's not meant to be user-visible outside of _bsplines.py
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _find_interval(const double[::1] t,
+def _py_find_interval(const double[::1] t,
                    int k,
                    double xval,
                    int prev_l,
@@ -844,3 +853,80 @@ def _colloc_nd(const double[:, ::1] xvals, tuple t not None, const npy_int32[::1
             csr_data[j*volume + iflat] = factor
 
     return np.asarray(csr_data), np.asarray(csr_indices), csr_indptr
+
+
+
+# ---------------------------
+# wrappers for fitpack repro
+# ---------------------------
+def _qr_reduce(double[:, ::1] a, ssize_t[::1] offset, ssize_t nc,   # A packed
+               double[:, ::1] y,
+               ssize_t startrow=1
+):
+    # (A, offset, nc) is a PackedMatrix instance, unpacked
+    qr_reduce(&a[0, 0], a.shape[0], a.shape[1],
+              &offset[0],
+              nc,
+              &y[0, 0], y.shape[1],
+              startrow)
+
+
+def _data_matrix(const double[::1] x,
+                 const double[::1] t,
+                 int k,
+                 const double[::1] w):
+    cdef:
+         ssize_t m = x.shape[0]
+         double[:, ::1] A = np.empty((m, k+1), dtype=float)
+         ssize_t[::1] offset = np.zeros(m, dtype=np.intp)
+         double[::1] wrk = np.empty(2*k+2, dtype=float)
+         ssize_t nc
+
+    if w.shape[0] != x.shape[0]:
+        raise ValueError(f"{len(w) =} != {len(x) =}.")
+
+    data_matrix(&x[0], m,
+                &t[0], t.shape[0],
+                k,
+                &w[0],
+                &A[0, 0],    # output: (A, offset, nc)
+                &offset[0],
+                &nc,
+                &wrk[0],     # work array
+    )
+    return np.asarray(A), np.asarray(offset), int(nc)
+
+
+def _fpback(const double[:, ::1] R, ssize_t nc,  # (R, offset, nc) triangular => offset is range(nc)
+            const double[:, ::1] y
+):
+    cdef:
+        ssize_t m = R.shape[0]
+        ssize_t nz = R.shape[1]
+
+    if y.shape[0] != m:
+        raise ValueError(f"{y.shape = } != {m =}.")
+    if nc > m:
+        raise ValueError(f"{nc = } > {m = }.")
+
+    cdef double[:, ::1] c = np.empty_like(y[:nc, :])
+
+    fpback(&R[0, 0], m, nz,
+           nc,
+           &y[0, 0], y.shape[1],
+           &c[0, 0])
+
+    return np.asarray(c)
+
+
+def _fpknot(const double[::1] x,
+            const double[::1] t,
+            int k,
+            const double[::1] residuals):
+    if x.shape[0] != residuals.shape[0]:
+        raise ValueError(f"{len(x) = } != {len(residuals) =}")
+
+    return fpknot(&x[0], x.shape[0],
+                  &t[0], t.shape[0],
+                  k,
+                  &residuals[0])

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -13,6 +13,7 @@ from scipy.sparse import csr_array
 from scipy.special import poch
 from itertools import combinations
 
+
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
 
@@ -336,7 +337,7 @@ class BSpline:
         return cls.construct_fast(t, c, k, extrapolate)
 
     @classmethod
-    def design_matrix(cls, x, t, k, extrapolate=False):
+    def design_matrix(cls, x, t, k, extrapolate=False, nu=0):
         """
         Returns a design matrix as a CSR format sparse array.
 
@@ -455,7 +456,7 @@ class BSpline:
 
         # indptr is not passed to Cython as it is already fully computed
         data, indices = _bspl._make_design_matrix(
-            x, t, k, extrapolate, indices
+            x, t, k, extrapolate, indices, nu
         )
         return csr_array(
             (data, indices, indptr),
@@ -998,13 +999,22 @@ def _insert(xval, t, c, k, periodic=False):
 
 def _not_a_knot(x, k):
     """Given data x, construct the knot vector w/ not-a-knot BC.
-    cf de Boor, XIII(12)."""
-    x = np.asarray(x)
-    if k % 2 != 1:
-        raise ValueError(f"Odd degree for now only. Got {k}.")
+    cf de Boor, XIII(12).
 
-    m = (k - 1) // 2
-    t = x[m+1:-m-1]
+    For even k, it's a bit ad hoc: Greville sites + omit 2nd and 2nd-to-last
+    data points, a la not-a-knot.
+    This seems to match what Dierckx does, too:
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L63-L80
+    """
+    x = np.asarray(x)
+    if k % 2 == 1:
+        k2 = (k + 1) // 2
+        t = x.copy()
+    else:
+        k2 = k // 2
+        t = (x[1:] + x[:-1]) / 2
+
+    t = t[k2:-k2]
     t = np.r_[(x[0],)*(k+1), t, (x[-1],)*(k+1)]
     return t
 
@@ -1490,13 +1500,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         if deriv_l is None and deriv_r is None:
             if bc_type == 'periodic':
                 t = _periodic_knots(x, k)
-            elif k == 2:
-                # OK, it's a bit ad hoc: Greville sites + omit
-                # 2nd and 2nd-to-last points, a la not-a-knot
-                t = (x[1:] + x[:-1]) / 2.
-                t = np.r_[(x[0],)*(k+1),
-                          t[1:-1],
-                          (x[-1],)*(k+1)]
             else:
                 t = _not_a_knot(x, k)
         else:
@@ -1582,7 +1585,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     return BSpline.construct_fast(t, c, k, axis=axis)
 
 
-def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
+def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *, method="qr"):
     r"""Compute the (coefficients of) an LSQ (Least SQuared) based
     fitting B-spline.
 
@@ -1620,6 +1623,11 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
         Default is True.
+    method : str, optional
+        Method for solving the linear LSQ problem. Allowed values are "norm-eq"
+        (Explicitly construct and solve the normal system of equations), and
+        "qr" (Use the QR factorization of the design matrix).
+        Default is "qr".
 
     Returns
     -------
@@ -1702,20 +1710,24 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
 
     y = np.moveaxis(y, axis, 0)    # now internally interp axis is zero
 
-    if x.ndim != 1 or np.any(x[1:] - x[:-1] <= 0):
-        raise ValueError("Expect x to be a 1-D sorted array_like.")
+    if x.ndim != 1:
+        raise ValueError("Expect x to be a 1-D sequence.")
     if x.shape[0] < k+1:
         raise ValueError("Need more x points.")
     if k < 0:
         raise ValueError("Expect non-negative k.")
     if t.ndim != 1 or np.any(t[1:] - t[:-1] < 0):
-        raise ValueError("Expect t to be a 1-D sorted array_like.")
+        raise ValueError("Expect t to be a 1D strictly increasing sequence.")
     if x.size != y.shape[0]:
         raise ValueError(f'Shapes of x {x.shape} and y {y.shape} are incompatible')
     if k > 0 and np.any((x < t[k]) | (x > t[-k])):
         raise ValueError(f'Out of bounds w/ x = {x}.')
     if x.size != w.size:
         raise ValueError(f'Shapes of x {x.shape} and w {w.shape} are incompatible')
+    if method == "norm-eq" and np.any(x[1:] - x[:-1] <= 0):
+        raise ValueError("Expect x to be a 1D strictly increasing sequence.")
+    if method == "qr" and any(x[1:] - x[:-1] < 0):
+        raise ValueError("Expect x to be a 1D non-decreasing sequence.")
 
     # number of coefficients
     n = t.size - k - 1
@@ -1730,30 +1742,73 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
     extradim = prod(yy.shape[1:])
     yy = yy.reshape(-1, extradim)
 
-    # construct A.T @ A and rhs with A the collocation matrix, and
-    # rhs = A.T @ y for solving the LSQ problem  ``A.T @ A @ c = A.T @ y``
-    lower = True
-    ab = np.zeros((k+1, n), dtype=np.float64, order='F')
-    rhs = np.zeros((n, extradim), dtype=np.float64)
-    _bspl._norm_eq_lsq(x, t, k,
-                       yy,
-                       w,
-                       ab, rhs)
+    # complex y: view as float, preserve the length
+    was_complex =  y.dtype.kind == 'c'
+    yy = y.view(float)
+    if was_complex and y.ndim == 1:
+        yy = yy.reshape(y.shape[0], 2)
 
-    # undo complex -> float and flattening the trailing dims
-    if was_complex:
-        rhs = rhs.view(complex)
+    # multiple r.h.s
+    extradim = prod(yy.shape[1:])
+    yy = yy.reshape(-1, extradim)
 
-    rhs = rhs.reshape((n,) + y.shape[1:])
+    if method == "norm-eq":
+        # construct A.T @ A and rhs with A the collocation matrix, and
+        # rhs = A.T @ y for solving the LSQ problem  ``A.T @ A @ c = A.T @ y``
+        lower = True
+        ab = np.zeros((k+1, n), dtype=np.float64, order='F')
+        rhs = np.zeros((n, extradim), dtype=np.float64)
+        _bspl._norm_eq_lsq(x, t, k,
+                           yy,
+                           w,
+                           ab, rhs)
 
-    # have observation matrix & rhs, can solve the LSQ problem
-    cho_decomp = cholesky_banded(ab, overwrite_ab=True, lower=lower,
-                                 check_finite=check_finite)
-    c = cho_solve_banded((cho_decomp, lower), rhs, overwrite_b=True,
-                         check_finite=check_finite)
+        # undo complex -> float and flattening the trailing dims
+        if was_complex:
+            rhs = rhs.view(complex)
 
+        rhs = rhs.reshape((n,) + y.shape[1:])
+
+        # have observation matrix & rhs, can solve the LSQ problem
+        cho_decomp = cholesky_banded(ab, overwrite_ab=True, lower=lower,
+                                     check_finite=check_finite)
+        c = cho_solve_banded((cho_decomp, lower), rhs, overwrite_b=True,
+                             check_finite=check_finite)
+    elif method == "qr":
+        _, _, c = _lsq_solve_qr(x, yy, t, k, w)
+
+        if was_complex:
+            c = c.view(complex)
+
+    else:
+        raise ValueError(f"Unknown {method =}.")
+
+
+    # restore the shape of `c` for both single and multiple r.h.s.
+    c = c.reshape((n,) + y.shape[1:])
     c = np.ascontiguousarray(c)
     return BSpline.construct_fast(t, c, k, axis=axis)
+
+
+######################
+# LSQ spline helpers #
+######################
+
+def _lsq_solve_qr(x, y, t, k, w):
+    """Solve for the LSQ spline coeffs given x, y and knots.
+
+    `y` is always 2D: for 1D data, the shape is ``(m, 1)``.
+    `w` is always 1D: one weight value per `x` value.
+
+    """
+    assert y.ndim == 2
+
+    y_w = y * w[:, None]
+    A, offset, nc = _bspl._data_matrix(x, t, k, w)
+    _bspl._qr_reduce(A, offset, nc, y_w)         # modifies arguments in-place
+    c = _bspl._fpback(A, nc, y_w)
+
+    return A, y_w, c
 
 
 #############################

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -940,7 +940,7 @@ def _insert(xval, t, c, k, periodic=False):
     # satisfy these boundary constraints, i.e.
     #      tt(i+nn-2*k-1) = tt(i)+per  ,i=1,2,...,2*k+1
     #      cc(i+nn-2*k-1) = cc(i)      ,i=1,2,...,k
-    interval = _bspl._find_interval(t, k, xval, k, False)
+    interval = _bspl._py_find_interval(t, k, xval, k, False)
     if interval < 0:
         # extrapolated values are guarded for in BSpline.insert_knot
         raise ValueError(f"Cannot insert the knot at {xval}.")

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1,0 +1,988 @@
+""" Replicate FITPACK's logic for constructing smoothing spline functions and curves.
+
+    Currently provides analogs of splrep and splprep python routines, i.e.
+    curfit.f and parcur.f routines (the drivers are fpcurf.f and fppara.f, respectively)
+
+    The Fortran sources are from
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/
+
+    .. [1] P. Dierckx, "Algorithms for smoothing data with periodic and
+        parametric splines, Computer Graphics and Image Processing",
+        20 (1982) 171-184.
+        :doi:`10.1016/0146-664X(82)90043-0`.
+    .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs on
+         Numerical Analysis, Oxford University Press, 1993.
+    .. [3] P. Dierckx, "An algorithm for smoothing, differentiation and integration
+         of experimental data using spline functions",
+         Journal of Computational and Applied Mathematics, vol. I, no 3, p. 165 (1975).
+         https://doi.org/10.1016/0771-050X(75)90034-0
+"""
+import warnings
+import operator
+import numpy as np
+
+from scipy.interpolate._bsplines import (
+    _not_a_knot, make_interp_spline, BSpline, fpcheck, _lsq_solve_qr
+)
+from scipy.interpolate._bspl import _qr_reduce, _fpback, _fpknot
+
+#    cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+#    c  part 1: determination of the number of knots and their position     c
+#    c  **************************************************************      c
+#
+# https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L31
+
+
+# Hardcoded in curfit.f
+TOL = 0.001
+MAXIT = 20
+
+
+def _get_residuals(x, y, t, k, w):
+    # FITPACK has (w*(spl(x)-y))**2; make_lsq_spline has w*(spl(x)-y)**2
+    w2 = w**2
+
+    # inline the relevant part of
+    # >>> spl = make_lsq_spline(x, y, w=w2, t=t, k=k)
+    # NB:
+    #     1. y is assumed to be 2D here. For 1D case (parametric=False),
+    #        the call must have been preceded by y = y[:, None] (cf _validate_inputs)
+    #     2. We always sum the squares across axis=1:
+    #         * For 1D (parametric=False), the last dimension has size one,
+    #           so the summation is a no-op.
+    #         * For 2D (parametric=True), the summation is actually how the
+    #           'residuals' are defined, see Eq. (42) in Dierckx1982
+    #           (the reference is in the docstring of `class F`) below.
+    _, _, c = _lsq_solve_qr(x, y, t, k, w)
+    c = np.ascontiguousarray(c)
+    spl = BSpline(t, c, k)
+    return _compute_residuals(w2, spl(x), y)
+
+
+def _compute_residuals(w2, splx, y):
+    delta = ((splx - y)**2).sum(axis=1)
+    return w2 * delta
+
+
+def add_knot(x, t, k, residuals):
+    """Add a new knot.
+
+    (Approximately) replicate FITPACK's logic:
+      1. split the `x` array into knot intervals, ``t(j+k) <= x(i) <= t(j+k+1)``
+      2. find the interval with the maximum sum of residuals
+      3. insert a new knot into the middle of that interval.
+
+    NB: a new knot is in fact an `x` value at the middle of the interval.
+    So *the knots are a subset of `x`*.
+
+    This routine is an analog of
+    https://github.com/scipy/scipy/blob/v1.11.4/scipy/interpolate/fitpack/fpcurf.f#L190-L215
+    (cf _split function)
+
+    and https://github.com/scipy/scipy/blob/v1.11.4/scipy/interpolate/fitpack/fpknot.f
+    """
+    new_knot = _fpknot(x, t, k, residuals)
+
+    idx_t = np.searchsorted(t, new_knot)
+    t_new = np.r_[t[:idx_t], new_knot, t[idx_t:]]
+    return t_new
+
+
+def _validate_inputs(x, y, w, k, s, xb, xe, parametric):
+    """Common input validations for generate_knots and make_splrep.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    if w is None:
+        w = np.ones_like(x, dtype=float)
+    else:
+        w = np.asarray(w, dtype=float)
+        if w.ndim != 1:
+            raise ValueError(f"{w.ndim = } not implemented yet.")
+        if (w < 0).any():
+            raise ValueError("Weights must be non-negative")
+
+    if y.ndim == 0 or y.ndim > 2:
+        raise ValueError(f"{y.ndim = } not supported (must be 1 or 2.)")
+
+    parametric = bool(parametric)
+    if parametric:
+        if y.ndim != 2:
+            raise ValueError(f"{y.ndim = } != 2 not supported with {parametric =}.")
+    else:
+        if y.ndim != 1:
+            raise ValueError(f"{y.ndim = } != 1 not supported with {parametric =}.")
+        # all _impl functions expect y.ndim = 2
+        y = y[:, None]
+
+    if w.shape[0] != x.shape[0]:
+        raise ValueError(f"Weights is incompatible: {w.shape =} != {x.shape}.")
+
+    if x.shape[0] != y.shape[0]:
+        raise ValueError(f"Data is incompatible: {x.shape = } and {y.shape = }.")
+    if x.ndim != 1 or (x[1:] < x[:-1]).any():
+        raise ValueError("Expect `x` to be an ordered 1D sequence.")
+
+    k = operator.index(k)
+
+    if s < 0:
+        raise ValueError(f"`s` must be non-negative. Got {s = }")
+
+    if xb is None:
+        xb = min(x)
+    if xe is None:
+        xe = max(x)
+
+    return x, y, w, k, s, xb, xe
+
+
+def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
+    """Replicate FITPACK's constructing the knot vector.
+
+    Parameters
+    ----------
+    x, y : array_like
+        The data points defining the curve ``y = f(x)``.
+    w : array_like, optional
+        Weights.
+    xb : float, optional
+        The boundary of the approximation interval. If None (default),
+        is set to ``x[0]``.
+    xe : float, optional
+        The boundary of the approximation interval. If None (default),
+        is set to ``x[-1]``.
+    k : int, optional
+        The spline degree. Default is cubic, ``k = 3``.
+    s : float, optional
+        The smoothing factor. Default is ``s = 0``.
+    nest : int, optional
+        Stop when at least this many knots are placed.
+
+    Yields
+    ------
+    t : ndarray
+        Knot vectors with an increasing number of knots.
+        The generator is finite: it stops when the smoothing critetion is
+        satisfied, or when then number of knots exceeds the maximum value:
+        the user-provided `nest` or `x.size + k + 1` --- which is the knot vector
+        for the interpolating spline.
+
+    Examples
+    --------
+    Generate some noisy data and fit a sequence of LSQ splines:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.interpolate import make_lsq_spline, generate_knots
+    >>> rng = np.random.default_rng(12345)
+    >>> x = np.linspace(-3, 3, 50)
+    >>> y = np.exp(-x**2) + 0.1 * rng.standard_normal(size=50)
+
+    >>> knots = list(generate_knots(x, y, s=1e-10))
+    >>> for t in knots[::3]:
+    ...     spl = make_lsq_spline(x, y, t)
+    ...     xs = xs = np.linspace(-3, 3, 201)
+    ...     plt.plot(xs, spl(xs), '-', label=f'n = {len(t)}', lw=3, alpha=0.7)
+    >>> plt.plot(x, y, 'o', label='data')
+    >>> plt.plot(xs, np.exp(-xs**2), '--')
+    >>> plt.legend()
+
+    Note that increasing the number of knots make the result follow the data
+    more and more closely.
+
+    Also note that a step of the generator may add multiple knots:
+
+    >>> [len(t) for t in knots]
+    [8, 9, 10, 12, 16, 24, 40, 48, 52]
+
+    Notes
+    -----
+    The routine generates successive knots vectors of increasing length, starting
+    from ``2*(k+1)`` to ``len(x) + k + 1``, trying to make knots more dense
+    in the regions where the deviation of the LSQ spline from data is large.
+
+    When the maximum number of knots, ``len(x) + k + 1`` is reached
+    (this happens when ``s`` is small and ``nest`` is large), the generator
+    stops, and the last output is the knots for the interpolation with the
+    not-a-knot boundary condition.
+
+    Knots are located at data sites, unless ``k`` is even and the number of knots
+    is ``len(x) + k + 1``. In that case, the last output of the generator
+    has internal knots at Greville sites, ``(x[1:] + x[:-1]) / 2``.
+
+    .. versionadded:: 1.14.0
+
+    """
+    if s == 0:
+        if nest is not None or w is not None:
+            raise ValueError("s == 0 is interpolation only")
+        t = _not_a_knot(x, k)
+        yield t
+        return
+
+    x, y, w, k, s, xb, xe = _validate_inputs(
+        x, y, w, k, s, xb, xe, parametric=np.ndim(y) == 2
+    )
+
+    yield from _generate_knots_impl(x, y, w=w, xb=xb, xe=xe, k=k, s=s, nest=nest)
+
+
+def _generate_knots_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
+
+    acc = s * TOL
+    m = x.size    # the number of data points
+
+    if nest is None:
+        # the max number of knots. This is set in _fitpack_impl.py line 274
+        # and fitpack.pyf line 198
+        nest = max(m + k + 1, 2*k + 3)
+    else:
+        if nest < 2*(k + 1):
+            raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")
+
+    nmin = 2*(k + 1)    # the number of knots for an LSQ polynomial approximation
+    nmax = m + k + 1  # the number of knots for the spline interpolation
+
+    # start from no internal knots
+    t = np.asarray([xb]*(k+1) + [xe]*(k+1), dtype=float)
+    n = t.shape[0]
+    fp = 0.0
+    fpold = 0.0
+
+    # c  main loop for the different sets of knots. m is a safe upper bound
+    # c  for the number of trials.
+    for _ in range(m):
+        yield t
+
+        # construct the LSQ spline with this set of knots
+        fpold = fp
+        residuals = _get_residuals(x, y, t, k, w=w)
+        fp = residuals.sum()
+        fpms = fp - s
+
+        # c  test whether the approximation sinf(x) is an acceptable solution.
+        # c  if f(p=inf) < s accept the choice of knots.
+        if (abs(fpms) < acc) or (fpms < 0):
+            return
+
+        # ### c  increase the number of knots. ###
+
+        # c  determine the number of knots nplus we are going to add.
+        if n == nmin:
+            # the first iteration
+            nplus = 1
+        else:
+            delta = fpold - fp
+            npl1 = int(nplus * fpms / delta) if delta > acc else nplus*2
+            nplus = min(nplus*2, max(npl1, nplus//2, 1))
+
+        # actually add knots
+        for j in range(nplus):
+            t = add_knot(x, t, k, residuals)
+
+            # check if we have enough knots already
+
+            n = t.shape[0]
+            # c  if n = nmax, sinf(x) is an interpolating spline.
+            # c  if n=nmax we locate the knots as for interpolation.
+            if n >= nmax:
+                t = _not_a_knot(x, k)
+                yield t
+                return
+
+            # c  if n=nest we cannot increase the number of knots because of
+            # c  the storage capacity limitation.
+            if n >= nest:
+                yield t
+                return
+
+            # recompute if needed
+            if j < nplus - 1:
+                residuals = _get_residuals(x, y, t, k, w=w)
+
+    # this should never be reached
+    return
+
+
+#   cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+#   c  part 2: determination of the smoothing spline sp(x).                c
+#   c  ***************************************************                 c
+#   c  we have determined the number of knots and their position.          c
+#   c  we now compute the b-spline coefficients of the smoothing spline    c
+#   c  sp(x). the observation matrix a is extended by the rows of matrix   c
+#   c  b expressing that the kth derivative discontinuities of sp(x) at    c
+#   c  the interior knots t(k+2),...t(n-k-1) must be zero. the corres-     c
+#   c  ponding weights of these additional rows are set to 1/p.            c
+#   c  iteratively we then have to determine the value of p such that      c
+#   c  f(p)=sum((w(i)*(y(i)-sp(x(i))))**2) be = s. we already know that    c
+#   c  the least-squares kth degree polynomial corresponds to p=0, and     c
+#   c  that the least-squares spline corresponds to p=infinity. the        c
+#   c  iteration process which is proposed here, makes use of rational     c
+#   c  interpolation. since f(p) is a convex and strictly decreasing       c
+#   c  function of p, it can be approximated by a rational function        c
+#   c  r(p) = (u*p+v)/(p+w). three values of p(p1,p2,p3) with correspond-  c
+#   c  ing values of f(p) (f1=f(p1)-s,f2=f(p2)-s,f3=f(p3)-s) are used      c
+#   c  to calculate the new value of p such that r(p)=s. convergence is    c
+#   c  guaranteed by taking f1>0 and f3<0.                                 c
+#   cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+
+def prodd(t, i, j, k):
+    res = 1.0
+    for s in range(k+2):
+        if i + s != j:
+            res *= (t[j] - t[i+s])
+    return res
+
+
+def disc(t, k):
+    """Discontinuity matrix: jumps of k-th derivatives of b-splines at internal knots.
+
+    See Eqs. (9)-(10) of Ref. [1], or, equivalently, Eq. (3.43) of Ref. [2].
+
+    This routine assumes internal knots are all simple (have multiplicity =1).
+
+    Parameters
+    ----------
+    t : ndarray, 1D, shape(n,)
+        Knots.
+    k : int
+        The spline degree
+
+    Returns
+    -------
+    disc : ndarray, shape(n-2*k-1, k+2)
+        The jumps of the k-th derivatives of b-splines at internal knots,
+        ``t[k+1], ...., t[n-k-1]``.
+
+    Notes
+    -----
+
+    The normalization here follows FITPACK:
+    (https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpdisc.f#L36)
+
+    The k-th derivative jumps are multiplied by a factor::
+
+        (delta / nrint)**k / k!
+
+    where ``delta`` is the length of the interval spanned by internal knots, and
+    ``nrint`` is one less the number of internal knots (i.e., the number of
+    subintervals between them).
+
+    References
+    ----------
+    .. [1] Paul Dierckx, Algorithms for smoothing data with periodic and parametric
+           splines, Computer Graphics and Image Processing, vol. 20, p. 171 (1982).
+           :doi:`10.1016/0146-664X(82)90043-0`
+
+    .. [2] Tom Lyche and Knut Morken, Spline methods,
+        http://www.uio.no/studier/emner/matnat/ifi/INF-MAT5340/v05/undervisningsmateriale/
+
+    """
+    n = t.shape[0]
+
+    # the length of the base interval spanned by internal knots & the number
+    # of subintervas between these internal knots
+    delta = t[n - k - 1] - t[k]
+    nrint = n - 2*k - 1
+
+    matr = np.empty((nrint - 1, k + 2), dtype=float)
+    for jj in range(nrint - 1):
+        j = jj + k + 1
+        for ii in range(k + 2):
+            i = jj + ii
+            matr[jj, ii] = (t[i + k + 1] - t[i]) / prodd(t, i, j, k)
+        # NB: equivalent to
+        # row = [(t[i + k + 1] - t[i]) / prodd(t, i, j, k) for i in range(j-k-1, j+1)]
+        # assert (matr[j-k-1, :] == row).all()
+
+    # follow FITPACK
+    matr *= (delta/ nrint)**k
+
+    # make it packed
+    offset = np.array([i for i in range(nrint-1)])
+    nc = n - k - 1
+    return matr, offset, nc
+
+
+class F:
+    """ The r.h.s. of ``f(p) = s``.
+
+    Given scalar `p`, we solve the system of equations in the LSQ sense:
+
+        | A     |  @ | c | = | y |
+        | B / p |    | 0 |   | 0 |
+
+    where `A` is the matrix of b-splines and `b` is the discontinuity matrix
+    (the jumps of the k-th derivatives of b-spline basis elements at knots).
+
+    Since we do that repeatedly while minimizing over `p`, we QR-factorize
+    `A` only once and update the QR factorization only of the `B` rows of the
+    augmented matrix |A, B/p|.
+
+    The system of equations is Eq. (15) Ref. [1]_, the strategy and implementation
+    follows that of FITPACK, see specific links below.
+
+    References
+    ----------
+    [1] P. Dierckx, Algorithms for Smoothing Data with Periodic and Parametric Splines,
+        COMPUTER GRAPHICS AND IMAGE PROCESSING vol. 20, pp 171-184 (1982.)
+        https://doi.org/10.1016/0146-664X(82)90043-0
+
+    """
+    def __init__(self, x, y, t, k, s, w=None, *, R=None, Y=None):
+        self.x = x
+        self.y = y
+        self.t = t
+        self.k = k
+        w = np.ones_like(x, dtype=float) if w is None else w
+        if w.ndim != 1:
+            raise ValueError(f"{w.ndim = } != 1.")
+        self.w = w
+        self.s = s
+
+        if y.ndim != 2:
+            raise ValueError(f"F: expected y.ndim == 2, got {y.ndim = } instead.")
+
+        # ### precompute what we can ###
+
+        # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L250
+        # c  evaluate the discontinuity jump of the kth derivative of the
+        # c  b-splines at the knots t(l),l=k+2,...n-k-1 and store in b.
+        b, b_offset, b_nc = disc(t, k)
+
+        # the QR factorization of the data matrix, if not provided
+        # NB: otherwise, must be consistent with x,y & s, but this is not checked
+        if R is None and Y is None:
+            R, Y, _ = _lsq_solve_qr(x, y, t, k, w)
+
+        # prepare to combine R and the discontinuity matrix (AB); also r.h.s. (YY)
+        # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L269
+        # c  the rows of matrix b with weight 1/p are rotated into the
+        # c  triangularised observation matrix a which is stored in g.
+        nc = t.shape[0] - k - 1
+        nz = k + 1
+        if R.shape[1] != nz:
+            raise ValueError(f"Internal error: {R.shape[1] =} != {k+1 =}.")
+
+        # r.h.s. of the augmented system
+        z = np.zeros((b.shape[0], Y.shape[1]), dtype=float)
+        self.YY = np.r_[Y[:nc], z]
+
+        # l.h.s. of the augmented system
+        AA = np.zeros((nc + b.shape[0], self.k+2), dtype=float)
+        AA[:nc, :nz] = R[:nc, :]
+        # AA[nc:, :] = b.a / p  # done in __call__(self, p)
+        self.AA  = AA
+        self.offset = np.r_[np.arange(nc, dtype=np.intp), b_offset]
+
+        self.nc = nc
+        self.b = b
+
+    def __call__(self, p):
+        # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L279
+        # c  the row of matrix b is rotated into triangle by givens transformation
+
+        # copy the precomputed matrices over for in-place work
+        # R = PackedMatrix(self.AB.a.copy(), self.AB.offset.copy(), nc)
+        AB = self.AA.copy()
+        offset = self.offset.copy()
+        nc = self.nc
+
+        AB[nc:, :] = self.b / p
+        QY = self.YY.copy()
+
+        # heavy lifting happens here, in-place
+        _qr_reduce(AB, offset, nc, QY, startrow=nc)
+
+        # solve for the coefficients
+        c = _fpback(AB, nc, QY)
+
+        spl = BSpline(self.t, c, self.k)
+        residuals = _compute_residuals(self.w**2, spl(self.x), self.y)
+        fp = residuals.sum()
+
+        self.spl = spl   # store it
+
+        return fp - self.s
+
+
+def fprati(p1, f1, p2, f2, p3, f3):
+    """The root of r(p) = (u*p + v) / (p + w) given three points and values,
+    (p1, f2), (p2, f2) and (p3, f3).
+
+    The FITPACK analog adjusts the bounds, and we do not
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fprati.f
+
+    NB: FITPACK uses p < 0 to encode p=infinity. We just use the infinity itself.
+    Since the bracket is ``p1 <= p2 <= p3``, ``p3`` can be infinite (in fact,
+    this is what the minimizer starts with, ``p3=inf``).
+    """
+    h1 = f1 * (f2 - f3)
+    h2 = f2 * (f3 - f1)
+    h3 = f3 * (f1 - f2)
+    if p3 == np.inf:
+        return -(p2*h1 + p1*h2) / h3
+    return -(p1*p2*h3 + p2*p3*h1 + p1*p3*h2) / (p1*h1 + p2*h2 + p3*h3)
+
+
+class Bunch:
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
+
+
+_iermesg = {
+2: """error. a theoretically impossible result was found during
+the iteration process for finding a smoothing spline with
+fp = s. probably causes : s too small.
+there is an approximation returned but the corresponding
+weighted sum of squared residuals does not satisfy the
+condition abs(fp-s)/s < tol.
+""",
+3: """error. the maximal number of iterations maxit (set to 20
+by the program) allowed for finding a smoothing spline
+with fp=s has been reached. probably causes : s too small
+there is an approximation returned but the corresponding
+weighted sum of squared residuals does not satisfy the
+condition abs(fp-s)/s < tol.
+"""
+}
+
+
+def root_rati(f, p0, bracket, acc):
+    """Solve `f(p) = 0` using a rational function approximation.
+
+    In a nutshell, since the function f(p) is known to be monotonically decreasing, we
+       - maintain the bracket (p1, f1), (p2, f2) and (p3, f3)
+       - at each iteration step, approximate f(p) by a rational function
+         r(p) = (u*p + v) / (p + w)
+         and make a step to p_new to the root of f(p): r(p_new) = 0.
+         The coefficients u, v and w are found from the bracket values p1..3 and f1...3
+
+    The algorithm and implementation follows
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L229
+    and
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fppara.f#L290
+
+    Note that the latter is for parametric splines and the former is for 1D spline
+    functions. The minimization is indentical though [modulo a summation over the
+    dimensions in the computation of f(p)], so we reuse the minimizer for both
+    d=1 and d>1.
+    """
+    # Magic values from
+    # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L27
+    con1 = 0.1
+    con9 = 0.9
+    con4 = 0.04
+
+    # bracketing flags (follow FITPACK)
+    # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fppara.f#L365
+    ich1, ich3 = 0, 0
+
+    (p1, f1), (p3, f3)  = bracket
+    p = p0
+
+    for it in range(MAXIT):
+        p2, f2 = p, f(p)
+
+        # c  test whether the approximation sp(x) is an acceptable solution.
+        if abs(f2) < acc:
+            ier, converged = 0, True
+            break
+
+        # c  carry out one more step of the iteration process.
+        if ich3 == 0:
+            if f2 - f3 <= acc:
+                # c  our initial choice of p is too large.
+                p3 = p2
+                f3 = f2
+                p = p*con4
+                if p <= p1:
+                     p = p1*con9 + p2*con1
+                continue
+            else:
+                if f2 < 0:
+                    ich3 = 1
+
+        if ich1 == 0:
+            if f1 - f2 <= acc:
+                # c  our initial choice of p is too small
+                p1 = p2
+                f1 = f2
+                p = p/con4
+                if p3 != np.inf and p <= p3:
+                     p = p2*con1 + p3*con9
+                continue
+            else:
+                if f2 > 0:
+                    ich1 = 1
+
+        # c  test whether the iteration process proceeds as theoretically expected.
+        # [f(p) should be monotonically decreasing]
+        if f1 <= f2 or f2 <= f3:
+            ier, converged = 2, False
+            break
+
+        # actually make the iteration step
+        p = fprati(p1, f1, p2, f2, p3, f3)
+
+        # c  adjust the value of p1,f1,p3 and f3 such that f1 > 0 and f3 < 0.
+        if f2 < 0:
+            p3, f3 = p2, f2
+        else:
+            p1, f1 = p2, f2
+
+    else:
+        # not converged in MAXIT iterations
+        ier, converged = 3, False
+
+    if ier != 0:
+        warnings.warn(RuntimeWarning(_iermesg[ier]), stacklevel=2)
+
+    return Bunch(converged=converged, root=p, iterations=it, ier=ier)
+
+
+def _make_splrep_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
+    """Shared infra for make_splrep and make_splprep.
+    """
+    acc = s * TOL
+    m = x.size    # the number of data points
+
+    if nest is None:
+        # the max number of knots. This is set in _fitpack_impl.py line 274
+        # and fitpack.pyf line 198
+        nest = max(m + k + 1, 2*k + 3)
+    else:
+        if nest < 2*(k + 1):
+            raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")    
+        if t is not None:
+            raise ValueError("Either supply `t` or `nest`.")
+
+    if t is None:
+        gen = _generate_knots_impl(x, y, w=w, k=k, s=s, xb=xb, xe=xe, nest=nest)
+        t = list(gen)[-1]
+    else:
+        fpcheck(x, t, k)
+
+    if t.shape[0] == 2 * (k + 1):
+        # nothing to optimize
+        _, _, c = _lsq_solve_qr(x, y, t, k, w)
+        return BSpline(t, c, k)
+
+    ### solve ###
+
+    # c  initial value for p.
+    # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L253
+    R, Y, _ = _lsq_solve_qr(x, y, t, k, w)
+    nc = t.shape[0] -k -1
+    p = nc / R[:, 0].sum()
+
+    # ### bespoke solver ####
+    # initial conditions
+    # f(p=inf) : LSQ spline with knots t   (XXX: reuse R, c)
+    residuals = _get_residuals(x, y, t, k, w=w)
+    fp = residuals.sum()
+    fpinf = fp - s
+
+    # f(p=0): LSQ spline without internal knots
+    residuals = _get_residuals(x, y, np.array([xb]*(k+1) + [xe]*(k+1)), k, w)
+    fp0 = residuals.sum()
+    fp0 = fp0 - s
+
+    # solve
+    bracket = (0, fp0), (np.inf, fpinf)
+    f = F(x, y, t, k=k, s=s, w=w, R=R, Y=Y)
+    _ = root_rati(f, p, bracket, acc)
+
+    # solve ALTERNATIVE: is roughly equivalent, gives slightly different results
+    # starting from scratch, that would have probably been tolerable;
+    # backwards compatibility dictates that we replicate the FITPACK minimizer though.
+ #   f = F(x, y, t, k=k, s=s, w=w, R=R, Y=Y)
+ #   from scipy.optimize import root_scalar
+ #   res_ = root_scalar(f, x0=p, rtol=acc)
+ #   assert res_.converged
+
+    # f.spl is the spline corresponding to the found `p` value
+    return f.spl
+
+
+def make_splrep(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
+    r"""Find the B-spline representation of a 1D function.
+
+    Given the set of data points ``(x[i], y[i])``, determine a smooth spline
+    approximation of degree ``k`` on the interval ``xb <= x <= xe``.
+
+    Parameters
+    ----------
+    x, y : array_like, shape (m,)
+        The data points defining a curve ``y = f(x)``.
+    w : array_like, shape (m,), optional
+        Strictly positive 1D array of weights, of the same length as `x` and `y`.
+        The weights are used in computing the weighted least-squares spline
+        fit. If the errors in the y values have standard-deviation given by the
+        vector ``d``, then `w` should be ``1/d``.
+        Default is ``np.ones(m)``.
+    xb, xe : float, optional
+        The interval to fit.  If None, these default to ``x[0]`` and ``x[-1]``,
+        respectively.
+    k : int, optional
+        The degree of the spline fit. It is recommended to use cubic splines,
+        ``k=3``, which is the default. Even values of `k` should be avoided,
+        especially with small `s` values.
+    s : float, optional
+        The smoothing condition. The amount of smoothness is determined by
+        satisfying the conditions::
+
+            sum((w * (g(x)  - y))**2 ) <= s
+
+        where ``g(x)`` is the smoothed fit to ``(x, y)``. The user can use `s`
+        to control the tradeoff between closeness to data and smoothness of fit.
+        Larger `s` means more smoothing while smaller values of `s` indicate less
+        smoothing.
+        Recommended values of `s` depend on the weights, `w`. If the weights
+        represent the inverse of the standard deviation of `y`, then a good `s`
+        value should be found in the range ``(m-sqrt(2*m), m+sqrt(2*m))`` where
+        ``m`` is the number of datapoints in `x`, `y`, and `w`.
+        Default is ``s = 0.0``, i.e. interpolation.
+    t : array_like, optional
+        The spline knots. If None (default), the knots will be constructed
+        automatically.
+        There must be at least ``2*k + 2`` and at most ``m + k + 1`` knots.
+    nest : int, optional
+        The target length of the knot vector. Should be between ``2*(k + 1)``
+        (the minimum number of knots for a degree-``k`` spline), and
+        ``m + k + 1`` (the number of knots of the interpolating spline).
+        The actual number of knots returned by this routine may be slightly
+        larger than `nest`.
+        Default is None (no limit, add up to ``m + k + 1`` knots).
+
+    Returns
+    -------
+    spl : a `BSpline` instance
+        For `s=0`,  ``spl(x) == y``.
+        For non-zero values of `s` the `spl` represents the smoothed approximation
+        to `(x, y)`, generally with fewer knots.
+
+    See Also
+    --------
+    generate_knots : is used under the hood for generating the knots
+    make_splprep : the analog of this routine for parametric curves
+    make_interp_spline : construct an interpolating spline (``s = 0``)
+    make_lsq_spline : construct the least-squares spline given the knot vector
+    splrep : a FITPACK analog of this routine
+
+    References
+    ----------
+    .. [1] P. Dierckx, "Algorithms for smoothing data with periodic and
+        parametric splines, Computer Graphics and Image Processing",
+        20 (1982) 171-184.
+    .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs on
+        Numerical Analysis, Oxford University Press, 1993.
+
+    Notes
+    -----
+    This routine constructs the smoothing spline function, :math:`g(x)`, to
+    minimize the sum of jumps, :math:`D_j`, of the ``k``-th derivative at the
+    internal knots (:math:`x_b < t_i < x_e`), where
+
+        .. math::
+
+            D_i = g^{(k)}(t_i + 0) - g^{(k)}(t_i - 0)
+
+    Specifically, the routine constructs the spline function :math:`g(x)` which
+    minimizes
+
+        .. math::
+
+                \sum_i | D_i |^2 \to \mathrm{min}
+
+    provided that
+
+        .. math::
+
+               \sum_{j=1}^m (w_j \times (g(x_j) - y_j))^2 \leqslant s ,
+
+    where :math:`s > 0` is the input parameter.
+
+    In other words, we balance maximizing the smoothness (measured as the jumps
+    of the derivative, the first criterion), and the deviation of :math:`g(x_j)`
+    from the data :math:`y_j` (the second criterion).
+
+    Note that the summation in the second criterion is over all data points,
+    and in the first criterion it is over the internal spline knots (i.e.
+    those with ``xb < t[i] < xe``). The spline knots are in general a subset
+    of data, see `generate_knots` for details.
+
+    Also note the difference of this routine to `make_lsq_spline`: the latter
+    routine does not consider smoothness and simply solves a least-squares
+    problem
+
+        .. math::
+
+            \sum w_j \times (g(x_j) - y_j)^2 \to \mathrm{min}
+
+    for a spline function :math:`g(x)` with a _fixed_ knot vector ``t``.
+
+    .. versionadded:: 1.14.0
+    """
+    if s == 0:
+        if t is not None or w is not None or nest is not None:
+            raise ValueError("s==0 is for interpolation only")
+        return make_interp_spline(x, y, k=k)
+
+    x, y, w, k, s, xb, xe = _validate_inputs(x, y, w, k, s, xb, xe, parametric=False)
+
+    spl = _make_splrep_impl(x, y, w=w, xb=xb, xe=xe, k=k, s=s, t=t, nest=nest)
+
+    # postprocess: squeeze out the last dimension: was added to simplify the internals.
+    spl.c = spl.c[:, 0]
+    return spl
+
+
+def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=None):
+    r"""
+    Find a smoothed B-spline representation of a parametric N-D curve.
+
+    Given a list of N 1D arrays, `x`, which represent a curve in
+    N-dimensional space parametrized by `u`, find a smooth approximating
+    spline curve ``g(u)``.
+
+    Parameters
+    ----------
+    x : array_like, shape (m, ndim)
+        Sampled data points representing the curve in ``ndim`` dimensions.
+        The typical use is a list of 1D arrays, each of length ``m``.
+    w : array_like, shape(m,), optional
+        Strictly positive 1D array of weights.
+        The weights are used in computing the weighted least-squares spline
+        fit. If the errors in the `x` values have standard deviation given by
+        the vector d, then `w` should be 1/d. Default is ``np.ones(m)``.
+    u : array_like, optional
+        An array of parameter values for the curve in the parametric form.
+        If not given, these values are calculated automatically, according to::
+
+            v[0] = 0
+            v[i] = v[i-1] + distance(x[i], x[i-1])
+            u[i] = v[i] / v[-1]
+
+    ub, ue : float, optional
+        The end-points of the parameters interval. Default to ``u[0]`` and ``u[-1]``.
+    k : int, optional
+        Degree of the spline. Cubic splines, ``k=3``, are recommended.
+        Even values of `k` should be avoided especially with a small ``s`` value.
+        Default is ``k=3``
+    s : float, optional
+        A smoothing condition.  The amount of smoothness is determined by
+        satisfying the conditions::
+
+            sum((w * (g(u) - x))**2) <= s,
+
+        where ``g(u)`` is the smoothed approximation to ``x``.  The user can
+        use `s` to control the trade-off between closeness and smoothness
+        of fit.  Larger ``s`` means more smoothing while smaller values of ``s``
+        indicate less smoothing.
+        Recommended values of ``s`` depend on the weights, ``w``.  If the weights
+        represent the inverse of the standard deviation of ``x``, then a good
+        ``s`` value should be found in the range ``(m - sqrt(2*m), m + sqrt(2*m))``,
+        where ``m`` is the number of data points in ``x`` and ``w``.
+    t : array_like, optional
+        The spline knots. If None (default), the knots will be constructed
+        automatically.
+        There must be at least ``2*k + 2`` and at most ``m + k + 1`` knots.
+    nest : int, optional
+        The target length of the knot vector. Should be between ``2*(k + 1)``
+        (the minimum number of knots for a degree-``k`` spline), and
+        ``m + k + 1`` (the number of knots of the interpolating spline).
+        The actual number of knots returned by this routine may be slightly
+        larger than `nest`.
+        Default is None (no limit, add up to ``m + k + 1`` knots).
+
+    Returns
+    -------
+    spl : a `BSpline` instance
+        For `s=0`,  ``spl(u) == x``.
+        For non-zero values of ``s``, `spl` represents the smoothed approximation
+        to ``x``, generally with fewer knots.
+    u : ndarray
+        The values of the parameters
+
+    See Also
+    --------
+    generate_knots : is used under the hood for generating the knots
+    make_splrep : the analog of this routine 1D functions
+    make_interp_spline : construct an interpolating spline (``s = 0``)
+    make_lsq_spline : construct the least-squares spline given the knot vector
+    splprep : a FITPACK analog of this routine
+
+    Notes
+    -----
+    Given a set of :math:`m` data points in :math:`D` dimensions, :math:`\vec{x}_j`,
+    with :math:`j=1, ..., m` and :math:`\vec{x}_j = (x_{j; 1}, ..., x_{j; D})`,
+    this routine constructs the parametric spline curve :math:`g_a(u)` with
+    :math:`a=1, ..., D`, to minimize the sum of jumps, :math:`D_{i; a}`, of the
+    ``k``-th derivative at the internal knots (:math:`u_b < t_i < u_e`), where
+
+        .. math::
+
+            D_{i; a} = g_a^{(k)}(t_i + 0) - g_a^{(k)}(t_i - 0)
+
+    Specifically, the routine constructs the spline function :math:`g(u)` which
+    minimizes
+
+        .. math::
+
+                \sum_i \sum_{a=1}^D | D_{i; a} |^2 \to \mathrm{min}
+
+    provided that
+
+        .. math::
+
+            \sum_{j=1}^m \sum_{a=1}^D (w_j \times (g_a(u_j) - x_{j; a}))^2 \leqslant s
+
+    where :math:`u_j` is the value of the parameter corresponding to the data point
+    :math:`(x_{j; 1}, ..., x_{j; D})`, and :math:`s > 0` is the input parameter.
+
+    In other words, we balance maximizing the smoothness (measured as the jumps
+    of the derivative, the first criterion), and the deviation of :math:`g(u_j)`
+    from the data :math:`x_j` (the second criterion).
+
+    Note that the summation in the second criterion is over all data points,
+    and in the first criterion it is over the internal spline knots (i.e.
+    those with ``ub < t[i] < ue``). The spline knots are in general a subset
+    of data, see `generate_knots` for details.
+
+    .. versionadded:: 1.14.0
+
+    References
+    ----------
+    .. [1] P. Dierckx, "Algorithms for smoothing data with periodic and
+        parametric splines, Computer Graphics and Image Processing",
+        20 (1982) 171-184.
+    .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs on
+        Numerical Analysis, Oxford University Press, 1993.
+    """
+    x = np.stack(x, axis=1)
+
+    # construct the default parametrization of the curve
+    if u is None:
+        dp = (x[1:, :] - x[:-1, :])**2
+        u = np.sqrt((dp).sum(axis=1)).cumsum()
+        u = np.r_[0, u / u[-1]]
+
+    if s == 0:
+        if t is not None or w is not None or nest is not None:
+            raise ValueError("s==0 is for interpolation only")
+        return make_interp_spline(u, x.T, k=k, axis=1), u
+
+    u, x, w, k, s, ub, ue = _validate_inputs(u, x, w, k, s, ub, ue, parametric=True)
+
+    spl = _make_splrep_impl(u, x, w=w, xb=ub, xe=ue, k=k, s=s, t=t, nest=nest)
+
+    # posprocess: `axis=1` so that spl(u).shape == np.shape(x)
+    # when `x` is a list of 1D arrays (cf original splPrep)
+    cc = spl.c.T
+    spl1 = BSpline(spl.t, cc, spl.k, axis=1)
+
+    return spl1, u
+

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -194,7 +194,7 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
     Also note that a step of the generator may add multiple knots:
 
     >>> [len(t) for t in knots]
-    [8, 9, 10, 12, 16, 24, 40, 48, 52]
+    [8, 9, 10, 12, 16, 24, 40, 48, 52, 54]
 
     Notes
     -----
@@ -211,7 +211,7 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
     is ``len(x) + k + 1``. In that case, the last output of the generator
     has internal knots at Greville sites, ``(x[1:] + x[:-1]) / 2``.
 
-    .. versionadded:: 1.14.0
+    .. versionadded:: 1.15.0
 
     """
     if s == 0:
@@ -824,7 +824,7 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
 
     for a spline function :math:`g(x)` with a _fixed_ knot vector ``t``.
 
-    .. versionadded:: 1.14.0
+    .. versionadded:: 1.15.0
     """
     if s == 0:
         if t is not None or w is not None or nest is not None:
@@ -952,7 +952,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
     those with ``ub < t[i] < ue``). The spline knots are in general a subset
     of data, see `generate_knots` for details.
 
-    .. versionadded:: 1.14.0
+    .. versionadded:: 1.15.0
 
     References
     ----------

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from math import prod
 
-from . import _bspl  # type: ignore
+from . import _bspl
 
 import scipy.sparse.linalg as ssl
 from scipy.sparse import csr_array

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -123,8 +123,7 @@ py3.extension_module('_rgi_cython',
 
 __fitpack_lib = static_library('__fitpack',
     ['src/__fitpack.h', 'src/__fitpack.cc'],
-    dependencies:[lapack]
-    # XXX: static_library or (dynamic) library(...)? If dynamic, how to install
+    dependencies:[lapack, np_dep, py3_dep]
 )
 
 __fitpack_dep = declare_dependency(

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -121,11 +121,21 @@ py3.extension_module('_rgi_cython',
   subdir: 'scipy/interpolate'
 )
 
+__fitpack_lib = static_library('__fitpack',
+    ['src/__fitpack.h', 'src/__fitpack.cc'],
+    dependencies:[lapack]
+    # XXX: static_library or (dynamic) library(...)? If dynamic, how to install
+)
+
+__fitpack_dep = declare_dependency(
+    link_with: __fitpack_lib,
+)
+
 py3.extension_module('_bspl',
-  cython_gen.process('_bspl.pyx'),
-  c_args: cython_c_args,
+  cython_gen_cpp.process('_bspl.pyx'),
+  cpp_args: cython_cpp_args,
   include_directories: 'src/',
-  dependencies: np_dep,
+  dependencies: [lapack, np_dep, __fitpack_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/interpolate'

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -190,6 +190,7 @@ py3.install_sources([
     '_fitpack_impl.py',
     '_fitpack_py.py',
     '_fitpack2.py',
+    '_fitpack_repro.py',
     '_interpolate.py',
     '_ndgriddata.py',
     '_pade.py',

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -205,6 +205,7 @@ data_matrix( /* inputs */
     the `s-1` corresponding rows form an `(s-1, k+1)`-sized "block".
     Then a blocked QR implementation could look like
     https://people.sc.fsu.edu/~jburkardt/f77_src/band_qr/band_qr.f
+
     The `startrow` optional argument accounts for the scenatio with a two-step
     factorization. Namely, the preceding rows are assumend to be already
     processed and are skipped.
@@ -339,7 +340,7 @@ _split(ConstRealArray1D x, ConstRealArray1D t, int k, ConstRealArray1D residuals
     ssize_t nc = t.nelem - k - 1;
 
     std::vector<ssize_t> ix;
-    ix.push_back(0.0);
+    ix.push_back(0);
 
     std::vector<double> fparts;
     double fpart = 0.0;

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -1,0 +1,425 @@
+#include <cstring>
+#include "__fitpack.h"
+
+namespace fitpack{
+
+/*
+ * B-spline evaluation routine.
+ */
+void
+_deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
+    /*
+     * On completion the result array stores
+     * the k+1 non-zero values of beta^(m)_i,k(x):  for i=ell, ell-1, ell-2, ell-k.
+     * Where t[ell] <= x < t[ell+1].
+     */
+    /*
+     * Implements a recursive algorithm similar to the original algorithm of
+     * deBoor.
+     */
+    double *hh = result + k + 1;
+    double *h = result;
+    double xb, xa, w;
+    int ind, j, n;
+
+    /*
+     * Perform k-m "standard" deBoor iterations
+     * so that h contains the k+1 non-zero values of beta_{ell,k-m}(x)
+     * needed to calculate the remaining derivatives.
+     */
+    result[0] = 1.0;
+    for (j = 1; j <= k - m; j++) {
+        memcpy(hh, h, j*sizeof(double));
+        h[0] = 0.0;
+        for (n = 1; n <= j; n++) {
+            ind = ell + n;
+            xb = t[ind];
+            xa = t[ind - j];
+            if (xb == xa) {
+                h[n] = 0.0;
+                continue;
+            }
+            w = hh[n - 1]/(xb - xa);
+            h[n - 1] += w*(xb - x);
+            h[n] = w*(x - xa);
+        }
+    }
+
+    /*
+     * Now do m "derivative" recursions
+     * to convert the values of beta into the mth derivative
+     */
+    for (j = k - m + 1; j <= k; j++) {
+        memcpy(hh, h, j*sizeof(double));
+        h[0] = 0.0;
+        for (n = 1; n <= j; n++) {
+            ind = ell + n;
+            xb = t[ind];
+            xa = t[ind - j];
+            if (xb == xa) {
+                h[m] = 0.0;
+                continue;
+            }
+            w = j*hh[n - 1]/(xb - xa);
+            h[n - 1] -= w;
+            h[n] = w;
+        }
+    }
+}
+
+
+/*
+ *  Find an interval such that t[interval] <= xval < t[interval+1].
+ */
+ssize_t
+_find_interval(const double* tptr, ssize_t len_t,
+               int k,
+               double xval,
+               ssize_t prev_l,
+               int extrapolate)
+{
+    ConstRealArray1D t = ConstRealArray1D(tptr, len_t);
+
+    ssize_t n = t.nelem - k - 1;
+    double tb = t(k);
+    double te = t(n);
+
+    if (xval != xval) {
+        // nan
+        return -1;
+    }
+
+    if (((xval < tb) || (xval > te)) && !extrapolate) {
+        return -1;
+    }
+    ssize_t l = (k < prev_l) && (prev_l < n) ? prev_l : k;
+
+    // xval is in support, search for interval s.t. t[interval] <= xval < t[l+1]
+    while ((xval < t(l)) && (l != k)) {
+        l -= 1;
+    }
+
+    l += 1;
+    while ((xval >= t(l)) && (l != n)) {
+        l += 1;
+    }
+
+    return l-1;
+}
+
+
+/*
+ * Fill the (m, k+1) matrix of non-zero b-splines.
+ *
+ * A row gives b-splines which are non-zero at the corresponding value of `x`.
+ * Also for each row store the `offset`: with full matrices, the non-zero elements
+ * in row `i` start at `offset[i]`. IOW,
+ * A_full[i, offset[i]: offset[i] + k + 1] = A_packed[i, :].
+ *
+ * What we construct here is `A_packed` and `offset` arrays.
+ *
+ * We also take into account possible weights for each `x` value: they
+ * multiply the rows of the data matrix.
+ *
+ * To reconstruct the full dense matrix, `A_full`, we would need to know the
+ * number of its columns, `nc`. So we return it, too.
+ */
+void
+data_matrix( /* inputs */
+            const double *xptr, ssize_t m,      // x, shape (m,)
+            const double *tptr, ssize_t len_t,  // t, shape (len_t,)
+            int k,
+            const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+            /* outputs */
+            double *Aptr,                       // A, shape(m, k+1)
+            ssize_t *offset_ptr,                // offset, shape (m,)
+            ssize_t *nc,                        // the number of coefficient
+            /* work array*/
+            double *wrk)                        // work, shape (2k+2)
+{
+    auto x = ConstRealArray1D(xptr, m);
+    auto t = ConstRealArray1D(tptr, len_t);
+    auto w = ConstRealArray1D(wptr, m);
+    auto A = RealArray2D(Aptr, m, k+1);
+    auto offset = Array1D<ssize_t, false>(offset_ptr, m);
+
+    ssize_t ind = k;
+    for (int i=0; i < m; ++i) {
+        double xval = x(i);
+
+        // find the interval
+        ind = _find_interval(t.data, len_t, k, xval, ind, 0);
+        if (ind < 0){
+            // should not happen here, validation is expected on the python side
+            throw std::runtime_error("find_interval: out of bounds with x = " + std::to_string(xval));
+        }
+        offset(i) = ind - k;
+
+        // compute non-zero b-splines
+        _deBoor_D(t.data, xval, k, ind, 0, wrk);
+
+        for (ssize_t j=0; j < k+1; ++j) {
+            A(i, j) = wrk[j] * w(i);
+        }
+    }
+
+    *nc = len_t - k - 1;
+}
+
+
+/*
+ *   Solve the LSQ problem ||y - A@c||^2 via QR factorization.
+ *  
+    QR factorization follows FITPACK: we reduce A row-by-row by Givens rotations.
+    To zero out the lower triangle, we use in the row `i` and column `j < i`,
+    the diagonal element in that column. That way, the sequence is
+    (here `[x]` are the pair of elements to Givens-rotate)
+
+     [x] x x x       x  x  x x      x  x  x x      x x  x  x      x x x x
+     [x] x x x  ->   0 [x] x x  ->  0 [x] x x  ->  0 x  x  x  ->  0 x x x
+      0  x x x       0 [x] x x      0  0  x x      0 0 [x] x      0 0 x x
+      0  x x x       0  x  x x      0 [x] x x      0 0 [x] x      0 0 0 x
+
+    The matrix A has a special structure: each row has at most (k+1) non-zeros, so
+    is encoded as a PackedMatrix instance.
+
+    On exit, the return matrix, also of shape (m, k+1), contains
+    elements of the upper triangular matrix `R[i, i: i + k + 1]`.
+    When we process the element (i, j), we store the rotated row in R[i, :],
+    and *shift it to the left*, so that the the diagonal element is always in the
+    zero-th place. This way, the process above becomes
+
+     [x] x x x       x  x x x       x  x x x       x  x x x      x x x x
+     [x] x x x  ->  [x] x x -  ->  [x] x x -   ->  x  x x -  ->  x x x -
+      x  x x -      [x] x x -       x  x - -      [x] x - -      x x - -
+      x  x x -       x  x x -      [x] x x -      [x] x - -      x - - -
+
+    The most confusing part is that when rotating the row `i` with a row `j`
+    above it, the offsets differ: for the upper row  `j`, `R[j, 0]` is the diagonal
+    element, while for the row `i`, `R[i, 0]` is the element being annihilated.
+
+    NB. This row-by-row Givens reduction process follows FITPACK:
+    https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L112-L161
+    A possibly more efficient way could be to note that all data points which
+    lie between two knots all have the same offset: if `t[i] < x_1 .... x_s < t[i+1]`,
+    the `s-1` corresponding rows form an `(s-1, k+1)`-sized "block".
+    Then a blocked QR implementation could look like
+    https://people.sc.fsu.edu/~jburkardt/f77_src/band_qr/band_qr.f
+    The `startrow` optional argument accounts for the scenatio with a two-step
+    factorization. Namely, the preceding rows are assumend to be already
+    processed and are skipped.
+    This is to account for the scenario where we append new rows to an already
+    triangularized matrix.
+
+    This routine MODIFIES `a` & `y` in-place.
+
+ */
+void
+qr_reduce(double *aptr, const ssize_t m, const ssize_t nz, // a(m, nz), packed
+          ssize_t *offset,                                 // offset(m)
+          const ssize_t nc,                                // dense would be a(m, nc)
+          double *yptr, const ssize_t ydim1,               // y(m, ydim2)
+          const ssize_t startrow
+)
+{
+    auto R = RealArray2D(aptr, m, nz);
+    auto y = RealArray2D(yptr, m, ydim1);
+
+    for (ssize_t i=startrow; i < m; ++i) {
+        ssize_t oi = offset[i];
+        for (ssize_t j=oi; j < nc; ++j) {
+
+            // rotate only the lower diagonal
+            if (j >= std::min(i, nc)) {
+                break;
+            }
+
+            // in dense format: diag a1[j, j] vs a1[i, j]
+            double c, s, r;
+            DLARTG(&R(j, 0), &R(i, 0), &c, &s, &r);
+
+            // rotate l.h.s.
+            R(j, 0) = r;
+            for (ssize_t l=1; l < R.ncols; ++l) {
+                std::tie(R(j, l), R(i, l-1)) = fprota(c, s, R(j, l), R(i, l));
+            }
+            R(i, R.ncols-1) = 0.0;
+
+            // rotate r.h.s.
+            for (ssize_t l=0; l < y.ncols; ++l) {
+                std::tie(y(j, l), y(i, l)) = fprota(c, s, y(j, l), y(i, l));
+            }
+        }
+        if (i < nc) {
+            offset[i] = i;
+        }
+
+    } // for(i = ...
+}
+
+
+/*
+ * Back substitution solve of `R @ c = y` with an upper triangular R.
+ *
+ * R is in the 'packed' format:
+ *    1. Each row has at most `nz` non-zero elements, stored in a (m, nz) array
+ *    2. All non-zeros are consecutive.
+ * Since R is upper triangular, non-zeros in row `i` start at `i`. IOW,
+ * the 'offset' array is `np.arange(nc)`.
+ *
+ * If `R` were dense, it would have had shape `(m, nc)`. Since R is upper triangular,
+ * the first `nc` rows contain non-zeros; the last `m-nc` rows are all zeros
+ * (in fact, they may contain whatever, and are not referenced in the routine).
+ *
+ * `y` array is always two-dimensional, and has shape `(m, ydim2)`.
+ * IOW, if the original data is 1D, `y.shape == (m, 1)`.
+ *
+ * The output `c` array has the shape `(nc, ydim2)`.
+ */
+void
+fpback( /* inputs*/
+       const double *Rptr, ssize_t m, ssize_t nz,    // R(m, nz), packed
+       ssize_t nc,                                   // dense R would be (m, nc)
+       const double *yptr, ssize_t ydim2,            // y(m, ydim2)
+        /* output */
+       double *cptr)                                 // c(nc, ydim2)
+{
+    auto R = ConstRealArray2D(Rptr, m, nz);
+    auto y = ConstRealArray2D(yptr, m, ydim2);
+    auto c = RealArray2D(cptr, nc, ydim2);
+
+    // c[nc-1, ...] = y[nc-1] / R[nc-1, 0]
+    for (ssize_t l=0; l < ydim2; ++l) {
+        c(nc - 1, l) = y(nc - 1, l) / R(nc-1, 0);
+    }
+
+    //for i in range(nc-2, -1, -1):
+    //    nel = min(nz, nc-i)
+    //    c[i, ...] = ( y[i] - (R[i, 1:nel, None] * c[i+1:i+nel, ...]).sum(axis=0) ) / R[i, 0]
+    for (ssize_t i=nc-2; i >= 0; --i) {
+        ssize_t nel = std::min(nz, nc - i);
+        for (ssize_t l=0; l < ydim2; ++l){
+            double ssum = y(i, l);
+            for (ssize_t j=1; j < nel; ++j) {
+                ssum -= R(i, j) * c(i + j, l);
+            }
+            ssum /= R(i, 0);
+            c(i, l) = ssum;
+        }
+    }
+}
+
+
+/*
+ * A helper for _fpknot:
+ *
+ * Split the `x` array into knot "runs" and sum the residuals per "run".
+ *
+ * Here a "run" is a set of `x` values which lie between consecutive knots:
+ * these are `x(i)` which for a given `j` satisfy `t(j+k) <= x(i) <= t(j+k+1)`.
+ *
+ * The _split routine returns two vectors: a vector of indices into `x`, `ix`,
+ * and a vector of partial sums of residuals, `fparts`.
+ * The i-th entry is the i-th "run". IOW the pair (fparts, ix) means that
+ * `fparts[i]` is the sum of residuals over the "run" x[ix[i]] <= xvalue <= x[ix[i+1]].
+ *
+ * This routine is a (best-effort) translation of
+ * https://github.com/scipy/scipy/blob/v1.11.4/scipy/interpolate/fitpack/fpcurf.f#L190-L215
+ *
+ */
+pair_t
+_split(ConstRealArray1D x, ConstRealArray1D t, int k, ConstRealArray1D residuals)
+{
+    /*
+     * c  search for knot interval t(number+k) <= x <= t(number+k+1) where
+     * c  fpint(number) is maximal on the condition that nrdata(number)
+     * c  not equals zero.
+     */
+    ssize_t interval = k+1;
+    ssize_t nc = t.nelem - k - 1;
+
+    std::vector<ssize_t> ix;
+    ix.push_back(0.0);
+
+    std::vector<double> fparts;
+    double fpart = 0.0;
+
+    for(ssize_t i=0; i < x.nelem; i++) {
+        double xv = x(i);
+        double rv = residuals(i);
+        fpart += rv;
+
+        if ((xv >= t(interval)) && (interval < nc)) {
+            // end of the current interval: split the weight at xv by 1/2
+            // between two intervals
+            double carry = rv / 2.0;
+            fpart -= carry;
+            fparts.push_back(fpart);
+
+            fpart = carry;
+            interval++;
+
+            ix.push_back(i);
+        }
+    } // for i
+
+    // the last interval
+    ix.push_back(x.nelem - 1);
+    fparts.push_back(fpart);
+
+    return std::make_tuple(fparts, ix);
+}
+
+
+/*
+ * Find a position for a new knot, a la FITPACK.
+ *
+ *   (Approximately) replicate FITPACK's logic:
+ *     1. split the `x` array into knot intervals, ``t(j+k) <= x(i) <= t(j+k+1)``
+ *     2. find the interval with the maximum sum of residuals
+ *     3. insert a new knot into the middle of that interval.
+ *
+ *   NB: a new knot is in fact an `x` value at the middle of the interval.
+ *   So *the knots are a subset of `x`*.
+ *
+ *   This routine is an analog of
+ *   https://github.com/scipy/scipy/blob/v1.11.4/scipy/interpolate/fitpack/fpcurf.f#L190-L215
+ *   (cf _split function)
+ *
+ *   and https://github.com/scipy/scipy/blob/v1.11.4/scipy/interpolate/fitpack/fpknot.f
+ */
+double
+fpknot(const double *x_ptr, ssize_t m,
+       const double *t_ptr, ssize_t len_t,
+       int k,
+       const double *residuals_ptr)
+{
+    auto x = ConstRealArray1D(x_ptr, m);
+    auto t = ConstRealArray1D(t_ptr, len_t);
+    auto residuals = ConstRealArray1D(residuals_ptr, m);
+
+    std::vector<double> fparts;
+    std::vector<ssize_t> ix;
+    std::tie(fparts, ix) = _split(x, t, k, residuals);
+
+    ssize_t idx_max = -101;
+    double fpart_max = -1e100;
+    for (size_t i=0; i < fparts.size(); i++) {
+        bool is_better = (ix[i+1] - ix[i] > 1) && (fparts[i] > fpart_max);
+        if(is_better) {
+            idx_max = i;
+            fpart_max = fparts[i];
+        }
+    }
+
+    if (idx_max == -101) {
+        throw std::runtime_error("Internal error. Please report it to SciPy developers.");
+    }
+
+    // round up, like Dierckx does? This is really arbitrary though.
+    ssize_t idx_newknot = (ix[idx_max] + ix[idx_max+1] + 1) / 2;
+
+    return x(idx_newknot);
+}
+
+} // namespace fitpack

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -2,12 +2,15 @@
 #include <iostream>
 #include <tuple>
 #include <vector>
+#include <string>
 
 #include "../_build_utils/src/npy_cblas.h"
 #include "../_build_utils/src/fortran_defs.h"
 
 #define DLARTG BLAS_FUNC(dlartg)
 
+/* MSVC */
+#define ssize_t ptrdiff_t
 
 namespace fitpack {
 

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -63,10 +63,12 @@ struct Array2D
 
 
 // Flip boundschecking on/off here
-typedef Array2D<double, false> RealArray2D;
-typedef Array1D<double, false> RealArray1D;
-typedef Array1D<const double, false> ConstRealArray1D;
-typedef Array2D<const double, false> ConstRealArray2D;
+constexpr bool BOUNDS_CHECK = false;
+
+typedef Array2D<double, BOUNDS_CHECK> RealArray2D;
+typedef Array1D<double, BOUNDS_CHECK> RealArray1D;
+typedef Array1D<const double, BOUNDS_CHECK> ConstRealArray1D;
+typedef Array2D<const double, BOUNDS_CHECK> ConstRealArray2D;
 
 
 /*

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -2,9 +2,11 @@
 #include <iostream>
 #include <tuple>
 #include <vector>
+
+#include "../_build_utils/src/npy_cblas.h"
 #include "../_build_utils/src/fortran_defs.h"
 
-#define DLARTG F_FUNC(dlartg, DLARTG)
+#define DLARTG BLAS_FUNC(dlartg)
 
 
 namespace fitpack {

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -1,64 +1,178 @@
+#pragma once
+#include <iostream>
+#include <tuple>
+#include <vector>
+#include "../_build_utils/src/fortran_defs.h"
+
+#define DLARTG F_FUNC(dlartg, DLARTG)
+
+
+namespace fitpack {
+
+
+/*
+ * 1D and 2D array wrappers, with and without boundschecking
+ */
+
+
+// Bounds checking
+template<bool boundscheck> inline void _bcheck(ssize_t index, ssize_t size, ssize_t dim);
+
+
+template<>
+inline void _bcheck<true>(ssize_t index, ssize_t size, ssize_t dim) {
+    if (!((0 <= index) && (index < size))){
+        auto mesg = "Out of bounds with index = " + std::to_string(index) + " of size = ";
+        mesg = mesg + std::to_string(size) + " in dimension = " + std::to_string(dim);
+        throw(std::runtime_error(mesg) );
+    }
+}
+
+template<>
+inline void _bcheck<false>(ssize_t index, ssize_t size, ssize_t dim) { /* noop*/ }
+
+
+// Arrays: C contiguous only
+template<typename T, bool boundscheck=true>
+struct Array1D
+{
+    T* data;
+    ssize_t nelem;
+    T& operator()(const ssize_t i) {
+        _bcheck<boundscheck>(i, nelem, 0);
+        return *(data + i);
+    }
+    Array1D(T *ptr, ssize_t num_elem) : data(ptr), nelem(num_elem) {};
+};
+
+
+
+template<typename T, bool boundscheck=true>
+struct Array2D
+{
+    T* data;
+    ssize_t nrows;
+    ssize_t ncols;
+    T& operator()(const ssize_t i, const ssize_t j) {
+        _bcheck<boundscheck>(i, nrows, 0);
+        _bcheck<boundscheck>(j, ncols, 1);
+        return *(data + ncols*i + j);
+    }
+    Array2D(T *ptr, ssize_t num_rows, ssize_t num_columns) : data(ptr), nrows(num_rows), ncols(num_columns) {};
+};
+
+
+// Flip boundschecking on/off here
+typedef Array2D<double, false> RealArray2D;
+typedef Array1D<double, false> RealArray1D;
+typedef Array1D<const double, false> ConstRealArray1D;
+typedef Array2D<const double, false> ConstRealArray2D;
+
+
+/*
+ * LAPACK Givens rotation
+ */
+extern "C" {
+void DLARTG(double *f, double *g, double *cs, double *sn, double *r);
+}
+
+
+/*
+ * Apply a Givens transform.
+ */
+template<typename T>
+inline
+std::tuple<T, T>
+fprota(T c, T s, T a, T b)
+{
+    return std::make_tuple(
+        c*a + s*b,
+       -s*a + c*b
+    );
+}
+
+
 /*
  * B-spline evaluation routine.
  */
+void
+_deBoor_D(const double *t, double x, int k, int ell, int m, double *result);
 
-static inline void
-_deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
-    /*
-     * On completion the result array stores
-     * the k+1 non-zero values of beta^(m)_i,k(x):  for i=ell, ell-1, ell-2, ell-k.
-     * Where t[ell] <= x < t[ell+1].
-     */
-    /*
-     * Implements a recursive algorithm similar to the original algorithm of
-     * deBoor.
-     */
-    double *hh = result + k + 1;
-    double *h = result;
-    double xb, xa, w;
-    int ind, j, n;
 
-    /*
-     * Perform k-m "standard" deBoor iterations
-     * so that h contains the k+1 non-zero values of beta_{ell,k-m}(x)
-     * needed to calculate the remaining derivatives.
-     */
-    result[0] = 1.0;
-    for (j = 1; j <= k - m; j++) {
-        memcpy(hh, h, j*sizeof(double));
-        h[0] = 0.0;
-        for (n = 1; n <= j; n++) {
-            ind = ell + n;
-            xb = t[ind];
-            xa = t[ind - j];
-            if (xb == xa) {
-                h[n] = 0.0;
-                continue;
-            }
-            w = hh[n - 1]/(xb - xa);
-            h[n - 1] += w*(xb - x);
-            h[n] = w*(x - xa);
-        }
-    }
+/*
+ *  Find an interval such that t[interval] <= xval < t[interval+1].
+ */
+ssize_t
+_find_interval(const double* tptr, ssize_t len_t,
+               int k,
+               double xval,
+               ssize_t prev_l,
+               int extrapolate);
 
-    /*
-     * Now do m "derivative" recursions
-     * to convert the values of beta into the mth derivative
-     */
-    for (j = k - m + 1; j <= k; j++) {
-        memcpy(hh, h, j*sizeof(double));
-        h[0] = 0.0;
-        for (n = 1; n <= j; n++) {
-            ind = ell + n;
-            xb = t[ind];
-            xa = t[ind - j];
-            if (xb == xa) {
-                h[m] = 0.0;
-                continue;
-            }
-            w = j*hh[n - 1]/(xb - xa);
-            h[n - 1] -= w;
-            h[n] = w;
-        }
-    }
-}
+
+
+/*
+ * Fill the (m, k+1) matrix of non-zero b-splines.
+ */
+void
+data_matrix(/* inputs */
+            const double *xptr, ssize_t m,      // x, shape (m,)
+            const double *tptr, ssize_t len_t,  // t, shape (len_t,)
+            int k,
+            const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+            /* outputs */
+            double *Aptr,                       // A, shape(m, k+1)
+            ssize_t *offset_ptr,                // offset, shape (m,)
+            ssize_t *nc,                        // the number of coefficient
+            /* work array*/
+            double *wrk                         // work, shape (2k+2)
+);
+
+
+/*
+    Solve the LSQ problem ||y - A@c||^2 via QR factorization.
+    This routine MODIFIES `a` & `y` in-place.
+*/
+void
+qr_reduce(double *aptr, const ssize_t m, const ssize_t nz, // a(m, nz), packed
+          ssize_t *offset,                                 // offset(m)
+          const ssize_t nc,                                // dense would be a(m, nc)
+          double *yptr, const ssize_t ydim1,               // y(m, ydim2)
+          const ssize_t startrow=1
+);
+
+
+/*
+ * Back substitution solve of `R @ c = y` with an upper triangular R.
+ */
+void
+fpback( /* inputs*/
+       const double *Rptr, ssize_t m, ssize_t nz,    // R(m, nz), packed
+       ssize_t nc,                                   // dense R would be (m, nc)
+       const double *yptr, ssize_t ydim2,            // y(m, ydim2)
+        /* output */
+       double *cptr                                 // c(nc, ydim2)
+);
+
+
+/*
+ * A helper for _fpknot:
+ * Split the `x` array into knot "runs" and sum the residuals per "run".
+ */
+typedef std::tuple<std::vector<double>, std::vector<ssize_t>> pair_t;
+
+pair_t
+_split(ConstRealArray1D x, ConstRealArray1D t, int k, ConstRealArray1D residuals);
+
+
+/*
+ * Find a position for a new knot, a la FITPACK
+ */
+double
+fpknot(const double *x_ptr, ssize_t m,
+       const double *t_ptr, ssize_t len_t,
+       int k,
+       const double *residuals_ptr);
+
+
+} // namespace fitpack

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -4,7 +4,6 @@
 #define PyInt_AsLong PyLong_AsLong
 
 static PyObject *fitpack_error;
-#include "__fitpack.h"
 
 #ifdef HAVE_ILP64
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3160,7 +3160,7 @@ index 1afb1900f1..d817e51ad8 100644
  c  if n=nmax we locate the knots as for interpolation.
            if(n.eq.nmax) go to 10
  c  test whether we cannot further increase the number of knots.
-        """
+        """  # NOQA: E501
         x = np.arange(8)
         y = np.sin(x*np.pi/8)
         k = 3

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -84,8 +84,8 @@ class TestSmokeTests:
             if not per:
                 spl = make_splrep(x, v, k=k, s=s, xb=xb, xe=xe)
                 if len(spl.t) == len(tck[0]):
-                    assert_allclose(spl.t, tck[0], atol=1e-15)
-                    assert_allclose(spl.c, tck[1][:spl.c.size], atol=1e-13)
+                    xp_assert_close(spl.t, tck[0], atol=1e-15)
+                    xp_assert_close(spl.c, tck[1][:spl.c.size], atol=1e-13)
                 else:
                     assert k == 5   # knot length differ in some k=5 cases
 

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -10,6 +10,7 @@ import pytest
 from scipy._lib._testutils import check_free_memory
 
 from scipy.interpolate import RectBivariateSpline
+from scipy.interpolate import make_splrep
 
 from scipy.interpolate._fitpack_py import (splrep, splev, bisplrep, bisplev,
      sproot, splprep, splint, spalde, splder, splantider, insert, dblint)
@@ -78,6 +79,15 @@ class TestSmokeTests:
                 tol = err_est(k, d)
                 err = norm2(f1(tt, d) - splev(tt, tck, d)) / norm2(f1(tt, d))
                 assert err < tol
+
+            # smoke test make_splrep
+            if not per:
+                spl = make_splrep(x, v, k=k, s=s, xb=xb, xe=xe)
+                if len(spl.t) == len(tck[0]):
+                    assert_allclose(spl.t, tck[0], atol=1e-15)
+                    assert_allclose(spl.c, tck[1][:spl.c.size], atol=1e-13)
+                else:
+                    assert k == 5   # knot length differ in some k=5 cases
 
     def check_2(self, per=0, N=20, ia=0, ib=2*np.pi):
         a, b, dx = 0, 2*np.pi, 0.2*np.pi

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -17,6 +17,7 @@ from scipy.interpolate._fitpack2 import (UnivariateSpline,
 
 from scipy._lib._testutils import _run_concurrent_barrier
 
+from scipy.interpolate import make_splrep
 
 class TestUnivariateSpline:
     def test_linear_constant(self):
@@ -27,6 +28,10 @@ class TestUnivariateSpline:
         assert_array_almost_equal(lut.get_coeffs(), [3, 3])
         assert abs(lut.get_residual()) < 1e-10
         assert_array_almost_equal(lut([1, 1.5, 2]), [3, 3, 3])
+
+        spl = make_splrep(x, y, k=1, s=len(x))
+        assert_allclose(spl.t[1:-1], lut.get_knots(), atol=1e-15)
+        assert_allclose(spl.c, lut.get_coeffs(), atol=1e-15)
 
     def test_preserve_shape(self):
         x = [1, 2, 3]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -30,8 +30,8 @@ class TestUnivariateSpline:
         assert_array_almost_equal(lut([1, 1.5, 2]), [3, 3, 3])
 
         spl = make_splrep(x, y, k=1, s=len(x))
-        assert_allclose(spl.t[1:-1], lut.get_knots(), atol=1e-15)
-        assert_allclose(spl.c, lut.get_coeffs(), atol=1e-15)
+        xp_assert_close(spl.t[1:-1], lut.get_knots(), atol=1e-15)
+        xp_assert_close(spl.c, lut.get_coeffs(), atol=1e-15)
 
     def test_preserve_shape(self):
         x = [1, 2, 3]


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Implement a clone of `splrep` (== UnivariateSpline)  and `splprep` in python, without FITPACK.

Three objects are added:

- `scipy.interpolate.make_splrep` : a clone of `splrep`
- `scipy.interpolate.make_splprep` : a clone of `splprep`

These two functions have signatures consistent with their FITPACK counterparts, and return a BSpline object, which is consistent with `make_interp_spline`.

- `scipy.interpolate.generate_knots`: this is a generator which constructs knot vectors of increasing length for spline fitting. The core logic replicates that of FITPACK and the code closely follows the Fortran source.

The use of a generator was suggested in https://github.com/scipy/scipy/issues/2579 as alternative to FITPACK's black box routine (see the issue for detailed critique of the existing API).

The `generate_knots` API is a bit lower level: it generates knot vectors only, not smoothing splines. This way, we decouple the knot selection from spline construction, and power users can mix and match various strategies for constructing the spline itself given knots.

One other argument for exposing a generator is that it steps around task={-1, 0, 1} arguments completely (https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.splrep.html).

The generator has two stopping conditions:

- via the smoothing factor s, or
- via the maximum number of knots, nest (the name follows that of FITPACK, maybe worth renaming if user-facing).

The latter is available in the Fortran FITPACK, but effectively disabled in the Fortran-to-python glue layer: https://github.com/scipy/scipy/blob/main/scipy/interpolate/src/fitpack.pyf#L277 or https://github.com/scipy/scipy/blob/main/scipy/interpolate/src/fitpack.pyf#L310.


#### Additional information
<!--Any additional information you think is important.-->

Implementation closely follows that of FITPACK, mainly https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f and its dependencies.