### PR TITLE
BUG: linalg: fix int overflow in Cholesky (potrf)

### DIFF
--- a/scipy/linalg/flapack_pos_def.pyf.src
+++ b/scipy/linalg/flapack_pos_def.pyf.src
@@ -129,7 +129,7 @@ subroutine <prefix2>potrf(n,a,lda,info,lower,clean)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
     ! clean==1 zeros strictly lower or upper parts of U or L, respectively
  
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){F_INT i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){Py_ssize_t i,j;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) *(a+j*n+i)=0.0;} else {for(i=0;i\<n;++i) for(j=i+1;j<n;++j) *(a+i*n+j)=0.0;}}
     callprotoargument char*,F_INT*,<ctype2>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,6 +1,8 @@
+import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pytest import raises as assert_raises
 
+import numpy as np
 from numpy import array, transpose, dot, conjugate, zeros_like, empty
 from numpy.random import random
 from scipy.linalg import cholesky, cholesky_banded, cho_solve_banded, \
@@ -64,6 +66,19 @@ class TestCholesky:
             c = transpose(c)
             a = dot(c, transpose(conjugate(c)))
             assert_array_almost_equal(cholesky(a, lower=1), c)
+
+    @pytest.mark.xslow
+    def test_int_overflow(self):
+       # regression test for
+       # https://github.com/scipy/scipy/issues/17436
+       # the problem was an int overflow in zeroing out
+       # the unused triangular part
+       n = 47_000
+       np.random.seed(1234)
+       x = np.random.uniform(size=n)
+       a = x[:, None] @ x[None, :] + np.identity(n)
+
+       cholesky(a)   # does not segfault
 
 
 class TestCholeskyBanded:

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -74,11 +74,13 @@ class TestCholesky:
        # the problem was an int overflow in zeroing out
        # the unused triangular part
        n = 47_000
-       np.random.seed(1234)
-       x = np.random.uniform(size=n)
-       a = x[:, None] @ x[None, :] + np.identity(n)
+       x = np.eye(n, dtype=np.float64, order='F')
+       x[:4, :4] = np.array([[4, -2, 3, -1],
+                             [-2, 4, -3, 1],
+                             [3, -3, 5, 0],
+                             [-1, 1, 0, 5]])
 
-       cholesky(a)   # does not segfault
+       cholesky(x, check_finite=False, overwrite_a=True)  # should not segfault
 
 
 class TestCholeskyBanded:


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/17436

`scipy.linalg.cholesky` explicitly zeros out the "other" triangle of the output matrix. For the matrix size 47_000, flat indexing into the underlying buffer overflows int32 since (47_000)**2 > INT_MAX

