### PR TITLE
BUG: Fix invalid default bracket selection in _bracket_minimum

### DIFF
--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -435,13 +435,13 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     if xl0_not_supplied:
         xl0 = xl0.copy()
         cond = ~np.isinf(xmin) & (xl0 < xmin)
-        xl0[cond] = (
+        xl0[cond] = xm0[cond] - (
             xm0[cond] - xmin[cond]
         ) / np.array(16, dtype=xl0.dtype)
     if xr0_not_supplied:
         xr0 = xr0.copy()
         cond = ~np.isinf(xmax) & (xmax < xr0)
-        xr0[cond] = (
+        xr0[cond] = xm0[cond] + (
             xmax[cond] - xm0[cond]
         ) / np.array(16, dtype=xr0.dtype)
 

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -397,14 +397,17 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     xmin = -np.inf if xmin is None else xmin
     xmax = np.inf if xmax is None else xmax
 
+    # If xl0 (xr0) is not supplied, fill with a dummy value for the sake
+    # of broadcasting. We need to wait until xmin (xmax) has been validated
+    # to compute the default values.
     xl0_not_supplied = False
     if xl0 is None:
-        xl0 = xm0 - 0.5
+        xl0 = np.nan
         xl0_not_supplied = True
 
     xr0_not_supplied = False
     if xr0 is None:
-        xr0 = xm0 + 0.5
+        xr0 = np.nan
         xr0_not_supplied = True
 
     factor = 2.0 if factor is None else factor
@@ -429,21 +432,13 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     if not np.all(factor > 1):
         raise ValueError('All elements of `factor` must be greater than 1.')
 
-    # Default choices for xl or xr might have exceeded xmin or xmax. Adjust
-    # to make sure this doesn't happen. We replace with copies because xl, and xr
-    # are read-only views produced by broadcast_arrays.
+    # Calculate default values of xl0 and/or xr0 if they have not been supplied
+    # by the user. We need to be careful to ensure xl0 and xr0 are not outside
+    # of (xmin, xmax).
     if xl0_not_supplied:
-        xl0 = xl0.copy()
-        cond = ~np.isinf(xmin) & (xl0 < xmin)
-        xl0[cond] = xm0[cond] - (
-            xm0[cond] - xmin[cond]
-        ) / np.array(16, dtype=xl0.dtype)
+        xl0 = xm0 - np.minimum((xm0 - xmin)/16, 0.5)
     if xr0_not_supplied:
-        xr0 = xr0.copy()
-        cond = ~np.isinf(xmax) & (xmax < xr0)
-        xr0[cond] = xm0[cond] + (
-            xmax[cond] - xm0[cond]
-        ) / np.array(16, dtype=xr0.dtype)
+        xr0 = xm0 + np.minimum((xmax - xm0)/16, 0.5)
 
     maxiter = np.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -778,3 +778,29 @@ class TestBracketMinimum:
             [result.fl, result.fm, result.fr],
             [f(xl0, *args), f(xm0, *args), f(xr0, *args)],
         )
+
+    def test_gh_20562_left(self):
+        # Regression test for https://github.com/scipy/scipy/issues/20562
+        # minimum of f in [xmin, xmax] is at xmin.
+        xmin, xmax = 0.21933608, 1.39713606
+
+        def f(x):
+            log_a, log_b = np.log([xmin, xmax])
+            return -((log_b - log_a)*x)**-1
+
+        result = _bracket_minimum(f, 0.5535723499480897, xmin=xmin, xmax=xmax)
+        assert not result.success
+        assert xmin == result.xl
+
+    def test_gh_20562_right(self):
+        # Regression test for https://github.com/scipy/scipy/issues/20562
+        # minimum of f in [xmin, xmax] is at xmax.
+        xmin, xmax = -1.39713606, -0.21933608,
+
+        def f(x):
+            log_a, log_b = np.log([-xmax, -xmin])
+            return ((log_b - log_a)*x)**-1
+
+        result = _bracket_minimum(f, -0.5535723499480897, xmin=xmin, xmax=xmax)
+        assert not result.success
+        assert xmax == result.xr


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-20562

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes invalid default bracket selection for the private function [scipy.optimize._bracket_minimum](https://github.com/scipy/scipy/blob/d55cb95282b5cfab381e373d3c127630c7e915a0/scipy/optimize/_bracket.py#L465), which provides vectorized initial bracket finding for bracketing scalar minimization algorithms. For the initial bracket, users must specify at least the midpoint of the bracket `xm0`. Default values are then chosen for `xl0` and `xr0` if values are not supplied by the user. If the region in which a minimum is sought is bounded on the left and/or right by passing `xmin` and/or `xmax` respectively, then the default choice for the endpoints must fall within the boundaries. I had made a careless mistake in how these default endpoints are chosen, which made it so they can still fall outside of the boundaries.
