### PR TITLE
MAINT: sparse: Un-deprecate getnnz()

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1422,11 +1422,6 @@ settable. To change the array shape, use `X.reshape` instead.
     def getnnz(self, axis=None):
         """Number of stored values, including explicit zeros.
 
-        .. deprecated:: 1.11.0
-           This method will be removed in SciPy 1.14.0. Use `X.nnz`
-           instead.  The `axis` argument will no longer be supported;
-           please let us know if you still need this functionality.
-
         Parameters
         ----------
         axis : None, 0, or 1
@@ -1437,11 +1432,6 @@ settable. To change the array shape, use `X.reshape` instead.
         --------
         count_nonzero : Number of non-zero entries
         """
-        msg = (
-            "`getnnz` is deprecated and will be removed in v1.14.0; "
-            "use `X.nnz` instead."
-        )
-        warn(msg, DeprecationWarning, stacklevel=2)
         return self._getnnz(axis=axis)
 
     def getH(self):

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -22,9 +22,6 @@ def test_array_api_deprecations():
         X.getmaxprint()
 
     with pytest.deprecated_call(match=msg):
-        X.getnnz()
-
-    with pytest.deprecated_call(match=msg):
         X.getH()
 
     with pytest.deprecated_call(match=msg):


### PR DESCRIPTION
We deprecated several methods on sparse array classes in gh-18507, but this PR reverts the deprecation notice for `getnnz()`. This is because we don't currently have a replacement for the `axis=` keyword argument usage, and we don't want to leave users to implement the logic themselves.

When/if we add a better method for finding the number of stored entries beyond a simple scalar count, we can re-deprecate this.