### PR TITLE
CI/MAINT: Increase minimum required compiler versions to GCC 9.1 and Clang 14.0; adapt CI

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -217,14 +217,14 @@ jobs:
           python3-dbg -m pytest --pyargs scipy -n2 --durations=10 -m "not slow"
 
   #################################################################################
-  gcc8:
+  gcc9:
     # Purpose is to examine builds with oldest-supported gcc and test with pydata/sparse.
-    name: Build with gcc-8
+    name: Build with gcc-9
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: ubuntu-20.04  # 22.04 doesn't support gcc-8
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
         with:
@@ -238,7 +238,7 @@ jobs:
       - name: Setup system dependencies
         run: |
           sudo apt-get -y update
-          sudo apt install -y g++-8 gcc-8 gfortran-8
+          sudo apt install -y g++-9 gcc-9 gfortran-9
           sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
             libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev
 
@@ -252,7 +252,7 @@ jobs:
           export PYTHONOPTIMIZE=2
 
           # specify which compilers to use using environment variables
-          CC=gcc-8 CXX=g++-8 FC=gfortran-8 python -m build --wheel --no-isolation -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
+          CC=gcc-9 CXX=g++-9 FC=gfortran-9 python -m build --wheel --no-isolation -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
           python -m pip install dist/scipy*.whl
 
       - name: Install test dependencies

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -40,7 +40,7 @@ GitHub Actions
 * ``Check the rendered docs here!``: live preview of the documentation
 * ``prerelease_deps_coverage_64bit_blas``: use pre-released version of the
   dependencies and check coverage
-* ``gcc-8``: build with minimal supported version of GCC, install the wheel,
+* ``gcc-9``: build with minimal supported version of GCC, install the wheel,
   then run the test suite with `python -OO`
 * ``Array API``: test Array API support
 

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,10 @@ if cc.get_id() == 'gcc'
   if not cc.version().version_compare('>=9.1')
     error('SciPy requires GCC >= 9.1')
   endif
+elif cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
+  if not cc.version().version_compare('>=14.0')
+    error('SciPy requires clang >= 14.0')
+  endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.20')
     error('SciPy requires at least vc142 (default with Visual Studio 2019) ' + \

--- a/meson.build
+++ b/meson.build
@@ -39,8 +39,8 @@ cython = find_program(cy.cmd_array()[0])
 
 # Check compiler is recent enough (see "Toolchain Roadmap" for details)
 if cc.get_id() == 'gcc'
-  if not cc.version().version_compare('>=8.0')
-    error('SciPy requires GCC >= 8.0')
+  if not cc.version().version_compare('>=9.1')
+    error('SciPy requires GCC >= 9.1')
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.20')


### PR DESCRIPTION
Follow-up to https://github.com/scipy/scipy/pull/20454