### PR TITLE
BUG: Add proper error message for `ShortTimeFFT` for onesided FFTs and complex signals

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -545,8 +545,10 @@ class ShortTimeFFT:
             If the FFT length `mfft` is even, the last FFT value is not paired,
             and thus it is not scaled.
 
-        Note that the frequency values can be obtained by reading the `f`
-        property, and the number of samples by accessing the `f_pts` property.
+        Note that`onesided` and `onesided2X` do not work for complex-valued signals or
+        complex-valued windows. Furthermore, the frequency values can be obtained by
+        reading the `f` property, and the number of samples by accessing the `f_pts`
+        property.
 
         See Also
         --------
@@ -750,7 +752,8 @@ class ShortTimeFFT:
         Parameters
         ----------
         x
-            The input signal as real or complex valued array.
+            The input signal as real or complex valued array. For complex values, the
+            property `fft_mode` must be set to 'twosided' or 'centered'.
         p0
             The first element of the range of slices to calculate. If ``None``
             then it is set to :attr:`p_min`, which is the smallest possible
@@ -821,6 +824,9 @@ class ShortTimeFFT:
                                    (without detrending).
         :class:`scipy.signal.ShortTimeFFT`: Class this method belongs to.
         """
+        if self.onesided_fft and np.iscomplexobj(x):
+            raise ValueError(f"Complex-valued `x` not allowed for {self.fft_mode=}'! "
+                             "Set property `fft_mode` to 'twosided' or 'centered'.")
         if isinstance(detr, str):
             detr = partial(detrend, type=detr)
         elif not (detr is None or callable(detr)):

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -155,8 +155,8 @@ def test_exceptions_properties_methods():
 
 @pytest.mark.parametrize('m', ('onesided', 'onesided2X'))
 def test_exceptions_fft_mode_complex_win(m: FFT_MODE_TYPE):
-    """Verify hat one-sided spectra are not allowed with complex-valued
-    windows.
+    """Verify that one-sided spectra are not allowed with complex-valued
+    windows or with complex-valued signals.
 
     The reason being, the `rfft` function only accepts real-valued input.
     """
@@ -168,6 +168,13 @@ def test_exceptions_fft_mode_complex_win(m: FFT_MODE_TYPE):
     with pytest.raises(ValueError,
                        match=f"One-sided spectra, i.e., fft_mode='{m}'.*"):
         SFT.fft_mode = m
+
+    SFT = ShortTimeFFT(np.ones(8), hop=4, fs=1, scale_to='psd', fft_mode='onesided')
+    with pytest.raises(ValueError, match="Complex-valued `x` not allowed for self.*"):
+        SFT.stft(np.ones(8)*1j)
+    SFT.fft_mode = 'onesided2X'
+    with pytest.raises(ValueError, match="Complex-valued `x` not allowed for self.*"):
+        SFT.stft(np.ones(8)*1j)
 
 
 def test_invalid_fft_mode_RuntimeError():


### PR DESCRIPTION
* Raise ValueError in `ShortTimeFFT.sft_detrend` if parameter `x` is complex and `ShortTimeFFT.onesided_fft` is true.
* Added unit test.
* Updated documentation.

Closes issue #20009. 

