### PR TITLE
BUG: Fixed `fftshift()` in `ShortTimeFFT`.

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1096,7 +1096,7 @@ The following plot shows three different spectral representations of four sine s
 
 Note that depending on the representation, the height of the peaks vary. Only the
 interpretation of the magnitude spectrum is straightforward: The peak at :math:`f_z` in
-the  represents half the magnitude :math:`|a|` of the sine signal. For all other
+the second plot represents half the magnitude :math:`|a|` of the sine signal. For all other
 representations the duration :math:`\tau` needs to be taken into account to extract
 information about the signal's amplitude.
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1582,7 +1582,7 @@ class ShortTimeFFT:
         if self.fft_mode == 'twosided':
             return fft_lib.fft(x, n=self.mfft, axis=-1)
         if self.fft_mode == 'centered':
-            return fft_lib.fftshift(fft_lib.fft(x, self.mfft, axis=-1))
+            return fft_lib.fftshift(fft_lib.fft(x, self.mfft, axis=-1), axes=-1)
         if self.fft_mode == 'onesided':
             return fft_lib.rfft(x, n=self.mfft, axis=-1)
         if self.fft_mode == 'onesided2X':
@@ -1607,7 +1607,7 @@ class ShortTimeFFT:
         if self.fft_mode == 'twosided':
             x = fft_lib.ifft(X, n=self.mfft, axis=-1)
         elif self.fft_mode == 'centered':
-            x = fft_lib.ifft(fft_lib.ifftshift(X), n=self.mfft, axis=-1)
+            x = fft_lib.ifft(fft_lib.ifftshift(X, axes=-1), n=self.mfft, axis=-1)
         elif self.fft_mode == 'onesided':
             x = fft_lib.irfft(X, n=self.mfft, axis=-1)
         elif self.fft_mode == 'onesided2X':


### PR DESCRIPTION
Using ``fft_mode='centered'`` with multidimensional signals produced incorrect results due to `fft_shift()` shifting all axes and not just the last one. This was caused by a missing ``axes=-1`` parameter.

* Fixed `ShortTimeFFT._fft_funct()` / `ShortTimeFFT._ifft_funct()`
*  Added appropriate unit test.
* Fixed unrelated typo in file `signal.rst`
