### PR TITLE
MAINT, ENH: Hausdorff simplification

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -29,7 +29,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
     cdef Py_ssize_t N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
     cdef Py_ssize_t i, j, k
-    cdef Py_ssize_t i_store = 0, j_store = 0, i_ret = 0, j_ret = 0
+    cdef Py_ssize_t j_store = 0, i_ret = 0, j_ret = 0
     cdef np.ndarray[np.int64_t, ndim=1, mode='c'] resort1, resort2
 
     # shuffling the points in each array generally increases the likelihood of
@@ -57,7 +57,6 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
             if d < cmin: # always true on first iteration of for-j loop
                 cmin = d
-                i_store = i
                 j_store = j
 
         # Note: The reference paper by A. A. Taha and A. Hanbury has this line
@@ -69,7 +68,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
         # The logic here accounts for that case.
         if cmin >= cmax and d >= cmax:
             cmax = cmin
-            i_ret = i_store
+            i_ret = i
             j_ret = j_store
 
     return (sqrt(cmax), resort1[i_ret], resort2[j_ret])


### PR DESCRIPTION
* we can remove an extraneous variable and assignement operation from this algorithm (ok, I'm trying to avoid grant writing...)

* the result of the benchmark command was performance neutral:
`asv continuous -E virtualenv -e -b "time_directed_hausdorff" main treddy_hausdorff_simplify`

[skip cirrus] [skip circle]
