### PR TITLE
BUG: spatial.cKDTree: do not slide the median

### DIFF
--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -121,24 +121,24 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
             split = (maxval + minval) / 2;
 
             p = partition_pivot(indices + start_idx, indices + end_idx, split);
-        }
 
-        /* slide midpoint if necessary */
-        if (p == start_idx) {
-            /* no points less than split */
-            auto min_idx = *std::min_element(
-                indices + start_idx, indices + end_idx, index_compare);
-            split = std::nextafter(data[min_idx * m + d], HUGE_VAL);
-            p = partition_pivot(indices + start_idx, indices + end_idx, split);
+            /* slide midpoint if necessary */
+            if (p == start_idx) {
+                /* no points less than split */
+                auto min_idx = *std::min_element(
+                    indices + start_idx, indices + end_idx, index_compare);
+                split = std::nextafter(data[min_idx * m + d], HUGE_VAL);
+                p = partition_pivot(indices + start_idx, indices + end_idx, split);
+            }
+            else if (p == end_idx) {
+                /* no points greater than split */
+                auto max_idx = *std::max_element(
+                    indices + start_idx, indices + end_idx, index_compare);
+                split = data[max_idx * m + d];
+                p = partition_pivot(indices + start_idx, indices + end_idx, split);
+            }
         }
-        else if (p == end_idx) {
-            /* no points greater than split */
-            auto max_idx = *std::max_element(
-                indices + start_idx, indices + end_idx, index_compare);
-            split = data[max_idx * m + d];
-            p = partition_pivot(indices + start_idx, indices + end_idx, split);
-        }
-
+          
         if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
             // All children are equal in this dimension, try again with new bounds
             assert(!_compact);

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -204,7 +204,7 @@ int build_ckdtree(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
 {
     std::vector<bool> taboo(self->m);
     for (intptr_t i=0; i<self->m; ++i) taboo[i] = false;
-    taboo_depth = 0;
+    intptr_t taboo_depth = 0;
       
     build(self, start_idx, end_idx, maxes, mins, _median, _compact, taboo, taboo_depth);
     return 0;

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -120,34 +120,34 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
             auto mid = node_indices + n_points / 2;
             std::nth_element(
                 node_indices, mid, node_indices + n_points, index_compare);
-
             split = data[*mid * m + d];
             p = partition_pivot(indices + start_idx, indices + end_idx, split);
         }
         else {
             /* split with the sliding midpoint rule */
             split = (maxval + minval) / 2;
-
-            p = partition_pivot(indices + start_idx, indices + end_idx, split);
-
-            /* slide midpoint if necessary */
-            if (p == start_idx) {
-                /* no points less than split */
-                auto min_idx = *std::min_element(
-                    indices + start_idx, indices + end_idx, index_compare);
-                split = std::nextafter(data[min_idx * m + d], std::numeric_limits<double>::max() );
-                p = partition_pivot(indices + start_idx, indices + end_idx, split);
-            }
-            else if (p == end_idx) {
-                /* no points greater than split */
-                auto max_idx = *std::max_element(
-                    indices + start_idx, indices + end_idx, index_compare);
-                split = std::nextafter(data[max_idx * m + d], std::numeric_limits<double>::lowest() );
-                p = partition_pivot(indices + start_idx, indices + end_idx, split);
-            }
+            p = partition_pivot(indices + start_idx, indices + end_idx, split);            
         }
-
-        if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
+        
+        // slide midpoint/pivot if necessary
+        // we might even need to do this for the median pivot to avoid infinite
+        // recursion          
+        if (p == start_idx) {
+            /* no points less than split */
+            auto min_idx = *std::min_element(
+                    indices + start_idx, indices + end_idx, index_compare);
+            split = std::nextafter(data[min_idx * m + d], std::numeric_limits<double>::max() );
+            p = partition_pivot(indices + start_idx, indices + end_idx, split);
+         }
+         else if (p == end_idx) {
+            /* no points greater than split */
+            auto max_idx = *std::max_element(
+                    indices + start_idx, indices + end_idx, index_compare);
+            split = std::nextafter(data[max_idx * m + d], std::numeric_limits<double>::lowest() );
+            p = partition_pivot(indices + start_idx, indices + end_idx, split);
+         }
+          
+         if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
             // All children are equal in this dimension, try again with 
             // this dimension tabooed
             assert(!_compact);

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -139,23 +139,6 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
                 p = partition_pivot(indices + start_idx, indices + end_idx, split);
             }
         }
-          
-        if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
-            // All children are equal in this dimension, try again with new bounds
-            assert(!_compact);
-            self->tree_buffer->pop_back();
-            std::vector<double> tmp_bounds(2 * m);
-            double* tmp_mins = &tmp_bounds[0];
-            std::copy_n(mins, m, tmp_mins);
-            double* tmp_maxes = &tmp_bounds[m];
-            std::copy_n(maxes, m, tmp_maxes);
-
-            const auto fixed_val = data[indices[start_idx]*m + d];
-            tmp_mins[d] = fixed_val;
-            tmp_maxes[d] = fixed_val;
-
-            return build(self, start_idx, end_idx, tmp_maxes, tmp_mins, _median, _compact);
-        }
 
         if (CKDTREE_LIKELY(_compact)) {
             _less = build(self, start_idx, p, maxes, mins, _median, _compact);

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -12,6 +12,7 @@
 #include <typeinfo>
 #include <stdexcept>
 #include <ios>
+#include <limits>
 
 #define tree_buffer_root(buf) (&(buf)[0][0])
 
@@ -114,7 +115,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
                 node_indices, mid, node_indices + n_points, index_compare);
 
             split = data[*mid * m + d];
-            p = partition_pivot(node_indices, mid, split);
+            p = partition_pivot(indices + start_idx, indices + end_idx, split);
         }
         else {
             /* split with the sliding midpoint rule */
@@ -127,14 +128,14 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
                 /* no points less than split */
                 auto min_idx = *std::min_element(
                     indices + start_idx, indices + end_idx, index_compare);
-                split = std::nextafter(data[min_idx * m + d], HUGE_VAL);
+                split = std::nextafter(data[min_idx * m + d], std::numeric_limits<double>::max() );
                 p = partition_pivot(indices + start_idx, indices + end_idx, split);
             }
             else if (p == end_idx) {
                 /* no points greater than split */
                 auto max_idx = *std::max_element(
                     indices + start_idx, indices + end_idx, index_compare);
-                split = data[max_idx * m + d];
+                split = std::nextafter(data[max_idx * m + d], std::numeric_limits<double>::lowest() );
                 p = partition_pivot(indices + start_idx, indices + end_idx, split);
             }
         }

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1531,3 +1531,10 @@ def test_gh_18800(incantation):
     tree = incantation(points, 10)
     tree.query(arr_like, 1)
     tree.query_ball_point(arr_like, 200)
+
+
+def test_gh_20605():
+    data = np.full((100, 2), 4)
+    data[:50, :] = 5
+    data[52:60, 1] = 8
+    balanced_tree = KDTree(data=data,balanced_tree=True)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1537,4 +1537,4 @@ def test_gh_20605():
     data = np.full((100, 2), 4)
     data[:50, :] = 5
     data[52:60, 1] = 8
-    balanced_tree = KDTree(data=data,balanced_tree=True)
+    KDTree(data=data,balanced_tree=True)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1537,4 +1537,7 @@ def test_gh_20605():
     data = np.full((100, 2), 4)
     data[:50, :] = 5
     data[52:60, 1] = 8
-    KDTree(data=data,balanced_tree=True)
+    #KDTree(data=data,balanced_tree=True)
+    KDTree(data=data,balanced_tree=False)
+
+

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1537,7 +1537,7 @@ def test_gh_20605():
     data = np.full((100, 2), 4)
     data[:50, :] = 5
     data[52:60, 1] = 8
-    #KDTree(data=data,balanced_tree=True)
-    KDTree(data=data,balanced_tree=False)
+    KDTree(data=data, balanced_tree=True)
+    KDTree(data=data, balanced_tree=False)
 
 


### PR DESCRIPTION
Never slide the pivot when using median as pivot. Only slide the pivot when pivot is the midpoint. That’s what sliding midpoint means.

Sliding median is not a thing. A median is always the median.

Closes #20605 