### PR TITLE
MAINT: special: factorial clean-ups

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2961,6 +2961,32 @@ def _factorialx_approx_core(n, k):
     return result
 
 
+def _is_subdtype(dtype, dtypes):
+    """
+    Shorthand for calculating whether dtype is subtype of some dtypes.
+
+    Also allows specifying a list instead of just a single dtype.
+
+    Additionaly, the most important supertypes from
+        https://numpy.org/doc/stable/reference/arrays.scalars.html
+    can optionally be specified using abbreviations as follows:
+        "i": np.integer
+        "f": np.floating
+        "c": np.complexfloating
+        "n": np.number (contains the other three)
+    """
+    dtypes = dtypes if isinstance(dtypes, list) else [dtypes]
+    # map single character abbreviations, if they are in dtypes
+    mapping = {
+        "i": np.integer,
+        "f": np.floating,
+        "c": np.complexfloating,
+        "n": np.number
+    }
+    dtypes = [mapping.get(x, x) for x in dtypes]
+    return any(np.issubdtype(dtype, dt) for dt in dtypes)
+
+
 def factorial(n, exact=False):
     """
     The factorial of a number or array of numbers.
@@ -3014,15 +3040,14 @@ def factorial(n, exact=False):
         # scalar cases
         if n is None or np.isnan(n):
             return np.nan
-        elif not (np.issubdtype(type(n), np.integer)
-                  or np.issubdtype(type(n), np.floating)):
+        elif not _is_subdtype(type(n), ["i", "f"]):
             raise ValueError(
                 f"Unsupported datatype for factorial: {type(n)}\n"
                 "Permitted data types are integers and floating point numbers"
             )
         elif n < 0:
             return 0
-        elif exact and np.issubdtype(type(n), np.integer):
+        elif exact and _is_subdtype(type(n), "i"):
             return math.factorial(n)
         elif exact:
             msg = ("Non-integer values of `n` together with `exact=True` are "
@@ -3035,13 +3060,12 @@ def factorial(n, exact=False):
     if n.size == 0:
         # return empty arrays unchanged
         return n
-    if not (np.issubdtype(n.dtype, np.integer)
-            or np.issubdtype(n.dtype, np.floating)):
+    if not _is_subdtype(n.dtype, ["i", "f"]):
         raise ValueError(
             f"Unsupported datatype for factorial: {n.dtype}\n"
             "Permitted data types are integers and floating point numbers"
         )
-    if exact and not np.issubdtype(n.dtype, np.integer):
+    if exact and not _is_subdtype(n.dtype, "i"):
         msg = ("factorial with `exact=True` does not "
                "support non-integral arrays")
         raise ValueError(msg)
@@ -3091,7 +3115,7 @@ def factorial2(n, exact=False):
         # scalar cases
         if n is None or np.isnan(n):
             return np.nan
-        elif not np.issubdtype(type(n), np.integer):
+        elif not _is_subdtype(type(n), "i"):
             msg = "factorial2 does not support non-integral scalar arguments"
             raise ValueError(msg)
         elif n < 0:
@@ -3107,7 +3131,7 @@ def factorial2(n, exact=False):
     if n.size == 0:
         # return empty arrays unchanged
         return n
-    if not np.issubdtype(n.dtype, np.integer):
+    if not _is_subdtype(n.dtype, "i"):
         raise ValueError("factorial2 does not support non-integral arrays")
     if exact:
         return _factorialx_array_exact(n, k=2)
@@ -3175,7 +3199,7 @@ def factorialk(n, k, exact=None):
     .. [1] Complex extension to multifactorial
             https://en.wikipedia.org/wiki/Double_factorial#Alternative_extension_of_the_multifactorial
     """
-    if not np.issubdtype(type(k), np.integer) or k < 1:
+    if not _is_subdtype(type(k), "i") or k < 1:
         raise ValueError(f"k must be a positive integer, received: {k}")
     if exact is None:
         msg = (
@@ -3197,7 +3221,7 @@ def factorialk(n, k, exact=None):
         # scalar cases
         if n is None or np.isnan(n):
             return np.nan
-        elif not np.issubdtype(type(n), np.integer):
+        elif not _is_subdtype(type(n), "i"):
             msg = "factorialk does not support non-integral scalar arguments!"
             raise ValueError(msg + helpmsg)
         elif n < 0:
@@ -3213,7 +3237,7 @@ def factorialk(n, k, exact=None):
     if n.size == 0:
         # return empty arrays unchanged
         return n
-    if not np.issubdtype(n.dtype, np.integer):
+    if not _is_subdtype(n.dtype, "i"):
         msg = "factorialk does not support non-integral arrays!"
         raise ValueError(msg + helpmsg)
     if exact:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3035,16 +3035,18 @@ def factorial(n, exact=False):
     120
 
     """
+    msg_wrong_dtype = (
+        "Unsupported data type for factorial: {dtype}\n"
+        "Permitted data types are integers and floating point numbers."
+    )
+
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
         if n is None or np.isnan(n):
             return np.nan
         elif not _is_subdtype(type(n), ["i", "f"]):
-            raise ValueError(
-                f"Unsupported datatype for factorial: {type(n)}\n"
-                "Permitted data types are integers and floating point numbers"
-            )
+            raise ValueError(msg_wrong_dtype.format(dtype=type(n)))
         elif n < 0:
             return 0
         elif exact and _is_subdtype(type(n), "i"):
@@ -3061,10 +3063,7 @@ def factorial(n, exact=False):
         # return empty arrays unchanged
         return n
     if not _is_subdtype(n.dtype, ["i", "f"]):
-        raise ValueError(
-            f"Unsupported datatype for factorial: {n.dtype}\n"
-            "Permitted data types are integers and floating point numbers"
-        )
+        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype))
     if exact and not _is_subdtype(n.dtype, "i"):
         msg = ("factorial with `exact=True` does not "
                "support non-integral arrays")
@@ -3109,6 +3108,10 @@ def factorial2(n, exact=False):
     105
 
     """
+    msg_wrong_dtype = (
+        "Unsupported data type for factorial2: {dtype}\n"
+        "Only integers are permitted."
+    )
 
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
@@ -3116,8 +3119,7 @@ def factorial2(n, exact=False):
         if n is None or np.isnan(n):
             return np.nan
         elif not _is_subdtype(type(n), "i"):
-            msg = "factorial2 does not support non-integral scalar arguments"
-            raise ValueError(msg)
+            raise ValueError(msg_wrong_dtype.format(dtype=type(n)))
         elif n < 0:
             return 0
         elif n in {0, 1}:
@@ -3132,7 +3134,7 @@ def factorial2(n, exact=False):
         # return empty arrays unchanged
         return n
     if not _is_subdtype(n.dtype, "i"):
-        raise ValueError("factorial2 does not support non-integral arrays")
+        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype))
     if exact:
         return _factorialx_array_exact(n, k=2)
     return _factorialx_array_approx(n, k=2)
@@ -3211,6 +3213,11 @@ def factorialk(n, k, exact=None):
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
         exact = True
 
+    msg_wrong_dtype = (
+        "Unsupported data type for factorialk: {dtype}\n"
+        "Only integers are permitted."
+    )
+
     helpmsg = ""
     if k in {1, 2}:
         func = "factorial" if k == 1 else "factorial2"
@@ -3222,8 +3229,7 @@ def factorialk(n, k, exact=None):
         if n is None or np.isnan(n):
             return np.nan
         elif not _is_subdtype(type(n), "i"):
-            msg = "factorialk does not support non-integral scalar arguments!"
-            raise ValueError(msg + helpmsg)
+            raise ValueError(msg_wrong_dtype.format(dtype=type(n)) + helpmsg)
         elif n < 0:
             return 0
         elif n in {0, 1}:
@@ -3238,8 +3244,7 @@ def factorialk(n, k, exact=None):
         # return empty arrays unchanged
         return n
     if not _is_subdtype(n.dtype, "i"):
-        msg = "factorialk does not support non-integral arrays!"
-        raise ValueError(msg + helpmsg)
+        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype) + helpmsg)
     if exact:
         return _factorialx_array_exact(n, k=k)
     return _factorialx_array_approx(n, k=k)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -52,6 +52,12 @@ from scipy.special._testutils import with_special_errors, \
 import math
 
 
+native_int = np.int32 if (
+    sys.platform == 'win32'
+    or platform.architecture()[0] == "32bit"
+) else np.int64
+
+
 class TestCephes:
     def test_airy(self):
         cephes.airy(0)
@@ -2123,7 +2129,7 @@ class TestFactorialFunctions:
         rtol = 1e-15
         n = [-5, -4, 0, 1]
         # Consistent output for n < 0
-        expected = np.array([0, 0, 1, 1], dtype=np.int64 if exact else np.float64)
+        expected = np.array([0, 0, 1, 1], dtype=native_int if exact else np.float64)
         xp_assert_close(special.factorial(n, **kw), expected, rtol=rtol)
         xp_assert_close(special.factorial2(n, **kw), expected, rtol=rtol)
         xp_assert_close(special.factorialk(n, k=3, **kw), expected, rtol=rtol)
@@ -2312,7 +2318,7 @@ class TestFactorialFunctions:
             # result is empty if and only if n is empty, and has the same dimension
             # as n; dtype stays the same, except when not empty and not exact:
             if n.size:
-                dtype = np.int64 if exact else np.float64
+                dtype = native_int if exact else np.float64
             expected = np.array(ref, ndmin=dim, dtype=dtype)
             xp_assert_equal(result, expected)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2243,7 +2243,7 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorial(n, exact=True))
         assert_array_equal(correct, special.factorial([n], exact=True)[0])
 
-        rtol = 6e-14 if sys.platform == 'win32' else 1e-15
+        rtol = 8e-14 if sys.platform == 'win32' else 1e-15
         # need to cast exact result to float due to numpy/numpy#21220
         correct = float(correct)
         assert_allclose(correct, special.factorial(n, exact=False), rtol=rtol)
@@ -2251,7 +2251,7 @@ class TestFactorialFunctions:
 
     def test_factorial_float_reference(self):
         def _check(n, expected):
-            rtol = 1e-15
+            rtol = 8e-14 if sys.platform == 'win32' else 1e-15
             assert_allclose(special.factorial(n), expected, rtol=rtol)
             assert_allclose(special.factorial([n])[0], expected, rtol=rtol)
             # using floats with `exact=True` raises an error for scalars and arrays
@@ -2356,7 +2356,7 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorial2(n, exact=True))
         assert_array_equal(correct, special.factorial2([n], exact=True)[0])
 
-        rtol = 1e-15
+        rtol = 2e-14 if sys.platform == 'win32' else 1e-15
         # need to cast exact result to float due to numpy/numpy#21220
         correct = float(correct)
         assert_allclose(correct, special.factorial2(n, exact=False), rtol=rtol)
@@ -2422,7 +2422,7 @@ class TestFactorialFunctions:
         # Compare exact=True vs False, i.e. that the accuracy of the
         # approximation is better than the specified tolerance.
 
-        rtol = 2e-14
+        rtol = 6e-14 if sys.platform == 'win32' else 2e-14
         # need to cast exact result to float due to numpy/numpy#21220
         assert_allclose(float(special.factorialk(n, k=k, exact=True)),
                         special.factorialk(n, k=k, exact=False), rtol=rtol)
@@ -2442,7 +2442,7 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorialk(n, k, exact=True))
         assert_array_equal(correct, special.factorialk([n], k, exact=True)[0])
 
-        rtol = 1e-14
+        rtol = 3e-14 if sys.platform == 'win32' else 1e-14
         # need to cast exact result to float due to numpy/numpy#21220
         correct = float(correct)
         assert_allclose(correct, special.factorialk(n, k, exact=False), rtol=rtol)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2156,7 +2156,7 @@ class TestFactorialFunctions:
         # array-like (initializes np.array with default dtype)
         if content is not np.nan:
             # None causes object dtype, which is not supported; as is datetime
-            with pytest.raises(ValueError, match="Unsupported datatype.*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorial([content], exact=exact)
         elif exact:
             with pytest.raises(ValueError, match="factorial with `exact=Tr.*"):
@@ -2164,9 +2164,9 @@ class TestFactorialFunctions:
         else:
             assert np.isnan(special.factorial([content], exact=exact)[0])
         # factorial{2,k} don't support array case due to dtype constraints
-        with pytest.raises(ValueError, match="factorial2 does not support.*"):
+        with pytest.raises(ValueError, match="Unsupported data type.*"):
             special.factorial2([content], exact=exact)
-        with pytest.raises(ValueError, match="factorialk does not support.*"):
+        with pytest.raises(ValueError, match="Unsupported data type.*"):
             special.factorialk([content], 3, exact=exact)
         # array-case also tested in test_factorial{,2,k}_corner_cases
 
@@ -2304,7 +2304,7 @@ class TestFactorialFunctions:
         if not content:
             result = special.factorial(n, exact=exact)
         elif not _is_subdtype(n.dtype, ["i", "f"]):
-            with pytest.raises(ValueError, match="Unsupported datatype*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorial(n, exact=exact)
         elif exact and not _is_subdtype(n.dtype, "i"):
             with pytest.raises(ValueError, match="factorial with `exact=.*"):
@@ -2337,7 +2337,7 @@ class TestFactorialFunctions:
                 exp = np.nan if n is np.nan or n is None else special.factorial(n)
                 assert_equal(result, exp)
         else:
-            with pytest.raises(ValueError, match="Unsupported datatype*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorial(n, exact=exact)
 
     # use odd increment to make sure both odd & even numbers are tested!
@@ -2388,7 +2388,7 @@ class TestFactorialFunctions:
             func = assert_equal if exact or (not content) else assert_allclose
             func(result, n)
         else:
-            with pytest.raises(ValueError, match="factorial2 does not*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorial2(n, 3)
 
     @pytest.mark.parametrize("exact", [True, False])
@@ -2401,7 +2401,7 @@ class TestFactorialFunctions:
             exp = np.nan if n is np.nan or n is None else special.factorial(n)
             assert_equal(result, exp)
         else:
-            with pytest.raises(ValueError, match="factorial2 does not*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorial2(n, exact=exact)
 
     @pytest.mark.parametrize("k", range(1, 5))
@@ -2451,7 +2451,7 @@ class TestFactorialFunctions:
             # no error; expected result is identical to n
             assert_equal(special.factorialk(n, 3, exact=exact), n)
         else:
-            with pytest.raises(ValueError, match="factorialk does not*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorialk(n, 3, exact=exact)
 
     @pytest.mark.parametrize("exact", [True, False])
@@ -2467,7 +2467,7 @@ class TestFactorialFunctions:
             expected = np.nan if nan_cond else 1
             assert_equal(result, expected)
         else:
-            with pytest.raises(ValueError, match="factorialk does not*"):
+            with pytest.raises(ValueError, match="Unsupported data type.*"):
                 special.factorialk(n, k=k, exact=exact)
 
     @pytest.mark.parametrize("k", range(1, 5))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2297,7 +2297,8 @@ class TestFactorialFunctions:
                              [[], [1], [1.1], [np.nan], [np.nan, 1]],
                              ids=["[]", "[1]", "[1.1]", "[NaN]", "[NaN, 1]"])
     def test_factorial_array_corner_cases(self, content, dim, exact, dtype):
-        if dtype == np.int64 and any(np.isnan(x) for x in content):
+        # get dtype without calling array constructor (that might fail or mutate)
+        if dtype == np.int64 and any(np.isnan(x) or (x != int(x)) for x in content):
             pytest.skip("impossible combination")
 
         kw = {"exact": exact}
@@ -2377,10 +2378,11 @@ class TestFactorialFunctions:
     @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("dim", range(0, 5))
     # test empty & non-empty arrays, with nans and mixed
-    @pytest.mark.parametrize("content", [[], [1], [np.nan], [np.nan, 1]],
-                             ids=["[]", "[1]", "[NaN]", "[NaN, 1]"])
+    @pytest.mark.parametrize("content", [[], [1], [1.1], [np.nan], [np.nan, 1]],
+                             ids=["[]", "[1]", "[1.1]", "[NaN]", "[NaN, 1]"])
     def test_factorial2_array_corner_cases(self, content, dim, exact, dtype):
-        if dtype == np.int64 and any(np.isnan(x) for x in content):
+        # get dtype without calling array constructor (that might fail or mutate)
+        if dtype == np.int64 and any(np.isnan(x) or (x != int(x)) for x in content):
             pytest.skip("impossible combination")
 
         kw = {"exact": exact}
@@ -2458,10 +2460,11 @@ class TestFactorialFunctions:
     @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("dim", range(0, 5))
     # test empty & non-empty arrays, with nans and mixed
-    @pytest.mark.parametrize("content", [[], [1], [np.nan], [np.nan, 1]],
-                             ids=["[]", "[1]", "[NaN]", "[NaN, 1]"])
+    @pytest.mark.parametrize("content", [[], [1], [1.1], [np.nan], [np.nan, 1]],
+                             ids=["[]", "[1]", "[1.1]", "[NaN]", "[NaN, 1]"])
     def test_factorialk_array_corner_cases(self, content, dim, exact, dtype):
-        if dtype == np.int64 and any(np.isnan(x) for x in content):
+        # get dtype without calling array constructor (that might fail or mutate)
+        if dtype == np.int64 and any(np.isnan(x) or (x != int(x)) for x in content):
             pytest.skip("impossible combination")
 
         kw = {"k": 3, "exact": exact}

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2454,18 +2454,13 @@ class TestFactorialFunctions:
             with pytest.raises(ValueError, match="factorialk does not*"):
                 special.factorialk(n, 3, exact=exact)
 
-    @pytest.mark.parametrize("exact", [True, False, None])
+    @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("k", range(1, 5))
     @pytest.mark.parametrize("n", [1, 1.1, 2 + 2j, np.nan, None],
                              ids=["1", "1.1", "2+2j", "NaN", "None"])
     def test_factorialk_scalar_corner_cases(self, n, k, exact):
         if n is None or n is np.nan or _is_subdtype(type(n), "i"):
-            if exact is None:
-                with pytest.deprecated_call(match="factorialk will default.*"):
-                    result = special.factorialk(n, k=k, exact=exact)
-            else:
-                # no error
-                result = special.factorialk(n, k=k, exact=exact)
+            result = special.factorialk(n, k=k, exact=exact)
 
             nan_cond = n is np.nan or n is None
             # factorialk(1, k) == 1 for all k
@@ -2473,9 +2468,14 @@ class TestFactorialFunctions:
             assert_equal(result, expected)
         else:
             with pytest.raises(ValueError, match="factorialk does not*"):
-                with suppress_warnings() as sup:
-                    sup.filter(DeprecationWarning, "factorialk will default")
-                    special.factorialk(n, k=k, exact=exact)
+                special.factorialk(n, k=k, exact=exact)
+
+    @pytest.mark.parametrize("k", range(1, 5))
+    def test_factorialk_deprecation_exact(self, k):
+        with pytest.deprecated_call(match="factorialk will default.*"):
+            # leaving exact= unspecified raises warning;
+            # cannot happen for extend="complex" because it requires non-default exact
+            special.factorialk(1, k=k)
 
     @pytest.mark.parametrize("k", [0, 1.1, np.nan, "1"])
     def test_factorialk_raises_k(self, k):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2261,18 +2261,19 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorial([n], True)[0])
 
         rtol = 6e-14 if sys.platform == 'win32' else 1e-15
-        assert_allclose(float(correct), special.factorial(n, False),
-                        rtol=rtol)
-        assert_allclose(float(correct), special.factorial([n], False)[0],
-                        rtol=rtol)
+        # need to cast exact result to float due to numpy/numpy#21220
+        correct = float(correct)
+        assert_allclose(correct, special.factorial(n, exact=False), rtol=rtol)
+        assert_allclose(correct, special.factorial([n], exact=False)[0], rtol=rtol)
 
     def test_factorial_float_reference(self):
         def _check(n, expected):
-            assert_allclose(special.factorial(n), expected)
-            assert_allclose(special.factorial([n])[0], expected)
+            rtol = 1e-15
+            assert_allclose(special.factorial(n), expected, rtol=rtol)
+            assert_allclose(special.factorial([n])[0], expected, rtol=rtol)
             # using floats with `exact=True` raises an error for scalars and arrays
             with pytest.raises(ValueError, match="Non-integer values.*"):
-                assert_allclose(special.factorial(n, exact=True), expected)
+                assert_allclose(special.factorial(n, exact=True), expected, rtol=rtol)
             with pytest.raises(ValueError, match="factorial with `exact=Tr.*"):
                 special.factorial([n], exact=True)
 
@@ -2370,8 +2371,11 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorial2(n, True))
         assert_array_equal(correct, special.factorial2([n], True)[0])
 
-        assert_allclose(float(correct), special.factorial2(n, False))
-        assert_allclose(float(correct), special.factorial2([n], False)[0])
+        rtol = 1e-15
+        # need to cast exact result to float due to numpy/numpy#21220
+        correct = float(correct)
+        assert_allclose(correct, special.factorial2(n, exact=False), rtol=rtol)
+        assert_allclose(correct, special.factorial2([n], exact=False)[0], rtol=rtol)
 
     @pytest.mark.parametrize("dtype", [np.int64, np.float64,
                                        np.complex128, object])
@@ -2433,11 +2437,12 @@ class TestFactorialFunctions:
         # Compare exact=True vs False, i.e. that the accuracy of the
         # approximation is better than the specified tolerance.
 
+        rtol = 2e-14
         # need to cast exact result to float due to numpy/numpy#21220
         assert_allclose(float(special.factorialk(n, k=k, exact=True)),
-                        special.factorialk(n, k=k, exact=False))
+                        special.factorialk(n, k=k, exact=False), rtol=rtol)
         assert_allclose(special.factorialk([n], k=k, exact=True).astype(float),
-                        special.factorialk([n], k=k, exact=False))
+                        special.factorialk([n], k=k, exact=False), rtol=rtol)
 
     @pytest.mark.parametrize('k', list(range(1, 5)) + [10, 20])
     @pytest.mark.parametrize('n',
@@ -2452,8 +2457,11 @@ class TestFactorialFunctions:
         assert_array_equal(correct, special.factorialk(n, k, True))
         assert_array_equal(correct, special.factorialk([n], k, True)[0])
 
-        assert_allclose(float(correct), special.factorialk(n, k, False))
-        assert_allclose(float(correct), special.factorialk([n], k, False)[0])
+        rtol = 1e-14
+        # need to cast exact result to float due to numpy/numpy#21220
+        correct = float(correct)
+        assert_allclose(correct, special.factorialk(n, k, exact=False), rtol=rtol)
+        assert_allclose(correct, special.factorialk([n], k, exact=False)[0], rtol=rtol)
 
     @pytest.mark.parametrize("dtype", [np.int64, np.float64,
                                        np.complex128, object])


### PR DESCRIPTION
Preparation for complex support in factorial functions (see #18409), which needs some preparations in the tests, as well as an auxiliary function `_is_subdtype` to be able to sanely express the necessary subtype conditions.

No functional changes in this PR, aside from changing the text of some warning messages. Also tightens some tests that were using the woefully inadequate default of `rtol=1e-7` in `assert_allclose`

Preview of what this PR is preparing for can be found in #19988