### PR TITLE
DOC: Use vanilla MathJax distribution, fall back to vendored `scipy-mathjax` if not available

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -273,19 +273,16 @@ htmlhelp_basename = 'scipy'
 # Check if we have access to the internet. If so, use MathJax via its CDN. If not
 # we are most likely building locally without internet access and therefore we use
 # the local vendored MathJax distribution present in the scipy-mathjax directory.
+# We assume no internet connection + use local MathJax.
 
 import socket  # noqa: E402
 
-INTERNET_AVAILABLE = False  # assume no internet connection + use local MathJax
-
 try:
-    # Attributed to https://stackoverflow.com/a/33117579/14001839
-    socket.setdefaulttimeout(1)
-    socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("8.8.8.8", 53))
-    socket.socket(socket.AF_INET, socket.SOCK_STREAM).close()
+    host = socket.gethostbyname("www.google.com")
+    conn = socket.create_connection((host, 80), 2)
+    conn.close()
     print("Internet connection available.")
-    INTERNET_AVAILABLE = True
-except socket.error as err:  # noqa: UP024
+except Exception as err:
     print("No internet connection available. Error:", err)
     print("Using local MathJax distribution.")
     mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -268,7 +268,27 @@ html_file_suffix = '.html'
 
 htmlhelp_basename = 'scipy'
 
-mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
+
+# Temporary workaround for https://github.com/executablebooks/MyST-NB/issues/590
+# Check if we have access to the internet. If so, use MathJax via its CDN. If not
+# we are most likely building locally without internet access and therefore we use
+# the local vendored MathJax distribution present in the scipy-mathjax directory.
+
+import socket  # noqa: E402
+
+INTERNET_AVAILABLE = False  # assume no internet connection + use local MathJax
+
+try:
+    # Attributed to https://stackoverflow.com/a/33117579/14001839
+    socket.setdefaulttimeout(1)
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("8.8.8.8", 53))
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM).close()
+    print("Internet connection available.")
+    INTERNET_AVAILABLE = True
+except socket.error as err:  # noqa: UP024
+    print("No internet connection available. Error:", err)
+    print("Using local MathJax distribution.")
+    mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
 
 # -----------------------------------------------------------------------------
 # Intersphinx configuration


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

This change was proposed in the SciPy Community Call (Americas) on 17/04/2024 (please read through the [meeting notes](https://hackmd.io/pyhudrC5TgSwdJtpPldHgQ#Agenda-for-April-17th-2024) for more context about this change).

#### What does this implement/fix?

This PR adds a small code snippet to check for an internet connection by pinging Google's DNS at `8.8.8.8`. If an internet connection is available, it will use the vanilla MathJax distribution, and if there isn't, then the local (vendored) MathJax distribution will be used. This ensures that the local one is used as just a fallback with a mechanism to check for the
availability of the usual distribution.

#### Additional information

Here are the three possible scenarios:

1. Building the documentation for deployment via GitHub Pages or on CircleCI: the vanilla MathJax distribution will be used
2. Building the documentation locally with an internet connection: the vanilla MathJax distribution will be used
3. Building the documentation locally without an internet connection: the vendored MathJax distribution will be used

The third scenario is quite rare and will affect just contributors and developers for SciPy (and those without access to the internet). Therefore, the vendored MathJax (`scipy-mathjax`) will be used only without the presence of an internet connection – in the case of the first scenario, GitHub Actions runners used to deploy to GitHub Pages and runners on CircleCI both have access to the internet.

To not produce any breaking changes and keep behaviour consistent with what SciPy has been doing in the past (starting with gh-7376), I think it would be great to continue using the vendored distribution for the official SciPy docs, so if there is a handy environment variable that can be used to check if they are being deployed as a part of a release, I shall modify the logic here to include that (and therefore refine scenario 1).

xref: https://github.com/executablebooks/MyST-NB/issues/590 for why this change is being proposed – it would be better to resolve this issue, so this PR is being opened just for visibility.

cc: @melissawm
