### PR TITLE
MAINT/DEV: lint: disable UP032

### DIFF
--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -18,7 +18,7 @@ target-version = "py39"
 # `ICN001` added in gh-20382 to enforce common conventions for imports
 select = ["E", "F", "PGH004", "UP", "B028", "ICN001"]
 # UP031 should be enabled once someone fixes the errors.
-ignore = ["E741", "UP031"]
+ignore = ["E741", "UP031", "UP032"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
Showed up as a linting error in an unrelated PR for me:
```
scipy/interpolate/_interpolate.py:918:30: UP032 [*] Use f-string instead of `format` call
scipy/interpolate/_interpolate.py:1972:30: UP032 [*] Use f-string instead of `format` call
```
This should not happen; the old code is fine, so this check needs to be silenced or fixed separately. Similar to gh-20601.

[skip ci]

I believe I saw @mdhaber also complaining about having to chase f-string related issues unrelated to code he was touching this week (just can't find the PR back).