### PR TITLE
DEP: sparse: deprecate conjtransp() method for dok_array/matrix classes

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -5,7 +5,9 @@ __docformat__ = "restructuredtext en"
 __all__ = ['dok_array', 'dok_matrix', 'isspmatrix_dok']
 
 import itertools
+from warnings import warn
 import numpy as np
+from scipy._lib._util import VisibleDeprecationWarning
 
 from ._matrix import spmatrix
 from ._base import _spbase, sparray, issparse
@@ -394,11 +396,22 @@ class _dok_base(_spbase, IndexMixin, dict):
     transpose.__doc__ = _spbase.transpose.__doc__
 
     def conjtransp(self):
-        """Return the conjugate transpose."""
+        """DEPRECATED: Return the conjugate transpose.
+
+        .. deprecated:: 1.13.0
+
+            `conjtransp` is deprecated and will be removed in v1.15.0.
+            Use `.T.conj()` instead.
+        """
+        message = ("`conjtransp` is deprecated and will be removed in v1.15.0. "
+                   "Use `.T.conj()` instead.")
+        warn(VisibleDeprecationWarning(message), stacklevel=2)
+
         if self.ndim == 1:
             new = self.tocoo()
             new.data = new.data.conjugate()
             return new
+
         M, N = self.shape
         new = self._dok_container((N, M), dtype=self.dtype)
         new._dict = {(right, left): np.conj(val) for (left, right), val in self.items()}

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -7,7 +7,6 @@ __all__ = ['dok_array', 'dok_matrix', 'isspmatrix_dok']
 import itertools
 from warnings import warn
 import numpy as np
-from scipy._lib._util import VisibleDeprecationWarning
 
 from ._matrix import spmatrix
 from ._base import _spbase, sparray, issparse
@@ -398,14 +397,14 @@ class _dok_base(_spbase, IndexMixin, dict):
     def conjtransp(self):
         """DEPRECATED: Return the conjugate transpose.
 
-        .. deprecated:: 1.13.0
+        .. deprecated:: 1.14.0
 
-            `conjtransp` is deprecated and will be removed in v1.15.0.
+            `conjtransp` is deprecated and will be removed in v1.16.0.
             Use `.T.conj()` instead.
         """
-        message = ("`conjtransp` is deprecated and will be removed in v1.15.0. "
+        msg = ("`conjtransp` is deprecated and will be removed in v1.16.0. "
                    "Use `.T.conj()` instead.")
-        warn(VisibleDeprecationWarning(message), stacklevel=2)
+        warn(msg, DeprecationWarning, stacklevel=2)
 
         if self.ndim == 1:
             new = self.tocoo()

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -39,5 +39,5 @@ def test_dok_deprecations():
     ])
     msg = "1.15.0"
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning, match=msg):
         X.conjtransp()

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -1,6 +1,5 @@
 import scipy as sp
 import pytest
-from scipy._lib._util import VisibleDeprecationWarning
 
 
 def test_array_api_deprecations():
@@ -37,7 +36,7 @@ def test_dok_deprecations():
         [0,1,3],
         [2,0,0]
     ])
-    msg = "1.15.0"
+    msg = "1.16.0"
 
-    with pytest.warns(VisibleDeprecationWarning, match=msg):
+    with pytest.deprecated_call(match=msg):
         X.conjtransp()

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -29,3 +29,14 @@ def test_array_api_deprecations():
 
     with pytest.deprecated_call(match=msg):
         X.getrow(1).todense()
+
+
+def test_dok_deprecations():
+    X = sp.sparse.dok_array([
+        [0,1,3],
+        [2,0,0]
+    ])
+    msg = "1.15.0"
+
+    with pytest.deprecated_call(match=msg):
+        X.conjtransp().toarray()

--- a/scipy/sparse/tests/test_deprecations.py
+++ b/scipy/sparse/tests/test_deprecations.py
@@ -1,5 +1,6 @@
 import scipy as sp
 import pytest
+from scipy._lib._util import VisibleDeprecationWarning
 
 
 def test_array_api_deprecations():
@@ -38,5 +39,5 @@ def test_dok_deprecations():
     ])
     msg = "1.15.0"
 
-    with pytest.deprecated_call(match=msg):
-        X.conjtransp().toarray()
+    with pytest.warns(VisibleDeprecationWarning):
+        X.conjtransp()


### PR DESCRIPTION
`A.conjtransp()` returns the conjugate transpose. So does `A.T.conj()`.
But `conjtransp` only exists for sparse DOK format. And it is not tested, is unused anywhere in Scipy, and searching all Github repositories for "language:python '.conjtransp('" reveals one use of this method in all of github. Most people I've talked to about this didn't know the method existed.

I propose that we deprecate `conjtransp` from the DOK classes. The proposed message says:
```
        .. deprecated:: 1.13.0

            `conjtransp` is deprecated and will be removed in v1.15.0.
            Use `.T.conj()` instead.
``` 
But the versions can be changed easily if this can't get into v1.13.
