### PR TITLE
ENH: sparse: special-case DIA * scalar

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -445,6 +445,8 @@ class _spbase:
 
     def multiply(self, other):
         """Point-wise multiplication by another array/matrix."""
+        if isscalarlike(other):
+            return self._mul_scalar(other)
         return self.tocsr().multiply(other)
 
     def maximum(self, other):
@@ -652,13 +654,9 @@ class _spbase:
             raise ValueError('could not interpret dimensions')
 
     def __mul__(self, other):
-        if isscalarlike(other):
-            return self._mul_scalar(other)
         return self.multiply(other)
 
     def __rmul__(self, other):  # other * self
-        if isscalarlike(other):
-            return self._mul_scalar(other)
         return self.multiply(other)
 
     # by default, use CSR for __mul__ handlers

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -652,9 +652,13 @@ class _spbase:
             raise ValueError('could not interpret dimensions')
 
     def __mul__(self, other):
+        if isscalarlike(other):
+            return self._mul_scalar(other)
         return self.multiply(other)
 
     def __rmul__(self, other):  # other * self
+        if isscalarlike(other):
+            return self._mul_scalar(other)
         return self.multiply(other)
 
     # by default, use CSR for __mul__ handlers

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -200,6 +200,9 @@ class _dia_base(_data_matrix):
                 m.setdiag(other.diagonal(d), d)
         return m
 
+    def _mul_scalar(self, other):
+        return self._with_data(self.data * other)
+
     def _matmul_vector(self, other):
         x = other
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4614,6 +4614,10 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         assert isinstance(res, dia_matrix)
         assert_array_equal(res.toarray(), [[3, 6], [0, 12]])
 
+        res2 = m.multiply(3)
+        assert isinstance(res2, dia_matrix)
+        assert_array_equal(res2.toarray(), [[3, 6], [0, 12]])
+
 
 TestDIA.init_class()
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4607,6 +4607,13 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         csc = dia.tocsc()
         assert csc.indices.dtype == np.int32
 
+    def test_mul_scalar(self):
+        # repro for gh-20434
+        m = dia_matrix([[1, 2], [0, 4]])
+        res = m * 3
+        assert isinstance(res, dia_matrix)
+        assert_array_equal(res.toarray(), [[3, 6], [0, 12]])
+
 
 TestDIA.init_class()
 


### PR DESCRIPTION
#### Reference issue
Fixes gh-20434.

#### What does this implement/fix?
This adds an override for sparse * scalar multiplication, to avoid a potentially costly conversion to CSR format.

#### Performance

```python
In [1]: import scipy.sparse as ss
In [2]: import numpy as np
In [3]: a = ss.diags_array(np.random.random((5, 10000)), offsets=[-4, -2, 0, 1, 6], shape=(10000, 10000))
In [4]: %timeit a * 5
38.4 µs ± 246 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
In [5]: %timeit a.tocsr() * 5
643 µs ± 3.63 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
And a perfplot:
![perfplot](https://github.com/scipy/scipy/assets/82855/71d65ab1-1324-4da2-865e-1396d3783ccf)
generated via:
```python
import perfplot
perfplot.show(
   setup=lambda n: ss.diags_array(np.random.random((5, n)), offsets=[-4, -2, 0, 1, 6], shape=(n, n)),
   kernels=[lambda x: x * 5, lambda x: x.tocsr() * 5],
   labels=['new', 'old'],
   n_range=[1e2, 1e3, 1e4, 1e5, 1e6],
   xlabel='NxN shape',
   equality_check=None,
)
```