### PR TITLE
TST, MAINT: test_immediate_updating fix

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -709,7 +709,7 @@ class TestDifferentialEvolutionSolver:
             with warns(UserWarning):
                 with DifferentialEvolutionSolver(rosen, bounds, workers=p.map) as s:
                     pass
-            assert_(s._updating == 'deferred')
+            assert s._updating == 'deferred'
 
     def test_parallel(self):
         # smoke test for parallelization with deferred updating

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -698,12 +698,18 @@ class TestDifferentialEvolutionSolver:
         solver = DifferentialEvolutionSolver(rosen, bounds)
         assert_(solver._updating == 'immediate')
 
-        # should raise a UserWarning because the updating='immediate'
-        # is being overridden by the workers keyword
-        with warns(UserWarning):
-            with DifferentialEvolutionSolver(rosen, bounds, workers=2) as solver:
-                pass
-        assert_(solver._updating == 'deferred')
+        # Safely forking from a multithreaded process is
+        # problematic, and deprecated in Python 3.12, so
+        # we use a slower but portable alternative
+        # see gh-19848
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(2) as p:
+            # should raise a UserWarning because the updating='immediate'
+            # is being overridden by the workers keyword
+            with warns(UserWarning):
+                with DifferentialEvolutionSolver(rosen, bounds, workers=p.map) as s:
+                    pass
+            assert_(s._updating == 'deferred')
 
     def test_parallel(self):
         # smoke test for parallelization with deferred updating


### PR DESCRIPTION
* Fixes #19848

* Safely forking from a multithreaded process is problematic and deprecated in Python 3.12+; the test failure in the linked issue is fully reproducible on x86_64 Linux when using `pytest-xdist` and more than 1 process with Python `3.12`.

* Andrew's solution seemed the most effective in my hands; I did also explore using one of the environment variables that tells you if you're in a `pytest-xdist` worker, but the code seemed messier without much benefit.

* The alternative start method used here (`spawn`) is slower of course, as the docs indicate. For 1 core, the test runs in 0.02 s locally, and the worst I saw was 0.12 s with 32 cores (using the timing from `--durations`, not overall suite time of course) vs. 0.07 s with 32 cores using `fork` (both methods are 0.02 s locally with 2 `xdist` cores, I suppose that's closest to what we'd do in CI)

* the `solver` variable name was shortened to accommodate line length (I was `-0.5` on that but linter was complaining)

* sample detailed discussion here, including community complaints and response from CPython devs: https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555

* `forkserver` is another start method/option, but its portability description made me nervous: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

[skip cirrus] [skip circle]