### PR TITLE
BUG: sparse: align dok_array.pop() to dict.pop() for case with no default arg

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -90,8 +90,8 @@ class _dok_base(_spbase, IndexMixin, dict):
     def clear(self):
         return self._dict.clear()
 
-    def pop(self, key, default=None, /):
-        return self._dict.pop(key, default)
+    def pop(self, /, *args):
+        return self._dict.pop(*args)
 
     def __reversed__(self):
         raise TypeError("reversed is not defined for dok_array type")

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -83,6 +83,13 @@ def test_pop(d, Asp):
     assert Asp.pop((0, 1)) == 1
     assert d.items() == Asp.items()
 
+    assert Asp.pop((22, 21), None) is None
+    assert Asp.pop((22, 21), "other") == "other"
+    with pytest.raises(KeyError, match="(22, 21)"):
+        Asp.pop((22, 21))
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        Asp.pop((22, 21), default=5)
+
 def test_popitem(d, Asp):
     assert d.popitem() == Asp.popitem()
     assert d.items() == Asp.items()


### PR DESCRIPTION
PR #20175  fixed an omission of the `pop` method for `dok_array` and `dok_matrix`, but did not correctly handle the case when no `default` parameter is specified. The method should mimic `dict.pop` by raising a KeyError when `default` is not specified.  This PR fixes that error.

If PR #20175 is backported then this PR should be also.
