### PR TITLE
MAINT: Pin jupyterlite-sphinx to >=0.13.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
   - sphinx-design
   - jupytext
   - myst-nb
-  - jupyterlite-sphinx>=0.12.0
+  - jupyterlite-sphinx>=0.13.1
   # Some optional test dependencies
   - mpmath
   - gmpy2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ doc = [
     "jupytext",
     "myst-nb",
     "pooch",
-    "jupyterlite-sphinx>=0.13.0",
+    "jupyterlite-sphinx>=0.13.1",
     "jupyterlite-pyodide-kernel",
 ]
 dev = [

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,5 +8,5 @@ numpydoc
 jupytext
 myst-nb
 pooch
-jupyterlite-sphinx>=0.13.0
+jupyterlite-sphinx>=0.13.1
 jupyterlite-pyodide-kernel


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #20277 #20296 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR pins `jupyterlite-sphinx` to be greater than `0.13.1`.  The pin is done for both `pyproject.toml` and `environment.yml`, correcting an oversight noticed by @melissawm after the previous PR was merged: https://github.com/scipy/scipy/issues/20296#issuecomment-2013251686. 

#### Additional information
<!--Any additional information you think is important.-->
Versions prior to `0.13.x` resulted in very noisy docs builds due to the verbosity of `jupyterlite` builds as noted in #20277. Version `0.13.0` contained an attempt to suppress the noise which unfortunately broke `jupyterlite-sphinx`. `0.13.0`  was yanked from PyPI, causing SciPy's circleci builds to fail due to `jupyterlite-sphinx` being pinned to `>=0.13.0` in  https://github.com/scipy/scipy/pull/20289. https://github.com/jupyterlite/jupyterlite-sphinx/pull/153 correctly suppressed the noise without breaking `jupyterlite-sphinx` and version `0.13.1` containing this fix was released today.

cc @j-bowhay 
