### PR TITLE
ENH: allow shape parameter kappa to be zero in vonmises distribution.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10498,7 +10498,7 @@ class vonmises_gen(rv_continuous):
 
         f(x, \kappa) = \frac{ \exp(\kappa \cos(x)) }{ 2 \pi I_0(\kappa) }
 
-    for :math:`-\pi \le x \le \pi`, :math:`\kappa > 0`. :math:`I_0` is the
+    for :math:`-\pi \le x \le \pi`, :math:`\kappa \ge 0`. :math:`I_0` is the
     modified Bessel function of order zero (`scipy.special.i0`).
 
     `vonmises` is a circular distribution which does not restrict the
@@ -10577,7 +10577,10 @@ class vonmises_gen(rv_continuous):
 
     """
     def _shape_info(self):
-        return [_ShapeInfo("kappa", False, (0, np.inf), (False, False))]
+        return [_ShapeInfo("kappa", False, (0, np.inf), (True, False))]
+
+    def _argcheck(self, kappa):
+        return kappa >= 0
 
     def _rvs(self, kappa, size=None, random_state=None):
         return random_state.vonmises(0.0, kappa, size=size)

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -27,7 +27,7 @@ cdef double von_mises_cdf_series(double k, double x, unsigned int p) noexcept:
     V = 0
     for n in range(p - 1, 0, -1):
         sn, cn = sn * c - cn * s, cn * c + sn * s
-        R = 1. / (2 * n / k + R)
+        R = k / (2 * n + k * R)
         V = R * (sn / n + V)
 
     with cython.cdivision(True):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -247,6 +247,17 @@ class TestVonMises:
         assert scale_fit == 1
         assert -np.pi < loc_fit < np.pi
 
+    def test_vonmises_kappa_0_gh18166(self):
+        # Check that kappa = 0 is supported.
+        dist = stats.vonmises(0)
+        assert_allclose(dist.pdf(0), 1 / (2 * np.pi), rtol=1e-15)
+        assert_allclose(dist.cdf(np.pi/2), 0.75, rtol=1e-15)
+        assert_allclose(dist.sf(-np.pi/2), 0.75, rtol=1e-15)
+        assert_allclose(dist.ppf(0.9), np.pi*0.8, rtol=1e-15)
+        assert_allclose(dist.mean(), 0, atol=1e-15)
+        assert_allclose(dist.expect(), 0, atol=1e-15)
+        assert np.all(np.abs(dist.rvs(size=10, random_state=1234)) <= np.pi)
+
 
 def _assert_less_or_close_loglike(dist, data, func=None, maybe_identical=False,
                                   **kwds):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-18166.

#### What does this implement/fix?
Most of the existing formulas work readily for $\kappa = 0$.  The C function `von_mises_cdf_series` is updated to avoid division-by-zero error.  A test case is added.  The doc is updated.

#### Additional information
When $\kappa = 0$, the vonmises distribution reduces to a [circular uniform distribution](https://en.wikipedia.org/wiki/Circular_uniform_distribution). It is nevertheless desirable to support $\kappa=0$ because it is mathematically well-defined.

<!--Any additional information you think is important.-->
