### PR TITLE
DOC/MAINT: add examples for nctdtridf, nctdtrinc, nctdtrit

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -10932,8 +10932,8 @@ add_newdoc("nctdtridf",
 
     Returns
     -------
-    cdf : scalar or ndarray
-        The calculated CDF. If all inputs are scalar, the return will be a
+    df : scalar or ndarray
+        The degrees of freedom. If all inputs are scalar, the return will be a
         float. Otherwise, it will be an array.
 
     See Also
@@ -10941,6 +10941,22 @@ add_newdoc("nctdtridf",
     nctdtr :  CDF of the non-central `t` distribution.
     nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
     nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
+
+    Examples
+    --------
+    >>> from scipy.special import nctdtr, nctdtridf
+
+    Compute the CDF for several values of `df`:
+
+    >>> df = [1, 2, 3]
+    >>> p = nctdtr(df, 0.25, 1)
+    >>> p
+    array([0.67491974, 0.716464  , 0.73349456])
+
+    Compute the inverse. We recover the values of `df`, as expected:
+
+    >>> nctdtridf(p, 0.25, 1)
+    array([1., 2., 3.])
 
     """)
 
@@ -10974,6 +10990,22 @@ add_newdoc("nctdtrinc",
     nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
     nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
 
+    Examples
+    --------
+    >>> from scipy.special import nctdtr, nctdtrinc
+
+    Compute the CDF for several values of `nc`:
+
+    >>> nc = [0.5, 1.5, 2.5]
+    >>> p = nctdtr(3, nc, 1.5)
+    >>> p
+    array([0.77569497, 0.45524533, 0.1668691 ])
+
+    Compute the inverse. We recover the values of `nc`, as expected:
+
+    >>> nctdtrinc(3, p, 1.5)
+    array([0.5, 1.5, 2.5])
+
     """)
 
 add_newdoc("nctdtrit",
@@ -11005,6 +11037,22 @@ add_newdoc("nctdtrit",
     nctdtr :  CDF of the non-central `t` distribution.
     nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
     nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
+
+    Examples
+    --------
+    >>> from scipy.special import nctdtr, nctdtrit
+
+    Compute the CDF for several values of `t`:
+
+    >>> t = [0.5, 1, 1.5]
+    >>> p = nctdtr(3, 1, t)
+    >>> p
+    array([0.29811049, 0.46922687, 0.6257559 ])
+
+    Compute the inverse. We recover the values of `t`, as expected:
+
+    >>> nctdtrit(3, 1, p)
+    array([0.5, 1. , 1.5])
 
     """)
 

--- a/scipy/special/_cdflib.pyx
+++ b/scipy/special/_cdflib.pyx
@@ -3630,8 +3630,8 @@ cdef inline (double, int, double) cdftnc_which3(
                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                     0, 0, 0, 0, 0, 0, 0)
 
-    DS.small = 0
-    DS.big = 1.e6
+    DS.small = 1e-100
+    DS.big = 1.e10
     DS.absstp = 0.5
     DS.relstp = 0.5
     DS.stpmul = 5.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards gh-7168

#### What does this implement/fix?
<!--Please explain your changes.-->
- Add examples to docstrings of of functions of Noncentral t distribution in `scipy.special`.
- When working on `nctdtridf`, I found that it returns only `inf` but not the correct output. I changed the corresponding code in cdflib to make it works as expected.

#### Additional information
<!--Any additional information you think is important.-->
