### PR TITLE
BLD: linalg: fix rebuild dependencies for .pyf.src files

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -60,7 +60,13 @@ linalg_cython_gen = generator(cython,
 fblas_module = custom_target('fblas_module',
   output: ['_fblasmodule.c'],
   input: 'fblas.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'],
+  depend_files:
+    [
+      'fblas_l1.pyf.src',
+      'fblas_l2.pyf.src',
+      'fblas_l3.pyf.src',
+    ]
 )
 
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
@@ -80,7 +86,18 @@ py3.extension_module('_fblas',
 flapack_module = custom_target('flapack_module',
   output: ['_flapackmodule.c'],
   input: 'flapack.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'],
+  depend_files:
+    [
+      'flapack_user.pyf.src',
+      'flapack_gen.pyf.src',
+      'flapack_gen_banded.pyf.src',
+      'flapack_gen_tri.pyf.src',
+      'flapack_sym_herm.pyf.src',
+      'flapack_pos_def.pyf.src',
+      'flapack_pos_def_tri.pyf.src',
+      'flapack_other.pyf.src',
+    ]
 )
 
 # Note that -Wno-empty-body is Clang-specific and comes from `callstatement`s


### PR DESCRIPTION
This is a follow-up to gh-20229, which noticed that some edits to `.pyf.src` files that are `include`'d in other `.pyf.src` files didn't trigger a rebuild.