### PR TITLE
MAINT: (additional) array copy semantics shims

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -65,7 +65,7 @@ elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
 else:
     # 2.0.0 dev versions, handle cases where copy may or may not exist
     try:
-        np.array([1]).__array__(copy=None)
+        np.array([1]).__array__(copy=None)  # type: ignore[call-overload]
         copy_if_needed = None
     except TypeError:
         copy_if_needed = False

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -56,6 +56,20 @@ else:
 IntNumber = Union[int, np.integer]
 DecimalNumber = Union[float, np.floating, np.integer]
 
+copy_if_needed: Optional[bool]
+
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+    copy_if_needed = False
+else:
+    # 2.0.0 dev versions, handle cases where copy may or may not exist
+    try:
+        np.array([1]).__array__(copy=None)
+        copy_if_needed = None
+    except TypeError:
+        copy_if_needed = False
+
 # Since Generator was introduced in numpy 1.17, the following condition is needed for
 # backward compatibility
 if TYPE_CHECKING:

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -7,6 +7,7 @@ import contextlib
 import numpy as np
 # good_size is exposed (and used) from this import
 from .pypocketfft import good_size
+from scipy._lib import _pep440
 
 __all__ = ['good_size', 'set_workers', 'get_workers']
 
@@ -96,6 +97,9 @@ def _asfarray(x):
     dtype = x.dtype.newbyteorder('=')
     # Always align input
     copy = not x.flags['ALIGNED']
+    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+        if copy == False:
+            copy = None
     return np.array(x, dtype=dtype, copy=copy)
 
 def _datacopied(arr, original):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -5,9 +5,12 @@ import threading
 import contextlib
 
 import numpy as np
+
+from scipy._lib._util import copy_if_needed
+
 # good_size is exposed (and used) from this import
 from .pypocketfft import good_size
-from scipy._lib import _pep440
+
 
 __all__ = ['good_size', 'set_workers', 'get_workers']
 
@@ -96,10 +99,7 @@ def _asfarray(x):
     # Require native byte order
     dtype = x.dtype.newbyteorder('=')
     # Always align input
-    copy = not x.flags['ALIGNED']
-    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-        if copy == False:
-            copy = None
+    copy = True if not x.flags['ALIGNED'] else copy_if_needed
     return np.array(x, dtype=dtype, copy=copy)
 
 def _datacopied(arr, original):

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -853,7 +853,7 @@ class FakeArray2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self):
+    def __array__(self, copy=None):
         return self._data
 
 # TODO: Is this test actually valuable? The behavior it's testing shouldn't be

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -853,7 +853,7 @@ class FakeArray2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self, copy=None):
+    def __array__(self, dtype=None, copy=None):
         return self._data
 
 # TODO: Is this test actually valuable? The behavior it's testing shouldn't be

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -743,7 +743,7 @@ class FakeArray2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self, copy=None):
+    def __array__(self, dtype=None, copy=None):
         return self._data
 
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -743,7 +743,7 @@ class FakeArray2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self):
+    def __array__(self, copy=None):
         return self._data
 
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -8,7 +8,7 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
                    ravel, poly1d, asarray, intp)
 
 import scipy.special as spec
-from scipy._lib import _pep440
+from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from . import _fitpack_py
@@ -504,9 +504,8 @@ class interp1d(_Interpolator1D):
         # `copy` keyword semantics changed in NumPy 2.0, once that is
         # the minimum version this can use `copy=None`.
         self.copy = copy
-        if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-            if self.copy == False:
-                self.copy = None
+        if not copy:
+            self.copy = copy_if_needed
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
             order = {'zero': 0, 'slinear': 1,

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -8,6 +8,7 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
                    ravel, poly1d, asarray, intp)
 
 import scipy.special as spec
+from scipy._lib import _pep440
 from scipy.special import comb
 
 from . import _fitpack_py
@@ -502,7 +503,10 @@ class interp1d(_Interpolator1D):
 
         # `copy` keyword semantics changed in NumPy 2.0, once that is
         # the minimum version this can use `copy=None`.
-        self.copy = np._CopyMode.ALWAYS if copy else np._CopyMode.IF_NEEDED
+        self.copy = copy
+        if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+            if self.copy == False:
+                self.copy = None
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
             order = {'zero': 0, 'slinear': 1,

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -703,7 +703,7 @@ class MyValue:
     def __array_interface__(self):
         return None
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         raise RuntimeError("No array representation")
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1239,7 +1239,7 @@ def test_save_unicode_field(tmpdir):
 
 def test_save_custom_array_type(tmpdir):
     class CustomArray:
-        def __array__(self, copy=None):
+        def __array__(self, dtype=None, copy=None):
             return np.arange(6.0).reshape(2, 3)
     a = CustomArray()
     filename = os.path.join(str(tmpdir), 'test.mat')

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1239,7 +1239,7 @@ def test_save_unicode_field(tmpdir):
 
 def test_save_custom_array_type(tmpdir):
     class CustomArray:
-        def __array__(self):
+        def __array__(self, copy=None):
             return np.arange(6.0).reshape(2, 3)
     a = CustomArray()
     filename = os.path.join(str(tmpdir), 'test.mat')

--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -11,7 +11,7 @@ class _FakeMatrix2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self, copy=None):
+    def __array__(self, dtype=None, copy=None):
         return self._data
 
 

--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -11,7 +11,7 @@ class _FakeMatrix2:
     def __init__(self, data):
         self._data = data
 
-    def __array__(self):
+    def __array__(self, copy=None):
         return self._data
 
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2361,7 +2361,7 @@ class TestDatacopied:
         M2 = M.copy()
 
         class Fake1:
-            def __array__(self, copy=None):
+            def __array__(self, dtype=None, copy=None):
                 return A
 
         class Fake2:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2361,7 +2361,7 @@ class TestDatacopied:
         M2 = M.copy()
 
         class Fake1:
-            def __array__(self):
+            def __array__(self, copy=None):
                 return A
 
         class Fake2:

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -423,7 +423,9 @@ class Jacobian:
 
 
         if hasattr(self, "todense"):
-            def __array__(self, copy=None):
+            def __array__(self, dtype=None, copy=None):
+                if dtype is not None:
+                    raise ValueError(f"`dtype` must be None, was {dtype}")
                 return self.todense()
 
     def aspreconditioner(self):

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -421,8 +421,10 @@ class Jacobian:
             if value is not None:
                 setattr(self, name, kw[name])
 
-        if hasattr(self, 'todense'):
-            self.__array__ = lambda: self.todense()
+
+        if hasattr(self, "todense"):
+            def __array__(self, copy=None):
+                return self.todense()
 
     def aspreconditioner(self):
         return InverseJacobian(self)
@@ -675,7 +677,7 @@ class LowRankMatrix:
         if len(self.cs) > c.size:
             self.collapse()
 
-    def __array__(self):
+    def __array__(self, copy=None):
         if self.collapsed is not None:
             return self.collapsed
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1,14 +1,17 @@
 # Copyright (C) 2009, Pauli Virtanen <pav@iki.fi>
 # Distributed under the same license as SciPy.
 
+import inspect
 import sys
+import warnings
+
 import numpy as np
-from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 from numpy import asarray, dot, vdot
+
+from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
-import inspect
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 
@@ -679,7 +682,15 @@ class LowRankMatrix:
         if len(self.cs) > c.size:
             self.collapse()
 
-    def __array__(self, copy=None):
+    def __array__(self, dtype=None, copy=None):
+        if dtype is not None:
+            warnings.warn("LowRankMatrix is scipy-internal code, `dtype` "
+                          f"should only be None but was {dtype} (not handled)",
+                          stacklevel=3)
+        if copy is not None:
+            warnings.warn("LowRankMatrix is scipy-internal code, `copy` "
+                          f"should only be None but was {copy} (not handled)",
+                          stacklevel=3)
         if self.collapsed is not None:
             return self.collapsed
 

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -18,6 +18,7 @@ from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_maxnnz,
                            bsr_matmat, bsr_transpose, bsr_sort_indices,
                            bsr_tocsr)
+from scipy._lib import _pep440
 
 
 class _bsr_base(_cs_matrix, _minmax_mixin):
@@ -78,6 +79,9 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                     maxval = max(maxval, max(blocksize))
                 idx_dtype = self._get_index_dtype((indices, indptr), maxval=maxval,
                                                   check_contents=True)
+                if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+                    if copy == False:
+                        copy = None
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                 self.data = getdata(data, copy=copy, dtype=dtype)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 import numpy as np
 
+from scipy._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._data import _data_matrix, _minmax_mixin
 from ._compressed import _cs_matrix
@@ -18,7 +19,6 @@ from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_maxnnz,
                            bsr_matmat, bsr_transpose, bsr_sort_indices,
                            bsr_tocsr)
-from scipy._lib import _pep440
 
 
 class _bsr_base(_cs_matrix, _minmax_mixin):
@@ -79,9 +79,8 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                     maxval = max(maxval, max(blocksize))
                 idx_dtype = self._get_index_dtype((indices, indptr), maxval=maxval,
                                                   check_contents=True)
-                if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-                    if copy == False:
-                        copy = None
+                if not copy:
+                    copy = copy_if_needed
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                 self.data = getdata(data, copy=copy, dtype=dtype)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -5,6 +5,7 @@ from warnings import warn
 import operator
 
 import numpy as np
+from scipy._lib import _pep440
 from scipy._lib._util import _prune_array
 
 from ._base import _spbase, issparse, SparseEfficiencyWarning
@@ -67,6 +68,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                                                 maxval=maxval,
                                                 check_contents=True)
 
+                    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+                        if copy == False:
+                            copy = None
                     self.indices = np.array(indices, copy=copy,
                                             dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -5,8 +5,7 @@ from warnings import warn
 import operator
 
 import numpy as np
-from scipy._lib import _pep440
-from scipy._lib._util import _prune_array
+from scipy._lib._util import _prune_array, copy_if_needed
 
 from ._base import _spbase, issparse, SparseEfficiencyWarning
 from ._data import _data_matrix, _minmax_mixin
@@ -68,9 +67,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                                                 maxval=maxval,
                                                 check_contents=True)
 
-                    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-                        if copy == False:
-                            copy = None
+                    if not copy:
+                        copy = copy_if_needed
                     self.indices = np.array(indices, copy=copy,
                                             dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -9,6 +9,7 @@ from warnings import warn
 
 import numpy as np
 
+from .._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from ._base import issparse, SparseEfficiencyWarning, _spbase, sparray
@@ -16,7 +17,6 @@ from ._data import _data_matrix, _minmax_mixin
 from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index, get_index_dtype,
                        check_shape, check_reshape_kwargs)
-from scipy._lib import _pep440
 
 import operator
 
@@ -27,6 +27,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
         is_array = isinstance(self, sparray)
+        if not copy:
+            copy = copy_if_needed
 
         if isinstance(arg1, tuple):
             if isshape(arg1, allow_1d=is_array):
@@ -54,9 +56,6 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 idx_dtype = self._get_index_dtype(coords,
                                                   maxval=max(self.shape),
                                                   check_contents=True)
-                if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-                    if copy == False:
-                        copy = None
                 self.coords = tuple(np.array(idx, copy=copy, dtype=idx_dtype)
                                      for idx in coords)
                 self.data = getdata(obj, copy=copy, dtype=dtype)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -16,6 +16,7 @@ from ._data import _data_matrix, _minmax_mixin
 from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index, get_index_dtype,
                        check_shape, check_reshape_kwargs)
+from scipy._lib import _pep440
 
 import operator
 
@@ -53,6 +54,9 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 idx_dtype = self._get_index_dtype(coords,
                                                   maxval=max(self.shape),
                                                   check_contents=True)
+                if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+                    if copy == False:
+                        copy = None
                 self.coords = tuple(np.array(idx, copy=copy, dtype=idx_dtype)
                                      for idx in coords)
                 self.data = getdata(obj, copy=copy, dtype=dtype)

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -13,6 +13,7 @@ from ._sputils import (
     isshape, upcast_char, getdtype, get_sum_dtype, validateaxis, check_shape
 )
 from ._sparsetools import dia_matvec
+from scipy._lib import _pep440
 
 
 class _dia_base(_data_matrix):
@@ -54,6 +55,9 @@ class _dia_base(_data_matrix):
                 else:
                     if shape is None:
                         raise ValueError('expected a shape argument')
+                    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+                        if copy == False:
+                            copy = None
                     self.data = np.atleast_2d(np.array(arg1[0], dtype=dtype, copy=copy))
                     offsets = np.array(arg1[1],
                                        dtype=self._get_index_dtype(maxval=max(shape)),

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -6,6 +6,7 @@ __all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
 
 import numpy as np
 
+from .._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._base import issparse, _formats, _spbase, sparray
 from ._data import _data_matrix
@@ -13,7 +14,6 @@ from ._sputils import (
     isshape, upcast_char, getdtype, get_sum_dtype, validateaxis, check_shape
 )
 from ._sparsetools import dia_matvec
-from scipy._lib import _pep440
 
 
 class _dia_base(_data_matrix):
@@ -55,9 +55,8 @@ class _dia_base(_data_matrix):
                 else:
                     if shape is None:
                         raise ValueError('expected a shape argument')
-                    if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-                        if copy == False:
-                            copy = None
+                    if not copy:
+                        copy = copy_if_needed
                     self.data = np.atleast_2d(np.array(arg1[0], dtype=dtype, copy=copy))
                     offsets = np.array(arg1[1],
                                        dtype=self._get_index_dtype(maxval=max(shape)),

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -9,7 +9,7 @@
 
 import numpy as np
 import scipy.sparse
-from scipy._lib import _pep440
+from scipy._lib._util import copy_if_needed
 
 cimport numpy as np
 
@@ -552,9 +552,8 @@ cdef class cKDTree:
 
         self._python_tree = None
 
-        if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
-            if copy_data == False:
-                copy_data = None
+        if not copy_data:
+            copy_data = copy_if_needed
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
         if data.ndim != 2:

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -9,6 +9,7 @@
 
 import numpy as np
 import scipy.sparse
+from scipy._lib import _pep440
 
 cimport numpy as np
 
@@ -551,6 +552,9 @@ cdef class cKDTree:
 
         self._python_tree = None
 
+        if _pep440.parse(np.__version__) >= _pep440.Version("2.0.0.dev0"):
+            if copy_data == False:
+                copy_data = None
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
         if data.ndim != 2:

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1168,23 +1168,21 @@ def test_raise_invalid_args_g17713():
     with pytest.raises(TypeError, match=message):
         stats.gmean([1, 2, 3], 0, float, [1, 1, 1], 10)
 
-@pytest.mark.parametrize(
-    'dtype',
-    (list(np.typecodes['Float']
-          + np.typecodes['Integer']
-          + np.typecodes['Complex'])))
+
+@pytest.mark.parametrize('dtype', [np.int16, np.float32, np.complex128])
 def test_array_like_input(dtype):
     # Check that `_axis_nan_policy`-decorated functions work with custom
     # containers that are coercible to numeric arrays
 
     class ArrLike:
-        def __init__(self, x):
+        def __init__(self, x, dtype):
             self._x = x
+            self._dtype = dtype
 
-        def __array__(self, copy=None):
-            return np.asarray(x, dtype=dtype)
+        def __array__(self, dtype=None, copy=None):
+            return np.asarray(x, dtype=self._dtype)
 
     x = [1]*2 + [3, 4, 5]
-    res = stats.mode(ArrLike(x))
+    res = stats.mode(ArrLike(x, dtype=dtype))
     assert res.mode == 1
     assert res.count == 2

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1181,7 +1181,7 @@ def test_array_like_input(dtype):
         def __init__(self, x):
             self._x = x
 
-        def __array__(self):
+        def __array__(self, copy=None):
             return np.asarray(x, dtype=dtype)
 
     x = [1]*2 + [3, 4, 5]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2478,7 +2478,7 @@ class TestMode:
             def __init__(self, x):
                 self._x = x
 
-            def __array__(self):
+            def __array__(self, copy=None):
                 return self._x.astype(object)
 
         with pytest.raises(TypeError, match=message):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2478,7 +2478,7 @@ class TestMode:
             def __init__(self, x):
                 self._x = x
 
-            def __array__(self, copy=None):
+            def __array__(self, dtype=None, copy=None):
                 return self._x.astype(object)
 
         with pytest.raises(TypeError, match=message):


### PR DESCRIPTION
* Fixes gh-20170

* restore the old `copy` behavior when using NumPy >= `2.0.0dev0` for now; I think Mateusz
was using `asarray` to solve the same problem more concisely previously--I'm not bothered if folks prefer that, this was just more obviously restoring the original behavior to me (at least, I think it is...)

* `test_raise_non_numeric_gh18254` was mocking an array-like object so it gained an otherwise
unused `copy` argument for compliance; same goes
for `FakeArray2` in FFT testing (and in other
places that use arr mocking after that...)

* old shims using `np._CopyMode` are not safe to use (well, they appear to be more complex
than just bools now)

* some non-mock objects (I think) like `LowRankMatrix` and `Jacobian` were also given a `copy` argument for arr to play along, though I haven't thought about the deeper consequences of doing that

* `array_api_strict` needs a `copy` shim or two as well I think; that's external and not in scope here I don't think, but will cause this to fail until then:
`test_dispatch_to_unrecognize_library`

* apart from that one test vs. NumPy `main`, the rest of the suite passed with NumPy `main` and `1.26.4` on this branch in my hands

[skip circle] [skip cirrus]

@mtsokol I'm happy to back out the stuff you already covered in gh-20171, I think that's just a tiny subset of this though, so shouldn't be too disruptive.