### PR TITLE
ENH: special: fix premature overflow in `boxcox`

### DIFF
--- a/scipy/special/_boxcox.pxd
+++ b/scipy/special/_boxcox.pxd
@@ -11,6 +11,8 @@ cdef inline double boxcox(double x, double lmbda) noexcept nogil:
     # which is ~2.98e-19.  
     if fabs(lmbda) < 1e-19:
         return log(x)
+    elif lmbda * log(x) < 709.78:
+        return expm1(lmbda * log(x)) / lmbda
     else:
         return copysign(1., lmbda) * exp(lmbda * log(x) - log(fabs(lmbda))) - 1 / lmbda
 
@@ -23,6 +25,8 @@ cdef inline double boxcox1p(double x, double lmbda) noexcept nogil:
     cdef double lgx = log1p(x)
     if fabs(lmbda) < 1e-19 or (fabs(lgx) < 1e-289 and fabs(lmbda) < 1e273):
         return lgx
+    elif lmbda * lgx < 709.78:
+        return expm1(lmbda * lgx) / lmbda
     else:
         return copysign(1., lmbda) * exp(lmbda * lgx - log(fabs(lmbda))) - 1 / lmbda
 
@@ -30,6 +34,8 @@ cdef inline double boxcox1p(double x, double lmbda) noexcept nogil:
 cdef inline double inv_boxcox(double x, double lmbda) noexcept nogil:
     if lmbda == 0:
         return exp(x)
+    elif lmbda * x < 1.79e308:
+        return exp(log1p(lmbda * x) / lmbda)
     else:
         return exp((log(copysign(1., lmbda) * (x + 1 / lmbda)) + log(fabs(lmbda))) / lmbda)
 
@@ -39,5 +45,7 @@ cdef inline double inv_boxcox1p(double x, double lmbda) noexcept nogil:
         return expm1(x)
     elif fabs(lmbda * x) < 1e-154:
         return x
+    elif lmbda * x < 1.79e308:
+        return expm1(log1p(lmbda * x) / lmbda)
     else:
         return expm1((log(copysign(1., lmbda) * (x + 1 / lmbda)) + log(fabs(lmbda))) / lmbda)

--- a/scipy/special/_boxcox.pxd
+++ b/scipy/special/_boxcox.pxd
@@ -1,5 +1,5 @@
 
-from libc.math cimport log, log1p, expm1, exp, fabs
+from libc.math cimport log, log1p, expm1, exp, fabs, copysign
 
 
 cdef inline double boxcox(double x, double lmbda) noexcept nogil:
@@ -12,7 +12,7 @@ cdef inline double boxcox(double x, double lmbda) noexcept nogil:
     if fabs(lmbda) < 1e-19:
         return log(x)
     else:
-        return expm1(lmbda * log(x)) / lmbda
+        return copysign(1., lmbda) * exp(lmbda * log(x) - log(fabs(lmbda))) - 1 / lmbda
 
 
 cdef inline double boxcox1p(double x, double lmbda) noexcept nogil:
@@ -24,14 +24,14 @@ cdef inline double boxcox1p(double x, double lmbda) noexcept nogil:
     if fabs(lmbda) < 1e-19 or (fabs(lgx) < 1e-289 and fabs(lmbda) < 1e273):
         return lgx
     else:
-        return expm1(lmbda * lgx) / lmbda
+        return copysign(1., lmbda) * exp(lmbda * lgx - log(fabs(lmbda))) - 1 / lmbda
 
 
 cdef inline double inv_boxcox(double x, double lmbda) noexcept nogil:
     if lmbda == 0:
         return exp(x)
     else:
-        return exp(log1p(lmbda * x) / lmbda)
+        return exp((log(copysign(1., lmbda) * (x + 1 / lmbda)) + log(fabs(lmbda))) / lmbda)
 
 
 cdef inline double inv_boxcox1p(double x, double lmbda) noexcept nogil:
@@ -40,4 +40,4 @@ cdef inline double inv_boxcox1p(double x, double lmbda) noexcept nogil:
     elif fabs(lmbda * x) < 1e-154:
         return x
     else:
-        return expm1(log1p(lmbda * x) / lmbda)
+        return expm1((log(copysign(1., lmbda) * (x + 1 / lmbda)) + log(fabs(lmbda))) / lmbda)

--- a/scipy/special/tests/test_boxcox.py
+++ b/scipy/special/tests/test_boxcox.py
@@ -116,10 +116,10 @@ def test_boxcox_premature_overflow(x, lmb):
     y = boxcox(x, lmb)
     assert np.isfinite(y)
     x_inv = inv_boxcox(y, lmb)
-    assert_almost_equal(x, x_inv)
+    assert_allclose(x, x_inv)
 
     # test boxcox1p & inv_boxcox1p
     y1p = boxcox1p(x-1, lmb)
     assert np.isfinite(y1p)
     x1p_inv = inv_boxcox1p(y1p, lmb)
-    assert_almost_equal(x-1, x1p_inv)
+    assert_allclose(x-1, x1p_inv)

--- a/scipy/special/tests/test_boxcox.py
+++ b/scipy/special/tests/test_boxcox.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
 from scipy.special import boxcox, boxcox1p, inv_boxcox, inv_boxcox1p
+import pytest
 
 
 # There are more tests of boxcox and boxcox1p in test_mpmath.py.
@@ -104,3 +105,21 @@ def test_inv_boxcox1p_underflow():
     y = inv_boxcox1p(x, lam)
     assert_allclose(y, x, rtol=1e-14)
 
+
+@pytest.mark.parametrize(
+    "x, lmb",
+    [[100, 155],
+     [0.01, -155]]
+)
+def test_boxcox_premature_overflow(x, lmb):
+    # test boxcox & inv_boxcox
+    y = boxcox(x, lmb)
+    assert np.isfinite(y)
+    x_inv = inv_boxcox(y, lmb)
+    assert_almost_equal(x, x_inv)
+
+    # test boxcox1p & inv_boxcox1p
+    y1p = boxcox1p(x-1, lmb)
+    assert np.isfinite(y1p)
+    x1p_inv = inv_boxcox1p(y1p, lmb)
+    assert_almost_equal(x-1, x1p_inv)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/19604#issuecomment-1833218049
Towards #19016

#### What does this implement/fix?
<!--Please explain your changes.-->
Fix premature overflow of the following modules.
`special.boxcox`, `special.inv_boxcox`, `special.boxcox1p`, `special.inv_boxcox1p` 

#### Additional information
<!--Any additional information you think is important.-->
