### PR TITLE
ENH: optimize._chandrupatla: allow infinite function value at bracket endpoints

### DIFF
--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -181,8 +181,9 @@ def _chandrupatla(func, a, b, *, args=(), xatol=_xtol, xrtol=_rtol,
         work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._ESIGNERR
         stop[i] = True
 
-        i = ~((np.isfinite(work.x1) & np.isfinite(work.x2)
-               & np.isfinite(work.f1) & np.isfinite(work.f2)) | stop)
+        x_nonfinite = ~(np.isfinite(work.x1) & np.isfinite(work.x2))
+        f_nan = np.isnan(work.f1) & np.isnan(work.f2)
+        i = (x_nonfinite | f_nan) & ~stop
         work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._EVALUEERR
         stop[i] = True
 

--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -164,27 +164,34 @@ def _chandrupatla(func, a, b, *, args=(), xatol=_xtol, xrtol=_rtol,
         work.fmin = np.choose(i, (work.f2, work.f1))
         stop = np.zeros_like(work.x1, dtype=bool)  # termination condition met
 
+        # If function value tolerance is met, report successful convergence,
+        # regardless of other conditions. Note that `frtol` has been redefined
+        # as `frtol = frtol * np.minimum(f1, f2)`, where `f1` and `f2` are the
+        # function evaluated at the original ends of the bracket.
+        i = np.abs(work.fmin) <= work.fatol + work.frtol
+        work.status[i] = eim._ECONVERGED
+        stop[i] = True
+
+        # If the bracket is no longer valid, report failure (unless a function
+        # tolerance is met, as detected above).
+        i = (np.sign(work.f1) == np.sign(work.f2)) & ~stop
+        work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._ESIGNERR
+        stop[i] = True
+
+        # If the abscissae are non-finite or either function value is NaN,
+        # report failure.
+        x_nonfinite = ~(np.isfinite(work.x1) & np.isfinite(work.x2))
+        f_nan = np.isnan(work.f1) & np.isnan(work.f2)
+        i = (x_nonfinite | f_nan) & ~stop
+        work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._EVALUEERR
+        stop[i] = True
+
         # This is the convergence criterion used in bisect. Chandrupatla's
         # criterion is equivalent to this except with a factor of 4 on `xrtol`.
         work.dx = abs(work.x2 - work.x1)
         work.tol = abs(work.xmin) * work.xrtol + work.xatol
         i = work.dx < work.tol
-        # Modify in place to incorporate tolerance on function value. Note that
-        # `frtol` has been redefined as `frtol = frtol * np.minimum(f1, f2)`,
-        # where `f1` and `f2` are the function evaluated at the original ends of
-        # the bracket.
-        i |= np.abs(work.fmin) <= work.fatol + work.frtol
         work.status[i] = eim._ECONVERGED
-        stop[i] = True
-
-        i = (np.sign(work.f1) == np.sign(work.f2)) & ~stop
-        work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._ESIGNERR
-        stop[i] = True
-
-        x_nonfinite = ~(np.isfinite(work.x1) & np.isfinite(work.x2))
-        f_nan = np.isnan(work.f1) & np.isnan(work.f2)
-        i = (x_nonfinite | f_nan) & ~stop
-        work.xmin[i], work.fmin[i], work.status[i] = np.nan, np.nan, eim._EVALUEERR
         stop[i] = True
 
         return stop

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -779,13 +779,14 @@ class TestChandrupatla(TestScalarRootFinders):
         assert_allclose(res.x, 1)
 
         # Test that if both ends of bracket equal root, algorithm reports
-        # convergence
-        def f(x):
-            return x**2 - 1
+        # convergence.
+        def f(x, root):
+            return x**2 - root
 
-        res = _chandrupatla_root(f, 1, 1)
-        assert res.success
-        assert_equal(res.x, 1)
+        root = [0, 1]
+        res = _chandrupatla_root(f, 1, 1, args=(root,))
+        assert_equal(res.success, [False, True])
+        assert_equal(res.x, [np.nan, 1])
 
         def f(x):
             return 1/x

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -758,6 +758,16 @@ class TestChandrupatla(TestScalarRootFinders):
     def test_special_cases(self):
         # Test edge cases and other special cases
 
+        # Test infinite function values
+        def f(x):
+            return 1 / x + 1 - 1 / (-x + 1)
+
+        with np.errstate(divide='ignore', invalid='ignore'):
+            res = _chandrupatla_root(f, [0.1, 0., 0., 0.1],
+                                     [0.9, 1.0, 0.9, 1.0])
+        assert np.all(res.success)
+        assert_allclose(res.x[1:], res.x[0])
+
         # Test that integers are not passed to `f`
         # (otherwise this would overflow)
         def f(x):


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
The `_chandrupala` rootfinder was unnecessarily picky about the function values at bracket endpoints, requiring that they be finite. If they are infinite but the bracket is valid otherwise, the algorithm natural resorts to bisection, which has no problem with infinite function values.

I also found and fixed a little bug while working on this: if the initial bracket was small enough to satisfy the x-tolerance condition, the function would report successful termination, even if the bracket was not valid.

#### Additional information
I'd suggest taking a look at the two commits separately.

I think it's time to make this public. I hesitate to work it into `root_scalar` for the following reasons:
- The object returned by `root_scalar` has non-standard optimize names. For example, where `minimize_scalar` and `root` return an object with attributes `x`, `success`, and `status`,  `root_scalar` returns calls essentially analogous attributes `root`, `converged`, and `flag`. I'd prefer not to perpetuate unnecessary inconsistency.
- `root_scalar` has tolerance arguments named `xtol` and `rtol`. These names are ambiguous, especially when `_chandrupatla` has absolute and relative tolerances on both the argument and function value.
- (subjective) `root_scalar` uses arguments `x0` and `x1` for the non-bracketing root finders, and a mutually exclusive `bracket` (tuple) argument for the bracketing root finders. I'd suggest that _either_ it is acceptable for the same two arguments to be used for left and right bracket endpoints as for first and second guesses, or these two types of scalar root finders should not be exposed via the same function.
- Most of the root finders exposed via `root_scalar` will not support the same feature set as `_chandrupatla` (e.g. elementwise operation, callback interface). For something as simple and fundamental as scalar root-finding, it would be nice if all the options supported a consistent feature set. 

If these are valid concerns, how should they be addressed? The easiest would be to create a new function, e.g. `solve_scalar`.