### PR TITLE
BUG: linalg: fix eigh(1x1 array, driver='evd') f2py check

### DIFF
--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -124,7 +124,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?1+6*n+2*n*n:2*n+1),1)
-    check(lwork>=(compute_v?1+6*n+2*n*n:2*n+1)) :: lwork
+    check( (lwork>=((compute_v?1+6*n+2*n*n:2*n+1))) || ((n==1)&&(lwork>=1)) ) :: lwork
     <ftype2> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
     integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -180,7 +180,7 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwo
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?2*n+n*n:n+1),1)
-    check(lwork>=(compute_v?2*n+n*n:n+1)) :: lwork
+    check( (lwork>=(compute_v?2*n+n*n:n+1)) || ((n==1)&&(lwork>=1)) ) :: lwork
     <ftype2c> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
     integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -925,6 +925,12 @@ class TestEigh:
                         atol=1000*np.finfo(dtype_).eps,
                         rtol=0.)
 
+    @pytest.mark.parametrize('driver', ("ev", "evd", "evr", "evx"))
+    def test_1x1_lwork(self, driver):
+        w, v = eigh([[1]], driver=driver)
+        assert_allclose(w, array([1.]), atol=1e-15)
+        assert_allclose(v, array([[1.]]), atol=1e-15)
+
     @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
     def test_various_drivers_generalized(self, driver, type):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -931,6 +931,11 @@ class TestEigh:
         assert_allclose(w, array([1.]), atol=1e-15)
         assert_allclose(v, array([[1.]]), atol=1e-15)
 
+        # complex case now
+        w, v = eigh([[1j]], driver=driver)
+        assert_allclose(w, array([0]), atol=1e-15)
+        assert_allclose(v, array([[1.]]), atol=1e-15)
+
     @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
     def test_various_drivers_generalized(self, driver, type):


### PR DESCRIPTION
f2py check was just too strict;
LAPACK docs indicate that for N=1, lwork>=1 is acceptable:

```
*  LWORK   (input) INTEGER
*          The dimension of the array WORK.
*          If N <= 1,               LWORK must be at least 1.
*          If JOBZ = 'N' and N > 1, LWORK must be at least 2*N+1.
*          If JOBZ = 'V' and N > 1, LWORK must be at least
*                                                1 + 6*N + 2*N**2.
```

https://www.netlib.org/lapack/explore-3.1.1-html/ssyevd.f.html

closes gh-20512

The issue is not new, observed with scipy 1.9.1 at least.