### PR TITLE
BLD: Ensure Python.h is included before system headers.

### DIFF
--- a/scipy/io/_fast_matrix_market/src/_fmm_core.hpp
+++ b/scipy/io/_fast_matrix_market/src/_fmm_core.hpp
@@ -8,6 +8,7 @@
 #define FMM_NO_VECTOR
 #endif
 
+#include <Python.h>
 #include <fstream>
 
 #include <pybind11/pybind11.h>

--- a/scipy/io/_fast_matrix_market/src/pystreambuf.h
+++ b/scipy/io/_fast_matrix_market/src/pystreambuf.h
@@ -57,6 +57,7 @@ derivative works thereof, in binary and source code form.
 
 #pragma once
 
+#include <Python.h>
 #include <pybind11/pybind11.h>
 
 #include <streambuf>

--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -5,8 +5,8 @@
  * Use numpy to provide some platform independency.
  * Define these functions for your platform
  * */
-#include <cmath>
 #include <numpy/npy_common.h>
+#include <cmath>
 #define CKDTREE_LIKELY(x) NPY_LIKELY(x)
 #define CKDTREE_UNLIKELY(x)  NPY_UNLIKELY(x)
 #define CKDTREE_PREFETCH(x, rw, loc)  NPY_PREFETCH(x, rw, loc)

--- a/scipy/special/_special.h
+++ b/scipy/special/_special.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <complex>
 #include <numpy/npy_math.h>
+#include <complex>
 
 
 #include "special/binom.h"

--- a/scipy/special/ellint_carlson_wrap.hh
+++ b/scipy/special/ellint_carlson_wrap.hh
@@ -12,15 +12,15 @@
 #define _END_EXTERN_C	/* nothing */
 #endif
 
+_BEGIN_EXTERN_C
+#include <numpy/npy_math.h>
+_END_EXTERN_C
 
 #define ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
 #include "ellint_carlson_cpp_lite/ellint_carlson.hh"
 
 
 _BEGIN_EXTERN_C
-
-
-#include <numpy/npy_math.h>
 
 
 extern double fellint_RC(double x, double y);


### PR DESCRIPTION
numpy headers take care that Python.h is first.
pybind11 headers do not.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Refresh of #18049.

#### What does this implement/fix?
<!--Please explain your changes.-->
[`Python.h` must be included before any system headers](https://docs.python.org/3/c-api/intro.html#include-files).

#### Additional information
<!--Any additional information you think is important.-->
Repository checked using attached [check_python_h_first.py](https://github.com/scipy/scipy/files/14398997/check_python_h_first.txt)

```bash
 python check_python_h_first.py $(find scipy -maxdepth 4 \( -name __pycache__ -o -name .git -prune \) \
                                                         -o -type f -a \( -name \*.c\* -o -name \*.h\* -print \))
```