### PR TITLE
BLD: default to C17 rather than C99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',
-    'c_std=c99',
+    'c_std=c17',
     'cpp_std=c++17',
     'fortran_std=legacy',
     'blas=openblas',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -134,6 +134,15 @@ fortranobject_dep = declare_dependency(
   link_with: fortranobject_lib,
   include_directories: [inc_np, inc_f2py],
 )
+# Workaround for numpy#24761 on numpy<1.26.1 (see also gh-20515)
+_f2py_c_args = []
+if is_mingw
+  _f2py_c_args = '-DNPY_OS_MINGW'
+endif
+fortranobject_dep = declare_dependency(
+  dependencies: fortranobject_dep,
+  compile_args: _f2py_c_args,
+)
 
 # TODO: 64-bit BLAS and LAPACK
 #


### PR DESCRIPTION
This update should be a safe bump, because C17 is a pure maintenance update of C11 with no new features; and C11 is mostly a maintenance/bugfix update of C99 with a few new features. Our [toolchain roadmap](http://scipy.github.io/devdocs/dev/toolchain.html#c-compilers), which was updated just days ago, says that we can use C17 given our minimum compiler versions.

I also note that in [numpy#25072](https://github.com/numpy/numpy/pull/25072), the numpy default was updated from C99 to C11 and that went fine (the one change needed was a Cython bug fix, which went into Cython 3.0.6 - and our minimum version is currently 3.0.8).

Finally, another motivation to do this now is that under the `--disable-gil` build of CPython 3.13, Cython currently generates code that uses `static_assert`, which is a C11 feature. Hence our current default of `-std=c99` doesn't build with that nogil build. (hat tip to @ngoldbaum for pointing out this problem). EDIT: PEP 7 is also relevant here, since it specifies what C standard version is used by CPython (see https://peps.python.org/pep-0007/#c-dialect). To be safe, be should be using >= the version used by CPython.

For a description of changes in C17, see https://gustedt.wordpress.com/2018/04/17/c17/.

Note: opening as draft until I've checked the CI logs for (the absence of) new warnings.