### PR TITLE
MAINT: Add special handling for complex infinite input in digamma

### DIFF
--- a/scipy/special/special/digamma.h
+++ b/scipy/special/special/digamma.h
@@ -93,6 +93,14 @@ namespace detail {
         std::complex<double> term;
         std::complex<double> res;
 
+        if (!(std::isfinite(z.real()) && std::isfinite(z.imag()))) {
+            /* Check for infinity (or nan) and return early.
+             * Result of division by complex infinity is implementation dependent.
+             * and has been observed to vary between C++ stdlib and CUDA stdlib.
+             */
+            return std::log(z);
+        }
+
         res = std::log(z) - 0.5 / z;
 
         for (int k = 1; k < 17; k++) {


### PR DESCRIPTION
This PR changes how complex infinite input is handled in the `digamma` function to not depend on the outcome of a division by complex infinity. While working on a PR to add `digamma` to CuPy, https://github.com/cupy/cupy/pull/8163, I found that the outcome of division by complex infinity is not specified in the C++ standard library; it is implementation dependent. On my machine, when using the regular C++ standard library,  `1/(inf + 0j)` evaluates to `0i`, but using `thrust::complex` in CUDA, `1/(inf + 0j)` evaluates to `nan + nan*1j`. (I've used Python notation for complex numbers for the sake of clarity).

This division occurs in the asymptotic expansion for `digamma`, `log(z) - 0.5/z`. Since the `O(1/z)` term is negligible for infinite input, I've modified the code to check for infinity and simply return `log(z)` in those cases. `log(z)` handles infinities in different complex directions, which is why it is useful to have here (https://en.cppreference.com/w/cpp/numeric/complex/log).

cc @rlucas7 @izaid 


