### PR TITLE
ENH: use analytical formula in scipy.stats.powerlaw._munp().

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8221,6 +8221,10 @@ class powerlaw_gen(rv_continuous):
     def _sf(self, p, a):
         return -sc.powm1(p, a)
 
+    def _munp(self, n, a):
+        # The following expression is correct for all real n (provided a > 0).
+        return a / (a + n)
+
     def _stats(self, a):
         return (a / (a + 1.0),
                 a / (a + 2.0) / (a + 1.0) ** 2,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3099,6 +3099,12 @@ class TestPowerlaw:
     def test_sf(self, x, a, sf):
         assert_allclose(stats.powerlaw.sf(x, a), sf, rtol=1e-15)
 
+    @pytest.mark.parametrize('r', [1, 5, 10])
+    @pytest.mark.parametrize('a', [0.1, 1, 2.5])
+    def test_moment(self, r, a):
+        assert_allclose(stats.powerlaw.moment(r, a),
+                        stats.powerlaw.expect((lambda x: x ** r), (a,)))
+
     @pytest.fixture(scope='function')
     def rng(self):
         return np.random.default_rng(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3099,12 +3099,6 @@ class TestPowerlaw:
     def test_sf(self, x, a, sf):
         assert_allclose(stats.powerlaw.sf(x, a), sf, rtol=1e-15)
 
-    @pytest.mark.parametrize('r', [1, 5, 10])
-    @pytest.mark.parametrize('a', [0.1, 1, 2.5])
-    def test_moment(self, r, a):
-        assert_allclose(stats.powerlaw.moment(r, a),
-                        stats.powerlaw.expect((lambda x: x ** r), (a,)))
-
     @pytest.fixture(scope='function')
     def rng(self):
         return np.random.default_rng(1234)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-20036.

#### What does this implement/fix?
Use analytical formula in `scipy.stats.powerlaw._munp`. The formula is derived by simple integration, and elaborated in gh-20036.

#### Additional information
A simple unit test case is supplied.