### PR TITLE
REV: 1.13.x: revert changes to f2py and tempita handling in meson.build files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -131,7 +131,7 @@ if not cc.links('', name: '-Wl,--version-script', args: ['-shared', version_link
 endif
 
 generate_f2pymod = files('tools/generate_f2pymod.py')
-tempita = find_program('scipy/_build_utils/tempita.py')
+tempita = files('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')
 if use_pythran

--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ if not cc.links('', name: '-Wl,--version-script', args: ['-shared', version_link
   version_link_args = []
 endif
 
-generate_f2pymod = find_program('tools/generate_f2pymod.py')
+generate_f2pymod = files('tools/generate_f2pymod.py')
 tempita = find_program('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')

--- a/scipy/_build_utils/tempita.py
+++ b/scipy/_build_utils/tempita.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import sys
 import os
 import argparse
@@ -31,8 +30,6 @@ def main():
                         help="Path to the input file")
     parser.add_argument("-o", "--outdir", type=str,
                         help="Path to the output directory")
-    parser.add_argument("--outfile", type=str,
-                        help="Path to the output file (use either this or outdir)")
     parser.add_argument("-i", "--ignore", type=str,
                         help="An ignored input - may be useful to add a "
                              "dependency between custom targets")
@@ -41,15 +38,12 @@ def main():
     if not args.infile.endswith('.in'):
         raise ValueError(f"Unexpected extension: {args.infile}")
 
-    if not (args.outdir or args.outfile):
-        raise ValueError("Missing `--outdir` or `--outfile` argument to tempita.py")
+    if not args.outdir:
+        raise ValueError("Missing `--outdir` argument to tempita.py")
 
-    if args.outfile:
-        outfile = args.outfile
-    else:
-        outdir_abs = os.path.join(os.getcwd(), args.outdir)
-        outfile = os.path.join(outdir_abs,
-                               os.path.splitext(os.path.split(args.infile)[1])[0])
+    outdir_abs = os.path.join(os.getcwd(), args.outdir)
+    outfile = os.path.join(outdir_abs,
+                           os.path.splitext(os.path.split(args.infile)[1])[0])
 
     process_tempita(args.infile, outfile)
 

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -126,7 +126,7 @@ py3.extension_module('_odepack',
 vode_module = custom_target('vode_module',
   output: ['_vode-f2pywrappers.f', '_vodemodule.c'],
   input: 'vode.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_vode',
@@ -143,7 +143,7 @@ py3.extension_module('_vode',
 lsoda_module = custom_target('lsoda_module',
   output: ['_lsoda-f2pywrappers.f', '_lsodamodule.c'],
   input: 'lsoda.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_lsoda',
@@ -160,7 +160,7 @@ py3.extension_module('_lsoda',
 _dop_module = custom_target('_dop_module',
   output: ['_dop-f2pywrappers.f', '_dopmodule.c'],
   input: 'dop.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_dop',
@@ -184,7 +184,7 @@ py3.extension_module('_test_multivariate',
 _test_odeint_banded_module = custom_target('_test_odeint_banded_module',
   output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
   input: 'tests/banded5x5.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_test_odeint_banded',

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -145,7 +145,7 @@ py3.extension_module('_fitpack',
 dfitpack_module = custom_target('dfitpack_module',
   output: ['dfitpack-f2pywrappers.f', 'dfitpackmodule.c'],
   input: 'src/fitpack.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # TODO: Add flags for 64 bit ints

--- a/scipy/io/meson.build
+++ b/scipy/io/meson.build
@@ -1,7 +1,7 @@
 _test_fortran_module = custom_target('_test_fortran_module',
   output: ['_test_fortranmodule.c'],
   input: '_test_fortran.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_test_fortran',

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -60,7 +60,7 @@ linalg_cython_gen = generator(cython,
 fblas_module = custom_target('fblas_module',
   output: ['_fblasmodule.c'],
   input: 'fblas.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
@@ -80,7 +80,7 @@ py3.extension_module('_fblas',
 flapack_module = custom_target('flapack_module',
   output: ['_flapackmodule.c'],
   input: 'flapack.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # Note that -Wno-empty-body is Clang-specific and comes from `callstatement`s
@@ -101,7 +101,7 @@ py3.extension_module('_flapack',
 interpolative_module = custom_target('interpolative_module',
   output: '_interpolativemodule.c',
   input: 'interpolative.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 # id_dist contains a copy of FFTPACK, which has type mismatch warnings

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -218,7 +218,7 @@ py3.extension_module('_decomp_lu_cython',
 _decomp_update_pyx = custom_target('_decomp_update',
   output: '_decomp_update.pyx',
   input: '_decomp_update.pyx.in',
-  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_decomp_update',
@@ -234,7 +234,7 @@ py3.extension_module('_decomp_update',
 _matfuncs_expm_pyx = custom_target('_matfuncs_expm',
   output: '_matfuncs_expm.pyx',
   input: '_matfuncs_expm.pyx.in',
-  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_matfuncs_expm',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -275,12 +275,6 @@ if use_pythran
   )
 endif
 
-# Used for templated C code (not Cython code since Cython is path-dependent)
-tempita_gen = generator(tempita,
-  arguments : ['@INPUT@', '--outfile', '@OUTPUT@'],
-  output : '@BASENAME@',
-)
-
 # Check if compiler flags are supported. This is necessary to ensure that SciPy
 # can be built with any supported compiler. We need so many warning flags
 # because we want to be able to build with `-Werror` in CI; that ensures that

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -8,7 +8,7 @@ _zeros_pyx = custom_target('_zeros_pyx',
   output: '_zeros.pyx',
   input: '_zeros.pyx.in',
   command: [
-    tempita, '@INPUT@', '-o', '@OUTDIR@',
+    py3, tempita, '@INPUT@', '-o', '@OUTDIR@',
     '--ignore', _dummy_init_cyoptimize[0]
   ]
 )

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -92,7 +92,7 @@ py3.extension_module('_zeros',
 lbfgsb_module = custom_target('lbfgsb_module',
   output: ['_lbfgsb-f2pywrappers.f', '_lbfgsbmodule.c'],
   input: 'lbfgsb_src/lbfgsb.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_lbfgsb',
@@ -126,7 +126,7 @@ py3.extension_module('_moduleTNC',
 cobyla_module = custom_target('cobyla_module',
   output: ['_cobylamodule.c'],
   input: 'cobyla/cobyla.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_cobyla',
@@ -143,7 +143,7 @@ py3.extension_module('_cobyla',
 minpack2_module = custom_target('minpack2_module',
   output: ['_minpack2module.c'],
   input: 'minpack2/minpack2.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_minpack2',
@@ -160,7 +160,7 @@ py3.extension_module('_minpack2',
 slsqp_module = custom_target('slsqp_module',
   output: ['_slsqpmodule.c'],
   input: 'slsqp/slsqp.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_slsqp',

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -1,10 +1,23 @@
+correlate_nd_c = custom_target('_correlate_nd',
+  output: '_correlate_nd.c',
+  input: '_correlate_nd.c.in',
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+)
+
+lfilter_c = custom_target('_lfilter',
+  output: '_lfilter.c',
+  input: '_lfilter.c.in',
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+)
+
 py3.extension_module('_sigtools',
   [
-    '_firfilter.c',
     '_sigtoolsmodule.c',
+    '_firfilter.c',
+    '_sigtools.h',
     '_medianfilter.c',
-    tempita_gen.process('_correlate_nd.c.in'),
-    tempita_gen.process('_lfilter.c.in'),
+    lfilter_c,
+    correlate_nd_c
   ],
   dependencies: np_dep,
   link_args: version_link_args,
@@ -68,11 +81,14 @@ foreach pyx_file: pyx_files
   )
 endforeach
 
+bspline_util = custom_target('_bspline_util',
+  output: '_bspline_util.c',
+  input: '_bspline_util.c.in',
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+)
+
 py3.extension_module('_spline',
-  [
-    '_splinemodule.c',
-    tempita_gen.process('_bspline_util.c.in'),
-  ],
+  ['_splinemodule.c', bspline_util],
   dependencies: np_dep,
   link_args: version_link_args,
   install: true,

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -95,7 +95,7 @@ arpack_lib = static_library('arpack_lib',
 arpack_module = custom_target('arpack_module',
   output: ['_arpackmodule.c', '_arpack-f2pywrappers.f'],
   input: 'arpack.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 _arpack = py3.extension_module('_arpack',

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -99,7 +99,7 @@ foreach ele: elements
   propack_module = custom_target('propack_module' + ele[0],
     output: [ele[0] + '-f2pywrappers.f', ele[0] + 'module.c'],
     input: ele[2],
-    command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+    command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
   )
 
   propacklib = py3.extension_module(ele[0],

--- a/scipy/sparse/meson.build
+++ b/scipy/sparse/meson.build
@@ -1,7 +1,7 @@
 _csparsetools_pyx = custom_target('_csparsetools_pyx',
   output: '_csparsetools.pyx',
   input: '_csparsetools.pyx.in',
-  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_csparsetools',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -35,7 +35,7 @@ py3.extension_module('_ansari_swilk_statistics',
 mvn_module = custom_target('mvn_module',
   output: ['_mvn-f2pywrappers.f', '_mvnmodule.c'],
   input: 'mvn.pyf',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
 py3.extension_module('_mvn',

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Process f2py template files (`filename.pyf.src` -> `filename.pyf`)
 


### PR DESCRIPTION
Reverts the last two commits of gh-20121. Those were not robust against Meson picking up a different Python interpreter for which `numpy` and/or `cython` were not installed. This is rare, but can happen when a distro builds for a non-default version of Python _and_ disables build isolation.

Addresses the issue reported in gh-20535 in the `1.13.x` branch. Leaving the issue open because I'd like a different change in `main`. In a release branch a straight revert seems best though, since we had no issues opened related to this for 1.12.x.