### PR TITLE
BUG: sparse: Clean up 1D input handling to sparse array/matrix and add tests

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -107,6 +107,16 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
+            if arg1.ndim != 2:
+                if isinstance(self, sparray):
+                    raise ValueError(
+                        f"BSR arrays do not support {arg1.ndim}D input. Use 2D"
+                    )
+                else:
+                    warn(
+                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
+                        FutureWarning, stacklevel=2
+                    )
             arg1 = self._coo_container(
                 arg1, dtype=dtype
             ).tobsr(blocksize=blocksize)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -107,19 +107,9 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
-            if arg1.ndim != 2:
-                if isinstance(self, sparray):
-                    raise ValueError(
-                        f"BSR arrays do not support {arg1.ndim}D input. Use 2D"
-                    )
-                else:
-                    warn(
-                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
-                        FutureWarning, stacklevel=2
-                    )
-            arg1 = self._coo_container(
-                arg1, dtype=dtype
-            ).tobsr(blocksize=blocksize)
+            if isinstance(self, sparray) and arg1.ndim != 2:
+                raise ValueError(f"BSR arrays don't support {arg1.ndim}D input. Use 2D")
+            arg1 = self._coo_container(arg1, dtype=dtype).tobsr(blocksize=blocksize)
             self.indptr, self.indices, self.data, self._shape = (
                 arg1.indptr, arg1.indices, arg1.data, arg1._shape
             )

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -84,9 +84,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 raise ValueError(f"unrecognized {self.__class__.__name__} "
                                  f"constructor input: {arg1}") from e
-            if isinstance(self, sparray) and arg1.ndim < 2 and self.format != "csr":
+            if isinstance(self, sparray) and arg1.ndim < 2 and self.format == "csc":
                 raise ValueError(
-                    f"Non-CSR Compressed arrays don't take {arg1.ndim}D input. Use 2D"
+                    f"CSC arrays don't support {arg1.ndim}D input. Use 2D"
                 )
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -84,6 +84,18 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 raise ValueError(f"unrecognized {self.__class__.__name__} "
                                  f"constructor input: {arg1}") from e
+            if arg1.ndim < 2:
+                if not isinstance(self, sparray):
+                    warn(
+                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
+                        FutureWarning, stacklevel=2
+                    )
+                if self.format != "csr":
+                    raise ValueError(
+                        "Compressed arrays other than CSR do not support "
+                        f"{arg1.ndim}D input. Use 2D"
+                    )
+
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, self._shape = arrays

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -84,18 +84,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 raise ValueError(f"unrecognized {self.__class__.__name__} "
                                  f"constructor input: {arg1}") from e
-            if arg1.ndim < 2:
-                if not isinstance(self, sparray):
-                    warn(
-                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
-                        FutureWarning, stacklevel=2
-                    )
-                if self.format != "csr":
-                    raise ValueError(
-                        "Compressed arrays other than CSR do not support "
-                        f"{arg1.ndim}D input. Use 2D"
-                    )
-
+            if isinstance(self, sparray) and arg1.ndim < 2 and self.format != "csr":
+                raise ValueError(
+                    f"Non-CSR Compressed arrays don't take {arg1.ndim}D input. Use 2D"
+                )
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, self._shape = arrays

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -77,11 +77,6 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 # dense argument
                 M = np.asarray(arg1)
                 if not is_array:
-                    if M.ndim < 2:
-                        warn(
-                            f"{M.ndim}D input will not be valid for matrices. Use 2D",
-                            FutureWarning, stacklevel=2
-                        )
                     M = np.atleast_2d(M)
                     if M.ndim != 2:
                         raise TypeError(f'expected 2D array or matrix, not {M.ndim}D')

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -77,9 +77,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 # dense argument
                 M = np.asarray(arg1)
                 if not is_array:
+                    if M.ndim < 2:
+                        warn(
+                            f"{M.ndim}D input will not be valid for matrices. Use 2D",
+                            FutureWarning, stacklevel=2
+                        )
                     M = np.atleast_2d(M)
                     if M.ndim != 2:
-                        raise TypeError('expected dimension <= 2 array or matrix')
+                        raise TypeError(f'expected 2D array or matrix, not {M.ndim}D')
 
                 self._shape = check_shape(M.shape, allow_1d=is_array)
                 if shape is not None:

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -4,6 +4,8 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
 
+from warnings import warn
+
 import numpy as np
 
 from .._lib._util import copy_if_needed
@@ -70,6 +72,16 @@ class _dia_base(_data_matrix):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
+            if arg1.ndim != 2:
+                if isinstance(self, sparray):
+                    raise ValueError(
+                        f"DIA arrays do not support {arg1.ndim}D input. Use 2D"
+                    )
+                else:
+                    warn(
+                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
+                        FutureWarning, stacklevel=2
+                    )
             A = self._coo_container(arg1, dtype=dtype, shape=shape).todia()
             self.data = A.data
             self.offsets = A.offsets

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -4,8 +4,6 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
 
-from warnings import warn
-
 import numpy as np
 
 from .._lib._util import copy_if_needed
@@ -72,16 +70,8 @@ class _dia_base(_data_matrix):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
-            if arg1.ndim != 2:
-                if isinstance(self, sparray):
-                    raise ValueError(
-                        f"DIA arrays do not support {arg1.ndim}D input. Use 2D"
-                    )
-                else:
-                    warn(
-                        f"{arg1.ndim}D input will not be valid for matrices. Use 2D",
-                        FutureWarning, stacklevel=2
-                    )
+            if isinstance(self, sparray) and arg1.ndim != 2:
+                raise ValueError(f"DIA arrays don't support {arg1.ndim}D input. Use 2D")
             A = self._coo_container(arg1, dtype=dtype, shape=shape).todia()
             self.data = A.data
             self.offsets = A.offsets

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -6,7 +6,6 @@ __docformat__ = "restructuredtext en"
 __all__ = ['lil_array', 'lil_matrix', 'isspmatrix_lil']
 
 from bisect import bisect_left
-from warnings import warn
 
 import numpy as np
 
@@ -58,16 +57,8 @@ class _lil_base(_spbase, IndexMixin):
                 A = self._ascontainer(arg1)
             except TypeError as e:
                 raise TypeError('unsupported matrix type') from e
-            if A.ndim != 2:
-                if isinstance(self, sparray):
-                    raise ValueError(
-                        f"LIL arrays do not support {A.ndim}D input. Use 2D"
-                    )
-                else:
-                    warn(
-                        f"{A.ndim}D input will not be valid for matrices. Use 2D",
-                        FutureWarning, stacklevel=2
-                    )
+            if isinstance(self, sparray) and A.ndim != 2:
+                raise ValueError(f"LIL arrays don't support {A.ndim}D input. Use 2D")
             A = self._csr_container(A, dtype=dtype).tolil()
 
             self._shape = check_shape(A.shape)

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -6,6 +6,7 @@ __docformat__ = "restructuredtext en"
 __all__ = ['lil_array', 'lil_matrix', 'isspmatrix_lil']
 
 from bisect import bisect_left
+from warnings import warn
 
 import numpy as np
 
@@ -57,13 +58,22 @@ class _lil_base(_spbase, IndexMixin):
                 A = self._ascontainer(arg1)
             except TypeError as e:
                 raise TypeError('unsupported matrix type') from e
-            else:
-                A = self._csr_container(A, dtype=dtype).tolil()
+            if A.ndim != 2:
+                if isinstance(self, sparray):
+                    raise ValueError(
+                        f"LIL arrays do not support {A.ndim}D input. Use 2D"
+                    )
+                else:
+                    warn(
+                        f"{A.ndim}D input will not be valid for matrices. Use 2D",
+                        FutureWarning, stacklevel=2
+                    )
+            A = self._csr_container(A, dtype=dtype).tolil()
 
-                self._shape = check_shape(A.shape)
-                self.dtype = A.dtype
-                self.rows = A.rows
-                self.data = A.data
+            self._shape = check_shape(A.shape)
+            self.dtype = A.dtype
+            self.rows = A.rows
+            self.data = A.data
 
     def __iadd__(self,other):
         self[:,:] = self + other

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3736,10 +3736,8 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                 continue
             old_cls = names.get(name)
             if old_cls is not None:
-                cls_nm = cls.__name__
-                old_nm = old_cls.__name__
-                raise ValueError(f"Test class {cls_nm} overloads test {name} "
-                                 f"defined in {old_nm}")
+                raise ValueError(f"Test class {cls.__name__} overloads test "
+                                 f"{name} defined in {old_cls.__name__}")
             names[name] = cls
 
     return type("TestBase", bases, {})
@@ -4413,24 +4411,18 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(mat)
         assert_array_equal(coo.toarray(), mat)
 
-        # upgrade rank 1 arrays to row matrix, but raise FutureWarning
+        # upgrade rank 1 arrays to row matrix
         mat = array([0,1,0,0])
-        with suppress_warnings() as sup:
-            sup.filter(FutureWarning, "1D input will not be valid for matrices.")
-            coo = coo_matrix(mat)
+        coo = coo_matrix(mat)
         assert_array_equal(coo.toarray(), mat.reshape(1, -1))
 
         # error if second arg interpreted as shape (gh-9919)
         with pytest.raises(TypeError, match=r'object cannot be interpreted'):
-            with suppress_warnings() as sup:
-                sup.filter(FutureWarning, "1D input will not be valid for matrices.")
-                coo_matrix([0, 11, 22, 33], ([0, 1, 2, 3], [0, 0, 0, 0]))
+            coo_matrix([0, 11, 22, 33], ([0, 1, 2, 3], [0, 0, 0, 0]))
 
         # error if explicit shape arg doesn't match the dense matrix
         with pytest.raises(ValueError, match=r'inconsistent shapes'):
-            with suppress_warnings() as sup:
-                sup.filter(FutureWarning, "1D input will not be valid for matrices.")
-                coo_matrix([0, 11, 22, 33], shape=(4, 4))
+            coo_matrix([0, 11, 22, 33], shape=(4, 4))
 
     def test_constructor_data_ij_dtypeNone(self):
         data = [1]

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -10,7 +10,6 @@ from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy.sparse import (
         bsr_array, csc_array, dia_array, lil_array,
         coo_array, csr_array, dok_array,
-        coo_matrix, csr_matrix, dia_matrix
     )
 from scipy._lib._util import ComplexWarning
 
@@ -38,33 +37,18 @@ def datsp_math_dtypes(dat1d):
 
 
 # Test init with 1D dense input
-# spmatrix -- only test a few formats
-@pytest.mark.parametrize("sp_matrix", [csr_matrix, coo_matrix, dia_matrix])
-def test_matrix_init_of_1d(sp_matrix):
-    with pytest.warns(FutureWarning, match='D input will not be valid'):
-        A = sp_matrix([0, 1, 2, 3])
-    assert A.ndim == 2
+# sparrays which do not plan to support 1D
+@pytest.mark.parametrize("spcreator", [bsr_array, csc_array, dia_array, lil_array])
+def test_no_1d_support_in_init(spcreator):
+    with pytest.raises(ValueError, match="arrays don't support 1D input"):
+        spcreator([0, 1, 2, 3])
 
 
 # csr_array -- will soon support 1D
 @pytest.mark.parametrize("spcreator", [csr_array])
 def test_csr_init_of_1d(spcreator):
-    with pytest.raises(ValueError, match='arrays do not support 1D input yet'):
+    with pytest.raises(ValueError, match="arrays don't support 1D input yet"):
         spcreator([0, 1, 2, 3])
-
-
-# sparrays which do not plan to support 1D
-@pytest.mark.parametrize("spcreator", [bsr_array, csc_array, dia_array, lil_array])
-def test_no_1d_support_in_init(spcreator):
-    with pytest.raises(ValueError, match='arrays do not support 1D input'):
-        spcreator([0, 1, 2, 3])
-
-
-# sparrays which do support 1D
-@pytest.mark.parametrize("spcreator", spcreators)
-def test_1d_supported_init(spcreator):
-    A = spcreator([0, 1, 2, 3])
-    assert A.ndim == 1
 
 
 # Main tests class
@@ -90,6 +74,10 @@ class TestCommon1D:
     def test_neg(self, spcreator):
         A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
         assert_equal(-A, (-spcreator(A)).toarray())
+
+    def test_1d_supported_init(self, spcreator):
+        A = spcreator([0, 1, 2, 3])
+        assert A.ndim == 1
 
     def test_reshape_1d_tofrom_row_or_column(self, spcreator):
         # add a dimension 1d->2d

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -43,13 +43,6 @@ def test_no_1d_support_in_init(spcreator):
         spcreator([0, 1, 2, 3])
 
 
-# csr_array -- will soon support 1D
-@pytest.mark.parametrize("spcreator", [csr_array])
-def test_csr_init_of_1d(spcreator):
-    with pytest.raises(ValueError, match="arrays don't support 1D input yet"):
-        spcreator([0, 1, 2, 3])
-
-
 # Main tests class
 @pytest.mark.parametrize("spcreator", spcreators)
 class TestCommon1D:

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -7,6 +7,11 @@ from numpy.testing import assert_equal, assert_allclose
 
 from scipy.sparse import coo_array, csr_array, dok_array, SparseEfficiencyWarning
 from scipy.sparse._sputils import supported_dtypes, matrix
+from scipy.sparse import (
+        bsr_array, csc_array, dia_array, lil_array,
+        coo_array, csr_array, dok_array,
+        coo_matrix, csr_matrix, dia_matrix
+    )
 from scipy._lib._util import ComplexWarning
 
 
@@ -32,6 +37,37 @@ def datsp_math_dtypes(dat1d):
     }
 
 
+# Test init with 1D dense input
+# spmatrix -- only test a few formats
+@pytest.mark.parametrize("sp_matrix", [csr_matrix, coo_matrix, dia_matrix])
+def test_matrix_init_of_1d(sp_matrix):
+    with pytest.warns(FutureWarning, match='D input will not be valid'):
+        A = sp_matrix([0, 1, 2, 3])
+    assert A.ndim == 2
+
+
+# csr_array -- will soon support 1D
+@pytest.mark.parametrize("spcreator", [csr_array])
+def test_csr_init_of_1d(spcreator):
+    with pytest.raises(ValueError, match='arrays do not support 1D input yet'):
+        spcreator([0, 1, 2, 3])
+
+
+# sparrays which do not plan to support 1D
+@pytest.mark.parametrize("spcreator", [bsr_array, csc_array, dia_array, lil_array])
+def test_no_1d_support_in_init(spcreator):
+    with pytest.raises(ValueError, match='arrays do not support 1D input'):
+        spcreator([0, 1, 2, 3])
+
+
+# sparrays which do support 1D
+@pytest.mark.parametrize("spcreator", spcreators)
+def test_1d_supported_init(spcreator):
+    A = spcreator([0, 1, 2, 3])
+    assert A.ndim == 1
+
+
+# Main tests class
 @pytest.mark.parametrize("spcreator", spcreators)
 class TestCommon1D:
     """test common functionality shared by 1D sparse formats"""

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -5,12 +5,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-from scipy.sparse import coo_array, csr_array, dok_array, SparseEfficiencyWarning
-from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy.sparse import (
         bsr_array, csc_array, dia_array, lil_array,
-        coo_array, csr_array, dok_array,
+        coo_array, csr_array, dok_array, SparseEfficiencyWarning,
     )
+from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy._lib._util import ComplexWarning
 
 


### PR DESCRIPTION
Fixes #20415  
1D input to sparse matrix constructor creates a 2D matrix with one row. This could be thought of as a bug (1D input should not create 2D output) or a feature (1D input saves an extra square bracket pair of typing). But it definitely needs to be changed when moving to a sparse array api that supports 1D sparse arrays.

In addition, the 1D input case is not handled gracefully in 1.13 for `csr_array` because the CSR 1D support PR did not get in in time. 

The 1D input case to 2D output does have a test for sparse matrices, but not for arrays. So new tests are needed as well. The module `test_base.py` even uses 1D input in 2 places -- this PR changes those to 2D input. The test for the 1D input -> 2D output behavior is left as is. The test for arrays depends on format and in this PR is added to test_common1d.py ~~updated to check arrays as well as matrices that the FutureWarning is in place.~~

This PR also adds tests to ensure behavior is determined for 1D input for all formats. It improves the ValueError message for the `csr_array` case to adjust the reported confusing ValueError message (which will become moot when the csr PR is merged).  It adds FutureWarnings for sparse matrix when 1D constructor input occurs in all formats. It adds ValueErrors with better error messages for sparse formats that are not planned to support 1D arrays.

The sparse working group should discuss this on Monday to ensure no other similar cases have been missed.

Precommit linting required some changes which are not directly related to the other content in this PR.