### PR TITLE
BLD: signal: do not install Pythran source alongside the Cython extension

### DIFF
--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -120,7 +120,6 @@ py3.install_sources([
     '_savitzky_golay.py',
     '_short_time_fft.py',
     '_signaltools.py',
-    '_spectral.py',
     '_spectral_py.py',
     '_upfirdn.py',
     '_waveforms.py',


### PR DESCRIPTION
If `use_pythran` is True, the `signal._spectral` extension is built via Pythran from `scipy/signal/_spectral.py`; otherwise, the extension is built from `scipy/signal/_spectral.pyx`

On main with no pythran, we end up with two duplicate modules of the same name:

```
$ ll build-install/lib/python3.10/site-packages/scipy/signal/*_spectral*
-rwxr-xr-x 1 br br 604368 фев 19 13:07 build-install/lib/python3.10/site-packages/scipy/signal/_spectral.cpython-310-x86_64-linux-gnu.so*
-rw-r--r-- 1 br br   1940 июл 20  2022 build-install/lib/python3.10/site-packages/scipy/signal/_spectral.py
-rw-r--r-- 1 br br  78552 фев 16 17:03 build-install/lib/python3.10/site-packages/scipy/signal/_spectral_py.py
```

No idea if it's luck that `from scipy.signal import _spectral` finds the binary extension and not the python source, or if the precedence is defined somewhere. Either way, we should not be installing a source which is not meant to be imported.

Other pythran sources we do not install either: in scipy.signal (_max_len_seq_inner.py) or stats (_stats_pythran.py).
