### PR TITLE
Draft: Optimize performance of scipy.stats.chi.rvs

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1047,8 +1047,8 @@ class rv_generic:
         discrete = kwds.pop('discrete', None)
         rndm = kwds.pop('random_state', None)
         args, loc, scale, size = self._parse_args_rvs(*args, **kwds)
-        cond = self._argcheck(*args) and (scale >= 0)
-        if not cond:
+        cond = logical_and(self._argcheck(*args), (scale >= 0))
+        if not cond.all():
             message = ("Domain error in arguments. The `scale` parameter must "
                        "be positive for all distributions, and many "
                        "distributions have restrictions on shape parameters. "
@@ -1056,7 +1056,7 @@ class rv_generic:
                        "documentation for details.")
             raise ValueError(message)
 
-        if not scale: 
+        if not scale.any():
             return loc*ones(size, 'd')
 
         # extra gymnastics needed for a custom random_state

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1047,8 +1047,8 @@ class rv_generic:
         discrete = kwds.pop('discrete', None)
         rndm = kwds.pop('random_state', None)
         args, loc, scale, size = self._parse_args_rvs(*args, **kwds)
-        cond = logical_and(self._argcheck(*args), (scale >= 0))
-        if not np.all(cond):
+        cond = self._argcheck(*args) and (scale >= 0)
+        if not cond:
             message = ("Domain error in arguments. The `scale` parameter must "
                        "be positive for all distributions, and many "
                        "distributions have restrictions on shape parameters. "
@@ -1056,7 +1056,7 @@ class rv_generic:
                        "documentation for details.")
             raise ValueError(message)
 
-        if np.all(scale == 0):
+        if not scale: 
             return loc*ones(size, 'd')
 
         # extra gymnastics needed for a custom random_state


### PR DESCRIPTION
Benchmark
```
from scipy.stats import chi
import timeit
nn=20_000
df = 78
dt=timeit.timeit('chi.rvs(df, size=200)', number=nn, globals=globals())
print(f'{1e6*dt/nn:.3f} [us]')        
# main 35.786 [us]
# PR 29.558 [us]

dt=timeit.timeit('chi.rvs(df, size=(20,3))', number=nn, globals=globals())
print(f'{1e6*dt/nn:.3f} [us]')        
# main 31.543 [us]
# PR 24.602 [us]
```


