### PR TITLE
TST: shims for NumPy fft changes

### DIFF
--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -222,7 +222,7 @@ class _TestIFFTBase:
             n = 2**i
             x = np.arange(n)
             y = ifft(x.astype(self.cdt))
-            y2 = numpy.fft.ifft(x)
+            y2 = numpy.fft.ifft(x.astype(self.cdt))
             assert_allclose(y,y2, rtol=self.rtol, atol=self.atol)
             y = ifft(x)
             assert_allclose(y,y2, rtol=self.rtol, atol=self.atol)

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -56,7 +56,7 @@ mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
 @pytest.mark.parametrize("func, np_func, mock", zip(funcs, np_funcs, mocks))
 def test_backend_call(func, np_func, mock):
     x = np.arange(20).reshape((10,2))
-    answer = np_func(x)
+    answer = np_func(x.astype(np.float64))
     assert_allclose(func(x), answer, atol=1e-10)
 
     with set_backend(mock_backend, only=True):

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -80,7 +80,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec',
-                             [(numpy.complex64, 6), (numpy.complex128, 11)])
+                             [(numpy.complex64, 4), (numpy.complex128, 11)])
     def test_fourier_shift_complex01(self, shape, dtype, dec):
         expected = numpy.arange(shape[0] * shape[1], dtype=dtype)
         expected.shape = shape


### PR DESCRIPTION
* Fixes #20062

* for 2/3 of the problem tests I was able to adopt the philosophy of "let's keep the expected value the same; we don't really care what NumPy is doing as long as the expected value in the test is the same as before"; so, we compensate for the casting changes in NumPy by generating the expected value with a more explicit cast

* for `test_fourier_shift_complex01` that would be more surgery though--this one is a real mess--it calls NumPy FFT functionality twice before the SciPy function under test, then feeds that input to the SciPy function under test, then calls NumPy FFT functionality twice on the output of the SciPy function under test; here, I dropped the lower-precision pass-through test precision expectations, because we can't lean on NumPy to automatically preserve as much precision here anymore; a stricter view on preserving the essence of this test might be to either hardcode the expected value in the lower-precision dtype case, or carefully craft it with NumPy wider dtype while not feeding the wider dtype to the SciPy function under test

[skip cirrus] [skip circle]