### PR TITLE
Changed assert_warns in stats testing to pytest.warns. 

### DIFF
--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -115,16 +115,16 @@ For more information about writing unit tests, see the
 :doc:`NumPy Testing Guidelines <numpy:reference/testing>`.
 
 
-Testing that expected exceptions are raised
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When writing a new test that a function call raises a certain exception,
-the preferred style is to use ``pytest.raises`` as a context manager, with
-the code that is supposed to raise the exception in the code block defined
-by the context manager.  The `match` keyword argument of ``pytest.raises``
-is given with enough of the expected error message attached to the exception
-to ensure that the expected exception is raised. Do not use
-``np.testing.assert_warns`` with a `match` parameter, as this ignores that
-parameter.
+Testing expected exceptions/ warnings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When writing a new test that a function call raises an exception or emits a
+warning, the preferred style is to use ``pytest.raises``/``pytest.warns`` as
+a context manager, with the code that is supposed to raise the exception in
+the code block defined by the context manager. The ``match`` keyword argument
+is given with enough of the expected message attached to the exception/warning
+to distinguish it from other exceptions/warnings of the same class. Do not use
+``np.testing.assert_raises`` or ``np.testing.assert_warns``, as they do not
+support a ``match`` parameter.
 
 For example, the function `scipy.stats.zmap` is supposed to raise a
 ``ValueError`` if the input contains ``nan`` and ``nan_policy`` is ``"raise"``.

--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -104,9 +104,7 @@ Finally, hide private attributes if any::
 Test functions from `numpy.testing`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In new code, don't use `assert_almost_equal`, `assert_approx_equal` or
-`assert_array_almost_equal`. In addition, do not use `assert_warns` with a
-`match` parameter, as this ignores that parameter. This is from the docstrings of
-these functions::
+`assert_array_almost_equal`. This is from the docstrings of these functions::
 
     It is recommended to use one of `assert_allclose`,
     `assert_array_almost_equal_nulp` or `assert_array_max_ulp`
@@ -124,7 +122,9 @@ the preferred style is to use ``pytest.raises`` as a context manager, with
 the code that is supposed to raise the exception in the code block defined
 by the context manager.  The `match` keyword argument of ``pytest.raises``
 is given with enough of the expected error message attached to the exception
-to ensure that the expected exception is raised.
+to ensure that the expected exception is raised. Do not use
+``np.testing.assert_warns`` with a `match` parameter, as this ignores that
+parameter.
 
 For example, the function `scipy.stats.zmap` is supposed to raise a
 ``ValueError`` if the input contains ``nan`` and ``nan_policy`` is ``"raise"``.

--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -104,8 +104,9 @@ Finally, hide private attributes if any::
 Test functions from `numpy.testing`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In new code, don't use `assert_almost_equal`, `assert_approx_equal` or
-`assert_array_almost_equal`. This is from the docstrings of these
-functions::
+`assert_array_almost_equal`. In addition, do not use `assert_warns` with a
+`match` parameter, as this ignores that parameter. This is from the docstrings of
+these functions::
 
     It is recommended to use one of `assert_allclose`,
     `assert_array_almost_equal_nulp` or `assert_array_max_ulp`

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8981,7 +8981,7 @@ def test_histogram_non_uniform():
 
     # Omitting density produces a warning for non-uniform bins...
     message = "Bin widths are not constant. Assuming..."
-    with assert_warns(RuntimeWarning, match=message):
+    with pytest.warns(RuntimeWarning, match=message):
         dist = stats.rv_histogram((counts, bins))
         assert dist.median() == 1001/2  # default is like `density=True`
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -380,7 +380,7 @@ class TestCorrPearsonr:
         # Zero variance input
         # See https://github.com/scipy/scipy/issues/3728
         msg = "An input array is constant"
-        with assert_warns(stats.ConstantInputWarning, match=msg):
+        with pytest.warns(stats.ConstantInputWarning, match=msg):
             r, p = stats.pearsonr([0.667, 0.667, 0.667], [0.123, 0.456, 0.789])
             assert_equal(r, np.nan)
             assert_equal(p, np.nan)
@@ -390,7 +390,7 @@ class TestCorrPearsonr:
         x = [2, 2, 2 + np.spacing(2)]
         y = [3, 3, 3 + 6*np.spacing(3)]
         msg = "An input array is nearly constant; the computed"
-        with assert_warns(stats.NearConstantInputWarning, match=msg):
+        with pytest.warns(stats.NearConstantInputWarning, match=msg):
             # r and p are garbage, so don't bother checking them in this case.
             # (The exact value of r would be 1.)
             r, p = stats.pearsonr(x, y)
@@ -1039,7 +1039,7 @@ class TestCorrSpearmanr2:
     def test_tie0(self):
         # with only ties in one or both inputs
         warn_msg = "An input array is constant"
-        with assert_warns(stats.ConstantInputWarning, match=warn_msg):
+        with pytest.warns(stats.ConstantInputWarning, match=warn_msg):
             r, p = stats.spearmanr([2, 2, 2], [2, 2, 2])
             assert_equal(r, np.nan)
             assert_equal(p, np.nan)
@@ -1082,7 +1082,7 @@ class TestCorrSpearmanr2:
         z2 = np.array([[1, 2, 3, 4], [1, 1, 1, 1]])
         z3 = np.array([[1, 1, 1, 1], [1, 1, 1, 1]])
         warn_msg = "An input array is constant"
-        with assert_warns(stats.ConstantInputWarning, match=warn_msg):
+        with pytest.warns(stats.ConstantInputWarning, match=warn_msg):
             r, p = stats.spearmanr(z1, axis=1)
             assert_equal(r, np.nan)
             assert_equal(p, np.nan)
@@ -1099,7 +1099,7 @@ class TestCorrSpearmanr2:
                       0.0007535430349118562, 0.0002661781514710257, 0, 0,
                       0.0007835762419683435])
         warn_msg = "An input array is constant"
-        with assert_warns(stats.ConstantInputWarning, match=warn_msg):
+        with pytest.warns(stats.ConstantInputWarning, match=warn_msg):
             r, p = stats.spearmanr(x, y)
             assert_equal(r, np.nan)
             assert_equal(p, np.nan)
@@ -7037,7 +7037,7 @@ class TestAlexanderGovern:
     def test_constant_input(self):
         # Zero variance input, consistent with `stats.pearsonr`
         msg = "An input array is constant; the statistic is not defined."
-        with assert_warns(stats.ConstantInputWarning, match=msg):
+        with pytest.warns(stats.ConstantInputWarning, match=msg):
             res = stats.alexandergovern([0.667, 0.667, 0.667],
                                         [0.123, 0.456, 0.789])
             assert_equal(res.statistic, np.nan)
@@ -7123,7 +7123,7 @@ class TestFOneWay:
     def test_constant_input(self, a, b, expected):
         # For more details, look on https://github.com/scipy/scipy/issues/11669
         msg = "Each of the input arrays is constant;"
-        with assert_warns(stats.ConstantInputWarning, match=msg):
+        with pytest.warns(stats.ConstantInputWarning, match=msg):
             f, p = stats.f_oneway(a, b)
             assert f, p == expected
 
@@ -7156,7 +7156,7 @@ class TestFOneWay:
             take_axis = 1
 
         warn_msg = "Each of the input arrays is constant;"
-        with assert_warns(stats.ConstantInputWarning, match=warn_msg):
+        with pytest.warns(stats.ConstantInputWarning, match=warn_msg):
             f, p = stats.f_oneway(a, b, c, axis=axis)
 
         # Verify that the result computed with the 2d arrays matches
@@ -7168,7 +7168,7 @@ class TestFOneWay:
             assert_allclose(f[j], fj, rtol=1e-14)
             assert_allclose(p[j], pj, rtol=1e-14)
         for j in [2, 3]:
-            with assert_warns(stats.ConstantInputWarning, match=warn_msg):
+            with pytest.warns(stats.ConstantInputWarning, match=warn_msg):
                 fj, pj = stats.f_oneway(np.take(a, j, take_axis),
                                         np.take(b, j, take_axis),
                                         np.take(c, j, take_axis))
@@ -7194,14 +7194,14 @@ class TestFOneWay:
 
     def test_length0_1d_error(self):
         # Require at least one value in each group.
-        msg = 'all input arrays have length 1.'
-        with assert_warns(stats.DegenerateDataWarning, match=msg):
+        msg = 'at least one input has length 0'
+        with pytest.warns(stats.DegenerateDataWarning, match=msg):
             result = stats.f_oneway([1, 2, 3], [], [4, 5, 6, 7])
             assert_equal(result, (np.nan, np.nan))
 
     def test_length0_2d_error(self):
-        msg = 'all input arrays have length 1.'
-        with assert_warns(stats.DegenerateDataWarning, match=msg):
+        msg = 'at least one input has length 0'
+        with pytest.warns(stats.DegenerateDataWarning, match=msg):
             ncols = 3
             a = np.ones((4, ncols))
             b = np.ones((0, ncols))
@@ -7213,7 +7213,7 @@ class TestFOneWay:
 
     def test_all_length_one(self):
         msg = 'all input arrays have length 1.'
-        with assert_warns(stats.DegenerateDataWarning, match=msg):
+        with pytest.warns(stats.DegenerateDataWarning, match=msg):
             result = stats.f_oneway([10], [11], [12], [13])
             assert_equal(result, (np.nan, np.nan))
 


### PR DESCRIPTION

#### Reference issue
Closes #20031 

#### What does this implement/fix?
Change test using `np.testing.assert_warns` with a match parameter to `pytest.warns`. Updated documentation to indicate not to use `np.testing.assert_warns` with a match parameter.

#### Additional information
Tests pass locally and docs build successfully. I changed the `msg` in scipy.stats.tests.test_stats.TestFOneWay. Since `assert_warns` was ignoring the message, the tests were failing and the message wasn't matching the failure output. Though I believe checking that _'at least one input has length 0'_ was the original intent of these tests.