### PR TITLE
REL: set version to 1.14.0dev0

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.14.0-notes
    release/1.13.0-notes
    release/1.12.0-notes
    release/1.11.4-notes

--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -1,0 +1,130 @@
+==========================
+SciPy 1.14.0 Release Notes
+==========================
+
+.. note:: SciPy 1.14.0 is not released yet!
+
+.. contents::
+
+SciPy 1.14.0 is the culmination of X months of hard work. It contains
+many new features, numerous bug-fixes, improved test coverage and better
+documentation. There have been a number of deprecations and API changes
+in this release, which are documented below. All users are encouraged to
+upgrade to this release, as there are a large number of bug-fixes and
+optimizations. Before upgrading, we recommend that users check that
+their own code does not use deprecated SciPy functionality (to do so,
+run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
+Our development attention will now shift to bug-fix releases on the
+1.14.x branch, and on adding new features on the main branch.
+
+This release requires Python 3.10+ and NumPy 1.22.4 or greater.
+
+For running on PyPy, PyPy3 6.0+ is required.
+
+
+**************************
+Highlights of this release
+**************************
+
+
+************
+New features
+************
+
+`scipy.cluster` improvements
+============================
+
+
+`scipy.interpolate` improvements
+================================
+
+
+`scipy.linalg` improvements
+===========================
+
+
+`scipy.ndimage` improvements
+============================
+
+
+`scipy.optimize` improvements
+=============================
+
+
+`scipy.signal` improvements
+===========================
+
+
+`scipy.sparse` improvements
+===========================
+
+
+
+`scipy.spatial` improvements
+============================
+
+
+`scipy.special` improvements
+============================
+
+
+`scipy.stats` improvements
+==========================
+
+Hypothesis Tests
+----------------
+
+
+Sample statistics
+-----------------
+
+
+Statistical Distributions
+-------------------------
+
+
+Other
+-----
+
+
+
+
+*******************
+Deprecated features
+*******************
+
+`scipy.linalg` deprecations
+===========================
+
+
+`scipy.spatial` deprecations
+============================
+
+
+
+******************************
+Backwards incompatible changes
+******************************
+
+*************
+Other changes
+*************
+
+
+
+*******
+Authors
+*******
+
+
+
+************************
+Issues closed for 1.14.0
+************************
+
+
+************************
+Pull requests for 1.14.0
+************************
+
+

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.13.0.dev0',
+  version: '1.14.0.dev0',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.13.0.dev0"
+version = "1.14.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -4,7 +4,7 @@ import argparse
 
 
 MAJOR = 1
-MINOR = 13
+MINOR = 14
 MICRO = 0
 ISRELEASED = False
 IS_RELEASE_BRANCH = False


### PR DESCRIPTION
* don't merge until until the `1.13.0` release notes have been merged and the `maintenance/1.13.x` branched has been pushed (I will probably self merge when the time is right)

* I checked that a clean build from source (`python dev.py test -j 32`) on this branch succeeds locally, as does the doc build (`python dev.py doc -j 1`)

* Although I did change the minimum Python version from `3.9` to `3.10` in the draft release notes for `1.14.0`, I'm intentionally avoiding broader code changes to bring us in line with the next (`2.1.0`) NumPy release in this regard, because the purpose here is really just to create a marker for the start of the next release and that's a bigger undertaking with CI changes, etc.

[skip cirrus]