### PR TITLE
BUG: Include Python.h before system headers.

### DIFF
--- a/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
+++ b/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the BSD 2-clause license found in the LICENSE.txt file.
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include <Python.h>
 #include <fast_matrix_market/types.hpp>
 #include <cstdint>
 namespace fast_matrix_market {

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -1,4 +1,7 @@
+#include "ufunc.h"
+
 #include <cmath>
+#include <complex>
 
 #include "ufunc.h"
 

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <complex>
 
-#include "ufunc.h"
-
 #include "sf_error.h"
 #include "special.h"
 #include "special/airy.h"

--- a/scipy/special/_wright.cxx
+++ b/scipy/special/_wright.cxx
@@ -1,6 +1,6 @@
-#include <complex>
-
 #include "_wright.h"
+
+#include <complex>
 
 using namespace std;
 

--- a/scipy/special/ufunc.h
+++ b/scipy/special/ufunc.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #20491

#### What does this implement/fix?
<!--Please explain your changes.-->
Python.h needs to be included before any system header: `_fmm_core.hpp` does, but is not first.

#### Additional information
<!--Any additional information you think is important.-->
The script from #20149 would not catch this.  I might need to add `pybind11::` to the regex.
