### PR TITLE
FIX: Allow any dtype-specifier for ndimage output

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -87,7 +87,7 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        output = np.dtype(output)
+        output = numpy.dtype(output)
         if complex_output and output.kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -87,14 +87,8 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        # testsuite only appears to cover
-        # f->np.float32 here
-        f_dict = {"f": numpy.float32,
-                  "d": numpy.float64,
-                  "F": numpy.complex64,
-                  "D": numpy.complex128}
-        output = f_dict[output]
-        if complex_output and numpy.dtype(output).kind != 'c':
+        output = np.dtype(output)
+        if complex_output and output.kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)
     elif output.shape != shape:

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -90,6 +90,8 @@ def _get_output(output, input, shape=None, complex_output=False):
         output = numpy.dtype(output)
         if complex_output and output.kind != 'c':
             raise RuntimeError("output must have complex dtype")
+        elif not issubclass(output.type, numpy.number):
+            raise RuntimeError("output must have numeric dtype")
         output = numpy.zeros(shape, dtype=output)
     elif output.shape != shape:
         raise RuntimeError("output shape not correct")

--- a/scipy/ndimage/tests/meson.build
+++ b/scipy/ndimage/tests/meson.build
@@ -8,6 +8,7 @@ python_sources = [
   'test_interpolation.py',
   'test_measurements.py',
   'test_morphology.py',
+  'test_ni_support.py',
   'test_splines.py'
 ]
 

--- a/scipy/ndimage/tests/test_ni_support.py
+++ b/scipy/ndimage/tests/test_ni_support.py
@@ -1,0 +1,74 @@
+import pytest
+
+import numpy as np
+from .._ni_support import _get_output
+
+
+@pytest.mark.parametrize(
+    ('output', 'in_spec', 'shape', 'cplx_out', 'expect_spec', 'error'),
+    [
+        # Different ways to spell float32
+        ('f', ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        ('f4', ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        ('float32', ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        (np.float32, ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        (np.dtype('float32'), ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        # Float64
+        ('float', ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float64'), None),
+        ('float64', ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float64'), None),
+        (np.float64, ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float64'), None),
+        (float, ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float64'), None),
+        # Complex output
+        ('complex64', ((2, 3), 'float32'), None, True,
+         ((2, 3), 'complex64'), None),
+        ('F', ((2, 3), 'float32'), None, True,
+         ((2, 3), 'complex64'), None),
+        (np.complex64, ((2, 3), 'float32'), None, True,
+         ((2, 3), 'complex64'), None),
+        (complex, ((2, 3), 'float32'), None, True,
+         ((2, 3), 'complex128'), None),
+        # Pre-allocated arrays - shape must match input shape or explicit shape
+        (np.zeros((2, 3), 'float32'), ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        (np.zeros((2, 3), 'float64'), ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float64'), None),
+        (np.zeros((3, 2), 'float32'), ((2, 3), 'float32'), (3, 2), False,
+         ((3, 2), 'float32'), None),
+        # None output follows input, shape and complex_output
+        (None, ((2, 3), 'float32'), None, False,
+         ((2, 3), 'float32'), None),
+        (None, ((2, 3), 'float32'), (3, 2), False,
+         ((3, 2), 'float32'), None),
+        (None, ((2, 3), 'float32'), None, True,
+         ((2, 3), 'complex64'), None),
+        (None, ((2, 3), 'float64'), None, True,
+         ((2, 3), 'complex128'), None),
+        # Error cases
+        ('float32', ((2, 3), 'float32'), None, True,
+         None, "output must have complex dtype"),
+        ('void', ((2, 3), 'float32'), None, False,
+         None, "output must have numeric dtype"),
+        (np.zeros((3, 2)), ((2, 3), 'float32'), None, False,
+         None, "shape not correct"),
+        (np.zeros((2, 3)), ((2, 3), 'float32'), None, True,
+         None, "output must have complex dtype"),
+    ],
+)
+def test_get_output_defaults(output, in_spec, shape, cplx_out, expect_spec, error):
+    input = np.zeros(*in_spec)
+    if expect_spec is None:
+        with pytest.raises(RuntimeError, match=error):
+            _get_output(output, input, shape=shape, complex_output=cplx_out)
+    else:
+        result = _get_output(output, input, shape=shape, complex_output=cplx_out)
+        assert result.shape == expect_spec[0]
+        assert result.dtype == np.dtype(expect_spec[1])

--- a/scipy/ndimage/tests/test_ni_support.py
+++ b/scipy/ndimage/tests/test_ni_support.py
@@ -5,70 +5,73 @@ from .._ni_support import _get_output
 
 
 @pytest.mark.parametrize(
-    ('output', 'in_spec', 'shape', 'cplx_out', 'expect_spec', 'error'),
+    'dtype',
     [
-        # Different ways to spell float32
-        ('f', ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        ('f4', ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        ('float32', ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        (np.float32, ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        (np.dtype('float32'), ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        # Float64
-        ('float', ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float64'), None),
-        ('float64', ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float64'), None),
-        (np.float64, ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float64'), None),
-        (float, ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float64'), None),
-        # Complex output
-        ('complex64', ((2, 3), 'float32'), None, True,
-         ((2, 3), 'complex64'), None),
-        ('F', ((2, 3), 'float32'), None, True,
-         ((2, 3), 'complex64'), None),
-        (np.complex64, ((2, 3), 'float32'), None, True,
-         ((2, 3), 'complex64'), None),
-        (complex, ((2, 3), 'float32'), None, True,
-         ((2, 3), 'complex128'), None),
-        # Pre-allocated arrays - shape must match input shape or explicit shape
-        (np.zeros((2, 3), 'float32'), ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        (np.zeros((2, 3), 'float64'), ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float64'), None),
-        (np.zeros((3, 2), 'float32'), ((2, 3), 'float32'), (3, 2), False,
-         ((3, 2), 'float32'), None),
-        # None output follows input, shape and complex_output
-        (None, ((2, 3), 'float32'), None, False,
-         ((2, 3), 'float32'), None),
-        (None, ((2, 3), 'float32'), (3, 2), False,
-         ((3, 2), 'float32'), None),
-        (None, ((2, 3), 'float32'), None, True,
-         ((2, 3), 'complex64'), None),
-        (None, ((2, 3), 'float64'), None, True,
-         ((2, 3), 'complex128'), None),
-        # Error cases
-        ('float32', ((2, 3), 'float32'), None, True,
-         None, "output must have complex dtype"),
-        ('void', ((2, 3), 'float32'), None, False,
-         None, "output must have numeric dtype"),
-        (np.zeros((3, 2)), ((2, 3), 'float32'), None, False,
-         None, "shape not correct"),
-        (np.zeros((2, 3)), ((2, 3), 'float32'), None, True,
-         None, "output must have complex dtype"),
+        # String specifiers
+        'f4', 'float32', 'complex64', 'complex128',
+        # Type and dtype specifiers
+        np.float32, float, np.dtype('f4'),
+        # Derive from input
+        None,
     ],
 )
-def test_get_output_defaults(output, in_spec, shape, cplx_out, expect_spec, error):
-    input = np.zeros(*in_spec)
-    if expect_spec is None:
-        with pytest.raises(RuntimeError, match=error):
-            _get_output(output, input, shape=shape, complex_output=cplx_out)
-    else:
-        result = _get_output(output, input, shape=shape, complex_output=cplx_out)
-        assert result.shape == expect_spec[0]
-        assert result.dtype == np.dtype(expect_spec[1])
+def test_get_output_basic(dtype):
+    shape = (2, 3)
+
+    input_ = np.zeros(shape, 'float32')
+
+    # For None, derive dtype from input
+    expected_dtype = 'float32' if dtype is None else dtype
+
+    # Output is dtype-specifier, retrieve shape from input
+    result = _get_output(dtype, input_)
+    assert result.shape == shape
+    assert result.dtype == np.dtype(expected_dtype)
+
+    # Output is dtype specifier, with explicit shape, overriding input
+    result = _get_output(dtype, input_, shape=(3, 2))
+    assert result.shape == (3, 2)
+    assert result.dtype == np.dtype(expected_dtype)
+
+    # Output is pre-allocated array, return directly
+    output = np.zeros(shape, dtype)
+    result = _get_output(output, input_)
+    assert result is output
+
+
+def test_get_output_complex():
+    shape = (2, 3)
+
+    input_ = np.zeros(shape)
+
+    # None, promote input type to complex
+    result = _get_output(None, input_, complex_output=True)
+    assert result.shape == shape
+    assert result.dtype == np.dtype('complex128')
+
+    # Explicit type, promote type to complex
+    with pytest.warns(UserWarning, match='promoting specified output dtype to complex'):
+        result = _get_output(float, input_, complex_output=True)
+    assert result.shape == shape
+    assert result.dtype == np.dtype('complex128')
+
+    # String specifier, simply verify complex output
+    result = _get_output('complex64', input_, complex_output=True)
+    assert result.shape == shape
+    assert result.dtype == np.dtype('complex64')
+
+
+def test_get_output_error_cases():
+    input_ = np.zeros((2, 3), 'float32')
+
+    # Two separate paths can raise the same error
+    with pytest.raises(RuntimeError, match='output must have complex dtype'):
+        _get_output('float32', input_, complex_output=True)
+    with pytest.raises(RuntimeError, match='output must have complex dtype'):
+        _get_output(np.zeros((2, 3)), input_, complex_output=True)
+
+    with pytest.raises(RuntimeError, match='output must have numeric dtype'):
+        _get_output('void', input_)
+
+    with pytest.raises(RuntimeError, match='shape not correct'):
+        _get_output(np.zeros((3, 2)), input_)


### PR DESCRIPTION
#### Reference issue
Fixes bug introduced in gh-18841.

#### What does this implement/fix?
As of #18841, calling `ndimage.map_coordinates(..., output='float32')` fails with:

```python
File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/sdcflows/transform.py", line 105, in _sdc_unwarp
	resampled = ndi.map_coordinates(
	            ^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/scipy/ndimage/_interpolation.py", line 455, in map_coordinates
	output = _ni_support._get_output(output, input, shape=output_shape,
	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/scipy/ndimage/_ni_support.py", line 96, in _get_output
	output = f_dict[output]
	         ~~~~~~^^^^^^^^
KeyError: 'float32'
```

This replaced `output = np.sctypeDict[output]`, which would normalize scalar types to their numpy types. Looking at the codes in that `dict`, it is basically equivalent to:

```Python
def __getitem__(self, key)
    dtype = np.dtype(key)
    if len(dtype) != 0:
        raise KeyError(key)
    return dtype.type
```

Which will fail for record types, but not much else.

The proposed solution just uses `np.dtype()` directly and moves on. If desired, I could add more checks, such as that `len(output)` must be 0 or `output.type` must not be void or must be numeric, or whatever the actual intent of this section is.

#### Additional information
xref nipreps/sdcflows#433
