### PR TITLE
TST: tolerance bumps for the conda-forge builds

### DIFF
--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -2,7 +2,7 @@ import pickle
 import pytest
 import numpy as np
 from numpy.linalg import LinAlgError
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose
 from scipy.stats.qmc import Halton
 from scipy.spatial import cKDTree
 from scipy.interpolate._rbfinterp import (
@@ -415,7 +415,7 @@ class _TestRBFInterpolator:
         yitp1 = interp(xitp)
         yitp2 = pickle.loads(pickle.dumps(interp))(xitp)
 
-        assert_array_equal(yitp1, yitp2)
+        assert_allclose(yitp1, yitp2, atol=1e-16)
 
 
 class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -137,7 +137,7 @@ class TestRegularGridInterpolator:
 
         # 2nd derivatives of a linear function are zero
         assert_allclose(interp(sample, nu=(0, 1, 1, 0)),
-                        [0, 0, 0], atol=1e-12)
+                        [0, 0, 0], atol=2e-12)
 
     @parametrize_rgi_interp_methods
     def test_complex(self, method):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -983,7 +983,11 @@ class TestInterpN:
 
         v1 = interpn((x, y), values, sample, method=method)
         v2 = interpn((x, y), np.asarray(values), sample, method=method)
-        assert_allclose(v1, v2)
+        if method == "quintic":
+            # https://github.com/scipy/scipy/issues/20472
+            assert_allclose(v1, v2, atol=5e-5, rtol=2e-6)
+        else:
+            assert_allclose(v1, v2)
 
     def test_length_one_axis(self):
         # gh-5890, gh-9524 : length-1 axis is legal for method='linear'.

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -266,7 +266,7 @@ class SVDSCommonTests:
         else:
             res = svds(A, k=k, which=which, solver=self.solver,
                        random_state=0)
-        _check_svds(A, k, *res, which=which, atol=8e-10)
+        _check_svds(A, k, *res, which=which, atol=1e-9, rtol=2e-13)
 
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

addresses three items reported in https://github.com/scipy/scipy/issues/20472

#### What does this implement/fix?
<!--Please explain your changes.-->

Two RGI tolerance bumps are benign, can be expected, and are due to RGI doing sparse linear algebra under the hood, which is new in SciPy 1.13. Hence am tentatively labeling as backport-candidate. 

The RBF failure is less clear-cut: a test which is apparently flaky checks that pickling and unickling of an RBF instance does not change the evaluated result using an exact equality. I honestly don't know if we can/should really guarantee exact equality. So this PR changes the test to compare results to agree up to ~machine epsilon.
There is nothing in SciPy 1.13 itself to change the behavior, so I'd handwave that it's due to new versions of compilers or linalg libraries.

#### Additional information
<!--Any additional information you think is important.-->
