### PR TITLE
MAINT: special: fix compiler warning for unused variable

### DIFF
--- a/scipy/special/special/hyp2f1.h
+++ b/scipy/special/special/hyp2f1.h
@@ -413,9 +413,9 @@ namespace detail {
          * for the 1 - z transform also has an initial finite sum, but it is a standard hypergeometric
          * series. */
       public:
-        SPECFUN_HOST_DEVICE Hyp2f1Transform2LimitFinitePartGenerator(double a, double b, double c, double m,
+        SPECFUN_HOST_DEVICE Hyp2f1Transform2LimitFinitePartGenerator(double b, double c, double m,
                                                                      std::complex<double> z)
-            : a_(a), b_(b), c_(c), m_(m), z_(z), term_(cephes::Gamma(m) / cephes::Gamma(c - b)), k_(0) {}
+            : b_(b), c_(c), m_(m), z_(z), term_(cephes::Gamma(m) / cephes::Gamma(c - b)), k_(0) {}
 
         SPECFUN_HOST_DEVICE std::complex<double> operator()() {
             std::complex<double> output = term_;
@@ -425,7 +425,7 @@ namespace detail {
         }
 
       private:
-        double a_, b_, c_, m_;
+        double b_, c_, m_;
         std::complex<double> z_, term_;
         std::uint64_t k_;
     };
@@ -498,7 +498,7 @@ namespace detail {
                                                                              std::complex<double> z) {
         /* 1 / z transform in limiting case where a - b approaches a non-negative integer m. Negative integer case
          * can be handled by swapping a and b. */
-        auto series_generator1 = Hyp2f1Transform2LimitFinitePartGenerator(a, b, c, m, z);
+        auto series_generator1 = Hyp2f1Transform2LimitFinitePartGenerator(b, c, m, z);
         std::complex<double> result = cephes::Gamma(c) / cephes::Gamma(a) * std::pow(-z, -b);
         result *=
             series_eval_fixed_length(series_generator1, std::complex<double>{0.0, 0.0}, static_cast<std::uint64_t>(m));


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/20457#issuecomment-2053632168
https://github.com/scipy/scipy/pull/20457#issuecomment-2053657886
#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes compiler warning by removing unused variable `a_`
#### Additional information
<!--Any additional information you think is important.-->
