### PR TITLE
DOC: stats.linregress: split stats/mstats documentation

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -1043,10 +1043,109 @@ def pointbiserialr(x, y):
 
 def linregress(x, y=None):
     r"""
-    Linear regression calculation
+    Calculate a linear least-squares regression for two sets of measurements.
 
-    Note that the non-masked version is used, and that this docstring is
-    replaced by the non-masked docstring + some info on missing data.
+    Parameters
+    ----------
+    x, y : array_like
+        Two sets of measurements.  Both arrays should have the same length N.  If
+        only `x` is given (and ``y=None``), then it must be a two-dimensional
+        array where one dimension has length 2.  The two sets of measurements
+        are then found by splitting the array along the length-2 dimension. In
+        the case where ``y=None`` and `x` is a 2xN array, ``linregress(x)`` is
+        equivalent to ``linregress(x[0], x[1])``.
+
+    Returns
+    -------
+    result : ``LinregressResult`` instance
+        The return value is an object with the following attributes:
+
+        slope : float
+            Slope of the regression line.
+        intercept : float
+            Intercept of the regression line.
+        rvalue : float
+            The Pearson correlation coefficient. The square of ``rvalue``
+            is equal to the coefficient of determination.
+        pvalue : float
+            The p-value for a hypothesis test whose null hypothesis is
+            that the slope is zero, using Wald Test with t-distribution of
+            the test statistic. See `alternative` above for alternative
+            hypotheses.
+        stderr : float
+            Standard error of the estimated slope (gradient), under the
+            assumption of residual normality.
+        intercept_stderr : float
+            Standard error of the estimated intercept, under the assumption
+            of residual normality.
+
+    See Also
+    --------
+    scipy.optimize.curve_fit :
+        Use non-linear least squares to fit a function to data.
+    scipy.optimize.leastsq :
+        Minimize the sum of squares of a set of equations.
+
+    Notes
+    -----
+    Missing values are considered pair-wise: if a value is missing in `x`,
+    the corresponding value in `y` is masked.
+
+    For compatibility with older versions of SciPy, the return value acts
+    like a ``namedtuple`` of length 5, with fields ``slope``, ``intercept``,
+    ``rvalue``, ``pvalue`` and ``stderr``, so one can continue to write::
+
+        slope, intercept, r, p, se = linregress(x, y)
+
+    With that style, however, the standard error of the intercept is not
+    available.  To have access to all the computed values, including the
+    standard error of the intercept, use the return value as an object
+    with attributes, e.g.::
+
+        result = linregress(x, y)
+        print(result.intercept, result.intercept_stderr)
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import stats
+    >>> rng = np.random.default_rng()
+
+    Generate some data:
+
+    >>> x = rng.random(10)
+    >>> y = 1.6*x + rng.random(10)
+
+    Perform the linear regression:
+
+    >>> res = stats.mstats.linregress(x, y)
+
+    Coefficient of determination (R-squared):
+
+    >>> print(f"R-squared: {res.rvalue**2:.6f}")
+    R-squared: 0.717533
+
+    Plot the data along with the fitted line:
+
+    >>> plt.plot(x, y, 'o', label='original data')
+    >>> plt.plot(x, res.intercept + res.slope*x, 'r', label='fitted line')
+    >>> plt.legend()
+    >>> plt.show()
+
+    Calculate 95% confidence interval on slope and intercept:
+
+    >>> # Two-sided inverse Students t-distribution
+    >>> # p - probability, df - degrees of freedom
+    >>> from scipy.stats import t
+    >>> tinv = lambda p, df: abs(t.ppf(p/2, df))
+
+    >>> ts = tinv(0.05, len(x)-2)
+    >>> print(f"slope (95%): {res.slope:.6f} +/- {ts*res.stderr:.6f}")
+    slope (95%): 1.453392 +/- 0.743465
+    >>> print(f"intercept (95%): {res.intercept:.6f}"
+    ...       f" +/- {ts*res.intercept_stderr:.6f}")
+    intercept (95%): 0.616950 +/- 0.544475
 
     """
     if y is None:

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -3,7 +3,7 @@ import numpy as np
 from . import distributions
 from .._lib._bunch import _make_tuple_bunch
 from ._stats_pythran import siegelslopes as siegelslopes_pythran
-from . import _mstats_basic
+from scipy.stats import _stats_py
 
 __all__ = ['_find_repeats', 'linregress', 'theilslopes', 'siegelslopes']
 
@@ -26,11 +26,11 @@ def linregress(x, y=None, alternative='two-sided'):
     Parameters
     ----------
     x, y : array_like
-        Two sets of measurements.  Both arrays should have the same length.  If
+        Two sets of measurements.  Both arrays should have the same length N.  If
         only `x` is given (and ``y=None``), then it must be a two-dimensional
         array where one dimension has length 2.  The two sets of measurements
         are then found by splitting the array along the length-2 dimension. In
-        the case where ``y=None`` and `x` is a 2x2 array, ``linregress(x)`` is
+        the case where ``y=None`` and `x` is a 2xN array, ``linregress(x)`` is
         equivalent to ``linregress(x[0], x[1])``.
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
@@ -75,9 +75,6 @@ def linregress(x, y=None, alternative='two-sided'):
 
     Notes
     -----
-    Missing values are considered pair-wise: if a value is missing in `x`,
-    the corresponding value in `y` is masked.
-
     For compatibility with older versions of SciPy, the return value acts
     like a ``namedtuple`` of length 5, with fields ``slope``, ``intercept``,
     ``rvalue``, ``pvalue`` and ``stderr``, so one can continue to write::
@@ -194,7 +191,7 @@ def linregress(x, y=None, alternative='two-sided'):
         # n-2 degrees of freedom because 2 has been used up
         # to estimate the mean and standard deviation
         t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
-        t, prob = _mstats_basic._ttest_finish(df, t, alternative)
+        prob = _stats_py._get_pvalue(t, distributions.t(df), alternative)
 
         slope_stderr = np.sqrt((1 - r**2) * ssym / ssxm / df)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2025,7 +2025,7 @@ class TestRegression:
         y = 0.2 * np.linspace(0, 100, 100) + 10  # slope is greater than zero
         y += np.sin(np.linspace(0, 20, 100))
 
-        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+        with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
             stats.linregress(x, y, alternative="ekki-ekki")
 
         res1 = stats.linregress(x, y, alternative="two-sided")


### PR DESCRIPTION
#### Reference issue
NA

#### What does this implement/fix?
The documentation of [`scipy.stats.linregress`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.linregress.html) incorrectly suggests that masked arrays are supported:

> Missing values are considered pair-wise: if a value is missing in x, the corresponding value in y is masked.

Masks are silently ignored by this function, so this PR removes the statement. This PR also corrects a typo about the first argument being a 2x2 array; it meant 2x*N* array, where *N* is the number of observations.

Also, the documentation of [`scipy.stats.mstats.linregress`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.linregress.html) currently looks like:

![image](https://github.com/scipy/scipy/assets/6570539/8fa952d2-f071-45ec-a2cc-2220823eef0d)

suggesting that the docstring was supposed to be replaced automatically. I'm not aware of any machinery to do that, so I copied the [`scipy.stats.linregress`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.linregress.html) documentation over and changed the example to use `stats.mstats.linregress` instead of `stats.linregress`.

#### Additional information
I decided against adding a mask to the example in the `mstats` version. For one thing, the `mstats` version of the function offers little value since it simply calls the `stats` version after compressing the arrays, so it is not worth much time to maintain it. Also, if nobody noticed that the documentation was missing entirely, it is unlikely that anyone would appreciate an improved example.

If we want `scipy.stats.linregress` to be translated to array-API, I think we should deprecate the `y=None` behavior and make `y` a required argument. It's not strictly required, but I think it would be confusing to preserve this behavior when there can be arrays of arbitrary dimensionality. Please indicate whether you agree, and I'll make the change in a separate PR.