### PR TITLE
MAINT/DEV: rename `skip_if_array_api` to `skip_xp_backends`

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -230,29 +230,29 @@ The following pytest markers are available:
 
 * ``array_api_compatible -> xp``: use a parametrisation to run a test on
   multiple array backends.
-* ``skip_if_array_api(*backends, reasons=None, np_only=False, cpu_only=False)``:
+* ``skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False)``:
   skip certain backends and/or devices. ``np_only`` skips tests for all backends
   other than the default NumPy backend.
-  ``@pytest.mark.usefixtures("skip_if_array_api")`` must be used alongside this
+  ``@pytest.mark.usefixtures("skip_xp_backends")`` must be used alongside this
   marker for the skipping to apply.
 
 The following is an example using the markers::
 
   from scipy.conftest import array_api_compatible
   ...
-  @pytest.mark.skip_if_array_api(np_only=True,
+  @pytest.mark.skip_xp_backends(np_only=True,
                                  reasons=['skip reason'])
-  @pytest.mark.usefixtures("skip_if_array_api")
+  @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto1(self, xp):
       a = xp.asarray([1, 2, 3])
       b = xp.asarray([0, 2, 5])
       toto(a, b)
   ...
-  @pytest.mark.skip_if_array_api('array_api_strict', 'cupy',
+  @pytest.mark.skip_xp_backends('array_api_strict', 'cupy',
                                  reasons=['skip reason 1',
                                           'skip reason 2',])
-  @pytest.mark.usefixtures("skip_if_array_api")
+  @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto2(self, xp):
       a = xp.asarray([1, 2, 3])
@@ -270,10 +270,10 @@ markers to every test function using ``pytestmark``::
 
     from scipy.conftest import array_api_compatible
     
-    pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-    skip_if_array_api = pytest.mark.skip_if_array_api
+    pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+    skip_xp_backends = pytest.mark.skip_xp_backends
     ...
-    @skip_if_array_api(np_only=True, reasons=['skip reason'])
+    @skip_xp_backends(np_only=True, reasons=['skip reason'])
     def test_toto1(self, xp):
         a = xp.asarray([1, 2, 3])
         b = xp.asarray([0, 2, 5])

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -66,13 +66,13 @@ except Exception:
     have_matplotlib = False
 
 
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-skip_if_array_api = pytest.mark.skip_if_array_api
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 class TestLinkage:
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_linkage_non_finite_elements_in_distance_matrix(self, xp):
         # Tests linkage(Y) where Y contains a non-finite element (e.g. NaN or Inf).
         # Exception expected.
@@ -80,13 +80,13 @@ class TestLinkage:
         y[0] = xp.nan
         assert_raises(ValueError, linkage, y)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_linkage_empty_distance_matrix(self, xp):
         # Tests linkage(Y) where Y is a 0x4 linkage matrix. Exception expected.
         y = xp.zeros((0,))
         assert_raises(ValueError, linkage, y)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_linkage_tdist(self, xp):
         for method in ['single', 'complete', 'average', 'weighted']:
             self.check_linkage_tdist(method, xp)
@@ -97,7 +97,7 @@ class TestLinkage:
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_' + method)
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_linkage_X(self, xp):
         for method in ['centroid', 'median', 'ward']:
             self.check_linkage_q(method, xp)
@@ -113,7 +113,7 @@ class TestLinkage:
         Z = linkage(xp.asarray(y), method)
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_compare_with_trivial(self, xp):
         rng = np.random.RandomState(0)
         n = 20
@@ -125,14 +125,14 @@ class TestLinkage:
             Z = linkage(xp.asarray(d), method)
             xp_assert_close(Z, xp.asarray(Z_trivial), rtol=1e-14, atol=1e-15)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_optimal_leaf_ordering(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), optimal_ordering=True)
         expectedZ = getattr(hierarchy_test_data, 'linkage_ytdist_single_olo')
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-10)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestLinkageTies:
 
     _expectations = {
@@ -164,7 +164,7 @@ class TestLinkageTies:
         xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestInconsistent:
 
     def test_inconsistent_tdist(self, xp):
@@ -177,7 +177,7 @@ class TestInconsistent:
                         xp.asarray(hierarchy_test_data.inconsistent_ytdist[depth]))
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestCopheneticDistance:
 
     def test_linkage_cophenet_tdist_Z(self, xp):
@@ -207,7 +207,7 @@ class TestMLabLinkageConversion:
         xp_assert_equal(from_mlab_linkage(X), X)
         xp_assert_equal(to_mlab_linkage(X), X)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_mlab_linkage_conversion_single_row(self, xp):
         # Tests from/to_mlab_linkage on linkage array with single row.
         Z = xp.asarray([[0., 1., 3., 2.]])
@@ -217,7 +217,7 @@ class TestMLabLinkageConversion:
         xp_assert_close(to_mlab_linkage(Z), xp.asarray(Zm, dtype=xp.float64),
                         rtol=1e-15)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_mlab_linkage_conversion_multiple_rows(self, xp):
         # Tests from/to_mlab_linkage on linkage array with multiple rows.
         Zm = xp.asarray([[3, 6, 138], [4, 5, 219],
@@ -233,7 +233,7 @@ class TestMLabLinkageConversion:
                         rtol=1e-15)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestFcluster:
 
     def test_fclusterdata(self, xp):
@@ -285,7 +285,7 @@ class TestFcluster:
         assert_(is_isomorphic(T, expectedT))
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestLeaders:
 
     def test_leaders_single(self, xp):
@@ -301,11 +301,11 @@ class TestLeaders:
         assert_allclose(np.concatenate(L), np.concatenate(Lright), rtol=1e-15)
 
 
-@skip_if_array_api(np_only=True,
+@skip_xp_backends(np_only=True,
                    reasons=['`is_isomorphic` only supports NumPy backend'])
 class TestIsIsomorphic:
 
-    @skip_if_array_api(np_only=True,
+    @skip_xp_backends(np_only=True,
                        reasons=['array-likes only supported for NumPy backend'])
     def test_array_like(self, xp):
         assert is_isomorphic([1, 1, 1], [2, 2, 2])
@@ -392,7 +392,7 @@ class TestIsIsomorphic:
             assert is_isomorphic(b, a) == (not noniso)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestIsValidLinkage:
 
     def test_is_valid_linkage_various_size(self, xp):
@@ -476,7 +476,7 @@ class TestIsValidLinkage:
             assert_raises(ValueError, is_valid_linkage, Z, throw=True)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestIsValidInconsistent:
 
     def test_is_valid_im_int_type(self, xp):
@@ -555,7 +555,7 @@ class TestIsValidInconsistent:
 
 class TestNumObsLinkage:
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_num_obs_linkage_empty(self, xp):
         # Tests num_obs_linkage(Z) with empty linkage.
         Z = xp.zeros((0, 4), dtype=xp.float64)
@@ -572,7 +572,7 @@ class TestNumObsLinkage:
                         [3, 2, 4.0, 3]], dtype=xp.float64)
         assert_equal(num_obs_linkage(Z), 3)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_num_obs_linkage_4_and_up(self, xp):
         # Tests num_obs_linkage(Z) on linkage on observation sets between sizes
         # 4 and 15 (step size 3).
@@ -583,7 +583,7 @@ class TestNumObsLinkage:
             assert_equal(num_obs_linkage(Z), i)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestLeavesList:
 
     def test_leaves_list_1x4(self, xp):
@@ -621,7 +621,7 @@ class TestLeavesList:
                         rtol=1e-15)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestCorrespond:
 
     def test_correspond_empty(self, xp):
@@ -682,7 +682,7 @@ class TestCorrespond:
             assert_equal(num_obs_linkage(Z), n)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestIsMonotonic:
 
     def test_is_monotonic_empty(self, xp):
@@ -756,7 +756,7 @@ class TestIsMonotonic:
         assert is_monotonic(Z)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestMaxDists:
 
     def test_maxdists_empty_linkage(self, xp):
@@ -786,7 +786,7 @@ class TestMaxDists:
 
 class TestMaxInconsts:
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxinconsts_empty_linkage(self, xp):
         # Tests maxinconsts(Z, R) on empty linkage. Expecting exception.
         Z = xp.zeros((0, 4), dtype=xp.float64)
@@ -801,7 +801,7 @@ class TestMaxInconsts:
         R = xp.asarray(R)
         assert_raises(ValueError, maxinconsts, Z, R)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxinconsts_one_cluster_linkage(self, xp):
         # Tests maxinconsts(Z, R) on linkage with one cluster.
         Z = xp.asarray([[0, 1, 0.3, 4]], dtype=xp.float64)
@@ -810,7 +810,7 @@ class TestMaxInconsts:
         expectedMD = calculate_maximum_inconsistencies(Z, R, xp=xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxinconsts_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             self.check_maxinconsts_Q_linkage(method, xp)
@@ -840,7 +840,7 @@ class TestMaxRStat:
         else:
             assert_raises(TypeError, maxRstat, Z, R, i)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxRstat_empty_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_empty_linkage(i, xp)
@@ -863,7 +863,7 @@ class TestMaxRStat:
         R = xp.asarray(R)
         assert_raises(ValueError, maxRstat, Z, R, i)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxRstat_one_cluster_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_one_cluster_linkage(i, xp)
@@ -876,7 +876,7 @@ class TestMaxRStat:
         expectedMD = calculate_maximum_inconsistencies(Z, R, 1, xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_maxRstat_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             for i in range(4):
@@ -892,7 +892,7 @@ class TestMaxRStat:
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestDendrogram:
 
     def test_dendrogram_single_linkage_tdist(self, xp):
@@ -1116,7 +1116,7 @@ def calculate_maximum_inconsistencies(Z, R, k=3, xp=np):
     return B
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 def test_unsupported_uncondensed_distance_matrix_linkage_warning(xp):
     assert_warns(ClusterWarning, linkage, xp.asarray([[0, 1], [1, 0]]))
 
@@ -1127,14 +1127,14 @@ def test_euclidean_linkage_value_error(xp):
                       method=method, metric='cityblock')
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 def test_2x2_linkage(xp):
     Z1 = linkage(xp.asarray([1]), method='single', metric='euclidean')
     Z2 = linkage(xp.asarray([[0, 1], [0, 0]]), method='single', metric='euclidean')
     xp_assert_close(Z1, Z2, rtol=1e-15)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 def test_node_compare(xp):
     np.random.seed(23)
     nobs = 50
@@ -1148,7 +1148,7 @@ def test_node_compare(xp):
     assert_(tree.get_right() != tree.get_left())
 
 
-@skip_if_array_api(np_only=True, reasons=['`cut_tree` uses non-standard indexing'])
+@skip_xp_backends(np_only=True, reasons=['`cut_tree` uses non-standard indexing'])
 def test_cut_tree(xp):
     np.random.seed(23)
     nobs = 50
@@ -1177,7 +1177,7 @@ def test_cut_tree(xp):
                     cut_tree(Z, height=[10, 5]), rtol=1e-15)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 def test_optimal_leaf_ordering(xp):
     # test with the distance vector y
     Z = optimal_leaf_ordering(linkage(xp.asarray(hierarchy_test_data.ytdist)),
@@ -1192,7 +1192,7 @@ def test_optimal_leaf_ordering(xp):
     xp_assert_close(Z, xp.asarray(expectedZ), atol=1e-06)
 
 
-@skip_if_array_api(np_only=True, reasons=['`Heap` only supports NumPy backend'])
+@skip_xp_backends(np_only=True, reasons=['`Heap` only supports NumPy backend'])
 def test_Heap(xp):
     values = xp.asarray([2, -1, 0, -1.5, 3])
     heap = Heap(values)

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -19,8 +19,8 @@ from scipy._lib._array_api import (
     SCIPY_ARRAY_API, copy, cov, xp_assert_close, xp_assert_equal
 )
 
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-skip_if_array_api = pytest.mark.skip_if_array_api
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 TESTDATA_2D = np.array([
     -2.2, 1.17, -1.63, 1.69, -2.04, 4.38, -3.09, 0.95, -1.7, 4.79, -1.68, 0.68,
@@ -133,7 +133,7 @@ class TestWhiten:
 
 class TestVq:
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_py_vq(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         # label1.dtype varies between int32 and int64 over platforms
@@ -149,7 +149,7 @@ class TestVq:
         label1 = py_vq(matrix(X), matrix(initc))[0]
         assert_array_equal(label1, LABEL1)
 
-    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    @skip_xp_backends(np_only=True, reasons=['`_vq` only supports NumPy backend'])
     def test_vq(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         label1, _ = _vq.vq(xp.asarray(X), xp.asarray(initc))
@@ -164,7 +164,7 @@ class TestVq:
         assert_array_equal(label1, LABEL1)
         _, _ = vq(matrix(X), matrix(initc))
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_vq_1d(self, xp):
         # Test special rank 1 vq algo, python implementation.
         data = X[:, 0]
@@ -177,18 +177,18 @@ class TestVq:
         xp_assert_equal(ta, xp.asarray(a, dtype=xp.int64), check_dtype=False)
         xp_assert_equal(tb, xp.asarray(b))
 
-    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    @skip_xp_backends(np_only=True, reasons=['`_vq` only supports NumPy backend'])
     def test__vq_sametype(self, xp):
         a = xp.asarray([1.0, 2.0], dtype=xp.float64)
         b = a.astype(xp.float32)
         assert_raises(TypeError, _vq.vq, a, b)
 
-    @skip_if_array_api(np_only=True, reasons=['`_vq` only supports NumPy backend'])
+    @skip_xp_backends(np_only=True, reasons=['`_vq` only supports NumPy backend'])
     def test__vq_invalid_type(self, xp):
         a = xp.asarray([1, 2], dtype=int)
         assert_raises(TypeError, _vq.vq, a, a)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_vq_large_nfeat(self, xp):
         X = np.random.rand(20, 20)
         code_book = np.random.rand(3, 20)
@@ -212,7 +212,7 @@ class TestVq:
         # codes1.dtype varies between int32 and int64 over platforms
         xp_assert_equal(codes1, xp.asarray(codes0, dtype=xp.int64), check_dtype=False)
 
-    @skip_if_array_api(cpu_only=True)
+    @skip_xp_backends(cpu_only=True)
     def test_vq_large_features(self, xp):
         X = np.random.rand(10, 5) * 1000000
         code_book = np.random.rand(2, 5) * 1000000
@@ -228,7 +228,7 @@ class TestVq:
 
 # Whole class skipped on GPU for now;
 # once pdist/cdist are hooked up for CuPy, more tests will work
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestKMean:
 
     def test_large_features(self, xp):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -28,8 +28,8 @@ def pytest_configure(config):
         config.addinivalue_line(
             "markers", 'timeout: mark a test for a non-default timeout')
     config.addinivalue_line("markers",
-        "skip_if_array_api(*backends, reasons=None, np_only=False, cpu_only=False): "
-        "mark the desired skip configuration for the `skip_if_array_api` fixture.")
+        "skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False): "
+        "mark the desired skip configuration for the `skip_xp_backends` fixture.")
 
 
 def _get_mark(item, name):
@@ -153,9 +153,9 @@ array_api_compatible = pytest.mark.parametrize("xp", xp_available_backends.value
 
 
 @pytest.fixture
-def skip_if_array_api(xp, request):
+def skip_xp_backends(xp, request):
     """
-    Skip based on the ``skip_if_array_api`` marker.
+    Skip based on the ``skip_xp_backends`` marker.
 
     Parameters
     ----------
@@ -180,10 +180,10 @@ def skip_if_array_api(xp, request):
         but any ``backends`` will also be skipped on the CPU.
         Default: ``False``.
     """
-    if "skip_if_array_api" not in request.keywords:
+    if "skip_xp_backends" not in request.keywords:
         return
-    backends = request.keywords["skip_if_array_api"].args
-    kwargs = request.keywords["skip_if_array_api"].kwargs
+    backends = request.keywords["skip_xp_backends"].args
+    kwargs = request.keywords["skip_xp_backends"].kwargs
     np_only = kwargs.get("np_only", False)
     cpu_only = kwargs.get("cpu_only", False)
     if np_only:

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -12,8 +12,8 @@ from scipy._lib._array_api import (
     array_namespace, size, xp_assert_close, xp_assert_equal
 )
 
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-skip_if_array_api = pytest.mark.skip_if_array_api
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 # Expected input dtypes. Note that `scipy.fft` is more flexible for numpy,
@@ -77,7 +77,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ifft(fft.fft(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_fft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -88,7 +88,7 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.fft2(x, norm="forward"), expect / (30 * 20))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ifft2(self, xp):
         x = xp.asarray(random((30, 20)) + 1j*random((30, 20)))
@@ -99,7 +99,7 @@ class TestFFT1D:
                         expect * xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.ifft2(x, norm="forward"), expect * (30 * 20))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_fftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
@@ -110,7 +110,7 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20 * 10, dtype=xp.float64)))
         xp_assert_close(fft.fftn(x, norm="forward"), expect / (30 * 20 * 10))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ifftn(self, xp):
         x = xp.asarray(random((30, 20, 10)) + 1j*random((30, 20, 10)))
@@ -141,7 +141,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft(fft.rfft(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_rfft2(self, xp):
         x = xp.asarray(random((30, 20)), dtype=xp.float64)
@@ -152,7 +152,7 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20, dtype=xp.float64)))
         xp_assert_close(fft.rfft2(x, norm="forward"), expect / (30 * 20))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_irfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -160,7 +160,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.irfft2(fft.rfft2(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_rfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)), dtype=xp.float64)
@@ -171,7 +171,7 @@ class TestFFT1D:
                         expect / xp.sqrt(xp.asarray(30 * 20 * 10, dtype=xp.float64)))
         xp_assert_close(fft.rfftn(x, norm="forward"), expect / (30 * 20 * 10))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_irfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -202,7 +202,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.ihfft(fft.hfft(x_herm, norm=norm), norm=norm), x_herm)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_hfft2(self, xp):
         x = xp.asarray(random((30, 20)))
@@ -210,7 +210,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfft2(fft.ihfft2(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ihfft2(self, xp):
         x = xp.asarray(random((30, 20)), dtype=xp.float64)
@@ -223,7 +223,7 @@ class TestFFT1D:
         )
         xp_assert_close(fft.ihfft2(x, norm="forward"), expect * (30 * 20))
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_hfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)))
@@ -231,7 +231,7 @@ class TestFFT1D:
         for norm in ["backward", "ortho", "forward"]:
             xp_assert_close(fft.hfftn(fft.ihfftn(x, norm=norm), norm=norm), x)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     def test_ihfftn(self, xp):
         x = xp.asarray(random((30, 20, 10)), dtype=xp.float64)
@@ -254,19 +254,19 @@ class TestFFT1D:
             tr_op = xp_test.permute_dims(op(x, axes=a), axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fftn, fft.ifftn, fft.rfftn, fft.irfftn])
     def test_axes_standard(self, op, xp):
         self._check_axes(op, xp)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.hfftn, fft.ihfftn])
     def test_axes_non_standard(self, op, xp):
         self._check_axes(op, xp)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fftn, fft.ifftn,
                                     fft.rfftn, fft.irfftn])
@@ -286,7 +286,7 @@ class TestFFT1D:
                                          axes=a)
             xp_assert_close(op_tr, tr_op)
 
-    @skip_if_array_api('torch',
+    @skip_xp_backends('torch',
                        reasons=['torch.fft not yet implemented by array-api-compat'])
     @pytest.mark.parametrize("op", [fft.fft2, fft.ifft2,
                                     fft.rfft2, fft.irfft2,
@@ -329,7 +329,7 @@ class TestFFT1D:
                     tmp = back(tmp, n=n, norm=norm)
                     xp_assert_close(xp_test.linalg.vector_norm(tmp), x_norm)
 
-    @skip_if_array_api(np_only=True)
+    @skip_xp_backends(np_only=True)
     @pytest.mark.parametrize("dtype", [np.float16, np.longdouble])
     def test_dtypes_nonstandard(self, dtype):
         x = random(30).astype(dtype)
@@ -367,7 +367,7 @@ class TestFFT1D:
         rtol = {"complex64": 1.2e-4, "complex128": 1e-8}[dtype]
         xp_assert_close(res_fft, x, rtol=rtol, atol=0)
 
-@skip_if_array_api(np_only=True)
+@skip_xp_backends(np_only=True)
 @pytest.mark.parametrize(
         "dtype",
         [np.float32, np.float64, np.longdouble,
@@ -456,7 +456,7 @@ class TestFFTThreadSafe:
         self._test_mtsame(fft.ihfft, a, xp=xp)
 
 
-@skip_if_array_api(np_only=True)
+@skip_xp_backends(np_only=True)
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)
@@ -469,7 +469,7 @@ def test_multiprocess(func):
         assert_allclose(x, expect)
 
 
-@skip_if_array_api('torch',
+@skip_xp_backends('torch',
                    reasons=['torch.fft not yet implemented by array-api-compat'])
 class TestIRFFTN:
 
@@ -484,7 +484,7 @@ class TestIRFFTN:
         fft.irfftn(a, axes=axes)
 
 
-@skip_if_array_api('torch',
+@skip_xp_backends('torch',
                    reasons=['torch.fft not yet implemented by array-api-compat'])
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft,
                                   fft.fftn, fft.ifftn,

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -14,8 +14,8 @@ from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close, SCIPY_DEVICE
 from scipy import fft
 
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-skip_if_array_api = pytest.mark.skip_if_array_api
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 _5_smooth_numbers = [
     2, 3, 4, 5, 6, 8, 9, 10,
@@ -51,7 +51,7 @@ def _assert_n_smooth(x, n):
            f'x={x_orig} is not {n}-smooth, remainder={x}'
 
 
-@skip_if_array_api(np_only=True)
+@skip_xp_backends(np_only=True)
 class TestNextFastLen:
 
     def test_next_fast_len(self):
@@ -126,7 +126,7 @@ class TestNextFastLen:
         assert next_fast_len(target=7, real=False) == 7
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class Test_init_nd_shape_and_axes:
 
     def test_py_0d_defaults(self, xp):
@@ -315,7 +315,7 @@ class Test_init_nd_shape_and_axes:
             _init_nd_shape_and_axes(x, shape=-2, axes=None)
 
 
-@skip_if_array_api('torch',
+@skip_xp_backends('torch',
                    reasons=['torch.fft not yet implemented by array-api-compat'])
 class TestFFTShift:
 
@@ -391,7 +391,7 @@ class TestFFTShift:
         xp_assert_close(fft.ifftshift(shift_dim_both), freqs)
 
 
-@skip_if_array_api('array_api_strict', 'cupy',
+@skip_xp_backends('array_api_strict', 'cupy',
                    reasons=['fft not yet implemented by array-api-strict',
                             'cupy.fft not yet implemented by array-api-compat'])
 class TestFFTFreq:
@@ -419,7 +419,7 @@ class TestFFTFreq:
         xp_assert_close(y, x2)
 
 
-@skip_if_array_api('array_api_strict', 'cupy',
+@skip_xp_backends('array_api_strict', 'cupy',
                    reasons=['fft not yet implemented by array-api-strict',
                             'cupy.fft not yet implemented by array-api-compat'])
 class TestRFFTFreq:

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -9,8 +9,8 @@ from scipy import fftpack
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import copy, xp_assert_close
 
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_if_array_api")]
-skip_if_array_api = pytest.mark.skip_if_array_api
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 SQRT_2 = math.sqrt(2)
 
@@ -19,7 +19,7 @@ SQRT_2 = math.sqrt(2)
 # fftpack/test_real_transforms.py
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("n", [2, 3, 4, 5, 10, 16])
@@ -42,7 +42,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize, xp):
     xp_assert_close(z2, x)
 
 
-@skip_if_array_api(np_only=True,
+@skip_xp_backends(np_only=True,
                    reasons=['`overwrite_x` only supported for NumPy backend.'])
 @pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
@@ -68,7 +68,7 @@ def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
         assert_allclose(z, x_orig, rtol=1e-6, atol=1e-6)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("shape, axes",
@@ -115,7 +115,7 @@ def test_identity_nd(forward, backward, type, shape, axes, norm,
     xp_assert_close(z2, x)
 
 
-@skip_if_array_api(np_only=True,
+@skip_xp_backends(np_only=True,
                    reasons=['`overwrite_x` only supported for NumPy backend.'])
 @pytest.mark.parametrize("forward, backward", [(dctn, idctn), (dstn, idstn)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
@@ -150,7 +150,7 @@ def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
         assert_array_equal(y, y_orig)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("func", ['dct', 'dst', 'dctn', 'dstn'])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
@@ -163,7 +163,7 @@ def test_fftpack_equivalience(func, type, norm, xp):
     xp_assert_close(fft_res, fftpack_res)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("func", [dct, dst, dctn, dstn])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 def test_orthogonalize_default(func, type, xp):
@@ -180,7 +180,7 @@ def test_orthogonalize_default(func, type, xp):
         xp_assert_close(a, b)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func, type", [
     (dct, 4), (dst, 1), (dst, 4)])
@@ -192,7 +192,7 @@ def test_orthogonalize_noop(func, type, norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 def test_orthogonalize_dct1(norm, xp):
     x = xp.asarray(np.random.rand(100))
@@ -209,7 +209,7 @@ def test_orthogonalize_dct1(norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst2(func, norm, xp):
@@ -221,7 +221,7 @@ def test_orthogonalize_dcst2(func, norm, xp):
     xp_assert_close(y1, y2)
 
 
-@skip_if_array_api(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst3(func, norm, xp):


### PR DESCRIPTION
#### Reference issue
Discussion in gh-20285 @mdhaber 

#### What does this implement/fix?
Renames the marker and the fixture to avoid confusion.

#### Additional information
Open to suggestions for a better name.