### PR TITLE
TST:linalg:Reduce the size of the cossin test

### DIFF
--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -170,7 +170,8 @@ def cossin(X, p=None, q=None, separate=False,
 
     method_name = csd.typecode + driver
     if info < 0:
-        raise ValueError(f'illegal value in argument {-info} of internal {method_name}')
+        raise ValueError(f'illegal value in argument {-info} '
+                         f'of internal {method_name}')
     if info > 0:
         raise LinAlgError(f"{method_name} did not converge: {info}")
 


### PR DESCRIPTION
Closes #20034 

The test size is unnecessarily big and prone to occasional column/sign flips. It can be for various reasons but it is only happening in the atlas job and probably not worth investigating. Since it has been running for quite a long time with the large size, it does not hurt to reduce the size a little bit so that it has a higher chance to converge to the same result. 

Also some PEP8 and `random.seed()` cleanup is done. 
