### PR TITLE
MAINT: Adjust some comments in special C++ library

### DIFF
--- a/scipy/special/special/binom.h
+++ b/scipy/special/special/binom.h
@@ -1,4 +1,11 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ *
+ * Original authors: Pauli Virtanen, Eric Moore
+ */
+
+
 // Binomial coefficient
+
 #pragma once
 
 #include "config.h"

--- a/scipy/special/special/binom.h
+++ b/scipy/special/special/binom.h
@@ -3,7 +3,6 @@
  * Original authors: Pauli Virtanen, Eric Moore
  */
 
-
 // Binomial coefficient
 
 #pragma once

--- a/scipy/special/special/cephes/beta.h
+++ b/scipy/special/special/cephes/beta.h
@@ -2,7 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
 /*                                                     beta.c
  *
  *     Beta function

--- a/scipy/special/special/cephes/beta.h
+++ b/scipy/special/special/cephes/beta.h
@@ -1,3 +1,8 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+
 /*                                                     beta.c
  *
  *     Beta function

--- a/scipy/special/special/cephes/const.h
+++ b/scipy/special/special/cephes/const.h
@@ -5,7 +5,6 @@
  * supporting other arithmetic types has been removed.
  */
 
-
 /*
  *
  *

--- a/scipy/special/special/cephes/const.h
+++ b/scipy/special/special/cephes/const.h
@@ -1,7 +1,12 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ *
+ * Since we support only IEEE-754 floating point numbers, conditional logic
+ * supporting other arithmetic types has been removed.
+ */
+
+
 /*
- * Taken from Stephen Moshier's cephes library. Since we support only IEEE-754
- * floating point numbers, conditional logic supporting other arithmetic types
- * is removed. Original header comment appears unmodified below.
  *
  *
  *                                                   const.c

--- a/scipy/special/special/cephes/gamma.h
+++ b/scipy/special/special/cephes/gamma.h
@@ -1,3 +1,8 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+
 /*
  *     Gamma function
  *

--- a/scipy/special/special/cephes/gamma.h
+++ b/scipy/special/special/cephes/gamma.h
@@ -2,7 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
 /*
  *     Gamma function
  *

--- a/scipy/special/special/cephes/polevl.h
+++ b/scipy/special/special/cephes/polevl.h
@@ -1,3 +1,9 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+
+
 /*                                                     polevl.c
  *                                                     p1evl.c
  *

--- a/scipy/special/special/cephes/polevl.h
+++ b/scipy/special/special/cephes/polevl.h
@@ -2,8 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
-
 /*                                                     polevl.c
  *                                                     p1evl.c
  *

--- a/scipy/special/special/cephes/psi.h
+++ b/scipy/special/special/cephes/psi.h
@@ -2,7 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
 /*                                                     psi.c
  *
  *     Psi (digamma) function

--- a/scipy/special/special/cephes/psi.h
+++ b/scipy/special/special/cephes/psi.h
@@ -1,3 +1,8 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+
 /*                                                     psi.c
  *
  *     Psi (digamma) function

--- a/scipy/special/special/cephes/trig.h
+++ b/scipy/special/special/cephes/trig.h
@@ -3,7 +3,6 @@
  * Original author: Josh Wilson, 2020.
  */
 
-
 /*
  * Implement sin(pi * x) and cos(pi * x) for real x. Since the periods
  * of these functions are integral (and thus representable in double

--- a/scipy/special/special/cephes/trig.h
+++ b/scipy/special/special/cephes/trig.h
@@ -1,3 +1,9 @@
+/* Translated into C++ by SciPy developers in 2024.
+ *
+ * Original author: Josh Wilson, 2020.
+ */
+
+
 /*
  * Implement sin(pi * x) and cos(pi * x) for real x. Since the periods
  * of these functions are integral (and thus representable in double

--- a/scipy/special/special/cephes/zeta.h
+++ b/scipy/special/special/cephes/zeta.h
@@ -2,7 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
 /*                                                     zeta.c
  *
  *     Riemann zeta function of two arguments

--- a/scipy/special/special/cephes/zeta.h
+++ b/scipy/special/special/cephes/zeta.h
@@ -1,3 +1,8 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+
 /*                                                     zeta.c
  *
  *     Riemann zeta function of two arguments

--- a/scipy/special/special/digamma.h
+++ b/scipy/special/special/digamma.h
@@ -1,9 +1,10 @@
-#pragma once
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ * Original header comment appears below.
+ */
 
 /* An implementation of the digamma function for complex arguments.
  *
  * Author: Josh Wilson
- * Translated from Cython to C++ by SciPy developers 2023.
  *
  * Distributed under the same license as Scipy.
  *
@@ -12,6 +13,8 @@
  *
  * [2] mpmath (version 0.19), http://mpmath.org
  */
+
+#pragma once
 
 #include "cephes/psi.h"
 #include "cephes/zeta.h"

--- a/scipy/special/special/evalpoly.h
+++ b/scipy/special/special/evalpoly.h
@@ -1,3 +1,9 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ *
+ * Original author: Josh Wilson, 2016.
+ */
+
+
 /* Evaluate polynomials.
  *
  * All of the coefficients are stored in reverse order, i.e. if the

--- a/scipy/special/special/evalpoly.h
+++ b/scipy/special/special/evalpoly.h
@@ -3,7 +3,6 @@
  * Original author: Josh Wilson, 2016.
  */
 
-
 /* Evaluate polynomials.
  *
  * All of the coefficients are stored in reverse order, i.e. if the

--- a/scipy/special/special/lambertw.h
+++ b/scipy/special/special/lambertw.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "config.h"
 #include "error.h"
 #include "evalpoly.h"
 

--- a/scipy/special/special/lambertw.h
+++ b/scipy/special/special/lambertw.h
@@ -2,7 +2,6 @@
  * Original header with Copyright information appears below.
  */
 
-
 /* Implementation of the Lambert W function [1]. Based on MPMath
  *  Implementation [2], and documentation [3].
  *

--- a/scipy/special/special/lambertw.h
+++ b/scipy/special/special/lambertw.h
@@ -1,3 +1,8 @@
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ * Original header with Copyright information appears below.
+ */
+
+
 /* Implementation of the Lambert W function [1]. Based on MPMath
  *  Implementation [2], and documentation [3].
  *
@@ -5,7 +10,7 @@
  * Author email: mellerf@netvision.net.il
  *
  * Distributed under the same license as SciPy
- * Translated into C++ by SciPy developers, 2023.
+ *
  *
  * References:
  * [1] On the Lambert W function, Adv. Comp. Math. 5 (1996) 329-359,

--- a/scipy/special/special/loggamma.h
+++ b/scipy/special/special/loggamma.h
@@ -19,7 +19,6 @@
  *     https://github.com/JuliaLang/julia/blob/master/base/special/gamma.jl
  */
 
-
 #pragma once
 
 #include "cephes/gamma.h"

--- a/scipy/special/special/loggamma.h
+++ b/scipy/special/special/loggamma.h
@@ -1,11 +1,12 @@
-#pragma once
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ * Original header comment appears below.
+ */
 
 /* An implementation of the principal branch of the logarithm of
  * Gamma. Also contains implementations of Gamma and 1/Gamma which are
  * easily computed from log-Gamma.
  *
  * Author: Josh Wilson
- * Translated from Cython to C++ in 2023 by SciPy developers.
  *
  * Distributed under the same license as Scipy.
  *
@@ -17,6 +18,9 @@
  * [2] Julia,
  *     https://github.com/JuliaLang/julia/blob/master/base/special/gamma.jl
  */
+
+
+#pragma once
 
 #include "cephes/gamma.h"
 #include "config.h"

--- a/scipy/special/special/trig.h
+++ b/scipy/special/special/trig.h
@@ -1,10 +1,12 @@
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ *
+ * Original author: Josh Wilson, 2016.
+ */
+
 /* Implement sin(pi*z) and cos(pi*z) for complex z. Since the periods
  * of these functions are integral (and thus better representable in
  * floating point), it's possible to compute them with greater accuracy
  * than sin(z), cos(z).
- *
- * Originally written in Cython by Josh Wilson (github @person142) 2016.
- * Translated to C++ by SciPy developers in 2023.
  */
 
 #pragma once

--- a/scipy/special/special/zlog1.h
+++ b/scipy/special/special/zlog1.h
@@ -1,8 +1,10 @@
-#pragma once
-
-/* Author: Josh Wilson 2016
- * Translated from Cython to C++ by SciPy developers 2023.
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ *
+ * Original author: Josh Wilson, 2016.
  */
+
+
+#pragma once
 
 #include "config.h"
 

--- a/scipy/special/special/zlog1.h
+++ b/scipy/special/special/zlog1.h
@@ -3,7 +3,6 @@
  * Original author: Josh Wilson, 2016.
  */
 
-
 #pragma once
 
 #include "config.h"


### PR DESCRIPTION
This PR adds more consistent header comments at the top of files in the special function C++ library that's now under construction. This comments point out that the files have recently been translated into C++, and that the original header comments are below. I've also added a missing `#include "config.h"` to `lambertw.h`. The absence of this include is not felt because `config.h` is transitively included from `error.h`, but I think it's still better to be explicit here.

The header comment adjustments are motivated by comments such as this one, https://github.com/scipy/scipy/pull/19954#discussion_r1464237235, by @h-vetinari in the `wright_bessel` PR, https://github.com/scipy/scipy/pull/19954. It should be more clear that these files are translations, and the original header comments are being preserved from the original files.

@rlucas7, this should be a quick one if you have time to look at it.