### PR TITLE
MAINT: unify factorial implementations

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3232,7 +3232,7 @@ def factorial2(n, exact=False, extend="zero"):
     return _factorialx_wrapper("factorial2", n, k=2, exact=exact, extend=extend)
 
 
-def factorialk(n, k, exact=None, extend="zero"):
+def factorialk(n, k, exact=False, extend="zero"):
     """Multifactorial of n of order k, n(!!...!).
 
     This is the multifactorial of n skipping k values.  For example,
@@ -3255,10 +3255,6 @@ def factorialk(n, k, exact=None, extend="zero"):
         If exact is set to True, calculate the answer exactly using
         integer arithmetic, otherwise use an approximation (faster,
         but yields floats instead of integers)
-
-        .. warning::
-           The default value for ``exact`` will be changed to
-           ``False`` in SciPy 1.15.0.
     extend : string, optional
         One of ``'zero'`` or ``'complex'``; this determines how values `n<0` are
         handled - by default they are 0, but it is possible to opt into the complex
@@ -3314,16 +3310,6 @@ def factorialk(n, k, exact=None, extend="zero"):
     .. [1] Complex extension to multifactorial
             https://en.wikipedia.org/wiki/Double_factorial#Alternative_extension_of_the_multifactorial
     """
-    if exact is None:
-        msg = (
-            "factorialk will default to `exact=False` starting from SciPy "
-            "1.15.0. To avoid behaviour changes due to this, explicitly "
-            "specify either `exact=False` (faster, returns floats), or the "
-            "past default `exact=True` (slower, lossless result as integer)."
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        exact = True
-
     return _factorialx_wrapper("factorialk", n, k=k, exact=exact, extend=extend)
 
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2830,6 +2830,9 @@ def _range_prod(lo, hi, k=1):
     Breaks into smaller products first for speed:
     _range_prod(2, 9) = ((2*3)*(4*5))*((6*7)*(8*9))
     """
+    if lo == 1 and k == 1:
+        return math.factorial(hi)
+
     if lo + k < hi:
         mid = (hi + lo) // 2
         if k > 1:
@@ -3108,7 +3111,7 @@ def factorial(n, exact=False, extend="zero"):
         elif extend == "zero" and n < 0:
             return 0 if exact else np.float64(0)
         elif exact and _is_subdtype(type(n), "i"):
-            return math.factorial(n)
+            return _range_prod(1, n, k=1)
         elif exact:
             raise ValueError(msg_exact_not_possible.format(dtype=type(n)))
         return _factorialx_approx_core(n, k=1, extend=extend)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3134,22 +3134,24 @@ def factorial(n, exact=False, extend="zero"):
 
     Parameters
     ----------
-    n : int or array_like of ints
-        Input values.  If ``n < 0``, the return value is 0.
+    n : int or float or complex (or array_like thereof)
+        Input values for ``n!``. Complex values require ``extend='complex'``.
+        By default, the return value for ``n < 0`` is 0.
     exact : bool, optional
-        If True, calculate the answer exactly using long integer arithmetic.
-        If False, result is approximated in floating point rapidly using the
-        `gamma` function.
+        If ``exact`` is set to True, calculate the answer exactly using
+        integer arithmetic, otherwise approximate using the gamma function
+        (faster, but yields floats instead of integers).
         Default is False.
     extend : string, optional
         One of ``'zero'`` or ``'complex'``; this determines how values ``n<0``
         are handled - by default they are 0, but it is possible to opt into the
-        complex extension of the factorial (the Gamma function).
+        complex extension of the factorial (see below).
 
     Returns
     -------
-    nf : float or int or ndarray
-        Factorial of `n`, as integer or float depending on `exact`.
+    nf : int or float or complex or ndarray
+        Factorial of ``n``, as integer, float or complex (depending on ``exact``
+        and ``extend``). Array inputs are returned as arrays.
 
     Notes
     -----
@@ -3158,7 +3160,7 @@ def factorial(n, exact=False, extend="zero"):
     The output dtype is increased to ``int64`` or ``object`` if necessary.
 
     With ``exact=False`` the factorial is approximated using the gamma
-    function:
+    function (which is also the definition of the complex extension):
 
     .. math:: n! = \\Gamma(n+1)
 
@@ -3188,16 +3190,18 @@ def factorial2(n, exact=False, extend="zero"):
           = 2 ** (n / 2) * gamma(n / 2 + 1)                 n even
           = 2 ** (n / 2) * (n / 2)!                         n even
 
-    The formula for `n odd` is the basis for the complex extension.
+    The formula for odd ``n`` is the basis for the complex extension.
 
     Parameters
     ----------
-    n : int or array_like
-        Calculate ``n!!``.  If ``n < 0``, the return value is 0.
+    n : int or float or complex (or array_like thereof)
+        Input values for ``n!!``. Non-integer values require ``extend='complex'``.
+        By default, the return value for ``n < 0`` is 0.
     exact : bool, optional
-        The result can be approximated rapidly using the gamma-formula
-        above (default).  If `exact` is set to True, calculate the
-        answer exactly using integer arithmetic.
+        If ``exact`` is set to True, calculate the answer exactly using
+        integer arithmetic, otherwise use above approximation (faster,
+        but yields floats instead of integers).
+        Default is False.
     extend : string, optional
         One of ``'zero'`` or ``'complex'``; this determines how values ``n<0``
         are handled - by default they are 0, but it is possible to opt into the
@@ -3212,9 +3216,9 @@ def factorial2(n, exact=False, extend="zero"):
 
     Returns
     -------
-    nff : float or int
-        Double factorial of `n`, as an int or a float depending on
-        `exact`.
+    nf : int or float or complex or ndarray
+        Double factorial of ``n``, as integer, float or complex (depending on
+        ``exact`` and ``extend``). Array inputs are returned as arrays.
 
     Examples
     --------
@@ -3247,16 +3251,18 @@ def factorialk(n, k, exact=False, extend="zero"):
 
     Parameters
     ----------
-    n : int or array_like
-        Calculate multifactorial. If ``n < 0``, the return value is 0.
-    k : int
-        Order of multifactorial.
+    n : int or float or complex (or array_like thereof)
+        Input values for multifactorial. Non-integer values require
+        ``extend='complex'``. By default, the return value for ``n < 0`` is 0.
+    n : int or float or complex (or array_like thereof)
+        Order of multifactorial. Non-integer values require ``extend='complex'``.
     exact : bool, optional
-        If exact is set to True, calculate the answer exactly using
+        If ``exact`` is set to True, calculate the answer exactly using
         integer arithmetic, otherwise use an approximation (faster,
         but yields floats instead of integers)
+        Default is False.
     extend : string, optional
-        One of ``'zero'`` or ``'complex'``; this determines how values `n<0` are
+        One of ``'zero'`` or ``'complex'``; this determines how values ``n<0`` are
         handled - by default they are 0, but it is possible to opt into the complex
         extension of the multifactorial. This enables passing complex values,
         not only to ``n`` but also to ``k``.
@@ -3269,8 +3275,9 @@ def factorialk(n, k, exact=False, extend="zero"):
 
     Returns
     -------
-    val : int
-        Multifactorial of `n`.
+    nf : int or float or complex or ndarray
+        Multifactorial (order ``k``) of ``n``, as integer, float or complex (depending
+        on ``exact`` and ``extend``). Array inputs are returned as arrays.
 
     Examples
     --------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2177,8 +2177,7 @@ class TestFactorialFunctions:
 
     @pytest.mark.parametrize("n", [-1.1, -2.2, -3.3])
     def test_factorialx_negative_extend_complex(self, n):
-        # factorialk defaults to exact=True, need to explicitly set to False
-        kw = {"exact": False, "extend": "complex"}
+        kw = {"extend": "complex"}
         exp_1 = {-1.1: -10.686287021193184771,
                  -2.2:   4.8509571405220931958,
                  -3.3:  -1.4471073942559181166}
@@ -2199,13 +2198,12 @@ class TestFactorialFunctions:
     @pytest.mark.parametrize("imag", [0, 0j])
     @pytest.mark.parametrize("n_outer", [-1, -2, -3])
     def test_factorialx_negative_extend_complex_poles(self, n_outer, imag):
+        kw = {"extend": "complex"}
         def _check(n):
             complexify = _is_subdtype(type(n), "c")
             # like for gamma, we expect complex nans for complex inputs
             complex_nan = np.complex128("nan+nanj")
             exp = np.complex128("nan+nanj") if complexify else np.float64("nan")
-            # factorialk defaults to incompatible exact=True, explicitly set to False
-            kw = {"exact": False, "extend": "complex"}
             # poles are at negative integers that are multiples of k
             assert_really_equal(special.factorial(n, **kw), exp)
             assert_really_equal(special.factorial2(n * 2, **kw), exp)
@@ -2778,13 +2776,6 @@ class TestFactorialFunctions:
         else:
             expected = self.factorialk_ref(n, **kw)
             assert_really_equal(special.factorialk(n, **kw), expected, rtol=1e-15)
-
-    @pytest.mark.parametrize("k", range(1, 5))
-    def test_factorialk_deprecation_exact(self, k):
-        with pytest.deprecated_call(match="factorialk will default.*"):
-            # leaving exact= unspecified raises warning;
-            # cannot happen for extend="complex" because it requires non-default exact
-            special.factorialk(1, k=k)
 
     @pytest.mark.parametrize("boxed", [True, False])
     @pytest.mark.parametrize("exact,extend",


### PR DESCRIPTION
After a bunch of work on the factorial functions (in terms of unifying API and code paths), we should now be able to switch to a single unified implementation without any extra cost. Despite needing some minor indirection (e.g. to distinguish warning messages), I believe it's vastly preferable to have one implementation, rather than 3 that are very similar.

Follows (i.a.):
* #18409
* #19716
* #19989
* #21702
* #21801
