### PR TITLE
DEP: linalg: remove turbo / eigvals kwargs from linalg.{eigh,eigvalsh} and switch to kwarg-only

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -16,8 +16,6 @@ __all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
            'eig_banded', 'eigvals_banded',
            'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf']
 
-import warnings
-
 import numpy as np
 from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
                    flatnonzero, conj, asarray, argsort, empty,
@@ -26,7 +24,6 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
 from scipy._lib._util import _asarray_validated
 from ._misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 
 _I = np.array(1j, dtype='F')
@@ -283,11 +280,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
-@_deprecate_positional_args(version="1.14.0")
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
-         overwrite_b=False, turbo=_NoValue, eigvals=_NoValue, type=1,
-         check_finite=True, subset_by_index=None, subset_by_value=None,
-         driver=None):
+         overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
+         subset_by_value=None, driver=None):
     """
     Solve a standard or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
@@ -355,16 +350,6 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
-    turbo : bool, optional, deprecated
-            .. deprecated:: 1.5.0
-                `eigh` keyword argument `turbo` is deprecated in favour of
-                ``driver=gvd`` keyword instead and will be removed in SciPy
-                1.14.0.
-    eigvals : tuple (lo, hi), optional, deprecated
-            .. deprecated:: 1.5.0
-                `eigh` keyword argument `eigvals` is deprecated in favour of
-                `subset_by_index` keyword instead and will be removed in SciPy
-                1.14.0.
 
     Returns
     -------
@@ -460,17 +445,6 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     (5, 1)
 
     """
-    if turbo is not _NoValue:
-        warnings.warn("Keyword argument 'turbo' is deprecated in favour of '"
-                      "driver=gvd' keyword instead and will be removed in "
-                      "SciPy 1.14.0.",
-                      DeprecationWarning, stacklevel=2)
-    if eigvals is not _NoValue:
-        warnings.warn("Keyword argument 'eigvals' is deprecated in favour of "
-                      "'subset_by_index' keyword instead and will be removed "
-                      "in SciPy 1.14.0.",
-                      DeprecationWarning, stacklevel=2)
-
     # set lower
     uplo = 'L' if lower else 'U'
     # Set job for Fortran routines
@@ -516,18 +490,11 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         cplx = True if iscomplexobj(b1) else (cplx or False)
         drv_args.update({'overwrite_b': overwrite_b, 'itype': type})
 
-    # backwards-compatibility handling
-    subset_by_index = subset_by_index if (eigvals in (None, _NoValue)) else eigvals
-
     subset = (subset_by_index is not None) or (subset_by_value is not None)
 
     # Both subsets can't be given
     if subset_by_index and subset_by_value:
         raise ValueError('Either index or value subset can be requested.')
-
-    # Take turbo into account if all conditions are met otherwise ignore
-    if turbo not in (None, _NoValue) and b is not None:
-        driver = 'gvx' if subset else 'gvd'
 
     # Check indices if given
     if subset_by_index:
@@ -943,11 +910,9 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
                homogeneous_eigvals=homogeneous_eigvals)
 
 
-@_deprecate_positional_args(version="1.14.0")
 def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
-             overwrite_b=False, turbo=_NoValue, eigvals=_NoValue, type=1,
-             check_finite=True, subset_by_index=None, subset_by_value=None,
-             driver=None):
+             overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
+             subset_by_value=None, driver=None):
     """
     Solves a standard or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
@@ -1010,15 +975,6 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
         generalized (where b is not None) problems. See the Notes section of
         `scipy.linalg.eigh`.
-    turbo : bool, optional, deprecated
-        .. deprecated:: 1.5.0
-            'eigvalsh' keyword argument `turbo` is deprecated in favor of
-            ``driver=gvd`` option and will be removed in SciPy 1.14.0.
-
-    eigvals : tuple (lo, hi), optional
-        .. deprecated:: 1.5.0
-            'eigvalsh' keyword argument `eigvals` is deprecated in favor of
-            `subset_by_index` option and will be removed in SciPy 1.14.0.
 
     Returns
     -------
@@ -1066,11 +1022,10 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
     array([-3.74637491, -0.76263923,  6.08502336, 12.42399079])
 
     """
-    return eigh(a, b=b, lower=lower, eigvals_only=True,
-                overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, eigvals=eigvals, type=type,
-                check_finite=check_finite, subset_by_index=subset_by_index,
-                subset_by_value=subset_by_value, driver=driver)
+    return eigh(a, b=b, lower=lower, eigvals_only=True, overwrite_a=overwrite_a,
+                overwrite_b=overwrite_b, type=type, check_finite=check_finite,
+                subset_by_index=subset_by_index, subset_by_value=subset_by_value,
+                driver=driver)
 
 
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -844,31 +844,15 @@ class TestEigh:
         # Both value and index subsets requested
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_value=[1, 2], subset_by_index=[2, 4])
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'eigvals")
-            assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
-                          subset_by_value=[1, 2], eigvals=[2, 4])
         # Invalid upper index spec
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_index=[0, 4])
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'eigvals")
-            assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
-                          eigvals=[0, 4])
         # Invalid lower index
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_index=[-2, 2])
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'eigvals")
-            assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
-                          eigvals=[-2, 2])
         # Invalid index spec #2
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_index=[2, 0])
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'eigvals")
-            assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
-                          subset_by_index=[2, 0])
         # Invalid value spec
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_value=[2, 0])
@@ -963,38 +947,6 @@ class TestEigh:
         w3 = eigvalsh(b, subset_by_value=[1, 1.4])
         assert_equal(len(w3), 2)
         assert_allclose(w3, np.array([1.2, 1.3]))
-
-    @pytest.mark.parametrize("method", [eigh, eigvalsh])
-    def test_deprecation_warnings(self, method):
-        with pytest.warns(DeprecationWarning,
-                          match="Keyword argument 'turbo'"):
-            method(np.zeros((2, 2)), turbo=True)
-        with pytest.warns(DeprecationWarning,
-                          match="Keyword argument 'eigvals'"):
-            method(np.zeros((2, 2)), eigvals=[0, 1])
-        with pytest.deprecated_call(match="use keyword arguments"):
-            method(np.zeros((2,2)), np.eye(2, 2), True)
-
-    def test_deprecation_results(self):
-        a = _random_hermitian_matrix(3)
-        b = _random_hermitian_matrix(3, posdef=True)
-
-        # check turbo gives same result as driver='gvd'
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'turbo'")
-            w_dep, v_dep = eigh(a, b, turbo=True)
-        w, v = eigh(a, b, driver='gvd')
-        assert_allclose(w_dep, w)
-        assert_allclose(v_dep, v)
-
-        # check eigvals gives the same result as subset_by_index
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "Keyword argument 'eigvals'")
-            w_dep, v_dep = eigh(a, eigvals=[0, 1])
-        w, v = eigh(a, subset_by_index=[0, 1])
-        assert_allclose(w_dep, w)
-        assert_allclose(v_dep, v)
-
 
     @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt):


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#15765
follow up to https://github.com/scipy/scipy/pull/16355 and https://github.com/scipy/scipy/pull/18946
#### What does this implement/fix?
<!--Please explain your changes.-->
Scheduled for this release
#### Additional information
<!--Any additional information you think is important.-->
