### PR TITLE
BUG: prevent QHull message stream being closed twice

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -361,7 +361,7 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
-        self._messages.close()
+            self._messages.close()
 
     @cython.final
     def close(self):
@@ -387,7 +387,7 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
-        self._messages.close()
+            self._messages.close()
 
     @cython.final
     def get_points(self):

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -361,6 +361,7 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
+        if self._messages is not None:
             self._messages.close()
 
     @cython.final
@@ -387,6 +388,7 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
+        if self._messages is not None:
             self._messages.close()
 
     @cython.final


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
This makes part of the current effort to remove the GIL from Python. After https://github.com/numpy/numpy/pull/26348 and this PR, all the test suite passes successfully when ran locally.

#### What does this implement/fix?
This PR prevents releasing the `MessageStream` object in QHull twice. This may occur because the deallocation logic is duplicated both in the `close` and the `__dealloc__` methods (there's a note mentioning that this is required to support PyPy). Before, a call to `close` followed by `__dealloc__` would segfault, since `close` would have closed the `MessageStream` before `__dealloc__` would have attempted to close it, thus trying to free a null pointer.

#### Additional information
This behaviour occurs independent of locking, since the closing attempt would have occurred without checking if `self._qh != NULL`