### PR TITLE
BUG: sparse: Restore random coordinate ordering to pre-1.12 results

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1208,7 +1208,7 @@ def _random(shape, density=0.01, format=None, dtype=None,
     # rng.choice uses int64 if first arg is an int
     if tot_prod < np.iinfo(np.int64).max:
         raveled_ind = rng.choice(tot_prod, size=size, replace=False)
-        ind = np.unravel_index(raveled_ind, shape=shape)
+        ind = np.unravel_index(raveled_ind, shape=shape, order='F')
     else:
         # for ravel indices bigger than dtype max, use sets to remove duplicates
         ndim = len(shape)


### PR DESCRIPTION
#### Reference issue
Fixes gh-20027.

#### What does this implement/fix?
This restores the coordinate ordering that we used to return in version 1.11, which was inadvertently changed when we overhauled the sparse array creation functions for 1.12.

#### Additional information
We don't 100% guarantee that the random creation functions will produce exactly the same results from version to version, but this was a simple enough fix that I think it's worth maintaining consistency.

Demo of the new behavior with this PR (see gh-20027 for reference):

```
In [3]: x = ss.random(3, 3, density=0.7, random_state=1)

In [4]: print(str(x))
  (2, 2)        0.23608897695197606
  (2, 0)        0.3965807272960261
  (0, 2)        0.3879107411620074
  (1, 2)        0.66974603680348
  (1, 0)        0.9355390708060318
  (0, 0)        0.8463109166860171
```
