### PR TITLE
BUG: Use Cython implementation of complex hyp2f1 in orthogonal_eval.pxd

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -37,9 +37,10 @@ from . cimport sf_error
 from ._cephes cimport Gamma, lgam, beta, lbeta, gammasgn
 from ._cephes cimport hyp2f1 as hyp2f1_wrap
 
+from ._hyp2f1 cimport hyp2f1_complex
+
 cdef extern from "specfun_wrappers.h":
     double hyp1f1_wrap(double a, double b, double x) nogil
-    npy_cdouble chyp2f1_wrap( double a, double b, double c, npy_cdouble z) nogil
     npy_cdouble chyp1f1_wrap( double a, double b, npy_cdouble z) nogil
 
 # Fused type wrappers
@@ -49,8 +50,7 @@ cdef inline number_t hyp2f1(double a, double b, double c, number_t z) noexcept n
     if number_t is double:
         return hyp2f1_wrap(a, b, c, z)
     else:
-        r = chyp2f1_wrap(a, b, c, npy_cdouble_from_double_complex(z))
-        return double_complex_from_npy_cdouble(r)
+        return hyp2f1_complex(a, b, c, z)
 
 cdef inline number_t hyp1f1(double a, double b, number_t z) noexcept nogil:
     cdef npy_cdouble r

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -15,6 +15,10 @@ def test_eval_chebyt():
     assert_(np.allclose(v1, v2, rtol=1e-15))
 
 
+def test_eval_chebyt_gh20129():
+    # https://github.com/scipy/scipy/issues/20129
+    assert _ufuncs.eval_chebyt(7, 2 + 0j) == 5042.0
+
 def test_eval_genlaguerre_restriction():
     # check it returns nan for alpha <= -1
     assert_(np.isnan(_ufuncs.eval_genlaguerre(0, -1, 0)))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #20129 

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR replaces the direct use of the implementation of `hyp2f1` for complex numbers from `specfun` with the Cython implementation https://github.com/scipy/scipy/blob/main/scipy/special/_hyp2f1.pxd#L262. The Cython implementation includes a number of bug fixes and improvements beyond what is in `specfun` (https://github.com/scipy/scipy/pull/14454, https://github.com/scipy/scipy/pull/14692, https://github.com/scipy/scipy/pull/14706, https://github.com/scipy/scipy/pull/15287, https://github.com/scipy/scipy/pull/15588). It was an oversight to not use the Cython implementation in `orthogonal_eval.pxd`.

#### Additional information
<!--Any additional information you think is important.-->
A regression introduced into the `hyp2f1` implementation in specfun when translated from Fortran to C in https://github.com/scipy/scipy/pull/19824 was missed because these cases in the Fortran implementation were not tested. This lead to a regression in `eval_chebyt` as noted by @oscarbenjamin in #20129. Rather than attempting to fix the C implementation in `specfun.c`, which will be removed anway when the improved C++ implementation in #20089 is merged, the regression in `eval_cheybt` can be fixed by using the Cython implementation (which is extensively tested) in `orthogonal_eval.pxd`.

I've added a test to verify that #20129 has been fixed.
