### PR TITLE
DEP: linalg: deprecate kron in favour of numpy.kron

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -19,7 +19,7 @@ from ._decomp_lu import lu
 from ._decomp_qr import qr
 from ._decomp_qz import ordqz
 from ._decomp import _asarray_validated
-from ._special_matrices import kron, block_diag
+from ._special_matrices import block_diag
 
 __all__ = ['solve_sylvester',
            'solve_continuous_lyapunov', 'solve_discrete_lyapunov',
@@ -210,7 +210,7 @@ def _solve_discrete_lyapunov_direct(a, q):
     `method=direct`. It is not supposed to be called directly.
     """
 
-    lhs = kron(a, a.conj())
+    lhs = np.kron(a, a.conj())
     lhs = np.eye(lhs.shape[0]) - lhs
     x = solve(lhs, q.flatten())
 

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
@@ -308,6 +309,10 @@ def kron(a, b):
     """
     Kronecker product.
 
+    .. deprecated:: 1.13.0
+        `kron` is deprecated and from be removed from SciPy 1.15.0 onwards. Use
+        `numpy.kron` instead.
+
     The result is the block matrix::
 
         a[0,0]*b    a[0,1]*b  ... a[0,-1]*b
@@ -336,6 +341,10 @@ def kron(a, b):
            [3, 3, 3, 4, 4, 4]])
 
     """
+    warnings.warn("`kron` is deprecated as of SciPy 1.13.0 and may be removed from "
+                  "SciPy 1.15.0 onwards. Use `numpy.kron` instead.",
+                  DeprecationWarning, stacklevel=2)
+
     if not a.flags['CONTIGUOUS']:
         a = np.reshape(a, a.shape)
     if not b.flags['CONTIGUOUS']:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -205,14 +205,15 @@ class TestBlockDiag:
 class TestKron:
 
     def test_basic(self):
-
-        a = kron(array([[1, 2], [3, 4]]), array([[1, 1, 1]]))
+        with pytest.deprecated_call(match="`kron`"):
+            a = kron(array([[1, 2], [3, 4]]), array([[1, 1, 1]]))
         assert_array_equal(a, array([[1, 1, 1, 2, 2, 2],
                                      [3, 3, 3, 4, 4, 4]]))
 
         m1 = array([[1, 2], [3, 4]])
         m2 = array([[10], [11]])
-        a = kron(m1, m2)
+        with pytest.deprecated_call(match="`kron`"):
+            a = kron(m1, m2)
         expected = array([[10, 20],
                           [11, 22],
                           [30, 40],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #20072
#### What does this implement/fix?
<!--Please explain your changes.-->
`kron` does not support nd arrays with n>2 whereas `numpy.kron` does. It was proposed in #20077 to deprecate `kron` since the numpy version provides strictly more functionality, for which 3 core devs expressed support.
#### Additional information
<!--Any additional information you think is important.-->
