### PR TITLE
MAINT: Adjust the codebase to the new `np.array`'s `copy` keyword meaning

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -420,8 +420,8 @@ class interp1d(_Interpolator1D):
         Axis in the ``y`` array corresponding to the x-coordinate values. Unlike
         other interpolators, defaults to ``axis=-1``.
     copy : bool, optional
-        If True, the class makes internal copies of x and y.
-        If False, references to `x` and `y` are used. The default is to copy.
+        If ``True``, the class makes internal copies of x and y. If ``False``,
+        references to ``x`` and ``y`` are used if possible. The default is to copy.
     bounds_error : bool, optional
         If True, a ValueError is raised any time interpolation is attempted on
         a value outside of the range of x (where extrapolation is
@@ -499,7 +499,10 @@ class interp1d(_Interpolator1D):
         _Interpolator1D.__init__(self, x, y, axis=axis)
 
         self.bounds_error = bounds_error  # used by fill_value setter
-        self.copy = copy
+
+        # `copy` keyword semantics changed in NumPy 2.0, once that is
+        # the minimum version this can use `copy=None`.
+        self.copy = np._CopyMode.ALWAYS if copy else np._CopyMode.IF_NEEDED
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
             order = {'zero': 0, 'slinear': 1,

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1292,7 +1292,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     ([32], array([ 1.6]), array([ 0.9995736]))
 
     """
-    widths = np.array(widths, copy=False, ndmin=1)
+    widths = np.atleast_1d(np.asarray(widths))
 
     if gap_thresh is None:
         gap_thresh = np.ceil(widths[0])

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2131,9 +2131,9 @@ def lfilter(b, a, x, axis=-1, zi=None):
             raise NotImplementedError("input type '%s' not supported" % dtype)
 
         b = np.array(b, dtype=dtype)
-        a = np.array(a, dtype=dtype, copy=False)
+        a = np.asarray(a, dtype=dtype)
         b /= a[0]
-        x = np.array(x, dtype=dtype, copy=False)
+        x = np.asarray(x, dtype=dtype)
 
         out_full = np.apply_along_axis(lambda y: np.convolve(b, y), axis, x)
         ind = out_full.ndim * [slice(None)]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1489,7 +1489,7 @@ class _TestLinearFilter:
                 y[...] = self.type(x[()])
             return out
         else:
-            return np.array(arr, self.dtype, copy=False)
+            return np.asarray(arr, dtype=self.dtype)
 
     def test_rank_1_IIR(self):
         x = self.generate((6,))

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -897,8 +897,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise IndexError('index (%d) out of range (< -%d)' %
                                  (idx, bound))
 
-        i = np.array(i, dtype=self.indices.dtype, copy=False, ndmin=1).ravel()
-        j = np.array(j, dtype=self.indices.dtype, copy=False, ndmin=1).ravel()
+        i = np.atleast_1d(np.asarray(i, dtype=self.indices.dtype)).ravel()
+        j = np.atleast_1d(np.asarray(j, dtype=self.indices.dtype)).ravel()
         check_bounds(i, M)
         check_bounds(j, N)
         return i, j, M, N
@@ -910,7 +910,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         duplicate entries.
         """
         i, j, M, N = self._prepare_indices(i, j)
-        x = np.array(x, dtype=self.dtype, copy=False, ndmin=1).ravel()
+        x = np.atleast_1d(np.asarray(x, dtype=self.dtype)).ravel()
 
         n_samples = x.size
         offsets = np.empty(n_samples, dtype=self.indices.dtype)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -121,8 +121,8 @@ def _get_umf_family(A):
     # but that didn't always fix the issue.
     family = family[0] + "l"
     A_new = copy.copy(A)
-    A_new.indptr = np.array(A.indptr, copy=False, dtype=np.int64)
-    A_new.indices = np.array(A.indices, copy=False, dtype=np.int64)
+    A_new.indptr = np.asarray(A.indptr, dtype=np.int64)
+    A_new.indices = np.asarray(A.indices, dtype=np.int64)
 
     return family, A_new
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -52,7 +52,7 @@ def _as2d(ar):
     if ar.ndim == 2:
         return ar
     else:  # Assume 1!
-        aux = np.array(ar, copy=False)
+        aux = np.asarray(ar)
         aux.shape = (ar.shape[0], 1)
         return aux
 

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -3192,7 +3192,7 @@ def mquantiles(a, prob=list([.25,.5,.75]), alphap=.4, betap=.4, axis=None,
         condition = (limit[0] < data) & (data < limit[1])
         data[~condition.filled(True)] = masked
 
-    p = np.array(prob, copy=False, ndmin=1)
+    p = np.atleast_1d(np.asarray(prob))
     m = alphap + p*(1.-alphap-betap)
     # Computes quantiles along axis (or globally)
     if (axis is None):
@@ -3492,7 +3492,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     >>> brunnermunzel(x1, x2)
     BrunnerMunzelResult(statistic=1.4723186918922935, pvalue=0.15479415300426624)  # may vary
 
-    """
+    """  # noqa: E501
     x = ma.asarray(x).compressed().view(ndarray)
     y = ma.asarray(y).compressed().view(ndarray)
     nx = len(x)

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -108,7 +108,7 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False,):
         return hd[0]
     # Initialization & checks
     data = ma.array(data, copy=False, dtype=float64)
-    p = np.array(prob, copy=False, ndmin=1)
+    p = np.atleast_1d(np.asarray(prob))
     # Computes quantiles along axis (or globally)
     if (axis is None) or (data.ndim == 1):
         result = _hd_1D(data, p, var)
@@ -197,7 +197,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
 
     # Initialization & checks
     data = ma.array(data, copy=False, dtype=float64)
-    p = np.array(prob, copy=False, ndmin=1)
+    p = np.atleast_1d(np.asarray(prob))
     # Computes quantiles along axis (or globally)
     if (axis is None):
         result = _hdsd_1D(data, p)
@@ -298,7 +298,7 @@ def mjci(data, prob=[0.25,0.5,0.75], axis=None):
         raise ValueError("Array 'data' must be at most two dimensional, "
                          "but got data.ndim = %d" % data.ndim)
 
-    p = np.array(prob, copy=False, ndmin=1)
+    p = np.atleast_1d(np.asarray(prob))
     # Computes quantiles along axis (or globally)
     if (axis is None):
         return _mjci_1D(data, p)
@@ -508,7 +508,7 @@ def rsh(data, points=None):
     if points is None:
         points = data
     else:
-        points = np.array(points, copy=False, ndmin=1)
+        points = np.atleast_1d(np.asarray(points))
 
     if data.ndim != 1:
         raise AttributeError("The input array should be 1D only !")

--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -313,7 +313,7 @@ def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):
     if method not in methods:
         raise ValueError(f"`method` must be in {set(methods)}")
 
-    ranks = np.array(data, copy=False)
+    ranks = np.asarray(data)
     if ranks.ndim != 2:  # TODO: relax this to accept 3d arrays?
         raise ValueError("`data` must be a 2d array.")
 
@@ -340,7 +340,7 @@ def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):
     if predicted_ranks is None:
         predicted_ranks = np.arange(1, n+1)
     else:
-        predicted_ranks = np.array(predicted_ranks, copy=False)
+        predicted_ranks = np.asarray(predicted_ranks)
         if (predicted_ranks.ndim < 1 or
                 (set(predicted_ranks) != set(range(1, n+1)) or
                  len(predicted_ranks) != n)):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2215,11 +2215,11 @@ class MultivariateNormalQMC:
             engine: QMCEngine | None = None,
             seed: SeedType = None
     ) -> None:
-        mean = np.array(mean, copy=False, ndmin=1)
+        mean = np.asarray(np.atleast_1d(mean))
         d = mean.shape[0]
         if cov is not None:
             # covariance matrix provided
-            cov = np.array(cov, copy=False, ndmin=2)
+            cov = np.asarray(np.atleast_2d(cov))
             # check for square/symmetric cov matrix and mean vector has the
             # same d
             if not mean.shape[0] == cov.shape[0]:
@@ -2380,7 +2380,7 @@ class MultinomialQMC:
         *, engine: QMCEngine | None = None,
         seed: SeedType = None
     ) -> None:
-        self.pvals = np.array(pvals, copy=False, ndmin=1)
+        self.pvals = np.atleast_1d(np.asarray(pvals))
         if np.min(pvals) < 0:
             raise ValueError('Elements of pvals must be non-negative.')
         if not np.isclose(np.sum(pvals), 1):


### PR DESCRIPTION
Hi @rgommers,

Here's a PR that addresses changes planned for NumPy in https://github.com/numpy/numpy/pull/25168 (new `copy` keyword for `np.asarray` and `np.array`).

I applied changes in a backward-compatible way, so that no NumPy version check & branching is needed. 