### PR TITLE
BUG: signal: corrections to `iir{peak,notch,comb}` filter gain

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -5149,10 +5149,9 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=2.0):
     if ftype not in ("notch", "peak"):
         raise ValueError("Unknown ftype.")
 
-    # Compute beta
-    # Eqs. 11.3.4 (p.575) and 11.3.19 (p.579) from reference [1]
-    # Note that formulas can be further simplified when -3dB attenuation value
-    # gb = 1 / np.sqrt(2):
+    # Compute beta according to Eqs. 11.3.4 (p.575) and 11.3.19 (p.579) from reference [1]
+    # Due to assuming a -3 dB attenuation value, i.e, assuming gb = 1 / np.sqrt(2),
+    # the following terms simplify to:
     #   (np.sqrt(1.0 - gb**2.0) / gb) = 1
     #   (gb / np.sqrt(1.0 - gb**2.0)) = 1
     beta = np.tan(bw/2.0)
@@ -5341,10 +5340,8 @@ def iircomb(w0, Q, ftype='notch', fs=2.0, *, pass_zero=False):
     elif ftype == 'peak':
         G0, G = 0, 1
 
-    # Compute beta
-    # Eq. 11.5.3 (p. 591) from reference [1]
-    # Note that formulas can be further simplified when -3dB attenuation value
-    # GB = 1 / np.sqrt(2):
+    # Due to assuming a -3 dB attenuation value, i.e, assuming GB = 1 / np.sqrt(2),
+    # the following term of Eq. 11.5.3 simplifies to:
     #   np.sqrt((GB**2 - G0**2) / (G**2 - GB**2)) = 1
     beta = np.tan(N * w_delta / 4)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -5146,17 +5146,16 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=2.0):
     bw = bw*np.pi
     w0 = w0*np.pi
 
-    # Compute -3dB attenuation
-    gb = 1/np.sqrt(2)
-
-    if ftype == "notch":
-        # Compute beta: formula 11.3.4 (p.575) from reference [1]
-        beta = (np.sqrt(1.0-gb**2.0)/gb)*np.tan(bw/2.0)
-    elif ftype == "peak":
-        # Compute beta: formula 11.3.19 (p.579) from reference [1]
-        beta = (gb/np.sqrt(1.0-gb**2.0))*np.tan(bw/2.0)
-    else:
+    if ftype not in ("notch", "peak"):
         raise ValueError("Unknown ftype.")
+
+    # Compute beta
+    # Eqs. 11.3.4 (p.575) and 11.3.19 (p.579) from reference [1]
+    # Note that formulas can be further simplified when -3dB attenuation value
+    # gb = 1 / np.sqrt(2):
+    #   (np.sqrt(1.0 - gb**2.0) / gb) = 1
+    #   (gb / np.sqrt(1.0 - gb**2.0)) = 1
+    beta = np.tan(bw/2.0)
 
     # Compute gain: formula 11.3.6 (p.575) from reference [1]
     gain = 1.0/(1.0+beta)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -5149,9 +5149,9 @@ def _design_notch_peak_filter(w0, Q, ftype, fs=2.0):
     if ftype not in ("notch", "peak"):
         raise ValueError("Unknown ftype.")
 
-    # Compute beta according to Eqs. 11.3.4 (p.575) and 11.3.19 (p.579) from reference [1]
-    # Due to assuming a -3 dB attenuation value, i.e, assuming gb = 1 / np.sqrt(2),
-    # the following terms simplify to:
+    # Compute beta according to Eqs. 11.3.4 (p.575) and 11.3.19 (p.579) from
+    # reference [1]. Due to assuming a -3 dB attenuation value, i.e, assuming
+    # gb = 1 / np.sqrt(2), the following terms simplify to:
     #   (np.sqrt(1.0 - gb**2.0) / gb) = 1
     #   (gb / np.sqrt(1.0 - gb**2.0)) = 1
     beta = np.tan(bw/2.0)
@@ -5340,8 +5340,9 @@ def iircomb(w0, Q, ftype='notch', fs=2.0, *, pass_zero=False):
     elif ftype == 'peak':
         G0, G = 0, 1
 
-    # Due to assuming a -3 dB attenuation value, i.e, assuming GB = 1 / np.sqrt(2),
-    # the following term of Eq. 11.5.3 simplifies to:
+    # Compute beta according to Eq. 11.5.3 (p. 591) from reference [1]. Due to
+    # assuming a -3 dB attenuation value, i.e, assuming GB = 1 / np.sqrt(2),
+    # the following term simplifies to:
     #   np.sqrt((GB**2 - G0**2) / (G**2 - GB**2)) = 1
     beta = np.tan(N * w_delta / 4)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -5340,11 +5340,13 @@ def iircomb(w0, Q, ftype='notch', fs=2.0, *, pass_zero=False):
         G0, G = 1, 0
     elif ftype == 'peak':
         G0, G = 0, 1
-    GB = 1 / np.sqrt(2)
 
     # Compute beta
     # Eq. 11.5.3 (p. 591) from reference [1]
-    beta = np.sqrt((GB**2 - G0**2) / (G**2 - GB**2)) * np.tan(N * w_delta / 4)
+    # Note that formulas can be further simplified when -3dB attenuation value
+    # GB = 1 / np.sqrt(2):
+    #   np.sqrt((GB**2 - G0**2) / (G**2 - GB**2)) = 1
+    beta = np.tan(N * w_delta / 4)
 
     # Compute filter coefficients
     # Eq 11.5.1 (p. 590) variables a, b, c from reference [1]


### PR DESCRIPTION
#### Reference issue
Closes #20394

#### What does this implement/fix?
Simplify `scipy.signal` functions: `iirpeak`, `iirnotch`, and `iircomb` gain formulas for -3dB attenuation value of 1/sqrt(2), thus reducing (small) rounding error due to extra computations.

#### Additional information
None.
