### PR TITLE
TST: linalg: fix complex sort in test_bad_geneig

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -59,22 +59,6 @@ COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
-def clear_fuss(ar, fuss_binary_bits=7):
-    """Clears trailing `fuss_binary_bits` of mantissa of a floating number"""
-    x = np.asanyarray(ar)
-    if np.iscomplexobj(x):
-        return clear_fuss(x.real) + 1j * clear_fuss(x.imag)
-
-    significant_binary_bits = np.finfo(x.dtype).nmant
-    x_mant, x_exp = np.frexp(x)
-    f = 2.0**(significant_binary_bits - fuss_binary_bits)
-    x_mant *= f
-    np.rint(x_mant, out=x_mant)
-    x_mant /= f
-
-    return np.ldexp(x_mant, x_exp)
-
-
 # XXX: This function should not be defined here, but somewhere in
 #      scipy.linalg namespace
 def symrand(dim_or_eigv, rng):
@@ -238,11 +222,18 @@ class TestEig:
                 assert_allclose(res[:, i], 0,
                                 rtol=1e-13, atol=1e-13, err_msg=msg)
 
+        # try to consistently order eigenvalues, including complex conjugate pairs
         w_fin = w[isfinite(w)]
         wt_fin = wt[isfinite(wt)]
-        perm = argsort(clear_fuss(w_fin))
-        permt = argsort(clear_fuss(wt_fin))
-        assert_allclose(w[perm], wt[permt],
+
+        # prune noise in the real parts
+        w_fin = -1j * np.real_if_close(1j*w_fin, tol=1e-10)
+        wt_fin = -1j * np.real_if_close(1j*wt_fin, tol=1e-10)
+
+        perm = argsort(w_fin)
+        permt = argsort(wt_fin)
+
+        assert_allclose(w_fin[perm], wt_fin[permt],
                         atol=1e-7, rtol=1e-7, err_msg=msg)
 
         length = np.empty(len(vr))


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/17125

#### What does this implement/fix?
<!--Please explain your changes.-->

The failure is relatively benign if annoying: the computation is most likely always correct, what fails is ordering of eigenvalues consistently on the complex plane, as Warren's analysis in  https://github.com/scipy/scipy/issues/17125#issuecomment-1264644368 shows.

So try a bit harder to trim numerical noise and account for complex conjugate pairs.

Have to admit I cannot repro locally. @h-vetinari you mentioned it's reproducible on conda-forge? https://github.com/scipy/scipy/issues/17125#issuecomment-1609160730

#### Additional information
<!--Any additional information you think is important.-->
