### PR TITLE
BUG: Fix for scipy.special seterr, geterr, errstate

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -145,8 +145,8 @@ jobs:
           python -m build --no-isolation -x -Csetup-args="-Duse-pythran=false"
 
           # Vendor openblas.dll and the DLL's it depends on into the wheel
-          # Ignore, libsf_error_state.dll for special function error handling. This
-          # will be loaded later using ctypes in scipy/special/__init__.py.
+          # Ignore `libsf_error_state.dll` for special function error handling;
+          # it will be loaded using ctypes in scipy/special/__init__.py.
           $env:wheel_name=Get-ChildItem -Path dist/* -Include *.whl
           delvewheel repair --add-path c:\opt\openblas\openblas_dll --no-dll libsf_error_state.dll -w dist $env:wheel_name
           

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -144,9 +144,11 @@ jobs:
         run: |
           python -m build --no-isolation -x -Csetup-args="-Duse-pythran=false"
 
-          # Vendor openblas.dll and the DLL's it depends on into the wheel 
+          # Vendor openblas.dll and the DLL's it depends on into the wheel
+          # Ignore, libsf_error_state.dll for special function error handling. This
+          # will be loaded later using ctypes in scipy/special/__init__.py.
           $env:wheel_name=Get-ChildItem -Path dist/* -Include *.whl
-          delvewheel repair --add-path c:\opt\openblas\openblas_dll -w dist $env:wheel_name
+          delvewheel repair --add-path c:\opt\openblas\openblas_dll --no-dll libsf_error_state.dll -w dist $env:wheel_name
           
           python -m pip install $env:wheel_name
 

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -211,6 +211,7 @@ def is_unexpected(name):
 SKIP_LIST = [
     'scipy.conftest',
     'scipy.version',
+    'scipy.special.libsf_error_state'
 ]
 
 

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -770,7 +770,39 @@ Convenience functions
 
 """  # noqa: E501
 
+import os
 import warnings
+
+
+def _load_libsf_error_state():
+    """Load libsf_error_state.dll shared library on Windows
+
+    libsf_error_state manages shared state used by
+    ``scipy.special.seterr`` and ``scipy.special.geterr`` so that these
+    can work consistently between special functions provided by different
+    extension modules. This shared library is installed in scipy/special
+    alongside this __init__.py file. Due to lack of rpath support, Windows
+    cannot find shared libraries installed within wheels. To circumvent this,
+    we pre-load ``lib_sf_error_state.dll`` when on Windows.
+
+    The logic for this function was borrowed from the function ``make_init``
+    in `scipy/tools/openblas_support.py`:
+    https://github.com/scipy/scipy/blob/bb92c8014e21052e7dde67a76b28214dd1dcb94a/tools/openblas_support.py#L239-L274
+    """  # noqa: E501
+    if os.name == "nt":
+        try:
+            from ctypes import WinDLL
+            basedir = os.path.dirname(__file__)
+        except:  # noqa: E722
+            pass
+        else:
+            dll_path = os.path.join(basedir, "libsf_error_state.dll")
+            if os.path.exists(dll_path):
+                WinDLL(dll_path)
+
+
+_load_libsf_error_state()
+
 
 from ._sf_error import SpecialFunctionWarning, SpecialFunctionError
 
@@ -862,36 +894,3 @@ def _get_include():
     import os
     return os.path.dirname(__file__)
 
-
-def _load_libsf_error_state():
-    """Load libsf_error_state.dll shared library on Windows
-
-    libsf_error_state manages shared state used by
-    ``scipy.special.seterr`` and ``scipy.special.geterr`` so that these
-    can work consistently between special functions provided by different
-    extension modules. This shared library is installed in scipy/special
-    alongside this __init__.py file. Due to lack of rpath support, Windows
-    cannot find shared libraries installed within wheels. To circumvent this,
-    we directly load lib_sf_error_state.dll when on Windows.
-
-    The logic for this function was borrowed from the function ``make__init``
-    in `scipy/tools/openblas_support.py`.
-
-    https://github.com/scipy/scipy/blob/bb92c8014e21052e7dde67a76b28214dd1dcb94a/tools/openblas_support.py#L239-L274
-    """  # noqa: E501
-    import os
-    if os.name == "nt":
-        # convention for storing / loading the DLL from
-        # numpy/.libs/, if present
-        try:
-            from ctypes import WinDLL
-            basedir = os.path.dirname(__file__)
-        except:  # noqa: E722
-            pass
-        else:
-            dll_path = os.path.join(basedir, "libsf_error_state.dll")
-            if os.path.exists(dll_path):
-                WinDLL(dll_path)
-
-
-_load_libsf_error_state()

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -861,3 +861,35 @@ def _get_include():
     """
     import os
     return os.path.dirname(__file__)
+
+
+def _load_libsf_error_state():
+    """Load libsf_error_state.dll shared library on Windows
+
+    libsf_error_state manages shared state used by
+    ``scipy.special.seterr`` and ``scipy.special.geterr`` so that these
+    can work consistently between special functions provided by different
+    extension modules. This shared library is installed in scipy/special
+    alongside this __init__.py file. Due to lack of rpath support, Windows
+    cannot find shared libraries installed within wheels. To circumvent this,
+    we directly load lib_sf_error_state.dll when on Windows.
+
+    The logic for this function was borrowed from the function ``make__init``
+    in `scipy/tools/openblas_support.py`.
+
+    https://github.com/scipy/scipy/blob/bb92c8014e21052e7dde67a76b28214dd1dcb94a/tools/openblas_support.py#L239-L274
+    """  # noqa: E501
+    import os
+    if os.name == "nt":
+        try:
+            from ctypes import WinDLL
+            basedir = os.path.dirname(__file__)
+        except:
+            pass
+        else:
+            dll_path = os.path.join(basedir, "libsf_error_state.dll")
+            if os.path.exists(dll_path):
+                WinDLL(dll_path)
+
+
+_load_libsf_error_state()

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -881,6 +881,8 @@ def _load_libsf_error_state():
     """  # noqa: E501
     import os
     if os.name == "nt":
+        # convention for storing / loading the DLL from
+        # numpy/.libs/, if present
         try:
             from ctypes import WinDLL
             basedir = os.path.dirname(__file__)

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -884,7 +884,7 @@ def _load_libsf_error_state():
         try:
             from ctypes import WinDLL
             basedir = os.path.dirname(__file__)
-        except:
+        except:  # noqa: E722
             pass
         else:
             dll_path = os.path.join(basedir, "libsf_error_state.dll")

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -142,6 +142,7 @@ py3.extension_module('_special_ufuncs',
   link_with: [sf_error_state_lib],
   link_args: version_link_args,
   install: true,
+  cpp_args: ['-DSP_SPECFUN_ERROR'],
   subdir: 'scipy/special'
 )
 

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -144,7 +144,8 @@ py3.extension_module('_special_ufuncs',
   link_args: version_link_args,
   install: true,
   cpp_args: ['-DSP_SPECFUN_ERROR'],
-  subdir: 'scipy/special'
+  subdir: 'scipy/special',
+  install_rpath: '$ORIGIN',
 )
 
 py3.extension_module('_specfun',
@@ -224,7 +225,8 @@ py3.extension_module('_ufuncs',
     cephes_lib
   ],
   install: true,
-  subdir: 'scipy/special'
+  subdir: 'scipy/special',
+  install_rpath: '$ORIGIN',
 )
 
 ellint_files = [
@@ -262,7 +264,8 @@ py3.extension_module('_ufuncs_cxx',
     link_with: [sf_error_state_lib, cephes_lib],
   dependencies: [np_dep, ellint_dep],
   install: true,
-  subdir: 'scipy/special'
+  subdir: 'scipy/special',
+  install_rpath: '$ORIGIN',
 )
 
 py3.extension_module('_ellip_harm_2',
@@ -273,7 +276,8 @@ py3.extension_module('_ellip_harm_2',
   link_args: version_link_args,
   dependencies: [lapack, np_dep],
   install: true,
-  subdir: 'scipy/special'
+  subdir: 'scipy/special',
+  install_rpath: '$ORIGIN',
 )
 
 py3.extension_module('cython_special',
@@ -294,7 +298,8 @@ py3.extension_module('cython_special',
     cephes_lib
   ],
   install: true,
-  subdir: 'scipy/special'
+  subdir: 'scipy/special',
+  install_rpath: '$ORIGIN',
 )
 
 py3.extension_module('_comb',

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -104,6 +104,13 @@ cephes_sources = [
   'cephes/zetac.c'
 ]
 
+sf_error_state_lib = shared_library('sf_error_state',
+  ['sf_error_state.c'],
+  include_directories: ['../_lib', '../_build_utils/src'],
+  cpp_args: ['-DSP_SPECFUN_ERROR'],
+  install: true,
+)
+
 ufuncs_sources = [
   '_cosine.c',
   'scaled_exp1.c',
@@ -132,6 +139,7 @@ py3.extension_module('_special_ufuncs',
   ['_special_ufuncs.cpp', '_special_ufuncs_docs.cpp', 'sf_error.cc'],
   include_directories: ['../_lib', '../_build_utils/src'],
   dependencies: [np_dep],
+  link_with: [sf_error_state_lib],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/special'
@@ -210,6 +218,7 @@ py3.extension_module('_ufuncs',
   ],
   link_args: version_link_args,
   link_with: [
+    sf_error_state_lib,
     cephes_lib
   ],
   install: true,
@@ -248,7 +257,7 @@ py3.extension_module('_ufuncs_cxx',
   include_directories: ['../_lib/boost_math/include', '../_lib',
                         '../_build_utils/src'],
   link_args: version_link_args,
-    link_with: [cephes_lib],
+    link_with: [sf_error_state_lib, cephes_lib],
   dependencies: [np_dep, ellint_dep],
   install: true,
   subdir: 'scipy/special'
@@ -258,6 +267,7 @@ py3.extension_module('_ellip_harm_2',
   [uf_cython_gen.process('_ellip_harm_2.pyx'), 'sf_error.c'],
   c_args: cython_c_args,
   include_directories: ['../_lib', '../_build_utils/src'],
+  link_with: [sf_error_state_lib],
   link_args: version_link_args,
   dependencies: [lapack, np_dep],
   install: true,
@@ -278,6 +288,7 @@ py3.extension_module('cython_special',
   link_args: version_link_args,
   dependencies: [np_dep, npymath_lib, lapack],
   link_with: [
+    sf_error_state_lib,
     cephes_lib
   ],
   install: true,

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -109,6 +109,7 @@ sf_error_state_lib = shared_library('sf_error_state',
   include_directories: ['../_lib', '../_build_utils/src'],
   cpp_args: ['-DSP_SPECFUN_ERROR'],
   install: true,
+  install_dir: py3.get_install_dir() / 'scipy/special',
 )
 
 ufuncs_sources = [

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -5,48 +5,8 @@
 
 #include "sf_error.h"
 
-const char *sf_error_messages[] = {
-    "no error",
-    "singularity",
-    "underflow",
-    "overflow",
-    "too slow convergence",
-    "loss of precision",
-    "no result obtained",
-    "domain error",
-    "invalid input argument",
-    "other error",
-    NULL
-};
-
-/* If this isn't volatile clang tries to optimize it away */
-static volatile sf_action_t sf_error_actions[] = {
-    SF_ERROR_IGNORE, /* SF_ERROR_OK */
-    SF_ERROR_IGNORE, /* SF_ERROR_SINGULAR */
-    SF_ERROR_IGNORE, /* SF_ERROR_UNDERFLOW */
-    SF_ERROR_IGNORE, /* SF_ERROR_OVERFLOW */
-    SF_ERROR_IGNORE, /* SF_ERROR_SLOW */
-    SF_ERROR_IGNORE, /* SF_ERROR_LOSS */
-    SF_ERROR_IGNORE, /* SF_ERROR_NO_RESULT */
-    SF_ERROR_IGNORE, /* SF_ERROR_DOMAIN */
-    SF_ERROR_IGNORE, /* SF_ERROR_ARG */
-    SF_ERROR_IGNORE, /* SF_ERROR_OTHER */
-    SF_ERROR_IGNORE  /* SF_ERROR__LAST */
-};
 
 extern int wrap_PyUFunc_getfperr(void);
-
-
-void sf_error_set_action(sf_error_t code, sf_action_t action)
-{
-    sf_error_actions[(int)code] = action;
-}
-
-
-sf_action_t sf_error_get_action(sf_error_t code)
-{
-    return sf_error_actions[(int)code];
-}
 
 
 void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list ap)

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -6,6 +6,21 @@
 #include "sf_error.h"
 
 
+const char *sf_error_messages[] = {
+    "no error",
+    "singularity",
+    "underflow",
+    "overflow",
+    "too slow convergence",
+    "loss of precision",
+    "no result obtained",
+    "domain error",
+    "invalid input argument",
+    "other error",
+    NULL
+};
+
+
 extern int wrap_PyUFunc_getfperr(void);
 
 
@@ -23,7 +38,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     if ((int)code < 0 || (int)code >= 10) {
 	code = SF_ERROR_OTHER;
     }
-    action = sf_error_get_action(code);
+    action = scipy_sf_error_get_action(code);
     if (action == SF_ERROR_IGNORE) {
         return;
     }

--- a/scipy/special/sf_error.h
+++ b/scipy/special/sf_error.h
@@ -1,27 +1,15 @@
-#ifndef SF_ERROR_H_
-#define SF_ERROR_H_
+#pragma once
 
-#include "special/error.h"
+#include "sf_error_state.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-typedef enum {
-    SF_ERROR_IGNORE = 0,  /* Ignore errors */
-    SF_ERROR_WARN,        /* Warn on errors */
-    SF_ERROR_RAISE        /* Raise on errors */
-} sf_action_t;
-
-extern const char *sf_error_messages[];
 void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...);
 void sf_error_check_fpe(const char *func_name);
-void sf_error_set_action(sf_error_t code, sf_action_t action);
-sf_action_t sf_error_get_action(sf_error_t code);
+
 
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SF_ERROR_H_ */

--- a/scipy/special/sf_error.h
+++ b/scipy/special/sf_error.h
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+extern const char *sf_error_messages[];
 void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...);
 void sf_error_check_fpe(const char *func_name);
 

--- a/scipy/special/sf_error.pxd
+++ b/scipy/special/sf_error.pxd
@@ -21,8 +21,8 @@ cdef extern from "sf_error.h":
     char **sf_error_messages
     void error "sf_error" (char *func_name, sf_error_t code, char *fmt, ...) nogil
     void check_fpe "sf_error_check_fpe" (char *func_name) nogil
-    void set_action "sf_error_set_action" (sf_error_t code, sf_action_t action) nogil
-    sf_action_t get_action "sf_error_get_action" (sf_error_t code) nogil
+    void set_action "scipy_sf_error_set_action" (sf_error_t code, sf_action_t action) nogil
+    sf_action_t get_action "scipy_sf_error_get_action" (sf_error_t code) nogil
 
 
 cdef inline int _sf_error_test_function(int code) noexcept nogil:

--- a/scipy/special/sf_error_state.c
+++ b/scipy/special/sf_error_state.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+
+#include "sf_error_state.h"
+
+const char *sf_error_messages[] = {
+    "no error",
+    "singularity",
+    "underflow",
+    "overflow",
+    "too slow convergence",
+    "loss of precision",
+    "no result obtained",
+    "domain error",
+    "invalid input argument",
+    "other error",
+    NULL
+};
+
+/* If this isn't volatile clang tries to optimize it away */
+static volatile sf_action_t sf_error_actions[] = {
+    SF_ERROR_IGNORE, /* SF_ERROR_OK */
+    SF_ERROR_IGNORE, /* SF_ERROR_SINGULAR */
+    SF_ERROR_IGNORE, /* SF_ERROR_UNDERFLOW */
+    SF_ERROR_IGNORE, /* SF_ERROR_OVERFLOW */
+    SF_ERROR_IGNORE, /* SF_ERROR_SLOW */
+    SF_ERROR_IGNORE, /* SF_ERROR_LOSS */
+    SF_ERROR_IGNORE, /* SF_ERROR_NO_RESULT */
+    SF_ERROR_IGNORE, /* SF_ERROR_DOMAIN */
+    SF_ERROR_IGNORE, /* SF_ERROR_ARG */
+    SF_ERROR_IGNORE, /* SF_ERROR_OTHER */
+    SF_ERROR_IGNORE  /* SF_ERROR__LAST */
+};
+
+
+void sf_error_set_action(sf_error_t code, sf_action_t action)
+{
+    sf_error_actions[(int)code] = action;
+}
+
+
+sf_action_t sf_error_get_action(sf_error_t code)
+{
+    return sf_error_actions[(int)code];
+}

--- a/scipy/special/sf_error_state.c
+++ b/scipy/special/sf_error_state.c
@@ -2,19 +2,6 @@
 
 #include "sf_error_state.h"
 
-const char *sf_error_messages[] = {
-    "no error",
-    "singularity",
-    "underflow",
-    "overflow",
-    "too slow convergence",
-    "loss of precision",
-    "no result obtained",
-    "domain error",
-    "invalid input argument",
-    "other error",
-    NULL
-};
 
 /* If this isn't volatile clang tries to optimize it away */
 static volatile sf_action_t sf_error_actions[] = {
@@ -32,13 +19,13 @@ static volatile sf_action_t sf_error_actions[] = {
 };
 
 
-void sf_error_set_action(sf_error_t code, sf_action_t action)
+void scipy_sf_error_set_action(sf_error_t code, sf_action_t action)
 {
     sf_error_actions[(int)code] = action;
 }
 
 
-sf_action_t sf_error_get_action(sf_error_t code)
+sf_action_t scipy_sf_error_get_action(sf_error_t code)
 {
     return sf_error_actions[(int)code];
 }

--- a/scipy/special/sf_error_state.h
+++ b/scipy/special/sf_error_state.h
@@ -1,0 +1,23 @@
+#pragma once
+
+
+#include "special/error.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    typedef enum {
+        SF_ERROR_IGNORE = 0,  /* Ignore errors */
+        SF_ERROR_WARN,        /* Warn on errors */
+        SF_ERROR_RAISE        /* Raise on errors */
+    } sf_action_t;
+    
+    extern const char *sf_error_messages[];
+    void sf_error_set_action(sf_error_t code, sf_action_t action);
+    sf_action_t sf_error_get_action(sf_error_t code);
+
+#ifdef __cplusplus
+}
+#endif

--- a/scipy/special/sf_error_state.h
+++ b/scipy/special/sf_error_state.h
@@ -14,9 +14,8 @@ extern "C" {
         SF_ERROR_RAISE        /* Raise on errors */
     } sf_action_t;
     
-    extern const char *sf_error_messages[];
-    void sf_error_set_action(sf_error_t code, sf_action_t action);
-    sf_action_t sf_error_get_action(sf_error_t code);
+    void scipy_sf_error_set_action(sf_error_t code, sf_action_t action);
+    sf_action_t scipy_sf_error_get_action(sf_error_t code);
 
 #ifdef __cplusplus
 }

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -120,7 +120,7 @@ def test_errstate_cpp_alt_ufunc_machinery():
     olderr = sc.geterr()
     with sc.errstate(singular='raise'):
         with assert_raises(sc.SpecialFunctionError):
-            sc.gammln(0)
+            sc.gammaln(0)
     assert_equal(olderr, sc.geterr())
 
 

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -116,6 +116,14 @@ def test_errstate_cpp_scipy_special():
     assert_equal(olderr, sc.geterr())
 
 
+def test_errstate_cpp_alt_ufunc_machinery():
+    olderr = sc.geterr()
+    with sc.errstate(singular='raise'):
+        with assert_raises(sc.SpecialFunctionError):
+            sc.gammln(0)
+    assert_equal(olderr, sc.geterr())
+
+
 def test_errstate():
     for category, error_code in _sf_error_code_map.items():
         for action in _sf_error_actions:

--- a/tools/check_pyext_symbol_hiding.sh
+++ b/tools/check_pyext_symbol_hiding.sh
@@ -8,12 +8,22 @@
 
 set -e
 
+
 count_text_symbols() {
     nm -D --defined-only "$1" | wc -l
 }
 
 check_symbols() {
     NUM=`count_text_symbols "$1"`
+    FILENAME=$(basename "$1")
+
+    # special function error handling requires shared state between extension
+    # modules that depend on it. There is a shared library encapsulating this
+    # state which is an exception.
+    if [[ "$FILENAME" == "libsf_error_state.so" ]]; then
+        return 0
+    fi
+
     if [[ "$NUM" != "1" ]]; then
         echo "$1: too many public symbols!"
         nm -D --defined-only "$1"

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -117,8 +117,6 @@ DOCTEST_SKIPLIST = set([
     'scipy.linalg.LinAlgError',
     'scipy.optimize.show_options',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
-    'scipy.special.errstate',
-    'scipy.special.seterr',
 ])
 
 # these names are not required to be present in ALL despite being in

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -29,4 +29,4 @@ rm -rf tmp
 
 # the libopenblas.dll is placed into this directory in the cibw_before_build
 # script.
-delvewheel repair --add-path /c/opt/openblas/openblas_dll -w $DEST_DIR $WHEEL
+delvewheel repair --add-path /c/opt/openblas/openblas_dll --no-dll libsf_error_state.dll -w $DEST_DIR $WHEEL


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR is an alternative to #20316. `scipy.special.seterr`, `scipy.special.geterr`, `scipy.special.errstate` currently do not work for ufuncs not implemented in the extension module `_ufuncs` (whose cython code is generated by `_generate_pyx.py`). This is because `sf_error.c` manages an error state in a static array, and currently each extension module has a separate copy of `sf_error.c` compiled in, when they actually all should be sharing this state. As identified by @izaid, a potential solution is to manage this state in a shared library. This PR differs from #20316 in that the shared library only manages the shared state and nothing else. I think it's best to go with the minimal set of changes for now in order to leave more options open for the future.