### PR TITLE
ENH: stats.combine_pvalues: add axis/nan_policy/keepdims support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9524,7 +9524,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     Parameters
     ----------
-    pvalues : array_like, 1-D
+    pvalues : array_like
         Array of p-values assumed to come from independent tests based on
         continuous distributions.
     method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}
@@ -9538,8 +9538,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         * 'mudholkar_george': Mudholkar's and George's method
         * 'tippett': Tippett's method
         * 'stouffer': Stouffer's Z-score method
-    weights : array_like, 1-D, optional
+    weights : array_like, optional
         Optional array of weights used only for Stouffer's Z-score method.
+        Ignored by other methods.
 
     Returns
     -------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9508,6 +9508,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
     return BrunnerMunzelResult(wbfn, p)
 
 
+@_axis_nan_policy_factory(SignificanceResult, kwd_samples=['weights'], paired=True)
 def combine_pvalues(pvalues, method='fisher', weights=None):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9629,9 +9629,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     .. [8] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
 
     """
-    pvalues = np.asarray(pvalues)
-    if pvalues.ndim != 1:
-        raise ValueError("pvalues is not 1-D")
+    if pvalues.size == 0:
+        NaN = _get_nan(pvalues)
+        return SignificanceResult(NaN, NaN)
 
     if method == 'fisher':
         statistic = -2 * np.sum(np.log(pvalues))
@@ -9654,10 +9654,6 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
             weights = np.ones_like(pvalues)
         elif len(weights) != len(pvalues):
             raise ValueError("pvalues and weights must be of the same size.")
-
-        weights = np.asarray(weights)
-        if weights.ndim != 1:
-            raise ValueError("weights is not 1-D")
 
         Zi = distributions.norm.isf(pvalues)
         statistic = np.dot(weights, Zi) / np.linalg.norm(weights)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1066,8 +1066,16 @@ def test_other_axis_tuples(axis):
     np.testing.assert_array_equal(res, res2)
 
 
-@pytest.mark.parametrize(("weighted_fun_name"), ["gmean", "hmean", "pmean"])
-def test_mean_mixed_mask_nan_weights(weighted_fun_name):
+@pytest.mark.parametrize(
+    ("weighted_fun_name, unpacker"),
+    [
+        ("gmean", lambda x: x),
+        ("hmean", lambda x: x),
+        ("pmean", lambda x: x),
+        ("combine_pvalues", lambda x: (x.pvalue, x.statistic)),
+    ],
+)
+def test_mean_mixed_mask_nan_weights(weighted_fun_name, unpacker):
     # targeted test of _axis_nan_policy_factory with 2D masked sample:
     # omitting samples with masks and nan_policy='omit' are equivalent
     # also checks paired-sample sentinel value removal
@@ -1115,20 +1123,33 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name):
     with np.testing.suppress_warnings() as sup:
         message = 'invalid value encountered'
         sup.filter(RuntimeWarning, message)
-        res = weighted_fun(a_nans, weights=b_nans,
-                           nan_policy='omit', axis=axis)
-        res1 = weighted_fun(a_masked1, weights=b_masked1,
-                            nan_policy='omit', axis=axis)
-        res2 = weighted_fun(a_masked2, weights=b_masked2,
-                            nan_policy='omit', axis=axis)
-        res3 = weighted_fun(a_masked3, weights=b_masked3,
-                            nan_policy='raise', axis=axis)
-        res4 = weighted_fun(a_masked3, weights=b_masked3,
-                            nan_policy='propagate', axis=axis)
+        res = unpacker(
+            weighted_fun(a_nans, weights=b_nans, nan_policy="omit", axis=axis)
+        )
+        res1 = unpacker(
+            weighted_fun(
+                a_masked1, weights=b_masked1, nan_policy="omit", axis=axis
+            )
+        )
+        res2 = unpacker(
+            weighted_fun(
+                a_masked2, weights=b_masked2, nan_policy="omit", axis=axis
+            )
+        )
+        res3 = unpacker(
+            weighted_fun(
+                a_masked3, weights=b_masked3, nan_policy="raise", axis=axis
+            )
+        )
+        res4 = unpacker(
+            weighted_fun(
+                a_masked3, weights=b_masked3, nan_policy="propagate", axis=axis
+            )
+        )
         # Would test with a_masked3/b_masked3, but there is a bug in np.average
         # that causes a bug in _no_deco mean with masked weights. Would use
         # np.ma.average, but that causes other problems. See numpy/numpy#7330.
-        if weighted_fun_name not in {'pmean', 'gmean'}:
+        if weighted_fun_name in {"hmean"}:
             weighted_fun_ma = getattr(stats.mstats, weighted_fun_name)
             res5 = weighted_fun_ma(a_masked4, weights=b_masked4,
                                    axis=axis, _no_deco=True)
@@ -1137,7 +1158,7 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name):
     np.testing.assert_array_equal(res2, res)
     np.testing.assert_array_equal(res3, res)
     np.testing.assert_array_equal(res4, res)
-    if weighted_fun_name not in {'pmean', 'gmean'}:
+    if weighted_fun_name in {"hmean"}:
         # _no_deco mean returns masked array, last element was masked
         np.testing.assert_allclose(res5.compressed(), res[~np.isnan(res)])
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1085,6 +1085,9 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name, unpacker):
             return stats.pmean(a, p=0.42, **kwargs)
     else:
         weighted_fun = getattr(stats, weighted_fun_name)
+        
+    def func(*args, **kwargs):
+        return unpacker(weighted_fun(*args, **kwargs))
 
     m, n = 3, 20
     axis = -1
@@ -1123,29 +1126,11 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name, unpacker):
     with np.testing.suppress_warnings() as sup:
         message = 'invalid value encountered'
         sup.filter(RuntimeWarning, message)
-        res = unpacker(
-            weighted_fun(a_nans, weights=b_nans, nan_policy="omit", axis=axis)
-        )
-        res1 = unpacker(
-            weighted_fun(
-                a_masked1, weights=b_masked1, nan_policy="omit", axis=axis
-            )
-        )
-        res2 = unpacker(
-            weighted_fun(
-                a_masked2, weights=b_masked2, nan_policy="omit", axis=axis
-            )
-        )
-        res3 = unpacker(
-            weighted_fun(
-                a_masked3, weights=b_masked3, nan_policy="raise", axis=axis
-            )
-        )
-        res4 = unpacker(
-            weighted_fun(
-                a_masked3, weights=b_masked3, nan_policy="propagate", axis=axis
-            )
-        )
+        res = func(a_nans, weights=b_nans, nan_policy="omit", axis=axis)
+        res1 = func(a_masked1, weights=b_masked1, nan_policy="omit", axis=axis)
+        res2 = func(a_masked2, weights=b_masked2, nan_policy="omit", axis=axis)
+        res3 = func(a_masked3, weights=b_masked3, nan_policy="raise", axis=axis)
+        res4 = func(a_masked3, weights=b_masked3, nan_policy="propagate", axis=axis)
         # Would test with a_masked3/b_masked3, but there is a bug in np.average
         # that causes a bug in _no_deco mean with masked weights. Would use
         # np.ma.average, but that causes other problems. See numpy/numpy#7330.

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -105,6 +105,7 @@ axis_nan_policy_cases = [
     (stats.f_oneway, tuple(), {}, 2, 2, False, None),
     (stats.alexandergovern, tuple(), {}, 2, 2, False,
      lambda res: (res.statistic, res.pvalue)),
+    (stats.combine_pvalues, tuple(), {}, 1, 2, False, None),
 ]
 
 # If the message is one of those expected, put nans in


### PR DESCRIPTION
#### Reference issue
Toward gh-14651

#### What does this implement/fix?
Adds axis / nan_policy / keepdims support to `scipy.stats.combine_pvalues`.

#### Additional information
@tirthasheshpatel I know you reported trouble with this one, but I didn't run into much except maybe related to gh-19764. 
Specifically, when `method='stouffer'`, I think this will error out whenever the length of `weights` along `axis` doesn't match the length of `pvalues` along `axis`, although it is probably preferable to return NaNs.  gh-19764 needs to be merged before we can really fix this. That said, the function completely/silently ignores `weights` when `method != 'stouffer'`, so this edge case is not the greatest shortcoming when it comes to `weights`. 

I imagine you also noticed the inconsistent behavior with empty input, but I think we can resolve that here. We'll talk about it Wednesday!