### PR TITLE
ENH: spatial: faster Chebyshev distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1077,7 +1077,7 @@ def chebyshev(u, v, w=None):
         if has_weight.sum() < w.size:
             u = u[has_weight]
             v = v[has_weight]
-    return max(abs(u - v))
+    return np.max(abs(u - v))
 
 
 def braycurtis(u, v, w=None):


### PR DESCRIPTION
ENH: spatial: faster Chebychev distance
Implemented issue #20561

Replaced `max` by `np.max` at the end of `chebyshev`.
The `np.max` function is faster than `max` for large arrays.
For (very) short arrays (len < 40), `max` is faster than `np.max` but the times of computation are very short. 
For very short arrays, if the parameter `w` (weights) is specified, the times of computation of `max` and `np.max` are nearly comparable.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See #20561.

#### What does this implement/fix?
Faster computation of the Chebyshev distance for large arrays.

#### Additional information
Two additional benchmarks.
In the two benchmarks, we compare the times of computation of three implementations of `chebyshev`. The only difference between the three functions is that:
- `Cheb max` returns `max(abs(u - v))`                  <-- scipy right now 
- `Cheb np.max` returns `np.max(abs(u - v))`      <-- proposition
- `Cheb cond` returns `max(abs(u - v)) if len(u) < 40 else np.max(abs(u - v))`

Each point on the plot quantifies the time taken by 5 computations of `chebyshev`.
Entries (`u`, `v` -- and `w` for the "weight" plot) are obtained with `np.random.random`.
`no weights` means that `w` was set to None, `weights` means that an array `w` (`np.random.random`) was given.

`Cheb cond` provides a good trade-off, but the value used (here `40`) may depend on the machine used.

![scipy11](https://github.com/scipy/scipy/assets/125293676/7f4432b3-2863-4a52-a9ee-c2cffc04a14d)
![scipy12](https://github.com/scipy/scipy/assets/125293676/2db60744-cebe-4d24-9b9a-9b70c707df10)
