### PR TITLE
BLD: Move Python-including files to start of source.

### DIFF
--- a/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
+++ b/scipy/io/_fast_matrix_market/src/_fmm_core.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the BSD 2-clause license found in the LICENSE.txt file.
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "_fmm_core.hpp"
+
 #include <fast_matrix_market/types.hpp>
 #include <cstdint>
 namespace fast_matrix_market {
@@ -15,8 +17,6 @@ namespace fast_matrix_market {
     }
 }
 #include <fast_matrix_market/fast_matrix_market.hpp>
-
-#include "_fmm_core.hpp"
 
 ////////////////////////////////////////////////
 //// Header methods

--- a/scipy/special/_wright.cxx
+++ b/scipy/special/_wright.cxx
@@ -1,6 +1,6 @@
-#include <complex>
-
 #include "_wright.h"
+
+#include <complex>
 
 using namespace std;
 


### PR DESCRIPTION
This should allow Cygwin to build in the next release.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Backport of #20505
Closes #20491

#### What does this implement/fix?
<!--Please explain your changes.-->
This moves a few python-including headers earlier in their respective files.

#### Additional information
<!--Any additional information you think is important.-->
DWesl/scipy#7 tests whether this compiles on Cygwin.