### PR TITLE
MAINT: refactor array API testing

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -238,10 +238,9 @@ The following pytest markers are available:
 
 The following is an example using the markers::
 
-  from scipy.conftest import array_api_compatible
+  from scipy._lib._array_api import array_api_compatible, skip_xp_backends
   ...
-  @pytest.mark.skip_xp_backends(np_only=True,
-                                 reasons=['skip reason'])
+  @skip_xp_backends(np_only=True, reasons=['skip reason'])
   @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto1(self, xp):
@@ -249,9 +248,8 @@ The following is an example using the markers::
       b = xp.asarray([0, 2, 5])
       toto(a, b)
   ...
-  @pytest.mark.skip_xp_backends('array_api_strict', 'cupy',
-                                 reasons=['skip reason 1',
-                                          'skip reason 2',])
+  @skip_xp_backends('array_api_strict', 'cupy',
+                    reasons=['skip reason 1', 'skip reason 2',])
   @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto2(self, xp):
@@ -268,10 +266,9 @@ When every test function in a file has been updated for array API
 compatibility, one can reduce verbosity by telling ``pytest`` to apply the
 markers to every test function using ``pytestmark``::
 
-    from scipy.conftest import array_api_compatible
+    from scipy._lib._array_api import array_api_compatible, skip_xp_backends
     
     pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-    skip_xp_backends = pytest.mark.skip_xp_backends
     ...
     @skip_xp_backends(np_only=True, reasons=['skip reason'])
     def test_toto1(self, xp):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -20,13 +20,44 @@ from scipy._lib.array_api_compat import (
     numpy as np_compat,
 )
 
-__all__ = ['array_namespace', '_asarray', 'size']
+try:
+    # try to get the experimental variables and pytest marks from conftest,
+    # will error if pytest is not installed.
+    import pytest
+    from scipy.conftest import (
+        array_api_compatible, SCIPY_ARRAY_API, SCIPY_DEVICE
+    )
 
+    skip_xp_backends = pytest.mark.skip_xp_backends
+except ImportError:
+    # define the experimental variables here instead
 
-# To enable array API and strict array-like input validation
-SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)
-# To control the default device - for use in the test suite only
-SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")
+    # To enable array API and strict array-like input validation
+    SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)  # type: ignore[no-redef]  # noqa: E501
+    # To control the default device - for use in the test suite only
+    SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")
+
+__all__ = [
+    '_GLOBAL_CONFIG',
+    'array_api_compatible',
+    'array_namespace',
+    '_asarray',
+    'atleast_nd',
+    'copy',
+    'cov',
+    'is_complex',
+    'is_cupy',
+    'is_numpy',
+    'is_torch',
+    'SCIPY_ARRAY_API',
+    'SCIPY_DEVICE',
+    'size',
+    'skip_xp_backends',
+    'xp_assert_close',
+    'xp_assert_equal',
+    'xp_assert_less',
+    'xp_unsupported_param_msg'
+]
 
 _GLOBAL_CONFIG = {
     "SCIPY_ARRAY_API": SCIPY_ARRAY_API,

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -9,14 +9,14 @@ from numpy.testing import assert_equal, assert_
 import pytest
 from pytest import raises as assert_raises
 import hypothesis.extra.numpy as npst
-from hypothesis import given, strategies, reproduce_failure  # noqa: F401
-from scipy.conftest import array_api_compatible
+from hypothesis import given, strategies  # noqa: F401
 
-from scipy._lib._array_api import xp_assert_equal
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
                               getfullargspec_no_self, FullArgSpec,
                               rng_integers, _validate_int, _rename_parameter,
                               _contains_nan, _rng_html_rewrite, _lazywhere)
+
+from scipy._lib._array_api import array_api_compatible, xp_assert_equal
 
 
 def test__aligned_zeros():

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -1,18 +1,24 @@
 import numpy as np
 import pytest
 
-from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, _asarray, copy, xp_assert_equal, is_numpy
+    _GLOBAL_CONFIG,
+    array_api_compatible,
+    array_namespace,
+    _asarray,
+    copy,
+    is_numpy,
+    xp_assert_equal, 
 )
 import scipy._lib.array_api_compat.numpy as np_compat
 
 
+@array_api_compatible
 @pytest.mark.skipif(not _GLOBAL_CONFIG["SCIPY_ARRAY_API"],
         reason="Array API test; set environment variable SCIPY_ARRAY_API=1 to run it")
 class TestArrayAPI:
 
-    def test_array_namespace(self):
+    def test_array_namespace(self, xp):
         x, y = np.array([0, 1, 2]), np.array([0, 1, 2])
         xp = array_namespace(x, y)
         assert 'array_api_compat.numpy' in xp.__name__
@@ -22,7 +28,6 @@ class TestArrayAPI:
         assert 'array_api_compat.numpy' in xp.__name__
         _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = True
 
-    @array_api_compatible
     def test_asarray(self, xp):
         x, y = _asarray([0, 1, 2], xp=xp), _asarray(np.arange(3), xp=xp)
         ref = xp.asarray([0, 1, 2])
@@ -30,7 +35,7 @@ class TestArrayAPI:
         xp_assert_equal(y, ref)
 
     @pytest.mark.filterwarnings("ignore: the matrix subclass")
-    def test_raises(self):
+    def test_raises(self, xp):
         msg = "of type `numpy.ma.MaskedArray` are not supported"
         with pytest.raises(TypeError, match=msg):
             array_namespace(np.ma.array(1), np.array(1))
@@ -45,13 +50,12 @@ class TestArrayAPI:
         with pytest.raises(TypeError, match=msg):
             array_namespace('abc')
 
-    def test_array_likes(self):
+    def test_array_likes(self, xp):
         # should be no exceptions
         array_namespace([0, 1, 2])
         array_namespace(1, 2, 3)
         array_namespace(1)
 
-    @array_api_compatible
     def test_copy(self, xp):
         for _xp in [xp, None]:
             x = xp.asarray([1, 2, 3])
@@ -67,7 +71,6 @@ class TestArrayAPI:
             assert x[2] != y[2]
             assert id(x) != id(y)
 
-    @array_api_compatible
     @pytest.mark.parametrize('dtype', ['int32', 'int64', 'float32', 'float64'])
     @pytest.mark.parametrize('shape', [(), (3,)])
     def test_strict_checks(self, xp, dtype, shape):
@@ -98,7 +101,6 @@ class TestArrayAPI:
             with pytest.raises(AssertionError, match="Shapes do not match."):
                 xp_assert_equal(x, y, **options)
 
-    @array_api_compatible
     def test_check_scalar(self, xp):
         if not is_numpy(xp):
             pytest.skip("Scalars only exist in NumPy")

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -47,11 +47,11 @@ from scipy.cluster.hierarchy import (
     _order_cluster_tree, _hierarchy, _LINKAGE_METHODS)
 from scipy.spatial.distance import pdist
 from scipy.cluster._hierarchy import Heap
-from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_close, xp_assert_equal
-
 from . import hierarchy_test_data
 
+from scipy._lib._array_api import (
+    array_api_compatible, skip_xp_backends, xp_assert_close, xp_assert_equal,
+)
 
 # Matplotlib is not a scipy dependency but is optionally used in dendrogram, so
 # check if it's available
@@ -65,9 +65,7 @@ try:
 except Exception:
     have_matplotlib = False
 
-
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 class TestLinkage:

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -12,15 +12,19 @@ from pytest import raises as assert_raises
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, vq, whiten,
                               ClusterError, _krandinit)
 from scipy.cluster import _vq
-from scipy.conftest import array_api_compatible
 from scipy.sparse._sputils import matrix
 
 from scipy._lib._array_api import (
-    SCIPY_ARRAY_API, copy, cov, xp_assert_close, xp_assert_equal
+    array_api_compatible,
+    copy,
+    cov,
+    SCIPY_ARRAY_API,
+    skip_xp_backends,
+    xp_assert_close,
+    xp_assert_equal,
 )
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-skip_xp_backends = pytest.mark.skip_xp_backends
 
 TESTDATA_2D = np.array([
     -2.2, 1.17, -1.63, 1.69, -2.04, 4.38, -3.09, 0.95, -1.7, 4.79, -1.68, 0.68,

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -67,13 +67,14 @@ code book.
 import warnings
 import numpy as np
 from collections import deque
-from scipy._lib._array_api import (
-    _asarray, array_namespace, size, atleast_nd, copy, cov
-)
+
 from scipy._lib._util import check_random_state, rng_integers
 from scipy.spatial.distance import cdist
-
 from . import _vq
+
+from scipy._lib._array_api import (
+    _asarray, array_namespace, atleast_nd, copy, cov, size,
+)
 
 __docformat__ = 'restructuredtext'
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -1,4 +1,5 @@
 # Pytest customization
+from __future__ import annotations
 import json
 import os
 import warnings
@@ -12,7 +13,6 @@ import hypothesis
 from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
 from scipy._lib import _pep440
-from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
 
 
 def pytest_configure(config):
@@ -106,6 +106,11 @@ def check_fpu_mode(request):
 
 # Array API backend handling
 xp_available_backends = {'numpy': np}
+
+# To enable array API and strict array-like input validation
+SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)
+# To control the default device - for use in the test suite only
+SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")
 
 if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
     # fill the dict of backends with available libraries

--- a/scipy/fft/_basic_backend.py
+++ b/scipy/fft/_basic_backend.py
@@ -1,8 +1,9 @@
-from scipy._lib._array_api import (
-    array_namespace, is_numpy, xp_unsupported_param_msg, is_complex
-)
-from . import _pocketfft
 import numpy as np
+from . import _pocketfft
+
+from scipy._lib._array_api import (
+    array_namespace, is_complex, is_numpy, xp_unsupported_param_msg,
+)
 
 
 def _validate_fft_args(workers, plan, norm):

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -1,9 +1,9 @@
 from functools import update_wrapper, lru_cache
 import inspect
 
+import numpy as np
 from ._pocketfft import helper as _helper
 
-import numpy as np
 from scipy._lib._array_api import array_namespace
 
 

--- a/scipy/fft/_realtransforms_backend.py
+++ b/scipy/fft/_realtransforms_backend.py
@@ -1,6 +1,7 @@
-from scipy._lib._array_api import array_namespace
 import numpy as np
 from . import _pocketfft
+
+from scipy._lib._array_api import array_namespace
 
 __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -6,14 +6,19 @@ import pytest
 from numpy.random import random
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from pytest import raises as assert_raises
+
 import scipy.fft as fft
-from scipy.conftest import array_api_compatible
+
 from scipy._lib._array_api import (
-    array_namespace, size, xp_assert_close, xp_assert_equal
+    array_api_compatible,
+    array_namespace,
+    size,
+    skip_xp_backends,
+    xp_assert_close,
+    xp_assert_equal,
 )
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 # Expected input dtypes. Note that `scipy.fft` is more flexible for numpy,

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -5,8 +5,7 @@ import pytest
 from scipy.fft._fftlog import fht, ifht, fhtoffset
 from scipy.special import poch
 
-from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_close
+from scipy._lib._array_api import array_api_compatible, xp_assert_close
 
 pytestmark = array_api_compatible
 

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -4,18 +4,21 @@ Copied from fftpack.helper by Pearu Peterson, October 2005
 Modified for Array API, 2023
 
 """
-from scipy.fft._helper import next_fast_len, _init_nd_shape_and_axes
+
 from numpy.testing import assert_equal
 from pytest import raises as assert_raises
 import pytest
 import numpy as np
 import sys
-from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_close, SCIPY_DEVICE
+
 from scipy import fft
+from scipy.fft._helper import next_fast_len, _init_nd_shape_and_axes
+
+from scipy._lib._array_api import (
+    array_api_compatible, SCIPY_DEVICE, skip_xp_backends, xp_assert_close,
+)
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-skip_xp_backends = pytest.mark.skip_xp_backends
 
 _5_smooth_numbers = [
     2, 3, 4, 5, 6, 8, 9, 10,
@@ -23,6 +26,7 @@ _5_smooth_numbers = [
     2**3 * 3**5,
     2**3 * 3**3 * 5**2,
 ]
+
 
 def test_next_fast_len():
     for n in _5_smooth_numbers:

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -6,11 +6,12 @@ import math
 from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
 import scipy.fft as fft
 from scipy import fftpack
-from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import copy, xp_assert_close
+
+from scipy._lib._array_api import (
+    array_api_compatible, copy, skip_xp_backends, xp_assert_close,
+)
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
-skip_xp_backends = pytest.mark.skip_xp_backends
 
 SQRT_2 = math.sqrt(2)
 

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -3,7 +3,8 @@ import scipy.sparse as sps
 from ._numdiff import approx_derivative, group_columns
 from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy.sparse.linalg import LinearOperator
-from scipy._lib._array_api import atleast_nd, array_namespace
+
+from scipy._lib._array_api import array_namespace, atleast_nd
 
 
 FD_METHODS = ('2-point', '3-point', 'cs')

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -6,7 +6,8 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, csc_matrix, csr_matrix, coo_matrix, find
 from ._group_columns import group_dense, group_sparse
-from scipy._lib._array_api import atleast_nd, array_namespace
+
+from scipy._lib._array_api import array_namespace, atleast_nd
 
 
 def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -24,7 +24,8 @@ from ._optimize import (OptimizeResult, _check_unknown_options,
                         _check_clip_x)
 from ._numdiff import approx_derivative
 from ._constraints import old_bound_to_new, _arr_to_scalar
-from scipy._lib._array_api import atleast_nd, array_namespace
+
+from scipy._lib._array_api import array_namespace, atleast_nd
 
 # deprecated imports to be removed in SciPy 1.13.0
 from numpy import exp, inf  # noqa: F401

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -36,7 +36,8 @@ from scipy.optimize import _moduleTNC as moduleTNC
 from ._optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._constraints import old_bound_to_new
-from scipy._lib._array_api import atleast_nd, array_namespace
+
+from scipy._lib._array_api import array_namespace, atleast_nd
 
 from numpy import inf, array, zeros
 

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -1,9 +1,7 @@
-import os
 import sys
 import functools
 
 import numpy as np
-from scipy._lib._array_api import array_namespace, is_cupy, is_torch, is_numpy
 from . import _ufuncs
 # These don't really need to be imported, but otherwise IDEs might not realize
 # that these are defined in this file / report an error in __init__.py
@@ -11,7 +9,10 @@ from ._ufuncs import (
     log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e,  # noqa: F401
     gammaln, gammainc, gammaincc, logit, expit)  # noqa: F401
 
-_SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
+from scipy._lib._array_api import (
+    array_namespace, is_cupy, is_numpy, is_torch, SCIPY_ARRAY_API,
+)
+
 array_api_compat_prefix = "scipy._lib.array_api_compat"
 
 
@@ -68,7 +69,7 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args) if _SCIPY_ARRAY_API
+    f = (support_alternative_backends(f_name, n_array_args) if SCIPY_ARRAY_API
          else getattr(_ufuncs, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -1,13 +1,13 @@
 import pytest
 from hypothesis import given, strategies, reproduce_failure  # noqa: F401
 import hypothesis.extra.numpy as npst
+import numpy as np
 
 from scipy.special._support_alternative_backends import (get_array_special_func,
                                                          array_special_func_map)
-from scipy.conftest import array_api_compatible
 from scipy import special
-from scipy._lib._array_api import xp_assert_close
-from scipy._lib.array_api_compat import numpy as np
+
+from scipy._lib._array_api import array_api_compatible, xp_assert_close
 
 try:
     import array_api_strict

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -68,6 +68,7 @@ from scipy import stats
 from scipy.optimize import root_scalar
 from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 from scipy._lib._util import normalize_axis_index
+
 from scipy._lib._array_api import array_namespace, is_numpy
 
 # In __all__ but deprecated for removal in SciPy 1.13.0

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -38,8 +38,15 @@ from scipy.spatial.distance import cdist
 from scipy.stats._axis_nan_policy import _broadcast_concatenate
 from scipy.stats._stats_py import _permutation_distribution_t
 from scipy._lib._util import AxisError
-from scipy._lib._array_api import xp_assert_close, xp_assert_equal, copy, is_numpy
-from scipy.conftest import array_api_compatible
+
+from scipy._lib._array_api import (
+    array_api_compatible,
+    copy,
+    is_numpy,
+    skip_xp_backends,
+    xp_assert_close,
+    xp_assert_equal,
+)
 
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
@@ -348,9 +355,9 @@ class TestPearsonrWilkinson:
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends(cpu_only=True)
+@skip_xp_backends(cpu_only=True)
 class TestPearsonr:
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     def test_pearsonr_result_attributes(self):
         res = stats.pearsonr(X, X)
         attributes = ('correlation', 'pvalue')
@@ -485,7 +492,7 @@ class TestPearsonr:
     # cor.test(x, y, method = "pearson", alternative = "g")
     # correlation coefficient and p-value for alternative='two-sided'
     # calculated with mpmath agree to 16 digits.
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     @pytest.mark.parametrize('alternative, pval, rlow, rhigh, sign',
             [('two-sided', 0.325800137536, -0.814938968841, 0.99230697523, 1),
              ('less', 0.8370999312316, -1, 0.985600937290653, 1),
@@ -524,7 +531,7 @@ class TestPearsonr:
         xp_assert_equal(low, -one)
         xp_assert_equal(high, one)
 
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     def test_input_validation(self):
         x = [1, 2, 3]
         y = [4, 5]
@@ -552,7 +559,7 @@ class TestPearsonr:
         with pytest.raises(ValueError, match=message):
             res.confidence_interval(method="exact")
 
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     @pytest.mark.xfail_on_32bit("Monte Carlo method needs > a few kB of memory")
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))
     @pytest.mark.parametrize('method', ('permutation', 'monte_carlo'))
@@ -569,7 +576,7 @@ class TestPearsonr:
         assert_allclose(res.statistic, ref.statistic, rtol=1e-15)
         assert_allclose(res.pvalue, ref.pvalue, rtol=1e-2, atol=1e-3)
 
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))
     def test_bootstrap_ci(self, alternative):
         rng = np.random.default_rng(2462935790378923)
@@ -583,7 +590,7 @@ class TestPearsonr:
 
         assert_allclose(res_ci, ref_ci, atol=1.5e-2)
 
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     @pytest.mark.parametrize('axis', [0, 1])
     def test_axis01(self, axis, xp):
         rng = np.random.default_rng(38572345825)
@@ -601,7 +608,7 @@ class TestPearsonr:
             assert_allclose(ci.low[i], ci_i.low)
             assert_allclose(ci.high[i], ci_i.high)
 
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends(np_only=True)
     def test_axis_None(self, xp):
         rng = np.random.default_rng(38572345825)
         shape = (9, 10)


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
Various improvements to code quality and minor refactors.

- The shorthand for `pytest.mark.skip_xp_backends` is now only defined once and imported.
- Organised imports
- Updated `scipy._lib._array_api.__all__`

This has introduced a few extra shims in the `_lib` and `conftest` code, but I think it is worth it for simplifying the imports.

#### Additional information
I'll add a blame-ignore before merge.