### PR TITLE
MAINT: Fix DOI visibility badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 .. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
   :target: https://stackoverflow.com/questions/tagged/scipy
 
-.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue
+.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue.svg
   :target: https://www.nature.com/articles/s41592-019-0686-2
 
 SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,


### PR DESCRIPTION
MAINT: Fix DOI visibility badge in README

#### Reference issue
In README file in `.rst` format, some badges from [Shields.io](https://shields.io/) on Github may require a `.svg` in the path

#### What does this implement/fix?
It fixes DOI visibility badge in the `README.rst` file
