### PR TITLE
MAINT: optimize: Remove warnings from building highs

### DIFF
--- a/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
+++ b/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
@@ -67,7 +67,7 @@ for _r in _ref_opts.records:
     _ref_opt_lookup[_r.name] = _r
 
 
-cdef str _opt_warning(string name, val, valid_set=None) noexcept:
+cdef str _opt_warning(string name, val, valid_set=None):
     cdef OptionRecord * r = _ref_opt_lookup[name]
 
     # BOOL
@@ -112,7 +112,7 @@ cdef str _opt_warning(string name, val, valid_set=None) noexcept:
            'See documentation for valid options. '
            'Using default.' % (name.decode(), str(val)))
 
-cdef apply_options(dict options, Highs & highs) noexcept:
+cdef void apply_options(dict options, Highs & highs) noexcept:
     '''Take options from dictionary and apply to HiGHS object.'''
 
     # Initialize for error checking


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
`N/A`

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR removes two build time warnings for the Cython interface for highs. These warnings are:

```
[1457/1477] Generating 'scipy/optimize/_highs/_highs_wrapper.cpython-311-x86_64-linux-gnu.so.p/_highs_wrapper.cpp'
warning: /home/kai/Projects/scipy/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx:70:21: noexcept clause is ignored for function returning Python object
warning: /home/kai/Projects/scipy/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx:115:18: noexcept clause is ignored for function returning Python object
```

#### Additional information
<!--Any additional information you think is important.-->
Only a small change that causes no changes in how Highs is built. Not a high priority just something nice to have.