### PR TITLE
DOC, DX: Remove version warning banner in latest version

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -229,6 +229,7 @@ html_theme_options = {
 
 if 'dev' in version:
     html_theme_options["switcher"]["version_match"] = "development"
+    html_theme_options["show_version_warning_banner"] = False
 
 if 'versionwarning' in tags:  # noqa: F821
     # Specific to docs.scipy.org deployment.


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/issues/19699#issuecomment-1970568566

#### What does this implement/fix?
Do not include the version warning banner at the top of the pages on "latest".

If I understand the docs release process correctly, once the docs are built for stable, the version warning banner code will be present so that:

- stable (1.12.0) won't show any banners, but the banner code will be included in the build;
- once 1.12.X is released, 1.12.0 will show the banner.
- "latest" will never show the banner.

#### Additional information
Perhaps @tylerjereddy can confirm the docs building/release process.