### PR TITLE
BUG: Fix pair of bugs in Amos and Cephes yv which masked each other

### DIFF
--- a/scipy/special/cephes/yn.c
+++ b/scipy/special/cephes/yn.c
@@ -98,7 +98,7 @@ double yn(int n, double x)
 	r += 2.0;
 	++k;
     }
-    while (k < n);
+    while (k < n && isfinite(an));
 
 
     return (sign * an);

--- a/scipy/special/special/amos/amos.h
+++ b/scipy/special/special/amos/amos.h
@@ -5743,6 +5743,16 @@ inline int unk2(
             kdflg = 2;
             continue;
         }
+        /* GO TO 70 */
+        if (rs1 > 0.0) { return -1; }
+        /* FOR X < 0.0, THE I FUNCTION TO BE ADDED WILL OVERFLOW */
+        if (x < 0.0) { return -1; }
+        kdflg = 1;
+        y[i-1] = 0.0;
+        cs *= -std::complex<double>(0, 1);
+        nz += 1;
+        if (i != 1) { if (y[i-2] != 0.0) { y[i-2] = 0.0;nz += 1; } }
+        continue;
     }
     /* Check for exhausted loop */
     if (i == n+1) { i = n; }

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3169,6 +3169,11 @@ class TestBessel:
         yn2n = special.yn(1,.2)
         assert_almost_equal(yn2n,-3.3238249881118471,8)
 
+    def test_yn_gh_20405(self):
+        # Enforce correct asymptotic behavior for large n.
+        observed = cephes.yn(500, 1)
+        assert observed == -np.inf
+
     def test_negv_yv(self):
         assert_almost_equal(special.yv(-3,2), -special.yv(3,2), 14)
 


### PR DESCRIPTION
This PR fixes a pair of matching bugs in cephes and amos respectively which went unnoticed because they cancel each other out. I discovered this while working on #20390.

The issues

## Amos

Here in the original Fortran
https://github.com/scipy/scipy/blob/f133c27843a36c8fe1c2979b3a072ac4f5a00624/scipy/special/amos/zunk2.f#L122
If `abs(rs1) > elim`, the code should go to block 70. 

But looking at the (now C++) translation

https://github.com/scipy/scipy/blob/2e7690b40c736474d2e493cb8a7ea7e7f10d78dc/scipy/special/special/amos/amos.h#L5687

and following through, we see that if this condition does not hold, nothing happens. The block is skipped.
https://github.com/scipy/scipy/blob/2e7690b40c736474d2e493cb8a7ea7e7f10d78dc/scipy/special/special/amos/amos.h#L5745-L5746.

## Cephes

In the implementation of cephes `yn`, which is used in cephes `yv`, which the `amos` `yv` in SciPy falls back to when `amos` returns `NaN`

https://github.com/scipy/scipy/blob/2e7690b40c736474d2e493cb8a7ea7e7f10d78dc/scipy/special/special/amos.h#L500-L502

the termination condition here

https://github.com/scipy/scipy/blob/2e7690b40c736474d2e493cb8a7ea7e7f10d78dc/scipy/special/cephes/yn.c#L94-L101

will not stop the loop when the answer becomes infinite, causing further iterations to result in NaN.

Prior to the Amos Fortran->C translation, Amos correctly returned `-inf` for `yv(300, 1)` and `yv(300, 1 + 0j)`. This case is tested in `special/test_basic.py`. After the translation,  the real value path from Amos for `yv(300, 1)` incorrectly returned NaN. The function then fell back to cephes, which also incorrectly returned NaN. The complex valued path incorrectly returned NaN and had no fall back to cephes.

Note that the tests will still pass if the cephes bug is not fixed, because no fall back is necessary in this case, however the cephes bug defeats the purpose of the fallback, so I've fixed it here too.

cc @ilayn

