### PR TITLE
DOC: fix small typo in odds_ratio

### DIFF
--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -401,7 +401,7 @@ def odds_ratio(table, *, kind='conditional'):
     between being exposed and being a case.
 
     Interchanging the rows or columns of the contingency table inverts
-    the odds ratio, so it is import to understand the meaning of labels
+    the odds ratio, so it is important to understand the meaning of labels
     given to the rows and columns of the table when interpreting the
     odds ratio.
 


### PR DESCRIPTION
#### Reference issue
None.

#### What does this implement/fix?
Small typo in odds_ratio function's documentation.
Seems to be a unique occurrence.

#### Additional information
Was unable to build nor test locally.
Debian 12, Python 3.11.2.
