### PR TITLE
TST: Tweak tols and ignore warnings for more reliable SVD tests

### DIFF
--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -153,7 +153,7 @@ class SVDSCommonTests:
 
         # propack can do complete SVD
         if self.solver == 'propack' and k == 3:
-            res = svds(A, k=k, solver=self.solver)
+            res = svds(A, k=k, solver=self.solver, random_state=0)
             _check_svds(A, k, *res, check_usvh_A=True, check_svd=True)
             return
 
@@ -292,7 +292,7 @@ class SVDSCommonTests:
 
         def err(tol):
             _, s2, _ = svds(A, k=k, v0=np.ones(n), maxiter=1000,
-                            solver=self.solver, tol=tol)
+                            solver=self.solver, tol=tol, random_state=0)
             return np.linalg.norm((s2 - s[k-1::-1])/s[k-1::-1])
 
         tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
@@ -439,7 +439,8 @@ class SVDSCommonTests:
             with pytest.raises(np.linalg.LinAlgError, match=message):
                 svds(A, k, maxiter=1, solver=self.solver)
 
-        ud, sd, vhd = svds(A, k, solver=self.solver, maxiter=maxiter)
+        ud, sd, vhd = svds(A, k, solver=self.solver, maxiter=maxiter,
+                           random_state=0)
         _check_svds(A, k, ud, sd, vhd, atol=1e-8)
         assert_allclose(np.abs(ud), np.abs(u), atol=1e-8)
         assert_allclose(np.abs(vhd), np.abs(vh), atol=1e-8)
@@ -548,9 +549,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                u, s, vh = svds(A2, k, solver=self.solver)
+                u, s, vh = svds(A2, k, solver=self.solver, random_state=0)
         else:
-            u, s, vh = svds(A2, k, solver=self.solver)
+            u, s, vh = svds(A2, k, solver=self.solver, random_state=0)
         _check_svds(A, k, u, s, vh, atol=atol)
 
     def test_svd_linop(self):
@@ -576,11 +577,15 @@ class SVDSCommonTests:
                 v0 = np.ones(min(A.shape))
             if solver == 'lobpcg':
                 with pytest.warns(UserWarning, match="The problem size"):
-                    U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver))
-                    U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver))
+                    U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver,
+                                               random_state=0))
+                    U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver, 
+                                               random_state=0))
             else:
-                U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver))
-                U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver))
+                U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver,
+                                           random_state=0))
+                U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver,
+                                           random_state=0))
 
             assert_allclose(np.abs(U1), np.abs(U2))
             assert_allclose(s1, s2)
@@ -597,14 +602,14 @@ class SVDSCommonTests:
             if self.solver == 'lobpcg':
                 with pytest.warns(UserWarning, match="The problem size"):
                     U1, s1, VH1 = reorder(svds(A, k, which="SM", solver=solver,
-                                               **kwargs))
+                                               random_state=0, **kwargs))
                     U2, s2, VH2 = reorder(svds(L, k, which="SM", solver=solver,
-                                               **kwargs))
+                                               random_state=0, **kwargs))
             else:
                 U1, s1, VH1 = reorder(svds(A, k, which="SM", solver=solver,
-                                           **kwargs))
+                                           random_state=0, **kwargs))
                 U2, s2, VH2 = reorder(svds(L, k, which="SM", solver=solver,
-                                           **kwargs))
+                                           random_state=0, **kwargs))
 
             assert_allclose(np.abs(U1), np.abs(U2))
             assert_allclose(s1 + 1, s2 + 1)
@@ -623,14 +628,18 @@ class SVDSCommonTests:
                         with pytest.warns(UserWarning,
                                           match="The problem size"):
                             U1, s1, VH1 = reorder(svds(A, k, which="LM",
-                                                       solver=solver))
+                                                       solver=solver,
+                                                       random_state=0))
                             U2, s2, VH2 = reorder(svds(L, k, which="LM",
-                                                       solver=solver))
+                                                       solver=solver,
+                                                       random_state=0))
                     else:
                         U1, s1, VH1 = reorder(svds(A, k, which="LM",
-                                                   solver=solver))
+                                                   solver=solver,
+                                                   random_state=0))
                         U2, s2, VH2 = reorder(svds(L, k, which="LM",
-                                                   solver=solver))
+                                                   solver=solver,
+                                                   random_state=0))
 
                     assert_allclose(np.abs(U1), np.abs(U2), rtol=eps)
                     assert_allclose(s1, s2, rtol=eps)
@@ -662,7 +671,8 @@ class SVDSCommonTests:
         e[0:5] *= 1e1 ** np.arange(-5, 0, 1)
         S = spdiags(e, 0, m, m) @ S
         S = S.astype(dtype)
-        u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000)
+        u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000,
+                        random_state=0)
         c_svd = False  # partial SVD can be different from full SVD
         _check_svds_n(S, k, u, s, vh, which="SM", check_svd=c_svd, atol=2e-1)
 
@@ -679,9 +689,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                U, s, VH = svds(A, k, solver=self.solver)
+                U, s, VH = svds(A, k, solver=self.solver, random_state=0)
         else:
-            U, s, VH = svds(A, k, solver=self.solver)
+            U, s, VH = svds(A, k, solver=self.solver, random_state=0)
 
         _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
 
@@ -714,9 +724,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                U, s, VH = svds(A, k, solver=self.solver)
+                U, s, VH = svds(A, k, solver=self.solver, random_state=0)
         else:
-            U, s, VH = svds(A, k, solver=self.solver)
+            U, s, VH = svds(A, k, solver=self.solver, random_state=0)
 
         # Check some generic properties of svd.
         _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
@@ -740,7 +750,7 @@ class SVDSCommonTests:
         t = e**(-np.arange(len(vh))).astype(dtype)
         A = (u*t).dot(vh)
         k = 4
-        u, s, vh = svds(A, k, solver=self.solver, maxiter=100)
+        u, s, vh = svds(A, k, solver=self.solver, maxiter=100, random_state=0)
         t = np.sum(s > 0)
         assert_equal(t, k)
         # LOBPCG needs larger atol and rtol to pass
@@ -772,7 +782,8 @@ class SVDSCommonTests:
 
         # Smallest singular values should be 0
         sp_mat = csc_matrix(mat)
-        su, ss, svh = svds(sp_mat, k=dim, which='SM', solver=self.solver)
+        su, ss, svh = svds(sp_mat, k=dim, which='SM', solver=self.solver,
+                           random_state=0)
         # Smallest dim singular values are 0:
         assert_allclose(ss, 0, atol=1e-5, rtol=1e0)
         # Smallest singular vectors via svds in null space:
@@ -803,7 +814,7 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         A = rng.random((6, 7))
         k = 3
         if ncv in {4, 5}:
-            u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver)
+            u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver, random_state=0)
         # partial decomposition, so don't check that u@diag(s)@vh=A;
         # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
             _check_svds(A, k, u, s, vh)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -392,6 +392,8 @@ class SVDSCommonTests:
     @pytest.mark.parametrize("random_state", (None,
                                               np.random.RandomState(0),
                                               np.random.default_rng(0)))
+    @pytest.mark.filterwarnings("ignore:Exited",
+                                reason="Ignore LOBPCG early exit.")
     def test_svd_random_state_3(self, random_state):
         n = 100
         k = 5
@@ -399,12 +401,14 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         A = rng.random((n, n))
 
+        random_state = copy.deepcopy(random_state)
+
         # random_state in different state produces accurate - but not
         # not necessarily identical - results
-        res1a = svds(A, k, solver=self.solver, random_state=random_state)
-        res2a = svds(A, k, solver=self.solver, random_state=random_state)
-        _check_svds(A, k, *res1a, atol=2e-9, rtol=2e-6)
-        _check_svds(A, k, *res2a, atol=2e-9, rtol=2e-6)
+        res1a = svds(A, k, solver=self.solver, random_state=random_state, maxiter=1000)
+        res2a = svds(A, k, solver=self.solver, random_state=random_state, maxiter=1000)
+        _check_svds(A, k, *res1a, atol=2e-7)
+        _check_svds(A, k, *res2a, atol=2e-7)
 
         message = "Arrays are not equal"
         with pytest.raises(AssertionError, match=message):
@@ -832,9 +836,6 @@ class Test_SVDS_LOBPCG(SVDSCommonTests):
 
     def setup_method(self):
         self.solver = 'lobpcg'
-
-    def test_svd_random_state_3(self):
-        pytest.xfail("LOBPCG is having trouble with accuracy.")
 
 
 class Test_SVDS_PROPACK(SVDSCommonTests):

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -652,8 +652,6 @@ class SVDSCommonTests:
         # 2do: PROPACK fails orthogonality of singular vectors
         # if dtype == complex and self.solver == 'propack':
         #    pytest.skip("PROPACK unsupported for complex dtype")
-        if solver == 'propack':
-            pytest.skip("PROPACK failures unrelated to PR")
         rng = np.random.default_rng(0)
         k = 5
         (m, n) = shape
@@ -666,7 +664,7 @@ class SVDSCommonTests:
         S = S.astype(dtype)
         u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000)
         c_svd = False  # partial SVD can be different from full SVD
-        _check_svds_n(S, k, u, s, vh, which="SM", check_svd=c_svd, atol=1e-1)
+        _check_svds_n(S, k, u, s, vh, which="SM", check_svd=c_svd, atol=2e-1)
 
     # --- Test Edge Cases ---
     # Checks a few edge cases.
@@ -732,9 +730,6 @@ class SVDSCommonTests:
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
     def test_small_sigma(self, shape, dtype):
-        # https://github.com/scipy/scipy/pull/11829
-        if dtype == complex and self.solver == 'propack':
-            pytest.skip("PROPACK unsupported for complex dtype")
         rng = np.random.default_rng(179847540)
         A = rng.random(shape).astype(dtype)
         u, _, vh = svd(A, full_matrices=False)


### PR DESCRIPTION
#### Reference issue
Closes gh-20157.

#### What does this implement/fix?
I was able to reproduce the `Test_SVDS_LOBPCG.test_svds_parameter_tol` failure on my M2 macOS and x64 Linux machines. Some of the failures were due to overly stringent tolerances. Others were due to inconsistent warning messages.

In the process of fixing that issue, I found a few additional tests in `test_svds.py` that intermittently failed using:
```
python dev.py test -t scipy/sparse/linalg/_eigen/tests/test_svds.py -- --count=1000
```

For all such failing tests, I either increased tolerances or ignored warnings to achieve the following reduction in failures over 10,000 iterations. For some test functions below, the actual number of tests that were run was >10,000 due to pytest parameterization (total count in parentheses).


##### Test_SVDS_LOBPCG.test_svds_parameter_tol (10,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 3238 | 0 |
| x64 Ubuntu 22.04  | 3224 | 0 |


##### Test_SVDS_PROPACK.test_svd_random_state_3 (30,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 336 | 1 |
| x64 Ubuntu 22.04  | 318 | 1 |


##### Test_SVDS_LOBPCG.test_svd_maxiter (10,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 101  | 0 |
| x64 Ubuntu 22.04  | 92 | 0 |


##### Test_SVDS_LOBPCG.test_small_sigma (90,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 187 | 0 |
| x64 Ubuntu 22.04  | 202 | 0 |


##### Test_SVDS_PROPACK.test_svd_linop (10,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 7 | 1 |
| x64 Ubuntu 22.04  | 8 | 1 |


##### Test_SVDS_PROPACK.test_svd_simple (840,000 total)
| Machine  | 3444b2d | 2bfd351 |
| ------------- | ------------- | ------------- |
| M2 macOS 14 | 13 | 0 |
| x64 Ubuntu 22.04  | 10 | 0 |

These are all approximate numbers because the tests are very noisy.

#### Additional Info
To fix the `Test_SVDS_LOBPCG.test_svd_maxiter` failures, I increased the default `maxiter` for `LOBPCG` from 20 to 30. Hopefully, this is fine.

`Test_SVDS_PROPACK.test_small_sigma2` blows up sometimes with massive errors (~50 times out of 30000, more often for `float` and `float32` than `complex`). Relative errors of `inf` and absolute errors on the order of 0.01-2. This cannot be fixed with a simple tolerance tweak, so I left it alone.

@tylerjereddy Would appreciate it if you could test on your machine to see if `test_svds_parameter_tol` passes. Thanks!