### PR TITLE
DOC: linalg: mention that eigenvalues_only=True/False may change the eigenvalues

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -400,7 +400,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     Note that the underlying LAPACK algorithms are different depending on whether
     `eigvals_only` is True or False --- thus the eigenvalues may differ
     depending on whether eigenvectors are requested or not. The difference is
-    generally of the order of machine epsilon, so is likely only visible
+    generally of the order of machine epsilon times the largest eigenvalue, so is likely only visible
     for zero or nearly zero eigenvalues.
 
     For the generalized problem, normalization with respect to the given

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -400,8 +400,8 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     Note that the underlying LAPACK algorithms are different depending on whether
     `eigvals_only` is True or False --- thus the eigenvalues may differ
     depending on whether eigenvectors are requested or not. The difference is
-    generally of the order of machine epsilon times the largest eigenvalue, so is likely only visible
-    for zero or nearly zero eigenvalues.
+    generally of the order of machine epsilon times the largest eigenvalue,
+    so is likely only visible for zero or nearly zero eigenvalues.
 
     For the generalized problem, normalization with respect to the given
     type argument::

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -397,6 +397,11 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     often performs worse than the rest except when very few eigenvalues are
     requested for large arrays though there is still no performance guarantee.
 
+    Note that the underlying LAPACK algorithms are different depending on whether
+    `eigvals_only` is True or False --- thus the eigenvalues may differ
+    depending on whether eigenvectors are requested or not. The difference is
+    generally of the order of machine epsilon, so is likely only visible
+    for zero or nearly zero eigenvalues.
 
     For the generalized problem, normalization with respect to the given
     type argument::


### PR DESCRIPTION
[docs only]

Per the discussion in https://github.com/Reference-LAPACK/lapack/issues/997 : this is apparently known (widely known in somewhat narrow circles, it looks like) that `eig(a)[0]` and `eig(a, eigenvalues_only=True)` are not exactly equivalent: The reported eigenvalues may differ by something of the order of machine epsilon. This is not a big deal unless the true eigenvalue is of the same order itself.

Since this is not going to get fixed in LAPACK, let's add a note to our docs.