### PR TITLE
MAINT: special: Drop unused function_calls variable in kolmogorov.h

### DIFF
--- a/scipy/special/special/cephes/kolmogorov.h
+++ b/scipy/special/special/cephes/kolmogorov.h
@@ -818,7 +818,6 @@ namespace cephes {
              */
             double x, logpcdf;
             int iterations = 0;
-            int function_calls = 0;
             double a = 0, b = 1;
             double maxlogpcdf, psfrootn;
             double dx, dxold;
@@ -923,7 +922,6 @@ namespace cephes {
                 SPECFUN_ASSERT(x > 0);
                 {
                     ThreeProbs probs = _smirnov(n, x0);
-                    ++function_calls;
                     df = ((pcdf < 0.5) ? (pcdf - probs.cdf) : (probs.sf - psf));
                     dfdx = -probs.pdf;
                 }


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
function_calls is never used

#### Additional information
hello,
I borrowed the cephes code for a c++ project and noticed this was emitting a warning
