### PR TITLE
MAINT: sparse: add missing dict methods to DOK and tests

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -89,6 +89,25 @@ class _dok_base(_spbase, IndexMixin, dict):
     def clear(self):
         return self._dict.clear()
 
+    def pop(self, key, default=None, /):
+        return self._dict.pop(key, default)
+
+    def __reversed__(self):
+        return self._dict.__reversed__()
+
+    def __or__(self, other):
+        if isinstance(other, _dok_base):
+            return self._dict.__or__(other._dict)
+        return self._dict.__or__(other)
+
+    def __ror__(self, other):
+        if isinstance(other, _dok_base):
+            return self._dict.__ror__(other._dict)
+        return self._dict.__ror__(other)
+
+    def __ior__(self, other):
+        raise NotImplementedError('DOK sparse format does not support the |= operator')
+
     def popitem(self):
         return self._dict.popitem()
 
@@ -414,11 +433,10 @@ class _dok_base(_spbase, IndexMixin, dict):
     @classmethod
     def fromkeys(cls, iterable, value=1, /):
         tmp = dict.fromkeys(iterable, value)
-        keys = tmp.keys()
-        if isinstance(next(iter(keys)), tuple):
-            shape = tuple(max(idx) + 1 for idx in zip(*keys))
+        if isinstance(next(iter(tmp)), tuple):
+            shape = tuple(max(idx) + 1 for idx in zip(*tmp))
         else:
-            shape = (max(keys) + 1,)
+            shape = (max(tmp) + 1,)
         result = cls(shape, dtype=type(value))
         result._dict = tmp
         return result

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -93,20 +93,19 @@ class _dok_base(_spbase, IndexMixin, dict):
         return self._dict.pop(key, default)
 
     def __reversed__(self):
-        return self._dict.__reversed__()
+        raise TypeError("reversed is not defined for dok_array type")
 
     def __or__(self, other):
-        if isinstance(other, _dok_base):
-            return self._dict.__or__(other._dict)
-        return self._dict.__or__(other)
+        type_names = f"{type(self).__name__} and {type(other).__name__}"
+        raise TypeError(f"unsupported operand type for |: {type_names}")
 
     def __ror__(self, other):
-        if isinstance(other, _dok_base):
-            return self._dict.__ror__(other._dict)
-        return self._dict.__ror__(other)
+        type_names = f"{type(self).__name__} and {type(other).__name__}"
+        raise TypeError(f"unsupported operand type for |: {type_names}")
 
     def __ior__(self, other):
-        raise NotImplementedError('DOK sparse format does not support the |= operator')
+        type_names = f"{type(self).__name__} and {type(other).__name__}"
+        raise TypeError(f"unsupported operand type for |: {type_names}")
 
     def popitem(self):
         return self._dict.popitem()
@@ -651,3 +650,23 @@ class dok_matrix(spmatrix, _dok_base):
         return self._shape
 
     shape = property(fget=get_shape, fset=set_shape)
+
+    def __reversed__(self):
+        return self._dict.__reversed__()
+
+    def __or__(self, other):
+        if isinstance(other, _dok_base):
+            return self._dict | other._dict
+        return self._dict | other
+
+    def __ror__(self, other):
+        if isinstance(other, _dok_base):
+            return self._dict | other._dict
+        return self._dict | other
+
+    def __ior__(self, other):
+        if isinstance(other, _dok_base):
+            self._dict |= other._dict
+        else:
+            self._dict |= other
+        return self

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
 import scipy as sp
 from scipy.sparse import dok_array, dok_matrix
 
@@ -49,22 +49,22 @@ def test_copy(d, Asp):
 def test_fromkeys_default():
     # test with default value
     edges = [(0, 2), (1, 0), (2, 1)]
-    Xdok = sp.sparse.dok_array.fromkeys(edges)
+    Xdok = dok_array.fromkeys(edges)
     X = [[0, 0, 1], [1, 0, 0], [0, 1, 0]]
-    assert_array_equal(Xdok.toarray(), X)
+    assert_equal(Xdok.toarray(), X)
 
 def test_fromkeys_positional():
     # test with positional value
     edges = [(0, 2), (1, 0), (2, 1)]
-    Xdok = sp.sparse.dok_array.fromkeys(edges, -1)
+    Xdok = dok_array.fromkeys(edges, -1)
     X = [[0, 0, -1], [-1, 0, 0], [0, -1, 0]]
-    assert_array_equal(Xdok.toarray(), X)
+    assert_equal(Xdok.toarray(), X)
 
 def test_fromkeys_iterator():
     it = ((a, a % 2) for a in range(4))
-    Xdok = sp.sparse.dok_array.fromkeys(it)
+    Xdok = dok_array.fromkeys(it)
     X = [[1, 0], [0, 1], [1, 0], [0, 1]]
-    assert_array_equal(Xdok.toarray(), X)
+    assert_equal(Xdok.toarray(), X)
 
 def test_get(d, Asp):
     assert Asp.get((0, 1)) == d.get((0, 1))
@@ -196,7 +196,7 @@ def test_dunder_ge(A, Asp):
 
 # Note: iter dunder follows np.array not dict
 def test_dunder_iter(A, Asp):
-    if isinstance(Asp, sp.sparse.dok_array):
+    if isinstance(Asp, dok_array):
         with pytest.raises(NotImplementedError):
             [a.toarray() for a in Asp]
     else:

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -1,29 +1,177 @@
+import pytest
+import numpy as np
 from numpy.testing import assert_array_equal
-from scipy.sparse import dok_array
+import scipy as sp
+from scipy.sparse import dok_array, dok_matrix
 
+
+@pytest.fixture
+def d():
+    return {(0, 1): 1, (0, 2): 2}
+
+@pytest.fixture
+def A():
+    return np.array([[0, 1, 2], [0, 0, 0], [0, 0, 0]])
+
+@pytest.fixture(params=[dok_array, dok_matrix])
+def Asp(request):
+    A = request.param((3, 3))
+    A[(0, 1)] = 1
+    A[(0, 2)] = 2
+    yield A
+
+# Note: __iter__ and comparison dunders act like ndarrays for DOK, not dict.
+# All other dict methods on DOK format act like dict methods (with extra checks).
+
+# Start of tests
+################
+def test_dict_methods_covered(d, Asp):
+    d_methods = set(dir(d)) - {"__class_getitem__"}
+    asp_methods = set(dir(Asp))
+    assert d_methods < asp_methods
+
+def test_clear(d, Asp):
+    assert d.items() == Asp.items()
+    d.clear()
+    Asp.clear()
+    assert d.items() == Asp.items()
+
+def test_copy(d, Asp):
+    assert d.items() == Asp.items()
+    dd = d.copy()
+    asp = Asp.copy()
+    assert dd.items() == asp.items()
+    assert asp.items() == Asp.items()
+    asp[(0, 1)] = 3
+    assert Asp[(0, 1)] == 1
 
 def test_fromkeys_default():
     # test with default value
     edges = [(0, 2), (1, 0), (2, 1)]
-    Xdok = dok_array.fromkeys(edges)
-    assert_array_equal(
-        Xdok.toarray(),
-        [[0, 0, 1], [1, 0, 0], [0, 1, 0]],
-    )
+    Xdok = sp.sparse.dok_array.fromkeys(edges)
+    X = [[0, 0, 1], [1, 0, 0], [0, 1, 0]]
+    assert_array_equal(Xdok.toarray(), X)
 
 def test_fromkeys_positional():
     # test with positional value
     edges = [(0, 2), (1, 0), (2, 1)]
-    Xdok = dok_array.fromkeys(edges, -1)
-    assert_array_equal(
-        Xdok.toarray(),
-        [[0, 0, -1], [-1, 0, 0], [0, -1, 0]],
-    )
+    Xdok = sp.sparse.dok_array.fromkeys(edges, -1)
+    X = [[0, 0, -1], [-1, 0, 0], [0, -1, 0]]
+    assert_array_equal(Xdok.toarray(), X)
 
 def test_fromkeys_iterator():
     it = ((a, a % 2) for a in range(4))
-    Xdok = dok_array.fromkeys(it)
-    assert_array_equal(
-        Xdok.toarray(),
-        [[1, 0], [0, 1], [1, 0], [0, 1]],
-    )
+    Xdok = sp.sparse.dok_array.fromkeys(it)
+    X = [[1, 0], [0, 1], [1, 0], [0, 1]]
+    assert_array_equal(Xdok.toarray(), X)
+
+def test_get(d, Asp):
+    assert Asp.get((0, 1)) == d.get((0, 1))
+    assert Asp.get((0, 0), 99) == d.get((0, 0), 99)
+    with pytest.raises(IndexError, match="out of bounds"):
+        Asp.get((0, 4), 99)
+
+def test_items(d, Asp):
+    assert Asp.items() == d.items()
+
+def test_keys(d, Asp):
+    assert Asp.keys() == d.keys()
+
+def test_pop(d, Asp):
+    assert d.pop((0, 1)) == 1
+    assert Asp.pop((0, 1)) == 1
+    assert d.items() == Asp.items()
+
+def test_popitem(d, Asp):
+    assert d.popitem() == Asp.popitem()
+    assert d.items() == Asp.items()
+
+def test_setdefault(d, Asp):
+    assert Asp.setdefault((0, 1), 4) == 1
+    assert Asp.setdefault((2, 2), 4) == 4
+    d.setdefault((0, 1), 4)
+    d.setdefault((2, 2), 4)
+    assert d.items() == Asp.items()
+
+def test_update(d, Asp):
+    with pytest.raises(NotImplementedError):
+        Asp.update(Asp)
+
+def test_values(d, Asp):
+    # Note: dict.values are strange: d={1: 1}; d.values() == d.values() is False
+    # Using list(d.values()) makes them comparable.
+    assert list(Asp.values()) == list(d.values())
+
+def test_dunder_reversed(d, Asp):
+    assert list(reversed(Asp)) == list(reversed(d))
+
+def test_dunder_getitem(d, Asp):
+    assert Asp[(0, 1)] == d[(0, 1)]
+
+def test_dunder_setitem(d, Asp):
+    Asp[(1, 1)] = 5
+    d[(1, 1)] = 5
+    assert d.items() == Asp.items()
+
+def test_dunder_delitem(d, Asp):
+    del Asp[(0, 1)]
+    del d[(0, 1)]
+    assert d.items() == Asp.items()
+
+def test_dunder_contains(d, Asp):
+    assert ((0, 1) in d) == ((0, 1) in Asp)
+    assert ((0, 0) in d) == ((0, 0) in Asp)
+
+def test_dunder_len(d, Asp):
+    assert len(d) == len(Asp)
+
+def test_dunder_ior(d, Asp):
+    with pytest.raises(NotImplementedError):
+        Asp |= Asp
+
+def test_dunder_or(d, Asp):
+    assert d | d == Asp | d
+    assert d | d == Asp | Asp
+
+def test_dunder_ror(d, Asp):
+    assert Asp.__ror__(d) == Asp.__ror__(Asp)
+    assert d.__ror__(d) == Asp.__ror__(d)
+
+# Note: comparison dunders, e.g. ==, >=, etc follow np.array not dict
+def test_dunder_eq(A, Asp):
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(sp.sparse.SparseEfficiencyWarning)
+        assert (Asp == Asp).toarray().all()
+        assert (A == Asp).all()
+
+def test_dunder_ne(A, Asp):
+    assert not (Asp != Asp).toarray().any()
+    assert not (A != Asp).any()
+
+def test_dunder_lt(A, Asp):
+    assert not (Asp < Asp).toarray().any()
+    assert not (A < Asp).any()
+
+def test_dunder_gt(A, Asp):
+    assert not (Asp > Asp).toarray().any()
+    assert not (A > Asp).any()
+
+def test_dunder_le(A, Asp):
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(sp.sparse.SparseEfficiencyWarning)
+        assert (Asp <= Asp).toarray().all()
+        assert (A <= Asp).all()
+
+def test_dunder_ge(A, Asp):
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(sp.sparse.SparseEfficiencyWarning)
+        assert (Asp >= Asp).toarray().all()
+        assert (A >= Asp).all()
+
+# Note: iter dunder follows np.array not dict
+def test_dunder_iter(A, Asp):
+    if isinstance(Asp, sp.sparse.dok_array):
+        with pytest.raises(NotImplementedError):
+            [a.toarray() for a in Asp]
+    else:
+        assert all((a == asp).all() for a, asp in zip(A, Asp))


### PR DESCRIPTION
A few `dict` methods are not being overloaded by the DOK sparse format. Most are likely due to new features added to `dict` in recent years. But others such as `pop` and `fromkeys` have recently been missed by users. (see Issue #20156 which this fixes and `dok.array.fromkeys` which was recently fixed in #20154).

This PR adds all the missing methods from dict (which otherwise call dict.method() on the sparse dok class and that often doesn't work).  The methods are:
```
pop()
__reversed__
__or__, __ror__, __ior__,
```
It also adds tests of all the dict methods to `sparse/tests/test_dok.py`.  Those tests are not meant to be exhaustive, but check that the methods exist and work for typical cases.

Fixes #20156 

This can be merged before or after the other open PR for DOK format:  #19715 since the rebase/merge is simple. That PR is ready to merge with 2 approvals and now rebased on main. This one is fairly short so maybe quick to review.  When either is merged, I will update the other.
