### PR TITLE
TST: signal: bump tolerance for new `signal.group_delay` test

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4252,9 +4252,9 @@ class TestGroupDelay:
         b = [alpha,1]
         a = [1, np.conjugate(alpha)]
         gdtest = group_delay((b,a), wref)[1]
-        # need nulp=10 for Ubuntu x86-64; added 1 for some robustness
-        # on other platforms.
-        assert_array_almost_equal_nulp(gdtest, gdref, nulp=11)
+        # need nulp=14 for macOS arm64 wheel builds; added 2 for some
+        # robustness on other platforms.
+        assert_array_almost_equal_nulp(gdtest, gdref, nulp=16)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):


### PR DESCRIPTION
This showed up as a failure in macOS arm64 wheel builds after gh-19627 was merged last week: https://github.com/scipy/scipy/pull/20321#issuecomment-2020928526

Skipping CI, since there's nothing of interest to test when bumping the tolerance of a test.

