### PR TITLE
DOC: Pin Jupyterlite Sphinx to avoid noisy doc builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ doc = [
     "jupytext",
     "myst-nb",
     "pooch",
-    "jupyterlite-sphinx>=0.12.0",
+    "jupyterlite-sphinx>=0.13.0",
     "jupyterlite-pyodide-kernel",
 ]
 dev = [

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,5 +8,5 @@ numpydoc
 jupytext
 myst-nb
 pooch
-jupyterlite-sphinx>=0.12.0
+jupyterlite-sphinx>=0.13.0
 jupyterlite-pyodide-kernel


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See https://github.com/scipy/scipy/issues/20277.

#### What does this implement/fix?
<!--Please explain your changes.-->
This pins `jupyterlite-sphinx` to version 0.13.0 or higher. Previously it had been pinned to version 0.12.0 or higher. Versions prior to 0.13.0 had highly verbose builds that produced absurd amounts of noise when were built. This was fixed in https://github.com/jupyterlite/jupyterlite-sphinx/pull/150.
