### PR TITLE
Add sorting requirement for partial_match and partial_guess

### DIFF
--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -598,6 +598,7 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
         ``partial_match[i, 0]`` of `A` is matched to node
         ``partial_match[i, 1]`` of `B`. The array has shape ``(m, 2)``,
         where ``m`` is not greater than the number of nodes, :math:`n`.
+        .. note:: It is important to sort `partial_match` by the first column before passing it to the function.
     partial_guess : 2-D array of integers, optional (default: None)
         A guess for the matching between the two matrices. Unlike
         `partial_match`, `partial_guess` does not fix the indices; they are
@@ -607,6 +608,7 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
         ``partial_guess[i, 0]`` of `A` is matched to node
         ``partial_guess[i, 1]`` of `B`. The array has shape ``(m, 2)``,
         where ``m`` is not greater than the number of nodes, :math:`n`.
+        .. note:: It is important to sort `partial_guess` by the first column before passing it to the function.
 
     Returns
     -------

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -598,7 +598,10 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
         ``partial_match[i, 0]`` of `A` is matched to node
         ``partial_match[i, 1]`` of `B`. The array has shape ``(m, 2)``,
         where ``m`` is not greater than the number of nodes, :math:`n`.
-        .. note:: It is important to sort `partial_match` by the first column before passing it to the function.
+
+        .. note::
+             `partial_match` must be sorted by the first column.
+
     partial_guess : 2-D array of integers, optional (default: None)
         A guess for the matching between the two matrices. Unlike
         `partial_match`, `partial_guess` does not fix the indices; they are
@@ -608,7 +611,9 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
         ``partial_guess[i, 0]`` of `A` is matched to node
         ``partial_guess[i, 1]`` of `B`. The array has shape ``(m, 2)``,
         where ``m`` is not greater than the number of nodes, :math:`n`.
-        .. note:: It is important to sort `partial_guess` by the first column before passing it to the function.
+
+        .. note:: 
+                `partial_guess` must be sorted by the first column.
 
     Returns
     -------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!-- Example: Closes gh-WXYZ. -->
Closes #18722

#### What does this implement/fix?
<!-- Please explain your changes. -->
This pull request addresses the issue related to the `quadratic_assignment` function documentation. It adds explicit information stating that the optional arguments `partial_match` and `partial_guess` should be sorted in the first column for proper functionality. 

#### Additional information
<!-- Any additional information you think is important. -->
-the documentation now reflects the sorting requirement.
- The changes are made to the relevant documentation file (_qap.py) in the `scipy/optimize` directory.
<img width="973" alt="Screenshot 2024-02-08 at 2 36 46 PM" src="https://github.com/scipy/scipy/assets/122628569/2aea8479-cf23-4abb-8bae-cf209d86ae86">

