### PR TITLE
MAINT: optimize.linprog: fix bug when integrality is a list of all zeros

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -625,6 +625,8 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         warn(warning_message, OptimizeWarning, stacklevel=2)
     elif np.any(integrality):
         integrality = np.broadcast_to(integrality, np.shape(c))
+    else:
+        integrality = None
 
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality)
     lp, solver_options = _parse_linprog(lp, options, meth)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1703,6 +1703,21 @@ class LinprogCommonTests:
                           method=self.method, options=o)
         assert_allclose(res.fun, -8589934560)
 
+    def test_bug_20584(self):
+        """
+        Test that when integrality is a list of all zeros, linprog gives the
+        same result as when it is an array of all zeros / integrality=None
+        """
+        c = [1, 1]
+        A_ub = [[-1, 0]]
+        b_ub = [-2.5]
+        res1 = linprog(c, A_ub=A_ub, b_ub=b_ub, integrality=[0, 0])
+        res2 = linprog(c, A_ub=A_ub, b_ub=b_ub, integrality=np.asarray([0, 0]))
+        res3 = linprog(c, A_ub=A_ub, b_ub=b_ub, integrality=None)
+        assert_equal(res1.x, res2.x)
+        assert_equal(res1.x, res3.x)
+
+
 #########################
 # Method-specific Tests #
 #########################


### PR DESCRIPTION
#### Reference issue
Closes gh-20584

#### What does this implement/fix?
This fixes an edge cases in `linprog` in which a list of all zeros passed to `integrality` is never converted into either an array or `None`. HiGHS is happy with it, but a post-solve check fails. Now, if there are no nonzeros in `integrality`, it is converted to `None`.
