### PR TITLE
DOC/REL: add missing expired deprecations to 1.12.0 notes

### DIFF
--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -303,6 +303,10 @@ The following previously deprecated features are affected:
 - ``scipy.stats.binom_test`` has been removed in favour of `scipy.stats.binomtest`.
 - In `scipy.stats.iqr`, the use of ``scale='raw'`` has been removed in favour 
   of ``scale=1``.
+- Functions from NumPy's main namespace which were exposed in SciPy's main
+  namespace, such as ``numpy.histogram`` exposed by ``scipy.histogram``, have
+  been removed from SciPy's main namespace. Please use the functions directly
+  from ``numpy``.
 
 
 ******************************


### PR DESCRIPTION
#### Reference issue
Closes gh-19974

#### What does this implement/fix?
Adds the missing expired deprecations from gh-19067, which received a few complaints for being missing from the notes.

#### Additional information
GitHub notes can be edited following this.
