### PR TITLE
MAINT: bump OpenBLAS "the old way"

### DIFF
--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,6 +14,7 @@ from numpy import float32, float64, complex64, complex128, arange, triu, \
                   nonzero
 
 from numpy.random import rand, seed
+import scipy
 from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
 
 try:
@@ -1092,3 +1093,10 @@ def test_trsm():
         Al[arange(m), arange(m)] = dtype(1)
         x2 = solve(Al.conj().T, alpha*B2.conj().T)
         assert_allclose(x1, x2.conj().T, atol=tol)
+
+
+def test_gh_169309():
+    x = np.repeat(10, 9)
+    actual = scipy.linalg.blas.dnrm2(x, 5, 3, -1)
+    expected = math.sqrt(500)
+    assert_allclose(actual, expected)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -1095,6 +1095,8 @@ def test_trsm():
         assert_allclose(x1, x2.conj().T, atol=tol)
 
 
+@pytest.mark.xfail(run=False,
+                   reason="gh-16930")
 def test_gh_169309():
     x = np.repeat(10, 9)
     actual = scipy.linalg.blas.dnrm2(x, 5, 3, -1)

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -59,10 +59,7 @@ def get_ilp64():
 
 
 def get_manylinux(arch):
-    if arch in ('i686'):
-        default = '2010'
-    else:
-        default = '2014'
+    default = '2014'
     ml_ver = os.environ.get("MB_ML_VER", default)
     # XXX For PEP 600 this can be a glibc version
     assert ml_ver in ('2010', '2014', '_2_24'), f'invalid MB_ML_VER {ml_ver}'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.21.dev'
-OPENBLAS_LONG = 'v0.3.20-571-g3dec11c6'
+OPENBLAS_V = '0.3.26'
+OPENBLAS_LONG = 'v0.3.26'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 NIGHTLY_BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'


### PR DESCRIPTION
Not ready for merge... this is actually quite messy to fix I think, because of our current infrastructure transition around OpenBLAS.

* Related to gh-16930

* added a regression test, based on the reproducer in the issue, that I confirmed does indeed fail locally on x86_64 Linux via: `CIBW_BUILD=cp311-* cibuildwheel --platform linux --archs x86_64`

* this assumes that gh-20074 needs a little more time because of all the moving parts related to that

* I spent a few hours on this today, and unfortunately I don't see an obvious fix because the "newest of the old" OpenBLAS binaries we were using at https://anaconda.org/multibuild-wheels-staging/openblas-libs/files are too old to fix the test via `cibuildwheel` in my hands; conversely, the new OpenBLAS binaries (https://anaconda.org/scientific-python-nightly-wheels/openblas-libs/files) don't seem to offer a version that is simultaneously new enough while not introducing at least a subset of the challenges experienced by gh-20074, like the symbol/linking issues (yikes!)

[skip cirrus] [skip circle]