### PR TITLE
ENH: support custom statistic in goodness_of_fit function (gh-19894)

### DIFF
--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -788,10 +788,11 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
         Anderson-Darling ("ad") [1]_, Kolmogorov-Smirnov ("ks") [1]_,
         Cramer-von Mises ("cvm") [1]_, and Filliben ("filliben") [7]_
         statistics are available.  Alternatively, a callable with signature
-        ``(dist, data, axis)`` may be supplied to compute the statistics. Here
-        ``dist`` is a frozen dist object of one or more fitted distributions,
-        and ``data`` is an array containing one or more samples.  The callable
-        must return the statistics along the given ``axis`` of ``data``.
+        ``(dist, data, axis)`` may be supplied to compute the statistic. Here
+        ``dist`` is a frozen distribution object (potentially with array
+        parameters), ``data`` is an array of Monte Carlo samples (of
+        compatible shape), and ``axis`` is the axis of ``data`` along which
+        the statistic must be computed.
     n_mc_samples : int, default: 9999
         The number of Monte Carlo samples drawn from the null hypothesized
         distribution to form the null distribution of the statistic. The
@@ -1218,7 +1219,6 @@ _fit_funs = {stats.norm: _fit_norm}  # type: ignore[attr-defined]
 
 
 def _anderson_darling(dist, data, axis):
-    assert axis == -1
     x = np.sort(data, axis=-1)
     n = data.shape[-1]
     i = np.arange(1, n+1)
@@ -1238,7 +1238,6 @@ def _compute_dminus(cdfvals):
 
 
 def _kolmogorov_smirnov(dist, data, axis):
-    assert axis == -1
     x = np.sort(data, axis=-1)
     cdfvals = dist.cdf(x)
     Dplus = _compute_dplus(cdfvals)  # always works along last axis
@@ -1258,8 +1257,6 @@ def _corr(X, M):
 
 
 def _filliben(dist, data, axis):
-    assert axis == -1
-
     # [7] Section 8 # 1
     X = np.sort(data, axis=-1)
 
@@ -1285,7 +1282,6 @@ _filliben.alternative = 'less'  # type: ignore[attr-defined]
 
 
 def _cramer_von_mises(dist, data, axis):
-    assert axis == -1
     x = np.sort(data, axis=-1)
     n = data.shape[-1]
     cdfvals = dist.cdf(x)

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -788,10 +788,10 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
         Anderson-Darling ("ad") [1]_, Kolmogorov-Smirnov ("ks") [1]_,
         Cramer-von Mises ("cvm") [1]_, and Filliben ("filliben") [7]_
         statistics are available.  Alternatively, a callable with signature
-        ``(dist, data) ``may be supplied to compute the statistics.  Here
+        ``(dist, data, axis)`` may be supplied to compute the statistics. Here
         ``dist`` is a frozen dist object of one or more fitted distributions,
         and ``data`` is an array containing one or more samples.  The callable
-        must return the statistic along the last axis of ``data``.
+        must return the statistics along the given ``axis`` of ``data``.
     n_mc_samples : int, default: 9999
         The number of Monte Carlo samples drawn from the null hypothesized
         distribution to form the null distribution of the statistic. The
@@ -1140,7 +1140,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
         data = np.moveaxis(data, axis, -1)
         rfd_vals = fit_fun(data)
         rfd_dist = dist(*rfd_vals)
-        return compare_fun(rfd_dist, data)
+        return compare_fun(rfd_dist, data, axis=-1)
 
     res = stats.monte_carlo_test(data, rvs, statistic_fun, vectorized=True,
                                  n_resamples=n_mc_samples, axis=-1,
@@ -1217,7 +1217,8 @@ _fit_funs = {stats.norm: _fit_norm}  # type: ignore[attr-defined]
 # a sample.
 
 
-def _anderson_darling(dist, data):
+def _anderson_darling(dist, data, axis):
+    assert axis == -1
     x = np.sort(data, axis=-1)
     n = data.shape[-1]
     i = np.arange(1, n+1)
@@ -1236,7 +1237,8 @@ def _compute_dminus(cdfvals):
     return (cdfvals - np.arange(0.0, n)/n).max(axis=-1)
 
 
-def _kolmogorov_smirnov(dist, data):
+def _kolmogorov_smirnov(dist, data, axis):
+    assert axis == -1
     x = np.sort(data, axis=-1)
     cdfvals = dist.cdf(x)
     Dplus = _compute_dplus(cdfvals)  # always works along last axis
@@ -1255,7 +1257,9 @@ def _corr(X, M):
     return num/den
 
 
-def _filliben(dist, data):
+def _filliben(dist, data, axis):
+    assert axis == -1
+
     # [7] Section 8 # 1
     X = np.sort(data, axis=-1)
 
@@ -1280,7 +1284,8 @@ def _filliben(dist, data):
 _filliben.alternative = 'less'  # type: ignore[attr-defined]
 
 
-def _cramer_von_mises(dist, data):
+def _cramer_von_mises(dist, data, axis):
+    assert axis == -1
     x = np.sort(data, axis=-1)
     n = data.shape[-1]
     cdfvals = dist.cdf(x)

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -782,12 +782,16 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
         to the Monte Carlo samples drawn from the null-hypothesized
         distribution. The purpose of these `guessed_params` is to be used as
         initial values for the numerical fitting procedure.
-    statistic : {"ad", "ks", "cvm", "filliben"}, optional
+    statistic : {"ad", "ks", "cvm", "filliben"} or callable, optional
         The statistic used to compare data to a distribution after fitting
         unknown parameters of the distribution family to the data. The
         Anderson-Darling ("ad") [1]_, Kolmogorov-Smirnov ("ks") [1]_,
         Cramer-von Mises ("cvm") [1]_, and Filliben ("filliben") [7]_
-        statistics are available.
+        statistics are available.  Alternatively, a callable with signature
+        ``(dist, data) ``may be supplied to compute the statistics.  Here
+        ``dist`` is a frozen dist object of one or more fitted distributions,
+        and ``data`` is an array containing one or more samples.  The callable
+        must return the statistic along the last axis of ``data``.
     n_mc_samples : int, default: 9999
         The number of Monte Carlo samples drawn from the null hypothesized
         distribution to form the null distribution of the statistic. The
@@ -1125,10 +1129,13 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
 
     # Define statistic
     fit_fun = _get_fit_fun(dist, data, guessed_rfd_params, fixed_rfd_params)
-    compare_fun = _compare_dict[statistic]
+    if callable(statistic):
+        compare_fun = statistic
+    else:
+        compare_fun = _compare_dict[statistic]
     alternative = getattr(compare_fun, 'alternative', 'greater')
 
-    def statistic_fun(data, axis=-1):
+    def statistic_fun(data, axis):
         # Make things simple by always working along the last axis.
         data = np.moveaxis(data, axis, -1)
         rfd_vals = fit_fun(data)
@@ -1224,7 +1231,7 @@ def _compute_dplus(cdfvals):  # adapted from _stats_py before gh-17062
     return (np.arange(1.0, n + 1) / n - cdfvals).max(axis=-1)
 
 
-def _compute_dminus(cdfvals, axis=-1):
+def _compute_dminus(cdfvals):
     n = cdfvals.shape[-1]
     return (cdfvals - np.arange(0.0, n)/n).max(axis=-1)
 
@@ -1308,7 +1315,7 @@ def _gof_iv(dist, data, known_params, fit_params, guessed_params, statistic,
     known_params_f = {("f"+key): val for key, val in known_params.items()}
     fit_params_f = {("f"+key): val for key, val in fit_params.items()}
 
-    # These the the values of parameters of the null distribution family
+    # These are the values of parameters of the null distribution family
     # with which resamples are drawn
     fixed_nhd_params = known_params_f.copy()
     fixed_nhd_params.update(fit_params_f)
@@ -1325,11 +1332,12 @@ def _gof_iv(dist, data, known_params, fit_params, guessed_params, statistic,
     guessed_rfd_params = fit_params.copy()
     guessed_rfd_params.update(guessed_params)
 
-    statistic = statistic.lower()
-    statistics = {'ad', 'ks', 'cvm', 'filliben'}
-    if statistic not in statistics:
-        message = f"`statistic` must be one of {statistics}."
-        raise ValueError(message)
+    if not callable(statistic):
+        statistic = statistic.lower()
+        statistics = {'ad', 'ks', 'cvm', 'filliben'}
+        if statistic not in statistics:
+            message = f"`statistic` must be one of {statistics}."
+            raise ValueError(message)
 
     n_mc_samples_int = int(n_mc_samples)
     if n_mc_samples_int != n_mc_samples:

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -971,19 +971,36 @@ class TestGoodnessOfFit:
         assert not np.allclose(res3.null_distribution, res1.null_distribution)
 
     def test_custom_statistic(self):
-        # Test support for custom statistic function
-        def ks_plus(dist, data):
-            x = np.sort(data, axis=-1)
-            n = x.shape[-1]
-            cdfvals = dist.cdf(x)
-            return (np.arange(1.0, n + 1) / n - cdfvals).max(axis=-1)
+        # Test support for custom statistic function.
 
+        # References:
+        # [1] Pyke, R. (1965).  "Spacings".  Journal of the Royal Statistical
+        #     Society: Series B (Methodological), 27(3): 395-436.
+        # [2] Burrows, P. M. (1979).  "Selected Percentage Points of
+        #     Greenwood's Statistics".  Journal of the Royal Statistical
+        #     Society. Series A (General), 142(2): 256-258.
+
+        # Use the Greenwood statistic for illustration; see [1, p.402].
+        def greenwood(dist, data, *, axis):
+            x = np.sort(data, axis=axis)
+            y = dist.cdf(x)
+            d = np.diff(y, axis=axis, prepend=0, append=1)
+            return np.sum(d ** 2, axis=axis)
+
+        # Run the Monte Carlo test with sample size = 5 on a fully specified
+        # null distribution, and compare the simulated quantiles to the exact
+        # ones given in [2, Table 1, column (n = 5)].
         rng = np.random.default_rng(9121950977643805391)
-        res = goodness_of_fit(stats.expon,
-                              stats.expon.rvs(size=100, random_state=rng),
-                              statistic=ks_plus,
-                              random_state=rng)
-        assert_allclose(res.statistic, 0.041086274)
+        data = stats.expon.rvs(size=5, random_state=rng)
+        result = goodness_of_fit(stats.expon, data,
+                                known_params={'loc': 0, 'scale': 1},
+                                statistic=greenwood, random_state=rng)
+        p = [.01, .05, .1, .2, .3, .4, .5, .6, .7, .8, .9, .95, .99]
+        exact_quantiles = [
+            .183863, .199403, .210088, .226040, .239947, .253677, .268422,
+            .285293, .306002, .334447, .382972, .432049, .547468]
+        simulated_quantiles = np.quantile(result.null_distribution, p)
+        assert_allclose(simulated_quantiles, exact_quantiles, atol=0.005)
 
 class TestFitResult:
     def test_plot_iv(self):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -970,6 +970,20 @@ class TestGoodnessOfFit:
         assert_equal(res3.fit_result.params.loc, -13.85)
         assert not np.allclose(res3.null_distribution, res1.null_distribution)
 
+    def test_custom_statistic(self):
+        # Test support for custom statistic function
+        def ks_plus(dist, data):
+            x = np.sort(data, axis=-1)
+            n = x.shape[-1]
+            cdfvals = dist.cdf(x)
+            return (np.arange(1.0, n + 1) / n - cdfvals).max(axis=-1)
+
+        rng = np.random.default_rng(9121950977643805391)
+        res = goodness_of_fit(stats.expon,
+                              stats.expon.rvs(size=100, random_state=rng),
+                              statistic=ks_plus,
+                              random_state=rng)
+        assert_allclose(res.statistic, 0.041086274)
 
 class TestFitResult:
     def test_plot_iv(self):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -993,8 +993,8 @@ class TestGoodnessOfFit:
         rng = np.random.default_rng(9121950977643805391)
         data = stats.expon.rvs(size=5, random_state=rng)
         result = goodness_of_fit(stats.expon, data,
-                                known_params={'loc': 0, 'scale': 1},
-                                statistic=greenwood, random_state=rng)
+                                 known_params={'loc': 0, 'scale': 1},
+                                 statistic=greenwood, random_state=rng)
         p = [.01, .05, .1, .2, .3, .4, .5, .6, .7, .8, .9, .95, .99]
         exact_quantiles = [
             .183863, .199403, .210088, .226040, .239947, .253677, .268422,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-19894

#### What does this implement/fix?
Support custom statistic in `Scipy.stats.goodness_of_fit` function.

#### Additional information
A test case is also included.
