### PR TITLE
BUG: spatial.HalfspaceIntersection: raise on non-feasible half space

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2935,6 +2935,16 @@ class HalfspaceIntersection(_QhullUser):
         of halfspaces is also not possible after `close` has been called.
 
         """
+        # We check for non-feasibility of incremental additions
+        # in a manner similar to `qh_sethalfspace`
+        halfspaces = np.atleast_2d(halfspaces)
+        dims = halfspaces.shape[1] - 1
+        for halfspace in halfspaces:
+            dist = halfspace[-1]
+            dist += np.dot(halfspace[:dims], self.interior_point[:dims])
+            if dist > 0:
+                msg = f"feasible point is not clearly inside halfspace: {halfspace}"
+                raise QhullError(msg)
         self._add_points(halfspaces, restart, self.interior_point)
 
     @property

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2935,6 +2935,8 @@ class HalfspaceIntersection(_QhullUser):
         of halfspaces is also not possible after `close` has been called.
 
         """
+        if halfspaces.ndim > 2:
+            raise ValueError("`halfspaces` should be provided as a 2D array")
         # We check for non-feasibility of incremental additions
         # in a manner similar to `qh_sethalfspace`
         halfspaces = np.atleast_2d(halfspaces)
@@ -2942,7 +2944,7 @@ class HalfspaceIntersection(_QhullUser):
         # HalfspaceIntersection uses closed half spaces so
         # the feasible point also cannot be directly on the boundary
         viols = dists >= 0
-        if viols.sum() > 0:
+        if viols.any():
             # error out with an indication of the first violating
             # half space discovered
             first_viol = np.nonzero(viols)[0].min()

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1186,6 +1186,7 @@ class Test_HalfspaceIntersection:
 
         assert_allclose(hs.dual_points, qhalf_points)
 
+
     @pytest.mark.parametrize("k", range(1,4))
     def test_halfspace_batch(self, k):
         # Test that we can add halfspaces a few at a time
@@ -1219,6 +1220,34 @@ class Test_HalfspaceIntersection:
         ind1 = np.lexsort((actual_intersections[:, 1], actual_intersections[:, 0]))
         ind2 = np.lexsort((expected_intersections[:, 1], expected_intersections[:, 0]))
         assert_allclose(actual_intersections[ind1], expected_intersections[ind2])
+
+
+    @pytest.mark.parametrize("halfspaces", [
+    (np.array([-0.70613882, -0.45589431, 0.04178256])),
+    (np.array([[-0.70613882, -0.45589431,  0.04178256],
+               [0.70807342, -0.45464871, -0.45969769],
+               [0.,  0.76515026, -0.35614825]])),
+    ])
+    def test_gh_19865(self, halfspaces):
+        # starting off with a feasible interior point and
+        # adding halfspaces for which it is no longer feasible
+        # should result in an error rather than a problematic
+        # intersection polytope
+        initial_square =  np.array(
+                    [[1, 0, -1], [0, 1, -1], [-1, 0, -1], [0, -1, -1]]
+                )
+        incremental_intersector = qhull.HalfspaceIntersection(initial_square,
+                                                              np.zeros(2),
+                                                              incremental=True)
+        with pytest.raises(qhull.QhullError, match="feasible"):
+            if halfspaces.ndim == 2:
+                # add a few 2d half spaces
+                for h in halfspaces:
+                    incremental_intersector.add_halfspaces(h[np.newaxis])
+            else:
+                # add a 1d half space
+                incremental_intersector.add_halfspaces(halfspaces)
+
 
 @pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
 def test_gh_20623(diagram_type):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1261,6 +1261,31 @@ class Test_HalfspaceIntersection:
             incremental_intersector.add_halfspaces(halfspaces)
 
 
+    def test_2d_add_halfspace_input(self):
+        # incrementally added halfspaces should respect the 2D
+        # array shape requirement
+        initial_square =  np.array(
+                    [[1, 0, -1], [0, 1, -1], [-1, 0, -1], [0, -1, -1]]
+                )
+        incremental_intersector = qhull.HalfspaceIntersection(initial_square,
+                                                              np.zeros(2),
+                                                              incremental=True)
+        with pytest.raises(ValueError, match="2D array"):
+            incremental_intersector.add_halfspaces(np.ones((4, 4, 4)))
+
+    def test_1d_add_halfspace_input(self):
+        # we do allow 1D `halfspaces` input to add_halfspaces()
+        initial_square =  np.array(
+                    [[1, 0, -1], [0, 1, -1], [-1, 0, -1], [0, -1, -1]]
+                )
+        incremental_intersector = qhull.HalfspaceIntersection(initial_square,
+                                                              np.zeros(2),
+                                                              incremental=True)
+        assert_allclose(incremental_intersector.dual_vertices, np.arange(4))
+        incremental_intersector.add_halfspaces(np.array([2, 2, -1]))
+        assert_allclose(incremental_intersector.dual_vertices, np.arange(5))
+
+
 @pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
 def test_gh_20623(diagram_type):
     rng = np.random.default_rng(123)


### PR DESCRIPTION
* Fixes #19865

* Rather than returning a problematic half space intersection polytope, we raise an error for incremental processing when a new half space is added for which the interior point is no longer clearly interior

[skip cirrus]