### PR TITLE
BUG: Fix fancy indexing on compressed sparse arrays with mixed `indices`/ `indptr` dtypes

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -697,7 +697,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _major_index_fancy(self, idx):
         """Index along the major axis where idx is an array of ints.
         """
-        idx_dtype = self.indices.dtype
+        idx_dtype = self._get_index_dtype((self.indptr, self.indices))
         indices = np.asarray(idx, dtype=idx_dtype).ravel()
 
         _, N = self._swap(self.shape)
@@ -706,8 +706,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape, dtype=self.dtype)
 
-        row_nnz = self.indptr[indices + 1] - self.indptr[indices]
-        idx_dtype = self.indices.dtype
+        row_nnz = (self.indptr[indices + 1] - self.indptr[indices]).astype(idx_dtype)
+
+        self.indices = self.indices.astype(idx_dtype, copy=False)
+        self.indptr = self.indptr.astype(idx_dtype, copy=False)
+
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
         np.cumsum(row_nnz, out=res_indptr[1:])
 
@@ -763,7 +766,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _minor_index_fancy(self, idx):
         """Index along the minor axis where idx is an array of ints.
         """
-        idx_dtype = self.indices.dtype
+        idx_dtype = self._get_index_dtype((self.indices, self.indptr))
+        self.indices = self.indices.astype(idx_dtype, copy=False)
+        self.indptr = self.indptr.astype(idx_dtype, copy=False)
+
         idx = np.asarray(idx, dtype=idx_dtype).ravel()
 
         M, N = self._swap(self.shape)

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -173,6 +173,7 @@ def test_csr_hstack_int64():
 
 @pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 def test_mixed_index_dtype_int_indexing(cls):
+    # https://github.com/scipy/scipy/issues/20182
     rng = np.random.default_rng(0)
     base_mtx = cls(sparse.random(50, 50, random_state=rng, density=0.1))
     indptr_64bit = base_mtx.copy()

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,5 +1,3 @@
-from itertools import product
-
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
 from scipy.sparse import csr_matrix, csc_matrix, csr_array, csc_array, hstack
@@ -179,8 +177,8 @@ def test_mixed_index_dtype_int_indexing(cls):
     indptr_64bit = base_mtx.copy()
     indices_64bit = base_mtx.copy()
     indptr_64bit.indptr = base_mtx.indptr.astype(np.int64)
-    indptr_64bit.indices = base_mtx.indices.astype(np.int64)
+    indices_64bit.indices = base_mtx.indices.astype(np.int64)
 
-    indices = [([2, 3, 4], slice(None)), (slice(None), [2, 3, 4])]
-    for idx, mtx in product(indices, [base_mtx, indptr_64bit, indices_64bit]):
-        np.testing.assert_array_equal(mtx[idx].toarray(), base_mtx[idx].toarray())
+    for mtx in [base_mtx, indptr_64bit, indices_64bit]:
+        np.testing.assert_array_equal(mtx[[1,2], :].toarray(), base_mtx[[1, 2], :].toarray())
+        np.testing.assert_array_equal(mtx[:, [1, 2]].toarray(), base_mtx[:, [1, 2]].toarray())

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,6 +1,9 @@
+from itertools import product
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
-from scipy.sparse import csr_matrix, hstack
+from scipy.sparse import csr_matrix, csc_matrix, csr_array, csc_array, hstack
+from scipy import sparse
 import pytest
 
 
@@ -167,3 +170,16 @@ def test_csr_hstack_int64():
     X_hs_32 = hstack([X_1, X_3], format="csr")
     assert X_hs_32.indices.dtype == np.int32
     assert X_hs_32.indices.max() == max_int32 - 1
+
+@pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
+def test_mixed_index_dtype_int_indexing(cls):
+    rng = np.random.default_rng(0)
+    base_mtx = cls(sparse.random(50, 50, random_state=rng, density=0.1))
+    indptr_64bit = base_mtx.copy()
+    indices_64bit = base_mtx.copy()
+    indptr_64bit.indptr = base_mtx.indptr.astype(np.int64)
+    indptr_64bit.indices = base_mtx.indices.astype(np.int64)
+
+    indices = [([2, 3, 4], slice(None)), (slice(None), [2, 3, 4])]
+    for idx, mtx in product(indices, [base_mtx, indptr_64bit, indices_64bit]):
+        np.testing.assert_array_equal(mtx[idx].toarray(), base_mtx[idx].toarray())


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

* Fixes https://github.com/scipy/scipy/issues/20182

#### What does this implement/fix?
<!--Please explain your changes.-->

This coerces the `indices`/ `indptr` arrays instead of erroring

#### Additional information
<!--Any additional information you think is important.-->

I'm not totally sure on the implementation. It could be worth bundling this behaviour into a method, and maybe warning.