### PR TITLE
BUG: interpolate: fix high memory usage for 2 classes

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -89,7 +89,7 @@ class GridData(Benchmark):
 class GridDataPeakMem(Benchmark):
 
     def setup(self):
-        shape = (14790, 12816)
+        shape = (7395, 6408)
         num_nonzero = 488686
 
         rng = np.random.default_rng(1234)
@@ -97,7 +97,7 @@ class GridDataPeakMem(Benchmark):
         random_rows = rng.integers(0, shape[0], num_nonzero)
         random_cols = rng.integers(0, shape[1], num_nonzero)
 
-        random_values = np.random.rand(num_nonzero).astype(np.float32)
+        random_values = rng.random(num_nonzero, dtype=np.float32)
 
         sparse_matrix = csr_matrix((random_values, (random_rows, random_cols)), 
                                    shape=shape, dtype=np.float32)

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -87,7 +87,9 @@ class GridData(Benchmark):
                              method=method)
         
 class GridDataPeakMem(Benchmark):
-
+    """
+    Benchmark based on https://github.com/scipy/scipy/issues/20357
+    """
     def setup(self):
         shape = (7395, 6408)
         num_nonzero = 488686

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -424,9 +424,6 @@ class CloughTocherInterpolatorValues(interpolate.CloughTocher2DInterpolator):
                                                         tol=tol, maxiter=maxiter)
         self.xi = None
         self._preprocess_xi(*xi)
-        self.simplices, self.c = (
-            interpolate.CloughTocher2DInterpolator._find_simplicies(self, self.xi)
-        )
 
     def _preprocess_xi(self, *args):
         if self.xi is None:
@@ -435,9 +432,6 @@ class CloughTocherInterpolatorValues(interpolate.CloughTocher2DInterpolator):
             )
         return self.xi, self.interpolation_points_shape
     
-    def _find_simplicies(self, xi):
-        return self.simplices, self.c
-
     def __call__(self, values):
         self._set_values(values)
         return super().__call__(self.xi)

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -203,7 +203,7 @@ class TestGriddata:
         griddata(coords, values, (grid_x, grid_y), method='cubic')
         final_memory = psutil.Process().memory_info().rss
         memory_used = final_memory - initial_memory
-        assert_allclose(memory_used, 52 * 2 ** 20, atol = 52 * 2 ** 20)
+        assert_allclose(memory_used, 52 * 2 ** 20, atol = 2 ** 27)
 
 class TestNearestNDInterpolator:
     def test_nearest_options(self):

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -169,7 +169,8 @@ class TestGriddata:
                           method=method)
             assert_raises(ValueError, griddata, x, y, xi3,
                           method=method)
-            
+
+
 class TestNearestNDInterpolator:
     def test_nearest_options(self):
         # smoke test that NearestNDInterpolator accept cKDTree options

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -3,8 +3,6 @@ from numpy.testing import assert_equal, assert_array_equal, assert_allclose
 import pytest
 from pytest import raises as assert_raises
 
-from scipy.sparse import csr_matrix
-
 from scipy.interpolate import (griddata, NearestNDInterpolator,
                                LinearNDInterpolator,
                                CloughTocher2DInterpolator)
@@ -172,39 +170,6 @@ class TestGriddata:
             assert_raises(ValueError, griddata, x, y, xi3,
                           method=method)
             
-    def test_memory_usage(self):
-        try:
-            import psutil
-        except ModuleNotFoundError:
-            pytest.skip("psutil required to check available memory")
-        if psutil.virtual_memory().available < 8*2**30:
-        # Don't run the test if there is less than 8 gig of RAM available.
-            pytest.skip('insufficient memory available to run this test')
-                
-        shape = (14790, 12816)
-        num_nonzero = 488686
-
-        np.random.seed(0)
-
-        random_rows = np.random.randint(0, shape[0], num_nonzero)
-        random_cols = np.random.randint(0, shape[1], num_nonzero)
-
-        random_values = np.random.rand(num_nonzero).astype(np.float32)
-
-        sparse_matrix = csr_matrix((random_values, (random_rows, random_cols)), 
-                                   shape=shape, dtype=np.float32)
-        sparse_matrix = sparse_matrix.toarray()
-
-        coords = np.column_stack(np.nonzero(sparse_matrix))
-        values = sparse_matrix[coords[:, 0], coords[:, 1]]
-        grid_x, grid_y = np.mgrid[0:sparse_matrix.shape[0], 0:sparse_matrix.shape[1]]
-
-        initial_memory = psutil.Process().memory_info().rss
-        griddata(coords, values, (grid_x, grid_y), method='cubic')
-        final_memory = psutil.Process().memory_info().rss
-        memory_used = final_memory - initial_memory
-        assert_allclose(memory_used, 52 * 2 ** 20, atol = 2**29)
-
 class TestNearestNDInterpolator:
     def test_nearest_options(self):
         # smoke test that NearestNDInterpolator accept cKDTree options

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -203,7 +203,7 @@ class TestGriddata:
         griddata(coords, values, (grid_x, grid_y), method='cubic')
         final_memory = psutil.Process().memory_info().rss
         memory_used = final_memory - initial_memory
-        assert_allclose(memory_used, 52 * 2 ** 20, atol = 2 ** 27)
+        assert_allclose(memory_used, 52 * 2 ** 20, atol = 2**29)
 
 class TestNearestNDInterpolator:
     def test_nearest_options(self):


### PR DESCRIPTION
#### Reference issue
Closes #20357

#### What does this implement/fix?
When using the LinearNDInterpolator and CloughTocher2DInterpolator classes, instead of keeping the data about the location and simplicies of all the input points in the memory at once, only keep the data about a single simplex at once, greatly reducing the memory usage with larger inputs