### PR TITLE
BLD: Install cython_special.pxd

### DIFF
--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -405,6 +405,7 @@ python_sources = [
   '_ufuncs.pyi',
   'add_newdocs.py',
   'basic.py',
+  'cython_special.pxd',
   'cython_special.pyi',
   'orthogonal.py',
   'sf_error.py',


### PR DESCRIPTION
#### What does this implement/fix?
Brings back `cython_special.pxd` that was accidentally dropped in gh-20417.
