### PR TITLE
Fix small issues in docstrings

### DIFF
--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -35,7 +35,8 @@ first create this list. The system word lists consist of a file with one
 word per line. The following should be modified to use the particular word
 list you have available::
 
-    >>> word_list = open('/usr/share/dict/words').readlines()
+    >>> with open('/usr/share/dict/words') as f:
+    ...    word_list = f.readlines()
     >>> word_list = map(str.strip, word_list)
 
 We want to look at words of length 3, so let's select just those words of the

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -317,7 +317,7 @@ of order 2 or less.
 >>> x = np.array([1,3,4])
 >>> y1 = f1(x)
 >>> from scipy import integrate
->>> I1 = integrate.simpson(y1, x)
+>>> I1 = integrate.simpson(y1, x=x)
 >>> print(I1)
 21.0
 
@@ -331,7 +331,7 @@ This corresponds exactly to
 whereas integrating the second function
 
 >>> y2 = f2(x)
->>> I2 = integrate.simpson(y2, x)
+>>> I2 = integrate.simpson(y2, x=x)
 >>> print(I2)
 61.5
 

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -139,6 +139,8 @@ def fftfreq(n, d=1.0, *, xp=None, device=None):
 
     Examples
     --------
+    >>> import numpy as np
+    >>> import scipy.fft
     >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5], dtype=float)
     >>> fourier = scipy.fft.fft(signal)
     >>> n = signal.size
@@ -193,6 +195,8 @@ def rfftfreq(n, d=1.0, *, xp=None, device=None):
 
     Examples
     --------
+    >>> import numpy as np
+    >>> import scipy.fft
     >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5, -3, 4], dtype=float)
     >>> fourier = scipy.fft.rfft(signal)
     >>> n = signal.size
@@ -239,6 +243,7 @@ def fftshift(x, axes=None):
 
     Examples
     --------
+    >>> import numpy as np
     >>> freqs = np.fft.fftfreq(10, 0.1)
     >>> freqs
     array([ 0.,  1.,  2., ..., -3., -2., -1.])
@@ -288,6 +293,7 @@ def ifftshift(x, axes=None):
 
     Examples
     --------
+    >>> import numpy as np
     >>> freqs = np.fft.fftfreq(9, d=1./9).reshape(3, 3)
     >>> freqs
     array([[ 0.,  1.,  2.],

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -680,16 +680,16 @@ def simpson(y, *, x=None, dx=1.0, axis=-1, even=_NoValue):
     >>> x = np.arange(0, 10)
     >>> y = np.arange(0, 10)
 
-    >>> integrate.simpson(y, x)
+    >>> integrate.simpson(y, x=x)
     40.5
 
     >>> y = np.power(x, 3)
-    >>> integrate.simpson(y, x)
+    >>> integrate.simpson(y, x=x)
     1640.5
     >>> integrate.quad(lambda x: x**3, 0, 9)[0]
     1640.25
 
-    >>> integrate.simpson(y, x, even='first')
+    >>> integrate.simpson(y, x=x, even='first')
     1644.5
 
     """

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6097,7 +6097,7 @@ add_newdoc("gdtr",
     >>> for parameter_set in parameters_list:
     ...     a, b, style = parameter_set
     ...     gdtr_vals = gdtr(a, b, x)
-    ...     ax.plot(x, gdtr_vals, label=f"$a= {a},\, b={b}$", ls=style)
+    ...     ax.plot(x, gdtr_vals, label=fr"$a= {a},\, b={b}$", ls=style)
     >>> ax.legend()
     >>> ax.set_xlabel("$x$")
     >>> ax.set_title("Gamma distribution cumulative distribution function")
@@ -6216,7 +6216,7 @@ add_newdoc("gdtrc",
     >>> for parameter_set in parameters_list:
     ...     a, b, style = parameter_set
     ...     gdtrc_vals = gdtrc(a, b, x)
-    ...     ax.plot(x, gdtrc_vals, label=f"$a= {a},\, b={b}$", ls=style)
+    ...     ax.plot(x, gdtrc_vals, label=fr"$a= {a},\, b={b}$", ls=style)
     >>> ax.legend()
     >>> ax.set_xlabel("$x$")
     >>> ax.set_title("Gamma distribution survival function")
@@ -6731,10 +6731,10 @@ add_newdoc("huber",
     >>> fig, ax = plt.subplots()
     >>> combined_plot_parameters = list(zip(deltas, linestyles))
     >>> for delta, style in combined_plot_parameters:
-    ...     ax.plot(x, huber(delta, x), label=f"$\delta={delta}$", ls=style)
+    ...     ax.plot(x, huber(delta, x), label=fr"$\delta={delta}$", ls=style)
     >>> ax.legend(loc="upper center")
     >>> ax.set_xlabel("$x$")
-    >>> ax.set_title("Huber loss function $h_{\delta}(x)$")
+    >>> ax.set_title(r"Huber loss function $h_{\delta}(x)$")
     >>> ax.set_xlim(-4, 4)
     >>> ax.set_ylim(0, 8)
     >>> plt.show()
@@ -7598,10 +7598,10 @@ add_newdoc(
     >>> x = np.linspace(-10, 10, 500)
     >>> apt, bpt, ant, bnt = itairy(x)
     >>> fig, ax = plt.subplots(figsize=(6, 5))
-    >>> ax.plot(x, apt, label="$\int_0^x\, Ai(t)\, dt$")
-    >>> ax.plot(x, bpt, ls="dashed", label="$\int_0^x\, Bi(t)\, dt$")
-    >>> ax.plot(x, ant, ls="dashdot", label="$\int_0^x\, Ai(-t)\, dt$")
-    >>> ax.plot(x, bnt, ls="dotted", label="$\int_0^x\, Bi(-t)\, dt$")
+    >>> ax.plot(x, apt, label=r"$\int_0^x\, Ai(t)\, dt$")
+    >>> ax.plot(x, bpt, ls="dashed", label=r"$\int_0^x\, Bi(t)\, dt$")
+    >>> ax.plot(x, ant, ls="dashdot", label=r"$\int_0^x\, Ai(-t)\, dt$")
+    >>> ax.plot(x, bnt, ls="dotted", label=r"$\int_0^x\, Bi(-t)\, dt$")
     >>> ax.set_ylim(-2, 1.5)
     >>> ax.legend(loc="lower right")
     >>> plt.show()
@@ -7665,8 +7665,8 @@ add_newdoc("iti0k0",
     >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 5., 1000)
     >>> int_i, int_k = iti0k0(x)
-    >>> ax.plot(x, int_i, label="$\int_0^x I_0(t)\,dt$")
-    >>> ax.plot(x, int_k, label="$\int_0^x K_0(t)\,dt$")
+    >>> ax.plot(x, int_i, label=r"$\int_0^x I_0(t)\,dt$")
+    >>> ax.plot(x, int_k, label=r"$\int_0^x K_0(t)\,dt$")
     >>> ax.legend()
     >>> plt.show()
     """)
@@ -7729,8 +7729,8 @@ add_newdoc("itj0y0",
     >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> int_j, int_y = itj0y0(x)
-    >>> ax.plot(x, int_j, label="$\int_0^x J_0(t)\,dt$")
-    >>> ax.plot(x, int_y, label="$\int_0^x Y_0(t)\,dt$")
+    >>> ax.plot(x, int_j, label=r"$\int_0^x J_0(t)\,dt$")
+    >>> ax.plot(x, int_y, label=r"$\int_0^x Y_0(t)\,dt$")
     >>> ax.legend()
     >>> plt.show()
 
@@ -8080,7 +8080,7 @@ add_newdoc("ive",
     >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-5., 5., 1000)
     >>> for i in range(4):
-    ...     ax.plot(x, ive(i, x), label=f'$I_{i!r}(z)\cdot e^{{-|z|}}$')
+    ...     ax.plot(x, ive(i, x), label=fr'$I_{i!r}(z)\cdot e^{{-|z|}}$')
     >>> ax.legend()
     >>> ax.set_xlabel(r"$z$")
     >>> plt.show()
@@ -9346,7 +9346,7 @@ add_newdoc("kve",
     >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 5., 1000)
     >>> for i in range(4):
-    ...     ax.plot(x, kve(i, x), label=f'$K_{i!r}(z)\cdot e^z$')
+    ...     ax.plot(x, kve(i, x), label=fr'$K_{i!r}(z)\cdot e^z$')
     >>> ax.legend()
     >>> ax.set_xlabel(r"$z$")
     >>> ax.set_ylim(0, 4)
@@ -11062,7 +11062,7 @@ add_newdoc("ndtr",
     >>> x = np.linspace(-5, 5, 100)
     >>> fig, ax = plt.subplots()
     >>> ax.plot(x, ndtr(x))
-    >>> ax.set_title("Standard normal cumulative distribution function $\Phi$")
+    >>> ax.set_title(r"Standard normal cumulative distribution function $\Phi$")
     >>> plt.show()
     """)
 
@@ -12174,11 +12174,11 @@ add_newdoc("pseudo_huber",
     >>> fig, ax = plt.subplots()
     >>> combined_plot_parameters = list(zip(deltas, linestyles))
     >>> for delta, style in combined_plot_parameters:
-    ...     ax.plot(x, pseudo_huber(delta, x), label=f"$\delta={delta}$",
+    ...     ax.plot(x, pseudo_huber(delta, x), label=rf"$\delta={delta}$",
     ...             ls=style)
     >>> ax.legend(loc="upper center")
     >>> ax.set_xlabel("$x$")
-    >>> ax.set_title("Pseudo-Huber loss function $h_{\delta}(x)$")
+    >>> ax.set_title(r"Pseudo-Huber loss function $h_{\delta}(x)$")
     >>> ax.set_xlim(-4, 4)
     >>> ax.set_ylim(0, 8)
     >>> plt.show()
@@ -13451,9 +13451,9 @@ add_newdoc(
     >>> x = np.linspace(-12, 12, 500)
     >>> for k, lmbda in enumerate([-1.0, -0.5, 0.0]):
     ...     y = tklmbda(x, lmbda)
-    ...     ax.plot(x, y, styles[k], label=f'$\lambda$ = {lmbda:-4.1f}')
+    ...     ax.plot(x, y, styles[k], label=rf'$\lambda$ = {lmbda:-4.1f}')
 
-    >>> ax.set_title('tklmbda(x, $\lambda$)')
+    >>> ax.set_title(r'tklmbda(x, $\lambda$)')
     >>> ax.set_label('x')
     >>> ax.legend(framealpha=1, shadow=True)
     >>> ax.grid(True)
@@ -13466,13 +13466,13 @@ add_newdoc(
     >>> lmbdas = [0.25, 0.5, 1.0, 1.5]
     >>> for k, lmbda in enumerate(lmbdas):
     ...     y = tklmbda(x, lmbda)
-    ...     ax.plot(x, y, styles[k], label=f'$\lambda$ = {lmbda}')
+    ...     ax.plot(x, y, styles[k], label=fr'$\lambda$ = {lmbda}')
 
     >>> ax.set_prop_cycle(None)
     >>> for lmbda in lmbdas:
     ...     ax.plot([-1/lmbda, 1/lmbda], [0, 1], '.', ms=8)
 
-    >>> ax.set_title('tklmbda(x, $\lambda$)')
+    >>> ax.set_title(r'tklmbda(x, $\lambda$)')
     >>> ax.set_xlabel('x')
     >>> ax.legend(framealpha=1, shadow=True)
     >>> ax.grid(True)


### PR DESCRIPTION
Add small hopefully uncontroversial tweaks to docstrings/tutorials from gh-16391:

- add missing imports, now that we require explicit `import numpy as np`
- make several docstrings raw to shield TeX markup
- account for recent deprecations (`integrate.simpson`)

[skip actions] [skip cirrus]