### PR TITLE
MAINT: lint: temporarily disable UP031

### DIFF
--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -12,7 +12,8 @@ target-version = "py39"
 # `B028` added in gh-19623.
 # `ICN001` added in gh-20382 to enforce common conventions for imports
 select = ["E", "F", "PGH004", "UP", "B028", "ICN001"]
-ignore = ["E741"]
+# UP031 should be enabled once someone fixes the errors.
+ignore = ["E741", "UP031"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
New failures are showing up. At a guess, the detection was fixed / improved in the latest ruff version. These should be fixed, but I am a bit time-poor, and this will help keep everyone sane while we get a few PRs in.

I'll open a follow-up issue with the failures that I see.