### PR TITLE
MAINT: spatial: Fix type annotation of `query_ball_point`

### DIFF
--- a/scipy/spatial/_ckdtree.pyi
+++ b/scipy/spatial/_ckdtree.pyi
@@ -111,7 +111,7 @@ class cKDTree(Generic[_BoxType]):
         self,
         x: npt.ArrayLike,
         r: npt.ArrayLike,
-        p: float,
+        p: float = ...,
         eps: float = ...,
         workers: int | None = ...,
         return_sorted: bool | None = ...,


### PR DESCRIPTION
#### What does this implement/fix?
https://github.com/scipy/scipy/blob/483b75a0e9a089b4a0d8e7c26c6ad8b8b8b34007/scipy/spatial/_ckdtree.pyx#L850-L853

Fix type annotation of `query_ball_point`: `p` is keyword parameter