### PR TITLE
ENH: use analytic formula for log-laplace MLE when loc is known.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6385,6 +6385,7 @@ class loglaplace_gen(rv_continuous):
         return np.log(2.0/c) + 1.0
 
     @_call_super_mom
+    @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
         data, fc, floc, fscale = _check_fit_input_parameters(self, data,
                                                              args, kwds)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6411,11 +6411,10 @@ class loglaplace_gen(rv_continuous):
                            floc=np.log(fscale) if fscale is not None else None,
                            fscale=1/fc if fc is not None else None,
                            method='mle')
-        if fscale is None:
-            fscale = np.exp(a)
-        if fc is None:
-            fc = 1 / b
-        return fc, floc, fscale
+        loc = floc
+        scale = np.exp(a) if fscale is None else fscale
+        c = 1 / b if fc is None else fc
+        return c, loc, scale
 
 loglaplace = loglaplace_gen(a=0.0, name='loglaplace')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6405,15 +6405,16 @@ class loglaplace_gen(rv_continuous):
         # the Laplace distribution in that if X ~ Laplace(loc=a, scale=b),
         # then Y = exp(X) ~ LogLaplace(c=1/b, loc=0, scale=exp(a)).  It can
         # be shown that the MLE for Y is the same as the MLE for X = ln(Y).
-        # Therefore, we adapt the formulas from laplace.fit(), transformed
-        # into log-laplace's parameter space.
-
+        # Therefore, we reuse the formulas from laplace.fit() and transform
+        # the result back into log-laplace's parameter space.
+        a, b = laplace.fit(np.log(data),
+                           floc=np.log(fscale) if fscale is not None else None,
+                           fscale=1/fc if fc is not None else None,
+                           method='mle')
         if fscale is None:
-            fscale = np.median(data)
-
+            fscale = np.exp(a)
         if fc is None:
-            fc = 1 / np.mean(np.abs(np.log(data) - np.log(fscale)))
-
+            fc = 1 / b
         return fc, floc, fscale
 
 loglaplace = loglaplace_gen(a=0.0, name='loglaplace')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -248,7 +248,8 @@ class TestVonMises:
         assert -np.pi < loc_fit < np.pi
 
 
-def _assert_less_or_close_loglike(dist, data, func=None, **kwds):
+def _assert_less_or_close_loglike(dist, data, func=None, maybe_identical=False,
+                                  **kwds):
     """
     This utility function checks that the negative log-likelihood function
     (or `func`) of the result computed using dist.fit() is less than or equal
@@ -261,6 +262,13 @@ def _assert_less_or_close_loglike(dist, data, func=None, **kwds):
 
     mle_analytical = dist.fit(data, **kwds)
     numerical_opt = super(type(dist), dist).fit(data, **kwds)
+
+    # Sanity check that the analytical MLE is actually executed.
+    # Due to floating point arithmetic, the generic MLE is unlikely
+    # to produce the exact same result as the analytical MLE.
+    if not maybe_identical:
+        assert np.any(mle_analytical != numerical_opt)
+
     ll_mle_analytical = func(mle_analytical, data)
     ll_numerical_opt = func(numerical_opt, data)
     assert (ll_mle_analytical <= ll_numerical_opt or
@@ -1177,7 +1185,10 @@ class TestHalfNorm:
         if fix_scale:
             kwds['fscale'] = rvs_scale
 
-        _assert_less_or_close_loglike(stats.halfnorm, data, **kwds)
+        # Numerical result may equal analytical result if the initial guess
+        # computed from moment condition is already optimal.
+        _assert_less_or_close_loglike(stats.halfnorm, data, **kwds,
+                                      maybe_identical=True)
 
     def test_fit_error(self):
         # `floc` bigger than the minimal data point
@@ -1270,7 +1281,10 @@ class TestHalfLogistic:
         if fix_scale:
             kwds['fscale'] = rvs_scale
 
-        _assert_less_or_close_loglike(stats.halflogistic, data, **kwds)
+        # Numerical result may equal analytical result if the initial guess
+        # computed from moment condition is already optimal.
+        _assert_less_or_close_loglike(stats.halflogistic, data, **kwds,
+                                      maybe_identical=True)
 
     def test_fit_bad_floc(self):
         msg = r" Maximum likelihood estimation with 'halflogistic' requires"
@@ -3147,7 +3161,11 @@ class TestPowerlaw:
             kwds['floc'] = np.nextafter(data.min(), -np.inf)
         if fix_scale:
             kwds['fscale'] = rvs_scale
-        _assert_less_or_close_loglike(stats.powerlaw, data, **kwds)
+
+        # Numerical result may equal analytical result if some code path
+        # of the analytical routine makes use of numerical optimization.
+        _assert_less_or_close_loglike(stats.powerlaw, data, **kwds,
+                                      maybe_identical=True)
 
     def test_problem_case(self):
         # An observed problem with the test method indicated that some fixed
@@ -4300,7 +4318,10 @@ class TestLognorm:
         if fix_scale:
             kwds['fscale'] = rvs_scale
 
-        _assert_less_or_close_loglike(stats.lognorm, data, **kwds)
+        # Numerical result may equal analytical result if some code path
+        # of the analytical routine makes use of numerical optimization.
+        _assert_less_or_close_loglike(stats.lognorm, data, **kwds,
+                                      maybe_identical=True)
 
     def test_isf(self):
         # reference values were computed via the reference distribution, e.g.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3115,12 +3115,12 @@ class TestLogLaplace:
         data = stats.loglaplace.rvs(c, loc=loc, scale=scale, size=100,
                                     random_state=rng)
 
-        kwds = {'method': 'mle', 'floc': loc}
+        kwds = {'floc': loc}
         if fix_c:
             kwds['fc'] = c
         if fix_scale:
             kwds['fscale'] = scale
-        nfree = 4 - len(kwds)
+        nfree = 3 - len(kwds)
 
         if nfree == 0:
             error_msg = "All parameters fixed. There is nothing to optimize."

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3089,6 +3089,46 @@ class TestLogLaplace:
         # r-th non-central moment is non-finite (inf or nan) if r >= c.
         assert not np.any(np.isfinite(stats.loglaplace.stats(c, moments=mom)))
 
+    @pytest.mark.parametrize("c", [0.5, 1.0, 2.0])
+    @pytest.mark.parametrize("loc, scale", [(-1.2, 3.45)])
+    @pytest.mark.parametrize("fix_c", [True, False])
+    @pytest.mark.parametrize("fix_loc", [True])
+    @pytest.mark.parametrize("fix_scale", [True, False])
+    def test_fit_analytic_mle(self, c, loc, scale, fix_c, fix_loc, fix_scale):
+        # Test that the analytic MLE produces the same result as the generic
+        # (numerical) MLE.
+
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.loglaplace.rvs(c, loc=loc, scale=scale, size=100,
+                                    random_state=rng)
+
+        kwds = {}
+        if fix_c:
+            kwds['fc'] = c
+        if fix_loc:
+            kwds['floc'] = loc
+        if fix_scale:
+            kwds['fscale'] = scale
+        nfree = 3 - len(kwds)
+
+        if nfree == 0:
+            error_msg = "All parameters fixed. There is nothing to optimize."
+            with pytest.raises((RuntimeError, ValueError), match=error_msg):
+                stats.loglaplace.fit(data, method='mle', **kwds)
+            return
+
+        generic_args = super(type(stats.loglaplace),
+                             stats.loglaplace).fit(data, **kwds, method='mle')
+        analytic_args = stats.loglaplace.fit(data, **kwds, method='mle')
+
+        # Sanity check that the specialized MLE is actually executed.
+        # Due to floating point arithmetic, the generic MLE is unlikely
+        # to produce the exact same result as the analytic MLE.
+        assert np.any(generic_args != analytic_args)
+
+        generic_ll = -stats.loglaplace.nnlf(generic_args, data)
+        analytic_ll = -stats.loglaplace.nnlf(analytic_args, data)
+        assert np.allclose(analytic_ll, generic_ll)
 
 class TestPowerlaw:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-19996.

#### What does this implement/fix?
When `floc` is provided, use a closed-form formula to compute the MLE for log-laplace distribution. The estimator is consistent.

#### Additional information
MLE when `floc` is unknown is discussed in gh-19996, and is shown to be inconsistent in some cases. Therefore the MLE is not specialised for `floc` unknown.

Separately, closed-form expressions for the moment estimator when `floc` is known are given in gh-19996, and are shown to be inconsistent for many parameter combinations. Therefore MM estimator should not be used for log-laplace in practice.