### PR TITLE
MAINT: Avoid `descr->elsize` and use intp for it.

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -221,7 +221,8 @@ ArrayDescriptor get_descriptor(const py::array& arr) {
     const auto arr_shape = arr.shape();
     desc.shape.assign(arr_shape, arr_shape + ndim);
 
-    desc.element_size = arr.itemsize();
+    // TODO: Replace the following with `arr.itemsize()` this is a temporary workaround:
+    desc.element_size = PyArray_ITEMSIZE(reinterpret_cast<PyArrayObject *>(arr.ptr()));
     const auto arr_strides = arr.strides();
     desc.strides.assign(arr_strides, arr_strides + ndim);
     for (intptr_t i = 0; i < ndim; ++i) {

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -629,7 +629,8 @@ static PyObject *pdist_weighted_minkowski_double_wrap(
 static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) 
 {
   PyArrayObject *M_, *v_;
-  int n, elsize;
+  int n;
+  npy_intp elsize;
   if (!PyArg_ParseTuple(args, "O!O!",
             &PyArray_Type, &M_,
             &PyArray_Type, &v_)) {
@@ -637,7 +638,7 @@ static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args)
   }
   NPY_BEGIN_ALLOW_THREADS;
   n = PyArray_DIMS(M_)[0];
-  elsize = PyArray_DESCR(M_)->elsize;
+  elsize = PyArray_ITEMSIZE(M_);
   if (elsize == 8) {
     dist_to_squareform_from_vector_double(
         (double*)PyArray_DATA(M_), (const double*)PyArray_DATA(v_), n);
@@ -652,7 +653,8 @@ static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args)
 static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) 
 {
   PyArrayObject *M_, *v_;
-  int n, s;
+  int n;
+  npy_intp s;
   char *v;
   const char *M;
   if (!PyArg_ParseTuple(args, "O!O!",
@@ -665,7 +667,7 @@ static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args)
     M = (const char*)PyArray_DATA(M_);
     v = (char*)PyArray_DATA(v_);
     n = PyArray_DIMS(M_)[0];
-    s = PyArray_DESCR(M_)->elsize;
+    s = PyArray_ITEMSIZE(M_);
     dist_to_vector_from_squareform(M, v, n, s);
     NPY_END_ALLOW_THREADS;
   }


### PR DESCRIPTION
This is a small preparation for NumPy, it cleans up the code and adds a temporary workaround for pybind11 that needs to be updated (eventually).

All changes should be completely harmless, all functions already use or support the new intp size.

---

(Local tests are a bit shaky, but the changes are tiny, so just trying...)