### PR TITLE
MAINT: interpolate: define `F_INT` as `int` rather than `npy_int32`

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -28,8 +28,8 @@ static PyObject *fitpack_error;
 
 #else
 
-#define F_INT npy_int32
-#define F_INT_NPY NPY_INT32
+#define F_INT int
+#define F_INT_NPY NPY_INT
 #define F_INT_MAX NPY_MAX_INT32
 #if NPY_BITSOF_SHORT == 32
 #define F_INT_PYFMT   "h"

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -16,7 +16,7 @@ python module dfitpack ! in
 #ifdef HAVE_ILP64
 typedef npy_int64 F_INT;
 #else
-typedef npy_int32 F_INT;
+typedef int F_INT;
 #endif
 
 static double dmax(double* seq, F_INT len) {


### PR DESCRIPTION
This fixes an incompatible pointer issue that shows up as a warning in Windows CI jobs, and is reported to break the build with GCC 14 on Fedora 40 in gh-19993.

Using `#define F_INT int` is done in several other submodules; this was the only instance of using `npy_int32`.

Closes gh-19993