### PR TITLE
BUG: sparse: Fix hstack, etc for dok_array 

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -14,7 +14,7 @@ from ._sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
                        upcast, upcast_scalar, check_shape)
 
 
-class _dok_base(_spbase, IndexMixin):
+class _dok_base(_spbase, IndexMixin, dict):
     _format = 'dok'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
@@ -466,7 +466,7 @@ class dok_array(_dok_base, sparray):
     """
 
 
-class dok_matrix(spmatrix, _dok_base, dict):
+class dok_matrix(spmatrix, _dok_base):
     """
     Dictionary Of Keys based sparse matrix.
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -400,6 +400,8 @@ class TestConstructUtils:
         assert_equal(construct.vstack([A, B], dtype=np.float32).dtype,
                      np.float32)
 
+        assert_equal(construct.vstack([A.todok(), B.todok()]).toarray(), expected)
+
         assert_equal(construct.vstack([A.tocsr(), B.tocsr()]).toarray(),
                      expected)
         result = construct.vstack([A.tocsr(), B.tocsr()],
@@ -425,7 +427,7 @@ class TestConstructUtils:
         assert isinstance(construct.vstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
 
     @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
-    def test_hstack(self,coo_cls):
+    def test_hstack(self, coo_cls):
         A = coo_cls([[1,2],[3,4]])
         B = coo_cls([[5],[6]])
 
@@ -434,6 +436,9 @@ class TestConstructUtils:
         assert_equal(construct.hstack([A, B]).toarray(), expected)
         assert_equal(construct.hstack([A, B], dtype=np.float32).dtype,
                      np.float32)
+
+        assert_equal(construct.hstack([A.todok(), B.todok()]).toarray(), expected)
+
         assert_equal(construct.hstack([A.tocsc(), B.tocsc()]).toarray(),
                      expected)
         assert_equal(construct.hstack([A.tocsc(), B.tocsc()],


### PR DESCRIPTION
The sparse array format class `dok_array` both has a `__len__` method and is not a subclass of `dict` as of v1.12 (PR #18929). That ends up breaking `sp.sparse.hstack` and other related functions that rely on sparse arrays not being iterated over inside `np.asarray`. Instead they need to be treated as python object scalars. The simple solution is to keep `dok_array` as a subclass of `dict` as `dok_matrix` is and has been. This adds an item to the class MRO but doesn't impact functionality and allows `np.array` and friends to mark it as "don't coerce this into an array".

Fixes #20060 

Alternative Solutions:
- remove the `__len__` functionality from `dok_array`, which is somewhat confusing as it returns `nnz` which is also a property of the array. But if you view dok_array as primarily a dict of nonzero values in the array, then `len(A)` is a natural way of thinking about `nnz`. It is hard to know how much code relies on dok_array having a length.
- rewrite the `_construct.py` module to not rely on manipulating sparse arrays as python object elements in np arrays. I believe this is possible, but would take much more work than this quick fix, and would almost certainly involve other side-effects and/or backward incompatible changes.

Making `dok_array` a subclass of `dict` brings back some warts from what `dok_matrix` provides. But that is really a small negative impact while providing a big improvement for the `_construct.py` codebase, and those warts can be fixed by overriding the dict methods if and when they become problematic.  The warts I know of are incomplete or broken implementations of recent dict functions: `__or__`, `__ror__`, `__ior__`, `__reversed__`, and some broken implementations of `pop` and `fromkeys`.