### PR TITLE
BLD: simplifications in meson.build files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ if not cc.links('', name: '-Wl,--version-script', args: ['-shared', version_link
   version_link_args = []
 endif
 
-generate_f2pymod = files('tools/generate_f2pymod.py')
+generate_f2pymod = find_program('tools/generate_f2pymod.py')
 tempita = find_program('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')

--- a/meson.build
+++ b/meson.build
@@ -131,7 +131,7 @@ if not cc.links('', name: '-Wl,--version-script', args: ['-shared', version_link
 endif
 
 generate_f2pymod = files('tools/generate_f2pymod.py')
-tempita = files('scipy/_build_utils/tempita.py')
+tempita = find_program('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')
 if use_pythran

--- a/scipy/_build_utils/tempita.py
+++ b/scipy/_build_utils/tempita.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import argparse
@@ -30,6 +31,8 @@ def main():
                         help="Path to the input file")
     parser.add_argument("-o", "--outdir", type=str,
                         help="Path to the output directory")
+    parser.add_argument("--outfile", type=str,
+                        help="Path to the output file (use either this or outdir)")
     parser.add_argument("-i", "--ignore", type=str,
                         help="An ignored input - may be useful to add a "
                              "dependency between custom targets")
@@ -38,12 +41,15 @@ def main():
     if not args.infile.endswith('.in'):
         raise ValueError(f"Unexpected extension: {args.infile}")
 
-    if not args.outdir:
-        raise ValueError("Missing `--outdir` argument to tempita.py")
+    if not (args.outdir or args.outfile):
+        raise ValueError("Missing `--outdir` or `--outfile` argument to tempita.py")
 
-    outdir_abs = os.path.join(os.getcwd(), args.outdir)
-    outfile = os.path.join(outdir_abs,
-                           os.path.splitext(os.path.split(args.infile)[1])[0])
+    if args.outfile:
+        outfile = args.outfile
+    else:
+        outdir_abs = os.path.join(os.getcwd(), args.outdir)
+        outfile = os.path.join(outdir_abs,
+                               os.path.splitext(os.path.split(args.infile)[1])[0])
 
     process_tempita(args.infile, outfile)
 

--- a/scipy/cluster/meson.build
+++ b/scipy/cluster/meson.build
@@ -1,4 +1,4 @@
-slib = py3.extension_module('_hierarchy',
+py3.extension_module('_hierarchy',
   linalg_cython_gen.process('_hierarchy.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -7,7 +7,7 @@ slib = py3.extension_module('_hierarchy',
   subdir: 'scipy/cluster'
 )
 
-slib = py3.extension_module('_optimal_leaf_ordering',
+py3.extension_module('_optimal_leaf_ordering',
   linalg_cython_gen.process('_optimal_leaf_ordering.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -16,7 +16,7 @@ slib = py3.extension_module('_optimal_leaf_ordering',
   subdir: 'scipy/cluster'
 )
 
-slib = py3.extension_module('_vq',
+py3.extension_module('_vq',
   linalg_cython_gen.process('_vq.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -126,7 +126,7 @@ py3.extension_module('_odepack',
 vode_module = custom_target('vode_module',
   output: ['_vode-f2pywrappers.f', '_vodemodule.c'],
   input: 'vode.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_vode',
@@ -143,7 +143,7 @@ py3.extension_module('_vode',
 lsoda_module = custom_target('lsoda_module',
   output: ['_lsoda-f2pywrappers.f', '_lsodamodule.c'],
   input: 'lsoda.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_lsoda',
@@ -160,7 +160,7 @@ py3.extension_module('_lsoda',
 _dop_module = custom_target('_dop_module',
   output: ['_dop-f2pywrappers.f', '_dopmodule.c'],
   input: 'dop.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_dop',
@@ -184,7 +184,7 @@ py3.extension_module('_test_multivariate',
 _test_odeint_banded_module = custom_target('_test_odeint_banded_module',
   output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
   input: 'tests/banded5x5.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_test_odeint_banded',

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -145,7 +145,7 @@ py3.extension_module('_fitpack',
 dfitpack_module = custom_target('dfitpack_module',
   output: ['dfitpack-f2pywrappers.f', 'dfitpackmodule.c'],
   input: 'src/fitpack.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # TODO: Add flags for 64 bit ints

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -94,7 +94,7 @@ fitpack_lib = static_library('fitpack_lib',
   override_options: ['b_lto=false'],
 )
 
-interpnd = py3.extension_module('interpnd',
+py3.extension_module('interpnd',
   spt_cython_gen.process('interpnd.pyx'),
   c_args: [Wno_discarded_qualifiers, cython_c_args],
   dependencies: np_dep,
@@ -120,7 +120,7 @@ py3.extension_module('_rgi_cython',
   subdir: 'scipy/interpolate'
 )
 
-_bspl = py3.extension_module('_bspl',
+py3.extension_module('_bspl',
   cython_gen.process('_bspl.pyx'),
   c_args: cython_c_args,
   include_directories: 'src/',
@@ -131,7 +131,7 @@ _bspl = py3.extension_module('_bspl',
 )
 
 # TODO: Add flags for 64 bit ints
-_fitpack = py3.extension_module('_fitpack',
+py3.extension_module('_fitpack',
   ['src/_fitpackmodule.c'],
   link_with: [fitpack_lib],
   include_directories: 'src/',
@@ -149,7 +149,7 @@ dfitpack_module = custom_target('dfitpack_module',
 )
 
 # TODO: Add flags for 64 bit ints
-dfitpack = py3.extension_module('dfitpack',
+py3.extension_module('dfitpack',
   dfitpack_module,
   c_args: [Wno_unused_variable],
   link_args: version_link_args,

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -162,14 +162,8 @@ dfitpack = py3.extension_module('dfitpack',
 )
 
 if use_pythran
-  _rbfinterp_pythran = custom_target('_rbfinterp_pythran',
-    output: ['_rbfinterp_pythran.cpp'],
-    input: '_rbfinterp_pythran.py',
-    command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_rbfinterp_pythran.cpp']
-  )
-
-  _rbfinterp_pythran = py3.extension_module('_rbfinterp_pythran',
-    _rbfinterp_pythran,
+  py3.extension_module('_rbfinterp_pythran',
+    pythran_gen.process('_rbfinterp_pythran.py'),
     cpp_args: cpp_args_pythran,
     dependencies: [pythran_dep, np_dep],
     link_args: version_link_args,

--- a/scipy/io/matlab/meson.build
+++ b/scipy/io/matlab/meson.build
@@ -1,4 +1,4 @@
-streams = py3.extension_module('_streams',
+py3.extension_module('_streams',
   cython_gen.process('_streams.pyx'),
   c_args: cython_c_args,
   link_args: version_link_args,
@@ -6,7 +6,7 @@ streams = py3.extension_module('_streams',
   subdir: 'scipy/io/matlab'
 )
 
-mio_utils = py3.extension_module('_mio_utils',
+py3.extension_module('_mio_utils',
   cython_gen.process('_mio_utils.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -15,7 +15,7 @@ mio_utils = py3.extension_module('_mio_utils',
   subdir: 'scipy/io/matlab'
 )
 
-mio5_utils = py3.extension_module('_mio5_utils',
+py3.extension_module('_mio5_utils',
   cython_gen.process('_mio5_utils.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,

--- a/scipy/io/meson.build
+++ b/scipy/io/meson.build
@@ -1,7 +1,7 @@
 _test_fortran_module = custom_target('_test_fortran_module',
   output: ['_test_fortranmodule.c'],
   input: '_test_fortran.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_test_fortran',

--- a/scipy/io/meson.build
+++ b/scipy/io/meson.build
@@ -4,7 +4,7 @@ _test_fortran_module = custom_target('_test_fortran_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-_test_fortran = py3.extension_module('_test_fortran',
+py3.extension_module('_test_fortran',
   [
     _test_fortran_module,
     '_test_fortran.f'

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -233,7 +233,7 @@ py3.extension_module('_decomp_lu_cython',
 _decomp_update_pyx = custom_target('_decomp_update',
   output: '_decomp_update.pyx',
   input: '_decomp_update.pyx.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_decomp_update',
@@ -249,7 +249,7 @@ py3.extension_module('_decomp_update',
 _matfuncs_expm_pyx = custom_target('_matfuncs_expm',
   output: '_matfuncs_expm.pyx',
   input: '_matfuncs_expm.pyx.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_matfuncs_expm',

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -60,7 +60,7 @@ linalg_cython_gen = generator(cython,
 fblas_module = custom_target('fblas_module',
   output: ['_fblasmodule.c', '_fblas-f2pywrappers.f'],
   input: 'fblas.pyf.src',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
@@ -81,7 +81,7 @@ py3.extension_module('_fblas',
 flapack_module = custom_target('flapack_module',
   output: ['_flapackmodule.c', '_flapack-f2pywrappers.f'],
   input: 'flapack.pyf.src',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # Note that -Wno-empty-body is Clang-specific and comes from `callstatement`s
@@ -103,7 +103,7 @@ py3.extension_module('_flapack',
 interpolative_module = custom_target('interpolative_module',
   output: '_interpolativemodule.c',
   input: 'interpolative.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # id_dist contains a copy of FFTPACK, which has type mismatch warnings

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -275,6 +275,12 @@ if use_pythran
   )
 endif
 
+# Used for templated C code (not Cython code since Cython is path-dependent)
+tempita_gen = generator(tempita,
+  arguments : ['@INPUT@', '--outfile', '@OUTPUT@'],
+  output : '@BASENAME@',
+)
+
 # Check if compiler flags are supported. This is necessary to ensure that SciPy
 # can be built with any supported compiler. We need so many warning flags
 # because we want to be able to build with `-Werror` in CI; that ensures that

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -268,6 +268,13 @@ cython_gen_cpp = generator(cython,
   output : '@BASENAME@.cpp',
   depends : [_cython_tree])
 
+if use_pythran
+  pythran_gen = generator(pythran,
+    arguments : ['-E', '@INPUT@', '-o', '@OUTPUT@'],
+    output : '@BASENAME@.cpp',
+  )
+endif
+
 # Check if compiler flags are supported. This is necessary to ensure that SciPy
 # can be built with any supported compiler. We need so many warning flags
 # because we want to be able to build with `-Werror` in CI; that ensures that

--- a/scipy/optimize/_lsq/meson.build
+++ b/scipy/optimize/_lsq/meson.build
@@ -1,4 +1,4 @@
-_lsq = py3.extension_module('givens_elimination',
+py3.extension_module('givens_elimination',
   linalg_cython_gen.process('givens_elimination.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,

--- a/scipy/optimize/_trlib/meson.build
+++ b/scipy/optimize/_trlib/meson.build
@@ -1,4 +1,4 @@
-_trlib = py3.extension_module('_trlib',
+py3.extension_module('_trlib',
   [
     lib_cython_gen.process('_trlib.pyx'),
     'trlib_krylov.c',

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -8,7 +8,7 @@ _zeros_pyx = custom_target('_zeros_pyx',
   output: '_zeros.pyx',
   input: '_zeros.pyx.in',
   command: [
-    py3, tempita, '@INPUT@', '-o', '@OUTDIR@',
+    tempita, '@INPUT@', '-o', '@OUTDIR@',
     '--ignore', _dummy_init_cyoptimize[0]
   ]
 )

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -21,7 +21,7 @@ cy_opt_gen = generator(cython,
     _dummy_init_optimize,
     _dummy_init_cyoptimize])
 
-_zeros = py3.extension_module('_zeros',
+py3.extension_module('_zeros',
   cy_opt_gen.process(_zeros_pyx),
   c_args: cython_c_args,
   dependencies: np_dep,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -183,14 +183,8 @@ _pava_pybind = py3.extension_module('_pava_pybind',
 )
 
 if use_pythran
-  _group_columns_cpp = custom_target('_group_columns',
-    output: ['_group_columns.cpp'],
-    input: '_group_columns.py',
-    command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_group_columns.cpp']
-  )
-
-  _group_columns = py3.extension_module('_group_columns',
-    [_group_columns_cpp],
+  py3.extension_module('_group_columns',
+    pythran_gen.process('_group_columns.py'),
     cpp_args: cpp_args_pythran,
     dependencies: [pythran_dep, np_dep],
     link_args: version_link_args,
@@ -198,7 +192,7 @@ if use_pythran
     subdir: 'scipy/optimize'
   )
 else
-  _group_columns = py3.extension_module('_group_columns',
+  py3.extension_module('_group_columns',
     cython_gen.process('_group_columns.pyx'),
     c_args: cython_c_args,
     dependencies: np_dep,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -1,4 +1,4 @@
-_direct = py3.extension_module('_direct',
+py3.extension_module('_direct',
   ['_direct/direct_wrap.c',
    '_direct/direct-internal.h',
    '_direct/DIRect.c',
@@ -42,7 +42,7 @@ minpack_lib = static_library('minpack',
   ]
 )
 
-_minpack = py3.extension_module('_minpack',
+py3.extension_module('_minpack',
   ['minpack.h', '__minpack.h', '_minpackmodule.c'],
   link_with: minpack_lib,
   include_directories: '../_lib/src',
@@ -95,7 +95,7 @@ lbfgsb_module = custom_target('lbfgsb_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-_lbfgsb = py3.extension_module('_lbfgsb',
+py3.extension_module('_lbfgsb',
   [
     'lbfgsb_src/lbfgsb.f',
     'lbfgsb_src/linpack.f',
@@ -111,7 +111,7 @@ _lbfgsb = py3.extension_module('_lbfgsb',
   subdir: 'scipy/optimize'
 )
 
-moduleTNC = py3.extension_module('_moduleTNC',
+py3.extension_module('_moduleTNC',
   ['tnc/tnc.h',
     cython_gen.process('tnc/_moduleTNC.pyx'),
     'tnc/tnc.c'],
@@ -129,7 +129,7 @@ cobyla_module = custom_target('cobyla_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-_cobyla = py3.extension_module('_cobyla',
+py3.extension_module('_cobyla',
   [cobyla_module, 'cobyla/cobyla2.f', 'cobyla/trstlp.f'],
   c_args: [Wno_unused_variable],
   fortran_args: fortran_ignore_warnings,
@@ -146,7 +146,7 @@ minpack2_module = custom_target('minpack2_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-minpack2 = py3.extension_module('_minpack2',
+py3.extension_module('_minpack2',
   [minpack2_module, 'minpack2/dcsrch.f', 'minpack2/dcstep.f'],
   fortran_args: fortran_ignore_warnings,
   link_args: version_link_args,
@@ -163,7 +163,7 @@ slsqp_module = custom_target('slsqp_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-_slsqp = py3.extension_module('_slsqp',
+py3.extension_module('_slsqp',
   [slsqp_module, 'slsqp/slsqp_optmz.f'],
   fortran_args: fortran_ignore_warnings,
   link_args: version_link_args,
@@ -173,7 +173,7 @@ _slsqp = py3.extension_module('_slsqp',
   subdir: 'scipy/optimize'
 )
 
-_pava_pybind = py3.extension_module('_pava_pybind',
+py3.extension_module('_pava_pybind',
   ['_pava/pava_pybind.cpp'],
   include_directories: '_pava',
   dependencies: [np_dep, pybind11_dep],
@@ -215,10 +215,8 @@ opt_gen = generator(cython,
   output : '@BASENAME@.c',
   depends : [_cython_tree, cython_blas_pxd, cython_optimize_pxd, _dummy_init_optimize])
 
-_bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
-
 py3.extension_module('_bglu_dense',
-  _bglu_dense_c,
+  opt_gen.process('_bglu_dense.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
   link_args: version_link_args,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -92,7 +92,7 @@ py3.extension_module('_zeros',
 lbfgsb_module = custom_target('lbfgsb_module',
   output: ['_lbfgsb-f2pywrappers.f', '_lbfgsbmodule.c'],
   input: 'lbfgsb_src/lbfgsb.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_lbfgsb',
@@ -126,7 +126,7 @@ py3.extension_module('_moduleTNC',
 cobyla_module = custom_target('cobyla_module',
   output: ['_cobylamodule.c'],
   input: 'cobyla/cobyla.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_cobyla',
@@ -143,7 +143,7 @@ py3.extension_module('_cobyla',
 minpack2_module = custom_target('minpack2_module',
   output: ['_minpack2module.c'],
   input: 'minpack2/minpack2.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_minpack2',
@@ -160,7 +160,7 @@ py3.extension_module('_minpack2',
 slsqp_module = custom_target('slsqp_module',
   output: ['_slsqpmodule.c'],
   input: 'slsqp/slsqp.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_slsqp',

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -26,14 +26,8 @@ sigtools = py3.extension_module('_sigtools',
 )
 
 if use_pythran
-  _max_len_seq_inner = custom_target('_max_len_seq_inner',
-    output: ['_max_len_seq_inner.cpp'],
-    input: '_max_len_seq_inner.py',
-    command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_max_len_seq_inner.cpp']
-  )
-
-  _max_len_seq_inner = py3.extension_module('_max_len_seq_inner',
-    [_max_len_seq_inner],
+  py3.extension_module('_max_len_seq_inner',
+    pythran_gen.process('_max_len_seq_inner.py'),
     cpp_args: [cpp_args_pythran, _cpp_Wno_unused_local_typedefs],
     dependencies: [pythran_dep, np_dep],
     link_args: version_link_args,
@@ -41,14 +35,8 @@ if use_pythran
     subdir: 'scipy/signal'
   )
 
-  _spectral = custom_target('_spectral',
-    output: ['_spectral.cpp'],
-    input: '_spectral.py',
-    command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_spectral.cpp']
-  )
-
-  _spectral = py3.extension_module('_spectral',
-    [_spectral],
+  py3.extension_module('_spectral',
+    pythran_gen.process('_spectral.py'),
     cpp_args: cpp_args_pythran,
     dependencies: [pythran_dep, np_dep],
     link_args: version_link_args,
@@ -56,7 +44,7 @@ if use_pythran
     subdir: 'scipy/signal'
   )
 else
-  _max_len_seq_inner = py3.extension_module('_max_len_seq_inner',
+  py3.extension_module('_max_len_seq_inner',
     [cython_gen.process('_max_len_seq_inner.pyx')],
     c_args: cython_c_args,
     dependencies: np_dep,
@@ -65,7 +53,7 @@ else
     subdir: 'scipy/signal'
   )
 
-  _spectral = py3.extension_module('_spectral',
+  py3.extension_module('_spectral',
     [cython_gen.process('_spectral.pyx')],
     c_args: cython_c_args,
     dependencies: np_dep,

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -1,23 +1,10 @@
-correlate_nd_c = custom_target('_correlate_nd',
-  output: '_correlate_nd.c',
-  input: '_correlate_nd.c.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
-)
-
-lfilter_c = custom_target('_lfilter',
-  output: '_lfilter.c',
-  input: '_lfilter.c.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
-)
-
 py3.extension_module('_sigtools',
   [
-    '_sigtoolsmodule.c',
     '_firfilter.c',
-    '_sigtools.h',
+    '_sigtoolsmodule.c',
     '_medianfilter.c',
-    lfilter_c,
-    correlate_nd_c
+    tempita_gen.process('_correlate_nd.c.in'),
+    tempita_gen.process('_lfilter.c.in'),
   ],
   dependencies: np_dep,
   link_args: version_link_args,
@@ -80,14 +67,11 @@ foreach pyx_file: pyx_files
   )
 endforeach
 
-bspline_util = custom_target('_bspline_util',
-  output: '_bspline_util.c',
-  input: '_bspline_util.c.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
-)
-
 py3.extension_module('_spline',
-  ['_splinemodule.c', bspline_util],
+  [
+    '_splinemodule.c',
+    tempita_gen.process('_bspline_util.c.in'),
+  ],
   dependencies: np_dep,
   link_args: version_link_args,
   install: true,

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -10,7 +10,7 @@ lfilter_c = custom_target('_lfilter',
   command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-sigtools = py3.extension_module('_sigtools',
+py3.extension_module('_sigtools',
   [
     '_sigtoolsmodule.c',
     '_firfilter.c',
@@ -86,7 +86,7 @@ bspline_util = custom_target('_bspline_util',
   command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-spline = py3.extension_module('_spline',
+py3.extension_module('_spline',
   ['_splinemodule.c', bspline_util],
   dependencies: np_dep,
   link_args: version_link_args,

--- a/scipy/sparse/linalg/_dsolve/meson.build
+++ b/scipy/sparse/linalg/_dsolve/meson.build
@@ -199,7 +199,7 @@ superlu_lib = static_library('superlu_lib',
   include_directories: ['SuperLU/SRC']
 )
 
-_superlu = py3.extension_module('_superlu',
+py3.extension_module('_superlu',
   ['_superlumodule.c', '_superlu_utils.c', '_superluobject.c'],
   link_with: [superlu_lib],
   include_directories: ['SuperLU/SRC'],

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -95,7 +95,7 @@ arpack_lib = static_library('arpack_lib',
 arpack_module = custom_target('arpack_module',
   output: ['_arpackmodule.c', '_arpack-f2pywrappers.f'],
   input: 'arpack.pyf.src',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 _arpack = py3.extension_module('_arpack',

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -108,7 +108,7 @@ foreach ele: elements
   propack_module = custom_target('propack_module' + ele[0],
     output: [ele[0] + '-f2pywrappers.f', ele[0] + 'module.c'],
     input: ele[2],
-    command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+    command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
   )
 
   propacklib = py3.extension_module(ele[0],

--- a/scipy/sparse/meson.build
+++ b/scipy/sparse/meson.build
@@ -1,7 +1,7 @@
 _csparsetools_pyx = custom_target('_csparsetools_pyx',
   output: '_csparsetools.pyx',
   input: '_csparsetools.pyx.in',
-  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_csparsetools',

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -30,7 +30,7 @@ qhull_src = [
   'qhull_src/src/userprintf_rbox_r.c'
 ]
 
-qhull = py3.extension_module('_qhull',
+py3.extension_module('_qhull',
   [spt_cython_gen.process('_qhull.pyx'),
     'qhull_misc.h', 'qhull_misc.c'] + qhull_src,
   c_args: cython_c_args,
@@ -55,7 +55,7 @@ ckdtree_src = [
   'ckdtree/src/sparse_distances.cxx'
 ]
 
-ckdtree = py3.extension_module('_ckdtree',
+py3.extension_module('_ckdtree',
   ckdtree_src + [cython_gen_cpp.process('_ckdtree.pyx')],
   cpp_args: cython_cpp_args,
   include_directories: [
@@ -69,7 +69,7 @@ ckdtree = py3.extension_module('_ckdtree',
   subdir: 'scipy/spatial'
 )
 
-_distance_wrap = py3.extension_module('_distance_wrap',
+py3.extension_module('_distance_wrap',
   'src/distance_wrap.c',
   include_directories: '../_lib',
   dependencies: np_dep,
@@ -78,7 +78,7 @@ _distance_wrap = py3.extension_module('_distance_wrap',
   subdir: 'scipy/spatial'
 )
 
-_distance_pybind = py3.extension_module('_distance_pybind',
+py3.extension_module('_distance_pybind',
   ['src/distance_pybind.cpp'],
   include_directories: 'src/',
   dependencies: [np_dep, pybind11_dep],
@@ -87,7 +87,7 @@ _distance_pybind = py3.extension_module('_distance_pybind',
   subdir: 'scipy/spatial'
 )
 
-_voronoi = py3.extension_module('_voronoi',
+py3.extension_module('_voronoi',
   [cython_gen.process('_voronoi.pyx')],
   c_args: [cython_c_args, Wno_maybe_uninitialized],
   dependencies: np_dep,
@@ -96,7 +96,7 @@ _voronoi = py3.extension_module('_voronoi',
   subdir: 'scipy/spatial'
 )
 
-_hausdorff = py3.extension_module('_hausdorff',
+py3.extension_module('_hausdorff',
   [cython_gen.process('_hausdorff.pyx')],
   c_args: cython_c_args,
   dependencies: np_dep,

--- a/scipy/spatial/transform/meson.build
+++ b/scipy/spatial/transform/meson.build
@@ -1,4 +1,4 @@
-rotation = py3.extension_module('_rotation',
+py3.extension_module('_rotation',
   [cython_gen.process('_rotation.pyx')],
   c_args: [cython_c_args, Wno_maybe_uninitialized],
   dependencies: np_dep,

--- a/scipy/stats/_levy_stable/meson.build
+++ b/scipy/stats/_levy_stable/meson.build
@@ -8,7 +8,7 @@ _levyst = static_library('_levyst',
   ['c_src/levyst.c', 'c_src/levyst.h'],
 )
 
-levyst = py3.extension_module('levyst',
+py3.extension_module('levyst',
   cython_gen.process('levyst.pyx'),
   dependencies: np_dep,
   link_args: version_link_args,

--- a/scipy/stats/_rcont/meson.build
+++ b/scipy/stats/_rcont/meson.build
@@ -5,7 +5,7 @@ py3.install_sources([
   subdir: 'scipy/stats/_rcont'
 )
 
-rcont = py3.extension_module('rcont',
+py3.extension_module('rcont',
   ['_rcont.c', 'logfactorial.c'],
   cython_gen.process('rcont.pyx'),
   dependencies: [np_dep, npyrandom_lib, npymath_lib],

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -221,7 +221,7 @@ unuran_cython_gen = generator(cython,
   depends : [_cython_tree, _lib_pxd, _stats_pxd, _unuran_pxd]
 )
 
-statlib = py3.extension_module('unuran_wrapper',
+py3.extension_module('unuran_wrapper',
   [
     unuran_cython_gen.process('unuran_wrapper.pyx'),
     unuran_sources

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -14,7 +14,7 @@ stats_special_cython_gen = generator(cython,
     _stats_pxd,
     cython_special_pxd])
 
-_stats = py3.extension_module('_stats',
+py3.extension_module('_stats',
   stats_special_cython_gen.process('_stats.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -23,7 +23,7 @@ _stats = py3.extension_module('_stats',
   subdir: 'scipy/stats'
 )
 
-_ansari_swilk_statistics = py3.extension_module('_ansari_swilk_statistics',
+py3.extension_module('_ansari_swilk_statistics',
   cython_gen.process('_ansari_swilk_statistics.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -38,7 +38,7 @@ mvn_module = custom_target('mvn_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
-mvn = py3.extension_module('_mvn',
+py3.extension_module('_mvn',
   [mvn_module, 'mvndst.f'],
   # Wno-surprising is to suppress a pointless warning with GCC 10-12
   # (see GCC bug 98411: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98411)
@@ -50,7 +50,7 @@ mvn = py3.extension_module('_mvn',
   subdir: 'scipy/stats'
 )
 
-_sobol = py3.extension_module('_sobol',
+py3.extension_module('_sobol',
   cython_gen.process('_sobol.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
@@ -65,7 +65,7 @@ py3.install_sources([
   subdir: 'scipy/stats'
 )
 
-_qmc_cy = py3.extension_module('_qmc_cy',
+py3.extension_module('_qmc_cy',
   cython_gen_cpp.process('_qmc_cy.pyx'),
   cpp_args: cython_cpp_args,
   dependencies: [np_dep, thread_dep],
@@ -123,7 +123,7 @@ skewnorm_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
 invgauss_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
 
 
-biasedurn = py3.extension_module('_biasedurn',
+py3.extension_module('_biasedurn',
   [
     cython_gen_cpp.process('_biasedurn.pyx'),
     'biasedurn/fnchyppr.cpp',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -35,7 +35,7 @@ py3.extension_module('_ansari_swilk_statistics',
 mvn_module = custom_target('mvn_module',
   output: ['_mvn-f2pywrappers.f', '_mvnmodule.c'],
   input: 'mvn.pyf',
-  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_mvn',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -142,14 +142,8 @@ biasedurn = py3.extension_module('_biasedurn',
 )
 
 if use_pythran
-  _stats_pythran_cpp = custom_target('_stats_pythran',
-    output: ['_stats_pythran.cpp'],
-    input: '_stats_pythran.py',
-    command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_stats_pythran.cpp']
-  )
-
-  _stats_pythran = py3.extension_module('_stats_pythran',
-    _stats_pythran_cpp,
+  py3.extension_module('_stats_pythran',
+    pythran_gen.process('_stats_pythran.py'),
     cpp_args: cpp_args_pythran,
     dependencies: [pythran_dep, np_dep],
     link_args: version_link_args,

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Process f2py template files (`filename.pyf.src` -> `filename.pyf`)
 


### PR DESCRIPTION
- simplify Pythran usage, removing unnecessary `custom_target`'s
- remove unused variable names
- improve use of Tempita where possible
- avoid use of `py3` but rather rely on shebang files