### PR TITLE
DOC: Fix legacy admonition styling

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -40,13 +40,14 @@ div.admonition-legacy {
   border-color: var(--pst-color-warning);
 }
 
-.admonition-legacy.admonition > .admonition-title:before {
+.admonition>.admonition-title::after,
+div.admonition>.admonition-title::after {
   color: var(--pst-color-warning);
-  content: var(--pst-icon-admonition-attention);
 }
 
-.admonition-legacy.admonition > .admonition-title:after {
-  background-color: var(--pst-color-warning);
+.admonition>.admonition-title,
+div.admonition>.admonition-title {
+  background-color: var(--pst-color-warning-bg);
 }
 
 /* JupyterLite "Try Examples" directive */


### PR DESCRIPTION
#### Reference issue
--

#### What does this implement/fix?
Follow-up to #20460 

Fixes display of legacy admonition boxes. 

#### Additional information
Before:
![Screenshot_20240417_141728](https://github.com/scipy/scipy/assets/3949932/50e8680e-9752-4f50-8dcf-a06a4e6c4c2a)

After:
![Screenshot_20240417_153449](https://github.com/scipy/scipy/assets/3949932/239071c0-d2a2-4aaf-b8b1-8db2fe2b0031)

