### PR TITLE
MAINT Fix broken link in `scipy.stats._multivariate.py`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -5009,7 +5009,7 @@ class multivariate_hypergeom_gen(multi_rv_generic):
            http://www.randomservices.org/random/urn/MultiHypergeometric.html
     .. [2] Thomas J. Sargent and John Stachurski, 2020,
            Multivariate Hypergeometric Distribution
-           https://python.quantecon.org/_downloads/pdf/multi_hyper.pdf
+           https://python.quantecon.org/multi_hyper.html
     """
     def __init__(self, seed=None):
         super().__init__(seed)


### PR DESCRIPTION
#### Reference issue
No issue in existence.

#### What does this implement/fix?
This little PR fixes the broken link in module `scipy.stats._multivariate.py`.

#### Additional information
