### PR TITLE
BLD: interpolate: _interpnd_info does not need installing

### DIFF
--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -184,7 +184,6 @@ py3.install_sources([
     '_fitpack_impl.py',
     '_fitpack_py.py',
     '_fitpack2.py',
-    '_interpnd_info.py',
     '_interpolate.py',
     '_ndgriddata.py',
     '_pade.py',


### PR DESCRIPTION
There is no need to install `_interpnd_info.py`: this is a helper file, it does not provide any user-facing functionality, it is not accessible from the `scipy.interpolate` namespace --- it can live in the repo but there is hardly any reason for it to end up on a user system.