### PR TITLE
TST: _lib: remove redundant test for missing `stacklevel`

### DIFF
--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -115,23 +115,3 @@ def test_warning_calls_filters(warning_calls):
             "found in:\n    {}".format(
                 "\n    ".join(bad_filters)))
 
-
-@pytest.mark.slow
-@pytest.mark.xfail(reason="stacklevels currently missing")
-def test_warning_calls_stacklevels(warning_calls):
-    bad_filters, bad_stacklevels = warning_calls
-
-    msg = ""
-
-    if bad_filters:
-        msg += ("warning ignore filter should not be used, instead, use\n"
-                "numpy.testing.suppress_warnings (in tests only);\n"
-                "found in:\n    {}".format("\n    ".join(bad_filters)))
-        msg += "\n\n"
-
-    if bad_stacklevels:
-        msg += "warnings should have an appropriate stacklevel:\n    {}".format(
-                "\n    ".join(bad_stacklevels))
-
-    if msg:
-        raise AssertionError(msg)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #19623
#### What does this implement/fix?
<!--Please explain your changes.-->
#19623 added a lint check for missing stacklevels, this test was already xfailed but now is also redundant so we may as well remove it
#### Additional information
<!--Any additional information you think is important.-->
