### PR TITLE
MAINT, BUG: bump OpenBLAS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,7 +183,7 @@ jobs:
           fi
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.16.5
+    - python -m pip install cibuildwheel==2.17.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.26'
-OPENBLAS_LONG = 'v0.3.26'
+OPENBLAS_V = '0.3.26.dev'
+OPENBLAS_LONG = 'v0.3.26-382-gb1e8ba50'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 NIGHTLY_BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -232,6 +232,24 @@ def extract_tarfile_to(tarfileobj, target_path, archive_path):
             yield member
 
     tarfileobj.extractall(target_path, members=get_members())
+    reformat_pkg_file(target_path=target_path)
+
+
+def reformat_pkg_file(target_path):
+    # attempt to deal with:
+    # https://github.com/scipy/scipy/pull/20362#issuecomment-2028517797
+    pattern = os.path.join(target_path, "**", "*openblas*.pc")
+    pkg_path = glob.glob(pattern, recursive=True)[0]
+    new_pkg_lines = []
+    with open(pkg_path) as pkg_orig:
+        for line in pkg_orig:
+            if line.startswith("Libs:"):
+                new_line = line.replace("$(libprefix}", "${libprefix}")
+                new_pkg_lines.append(new_line)
+            else:
+                new_pkg_lines.append(line)
+    with open(pkg_path, "w") as new_pkg:
+        new_pkg.writelines(new_pkg_lines)
 
 
 def make_init(dirname):

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -238,8 +238,10 @@ def extract_tarfile_to(tarfileobj, target_path, archive_path):
 def reformat_pkg_file(target_path):
     # attempt to deal with:
     # https://github.com/scipy/scipy/pull/20362#issuecomment-2028517797
-    pattern = os.path.join(target_path, "**", "*openblas*.pc")
-    pkg_path = glob.glob(pattern, recursive=True)[0]
+    for root, dirs, files in os.walk(target_path):
+        for name in files:
+            if name.endswith(".pc") and "openblas" in name:
+                pkg_path = os.path.join(root, name)
     new_pkg_lines = []
     with open(pkg_path) as pkg_orig:
         for line in pkg_orig:

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -34,3 +34,6 @@ else
   unzip $target -d /c/opt/
   cp /c/opt/64/bin/*.dll /c/opt/openblas/openblas_dll
 fi
+# attempt to deal with:
+# https://github.com/scipy/scipy/pull/20362#issuecomment-2028517797
+python -c "import tools.openblas_support as obs; obs.reformat_pkg_file('/c/opt/')"

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -36,4 +36,4 @@ else
 fi
 # attempt to deal with:
 # https://github.com/scipy/scipy/pull/20362#issuecomment-2028517797
-python -c "import tools.openblas_support as obs; obs.reformat_pkg_file('/c/opt/')"
+python -c "import tools.openblas_support as obs; obs.reformat_pkg_file('C:/opt/')"


### PR DESCRIPTION
* Fixes #20294.

* Pull in new OpenBLAS binaries as discussed in the above issue, to solve a bug that affects downstream consumers like `scikit-learn`. The OpenBLAS binary builds happened via https://github.com/MacPython/openblas-libs/pull/149 with CI results at links below; the single s390x arch failure should be safe to ignore, we don't distribute binaries for that arch:
  *  https://app.travis-ci.com/github/MacPython/openblas-libs/builds/269741262
  * https://github.com/MacPython/openblas-libs/actions/runs/8493017997 
  * https://github.com/MacPython/openblas-libs/actions/runs/8493018404

* I had an issue when testing locally with `CIBW_BUILD=cp311-* cibuildwheel --platform linux --archs x86_64`. Let's see if the regular CI catches anything before I try a full blown wheel build here, hopefully that's just some local issue I have.

```
  [210/1479] Linking target scipy/special/_ellip_harm_2.cpython-311-x86_64-linux-gnu.so
  FAILED: scipy/special/_ellip_harm_2.cpython-311-x86_64-linux-gnu.so
  cc  -o scipy/special/_ellip_harm_2.cpython-311-x86_64-linux-gnu.so scipy/special/_ellip_harm_2.cpython-311-x86_64-linux-gnu.so.p/meson-generated__ellip_harm_2.c.o scipy/special/_ellip_harm_2.cpython-311-x86_64-linux-gnu.so.p/sf_error.c.o -Wl,--as-needed -Wl,--allow-shlib-undefined -Wl,-O1 -shared -fPIC -Wl,--start-group -lm -Wl,--version-script=/project/scipy/_build_utils/link-version-pyinit.map -L/usr/local/lib '-l$(libprefix}openblas' -Wl,--end-group
  /opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -l$(libprefix}openblas
  collect2: error: ld returned 1 exit status
```

[skip circle]