### PR TITLE
BUG: Fixes incorrect upper_band value for scipy.linalg.bandwidth

### DIFF
--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -193,11 +193,13 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
             break
 
     # upper triangular part
-    for r in range(n-1):
-        for c in range(m - 1, r + upper_band, -1):
+    for c in range(m - 1, 0, -1):
+        # Only bother if outside the existing band:
+        for r in range(min(c - upper_band, n - 1)):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
+        # If the first element is full don't go lower; we are done
         if upper_band == c:
             break
 
@@ -224,11 +226,13 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
             break
 
     # upper triangular part
-    for r in range(n-1):
-        for c in range(m - 1, r + upper_band, -1):
+    for c in range(m - 1, 0, -1):
+        # Only bother if outside the existing band:
+        for r in range(min(c - upper_band, n - 1)):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
+        # If the first element is full don't go lower; we are done
         if upper_band == c:
             break
 

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -193,15 +193,14 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
             break
 
     # upper triangular part
-    for c in range(m - 1, 0, -1):
-        # Only bother if outside the existing band:
-        for r in range(min(c - upper_band, n - 1)):
+    for r in range(n - 1):
+        if m - 1 <= r + upper_band:
+            # If existing band falls outside matrix; we are done
+            break
+        for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
-        # If the first element is full don't go lower; we are done
-        if upper_band == c:
-            break
 
     return lower_band, upper_band
 
@@ -226,15 +225,14 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
             break
 
     # upper triangular part
-    for c in range(m - 1, 0, -1):
-        # Only bother if outside the existing band:
-        for r in range(min(c - upper_band, n - 1)):
+    for r in range(n - 1):
+        if m - 1 <= r + upper_band:
+            # If existing band falls outside matrix; we are done
+            break
+        for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
-        # If the first element is full don't go lower; we are done
-        if upper_band == c:
-            break
 
     return lower_band, upper_band
 

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -194,8 +194,8 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
 
     # upper triangular part
     for r in range(n - 1):
-        if m - 1 <= r + upper_band:
-            # If existing band falls outside matrix; we are done
+        # If existing band falls outside matrix; we are done
+        if r + upper_band>m - 1:
             break
         for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:
@@ -226,8 +226,8 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
 
     # upper triangular part
     for r in range(n - 1):
-        if m - 1 <= r + upper_band:
-            # If existing band falls outside matrix; we are done
+        # If existing band falls outside matrix; we are done
+        if r + upper_band > m - 1:
             break
         for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -194,13 +194,13 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
 
     # upper triangular part
     for r in range(n-1):
-        # If existing band falls outside matrix; we are done
-        if r + upper_band>m - 1:
-            break
         for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
+        # If existing band falls outside matrix; we are done
+        if r + upper_band > m - 1:
+            break
 
     return lower_band, upper_band
 
@@ -226,13 +226,13 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
 
     # upper triangular part
     for r in range(n-1):
-        # If existing band falls outside matrix; we are done
-        if r + upper_band > m - 1:
-            break
         for c in range(m - 1, r + upper_band, -1):
             if A[r, c] != zero:
                 upper_band = c - r
                 break
+        # If existing band falls outside matrix; we are done
+        if r + upper_band > m - 1:
+            break
 
     return lower_band, upper_band
 

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -199,7 +199,7 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
                 upper_band = c - r
                 break
         # If existing band falls outside matrix; we are done
-        if r + upper_band > m - 1:
+        if r + 1 + upper_band > m - 1:
             break
 
     return lower_band, upper_band
@@ -231,7 +231,7 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
                 upper_band = c - r
                 break
         # If existing band falls outside matrix; we are done
-        if r + upper_band > m - 1:
+        if r + 1 + upper_band > m - 1:
             break
 
     return lower_band, upper_band

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -193,7 +193,7 @@ cdef inline (int, int) band_check_internal_c(const np_numeric_t[:, ::1]A) noexce
             break
 
     # upper triangular part
-    for r in range(n - 1):
+    for r in range(n-1):
         # If existing band falls outside matrix; we are done
         if r + upper_band>m - 1:
             break
@@ -225,7 +225,7 @@ cdef inline (int, int) band_check_internal_noncontig(const np_numeric_t[:, :]A) 
             break
 
     # upper triangular part
-    for r in range(n - 1):
+    for r in range(n-1):
         # If existing band falls outside matrix; we are done
         if r + upper_band > m - 1:
             break

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -35,6 +35,17 @@ def test_bandwidth_square_inputs(T):
     R[[x for x in range(1, n)], [x for x in range(n-1)]] = 1
     R[[x for x in range(k, n)], [x for x in range(n-k)]] = 1
     assert bandwidth(R) == (k, k)
+    A = np.array([
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 1, 1, 1],
+        [0, 0, 0, 0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0, 1, 0, 0],
+    ])
+    assert bandwidth(A) == (2, 2)
 
 
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']


### PR DESCRIPTION
#### Reference issue

Closes #20466 

#### What does this implement/fix?

now the upper band calulation algorithm mimics the lower band calculation.

#### Additional information

For the following code
```
import numpy as np

import scipy

mat = [
    [1, 1, 0, 0, 0, 0, 0, 0],
    [1, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 1, 1, 1],
    [0, 0, 0, 0, 0, 1, 0, 0],
    [0, 0, 0, 0, 0, 1, 0, 0],
]
A = np.asarray(
    mat, order='C'
)

print("C_CONTIGUOUS : ", scipy.linalg.bandwidth(A))
A = np.asarray(
    mat, order='F'
)
print("F_CONTIGUOUS: ", scipy.linalg.bandwidth(A))
```

Existing implementation returns the following (wrong output)

```
C_CONTIGUOUS :  (2, 1)
F_CONTIGUOUS:  (1, 2)
```

This patch fixes it (correct output)

```
C_CONTIGUOUS :  (2, 2)
F_CONTIGUOUS:  (2, 2)
```