### PR TITLE
DEP: linalg: remove cond / rcond kwargs from linalg.pinv and switch to kwarg-only

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -14,7 +14,6 @@ from ._decomp import _asarray_validated
 from . import _decomp, _decomp_svd
 from ._solve_toeplitz import levinson
 from ._cythonized_array_utils import find_det_from_lu
-from scipy._lib.deprecation import _NoValue, _deprecate_positional_args
 
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
            'solve_toeplitz', 'solve_circulant', 'inv', 'det', 'lstsq',
@@ -1345,9 +1344,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 lstsq.default_lapack_driver = 'gelsd'
 
 
-@_deprecate_positional_args(version="1.14")
-def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
-         cond=_NoValue, rcond=_NoValue):
+def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
@@ -1381,20 +1378,6 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
-    cond, rcond : float, optional
-        In older versions, these values were meant to be used as ``atol`` with
-        ``rtol=0``. If both were given ``rcond`` overwrote ``cond`` and hence
-        the code was not correct. Thus using these are strongly discouraged and
-        the tolerances above are recommended instead. In fact, if provided,
-        atol, rtol takes precedence over these keywords.
-
-        .. deprecated:: 1.7.0
-            Deprecated in favor of ``rtol`` and ``atol`` parameters above and
-            will be removed in SciPy 1.14.0.
-
-        .. versionchanged:: 1.3.0
-            Previously the default cutoff value was just ``eps*f`` where ``f``
-            was ``1e3`` for single precision and ``1e6`` for double precision.
 
     Returns
     -------
@@ -1464,17 +1447,6 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True,
     u, s, vh = _decomp_svd.svd(a, full_matrices=False, check_finite=False)
     t = u.dtype.char.lower()
     maxS = np.max(s, initial=0.)
-
-    if rcond is not _NoValue or cond is not _NoValue:
-        warn('Use of the "cond" and "rcond" keywords are deprecated and '
-             'will be removed in SciPy 1.14.0. Use "atol" and '
-             '"rtol" keywords instead', DeprecationWarning, stacklevel=2)
-
-    # backwards compatible only atol and rtol are both missing
-    if ((rcond not in (_NoValue, None) or cond not in (_NoValue, None))
-            and (atol is None) and (rtol is None)):
-        atol = rcond if rcond not in (_NoValue, None) else cond
-        rtol = 0.
 
     atol = 0. if atol is None else atol
     rtol = max(a.shape) * np.finfo(t).eps if (rtol is None) else rtol

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -20,7 +20,6 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinvh, norm,
 from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory, IS_MUSL
 from scipy.linalg.blas import HAS_ILP64
-from scipy._lib.deprecation import _NoValue
 
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
@@ -1534,21 +1533,6 @@ class TestPinv:
         adiff2 = a_m @ a_p @ a_m - a_m
         assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
         assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
-
-    @pytest.mark.parametrize("cond", [1, None, _NoValue])
-    @pytest.mark.parametrize("rcond", [1, None, _NoValue])
-    def test_cond_rcond_deprecation(self, cond, rcond):
-        if cond is _NoValue and rcond is _NoValue:
-            # the defaults if cond/rcond aren't set -> no warning
-            pinv(np.ones((2,2)), cond=cond, rcond=rcond)
-        else:
-            # at least one of cond/rcond has a user-supplied value -> warn
-            with pytest.deprecated_call(match='"cond" and "rcond"'):
-                pinv(np.ones((2,2)), cond=cond, rcond=rcond)
-
-    def test_positional_deprecation(self):
-        with pytest.deprecated_call(match="use keyword arguments"):
-            pinv(np.ones((2,2)), 0., 1e-10)
 
     @pytest.mark.parametrize('dt', [float, np.float32, complex, np.complex64])
     def test_empty(self, dt):


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#15765
follow-up of https://github.com/scipy/scipy/pull/18812 and https://github.com/scipy/scipy/pull/18935
#### What does this implement/fix?
<!--Please explain your changes.-->
Scheduled for this release
#### Additional information
<!--Any additional information you think is important.-->
