### PR TITLE
BUG: optimize: Fix wrong condition to check invalid optimization state in `optimize.scalar_search_wolfe2`

### DIFF
--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -414,7 +414,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
             return True
 
     for i in range(maxiter):
-        if alpha1 == 0 or (amax is not None and alpha0 == amax):
+        if alpha1 == 0 or (amax is not None and alpha0 > amax):
             # alpha1 == 0: This shouldn't happen. Perhaps the increment has
             # slipped below machine precision?
             alpha_star = None

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -159,9 +159,9 @@ class TestLineSearch:
         def derphi(alpha):
             return 2 * (alpha - 5)
 
-        s, _, _, _ = assert_warns(LineSearchWarning,
-                                  ls.scalar_search_wolfe2, phi, derphi, amax=0.001)
-        assert s is None
+        alpha_star, _, _, derphi_star = ls.scalar_search_wolfe2(phi, derphi, amax=0.001)
+        assert alpha_star is None  # Not converged
+        assert derphi_star is None  # Not converged
 
     def test_scalar_search_wolfe2_regression(self):
         # Regression test for gh-12157

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -17,8 +17,8 @@ def assert_wolfe(s, phi, derphi, c1=1e-4, c2=0.9, err_msg=""):
     phi0 = phi(0)
     derphi0 = derphi(0)
     derphi1 = derphi(s)
-    msg = "s = {}; phi(0) = {}; phi(s) = {}; phi'(0) = {}; phi'(s) = {}; {}".format(
-        s, phi0, phi1, derphi0, derphi1, err_msg)
+    msg = (f"s = {s}; phi(0) = {phi0}; phi(s) = {phi1}; phi'(0) = {derphi0};"
+           f" phi'(s) = {derphi1}; {err_msg}")
 
     assert phi1 <= phi0 + c1*s*derphi0, "Wolfe 1 failed: " + msg
     assert abs(derphi1) <= abs(c2*derphi0), "Wolfe 2 failed: " + msg


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #20340 

#### What does this implement/fix?
<!--Please explain your changes.-->
Based on this warning messsage of the invalid optimization state
https://github.com/scipy/scipy/blob/1686eb434a97ccfbd209b77226e38be1b1c4dad5/scipy/optimize/_linesearch.py#L428-L429
I think `amax` is a valid value as alpha parameter.
When we think about it this way, it makes sense that the value of alpha is clipped between min and amax here:
https://github.com/scipy/scipy/blob/1686eb434a97ccfbd209b77226e38be1b1c4dad5/scipy/optimize/_linesearch.py#L403-L404

So, the if condition should check "bigger than the `amax`" instead of "equals to the `amax`"

And related to that, I changed the `test_scalar_search_wolfe2_with_low_amax` test condition.
I think the warning message check is not needed if parameters are in the valid range, just checking the results are not converged is fine I think.


#### Additional information
<!--Any additional information you think is important.-->
- The invalid optimization state check is added in #7665
- The alpha value clipping is added in #9791
