### PR TITLE
MAINT: stats.sampling: Update UNU.RAN to remove the hooke implementation

### DIFF
--- a/scipy/stats/_unuran/unuran.pxd
+++ b/scipy/stats/_unuran/unuran.pxd
@@ -918,24 +918,6 @@ cdef extern from "unuran.h" nogil:
 
     int unur_vempk_chg_varcor(UNUR_GEN* generator, int varcor)
 
-    UNUR_PAR* unur_vnrou_new(UNUR_DISTR* distribution)
-
-    int unur_vnrou_set_u(UNUR_PAR* parameters, double* umin, double* umax)
-
-    int unur_vnrou_chg_u(UNUR_GEN* generator, double* umin, double* umax)
-
-    int unur_vnrou_set_v(UNUR_PAR* parameters, double vmax)
-
-    int unur_vnrou_chg_v(UNUR_GEN* generator, double vmax)
-
-    int unur_vnrou_set_r(UNUR_PAR* parameters, double r)
-
-    int unur_vnrou_set_verify(UNUR_PAR* parameters, int verify)
-
-    int unur_vnrou_chg_verify(UNUR_GEN* generator, int verify)
-
-    double unur_vnrou_get_volumehat(UNUR_GEN* generator)
-
     UNUR_PAR* unur_gibbs_new(UNUR_DISTR* distribution)
 
     int unur_gibbs_set_variant_coordinate(UNUR_PAR* parameters)
@@ -955,38 +937,6 @@ cdef extern from "unuran.h" nogil:
     int unur_gibbs_chg_state(UNUR_GEN* generator, double* state)
 
     int unur_gibbs_reset_state(UNUR_GEN* generator)
-
-    UNUR_PAR* unur_hitro_new(UNUR_DISTR* distribution)
-
-    int unur_hitro_set_variant_coordinate(UNUR_PAR* parameters)
-
-    int unur_hitro_set_variant_random_direction(UNUR_PAR* parameters)
-
-    int unur_hitro_set_use_adaptiveline(UNUR_PAR* parameters, int adaptive)
-
-    int unur_hitro_set_use_boundingrectangle(UNUR_PAR* parameters, int rectangle)
-
-    int unur_hitro_set_use_adaptiverectangle(UNUR_PAR* parameters, int adaptive)
-
-    int unur_hitro_set_r(UNUR_PAR* parameters, double r)
-
-    int unur_hitro_set_v(UNUR_PAR* parameters, double vmax)
-
-    int unur_hitro_set_u(UNUR_PAR* parameters, double* umin, double* umax)
-
-    int unur_hitro_set_adaptive_multiplier(UNUR_PAR* parameters, double factor)
-
-    int unur_hitro_set_startingpoint(UNUR_PAR* parameters, double* x0)
-
-    int unur_hitro_set_thinning(UNUR_PAR* parameters, int thinning)
-
-    int unur_hitro_set_burnin(UNUR_PAR* parameters, int burnin)
-
-    double* unur_hitro_get_state(UNUR_GEN* generator)
-
-    int unur_hitro_chg_state(UNUR_GEN* generator, double* state)
-
-    int unur_hitro_reset_state(UNUR_GEN* generator)
 
     UNUR_PAR* unur_cstd_new(UNUR_DISTR* distribution)
 


### PR DESCRIPTION
#### Reference issue

Addressed scipy/unuran#13

#### What does this implement/fix?

This PR syncs with the scipy/unuran repo to include a compliance fix scipy/unuran#14. Also removed the VNROU and HITRO methods from the declarations file (see https://github.com/scipy/unuran/pull/14#issuecomment-1956820891).
