### PR TITLE
ENH: use non-trivial bounds to solve for kappa of vonmises MLE.

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -262,6 +262,19 @@ class TestVonMises:
         kappa, loc, scale = stats.vonmises.fit([0])
         assert kappa == 1e16 and loc == 0 and scale == 1
 
+    def test_vonmises_fit_bounds(self):
+        # For certain input data, the root bracket is violated numerically.
+        # Test that this situation is handled.  The input data below are
+        # crafted to trigger the bound violation for the current choice of
+        # bounds and the specific way the bounds and the objective function
+        # are computed.
+
+        # Test that no exception is raised when the lower bound is violated.
+        scipy.stats.vonmises.fit([0, 3.7e-08], floc=0)
+
+        # Test that no exception is raised when the upper bound is violated.
+        scipy.stats.vonmises.fit([np.pi/2*(1-4.86e-9)], floc=0)
+
 
 def _assert_less_or_close_loglike(dist, data, func=None, maybe_identical=False,
                                   **kwds):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -221,7 +221,6 @@ class TestVonMises:
         _assert_less_or_close_loglike(stats.vonmises, data,
                                       stats.vonmises.nnlf, **kwds)
 
-    @pytest.mark.xslow
     def test_vonmises_fit_bad_floc(self):
         data = [-0.92923506, -0.32498224, 0.13054989, -0.97252014, 2.79658071,
                 -0.89110948, 1.22520295, 1.44398065, 2.49163859, 1.50315096,
@@ -257,6 +256,11 @@ class TestVonMises:
         assert_allclose(dist.mean(), 0, atol=1e-15)
         assert_allclose(dist.expect(), 0, atol=1e-15)
         assert np.all(np.abs(dist.rvs(size=10, random_state=1234)) <= np.pi)
+
+    def test_vonmises_fit_equal_data(self):
+        # When all data are equal, expect kappa = 1e16.
+        kappa, loc, scale = stats.vonmises.fit([0])
+        assert kappa == 1e16 and loc == 0 and scale == 1
 
 
 def _assert_less_or_close_loglike(dist, data, func=None, maybe_identical=False,


### PR DESCRIPTION
#### Reference issue
This is a follow-up commit for gh-18190.

#### What does this implement/fix?
The MLE of the vonmises distribution solves $r_0(\kappa):=I_1(\kappa)/I_0(\kappa)=r$ for $\kappa$ given $0 < r < 1$ using Brent's method. This PR provides non-trivial bounds for the root.

The non-trivial bounds save a few evaluations of $I_1(\kappa)/I_0(\kappa)$  compared to the trivial bounds. It also opens the possibility to solve the equation to arbitrary precision.

#### Algorithm description

The bounds of $\kappa$ are derived from the bounds of $r_\nu(x):=I_{\nu+1}(x)/I_\nu(x)$ given by [Amos (1973)](https://www.jstor.org/stable/2005830). He gave two set of bounds:

Equation (11):

$$
\frac{x}{\nu+1+\sqrt{x^2+(\nu+1)^2}}\le r_\nu(x)\le\frac{x}{\nu+\sqrt{x^2+(\nu+2)^2}}
$$

Equation (16):

$$
\frac{x}{\nu+0.5+\sqrt{x^2+(\nu+1.5)^2}}\le r_\nu(x)\le\frac{x}{\nu+0.5+\sqrt{x^2+(\nu+0.5)^2}}
$$

The lower bound of (16) is always tighter, while the upper bound of (16) is tighter only if $x\ge 2\sqrt{(\nu+1)(2\nu+3)}$.

From these bounds we derive the bounds for the solution $x=r_\nu^{-1}(r)$:

Equation (11’):

$$
\frac{r\nu+r\sqrt{\nu^2+4(\nu+1)(1-r^2)}}{1-r^2}\le r_\nu^{-1}(r)\le \frac{r(2\nu+2)}{1-r^2}
$$

Equation (16’):

$$
\frac{r(2\nu+1)}{1-r^2}\le r_\nu^{-1}(r) \le \frac{r(\nu+0.5)+r\sqrt{(\nu+0.5)^2+2(\nu+1)(1-r^2)}}{1-r^2}
$$

The upper bound of (16’) is always tighter, while the lower bound of (16’) is tighter only if $r\ge \frac{1}{2}\sqrt{(2\nu+3)/(\nu+1)}$.

The bounds are moderate for moderate values of $r$, but remarkably tight for small and large $r$. For example, as $r$ tends to 0, the ratio between the upper bound of (16’) and the lower bound of (11’) tends to 1. And as $r$ tends to 1, the width of the bounds (16’) tends to $(2\nu+2)/(2\nu+1)$.

When $\nu=0$, the bounds become

Equation (11’’):

$$
\frac{2r}{\sqrt{1-r^2}}\le r_0^{-1}(r) \le \frac{2r}{1-r^2}
$$

Equation (16’’):

$$
\frac{r}{1-r^2} \le r_0^{-1}(r) \le \frac{\frac{1}{2}r+r\sqrt{\frac{1}{4}+2(1-r^2)}}{1-r^2}
$$

Any (relaxation) of these  bounds may be used to bracket the root for Brent’s method. A convenient choice is the lower bound of (16’’) together with the upper bound of (11’’); this leads to

$$
\frac{r}{1-r^2} \le r_0^{-1}(r) \le \frac{2r}{1-r^2}
$$

This choice trivially guarantees that the lower bound is less than the upper bound numerically.

#### Additional information

[Segura (2023)](https://www.sciencedirect.com/science/article/pii/S0022247X23002147) gives an in-depth analysis of the bounds of $r_\nu(x)$.

[Hill (1981)](https://dl.acm.org/doi/10.1145/355945.355949) gives series expansions for $r_0(x)$, and uses Newton-Raphson to invert it.

For the higher-order `vonmises_fisher` distribution, Sra (2012) refines the guess using two Newton steps, and Song et al. (2012) refines the guess using two Halley steps. Hornik and Grün (2014) presents the same bounds as above.

**Reference**

Hornik, K. and Grün, B. (2014). "On maximum likelihood estimation of the concentration parameter of von Mises–Fisher distributions." _Computational Statistics_, 29:945-957. [PDF](https://link.springer.com/content/pdf/10.1007/s00180-013-0471-0.pdf)

Song, H., Liu, J., and Wang, G. (2012). "High-order parameter approximation for von Mises–Fisher distributions." _Applied Mathematics and Computation_, 218(24):11880-11890. [Link](https://www.sciencedirect.com/science/article/abs/pii/S0096300312005656)

Sra, S. (2012). "A short note on parameter approximation for von Mises-Fisher distributions: and a fast implementation of I<sub>s</sub>(x)." _Computational Statistics_, 27:177-190. [PDF](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=7d3405adc726356c4265bb9b26cdf3c6df6e9e7d)