### PR TITLE
BUG: fix `cluster.vq.kmeans2` with minit='++' for 1D data

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -140,7 +140,7 @@ class TestVq:
         label1 = py_vq(xp.asarray(X), xp.asarray(initc))[0]
         xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64),
                         check_dtype=False)
-      
+
     @pytest.mark.skipif(SCIPY_ARRAY_API,
                         reason='`np.matrix` unsupported in array API mode')
     def test_py_vq_matrix(self, xp):
@@ -327,16 +327,16 @@ class TestKMean:
         k = 3
 
         kmeans2(data, k, minit='points')
-        kmeans2(data[:, :1], k, minit='points')  # special case (1-D)
+        kmeans2(data[:, 1], k, minit='points')  # special case (1-D)
 
         kmeans2(data, k, minit='++')
-        kmeans2(data[:, :1], k, minit='++')  # special case (1-D)
+        kmeans2(data[:, 1], k, minit='++')  # special case (1-D)
 
         # minit='random' can give warnings, filter those
         with suppress_warnings() as sup:
             sup.filter(message="One of the clusters is empty. Re-run.")
             kmeans2(data, k, minit='random')
-            kmeans2(data[:, :1], k, minit='random')  # special case (1-D)
+            kmeans2(data[:, 1], k, minit='random')  # special case (1-D)
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='Fails with MemoryError in Wine.')

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -602,7 +602,11 @@ def _kpp(data, k, rng, xp):
        on Discrete Algorithms, 2007.
     """
 
-    dims = data.shape[1] if len(data.shape) > 1 else 1
+    ndim = len(data.shape)
+    if ndim == 1:
+        data = data[:, None]
+
+    dims = data.shape[1]
 
     init = xp.empty((int(k), dims))
 
@@ -618,6 +622,8 @@ def _kpp(data, k, rng, xp):
             cumprobs = np.asarray(cumprobs)
             init[i, :] = data[np.searchsorted(cumprobs, r), :]
 
+    if ndim == 1:
+        init = init[:, 0]
     return init
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-9950

#### What does this implement/fix?
<!--Please explain your changes.-->
Modify the kmeans++ initialization a bit to make it also work for 1d array.

#### Additional information
<!--Any additional information you think is important.-->
Other initialization methods do not have problem with 1d data.
