### PR TITLE
MAINT/BLD: Clean up scikit-umfpack dependency issue

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asv
 mpmath
 # gymp2  # does not yet support Python 3.12
 threadpoolctl
-# scikit-umfpack  # circular dependency issues
+scikit-umfpack
 pooch
 hypothesis>=6.30
 array-api-strict

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -25,10 +25,6 @@ header = [
 def generate_requirement_file(name, req_list, *, extra_list=None):
     req_fname = repo_dir / "requirements" / f"{name}.txt"
 
-    # remove once scikit-umfpack issues are resolved
-    comment = "# scikit-umfpack  # circular dependency issues"
-    req_list = [comment if x == "scikit-umfpack" else x for x in req_list]
-
     # remove once gmpy2 supports Python 3.12
     comment = "# gymp2  # does not yet support Python 3.12"
     req_list = [comment if x == "gmpy2" else x for x in req_list]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #19783 

#### What does this implement/fix?
<!--Please explain your changes.-->
Per https://github.com/scipy/scipy/issues/18912#issuecomment-1642418118 and https://github.com/scikit-umfpack/scikit-umfpack/issues/81 the circular dependency issue seems to be fixed upstream, so cleaning this up.

#### Additional information
<!--Any additional information you think is important.-->
None