### PR TITLE
BUG: special.struve: do not return NaN for values close to zeros

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3943,6 +3943,7 @@ class TestStruve:
         assert_allclose(special.struve(-8.01, 21), 0.0398716951023, rtol=1e-8)
         assert_allclose(special.struve(-3.0, 200), 0.0142134427432, rtol=1e-12)
         assert_allclose(special.struve(-8.0, -41), 0.0192469727846, rtol=1e-11)
+        assert_allclose(special.struve(0, 25.765368073883174), 4.381964346416636e-07)
         assert_equal(special.struve(-12, -41), -special.struve(-12, 41))
         assert_equal(special.struve(+12, -41), -special.struve(+12, 41))
         assert_equal(special.struve(-11, -41), +special.struve(-11, 41))


### PR DESCRIPTION
Closes #19580, closes #5979

When calculating the struve function using the power series (https://dlmf.nist.gov/11.2.1), if the z is close to giving result that is a zero of the function, the error boundaries don't evaluate the result accordingly, so the value calculated, even tough it is correct, doesn't pass the conditions and returns NaN. With Asymptotic expansions we can catch some of those situations (https://dlmf.nist.gov/11.6.5) and we can also check the error margin to let the values be returned.