### PR TITLE
ENH/TST: Refactor refguide-check, take 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           name: smoke-tutorials
           no_output_timeout: 10m
           command: |
-            python dev.py smoke-tutorial
+            python dev.py smoke-tutorials
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.
 # The keys are only available for builds on main branch.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           no_output_timeout: 35m
           command: |
             pip install matplotlib hypothesis
-            pip install git+https://github.com/scipy/scipy_doctest.git@main
+            pip install scipy-doctest
             python dev.py smoke-docs
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,9 @@ jobs:
             sudo apt-get install -y wamerican-small
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             python dev.py --no-build refguide-check
+            pip install matplotlib hypothesis
+            pip install git+https://github.com/ev-br/scpdt.git@main
+            python dev.py test --doctests
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.
 # The keys are only available for builds on main branch.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,19 @@ jobs:
             sudo apt-get install -y wamerican-small
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             python dev.py --no-build refguide-check
+
+      - run:
+          name: smoke-docs
+          no_output_timeout: 35m
+          command: |
             pip install matplotlib hypothesis
             pip install git+https://github.com/ev-br/scpdt.git@main
             python dev.py smoke-docs
+
+      - run:
+          name: smoke-tutorials
+          no_output_timeout: 10m
+          command: |
             python dev.py smoke-tutorial
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           no_output_timeout: 35m
           command: |
             pip install matplotlib hypothesis
-            pip install git+https://github.com/ev-br/scpdt.git@main
+            pip install git+https://github.com/scipy/scipy_doctest.git@main
             python dev.py smoke-docs
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,8 @@ jobs:
             python dev.py --no-build refguide-check
             pip install matplotlib hypothesis
             pip install git+https://github.com/ev-br/scpdt.git@main
-            python dev.py test --doctests
+            python dev.py smoke-docs
+            python dev.py smoke-tutorial
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.
 # The keys are only available for builds on main branch.

--- a/dev.py
+++ b/dev.py
@@ -670,8 +670,9 @@ class Test(Task):
     verbose = Option(
         ['--verbose', '-v'], default=False, is_flag=True,
         help="more verbosity")
-    # removed doctests as currently not supported by _lib/_testutils.py
-    # doctests = Option(['--doctests'], default=False)
+    doctests = Option(['--doctests'], default=False, is_flag=True,
+        help="Run doctests"
+    )
     coverage = Option(
         ['--coverage', '-c'], default=False, is_flag=True,
         help=("report coverage of project code. "
@@ -755,7 +756,7 @@ class Test(Task):
                 args.mode,
                 verbose=verbose,
                 extra_argv=extra_argv,
-                doctests=False,
+                doctests=args.doctests,
                 coverage=args.coverage,
                 tests=tests,
                 parallel=args.parallel)

--- a/dev.py
+++ b/dev.py
@@ -830,8 +830,8 @@ class SmokeDocs(Task):
         runner, version, mod_path = get_test_runner(PROJECT_MODULE)
         # FIXME: changing CWD is not a good practice
         with working_dir(dirs.site):
-            print("Running tests for {} version:{}, installed at:{}".format(
-                        PROJECT_MODULE, version, mod_path))
+            print(f"Running tests for {PROJECT_MODULE} version:{version}, "
+                  f"installed at:{mod_path}")
             # runner verbosity - convert bool to int
             verbose = int(args.verbose) + 1
             result = runner(  # scipy._lib._testutils:PytestTester

--- a/dev.py
+++ b/dev.py
@@ -189,7 +189,7 @@ rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "documentation",
-            "commands": ["doc", "refguide-check"],
+            "commands": ["doc", "refguide-check", "smoke-docs"],
         },
         {
             "name": "release",
@@ -670,9 +670,8 @@ class Test(Task):
     verbose = Option(
         ['--verbose', '-v'], default=False, is_flag=True,
         help="more verbosity")
-    doctests = Option(['--doctests'], default=False, is_flag=True,
-        help="Run doctests"
-    )
+    # removed doctests as currently not supported by _lib/_testutils.py
+    # doctests = Option(['--doctests'], default=False)
     coverage = Option(
         ['--coverage', '-c'], default=False, is_flag=True,
         help=("report coverage of project code. "
@@ -742,9 +741,6 @@ class Test(Task):
         else:
             tests = None
 
-        if args.doctests and not args.tests:
-            extra_argv += ['--doctest-collect=api']
-
         if len(args.array_api_backend) != 0:
             os.environ['SCIPY_ARRAY_API'] = json.dumps(list(args.array_api_backend))
 
@@ -759,7 +755,7 @@ class Test(Task):
                 args.mode,
                 verbose=verbose,
                 extra_argv=extra_argv,
-                doctests=args.doctests,
+                doctests=False,
                 coverage=args.coverage,
                 tests=tests,
                 parallel=args.parallel)
@@ -772,6 +768,90 @@ class Test(Task):
         Args = namedtuple('Args', [k for k in kwargs.keys()])
         args = Args(**kwargs)
         return cls.scipy_tests(args, pytest_args)
+
+
+@cli.cls_cmd('smoke-docs')
+class SmokeDocs(Task):
+    # XXX This essntially is a copy-paste of the Task class. Consider de-duplicating.
+    ctx = CONTEXT
+
+    verbose = Option(
+        ['--verbose', '-v'], default=False, is_flag=True,
+        help="more verbosity")
+    durations = Option(
+        ['--durations', '-d'], default=None, metavar="NUM_TESTS",
+        help="Show timing for the given number of slowest tests"
+    )
+    submodule = Option(
+        ['--submodule', '-s'], default=None, metavar='MODULE_NAME',
+        help="Submodule whose tests to run (cluster, constants, ...)")
+    tests = Option(
+        ['--tests', '-t'], default=None, multiple=True, metavar='TESTS',
+        help='Specify tests to run')
+    parallel = Option(
+        ['--parallel', '-j'], default=1, metavar='N_JOBS',
+        help="Number of parallel jobs for testing"
+    )
+    # Argument can't have `help=`; used to consume all of `-- arg1 arg2 arg3`
+    pytest_args = Argument(
+        ['pytest_args'], nargs=-1, metavar='PYTEST-ARGS', required=False
+    )
+
+    TASK_META = {
+        'task_dep': ['build'],
+    }
+
+    @classmethod
+    def scipy_tests(cls, args, pytest_args):
+        dirs = Dirs(args)
+        dirs.add_sys_path()
+        print(f"SciPy from development installed path at: {dirs.site}")
+
+        # FIXME: support pos-args with doit
+        extra_argv = list(pytest_args[:]) if pytest_args else []
+        if extra_argv and extra_argv[0] == '--':
+            extra_argv = extra_argv[1:]
+
+        if args.durations:
+            extra_argv += ['--durations', args.durations]
+
+        # convert options to test selection
+        if args.submodule:
+            tests = [PROJECT_MODULE + "." + args.submodule]
+        elif args.tests:
+            tests = args.tests
+        else:
+            tests = None
+
+        # use strategy=api unless -t path/to/specific/file
+        if not args.tests:
+            extra_argv += ['--doctest-collect=api']
+
+        runner, version, mod_path = get_test_runner(PROJECT_MODULE)
+        # FIXME: changing CWD is not a good practice
+        with working_dir(dirs.site):
+            print("Running tests for {} version:{}, installed at:{}".format(
+                        PROJECT_MODULE, version, mod_path))
+            # runner verbosity - convert bool to int
+            verbose = int(args.verbose) + 1
+            result = runner(  # scipy._lib._testutils:PytestTester
+                "fast",
+                verbose=verbose,
+                extra_argv=extra_argv,
+                doctests=True,
+                coverage=False,
+                tests=tests,
+                parallel=args.parallel)
+        return result
+
+    @classmethod
+    def run(cls, pytest_args, **kwargs):
+        """run unit-tests"""
+        kwargs.update(cls.ctx.get())
+        Args = namedtuple('Args', [k for k in kwargs.keys()])
+        args = Args(**kwargs)
+        return cls.scipy_tests(args, pytest_args)
+
 
 
 @cli.cls_cmd('bench')

--- a/dev.py
+++ b/dev.py
@@ -853,8 +853,8 @@ class SmokeDocs(Task):
         return cls.scipy_tests(args, pytest_args)
 
 
-@cli.cls_cmd('smoke-tutorial')
-class SmokeTutorial(Task):
+@cli.cls_cmd('smoke-tutorials')
+class SmokeTutorials(Task):
     """:wrench: Run smoke-tests on tutorial files."""
     ctx = CONTEXT
 

--- a/dev.py
+++ b/dev.py
@@ -742,6 +742,9 @@ class Test(Task):
         else:
             tests = None
 
+        if args.doctests and not args.tests:
+            extra_argv += ['--doctest-collect=api']
+
         if len(args.array_api_backend) != 0:
             os.environ['SCIPY_ARRAY_API'] = json.dumps(list(args.array_api_backend))
 

--- a/doc/source/tutorial/conftest.py
+++ b/doc/source/tutorial/conftest.py
@@ -1,0 +1,1 @@
+from scipy.conftest import dt_config

--- a/doc/source/tutorial/conftest.py
+++ b/doc/source/tutorial/conftest.py
@@ -1,1 +1,1 @@
-from scipy.conftest import dt_config
+from scipy.conftest import dt_config    # noqa: F401

--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -135,7 +135,7 @@ B-splines form an alternative (if formally equivalent) representation of piecewi
     >>> xx = np.linspace(0, 3/2, 51)
     >>> plt.plot(xx, bspl(xx), '--', label=r'$\sin(\pi x)$ approx')
     >>> plt.plot(x, y, 'o', label='data')
-    >>> plt.plot(xx, der(xx)/np.pi, '--', label='$d \sin(\pi x)/dx / \pi$ approx')
+    >>> plt.plot(xx, der(xx)/np.pi, '--', label=r'$d \sin(\pi x)/dx / \pi$ approx')
     >>> plt.legend()
     >>> plt.show()
 

--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -92,10 +92,10 @@ controlled by the ``fill_value`` keyword parameter:
     >>> rgi = RegularGridInterpolator((x, y), data,
     ...                               bounds_error=False, fill_value=None)
     >>> rgi([(2, 0), (2, 1), (2, -1)])   # extrapolates the value on the axis
-    array([2., 2., 2.]))
+    array([2., 2., 2.])
     >>> rgi.fill_value = -101
     >>> rgi([(2, 0), (2, 1), (2, -1)])
-    array([2., -101., -101.]))
+    array([2., -101., -101.])
 
 .. note::
 

--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -20,6 +20,7 @@ using each method.
 
 .. plot::
 
+   >>> import numpy as np
    >>> import matplotlib.pyplot as plt
    >>> from scipy.interpolate import RegularGridInterpolator
 
@@ -90,8 +91,8 @@ controlled by the ``fill_value`` keyword parameter:
     >>> data = np.array([[0], [5], [10]])
     >>> rgi = RegularGridInterpolator((x, y), data,
     ...                               bounds_error=False, fill_value=None)
-    >>> rgi([(2, 0), (2, 1), (2, -1)])
-    array([2., 2., 2.]))         # extrapolate the value on the axis
+    >>> rgi([(2, 0), (2, 1), (2, -1)])   # extrapolates the value on the axis
+    array([2., 2., 2.]))
     >>> rgi.fill_value = -101
     >>> rgi([(2, 0), (2, 1), (2, -1)])
     array([2., -101., -101.]))

--- a/doc/source/tutorial/interpolate/ND_unstructured.rst
+++ b/doc/source/tutorial/interpolate/ND_unstructured.rst
@@ -115,21 +115,21 @@ classes from the `scipy.interpolate` module.
     >>> ius = InterpolatedUnivariateSpline(x, y)
     >>> yi = ius(xi)
 
-    >>> plt.subplot(211)
-    >>> plt.plot(x, y, 'bo')
-    >>> plt.plot(xi, yi, 'g')
-    >>> plt.plot(xi, np.sin(xi), 'r')
-    >>> plt.title('Interpolation using univariate spline')
+    >>> fix, (ax1, ax2) = plt.subplots(2, 1)
+    >>> ax1.plot(x, y, 'bo')
+    >>> ax1.plot(xi, yi, 'g')
+    >>> ax1.plot(xi, np.sin(xi), 'r')
+    >>> ax1.set_title('Interpolation using univariate spline')
 
     >>> # use RBF method
     >>> rbf = RBFInterpolator(x, y)
     >>> fi = rbf(xi)
 
-    >>> plt.subplot(212)
-    >>> plt.plot(x, y, 'bo')
-    >>> plt.plot(xi, fi, 'g')
-    >>> plt.plot(xi, np.sin(xi), 'r')
-    >>> plt.title('Interpolation using RBF - multiquadrics')
+    >>> ax2.plot(x, y, 'bo')
+    >>> ax2.plot(xi, fi, 'g')
+    >>> ax2.plot(xi, np.sin(xi), 'r')
+    >>> ax2.set_title('Interpolation using RBF - multiquadrics')
+    >>> plt.tight_layout()
     >>> plt.show()
 
 ..   :caption: Example of a 1-D RBF interpolation.

--- a/doc/source/tutorial/interpolate/ND_unstructured.rst
+++ b/doc/source/tutorial/interpolate/ND_unstructured.rst
@@ -15,6 +15,7 @@ that do not form a regular grid.
 
     Suppose we want to interpolate the 2-D function
 
+    >>> import numpy as np
     >>> def func(x, y):
     ...     return x*(1-x)*np.cos(4*np.pi*x) * np.sin(4*np.pi*y**2)**2
 
@@ -114,7 +115,7 @@ classes from the `scipy.interpolate` module.
     >>> ius = InterpolatedUnivariateSpline(x, y)
     >>> yi = ius(xi)
 
-    >>> plt.subplot(2, 1, 1)
+    >>> plt.subplot(211)
     >>> plt.plot(x, y, 'bo')
     >>> plt.plot(xi, yi, 'g')
     >>> plt.plot(xi, np.sin(xi), 'r')
@@ -124,7 +125,7 @@ classes from the `scipy.interpolate` module.
     >>> rbf = RBFInterpolator(x, y)
     >>> fi = rbf(xi)
 
-    >>> plt.subplot(2, 1, 2)
+    >>> plt.subplot(212)
     >>> plt.plot(x, y, 'bo')
     >>> plt.plot(xi, fi, 'g')
     >>> plt.plot(xi, np.sin(xi), 'r')

--- a/doc/source/tutorial/interpolate/splines_and_polynomials.rst
+++ b/doc/source/tutorial/interpolate/splines_and_polynomials.rst
@@ -51,6 +51,7 @@ Manipulating `PPoly` objects
 and antiderivatives, computing integrals and root-finding. For example, we
 tabulate the sine function and find the roots of its derivative.
 
+    >>> import numpy as np
     >>> from scipy.interpolate import CubicSpline
     >>> x = np.linspace(0, 10, 71)
     >>> y = np.sin(x)
@@ -109,7 +110,7 @@ PCHIP interpolant (we could as well used a `CubicSpline`):
 
     >>> from scipy.interpolate import PchipInterpolator
     >>> x = np.linspace(0, np.pi/2, 70)
-    >>> y = (1 - m*np.sin(x)**2))**(-1/2)
+    >>> y = (1 - m*np.sin(x)**2)**(-1/2)
     >>> spl = PchipInterpolator(x, y)
 
 and integrate

--- a/doc/source/tutorial/interpolate/splines_and_polynomials.rst
+++ b/doc/source/tutorial/interpolate/splines_and_polynomials.rst
@@ -273,8 +273,8 @@ and construct the design matrix in the sparse CSR format
 >>> from scipy.interpolate import BSpline
 >>> mat = BSpline.design_matrix(xnew, t, k=3)
 >>> mat
-<3x7 sparse array of type '<class 'numpy.float64'>'
-	with 12 stored elements in Compressed Sparse Row format>
+<Compressed Sparse Row sparse array of dtype 'float64'
+	with 12 stored elements and shape (3, 7)>
 
 Here each row of the design matrix corresponds to a value in the ``xnew`` array,
 and a row has no more than ``k+1 = 4`` non-zero elements; row ``j``

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -85,13 +85,13 @@ Now, to Python:
 
   >>> mat_contents = sio.loadmat('octave_a.mat')
   >>> mat_contents
-  {'a': array([[[  1.,   4.,   7.,  10.],
-          [  2.,   5.,   8.,  11.],
-          [  3.,   6.,   9.,  12.]]]),
+  {'__header__': b'MATLAB 5.0 MAT-file, written
+   by Octave 3.2.3, 2010-05-30 02:13:40 UTC',
    '__version__': '1.0',
-   '__header__': 'MATLAB 5.0 MAT-file, written by
-   Octave 3.6.3, 2013-02-17 21:02:11 UTC',
-   '__globals__': []}
+   '__globals__': [],
+   'a': array([[[ 1.,  4.,  7., 10.],
+                [ 2.,  5.,  8., 11.],
+                [ 3.,  6.,  9., 12.]]])}
   >>> oct_a = mat_contents['a']
   >>> oct_a
   array([[[  1.,   4.,   7.,  10.],
@@ -156,8 +156,12 @@ We can load this in Python:
 
    >>> mat_contents = sio.loadmat('octave_struct.mat')
    >>> mat_contents
-   {'my_struct': array([[([[1.0]], [[2.0]])]],
-         dtype=[('field1', 'O'), ('field2', 'O')]), '__version__': '1.0', '__header__': 'MATLAB 5.0 MAT-file, written by Octave 3.6.3, 2013-02-17 21:23:14 UTC', '__globals__': []}
+    {'__header__': b'MATLAB 5.0 MAT-file, written by Octave 3.2.3, 2010-05-30 02:00:26 UTC',
+     '__version__': '1.0',
+     '__globals__': [],
+     'my_struct': array([[(array([[1.]]), array([[2.]]))]], dtype=[('field1', 'O'), ('field2', 'O')])
+    }
+
    >>> oct_struct = mat_contents['my_struct']
    >>> oct_struct.shape
    (1, 1)
@@ -214,7 +218,7 @@ this, use the ``struct_as_record=False`` parameter setting to ``loadmat``.
      File "<stdin>", line 1, in <module>
    AttributeError: 'mat_struct' object has no attribute 'shape'
    >>> type(oct_struct)
-   <class 'scipy.io.matlab.mio5_params.mat_struct'>
+   <class 'scipy.io.matlab._mio5_params.mat_struct'>
    >>> oct_struct.field1
    1.0
 
@@ -287,12 +291,12 @@ Back to Python:
 
 Saving to a MATLAB cell array just involves making a NumPy object array:
 
-   >>> obj_arr = np.zeros((2,), dtype=np.object)
+   >>> obj_arr = np.zeros((2,), dtype=object)
    >>> obj_arr[0] = 1
    >>> obj_arr[1] = 'a string'
    >>> obj_arr
    array([1, 'a string'], dtype=object)
-   >>> sio.savemat('np_cells.mat', {'obj_arr':obj_arr})
+   >>> sio.savemat('np_cells.mat', {'obj_arr': obj_arr})
 
 .. sourcecode:: octave
 

--- a/doc/source/tutorial/stats/analysing_one_sample.rst
+++ b/doc/source/tutorial/stats/analysing_one_sample.rst
@@ -5,6 +5,8 @@ First, we create some random variables. We set a seed so that in each run
 we get identical results to look at. As an example we take a sample from
 the Student t distribution:
 
+    >>> import numpy as np
+    >>> import scipy.stats as stats
     >>> x = stats.t.rvs(10, size=1000)
 
 Here, we set the required shape parameter of the t distribution, which

--- a/doc/source/tutorial/stats/comparing_two_samples.rst
+++ b/doc/source/tutorial/stats/comparing_two_samples.rst
@@ -11,6 +11,7 @@ Comparing means
 
 Test with sample with identical means:
 
+    >>> import scipy.stats as stats
     >>> rvs1 = stats.norm.rvs(loc=5, scale=10, size=500)
     >>> rvs2 = stats.norm.rvs(loc=5, scale=10, size=500)
     >>> stats.ttest_ind(rvs1, rvs2)

--- a/doc/source/tutorial/stats/continuous_kstwo.rst
+++ b/doc/source/tutorial/stats/continuous_kstwo.rst
@@ -35,6 +35,7 @@ with asymptotic estimates of Li-Chien, Pelz and Good to compute the CDF with 5-1
 Examples
 --------
 
+>>> import numpy as np
 >>> from scipy.stats import kstwo
 
 Show the probability of a gap at least as big as 0, 0.5 and 1.0 for a sample of size 5
@@ -50,17 +51,17 @@ a target N(0, 1) CDF.
 >>> gendist = norm(0.5, 1)       # Normal distribution, mean 0.5, stddev 1
 >>> x = np.sort(gendist.rvs(size=n, random_state=np.random.default_rng()))
 >>> x
-array([-1.59113056, -0.66335147,  0.54791569,  0.78009321,  1.27641365])
+array([-1.59113056, -0.66335147,  0.54791569,  0.78009321,  1.27641365])  # may vary
 >>> target = norm(0, 1)
 >>> cdfs = target.cdf(x)
 >>> cdfs
-array([0.0557901 , 0.25355274, 0.7081251 , 0.78233199, 0.89909533])
-# Construct the Empirical CDF and the K-S statistics (Dn+, Dn-, Dn)
+array([0.0557901 , 0.25355274, 0.7081251 , 0.78233199, 0.89909533])   # may vary
+>>> # Construct the Empirical CDF and the K-S statistics (Dn+, Dn-, Dn)
 >>> ecdfs = np.arange(n+1, dtype=float)/n
 >>> cols = np.column_stack([x, ecdfs[1:], cdfs, cdfs - ecdfs[:n], ecdfs[1:] - cdfs])
 >>> np.set_printoptions(precision=3)
 >>> cols
-array([[-1.591,  0.2  ,  0.056,  0.056,  0.144],
+array([[-1.591,  0.2  ,  0.056,  0.056,  0.144],     # may vary
        [-0.663,  0.4  ,  0.254,  0.054,  0.146],
        [ 0.548,  0.6  ,  0.708,  0.308, -0.108],
        [ 0.78 ,  0.8  ,  0.782,  0.182,  0.018],
@@ -70,17 +71,17 @@ array([[-1.591,  0.2  ,  0.056,  0.056,  0.144],
 >>> Dn = np.max(Dnpm)
 >>> iminus, iplus = np.argmax(gaps, axis=0)
 >>> print('Dn- = %f (at x=%.2f)' % (Dnpm[0], x[iminus]))
-Dn- = 0.308125 (at x=0.55)
+Dn- = 0.246201 (at x=-0.14)
 >>> print('Dn+ = %f (at x=%.2f)' % (Dnpm[1], x[iplus]))
-Dn+ = 0.146447 (at x=-0.66)
+Dn+ = 0.224726 (at x=0.19)
 >>> print('Dn  = %f' % (Dn))
-Dn  = 0.308125
+Dn  = 0.246201
 
 >>> probs = kstwo.sf(Dn, n)
 >>> print(chr(10).join(['For a sample of size %d drawn from a N(0, 1) distribution:' % n,
 ...      ' Kolmogorov-Smirnov 2-sided n=%d: Prob(Dn >= %f) = %.4f' % (n, Dn, probs)]))
 For a sample of size 5 drawn from a N(0, 1) distribution:
- Kolmogorov-Smirnov 2-sided n=5: Prob(Dn >= 0.308125) = 0.6319
+ Kolmogorov-Smirnov 2-sided n=5: Prob(Dn >= 0.246201) = 0.8562
 
 Plot the Empirical CDF against the target N(0, 1) CDF
 

--- a/doc/source/tutorial/stats/kernel_density_estimation.rst
+++ b/doc/source/tutorial/stats/kernel_density_estimation.rst
@@ -22,6 +22,7 @@ at the bottom of the figure (this is called a rug plot):
 .. plot::
     :alt: " "
 
+    >>> import numpy as np
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
 

--- a/doc/source/tutorial/stats/resampling.rst
+++ b/doc/source/tutorial/stats/resampling.rst
@@ -48,8 +48,8 @@ Your brother Kyle is the analytical one. He answers:
     >>> std = math.sqrt(n*p*(1-p))
     >>> # CDF of the normal distribution. (Unfortunately, Kyle forgets a continuity correction that would produce a more accurate answer.)
     >>> prob = 0.5 * (1 + math.erf((x - mean) / (std * math.sqrt(2))))
-    >>> print(f"The normal approximation estimates the probability as {prob}")
-    The normal approximation estimates the probability as 0.15865525393145713
+    >>> print(f"The normal approximation estimates the probability as {prob:.3f}")
+    The normal approximation estimates the probability as 0.159
 
 You are a little more practical, so you decide to take a computational
 approach (or more precisely, a Monte Carlo approach): just simulate many
@@ -63,8 +63,8 @@ count does not exceed 45.
     >>> simulation = rng.random(size=(n, N)) < p  # False for tails, True for heads
     >>> counts = np.sum(simulation, axis=0)  # count the number of heads each trial
     >>> prob = np.sum(counts <= x) / N  # estimate the probability as the observed proportion of cases in which the count did not exceed 45
-    >>> print(f"The Monte Carlo approach estimates the probability as {prob}")
-    The Monte Carlo approach estimates the probability as 0.18348
+    >>> print(f"The Monte Carlo approach estimates the probability as {prob:.3f}")
+    The Monte Carlo approach estimates the probability as 0.187
 
 The demon replies:
 

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -147,7 +147,8 @@ An example of this interface is shown below:
     ...         return -x * exp(-0.5 * x*x)
     ... 
     >>> dist = StandardNormal()
-    >>> 
+    >>>
+    >>> import numpy as np
     >>> urng = np.random.default_rng()
     >>> rng = TransformedDensityRejection(dist, random_state=urng)
 
@@ -238,7 +239,8 @@ by visualizing the histogram of the samples:
           :class:`~TransformedDensityRejection` would not be the same even for
           the same ``random_state``:
 
-          >>> from scipy.stats.sampling import norm, TransformedDensityRejection
+          >>> from scipy.stats import norm
+          >>> from scipy.stats.sampling import TransformedDensityRejection
           >>> from copy import copy
           >>> dist = StandardNormal()
           >>> urng1 = np.random.default_rng()
@@ -253,7 +255,7 @@ We can pass a ``domain`` parameter to truncate the distribution:
 
     >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), random_state=urng)
     >>> rng.rvs((5, 3))
-    array([[-0.99865691,  0.38104014,  0.31633526],
+    array([[-0.99865691,  0.38104014,  0.31633526],    # may vary
            [ 0.88433909, -0.45181849,  0.78574461],
            [ 0.3337244 ,  0.12924307,  0.40499404],
            [-0.51865761,  0.43252222, -0.6514866 ],

--- a/doc/source/tutorial/stats/sampling_dau.rst
+++ b/doc/source/tutorial/stats/sampling_dau.rst
@@ -26,7 +26,7 @@ constructing the tables is O(N).
     >>> urng = np.random.default_rng()
     >>> rng = DiscreteAliasUrn(pv, random_state=urng)
     >>> rng.rvs()
-    0
+    0      # may vary
 
 By default, the probability vector is indexed starting at 0. However, this
 can be changed by passing a ``domain`` parameter. When ``domain`` is given
@@ -36,7 +36,7 @@ distribution from ``(0, len(pv))`` to ``(domain[0]``, ``domain[0] + len(pv))``.
 
    >>> rng = DiscreteAliasUrn(pv, domain=(10, 13), random_state=urng)
    >>> rng.rvs()
-   12
+   12    # may vary
 
 The method also works when no probability vector but a PMF is given.
 In that case, a bounded (finite) domain must also be given either by
@@ -54,7 +54,7 @@ method in the distribution object:
     >>> dist = Distribution(2)
     >>> rng = DiscreteAliasUrn(dist, random_state=urng)
     >>> rng.rvs()
-    10
+    10    # may vary
 
 .. plot::
     :alt: " "
@@ -114,7 +114,7 @@ table which can be changed by passing a ``urn_factor`` parameter.
     >>> urn_factor = 2
     >>> rng = DiscreteAliasUrn(pv, urn_factor=urn_factor, random_state=urng)
     >>> rng.rvs()
-    2
+    2    # may vary
 
 .. note:: It is recommended to keep this parameter under 2.
 

--- a/doc/source/tutorial/stats/sampling_dgt.rst
+++ b/doc/source/tutorial/stats/sampling_dgt.rst
@@ -43,7 +43,7 @@ of the given probability vector can be set by the `guide_factor` parameter:
     >>> urng = np.random.default_rng()
     >>> rng = DiscreteGuideTable(pv, random_state=urng)
     >>> rng.rvs()
-    2
+    2    # may vary
 
 By default, the probability vector is indexed starting at 0. However, this
 can be changed by passing a ``domain`` parameter. When ``domain`` is given
@@ -53,7 +53,7 @@ distribution from ``(0, len(pv))`` to ``(domain[0], domain[0] + len(pv))``.
 
     >>> rng = DiscreteGuideTable(pv, random_state=urng, domain=(10, 13))
     >>> rng.rvs()
-    10
+    10   # may vary
 
 The method also works when no probability vector but a PMF is given.
 In that case, a bounded (finite) domain must also be given either by
@@ -71,7 +71,7 @@ method in the distribution object:
     >>> dist = Distribution(2)
     >>> rng = DiscreteGuideTable(dist, random_state=urng)
     >>> rng.rvs()
-    9
+    9     # may vary
 
 .. note:: As :class:`~DiscreteGuideTable` expects PMF with signature
           ``def pmf(self, x: float) -> float``, it first vectorizes the
@@ -99,7 +99,7 @@ time but require a more expensive setup.
     >>> guide_factor = 2
     >>> rng = DiscreteGuideTable(pv, random_state=urng, guide_factor=guide_factor)
     >>> rng.rvs()
-    2
+    2     # may vary
 
 Unfortunately, the PPF is rarely available in closed form or too slow when
 available. The user only has to provide the probability vector and the 
@@ -109,6 +109,7 @@ method calculates the (exact) PPF of the given distribution.
 For example to calculate the PPF of a binomial distribution with :math:`n=4` and
 :math:`p=0.1`: we can set up a guide table as follows:
 
+    >>> import scipy.stats as stats
     >>> n, p = 4, 0.1
     >>> dist = stats.binom(n, p)
     >>> rng = DiscreteGuideTable(dist, random_state=42)

--- a/doc/source/tutorial/stats/sampling_hinv.rst
+++ b/doc/source/tutorial/stats/sampling_hinv.rst
@@ -57,6 +57,7 @@ below the specified tolerance `u_resolution`. Refinement stops when the required
 tolerance is achieved or when the number of mesh intervals after the next
 refinement could exceed the maximum allowed number of intervals (100000).
 
+    >>> import numpy as np
     >>> from scipy.stats.sampling import NumericalInverseHermite
     >>> from scipy.stats import norm, genexpon
     >>> from scipy.special import ndtr
@@ -97,6 +98,7 @@ the same random state.
 To check that the random variates closely follow the given distribution, we can
 look at its histogram:
 
+    >>> import matplotlib.pyplot as plt
     >>> dist = StandardNormal()
     >>> urng = np.random.default_rng()
     >>> rng = NumericalInverseHermite(dist, random_state=urng)

--- a/doc/source/tutorial/stats/sampling_pinv.rst
+++ b/doc/source/tutorial/stats/sampling_pinv.rst
@@ -97,6 +97,7 @@ Following four steps are carried out by the algorithm during setup:
 
 To initialize the generator to sample from a standard normal distribution, do:
 
+    >>> import numpy as np
     >>> from scipy.stats.sampling import NumericalInversePolynomial
     >>> class StandardNormal:
     ...     def pdf(self, x):
@@ -173,7 +174,7 @@ PDF evaluations increase during setup for small values of ``u_resolution``.
     >>> rng = NumericalInversePolynomial(dist, u_resolution=1e-8,
     ...                                  random_state=urng)
     >>> dist.callbacks
-    4095
+    4095        # may vary
     >>> dist.callbacks = 0  # reset the number of callbacks
     >>> # u_resolution = 10^-10 (default)
     >>> # => more PDF evaluations required
@@ -181,14 +182,14 @@ PDF evaluations increase during setup for small values of ``u_resolution``.
     >>> rng = NumericalInversePolynomial(dist, u_resolution=1e-10,
     ...                                  random_state=urng)
     >>> dist.callbacks
-    11454
+    11454       # may vary
     >>> dist.callbacks = 0  # reset the number of callbacks
     >>> # u_resolution = 10^-12
     >>> # => lots of PDF evaluations required
     >>> # => very slow setup
     >>> rng = NumericalInversePolynomial(dist, u_resolution=1e-12,
     ...                                  random_state=urng)
-    13902
+    13902     # may vary
 
 As we can see, the number of PDF evaluations required is very high and a
 fast PDF is critical to the algorithm. Though, this helps reduce the number

--- a/doc/source/tutorial/stats/sampling_srou.rst
+++ b/doc/source/tutorial/stats/sampling_srou.rst
@@ -15,6 +15,7 @@ Simple Ratio-of-Uniforms (SROU)
 SROU is based on the ratio-of-uniforms method that uses universal inequalities for constructing
 a (universal) bounding rectangle. It works for T-concave distributions with T(x) = -1/sqrt(x).
 
+    >>> import numpy as np
     >>> from scipy.stats.sampling import SimpleRatioUniforms
 
 Suppose we have the normal distribution:
@@ -101,7 +102,7 @@ given by `np.arange(1.5, 5, 1000)`.
     ...     rng = SimpleRatioUniforms(dist, mode=p[i]-1,
     ...                               pdf_area=math.gamma(p[i]),
     ...                               random_state=urng)
-    ...     with np.suppress_warnings() as sup:
+    ...     with np.testing.suppress_warnings() as sup:
     ...         sup.filter(RuntimeWarning, "invalid value encountered in double_scalars")
     ...         sup.filter(RuntimeWarning, "overflow encountered in exp")
     ...         res[i] = rng.rvs(100)

--- a/doc/source/tutorial/stats/sampling_tdr.rst
+++ b/doc/source/tutorial/stats/sampling_tdr.rst
@@ -30,6 +30,7 @@ The variant that is implemented uses squeezes proportional to hat function ([1]_
 
 An example of using this method is shown below:
 
+    >>> import numpy as np
     >>> from scipy.stats.sampling import TransformedDensityRejection
     >>> from scipy.stats import norm
     >>> 

--- a/mypy.ini
+++ b/mypy.ini
@@ -222,6 +222,8 @@ ignore_missing_imports = True
 # Files with various errors. Likely some false positives, but likely
 # some real bugs too.
 #
+[mypy-scipy.conftest]
+ignore_errors = True
 
 [mypy-scipy.__config__]
 ignore_errors = True

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -95,7 +95,7 @@ class PytestTester:
         pytest_args = ['--showlocals', '--tb=short']
 
         if doctests:
-            raise ValueError("Doctests not supported")
+            pytest_args += ["--doctest-modules", "--ignore=scipy/interpolate/_interpnd_info.py", "--ignore=scipy/_lib/"]
 
         if extra_argv:
             pytest_args += list(extra_argv)

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -95,7 +95,16 @@ class PytestTester:
         pytest_args = ['--showlocals', '--tb=short']
 
         if doctests:
-            pytest_args += ["--doctest-modules", "--ignore=scipy/interpolate/_interpnd_info.py", "--ignore=scipy/_lib/"]
+            pytest_args += [
+                "--doctest-modules",
+                "--ignore=scipy/interpolate/_interpnd_info.py",
+                "--ignore=scipy/_lib/array_api_compat",
+                "--ignore=scipy/_lib/highs",
+                "--ignore=scipy/_lib/unuran",
+                "--ignore=scipy/_lib/_gcutils.py",
+                "--ignore=scipy/_lib/doccer.py",
+                "--ignore=scipy/_lib/_uarray",
+            ]
 
         if extra_argv:
             pytest_args += list(extra_argv)

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -119,6 +119,7 @@ def test_warning_calls_filters(warning_calls):
         os.path.join('stats', '_continuous_distns.py'),
         os.path.join('stats', '_binned_statistic.py'),  # gh-19345
         os.path.join('_lib', '_util.py'),  # gh-19341
+        "conftest.py",
     )
     bad_filters = [item for item in bad_filters if item.split(':')[0] not in
                    allowed_filters]

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -286,7 +286,7 @@ def warnings_errors_and_rng(test):
 
     # scipy.stats deliberately emits UserWarnings sometimes
     user_w = ['scipy.stats.anderson_ksamp', 'scipy.stats.kurtosistest',
-              'scipy.stats.normaltest']
+              'scipy.stats.normaltest', 'scipy.sparse.linalg.norm']
     for name in user_w:
         known_warnings[name] = dict(category=UserWarning)
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -353,4 +353,6 @@ dt_config.pytest_extra_skips = [
     "scipy.misc",
 ]
 
+dt_config.pseudocode = set(['integrate.nquad(func,'])
+dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -378,6 +378,7 @@ dt_config.pytest_extra_xfail = {
     "extrapolation_examples.rst": "ReST parser limitation",
     "sampling_pinv.rst": "__cinit__ unexpected argument",
     "sampling_srou.rst": "nan in scalar_power",
+    "probability_distributions.rst": "integration warning",
 }
 
 # tutorials

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -342,7 +342,7 @@ dt_config.skiplist = set([
 
 # these are affected by NumPy 2.0 scalar repr: they rely on string comparison
 if np.__version__ < "2":
-    dt_config.skiplist += set([
+    dt_config.skiplist.update(set([
         'scipy.io.hb_read',
         'scipy.io.hb_write',
         'scipy.sparse.csgraph.connected_components',
@@ -359,8 +359,8 @@ if np.__version__ < "2":
         'scipy.sparse.csgraph.construct_dist_matrix',
         'scipy.sparse.csgraph.reconstruct_path',
         'scipy.ndimage.value_indices',
-        'scipy.stats.describe',
-])
+        'scipy.stats.mstats.describe',
+]))
 
 # help pytest collection a bit: these names are either private (distributions),
 # or just do not need doctesting.

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -358,6 +358,7 @@ if np.__version__ < "2":
         'scipy.sparse.csgraph.structural_rank',
         'scipy.sparse.csgraph.construct_dist_matrix',
         'scipy.sparse.csgraph.reconstruct_path',
+        'scipy.ndimage.value_indices',
 ])
 
 # help pytest collection a bit: these names are either private (distributions),

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -238,3 +238,107 @@ hypothesis.settings.register_profile(
 SCIPY_HYPOTHESIS_PROFILE = os.environ.get("SCIPY_HYPOTHESIS_PROFILE",
                                           "deterministic")
 hypothesis.settings.load_profile(SCIPY_HYPOTHESIS_PROFILE)
+
+
+############################################################################
+# doctesting stuff
+
+from scpdt.conftest import dt_config
+from contextlib import contextmanager
+import warnings
+
+
+# FIXME: populate the dict once
+@contextmanager
+def warnings_errors_and_rng(test):
+    """Temporarily turn (almost) all warnings to errors.
+
+    Filter out known warnings which we allow.
+    """
+    known_warnings = dict()
+
+    # these functions are known to emit "divide by zero" RuntimeWarnings
+    divide_by_zero = [
+        'scipy.linalg.norm', 'scipy.ndimage.center_of_mass',
+    ]
+    for name in divide_by_zero:
+        known_warnings[name] = dict(category=RuntimeWarning,
+                                    message='divide by zero')
+
+    # Deprecated stuff in scipy.signal and elsewhere
+    deprecated = [
+        'scipy.signal.cwt', 'scipy.signal.morlet', 'scipy.signal.morlet2',
+        'scipy.signal.ricker',
+        'scipy.integrate.simpson',
+        'scipy.interpolate.interp2d',
+    ]
+    for name in deprecated:
+        known_warnings[name] = dict(category=DeprecationWarning)
+
+    from scipy import integrate
+    # the funcions are known to emit IntergrationWarnings
+    integration_w = ['scipy.special.ellip_normal',
+                     'scipy.special.ellip_harm_2',
+    ]
+    for name in integration_w:
+        known_warnings[name] = dict(category=integrate.IntegrationWarning,
+                                    message='The occurrence of roundoff')
+
+    # scipy.stats deliberately emits UserWarnings sometimes
+    user_w = ['scipy.stats.anderson_ksamp', 'scipy.stats.kurtosistest',
+              'scipy.stats.normaltest']
+    for name in user_w:
+        known_warnings[name] = dict(category=UserWarning)
+
+    # additional one-off warnings to filter
+    dct = {
+        'scipy.sparse.linalg.norm':
+            dict(category=UserWarning, message="Exited at iteration"),
+        # tutorials
+        'linalg.rst':
+            dict(message='the matrix subclass is not',
+                 category=PendingDeprecationWarning),
+        'stats.rst':
+            dict(message='The maximum number of subdivisions',
+                 category=integrate.IntegrationWarning),
+    }
+    known_warnings.update(dct)
+
+    # these legitimately emit warnings in examples
+    from scipy.signal._filter_design import BadCoefficients
+    legit = set('scipy.signal.normalize')
+
+    # Now, the meat of the matter: filter warnings,
+    # also control the random seed for each doctest.
+
+    # XXX: this matches the refguide-check behavior, but is a tad strange:
+    # makes sure that the seed the old-fashioned np.random* methods is *NOT*
+    # reproducible but the new-style `default_rng()` *IS* repoducible.
+    # Should these two be either both repro or both not repro?
+
+    from scipy._lib._util import _fixed_default_rng
+    import numpy as np
+    with _fixed_default_rng():
+        np.random.seed(None)
+        with warnings.catch_warnings():
+            if test.name in known_warnings:
+                warnings.filterwarnings('ignore', **known_warnings[test.name])
+                yield
+            elif test.name in legit:
+                yield
+            else:
+                warnings.simplefilter('error', Warning)
+                yield
+
+
+dt_config.user_context_mgr = warnings_errors_and_rng
+dt_config.skiplist = set([
+    'scipy.linalg.LinAlgError',     # comes from numpy
+    'scipy.fftpack.fftshift',       # fftpack stuff is also from numpy
+    'scipy.fftpack.ifftshift',
+    'scipy.fftpack.fftfreq',
+    'scipy.special.sinc',           # sinc is from numpy
+    'scipy.optimize.show_options',  # does not have much to doctest
+    'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
+])
+############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -340,6 +340,26 @@ dt_config.skiplist = set([
     'scipy.sparse.linalg.norm',     # XXX temp skip
 ])
 
+# these are affected by NumPy 2.0 scalar repr: they rely on string comparison
+if np.__version__ < "2":
+    dt_config.skiplist += set([
+        'scipy.io.hb_read',
+        'scipy.io.hb_write',
+        'scipy.sparse.csgraph.connected_components',
+        'scipy.sparse.csgraph.depth_first_order',
+        'scipy.sparse.csgraph.shortest_path',
+        'scipy.sparse.csgraph.floyd_warshall',
+        'scipy.sparse.csgraph.dijkstra',
+        'scipy.sparse.csgraph.bellman_ford',
+        'scipy.sparse.csgraph.johnson',
+        'scipy.sparse.csgraph.yen',
+        'scipy.sparse.csgraph.breadth_first_order',
+        'scipy.sparse.csgraph.reverse_cuthill_mckee',
+        'scipy.sparse.csgraph.structural_rank',
+        'scipy.sparse.csgraph.construct_dist_matrix',
+        'scipy.sparse.csgraph.reconstruct_path',
+])
+
 # help pytest collection a bit: these names are either private (distributions),
 # or just do not need doctesting.
 dt_config.pytest_extra_ignore = [

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -13,6 +13,9 @@ from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
 from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
 
+from scpdt.conftest import dt_config
+from contextlib import contextmanager
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers",
@@ -243,11 +246,6 @@ hypothesis.settings.load_profile(SCIPY_HYPOTHESIS_PROFILE)
 ############################################################################
 # doctesting stuff
 
-from scpdt.conftest import dt_config
-from contextlib import contextmanager
-import warnings
-
-
 # FIXME: populate the dict once
 @contextmanager
 def warnings_errors_and_rng(test):
@@ -305,7 +303,6 @@ def warnings_errors_and_rng(test):
     known_warnings.update(dct)
 
     # these legitimately emit warnings in examples
-    from scipy.signal._filter_design import BadCoefficients
     legit = set('scipy.signal.normalize')
 
     # Now, the meat of the matter: filter warnings,
@@ -365,6 +362,4 @@ dt_config.pytest_extra_xfail = {
 # tutorials
 dt_config.pseudocode = set(['integrate.nquad(func,'])
 dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
-
-dt_config.nameerror_after_exception = True
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -351,8 +351,16 @@ dt_config.pytest_extra_skips = [
     "scipy.test",
     "scipy.show_config",
     "scipy.misc",
+     # tutorials:
+    "io.rst",              # broken?
+    "ND_regular_grid.rst",
+    "ND_unstructured.rst",   # XXX: MPL deprecation?
+    "extrapolation_examples.rst",
+    "sampling_pinv.rst",
+    "sampling_srou.rst",
 ]
 
-dt_config.pseudocode = set(['integrate.nquad(func,'])
+# tutorials
+dt_config.pseudocode = set(['integrate.nquad(func,']) #, 'octave_struct.mat'])
 dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -352,4 +352,5 @@ dt_config.pytest_extra_skips = [
     "scipy.show_config",
     "scipy.misc",
 ]
+
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -3,6 +3,7 @@ import json
 import os
 import warnings
 import tempfile
+from contextlib import contextmanager
 
 import numpy as np
 import numpy.testing as npt
@@ -13,8 +14,11 @@ from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
 from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
 
-from scpdt.conftest import dt_config
-from contextlib import contextmanager
+try:
+    from scpdt.conftest import dt_config
+    HAVE_SCPDT = True
+except ModuleNotFoundError:
+    HAVE_SCPDT = False
 
 
 def pytest_configure(config):
@@ -246,142 +250,145 @@ hypothesis.settings.load_profile(SCIPY_HYPOTHESIS_PROFILE)
 ############################################################################
 # doctesting stuff
 
-# FIXME: populate the dict once
-@contextmanager
-def warnings_errors_and_rng(test):
-    """Temporarily turn (almost) all warnings to errors.
+if HAVE_SCPDT:
 
-    Filter out known warnings which we allow.
-    """
-    known_warnings = dict()
+    # FIXME: populate the dict once
+    @contextmanager
+    def warnings_errors_and_rng(test):
+        """Temporarily turn (almost) all warnings to errors.
 
-    # these functions are known to emit "divide by zero" RuntimeWarnings
-    divide_by_zero = [
-        'scipy.linalg.norm', 'scipy.ndimage.center_of_mass',
+        Filter out known warnings which we allow.
+        """
+        known_warnings = dict()
+
+        # these functions are known to emit "divide by zero" RuntimeWarnings
+        divide_by_zero = [
+            'scipy.linalg.norm', 'scipy.ndimage.center_of_mass',
+        ]
+        for name in divide_by_zero:
+            known_warnings[name] = dict(category=RuntimeWarning,
+                                        message='divide by zero')
+
+        # Deprecated stuff in scipy.signal and elsewhere
+        deprecated = [
+            'scipy.signal.cwt', 'scipy.signal.morlet', 'scipy.signal.morlet2',
+            'scipy.signal.ricker',
+            'scipy.integrate.simpson',
+            'scipy.interpolate.interp2d',
+        ]
+        for name in deprecated:
+            known_warnings[name] = dict(category=DeprecationWarning)
+
+        from scipy import integrate
+        # the funcions are known to emit IntergrationWarnings
+        integration_w = ['scipy.special.ellip_normal',
+                         'scipy.special.ellip_harm_2',
+        ]
+        for name in integration_w:
+            known_warnings[name] = dict(category=integrate.IntegrationWarning,
+                                        message='The occurrence of roundoff')
+
+        # scipy.stats deliberately emits UserWarnings sometimes
+        user_w = ['scipy.stats.anderson_ksamp', 'scipy.stats.kurtosistest',
+                  'scipy.stats.normaltest', 'scipy.sparse.linalg.norm']
+        for name in user_w:
+            known_warnings[name] = dict(category=UserWarning)
+
+        # additional one-off warnings to filter
+        dct = {
+            'scipy.sparse.linalg.norm':
+                dict(category=UserWarning, message="Exited at iteration"),
+            # tutorials
+            'linalg.rst':
+                dict(message='the matrix subclass is not',
+                     category=PendingDeprecationWarning),
+            'stats.rst':
+                dict(message='The maximum number of subdivisions',
+                     category=integrate.IntegrationWarning),
+        }
+        known_warnings.update(dct)
+
+        # these legitimately emit warnings in examples
+        legit = set('scipy.signal.normalize')
+
+        # Now, the meat of the matter: filter warnings,
+        # also control the random seed for each doctest.
+
+        # XXX: this matches the refguide-check behavior, but is a tad strange:
+        # makes sure that the seed the old-fashioned np.random* methods is
+        # *NOT* reproducible but the new-style `default_rng()` *IS* repoducible.
+        # Should these two be either both repro or both not repro?
+
+        from scipy._lib._util import _fixed_default_rng
+        import numpy as np
+        with _fixed_default_rng():
+            np.random.seed(None)
+            with warnings.catch_warnings():
+                if test.name in known_warnings:
+                    warnings.filterwarnings('ignore',
+                                            **known_warnings[test.name])
+                    yield
+                elif test.name in legit:
+                    yield
+                else:
+                    warnings.simplefilter('error', Warning)
+                    yield
+
+
+    dt_config.user_context_mgr = warnings_errors_and_rng
+    dt_config.skiplist = set([
+        'scipy.linalg.LinAlgError',     # comes from numpy
+        'scipy.fftpack.fftshift',       # fftpack stuff is also from numpy
+        'scipy.fftpack.ifftshift',
+        'scipy.fftpack.fftfreq',
+        'scipy.special.sinc',           # sinc is from numpy
+        'scipy.optimize.show_options',  # does not have much to doctest
+        'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
+        'scipy.sparse.linalg.norm',     # XXX temp skip
+    ])
+
+    # these are affected by NumPy 2.0 scalar repr: rely on string comparison
+    if np.__version__ < "2":
+        dt_config.skiplist.update(set([
+            'scipy.io.hb_read',
+            'scipy.io.hb_write',
+            'scipy.sparse.csgraph.connected_components',
+            'scipy.sparse.csgraph.depth_first_order',
+            'scipy.sparse.csgraph.shortest_path',
+            'scipy.sparse.csgraph.floyd_warshall',
+            'scipy.sparse.csgraph.dijkstra',
+            'scipy.sparse.csgraph.bellman_ford',
+            'scipy.sparse.csgraph.johnson',
+            'scipy.sparse.csgraph.yen',
+            'scipy.sparse.csgraph.breadth_first_order',
+            'scipy.sparse.csgraph.reverse_cuthill_mckee',
+            'scipy.sparse.csgraph.structural_rank',
+            'scipy.sparse.csgraph.construct_dist_matrix',
+            'scipy.sparse.csgraph.reconstruct_path',
+            'scipy.ndimage.value_indices',
+            'scipy.stats.mstats.describe',
+    ]))
+
+    # help pytest collection a bit: these names are either private
+    # (distributions), or just do not need doctesting.
+    dt_config.pytest_extra_ignore = [
+        "scipy.stats.distributions",
+        "scipy.optimize.cython_optimize",
+        "scipy.test",
+        "scipy.show_config",
     ]
-    for name in divide_by_zero:
-        known_warnings[name] = dict(category=RuntimeWarning,
-                                    message='divide by zero')
 
-    # Deprecated stuff in scipy.signal and elsewhere
-    deprecated = [
-        'scipy.signal.cwt', 'scipy.signal.morlet', 'scipy.signal.morlet2',
-        'scipy.signal.ricker',
-        'scipy.integrate.simpson',
-        'scipy.interpolate.interp2d',
-    ]
-    for name in deprecated:
-        known_warnings[name] = dict(category=DeprecationWarning)
-
-    from scipy import integrate
-    # the funcions are known to emit IntergrationWarnings
-    integration_w = ['scipy.special.ellip_normal',
-                     'scipy.special.ellip_harm_2',
-    ]
-    for name in integration_w:
-        known_warnings[name] = dict(category=integrate.IntegrationWarning,
-                                    message='The occurrence of roundoff')
-
-    # scipy.stats deliberately emits UserWarnings sometimes
-    user_w = ['scipy.stats.anderson_ksamp', 'scipy.stats.kurtosistest',
-              'scipy.stats.normaltest', 'scipy.sparse.linalg.norm']
-    for name in user_w:
-        known_warnings[name] = dict(category=UserWarning)
-
-    # additional one-off warnings to filter
-    dct = {
-        'scipy.sparse.linalg.norm':
-            dict(category=UserWarning, message="Exited at iteration"),
-        # tutorials
-        'linalg.rst':
-            dict(message='the matrix subclass is not',
-                 category=PendingDeprecationWarning),
-        'stats.rst':
-            dict(message='The maximum number of subdivisions',
-                 category=integrate.IntegrationWarning),
+    dt_config.pytest_extra_xfail = {
+        # name: reason
+        "io.rst": "",
+        "ND_regular_grid.rst": "ReST parser limitation",
+        "extrapolation_examples.rst": "ReST parser limitation",
+        "sampling_pinv.rst": "__cinit__ unexpected argument",
+        "sampling_srou.rst": "nan in scalar_power",
+        "probability_distributions.rst": "integration warning",
     }
-    known_warnings.update(dct)
 
-    # these legitimately emit warnings in examples
-    legit = set('scipy.signal.normalize')
-
-    # Now, the meat of the matter: filter warnings,
-    # also control the random seed for each doctest.
-
-    # XXX: this matches the refguide-check behavior, but is a tad strange:
-    # makes sure that the seed the old-fashioned np.random* methods is *NOT*
-    # reproducible but the new-style `default_rng()` *IS* repoducible.
-    # Should these two be either both repro or both not repro?
-
-    from scipy._lib._util import _fixed_default_rng
-    import numpy as np
-    with _fixed_default_rng():
-        np.random.seed(None)
-        with warnings.catch_warnings():
-            if test.name in known_warnings:
-                warnings.filterwarnings('ignore', **known_warnings[test.name])
-                yield
-            elif test.name in legit:
-                yield
-            else:
-                warnings.simplefilter('error', Warning)
-                yield
-
-
-dt_config.user_context_mgr = warnings_errors_and_rng
-dt_config.skiplist = set([
-    'scipy.linalg.LinAlgError',     # comes from numpy
-    'scipy.fftpack.fftshift',       # fftpack stuff is also from numpy
-    'scipy.fftpack.ifftshift',
-    'scipy.fftpack.fftfreq',
-    'scipy.special.sinc',           # sinc is from numpy
-    'scipy.optimize.show_options',  # does not have much to doctest
-    'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
-    'scipy.sparse.linalg.norm',     # XXX temp skip
-])
-
-# these are affected by NumPy 2.0 scalar repr: they rely on string comparison
-if np.__version__ < "2":
-    dt_config.skiplist.update(set([
-        'scipy.io.hb_read',
-        'scipy.io.hb_write',
-        'scipy.sparse.csgraph.connected_components',
-        'scipy.sparse.csgraph.depth_first_order',
-        'scipy.sparse.csgraph.shortest_path',
-        'scipy.sparse.csgraph.floyd_warshall',
-        'scipy.sparse.csgraph.dijkstra',
-        'scipy.sparse.csgraph.bellman_ford',
-        'scipy.sparse.csgraph.johnson',
-        'scipy.sparse.csgraph.yen',
-        'scipy.sparse.csgraph.breadth_first_order',
-        'scipy.sparse.csgraph.reverse_cuthill_mckee',
-        'scipy.sparse.csgraph.structural_rank',
-        'scipy.sparse.csgraph.construct_dist_matrix',
-        'scipy.sparse.csgraph.reconstruct_path',
-        'scipy.ndimage.value_indices',
-        'scipy.stats.mstats.describe',
-]))
-
-# help pytest collection a bit: these names are either private (distributions),
-# or just do not need doctesting.
-dt_config.pytest_extra_ignore = [
-    "scipy.stats.distributions",
-    "scipy.optimize.cython_optimize",
-    "scipy.test",
-    "scipy.show_config",
-]
-
-dt_config.pytest_extra_xfail = {
-    # name: reason
-    "io.rst": "",
-    "ND_regular_grid.rst": "ReST parser limitation",
-    "extrapolation_examples.rst": "ReST parser limitation",
-    "sampling_pinv.rst": "__cinit__ unexpected argument",
-    "sampling_srou.rst": "nan in scalar_power",
-    "probability_distributions.rst": "integration warning",
-}
-
-# tutorials
-dt_config.pseudocode = set(['integrate.nquad(func,'])
-dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
+    # tutorials
+    dt_config.pseudocode = set(['integrate.nquad(func,'])
+    dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -340,6 +340,7 @@ dt_config.skiplist = set([
     'scipy.special.sinc',           # sinc is from numpy
     'scipy.optimize.show_options',  # does not have much to doctest
     'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
+    'scipy.sparse.linalg.norm',     # XXX temp skip
 ])
 
 # help pytest collection a bit: these names are either private (distributions)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -341,4 +341,14 @@ dt_config.skiplist = set([
     'scipy.optimize.show_options',  # does not have much to doctest
     'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
 ])
+
+# help pytest collection a bit: these names are either private (distributions)
+# or deprecated (misc), or just do not need doctesting 
+dt_config.pytest_extra_skips = [
+    "scipy.stats.distributions",
+    "scipy.optimize.cython_optimize",
+    "scipy.test",
+    "scipy.show_config",
+    "scipy.misc",
+]
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -359,6 +359,7 @@ if np.__version__ < "2":
         'scipy.sparse.csgraph.construct_dist_matrix',
         'scipy.sparse.csgraph.reconstruct_path',
         'scipy.ndimage.value_indices',
+        'scipy.stats.describe',
 ])
 
 # help pytest collection a bit: these names are either private (distributions),

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -15,7 +15,7 @@ from scipy._lib._testutils import FPUModeChangeWarning
 from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
 
 try:
-    from scpdt.conftest import dt_config
+    from scipy_doctest.conftest import dt_config
     HAVE_SCPDT = True
 except ModuleNotFoundError:
     HAVE_SCPDT = False

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -353,7 +353,6 @@ dt_config.pytest_extra_xfail = {
     # name: reason
     "io.rst": "",
     "ND_regular_grid.rst": "ReST parser limitation",
-    "ND_unstructured.rst": "matplotlib deprecation",
     "extrapolation_examples.rst": "ReST parser limitation",
     "sampling_pinv.rst": "__cinit__ unexpected argument",
     "sampling_srou.rst": "nan in scalar_power",

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -343,24 +343,28 @@ dt_config.skiplist = set([
     'scipy.sparse.linalg.norm',     # XXX temp skip
 ])
 
-# help pytest collection a bit: these names are either private (distributions)
-# or deprecated (misc), or just do not need doctesting 
-dt_config.pytest_extra_skips = [
+# help pytest collection a bit: these names are either private (distributions),
+# or just do not need doctesting.
+dt_config.pytest_extra_ignore = [
     "scipy.stats.distributions",
     "scipy.optimize.cython_optimize",
     "scipy.test",
     "scipy.show_config",
-    "scipy.misc",
-     # tutorials:
-    "io.rst",              # broken?
-    "ND_regular_grid.rst",
-    "ND_unstructured.rst",   # XXX: MPL deprecation?
-    "extrapolation_examples.rst",
-    "sampling_pinv.rst",
-    "sampling_srou.rst",
 ]
 
+dt_config.pytest_extra_xfail = {
+    # name: reason
+    "io.rst": "",
+    "ND_regular_grid.rst": "ReST parser limitation",
+    "ND_unstructured.rst": "matplotlib deprecation",
+    "extrapolation_examples.rst": "ReST parser limitation",
+    "sampling_pinv.rst": "__cinit__ unexpected argument",
+    "sampling_srou.rst": "nan in scalar_power",
+}
+
 # tutorials
-dt_config.pseudocode = set(['integrate.nquad(func,']) #, 'octave_struct.mat'])
+dt_config.pseudocode = set(['integrate.nquad(func,'])
 dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
+
+dt_config.nameerror_after_exception = True
 ############################################################################

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -495,17 +495,13 @@ def hb_read(path_or_open_file):
     We can read and write a harwell-boeing format file:
 
     >>> from scipy.io import hb_read, hb_write
-    >>> from scipy.sparse import csr_matrix, eye
-    >>> data = csr_matrix(eye(3))  # create a sparse matrix
+    >>> from scipy.sparse import csr_array, eye
+    >>> data = csr_array(eye(3))  # create a sparse array
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
-    <Compressed Sparse Column sparse matrix of dtype 'float64'
-        with 3 stored elements and shape (3, 3)>
-      Coords    Values
-      (0, 0)	1.0
-      (1, 1)	1.0
-      (2, 2)	1.0
-
+    (np.int32(0), np.int32(0))	1.0
+    (np.int32(1), np.int32(1))	1.0
+    (np.int32(2), np.int32(2))	1.0
     """
     def _get_matrix(fid):
         hb = HBFile(fid)
@@ -549,17 +545,13 @@ def hb_write(path_or_open_file, m, hb_info=None):
     We can read and write a harwell-boeing format file:
 
     >>> from scipy.io import hb_read, hb_write
-    >>> from scipy.sparse import csr_matrix, eye
-    >>> data = csr_matrix(eye(3))  # create a sparse matrix
+    >>> from scipy.sparse import csr_array, eye
+    >>> data = csr_array(eye(3))  # create a sparse array
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
-    <Compressed Sparse Column sparse matrix of dtype 'float64'
-        with 3 stored elements and shape (3, 3)>
-      Coords    Values
-      (0, 0)	1.0
-      (1, 1)	1.0
-      (2, 2)	1.0
-
+    (np.int32(0), np.int32(0))	1.0
+    (np.int32(1), np.int32(1))	1.0
+    (np.int32(2), np.int32(2))	1.0
     """
     m = m.tocsc(copy=False)
 

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -387,7 +387,7 @@ def value_indices(arr, *, ignore_value=None):
     value in the input array.
 
     >>> val_indices.keys()
-    dict_keys([0, 1, 2, 3])
+    dict_keys([np.int64(0), np.int64(1), np.int64(2), np.int64(3)])
 
     The entry for each value is an index tuple, locating the elements
     with that value.
@@ -407,7 +407,7 @@ def value_indices(arr, *, ignore_value=None):
 
     >>> val_indices = ndimage.value_indices(a, ignore_value=0)
     >>> val_indices.keys()
-    dict_keys([1, 2, 3])
+    dict_keys([np.int64(1), np.int64(2), np.int64(3)])
 
     """
     # Cope with ignore_value being None, without too much extra complexity

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -238,10 +238,9 @@ class AdaptiveStepsize:
             # We're not accepting enough steps. Take smaller steps.
             self.takestep.stepsize *= self.factor
         if self.verbose:
-            print("adaptive stepsize: acceptance rate {:f} target {:f} new "
-                  "stepsize {:g} old stepsize {:g}".format(accept_rate,
-                  self.target_accept_rate, self.takestep.stepsize,
-                  old_stepsize))
+            print(f"adaptive stepsize: acceptance rate {accept_rate:f} target "
+                  f"{self.target_accept_rate:f} new stepsize "
+                  f"{self.takestep.stepsize:g} old stepsize {old_stepsize:g}")
 
     def take_step(self, x):
         self.nstep += 1

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -580,8 +580,9 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     >>> minimizer_kwargs = {"method": "BFGS"}
     >>> ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs,
     ...                    niter=200)
-    >>> print("global minimum: x = %.4f, f(x) = %.4f" % (ret.x, ret.fun))
-    global minimum: x = -0.1951, f(x) = -1.0009
+    >>> # the global minimum is:
+    >>> ret.x, ret.fun
+    -0.1951, -1.0009
 
     Next consider a 2-D minimization problem. Also, this time, we
     will use gradient information to significantly speed up the search.

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -322,7 +322,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     >>> A = np.array([[-1, 1], [3, 2], [2, 3]])
     >>> b_u = np.array([1, 12, 12])
-    >>> b_l = np.full_like(b_u, -np.inf)
+    >>> b_l = np.full_like(b_u, -np.inf, dtype=float)
 
     Because there is no lower limit on these constraints, we have defined a
     variable ``b_l`` full of values representing negative infinity. This may
@@ -350,7 +350,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> from scipy.optimize import milp
     >>> res = milp(c=c, constraints=constraints, integrality=integrality)
     >>> res.x
-    [1.0, 2.0]
+    [2.0, 2.0]
 
     Note that had we solved the relaxed problem (without integrality
     constraints):

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -230,7 +230,6 @@ Construct a 1000x1000 `lil_array` and add some values to it:
 
 >>> A = lil_array((1000, 1000))
 >>> A[0, :100] = rand(100)
->>> A[1, 100:200] = A[0, :100]
 >>> A.setdiag(rand(1000))
 
 Now convert it to CSR format and solve A x = b for x:

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -315,7 +315,7 @@ def laplacian(
     >>> for cut in ["max", "min"]:
     ...     G = -G  # 1.
     ...     L = csgraph.laplacian(G, symmetrized=True, form="lo")  # 2.
-    ...     _, eves = lobpcg(L, X, Y=Y, largest=False, tol=1e-3)  # 3.
+    ...     _, eves = lobpcg(L, X, Y=Y, largest=False, tol=1e-2)  # 3.
     ...     eves *= np.sign(eves[0, 0])  # 4.
     ...     print(cut + "-cut labels:\\n", 1 * (eves[:, 0]>0))  # 5.
     max-cut labels:

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -59,14 +59,11 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> reverse_cuthill_mckee(graph)
     array([3, 2, 1, 0], dtype=int32)
@@ -218,17 +215,14 @@ def structural_rank(graph):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 8 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 0)	1
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
-      (3, 1)	1
-      (3, 2)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(0))	1
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
+      (np.int32(3), np.int32(1))	1
+      (np.int32(3), np.int32(2))	3
 
     >>> structural_rank(graph)
     4

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -148,14 +148,11 @@ def shortest_path(csgraph, method='auto',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -297,15 +294,11 @@ def floyd_warshall(csgraph, directed=True,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
-
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_matrix, predecessors = floyd_warshall(csgraph=graph, directed=False, return_predecessors=True)
     >>> dist_matrix
@@ -525,13 +518,10 @@ def dijkstra(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 4 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_matrix, predecessors = dijkstra(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1013,14 +1003,11 @@ def bellman_ford(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_matrix, predecessors = bellman_ford(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1253,14 +1240,11 @@ def johnson(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_matrix, predecessors = johnson(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1786,14 +1770,11 @@ def yen(
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-    (0, 1)	1
-    (0, 2)	2
-    (1, 3)	1
-    (2, 0)	2
-    (2, 3)	3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> dist_array, predecessors = yen(csgraph=graph, source=0, sink=3, K=2,
     ...                                directed=False, return_predecessors=True)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -453,13 +453,10 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 4 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 3)	3
+       (np.int32(0), np.int32(1))	1
+       (np.int32(0), np.int32(2))	2
+       (np.int32(1), np.int32(3))	1
+       (np.int32(2), np.int32(3))	3
 
     >>> pred = np.array([-9999, 0, 0, 1], dtype=np.int32)
 
@@ -565,13 +562,10 @@ def construct_dist_matrix(graph,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 4 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 3)	3
+       (np.int32(0), np.int32(1))	1
+       (np.int32(0), np.int32(2))	2
+       (np.int32(1), np.int32(3))	1
+       (np.int32(2), np.int32(3))	3
 
     >>> pred = np.array([[-9999, 0, 0, 2],
     ...                  [1, -9999, 0, 1],

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -75,6 +75,7 @@ def connected_components(csgraph, directed=True, connection='weak',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+<<<<<<< HEAD
     <Compressed Sparse Row sparse matrix of dtype 'int64'
         with 4 stored elements and shape (5, 5)>
       Coords    Values
@@ -82,6 +83,12 @@ def connected_components(csgraph, directed=True, connection='weak',
       (0, 2)	1
       (1, 2)	1
       (3, 4)	1
+=======
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	1
+      (np.int32(1), np.int32(2))	1
+      (np.int32(3), np.int32(4))	1
+>>>>>>> DOC: sparse.csgraph: adjust docstrings to NumPy 2.0 scalar repr
 
     >>> n_components, labels = connected_components(csgraph=graph, directed=False, return_labels=True)
     >>> n_components
@@ -335,14 +342,11 @@ cpdef breadth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)    1
-      (0, 2)    2
-      (1, 3)    1
-      (2, 0)    2
-      (2, 3)    3
+      (np.int32(0), np.int32(1))	1
+      (np.int32(0), np.int32(2))	2
+      (np.int32(1), np.int32(3))	1
+      (np.int32(2), np.int32(0))	2
+      (np.int32(2), np.int32(3))	3
 
     >>> breadth_first_order(graph,0)
     (array([0, 1, 2, 3], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))
@@ -544,6 +548,7 @@ cpdef depth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+<<<<<<< HEAD
     <Compressed Sparse Row sparse matrix of dtype 'int64'
         with 5 stored elements and shape (4, 4)>
       Coords    Values
@@ -552,6 +557,13 @@ cpdef depth_first_order(csgraph, i_start,
       (1, 3)	1
       (2, 0)	2
       (2, 3)	3
+=======
+    (np.int32(0), np.int32(1))	1
+    (np.int32(0), np.int32(2))	2
+    (np.int32(1), np.int32(3))	1
+    (np.int32(2), np.int32(0))	2
+    (np.int32(2), np.int32(3))	3
+>>>>>>> DOC: sparse.csgraph: adjust docstrings to NumPy 2.0 scalar repr
 
     >>> depth_first_order(graph,0)
     (array([0, 1, 3, 2], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -75,20 +75,10 @@ def connected_components(csgraph, directed=True, connection='weak',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-<<<<<<< HEAD
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 4 stored elements and shape (5, 5)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	1
-      (1, 2)	1
-      (3, 4)	1
-=======
       (np.int32(0), np.int32(1))	1
       (np.int32(0), np.int32(2))	1
       (np.int32(1), np.int32(2))	1
       (np.int32(3), np.int32(4))	1
->>>>>>> DOC: sparse.csgraph: adjust docstrings to NumPy 2.0 scalar repr
 
     >>> n_components, labels = connected_components(csgraph=graph, directed=False, return_labels=True)
     >>> n_components
@@ -548,22 +538,11 @@ cpdef depth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-<<<<<<< HEAD
-    <Compressed Sparse Row sparse matrix of dtype 'int64'
-        with 5 stored elements and shape (4, 4)>
-      Coords    Values
-      (0, 1)	1
-      (0, 2)	2
-      (1, 3)	1
-      (2, 0)	2
-      (2, 3)	3
-=======
     (np.int32(0), np.int32(1))	1
     (np.int32(0), np.int32(2))	2
     (np.int32(1), np.int32(3))	1
     (np.int32(2), np.int32(0))	2
     (np.int32(2), np.int32(3))	3
->>>>>>> DOC: sparse.csgraph: adjust docstrings to NumPy 2.0 scalar repr
 
     >>> depth_first_order(graph,0)
     (array([0, 1, 3, 2], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -400,7 +400,7 @@ def lobpcg(
 
     and ``largest=False`` parameter
 
-    >>> eigenvalues, _ = lobpcg(A, X, largest=False, maxiter=80)
+    >>> eigenvalues, _ = lobpcg(A, X, largest=False, maxiter=90)
     >>> print(eigenvalues)  
     [1. 2. 3.]
 

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -82,7 +82,7 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     >>> from scipy.sparse.linalg import tfqmr
     >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
     >>> b = np.array([2, 4, -1], dtype=float)
-    >>> x, exitCode = tfqmr(A, b)
+    >>> x, exitCode = tfqmr(A, b, atol=0.0)
     >>> print(exitCode)            # 0 indicates successful convergence
     0
     >>> np.allclose(A.dot(x), b)

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1083,9 +1083,9 @@ def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
     >>> import scipy.stats as stats
     >>> res = stats.barnard_exact([[7, 12], [8, 3]], alternative="less")
     >>> res.statistic
-    -1.894...
+    -1.894
     >>> res.pvalue
-    0.03407...
+    0.03407
 
     Under the null hypothesis that the vaccine will not lower the chance of
     becoming infected, the probability of obtaining test results at least as
@@ -1097,7 +1097,7 @@ def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
 
     >>> _, pvalue = stats.fisher_exact([[7, 12], [8, 3]], alternative="less")
     >>> pvalue
-    0.0640...
+    0.0640
 
     With the same threshold significance of 5%, we would not have been able
     to reject the null hypothesis in favor of the alternative. As stated in
@@ -1307,9 +1307,9 @@ def boschloo_exact(table, alternative="two-sided", n=32):
     >>> import scipy.stats as stats
     >>> res = stats.boschloo_exact([[74, 31], [43, 32]], alternative="greater")
     >>> res.statistic
-    0.0483...
+    0.0483
     >>> res.pvalue
-    0.0355...
+    0.0355
 
     Under the null hypothesis that scientists are happier in their work than
     college professors, the probability of obtaining test

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -99,7 +99,7 @@ def bayes_mvs(data, alpha=0.90):
     >>> mean
     Mean(statistic=9.0, minmax=(7.103650222612533, 10.896349777387467))
     >>> var
-    Variance(statistic=10.0, minmax=(3.176724206..., 24.45910382...))
+    Variance(statistic=10.0, minmax=(3.176724206, 24.45910382))
     >>> std
     Std_dev(statistic=2.9724954732045084,
             minmax=(1.7823367265645143, 4.945614605014631))
@@ -1261,7 +1261,7 @@ def boxcox_normmax(
     ...     return optimize.minimize_scalar(fun, bounds=(6, 7),
     ...                                     method="bounded", options=options)
     >>> stats.boxcox_normmax(x, optimizer=optimizer)
-    6.000...
+    6.000000000
     """
     x = np.asarray(x)
 

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2975,7 +2975,8 @@ def describe(a, axis=0, ddof=0, bias=True):
                  mask=False,
            fill_value=999999), masked_array(data=2,
                  mask=False,
-           fill_value=999999)), mean=np.float64(1.0), variance=np.float64(0.6666666666666666),
+           fill_value=999999)), mean=np.float64(1.0),
+           variance=np.float64(0.6666666666666666),
            skewness=masked_array(data=0., mask=False, fill_value=1e+20),
             kurtosis=np.float64(-1.5))
 

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2971,13 +2971,13 @@ def describe(a, axis=0, ddof=0, bias=True):
     >>> from scipy.stats.mstats import describe
     >>> ma = np.ma.array(range(6), mask=[0, 0, 0, 1, 1, 1])
     >>> describe(ma)
-    DescribeResult(nobs=3, minmax=(masked_array(data=0,
+    DescribeResult(nobs=np.int64(3), minmax=(masked_array(data=0,
                  mask=False,
            fill_value=999999), masked_array(data=2,
                  mask=False,
-           fill_value=999999)), mean=1.0, variance=0.6666666666666666,
+           fill_value=999999)), mean=np.float64(1.0), variance=np.float64(0.6666666666666666),
            skewness=masked_array(data=0., mask=False, fill_value=1e+20),
-            kurtosis=-1.5)
+            kurtosis=np.float64(-1.5))
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -629,9 +629,9 @@ def logrank(
 
     >>> res = stats.logrank(x=x, y=y)
     >>> res.statistic
-    -2.73799...
+    -2.73799
     >>> res.pvalue
-    0.00618...
+    0.00618
 
     The p-value is less than 1%, so we can consider the data to be evidence
     against the null hypothesis in favor of the alternative that there is a

--- a/scipy/stats/qmc.py
+++ b/scipy/stats/qmc.py
@@ -233,3 +233,4 @@ References
 
 """
 from ._qmc import *  # noqa: F403
+from ._qmc import __all__  # noqa: F403

--- a/scipy/stats/qmc.py
+++ b/scipy/stats/qmc.py
@@ -233,4 +233,4 @@ References
 
 """
 from ._qmc import *  # noqa: F403
-from ._qmc import __all__  # noqa: F403
+from ._qmc import __all__  # noqa: F401

--- a/scipy/stats/sampling.py
+++ b/scipy/stats/sampling.py
@@ -66,3 +66,8 @@ from ._unuran.unuran_wrapper import (  # noqa: F401
    SimpleRatioUniforms,
    UNURANError
 )
+
+__all__ = ["NumericalInverseHermite", "NumericalInversePolynomial",
+           "TransformedDensityRejection", "SimpleRatioUniforms",
+           "RatioUniforms", "DiscreteAliasUrn", "DiscreteGuideTable",
+           "UNURANError", "FastGeneratorInversion"]

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -117,6 +117,26 @@ DOCTEST_SKIPLIST = set([
     'scipy.linalg.LinAlgError',
     'scipy.optimize.show_options',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
+    # XXX: skips to match smoke-docs
+    'scipy.stats.mstats.describe',
+    'scipy.io.hb_read',
+    'scipy.io.hb_write',
+    'scipy.sparse.csgraph.connected_components',
+    'scipy.sparse.csgraph.depth_first_order',
+    'scipy.sparse.csgraph.shortest_path',
+    'scipy.sparse.csgraph.floyd_warshall',
+    'scipy.sparse.csgraph.dijkstra',
+    'scipy.sparse.csgraph.bellman_ford',
+    'scipy.sparse.csgraph.johnson',
+    'scipy.sparse.csgraph.yen',
+    'scipy.sparse.csgraph.breadth_first_order',
+    'scipy.sparse.csgraph.reverse_cuthill_mckee',
+    'scipy.sparse.csgraph.structural_rank',
+    'scipy.sparse.csgraph.construct_dist_matrix',
+    'scipy.sparse.csgraph.reconstruct_path',
+    'scipy.ndimage.value_indices',
+    'scipy.special.jve',
+    'scipy.special.yve',
 ])
 
 # these names are not required to be present in ALL despite being in
@@ -676,7 +696,7 @@ class Checker(doctest.OutputChecker):
                 return True
         except Exception:
             pass
-        return np.allclose(want, got, atol=self.atol, rtol=self.rtol)
+        return np.allclose(want, got, atol=self.atol, rtol=self.rtol, equal_nan=True)
 
 
 def _run_doctests(tests, full_name, verbose, doctest_warnings):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Continues and closes gh-16391, supersedes and closes gh-19242

#### What does this implement/fix?
<!--Please explain your changes.-->

Continue gh-19242 by @Sheila-nk : refactor the doctesting part of the refguide-check into a standalone tool, use pytest for running and orchestration. 

So this PR has essentially two parts: 
- heavy lifting done by Sheila (see commit attributions) 
- additional fixes to docstring examples from gh-19242. A part with pytest ignores was suggested by Lucas in https://github.com/scipy/scipy/pull/19242#discussion_r1431636535, also commit-attributed.

The remaining TODOs follow https://github.com/scipy/scipy/pull/19242#issuecomment-1719964303. What's relevant now is

- [ ] finish plumbing the external tool as git submodule
- [x] activate checking the code in tutorials
- [ ] drop the obsoleted part of `refguide-check`. I'd prefer to do it in a quick follow-up PR.

On the 'scpdt' tool side, we need to

- [x] get a better name (doctest_sp, doctest_scipy, scipy_doctest, something else?) --- `doctest-scipy` unless there are other suggestions
- [x] get out of my GH --- will propose to move it to the scipy GH org on the ML

The tool itself is in a bit of a flux at the moment, nothing blocking though. Here's the tracker which is being actively worked on: https://github.com/ev-br/scpdt/issues

The pytest plugin is written by @Sheila-nk with inputs from @melissawm and myself. Thank you Sheila and Melissa!

#### Additional information
<!--Any additional information you think is important.-->

I am starting to dislike tagging this all as _doctesting_. The goal is not ---never was and will never be --- to mix doctests into unit testing. The goal is to keep the examples in the docs current. If somebody comes up with a catchy name for this, I'm all ears :-).

