### PR TITLE
MAINT: update `array_api_compat` to v1.5.1

### DIFF
--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -143,6 +143,7 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/common/__init__.py',
     'array_api_compat/array_api_compat/common/_aliases.py',
+    'array_api_compat/array_api_compat/common/_fft.py',
     'array_api_compat/array_api_compat/common/_helpers.py',
     'array_api_compat/array_api_compat/common/_linalg.py',
     'array_api_compat/array_api_compat/common/_typing.py',
@@ -155,6 +156,7 @@ py3.install_sources(
     'array_api_compat/array_api_compat/cupy/__init__.py',
     'array_api_compat/array_api_compat/cupy/_aliases.py',
     'array_api_compat/array_api_compat/cupy/_typing.py',
+    'array_api_compat/array_api_compat/cupy/fft.py',
     'array_api_compat/array_api_compat/cupy/linalg.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/cupy',
@@ -162,9 +164,26 @@ py3.install_sources(
 
 py3.install_sources(
   [
+    'array_api_compat/array_api_compat/dask/__init__.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/dask/',
+)
+
+py3.install_sources(
+  [
+    'array_api_compat/array_api_compat/dask/array/__init__.py',
+    'array_api_compat/array_api_compat/dask/array/_aliases.py',
+    'array_api_compat/array_api_compat/dask/array/linalg.py',
+  ],
+  subdir: 'scipy/_lib/array_api_compat/dask/array',
+)
+
+py3.install_sources(
+  [
     'array_api_compat/array_api_compat/numpy/__init__.py',
     'array_api_compat/array_api_compat/numpy/_aliases.py',
     'array_api_compat/array_api_compat/numpy/_typing.py',
+    'array_api_compat/array_api_compat/numpy/fft.py',
     'array_api_compat/array_api_compat/numpy/linalg.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/numpy',
@@ -174,6 +193,7 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/torch/__init__.py',
     'array_api_compat/array_api_compat/torch/_aliases.py',
+    'array_api_compat/array_api_compat/torch/fft.py',
     'array_api_compat/array_api_compat/torch/linalg.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/torch',

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -230,7 +230,10 @@ def test_all_modules_are_expected():
         # with the installed NumPy version, there can be errors on importing
         # `array_api_compat`. This should only raise if SciPy is configured with
         # that library as an available backend.
-        for backend, dir_name in {'cupy': 'cupy', 'pytorch': 'torch'}.items():
+        backends = {'cupy': 'cupy',
+                    'pytorch': 'torch',
+                    'dask.array': 'dask.array'}
+        for backend, dir_name in backends.items():
             path = f'array_api_compat.{dir_name}'
             if path in name and backend not in xp_available_backends:
                 return

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -180,5 +180,11 @@ def test_mixed_index_dtype_int_indexing(cls):
     indices_64bit.indices = base_mtx.indices.astype(np.int64)
 
     for mtx in [base_mtx, indptr_64bit, indices_64bit]:
-        np.testing.assert_array_equal(mtx[[1,2], :].toarray(), base_mtx[[1, 2], :].toarray())
-        np.testing.assert_array_equal(mtx[:, [1, 2]].toarray(), base_mtx[:, [1, 2]].toarray())
+        np.testing.assert_array_equal(
+            mtx[[1,2], :].toarray(),
+            base_mtx[[1, 2], :].toarray()
+        )
+        np.testing.assert_array_equal(
+            mtx[:, [1, 2]].toarray(),
+            base_mtx[:, [1, 2]].toarray()
+        )

--- a/tools/check_installation.py
+++ b/tools/check_installation.py
@@ -36,10 +36,11 @@ changed_installed_path = {
 
 # We do not want the following tests to be checked
 exception_list_test_files = [
+    "_lib/array_api_compat/tests/test_all.py",
+    "_lib/array_api_compat/tests/test_array_namespace.py",
     "_lib/array_api_compat/tests/test_common.py",
     "_lib/array_api_compat/tests/test_isdtype.py",
     "_lib/array_api_compat/tests/test_vendoring.py",
-    "_lib/array_api_compat/tests/test_array_namespace.py",
 ]
 
 


### PR DESCRIPTION
#### Reference issue
Splits out changes unrelated to JAX from gh-20085.

#### What does this implement/fix?
Update vendored `array_api_compat` and appease linter.

#### Additional information
Also useful to unblock stats array API work.