### PR TITLE
ENH: optimize._differentiate: add option preserve_shape

### DIFF
--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -96,7 +96,7 @@ def _initialize(func, xs, args, complex_ok=False, preserve_shape=None):
     message = ("The shape of the array returned by `func` must be the same as "
                "the broadcasted shape of `x` and all other `args`.")
     if preserve_shape is not None:  # only in tanhsinh for now
-        message = f"When `preserve_shape=False`, {message.lower}"
+        message = f"When `preserve_shape=False`, {message.lower()}"
     shapes_equal = [f.shape == shape for f in fs]
     if not np.all(shapes_equal):
         raise ValueError(message)


### PR DESCRIPTION
#### Reference issue
gh-19545

#### What does this implement/fix?
In order to allow `_differentiate` to compute (accurate, adaptive step size) Jacobians, it needs the `preserve_shape` option provided by the EIM infrastructure. This PR adds this support.

#### Additional information
This allows convenient calculation of first derivatives of single-input, multi-output functions; calculation of Jacobians and Hessians would be a follow-up.

```python3
from scipy.optimize._differentiate import _differentiate
from scipy import special

def f(x):
    return [x, special.loggamma(x)]

def df(x):
    return [1, special.digamma(x)]

x = 2.5
res = _differentiate(f, x, preserve_shape=True, rtol=1e-14)
np.testing.assert_allclose(res.df, df(x), rtol=1e-14)
```

Jacobian and Hessian gist:

<details>

```python3

import numpy as np
from scipy.optimize import rosen, rosen_der, rosen_hess
from scipy.optimize._differentiate import _differentiate

def jacobian(f, x):
    int_dtype = np.issubdtype(x.dtype, np.integer)
    x0 = np.asarray(x, dtype=float) if int_dtype else np.asarray(x)
    m = len(x0)
    i = np.arange(m)

    def wrapped(x):
        n = () if x.ndim == x0.ndim else (x.shape[-1],)  # number of abscissae
        new_dims = (1,) if x.ndim == x0.ndim else (1, -1)
        new_shape = (m, m) + x0.shape[1:] + n
        xph = np.expand_dims(x0, new_dims)
        xph = np.broadcast_to(xph, new_shape).copy()
        xph[i, i] = x
        return f(xph)
    res = _differentiate(wrapped, x, preserve_shape=True)

    return res

def hessian(f, x):
    def df(x):
        return jacobian(f, x).df
    return jacobian(df, x)

rng = np.random.default_rng(234823492323)

# vectorized calculation of gradient and Hessian of 3-input, 1-output function at four points
x = rng.random((3, 4))

np.testing.assert_allclose(jacobian(rosen, x).df, rosen_der(x))

ref = np.asarray([rosen_hess(xi) for xi in x.T])  # rosen_hess isn't vectorized
ref = np.moveaxis(ref, 0, -1)
np.testing.assert_allclose(hessian(rosen, x).df, ref, atol=1e-9)  # atol needed only for zeros
```

</details>