### PR TITLE
DOC:signal: Suggest remedies for slow speed in `resample` when the number of samples is prime and large.

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1,11 +1,15 @@
 # Author: Travis Oliphant
 # 1999 -- 2002
 
+from __future__ import annotations # Provides typing union operator `|` in Python 3.9
 import operator
 import math
 from math import prod as _prod
 import timeit
 import warnings
+from typing import Literal
+
+from numpy._typing import ArrayLike
 
 from scipy.spatial import cKDTree
 from . import _sigtools
@@ -27,7 +31,7 @@ __all__ = ['correlate', 'correlation_lags', 'correlate2d',
            'convolve', 'convolve2d', 'fftconvolve', 'oaconvolve',
            'order_filter', 'medfilt', 'medfilt2d', 'wiener', 'lfilter',
            'lfiltic', 'sosfilt', 'deconvolve', 'hilbert', 'hilbert2',
-           'cmplx_sort', 'unique_roots', 'invres', 'invresz', 'residue',
+           'unique_roots', 'invres', 'invresz', 'residue',
            'residuez', 'resample', 'resample_poly', 'detrend',
            'lfilter_zi', 'sosfilt_zi', 'sosfiltfilt', 'choose_conv_method',
            'filtfilt', 'decimate', 'vectorstrength']
@@ -1367,7 +1371,7 @@ def convolve(in1, in2, mode='full', method='auto'):
     `choose_conv_method` to choose the fastest method using pre-computed
     values (`choose_conv_method` can also measure real-world timing with a
     keyword argument). Because `fftconvolve` relies on floating point numbers,
-    there are certain constraints that may force `method=direct` (more detail
+    there are certain constraints that may force ``method='direct'`` (more detail
     in `choose_conv_method` docstring).
 
     Examples
@@ -1496,15 +1500,11 @@ def order_filter(a, domain, rank):
                              "should have an odd number of elements.")
 
     a = np.asarray(a)
-    if a.dtype in [object, 'float128']:
-        mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
-        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
+    if not (np.issubdtype(a.dtype, np.integer) 
+            or a.dtype in [np.float32, np.float64]):
+        raise ValueError(f"dtype={a.dtype} is not supported by order_filter")
 
-        result = _sigtools._order_filterND(a, domain, rank)
-    else:
-        result = ndimage.rank_filter(a, rank, footprint=domain, mode='constant')
-
+    result = ndimage.rank_filter(a, rank, footprint=domain, mode='constant')
     return result
 
 
@@ -1551,6 +1551,10 @@ def medfilt(volume, kernel_size=None):
 
     """
     volume = np.atleast_1d(volume)
+    if not (np.issubdtype(volume.dtype, np.integer) 
+            or volume.dtype in [np.float32, np.float64]):
+        raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
+
     if kernel_size is None:
         kernel_size = [3] * volume.ndim
     kernel_size = np.asarray(kernel_size)
@@ -1565,25 +1569,9 @@ def medfilt(volume, kernel_size=None):
                       'zero-padded.',
                       stacklevel=2)
 
-    domain = np.ones(kernel_size, dtype=volume.dtype)
-
-    numels = np.prod(kernel_size, axis=0)
-    order = numels // 2
-
-    if volume.dtype in [np.bool_, np.complex64, np.complex128, np.clongdouble,
-                        np.float16]:
-        raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
-
-    if volume.dtype.char in ['O', 'g']:
-        mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
-                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
-        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
-
-        result = _sigtools._order_filterND(volume, domain, order)
-    else:
-        size = math.prod(kernel_size)
-        result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
-                                     mode='constant')
+    size = math.prod(kernel_size)
+    result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
+                                 mode='constant')
 
     return result
 
@@ -1645,11 +1633,11 @@ def wiener(im, mysize=None, noise=None):
         mysize = np.repeat(mysize.item(), im.ndim)
 
     # Estimate the local mean
-    lMean = correlate(im, np.ones(mysize), 'same') / np.prod(mysize, axis=0)
+    size = math.prod(mysize)
+    lMean = correlate(im, np.ones(mysize), 'same') / size
 
     # Estimate the local variance
-    lVar = (correlate(im ** 2, np.ones(mysize), 'same') /
-            np.prod(mysize, axis=0) - lMean ** 2)
+    lVar = (correlate(im ** 2, np.ones(mysize), 'same') / size - lMean ** 2)
 
     # Estimate the noise power if needed.
     if noise is None:
@@ -1809,11 +1797,11 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     image:
 
     >>> import numpy as np
-    >>> from scipy import signal
-    >>> from scipy import datasets
+    >>> from scipy import signal, datasets, ndimage
     >>> rng = np.random.default_rng()
     >>> face = datasets.face(gray=True) - datasets.face(gray=True).mean()
-    >>> template = np.copy(face[300:365, 670:750])  # right eye
+    >>> face = ndimage.zoom(face[30:500, 400:950], 0.5)  # extract the face
+    >>> template = np.copy(face[135:165, 140:175])  # right eye
     >>> template -= template.mean()
     >>> face = face + rng.standard_normal(face.shape) * 50  # add noise
     >>> corr = signal.correlate2d(face, template, boundary='symm', mode='same')
@@ -2087,6 +2075,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
     >>> plt.show()
 
     """
+    b = np.atleast_1d(b)
     a = np.atleast_1d(a)
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
@@ -2128,7 +2117,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            raise NotImplementedError("input type '%s' not supported" % dtype)
+            raise NotImplementedError(f"input type '{dtype}' not supported")
 
         b = np.array(b, dtype=dtype)
         a = np.asarray(a, dtype=dtype)
@@ -2461,18 +2450,6 @@ def hilbert2(x, N=None):
         k -= 1
     x = sp_fft.ifft2(Xf * h, axes=(0, 1))
     return x
-
-
-_msg_cplx_sort="""cmplx_sort was deprecated in SciPy 1.12 and will be removed
-in SciPy 1.15. The exact equivalent for a numpy array argument is
->>> def cmplx_sort(p):
-...    idx = np.argsort(abs(p))
-...    return np.take(p, idx, 0), idx
-"""
-
-def cmplx_sort(p):
-    warnings.warn(_msg_cplx_sort, DeprecationWarning, stacklevel=2)
-    return _cmplx_sort(p)
 
 
 def _cmplx_sort(p):
@@ -3537,9 +3514,10 @@ def vectorstrength(events, period):
     return strength, phase
 
 
-def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
-    """
-    Remove linear trend along axis from data.
+def detrend(data: np.ndarray, axis: int = -1,
+            type: Literal['linear', 'constant'] = 'linear',
+            bp: ArrayLike | int = 0, overwrite_data: bool = False) -> np.ndarray:
+    r"""Remove linear or constant trend along axis from data.
 
     Parameters
     ----------
@@ -3566,17 +3544,55 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
     ret : ndarray
         The detrended input data.
 
+    Notes
+    -----
+    Detrending can be interpreted as subtracting a least squares fit polyonimial:
+    Setting the parameter `type` to 'constant' corresponds to fitting a zeroth degree
+    polynomial, 'linear' to a first degree polynomial. Consult the example below.
+
+    See Also
+    --------
+    numpy.polynomial.polynomial.Polynomial.fit: Create least squares fit polynomial.
+
+
     Examples
     --------
-    >>> import numpy as np
-    >>> from scipy import signal
-    >>> rng = np.random.default_rng()
-    >>> npoints = 1000
-    >>> noise = rng.standard_normal(npoints)
-    >>> x = 3 + 2*np.linspace(0, 1, npoints) + noise
-    >>> (signal.detrend(x) - noise).max()
-    0.06  # random
+    The following example detrends the function :math:`x(t) = \sin(\pi t) + 1/4`:
 
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> from scipy.signal import detrend
+    ...
+    >>> t = np.linspace(-0.5, 0.5, 21)
+    >>> x = np.sin(np.pi*t) + 1/4
+    ...
+    >>> x_d_const = detrend(x, type='constant')
+    >>> x_d_linear = detrend(x, type='linear')
+    ...
+    >>> fig1, ax1 = plt.subplots()
+    >>> ax1.set_title(r"Detrending $x(t)=\sin(\pi t) + 1/4$")
+    >>> ax1.set(xlabel="t", ylabel="$x(t)$", xlim=(t[0], t[-1]))
+    >>> ax1.axhline(y=0, color='black', linewidth=.5)
+    >>> ax1.axvline(x=0, color='black', linewidth=.5)
+    >>> ax1.plot(t, x, 'C0.-',  label="No detrending")
+    >>> ax1.plot(t, x_d_const, 'C1x-', label="type='constant'")
+    >>> ax1.plot(t, x_d_linear, 'C2+-', label="type='linear'")
+    >>> ax1.legend()
+    >>> plt.show()
+
+    Alternatively, NumPy's `~numpy.polynomial.polynomial.Polynomial` can be used for
+    detrending as well:
+
+    >>> pp0 = np.polynomial.Polynomial.fit(t, x, deg=0)  # fit degree 0 polynomial
+    >>> np.allclose(x_d_const, x - pp0(t))  # compare with constant detrend
+    True
+    >>> pp1 = np.polynomial.Polynomial.fit(t, x, deg=1)  # fit degree 1 polynomial
+    >>> np.allclose(x_d_linear, x - pp1(t))  # compare with linear detrend
+    True
+
+    Note that `~numpy.polynomial.polynomial.Polynomial` also allows fitting higher
+    degree polynomials. Consult its documentation on how to extract the polynomial
+    coefficients.
     """
     if type not in ['linear', 'l', 'constant', 'c']:
         raise ValueError("Trend type must be 'linear' or 'constant'.")
@@ -3675,7 +3691,7 @@ def lfilter_zi(b, a):
         A = scipy.linalg.companion(a).T
         B = b[1:] - a[1:]*b[0]
 
-    assuming `a[0]` is 1.0; if `a[0]` is not 1, `a` and `b` are first
+    assuming ``a[0]`` is 1.0; if ``a[0]`` is not 1, `a` and `b` are first
     divided by a[0].
 
     Examples
@@ -3703,7 +3719,7 @@ def lfilter_zi(b, a):
         0.44399389,  0.35505241])
 
     Note that the `zi` argument to `lfilter` was computed using
-    `lfilter_zi` and scaled by `x[0]`.  Then the output `y` has no
+    `lfilter_zi` and scaled by ``x[0]``.  Then the output `y` has no
     transient until the input drops from 0.5 to 0.0.
 
     """
@@ -3840,7 +3856,7 @@ def sosfilt_zi(sos):
 def _filtfilt_gust(b, a, x, axis=-1, irlen=None):
     """Forward-backward IIR filter that uses Gustafsson's method.
 
-    Apply the IIR filter defined by `(b,a)` to `x` twice, first forward
+    Apply the IIR filter defined by ``(b,a)`` to `x` twice, first forward
     then backward, using Gustafsson's initial conditions [1]_.
 
     Let ``y_fb`` be the result of filtering first forward and then backward,
@@ -4221,9 +4237,8 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
     if padtype not in ['even', 'odd', 'constant', None]:
-        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
-                          "must be 'even', 'odd', 'constant', or None.") %
-                         padtype)
+        raise ValueError(f"Unknown value '{padtype}' given to padtype. "
+                         "padtype must be 'even', 'odd', 'constant', or None.")
 
     if padtype is None:
         padlen = 0
@@ -4340,7 +4355,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
         inputs.append(np.asarray(zi))
     dtype = np.result_type(*inputs)
     if dtype.char not in 'fdgFDGO':
-        raise NotImplementedError("input type '%s' not supported" % dtype)
+        raise NotImplementedError(f"input type '{dtype}' not supported")
     if zi is not None:
         zi = np.array(zi, dtype)  # make a copy so that we can operate in place
         if zi.shape != x_zi_shape:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3087,7 +3087,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     As noted, `resample` uses FFT transformations, which can be very 
     slow if the number of input or output samples is large and prime; 
     see :func:`~scipy.fft.fft`. In such cases, it can be faster to first downsample 
-    a signal of length `n` with :func:`~scipy.signal.resample_poly` by a factor of 
+    a signal of length ``n`` with :func:`~scipy.signal.resample_poly` by a factor of 
     ``n//num`` before using `resample`. Note that this approach changes the 
     characteristics of the antialiasing filter.
 
@@ -3109,14 +3109,14 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     >>> plt.legend(['data', 'resampled'], loc='best')
     >>> plt.show()
 
-    Consider the following signal  `y` where ``len(y)`` is a large  prime number:
+    Consider the following signal  ``y`` where ``len(y)`` is a large  prime number:
 
     >>> N = 55949
     >>> freq = 100
     >>> x = np.linspace(0, 1, N)
     >>> y = np.cos(2 * np.pi * freq * x)
 
-    Due to `N` being prime, 
+    Due to ``N`` being prime, 
 
     >>> num = 5000  
     >>> f = signal.resample(signal.resample_poly(y, 1, N // num), num)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1,15 +1,11 @@
 # Author: Travis Oliphant
 # 1999 -- 2002
 
-from __future__ import annotations # Provides typing union operator `|` in Python 3.9
 import operator
 import math
 from math import prod as _prod
 import timeit
 import warnings
-from typing import Literal
-
-from numpy._typing import ArrayLike
 
 from scipy.spatial import cKDTree
 from . import _sigtools
@@ -31,7 +27,7 @@ __all__ = ['correlate', 'correlation_lags', 'correlate2d',
            'convolve', 'convolve2d', 'fftconvolve', 'oaconvolve',
            'order_filter', 'medfilt', 'medfilt2d', 'wiener', 'lfilter',
            'lfiltic', 'sosfilt', 'deconvolve', 'hilbert', 'hilbert2',
-           'unique_roots', 'invres', 'invresz', 'residue',
+           'cmplx_sort', 'unique_roots', 'invres', 'invresz', 'residue',
            'residuez', 'resample', 'resample_poly', 'detrend',
            'lfilter_zi', 'sosfilt_zi', 'sosfiltfilt', 'choose_conv_method',
            'filtfilt', 'decimate', 'vectorstrength']
@@ -1371,7 +1367,7 @@ def convolve(in1, in2, mode='full', method='auto'):
     `choose_conv_method` to choose the fastest method using pre-computed
     values (`choose_conv_method` can also measure real-world timing with a
     keyword argument). Because `fftconvolve` relies on floating point numbers,
-    there are certain constraints that may force ``method='direct'`` (more detail
+    there are certain constraints that may force `method=direct` (more detail
     in `choose_conv_method` docstring).
 
     Examples
@@ -1500,11 +1496,15 @@ def order_filter(a, domain, rank):
                              "should have an odd number of elements.")
 
     a = np.asarray(a)
-    if not (np.issubdtype(a.dtype, np.integer) 
-            or a.dtype in [np.float32, np.float64]):
-        raise ValueError(f"dtype={a.dtype} is not supported by order_filter")
+    if a.dtype in [object, 'float128']:
+        mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
+        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
-    result = ndimage.rank_filter(a, rank, footprint=domain, mode='constant')
+        result = _sigtools._order_filterND(a, domain, rank)
+    else:
+        result = ndimage.rank_filter(a, rank, footprint=domain, mode='constant')
+
     return result
 
 
@@ -1551,10 +1551,6 @@ def medfilt(volume, kernel_size=None):
 
     """
     volume = np.atleast_1d(volume)
-    if not (np.issubdtype(volume.dtype, np.integer) 
-            or volume.dtype in [np.float32, np.float64]):
-        raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
-
     if kernel_size is None:
         kernel_size = [3] * volume.ndim
     kernel_size = np.asarray(kernel_size)
@@ -1569,9 +1565,25 @@ def medfilt(volume, kernel_size=None):
                       'zero-padded.',
                       stacklevel=2)
 
-    size = math.prod(kernel_size)
-    result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
-                                 mode='constant')
+    domain = np.ones(kernel_size, dtype=volume.dtype)
+
+    numels = np.prod(kernel_size, axis=0)
+    order = numels // 2
+
+    if volume.dtype in [np.bool_, np.complex64, np.complex128, np.clongdouble,
+                        np.float16]:
+        raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
+
+    if volume.dtype.char in ['O', 'g']:
+        mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.14")
+        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
+
+        result = _sigtools._order_filterND(volume, domain, order)
+    else:
+        size = math.prod(kernel_size)
+        result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
+                                     mode='constant')
 
     return result
 
@@ -1633,11 +1645,11 @@ def wiener(im, mysize=None, noise=None):
         mysize = np.repeat(mysize.item(), im.ndim)
 
     # Estimate the local mean
-    size = math.prod(mysize)
-    lMean = correlate(im, np.ones(mysize), 'same') / size
+    lMean = correlate(im, np.ones(mysize), 'same') / np.prod(mysize, axis=0)
 
     # Estimate the local variance
-    lVar = (correlate(im ** 2, np.ones(mysize), 'same') / size - lMean ** 2)
+    lVar = (correlate(im ** 2, np.ones(mysize), 'same') /
+            np.prod(mysize, axis=0) - lMean ** 2)
 
     # Estimate the noise power if needed.
     if noise is None:
@@ -1797,11 +1809,11 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     image:
 
     >>> import numpy as np
-    >>> from scipy import signal, datasets, ndimage
+    >>> from scipy import signal
+    >>> from scipy import datasets
     >>> rng = np.random.default_rng()
     >>> face = datasets.face(gray=True) - datasets.face(gray=True).mean()
-    >>> face = ndimage.zoom(face[30:500, 400:950], 0.5)  # extract the face
-    >>> template = np.copy(face[135:165, 140:175])  # right eye
+    >>> template = np.copy(face[300:365, 670:750])  # right eye
     >>> template -= template.mean()
     >>> face = face + rng.standard_normal(face.shape) * 50  # add noise
     >>> corr = signal.correlate2d(face, template, boundary='symm', mode='same')
@@ -2075,7 +2087,6 @@ def lfilter(b, a, x, axis=-1, zi=None):
     >>> plt.show()
 
     """
-    b = np.atleast_1d(b)
     a = np.atleast_1d(a)
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
@@ -2117,7 +2128,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            raise NotImplementedError(f"input type '{dtype}' not supported")
+            raise NotImplementedError("input type '%s' not supported" % dtype)
 
         b = np.array(b, dtype=dtype)
         a = np.asarray(a, dtype=dtype)
@@ -2450,6 +2461,18 @@ def hilbert2(x, N=None):
         k -= 1
     x = sp_fft.ifft2(Xf * h, axes=(0, 1))
     return x
+
+
+_msg_cplx_sort="""cmplx_sort was deprecated in SciPy 1.12 and will be removed
+in SciPy 1.15. The exact equivalent for a numpy array argument is
+>>> def cmplx_sort(p):
+...    idx = np.argsort(abs(p))
+...    return np.take(p, idx, 0), idx
+"""
+
+def cmplx_sort(p):
+    warnings.warn(_msg_cplx_sort, DeprecationWarning, stacklevel=2)
+    return _cmplx_sort(p)
 
 
 def _cmplx_sort(p):
@@ -3084,9 +3107,12 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     If `t` is not None, then it is used solely to calculate the resampled
     positions `resampled_t`
 
-    As noted, `resample` uses FFT transformations, which can be very
-    slow if the number of input or output samples is large and prime;
-    see `scipy.fft.fft`.
+    As noted, `resample` uses FFT transformations, which can be very 
+    slow if the number of input or output samples is large and prime; 
+    see :func:`~scipy.fft.fft`. In such cases, it can be faster to first downsample 
+    a signal of length `n` with :func:`~scipy.signal.resample_poly` by a factor of 
+    ``n//num`` before using `resample`. Note that this approach changes the 
+    characteristics of the antialiasing filter.
 
     Examples
     --------
@@ -3105,6 +3131,22 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     >>> plt.plot(x, y, 'go-', xnew, f, '.-', 10, y[0], 'ro')
     >>> plt.legend(['data', 'resampled'], loc='best')
     >>> plt.show()
+
+    Consider the following signal  `y` where ``len(y)`` is a large  prime number:
+
+    >>> N = 55949
+    >>> freq = 100
+    >>> x = np.linspace(0, 1, N)
+    >>> y = np.cos(2 * np.pi * freq * x)
+
+    Due to `N` being prime, 
+
+    >>> num = 5000  
+    >>> f = signal.resample(signal.resample_poly(y, 1, N // num), num)
+
+    runs significantly faster than
+
+    >>> f = signal.resample(y, num)
     """
 
     if domain not in ('time', 'freq'):
@@ -3495,10 +3537,9 @@ def vectorstrength(events, period):
     return strength, phase
 
 
-def detrend(data: np.ndarray, axis: int = -1,
-            type: Literal['linear', 'constant'] = 'linear',
-            bp: ArrayLike | int = 0, overwrite_data: bool = False) -> np.ndarray:
-    r"""Remove linear or constant trend along axis from data.
+def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
+    """
+    Remove linear trend along axis from data.
 
     Parameters
     ----------
@@ -3525,55 +3566,17 @@ def detrend(data: np.ndarray, axis: int = -1,
     ret : ndarray
         The detrended input data.
 
-    Notes
-    -----
-    Detrending can be interpreted as subtracting a least squares fit polyonimial:
-    Setting the parameter `type` to 'constant' corresponds to fitting a zeroth degree
-    polynomial, 'linear' to a first degree polynomial. Consult the example below.
-
-    See Also
-    --------
-    numpy.polynomial.polynomial.Polynomial.fit: Create least squares fit polynomial.
-
-
     Examples
     --------
-    The following example detrends the function :math:`x(t) = \sin(\pi t) + 1/4`:
-
-    >>> import matplotlib.pyplot as plt
     >>> import numpy as np
-    >>> from scipy.signal import detrend
-    ...
-    >>> t = np.linspace(-0.5, 0.5, 21)
-    >>> x = np.sin(np.pi*t) + 1/4
-    ...
-    >>> x_d_const = detrend(x, type='constant')
-    >>> x_d_linear = detrend(x, type='linear')
-    ...
-    >>> fig1, ax1 = plt.subplots()
-    >>> ax1.set_title(r"Detrending $x(t)=\sin(\pi t) + 1/4$")
-    >>> ax1.set(xlabel="t", ylabel="$x(t)$", xlim=(t[0], t[-1]))
-    >>> ax1.axhline(y=0, color='black', linewidth=.5)
-    >>> ax1.axvline(x=0, color='black', linewidth=.5)
-    >>> ax1.plot(t, x, 'C0.-',  label="No detrending")
-    >>> ax1.plot(t, x_d_const, 'C1x-', label="type='constant'")
-    >>> ax1.plot(t, x_d_linear, 'C2+-', label="type='linear'")
-    >>> ax1.legend()
-    >>> plt.show()
+    >>> from scipy import signal
+    >>> rng = np.random.default_rng()
+    >>> npoints = 1000
+    >>> noise = rng.standard_normal(npoints)
+    >>> x = 3 + 2*np.linspace(0, 1, npoints) + noise
+    >>> (signal.detrend(x) - noise).max()
+    0.06  # random
 
-    Alternatively, NumPy's `~numpy.polynomial.polynomial.Polynomial` can be used for
-    detrending as well:
-
-    >>> pp0 = np.polynomial.Polynomial.fit(t, x, deg=0)  # fit degree 0 polynomial
-    >>> np.allclose(x_d_const, x - pp0(t))  # compare with constant detrend
-    True
-    >>> pp1 = np.polynomial.Polynomial.fit(t, x, deg=1)  # fit degree 1 polynomial
-    >>> np.allclose(x_d_linear, x - pp1(t))  # compare with linear detrend
-    True
-
-    Note that `~numpy.polynomial.polynomial.Polynomial` also allows fitting higher
-    degree polynomials. Consult its documentation on how to extract the polynomial
-    coefficients.
     """
     if type not in ['linear', 'l', 'constant', 'c']:
         raise ValueError("Trend type must be 'linear' or 'constant'.")
@@ -3672,7 +3675,7 @@ def lfilter_zi(b, a):
         A = scipy.linalg.companion(a).T
         B = b[1:] - a[1:]*b[0]
 
-    assuming ``a[0]`` is 1.0; if ``a[0]`` is not 1, `a` and `b` are first
+    assuming `a[0]` is 1.0; if `a[0]` is not 1, `a` and `b` are first
     divided by a[0].
 
     Examples
@@ -3700,7 +3703,7 @@ def lfilter_zi(b, a):
         0.44399389,  0.35505241])
 
     Note that the `zi` argument to `lfilter` was computed using
-    `lfilter_zi` and scaled by ``x[0]``.  Then the output `y` has no
+    `lfilter_zi` and scaled by `x[0]`.  Then the output `y` has no
     transient until the input drops from 0.5 to 0.0.
 
     """
@@ -3837,7 +3840,7 @@ def sosfilt_zi(sos):
 def _filtfilt_gust(b, a, x, axis=-1, irlen=None):
     """Forward-backward IIR filter that uses Gustafsson's method.
 
-    Apply the IIR filter defined by ``(b,a)`` to `x` twice, first forward
+    Apply the IIR filter defined by `(b,a)` to `x` twice, first forward
     then backward, using Gustafsson's initial conditions [1]_.
 
     Let ``y_fb`` be the result of filtering first forward and then backward,
@@ -4218,8 +4221,9 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
     if padtype not in ['even', 'odd', 'constant', None]:
-        raise ValueError(f"Unknown value '{padtype}' given to padtype. "
-                         "padtype must be 'even', 'odd', 'constant', or None.")
+        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
+                          "must be 'even', 'odd', 'constant', or None.") %
+                         padtype)
 
     if padtype is None:
         padlen = 0
@@ -4336,7 +4340,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
         inputs.append(np.asarray(zi))
     dtype = np.result_type(*inputs)
     if dtype.char not in 'fdgFDGO':
-        raise NotImplementedError(f"input type '{dtype}' not supported")
+        raise NotImplementedError("input type '%s' not supported" % dtype)
     if zi is not None:
         zi = np.array(zi, dtype)  # make a copy so that we can operate in place
         if zi.shape != x_zi_shape:


### PR DESCRIPTION
The documentation currently mentions that if the number of samples in the input or output is large and prime, then `resample` can be very slow. However, it does not provide any remedies. This PR gives two suggestions to the user:

1. Consider using `resample_poly`.
2. Consider using `decimate` before applying `resample`.