### PR TITLE
ENH: Generalised ufuncs in special

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -79,7 +79,7 @@ import textwrap
 import numpy
 
 special_ufuncs = [
-    '_cospi', '_sinpi', 'bei', 'beip', 'ber', 'berp', 'exp1', 'expi',
+    '_cospi', '_sinpi', '_lpn', 'bei', 'beip', 'ber', 'berp', 'exp1', 'expi',
     'gammaln', 'it2i0k0', 'it2j0y0', 'it2struve0', 'itairy',
     'iti0k0', 'itj0y0', 'itmodstruve0', 'itstruve0', 'kei', 'keip',
     'kelvin', 'ker', 'kerp', 'mathieu_a', 'mathieu_b',

--- a/scipy/special/_specfun.pyx
+++ b/scipy/special/_specfun.pyx
@@ -3,6 +3,10 @@ from libcpp.complex cimport complex as ccomplex
 cimport numpy as cnp
 cnp.import_array()
 
+import numpy as np
+
+from ._special_ufuncs import _lpn
+
 cdef extern from "special/specfun/specfun.h" nogil:
     void specfun_airyzo 'special::specfun::airyzo'(int nt, int kf, double *xa, double *xb, double *xc, double *xd)
     void specfun_bernob 'special::specfun::bernob'(int n, double *bn)
@@ -409,22 +413,15 @@ def lpmn(int m, int n, double x):
     return pm, pd
 
 
-def lpn(int n, double z):
+def lpn(n, z):
     """
     Compute Legendre polynomials Pn(x) and their derivatives
     Pn'(x). This is a wrapper for the function 'specfun_lpn'.
     """
-    cdef double *ppn
-    cdef double *ppd
-    cdef cnp.npy_intp dims[1]
-    dims[0] = n + 1
 
-    pn = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
-    pd = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
-    ppn = <cnp.float64_t *>cnp.PyArray_DATA(pn)
-    ppd = <cnp.float64_t *>cnp.PyArray_DATA(pd)
-    specfun_lpn(n, z, ppn, ppd)
-    return pn, pd
+    pn = np.zeros((n + 1,) + np.shape(z), dtype = np.float64)
+    pd = np.zeros((n + 1,) + np.shape(z), dtype = np.float64)
+    return _lpn(z, out = (pn, pd))
 
 
 def lqmn(int m, int n, double x):

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 
 #include "special/gamma.h"
+#include "special/legendre.h"
 #include "special/specfun.h"
 #include "special/trig.h"
 #include "special/zeta.h"
@@ -152,6 +153,9 @@ PyMODINIT_FUNC PyInit__special_ufuncs() {
 
     PyObject *kerp = SpecFun_NewUFunc({special::kerp<float>, special::kerp<double>}, "kerp", kerp_doc);
     PyModule_AddObjectRef(_special_ufuncs, "kerp", kerp);
+
+    PyObject *_lpn = SpecFun_NewGUFunc({special::lpn}, 2, "_lpn", nullptr, "()->(n),(n)");
+    PyModule_AddObjectRef(_special_ufuncs, "_lpn", _lpn);
 
     PyObject *mathieu_a =
         SpecFun_NewUFunc({special::cem_cva<float>, special::cem_cva<double>}, "mathieu_a", mathieu_a_doc);

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -140,10 +140,11 @@ cephes_lib = static_library('cephes',
 )
 
 py3.extension_module('_special_ufuncs',
-  ['_special_ufuncs.cpp', '_special_ufuncs_docs.cpp', 'sf_error.cc'],
+  ['_special_ufuncs.cpp', '_special_ufuncs_docs.cpp'],
   include_directories: ['../_lib', '../_build_utils/src'],
   dependencies: [np_dep],
   link_args: version_link_args,
+  link_with: [special_error_lib],
   install: true,
   subdir: 'scipy/special'
 )

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -115,7 +115,6 @@ ufuncs_sources = [
   'scaled_exp1.c',
   'amos_wrappers.c',
   'specfun_wrappers.cpp',
-  'sf_error.c'
 ]
 
 ufuncs_cxx_sources = [
@@ -123,9 +122,15 @@ ufuncs_cxx_sources = [
   '_wright.cxx',
   'ellint_carlson_wrap.cxx',
   'Faddeeva.cc',
-  'sf_error.cc',
   'wright.cc'
 ]
+
+special_error_lib = shared_library('special_error',
+  ['sf_error.cc'],
+  include_directories: ['../_lib', '../_build_utils/src'],
+  cpp_args: ['-DSP_SPECFUN_ERROR'],
+  install: true
+)
 
 cephes_lib = static_library('cephes',
   cephes_sources,
@@ -217,7 +222,8 @@ py3.extension_module('_ufuncs',
   link_args: version_link_args,
   link_with: [
     amos_lib,
-    cephes_lib
+    cephes_lib,
+    special_error_lib
   ],
   install: true,
   subdir: 'scipy/special'
@@ -255,17 +261,18 @@ py3.extension_module('_ufuncs_cxx',
   include_directories: ['../_lib/boost_math/include', '../_lib',
                         '../_build_utils/src'],
   link_args: version_link_args,
-    link_with: [cephes_lib],
+  link_with: [cephes_lib, special_error_lib],
   dependencies: [np_dep, ellint_dep],
   install: true,
   subdir: 'scipy/special'
 )
 
 py3.extension_module('_ellip_harm_2',
-  [uf_cython_gen.process('_ellip_harm_2.pyx'), 'sf_error.c'],
+  [uf_cython_gen.process('_ellip_harm_2.pyx')],
   c_args: cython_c_args,
   include_directories: ['../_lib', '../_build_utils/src'],
   link_args: version_link_args,
+  link_with: [special_error_lib],
   dependencies: [lapack, np_dep],
   install: true,
   subdir: 'scipy/special'
@@ -278,7 +285,6 @@ py3.extension_module('cython_special',
     'scaled_exp1.c',
     'amos_wrappers.c',
     'specfun_wrappers.cpp',
-    'sf_error.c'
   ],
   c_args: [cython_c_args, Wno_maybe_uninitialized],
   include_directories: ['../_lib', '../_build_utils/src', 'cephes'],
@@ -286,7 +292,8 @@ py3.extension_module('cython_special',
   dependencies: [np_dep, npymath_lib, lapack],
   link_with: [
     amos_lib,
-    cephes_lib
+    cephes_lib,
+    special_error_lib
   ],
   install: true,
   subdir: 'scipy/special'

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -1,23 +1,20 @@
-#include <Python.h>
-
-#include <stdlib.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "sf_error.h"
 
-const char *sf_error_messages[] = {
-    "no error",
-    "singularity",
-    "underflow",
-    "overflow",
-    "too slow convergence",
-    "loss of precision",
-    "no result obtained",
-    "domain error",
-    "invalid input argument",
-    "other error",
-    NULL
-};
+const char *sf_error_messages[] = {"no error",
+                                   "singularity",
+                                   "underflow",
+                                   "overflow",
+                                   "too slow convergence",
+                                   "loss of precision",
+                                   "no result obtained",
+                                   "domain error",
+                                   "invalid input argument",
+                                   "other error",
+                                   NULL};
 
 /* If this isn't volatile clang tries to optimize it away */
 static volatile sf_action_t sf_error_actions[] = {
@@ -34,34 +31,24 @@ static volatile sf_action_t sf_error_actions[] = {
     SF_ERROR_IGNORE  /* SF_ERROR__LAST */
 };
 
-extern int wrap_PyUFunc_getfperr(void);
+static sf_callback_t sf_error_callback;
 
+static sf_callback_fpe_t sf_error_callback_fpe;
 
-void sf_error_set_action(sf_error_t code, sf_action_t action)
-{
-    sf_error_actions[(int)code] = action;
-}
+void sf_error_set_action(sf_error_t code, sf_action_t action) { sf_error_actions[(int) code] = action; }
 
+sf_action_t sf_error_get_action(sf_error_t code) { return sf_error_actions[(int) code]; }
 
-sf_action_t sf_error_get_action(sf_error_t code)
-{
-    return sf_error_actions[(int)code];
-}
+void sf_error_set_callback(sf_callback_t callback) { sf_error_callback = callback; }
 
+void sf_error_set_callback_fpe(sf_callback_fpe_t callback_fpe) { sf_error_callback_fpe = callback_fpe; }
 
-void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list ap)
-{
-    /* Internal function which takes a va_list instead of variadic args.
-     * Makes this easier to wrap in error handling used in special C++
-     * namespace for special function kernels provided by SciPy. */
-    PyGILState_STATE save;
-    PyObject *scipy_special = NULL;
+void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list ap) {
     char msg[2048], info[1024];
-    static PyObject *py_SpecialFunctionWarning = NULL;
     sf_action_t action;
 
-    if ((int)code < 0 || (int)code >= 10) {
-	code = SF_ERROR_OTHER;
+    if ((int) code < 0 || (int) code >= 10) {
+        code = SF_ERROR_OTHER;
     }
     action = sf_error_get_action(code);
     if (action == SF_ERROR_IGNORE) {
@@ -73,71 +60,14 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     }
 
     if (fmt != NULL && fmt[0] != '\0') {
-        PyOS_vsnprintf(info, 1024, fmt, ap);
-        PyOS_snprintf(msg, 2048, "scipy.special/%s: (%s) %s",
-                      func_name, sf_error_messages[(int)code], info);
-    }
-    else {
-        PyOS_snprintf(msg, 2048, "scipy.special/%s: %s",
-                      func_name, sf_error_messages[(int)code]);
+        vsnprintf(info, 1024, fmt, ap);
+        snprintf(msg, 2048, "scipy.special/%s: (%s) %s", func_name, sf_error_messages[(int) code], info);
+    } else {
+        snprintf(msg, 2048, "scipy.special/%s: %s", func_name, sf_error_messages[(int) code]);
     }
 
-#ifdef WITH_THREAD
-    save = PyGILState_Ensure();
-#endif
-
-    if (PyErr_Occurred()) {
-      goto skip_warn;
-    }
-
-    scipy_special = PyImport_ImportModule("scipy.special");
-    if (scipy_special == NULL) {
-	PyErr_Clear();
-	goto skip_warn;
-    }
-
-    if (action == SF_ERROR_WARN) {
-	py_SpecialFunctionWarning =
-	    PyObject_GetAttrString(scipy_special, "SpecialFunctionWarning");
-    }
-    else if (action == SF_ERROR_RAISE) {
-	py_SpecialFunctionWarning =
-	    PyObject_GetAttrString(scipy_special, "SpecialFunctionError");
-    }
-    else {
-	/* Sentinel, should never get here */
-	py_SpecialFunctionWarning = NULL;
-    }
-    /* Done with scipy_special */
-    Py_DECREF(scipy_special);
-
-    if (py_SpecialFunctionWarning == NULL) {
-	PyErr_Clear();
-	goto skip_warn;
-    }
-
-    if (action == SF_ERROR_WARN) {
-	PyErr_WarnEx(py_SpecialFunctionWarning, msg, 1);
-	/*
-	 * For ufuncs the return value is ignored! We rely on the fact
-	 * that the Ufunc loop will call PyErr_Occurred() later on.
-	 */
-    }
-    else if (action == SF_ERROR_RAISE) {
-	PyErr_SetString(py_SpecialFunctionWarning, msg);
-    }
-    else {
-	goto skip_warn;
-    }
-
-    skip_warn:
-#ifdef WITH_THREAD
-        PyGILState_Release(save);
-#else
-	;
-#endif
+    sf_error_callback(action, msg);
 }
-
 
 void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
     va_list ap;
@@ -146,16 +76,13 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
     va_end(ap);
 }
 
+#define UFUNC_FPE_DIVIDEBYZERO 1
+#define UFUNC_FPE_OVERFLOW 2
+#define UFUNC_FPE_UNDERFLOW 4
+#define UFUNC_FPE_INVALID 8
 
-#define UFUNC_FPE_DIVIDEBYZERO  1
-#define UFUNC_FPE_OVERFLOW      2
-#define UFUNC_FPE_UNDERFLOW     4
-#define UFUNC_FPE_INVALID       8
-
-void sf_error_check_fpe(const char *func_name)
-{
-    int status;
-    status = wrap_PyUFunc_getfperr();
+void sf_error_check_fpe(const char *func_name) {
+    int status = sf_error_callback_fpe();
     if (status & UFUNC_FPE_DIVIDEBYZERO) {
         sf_error(func_name, SF_ERROR_SINGULAR, "floating point division by zero");
     }

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -1,7 +1,5 @@
-#include <Python.h>
-
-#include <stdlib.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 #include "special/error.h"
 // #include "sf_error.h"
@@ -10,10 +8,8 @@ extern "C" {
 #include "sf_error.c"
 }
 
-
 #ifdef SP_SPECFUN_ERROR
-void special::set_error(const char *func_name, sf_error_t code,
-			       const char *fmt, ...) {
+void special::set_error(const char *func_name, sf_error_t code, const char *fmt, ...) {
     /* Definition of error handling for special C++ library of special
      * functions used in SciPy.
      *

--- a/scipy/special/sf_error.h
+++ b/scipy/special/sf_error.h
@@ -14,11 +14,18 @@ typedef enum {
     SF_ERROR_RAISE        /* Raise on errors */
 } sf_action_t;
 
+typedef void (*sf_callback_t)(sf_action_t, const char *);
+
+typedef int (*sf_callback_fpe_t)();
+
 extern const char *sf_error_messages[];
 void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...);
 void sf_error_check_fpe(const char *func_name);
 void sf_error_set_action(sf_error_t code, sf_action_t action);
 sf_action_t sf_error_get_action(sf_error_t code);
+
+void sf_error_set_callback(sf_callback_t callback);
+void sf_error_set_callback_fpe(sf_callback_fpe_t callback_fpe);
 
 #ifdef __cplusplus
 }

--- a/scipy/special/sf_error.pxd
+++ b/scipy/special/sf_error.pxd
@@ -18,12 +18,17 @@ cdef extern from "sf_error.h":
         WARN "SF_ERROR_WARN"
         RAISE "SF_ERROR_RAISE"
 
+    ctypedef void (*sf_error_callback_t)(sf_action_t, const char *) except *
+
+    ctypedef int (*sf_error_callback_fpe_t)() noexcept
+
     char **sf_error_messages
     void error "sf_error" (char *func_name, sf_error_t code, char *fmt, ...) nogil
     void check_fpe "sf_error_check_fpe" (char *func_name) nogil
     void set_action "sf_error_set_action" (sf_error_t code, sf_action_t action) nogil
     sf_action_t get_action "sf_error_get_action" (sf_error_t code) nogil
-
+    void sf_error_set_callback(sf_error_callback_t) nogil
+    void sf_error_set_callback_fpe(sf_error_callback_fpe_t) nogil;
 
 cdef inline int _sf_error_test_function(int code) noexcept nogil:
     """Function that can raise every sf_error category for testing

--- a/scipy/special/special/config.h
+++ b/scipy/special/special/config.h
@@ -53,6 +53,33 @@
 #define M_SQRT1_2 0.707106781186547524401
 #endif
 
+namespace std {
+
+inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
+
+// TODO: Do we want this?
+template <typename T, size_t Extent = dynamic_extent>
+class span {
+  public:
+    using size_type = size_t;
+
+  private:
+    T *m_data;
+    size_t m_count;
+
+  public:
+    constexpr span() noexcept : m_data(nullptr), m_count(0) {}
+
+    template <typename It>
+    span(It first, size_t count) : m_data(first), m_count(count) {}
+
+    T *data() { return m_data; }
+
+    constexpr size_type size() const noexcept { return m_count; }
+};
+
+} // namespace std
+
 #ifdef __CUDACC__
 #define SPECFUN_HOST_DEVICE __host__ __device__
 

--- a/scipy/special/special/legendre.h
+++ b/scipy/special/special/legendre.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "config.h"
+#include "specfun/specfun.h"
+
+namespace special {
+
+inline void lpn(double x, std::span<double> pn, std::span<double> pd) {
+    specfun::lpn(pn.size() - 1, x, pn.data(), pd.data());
+}
+
+} // namespace special

--- a/scipy/special/ufunc.h
+++ b/scipy/special/ufunc.h
@@ -54,6 +54,11 @@ constexpr size_t arity_of_v = arity_of<Func>::value;
 template <typename T>
 struct npy_type;
 
+template <typename T>
+struct npy_type<std::span<T>> {
+    static constexpr int value = npy_type<T>::value;
+};
+
 template <>
 struct npy_type<long int> {
     static constexpr int value = NPY_LONG;
@@ -96,20 +101,26 @@ struct npy_type<npy_cdouble> {
 
 // Sets the value dst to be the value of type T at src
 template <typename T>
-void from_pointer(char *src, T &dst) {
+void from_pointer(char *src, T &dst, const npy_intp *dimensions, const npy_intp *steps) {
     dst = *reinterpret_cast<T *>(src);
+}
+
+// Sets the value dst to be the value of type T at src
+template <typename T>
+void from_pointer(char *src, std::span<T> &dst, const npy_intp *dimensions, const npy_intp *steps) {
+    dst = {reinterpret_cast<T *>(src), static_cast<size_t>(dimensions[1])};
 }
 
 // Sets the pointer dst to be the pointer of type T at src (helps for out arguments)
 template <typename T>
-void from_pointer(char *src, T *&dst) {
+void from_pointer(char *src, T *&dst, const npy_intp *dimensions, const npy_intp *steps) {
     dst = reinterpret_cast<T *>(src);
 }
 
 template <typename T>
-T from_pointer(char *src) {
+T from_pointer(char *src, const npy_intp *dimensions, const npy_intp *steps) {
     T dst;
-    from_pointer(src, dst);
+    from_pointer(src, dst, dimensions, steps);
 
     return dst;
 }
@@ -131,7 +142,7 @@ struct ufunc_traits<Res(Args...), std::index_sequence<I...>> {
         const char *func_name = static_cast<SpecFun_UFuncData *>(data)->name;
 
         for (npy_intp i = 0; i < dimensions[0]; ++i) {
-            *reinterpret_cast<Res *>(args[sizeof...(Args)]) = func(from_pointer<Args>(args[I])...);
+            *reinterpret_cast<Res *>(args[sizeof...(Args)]) = func(from_pointer<Args>(args[I], dimensions, steps)...);
 
             for (npy_uintp j = 0; j < sizeof...(Args); ++j) {
                 args[j] += steps[j];
@@ -152,7 +163,7 @@ struct ufunc_traits<void(Args...), std::index_sequence<I...>> {
         const char *func_name = static_cast<SpecFun_UFuncData *>(data)->name;
 
         for (npy_intp i = 0; i < dimensions[0]; ++i) {
-            func(from_pointer<Args>(args[I])...);
+            func(from_pointer<Args>(args[I], dimensions, steps)...);
 
             for (npy_uintp j = 0; j < sizeof...(Args); ++j) {
                 args[j] += steps[j];
@@ -246,4 +257,30 @@ PyObject *SpecFun_NewUFunc(std::initializer_list<SpecFun_Func> func, int nout, c
 
 PyObject *SpecFun_NewUFunc(std::initializer_list<SpecFun_Func> func, const char *name, const char *doc) {
     return SpecFun_NewUFunc(func, func.begin()->has_return(), name, doc);
+}
+
+PyObject *SpecFun_NewGUFunc(std::initializer_list<SpecFun_Func> func, int nout, const char *name, const char *doc,
+                            const char *signature) {
+    static std::vector<SpecFun_UFunc> ufuncs;
+
+    for (auto it = func.begin(); it != func.end(); ++it) {
+        if (it->nin_and_nout() != func.begin()->nin_and_nout()) {
+            PyErr_SetString(PyExc_RuntimeError, "all functions must have the same number of arguments");
+            return nullptr;
+        }
+        if (it->has_return() != func.begin()->has_return()) {
+            PyErr_SetString(PyExc_RuntimeError, "all functions must be void if any function is");
+            return nullptr;
+        }
+    }
+
+    const SpecFun_UFunc &ufunc = ufuncs.emplace_back(func, name);
+    return PyUFunc_FromFuncAndDataAndSignature(ufunc.func(), ufunc.data(), ufunc.types(), ufunc.ntypes(),
+                                               ufunc.nin_and_nout() - nout, nout, PyUFunc_None, name, doc, 0,
+                                               signature);
+}
+
+PyObject *SpecFun_NewGUFunc(std::initializer_list<SpecFun_Func> func, const char *name, const char *doc,
+                            const char *signature) {
+    return SpecFun_NewGUFunc(func, func.begin()->has_return(), name, doc, signature);
 }


### PR DESCRIPTION
This PR follows the [one](https://github.com/scipy/scipy/pull/20260) merged yesterday about overhauling the ufunc machinery. The purpose here is to extend that slightly (and only slightly) so that SciPy special can support generalised ufuncs for some of its existing functions. In particular, I am thinking of all the functions in `_specfun.pyx`. These include the Legendre polynomials, Airy and Bessel function zeros, and so on. No doubt others will follow.

These functions differ from their counterparts in that their kernels may take arrays as their inputs or outputs. A canonical example is matrix multiplication over stacks of matrices. Here it is a bit simpler, essentially we have special functions that return outputs with one or more additional dimensions. Usually these additional dimensions corrrespond simply to a value `n` in the input, so we have a function producing an array of shape `(n, ...)`. Currently, these functions in SciPy only work for scalar input, so given a value `x` the output is an array of size `n`. But there is no reason to have such a restriction, we could easily be given an array `x` of shape `(d0, ..., dm)` and get output of shape `(n, d0, ..., dm)`. Here we introduce such functionality.

This is actually quite a small change. We need to use NumPy's generalised ufunc machinery, namely `PyUFunc_FromFuncAndDataAndSignature` and pass an appropriate signature. Let's focus on `lpn`. With the new machinery, this is just:
```
PyObject *_lpn = SpecFun_NewGUFunc({special::lpn}, 2, "_lpn", "docstring here", "()->(n),(n)");
PyModule_AddObjectRef(_special_ufuncs, "_lpn", _lpn);
```

Then, at the Cython / Python level, The Legendre polynomials `lpn` went from:
```
def lpn(int n, double z):
    """
    Compute Legendre polynomials Pn(x) and their derivatives
    Pn'(x). This is a wrapper for the function 'specfun_lpn'.
    """
    cdef double *ppn
    cdef double *ppd
    cdef cnp.npy_intp dims[1]
    dims[0] = n + 1

    pn = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
    pd = cnp.PyArray_ZEROS(1, dims, cnp.NPY_FLOAT64, 0)
    ppn = <cnp.float64_t *>cnp.PyArray_DATA(pn)
    ppd = <cnp.float64_t *>cnp.PyArray_DATA(pd)
    specfun_lpn(n, z, ppn, ppd)
    return pn, pd
```
to
```
def lpn(n, z):
    """
    Compute Legendre polynomials Pn(x) and their derivatives
    Pn'(x). This is a wrapper for the function 'specfun_lpn'.
    """

    pn = np.zeros((n + 1,) + np.shape(z), dtype = np.float64)
    pd = np.zeros((n + 1,) + np.shape(z), dtype = np.float64)
    return _lpn(z, out = (pn, pd))
```
This also has the additional benefit of eliminating the need for Cython in these functions.

The last change is at the C++ level. This one is perhaps mostly for @steppi to check out. We need a very simple `struct` or `class` that can act as the C++-equivalent of a view (pointer, shape, and strides). Although there is nothing yet in C++17, that is actually already accepted into later versions of the standard, namely [std::span<T>](https://en.cppreference.com/w/cpp/container/span) in C++20 and  [std::mdspan<T>](https://en.cppreference.com/w/cpp/container/mdspan)  in C++23. Since we only support C++17, we can either create our own versions of these or create another data structure that is equivalent. It is just pointer, shape, and strides. CuPy does exactly the latter.

In this PR I made my own `std::span`. The Legendre polynomials then become, in C++.
```
inline void lpn(double x, std::span<double> pn, std::span<double> pd) {
    specfun::lpn(pn.size() - 1, x, pn.data(), pd.data());
}
```
And the generalised ufunc is published as above.

Putting this here now for thoughts.
