### PR TITLE
TST: optimize: silence the output from calling cobyla with disp=True

### DIFF
--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -749,7 +749,7 @@ class TestShgoArguments:
         run_test(test1_1, n=1, iters=7, options=options,
                  sampling_method='sobol')
 
-    def test_16_disp_bounds_minimizer(self):
+    def test_16_disp_bounds_minimizer(self, capsys):
         """Test disp=True with minimizers that do not support bounds """
         options = {'disp': True}
         minimizer_kwargs = {'method': 'nelder-mead'}

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -1,7 +1,8 @@
 import math
-import numpy as np
 
+import numpy as np
 from numpy.testing import assert_allclose, assert_, assert_array_equal
+import pytest
 
 from scipy.optimize import fmin_cobyla, minimize, Bounds
 
@@ -22,7 +23,8 @@ class TestCobyla:
     def con2(self, x):
         return -self.con1(x)
 
-    def test_simple(self):
+    @pytest.mark.xslow(True, reason='not slow, but noisy so only run rarely')
+    def test_simple(self, capfd):
         # use disp=True as smoke test for gh-8118
         x = fmin_cobyla(self.fun, self.x0, [self.con1, self.con2], rhobeg=1,
                         rhoend=1e-5, maxfun=100, disp=True)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1161,40 +1161,6 @@ class TestOptimizeSimple(CheckOptimize):
                                 options=dict(stepsize=0.05))
         assert_allclose(res.x, 1.0, rtol=1e-4, atol=1e-4)
 
-    @pytest.mark.xfail(reason="output not reliable on all platforms")
-    def test_gh13321(self, capfd):
-        # gh-13321 reported issues with console output in fmin_l_bfgs_b;
-        # check that iprint=0 works.
-        kwargs = {'func': optimize.rosen, 'x0': [4, 3],
-                  'fprime': optimize.rosen_der, 'bounds': ((3, 5), (3, 5))}
-
-        # "L-BFGS-B" is always in output; should show when iprint >= 0
-        # "At iterate" is iterate info; should show when iprint >= 1
-
-        optimize.fmin_l_bfgs_b(**kwargs, iprint=-1)
-        out, _ = capfd.readouterr()
-        assert "L-BFGS-B" not in out and "At iterate" not in out
-
-        optimize.fmin_l_bfgs_b(**kwargs, iprint=0)
-        out, _ = capfd.readouterr()
-        assert "L-BFGS-B" in out and "At iterate" not in out
-
-        optimize.fmin_l_bfgs_b(**kwargs, iprint=1)
-        out, _ = capfd.readouterr()
-        assert "L-BFGS-B" in out and "At iterate" in out
-
-        # `disp is not None` overrides `iprint` behavior
-        # `disp=0` should suppress all output
-        # `disp=1` should be the same as `iprint = 1`
-
-        optimize.fmin_l_bfgs_b(**kwargs, iprint=1, disp=False)
-        out, _ = capfd.readouterr()
-        assert "L-BFGS-B" not in out and "At iterate" not in out
-
-        optimize.fmin_l_bfgs_b(**kwargs, iprint=-1, disp=True)
-        out, _ = capfd.readouterr()
-        assert "L-BFGS-B" in out and "At iterate" in out
-
     def test_gh10771(self):
         # check that minimize passes bounds and constraints to a custom
         # minimizer without altering them.
@@ -2557,7 +2523,7 @@ class TestBrute:
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
 
-    def test_runtime_warning(self):
+    def test_runtime_warning(self, capsys):
         rng = np.random.default_rng(1234)
 
         def func(z, *params):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -380,7 +380,7 @@ class TestNewton(TestScalarRootFinders):
         assert_allclose(sol0.root, sol.root, atol=1e-8)
         assert_equal(3*sol.function_calls, sol0.function_calls)
 
-    def test_newton_full_output(self):
+    def test_newton_full_output(self, capsys):
         # Test the full_output capability, both when converging and not.
         # Use simple polynomials, to avoid hitting platform dependencies
         # (e.g., exp & trig) in number of iterations
@@ -582,7 +582,7 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
-def test_zero_der_nz_dp():
+def test_zero_der_nz_dp(capsys):
     """Test secant method with a non-zero dp, but an infinite newton step"""
     # pick a symmetrical functions and choose a point on the side that with dx
     # makes a secant that is a flat line with zero slope, EG: f = (x - 100)**2,


### PR DESCRIPTION
Not doing this prints pretty verbose output, which pytest then displays below the test summary at the end of a run of the test suite.

`capfd` and `capsys` are built-in pytest fixtures to capture such output. Note that they are not robust, and you have to choose between the "file descriptor" and "sys.stdout/stderr" modes, so when we have code that prints from both Python and Fortran, it doesn't seem possible to silence everything.

Note also that some output shows up with `python dev.py -s optimize` but not with `python dev.py -t scipy.optimize.tests`, so it's hard to track down.

The one removed test was already xfail-ed, still noisy, and not useful.

I also considered removing or changing some of the printing code, but decided against that because that code is likely to go away with the "remove Fortran 77 code" efforts.

Output tended to look like this (not always the same, depending on test selection and way of invoking `pytest`):
```
======= 3188 passed, 194 skipped, 11 deselected, 10 xfailed, 5 xpassed in 68.70s (0:01:08) ========

   Normal return from subroutine COBYLA

   NFVALS =   50   F = 2.485185E+01    MAXCV = 1.999965E-10
   X = 4.955358E+00   6.666553E-01
RUNNING THE L-BFGS-B CODE

           * * *

Machine precision = 2.220D-16
 N =            2     M =           10

           * * *

Tit   = total number of iterations
Tnf   = total number of function evaluations
Tnint = total number of segments explored during Cauchy searches
Skip  = number of BFGS updates skipped
Nact  = number of active bounds at final generalized Cauchy point
Projg = norm of the final projected gradient
F     = final function value

           * * *

   N    Tit     Tnf  Tnint  Skip  Nact     Projg        F
    2      1      2      2     0     2   0.000D+00   1.604D+03

CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL 
```