### PR TITLE
BLD: Fix error message for f2py generation fail

### DIFF
--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -290,9 +290,9 @@ def main():
                             cwd=os.getcwd())
         out, err = p.communicate()
         if not (p.returncode == 0):
-            raise RuntimeError(f"Writing {args.outfile} with f2py failed!\n"
-                            f"{out}\n"
-                            r"{err}")
+            raise RuntimeError(f"Writing {fname_pyf} with f2py failed!\n"
+                            f"{out.decode()}\n"
+                            f"{err.decode()}")
 
 
 if __name__ == "__main__":

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -290,9 +290,9 @@ def main():
                             cwd=os.getcwd())
         out, err = p.communicate()
         if not (p.returncode == 0):
-            raise RuntimeError(f"Writing {fname_pyf} with f2py failed!\n"
-                            f"{out.decode()}\n"
-                            f"{err.decode()}")
+            raise RuntimeError(f"Processing {fname_pyf} with f2py failed!\n"
+                               f"{out.decode()}\n"
+                               f"{err.decode()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What does this implement/fix?

I am currently packaging the openSUSE rpm for 1.13 and see a build failure for the HPC build with numpy 2.0.0rc1. I still have to investigate why the generation fails, but the current error message is not helpful:

```python
[   45s]   [177/1475] Generating scipy/linalg/fblas_module with a custom command
[   45s]   FAILED: scipy/linalg/_fblasmodule.c
[   45s]   /usr/bin/python3.11 /home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py ../scipy/linalg/fblas.pyf.src -o scipy/linalg
[   45s]   Traceback (most recent call last):
[   45s]     File "/home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py", line 299, in <module>
[   45s]       main()
[   45s]     File "/home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py", line 293, in main
[   45s]       raise RuntimeError(f"Writing {args.outfile} with f2py failed!\n"
[   45s]                                     ^^^^^^^^^^^^
[   45s]   AttributeError: 'Namespace' object has no attribute 'outfile'
[   45s]   [178/1475] Generating scipy/linalg/flapack_module with a custom command
[   45s]   FAILED: scipy/linalg/_flapackmodule.c
[   45s]   /usr/bin/python3.11 /home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py ../scipy/linalg/flapack.pyf.src -o scipy/linalg
[   45s]   Traceback (most recent call last):
[   45s]     File "/home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py", line 299, in <module>
[   45s]       main()
[   45s]     File "/home/abuild/rpmbuild/BUILD/scipy-1.13.0/tools/generate_f2pymod.py", line 293, in main
[   45s]       raise RuntimeError(f"Writing {args.outfile} with f2py failed!\n"
[   45s]                                     ^^^^^^^^^^^^
[   45s]   AttributeError: 'Namespace' object has no attribute 'outfile'
[   46s]   [179/1475] Generating 'scipy/special/cython_special.cpython-310-x86_64-linux-gnu.so.p/cython_special.c'
[   47s]   [180/1475] Compiling C++ object scipy/special/cython_special.cpython-310-x86_64-linux-gnu.so.p/specfun_wrappers.cpp.o
[   47s]   [181/1475] Linking target scipy/special/_test_internal.cpython-310-x86_64-linux-gnu.so
[   47s]   [182/1475] Linking target scipy/special/_ufuncs.cpython-310-x86_64-linux-gnu.so
[   47s]   ninja: build stopped: subcommand failed.
[   47s]   error: subprocess-exited-with-error
```

This PR fixes the error message with the missing attribute.