### PR TITLE
DOC: integrate: remove references to deprecated and legacy functions

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -265,23 +265,12 @@ which is the same result as before.
 Gaussian quadrature
 -------------------
 
-A few functions are also provided in order to perform simple Gaussian
-quadrature over a fixed interval. The first is :obj:`fixed_quad`, which
-performs fixed-order Gaussian quadrature. The second function is
-:obj:`quadrature`, which performs Gaussian quadrature of multiple
-orders until the difference in the integral estimate is beneath some
-tolerance supplied by the user. These functions both use the module
-``scipy.special.orthogonal``, which can calculate the roots and quadrature
-weights of a large variety of orthogonal polynomials (the polynomials
-themselves are available as special functions returning instances of
-the polynomial class --- e.g., :obj:`special.legendre <scipy.special.legendre>`).
-
-
-Romberg Integration
--------------------
-
-Romberg's method [WPR]_ is another method for numerically evaluating an
-integral. See the help function for :func:`romberg` for further details.
+:obj:`fixed_quad` performs fixed-order Gaussian quadrature over a fixed interval. This
+function uses the collection of orthogonal polynomials provided by ``scipy.special``,
+which can calculate the roots and quadrature weights of a large variety of orthogonal
+polynomials (the polynomials themselves are available as special functions returning
+instances of the polynomial class --- e.g.,
+:obj:`special.legendre <scipy.special.legendre>`).
 
 
 Integrating using Samples
@@ -786,7 +775,5 @@ Let's ensure that they have computed the same result::
 
 References
 ~~~~~~~~~~
-
-.. [WPR] https://en.wikipedia.org/wiki/Romberg's_method
 
 .. [MOL] https://en.wikipedia.org/wiki/Method_of_lines

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -122,9 +122,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     tplquad : triple integral
     nquad : n-dimensional integrals (uses `quad` recursively)
     fixed_quad : fixed-order Gaussian quadrature
-    quadrature : adaptive Gaussian quadrature
-    odeint : ODE integrator
-    ode : ODE integrator
     simpson : integrator for sampled data
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
@@ -727,9 +724,6 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     tplquad : triple integral
     nquad : N-dimensional integrals
     fixed_quad : fixed-order Gaussian quadrature
-    quadrature : adaptive Gaussian quadrature
-    odeint : ODE integrator
-    ode : ODE integrator
     simpson : integrator for sampled data
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
@@ -860,14 +854,11 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     See Also
     --------
     quad : Adaptive quadrature using QUADPACK
-    quadrature : Adaptive Gaussian quadrature
     fixed_quad : Fixed-order Gaussian quadrature
     dblquad : Double integrals
     nquad : N-dimensional integrals
     romb : Integrators for sampled data
     simpson : Integrators for sampled data
-    ode : ODE integrators
-    odeint : ODE integrators
     scipy.special : For coefficients and roots of orthogonal polynomials
 
     Notes
@@ -1045,7 +1036,6 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     quad : 1-D numerical integration
     dblquad, tplquad : double and triple integrals
     fixed_quad : fixed-order Gaussian quadrature
-    quadrature : adaptive Gaussian quadrature
 
     Notes
     -----

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -217,13 +217,9 @@ def fixed_quad(func, a, b, args=(), n=5):
     quad : adaptive quadrature using QUADPACK
     dblquad : double integrals
     tplquad : triple integrals
-    romberg : adaptive Romberg quadrature
-    quadrature : adaptive Gaussian quadrature
     romb : integrators for sampled data
     simpson : integrators for sampled data
     cumulative_trapezoid : cumulative integration for sampled data
-    ode : ODE integrator
-    odeint : ODE integrator
 
     Examples
     --------
@@ -345,7 +341,6 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
 
     See Also
     --------
-    romberg : adaptive Romberg quadrature
     fixed_quad : fixed-order Gaussian quadrature
     quad : adaptive quadrature using QUADPACK
     dblquad : double integrals
@@ -353,8 +348,6 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     romb : integrator for sampled data
     simpson : integrator for sampled data
     cumulative_trapezoid : cumulative integration for sampled data
-    ode : ODE integrator
-    odeint : ODE integrator
 
     Examples
     --------
@@ -437,14 +430,10 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
     numpy.cumsum, numpy.cumprod
     cumulative_simpson : cumulative integration using Simpson's 1/3 rule
     quad : adaptive quadrature using QUADPACK
-    romberg : adaptive Romberg quadrature
-    quadrature : adaptive Gaussian quadrature
     fixed_quad : fixed-order Gaussian quadrature
     dblquad : double integrals
     tplquad : triple integrals
     romb : integrators for sampled data
-    ode : ODE integrators
-    odeint : ODE integrators
 
     Examples
     --------
@@ -987,15 +976,11 @@ def romb(y, dx=1.0, axis=-1, show=False):
     See Also
     --------
     quad : adaptive quadrature using QUADPACK
-    romberg : adaptive Romberg quadrature
-    quadrature : adaptive Gaussian quadrature
     fixed_quad : fixed-order Gaussian quadrature
     dblquad : double integrals
     tplquad : triple integrals
     simpson : integrators for sampled data
     cumulative_trapezoid : cumulative integration for sampled data
-    ode : ODE integrators
-    odeint : ODE integrators
 
     Examples
     --------
@@ -1202,8 +1187,6 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
     romb : Integrators for sampled data.
     simpson : Integrators for sampled data.
     cumulative_trapezoid : Cumulative integration for sampled data.
-    ode : ODE integrator.
-    odeint : ODE integrator.
 
     References
     ----------


### PR DESCRIPTION
As it says on the tin!

`romberg` and `quadrature` are deprecated so I have removed them from the see also section.

`ode` and `odeint` are legacy so we shouldn't be directing people to them plus they show up in the see also of some fairly unrelated functions