### PR TITLE
TST: mark linalg.sqrtm test as xfail

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -416,6 +416,7 @@ class TestSqrtM:
         assert_allclose(np.dot(R, R), M, atol=1e-14)
         assert_allclose(sqrtm(M), R, atol=1e-14)
 
+    @pytest.mark.xfail(reason="failing on macOS after gh-20212")
     def test_gh17918(self):
         M = np.empty((19, 19))
         M.fill(0.94)


### PR DESCRIPTION
Caused by gh-20212. It's failing on macOS with both OpenBLAS and Accelerate, so there is some problem with that test or PR.

See https://github.com/scipy/scipy/pull/19816#issuecomment-1985656794 for more details.

[skip ci]