### PR TITLE
BUG: prevent file descriptor leak in `openblas_support.py` script

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -159,7 +159,8 @@ def setup_openblas(plat=get_plat(), ilp64=get_ilp64(), nightly=False):
         path to extracted files on success, otherwise indicates what went wrong
         To determine success, do ``os.path.exists(msg)``
     '''
-    _, tmp = mkstemp()
+    fd, tmp = mkstemp()
+    os.close(fd)
     if not plat:
         raise ValueError('unknown platform')
     openblas_version = "HEAD" if nightly else OPENBLAS_LONG


### PR DESCRIPTION
## Summary
This PR fixes a file descriptor leak related bug in your codebase. This IS NOT a security bug.


## Details
In file [openblas_support.py](https://github.com/scipy/scipy/blob/main/tools/openblas_support.py#L162) of your project, there's an statement that goes-
```py
_, tmp = mkstemp()
```

Here, the `mkstemp` method is being called to create a temporary file. According to [Python Documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp), the first argument of the `mkstemp` method returns the file descriptor associated with the file. It's mandatory that you close the file descriptor after using it. Keeping multiple open file descriptors can eventually lead to **file descriptor exhaustion.**

### Here's How It Works
In Linux/Unix systems, the maximum number of allowed file descriptors is 1024. Among them, file descriptor 0, 1, and 2 are assigned to `stdin`, `stdout`, and `stderr`. Which means only 1021 more file descriptors are allowed to be opened. However, in Windows/NT systems, the maximum number of allowed file descriptors is 8192.

Related Links:
- https://docs.oracle.com/cd/E19476-01/821-0505/file-descriptor-requirements.html
- https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-170#remarks


## Proof of Concept
For example, running the following piece of code in Linux or Windows machine will output `1021` and `8189` respectively- which denotes the number of possible open file descriptors before throwing an error.

```py
from tempfile import mkstemp

count = 999_999_999
for i in range(count):
    try:
        _, name = mkstemp()
    except Exception as e:
        print(i)
        print(e)
        break
```
