### PR TITLE
BUG: SciPy.interpolate.CubicSpline with periodic data

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -792,9 +792,8 @@ class CubicSpline(CubicHermiteSpline):
             elif n == 3 and bc[0] == 'periodic':
                 # In case when number of points is 3 we compute the derivatives
                 # manually
-                s = np.empty((n,) + y.shape[1:], dtype=y.dtype)
-                t = (slope / dxr).sum() / (1. / dxr).sum()
-                s.fill(t)
+                t = (slope / dxr).sum(axis) / (1. / dxr).sum(axis)
+                s = np.broadcast_to(t, (n,) + y.shape[1:])
             else:
                 # Find derivative values at each x[i] by solving a tridiagonal
                 # system.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -792,7 +792,7 @@ class CubicSpline(CubicHermiteSpline):
             elif n == 3 and bc[0] == 'periodic':
                 # In case when number of points is 3 we compute the derivatives
                 # manually
-                t = (slope / dxr).sum(axis) / (1. / dxr).sum(axis)
+                t = (slope / dxr).sum(0) / (1. / dxr).sum(0)
                 s = np.broadcast_to(t, (n,) + y.shape[1:])
             else:
                 # Find derivative values at each x[i] by solving a tridiagonal

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -781,6 +781,19 @@ class TestCubicSpline:
         self.check_correctness(S, 'periodic', 'periodic')
         assert_allclose(S.derivative(1)(x), np.array([-48.0, -48.0, -48.0]))
 
+    def test_periodic_three_points_multidim(self):
+        # make sure one multidimensional interpolator does the same as multiple
+        # one-dimensional interpolators
+        x = np.array([0.0, 1.0, 3.0])
+        y = np.array([[0.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+        S = CubicSpline(x, y, bc_type="periodic")
+        self.check_correctness(S, 'periodic', 'periodic')
+        S0 = CubicSpline(x, y[:, 0], bc_type="periodic")
+        S1 = CubicSpline(x, y[:, 1], bc_type="periodic")
+        q = np.linspace(0, 2, 5)
+        assert_allclose(S(q)[:, 0], S0(q))
+        assert_allclose(S(q)[:, 1], S1(q))
+
     def test_dtypes(self):
         x = np.array([0, 1, 2, 3], dtype=int)
         y = np.array([-5, 2, 3, 1], dtype=int)


### PR DESCRIPTION
When interpolating periodic data of length 3 the
calculations were assuming only one dimensional data.
Fixes the calculations to allow multidimensional data.

The following example demonstrates the Bug:

```python
import matplotlib.pyplot as plt
import math
import numpy as np
import scipy.interpolate as interp

x = [-1.0, 0.0, 3.0]
y1 = [[0.5, 1.0], [0.0, 2.5], [0.5, 1.0],]
y2 = [0.5,0.0,0.5]
y3 = [1.0,2.5,1.0]

interp1 = interp.CubicSpline(x,y1,bc_type="periodic")
interp2 = interp.CubicSpline(x,y2,bc_type="periodic")
interp3 = interp.CubicSpline(x,y3,bc_type="periodic")

q = np.linspace(-1.5, 3.5, 30)
plt.plot(q, interp1(q), linestyle='--')
plt.plot(q, interp2(q))
plt.plot(q, interp3(q))
plt.plot(x, y1, marker='o', linestyle='')
```
![Screenshot_20240208_212342](https://github.com/scipy/scipy/assets/31804124/d807c5a6-3862-4c31-b5af-af17a73ccbd7)
The dashed lines are created by interpolating on the multidimensional data `y1` they should exactly match the solid lines created by interpolating the one-dimensional data `y2` and `y3`.

The following is the expected plot which we get with this fix applied:
![Screenshot_20240208_214347](https://github.com/scipy/scipy/assets/31804124/2a6ebead-5a69-44fa-aa7a-6589036dacec)


