### PR TITLE
REL: set 1.13.0rc2 unreleased

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.13.0rc1',
+  version: '1.13.0rc2',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.13.0rc1"
+version = "1.13.0rc2"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -6,9 +6,9 @@ import argparse
 MAJOR = 1
 MINOR = 13
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
-VERSION = '%d.%d.%drc1' % (MAJOR, MINOR, MICRO)
+VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
 
 
 def get_version_info(source_root):


### PR DESCRIPTION
* set version to `1.13.0rc2` unreleased

Normally I just push this directly, but with CI skipped just a slightly
more visible way to say RC1 is out there and the release
branch is being prepared for RC2. Note that the announcement
to the mailing list will happen later tonight (US time) since 
Gmail is blocked at work.

[skip ci] [ci ckip] [skip circle] [skip cirrus]
