### PR TITLE
BUG: Fix error with 180 degree rotation in Rotation.align_vectors() with an infinite weight

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3491,8 +3491,8 @@ cdef class Rotation:
                 # At 180 degrees, cross = [0, 0, 0] so we need to flip the
                 # vectors (along an arbitrary orthogonal axis of rotation)
                 if cross_norm == 0:
-                    vec_non_parallel = np.roll(a_pri, 1) + np.array([1, 0, 0])
-                    vec_orthogonal = np.cross(a_pri, vec_non_parallel)
+                    vec_non_parallel = np.roll(a_pri[0], 1) + np.array([1, 0, 0])
+                    vec_orthogonal = np.cross(a_pri[0], vec_non_parallel)
                     r_flip = vec_orthogonal / _norm3(vec_orthogonal) * np.pi
                     R_flip = cls.from_rotvec(r_flip)
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1470,19 +1470,27 @@ def test_align_vectors_parallel():
 def test_align_vectors_antiparallel():
     # Test exact 180 deg rotation
     atol = 1e-12
-    a = [[0, 1, 0], [-1, 0, 0]]
-    b = [[0, -1, 0], [-1, 0, 0]]
-    R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
-    assert_allclose(R.magnitude(), np.pi, atol=atol)
+    as_to_test = np.array([[[1, 0, 0], [0, 1, 0]],
+                           [[0, 1, 0], [1, 0, 0]],
+                           [[0, 0, 1], [0, 1, 0]]])
+    bs_to_test = [[-a[0], a[1]] for a in as_to_test]
+    for a, b in zip(as_to_test, bs_to_test):
+        R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+        assert_allclose(R.magnitude(), np.pi, atol=atol)
+        assert_allclose(R.apply(b[0]), a[0], atol=atol)
 
     # Test exact rotations near 180 deg
-    as_to_test = [a,
-                  [[0, 1,  1e-4], [-1, 0, 0]],
-                  [[0, 1, -1e-4], [-1, 0, 0]]]
+    Rs = Rotation.random(100, random_state=0)
+    dRs = Rotation.from_rotvec(Rs.as_rotvec()*1e-4)  # scale down to small angle
+    a = [[ 1, 0, 0], [0, 1, 0]]
+    b = [[-1, 0, 0], [0, 1, 0]]
+    as_to_test = []
+    for dR in dRs:
+        as_to_test.append([dR.apply(a[0]), a[1]])
     for a in as_to_test:
         R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
         R2, _ = Rotation.align_vectors(a, b, weights=[1e10, 1])
-        assert R.approx_equal(R2, atol=atol)
+        assert_allclose(R.as_matrix(), R2.as_matrix(), atol=atol)
 
 
 def test_align_vectors_primary_only():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1467,6 +1467,24 @@ def test_align_vectors_parallel():
     assert_allclose(R.apply(b[0]), a[0], atol=atol)
 
 
+def test_align_vectors_antiparallel():
+    # Test exact 180 deg rotation
+    atol = 1e-12
+    a = [[0, 1, 0], [-1, 0, 0]]
+    b = [[0, -1, 0], [-1, 0, 0]]
+    R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert np.isclose(R.magnitude(), np.pi, atol=atol)
+
+    # Test exact rotations near 180 deg
+    as_to_test = [a,
+                  [[0, 1,  1e-4], [-1, 0, 0]],
+                  [[0, 1, -1e-4], [-1, 0, 0]]]
+    for a in as_to_test:
+        R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+        R2, _ = Rotation.align_vectors(a, b, weights=[1e10, 1])
+        assert R.approx_equal(R2, atol=atol)
+
+
 def test_align_vectors_primary_only():
     atol = 1e-12
     mats_a = Rotation.random(100, random_state=0).as_matrix()

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1473,7 +1473,7 @@ def test_align_vectors_antiparallel():
     a = [[0, 1, 0], [-1, 0, 0]]
     b = [[0, -1, 0], [-1, 0, 0]]
     R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
-    assert np.isclose(R.magnitude(), np.pi, atol=atol)
+    assert_allclose(R.magnitude(), np.pi, atol=atol)
 
     # Test exact rotations near 180 deg
     as_to_test = [a,


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/20555

#### What does this implement/fix?
There are two related issues with exact rotations near 180 degrees:

* A perfect 180 deg rotation results in r = cross = [0, 0, 0], and is thus cast to a 0 degree rotation (critical defect)
* Numerical instabilities near a 180 deg rotation (non-critical defect)

This fixes both. For the numerical instability part, near 180 degrees for the test case I'm seeing a pointing error of 2e-6 drop to 5e-9 (and now matches the non-exact code path to 1e-11). Tried to make the code path as compact as possible, but improvements welcome!