### PR TITLE
DOC: clarify accepted values for `dim` in `unitary_group`.

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4158,7 +4158,7 @@ class unitary_group_gen(multi_rv_generic):
     Parameters
     ----------
     dim : scalar
-        Dimension of matrices
+        Dimension of matrices, must be greater than 1.
     seed : {None, int, np.random.RandomState, np.random.Generator}, optional
         Used for drawing random variates.
         If `seed` is `None`, the `~np.random.RandomState` singleton is used.


### PR DESCRIPTION
#### Reference issue
Closes #19897

#### What does this implement/fix?
Clarify that the argument `dim` in `stats.unitary_group` must be greater than 1.
