### PR TITLE
update to openblas 0.3.26

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -59,10 +59,7 @@ def get_ilp64():
 
 
 def get_manylinux(arch):
-    if arch in ('i686'):
-        default = '2010'
-    else:
-        default = '2014'
+    default = '2014'
     ml_ver = os.environ.get("MB_ML_VER", default)
     # XXX For PEP 600 this can be a glibc version
     assert ml_ver in ('2010', '2014', '_2_24'), f'invalid MB_ML_VER {ml_ver}'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.21.dev'
-OPENBLAS_LONG = 'v0.3.20-571-g3dec11c6'
+OPENBLAS_V = '0.3.26'
+OPENBLAS_LONG = 'v0.3.26'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 NIGHTLY_BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'


### PR DESCRIPTION
Related to #20215 

Use newer versions of OpenBLAS until #19816 is in, which will allow resuming removing toos/openblas_support.py in favor of using sicpy-openblas wheels (#20074)