### PR TITLE
BLD/CI: use homebrew gfortran during wheel build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
           echo github.ref ${{ github.ref }}
 
   build_wheels:
-    name: Wheel, ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+    name: Whl, ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
       ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
       ${{ matrix.buildplat[4] }}
     needs: get_commit_message
@@ -118,19 +118,20 @@ jobs:
       - name: Setup macOS
         if: startsWith( matrix.buildplat[0], 'macos-' )
         run: |
+          # Use preinstalled gfortran for builds
+          ln -s $(which gfortran-13) gfortran
+          export PATH=$PWD:$PATH
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
+
           if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
             echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
-            # Always use preinstalled gfortran for Accelerate builds
-            ln -s $(which gfortran-13) gfortran
-            export PATH=$PWD:$PATH
-            echo "PATH=$PATH" >> "$GITHUB_ENV"
-            LIB_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
           fi
-          # Add libraries installed by cibw_before_build_macos.sh to path
+          # Add openblas libraries installed by cibw_before_build_macos.sh to path
           if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
-            LIB_PATH=$LIB_PATH:/opt/arm64-builds/lib
+            LIB_PATH=/opt/arm64-builds/lib
           else
-            LIB_PATH=$LIB_PATH:/usr/local/lib
+            LIB_PATH=/usr/local/lib
           fi
           if [[ ${{ matrix.buildplat[4] }} == '10.9' ]]; then
             # Newest version of Xcode that supports macOS 10.9
@@ -140,12 +141,9 @@ jobs:
           fi
           CIBW="sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app"
           echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
-          # setting SDKROOT necessary when using the gfortran compiler
-          # installed in cibw_before_build_macos.sh
           sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app
           CIBW="MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[4] }}\
             LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH\
-            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
             PIP_PRE=1\
             PIP_NO_BUILD_ISOLATION=false\
             PKG_CONFIG_PATH=$LIB_PATH/pkgconfig\
@@ -153,7 +151,6 @@ jobs:
           echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
 
           echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
-          GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
           CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-listdeps {wheel} &&\
             DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-wheel --require-archs \
             {delocate_archs} -w {dest_dir} {wheel}"

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -17,36 +17,6 @@ if [[ $PLATFORM == "macosx-x86_64" ]]; then
   # copy over the OpenBLAS library stuff first
   cp -r $basedir/lib/* /usr/local/lib
   cp $basedir/include/* /usr/local/include
-
-  #GFORTRAN=$(type -p gfortran-9)
-  #sudo ln -s $GFORTRAN /usr/local/bin/gfortran
-  # same version of gfortran as the openblas-libs and scipy-wheel builds
-  curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-x86_64-native.tar.gz -o gfortran.tar.gz
-
-  GFORTRAN_SHA256=$(shasum -a 256 gfortran.tar.gz)
-  KNOWN_SHA256="981367dd0ad4335613e91bbee453d60b6669f5d7e976d18c7bdb7f1966f26ae4  gfortran.tar.gz"
-  if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-      echo sha256 mismatch
-      exit 1
-  fi
-
-  sudo mkdir -p /opt/
-  # places gfortran in /opt/gfortran-darwin-x86_64-native. There's then
-  # bin, lib, include, libexec underneath that.
-  sudo tar -xv -C /opt -f gfortran.tar.gz
-
-  # Link these into /usr/local so that there's no need to add rpath or -L
-  for f in libgfortran.dylib libgfortran.5.dylib libgcc_s.1.dylib libgcc_s.1.1.dylib libquadmath.dylib libquadmath.0.dylib; do
-    ln -sf /opt/gfortran-darwin-x86_64-native/lib/$f /usr/local/lib/$f
-  done
-  ln -sf /opt/gfortran-darwin-x86_64-native/bin/gfortran /usr/local/bin/gfortran
-
-  # Set SDKROOT env variable if not set
-  # This step is required whenever the gfortran compilers sourced from
-  # conda-forge (built by isuru fernando) are used outside of a conda-forge
-  # environment (so it mirrors what is done in the conda-forge compiler
-  # activation scripts)
-  export SDKROOT=${SDKROOT:-$(xcrun --show-sdk-path)}
 fi
 
 if [[ $PLATFORM == "macosx-arm64" ]]; then
@@ -63,17 +33,4 @@ if [[ $PLATFORM == "macosx-arm64" ]]; then
 
   # we want to force a dynamic linking
   sudo rm /opt/arm64-builds/lib/*.a
-
-  curl -L https://github.com/fxcoudert/gfortran-for-macOS/releases/download/12.1-monterey/gfortran-ARM-12.1-Monterey.dmg -o gfortran.dmg
-  GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-  KNOWN_SHA256="e2e32f491303a00092921baebac7ffb7ae98de4ca82ebbe9e6a866dd8501acdf  gfortran.dmg"
-
-  if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-      echo sha256 mismatch
-      exit 1
-  fi
-
-  hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-  sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-  type -p gfortran
 fi


### PR DESCRIPTION
Switches solely to using homebrew gfortran during macos wheel building (x86_64/arm64/accelerate/openblas).

Has the advantage of:

- comes pre-installed on GHA runners
- easily obtainable through package manager (making build easier to reproduce locally)
- I would expect homebrew gfortran to be well curated
- cleans up the cibw_before_build_macos script

Has the disadvantage of:

- GHA runners will update from time to time, possibly bumping version

This is a follow up to #20510