### PR TITLE
MAINT: dev.py: allow --args after --

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -708,7 +708,7 @@ class Test(Task):
         print(f"SciPy from development installed path at: {dirs.site}")
 
         # FIXME: support pos-args with doit
-        extra_argv = pytest_args[:] if pytest_args else []
+        extra_argv = list(pytest_args[:]) if pytest_args else []
         if extra_argv and extra_argv[0] == '--':
             extra_argv = extra_argv[1:]
 


### PR DESCRIPTION
Otherwise `$ python dev.py test --durations 5 -- -x` fails to concat a tuple and a list.

closes gh-20161
