### PR TITLE
TST: Skip Cython tests for editable installs

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -13,6 +13,7 @@ import sysconfig
 from importlib.util import module_from_spec, spec_from_file_location
 
 import numpy as np
+import scipy
 
 try:
     # Need type: ignore[import-untyped] for mypy >= 1.6
@@ -41,6 +42,9 @@ IS_MUSL = False
 _v = sysconfig.get_config_var('HOST_GNU_TYPE') or ''
 if 'musl' in _v:
     IS_MUSL = True
+
+
+IS_EDITABLE = 'editable' in scipy.__path__[0]
 
 
 class FPUModeChangeWarning(RuntimeWarning):

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -4,11 +4,13 @@ import platform
 import numpy as np
 import pytest
 
-from scipy._lib._testutils import _test_cython_extension, cython
+from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
 from scipy.linalg.blas import cdotu  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
 
 
+@pytest.mark.skipif(IS_EDITABLE,
+                    reason='Editable install cannot find .pxd headers.')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")

--- a/scipy/optimize/tests/test_extending.py
+++ b/scipy/optimize/tests/test_extending.py
@@ -3,9 +3,11 @@ import platform
 
 import pytest
 
-from scipy._lib._testutils import _test_cython_extension, cython
+from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
 
 
+@pytest.mark.skipif(IS_EDITABLE,
+                    reason='Editable install cannot find .pxd headers.')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")

--- a/scipy/special/tests/test_extending.py
+++ b/scipy/special/tests/test_extending.py
@@ -3,10 +3,12 @@ import platform
 
 import pytest
 
-from scipy._lib._testutils import _test_cython_extension, cython
+from scipy._lib._testutils import IS_EDITABLE,_test_cython_extension, cython
 from scipy.special import beta, gamma
 
 
+@pytest.mark.skipif(IS_EDITABLE,
+                    reason='Editable install cannot find .pxd headers.')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")


### PR DESCRIPTION
#### Reference issue
Closes gh-20540. Since `scipy/optimize/cython_optimize.pxd` is not generated-on-the-fly, it should theoretically be visible to Cython, but I do not know how to change their codebase to enable that.