### PR TITLE
MAINT: lint: enforce `numpy as np` alias

### DIFF
--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -13,7 +13,7 @@ import math as _math
 from typing import TYPE_CHECKING, Any
 
 from ._codata import value as _cd
-import numpy as _np # noqa: ICN001
+import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -271,13 +271,13 @@ def convert_temperature(
     """
     # Convert from `old_scale` to Kelvin
     if old_scale.lower() in ['celsius', 'c']:
-        tempo = _np.asanyarray(val) + zero_Celsius
+        tempo = np.asanyarray(val) + zero_Celsius
     elif old_scale.lower() in ['kelvin', 'k']:
-        tempo = _np.asanyarray(val)
+        tempo = np.asanyarray(val)
     elif old_scale.lower() in ['fahrenheit', 'f']:
-        tempo = (_np.asanyarray(val) - 32) * 5 / 9 + zero_Celsius
+        tempo = (np.asanyarray(val) - 32) * 5 / 9 + zero_Celsius
     elif old_scale.lower() in ['rankine', 'r']:
-        tempo = _np.asanyarray(val) * 5 / 9
+        tempo = np.asanyarray(val) * 5 / 9
     else:
         raise NotImplementedError("%s scale is unsupported: supported scales "
                                   "are Celsius, Kelvin, Fahrenheit, and "
@@ -329,7 +329,7 @@ def lambda2nu(lambda_: npt.ArrayLike) -> Any:
     array([  2.99792458e+08,   1.00000000e+00])
 
     """
-    return c / _np.asanyarray(lambda_)
+    return c / np.asanyarray(lambda_)
 
 
 def nu2lambda(nu: npt.ArrayLike) -> Any:
@@ -359,4 +359,4 @@ def nu2lambda(nu: npt.ArrayLike) -> Any:
     array([  2.99792458e+08,   1.00000000e+00])
 
     """
-    return c / _np.asanyarray(nu)
+    return c / np.asanyarray(nu)

--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -13,7 +13,7 @@ import math as _math
 from typing import TYPE_CHECKING, Any
 
 from ._codata import value as _cd
-import numpy as _np
+import numpy as _np # noqa: ICN001
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -207,7 +207,7 @@ BLAS Level 3 functions
 
 __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
-import numpy as _np # noqa: ICN001
+import numpy as np
 import functools
 
 from scipy.linalg import _fblas
@@ -243,10 +243,10 @@ _type_score.update({x: 2 for x in 'iIlLqQd'})
 _type_score.update({'F': 3, 'D': 4, 'g': 2, 'G': 4})
 
 # Final mapping to the actual prefixes and dtypes
-_type_conv = {1: ('s', _np.dtype('float32')),
-              2: ('d', _np.dtype('float64')),
-              3: ('c', _np.dtype('complex64')),
-              4: ('z', _np.dtype('complex128'))}
+_type_conv = {1: ('s', np.dtype('float32')),
+              2: ('d', np.dtype('float64')),
+              3: ('c', np.dtype('complex64')),
+              4: ('z', np.dtype('complex128'))}
 
 # some convenience alias for complex functions
 _blas_alias = {'cnrm2': 'scnrm2', 'znrm2': 'dznrm2',
@@ -294,7 +294,7 @@ def find_best_blas_type(arrays=(), dtype=None):
     ('d', dtype('float64'), True)
 
     """
-    dtype = _np.dtype(dtype)
+    dtype = np.dtype(dtype)
     max_score = _type_score.get(dtype.char, 5)
     prefer_fortran = False
 
@@ -318,7 +318,7 @@ def find_best_blas_type(arrays=(), dtype=None):
 
     # Get the LAPACK prefix and the corresponding dtype if not fall back
     # to 'd' and double precision float.
-    prefix, dtype = _type_conv.get(max_score, ('d', _np.dtype('float64')))
+    prefix, dtype = _type_conv.get(max_score, ('d', np.dtype('float64')))
 
     return prefix, dtype, prefer_fortran
 
@@ -335,7 +335,7 @@ def _get_funcs(names, arrays, dtype,
 
     funcs = []
     unpack = False
-    dtype = _np.dtype(dtype)
+    dtype = np.dtype(dtype)
     module1 = (cmodule, cmodule_name)
     module2 = (fmodule, fmodule_name)
 
@@ -362,9 +362,9 @@ def _get_funcs(names, arrays, dtype,
         func.module_name, func.typecode = module_name, prefix
         func.dtype = dtype
         if not ilp64:
-            func.int_dtype = _np.dtype(_np.intc)
+            func.int_dtype = np.dtype(np.intc)
         else:
-            func.int_dtype = _np.dtype(_np.int64)
+            func.int_dtype = np.dtype(np.int64)
         func.prefix = prefix  # Backward compatibility
         funcs.append(func)
 

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -207,7 +207,7 @@ BLAS Level 3 functions
 
 __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
-import numpy as _np
+import numpy as _np # noqa: ICN001
 import functools
 
 from scipy.linalg import _fblas

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -822,7 +822,7 @@ All functions
 # Author: Pearu Peterson, March 2002
 #
 
-import numpy as _np # noqa: ICN001
+import numpy as np
 from .blas import _get_funcs, _memoize_get_funcs
 from scipy.linalg import _flapack
 from re import compile as regex_compile
@@ -975,8 +975,8 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
                           ilp64=True)
 
 
-_int32_max = _np.iinfo(_np.int32).max
-_int64_max = _np.iinfo(_np.int64).max
+_int32_max = np.iinfo(np.int32).max
+_int64_max = np.iinfo(np.int64).max
 
 
 def _compute_lwork(routine, *args, **kwargs):
@@ -1020,10 +1020,10 @@ def _check_work_float(value, dtype, int_dtype):
     carefully for single-precision types.
     """
 
-    if dtype == _np.float32 or dtype == _np.complex64:
+    if dtype == np.float32 or dtype == np.complex64:
         # Single-precision routine -- take next fp value to work
         # around possible truncation in LAPACK code
-        value = _np.nextafter(value, _np.inf, dtype=_np.float32)
+        value = np.nextafter(value, np.inf, dtype=np.float32)
 
     value = int(value)
     if int_dtype.itemsize == 4:

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -822,7 +822,7 @@ All functions
 # Author: Pearu Peterson, March 2002
 #
 
-import numpy as _np
+import numpy as _np # noqa: ICN001
 from .blas import _get_funcs, _memoize_get_funcs
 from scipy.linalg import _flapack
 from re import compile as regex_compile

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -59,8 +59,14 @@ def test_lapack_documented():
         pytest.skip('lapack.__doc__ is None')
     names = set(lapack.__doc__.split())
     ignore_list = {
-        'absolute_import', 'clapack', 'division', 'find_best_lapack_type',
-        'flapack', 'print_function', 'HAS_ILP64',
+        "absolute_import",
+        "clapack",
+        "division",
+        "find_best_lapack_type",
+        "flapack",
+        "print_function",
+        "HAS_ILP64",
+        "np",
     }
     missing = list()
     for name in dir(lapack):

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -10,7 +10,7 @@ target-version = "py39"
 # Also, `PGH004` which checks for blanket (non-specific) `noqa`s
 # and `B028` which checks that warnings include the `stacklevel` keyword.
 # `B028` added in gh-19623.
-select = ["E", "F", "PGH004", "UP", "B028"]
+select = ["E", "F", "PGH004", "UP", "B028", "ICN001"]
 ignore = ["E741"]
 
 # Allow unused variables when underscore-prefixed.
@@ -25,6 +25,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "scipy/linalg/_cython_signature_generator.py" = ["E501"]
 "scipy/linalg/_generate_pyx.py" = ["E501"]
 "scipy/spatial/transform/_rotation.pyi" = ["E501"]
+
+[lint.flake8-import-conventions.aliases]
+numpy = "np"
 
 [lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -10,6 +10,7 @@ target-version = "py39"
 # Also, `PGH004` which checks for blanket (non-specific) `noqa`s
 # and `B028` which checks that warnings include the `stacklevel` keyword.
 # `B028` added in gh-19623.
+# `ICN001` added in gh-20382 to enforce common conventions for imports
 select = ["E", "F", "PGH004", "UP", "B028", "ICN001"]
 ignore = ["E741"]
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Enforce `numpy` alias, as discussed in https://github.com/scipy/scipy/pull/20367#issuecomment-2033998396

#### Additional information
<!--Any additional information you think is important.-->
The lint rule works, the proof is the additional violations it picks up. I wonder what's the rational behind importing `numpy` as `_np`? The latest change is 8 years ago, so I think it might be an old convention. 

Happy to fix them too if it's fine to fix.

@lucascolley Can you review this PR, please? Thank you very much.
