### PR TITLE
MAINT: Remove partial from `__all__` (removed from submodule)

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -25,7 +25,6 @@ __all__ = [  # noqa: F822
     'kron',
     'kronsum',
     'numbers',
-    'partial',
     'rand',
     'random',
     'rng_integers',


### PR DESCRIPTION
It is still present in `__all__` despite not being importable. This can lead to error message from completer or other dynamic code.