### PR TITLE
MAINT: spatial: use cython_lapack in spatial/_qhull.pyx

### DIFF
--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -40,7 +40,7 @@ py3.extension_module('_qhull',
     'qhull_src/src'
   ],
   link_args: version_link_args,
-  dependencies: [lapack, np_dep],
+  dependencies: [np_dep],
   install: true,
   subdir: 'scipy/spatial'
 )

--- a/scipy/spatial/qhull_misc.h
+++ b/scipy/spatial/qhull_misc.h
@@ -1,18 +1,11 @@
 /*
- * Handle different Fortran conventions and qh_new_qhull_scipy entry point.
+ * Handle qh_new_qhull_scipy entry point.
  */
 #ifndef QHULL_MISC_H_
 #define QHULL_MISC_H_
 
+/* for CBLAS_INT only*/
 #include "npy_cblas.h"
-
-void BLAS_FUNC(dgetrf)(CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, CBLAS_INT*);
-void BLAS_FUNC(dgecon)(char*, CBLAS_INT*, double*, CBLAS_INT*, double*, double*, double*, CBLAS_INT*, CBLAS_INT*, size_t);
-void BLAS_FUNC(dgetrs)(char*, CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, double*, CBLAS_INT*, CBLAS_INT*, size_t);
-
-#define qh_dgetrf(m,n,a,lda,ipiv,info) BLAS_FUNC(dgetrf)(m,n,a,lda,ipiv,info)
-#define qh_dgecon(norm,n,a,lda,anorm,rcond,work,iwork,info) BLAS_FUNC(dgecon)(norm,n,a,lda,anorm,rcond,work,iwork,info,1)
-#define qh_dgetrs(trans,n,nrhs,a,lda,ipiv,b,ldb,info) BLAS_FUNC(dgetrs)(trans,n,nrhs,a,lda,ipiv,b,ldb,info,1)
 
 #define qhull_misc_lib_check() QHULL_LIB_CHECK
 


### PR DESCRIPTION
Use `linalg.cython_lapack` in `_qhull.pyx` instead of manual LAPACK wrappers (the qhull usage likely predates cython_lapack).

Just a small drive-by cleanup while looking at https://github.com/scipy/scipy/issues/20271