### PR TITLE
MAINT: Fix Cythonize bug in optimize with const view

### DIFF
--- a/scipy/optimize/_group_columns.pyx
+++ b/scipy/optimize/_group_columns.pyx
@@ -15,7 +15,7 @@ np.import_array()
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def group_dense(int m, int n, const int[:, :] A):
-    cdef int [:, :] B = A.T  # Transposed view for convenience.
+    cdef const int [:, :] B = A.T  # Transposed view for convenience.
 
     cdef int [:] groups = np.full(n, -1, dtype=np.int32)
     cdef int current_group = 0


### PR DESCRIPTION
No idea why I'm hitting https://github.com/scipy/scipy/actions/runs/8421482739/job/23058563336?pr=19706#step:7:1857 only in https://github.com/scipy/scipy/pull/19706 given that the latest Cython release was March 5th but this seems like a reasonable change anyway. Apologies if I missed an issue or PR looking into it already, I looked and didn't see anything obvious