### PR TITLE
DOC: update docstring of stats.percentileofscore

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2260,7 +2260,7 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     Parameters
     ----------
     a : array_like
-        Array to which `score` is compared.
+        A 1-D array to which `score` is compared.
     score : array_like
         Scores to compute percentiles for.
     kind : {'rank', 'weak', 'strict', 'mean'}, optional


### PR DESCRIPTION
#### Reference issue
Closes #20042

#### What does this implement/fix?
State that the input array `a` of scipy.stats.percentileofscore must be 1-dimensional.