### PR TITLE
BUG: linalg/sqrtm: more robust check for real->complex Schur decomp conversion

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -172,7 +172,11 @@ def sqrtm(A, disp=True, blocksize=64):
     keep_it_real = np.isrealobj(A)
     if keep_it_real:
         T, Z = schur(A)
-        if not np.allclose(T, np.triu(T)):
+        d0 = np.diagonal(T)
+        d1 = np.diagonal(T, -1)
+        eps = np.finfo(T.dtype).eps
+        needs_conversion = abs(d1) > eps * (abs(d0[1:]) + abs(d0[:-1]))
+        if needs_conversion.any():
             T, Z = rsf2csf(T, Z)
     else:
         T, Z = schur(A, output='complex')


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/19415

#### What does this implement/fix?
<!--Please explain your changes.-->

`sqrtm` goes to some shady lands to avoid going to complex arithmetics: it first constructs a real Schur decomposition of the input matrix, and then maybe converts it to the complex decomposition, depending on whether the lower triangular part is "small enough". Prior to version 1.11.1 "small" enough meant an exact zero; For 1.11.2 the criterion was changed to be `np.allclose` with the default tolerance `rtol=1e-05, atol=1e-08` in https://github.com/scipy/scipy/pull/17918.

While this makes more sense than requiring an exact equality in the floating point, it still produces wildly wrong results in some cases, see https://github.com/scipy/scipy/issues/19415 for an example.

This patch basically takes the logic from `rsf2csf` (cf https://github.com/scipy/scipy/blob/v1.12.0/scipy/linalg/_decomp_schur.py#L285): instead of looking at the lower triangular part we look at the relative magnitude of the lower subleading diagonal vs the main diagonal.

This is still heuristics, of course. It seems to make sense though: we check if the conversion would do anything and if the answer is "yes", we do it.

#### Additional information
<!--Any additional information you think is important.-->

In the example from gh-19415, we have --- here `T` is the result of `T, _ = schur(...)` call:  `np.allclose(T, np.triu(T)` is false because

```
(Pdb) p abs(T - np.triu(T)).max()
3.062928422623322e-16
```

so no `rsf2csf` is not called. However,

```
(Pdb) abs(np.diagonal(T, -1) / np.diagonal(T)[1:]).max()
2404.343135174231
```

It is full well possible that the internals of `_sqrtm_triu` may be rewritten in a more robust way. Until then, this PR fixes a problem reported in gh-19415 in what seems to be a not completely insane way.