### PR TITLE
MAINT: unpin pytest for wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ build-verbosity = "3"
 # gmpy2 and scikit-umfpack are usually added for testing. However, there are
 # currently wheels missing that make the test script fail.
 test-requires = [
-    "pytest==7.4.3",
+    "pytest",
     "pytest-cov",
     "pytest-xdist",
     "mpmath",


### PR DESCRIPTION
* Related to one of the points in gh-19826; I think we may as well try to unpin it now since `pytest` is now in the `8.1.x` series and I haven't heard of any other complaints. I won't mark this for backporting though, should suffice to have this tested in future nightlies and `1.14.0`.

[skip cirrus] [skip circle]