### PR TITLE
BLD: adjust lower bound on Clang/LLVM from 14.0 to 12.0

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -124,14 +124,14 @@ As explained in more detail below, the current minimal compiler versions are:
  Compiler    Default Platform (tested)    Secondary Platform (untested)    Minimal Version
 ==========  ===========================  ===============================  ============================
  GCC         Linux                        AIX, Alpine Linux, OSX           GCC 9.x
- LLVM        OSX                          Linux, FreeBSD, Windows          LLVM 14.x
+ LLVM        OSX                          Linux, FreeBSD, Windows          LLVM 12.x
  MSVC        Windows                      -                                Visual Studio 2019 (vc142)
 ==========  ===========================  ===============================  ============================
 
-Note that the lower bound for LLVM is not enforced. Older versions should
-work - as long as they support core (non-stdlib) C++17 -, but no version
-below LLVM 14 is tested regularly during development. Please file an issue
-if you encounter a problem during compilation.
+Note that there is currently no dedicated CI job to test the minimum supported
+LLVM/Clang version. Older versions than used in SciPy CI should work, as long
+as they support core (non-stdlib) C++17. Please file an issue if you encounter
+a problem during compilation.
 
 Official Builds
 ~~~~~~~~~~~~~~~
@@ -143,7 +143,7 @@ Currently, SciPy wheels are being built as follows:
 ================    ==============================   ==============================   =============================
 Linux x86            ``ubuntu-22.04``                 GCC 10.2.1                       ``cibuildwheel``
 Linux arm            ``docker-builder-arm64``         GCC 11.3.0                       ``cibuildwheel``
-OSX x86_64           ``macos-latest``                 clang-14/gfortran 13.0           ``cibuildwheel``
+OSX x86_64           ``macos-11``                     clang-13/gfortran 11.3           ``cibuildwheel``
 OSX arm64            ``macos-14``                     clang-14/gfortran 13.0           ``cibuildwheel``
 Windows              ``windows-2019``                 GCC 10.3 (`rtools`_)             ``cibuildwheel``
 ================    ==============================   ==============================   =============================

--- a/meson.build
+++ b/meson.build
@@ -43,8 +43,8 @@ if cc.get_id() == 'gcc'
     error('SciPy requires GCC >= 9.1')
   endif
 elif cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
-  if not cc.version().version_compare('>=14.0')
-    error('SciPy requires clang >= 14.0')
+  if not cc.version().version_compare('>=12.0')
+    error('SciPy requires clang >= 12.0')
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.20')


### PR DESCRIPTION
The bump done in gh-20478 was too aggressive, and the info added to the toolchain there was not fully correct. Also remove the sentence about the lower bound not being enforced from the docs, since it is now.

Closes gh-20523