### PR TITLE
ENH: stats.binned_statistic: allow structured/rec array input

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -589,8 +589,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
         dedges = [np.diff(edges[i]) for i in builtins.range(Ndim)]
         binnumbers = binned_statistic_result.binnumber
 
-    # Avoid overflow with double precision. Complex `values` -> `complex128`.
-    result_type = np.result_type(values, np.float64)
+    # If input is a structured/rec array, call the statistic
+    # to get a guess on the result dtype
+    if values.dtype.names is not None:
+        result_type = np.result_type(statistic(values[0]), np.float64)
+    else:
+        # Avoid overflow with double precision. Complex `values` -> `complex128`.
+        result_type = np.result_type(values, np.float64)
     result = np.empty([Vdim, nbin.prod()], dtype=result_type)
 
     if statistic in {'mean', np.mean}:

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -550,6 +550,25 @@ class TestBinnedStatistic:
                                            np.min, np.max, 'count',
                                            lambda x: (x**2).sum(),
                                            lambda x: (x**2).sum() * 1j])
+    def test_structured(self):
+        # Test with a structured array
+        names = ["x", "v"]
+        types = [float, float]
+        struc_array = np.empty(self.x.size, dtype=list(zip(names, types)))
+        struc_array["x"] = self.x
+        struc_array["v"] = self.v
+
+        def test_func(data):
+            return np.sum(data["x"] + data["v"])
+        bins = np.linspace(0, 1, 11)
+        stat, edges, bc = binned_statistic(self.x, struc_array, bins=bins,
+                                           statistic=test_func)
+        stat2, edges2, bc = binned_statistic(self.x,
+                                             struc_array["x"]+struc_array["v"],
+                                             bins=bins,
+                                             statistic=np.sum)
+        assert_allclose(stat, stat2)
+
     def test_dd_all(self, dtype, statistic):
         def ref_statistic(x):
             return len(x) if statistic == 'count' else statistic(x)


### PR DESCRIPTION
#### Reference issue
I was too lazy to make an issue for this.

#### What does this implement/fix?
Adding a check so `binned_statistic` can take a numpy structured or rec array as input. 

#### Additional information
I think most people would probably just convert to a pandas DataFrame and do a groupby, but for my use case I think the overhead of creating dataframes would become an issue. 
