### PR TITLE
MAINT: switch from `numpy.array_api` to `array-api-strict`

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis array-api-strict
 
     - name: Install PyTorch CPU
       run: |
@@ -92,6 +92,6 @@ jobs:
         export SCIPY_USE_PROPACK=1
         # expand as new modules are added
         # --array-api-backend == -b
-        python dev.py --no-build test -b pytorch -b numpy -b numpy.array_api -s cluster -- --durations 3 --timeout=60
-        python dev.py --no-build test -b pytorch -b numpy -b numpy.array_api -s fft -- --durations 3 --timeout=60
+        python dev.py --no-build test -b pytorch -b numpy -b array_api_strict -s cluster -- --durations 3 --timeout=60
+        python dev.py --no-build test -b pytorch -b numpy -b array_api_strict -s fft -- --durations 3 --timeout=60
         python dev.py --no-build test --array-api-backend all --tests scipy/_lib/tests/test_array_api.py

--- a/dev.py
+++ b/dev.py
@@ -689,7 +689,7 @@ class Test(Task):
         ['--array-api-backend', '-b'], default=None, metavar='ARRAY_BACKEND',
         multiple=True,
         help=(
-            "Array API backend ('all', 'numpy', 'pytorch', 'cupy', 'numpy.array_api')."
+            "Array API backend ('all', 'numpy', 'pytorch', 'cupy', 'array_api_strict')."
         )
     )
     # Argument can't have `help=`; used to consume all of `-- arg1 arg2 arg3`

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - pytest-timeout
   - asv >=0.6
   - hypothesis
+  - array-api-strict
   # For type annotations
   - mypy
   - typing_extensions

--- a/mypy.ini
+++ b/mypy.ini
@@ -79,6 +79,9 @@ ignore_missing_imports = True
 [mypy-appdirs]
 ignore_missing_imports = True
 
+[mypy-array_api_strict]
+ignore_missing_imports = True
+
 #
 # Extension modules without stubs.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ test = [
     "scikit-umfpack",
     "pooch",
     "hypothesis>=6.30",
+    "array-api-strict",
 ]
 doc = [
     "sphinx>=5.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,5 @@ filterwarnings =
     ignore:'contextfunction' is renamed to 'pass_context'
     ignore:.*The distutils.* is deprecated.*:DeprecationWarning
     ignore:\s*.*numpy.distutils.*:DeprecationWarning
-    ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning
     ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning
     ignore:.*In the future `np.long` will be defined as.*:FutureWarning

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,3 +11,4 @@ threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch
 hypothesis>=6.30
+array-api-strict

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -161,7 +161,7 @@ def _warning(s):
 
 
 def int_floor(arr, xp):
-    # numpy.array_api is strict about not allowing `int()` on a float array.
+    # array_api_strict is strict about not allowing `int()` on a float array.
     # That's typically not needed, here it is - so explicitly convert
     return int(xp.astype(xp.asarray(arr), xp.int64))
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1271,7 +1271,7 @@ def test_node_compare(xp):
 
 @skip_if_array_api_gpu
 @array_api_compatible
-@skip_if_array_api_backend('numpy.array_api')
+@skip_if_array_api_backend('array_api_strict')
 def test_cut_tree(xp):
     np.random.seed(23)
     nobs = 50

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -6,7 +6,6 @@ import tempfile
 from functools import wraps
 
 import numpy as np
-import numpy.array_api
 import numpy.testing as npt
 import pytest
 import hypothesis
@@ -108,7 +107,11 @@ xp_available_backends = {'numpy': np}
 
 if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
     # fill the dict of backends with available libraries
-    xp_available_backends.update({'numpy.array_api': numpy.array_api})
+    try:
+        import array_api_strict
+        xp_available_backends.update({'array_api_strict': array_api_strict})
+    except ImportError:
+        pass
 
     try:
         import torch  # type: ignore[import]

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -426,8 +426,8 @@ class TestFFTShift:
 
 class TestFFTFreq:
 
-    # fft not yet implemented by numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
+    # fft not yet implemented by array-api-strict
+    @skip_if_array_api_backend('array_api_strict')
     # cupy.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('cupy')
     @array_api_compatible
@@ -456,8 +456,8 @@ class TestFFTFreq:
 
 class TestRFFTFreq:
 
-    # fft not yet implemented by numpy.array_api
-    @skip_if_array_api_backend('numpy.array_api')
+    # fft not yet implemented by array-api-strict
+    @skip_if_array_api_backend('array_api_strict')
     # cupy.fft not yet implemented by array-api-compat
     @skip_if_array_api_backend('cupy')
     @array_api_compatible

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -344,12 +344,12 @@ class TestFFTShift:
     @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_definition(self, xp):
-        x = xp.asarray([0, 1, 2, 3, 4, -4, -3, -2, -1])
-        y = xp.asarray([-4, -3, -2, -1, 0, 1, 2, 3, 4])
+        x = xp.asarray([0., 1, 2, 3, 4, -4, -3, -2, -1])
+        y = xp.asarray([-4., -3, -2, -1, 0, 1, 2, 3, 4])
         xp_assert_close(fft.fftshift(x), y)
         xp_assert_close(fft.ifftshift(y), x)
-        x = xp.asarray([0, 1, 2, 3, 4, -5, -4, -3, -2, -1])
-        y = xp.asarray([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4])
+        x = xp.asarray([0., 1, 2, 3, 4, -5, -4, -3, -2, -1])
+        y = xp.asarray([-5., -4, -3, -2, -1, 0, 1, 2, 3, 4])
         xp_assert_close(fft.fftshift(x), y)
         xp_assert_close(fft.ifftshift(y), x)
 
@@ -365,8 +365,8 @@ class TestFFTShift:
     @skip_if_array_api_backend('torch')
     @array_api_compatible
     def test_axes_keyword(self, xp):
-        freqs = xp.asarray([[0, 1, 2], [3, 4, -4], [-3, -2, -1]])
-        shifted = xp.asarray([[-1, -3, -2], [2, 0, 1], [-4, 3, 4]])
+        freqs = xp.asarray([[0., 1, 2], [3, 4, -4], [-3, -2, -1]])
+        shifted = xp.asarray([[-1., -3, -2], [2, 0, 1], [-4, 3, 4]])
         xp_assert_close(fft.fftshift(freqs, axes=(0, 1)), shifted)
         xp_assert_close(fft.fftshift(freqs, axes=0), fft.fftshift(freqs, axes=(0,)))
         xp_assert_close(fft.ifftshift(shifted, axes=(0, 1)), freqs)
@@ -384,14 +384,14 @@ class TestFFTShift:
             [0, 1],
             [2, 3],
             [4, 5]
-        ])
+        ], dtype=xp.float64)
 
         # shift in dimension 0
         shift_dim0 = xp.asarray([
             [4, 5],
             [0, 1],
             [2, 3]
-        ])
+        ], dtype=xp.float64)
         xp_assert_close(fft.fftshift(freqs, axes=0), shift_dim0)
         xp_assert_close(fft.ifftshift(shift_dim0, axes=0), freqs)
         xp_assert_close(fft.fftshift(freqs, axes=(0,)), shift_dim0)
@@ -402,7 +402,7 @@ class TestFFTShift:
             [1, 0],
             [3, 2],
             [5, 4]
-        ])
+        ], dtype=xp.float64)
         xp_assert_close(fft.fftshift(freqs, axes=1), shift_dim1)
         xp_assert_close(fft.ifftshift(shift_dim1, axes=1), freqs)
 
@@ -411,7 +411,7 @@ class TestFFTShift:
             [5, 4],
             [1, 0],
             [3, 2]
-        ])
+        ], dtype=xp.float64)
         xp_assert_close(fft.fftshift(freqs, axes=(0, 1)), shift_dim_both)
         xp_assert_close(fft.ifftshift(shift_dim_both, axes=(0, 1)), freqs)
         xp_assert_close(fft.fftshift(freqs, axes=[0, 1]), shift_dim_both)

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -8,11 +8,18 @@ from scipy.conftest import array_api_compatible
 from scipy import special
 from scipy._lib._array_api import xp_assert_close
 from scipy._lib.array_api_compat import numpy as np
-import numpy.array_api as np_array_api
+
+try:
+    import array_api_strict
+    HAVE_ARRAY_API_STRICT = True
+except ImportError:
+    HAVE_ARRAY_API_STRICT = False
 
 
+@pytest.mark.skipif(not HAVE_ARRAY_API_STRICT,
+                    reason="`array_api_strict` not installed")
 def test_dispatch_to_unrecognize_library():
-    xp = np_array_api
+    xp = array_api_strict
     f = get_array_special_func('ndtr', xp=xp, n_array_args=1)
     x = [1, 2, 3]
     res = f(xp.asarray(x))


### PR DESCRIPTION
This is a standalone version of `numpy.array_api` that will be stable, and support multiple NumPy versions (at least 1.26 and 2.0 right now).

`numpy.array_api` is likely to be removed before the numpy 2.0 release, so we should make this switch now.