### PR TITLE
DOC: add hints on how to debug linalg issues with gdb

### DIFF
--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -522,7 +522,8 @@ Here is an example ``gdb`` session::
     ...
     > /home/br/temp/chol/chol.py(12)<module>()
     -> linalg.cholesky(a)   # execution stopped at the python breakpoint
-    (Pdb)   # ... inspect the python state here
+    (Pdb) p a.shape  # ... inspect the python state here
+    (40, 40)
     (Pdb) c     # continue execution until the C breakpoint
 
     Thread 1 "python" hit Breakpoint 1, 0x00007ffff4c48820 in dpotrf_ ()
@@ -534,8 +535,7 @@ Here is an example ``gdb`` session::
         capi_keywds=<optimized out>, f2py_func=0x7ffff4c48820 <dpotrf_>)
         at scipy/linalg/_flapackmodule.c:63281
     ....
-    (gdb) p lda    # inspect values of C variables (some symbols may be
-                   # missing or reported as <optimized out>)
+    (gdb) p lda    # inspect values of C variables
     $1 = 40
 
     # print out the C backtrace
@@ -547,3 +547,8 @@ Here is an example ``gdb`` session::
         keywords=('lower', 'overwrite_a', 'clean'))
         at /usr/local/src/conda/python-3.11.8/Objects/call.c:214
     ...
+
+Depending on your system, you may need to build SciPy with debug build type,
+and unset CFLAGS/CXXFLAGS environment variables. See the `NumPy debugging guide
+<https://numpy.org/devdocs/dev/development_environment.html#debugging>`__ for
+more details.

--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -492,8 +492,8 @@ First, prepare a small python reproducer, with a breakpoint. For example::
     import numpy as np
     from scipy import linalg
     n = 40
-    np.random.refault_rng(1234)
-    x = np.random.uniform(size=n)
+    rng = np.random.default_rng(1234)
+    x = rng.uniform(size=n)
     a = x[:, None] @ x[None, :] + np.identity(n)
 
     breakpoint()      # note a breakpoint
@@ -534,6 +534,16 @@ Here is an example ``gdb`` session::
         capi_keywds=<optimized out>, f2py_func=0x7ffff4c48820 <dpotrf_>)
         at scipy/linalg/_flapackmodule.c:63281
     ....
-    (gdb) p lda    # inspect values of C variables etc
+    (gdb) p lda    # inspect values of C variables (some symbols may be
+                   # missing or reported as <optimized out>)
     $1 = 40
 
+    # print out the C backtrace
+    (gdb) bt
+    #0  0x00007ffff3056b1e in f2py_rout.flapack_dpotrf ()
+       from /path/to/site-packages/scipy/linalg/_flapack.cpython-311-x86_64-linux-gnu.so
+    #1  0x0000555555734323 in _PyObject_MakeTpCall (tstate=0x555555ad0558 <_PyRuntime+166328>,
+        callable=<fortran at remote 0x7ffff40ffc00>, args=<optimized out>, nargs=1,
+        keywords=('lower', 'overwrite_a', 'clean'))
+        at /usr/local/src/conda/python-3.11.8/Objects/call.c:214
+    ...

--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -477,4 +477,63 @@ file to automate this and avoid the manual paths:
    machine, it's easy to accidentally pick up the wrong one during the build
    (remember: ``-lopenblas`` only says "link against *some*
    ``libopenblas.so``). If you're not sure, use ``ldd`` on the test executable
-   you built to inspect which shared library it's linked again.
+   you built to inspect which shared library it's linked against.
+
+
+Debugging linalg issues with ``gdb``
+------------------------------------
+
+When debugging linalg issues, it is sometimes useful to step through both Python
+and C code. You can use ``pdb`` for the former, and ``gdb`` for the latter.
+
+First, prepare a small python reproducer, with a breakpoint. For example::
+
+    $ cat chol.py
+    import numpy as np
+    from scipy import linalg
+    n = 40
+    np.random.seed(1234)
+    x = np.random.uniform(size=n)
+    a = x[:, None] @ x[None, :] + np.identity(n)
+
+    breakpoint()      # note a breakpoint
+    linalg.cholesky(a)
+
+Then, you will need to run it under the ``gdb`` and add a C-level breakpoint at
+the LAPACK function. This way, you execution will first stop twice: first on the
+Python breakpoint and then on the C breakpoint, and you will be able to step
+through and inspect values of both Python and C variables.
+
+To find out the LAPACK name, read the python source of the SciPy function and
+use ``nm`` on the ``.so`` library to find out the exact name.
+For the Cholesky factorization above, the LAPACK function is ``?potrf``, and the
+C name on Ubuntu linux is ``dpotrf_`` (it may be spelled with or without the
+trailing underscore, in uppper case or lower case, depending on the system).
+
+Here is an example ``gdb`` session::
+
+    $ gdb --args python chol.py
+    ...
+    (gdb) b dpotrf_     # this adds a C breakpoint (type "y" below)
+    Function "dpotrf_" not defined.
+    Make breakpoint pending on future shared library load? (y or [n]) y
+    Breakpoint 1 (dpotrf_) pending.
+    (gdb) run    # run the python script
+    ...
+    > /home/br/temp/chol/chol.py(12)<module>()
+    -> linalg.cholesky(a)   # execution stopped at the python breakpoint
+    (Pdb)   # ... inspect the python state here
+    (Pdb) c     # continue execution until the C breakpoint
+
+    Thread 1 "python" hit Breakpoint 1, 0x00007ffff4c48820 in dpotrf_ ()
+       from /home/br/mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/core/../../../../libcblas.so.3
+    (gdb) s     # step through the C function
+    Single stepping until exit from function dpotrf_,
+    which has no line number information.
+    f2py_rout__flapack_dpotrf (capi_self=<optimized out>, capi_args=<optimized out>, 
+        capi_keywds=<optimized out>, f2py_func=0x7ffff4c48820 <dpotrf_>)
+        at scipy/linalg/_flapackmodule.c:63281
+    ....
+    (gdb) p lda    # inspect values of C variables etc
+    $1 = 40
+

--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -492,7 +492,7 @@ First, prepare a small python reproducer, with a breakpoint. For example::
     import numpy as np
     from scipy import linalg
     n = 40
-    np.random.seed(1234)
+    np.random.refault_rng(1234)
     x = np.random.uniform(size=n)
     a = x[:, None] @ x[None, :] + np.identity(n)
 
@@ -500,7 +500,7 @@ First, prepare a small python reproducer, with a breakpoint. For example::
     linalg.cholesky(a)
 
 Then, you will need to run it under the ``gdb`` and add a C-level breakpoint at
-the LAPACK function. This way, you execution will first stop twice: first on the
+the LAPACK function. This way, your execution will stop twice: first on the
 Python breakpoint and then on the C breakpoint, and you will be able to step
 through and inspect values of both Python and C variables.
 


### PR DESCRIPTION
[docs only]

Add some brief info on how to use `gdb` to debug linalg issues. This by no means limited to linalg, and the information is in principle available elsewhere. That said, at least I had to ask for help with details (thank you @andfoy!), so am guessing that writing it down might be useful, even if only to point users to. 