### PR TITLE
BLD: update dependencies for 1.13.0 release and numpy 2.0

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -235,21 +235,16 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Setup OS
+      - name: Setup system dependencies
         run: |
           sudo apt-get -y update
           sudo apt install -y g++-8 gcc-8 gfortran-8
           sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
             libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev
 
-      - name: Setup Python deps
+      - name: Setup Python build deps
         run: |
-          pip install "numpy==1.22.4" &&
-          # build deps
-          pip install build meson-python ninja pythran pybind11 cython
-          # test deps
-          pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout hypothesis
-          pip install sparse
+          pip install build meson-python ninja pythran pybind11 cython "numpy>=2.0.0b1"
 
       - name: Build wheel and install
         run: |
@@ -259,6 +254,11 @@ jobs:
           # specify which compilers to use using environment variables
           CC=gcc-8 CXX=g++-8 FC=gfortran-8 python -m build --wheel --no-isolation -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
           python -m pip install dist/scipy*.whl
+
+      - name: Install test dependencies
+        run: |
+          # Downgrade numpy to oldest supported version
+          pip install gmpy2 threadpoolctl mpmath pooch pytest pytest-xdist==2.5.0 pytest-timeout hypothesis sparse "numpy==1.22.4"
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,35 +6,32 @@
 # the most recent version on PyPI:
 #
 #     "pybind11>=2.4.3,<2.5.0",
+#
+# Upper bounds in release branches must have notes on why they are added.
+# Distro packages can ignore upper bounds added only to prevent future
+# breakage; if we add pins or bounds because of known problems then they need
+# them too.
 
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.15.0",
-    "Cython>=3.0.8",  # when updating version, also update check in meson.build
+    # The upper bound on meson-python is pre-emptive only (looser on purpose,
+    # since change of breakage in 0.16/0.17 is low)
+    "meson-python>=0.15.0,<0.18.0",
+    # The upper bound on Cython is pre-emptive only
+    "Cython>=3.0.8,<3.1.0",  # when updating version, also update check in meson.build
+    # TODO: TBD, depending on https://github.com/pybind/pybind11/issues/5009
     "pybind11>=2.10.4",
-    "pythran>=0.14.0",
+    # The upper bound on Pythran is pre-emptive only
+    "pythran>=0.14.0,<0.16.0",
 
-    # When numpy 2.0.0rc1 comes out, we should update this to build against 2.0,
-    # and then runtime depend on the range 1.22.X to <2.3. No need to switch to
-    # 1.25.2 in the meantime (1.25.x is the first version which exports older C
-    # API versions by default).
-
-    # default numpy requirements
-    "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
-    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy>=1.26.0,<1.27; python_version=='3.12'",
-
-    # PyPy requirements; 1.25.0 was the first version to have pypy-3.9 wheels,
-    # and 1.25.0 also changed the C API target to 1.19.x, so no longer a need
-    # for an exact pin.
-    "numpy>=1.25.0; python_version>='3.9' and platform_python_implementation=='PyPy'",
-
-    # For Python versions which aren't yet officially supported, we specify an
-    # unpinned NumPy which allows source distributions to be used and allows
-    # wheels to be used as soon as they become available.
-    # Python 3.13 has known issues that are only fixed in numpy 2.0.0.dev0
-    "numpy>=2.0.0.dev0; python_version>='3.13'",
+    # numpy requirement for wheel builds for distribution on PyPI - building
+    # against 2.x yields wheels that are also compatible with numpy 1.x at
+    # runtime.
+    # Note that building against numpy 1.x works fine too - users and
+    # redistributors can do this by installing the numpy version they like and
+    # disabling build isolation.
+    "numpy>=2.0.0b1,<2.3",
 ]
 
 [project]
@@ -51,11 +48,7 @@ maintainers = [
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.9"
-dependencies = [
-    # TODO: update to "pin-compatible" once possible, see
-    # https://github.com/mesonbuild/meson-python/issues/29
-    "numpy>=1.22.4",
-]
+dependencies = ["numpy>=1.22.4,<2.3"]
 readme = "README.rst"
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
These are @rgommers proposed changes on the new release branch with respect to `pyproject.toml`.

We probably need a resolution to gh-20268 (which is this upstream: https://github.com/numpy/numpy/issues/26060) before further testing can proceed on wheel build viability, given the change in size of a public NumPy struct this late in the game. Anyway, either we backport a patch or they back that out, but probably not getting resolved this evening.