### PR TITLE
DOC: Fix small typos in `signal.rst` and `_short_time_fft.py`

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1322,7 +1322,7 @@ The :func:`~scipy.signal.periodogram` function calculates a power spectral densi
 (``scaling='density'``) or a squared magnitude spectrum (``scaling='spectrum'``). To
 obtain a smoothed periodogram, the :func:`~scipy.signal.welch` function can be used. It
 does the smoothing by dividing the input signal into overlapping segments, to then
-calculate the windowed DFT of each segment. The result is to the average of thoseDFTs.
+calculate the windowed DFT of each segment. The result is to the average of those DFTs.
 
 .. Consult ``TestSampledSpectralRepresentations.test_windowed_DFT`` in file
    `signal/test/test_spectral.py` for plausibility tests that the scalings of
@@ -1472,11 +1472,11 @@ reformulate Eq. :math:numref:`eq_dSTFT` as a two-step process:
    at :math:`t[p] :=  p \Delta t = h T` (see `delta_t`),
    i.e.,
 
-    .. math::
-        :label: eq_STFT_windowing
+   .. math::
+       :label: eq_STFT_windowing
 
-        x_p[m] = x\!\big[m - \lfloor M/2\rfloor + h p\big]\, \conj{w[m]}\ ,
-                 \quad m = 0, \ldots M-1\ ,
+       x_p[m] = x\!\big[m - \lfloor M/2\rfloor + h p\big]\, \conj{w[m]}\ ,
+                \quad m = 0, \ldots M-1\ ,
 
    where the integer :math:`\lfloor M/2\rfloor` represents ``M//2``, i.e, it is
    the mid point of the window (`m_num_mid`). For notational convenience,

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -545,7 +545,7 @@ class ShortTimeFFT:
             If the FFT length `mfft` is even, the last FFT value is not paired,
             and thus it is not scaled.
 
-        Note that`onesided` and `onesided2X` do not work for complex-valued signals or
+        Note that `onesided` and `onesided2X` do not work for complex-valued signals or
         complex-valued windows. Furthermore, the frequency values can be obtained by
         reading the `f` property, and the number of samples by accessing the `f_pts`
         property.
@@ -1449,8 +1449,6 @@ class ShortTimeFFT:
         ----------
         n
             Number of sample of the input signal.
-        x
-            The input signal as real or complex valued array.
         p0
             The first element of the range of slices to calculate. If ``None``
             then it is set to :attr:`p_min`, which is the smallest possible


### PR DESCRIPTION
* Remove unwanted highlighting of one equation in `signal.rst` which appeared due the updated `pydata-sphinx-theme`.
* Remove extra parameter from docstring in `ShorTimeFFT.t()``
* Added missing spaces.

The following screenshot shows the unwanted highlighting:
![Screenshot_20240215_232955](https://github.com/scipy/scipy/assets/12721170/0a6b06ab-22d5-4a11-85d8-dd74954fa47b)

