### PR TITLE
Remove import the "golden ratio" and calculate it in the actual test files

### DIFF
--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import itertools
 from numpy.testing import (assert_equal,
@@ -8,7 +9,6 @@ import pytest
 from pytest import raises as assert_raises
 from scipy.spatial import SphericalVoronoi, distance
 from scipy.optimize import linear_sum_assignment
-from scipy.constants import golden as phi
 from scipy.special import gamma
 
 
@@ -29,7 +29,7 @@ def _generate_octahedron():
 
 
 def _generate_dodecahedron():
-
+    phi = (1 + _math.sqrt(5)) / 2
     x1 = _generate_cube()
     x2 = np.array([[0, -phi, -1 / phi],
                    [0, -phi, +1 / phi],
@@ -47,6 +47,7 @@ def _generate_dodecahedron():
 
 
 def _generate_icosahedron():
+    phi = (1 + _math.sqrt(5)) / 2
     x = np.array([[0, -1, -phi],
                   [0, -1, +phi],
                   [0, +1, -phi],

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -1,4 +1,3 @@
-import math
 import numpy as np
 import itertools
 from numpy.testing import (assert_equal,
@@ -29,7 +28,7 @@ def _generate_octahedron():
 
 
 def _generate_dodecahedron():
-    phi = (1 + _math.sqrt(5)) / 2
+    phi = (1 + np.sqrt(5)) / 2
     x1 = _generate_cube()
     x2 = np.array([[0, -phi, -1 / phi],
                    [0, -phi, +1 / phi],
@@ -47,7 +46,7 @@ def _generate_dodecahedron():
 
 
 def _generate_icosahedron():
-    phi = (1 + _math.sqrt(5)) / 2
+    phi = (1 + np.sqrt(5)) / 2
     x = np.array([[0, -1, -phi],
                   [0, -1, +phi],
                   [0, +1, -phi],

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_array_almost_equal
 from scipy.spatial.transform import Rotation
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
-from scipy.constants import golden as phi
 from scipy.spatial import cKDTree
 
 
@@ -41,6 +40,7 @@ def _generate_prism(n, axis):
 
 
 def _generate_icosahedron():
+    phi = (1 + _math.sqrt(5)) / 2
     x = np.array([[0, -1, -phi],
                   [0, -1, +phi],
                   [0, +1, -phi],

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -1,5 +1,6 @@
 import pytest
 
+import math
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from scipy.spatial.transform import Rotation

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -1,6 +1,5 @@
 import pytest
 
-import math
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from scipy.spatial.transform import Rotation
@@ -41,7 +40,7 @@ def _generate_prism(n, axis):
 
 
 def _generate_icosahedron():
-    phi = (1 + _math.sqrt(5)) / 2
+    phi = (1 + np.sqrt(5)) / 2
     x = np.array([[0, -1, -phi],
                   [0, -1, +phi],
                   [0, +1, -phi],


### PR DESCRIPTION
#### Reference issue
There is none.

#### What does this implement/fix?
The tests of the spatial module imported the "golden ratio" as `phi` from the scipy.constants module. As the calculation is however a one-liner (or less), complexity can be reduced by calculating the "golden ratio" within the respective test files.
