### PR TITLE
ENH: fix numerical instability around zero in boxcox_llf

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -945,8 +945,8 @@ def boxcox_llf(lmb, data):
         # not affect the variance, and the subtraction of the offset can
         # lead to loss of precision.
         # The sign of lmb at the denominator doesn't affect the variance.
-        logx = lmb * logdata - np.log(abs(lmb))
-        logvar = _log_var(logx)
+        logx = lmb * logdata
+        logvar = _log_var(logx) - 2 * np.log(abs(lmb))
 
     return (lmb - 1) * np.sum(logdata, axis=0) - N/2 * logvar
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -944,7 +944,7 @@ def boxcox_llf(lmb, data):
         # Transform without the constant offset 1/lmb.  The offset does
         # not affect the variance, and the subtraction of the offset can
         # lead to loss of precision.
-        # The sign of lmb at the denominator doesn't affect the variance.
+        # Division by lmb can be factored out to enhance numerical stability.
         logx = lmb * logdata
         logvar = _log_var(logx) - 2 * np.log(abs(lmb))
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1813,6 +1813,12 @@ class TestBoxcox_llf:
         # The expected value was computed with mpmath.
         assert_allclose(llf, -17.93934208579061)
 
+    def test_instability_gh20021(self):
+        data = [2003, 1950, 1997, 2000, 2009]
+        llf = stats.boxcox_llf(1e-8, data)
+        # The expected value was computed with mpmath.
+        assert_allclose(llf, -15.324012728710974)
+
 
 # This is the data from github user Qukaiyi, given as an example
 # of a data set that caused boxcox to fail.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1816,8 +1816,8 @@ class TestBoxcox_llf:
     def test_instability_gh20021(self):
         data = [2003, 1950, 1997, 2000, 2009]
         llf = stats.boxcox_llf(1e-8, data)
-        # The expected value was computed with mpmath.
-        assert_allclose(llf, -15.324012728710974)
+        # The expected value was computed with mpsci, set mpmath.mp.dps=100
+        assert_allclose(llf, -15.32401272869016598)
 
 
 # This is the data from github user Qukaiyi, given as an example


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Follow up #19604

#### What does this implement/fix?
<!--Please explain your changes.-->

The computation in `boxcox_llf` is not numerically stable around lambda=0.
This PR modify the computation of the log variance term as follows.

$$\begin{aligned}
\ln\sigma^2_{\psi_{\text{BC}}(\lambda,x)}
&= \ln\text{Var}[(x^\lambda-1)/\lambda] && x \text{ is the sample data} \\
&= \ln\text{Var}(x^\lambda/\lambda) && \text{ Ignore the subtraction of a constant} \\
&= \ln\lambda^{-2}\text{Var}(x^\lambda) && \text{Factor out the division by } \lambda \\
&= -2\ln|\lambda|+\ln\text{Var}(x^\lambda) \\
\end{aligned}$$

#### Additional information
<!--Any additional information you think is important.-->

Comparasion of the computation in linear space, log space old (main branch), log space new (this PR) around lambda=0.

<div align=center>
    <img src="https://github.com/scipy/scipy/assets/41134380/071a4556-b7db-443d-9226-45aa1de08690" width=40% height=40%>
</div>

<div align=center>
    <img src="https://github.com/scipy/scipy/assets/41134380/3183e05c-ef91-4867-ab12-f98019c40267" width=40% height=40%>
</div>

<div align=center>
    <img src="https://github.com/scipy/scipy/assets/41134380/8119e7ed-6fab-4e6f-ac65-005226b244a8" width=40% height=40%>
</div>

<details>

<summary>code</summary>

```python
import numpy as np
from scipy.stats._morestats import _log_var
import matplotlib.pyplot as plt


def boxcox_llf_linear_space(lmb, data):
    data = np.asarray(data)
    N = data.shape[0]
    if N == 0:
        return np.nan
    logdata = np.log(data)

    if lmb == 0:
        logvar = np.log(np.var(logdata, axis=0))
    else:
        logvar = np.log(np.var(data**lmb / lmb, axis=0))

    return (lmb - 1) * np.sum(logdata, axis=0) - N/2 * logvar


def boxcox_llf_log_space_old(lmb, data):
    data = np.asarray(data)
    N = data.shape[0]
    if N == 0:
        return np.nan
    logdata = np.log(data)

    if lmb == 0:
        logvar = np.log(np.var(logdata, axis=0))
    else:
        logx = lmb * logdata - np.log(abs(lmb))
        logvar = _log_var(logx)

    return (lmb - 1) * np.sum(logdata, axis=0) - N/2 * logvar


def boxcox_llf_log_space_new(lmb, data):
    data = np.asarray(data)
    N = data.shape[0]
    if N == 0:
        return np.nan
    logdata = np.log(data)

    if lmb == 0:
        logvar = np.log(np.var(logdata, axis=0))
    else:
        logx = lmb * logdata
        logvar = _log_var(logx) - 2 * np.log(abs(lmb))

    return (lmb - 1) * np.sum(logdata, axis=0) - N/2 * logvar

x = [2003, 1950, 1997, 2000, 2009]

lmbs = np.linspace(-1e-5, 1e-5, 100)

llf_linear = [boxcox_llf_linear_space(l, x) for l in lmbs]
llf_log_old = [boxcox_llf_log_space_old(l, x) for l in lmbs]
llf_log_new = [boxcox_llf_log_space_new(l, x) for l in lmbs]

fig_linear, ax_linear = plt.subplots()
fig_log_old, ax_log_old = plt.subplots()
fig_log_new, ax_log_new = plt.subplots()

ax_linear.set_title('linear space')
ax_log_old.set_title('log space (old)')
ax_log_new.set_title('log space (new)')

ax_linear.plot(lmbs, llf_linear)
ax_log_old.plot(lmbs, llf_log_old)
ax_log_new.plot(lmbs, llf_log_new)

ylim = ax_log_old.get_ylim()
ax_linear.set_ylim(ylim)
ax_log_new.set_ylim(ylim)

fig_linear.savefig('linear.png', bbox_inches='tight', dpi=600)
fig_log_old.savefig('log-old.png', bbox_inches='tight', dpi=600)
fig_log_new.savefig('log-new.png', bbox_inches='tight', dpi=600)
```

</details>