### PR TITLE
BUG: signal.iirfilter: avoid integer overflow

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2565,7 +2565,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     if fs is not None:
         if analog:
             raise ValueError("fs cannot be specified for an analog filter")
-        Wn = 2*Wn/fs
+        Wn = Wn / (fs/2)
 
     if np.any(Wn <= 0):
         raise ValueError("filter critical frequencies must be greater than 0")

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4095,6 +4095,11 @@ class TestIIRFilter:
                       output='zpk')[2]
         k2 = 9.999999999999989e+47
         assert_allclose(k, k2)
+        # if fs is specified then the normalization of Wn to have 
+        # 0 <= Wn <= 1 should not cause an integer overflow
+        # the following line should not raise an exception
+        iirfilter(20, [1000000000, 1100000000], btype='bp', 
+                      analog=False, fs=6250000000)
 
     def test_invalid_wn_size(self):
         # low and high have 1 Wn, band and stop have 2 Wn


### PR DESCRIPTION
Avoid a potential integer overflow when using integer values for frequencies

#### Reference issue
#20455 

#### What does this implement/fix?
The line `2*Wn/fs` can cause an integer overflow when Wn is passed as (an array of) integers since it is stored as int32
