### PR TITLE
ENH: linalg: allow readonly arrays in expm et al

### DIFF
--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -158,7 +158,7 @@ def bandwidth(a):
 
 
 @cython.initializedcheck(False)
-def bandwidth_c(np_numeric_t[:, ::1]A):
+def bandwidth_c(const np_numeric_t[:, ::1]A):
     cdef int l, u
     with nogil:
         l, u = band_check_internal_c(A)
@@ -166,7 +166,7 @@ def bandwidth_c(np_numeric_t[:, ::1]A):
 
 
 @cython.initializedcheck(False)
-def bandwidth_noncontig(np_numeric_t[:, :]A):
+def bandwidth_noncontig(const np_numeric_t[:, :]A):
     cdef int l, u
     with nogil:
         l, u = band_check_internal_noncontig(A)
@@ -176,7 +176,7 @@ def bandwidth_noncontig(np_numeric_t[:, :]A):
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline (int, int) band_check_internal_c(np_numeric_t[:, ::1]A) noexcept nogil:
+cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], m = A.shape[1]
     cdef Py_ssize_t lower_band = 0, upper_band = 0, r, c
     cdef np_numeric_t zero = 0
@@ -207,7 +207,7 @@ cdef inline (int, int) band_check_internal_c(np_numeric_t[:, ::1]A) noexcept nog
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline (int, int) band_check_internal_noncontig(np_numeric_t[:, :]A) noexcept nogil:
+cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], m = A.shape[1]
     cdef Py_ssize_t lower_band = 0, upper_band = 0, r, c
     cdef np_numeric_t zero = 0
@@ -324,7 +324,7 @@ def issymmetric(a, atol=None, rtol=None):
 
 
 @cython.initializedcheck(False)
-def is_sym_her_real_c(np_numeric_t[:, ::1]A):
+def is_sym_her_real_c(const np_numeric_t[:, ::1]A):
     cdef bint s
     with nogil:
         s = is_sym_her_real_c_internal(A)
@@ -332,7 +332,7 @@ def is_sym_her_real_c(np_numeric_t[:, ::1]A):
 
 
 @cython.initializedcheck(False)
-def is_sym_her_real_noncontig(np_numeric_t[:, :]A):
+def is_sym_her_real_noncontig(const np_numeric_t[:, :]A):
     cdef bint s
     with nogil:
         s = is_sym_her_real_noncontig_internal(A)
@@ -342,7 +342,7 @@ def is_sym_her_real_noncontig(np_numeric_t[:, :]A):
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline bint is_sym_her_real_c_internal(np_numeric_t[:, ::1]A) noexcept nogil:
+cdef inline bint is_sym_her_real_c_internal(const np_numeric_t[:, ::1]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], r, c
 
     for r in xrange(n):
@@ -355,7 +355,7 @@ cdef inline bint is_sym_her_real_c_internal(np_numeric_t[:, ::1]A) noexcept nogi
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline bint is_sym_her_real_noncontig_internal(np_numeric_t[:, :]A) noexcept nogil:
+cdef inline bint is_sym_her_real_noncontig_internal(const np_numeric_t[:, :]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], r, c
 
     for r in xrange(n):
@@ -469,7 +469,7 @@ def ishermitian(a, atol=None, rtol=None):
 
 
 @cython.initializedcheck(False)
-def is_sym_her_complex_c(np_complex_numeric_t[:, ::1]A):
+def is_sym_her_complex_c(const np_complex_numeric_t[:, ::1]A):
     cdef bint s
     with nogil:
         s = is_sym_her_complex_c_internal(A)
@@ -485,7 +485,7 @@ def is_sym_her_complex_noncontig(np_complex_numeric_t[:, :]A):
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline bint is_sym_her_complex_c_internal(np_complex_numeric_t[:, ::1]A) noexcept nogil:
+cdef inline bint is_sym_her_complex_c_internal(const np_complex_numeric_t[:, ::1]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], r, c
 
     for r in xrange(n):
@@ -497,7 +497,7 @@ cdef inline bint is_sym_her_complex_c_internal(np_complex_numeric_t[:, ::1]A) no
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline bint is_sym_her_complex_noncontig_internal(np_complex_numeric_t[:, :]A) noexcept nogil:
+cdef inline bint is_sym_her_complex_noncontig_internal(const np_complex_numeric_t[:, :]A) noexcept nogil:
     cdef Py_ssize_t n = A.shape[0], r, c
 
     for r in xrange(n):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -231,6 +231,12 @@ class TestLogM:
         assert_allclose(expm(L), E, atol=1e-14)
         assert_allclose(logm(E), L, atol=1e-14)
 
+    def test_readonly(self):
+        n = 5
+        a = np.ones((n, n)) + np.identity(n)
+        a.flags.writeable = False
+        logm(a)
+
 
 class TestSqrtM:
     def test_round_trip_random_float(self):
@@ -714,6 +720,12 @@ class TestExpM:
                            [3/(2*E)-(3*E)/2, 5/(2*E)-(3*E)/2]]
                          ])
         assert_allclose(expm(a), a_res)
+
+    def test_readonly(self):
+        n = 7
+        a = np.ones((n, n))
+        a.flags.writeable = False
+        expm(a)
 
 
 class TestExpmFrechet:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/17172

#### What does this implement/fix?
<!--Please explain your changes.-->

Sprinkle `const` in memoryview declarations so that readonly arrays do not get rejected.

#### Additional information
<!--Any additional information you think is important.-->

per https://github.com/cython/cython/issues/5230, this needs cython 3.0.8