### PR TITLE
BLD: remove use of `NPY_VISIBILITY_HIDDEN`

### DIFF
--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -175,7 +175,7 @@ static PY_LONG_LONG %(name)s_thunk(int I_typenum, int T_typenum, void **a)
 """
 
 METHOD_TEMPLATE = """
-NPY_VISIBILITY_HIDDEN PyObject *
+PyObject *
 %(name)s_method(PyObject *self, PyObject *args)
 {
     return call_thunk('%(ret_spec)s', "%(arg_spec)s", %(name)s_thunk, args);
@@ -419,7 +419,7 @@ def main():
     # Generate code for method struct
     method_defs = ""
     for name in names:
-        method_defs += (f"NPY_VISIBILITY_HIDDEN PyObject *{name}"
+        method_defs += (f"PyObject *{name}"
                         f"_method(PyObject *, PyObject *);\n")
 
     method_struct = """\nstatic struct PyMethodDef sparsetools_methods[] = {"""

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -91,7 +91,7 @@ static PyObject *c_array_from_object(PyObject *obj, int typenum, int is_output);
  *     The Python return value
  *
  */
-NPY_VISIBILITY_HIDDEN PyObject *
+PyObject *
 call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
 {
     void *arg_list[MAX_ARGS];

--- a/scipy/sparse/sparsetools/sparsetools.h
+++ b/scipy/sparse/sparsetools/sparsetools.h
@@ -11,7 +11,7 @@
 
 typedef PY_LONG_LONG thunk_t(int I_typenum, int T_typenum, void **args);
 
-NPY_VISIBILITY_HIDDEN PyObject *
+PyObject *
 call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args);
 
 #endif


### PR DESCRIPTION
This usage in `sparsetools` predates the move to Meson; Meson hides symbols in Python extension modules by default (see gh-15996). I've checked that there is no change in binary size on Linux with GCC and macOS with Clang.

Use of `NPY_VISIBILITY_HIDDEN` is not only a minor cleanup, but technically more correct - in case SciPy gets built with a different compiler than NumPy, the value of this define may not be correct (most but not all compilers will support the non-standardized `__attribute__((visibility("hidden")))`.

We shouldn't need visibility attributes, but in case we want to reintroduce them in the future, it's better to copy the build-time compiler check for support of the attribute, rather than reuse the result of the NumPy check.

For completeness:
- https://mesonbuild.com/Release-notes-for-0-63-0.html#python-extension-modules-now-build-with-hidden-visibility
- https://github.com/scipy/scipy/blob/8c5c4fa7fb0a95456ac486781baee40287be0485/meson.build#L119-L131