### PR TITLE
TYP: add type annotations to `scipy/_lib/_array_api.py`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 warn_redundant_casts = True
-warn_unused_ignores = True
+# This is too fragile - can be tested locally with `True` once in a while,
+# and especially when upgrading to a new Mypy version. However, Mypy is
+# not consistent enough for this to be a reasonable default.
+warn_unused_ignores = False
 show_error_codes = True
 plugins = numpy.typing.mypy_plugin
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import os
 import warnings
 
+from types import ModuleType
+from typing import Any, Literal, TYPE_CHECKING
+
 import numpy as np
+import numpy.typing as npt
 
 from scipy._lib import array_api_compat
 from scipy._lib.array_api_compat import (
@@ -34,7 +38,12 @@ _GLOBAL_CONFIG = {
 }
 
 
-def compliance_scipy(arrays):
+if TYPE_CHECKING:
+    Array = Any  # To be changed to a Protocol later (see array-api#589)
+    ArrayLike = Array | npt.ArrayLike
+
+
+def compliance_scipy(arrays: list[ArrayLike]) -> list[Array]:
     """Raise exceptions on known-bad subclasses.
 
     The following subclasses are not supported and raise and error:
@@ -72,7 +81,7 @@ def compliance_scipy(arrays):
     return arrays
 
 
-def _check_finite(array, xp):
+def _check_finite(array: Array, xp: ModuleType) -> None:
     """Check for NaNs or Infs."""
     msg = "array must not contain infs or NaNs"
     try:
@@ -82,7 +91,7 @@ def _check_finite(array, xp):
         raise ValueError(msg)
 
 
-def array_namespace(*arrays):
+def array_namespace(*arrays: Array) -> ModuleType:
     """Get the array API compatible namespace for the arrays xs.
 
     Parameters
@@ -112,17 +121,23 @@ def array_namespace(*arrays):
         # here we could wrap the namespace if needed
         return np_compat
 
-    arrays = [array for array in arrays if array is not None]
+    _arrays = [array for array in arrays if array is not None]
 
-    arrays = compliance_scipy(arrays)
+    _arrays = compliance_scipy(_arrays)
 
-    return array_api_compat.array_namespace(*arrays)
+    return array_api_compat.array_namespace(*_arrays)
 
 
 def _asarray(
-    array, dtype=None, order=None, copy=None, *, xp=None, check_finite=False,
-    subok=False
-):
+        array: ArrayLike,
+        dtype: Any = None,
+        order: Literal['K', 'A', 'C', 'F'] | None = None,
+        copy: bool | None = None,
+        *,
+        xp: ModuleType | None = None,
+        check_finite: bool = False,
+        subok: bool = False,
+    ) -> Array:
     """SciPy-specific replacement for `np.asarray` with `order`, `check_finite`, and
     `subok`.
 
@@ -164,7 +179,7 @@ def _asarray(
     return array
 
 
-def atleast_nd(x, *, ndim, xp=None):
+def atleast_nd(x: Array, *, ndim: int, xp: ModuleType | None = None) -> Array:
     """Recursively expand the dimension to have at least `ndim`."""
     if xp is None:
         xp = array_namespace(x)
@@ -175,7 +190,7 @@ def atleast_nd(x, *, ndim, xp=None):
     return x
 
 
-def copy(x, *, xp=None):
+def copy(x: Array, *, xp: ModuleType | None = None) -> Array:
     """
     Copies an array.
 
@@ -202,15 +217,15 @@ def copy(x, *, xp=None):
     return _asarray(x, copy=True, xp=xp)
 
 
-def is_numpy(xp):
+def is_numpy(xp: ModuleType) -> bool:
     return xp.__name__ in ('numpy', 'scipy._lib.array_api_compat.numpy')
 
 
-def is_cupy(xp):
+def is_cupy(xp: ModuleType) -> bool:
     return xp.__name__ in ('cupy', 'scipy._lib.array_api_compat.cupy')
 
 
-def is_torch(xp):
+def is_torch(xp: ModuleType) -> bool:
     return xp.__name__ in ('torch', 'scipy._lib.array_api_compat.torch')
 
 
@@ -327,7 +342,7 @@ def xp_assert_less(actual, desired, check_namespace=True, check_dtype=True,
                                         err_msg=err_msg, verbose=verbose)
 
 
-def cov(x, *, xp=None):
+def cov(x: Array, *, xp: ModuleType | None = None) -> Array:
     if xp is None:
         xp = array_namespace(x)
 
@@ -355,9 +370,9 @@ def cov(x, *, xp=None):
     return xp.squeeze(c, axis=axes)
 
 
-def xp_unsupported_param_msg(param):
+def xp_unsupported_param_msg(param: Any) -> str:
     return f'Providing {param!r} is only supported for numpy arrays.'
 
 
-def is_complex(x, xp):
+def is_complex(x: Array, xp: ModuleType) -> bool:
     return xp.isdtype(x.dtype, 'complex floating')

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -871,8 +871,8 @@ class _RichResult(dict):
         except KeyError as e:
             raise AttributeError(name) from e
 
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+    __setattr__ = dict.__setitem__  # type: ignore[assignment]
+    __delattr__ = dict.__delitem__  # type: ignore[assignment]
 
     def __repr__(self):
         order_keys = ['message', 'success', 'status', 'fun', 'funl', 'x', 'xl',


### PR DESCRIPTION
This is a follow-up to gh-20593, where we had a little hiccup making Mypy happy. I added type annotations to all functions in `_lib/_array_api.py` other than testing functions (that are more work, and less critical since they're only used in tests).

The second commit adds some `# type: ignore` statements for `_RichResult`, which does something that Mypy intermittently complains about. It's the type of construct that is best simply ignored if the code works as intended (which I have no reason to believe it doesn't).