### PR TITLE
MAINT: stats._contains_nan: fix bug when -inf and inf are in sample

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -723,13 +723,11 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True,
 
     inexact = (xp.isdtype(a.dtype, "real floating")
                or xp.isdtype(a.dtype, "complex floating"))
-    if inexact:
-        # The summation method avoids creating another (potentially huge) array
-        if use_summation:
-            with np.errstate(invalid='ignore', over='ignore'):
-                contains_nan = xp.isnan(xp.sum(a))
-        else:
-            contains_nan = xp.any(xp.isnan(a))
+    if a.size == 0:
+        contains_nan = False
+    elif inexact:
+        # Faster and less memory-intensive than xp.any(xp.isnan(a))
+        contains_nan = xp.isnan(xp.max(a))
     elif is_numpy(xp) and np.issubdtype(a.dtype, object):
         contains_nan = False
         for el in a.ravel():

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -707,14 +707,11 @@ def _nan_allsame(a, axis, keepdims=False):
     return ((a0 == a) | np.isnan(a)).all(axis=axis, keepdims=keepdims)
 
 
-def _contains_nan(a, nan_policy='propagate', use_summation=True,
-                  policies=None, *, xp=None):
+def _contains_nan(a, nan_policy='propagate', policies=None, *, xp=None):
     if xp is None:
         xp = array_namespace(a)
     not_numpy = not is_numpy(xp)
 
-    if not_numpy:
-        use_summation = False  # some array_likes ignore nans (e.g. pandas)
     if policies is None:
         policies = ['propagate', 'raise', 'omit']
     if nan_policy not in policies:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2374,8 +2374,8 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     score = np.asarray(score)
 
     # Nan treatment
-    cna, npa = _contains_nan(a, nan_policy, use_summation=False)
-    cns, nps = _contains_nan(score, nan_policy, use_summation=False)
+    cna, npa = _contains_nan(a, nan_policy)
+    cns, nps = _contains_nan(score, nan_policy)
 
     if (cna or cns) and nan_policy == 'raise':
         raise ValueError("The input contains nan values")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4273,6 +4273,17 @@ class TestKSTest:
         self._test_kstest_and_ks1samp(x, 'greater', mode='exact')
         self._test_kstest_and_ks1samp(x, 'less', mode='exact')
 
+    def test_pm_inf_gh20386(self):
+        # Check that gh-20386 is resolved - `kstest` does not
+        # return NaNs when both -inf and inf are in sample.
+        vals = [-np.inf, 0, 1, np.inf]
+        res = stats.kstest(vals, stats.cauchy.cdf)
+        ref = stats.kstest(vals, stats.cauchy.cdf, _no_deco=True)
+        assert np.all(np.isfinite(res))
+        assert_equal(res, ref)
+        assert not np.isnan(res.statistic)
+        assert not np.isnan(res.pvalue)
+
     # missing: no test that uses *args
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-20386

#### What does this implement/fix?
gh-20386 reported that `stats.kstest` returned NaNs when both positive and negative infinities were present in the sample. This fixes the (very old) underlying bug.

#### Additional information
This includes all the gh-20292 commits, so that should merge first.

I could add a test for `_contains_nan` directly if desired. (Currently, this just adds a test for the reported issue in `kstest`.)