### PR TITLE
TST: Adapt to `__array__(copy=True)`

### DIFF
--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -12,6 +12,8 @@ class _FakeMatrix2:
         self._data = data
 
     def __array__(self, dtype=None, copy=None):
+        if copy:
+            return self._data.copy()
         return self._data
 
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -12,6 +12,7 @@ from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
+from scipy._lib._util import copy_if_needed
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 
@@ -701,7 +702,7 @@ class LowRankMatrix:
 
     def collapse(self):
         """Collapse the low-rank matrix to a full-rank one."""
-        self.collapsed = np.array(self)
+        self.collapsed = np.array(self, copy=copy_if_needed)
         self.cs = None
         self.ds = None
         self.alpha = None


### PR DESCRIPTION
Fixes test failures pointed out in https://github.com/scipy/scipy/pull/20510#issuecomment-2067065862 due to numpy enforcing `__array__(copy=True)` in https://github.com/numpy/numpy/pull/26215.