### PR TITLE
DOC/DX: array types: update `_asarray` description

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -1,7 +1,7 @@
 Support for the array API standard
 ==================================
 
-.. note:: array API standard support is still experimental and hidden behind an
+.. note:: Array API standard support is still experimental and hidden behind an
           environment variable. Only a small part of the public API is covered
           right now.
 
@@ -144,12 +144,14 @@ Three helper functions are available:
 * ``array_namespace``: return the namespace based on input arrays and do some
   input validation (like refusing to work with masked arrays, please see the
   `RFC`_.)
-* ``_asarray``: a drop-in replacement for ``np.asarray`` with additional
-  features like ``copy, check_finite``. As stated above, try to limit the use
-  of non standard features. In the end we would want to upstream our needs to
-  the compatibility library. Passing ``xp=xp`` avoids duplicate calls of
-  ``array_namespace`` internally.
-* ``copy``: an alias for ``_asarray(x, copy=True)``. Passing ``xp=xp`` avoids
+* ``_asarray``: a drop-in replacement for ``asarray`` with the additional
+  parameters ``check_finite`` and ``order``. As stated above, try to limit
+  the use of non-standard features. In the end we would want to upstream our
+  needs to the compatibility library. Passing ``xp=xp`` avoids duplicate calls
+  of ``array_namespace`` internally.
+* ``copy``: an alias for ``_asarray(x, copy=True)``.
+  The ``copy`` parameter was only introduced to ``np.asarray`` in NumPy 2.0,
+  so use of the helper is needed to support ``<2.0``. Passing ``xp=xp`` avoids
   duplicate calls of ``array_namespace`` internally.
 
 To add support to a SciPy function which is defined in a ``.py`` file, what you
@@ -162,7 +164,12 @@ have to change is:
 
 Input array validation uses the following pattern::
 
-   xp = array_namespace(arr)  # where `arr` is the first input array
+   xp = array_namespace(arr) # where arr is the input array 
+   # alternatively, if there are multiple array inputs, include them all:
+   xp = array_namespace(arr1, arr2)
+
+   # uses of non-standard parameters of np.asarray can be replaced with _asarray
+   arr = _asarray(arr, order='C', dtype=xp.float64, xp=xp)
 
 Note that if one input is a non-numpy array type, all array-like inputs have to
 be of that type; trying to mix non-numpy arrays with lists, Python scalars or


### PR DESCRIPTION
#### Reference issue
Closes gh-19799. Follow-up to gh-19869

#### What does this implement/fix?
Add some explanation back into the docs after the outdated bits I removed in gh-19869.