### PR TITLE
DOC: remove outdated NumPy imports note

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -84,12 +84,6 @@ section that the submodule in question is public. Of course you can still use::
 .. note:: SciPy is using a lazy loading mechanism which means that modules
           are only loaded in memory when you first try to access them.
 
-.. note::
-
-    The ``scipy`` namespace itself also contains functions imported from ``numpy``.
-    These functions still exist for backwards compatibility, but should be
-    imported from ``numpy`` directly.
-
 API definition
 --------------
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#20344 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removes the outdated numpy import docs

#### Additional information
<!--Any additional information you think is important.-->
