### PR TITLE
MAINT: shim for descr->f access

### DIFF
--- a/scipy/_build_utils/src/npy_2_compat.h
+++ b/scipy/_build_utils/src/npy_2_compat.h
@@ -31,23 +31,55 @@
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
 
 /*
- * Allow users to use `PyArray_RUNTIME_VERSION` when vendoring the file for
- * compilation with NumPy 1.x.
- * Simply do not define when compiling with 2.x.  It must be defined later
- * as it is set during `import_array()`.
+ * New macros for accessing real and complex part of a complex number can be
+ * found in "npy_2_complexcompat.h".
  */
-#if !defined(PyArray_RUNTIME_VERSION) && NPY_ABI_VERSION < 0x02000000
+
+
+/*
+ * This header is meant to be included by downstream directly for 1.x compat.
+ * In that case we need to ensure that users first included the full headers
+ * and not just `ndarraytypes.h`.
+ */
+#ifndef NPY_FEATURE_VERSION
+  #error "The NumPy 2 compat header requires `import_array()` for which "  \
+         "the `ndarraytypes.h` header include is not sufficient.  Please "  \
+         "include it after `numpy/ndarrayobject.h` or similar.\n"  \
+         "To simplify includsion, you may use `PyArray_ImportNumPy()` " \
+         "which is defined in the compat header and is lightweight (can be)."
+#endif
+
+#if NPY_ABI_VERSION < 0x02000000
+  /*
+   * Define 2.0 feature version as it is needed below to decide whether we
+   * compile for both 1.x and 2.x (defining it gaurantees 1.x only).
+   */
+  #define NPY_2_0_API_VERSION 0x00000012
   /*
    * If we are compiling with NumPy 1.x, PyArray_RUNTIME_VERSION so we
    * pretend the `PyArray_RUNTIME_VERSION` is `NPY_FEATURE_VERSION`.
+   * This allows downstream to use `PyArray_RUNTIME_VERSION` if they need to.
    */
   #define PyArray_RUNTIME_VERSION NPY_FEATURE_VERSION
 #endif
 
+
 /*
- * New macros for accessing real and complex part of a complex number can be
- * found in "npy_2_complexcompat.h".
+ * Define a better way to call `_import_array()` to simplify backporting as
+ * we now require imports more often (necessary to make ABI flexible).
  */
+#ifdef import_array1
+
+static inline int
+PyArray_ImportNumPyAPI()
+{
+    if (NPY_UNLIKELY(PyArray_API == NULL)) {
+        import_array1(-1);
+    }
+    return 0;
+}
+
+#endif  /* import_array1 */
 
 
 /*
@@ -70,7 +102,17 @@
  *
  * The number of built-in NumPy dtypes.
  */
-#if NPY_ABI_VERSION < 0x02000000
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    #define NPY_DEFAULT_INT NPY_INTP
+    #define NPY_RAVEL_AXIS NPY_MIN_INT
+    #define NPY_MAXARGS 64
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        return (unsigned char)dtype->flags;
+    }
+#elif NPY_ABI_VERSION < 0x02000000
     #define NPY_DEFAULT_INT NPY_LONG
     #define NPY_RAVEL_AXIS 32
     #define NPY_MAXARGS 32
@@ -107,7 +149,13 @@
 
 
 #if !(defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)
-#if NPY_ABI_VERSION < 0x02000000
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    static inline PyArray_ArrFuncs *
+    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    {
+        return _PyDataType_GetArrFuncs(descr);
+    }
+#elif NPY_ABI_VERSION < 0x02000000
     static inline PyArray_ArrFuncs *
     PyDataType_GetArrFuncs(PyArray_Descr *descr)
     {

--- a/scipy/_build_utils/src/npy_2_compat.h
+++ b/scipy/_build_utils/src/npy_2_compat.h
@@ -1,0 +1,132 @@
+/*
+ * This header file defines relevant features which:
+ * - Require runtime inspection depending on the NumPy version.
+ * - May be needed when compiling with an older version of NumPy to allow
+ *   a smooth transition.
+ *
+ * As such, it is shipped with NumPy 2.0, but designed to be vendored in full
+ * or parts by downstream projects.
+ *
+ * It must be included after any other includes.  `import_array()` must have
+ * been called in the scope or version dependency will misbehave, even when
+ * only `PyUFunc_` API is used.
+ *
+ * If required complicated defs (with inline functions) should be written as:
+ *
+ *     #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+ *         Simple definition when NumPy 2.0 API is guaranteed.
+ *     #else
+ *         static inline definition of a 1.x compatibility shim
+ *         #if NPY_ABI_VERSION < 0x02000000
+ *            Make 1.x compatibility shim the public API (1.x only branch)
+ *         #else
+ *             Runtime dispatched version (1.x or 2.x)
+ *         #endif
+ *     #endif
+ *
+ * An internal build always passes NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+ */
+
+#ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
+#define NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
+
+/*
+ * Allow users to use `PyArray_RUNTIME_VERSION` when vendoring the file for
+ * compilation with NumPy 1.x.
+ * Simply do not define when compiling with 2.x.  It must be defined later
+ * as it is set during `import_array()`.
+ */
+#if !defined(PyArray_RUNTIME_VERSION) && NPY_ABI_VERSION < 0x02000000
+  /*
+   * If we are compiling with NumPy 1.x, PyArray_RUNTIME_VERSION so we
+   * pretend the `PyArray_RUNTIME_VERSION` is `NPY_FEATURE_VERSION`.
+   */
+  #define PyArray_RUNTIME_VERSION NPY_FEATURE_VERSION
+#endif
+
+/*
+ * New macros for accessing real and complex part of a complex number can be
+ * found in "npy_2_complexcompat.h".
+ */
+
+
+/*
+ * NPY_DEFAULT_INT
+ *
+ * The default integer has changed, `NPY_DEFAULT_INT` is available at runtime
+ * for use as type number, e.g. `PyArray_DescrFromType(NPY_DEFAULT_INT)`.
+ *
+ * NPY_RAVEL_AXIS
+ *
+ * This was introduced in NumPy 2.0 to allow indicating that an axis should be
+ * raveled in an operation. Before NumPy 2.0, NPY_MAXDIMS was used for this purpose.
+ *
+ * NPY_MAXDIMS
+ *
+ * A constant indicating the maximum number dimensions allowed when creating
+ * an ndarray.
+ *
+ * NPY_NTYPES_LEGACY
+ *
+ * The number of built-in NumPy dtypes.
+ */
+#if NPY_ABI_VERSION < 0x02000000
+    #define NPY_DEFAULT_INT NPY_LONG
+    #define NPY_RAVEL_AXIS 32
+    #define NPY_MAXARGS 32
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        return (unsigned char)dtype->flags;
+    }
+
+    /* Aliases of 2.x names to 1.x only equivalent names */
+    #define NPY_NTYPES NPY_NTYPES_LEGACY
+    #define PyArray_DescrProto PyArray_Descr
+#else
+    #define NPY_DEFAULT_INT  \
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)
+    #define NPY_RAVEL_AXIS  \
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? -1 : 32)
+    #define NPY_MAXARGS  \
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? 64 : 32)
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
+            // TODO: This will change to a semi-private 2.0 struct name
+            return (unsigned char)((PyArray_Descr *)dtype)->flags;
+        }
+        else {
+            return (unsigned char)((PyArray_DescrProto *)dtype)->flags;
+        }
+    }
+#endif
+
+
+#if !(defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)
+#if NPY_ABI_VERSION < 0x02000000
+    static inline PyArray_ArrFuncs *
+    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    {
+        return descr->f;
+    }
+#else
+    static inline PyArray_ArrFuncs *
+    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    {
+        if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
+            return _PyDataType_GetArrFuncs(descr);
+        }
+        else {
+            return ((PyArray_DescrProto *)descr)->f;
+        }
+    }
+#endif
+
+
+#endif  /* not internal build */
+
+#endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_ */

--- a/scipy/signal/_correlate_nd.c.in
+++ b/scipy/signal/_correlate_nd.c.in
@@ -6,6 +6,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include "numpy/ndarrayobject.h"
+#include "npy_2_compat.h"
 #include "_sigtools.h"
 
 enum {
@@ -203,7 +204,7 @@ static int _imp_correlate_nd_object(PyArrayNeighborhoodIterObject *curx,
     npy_intp i, j;
     PyObject *tmp, *tmp2;
     char *zero;
-    PyArray_CopySwapFunc *copyswap = PyArray_DESCR(curx->ao)->f->copyswap;
+    PyArray_CopySwapFunc *copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(curx->ao))->copyswap;
 
     zero = PyArray_Zero(curx->ao);
 

--- a/scipy/signal/_lfilter.c.in
+++ b/scipy/signal/_lfilter.c.in
@@ -6,6 +6,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/ndarrayobject.h>
+#include "npy_2_compat.h"
 
 #include "_sigtools.h"
 
@@ -340,7 +341,7 @@ zfill(const PyArrayObject * x, npy_intp nx, char *xzfilled, npy_intp nxzfilled)
 {
     char *xzero;
     npy_intp i, nxl;
-    PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
+    PyArray_CopySwapFunc *copyswap = PyDataType_GetArrFuncs(PyArray_DESCR((PyArrayObject *)x))->copyswap;
 
     nxl = PyArray_ITEMSIZE(x);
 
@@ -384,7 +385,7 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
     npy_intp na, nb, nal, nbl;
     npy_intp nfilt;
     char *azfilled, *bzfilled, *zfzfilled, *yoyo;
-    PyArray_CopySwapFunc *copyswap = PyArray_DESCR((PyArrayObject *)x)->f->copyswap;
+    PyArray_CopySwapFunc *copyswap = PyDataType_GetArrFuncs(PyArray_DESCR((PyArrayObject *)x))->copyswap;
 
     itx = (PyArrayIterObject *) PyArray_IterAllButAxis((PyObject *) x,
                                                        &axis);

--- a/scipy/signal/_sigtoolsmodule.c
+++ b/scipy/signal/_sigtoolsmodule.c
@@ -7,6 +7,7 @@ is granted under the SciPy License.
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_signal_ARRAY_API
 #include "numpy/ndarrayobject.h"
+#include "npy_2_compat.h"
 
 #include "_sigtools.h"
 #include <setjmp.h>
@@ -916,7 +917,7 @@ PyObject *PyArray_OrderFilterND(PyObject *op1, PyObject *op2, int order) {
 	os = PyArray_ITEMSIZE(ret);
 	op = PyArray_DATA(ret);
 
-	copyswap = PyArray_DESCR(ret)->f->copyswap;
+	copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(ret))->copyswap;
 
 	bytes_in_array = PyArray_NDIM(ap1)*sizeof(npy_intp);
 	mode_dep = malloc(bytes_in_array);

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -8,6 +8,7 @@ py3.extension_module('_sigtools',
   ],
   dependencies: np_dep,
   link_args: version_link_args,
+  include_directories: ['../_build_utils/src'],
   install: true,
   subdir: 'scipy/signal'
 )


### PR DESCRIPTION
* Fixes gh-20107

* WIP for now because I don't like that I had to manually adjust the NumPy compat shim header...

* I confirmed that this branch restored full build/test suite passing on x86_64 Linux with NumPy in the following scenarios: build with NumPy `main`, test with NumPy `main`; build with NumPy `main`, test with NumPy `1.26.4` (and 1.x only of course)

* although I did apply the suggestions at or linked from: https://github.com/numpy/numpy/pull/25812
I'm not happy about the fact that I have to modify `npy_2_compat.h` manually (this seems very much not ideal, perhaps I'll open an upstream issue)

[skip cirrus] [skip circle]