### PR TITLE
MAINT: sparse: Update EfficiencyWarning message to reflect array/matrix

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -973,7 +973,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return
 
         else:
-            warn(f"Changing the sparsity structure of a {self.format}_matrix is"
+            warn(f"Changing the sparsity structure of a {self.__class__.__name__} is"
                  " expensive. lil and dok are more efficient.",
                  SparseEfficiencyWarning, stacklevel=3)
             # replace where possible

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -144,10 +144,7 @@ class TestExpM:
             a = scale * speye(3, 3, dtype=dtype, format='csc')
             e = exp(scale, dtype=dtype) * eye(3, dtype=dtype)
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive."
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 exact_onenorm = _expm(a, use_exact_onenorm=True).toarray()
                 inexact_onenorm = _expm(a, use_exact_onenorm=False).toarray()
             assert_array_almost_equal_nulp(exact_onenorm, e, nulp=100)
@@ -160,10 +157,7 @@ class TestExpM:
             a = scale * speye(3, 3, dtype=dtype, format='csc')
             e = exp(scale) * eye(3, dtype=dtype)
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive."
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -146,7 +146,7 @@ class TestExpM:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a csc_matrix is expensive."
+                    "Changing the sparsity structure of a cs.* is expensive."
                 )
                 exact_onenorm = _expm(a, use_exact_onenorm=True).toarray()
                 inexact_onenorm = _expm(a, use_exact_onenorm=False).toarray()
@@ -162,7 +162,7 @@ class TestExpM:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a csc_matrix is expensive."
+                    "Changing the sparsity structure of a cs.* is expensive."
                 )
                 assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -819,9 +819,10 @@ class _TestCommon:
 
                 dense_setdiag(a, v, k)
                 with suppress_warnings() as sup:
-                    message = ("Changing the sparsity structure of "
-                               "a cs[cr]_matrix is expensive")
-                    sup.filter(SparseEfficiencyWarning, message)
+                    sup.filter(
+                        SparseEfficiencyWarning,
+                        "Changing the sparsity structure of a cs.* is expensive",
+                    )
                     b.setdiag(v, k)
 
                 # check that dense_setdiag worked
@@ -859,7 +860,7 @@ class _TestCommon:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive",
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             assert_raises(ValueError, m.setdiag, values, k=4)
             m.setdiag(values)
@@ -2335,7 +2336,7 @@ class _TestGetSet:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[0, 0] = dtype.type(0)  # bug 870
                 A[1, 2] = dtype.type(4.0)
@@ -2377,7 +2378,7 @@ class _TestGetSet:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[0, -4] = 1
             assert_equal(A[0, -4], 1)
@@ -2394,7 +2395,7 @@ class _TestGetSet:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[i, j] = 1
             assert_almost_equal(A.sum(), nitems, err_msg=msg)
@@ -2411,7 +2412,7 @@ class _TestGetSet:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             for C in [A, B]:
                 C[0,1] = 1
@@ -2672,7 +2673,7 @@ class _TestSlicingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             for C in [A, B]:
                 C[0:1,1] = 1
@@ -2691,7 +2692,7 @@ class _TestSlicingAssign:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[i, j] = 1
             B = np.zeros((n, m))
@@ -2709,7 +2710,7 @@ class _TestSlicingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             B[0,0] = 2
             B[1,2] = 7
@@ -2739,7 +2740,7 @@ class _TestSlicingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             B[0,0] = 5
             B[1,2] = 3
@@ -2755,7 +2756,7 @@ class _TestSlicingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             B[0,0] = 5
             B[1,2] = 3
@@ -2778,7 +2779,7 @@ class _TestSlicingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             for j, a in enumerate(slices):
                 A[a] = j
@@ -3085,8 +3086,10 @@ class _TestFancyIndexing:
         # regression test for gh-10695
         mat = self.spcreator(array([[1, 0], [2, 3]]))
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure")
+            sup.filter(
+                SparseEfficiencyWarning,
+                "Changing the sparsity structure of a cs.* is expensive",
+            )
             mat[[0, 1], [1, 1]] = mat[[1, 0], [0, 0]]
         assert_equal(toarray(mat), array([[1, 2], [2, 1]]))
 
@@ -3137,7 +3140,7 @@ class _TestFancyIndexingAssign:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 B[i, j] = 1
                 with check_remains_sorted(A):
@@ -3157,7 +3160,7 @@ class _TestFancyIndexingAssign:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[[0,1],[0,1]] = dtype.type(1)
                 assert_equal(A.sum(), dtype.type(1)*2)
@@ -3180,7 +3183,7 @@ class _TestFancyIndexingAssign:
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             with check_remains_sorted(A):
                 A[0,i0] = B[i0,0].T
@@ -3318,7 +3321,7 @@ class _TestFancyMultidimAssign:
             with check_remains_sorted(A), suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 A[i, j] = 1
             B = asmatrix(np.zeros((n, m)))
@@ -3784,8 +3787,10 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                 continue
             old_cls = names.get(name)
             if old_cls is not None:
-                raise ValueError("Test class {} overloads test {} defined in {}".format(
-                    cls.__name__, name, old_cls.__name__))
+                raise ValueError(
+                    f"Test class {cls.__name__} overloads"
+                    f" test {name} defined in {old_cls.__name__}"
+                )
             names[name] = cls
 
     return type("TestBase", bases, {})
@@ -3799,8 +3804,10 @@ class TestCSR(sparse_test_class()):
     @classmethod
     def spcreator(cls, *args, **kwargs):
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a csr_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+                "Changing the sparsity structure of a cs.* is expensive",
+            )
             return csr_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
@@ -4052,8 +4059,10 @@ class TestCSC(sparse_test_class()):
     @classmethod
     def spcreator(cls, *args, **kwargs):
         with suppress_warnings() as sup:
-            sup.filter(SparseEfficiencyWarning,
-                       "Changing the sparsity structure of a csc_matrix is expensive")
+            sup.filter(
+                SparseEfficiencyWarning,
+                "Changing the sparsity structure of a cs.* is expensive",
+            )
             return csc_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
@@ -4898,7 +4907,7 @@ class _NonCanonicalMixin:
             with suppress_warnings() as sup:
                 sup.filter(
                     SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                    "Changing the sparsity structure of a cs.* is expensive",
                 )
                 M = self._insert_explicit_zero(M, zero_pos[0][k], zero_pos[1][k])
 
@@ -4985,7 +4994,7 @@ class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             A[1,:] = B
         assert_array_equal(A.toarray(), D)
@@ -4994,7 +5003,7 @@ class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
         with suppress_warnings() as sup:
             sup.filter(
                 SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive"
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             A[:,2] = B.T
         assert_array_equal(A.toarray(), D)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -819,10 +819,7 @@ class _TestCommon:
 
                 dense_setdiag(a, v, k)
                 with suppress_warnings() as sup:
-                    sup.filter(
-                        SparseEfficiencyWarning,
-                        "Changing the sparsity structure of a cs.* is expensive",
-                    )
+                    sup.filter(SparseEfficiencyWarning, "Changing the sparsity structu")
                     b.setdiag(v, k)
 
                 # check that dense_setdiag worked
@@ -858,10 +855,7 @@ class _TestCommon:
         m2 = self.spcreator((4, 4))
         values = [3, 2, 1]
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             assert_raises(ValueError, m.setdiag, values, k=4)
             m.setdiag(values)
             assert_array_equal(m.diagonal(), values)
@@ -2334,10 +2328,7 @@ class _TestGetSet:
         def check(dtype):
             A = self.spcreator((3,4), dtype=dtype)
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[0, 0] = dtype.type(0)  # bug 870
                 A[1, 2] = dtype.type(4.0)
                 A[0, 1] = dtype.type(3)
@@ -2376,10 +2367,7 @@ class _TestGetSet:
         def check(dtype):
             A = self.spcreator((3, 10), dtype=dtype)
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[0, -4] = 1
             assert_equal(A[0, -4], 1)
 
@@ -2393,10 +2381,7 @@ class _TestGetSet:
             msg = f"{i!r} ; {j!r} ; {nitems!r}"
             A = self.spcreator((n, m))
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[i, j] = 1
             assert_almost_equal(A.sum(), nitems, err_msg=msg)
             assert_almost_equal(A[i, j], 1, err_msg=msg)
@@ -2410,10 +2395,7 @@ class _TestGetSet:
         A = self.spcreator((5, 5))
         B = np.zeros((5, 5))
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             for C in [A, B]:
                 C[0,1] = 1
                 C[3,0] = 4
@@ -2671,10 +2653,7 @@ class _TestSlicingAssign:
         A = self.spcreator((5, 5))
         B = np.zeros((5, 5))
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             for C in [A, B]:
                 C[0:1,1] = 1
                 C[3:0,0] = 4
@@ -2690,10 +2669,7 @@ class _TestSlicingAssign:
             msg = f"i={i!r}; j={j!r}"
             A = self.spcreator((n, m))
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[i, j] = 1
             B = np.zeros((n, m))
             B[i, j] = 1
@@ -2708,10 +2684,7 @@ class _TestSlicingAssign:
         # another.
         B = self.spcreator((4,3))
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             B[0,0] = 2
             B[1,2] = 7
             B[2,1] = 3
@@ -2738,10 +2711,7 @@ class _TestSlicingAssign:
         block = [[1,0],[0,4]]
 
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             B[0,0] = 5
             B[1,2] = 3
             B[2,1] = 7
@@ -2754,10 +2724,7 @@ class _TestSlicingAssign:
     def test_sparsity_modifying_assignment(self):
         B = self.spcreator((4,3))
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             B[0,0] = 5
             B[1,2] = 3
             B[2,1] = 7
@@ -2777,10 +2744,7 @@ class _TestSlicingAssign:
                   array(-1), np.int8(-3)]
 
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             for j, a in enumerate(slices):
                 A[a] = j
                 B[a] = j
@@ -3086,10 +3050,7 @@ class _TestFancyIndexing:
         # regression test for gh-10695
         mat = self.spcreator(array([[1, 0], [2, 3]]))
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             mat[[0, 1], [1, 1]] = mat[[1, 0], [0, 0]]
         assert_equal(toarray(mat), array([[1, 2], [2, 1]]))
 
@@ -3138,10 +3099,7 @@ class _TestFancyIndexingAssign:
             A = self.spcreator((n, m))
             B = asmatrix(np.zeros((n, m)))
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 B[i, j] = 1
                 with check_remains_sorted(A):
                     A[i, j] = 1
@@ -3158,10 +3116,7 @@ class _TestFancyIndexingAssign:
         def check(dtype):
             A = self.spcreator((5, 5), dtype=dtype)
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[[0,1],[0,1]] = dtype.type(1)
                 assert_equal(A.sum(), dtype.type(1)*2)
                 A[0:2,0:2] = dtype.type(1.0)
@@ -3181,10 +3136,7 @@ class _TestFancyIndexingAssign:
         i2 = array(i0)
 
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             with check_remains_sorted(A):
                 A[0,i0] = B[i0,0].T
                 A[1,i1] = B[i1,1].T
@@ -3319,10 +3271,7 @@ class _TestFancyMultidimAssign:
         def _test_set_slice(i, j):
             A = self.spcreator((n, m))
             with check_remains_sorted(A), suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 A[i, j] = 1
             B = asmatrix(np.zeros((n, m)))
             B[i, j] = 1
@@ -3804,10 +3753,7 @@ class TestCSR(sparse_test_class()):
     @classmethod
     def spcreator(cls, *args, **kwargs):
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             return csr_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
@@ -4059,10 +4005,7 @@ class TestCSC(sparse_test_class()):
     @classmethod
     def spcreator(cls, *args, **kwargs):
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             return csc_matrix(*args, **kwargs)
     math_dtypes = [np.bool_, np.int_, np.float64, np.complex128]
 
@@ -4905,10 +4848,7 @@ class _NonCanonicalMixin:
         if has_zeros:
             k = zero_pos[0].size//2
             with suppress_warnings() as sup:
-                sup.filter(
-                    SparseEfficiencyWarning,
-                    "Changing the sparsity structure of a cs.* is expensive",
-                )
+                sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
                 M = self._insert_explicit_zero(M, zero_pos[0][k], zero_pos[1][k])
 
         arg1 = self._arg1_for_noncanonical(M, sorted_indices)
@@ -4992,19 +4932,13 @@ class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
 
         D[1,:] = B.toarray()
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             A[1,:] = B
         assert_array_equal(A.toarray(), D)
 
         D[:,2] = B.toarray().ravel()
         with suppress_warnings() as sup:
-            sup.filter(
-                SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             A[:,2] = B.T
         assert_array_equal(A.toarray(), D)
 

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -4,7 +4,7 @@ import pytest
 
 import numpy as np
 
-import scipy as sp
+from scipy.sparse import coo_array, dok_array, SparseEfficiencyWarning
 from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy._lib._util import ComplexWarning
 
@@ -13,7 +13,7 @@ sup_complex = np.testing.suppress_warnings()
 sup_complex.filter(ComplexWarning)
 
 
-spcreators = [sp.sparse.coo_array, sp.sparse.dok_array]
+spcreators = [coo_array, dok_array]
 math_dtypes = [np.int64, np.float64, np.complex128]
 
 
@@ -26,8 +26,8 @@ def dat1d():
 def datsp_math_dtypes(dat1d):
     dat_dtypes = {dtype: dat1d.astype(dtype) for dtype in math_dtypes}
     return {
-        sp: [(dtype, dat, sp(dat)) for dtype, dat in dat_dtypes.items()]
-        for sp in spcreators
+        spcreator: [(dtype, dat, spcreator(dat)) for dtype, dat in dat_dtypes.items()]
+        for spcreator in spcreators
     }
 
 
@@ -231,13 +231,13 @@ class TestCommon1D:
     @sup_complex
     def test_from_sparse(self, spcreator):
         D = np.array([1, 0, 0])
-        S = sp.sparse.coo_array(D)
+        S = coo_array(D)
         assert np.array_equal(spcreator(S).toarray(), D)
         S = spcreator(D)
         assert np.array_equal(spcreator(S).toarray(), D)
 
         D = np.array([1.0 + 3j, 0, -1])
-        S = sp.sparse.coo_array(D)
+        S = coo_array(D)
         assert np.array_equal(spcreator(S).toarray(), D)
         assert np.array_equal(spcreator(S, dtype='int16').toarray(), D.astype('int16'))
         S = spcreator(D)
@@ -397,7 +397,7 @@ class TestCommon1D:
         assert np.array_equal(S.toarray(), [1, 0, 3, 0, 0])
 
 
-@pytest.mark.parametrize("spcreator", [sp.sparse.dok_array])
+@pytest.mark.parametrize("spcreator", [dok_array])
 class TestGetSet1D:
     def test_getelement(self, spcreator):
         D = np.array([4, 3, 0])
@@ -423,10 +423,7 @@ class TestGetSet1D:
         dtype = np.float64
         A = spcreator((12,), dtype=dtype)
         with np.testing.suppress_warnings() as sup:
-            sup.filter(
-                sp.sparse.SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs.* is expensive",
-            )
+            sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
             A[0] = dtype(0)
             A[1] = dtype(3)
             A[8] = dtype(9.0)

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -425,7 +425,7 @@ class TestGetSet1D:
         with np.testing.suppress_warnings() as sup:
             sup.filter(
                 sp.sparse.SparseEfficiencyWarning,
-                "Changing the sparsity structure of a cs[cr]_matrix is expensive",
+                "Changing the sparsity structure of a cs.* is expensive",
             )
             A[0] = dtype(0)
             A[1] = dtype(3)


### PR DESCRIPTION
This is a change in the EfficiencyWarning text to reflect the class name (format and array/matrix).
It ends up touching a lot of tests (those that filter the warning based on the text). The tests now filter on less specific text to allow the message to evolve and still have the filter work.

I'm pulling this out as a separate PR because it is affecting multiple PRs -- reviewing this should be easier without other changes and then the other PRs don't have this large footprint, low information change.

When I committed these changes a couple of linting changes were required by the precommit. 
lines near 3740 in `test_base.py` and lines involving the abbreviation `sp` for import in `test_common1d.py`.