### PR TITLE
DOC: Fix a could of places that are parsed as substitution references by sphinx

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1047,7 +1047,7 @@ cdef int reorth(int m, int n, blas_t* q, int* qs, bint qisF, blas_t* u,
        length and orthogonal to the columns of q.
 
        This function returns 0 or 1 on success, and 2 if the recipercal
-       condition number of [q, u/||u||] is less than RCOND. This condition is
+       condition number of ``[q, u/||u||]`` is less than RCOND. This condition is
        important when inserting columns, because updating may not be meaningful
        if u is a linear combination of the columns of q.
 
@@ -1661,7 +1661,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
     ------
     LinAlgError :
         If updating a (M,N) (N,N) factorization and the reciprocal condition
-        number of Q augmented with u/||u|| is smaller than rcond.
+        number of Q augmented with ``u/||u||`` is smaller than rcond.
 
     See Also
     --------

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -89,7 +89,7 @@ class BaseQuadraticSubproblem:
 
     def get_boundaries_intersections(self, z, d, trust_radius):
         """
-        Solve the scalar quadratic equation ||z + t d|| == trust_radius.
+        Solve the scalar quadratic equation ``||z + t d|| == trust_radius``.
         This is like a line-sphere intersection.
         Return the two values of t, sorted from low to high.
         """

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -443,7 +443,7 @@ class LazyOperatorNormInfo:
 
     def d(self, p):
         """
-        Lazily estimate d_p(A) ~= || A^p ||^(1/p) where ||.|| is the 1-norm.
+        Lazily estimate :math:`d_p(A) ~= || A^p ||^(1/p)` where :math:`||.||` is the 1-norm.
         """
         if p not in self._d:
             est = _onenormest_matrix_power(self._A, p, self._ell)

--- a/scipy/stats/_ksstats.py
+++ b/scipy/stats/_ksstats.py
@@ -507,8 +507,8 @@ def kolmogn(n, x, cdf=True):
 
     The two-sided Kolmogorov-Smirnov distribution has as its CDF Pr(D_n <= x),
     for a sample of size n drawn from a distribution with CDF F(t), where
-    D_n &= sup_t |F_n(t) - F(t)|, and
-    F_n(t) is the Empirical Cumulative Distribution Function of the sample.
+    :math:`D_n &= sup_t |F_n(t) - F(t)|`, and
+    :math:`F_n(t)` is the Empirical Cumulative Distribution Function of the sample.
 
     Parameters
     ----------


### PR DESCRIPTION
A number of place are using pipes to denote absolute values/norm.

This is unfortunately interpreted by sphinx as a substitution reference.

Depending on the context I wrap those in verbatim (if the rest of the module use verbatim for other equations), or using an inline math directive.

[skip actions] [skip cirrus]
