### PR TITLE
MAINT: Improve performance of ndimage.binary_erosion

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -2275,8 +2275,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
 
     rank = dt.ndim
     if return_indices:
-        sz = numpy.prod(dt.shape, axis=0)
-        ft = numpy.arange(sz, dtype=numpy.int32)
+        ft = numpy.arange(dt.size, dtype=numpy.int32)
         ft.shape = dt.shape
     else:
         ft = None

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -46,7 +46,7 @@ __all__ = ['iterate_structure', 'generate_binary_structure', 'binary_erosion',
 
 
 def _center_is_true(structure, origin):
-    structure = numpy.array(structure)
+    structure = numpy.asarray(structure)
     coor = tuple([oo + ss // 2 for ss, oo in zip(structure.shape,
                                                  origin)])
     return bool(structure[coor])
@@ -231,7 +231,7 @@ def _binary_erosion(input, structure, iterations, mask, output,
         raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.contiguous:
         structure = structure.copy()
-    if numpy.prod(structure.shape, axis=0) < 1:
+    if structure.size < 1:
         raise RuntimeError('structure must not be empty')
     if mask is not None:
         mask = numpy.asarray(mask)


### PR DESCRIPTION
For smaller input of the `binary_erosion` method we improve performance by simplifying a check on the size of the array. We also avoid creation of a temporary array in `_center_is_true`

Benchmark:
```
import numpy as np
import scipy.ndimage as ndimage

data  = (np.random.rand(24, 20)+.5).astype(int)
structure=np.array([[1,1,1]])
%timeit ndimage.binary_erosion(data, structure)
```
Results:
```
main: 8.45 µs ± 273 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
PR random data 5.47 µs ± 48.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!

#### Reference issue

#### What does this implement/fix?

-->

#### Additional information

There are more places in the scipy codebase where we can improve performance by replacing `np.prod` with faster code. In this first PR we only update `scipy.ndimage._morphology`.
