### PR TITLE
BUG: Fix raising ValueError on a zero-size array for SciPy.special.logsumexp

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -102,7 +102,8 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     # Scale by real part for complex inputs, because this affects
     # the magnitude of the exponential.
-    a_max = np.amax(a.real, axis=axis, keepdims=True)
+    initial_value = -np.inf if np.size(a) == 0 else None
+    a_max = np.amax(a.real, axis=axis, keepdims=True, initial=initial_value)
 
     if a_max.ndim > 0:
         a_max[~np.isfinite(a_max)] = 0

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -6,6 +6,11 @@ from scipy.special import logsumexp, softmax
 
 
 def test_logsumexp():
+    # Test with zero-size array
+    a = []
+    desired = -np.inf
+    assert_equal(logsumexp(a), desired)
+
     # Test whether logsumexp() function correctly handles large inputs.
     a = np.arange(200)
     desired = np.log(np.sum(np.exp(a)))


### PR DESCRIPTION
#### Reference issue
Closes gh-20399

#### What does this implement/fix?
`scipy.special.logsumexp` raises a `ValueError` for a zero-size array even though mathematically the correct answer for a zero-size array is `-inf`, so I've added a check for empty array as simply adding to `initial` value `-np.inf` does not work due to typing issues when using for eg. integers in array.
