### PR TITLE
BUG: `ndimage.grey_erosion`: fix discrepancy in different calling styles

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1235,7 +1235,10 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         structure = numpy.asarray(structure, dtype=numpy.float64)
         separable = False
         if footprint is None:
-            footprint = numpy.ones(structure.shape, bool)
+            if size is None:
+                size = structure.shape
+                separable = True
+            footprint = numpy.ones(structure.shape, dtype=bool)
         else:
             footprint = numpy.asarray(footprint, dtype=bool)
     input = numpy.asarray(input)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1936,6 +1936,14 @@ class TestNdimageMorphology:
         assert_array_almost_equal([[1, 1, 0, 0, 0],
                                    [1, 2, 0, 2, 0],
                                    [4, 4, 2, 2, 0]], output)
+    
+    def test_grey_erosion04(self):
+        im = numpy.random.rand(50, 50)
+        filt_sz = 7
+        kernel = numpy.ones((filt_sz, filt_sz))
+        output_with_kernel = ndimage.grey_erosion(im, structure=kernel)
+        output_with_sz = ndimage.grey_erosion(im, (filt_sz, filt_sz))
+        assert_array_almost_equal(output_with_kernel, output_with_sz)
 
     def test_grey_dilation01(self):
         array = numpy.array([[3, 2, 5, 1, 4],
@@ -2125,7 +2133,7 @@ class TestNdimageMorphology:
                                 [0, 1, 1, 0, 0, 0, 1],
                                 [0, 0, 0, 1, 1, 1, 1]], dtype=numpy.bool_)
 
-        output = ndimage.white_tophat(array, structure=structure)
+        output = ndimage.white_tophat(array, size = 3, structure=structure)
         assert_array_equal(expected, output)
 
     def test_white_tophat04(self):
@@ -2275,7 +2283,7 @@ class TestDilateFix:
         self.dilated3x3 = dilated3x3.view(numpy.uint8)
 
     def test_dilation_square_structure(self):
-        result = ndimage.grey_dilation(self.array, structure=self.sq3x3)
+        result = ndimage.grey_dilation(self.array, size=3, structure=self.sq3x3)
         # +1 accounts for difference between grey and binary dilation
         assert_array_almost_equal(result, self.dilated3x3 + 1)
 


### PR DESCRIPTION
The grey_erosion function gives different values when calling grey_erosion(im, structure=kernel) vs grey_erosion(im, (filt_sz, filt_sz)). This is because when passing a structure, it doesn't use the same method as if only passing a size. The difference is related with separable and his boolean value. 

To fix this, when a structure is given and footprint and size aren't, use separable as if only size was given.

#### Reference issue
Closes #19384

#### What does this implement/fix?
Discrepancy of output values for function grey_erosion when calling with only a structure vs only a size 

#### Additional information