### PR TITLE
DEP: switch sparse methods to kwarg-only; remove tol/restrt kwargs

### DIFF
--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -54,7 +54,7 @@ class FindFuncs(ast.NodeVisitor):
                 case _:
                     raise ValueError("unknown ast node type")
             # check if filter is set to ignore
-            if argtext.split(":")[0] == "ignore":
+            if argtext == "ignore":
                 self.bad_filters.append(
                     f"{self.__filename}:{node.lineno}")
 

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -40,7 +40,21 @@ class FindFuncs(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-            if node.args[0].value == "ignore":
+            # get first argument of the `args` node of the filter call
+            match node.args[0]:
+                case ast.Constant() as c:
+                    argtext = c.value
+                case ast.JoinedStr() as js:
+                    # if we get an f-string, discard the templated pieces, which
+                    # are likely the type or specific message; we're interested
+                    # in the action, which is less likely to use a template
+                    argtext = "".join(
+                        x.value for x in js.values if isinstance(x, ast.Constant)
+                    )
+                case _:
+                    raise ValueError("unknown ast node type")
+            # check if filter is set to ignore
+            if argtext.split(":")[0] == "ignore":
                 self.bad_filters.append(
                     f"{self.__filename}:{node.lineno}")
 

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -6,7 +6,6 @@ from numpy.linalg import LinAlgError
 from scipy.linalg import (get_blas_funcs, qr, solve, svd, qr_insert, lstsq)
 from .iterative import _get_atol_rtol
 from scipy.sparse.linalg._isolve.utils import make_system
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = ['gcrotmk']
@@ -182,10 +181,8 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
     return Q, R, B, vs, zs, y, res
 
 
-@_deprecate_positional_args(version="1.14.0")
-def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
-            m=20, k=None, CU=None, discard_C=False, truncate='oldest',
-            atol=None, rtol=1e-5):
+def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=None,
+            m=20, k=None, CU=None, discard_C=False, truncate='oldest'):
     """
     Solve a matrix equation using flexible GCROT(m,k) algorithm.
 
@@ -203,12 +200,7 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     rtol, atol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
-        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
-
-        .. warning::
-
-           The default value for ``atol`` will be changed to ``0.0`` in
-           SciPy 1.14.0.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``0.0``.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -243,11 +235,6 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
         smallest singular values using the scheme discussed in [1,2].
         See [2]_ for detailed comparison.
         Default: 'oldest'
-    tol : float, optional, deprecated
-
-        .. deprecated:: 1.12.0
-           `gcrotmk` keyword argument ``tol`` is deprecated in favor of
-           ``rtol`` and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -313,8 +300,8 @@ def gcrotmk(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
 
     b_norm = nrm2(b)
 
-    # we call this to get the right atol/rtol and raise warnings as necessary
-    atol, rtol = _get_atol_rtol('gcrotmk', b_norm, tol, atol, rtol)
+    # we call this to get the right atol/rtol and raise errors as necessary
+    atol, rtol = _get_atol_rtol('gcrotmk', b_norm, atol, rtol)
 
     if b_norm == 0:
         x = b

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -6,17 +6,15 @@ from numpy.linalg import LinAlgError
 from scipy.linalg import get_blas_funcs
 from .iterative import _get_atol_rtol
 from .utils import make_system
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 from ._gcrotmk import _fgmres
 
 __all__ = ['lgmres']
 
 
-@_deprecate_positional_args(version="1.14.0")
-def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
+def lgmres(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
-           prepend_outer_v=False, atol=None, rtol=1e-5):
+           prepend_outer_v=False):
     """
     Solve a matrix equation using the LGMRES algorithm.
 
@@ -38,12 +36,7 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     rtol, atol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
-        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
-
-        .. warning::
-
-           The default value for ``atol`` will be changed to ``0.0`` in
-           SciPy 1.14.0.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``0.0``.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -77,11 +70,6 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
     prepend_outer_v : bool, optional
         Whether to put outer_v augmentation vectors before Krylov iterates.
         In standard LGMRES, prepend_outer_v=False.
-    tol : float, optional, deprecated
-
-        .. deprecated:: 1.12.0
-           `lgmres` keyword argument ``tol`` is deprecated in favor of ``rtol``
-           and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -147,8 +135,8 @@ def lgmres(A, b, x0=None, *, tol=_NoValue, maxiter=1000, M=None, callback=None,
 
     b_norm = nrm2(b)
 
-    # we call this to get the right atol/rtol and raise warnings as necessary
-    atol, rtol = _get_atol_rtol('lgmres', b_norm, tol, atol, rtol)
+    # we call this to get the right atol/rtol and raise errors as necessary
+    atol, rtol = _get_atol_rtol('lgmres', b_norm, atol, rtol)
 
     if b_norm == 0:
         x = b

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -1,17 +1,14 @@
-import warnings
 from numpy import inner, zeros, inf, finfo
 from numpy.linalg import norm
 from math import sqrt
 
 from .utils import make_system
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 __all__ = ['minres']
 
 
-@_deprecate_positional_args(version="1.14.0")
-def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
-           M=None, callback=None, show=False, check=False, rtol=1e-5):
+def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
+           M=None, callback=None, show=False, check=False):
     """
     Use MINimum RESidual iteration to solve Ax=b
 
@@ -66,11 +63,6 @@ def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
     check : bool
         If ``True``, run additional input validation to check that `A` and
         `M` (if specified) are symmetric. Default is ``False``.
-    tol : float, optional, deprecated
-
-        .. deprecated:: 1.12.0
-           `minres` keyword argument ``tol`` is deprecated in favor of ``rtol``
-           and will be removed in SciPy 1.14.0.
 
     Examples
     --------
@@ -98,13 +90,6 @@ def minres(A, b, x0=None, *, shift=0.0, tol=_NoValue, maxiter=None,
 
     """
     A, M, x, b, postprocess = make_system(A, M, x0, b)
-
-    if tol is not _NoValue:
-        msg = ("'scipy.sparse.linalg.minres' keyword argument `tol` is "
-               "deprecated in favor of `rtol` and will be removed in SciPy "
-               "v1.14. Until then, if set, it will override `rtol`.")
-        warnings.warn(msg, category=DeprecationWarning, stacklevel=4)
-        rtol = float(tol) if tol is not None else rtol
 
     matvec = A.matvec
     psolve = M.matvec

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -1,15 +1,13 @@
 import numpy as np
 from .iterative import _get_atol_rtol
 from .utils import make_system
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 __all__ = ['tfqmr']
 
 
-@_deprecate_positional_args(version="1.14.0")
-def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
-          callback=None, atol=None, rtol=1e-5, show=False):
+def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
+          callback=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
 
@@ -27,12 +25,7 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
     rtol, atol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
-        The default is ``rtol=1e-5``, the default for ``atol`` is ``rtol``.
-
-        .. warning::
-
-           The default value for ``atol`` will be changed to ``0.0`` in
-           SciPy 1.14.0.
+        The default is ``rtol=1e-5``, the default for ``atol`` is ``0.0``.
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -50,11 +43,6 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
         Specify ``show = True`` to show the convergence, ``show = False`` is
         to close the output of the convergence.
         Default is `False`.
-    tol : float, optional, deprecated
-
-        .. deprecated:: 1.12.0
-           `tfqmr` keyword argument ``tol`` is deprecated in favor of ``rtol``
-           and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -139,8 +127,8 @@ def tfqmr(A, b, x0=None, *, tol=_NoValue, maxiter=None, M=None,
     if r0norm == 0:
         return (postprocess(x), 0)
 
-    # we call this to get the right atol and raise warnings as necessary
-    atol, _ = _get_atol_rtol('tfqmr', r0norm, tol, atol, rtol)
+    # we call this to get the right atol and raise errors as necessary
+    atol, _ = _get_atol_rtol('tfqmr', r0norm, atol, rtol)
 
     for iter in range(maxiter):
         even = iter % 2 == 0


### PR DESCRIPTION
Follow-up to:
* #15738
* #16392
* #18934
* #18943
* #19702