### PR TITLE
ENH: linalg.expm: add explicit formula for 2d matrices

### DIFF
--- a/benchmarks/benchmarks/linalg_expm.py
+++ b/benchmarks/benchmarks/linalg_expm.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from .common import Benchmark, safe_import
+
+with safe_import():
+    from scipy.linalg import expm
+
+
+
+class Expm_2d(Benchmark):
+
+    def setup(self):
+        self.small_2d_matrices = np.array([
+            [[1, 4], [1, 1]],
+            [[1, 3], [1, -1]],
+            [[1, 3], [4, 5]],
+            [[1, 3], [5, 3]],
+            [[4, 5], [-3, -4]]
+            ], order='F')
+        
+        self.large_2d_matrices = np.array([
+            [[-494.08845191, 0], [12566.3706, - 12566.3706]],
+            [[200, 1000], [3, 4]],
+            [[90, 100], [500, 5]],
+            [[80, 30.5], [20.17, 200.5]]
+            ], order='F')
+        
+    
+    def time_2d_small(self):
+        expm(self.small_2d_matrices)
+    
+    def time_2d_large(self):
+        expm(self.large_2d_matrices)
+    
+
+class Expm_nd(Benchmark):
+    params = [[500, 1000],
+              [20, 50]
+              ]
+    param_names = ['n', 'num_matrices']
+
+    def setup(self, n, num_matrices):
+        self.nd_matrices = np.random.rand(num_matrices, n, n)
+    
+    def time_nd_matrices(self, n, num_matrices):
+        expm(self.nd_matrices)
+
+
+
+
+    
+
+

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -6,6 +6,7 @@ from itertools import product
 import numpy as np
 from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
+from numpy.lib.scimath import sqrt as csqrt
 
 # Local imports
 from scipy.linalg import LinAlgError, bandwidth
@@ -304,7 +305,7 @@ def expm(A):
 
     # Explicit formula for 2x2 case (formula (2.2) in [1]).
     if a.shape[-2:] == (2, 2): 
-        norm = np.max(np.abs(np.linalg.norm(a)).astype(int))
+        norm = np.max(np.linalg.norm(a).astype(int))
 
         # Normalizing the matrix to prevent cosh from overflowing.
         if norm < 1:
@@ -316,8 +317,7 @@ def expm(A):
                        a[..., [1], [0]], 
                        a[..., [1], [1]]) 
         
-        # Using np.emath.sqrt because np.sqrt doesn't work with negative values
-        mu = np.emath.sqrt((a1-a4)**2 + 4*a2*a3)/2.
+        mu = csqrt((a1-a4)**2 + 4*a2*a3)/2. # csqrt slow but handles neg.vals 
   
         eApD2 = np.exp((a1+a4)/2.) 
         AmD2 = (a1 - a4)/2. 
@@ -332,7 +332,7 @@ def expm(A):
         eA[..., [1], [1]] = eApD2 * (coshMu - AmD2*sinchMu) 
         if np.isrealobj(a): 
             return np.linalg.matrix_power(eA.real, norm) 
-        return np.linalg.matrix_power(eA, norm) 
+        return np.linalg.matrix_power(eA, norm).astype(a.dtype) 
 
 
     n = a.shape[-1]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
`http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping
`
Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #20262

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds the explicit formula for  $2\times2$ matrices in `linalg.expm`, while preventing the overflow of `numpy.cosh` by normalizing the input matrices first.  Also adds a benchmark file for `linalg.expm`

#### Additional information
<!--Any additional information you think is important.-->
From running the `linalg_expm.Expm_2d.time_2d_large` in the benchmark suite, the benchmark for the base branch was 50.2±0ms, while  the explicit formula's benchmark was 10.8±0ms. For matrices with small magnitudes, the difference between the two cases wasn't very large. To compute $A^n$, I used `numpy.linalg.matrix_power`, though I believe a faster alternative might be first diagonalizing $A$, if it is diagonalizable, and then simply exponentiating the diagonal elements, but I decided not to overcomplicate matters. 
