### PR TITLE
BLD: Accelerate wheels for macOS 14+

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -165,14 +165,14 @@ jobs:
         sudo xcode-select -s /Applications/Xcode_15.2.app
         
         git submodule update --init
-        # for some reason gfortran is not on the path
-        GFORTRAN_LOC=$(brew --prefix gfortran)/bin/gfortran 
+        GFORTRAN_LOC=$(which gfortran-13)
         ln -s $GFORTRAN_LOC gfortran
         export PATH=$PWD:$PATH
 
-        # make sure we have openblas
+        # make sure we have openblas and gfortran dylibs
         bash tools/wheels/cibw_before_build_macos.sh $PWD
-        export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
+        GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
+        export DYLD_LIBRARY_PATH=$GFORTRAN_LIB:/opt/arm64-builds/lib
         export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
     
         pip install click doit pydevtool rich_click meson cython pythran pybind11 ninja numpy
@@ -211,10 +211,13 @@ jobs:
         sudo xcode-select -s /Applications/Xcode_15.2.app
 
         git submodule update --init
-        # for some reason gfortran is not on the path
-        GFORTRAN_LOC=$(brew --prefix gfortran)/bin/gfortran
+        GFORTRAN_LOC=$(which gfortran-13)
         ln -s $GFORTRAN_LOC gfortran
         export PATH=$PWD:$PATH
+
+        # Ensure we have gfortran dylib
+        GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
+        export DYLD_LIBRARY_PATH=$GFORTRAN_LIB
 
         pip install click doit pydevtool rich_click meson cython pythran pybind11 ninja numpy
         python dev.py build -C-Dblas=accelerate

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,9 @@ jobs:
           echo github.ref ${{ github.ref }}
 
   build_wheels:
-    name: Build wheel for ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
+    name: Wheel, ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+      ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
+      ${{ matrix.buildplat[4] }}
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '1') ||
@@ -77,11 +79,13 @@ jobs:
         # should also be able to do multi-archs on a single entry, e.g.
         # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
-        - [ubuntu-22.04, manylinux, x86_64]
-        - [ubuntu-22.04, musllinux, x86_64]
-        - [macos-11, macosx, x86_64]
-        - [macos-14, macosx, arm64]
-        - [windows-2019, win, AMD64]
+        - [ubuntu-22.04, manylinux, x86_64, "", ""]
+        - [ubuntu-22.04, musllinux, x86_64, "", ""]
+        - [macos-12, macosx, x86_64, openblas, "10.9"]
+        - [macos-13, macosx, x86_64, accelerate, "14.0"]
+        - [macos-14, macosx, arm64, openblas, "12.0"]
+        - [macos-14, macosx, arm64, accelerate, "14.0"]
+        - [windows-2019, win, AMD64, "", ""]
 
         python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
         # python[0] is used to specify the python versions made by cibuildwheel
@@ -112,63 +116,53 @@ jobs:
         if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
 
       - name: Setup macOS
-        if: matrix.buildplat[0] == 'macos-11' || matrix.buildplat[0] == 'macos-14'
+        if: startsWith( matrix.buildplat[0], 'macos-' )
         run: |
-          if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
-            # macosx_arm64
-          
-            # use homebrew gfortran
-            sudo xcode-select -s /Applications/Xcode_15.2.app            
-            # for some reason gfortran is not on the path
-            GFORTRAN_LOC=$(brew --prefix gfortran)/bin/gfortran 
-            ln -s $GFORTRAN_LOC gfortran
+          if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
+            echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
+            # Always use preinstalled gfortran for Accelerate builds
+            ln -s $(which gfortran-13) gfortran
             export PATH=$PWD:$PATH
             echo "PATH=$PATH" >> "$GITHUB_ENV"
-          
-            # location of the gfortran's libraries
-            GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
-
-            CIBW="MACOSX_DEPLOYMENT_TARGET=12.0\
-              MACOS_DEPLOYMENT_TARGET=12.0\
-              LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH\
-              _PYTHON_HOST_PLATFORM=macosx-12.0-arm64\
-              PIP_PRE=1\
-              PIP_NO_BUILD_ISOLATION=false\
-              PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig\
-              PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
-            echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
-          
-            CIBW="sudo xcode-select -s /Applications/Xcode_15.2.app"
-            echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
-
-            echo "REPAIR_PATH=/opt/arm64-builds/lib" >> "$GITHUB_ENV"
-
-            CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:/opt/arm64-builds/lib delocate-listdeps {wheel} &&\
-              DYLD_LIBRARY_PATH=$GFORTRAN_LIB:/opt/arm64-builds/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
-            echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
-      
-          else
-            # macosx_x86_64 with OpenBLAS
-            # setting SDKROOT necessary when using the gfortran compiler
-            # installed in cibw_before_build_macos.sh
-            # MACOS_DEPLOYMENT_TARGET is set because of
-            # https://github.com/mesonbuild/meson-python/pull/309. Once
-            # an update is released, then that environment variable can
-            # be removed.
-            CIBW="MACOSX_DEPLOYMENT_TARGET=10.9\
-              MACOS_DEPLOYMENT_TARGET=10.9\
-              SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk\
-              LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH\
-              _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64\
-              PIP_PRE=1\
-              PIP_NO_BUILD_ISOLATION=false\
-              PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
-            echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"  
-          
-            CIBW="DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&\
-              DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
-            echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
+            LIB_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
           fi
+          # Add libraries installed by cibw_before_build_macos.sh to path
+          if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
+            LIB_PATH=$LIB_PATH:/opt/arm64-builds/lib
+          else
+            LIB_PATH=$LIB_PATH:/usr/local/lib
+          fi
+          if [[ ${{ matrix.buildplat[4] }} == '10.9' ]]; then
+            # Newest version of Xcode that supports macOS 10.9
+            XCODE_VER='13.4.1'
+          else
+            XCODE_VER='15.2'
+          fi
+          CIBW="sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app"
+          echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
+          # setting SDKROOT necessary when using the gfortran compiler
+          # installed in cibw_before_build_macos.sh
+          sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app
+          CIBW="MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[4] }}\
+            LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH\
+            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
+            PIP_PRE=1\
+            PIP_NO_BUILD_ISOLATION=false\
+            PKG_CONFIG_PATH=$LIB_PATH/pkgconfig\
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+          echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
+          GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
+          CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-listdeps {wheel} &&\
+            DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-wheel --require-archs \
+            {delocate_archs} -w {dest_dir} {wheel}"
+          # Rename x86 Accelerate wheel to test on macOS 13 runner
+          if [[ ${{ matrix.buildplat[0] }} == 'macos-13' && ${{ matrix.buildplat[4] }} == '14.0' ]]; then
+            CIBW+=" && mv {dest_dir}/\$(basename {wheel}) \
+              {dest_dir}/\$(echo \$(basename {wheel}) | sed 's/14_0/13_0/')"
+          fi
+          echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
@@ -195,10 +189,18 @@ jobs:
             PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
             PIP_NO_BUILD_ISOLATION=false
 
+      - name: Rename after test (macOS x86 Accelerate only)
+        # Rename x86 Accelerate wheel back so it targets macOS >= 14
+        if: matrix.buildplat[0] == 'macos-13' && matrix.buildplat[4] == '14.0'
+        run: |
+          mv ./wheelhouse/*.whl $(find ./wheelhouse -type f -name '*.whl' | sed 's/13_0/14_0/')
+
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
+          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+            ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
+            ${{ matrix.buildplat[4] }}
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
@@ -209,6 +211,7 @@ jobs:
           # build and test the wheel
           auto-update-conda: true
           python-version: "3.10"
+          miniconda-version: "latest"
 
       - name: Upload wheels
         if: success()

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -138,15 +138,17 @@ Official Builds
 
 Currently, SciPy wheels are being built as follows:
 
-================    ==============================   ==============================   =============================
- Platform            `CI`_ `Base`_ `Images`_          Compilers                        Comment
-================    ==============================   ==============================   =============================
-Linux x86            ``ubuntu-22.04``                 GCC 10.2.1                       ``cibuildwheel``
-Linux arm            ``docker-builder-arm64``         GCC 11.3.0                       ``cibuildwheel``
-OSX x86_64           ``macos-11``                     clang-13/gfortran 11.3           ``cibuildwheel``
-OSX arm64            ``macos-14``                     clang-14/gfortran 13.0           ``cibuildwheel``
-Windows              ``windows-2019``                 GCC 10.3 (`rtools`_)             ``cibuildwheel``
-================    ==============================   ==============================   =============================
+=========================   ==============================   ====================================   =============================
+ Platform                    `CI`_ `Base`_ `Images`_          Compilers                              Comment
+=========================   ==============================   ====================================   =============================
+ Linux x86                   ``ubuntu-22.04``                 GCC 10.2.1                             ``cibuildwheel``
+ Linux arm                   ``docker-builder-arm64``         GCC 11.3.0                             ``cibuildwheel``
+ OSX x86_64 (OpenBLAS)       ``macos-12``                     Apple clang 13.1.6/gfortran 11.3.0     ``cibuildwheel``
+ OSX x86_64 (Accelerate)     ``macos-13``                     Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
+ OSX arm64 (OpenBLAS)        ``macos-14``                     Apple clang 15.0.0/gfortran 12.1.0     ``cibuildwheel``
+ OSX arm64 (Accelerate)      ``macos-14``                     Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
+ Windows                     ``windows-2019``                 GCC 10.3.0 (`rtools`_)                 ``cibuildwheel``
+=========================   ==============================   ====================================   =============================
 
 .. _CI: https://github.com/actions/runner-images
 .. _Base: https://cirrus-ci.org/guide/docker-builder-vm/#under-the-hood

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -3,7 +3,7 @@ set -xe
 PROJECT_DIR="$1"
 
 # python $PROJECT_DIR/tools/wheels/check_license.py
-if [[ $(uname) == "Linux" || $(uname) == "Darwin" ]] ; then
+if [[ $(uname) == "Linux" ]] ; then
     python $PROJECT_DIR/tools/openblas_support.py --check_version
 fi
 echo $?


### PR DESCRIPTION
#### What does this implement/fix?
Adds GHA jobs to build Accelerate wheels for macOS >= 14 as discussed in https://github.com/scipy/scipy/issues/19816#issuecomment-2058042249.

#### Additional information
- Used the `gfortran` included with the [runner images](https://github.com/actions/runner-images/tree/main/images/macos) to build Accelerate wheels
- Bumped our x86 macOS OpenBLAS builds to use `macos-12` (`macos-11` is EOL)
- Tricked `pip` into installing and testing wheels targeting macOS >= 14 on the macOS 13 runner that built them (no free x86 runners on macOS 14) by renaming wheel during repair step and reverting name change after testing
  - These are the relevant issues for the failed tests:
    - gh-20216
    - gh-20472
  - The failing tests were addressed by gh-20522 and gh-20474
<!--Any additional information you think is important.-->
