### PR TITLE
BLD: Accelerate builds should not define `NO_APPEND_FORTRAN`

### DIFF
--- a/scipy/_build_utils/_wrappers_common.py
+++ b/scipy/_build_utils/_wrappers_common.py
@@ -38,8 +38,8 @@ WRAPPED_FUNCS = ['cdotc', 'cdotu', 'zdotc', 'zdotu', 'cladiv', 'zladiv']
 USE_OLD_ACCELERATE = ['lsame', 'dcabs1']
 
 C_PREAMBLE = """
-#include "fortran_defs.h"
 #include "npy_cblas.h"
+#include "fortran_defs.h"
 """
 
 LAPACK_DECLS = """
@@ -128,7 +128,8 @@ def get_blas_macro_and_name(name, accelerate):
         elif name == 'xerbla_array':
             return '', name + '__'
     if name in WRAPPED_FUNCS:
-        return '', name + 'wrp_'
+        name = name + 'wrp'
+        return 'F_FUNC', f'{name},{name.upper()}'
     return 'BLAS_FUNC', name
 
 

--- a/scipy/_build_utils/src/npy_cblas.h
+++ b/scipy/_build_utils/src/npy_cblas.h
@@ -26,15 +26,17 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 
 #define CBLAS_INDEX size_t  /* this may vary between platforms */
 
-#ifdef ACCELERATE_NEW_LAPACK
-#define NO_APPEND_FORTRAN
-#define BLAS_SYMBOL_SUFFIX $NEWLAPACK
-#endif
-
 #ifdef NO_APPEND_FORTRAN
 #define BLAS_FORTRAN_SUFFIX
 #else
 #define BLAS_FORTRAN_SUFFIX _
+#endif
+
+// New Accelerate suffix is always $NEWLAPACK (no underscore)
+#ifdef ACCELERATE_NEW_LAPACK
+#undef BLAS_FORTRAN_SUFFIX
+#define BLAS_FORTRAN_SUFFIX
+#define BLAS_SYMBOL_SUFFIX $NEWLAPACK
 #endif
 
 #ifndef BLAS_SYMBOL_PREFIX

--- a/scipy/_build_utils/src/wrap_dummy_g77_abi.c
+++ b/scipy/_build_utils/src/wrap_dummy_g77_abi.c
@@ -22,8 +22,8 @@ passing a pointer to a variable in which to store the computed result. Unlike
 return values, struct complex arguments work without segfaulting.
 */
 
-#include "fortran_defs.h"
 #include "npy_cblas.h"
+#include "fortran_defs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scipy/_build_utils/src/wrap_g77_abi.c
+++ b/scipy/_build_utils/src/wrap_g77_abi.c
@@ -22,8 +22,8 @@ passing a pointer to a variable in which to store the computed result. Unlike
 return values, struct complex arguments work without segfaulting.
 */
 
-#include "fortran_defs.h"
 #include "npy_cblas.h"
+#include "fortran_defs.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
#### What does this implement/fix?
Fixes fragile behavior exposed by gh-20536. Defining `NO_APPEND_FORTRAN` was an overreach: non-Accelerate symbols should still have a trailing underscore.
