### PR TITLE
BUG: linalg: raise an error in dnrm2(..., incx<0)

### DIFF
--- a/scipy/linalg/fblas_l1.pyf.src
+++ b/scipy/linalg/fblas_l1.pyf.src
@@ -388,7 +388,7 @@ function <prefix3>nrm2(n,x,offx,incx) result(n2)
 
   <ftype3> dimension(*),intent(in) :: x
 
-  integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
+  integer optional, intent(in),check(incx>0) :: incx = 1
 
   integer optional,intent(in),depend(x) :: offx=0
   check(offx>=0 && offx<len(x)) :: offx
@@ -410,7 +410,7 @@ function <prefix4>nrm2(n,x,offx,incx) result(n2)
 
   <ftype4> dimension(*),intent(in) :: x
 
-  integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
+  integer optional, intent(in),check(incx>0) :: incx = 1
 
   integer optional,intent(in),depend(x) :: offx=0
   check(offx>=0 && offx<len(x)) :: offx

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -1102,3 +1102,13 @@ def test_gh_169309():
     actual = scipy.linalg.blas.dnrm2(x, 5, 3, -1)
     expected = math.sqrt(500)
     assert_allclose(actual, expected)
+
+
+def test_dnrm2_neg_incx():
+    # check that dnrm2(..., incx < 0) raises
+    # XXX: remove the test after the lowest supported BLAS implements
+    # negative incx (new in LAPACK 3.10)
+    x = np.repeat(10, 9)
+    incx = -1
+    with assert_raises(fblas.__fblas_error):
+        scipy.linalg.blas.dnrm2(x, 5, 3, incx)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-16930

#### What does this implement/fix?
<!--Please explain your changes.-->

As discussed in the issue, esp https://github.com/scipy/scipy/issues/16930#issuecomment-1993994703


