### PR TITLE
MAINT: detect musl differently.

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -15,17 +15,13 @@ __all__ = ['PytestTester', 'check_free_memory', '_TestPythranFunc', 'IS_MUSL']
 
 
 IS_MUSL = False
-try:
-    # Note that packaging is not a dependency, hence we need this try-except:
-    from packaging.tags import sys_tags
-    _tags = list(sys_tags())
-    if 'musllinux' in _tags[0].platform:
-        IS_MUSL = True
-except ImportError:
-    # fallback to sysconfig (might be flaky)
-    v = sysconfig.get_config_var('HOST_GNU_TYPE') or ''
-    if 'musl' in v:
-        IS_MUSL = True
+# alternate way is
+# from packaging.tags import sys_tags
+#     _tags = list(sys_tags())
+#     if 'musllinux' in _tags[0].platform:
+_v = sysconfig.get_config_var('HOST_GNU_TYPE') or ''
+if 'musl' in _v:
+    IS_MUSL = True
 
 
 class FPUModeChangeWarning(RuntimeWarning):


### PR DESCRIPTION
Closes #20084.

Uses a similar approach to that used by numpy.