### PR TITLE
DOC: fix autosummary for scipy.signal.ShortTimeFFT.t/T under MacOS.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -302,6 +302,7 @@ autosummary_generate = True
 autosummary_filename_map = {
     "scipy.odr.odr": "odr-function",
     "scipy.signal.czt": "czt-function",
+    "scipy.signal.ShortTimeFFT.t": "scipy.signal.ShortTimeFFT.t.lower",
 }
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fix a recurrence of the same type of issue as gh-16862 (see [comment](https://github.com/scipy/scipy/pull/16862#issuecomment-1913078235)).

#### What does this implement/fix?
Apply the same type of fix as [this one](https://github.com/tylerjereddy/scipy/commit/e8bb60a907d171bbf0798a7afe2328441623a1a1).

#### Additional information
<!--Any additional information you think is important.-->
