### PR TITLE
MAINT: fix incorrect `noexcept` usage in Cython functions

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -432,7 +432,7 @@ cpdef void get_max_Rfield_for_each_cluster(double[:, :] Z, double[:, :] R,
     PyMem_Free(visited)
 
 
-cpdef get_max_dist_for_each_cluster(double[:, :] Z, double[:] MD, int n) noexcept:
+cpdef get_max_dist_for_each_cluster(double[:, :] Z, double[:] MD, int n):
     """
     Get the maximum inconsistency coefficient for each non-singleton cluster.
 
@@ -1089,7 +1089,7 @@ cdef class LinkageUnionFind:
         self.next_label += 1
         return size
 
-    cdef find(self, int x) noexcept:
+    cdef find(self, int x):
         cdef int p = x
 
         while self.parent[x] != x:
@@ -1101,10 +1101,11 @@ cdef class LinkageUnionFind:
         return x
 
 
-cdef label(double[:, :] Z, int n) noexcept:
+cdef label(double[:, :] Z, int n):
     """Correctly label clusters in unsorted dendrogram."""
     cdef LinkageUnionFind uf = LinkageUnionFind(n)
     cdef int i, x, y, x_root, y_root
+
     for i in range(n - 1):
         x, y = int(Z[i, 0]), int(Z[i, 1])
         x_root, y_root = uf.find(x), uf.find(y)

--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -240,7 +240,7 @@ def vq(np.ndarray obs, np.ndarray codes):
 
 @cython.cdivision(True)
 cdef np.ndarray _update_cluster_means(vq_type *obs, int32_t *labels,
-                                      vq_type *cb, int nobs, int nc, int nfeat) noexcept:
+                                      vq_type *cb, int nobs, int nc, int nfeat):
     """
     The underlying function (template) of _vq.update_cluster_means.
 

--- a/scipy/io/matlab/_mio5_utils.pyx
+++ b/scipy/io/matlab/_mio5_utils.pyx
@@ -405,7 +405,7 @@ cdef class VarReader5:
                 self.cstream.seek(8 - mod8, 1)
         return 0
 
-    cpdef cnp.ndarray read_numeric(self, int copy=True, size_t nnz=-1) noexcept:
+    cpdef cnp.ndarray read_numeric(self, int copy=True, size_t nnz=-1):
         ''' Read numeric data element into ndarray
 
         Reads element, then casts to ndarray.
@@ -557,7 +557,7 @@ cdef class VarReader5:
             byte_count[0] = u4s[1]
         return 0
 
-    cpdef VarHeader5 read_header(self, int check_stream_limit) noexcept:
+    cpdef VarHeader5 read_header(self, int check_stream_limit):
         ''' Return matrix header for current stream position
 
         Returns matrix headers at top level and sub levels
@@ -749,7 +749,7 @@ cdef class VarReader5:
             shape = tuple([x for x in shape if x != 1])
         return shape
 
-    cpdef cnp.ndarray read_real_complex(self, VarHeader5 header) noexcept:
+    cpdef cnp.ndarray read_real_complex(self, VarHeader5 header):
         ''' Read real / complex matrices from stream '''
         cdef:
             cnp.ndarray res, res_j
@@ -803,7 +803,7 @@ cdef class VarReader5:
             (data[:nnz], rowind[:nnz], indptr),
             shape=(M, N))
 
-    cpdef cnp.ndarray read_char(self, VarHeader5 header) noexcept:
+    cpdef cnp.ndarray read_char(self, VarHeader5 header):
         ''' Read char matrices from stream as arrays
 
         Matrices of char are likely to be converted to matrices of
@@ -872,7 +872,7 @@ cdef class VarReader5:
                           buffer=arr,
                           order='F')
 
-    cpdef cnp.ndarray read_cells(self, VarHeader5 header) noexcept:
+    cpdef cnp.ndarray read_cells(self, VarHeader5 header):
         ''' Read cell array from stream '''
         cdef:
             size_t i
@@ -928,7 +928,7 @@ cdef class VarReader5:
         n_names_ptr[0] = n_names
         return field_names
 
-    cpdef cnp.ndarray read_struct(self, VarHeader5 header) noexcept:
+    cpdef cnp.ndarray read_struct(self, VarHeader5 header):
         ''' Read struct or object array from stream
 
         Objects are just structs with an extra field *classname*,

--- a/scipy/io/matlab/_streams.pyx
+++ b/scipy/io/matlab/_streams.pyx
@@ -236,7 +236,7 @@ def _read_string(GenericStream st, size_t n):
     return bytes(my_str)
 
 
-cpdef GenericStream make_stream(object fobj) noexcept:
+cpdef GenericStream make_stream(object fobj):
     """ Make stream of correct type for file-like `fobj`
     """
     if isinstance(fobj, GenericStream):

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1180,8 +1180,7 @@ def _form_qTu(object a, object b):
     form_qTu(q, u, qTuvoid, qTus, 0)
     return qTu
 
-cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
-              int k) noexcept:
+cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus, int k):
     """ assuming here that q and u have compatible shapes, and are the same
         type + Q is contiguous.  This function is preferable over simply
         calling np.dot for two reasons: 1) this output is always in F order, 2)
@@ -1312,7 +1311,7 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus,
     else:
         raise ValueError('q must be either F or C contiguous')
 
-cdef validate_array(cnp.ndarray a, bint chkfinite) noexcept:
+cdef validate_array(cnp.ndarray a, bint chkfinite):
     # here we check that a has positive strides and that its size is small
     # enough to fit in into an int, as BLAS/LAPACK require
     cdef bint copy = False
@@ -1335,7 +1334,7 @@ cdef validate_array(cnp.ndarray a, bint chkfinite) noexcept:
     return a
 
 cdef tuple validate_qr(object q0, object r0, bint overwrite_q, int q_order,
-                       bint overwrite_r, int r_order, bint chkfinite) noexcept:
+                       bint overwrite_r, int r_order, bint chkfinite):
     cdef cnp.ndarray Q
     cdef cnp.ndarray R
     cdef int typecode
@@ -1757,7 +1756,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
     else:
         raise ValueError("'which' must be either 'row' or 'col'")
 
-cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite) noexcept:
+cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite):
     cdef cnp.ndarray q1, r1, u1, qnew, rnew
     cdef int j
     cdef int u_flags = cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
@@ -1877,7 +1876,7 @@ cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite) noexce
                 raise MemoryError('Unable to allocate memory for array')
         return qnew, rnew
 
-cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite) noexcept:
+cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite):
     cdef cnp.ndarray q1, r1, u1, qnew, rnew
     cdef int j
     cdef int q_flags = ARRAY_ANYORDER

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -33,11 +33,10 @@ prefixes = ['s', 'd', 'c', 'z']
 
 
 # ========================= norm1 : s, d, c, z ===============================
-# The generic abs() function is made nogil friendly in Cython 3.x (unreleased)
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
-cdef double norm1(lapack_t[:, ::1] A) noexcept:
+cdef double norm1(lapack_t[:, ::1] A):
     """
     Fast 1-norm computation for C-contiguous square arrays.
     Regardless of the dtype we work in double precision to prevent overflows
@@ -98,7 +97,7 @@ cdef double kth_power_norm_d(double* A, double* v1, double* v2, Py_ssize_t n, in
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
-cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am) noexcept:
+cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
     cdef Py_ssize_t n = Am.shape[1], i, j, k
     cdef int lm = 0, s = 0, intn = <int>n, n2= intn*intn, int_one = 1
     cdef {{ tname }}[:, :, ::1] Amv = Am

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -199,7 +199,7 @@ cdef np.uintp_t label_line_with_neighbor(np.uintp_t *line,
 ######################################################################
 cpdef _label(np.ndarray input,
              np.ndarray structure,
-             np.ndarray output) noexcept:
+             np.ndarray output):
     # check dimensions
     # To understand the need for the casts to object in order to use
     # tuple.__eq__, see https://github.com/cython/cython/issues/863


### PR DESCRIPTION
With Cython 3.1.0a0 (master), a lot of warnings like these are visible:

```
warning: scipy/linalg/_matfuncs_expm.pyx:90:26: noexcept clause is ignored for function returning Python object
warning: scipy/linalg/_matfuncs_expm.pyx:202:26: noexcept clause is ignored for function returning Python object
```
    
There can be several causes for this warning. The one given in the warning (returning a Python object), or the function does raise exceptions (in these cases `MemoryError` or `ValueError`), or it seems also functions/methods that don't return anything but use Python functionality internally (this is the least obvious, separated out in the second commit).

There's only one file with warnings that I left alone. That's `_highs_wrapper.pyx`; we're getting rid of that one and I don't want to create a merge conflict for gh-19255.