### PR TITLE
MAINT/CI: special/array types: test alternative backends in CI

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -91,7 +91,7 @@ jobs:
         export OMP_NUM_THREADS=2
         export SCIPY_USE_PROPACK=1
         # expand as new modules are added
-        # --array-api-backend == -b
-        python dev.py --no-build test -b pytorch -b numpy -b array_api_strict -s cluster -- --durations 3 --timeout=60
-        python dev.py --no-build test -b pytorch -b numpy -b array_api_strict -s fft -- --durations 3 --timeout=60
-        python dev.py --no-build test --array-api-backend all --tests scipy/_lib/tests/test_array_api.py
+        python dev.py --no-build test -b all -s cluster -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -s fft -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -t scipy.special.tests.test_support_alternative_backends -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -t scipy._lib.tests.test_array_api

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -56,8 +56,8 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
 
     eps = np.finfo(dtype).eps
     # PyTorch seems to struggle with precision near the poles of `gammaln`,
-    # so the tolerance needs to be quite loose (eps**0.2) - see gh-19935.
-    # To compensate, we aso check that that the root-mean-square error is
+    # so the tolerance needs to be quite loose (eps**0.2) - see gh-19935.
+    # To compensate, we also check that the root-mean-square error is
     # less than eps**0.5.
     ref = xp.asarray(ref, dtype=dtype_xp)
     xp_assert_close(res, ref, rtol=eps**0.2, atol=eps*10,

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -55,5 +55,13 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
     res = f(*args_xp)
 
     eps = np.finfo(dtype).eps
-    xp_assert_close(res, xp.asarray(ref, dtype=dtype_xp), rtol=eps**0.5, atol=eps*10,
-                    check_namespace=True, check_shape=True, check_dtype=True)
+    # PyTorch seems to struggle with precision near the poles of `gammaln`,
+    # so the tolerance needs to be quite loose (eps**0.2) - see gh-19935.
+    # To compensate, we aso check that that the root-mean-square error is
+    # less than eps**0.5.
+    ref = xp.asarray(ref, dtype=dtype_xp)
+    xp_assert_close(res, ref, rtol=eps**0.2, atol=eps*10,
+                    check_namespace=True, check_shape=True, check_dtype=True,)
+    xp_assert_close(xp.sqrt(xp.mean(res**2)), xp.sqrt(xp.mean(ref**2)),
+                    rtol=eps**0.5, atol=eps*10,
+                    check_namespace=False, check_shape=False, check_dtype=False,)


### PR DESCRIPTION
replacement for gh-19935. Closes gh-19928
