### PR TITLE
BUG:linalg:Remove the 2x2 branch in expm

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -6,7 +6,6 @@ from itertools import product
 import numpy as np
 from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
-from numpy.lib.scimath import sqrt as csqrt
 
 # Local imports
 from scipy.linalg import LinAlgError, bandwidth
@@ -303,9 +302,9 @@ def expm(A):
     elif a.dtype == np.float16:
         a = a.astype(np.float32)
 
-    # Explicit formula for 2x2 case exists; formula (2.2) in [1].
-    # Howver without Kahan's method numerical instabilities can occur (See gh-19584).
-    # Hence removed here until we have a more stable implementation.
+    # An explicit formula for 2x2 case exists (formula (2.2) in [1]). However, without
+    # Kahan's method, numerical instabilities can occur (See gh-19584). Hence removed
+    # here until we have a more stable implementation.
 
     n = a.shape[-1]
     eA = np.empty(a.shape, dtype=a.dtype)

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -86,7 +86,7 @@ def _maybe_real(A, B, tol=None):
     # Note that booleans and integers compare as real.
     if np.isrealobj(A) and np.iscomplexobj(B):
         if tol is None:
-            tol = {0:feps*1e3, 1:eps*1e6}[_array_precision[B.dtype.char]]
+            tol = {0: feps*1e3, 1: eps*1e6}[_array_precision[B.dtype.char]]
         if np.allclose(B.imag, 0.0, atol=tol):
             B = B.real
     return B
@@ -203,8 +203,8 @@ def logm(A, disp=True):
     F = scipy.linalg._matfuncs_inv_ssq._logm(A)
     F = _maybe_real(A, F)
     errtol = 1000*eps
-    #TODO use a better error approximation
-    errest = norm(expm(F)-A,1) / norm(A,1)
+    # TODO use a better error approximation
+    errest = norm(expm(F)-A, 1) / norm(A, 1)
     if disp:
         if not isfinite(errest) or errest >= errtol:
             print("logm result may be inaccurate, approximate err =", errest)
@@ -678,36 +678,36 @@ def funm(A, func, disp=True):
     A = _asarray_square(A)
     # Perform Shur decomposition (lapack ?gees)
     T, Z = schur(A)
-    T, Z = rsf2csf(T,Z)
-    n,n = T.shape
+    T, Z = rsf2csf(T, Z)
+    n, n = T.shape
     F = diag(func(diag(T)))  # apply function to diagonal elements
     F = F.astype(T.dtype.char)  # e.g., when F is real but T is complex
 
-    minden = abs(T[0,0])
+    minden = abs(T[0, 0])
 
     # implement Algorithm 11.1.1 from Golub and Van Loan
     #                 "matrix Computations."
-    for p in range(1,n):
-        for i in range(1,n-p+1):
+    for p in range(1, n):
+        for i in range(1, n-p+1):
             j = i + p
-            s = T[i-1,j-1] * (F[j-1,j-1] - F[i-1,i-1])
-            ksl = slice(i,j-1)
-            val = dot(T[i-1,ksl],F[ksl,j-1]) - dot(F[i-1,ksl],T[ksl,j-1])
+            s = T[i-1, j-1] * (F[j-1, j-1] - F[i-1, i-1])
+            ksl = slice(i, j-1)
+            val = dot(T[i-1, ksl], F[ksl, j-1]) - dot(F[i-1, ksl], T[ksl, j-1])
             s = s + val
-            den = T[j-1,j-1] - T[i-1,i-1]
+            den = T[j-1, j-1] - T[i-1, i-1]
             if den != 0.0:
                 s = s / den
-            F[i-1,j-1] = s
-            minden = min(minden,abs(den))
+            F[i-1, j-1] = s
+            minden = min(minden, abs(den))
 
     F = dot(dot(Z, F), transpose(conjugate(Z)))
     F = _maybe_real(A, F)
 
-    tol = {0:feps, 1:eps}[_array_precision[F.dtype.char]]
+    tol = {0: feps, 1: eps}[_array_precision[F.dtype.char]]
     if minden == 0.0:
         minden = tol
-    err = min(1, max(tol,(tol/minden)*norm(triu(T,1),1)))
-    if prod(ravel(logical_not(isfinite(F))),axis=0):
+    err = min(1, max(tol, (tol/minden)*norm(triu(T, 1), 1)))
+    if prod(ravel(logical_not(isfinite(F))), axis=0):
         err = np.inf
     if disp:
         if err > 1000*tol:
@@ -760,7 +760,7 @@ def signm(A, disp=True):
             c = 1e3*eps*amax(x)
         return sign((absolute(rx) > c) * rx)
     result, errest = funm(A, rounded_sign, disp=0)
-    errtol = {0:1e3*feps, 1:1e3*eps}[_array_precision[result.dtype.char]]
+    errtol = {0: 1e3*feps, 1: 1e3*eps}[_array_precision[result.dtype.char]]
     if errest < errtol:
         return result
 
@@ -784,8 +784,8 @@ def signm(A, disp=True):
     for i in range(100):
         iS0 = inv(S0)
         S0 = 0.5*(S0 + iS0)
-        Pp = 0.5*(dot(S0,S0)+S0)
-        errest = norm(dot(Pp,Pp)-Pp,1)
+        Pp = 0.5*(dot(S0, S0)+S0)
+        errest = norm(dot(Pp, Pp)-Pp, 1)
         if errest < errtol or prev_errest == errest:
             break
         prev_errest = errest

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -105,18 +105,17 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
         double two_pow_s
         double temp
         double [5] theta
-        double [5] coeff        
+        double [5] coeff
         numpy_lapack_t [:, :, ::1] Amv = Am
-        cnp.ndarray[ndim=2, dtype=cnp.float64_t] absA
-        cnp.ndarray[ndim=1, dtype=cnp.float64_t] work_arr
-
-    if numpy_lapack_t in numpy_lapack_sc_t:
-        u = (2.)**(-24)
 
     dims[0] = n
     dims[1] = n
 
-    work_arr = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
+    if numpy_lapack_t in numpy_lapack_sc_t:
+        u = (2.)**(-24)
+        work_arr = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT32, 0)
+    else:
+        work_arr = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
 
     theta[0] = 1.495585217958292e-002
     theta[1] = 2.539398330063230e-001
@@ -637,28 +636,28 @@ def pade_UV_calc(lapack_t[:, :, ::1]Am, int n, int m):
             pade_357_UV_calc_s(Am, n, m)
         elif m == 9:
             pade_9_UV_calc_s(Am, n)
-        else: 
+        else:
             pade_13_UV_calc_s(Am, n)
     elif lapack_t is double:
         if m in [3, 5, 7]:
             pade_357_UV_calc_d(Am, n, m)
         elif m == 9:
             pade_9_UV_calc_d(Am, n)
-        else: 
+        else:
             pade_13_UV_calc_d(Am, n)
     elif lapack_t is floatcomplex:
         if m in [3, 5, 7]:
             pade_357_UV_calc_c(Am, n, m)
         elif m == 9:
             pade_9_UV_calc_c(Am, n)
-        else: 
+        else:
             pade_13_UV_calc_c(Am, n)
     elif lapack_t is doublecomplex:
         if m in [3, 5, 7]:
             pade_357_UV_calc_z(Am, n, m)
         elif m == 9:
             pade_9_UV_calc_z(Am, n)
-        else: 
+        else:
             pade_13_UV_calc_z(Am, n)
     else:
         raise ValueError('Internal function "pade_UV_calc" received an unsupported dtype')


### PR DESCRIPTION
Closes #19584 

The 2x2 shortcut branch is not numerically stable for overflow/underflows. It might also be the numpy implementation of hyperbolic functions but there is not much performance gain to insist on that branch we can leave it for future. 

In the meantime, fixed a missing dtype branch separation. 