### PR TITLE
MAINT: Replace usage of np.prod

### DIFF
--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -2,6 +2,7 @@
 '''
 import sys
 import warnings
+import math
 
 import numpy as np
 
@@ -557,7 +558,7 @@ class VarWriter4:
             T=mxCHAR_CLASS)
         if arr.dtype.kind == 'U':
             # Recode unicode to latin1
-            n_chars = np.prod(dims)
+            n_chars = math.prod(dims)
             st_arr = np.ndarray(shape=(),
                                 dtype=arr_dtype_number(arr, n_chars),
                                 buffer=arr)

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -68,6 +68,7 @@ Small fragments of current code adapted from matfile.py by Heiko
 Henkelmann; parts of the code for simplify_cells=True adapted from
 http://blog.nephics.com/2019/08/28/better-loadmat-for-scipy/.
 '''
+
 import math
 import os
 import time

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -68,7 +68,7 @@ Small fragments of current code adapted from matfile.py by Heiko
 Henkelmann; parts of the code for simplify_cells=True adapted from
 http://blog.nephics.com/2019/08/28/better-loadmat-for-scipy/.
 '''
-
+import math
 import os
 import time
 import sys
@@ -728,7 +728,7 @@ class VarWriter5:
             # transpose here, because we're flattening the array, before
             # we write the bytes. The bytes have to be written in
             # Fortran order.
-            n_chars = np.prod(shape)
+            n_chars = math.prod(shape)
             st_arr = np.ndarray(shape=(),
                                 dtype=arr_dtype_number(arr, n_chars),
                                 buffer=arr.T.copy())  # Fortran order

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, prod, zeros, array, outer)
+                   asarray, zeros, array, outer)
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize
@@ -266,9 +266,9 @@ def ss2tf(A, B, C, D, input=0):
     except ValueError:
         den = 1
 
-    if (prod(B.shape, axis=0) == 0) and (prod(C.shape, axis=0) == 0):
+    if (B.size == 0) and (C.size == 0):
         num = numpy.ravel(D)
-        if (prod(D.shape, axis=0) == 0) and (prod(A.shape, axis=0) == 0):
+        if (D.size == 0) and (A.size == 0):
             den = []
         return num, den
 

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, prod, zeros, array, outer) # noqa: F401
+                   asarray, zeros, array, outer)
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, zeros, array, outer)
+                   asarray, prod, zeros, array, outer)
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, prod, zeros, array, outer) # ruff: disable=F401
+                   asarray, prod, zeros, array, outer) # noqa
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, prod, zeros, array, outer)
+                   asarray, prod, zeros, array, outer) # ruff: disable=F401
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -5,7 +5,7 @@ from one representation to another.
 import numpy
 import numpy as np
 from numpy import (r_, eye, atleast_2d, poly, dot,
-                   asarray, prod, zeros, array, outer) # noqa
+                   asarray, prod, zeros, array, outer) # noqa: F401
 from scipy import linalg
 
 from ._filter_design import tf2zpk, zpk2tf, normalize

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1645,11 +1645,11 @@ def wiener(im, mysize=None, noise=None):
         mysize = np.repeat(mysize.item(), im.ndim)
 
     # Estimate the local mean
-    lMean = correlate(im, np.ones(mysize), 'same') / np.prod(mysize, axis=0)
+    size = math.prod(mysize)
+    lMean = correlate(im, np.ones(mysize), 'same') / size
 
     # Estimate the local variance
-    lVar = (correlate(im ** 2, np.ones(mysize), 'same') /
-            np.prod(mysize, axis=0) - lMean ** 2)
+    lVar = (correlate(im ** 2, np.ones(mysize), 'same') / size - lMean ** 2)
 
     # Estimate the noise power if needed.
     if noise is None:

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -7,7 +7,7 @@ from scipy._lib.deprecation import _sub_module_deprecation
 __all__ = [  # noqa: F822
     'tf2ss', 'abcd_normalize', 'ss2tf', 'zpk2ss', 'ss2zpk',
     'cont2discrete','eye', 'atleast_2d',
-    'poly', 'prod', 'array', 'outer', 'linalg', 'tf2zpk', 'zpk2tf', 'normalize'
+    'poly', 'array', 'outer', 'linalg', 'tf2zpk', 'zpk2tf', 'normalize'
 ]
 
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -5,6 +5,7 @@
     as self but with a different data array
 
 """
+
 import math
 import numpy as np
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -5,7 +5,7 @@
     as self but with a different data array
 
 """
-
+import math
 import numpy as np
 
 from ._base import _spbase, _ufuncs_with_fixed_point_at_zero
@@ -223,7 +223,7 @@ class _minmax_mixin:
             if self.nnz == 0:
                 return zero
             m = min_or_max.reduce(self._deduped_data().ravel())
-            if self.nnz != np.prod(self.shape):
+            if self.nnz != math.prod(self.shape):
                 m = min_or_max(zero, m)
             return m
 
@@ -306,7 +306,7 @@ class _minmax_mixin:
             return int(mat.row[extreme_index]) * num_col + int(mat.col[extreme_index])
 
         # Cheap test for the rare case where we have no implicit zeros.
-        size = np.prod(self.shape)
+        size = math.prod(self.shape)
         if size == mat.nnz:
             return int(mat.row[extreme_index]) * num_col + int(mat.col[extreme_index])
 

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 
 from .arpack import _arpack  # type: ignore[attr-defined]
@@ -33,7 +34,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
             or np.issubdtype(A.dtype, np.floating)):
         message = "`A` must be of floating or complex floating data type."
         raise ValueError(message)
-    if A.size == 0:
+    if math.prod(A.shape) == 0:
         message = "`A` must not be empty."
         raise ValueError(message)
 

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -33,7 +33,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
             or np.issubdtype(A.dtype, np.floating)):
         message = "`A` must be of floating or complex floating data type."
         raise ValueError(message)
-    if np.prod(A.shape) == 0:
+    if A.size == 0:
         message = "`A` must not be empty."
         raise ValueError(message)
 

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -70,13 +70,12 @@ the same shared library.
 
 import itertools
 import json
+import math
 import os
 from stat import ST_MTIME
 import argparse
 import re
 import textwrap
-
-import numpy
 
 special_ufuncs = [
     '_cospi', '_sinpi', 'bei', 'beip', 'ber', 'berp', 'exp1', 'expi',
@@ -950,7 +949,7 @@ class FusedFunc(Func):
         all_codes = tuple([codes for _unused, codes in fused_types])
 
         codelens = [len(x) for x in all_codes]
-        last = numpy.prod(codelens) - 1
+        last = math.prod(codelens) - 1
         for m, codes in enumerate(itertools.product(*all_codes)):
             fused_codes, decs = [], []
             for n, fused_type in enumerate(fused_types):


### PR DESCRIPTION
We replace usage of `np.prod` with either a direct call to `array.size` if possible or else use `math.prod`.
Direct usage of the size leads to cleaner code. Both alternatives are significantly faster. For example:
```    
x = [1, 2, 3]

%timeit math.prod(x)
50.7 ns ± 2.24 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

%timeit np.prod(x)
2.53 µs ± 36 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

@ev-br This is similar to #20325. These are all the easy/clear cases I could find.
