### PR TITLE
MAINT: signal: use `sliding_window_view` instead of `as_strided`

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1987,16 +1987,15 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
 
     .. versionadded:: 0.16.0
     """
-    # Created strided array of data segments
+    # Created sliding window view of array
     if nperseg == 1 and noverlap == 0:
         result = x[..., np.newaxis]
     else:
-        # https://stackoverflow.com/a/5568169
         step = nperseg - noverlap
-        shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
-        strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])
-        result = np.lib.stride_tricks.as_strided(x, shape=shape,
-                                                 strides=strides)
+        result = np.lib.stride_tricks.sliding_window_view(
+            x, window_shape=nperseg, axis=-1, writeable=True
+        )
+        result = result[..., 0::step, :]
 
     # Detrend each data segment individually
     result = detrend_func(result)


### PR DESCRIPTION
Closes #20012, in case there is any interest in it. The change is small, so I've gone ahead and opened this PR.

I think the tests in [test_spectral.py](https://github.com/scipy/scipy/blob/fe967c70d783197511e1b0d45a0c34e0f1b5f8ba/scipy/signal/tests/test_spectral.py) should be sufficient, as this already tests a number of functions that make use of `_fft_helper` through `_spectral_helper`, e.g. `periodogram`, `csd`, `welch`, etc.