### PR TITLE
MAINT: stats: fix test failure in `kendalltau_seasonal`

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -968,7 +968,7 @@ def kendalltau_seasonal(x):
     z_tot_ind = msign(S_tot) * (abs(S_tot)-1) / ma.sqrt(var_szn.sum())
     z_tot_dep = msign(S_tot) * (abs(S_tot)-1) / ma.sqrt(covmat.sum())
 
-    prob_szn = special.erfc(abs(z_szn)/np.sqrt(2))
+    prob_szn = special.erfc(abs(z_szn.data)/np.sqrt(2))
     prob_tot_ind = special.erfc(abs(z_tot_ind)/np.sqrt(2))
     prob_tot_dep = special.erfc(abs(z_tot_dep)/np.sqrt(2))
 


### PR DESCRIPTION
This failure shows up when `SCIPY_ARRAY_API` is set:
```
FAILED scipy/stats/tests/test_mstats_basic.py::TestCorr::test_kendalltau_seasonal - TypeError: Inputs of type `numpy.ma.MaskedArray` are not supported.
```

What happens in the code is that a masked array was passed to `special.erfc`. That function (and `special` as a whole) is not aware of masked arrays and hence silently drops the mask. That was fine in this case because the masked array being passed always had a mask with only False values. So extracting the underlying data and passing only that changes nothing else, while avoiding the failure and implicit behavior.