### PR TITLE
MAINT: sparse: change method names _mul_* to _matmul_* all but _mul_scalar

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -564,14 +564,14 @@ class _spbase:
         else:
             return NotImplemented
 
-    def _mul_dispatch(self, other):
-        """`np.matrix`-compatible mul, i.e. `dot` or `NotImplemented`
+    def _matmul_dispatch(self, other):
+        """np.array-like matmul & `np.matrix`-like mul, i.e. `dot` or `NotImplemented`
 
         interpret other and call one of the following
         self._mul_scalar()
-        self._mul_vector()
-        self._mul_multivector()
-        self._mul_sparse_matrix()
+        self._matmul_vector()
+        self._matmul_multivector()
+        self._matmul_sparse()
         """
         # This method has to be different from `__matmul__` because it is also
         # called by sparse matrix classes.
@@ -584,11 +584,11 @@ class _spbase:
         if other.__class__ is np.ndarray:
             # Fast path for the most common case
             if other.shape == (N,):
-                return self._mul_vector(other)
+                return self._matmul_vector(other)
             elif other.shape == (N, 1):
-                return self._mul_vector(other.ravel()).reshape(M, 1)
+                return self._matmul_vector(other.ravel()).reshape(M, 1)
             elif other.ndim == 2 and other.shape[0] == N:
-                return self._mul_multivector(other)
+                return self._matmul_multivector(other)
 
         if isscalarlike(other):
             # scalar value
@@ -599,14 +599,14 @@ class _spbase:
                 raise ValueError('dimension mismatch')
             if other.ndim == 1:
                 raise ValueError('Cannot yet multiply a 1d sparse array')
-            return self._mul_sparse_matrix(other)
+            return self._matmul_sparse(other)
 
         # If it's a list or whatever, treat it like an array
         other_a = np.asanyarray(other)
 
         if other_a.ndim == 0 and other_a.dtype == np.object_:
             # Not interpretable as an array; return NotImplemented so that
-            # other's __rmul__ can kick in if that's implemented.
+            # other's __rmatmul__ can kick in if that's implemented.
             return NotImplemented
 
         try:
@@ -619,7 +619,7 @@ class _spbase:
             if other.shape != (N,) and other.shape != (N, 1):
                 raise ValueError('dimension mismatch')
 
-            result = self._mul_vector(np.ravel(other))
+            result = self._matmul_vector(np.ravel(other))
 
             if isinstance(other, np.matrix):
                 result = self._ascontainer(result)
@@ -637,7 +637,7 @@ class _spbase:
             if other.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
 
-            result = self._mul_multivector(np.asarray(other))
+            result = self._matmul_multivector(np.asarray(other))
 
             if isinstance(other, np.matrix):
                 result = self._ascontainer(result)
@@ -650,20 +650,23 @@ class _spbase:
     def __mul__(self, *args, **kwargs):
         return self.multiply(*args, **kwargs)
 
+    def __rmul__(self, *args, **kwargs):  # other * self
+        return self.multiply(*args, **kwargs)
+
     # by default, use CSR for __mul__ handlers
     def _mul_scalar(self, other):
         return self.tocsr()._mul_scalar(other)
 
-    def _mul_vector(self, other):
-        return self.tocsr()._mul_vector(other)
+    def _matmul_vector(self, other):
+        return self.tocsr()._matmul_vector(other)
 
-    def _mul_multivector(self, other):
-        return self.tocsr()._mul_multivector(other)
+    def _matmul_multivector(self, other):
+        return self.tocsr()._matmul_multivector(other)
 
-    def _mul_sparse_matrix(self, other):
-        return self.tocsr()._mul_sparse_matrix(other)
+    def _matmul_sparse(self, other):
+        return self.tocsr()._matmul_sparse(other)
 
-    def _rmul_dispatch(self, other):
+    def _rmatmul_dispatch(self, other):
         if isscalarlike(other):
             return self._mul_scalar(other)
         else:
@@ -672,13 +675,10 @@ class _spbase:
                 tr = other.transpose()
             except AttributeError:
                 tr = np.asarray(other).transpose()
-            ret = self.transpose()._mul_dispatch(tr)
+            ret = self.transpose()._matmul_dispatch(tr)
             if ret is NotImplemented:
                 return NotImplemented
             return ret.transpose()
-
-    def __rmul__(self, *args, **kwargs):  # other * self
-        return self.multiply(*args, **kwargs)
 
     #######################
     # matmul (@) operator #
@@ -688,13 +688,13 @@ class _spbase:
         if isscalarlike(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
-        return self._mul_dispatch(other)
+        return self._matmul_dispatch(other)
 
     def __rmatmul__(self, other):
         if isscalarlike(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
-        return self._rmul_dispatch(other)
+        return self._rmatmul_dispatch(other)
 
     ####################
     # Other Arithmetic #

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -251,7 +251,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
     def _add_dense(self, other):
         return self.tocoo(copy=False)._add_dense(other)
 
-    def _mul_vector(self, other):
+    def _matmul_vector(self, other):
         M,N = self.shape
         R,C = self.blocksize
 
@@ -263,7 +263,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
         return result
 
-    def _mul_multivector(self,other):
+    def _matmul_multivector(self,other):
         R,C = self.blocksize
         M,N = self.shape
         n_vecs = other.shape[1]  # number of column vectors
@@ -276,7 +276,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
         return result
 
-    def _mul_sparse_matrix(self, other):
+    def _matmul_sparse(self, other):
         M, K1 = self.shape
         K2, N = other.shape
 

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -385,37 +385,37 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return other._mul_scalar(self.toarray()[0, 0])
             # A row times a column.
             elif self.shape[1] == 1 and other.shape[0] == 1:
-                return self._mul_sparse_matrix(other.tocsc())
+                return self._matmul_sparse(other.tocsc())
             elif self.shape[0] == 1 and other.shape[1] == 1:
-                return other._mul_sparse_matrix(self.tocsc())
+                return other._matmul_sparse(self.tocsc())
             # Row vector times matrix. other is a row.
             elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
                 other = self._dia_container(
                     (other.toarray().ravel(), [0]),
                     shape=(other.shape[1], other.shape[1])
                 )
-                return self._mul_sparse_matrix(other)
+                return self._matmul_sparse(other)
             # self is a row.
             elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
                 copy = self._dia_container(
                     (self.toarray().ravel(), [0]),
                     shape=(self.shape[1], self.shape[1])
                 )
-                return other._mul_sparse_matrix(copy)
+                return other._matmul_sparse(copy)
             # Column vector times matrix. other is a column.
             elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
                 other = self._dia_container(
                     (other.toarray().ravel(), [0]),
                     shape=(other.shape[0], other.shape[0])
                 )
-                return other._mul_sparse_matrix(self)
+                return other._matmul_sparse(self)
             # self is a column.
             elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
                 copy = self._dia_container(
                     (self.toarray().ravel(), [0]),
                     shape=(self.shape[0], self.shape[0])
                 )
-                return copy._mul_sparse_matrix(other)
+                return copy._matmul_sparse(other)
             else:
                 raise ValueError("inconsistent shapes")
 
@@ -484,7 +484,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     # Multiplication handlers #
     ###########################
 
-    def _mul_vector(self, other):
+    def _matmul_vector(self, other):
         M, N = self.shape
 
         # output array
@@ -497,7 +497,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         return result
 
-    def _mul_multivector(self, other):
+    def _matmul_multivector(self, other):
         M, N = self.shape
         n_vecs = other.shape[1]  # number of column vectors
 
@@ -511,7 +511,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         return result
 
-    def _mul_sparse_matrix(self, other):
+    def _matmul_sparse(self, other):
         M, K1 = self.shape
         K2, N = other.shape
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -531,7 +531,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)
 
-    def _mul_vector(self, other):
+    def _matmul_vector(self, other):
         result_shape = self.shape[0] if self.ndim > 1 else 1
         result = np.zeros(result_shape,
                           dtype=upcast_char(self.dtype.char, other.dtype.char))
@@ -552,7 +552,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             return result[0]
         return result
 
-    def _mul_multivector(self, other):
+    def _matmul_multivector(self, other):
         result_dtype = upcast_char(self.dtype.char, other.dtype.char)
         if self.ndim == 2:
             result_shape = (other.shape[1], self.shape[0])

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -197,7 +197,7 @@ class _dia_base(_data_matrix):
                 m.setdiag(other.diagonal(d), d)
         return m
 
-    def _mul_vector(self, other):
+    def _matmul_vector(self, other):
         x = other
 
         y = np.zeros(self.shape[0], dtype=upcast_char(self.dtype.char,
@@ -212,8 +212,10 @@ class _dia_base(_data_matrix):
 
         return y
 
-    def _mul_multimatrix(self, other):
-        return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
+    def _matmul_multivector(self, other):
+        if other.size == 0:
+            return np.empty((self.shape[0], other.shape[1]), dtype=self.dtype)
+        return np.hstack([self._matmul_vector(col).reshape(-1,1) for col in other.T])
 
     def _setdiag(self, values, k=0):
         M, N = self.shape

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -212,11 +212,6 @@ class _dia_base(_data_matrix):
 
         return y
 
-    def _matmul_multivector(self, other):
-        if other.size == 0:
-            return np.empty((self.shape[0], other.shape[1]), dtype=self.dtype)
-        return np.hstack([self._matmul_vector(col).reshape(-1,1) for col in other.T])
-
     def _setdiag(self, values, k=0):
         M, N = self.shape
 

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -273,14 +273,14 @@ class _dok_base(_spbase, IndexMixin):
         new._dict.update(((k, v * other) for k, v in self.items()))
         return new
 
-    def _mul_vector(self, other):
+    def _matmul_vector(self, other):
         # matrix * vector
         result = np.zeros(self.shape[0], dtype=upcast(self.dtype, other.dtype))
         for (i, j), v in self.items():
             result[i] += v * other[j]
         return result
 
-    def _mul_multivector(self, other):
+    def _matmul_multivector(self, other):
         # matrix * multivector
         result_shape = (self.shape[0], other.shape[1])
         result_dtype = upcast(self.dtype, other.dtype)

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -41,10 +41,10 @@ class spmatrix:
 
     # Restore matrix multiplication
     def __mul__(self, other):
-        return self._mul_dispatch(other)
+        return self._matmul_dispatch(other)
 
     def __rmul__(self, other):
-        return self._rmul_dispatch(other)
+        return self._rmatmul_dispatch(other)
 
     # Restore matrix power
     def __pow__(self, power):

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -240,7 +240,7 @@ def test_1d_add_sparse():
         coo_array(den_a) + coo_array(den_b)
 
 
-def test_1d_mul_vector():
+def test_1d_matmul_vector():
     den_a = np.array([0, -2, -3, 0])
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
@@ -249,7 +249,7 @@ def test_1d_mul_vector():
     assert np.array_equal(res, exp)
 
 
-def test_1d_mul_multivector():
+def test_1d_matmul_multivector():
     den = np.array([0, -2, -3, 0])
     other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
     exp = den @ other
@@ -258,7 +258,7 @@ def test_1d_mul_multivector():
     assert np.array_equal(res, exp)
 
 
-def test_2d_mul_multivector():
+def test_2d_matmul_multivector():
     den = np.array([[0, 1, 2, 3], [3, 2, 1, 0]])
     arr2d = coo_array(den)
     exp = den @ den.T


### PR DESCRIPTION
In the long run, matmul methods should probably be named with `matmul` rather than `mul`. And at least in my case it would have helped reading the code. This is especially true when we do trickery inside `multiply` that uses `__matmul__` to do broadcasting for multiply in one operation. Also when using matmul to accomplish indexing. But this might look ugly to other folks, so take a look at the code with this and see if it works for you. All 3 names are private and the methods do the format-specific part of dot/matmul/matrix-* so it is unlikely they are used anywhere outside scipy.sparse.

Change names:   
- _mul_vector to _matmul_vector
- _mul_multivector to _matmul_multivector
- _mul_sparse_matrix to _matmul_sparse

I didn't change the name `_mul_scalar` because scalar multiplication is not matmul.  `5 @ A` raises.
I removed the `_matrix` from the  third name because it doesn't add any info and might be confusing if people thought it did. Similar issue if we replace it with array.

In doing this I noticed that DIA format had mis-spelled `def _mul_multivector` as `def _mul_multimatrix`. That name is not used anywhere and the method is next to, and uses `_mul_vector`. So, it is definitely a misspelling. Any DIA format multiplying a multi-vector  has been converting to `CSR`. Probably slower but I didn't explore that. The code that was there once engaged, didn't pass the test case of matmuling against an empty sparse matrix. I fixed that and it passes all tests now. 

See what you think of reading the code with the new names.