### PR TITLE
BUG: Remove keyword argument from ValueError in SciPy.optimize

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -745,8 +745,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         # check bounds
         if (lower_bound > upper_bound).any():
             raise ValueError("Nelder Mead - one of the lower bounds "
-                             "is greater than an upper bound.",
-                             stacklevel=3)
+                             "is greater than an upper bound.")
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, stacklevel=3)


### PR DESCRIPTION
#### Reference issue
Closes gh-20488

#### What does this implement/fix?
When given invalid bounds, `_minimize_neldermead` raises TypeError instead of ValueError due to keyword argument stacklevel

