### PR TITLE
MAINT/DEV: enforce minimum `ruff` version

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -32,3 +32,5 @@ fa9f13e6906e7d00510d593f7f982db30e4e4f14
 ecef3490da68a0c53ba543c618bab0c8e15dccee
 # Change to indent width of 4 in clang-format (gh-19660)
 852776a3fe0f3d08c0bed9174f6ac33f653a8677
+# Style cleanup in `pyproject.toml`
+7b921fd28659b02544bfb46368ddadd1048b37aa

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install ruff cython-lint
+        python -m pip install ruff cython-lint packaging
 
     - name: Lint
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -55,5 +55,5 @@ dependencies:
   - doit>=0.36.0
   - pydevtool
   # For linting
-  - ruff
+  - ruff>=0.0.292
   - cython-lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
     "typing_extensions",
     "types-psutil",
     "pycodestyle",
-    "ruff",
+    "ruff>=0.0.292",
     "cython-lint>=0.12.2",
     "rich-click",
     "doit>=0.36.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.15.0",
-    "Cython>=3.0.8",  # when updating version, also update check in meson.build
+    "Cython>=3.0.8",        # when updating version, also update check in meson.build
     "pybind11>=2.10.4",
     "pythran>=0.14.0",
 
@@ -42,10 +42,10 @@ name = "scipy"
 version = "1.14.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 description = "Fundamental algorithms for scientific computing in Python"
 maintainers = [
-    {name = "SciPy Developers", email = "scipy-dev@python.org"},
+    { name = "SciPy Developers", email = "scipy-dev@python.org" },
 ]
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
@@ -133,7 +133,15 @@ skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
 build-verbosity = "3"
 # gmpy2 and scikit-umfpack are usually added for testing. However, there are
 # currently wheels missing that make the test script fail.
-test-requires = ["pytest==7.4.3", "pytest-cov", "pytest-xdist", "mpmath", "threadpoolctl", "pooch", "hypothesis"]
+test-requires = [
+    "pytest==7.4.3",
+    "pytest-cov",
+    "pytest-xdist",
+    "mpmath",
+    "threadpoolctl",
+    "pooch",
+    "hypothesis",
+]
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]
@@ -159,4 +167,4 @@ select = "*-win_amd64"
 # Don't use double backslash for path separators, they don't get passed
 # to the build correctly
 # environment = { CMAKE_PREFIX_PATH="c:/opt/64" }
-environment = { PKG_CONFIG_PATH="c:/opt/64/lib/pkgconfig" }
+environment = { PKG_CONFIG_PATH = "c:/opt/64/lib/pkgconfig" }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ mypy
 typing_extensions
 types-psutil
 pycodestyle
-ruff
+ruff>=0.0.292
 cython-lint>=0.12.2
 rich-click
 doit>=0.36.0

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+import packaging.version
 from argparse import ArgumentParser
 
 
@@ -89,7 +90,20 @@ def run_cython_lint(files):
     return res.returncode, res.stdout
 
 
+def check_ruff_version():
+    min_version = packaging.version.parse('0.0.292')
+    res = subprocess.run(
+        ['ruff', '--version'],
+        stdout=subprocess.PIPE,
+        encoding='utf-8'
+    )
+    version = res.stdout.replace('ruff ', '')
+    if packaging.version.parse(version) < min_version:
+        raise RuntimeError("Linting requires `ruff>=0.0.292`. Please upgrade `ruff`.")
+
+
 def main():
+    check_ruff_version()
     parser = ArgumentParser(description="Also see `pre-commit-hook.py` which "
                                         "lints all files staged in git.")
     # In Python 3.9, can use: argparse.BooleanOptionalAction


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/20255#issuecomment-2003146589 @ev-br 

#### What does this implement/fix?
Instead of the rather annoying error message observed in the linked issue, we now have a nice error message, "Linting requires `ruff>=0.0.292`. Please upgrade `ruff`."

#### Additional information
This is a follow-up to gh-20070.

My IDE seems to have made some stylistic changes in `pyproject.toml`. These look good to me, but let me know if they should be removed.
