### PR TITLE
Add missing `copy=False` updates

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -56,6 +56,13 @@ else:
 IntNumber = Union[int, np.integer]
 DecimalNumber = Union[float, np.floating, np.integer]
 
+copy_false: Optional[bool]
+
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0.dev0":
+    copy_false = None
+else:
+    copy_false = False
+
 # Since Generator was introduced in numpy 1.17, the following condition is needed for
 # backward compatibility
 if TYPE_CHECKING:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -16,6 +16,7 @@ from ._data import _data_matrix, _minmax_mixin
 from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index, get_index_dtype,
                        check_shape, check_reshape_kwargs)
+from .._lib._util import copy_false
 
 import operator
 
@@ -26,6 +27,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
         is_array = isinstance(self, sparray)
+        if not copy:
+            copy = copy_false
 
         if isinstance(arg1, tuple):
             if isshape(arg1, allow_1d=is_array):

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -13,6 +13,7 @@ from ._sputils import (
     isshape, upcast_char, getdtype, get_sum_dtype, validateaxis, check_shape
 )
 from ._sparsetools import dia_matvec
+from .._lib._util import copy_false
 
 
 class _dia_base(_data_matrix):
@@ -20,6 +21,8 @@ class _dia_base(_data_matrix):
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
+        if not copy:
+            copy = copy_false
 
         if issparse(arg1):
             if arg1.format == "dia":


### PR DESCRIPTION
Addressing #20170 

@rgommers @matthewfeickert Here's a fix for "Unable to avoid copy" errors pointed out in #20170.
I missed those due to the fact that `np.array(..., copy=copy)` were placed in subclasses. 
