### PR TITLE
MAINT: optimize: expose `NoConvergence`

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -224,6 +224,7 @@ Multidimensional
    :toctree: generated/
 
    root - Unified interface for nonlinear solvers of multivariate functions.
+   NoConvergence -  Exception raised when nonlinear solver does not converge.
 
 The `root` function supports the following methods:
 

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -224,7 +224,6 @@ Multidimensional
    :toctree: generated/
 
    root - Unified interface for nonlinear solvers of multivariate functions.
-   NoConvergence -  Exception raised when nonlinear solver does not converge.
 
 The `root` function supports the following methods:
 
@@ -386,6 +385,7 @@ General nonlinear solvers:
    fsolve - Non-linear multivariable equation solver.
    broyden1 - Broyden's first method.
    broyden2 - Broyden's second method.
+   NoConvergence -  Exception raised when nonlinear solver does not converge.
 
 Large-scale nonlinear solvers:
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -16,7 +16,7 @@ from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 __all__ = [
     'broyden1', 'broyden2', 'anderson', 'linearmixing',
     'diagbroyden', 'excitingmixing', 'newton_krylov',
-    'BroydenFirst', 'KrylovJacobian', 'InverseJacobian']
+    'BroydenFirst', 'KrylovJacobian', 'InverseJacobian', 'NoConvergence']
 
 #------------------------------------------------------------------------------
 # Utility functions
@@ -24,6 +24,8 @@ __all__ = [
 
 
 class NoConvergence(Exception):
+    """Exception raised when nonlinear solver fails to converge within the specified
+    `maxiter`."""
     pass
 
 

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -363,8 +363,7 @@ def _root_broyden1_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -441,8 +440,7 @@ def _root_broyden2_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -506,8 +504,7 @@ def _root_anderson_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -548,8 +545,7 @@ def _root_linearmixing_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, ``NoConvergence`` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -585,8 +581,7 @@ def _root_diagbroyden_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -622,8 +617,7 @@ def _root_excitingmixing_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional
@@ -662,8 +656,7 @@ def _root_krylov_doc():
     disp : bool, optional
         Print status to stdout on every iteration.
     maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
+        Maximum number of iterations to make.
     ftol : float, optional
         Relative tolerance for the residual. If omitted, not used.
     fatol : float, optional

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -10,6 +10,7 @@ from scipy.sparse import csr_array
 from numpy import diag, dot
 from numpy.linalg import inv
 import numpy as np
+import scipy
 
 from .test_minpack import pressure_network
 
@@ -207,6 +208,13 @@ class TestNonlin:
                         self._check_func_fail(f, meth)
                     continue
                 self._check_root(f, meth)
+
+    def test_no_convergence(self):
+        def wont_converge(x):
+            return 1e3 + x
+        
+        with pytest.raises(scipy.optimize.NoConvergence):
+            nonlin.newton_krylov(wont_converge, xin=[0], maxiter=1)
 
 
 class TestSecant:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #20100 
#### What does this implement/fix?
<!--Please explain your changes.-->
Currently, this expectation is only exposed through the deprecated namespace `scipy.optimize.nonlin`. This PR exposes it in the main `scipy.optimize` namespace so that it can be accessed without a deprecation warning.
#### Additional information
<!--Any additional information you think is important.-->
