### PR TITLE
MAINT: Bump `npy2_compat.h` and add temporary pybind11 workaround

### DIFF
--- a/scipy/_build_utils/src/npy_2_compat.h
+++ b/scipy/_build_utils/src/npy_2_compat.h
@@ -41,6 +41,7 @@
  * In that case we need to ensure that users first included the full headers
  * and not just `ndarraytypes.h`.
  */
+
 #ifndef NPY_FEATURE_VERSION
   #error "The NumPy 2 compat header requires `import_array()` for which "  \
          "the `ndarraytypes.h` header include is not sufficient.  Please "  \
@@ -61,6 +62,8 @@
    * This allows downstream to use `PyArray_RUNTIME_VERSION` if they need to.
    */
   #define PyArray_RUNTIME_VERSION NPY_FEATURE_VERSION
+  /* Compiling on NumPy 1.x where these are the same: */
+  #define PyArray_DescrProto PyArray_Descr
 #endif
 
 
@@ -107,25 +110,17 @@ PyArray_ImportNumPyAPI()
     #define NPY_RAVEL_AXIS NPY_MIN_INT
     #define NPY_MAXARGS 64
 
-    static inline npy_uint64
-    PyDataType_FLAGS(const PyArray_Descr *dtype)
-    {
-        return (unsigned char)dtype->flags;
-    }
 #elif NPY_ABI_VERSION < 0x02000000
     #define NPY_DEFAULT_INT NPY_LONG
     #define NPY_RAVEL_AXIS 32
     #define NPY_MAXARGS 32
 
-    static inline npy_uint64
-    PyDataType_FLAGS(const PyArray_Descr *dtype)
-    {
-        return (unsigned char)dtype->flags;
-    }
-
     /* Aliases of 2.x names to 1.x only equivalent names */
     #define NPY_NTYPES NPY_NTYPES_LEGACY
     #define PyArray_DescrProto PyArray_Descr
+    #define _PyArray_LegacyDescr PyArray_Descr
+    /* NumPy 2 definition always works, but add it for 1.x only */
+    #define PyDataType_ISLEGACY(dtype) (1)
 #else
     #define NPY_DEFAULT_INT  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)
@@ -133,19 +128,93 @@ PyArray_ImportNumPyAPI()
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? -1 : 32)
     #define NPY_MAXARGS  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? 64 : 32)
+#endif
+
+
+/*
+ * Access inline functions for descriptor fields.  Except for the first
+ * few fields, these needed to be moved (elsize, alignment) for
+ * additional space.  Or they are descriptor specific and are not generally
+ * available anymore (metadata, c_metadata, subarray, names, fields).
+ *
+ * Most of these are defined via the `DESCR_ACCESSOR` macro helper.
+ */
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION || NPY_ABI_VERSION < 0x02000000
+    /* Compiling for 1.x or 2.x only, direct field access is OK: */
+
+    static inline void
+    PyDataType_SET_ELSIZE(PyArray_Descr *dtype, npy_intp size)
+    {
+        dtype->elsize = size;
+    }
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+    #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+        return dtype->flags;
+    #else
+        return (unsigned char)dtype->flags;  /* Need unsigned cast on 1.x */
+    #endif
+    }
+
+    #define DESCR_ACCESSOR(FIELD, field, type, legacy_only)    \
+        static inline type                                     \
+        PyDataType_##FIELD(const PyArray_Descr *dtype) {       \
+            if (legacy_only && !PyDataType_ISLEGACY(dtype)) {  \
+                return (type)0;                                \
+            }                                                  \
+            return ((_PyArray_LegacyDescr *)dtype)->field;     \
+        }
+#else  /* compiling for both 1.x and 2.x */
+
+    static inline void
+    PyDataType_SET_ELSIZE(PyArray_Descr *dtype, npy_intp size)
+    {
+        if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
+            ((_PyArray_DescrNumPy2 *)dtype)->elsize = size;
+        }
+        else {
+            ((PyArray_DescrProto *)dtype)->elsize = (int)size;
+        }
+    }
 
     static inline npy_uint64
     PyDataType_FLAGS(const PyArray_Descr *dtype)
     {
         if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
-            // TODO: This will change to a semi-private 2.0 struct name
-            return (unsigned char)((PyArray_Descr *)dtype)->flags;
+            return ((_PyArray_DescrNumPy2 *)dtype)->flags;
         }
         else {
             return (unsigned char)((PyArray_DescrProto *)dtype)->flags;
         }
     }
+
+    /* Cast to LegacyDescr always fine but needed when `legacy_only` */
+    #define DESCR_ACCESSOR(FIELD, field, type, legacy_only)        \
+        static inline type                                         \
+        PyDataType_##FIELD(const PyArray_Descr *dtype) {           \
+            if (legacy_only && !PyDataType_ISLEGACY(dtype)) {      \
+                return (type)0;                                    \
+            }                                                      \
+            if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {  \
+                return ((_PyArray_LegacyDescr *)dtype)->field;     \
+            }                                                      \
+            else {                                                 \
+                return ((PyArray_DescrProto *)dtype)->field;       \
+            }                                                      \
+        }
 #endif
+
+DESCR_ACCESSOR(ELSIZE, elsize, npy_intp, 0)
+DESCR_ACCESSOR(ALIGNMENT, alignment, npy_intp, 0)
+DESCR_ACCESSOR(METADATA, metadata, PyObject *, 1)
+DESCR_ACCESSOR(SUBARRAY, subarray, PyArray_ArrayDescr *, 1)
+DESCR_ACCESSOR(NAMES, names, PyObject *, 1)
+DESCR_ACCESSOR(FIELDS, fields, PyObject *, 1)
+DESCR_ACCESSOR(C_METADATA, c_metadata, NpyAuxData *, 1)
+
+#undef DESCR_ACCESSOR
 
 
 #if !(defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -80,7 +80,7 @@ py3.extension_module('_distance_wrap',
 
 py3.extension_module('_distance_pybind',
   ['src/distance_pybind.cpp'],
-  include_directories: 'src/',
+  include_directories: ['src/', '../_build_utils/src'],
   dependencies: [np_dep, pybind11_dep],
   link_args: version_link_args,
   install: true,

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -11,6 +11,8 @@
 #include <sstream>
 #include <string>
 
+#include "npy_2_compat.h"
+
 namespace py = pybind11;
 
 namespace {
@@ -374,7 +376,20 @@ template <typename Container>
 py::array prepare_out_argument(const py::object& obj, const py::dtype& dtype,
                                const Container& out_shape) {
     if (obj.is_none()) {
-        return py::array(dtype, out_shape);
+        // TODO: The strides are only passed for NumPy 2.0 transition to allow
+        //       pybind11 to catch up and can be removed at any time.  Also
+        //       remove `npy_2_compat.h` include and the `../_build_utils/src`
+        //       in meson.build.  (Same as PyArray_ITEMSIZE use above.)
+        npy_intp itemsize = PyDataType_ELSIZE((PyArray_Descr *)dtype.ptr());
+        Container strides;
+        if (strides.size() == 1) {
+            strides[0] = itemsize;
+        }
+        else {
+            strides[0] = itemsize * out_shape[1];
+            strides[1] = itemsize;
+        }
+        return py::array(dtype, out_shape, strides);
     }
 
     if (!py::isinstance<py::array>(obj)) {


### PR DESCRIPTION
This adds a temporary workaround for pybind11 and makes SciPy otherwise work with upcoming NumPy changes.

---

Accompanying PR to fix SciPy build when https://github.com/numpy/numpy/pull/25943 is merged/in the nightlies.

The change here is a bit ugly and (similar to the `PyArray_ITEMSIZE` use) be removed as soon as `pybind11` is fixed, it is thus really a stop-gap to allow at least SciPy to function until `pybind11` is fixed up.

(I haven't yet tested running with older NumPy or compiling with it, but those should be simple follow ups.)

**EDIT: Just to note, compilation failure against NumPy 2 are expected until the change happens there.**