### PR TITLE
BLD: ensure all static libraries use hidden visibility

### DIFF
--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -75,29 +75,34 @@ quadpack_test_src = [
 
 mach_lib = static_library('mach_lib',
   mach_src,
-  fortran_args: fortran_ignore_warnings
+  fortran_args: fortran_ignore_warnings,
+  gnu_symbol_visibility: 'hidden',
 )
 
 quadpack_lib = static_library('quadpack_lib',
   quadpack_src,
-  fortran_args: fortran_ignore_warnings
+  fortran_args: fortran_ignore_warnings,
+  gnu_symbol_visibility: 'hidden',
 )
 
 lsoda_lib = static_library('lsoda_lib',
   lsoda_src,
   fortran_args: fortran_ignore_warnings,
   override_options: ['b_lto=false'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 vode_lib = static_library('vode_lib',
   vode_src,
   fortran_args: fortran_ignore_warnings,
   override_options: ['b_lto=false'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 dop_lib = static_library('dop_lib',
   dop_src,
-  fortran_args: fortran_ignore_warnings
+  fortran_args: fortran_ignore_warnings,
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_quadpack',

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -92,6 +92,7 @@ fitpack_lib = static_library('fitpack_lib',
   fitpack_src,
   fortran_args: _fflag_Wno_maybe_uninitialized,
   override_options: ['b_lto=false'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('interpnd',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -130,6 +130,7 @@ fortranobject_lib = static_library('_fortranobject',
   c_args: numpy_nodepr_api,
   dependencies: py3_dep,
   include_directories: [inc_np, inc_f2py],
+  gnu_symbol_visibility: 'hidden',
 )
 fortranobject_dep = declare_dependency(
   link_with: fortranobject_lib,

--- a/scipy/odr/meson.build
+++ b/scipy/odr/meson.build
@@ -7,6 +7,7 @@ odrpack = static_library('odrpack',
   ],
   fortran_args: _fflag_Wno_conversion,  # silence "conversion from REAL(8) to INTEGER(4)"
   override_options: ['b_lto=false'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('__odrpack',

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -39,7 +39,8 @@ minpack_lib = static_library('minpack',
     'minpack/r1mpyq.f',
     'minpack/r1updt.f',
     'minpack/rwupdt.f'
-  ]
+  ],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_minpack',
@@ -58,6 +59,7 @@ rectangular_lsap = static_library('rectangular_lsap',
     'rectangular_lsap/rectangular_lsap.h',
     'rectangular_lsap/rectangular_lsap.cpp'
   ],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_lsap',
@@ -77,7 +79,8 @@ rootfind_lib = static_library('rootfind',
     'Zeros/brentq.c',
     'Zeros/ridder.c',
     'Zeros/zeros.h'
-  ]
+  ],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_zeros',

--- a/scipy/sparse/linalg/_dsolve/meson.build
+++ b/scipy/sparse/linalg/_dsolve/meson.build
@@ -196,7 +196,8 @@ superlu_lib = static_library('superlu_lib',
     'SuperLU/SRC/zutil.c'
   ],
   c_args: _superlu_lib_c_args,
-  include_directories: ['SuperLU/SRC']
+  include_directories: ['SuperLU/SRC'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_superlu',

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -90,6 +90,7 @@ arpack_lib = static_library('arpack_lib',
   fortran_args: [fortran_ignore_warnings, _suppress_all_warnings],
   include_directories: ['ARPACK/SRC'],
   override_options: ['b_lto=false'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 arpack_module = custom_target('arpack_module',

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -93,7 +93,8 @@ foreach ele: elements
       _fflag_Wno_intrinsic_shadow,
       _fflag_Wno_uninitialized,
       _fflag_fpp,
-    ]
+    ],
+    gnu_symbol_visibility: 'hidden',
   )
 
   propack_module = custom_target('propack_module' + ele[0],

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -124,11 +124,13 @@ cephes_lib = static_library('cephes',
   c_args: use_math_defines,
   include_directories: ['../_lib', '../_build_utils/src'],
   dependencies: [py3_dep, np_dep],
+  gnu_symbol_visibility: 'hidden',
 )
 
 cdflib_lib = static_library('cdflib',
   'cdflib.c',
   include_directories: ['../_lib', '../_build_utils/src'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('_special_ufuncs',

--- a/scipy/stats/_levy_stable/meson.build
+++ b/scipy/stats/_levy_stable/meson.build
@@ -6,6 +6,7 @@ py3.install_sources([
 
 _levyst = static_library('_levyst',
   ['c_src/levyst.c', 'c_src/levyst.h'],
+  gnu_symbol_visibility: 'hidden',
 )
 
 py3.extension_module('levyst',


### PR DESCRIPTION
This avoids exporting symbols from static libraries in the extension modules, which was happening for compilers that support GNU visibility attributes but not the linker script (e.g., Clang on macOS).

The gain in binary size for a wheel on macOS is only 0.06%, but every little bit helps.