### PR TITLE
BUG: optimize: correct `nfev` values

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -890,7 +890,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     ...     popt, pcov = curve_fit(func, xdata, ydata, method = 'trf')
     ... except RuntimeError as e:
     ...     print(e)
-    Optimal parameters not found: The maximum number of function evaluations is exceeded.
+    Optimal parameters not found: The maximum number of function evaluations is
+    exceeded.
 
     If parameter scale is roughly known beforehand, it can be defined in
     `x_scale` argument:

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -155,15 +155,15 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     array([ True,  True])
 
     """
-    nfev = 0
     def _wrapped_func(*fargs):
         """
         Wrapped `func` to track the number of times
         the function has been called.
         """
-        nonlocal nfev
-        nfev += 1
+        _wrapped_func.nfev += 1
         return func(*fargs)
+
+    _wrapped_func.nfev = 0
 
     options = {'col_deriv': col_deriv,
                'xtol': xtol,
@@ -174,7 +174,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
                'diag': diag}
 
     res = _root_hybr(_wrapped_func, x0, args, jac=fprime, **options)
-    res.nfev = nfev
+    res.nfev = _wrapped_func.nfev
 
     if full_output:
         x = res['x']

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -155,6 +155,16 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     array([ True,  True])
 
     """
+    nfev = 0
+    def _wrapped_func(*fargs):
+        """
+        Wrapped `func` to track the number of times
+        the function has been called.
+        """
+        nonlocal nfev
+        nfev += 1
+        return func(*fargs)
+
     options = {'col_deriv': col_deriv,
                'xtol': xtol,
                'maxfev': maxfev,
@@ -163,7 +173,9 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
                'factor': factor,
                'diag': diag}
 
-    res = _root_hybr(func, x0, args, jac=fprime, **options)
+    res = _root_hybr(_wrapped_func, x0, args, jac=fprime, **options)
+    res.nfev = nfev
+
     if full_output:
         x = res['x']
         info = {k: res.get(k)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -199,6 +199,16 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     >>> plt.show()
 
     """
+    nfev = 0
+    def _wrapped_fun(*fargs):
+        """
+        Wrapped `func` to track the number of times
+        the function has been called.
+        """
+        nonlocal nfev
+        nfev += 1
+        return fun(*fargs)
+
     if not isinstance(args, tuple):
         args = (args,)
 
@@ -233,22 +243,23 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
             options.setdefault('fatol', np.inf)
 
     if meth == 'hybr':
-        sol = _root_hybr(fun, x0, args=args, jac=jac, **options)
+        sol = _root_hybr(_wrapped_fun, x0, args=args, jac=jac, **options)
     elif meth == 'lm':
-        sol = _root_leastsq(fun, x0, args=args, jac=jac, **options)
+        sol = _root_leastsq(_wrapped_fun, x0, args=args, jac=jac, **options)
     elif meth == 'df-sane':
         _warn_jac_unused(jac, method)
-        sol = _root_df_sane(fun, x0, args=args, callback=callback,
+        sol = _root_df_sane(_wrapped_fun, x0, args=args, callback=callback,
                             **options)
     elif meth in ('broyden1', 'broyden2', 'anderson', 'linearmixing',
                   'diagbroyden', 'excitingmixing', 'krylov'):
         _warn_jac_unused(jac, method)
-        sol = _root_nonlin_solve(fun, x0, args=args, jac=jac,
+        sol = _root_nonlin_solve(_wrapped_fun, x0, args=args, jac=jac,
                                  _method=meth, _callback=callback,
                                  **options)
     else:
         raise ValueError('Unknown solver %s' % method)
 
+    sol.nfev = nfev
     return sol
 
 
@@ -291,10 +302,19 @@ def _root_leastsq(fun, x0, args=(), jac=None,
     diag : sequence
         N positive entries that serve as a scale factors for the variables.
     """
+    nfev = 0
+    def _wrapped_fun(*fargs):
+        """
+        Wrapped `func` to track the number of times
+        the function has been called.
+        """
+        nonlocal nfev
+        nfev += 1
+        return fun(*fargs)
 
     _check_unknown_options(unknown_options)
-    x, cov_x, info, msg, ier = leastsq(fun, x0, args=args, Dfun=jac,
-                                       full_output=True,
+    x, cov_x, info, msg, ier = leastsq(_wrapped_fun, x0, args=args,
+                                       Dfun=jac, full_output=True,
                                        col_deriv=col_deriv, xtol=xtol,
                                        ftol=ftol, gtol=gtol,
                                        maxfev=maxiter, epsfcn=eps,
@@ -303,6 +323,7 @@ def _root_leastsq(fun, x0, args=(), jac=None,
                          success=ier in (1, 2, 3, 4), cov_x=cov_x,
                          fun=info.pop('fvec'), method="lm")
     sol.update(info)
+    sol.nfev = nfev
     return sol
 
 

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -199,15 +199,15 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     >>> plt.show()
 
     """
-    nfev = 0
     def _wrapped_fun(*fargs):
         """
         Wrapped `func` to track the number of times
         the function has been called.
         """
-        nonlocal nfev
-        nfev += 1
+        _wrapped_fun.nfev += 1
         return fun(*fargs)
+
+    _wrapped_fun.nfev = 0
 
     if not isinstance(args, tuple):
         args = (args,)
@@ -259,7 +259,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     else:
         raise ValueError('Unknown solver %s' % method)
 
-    sol.nfev = nfev
+    sol.nfev = _wrapped_fun.nfev
     return sol
 
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -259,6 +259,27 @@ class TestRootLM:
         assert_array_almost_equal(final_flows, np.ones(4))
 
 
+class TestNfev:
+    def zero_f(self, y):
+        self.nfev += 1
+        return y**2-3
+
+    @pytest.mark.parametrize('method', ['hybr', 'lm', 'broyden1',
+                                        'broyden2', 'anderson',
+                                        'linearmixing', 'diagbroyden',
+                                        'excitingmixing', 'krylov',
+                                        'df-sane'])
+    def test_root_nfev(self, method):
+        self.nfev = 0
+        solution = optimize.root(self.zero_f, 100, method=method)
+        assert solution.nfev == self.nfev
+
+    def test_fsolve_nfev(self):
+        self.nfev = 0
+        x, info, ier, mesg = optimize.fsolve(self.zero_f, 100, full_output=True)
+        assert info['nfev'] == self.nfev
+
+
 class TestLeastSq:
     def setup_method(self):
         x = np.linspace(0, 10, 40)


### PR DESCRIPTION
The number of function evaluations was incorrect when using the `fsolve` and `root` methods in SciPy.optimize (see #5369). To solve this, the function is wrapped and the number of invocations counted. This value replaces the one returned by the optimizer.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #5369

#### What does this implement/fix?
This corrects the count of function invocations (`nfev`) in the `fsolve` and `root` methods of SciPy.optimize. It also adds the `nfev` value to other methods in `root` that previously did not return it (broyden1, broyden2, anderson,                        linearmixing, diagbroyden, excitingmixing, and krylov).

#### Additional information
This is my first PR so constructive feedback is very welcome. I'm happy to work on this further if required.
