### PR TITLE
BUG: Fix shape of single Rotation raised to the 0 or 1 power

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2642,11 +2642,14 @@ cdef class Rotation:
 
         # Exact short-cuts
         if n == 0:
-            return Rotation.identity(len(self._quat))
+            return Rotation.identity(None if self._single else len(self._quat))
         elif n == -1:
             return self.inv()
         elif n == 1:
-            return self.__class__(self._quat.copy())
+            if self._single:
+                return self.__class__(self._quat[0], copy=True)
+            else:
+                return self.__class__(self._quat, copy=True)
         else:  # general scaling of rotation angle
             return Rotation.from_rotvec(n * self.as_rotvec())
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1584,6 +1584,7 @@ def test_pow():
     p_inv = p.inv()
     # Test the short-cuts and other integers
     for n in [-5, -2, -1, 0, 1, 2, 5]:
+        # Test accuracy
         q = p ** n
         r = Rotation.identity(10)
         for _ in range(abs(n)):
@@ -1593,6 +1594,12 @@ def test_pow():
                 r = r * p_inv
         ang = (q * r.inv()).magnitude()
         assert np.all(ang < atol)
+
+        # Test shape preservation
+        r = Rotation.from_quat([0, 0, 0, 1])
+        assert (r**n).as_quat().shape == (4,)
+        r = Rotation.from_quat([[0, 0, 0, 1]])
+        assert (r**n).as_quat().shape == (1, 4)
 
     # Large angle fractional
     for n in [-1.5, -0.5, -0.0, 0.0, 0.5, 1.5]:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/20188

#### What does this implement/fix?
Previously, a single rotation raised to the 0th power would change its shape from (4,) to (1, 4). This change fixes that, and the test ensures we are preserving it over all power operations.

#### Additional information
<!--Any additional information you think is important.-->
