### PR TITLE
TST: integrate.tanhsinh: make test case XSLOW

### DIFF
--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -1,4 +1,5 @@
 # mypy: disable-error-code="attr-defined"
+import os
 import pytest
 
 import numpy as np
@@ -215,6 +216,8 @@ class TestTanhSinh:
         if distname in {'dgamma', 'dweibull', 'laplace', 'kstwo'}:
             # should split up interval at first-derivative discontinuity
             pytest.skip('tanh-sinh is not great for non-smooth integrands')
+        if distname in {'studentized_range'} and not int(os.getenv('SCIPY_XSLOW', 0)):
+            pytest.skip('This case passes, but it is too slow.')
         dist = getattr(stats, distname)(*params)
         x = dist.interval(ref)
         res = _tanhsinh(dist.pdf, *x)


### PR DESCRIPTION
#### Reference issue
gh-20624

#### What does this implement/fix?
The test of `_tanhsinh` that integrates the `studentized_range` PDF sometimes take >5s, but it was not marked as slow or xslow. This skips the test case unless `SCIPY_XSLOW=1`.