### PR TITLE
MAINT: Replace malloc in specfun

### DIFF
--- a/scipy/special/special/config.h
+++ b/scipy/special/special/config.h
@@ -154,5 +154,6 @@ SPECFUN_HOST_DEVICE complex<T> conj(const complex<T> &z) {
 #include <complex>
 #include <limits>
 #include <math.h>
+#include <memory>
 
 #endif

--- a/scipy/special/special/specfun.h
+++ b/scipy/special/special/specfun.h
@@ -676,140 +676,136 @@ inline int pbwa(double a, double x, double *wf, double *wd) {
 }
 
 inline int pbdv(double v, double x, double *pdf, double *pdd) {
-    double *dv;
-    double *dp;
-    int num;
-
-    if (isnan(v) || isnan(x)) {
+    if (std::isnan(v) || std::isnan(x)) {
         *pdf = std::numeric_limits<double>::quiet_NaN();
         *pdd = std::numeric_limits<double>::quiet_NaN();
         return 0;
     }
+
     /* NB. Indexing of DV/DP in specfun.f:PBDV starts from 0, hence +2 */
-    num = std::abs((int) v) + 2;
-    dv = (double *) malloc(sizeof(double) * 2 * num);
+    int num = std::abs(static_cast<int>(v)) + 2;
+    std::unique_ptr<double[]> dv = std::make_unique<double[]>(2 * num);
     if (dv == NULL) {
         set_error("pbdv", SF_ERROR_OTHER, "memory allocation error");
         *pdf = std::numeric_limits<double>::quiet_NaN();
         *pdd = std::numeric_limits<double>::quiet_NaN();
         return -1;
     }
-    dp = dv + num;
-    specfun::pbdv(x, v, dv, dp, pdf, pdd);
-    free(dv);
+
+    specfun::pbdv(x, v, dv.get(), dv.get() + num, pdf, pdd);
     return 0;
 }
 
 inline int pbvv(double v, double x, double *pvf, double *pvd) {
-    double *vv;
-    double *vp;
-    int num;
-
     if (isnan(v) || isnan(x)) {
         *pvf = std::numeric_limits<double>::quiet_NaN();
         *pvd = std::numeric_limits<double>::quiet_NaN();
         return 0;
     }
+
     /* NB. Indexing of DV/DP in specfun.f:PBVV starts from 0, hence +2 */
-    num = std::abs((int) v) + 2;
-    vv = (double *) malloc(sizeof(double) * 2 * num);
+    int num = std::abs((int) v) + 2;
+    std::unique_ptr<double[]> vv = std::make_unique<double[]>(2 * num);
     if (vv == NULL) {
         set_error("pbvv", SF_ERROR_OTHER, "memory allocation error");
         *pvf = std::numeric_limits<double>::quiet_NaN();
         *pvd = std::numeric_limits<double>::quiet_NaN();
         return -1;
     }
-    vp = vv + num;
-    specfun::pbvv(x, v, vv, vp, pvf, pvd);
-    free(vv);
+
+    specfun::pbvv(x, v, vv.get(), vv.get() + num, pvf, pvd);
     return 0;
 }
 
 inline double prolate_segv(double m, double n, double c) {
     int kd = 1;
     int int_m, int_n;
-    double cv = 0.0, *eg;
+    double cv = 0.0;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
 
     if ((m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         return std::numeric_limits<double>::quiet_NaN();
     }
+
     int_m = (int) m;
     int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
     if (eg == NULL) {
         set_error("prolate_segv", SF_ERROR_OTHER, "memory allocation error");
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    free(eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
+
     return cv;
 }
 
 inline double oblate_segv(double m, double n, double c) {
     int kd = -1;
     int int_m, int_n;
-    double cv = 0.0, *eg;
+    double cv = 0.0;
 
     if ((m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         return std::numeric_limits<double>::quiet_NaN();
     }
+
     int_m = (int) m;
     int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("oblate_segv", SF_ERROR_OTHER, "memory allocation error");
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    free(eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     return cv;
 }
 
 double prolate_aswfa_nocv(double m, double n, double c, double x, double *s1d) {
     int kd = 1;
-    int int_m, int_n;
-    double cv = 0.0, s1f, *eg;
+    double cv = 0.0, s1f;
 
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("prolate_aswfa_nocv", SF_ERROR_DOMAIN, NULL);
         *s1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("prolate_aswfa_nocv", SF_ERROR_OTHER, "memory allocation error");
         *s1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, s1d);
-    free(eg);
+
     return s1f;
 }
 
 double oblate_aswfa_nocv(double m, double n, double c, double x, double *s1d) {
     int kd = -1;
-    int int_m, int_n;
-    double cv = 0.0, s1f = 0.0, *eg;
+    double cv = 0.0, s1f = 0.0;
 
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("oblate_aswfa_nocv", SF_ERROR_DOMAIN, NULL);
         *s1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("oblate_aswfa_nocv", SF_ERROR_OTHER, "memory allocation error");
         *s1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, s1d);
-    free(eg);
     return s1f;
 }
 
@@ -847,49 +843,47 @@ inline int oblate_aswfa(double m, double n, double c, double cv, double x, doubl
 
 inline double prolate_radial1_nocv(double m, double n, double c, double x, double *r1d) {
     int kf = 1, kd = 1;
-    double r2f = 0.0, r2d = 0.0, r1f = 0.0, cv = 0.0, *eg;
-    int int_m, int_n;
-
+    double r2f = 0.0, r2d = 0.0, r1f = 0.0, cv = 0.0;
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("prolate_radial1_nocv", SF_ERROR_DOMAIN, NULL);
         *r1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("prolate_radial1_nocv", SF_ERROR_OTHER, "memory allocation error");
         *r1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, r1d, &r2f, &r2d);
-    free(eg);
     return r1f;
 }
 
 inline double prolate_radial2_nocv(double m, double n, double c, double x, double *r2d) {
     int kf = 2, kd = 1;
-    double r1f = 0.0, r1d = 0.0, r2f = 0.0, cv = 0.0, *eg;
-    int int_m, int_n;
-
+    double r1f = 0.0, r1d = 0.0, r2f = 0.0, cv = 0.0;
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("prolate_radial2_nocv", SF_ERROR_DOMAIN, NULL);
         *r2d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("prolate_radial2_nocv", SF_ERROR_OTHER, "memory allocation error");
         *r2d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, r2d);
-    free(eg);
     return r2f;
 }
 
@@ -929,49 +923,49 @@ inline int prolate_radial2(double m, double n, double c, double cv, double x, do
 
 inline double oblate_radial1_nocv(double m, double n, double c, double x, double *r1d) {
     int kf = 1, kd = -1;
-    double r2f = 0.0, r2d = 0.0, r1f = 0.0, cv = 0.0, *eg;
-    int int_m, int_n;
+    double r2f = 0.0, r2d = 0.0, r1f = 0.0, cv = 0.0;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("oblate_radial1_nocv", SF_ERROR_DOMAIN, NULL);
         *r1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("oblate_radial1_nocv", SF_ERROR_OTHER, "memory allocation error");
         *r1d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, r1d, &r2f, &r2d);
-    free(eg);
     return r1f;
 }
 
 inline double oblate_radial2_nocv(double m, double n, double c, double x, double *r2d) {
     int kf = 2, kd = -1;
-    double r1f = 0.0, r1d = 0.0, r2f = 0.0, cv = 0.0, *eg;
-    int int_m, int_n;
+    double r1f = 0.0, r1d = 0.0, r2f = 0.0, cv = 0.0;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
         set_error("oblate_radial2_nocv", SF_ERROR_DOMAIN, NULL);
         *r2d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    int_m = (int) m;
-    int_n = (int) n;
-    eg = (double *) malloc(sizeof(double) * (n - m + 2));
+
+    int int_m = (int) m;
+    int int_n = (int) n;
+    std::unique_ptr<double[]> eg = std::make_unique<double[]>(n - m + 2);
     if (eg == NULL) {
         set_error("oblate_radial2_nocv", SF_ERROR_OTHER, "memory allocation error");
         *r2d = std::numeric_limits<double>::quiet_NaN();
         return std::numeric_limits<double>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+
+    specfun::segv(int_m, int_n, c, kd, &cv, eg.get());
     specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, r2d);
-    free(eg);
     return r2f;
 }
 

--- a/scipy/special/special/specfun/specfun.h
+++ b/scipy/special/special/specfun/specfun.h
@@ -5377,11 +5377,11 @@ inline void kmn(int m, int n, double c, double cv, int kd, double *df, double *d
     double cs, gk0, gk1, gk2, gk3, t, r, dnp, su0, sw, r1, r2, r3, sa0, r4, r5, g0, sb0;
     nm = 25 + (int)(0.5 * (n - m) + c);
     nn = nm + m;
-    double *u =  (double *) malloc((nn + 4) * sizeof(double));
-    double *v =  (double *) malloc((nn + 4) * sizeof(double));
-    double *w =  (double *) malloc((nn + 4) * sizeof(double));
-    double *tp = (double *) malloc((nn + 4) * sizeof(double));
-    double *rk = (double *) malloc((nn + 4) * sizeof(double));
+    std::unique_ptr<double[]> u =  std::make_unique<double[]>(nn + 4);
+    std::unique_ptr<double[]> v =  std::make_unique<double[]>(nn + 4);
+    std::unique_ptr<double[]> w =  std::make_unique<double[]>(nn + 4);
+    std::unique_ptr<double[]> tp = std::make_unique<double[]>(nn + 4);
+    std::unique_ptr<double[]> rk = std::make_unique<double[]>(nn + 4);
 
     const double eps = 1.0e-14;
 
@@ -5466,7 +5466,6 @@ inline void kmn(int m, int n, double c, double cv, int kd, double *df, double *d
         *ck1 = sa0 * su0;
 
         if (kd == -1) {
-            free(u); free(v); free(w); free(tp); free(rk);
             return;
         }
     }
@@ -5486,9 +5485,6 @@ inline void kmn(int m, int n, double c, double cv, int kd, double *df, double *d
 
     sb0 = (ip + 1.0) * pow(c, ip + 1) / (2.0 * ip * (m - 2.0) + 1.0) / (2.0 * m - 1.0);
     *ck2 = pow(-1, ip) * sb0 * r4 * r5 * g0 / r1 * su0;
-
-    free(u); free(v); free(w); free(tp); free(rk);
-    return;
 }
 
 
@@ -7193,7 +7189,7 @@ inline double psi_spec(double x) {
 inline void qstar(int m, int n, double c, double ck1, double *ck, double *qs, double *qt) {
     int ip, i, l, k;
     double r, s, sk, qs0;
-    double *ap = (double *) malloc(200*sizeof(double));
+    double ap[200];
     ip = ((n - m) == 2 * ((n - m) / 2) ? 0 : 1);
     r = 1.0 / pow(ck[0], 2);
     ap[0] = r;
@@ -7219,7 +7215,6 @@ inline void qstar(int m, int n, double c, double ck1, double *ck, double *qs, do
     }
     *qs = pow(-1, ip) * (ck1) * (ck1 * qs0) / c;
     *qt = -2.0 / (ck1) * (*qs);
-    free(ap);
     return;
 }
 
@@ -7696,11 +7691,11 @@ inline void rmn2sp(int m, int n, double c, double x, double cv, int kd, double *
     double ip, nm1, nm, nm2, su0, sw, sd0, su1, sd1, sd2, ga, r1, r2, r3,\
            sf, gb, spl, gc, sd, r4, spd1, spd2, su2, ck1, ck2;
 
-    double *pm = (double *) malloc(252*sizeof(double));
-    double *pd = (double *) malloc(252*sizeof(double));
-    double *qm = (double *) malloc(252*sizeof(double));
-    double *qd = (double *) malloc(252*sizeof(double));
-    double *dn = (double *) malloc(201*sizeof(double));
+    double pm[252];
+    double pd[252];
+    double qm[252];
+    double qd[252];
+    double dn[252];
     const double eps = 1.0e-14;
 
     nm1 = (n - m) / 2;
@@ -7798,8 +7793,6 @@ inline void rmn2sp(int m, int n, double c, double x, double cv, int kd, double *
     sdm = sd0 + sd1 + sd2;
     *r2f = sum / ck2;
     *r2d = sdm / ck2;
-    free(pm); free(pd); free(qm); free(qd); free(dn);
-    return;
 }
 
 
@@ -7833,7 +7826,7 @@ inline void rswfp(int m, int n, double c, double x, double cv, int kf, double *r
     //          of the second kind for a small argument
     // ==============================================================
 
-    double *df = (double *) malloc(200*sizeof(double));
+    double df[200];
     int id, kd = 1;
 
     sdmn(m, n, c, cv, kd, df);
@@ -7847,7 +7840,6 @@ inline void rswfp(int m, int n, double c, double x, double cv, int kf, double *r
             rmn2sp(m, n, c, x, cv, kd, df, r2f, r2d);
         }
     }
-    free(df);
     return;
 }
 
@@ -7882,7 +7874,7 @@ inline void rswfo(int m, int n, double c, double x, double cv, int kf, double *r
     //          the second kind for a small argument
     // ==========================================================
 
-    double *df = (double *) malloc(200*sizeof(double));
+    double df[200];
     int id, kd = -1;
 
     sdmn(m, n, c, cv, kd, df);
@@ -7899,7 +7891,6 @@ inline void rswfo(int m, int n, double c, double x, double cv, int kf, double *r
             rmn2so(m, n, c, x, cv, kd, df, r2f, r2d);
         }
     }
-    free(df);
     return;
 }
 


### PR DESCRIPTION
This replaces all instances of malloc / free in specfun. Here is what I did:

- If it was a constant size, I replaced the malloc with a fixed-array array (like `double x[100]`).
- If it was a variable sized, I replaced it with `std::unique_ptr<double[]> x = std::make_unique<double[]>(n)`. This is the standard memory-safe way to do allocations in C++.

If, at a future date, it's determined that these allocations need to be done elsewhere up the call stack, we can then add in memory pointers to be passed in as parameters. But I don't see the need for that just yet.