### PR TITLE
ENH: stats.skew: add array-API support

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -403,6 +403,10 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 temp = args[0]
 
             if not is_numpy(array_namespace(temp)):
+                msg = ("Use of `nan_policy` and `keepdims` "
+                       "is incompatible with non-NumPy arrays.")
+                if 'nan_policy' in kwds or 'keepdims' in kwds:
+                    raise NotImplementedError(msg)
                 return hypotest_fun_in(*args, **kwds)
 
             # We need to be flexible about whether position or keyword

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1038,14 +1038,14 @@ def moment(a, order=1, axis=0, nan_policy='propagate', *, center=None):
         return _moment(a, order, axis, mean=center)
 
 
-def _moment(a, order, axis, *, mean=None):
+def _moment(a, order, axis, *, mean=None, xp=None):
     """Vectorized calculation of raw moment about specified center
 
     When `mean` is None, the mean is computed and used as the center;
     otherwise, the provided value is used as the center.
 
     """
-    xp = array_namespace(a)
+    xp = array_namespace(a) if xp is None else xp
 
     if xp.isdtype(a.dtype, 'integral'):
         a = xp.asarray(a, dtype=xp.float64)
@@ -1121,6 +1121,8 @@ def _var(x, axis=0, ddof=0, mean=None):
 @_axis_nan_policy_factory(
     lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
 )
+# nan_policy handled by `_axis_nan_policy, but needs to be left
+# in signature to preserve use as a positional argument
 def skew(a, axis=0, bias=True, nan_policy='propagate'):
     r"""Compute the sample skewness of a data set.
 
@@ -1195,23 +1197,24 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     0.2650554122698573
 
     """
-    a, axis = _chk_asarray(a, axis)
+    xp = array_namespace(a)
+    a, axis = _chk_asarray(a, axis, xp=xp)
     n = a.shape[axis]
 
-    mean = a.mean(axis, keepdims=True)
-    mean_reduced = mean.squeeze(axis)  # needed later
+    mean = xp.mean(a, axis, keepdims=True)
+    mean_reduced = xp.squeeze(mean, axis)  # needed later
     m2 = _moment(a, 2, axis, mean=mean)
     m3 = _moment(a, 3, axis, mean=mean)
     with np.errstate(all='ignore'):
-        eps = np.finfo(m2.dtype).resolution
+        eps = xp.finfo(m2.dtype).eps
         zero = m2 <= (eps * mean_reduced)**2
-        vals = np.where(zero, np.nan, m3 / m2**1.5)
+        vals = xp.where(zero, np.nan, m3 / m2**1.5)
     if not bias:
         can_correct = ~zero & (n > 2)
-        if np.any(can_correct):
+        if xp.any(can_correct):
             m2 = m2[can_correct]
             m3 = m3[can_correct]
-            nval = np.sqrt((n - 1.0) * n) / (n - 2.0) * m3 / m2**1.5
+            nval = xp.sqrt((n - 1.0) * n) / (n - 2.0) * m3 / m2**1.5
             vals[can_correct] = nval
 
     return vals[()] if vals.ndim == 0 else vals

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1198,12 +1198,6 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     a, axis = _chk_asarray(a, axis)
     n = a.shape[axis]
 
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
-
-    if contains_nan and nan_policy == 'omit':
-        a = ma.masked_invalid(a)
-        return mstats_basic.skew(a, axis, bias)
-
     mean = a.mean(axis, keepdims=True)
     m2 = _moment(a, 2, axis, mean=mean)
     m3 = _moment(a, 3, axis, mean=mean)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1201,20 +1201,20 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     a, axis = _chk_asarray(a, axis, xp=xp)
     n = a.shape[axis]
 
-    mean = xp.mean(a, axis, keepdims=True)
-    mean_reduced = xp.squeeze(mean, axis)  # needed later
+    mean = xp.mean(a, axis=axis, keepdims=True)
+    mean_reduced = xp.squeeze(mean, axis=axis)  # needed later
     m2 = _moment(a, 2, axis, mean=mean)
     m3 = _moment(a, 3, axis, mean=mean)
     with np.errstate(all='ignore'):
         eps = xp.finfo(m2.dtype).eps
         zero = m2 <= (eps * mean_reduced)**2
-        vals = xp.where(zero, np.nan, m3 / m2**1.5)
+        vals = xp.where(zero, xp.asarray(xp.nan), m3 / m2**1.5)
     if not bias:
         can_correct = ~zero & (n > 2)
         if xp.any(can_correct):
             m2 = m2[can_correct]
             m3 = m3[can_correct]
-            nval = xp.sqrt((n - 1.0) * n) / (n - 2.0) * m3 / m2**1.5
+            nval = ((n - 1.0) * n)**0.5 / (n - 2.0) * m3 / m2**1.5
             vals[can_correct] = nval
 
     return vals[()] if vals.ndim == 0 else vals

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3381,31 +3381,37 @@ class TestMoments:
         xp_assert_close(res, ref)
 
 
-class TestSkewKurtosis:
+class SkewKurtosisTest:
     scalar_testcase = 4.
     testcase = [1., 2., 3., 4.]
     testmathworks = [1.165, 0.6268, 0.0751, 0.3516, -0.6965]
 
+
+class TestSkew(SkewKurtosisTest):
     def test_empty_1d(self):
+        # This is not essential behavior to maintain w/ array API
         message = r"Mean of empty slice\.|invalid value encountered.*"
         with pytest.warns(RuntimeWarning, match=message):
             stats.skew([])
         with pytest.warns(RuntimeWarning, match=message):
             stats.kurtosis([])
 
-    def test_skewness(self):
+    @array_api_compatible
+    def test_skewness(self, xp):
         # Scalar test case
-        y = stats.skew(self.scalar_testcase)
-        assert np.isnan(y)
+        y = stats.skew(xp.asarray(self.scalar_testcase))
+        xp_assert_close(y, xp.asarray(xp.nan))
         # sum((testmathworks-mean(testmathworks,axis=0))**3,axis=0) /
         #     ((sqrt(var(testmathworks)*4/5))**3)/5
-        y = stats.skew(self.testmathworks)
-        assert_approx_equal(y, -0.29322304336607, 10)
-        y = stats.skew(self.testmathworks, bias=0)
-        assert_approx_equal(y, -0.437111105023940, 10)
-        y = stats.skew(self.testcase)
-        assert_approx_equal(y, 0.0, 10)
+        y = stats.skew(xp.asarray(self.testmathworks, dtype=xp.float64))
+        xp_assert_close(y, xp.asarray(-0.29322304336607, dtype=xp.float64), atol=1e-10)
+        y = stats.skew(xp.asarray(self.testmathworks, dtype=xp.float64), bias=0)
+        xp_assert_close(y, xp.asarray(-0.437111105023940, dtype=xp.float64), atol=1e-10)
+        y = stats.skew(xp.asarray(self.testcase, dtype=xp.float64))
+        xp_assert_close(y, xp.asarray(0.0, dtype=xp.float64), atol=1e-10)
 
+    def test_nan_policy(self):
+        # initially, nan_policy is ignored with alternative backends
         x = np.arange(10.)
         x[9] = np.nan
         with np.errstate(invalid='ignore'):
@@ -3415,42 +3421,78 @@ class TestSkewKurtosis:
         assert_raises(ValueError, stats.skew, x, nan_policy='foobar')
 
     def test_skewness_scalar(self):
-        # `skew` must return a scalar for 1-dim input
+        # `skew` must return a scalar for 1-dim input (only for NumPy arrays)
         assert_equal(stats.skew(arange(10)), 0.0)
 
-    def test_skew_propagate_nan(self):
+    @array_api_compatible
+    def test_skew_propagate_nan(self, xp):
         # Check that the shape of the result is the same for inputs
         # with and without nans, cf gh-5817
-        a = np.arange(8).reshape(2, -1).astype(float)
-        a[1, 0] = np.nan
+        a = xp.arange(8.)
+        a = xp.reshape(a, (2, -1))
+        a[1, 0] = xp.nan
         with np.errstate(invalid='ignore'):
             s = stats.skew(a, axis=1, nan_policy="propagate")
-        np.testing.assert_allclose(s, [0, np.nan], atol=1e-15)
+        xp_assert_equal(s, xp.asarray([0, xp.nan]))
 
-    def test_skew_constant_value(self):
+    @array_api_compatible
+    def test_skew_constant_value(self, xp):
         # Skewness of a constant input should be zero even when the mean is not
         # exact (gh-13245)
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
-            a = np.repeat(-0.27829495, 10)
-            assert np.isnan(stats.skew(a))
-            assert np.isnan(stats.skew(a * float(2**50)))
-            assert np.isnan(stats.skew(a / float(2**50)))
-            assert np.isnan(stats.skew(a, bias=False))
+            a = xp.asarray([-0.27829495]*10)  # xp.repeat not currently available
+            assert_equal(stats.skew(a), xp.asarray(xp.nan))
+            assert_equal(stats.skew(a*2.**50), xp.asarray(xp.nan))
+            assert_equal(stats.skew(a/2.**50), xp.asarray(xp.nan))
+            assert_equal(stats.skew(a, bias=False), xp.asarray(xp.nan))
 
-            # similarly, from gh-11086:
-            assert np.isnan(stats.skew([14.3]*7))
-            assert np.isnan(stats.skew(1 + np.arange(-3, 4)*1e-16))
+            # # similarly, from gh-11086:
+            a = xp.asarray([14.3]*7)
+            assert_equal(stats.skew(a), xp.asarray(xp.nan))
+            a = 1. + xp.arange(-3., 4)*1e-16
+            assert_equal(stats.skew(a), xp.asarray(xp.nan))
 
-    def test_precision_loss_gh15554(self):
+    @array_api_compatible
+    def test_precision_loss_gh15554(self, xp):
         # gh-15554 was one of several issues that have reported problems with
         # constant or near-constant input. We can't always fix these, but
         # make sure there's a warning.
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             rng = np.random.default_rng(34095309370)
-            a = rng.random(size=(100, 10))
+            a = xp.asarray(rng.random(size=(100, 10)))
             a[:, 0] = 1.01
-            stats.skew(a)[0]
+            stats.skew(a)
 
+    @array_api_compatible
+    @pytest.mark.parametrize('axis', [-1, 0, 2, None])
+    @pytest.mark.parametrize('bias', [False, True])
+    def test_vectorization(self, xp, axis, bias):
+        # Behavior with array input is barely tested above. Compare
+        # against naive implementation.
+        rng = np.random.default_rng(1283413549926)
+        x = xp.asarray(rng.random((3, 4, 5)))
+
+        def skewness(a, axis, bias):
+            # Simple implementation of skewness
+            if axis is None:
+                a = xp.reshape(a, (-1,))
+                axis = 0
+            xp_test = array_namespace(a)  # plain torch ddof=1 by default
+            mean = xp_test.mean(a, axis=axis, keepdims=True)
+            mu3 = xp_test.mean((a - mean)**3, axis=axis)
+            std = xp_test.std(a, axis=axis)
+            res = mu3 / std ** 3
+            if not bias:
+                n = a.shape[axis]
+                res *= ((n - 1.0) * n) ** 0.5 / (n - 2.0)
+            return res
+
+        res = stats.skew(x, axis=axis, bias=bias)
+        ref = skewness(x, axis=axis, bias=bias)
+        xp_assert_close(res, ref)
+
+
+class TestKurtosis(SkewKurtosisTest):
     def test_kurtosis(self):
         # Scalar test case
         y = stats.kurtosis(self.scalar_testcase)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3342,7 +3342,7 @@ class TestMoments:
         a = np.arange(8).reshape(2, -1).astype(float)
         a = xp.asarray(a)
         a[1, 0] = np.nan
-        mm = stats.moment(a, 2, axis=1, nan_policy="propagate")
+        mm = stats.moment(a, 2, axis=1)
         xp_assert_close(mm, xp.asarray([1.25, np.nan], dtype=xp.float64), atol=1e-15)
 
     @array_api_compatible
@@ -3432,7 +3432,7 @@ class TestSkew(SkewKurtosisTest):
         a = xp.reshape(a, (2, -1))
         a[1, 0] = xp.nan
         with np.errstate(invalid='ignore'):
-            s = stats.skew(a, axis=1, nan_policy="propagate")
+            s = stats.skew(a, axis=1)
         xp_assert_equal(s, xp.asarray([0, xp.nan]))
 
     @array_api_compatible
@@ -8920,3 +8920,20 @@ def test_chk_asarray(xp):
     x_out, axis_out = _chk_asarray(x[0, 0, 0], axis=axis, xp=xp)
     xp_assert_equal(x_out, xp.asarray(np.atleast_1d(x0[0, 0, 0])))
     assert_equal(axis_out, axis)
+
+
+@pytest.mark.skip_xp_backends('numpy',
+                              reasons=['These parameters *are* compatible with NumPy'])
+@pytest.mark.usefixtures("skip_xp_backends")
+@array_api_compatible
+def test_axis_nan_policy_keepdims_nanpolicy(xp):
+    # this test does not need to be repeated for every function
+    # using the _axis_nan_policy decorator. The test is here
+    # rather than in `test_axis_nanpolicy.py` because there is
+    # no reason to run those tests on an array API CI job.
+    x = xp.asarray([1, 2, 3, 4])
+    message = "Use of `nan_policy` and `keepdims`..."
+    with pytest.raises(NotImplementedError, match=message):
+        stats.skew(x, nan_policy='omit')
+    with pytest.raises(NotImplementedError, match=message):
+        stats.skew(x, keepdims=True)


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-20292

#### What does this implement/fix?
This adds array-API support to `scipy.stats.skew`. It might be useful to review one commit at a time:
- 788b54aa38cd25262d7a1e5bd34b762379785a4c removes code that is no longer used (`nan_policy` support is handled by the `_axis_nan_policy` decorator)
- bb3575679665d9ac6a6b359679b935f8a2eebd15 attempts to simplify some of the existing pure-NumPy code, making it look a little closer to what the array-API requires
- 0d33968873314f9fb5dfe6bc8f41a50d5edd7608 drafts the conversion to array API
- 69d0c8ab9b6acbf0e7eeafc20b99f0a539b8979d tests with array-API backends (and fixes some things in the implementation)
- 0b7317de0071a2db507d828903fdec0486b5ea4c (unrelated to the main point of this PR, but needs to get taken care of) Makes the `_axis_nan_policy` decorator raise when it gets arguments that won't currently work with the array API. It only works when these parameters are passed as keyword arguments (which they *should* be anyway), but I am not too concerned because a) array-API support is still experimental and behind an environment variable and b) these features should be available with non-NumPy backends by the time the environment variable is removed, at which point this error will be removed. Nothing like this commit will be needed with other array-API conversions.

#### Additional information
After this, I will open an issue with a list of stats functions I think are ripe for array API support. We can point to this PR as an example and hopefully crowdsource the effort. I'd be willing to review PRs for functions on that list.
