### PR TITLE
MAINT: stats.wilcoxon: pass `PermutationMethod` options to `permutation_test`; document `PermutationMethod` support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3955,7 +3955,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
         * 'greater': the distribution underlying ``d`` is stochastically
           greater than a distribution symmetric about zero.
 
-    method : {"auto", "exact", "approx"}, optional
+    method : {"auto", "exact", "approx"} or `PermutationMethod` instance, optional
         Method to calculate the p-value, see Notes. Default is "auto".
 
     axis : int or None, default: 0
@@ -4004,21 +4004,19 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
       execution time).
 
     - The default, ``method='auto'``, selects between the two: when
-      ``len(d) <= 50``, the exact method is used; otherwise, the approximate
-      method is used.
+      ``len(d) <= 50`` and there are no zeros, the exact method is used;
+      otherwise, the approximate method is used.
 
-    The presence of "ties" (i.e. not all elements of ``d`` are unique) and
+    The presence of "ties" (i.e. not all elements of ``d`` are unique) or
     "zeros" (i.e. elements of ``d`` are zero) changes the null distribution
     of the test statistic, and ``method='exact'`` no longer calculates
     the exact p-value. If ``method='approx'``, the z-statistic is adjusted
     for more accurate comparison against the standard normal, but still,
     for finite sample sizes, the standard normal is only an approximation of
-    the true null distribution of the z-statistic. There is no clear
-    consensus among references on which method most accurately approximates
-    the p-value for small samples in the presence of zeros and/or ties. In any
-    case, this is the behavior of `wilcoxon` when ``method='auto':
-    ``method='exact'`` is used when ``len(d) <= 50`` *and there are no zeros*;
-    otherwise, ``method='approx'`` is used.
+    the true null distribution of the z-statistic. For such situations, the
+    `method` parameter also accepts instances `PermutationMethod`. In this
+    case, the p-value is computed using `permutation_test` with the provided
+    configuration options and other appropriate settings.
 
     References
     ----------

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -221,10 +221,11 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
         else:
             p = 2 * np.minimum(dist.sf(r_plus), dist.cdf(r_plus))
             p = np.clip(p, 0, 1)
-    else:
+    else:  # `PermutationMethod` instance (already validated)
         p = stats.permutation_test(
             (d,), lambda d: _wilcoxon_statistic(d, zero_method)[0],
-            permutation_type='samples', alternative=alternative, axis=-1).pvalue
+            permutation_type='samples', **method._asdict(),
+            alternative=alternative, axis=-1).pvalue
 
     # for backward compatibility...
     statistic = np.minimum(r_plus, r_minus) if alternative=='two-sided' else r_plus

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1645,6 +1645,17 @@ class TestWilcoxon:
         assert_equal(res.statistic, ref.statistic)
         assert_equal(res.pvalue, ref.pvalue)
 
+        x = rng.random(size=size*10)
+        rng = np.random.default_rng(59234803482850134)
+        pm = stats.PermutationMethod(n_resamples=99, random_state=rng)
+        ref = stats.wilcoxon(x, method=pm)
+        rng = np.random.default_rng(59234803482850134)
+        pm = stats.PermutationMethod(n_resamples=99, random_state=rng)
+        res = stats.wilcoxon(x, method=pm)
+
+        assert_equal(np.round(res.pvalue, 2), res.pvalue)  # n_resamples used
+        assert_equal(res.pvalue, ref.pvalue)  # random_state used
+
 
 class TestKstat:
     def test_moments_normal_distribution(self):


### PR DESCRIPTION
#### Reference issue
gh-19770

#### What does this implement/fix?
During preparation of the release notes, I realized that I forgot to document the addition of `PermutationMethod` support for `wilcoxon`. I had also neglected to pass the options contained in the `PermutationMethod` object into `permutation_test` (bug). This PR corrects the mistakes and adds a test.

#### Additional information
If docs look good @tylerjereddy, I think this is safe enough to merge. (For comparison, see e.g. [`mannwhitneyu` `PermutationMethod` support](https://github.com/scipy/scipy/blob/9a5118633252eb714e1abcafba036d4295a146be/scipy/stats/_mannwhitneyu.py#L502).) Sorry to catch this at the last minute.