### PR TITLE
TST:special:Add partial tests for nrdtrimn and nrdtrisd

### DIFF
--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -10,8 +10,6 @@ The following functions still need tests:
 - ncfdtrinc
 - nbdtrik
 - nbdtrin
-- nrdtrimn
-- nrdtrisd
 - pdtrik
 - nctdtr
 - nctdtrit
@@ -280,6 +278,32 @@ class TestCDFlib:
              ProbArg()],
             rtol=1e-7,
             endpt_atol=[None, 1e-7, 1e-10])
+
+    # Overall nrdtrimn and nrdtrisd are not performing well with infeasible/edge
+    # combinations of sigma and x, hence restricted the domains to still use the
+    # testing machinery, also see gh-20069
+
+    # nrdtrimn signature: p, sd, x
+    # nrdtrisd signature: mn, p, x
+    def test_nrdtrimn(self):
+        _assert_inverts(
+            sp.nrdtrimn,
+            lambda x, y, z: mpmath.ncdf(z, x, y),
+            0,
+            [ProbArg(),  # CDF value p
+             Arg(0.1, np.inf, inclusive_a=False, inclusive_b=False),  # sigma
+             Arg(-1e10, 1e10)],  # x
+            rtol=1e-5)
+
+    def test_nrdtrisd(self):
+        _assert_inverts(
+            sp.nrdtrisd,
+            lambda x, y, z: mpmath.ncdf(z, x, y),
+            1,
+            [Arg(-np.inf, 10, inclusive_a=False, inclusive_b=False),  # mn
+             ProbArg(),  # CDF value p
+             Arg(10, 1e100)],  # x
+            rtol=1e-5)
 
     def test_stdtr(self):
         # Ideally the left endpoint for Arg() should be 0.


### PR DESCRIPTION

#### Reference issue
Related : #19953 

#### What does this implement/fix?
Adds partial tests for special functions. 

It seems to me that the generic testing infra we have right now is not suitable for customization of parameter domains and it is a bit convoluted. It takes quite some investigation to see what is going on and debugging what failed. Hence I think there is domain expertise needed for the rewrite of the testing suite.

But at least it is better than nothing for now.
