### PR TITLE
BUG: linalg: use SYEV not SYEVR for pinvh

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1523,7 +1523,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
 
     """
     a = _asarray_validated(a, check_finite=check_finite)
-    s, u = _decomp.eigh(a, lower=lower, check_finite=False)
+    s, u = _decomp.eigh(a, lower=lower, check_finite=False, driver='ev')
     t = u.dtype.char.lower()
     maxS = np.max(np.abs(s))
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1493,6 +1493,14 @@ class TestPinvSymmetric:
         a_pinv = pinvh(a.tolist())
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
+    def test_zero_eigenvalue(self):
+        # https://github.com/scipy/scipy/issues/12515
+        # the SYEVR eigh driver may give the zero eigenvalue > eps
+        a = np.array([[1,-1, 0], [-1, 2, -1], [0, -1, 1]])
+        p = pinvh(a)
+        assert_allclose(p @ a @ p, p, atol=1e-15)
+        assert_allclose(a @ p @ a, a, atol=1e-15)
+
     def test_atol_rtol(self):
         n = 12
         # get a random ortho matrix for shuffling


### PR DESCRIPTION
Apparently, SYEVR may sometimes give zero eigenvalue > epsilon.

cross-ref https://github.com/Reference-LAPACK/lapack/issues/997 for a discussion.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/12515

#### What does this implement/fix?
<!--Please explain your changes.-->

Change the `pinvh` driver to SYEV, which is apparently a bit more robust.

#### Additional information
<!--Any additional information you think is important.-->

An alternative is to expose a driver itself. This feels to be overkill though: we do expose `tol`, give a reasonable default, and it's not taxing to redo the whole pinvh calculation using either SVD or eigenvalues of whatnot in user code. 

As such, even this PR may be too much, actually.