### PR TITLE
MAINT: vulture/ruff fixups

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -895,7 +895,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(t, output)
 
     @pytest.mark.parametrize('dtype', types + complex_types)
-    def test_sobel01(sel, dtype):
+    def test_sobel01(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
                              [5, 6, 9, 3, 5]], dtype)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3196,7 +3196,7 @@ class genextreme_gen(rv_continuous):
         # skewness
         sk1 = _lazywhere(c >= -1./3,
                          (c, g1, g2, g3, g2mg12),
-                         lambda c, g1, g2, g3, g2gm12:
+                         lambda c, g1, g2, g3, g2mg12:
                              np.sign(c)*(-g3 + (g2 + 2*g2mg12)*g1)/g2mg12**1.5,
                          fillvalue=np.nan)
         sk = np.where(abs(c) <= eps**0.29, 12*np.sqrt(6)*_ZETA3/np.pi**3, sk1)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2786,7 +2786,7 @@ class TestMedianAbsDeviation:
         mad = stats.median_abs_deviation(x, axis=1)
         assert_equal(mad, np.array([np.nan, 3.0]))
 
-    def test_nan_policy_omit_with_inf(sef):
+    def test_nan_policy_omit_with_inf(self):
         z = np.array([1, 3, 4, 6, 99, np.nan, np.inf])
         mad = stats.median_abs_deviation(z, nan_policy='omit')
         assert_equal(mad, 3.0)

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -71,7 +71,7 @@ def run_ruff(files, fix):
         return 0, ""
     args = ['--fix', '--exit-non-zero-on-fix'] if fix else []
     res = subprocess.run(
-        ['ruff', f'--config={CONFIG}'] + args + list(files),
+        ['ruff', 'check', f'--config={CONFIG}'] + args + list(files),
         stdout=subprocess.PIPE,
         encoding='utf-8'
     )


### PR DESCRIPTION
* deals with the trivial subset of gh-11864, but not all of it

* these complaints from [`vulture`](https://github.com/jendrikseipp/vulture) are clearly things we should change, but not true bugs

* also deal with new `ruff` release and `dev.py lint` warning-- `lint: warning: ruff <path> is deprecated. Use ruff check <path> instead.`

[skip cirrus] [skip circle]