### PR TITLE
MAINT: backports/prep for 1.13.1

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Setup Python build deps
         run: |
-          pip install build meson-python ninja pythran pybind11 cython "numpy>=2.0.0b1"
+          pip install build meson-python ninja "pythran<0.16.0" pybind11 cython "numpy>=2.0.0b1"
 
       - name: Build wheel and install
         run: |

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -110,6 +110,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
+        mamba install python=${{ matrix.python-version}}
 
         # optional test dependencies
         mamba install scikit-umfpack scikit-sparse

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -167,13 +167,14 @@ jobs:
         
         git submodule update --init
         # for some reason gfortran is not on the path
-        GFORTRAN_LOC=$(brew --prefix gfortran)/bin/gfortran 
+        GFORTRAN_LOC=$(which gfortran-13)
         ln -s $GFORTRAN_LOC gfortran
         export PATH=$PWD:$PATH
 
         # make sure we have openblas
         bash tools/wheels/cibw_before_build_macos.sh $PWD
-        export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
+        GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
+        export DYLD_LIBRARY_PATH=$GFORTRAN_LIB
         export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
     
         pip install click doit pydevtool rich_click meson cython pythran pybind11 ninja numpy

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -128,21 +128,16 @@ jobs:
         run: |
           if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
             # macosx_arm64
-          
-            # use homebrew gfortran
+            LIB_PATH=$LIB_PATH:/opt/arm64-builds/lib
             sudo xcode-select -s /Applications/Xcode_15.2.app            
-            # for some reason gfortran is not on the path
-            GFORTRAN_LOC=$(brew --prefix gfortran)/bin/gfortran 
-            ln -s $GFORTRAN_LOC gfortran
-            export PATH=$PWD:$PATH
-            echo "PATH=$PATH" >> "$GITHUB_ENV"
           
             # location of the gfortran's libraries
-            GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
+            GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
 
             CIBW="MACOSX_DEPLOYMENT_TARGET=12.0\
               MACOS_DEPLOYMENT_TARGET=12.0\
-              LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH\
+              LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH\
+              SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
               _PYTHON_HOST_PLATFORM=macosx-12.0-arm64\
               PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig"
             echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
@@ -152,8 +147,8 @@ jobs:
 
             echo "REPAIR_PATH=/opt/arm64-builds/lib" >> "$GITHUB_ENV"
 
-            CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:/opt/arm64-builds/lib delocate-listdeps {wheel} &&\
-              DYLD_LIBRARY_PATH=$GFORTRAN_LIB:/opt/arm64-builds/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+            CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-listdeps {wheel} &&\
+              DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
             echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
       
           else

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ build-install/
 .doit.db.dir
 .doit.db.db
 .doit.db
+doc/source/.jupyterlite.doit.db
 
 # Logs and databases #
 ######################

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -19,6 +19,7 @@ cirrus_wheels_linux_aarch64_task:
     platform: linux
     cpu: 2
     memory: 4G
+    timeout_in: 72m
   matrix:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a

--- a/doc/source/release/1.13.0-notes.rst
+++ b/doc/source/release/1.13.0-notes.rst
@@ -140,7 +140,7 @@ Deprecated features
 - Complex dtypes in ``PchipInterpolator`` and ``Akima1DInterpolator`` have
   been deprecated and will raise an error in SciPy 1.15.0. If you are trying
   to use the real components of the passed array, use ``np.real`` on ``y``.
-- Non-integer values of ``n`` together with ```exact=True`` are deprecated for
+- Non-integer values of ``n`` together with ``exact=True`` are deprecated for
   `scipy.special.factorial`.
 
 

--- a/doc/source/release/1.13.0-notes.rst
+++ b/doc/source/release/1.13.0-notes.rst
@@ -149,6 +149,7 @@ Expired Deprecations
 *********************
 There is an ongoing effort to follow through on long-standing deprecations.
 The following previously deprecated features are affected:
+
 - ``scipy.signal.{lsim2,impulse2,step2}`` have been removed in favour of
   ``scipy.signal.{lsim,impulse,step}``.
 - Window functions can no longer be imported from the `scipy.signal` namespace and

--- a/doc/source/release/1.13.0-notes.rst
+++ b/doc/source/release/1.13.0-notes.rst
@@ -140,12 +140,37 @@ Deprecated features
 - Complex dtypes in ``PchipInterpolator`` and ``Akima1DInterpolator`` have
   been deprecated and will raise an error in SciPy 1.15.0. If you are trying
   to use the real components of the passed array, use ``np.real`` on ``y``.
+- Non-integer values of ``n`` together with ```exact=True`` are deprecated for
+  `scipy.special.factorial`.
 
+
+*********************
+Expired Deprecations
+*********************
+There is an ongoing effort to follow through on long-standing deprecations.
+The following previously deprecated features are affected:
+- ``scipy.signal.{lsim2,impulse2,step2}`` have been removed in favour of
+  ``scipy.signal.{lsim,impulse,step}``.
+- Window functions can no longer be imported from the `scipy.signal` namespace and
+  instead should be accessed through either `scipy.signal.windows` or
+  `scipy.signal.get_window`.
+- `scipy.sparse` no longer supports multi-Ellipsis indexing
+- ``scipy.signal.{bspline,quadratic,cubic}`` have been removed in favour of alternatives
+  in `scipy.interpolate`.
+- ``scipy.linalg.tri{,u,l}`` have been removed in favour of ``numpy.tri{,u,l}``.
+- Non-integer arrays in `scipy.special.factorial` with ``exact=True`` now raise an
+  error.
+- Functions from NumPy's main namespace which were exposed in SciPy's main
+  namespace, such as ``numpy.histogram`` exposed by ``scipy.histogram``, have
+  been removed from SciPy's main namespace. Please use the functions directly
+  from ``numpy``. This was originally performed for SciPy 1.12.0 however was missed from
+  the release notes so is included here for completeness.
 
 
 ******************************
 Backwards incompatible changes
 ******************************
+
 
 *************
 Other changes

--- a/doc/source/release/1.13.1-notes.rst
+++ b/doc/source/release/1.13.1-notes.rst
@@ -5,19 +5,66 @@ SciPy 1.13.1 Release Notes
 .. contents::
 
 SciPy 1.13.1 is a bug-fix release with no new features
-compared to 1.13.0.
+compared to 1.13.0. The version of OpenBLAS shipped with
+the PyPI binaries has been increased to 0.3.27.
 
 
 
 Authors
 =======
 * Name (commits)
+* h-vetinari (1)
+* Jake Bowhay (2)
+* Evgeni Burovski (6)
+* Sean Cheah (1)
+* Lucas Colley (1)
+* DWesl (2)
+* Ralf Gommers (6)
+* Ben Greiner (1) +
+* Philip Loche (1) +
+* Matti Picus (1)
+* Tyler Reddy (23)
+* Atsushi Sakai (1)
+* Dan Schult (1)
+* Scott Shambaugh (2)
+
+A total of 14 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.13.1
 ------------------------
 
+* `#20392 <https://github.com/scipy/scipy/issues/20392>`__: DOC: optimize.root(method='lm') option
+* `#20471 <https://github.com/scipy/scipy/issues/20471>`__: BUG: \`TestEig.test_falker\` fails on windows + MKL as well as...
+* `#20491 <https://github.com/scipy/scipy/issues/20491>`__: BUG: Cannot find \`OpenBLAS\` on Cygwin
+* `#20506 <https://github.com/scipy/scipy/issues/20506>`__: BUG: special.spherical_in: derivative at \`z=0, n=1\` incorrect
+* `#20512 <https://github.com/scipy/scipy/issues/20512>`__: BUG: \`eigh\` fails for size 1 array with driver=evd
+* `#20531 <https://github.com/scipy/scipy/issues/20531>`__: BUG: warning from \`optimize.least_squares\` for astropy with...
+* `#20555 <https://github.com/scipy/scipy/issues/20555>`__: BUG: spatial: error in \`Rotation.align_vectors()\` with an infinite...
+* `#20580 <https://github.com/scipy/scipy/issues/20580>`__: BUG: scipy.special.factorial2 doesn't handle \`uint32\` dtypes
 
 
 Pull requests for 1.13.1
 ------------------------
+
+* `#20322 <https://github.com/scipy/scipy/pull/20322>`__: BUG: sparse: align dok_array.pop() to dict.pop() for case with...
+* `#20333 <https://github.com/scipy/scipy/pull/20333>`__: BUG: sync pocketfft again
+* `#20381 <https://github.com/scipy/scipy/pull/20381>`__: REL, MAINT: prep for 1.13.1
+* `#20401 <https://github.com/scipy/scipy/pull/20401>`__: DOC: optimize: fix wrong optional argument name in \`root(method="lm")\`.
+* `#20435 <https://github.com/scipy/scipy/pull/20435>`__: DOC: add missing deprecations from 1.13.0 release notes
+* `#20437 <https://github.com/scipy/scipy/pull/20437>`__: MAINT/DOC: fix syntax in 1.13.0 release notes
+* `#20449 <https://github.com/scipy/scipy/pull/20449>`__: DOC: remove spurious backtick from release notes
+* `#20473 <https://github.com/scipy/scipy/pull/20473>`__: BUG: linalg: fix ordering of complex conj gen eigenvalues
+* `#20474 <https://github.com/scipy/scipy/pull/20474>`__: TST: tolerance bumps for the conda-forge builds
+* `#20484 <https://github.com/scipy/scipy/pull/20484>`__: TST: compare absolute values of U and VT in pydata-sparse SVD...
+* `#20505 <https://github.com/scipy/scipy/pull/20505>`__: BUG: Include Python.h before system headers.
+* `#20516 <https://github.com/scipy/scipy/pull/20516>`__: BUG: linalg: fix eigh(1x1 array, driver='evd') f2py check
+* `#20527 <https://github.com/scipy/scipy/pull/20527>`__: BUG: \`spherical_in\` for \`n=0\` and \`z=0\`
+* `#20530 <https://github.com/scipy/scipy/pull/20530>`__: BLD: Fix error message for f2py generation fail
+* `#20537 <https://github.com/scipy/scipy/pull/20537>`__: BLD: Move Python-including files to start of source.
+* `#20567 <https://github.com/scipy/scipy/pull/20567>`__: REV: 1.13.x: revert changes to f2py and tempita handling in meson.build...
+* `#20569 <https://github.com/scipy/scipy/pull/20569>`__: update openblas to 0.3.27
+* `#20573 <https://github.com/scipy/scipy/pull/20573>`__: BUG: Fix error with 180 degree rotation in Rotation.align_vectors()...
+* `#20607 <https://github.com/scipy/scipy/pull/20607>`__: BUG: handle uint arrays in factorial{,2,k}

--- a/doc/source/release/1.13.1-notes.rst
+++ b/doc/source/release/1.13.1-notes.rst
@@ -16,19 +16,24 @@ Authors
 * h-vetinari (1)
 * Jake Bowhay (2)
 * Evgeni Burovski (6)
-* Sean Cheah (1)
-* Lucas Colley (1)
+* Sean Cheah (2)
+* Lucas Colley (2)
 * DWesl (2)
-* Ralf Gommers (6)
+* Ralf Gommers (7)
 * Ben Greiner (1) +
+* Matt Haberland (2)
+* Gregory R. Lee (1)
 * Philip Loche (1) +
+* Sijo Valayakkad Manikandan (1) +
 * Matti Picus (1)
-* Tyler Reddy (23)
+* Tyler Reddy (62)
 * Atsushi Sakai (1)
-* Dan Schult (1)
+* Daniel Schmitz (2)
+* Dan Schult (3)
 * Scott Shambaugh (2)
+* Edgar Andrés Margffoy Tuay (1)
 
-A total of 14 people contributed to this release.
+A total of 19 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -36,25 +41,39 @@ This list of names is automatically generated, and may not be fully complete.
 Issues closed for 1.13.1
 ------------------------
 
+* `#19423 <https://github.com/scipy/scipy/issues/19423>`__: BUG: \`scipy.ndimage.value_indices\` returns empty dict for \`intc\`/\`uintc\` dtype on Windows
+* `#20264 <https://github.com/scipy/scipy/issues/20264>`__: DOC, MAINT: .jupyterlite.doit.db shows up untracked
 * `#20392 <https://github.com/scipy/scipy/issues/20392>`__: DOC: optimize.root(method='lm') option
+* `#20415 <https://github.com/scipy/scipy/issues/20415>`__: BUG: csr_array can no longer be initialized with 1D array
 * `#20471 <https://github.com/scipy/scipy/issues/20471>`__: BUG: \`TestEig.test_falker\` fails on windows + MKL as well as...
 * `#20491 <https://github.com/scipy/scipy/issues/20491>`__: BUG: Cannot find \`OpenBLAS\` on Cygwin
 * `#20506 <https://github.com/scipy/scipy/issues/20506>`__: BUG: special.spherical_in: derivative at \`z=0, n=1\` incorrect
 * `#20512 <https://github.com/scipy/scipy/issues/20512>`__: BUG: \`eigh\` fails for size 1 array with driver=evd
 * `#20531 <https://github.com/scipy/scipy/issues/20531>`__: BUG: warning from \`optimize.least_squares\` for astropy with...
 * `#20555 <https://github.com/scipy/scipy/issues/20555>`__: BUG: spatial: error in \`Rotation.align_vectors()\` with an infinite...
+* `#20576 <https://github.com/scipy/scipy/issues/20576>`__: MAINT, TST: two types of failures observed on maintenance/1.13.x...
 * `#20580 <https://github.com/scipy/scipy/issues/20580>`__: BUG: scipy.special.factorial2 doesn't handle \`uint32\` dtypes
+* `#20591 <https://github.com/scipy/scipy/issues/20591>`__: BUG: scipy.stats.wilcoxon in 1.13 fails on 2D array with nan...
+* `#20623 <https://github.com/scipy/scipy/issues/20623>`__: BUG: scipy.spatial.Delaunay, scipy.interpolate.LinearNDInterpolator...
+* `#20648 <https://github.com/scipy/scipy/issues/20648>`__: BUG: stats.yulesimon: incorrect kurtosis values
+* `#20652 <https://github.com/scipy/scipy/issues/20652>`__: BUG: incorrect origin tuple handling in ndimage \`minimum_filter\`...
+* `#20660 <https://github.com/scipy/scipy/issues/20660>`__: BUG: spatial: \`Rotation.align_vectors()\` incorrect for anti-parallel...
+* `#20670 <https://github.com/scipy/scipy/issues/20670>`__: BUG: sparse matrix creation in 1.13 with indices not summing...
+* `#20692 <https://github.com/scipy/scipy/issues/20692>`__: BUG: stats.zipf: incorrect pmf values
+* `#20714 <https://github.com/scipy/scipy/issues/20714>`__: CI: scipy installation failing in umfpack tests
 
 
 Pull requests for 1.13.1
 ------------------------
 
+* `#20280 <https://github.com/scipy/scipy/pull/20280>`__: MAINT: added doc/source/.jupyterlite.doit.db to .gitignore See...
 * `#20322 <https://github.com/scipy/scipy/pull/20322>`__: BUG: sparse: align dok_array.pop() to dict.pop() for case with...
 * `#20333 <https://github.com/scipy/scipy/pull/20333>`__: BUG: sync pocketfft again
 * `#20381 <https://github.com/scipy/scipy/pull/20381>`__: REL, MAINT: prep for 1.13.1
 * `#20401 <https://github.com/scipy/scipy/pull/20401>`__: DOC: optimize: fix wrong optional argument name in \`root(method="lm")\`.
 * `#20435 <https://github.com/scipy/scipy/pull/20435>`__: DOC: add missing deprecations from 1.13.0 release notes
 * `#20437 <https://github.com/scipy/scipy/pull/20437>`__: MAINT/DOC: fix syntax in 1.13.0 release notes
+* `#20444 <https://github.com/scipy/scipy/pull/20444>`__: BUG: sparse: Clean up 1D input handling to sparse array/matrix...
 * `#20449 <https://github.com/scipy/scipy/pull/20449>`__: DOC: remove spurious backtick from release notes
 * `#20473 <https://github.com/scipy/scipy/pull/20473>`__: BUG: linalg: fix ordering of complex conj gen eigenvalues
 * `#20474 <https://github.com/scipy/scipy/pull/20474>`__: TST: tolerance bumps for the conda-forge builds
@@ -63,8 +82,21 @@ Pull requests for 1.13.1
 * `#20516 <https://github.com/scipy/scipy/pull/20516>`__: BUG: linalg: fix eigh(1x1 array, driver='evd') f2py check
 * `#20527 <https://github.com/scipy/scipy/pull/20527>`__: BUG: \`spherical_in\` for \`n=0\` and \`z=0\`
 * `#20530 <https://github.com/scipy/scipy/pull/20530>`__: BLD: Fix error message for f2py generation fail
+* `#20533 <https://github.com/scipy/scipy/pull/20533>`__: TST: Adapt to \`__array__(copy=True)\`
 * `#20537 <https://github.com/scipy/scipy/pull/20537>`__: BLD: Move Python-including files to start of source.
 * `#20567 <https://github.com/scipy/scipy/pull/20567>`__: REV: 1.13.x: revert changes to f2py and tempita handling in meson.build...
 * `#20569 <https://github.com/scipy/scipy/pull/20569>`__: update openblas to 0.3.27
 * `#20573 <https://github.com/scipy/scipy/pull/20573>`__: BUG: Fix error with 180 degree rotation in Rotation.align_vectors()...
+* `#20586 <https://github.com/scipy/scipy/pull/20586>`__: MAINT: optimize.linprog: fix bug when integrality is a list of...
+* `#20592 <https://github.com/scipy/scipy/pull/20592>`__: MAINT: stats.wilcoxon: fix failure with multidimensional \`x\`...
+* `#20601 <https://github.com/scipy/scipy/pull/20601>`__: MAINT: lint: temporarily disable UP031
 * `#20607 <https://github.com/scipy/scipy/pull/20607>`__: BUG: handle uint arrays in factorial{,2,k}
+* `#20611 <https://github.com/scipy/scipy/pull/20611>`__: BUG: prevent QHull message stream being closed twice
+* `#20629 <https://github.com/scipy/scipy/pull/20629>`__: MAINT/DEV: lint: disable UP032
+* `#20633 <https://github.com/scipy/scipy/pull/20633>`__: BUG: fix Vor/Delaunay segfaults
+* `#20644 <https://github.com/scipy/scipy/pull/20644>`__: BUG: ndimage.value_indices: deal with unfixed types
+* `#20653 <https://github.com/scipy/scipy/pull/20653>`__: BUG: ndimage: fix origin handling for \`{minimum, maximum}_filter\`
+* `#20654 <https://github.com/scipy/scipy/pull/20654>`__: MAINT: stats.yulesimon: fix kurtosis
+* `#20687 <https://github.com/scipy/scipy/pull/20687>`__: BUG: sparse: Fix summing duplicates for CSR/CSC creation from...
+* `#20702 <https://github.com/scipy/scipy/pull/20702>`__: BUG: stats: Fix \`zipf.pmf\` and \`zipfian.pmf\` for int32 \`k\`
+* `#20727 <https://github.com/scipy/scipy/pull/20727>`__: CI: pin Python for MacOS conda

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -2,7 +2,7 @@ import pickle
 import pytest
 import numpy as np
 from numpy.linalg import LinAlgError
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose
 from scipy.stats.qmc import Halton
 from scipy.spatial import cKDTree
 from scipy.interpolate._rbfinterp import (
@@ -415,7 +415,7 @@ class _TestRBFInterpolator:
         yitp1 = interp(xitp)
         yitp2 = pickle.loads(pickle.dumps(interp))(xitp)
 
-        assert_array_equal(yitp1, yitp2)
+        assert_allclose(yitp1, yitp2, atol=1e-16)
 
 
 class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -137,7 +137,7 @@ class TestRegularGridInterpolator:
 
         # 2nd derivatives of a linear function are zero
         assert_allclose(interp(sample, nu=(0, 1, 1, 0)),
-                        [0, 0, 0], atol=1e-12)
+                        [0, 0, 0], atol=2e-12)
 
     @parametrize_rgi_interp_methods
     def test_complex(self, method):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -983,7 +983,11 @@ class TestInterpN:
 
         v1 = interpn((x, y), values, sample, method=method)
         v2 = interpn((x, y), np.asarray(values), sample, method=method)
-        assert_allclose(v1, v2)
+        if method == "quintic":
+            # https://github.com/scipy/scipy/issues/20472
+            assert_allclose(v1, v2, atol=5e-5, rtol=2e-6)
+        else:
+            assert_allclose(v1, v2)
 
     def test_length_one_axis(self):
         # gh-5890, gh-9524 : length-1 axis is legal for method='linear'.

--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -12,6 +12,8 @@ class _FakeMatrix2:
         self._data = data
 
     def __array__(self, dtype=None, copy=None):
+        if copy:
+            return self._data.copy()
         return self._data
 
 

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -124,7 +124,7 @@ subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?1+6*n+2*n*n:2*n+1),1)
-    check(lwork>=(compute_v?1+6*n+2*n*n:2*n+1)) :: lwork
+    check( (lwork>=((compute_v?1+6*n+2*n*n:2*n+1))) || ((n==1)&&(lwork>=1)) ) :: lwork
     <ftype2> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
     integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
@@ -180,7 +180,7 @@ subroutine <prefix2c>heevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwo
     <ftype2> dimension(n),intent(out),depend(n) :: w
 
     integer optional,intent(in),depend(n,compute_v) :: lwork=max((compute_v?2*n+n*n:n+1),1)
-    check(lwork>=(compute_v?2*n+n*n:n+1)) :: lwork
+    check( (lwork>=(compute_v?2*n+n*n:n+1)) || ((n==1)&&(lwork>=1)) ) :: lwork
     <ftype2c> dimension(lwork),intent(hide,cache),depend(lwork) :: work
 
     integer optional,intent(in),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -877,6 +877,17 @@ class TestEigh:
                         atol=1000*np.finfo(dtype_).eps,
                         rtol=0.)
 
+    @pytest.mark.parametrize('driver', ("ev", "evd", "evr", "evx"))
+    def test_1x1_lwork(self, driver):
+        w, v = eigh([[1]], driver=driver)
+        assert_allclose(w, array([1.]), atol=1e-15)
+        assert_allclose(v, array([[1.]]), atol=1e-15)
+
+        # complex case now
+        w, v = eigh([[1j]], driver=driver)
+        assert_allclose(w, array([0]), atol=1e-15)
+        assert_allclose(v, array([[1.]]), atol=1e-15)
+
     @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
     def test_various_drivers_generalized(self, driver, type):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -230,8 +230,8 @@ class TestEig:
         w_fin = -1j * np.real_if_close(1j*w_fin, tol=1e-10)
         wt_fin = -1j * np.real_if_close(1j*wt_fin, tol=1e-10)
 
-        perm = argsort(w_fin)
-        permt = argsort(wt_fin)
+        perm = argsort(abs(w_fin) + w_fin.imag)
+        permt = argsort(abs(wt_fin) + wt_fin.imag)
 
         assert_allclose(w_fin[perm], wt_fin[permt],
                         atol=1e-7, rtol=1e-7, err_msg=msg)

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1266,7 +1266,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         else:
             output[...] = input[...]
     else:
-        origins = _ni_support._normalize_sequence(origin, input.ndim)
+        origins = _ni_support._normalize_sequence(origin, num_axes)
         if num_axes < input.ndim:
             if footprint.ndim != num_axes:
                 raise RuntimeError("footprint array has incorrect shape")
@@ -1274,17 +1274,23 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 footprint,
                 tuple(ax for ax in range(input.ndim) if ax not in axes)
             )
+            # set origin = 0 for any axes not being filtered
+            origins_temp = [0,] * input.ndim
+            for o, ax in zip(origins, axes):
+                origins_temp[ax] = o
+            origins = origins_temp
+
         fshape = [ii for ii in footprint.shape if ii > 0]
         if len(fshape) != input.ndim:
             raise RuntimeError('footprint array has incorrect shape.')
         for origin, lenf in zip(origins, fshape):
             if (lenf // 2 + origin < 0) or (lenf // 2 + origin >= lenf):
-                raise ValueError('invalid origin')
+                raise ValueError("invalid origin")
         if not footprint.flags.contiguous:
             footprint = footprint.copy()
         if structure is not None:
             if len(structure.shape) != input.ndim:
-                raise RuntimeError('structure array has incorrect shape')
+                raise RuntimeError("structure array has incorrect shape")
             if num_axes != structure.ndim:
                 structure = numpy.expand_dims(
                     structure,

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -999,6 +999,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
         case NPY_UINT32: CASE_VALUEINDICES_SET_MINMAX(npy_uint32); break;
         case NPY_INT64:  CASE_VALUEINDICES_SET_MINMAX(npy_int64); break;
         case NPY_UINT64: CASE_VALUEINDICES_SET_MINMAX(npy_uint64); break;
+        default:
+            switch(arrType) {
+            case NPY_UINT: CASE_VALUEINDICES_SET_MINMAX(npy_uint); break;
+            case NPY_INT: CASE_VALUEINDICES_SET_MINMAX(npy_int); break;
+            }
         }
         NI_ITERATOR_NEXT(ndiIter, arrData);
     }
@@ -1016,6 +1021,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
         case NPY_UINT32: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint32); break;
         case NPY_INT64:  CASE_VALUEINDICES_MAKEHISTOGRAM(npy_int64); break;
         case NPY_UINT64: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint64); break;
+        default:
+            switch(arrType) {
+            case NPY_INT:  CASE_VALUEINDICES_MAKEHISTOGRAM(npy_int); break;
+            case NPY_UINT: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint); break;
+            }
         }
     }
 
@@ -1047,6 +1057,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
                 case NPY_UINT32: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint32, ii); break;
                 case NPY_INT64:  CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_int64, ii); break;
                 case NPY_UINT64: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint64, ii); break;
+                default:
+                    switch(arrType) {
+                    case NPY_INT:  CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_int, ii); break;
+                    case NPY_UINT: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint, ii); break;
+                    }
                 }
                 /* Create a tuple of <ndim> index arrays */
                 t = PyTuple_New(ndim);
@@ -1093,6 +1108,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
                 case NPY_UINT32: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint32); break;
                 case NPY_INT64:  CASE_VALUEINDICES_GET_VALUEOFFSET(npy_int64); break;
                 case NPY_UINT64: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint64); break;
+                default:
+                    switch(arrType) {
+                    case NPY_INT:  CASE_VALUEINDICES_GET_VALUEOFFSET(npy_int); break;
+                    case NPY_UINT: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint); break;
+                    }
                 }
 
                 if (ignoreValIsNone || (!valueIsIgnore)) {

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -8,6 +8,7 @@ from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal,
                            assert_array_equal, assert_almost_equal,
                            suppress_warnings, assert_)
+import numpy as np
 import pytest
 from pytest import raises as assert_raises
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -10,6 +10,7 @@ from numpy.testing import (
     assert_equal,
     suppress_warnings,
 )
+import pytest
 from pytest import raises as assert_raises
 
 import scipy.ndimage as ndimage
@@ -1407,3 +1408,12 @@ class TestWatershedIft:
         expected = [[1, 1],
                     [1, 1]]
         assert_allclose(out, expected)
+
+
+@pytest.mark.parametrize("dt", [np.intc, np.uintc])
+def test_gh_19423(dt):
+    rng = np.random.default_rng(123)
+    max_val = 8
+    image = rng.integers(low=0, high=max_val, size=(10, 12)).astype(dtype=dt)
+    val_idx = ndimage.value_indices(image)
+    assert len(val_idx.keys()) == max_val

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -12,6 +12,7 @@ from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
+from scipy._lib._util import copy_if_needed
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 
@@ -701,7 +702,7 @@ class LowRankMatrix:
 
     def collapse(self):
         """Collapse the low-rank matrix to a full-rank one."""
-        self.collapsed = np.array(self)
+        self.collapsed = np.array(self, copy=copy_if_needed)
         self.cs = None
         self.ds = None
         self.alpha = None

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -280,9 +280,9 @@ def _root_leastsq(fun, x0, args=(), jac=None,
     maxiter : int
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    epsfcn : float
+    eps : float
         A suitable step length for the forward-difference approximation of
-        the Jacobian (for Dfun=None). If epsfcn is less than the machine
+        the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
         are of the order of the machine precision.
     factor : float

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -105,9 +105,9 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
-            arg1 = self._coo_container(
-                arg1, dtype=dtype
-            ).tobsr(blocksize=blocksize)
+            if isinstance(self, sparray) and arg1.ndim != 2:
+                raise ValueError(f"BSR arrays don't support {arg1.ndim}D input. Use 2D")
+            arg1 = self._coo_container(arg1, dtype=dtype).tobsr(blocksize=blocksize)
             self.indptr, self.indices, self.data, self._shape = (
                 arg1.indptr, arg1.indices, arg1.data, arg1._shape
             )

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -55,6 +55,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     coo = self._coo_container(arg1, shape=shape, dtype=dtype)
                     arrays = coo._coo_to_compressed(self._swap)
                     self.indptr, self.indices, self.data, self._shape = arrays
+                    self.sum_duplicates()
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
                     (data, indices, indptr) = arg1

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -84,6 +84,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 msg = f"unrecognized {self.format}_matrix constructor usage"
                 raise ValueError(msg) from e
+            if isinstance(self, sparray) and arg1.ndim < 2 and self.format == "csc":
+                raise ValueError(
+                    f"CSC arrays don't support {arg1.ndim}D input. Use 2D"
+                )
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, self._shape = arrays

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -7,7 +7,7 @@ import operator
 import numpy as np
 from scipy._lib._util import _prune_array, copy_if_needed
 
-from ._base import _spbase, issparse, SparseEfficiencyWarning
+from ._base import _spbase, issparse, SparseEfficiencyWarning, sparray
 from ._data import _data_matrix, _minmax_mixin
 from . import _sparsetools
 from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -79,7 +79,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 if not is_array:
                     M = np.atleast_2d(M)
                     if M.ndim != 2:
-                        raise TypeError('expected dimension <= 2 array or matrix')
+                        raise TypeError(f'expected 2D array or matrix, not {M.ndim}D')
 
                 self._shape = check_shape(M.shape, allow_1d=is_array)
                 if shape is not None:

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -70,6 +70,8 @@ class _dia_base(_data_matrix):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
+            if isinstance(self, sparray) and arg1.ndim != 2:
+                raise ValueError(f"DIA arrays don't support {arg1.ndim}D input. Use 2D")
             A = self._coo_container(arg1, dtype=dtype, shape=shape).todia()
             self.data = A.data
             self.offsets = A.offsets

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -89,8 +89,8 @@ class _dok_base(_spbase, IndexMixin, dict):
     def clear(self):
         return self._dict.clear()
 
-    def pop(self, key, default=None, /):
-        return self._dict.pop(key, default)
+    def pop(self, /, *args):
+        return self._dict.pop(*args)
 
     def __reversed__(self):
         raise TypeError("reversed is not defined for dok_array type")

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -57,13 +57,14 @@ class _lil_base(_spbase, IndexMixin):
                 A = self._ascontainer(arg1)
             except TypeError as e:
                 raise TypeError('unsupported matrix type') from e
-            else:
-                A = self._csr_container(A, dtype=dtype).tolil()
+            if isinstance(self, sparray) and A.ndim != 2:
+                raise ValueError(f"LIL arrays don't support {A.ndim}D input. Use 2D")
+            A = self._csr_container(A, dtype=dtype).tolil()
 
-                self._shape = check_shape(A.shape)
-                self.dtype = A.dtype
-                self.rows = A.rows
-                self.data = A.data
+            self._shape = check_shape(A.shape)
+            self.dtype = A.dtype
+            self.rows = A.rows
+            self.data = A.data
 
     def __iadd__(self,other):
         self[:,:] = self + other

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -266,7 +266,7 @@ class SVDSCommonTests:
         else:
             res = svds(A, k=k, which=which, solver=self.solver,
                        random_state=0)
-        _check_svds(A, k, *res, which=which, atol=8e-10)
+        _check_svds(A, k, *res, which=which, atol=1e-9, rtol=2e-13)
 
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -121,8 +121,8 @@ def test_svds(matrices):
     u, s, vt = splin.svds(A_sparse, k=2, v0=v0)
 
     assert_allclose(s, s0)
-    assert_allclose(u, u0)
-    assert_allclose(vt, vt0)
+    assert_allclose(np.abs(u), np.abs(u0))
+    assert_allclose(np.abs(vt), np.abs(vt0))
 
 
 def test_lobpcg(matrices):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -292,8 +292,8 @@ class _TestCommon:
             datsp = self.datsp_dtypes[dtype]
 
             assert_raises(ValueError, bool, datsp)
-            assert_(self.spcreator([1]))
-            assert_(not self.spcreator([0]))
+            assert_(self.spcreator([[1]]))
+            assert_(not self.spcreator([[0]]))
 
         if isinstance(self, TestDOK):
             pytest.skip("Cannot create a rank <= 2 DOK matrix.")
@@ -3504,7 +3504,7 @@ class _TestMinMax:
         assert_equal(X.max(), -1)
 
         # and a fully sparse matrix
-        Z = self.spcreator(np.zeros(1))
+        Z = self.spcreator(np.zeros((1, 1)))
         assert_equal(Z.min(), 0)
         assert_equal(Z.max(), 0)
         assert_equal(Z.max().dtype, Z.dtype)
@@ -3784,8 +3784,8 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                 continue
             old_cls = names.get(name)
             if old_cls is not None:
-                raise ValueError("Test class {} overloads test {} defined in {}".format(
-                    cls.__name__, name, old_cls.__name__))
+                raise ValueError(f"Test class {cls.__name__} overloads test "
+                                 f"{name} defined in {old_cls.__name__}")
             names[name] = cls
 
     return type("TestBase", bases, {})
@@ -4039,8 +4039,8 @@ class TestCSR(sparse_test_class()):
     def test_binop_explicit_zeros(self):
         # Check that binary ops don't introduce spurious explicit zeros.
         # See gh-9619 for context.
-        a = csr_matrix([0, 1, 0])
-        b = csr_matrix([1, 1, 0])
+        a = csr_matrix([[0, 1, 0]])
+        b = csr_matrix([[1, 1, 0]])
         assert (a + b).nnz == 2
         assert a.multiply(b).nnz == 1
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3851,6 +3851,10 @@ class TestCSR(sparse_test_class()):
         dense = array([[2**63 + 1, 0], [0, 1]], dtype=np.uint64)
         assert_array_equal(dense, csr.toarray())
 
+        # with duplicates (should sum the duplicates)
+        csr = csr_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
+        assert csr.nnz == 2
+
     def test_constructor5(self):
         # infer dimensions from arrays
         indptr = array([0,1,3,3])
@@ -4091,6 +4095,10 @@ class TestCSC(sparse_test_class()):
         ij = vstack((row,col))
         csc = csc_matrix((data,ij),(4,3))
         assert_array_equal(arange(12).reshape(4, 3), csc.toarray())
+
+        # with duplicates (should sum the duplicates)
+        csc = csc_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
+        assert csc.nnz == 2
 
     def test_constructor5(self):
         # infer dimensions from arrays
@@ -4505,6 +4513,13 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
         dok = coo.todok()
         assert_array_equal(dok.toarray(), coo.toarray())
+
+    def test_tocompressed_duplicates(self):
+        coo = coo_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
+        csr = coo.tocsr()
+        assert_equal(csr.nnz + 2, coo.nnz)
+        csc = coo.tocsc()
+        assert_equal(csc.nnz + 2, coo.nnz)
 
     def test_eliminate_zeros(self):
         data = array([1, 0, 0, 0, 2, 0, 3, 0])

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -7,7 +7,6 @@ import numpy as np
 import scipy as sp
 from scipy.sparse import (
         bsr_array, csc_array, dia_array, lil_array,
-        coo_array, csr_array, dok_array, SparseEfficiencyWarning,
     )
 from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy._lib._util import ComplexWarning

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -5,6 +5,10 @@ import pytest
 import numpy as np
 
 import scipy as sp
+from scipy.sparse import (
+        bsr_array, csc_array, dia_array, lil_array,
+        coo_array, csr_array, dok_array, SparseEfficiencyWarning,
+    )
 from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy._lib._util import ComplexWarning
 
@@ -31,6 +35,15 @@ def datsp_math_dtypes(dat1d):
     }
 
 
+# Test init with 1D dense input
+# sparrays which do not plan to support 1D
+@pytest.mark.parametrize("spcreator", [bsr_array, csc_array, dia_array, lil_array])
+def test_no_1d_support_in_init(spcreator):
+    with pytest.raises(ValueError, match="arrays don't support 1D input"):
+        spcreator([0, 1, 2, 3])
+
+
+# Main tests class
 @pytest.mark.parametrize("spcreator", spcreators)
 class TestCommon1D:
     """test common functionality shared by 1D sparse formats"""
@@ -53,6 +66,10 @@ class TestCommon1D:
     def test_neg(self, spcreator):
         A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
         assert np.array_equal(-A, (-spcreator(A)).toarray())
+
+    def test_1d_supported_init(self, spcreator):
+        A = spcreator([0, 1, 2, 3])
+        assert A.ndim == 1
 
     def test_reshape_1d_tofrom_row_or_column(self, spcreator):
         # add a dimension 1d->2d

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -83,6 +83,13 @@ def test_pop(d, Asp):
     assert Asp.pop((0, 1)) == 1
     assert d.items() == Asp.items()
 
+    assert Asp.pop((22, 21), None) is None
+    assert Asp.pop((22, 21), "other") == "other"
+    with pytest.raises(KeyError, match="(22, 21)"):
+        Asp.pop((22, 21))
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        Asp.pop((22, 21), default=5)
+
 def test_popitem(d, Asp):
     assert d.popitem() == Asp.popitem()
     assert d.items() == Asp.items()

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1804,6 +1804,8 @@ class Delaunay(_QhullUser):
         if np.ma.isMaskedArray(points):
             raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
+        if points.ndim != 2:
+            raise ValueError("Input points array must have 2 dimensions.")
 
         if qhull_options is None:
             if not incremental:
@@ -2594,6 +2596,8 @@ class Voronoi(_QhullUser):
         if np.ma.isMaskedArray(points):
             raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
+        if points.ndim != 2:
+            raise ValueError("Input points array must have 2 dimensions.")
 
         if qhull_options is None:
             if not incremental:

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -361,7 +361,8 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
-        self._messages.close()
+        if self._messages is not None:
+            self._messages.close()
 
     @cython.final
     def close(self):
@@ -387,7 +388,8 @@ cdef class _Qhull:
                     "qhull: did not free %d bytes (%d pieces)" %
                     (totlong, curlong))
 
-        self._messages.close()
+        if self._messages is not None:
+            self._messages.close()
 
     @cython.final
     def get_points(self):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1176,3 +1176,11 @@ class Test_HalfspaceIntersection:
             assert set(a) == set(b)  # facet orientation can differ
 
         assert_allclose(hs.dual_points, qhalf_points)
+
+
+@pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
+def test_gh_20623(diagram_type):
+    rng = np.random.default_rng(123)
+    invalid_data = rng.random((4, 10, 3))
+    with pytest.raises(ValueError, match="dimensions"):
+        diagram_type(invalid_data)

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3431,13 +3431,32 @@ cdef class Rotation:
             # We first find the minimum angle rotation between the primary
             # vectors.
             cross = np.cross(b_pri[0], a_pri[0])
-            theta = atan2(_norm3(cross), np.dot(a_pri[0], b_pri[0]))
-            if theta < 1e-3:  # small angle Taylor series approximation
+            cross_norm = _norm3(cross)
+            theta = atan2(cross_norm, _dot3(a_pri[0], b_pri[0]))
+            tolerance = 1e-3  # tolerance for small angle approximation (rad)
+            R_flip = cls.identity()
+            if (np.pi - theta) < tolerance:
+                # Near pi radians, the Taylor series appoximation of x/sin(x)
+                # diverges, so for numerical stability we flip pi and then
+                # rotate back by the small angle pi - theta
+                if cross_norm == 0:
+                    # For antiparallel vectors, cross = [0, 0, 0] so we need to
+                    # manually set an arbitrary orthogonal axis of rotation
+                    i = np.argmin(np.abs(a_pri[0]))
+                    r = np.zeros(3)
+                    r[i - 1], r[i - 2] = a_pri[0][i - 2], -a_pri[0][i - 1]
+                else:
+                    r = cross  # Shortest angle orthogonal axis of rotation
+                R_flip = Rotation.from_rotvec(r / np.linalg.norm(r) * np.pi)
+                theta = np.pi - theta
+                cross = -cross
+            if abs(theta) < tolerance:
+                # Small angle Taylor series approximation for numerical stability
                 theta2 = theta * theta
                 r = cross * (1 + theta2 / 6 + theta2 * theta2 * 7 / 360)
             else:
                 r = cross * theta / np.sin(theta)
-            R_pri = cls.from_rotvec(r)
+            R_pri = cls.from_rotvec(r) * R_flip
 
             if N == 1:
                 # No secondary vectors, so we are done

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1417,6 +1417,32 @@ def test_align_vectors_parallel():
     assert_allclose(R.apply(b[0]), a[0], atol=atol)
 
 
+def test_align_vectors_antiparallel():
+    # Test exact 180 deg rotation
+    atol = 1e-12
+    as_to_test = np.array([[[1, 0, 0], [0, 1, 0]],
+                           [[0, 1, 0], [1, 0, 0]],
+                           [[0, 0, 1], [0, 1, 0]]])
+    bs_to_test = [[-a[0], a[1]] for a in as_to_test]
+    for a, b in zip(as_to_test, bs_to_test):
+        R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+        assert_allclose(R.magnitude(), np.pi, atol=atol)
+        assert_allclose(R.apply(b[0]), a[0], atol=atol)
+
+    # Test exact rotations near 180 deg
+    Rs = Rotation.random(100, random_state=0)
+    dRs = Rotation.from_rotvec(Rs.as_rotvec()*1e-4)  # scale down to small angle
+    a = [[ 1, 0, 0], [0, 1, 0]]
+    b = [[-1, 0, 0], [0, 1, 0]]
+    as_to_test = []
+    for dR in dRs:
+        as_to_test.append([dR.apply(a[0]), a[1]])
+    for a in as_to_test:
+        R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+        R2, _ = Rotation.align_vectors(a, b, weights=[1e10, 1])
+        assert_allclose(R.as_matrix(), R2.as_matrix(), atol=atol)
+
+
 def test_align_vectors_primary_only():
     atol = 1e-12
     mats_a = Rotation.random(100, random_state=0).as_matrix()

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2931,7 +2931,8 @@ def _factorialx_approx_core(n, k):
     for r in np.unique(n_mod_k):
         if r == 0:
             continue
-        result[n_mod_k == r] *= corr(k, r)
+        # cast to int because uint types break on `-r`
+        result[n_mod_k == r] *= corr(k, int(r))
     return result
 
 

--- a/scipy/special/_spherical_bessel.pxd
+++ b/scipy/special/_spherical_bessel.pxd
@@ -343,7 +343,10 @@ cdef inline double spherical_in_d_real(long n, double x) noexcept nogil:
         return spherical_in_real(1, x)
     else:
         if x == 0:
-            return 0
+            if n == 1:
+                return 1 / 3.
+            else:
+                return 0
         return (spherical_in_real(n - 1, x) -
                 (n + 1)*spherical_in_real(n, x)/x)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2171,9 +2171,13 @@ class TestFactorialFunctions:
         _check(special.factorialk(n, 3, exact=exact), exp_nucleus[3])
 
     @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("dtype", [
+        None, int, np.int8, np.int16, np.int32, np.int64,
+        np.uint8, np.uint16, np.uint32, np.uint64
+    ])
     @pytest.mark.parametrize("dim", range(0, 5))
-    def test_factorialx_array_dimension(self, dim, exact):
-        n = np.array(5, ndmin=dim)
+    def test_factorialx_array_dimension(self, dim, dtype, exact):
+        n = np.array(5, dtype=dtype, ndmin=dim)
         exp = {1: 120, 2: 15, 3: 10}
         assert_allclose(special.factorial(n, exact=exact),
                         np.array(exp[1], ndmin=dim))

--- a/scipy/special/tests/test_spherical_bessel.py
+++ b/scipy/special/tests/test_spherical_bessel.py
@@ -286,9 +286,10 @@ class TestSphericalInDerivatives(SphericalDerivativesTestCase):
         return spherical_in(n, z, derivative=True)
 
     def test_spherical_in_d_zero(self):
-        n = np.array([1, 2, 3, 7, 15])
+        n = np.array([0, 1, 2, 3, 7, 15])
+        spherical_in(n, 0, derivative=False)
         assert_allclose(spherical_in(n, 0, derivative=True),
-                        np.zeros(5))
+                        np.array([0, 1/3, 0, 0, 0, 0]))
 
 
 class TestSphericalKnDerivatives(SphericalDerivativesTestCase):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -692,12 +692,10 @@ class beta_gen(rv_continuous):
         return _boost._beta_sf(x, a, b)
 
     def _isf(self, x, a, b):
-        with np.errstate(over='ignore'):  # see gh-17432
-            return _boost._beta_isf(x, a, b)
+        return sc.betainccinv(a, b, x)
 
     def _ppf(self, q, a, b):
-        with np.errstate(over='ignore'):  # see gh-17432
-            return _boost._beta_ppf(q, a, b)
+        return sc.betaincinv(a, b, q)
 
     def _stats(self, a, b):
         return (

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1305,8 +1305,9 @@ class zipf_gen(rv_discrete):
         return a > 1
 
     def _pmf(self, k, a):
+        k = k.astype(np.float64)
         # zipf.pmf(k, a) = 1/(zeta(a) * k**a)
-        Pk = 1.0 / special.zeta(a, 1) / k**a
+        Pk = 1.0 / special.zeta(a, 1) * k**-a
         return Pk
 
     def _munp(self, n, a):
@@ -1404,7 +1405,8 @@ class zipfian_gen(rv_discrete):
         return 1, n
 
     def _pmf(self, k, a, n):
-        return 1.0 / _gen_harmonic(n, a) / k**a
+        k = k.astype(np.float64)
+        return 1.0 / _gen_harmonic(n, a) * k**-a
 
     def _cdf(self, k, a, n):
         return _gen_harmonic(k, a) / _gen_harmonic(n, a)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1658,7 +1658,7 @@ class yulesimon_gen(rv_discrete):
                       np.inf)
         g1 = np.where(alpha <= 2, np.nan, g1)
         g2 = np.where(alpha > 4,
-                      alpha + 3 + ((alpha**3 - 49 * alpha - 22) /
+                      alpha + 3 + ((11 * alpha**3 - 49 * alpha - 22) /
                                    (alpha * (alpha - 4) * (alpha - 3))),
                       np.inf)
         g2 = np.where(alpha <= 2, np.nan, g2)

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -142,7 +142,7 @@ distdiscrete = [
     ['poisson', (0.6,)],
     ['randint', (7, 31)],
     ['skellam', (15, 8)],
-    ['zipf', (6.5,)],
+    ['zipf', (6.6,)],
     ['zipfian', (0.75, 15)],
     ['zipfian', (1.25, 10)],
     ['yulesimon', (11.0,)],

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -102,6 +102,7 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
                    "an instance of `stats.PermutationMethod`.")
         if method not in methods:
             raise ValueError(message)
+    output_z = True if method == 'approx' else False
 
     # logic unchanged here for backward compatibility
     n_zero = np.sum(d == 0, axis=-1)
@@ -127,7 +128,7 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
     if 0 < d.shape[-1] < 10 and method == "approx":
         warnings.warn("Sample size too small for normal approximation.", stacklevel=2)
 
-    return d, zero_method, correction, alternative, method, axis
+    return d, zero_method, correction, alternative, method, axis, output_z
 
 
 def _wilcoxon_statistic(d, zero_method='wilcox'):
@@ -196,7 +197,7 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
                  alternative='two-sided', method='auto', axis=0):
 
     temp = _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis)
-    d, zero_method, correction, alternative, method, axis = temp
+    d, zero_method, correction, alternative, method, axis, output_z = temp
 
     if d.size == 0:
         NaN = _get_nan(d)
@@ -232,6 +233,6 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
     z = -np.abs(z) if (alternative == 'two-sided' and method == 'approx') else z
 
     res = _morestats.WilcoxonResult(statistic=statistic, pvalue=p[()])
-    if method == 'approx':
+    if output_z:
         res.zstatistic = z[()]
     return res

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -91,7 +91,9 @@ def test_moments(distname, arg):
     check_mean_expect(distfn, arg, m, distname)
     check_var_expect(distfn, arg, m, v, distname)
     check_skew_expect(distfn, arg, m, v, s, distname)
-    if distname not in ['zipf', 'yulesimon', 'betanbinom']:
+    with np.testing.suppress_warnings() as sup:
+        if distname in ['zipf', 'betanbinom']:
+            sup.filter(RuntimeWarning)
         check_kurt_expect(distfn, arg, m, v, k, distname)
 
     # frozen distr moments

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -351,6 +351,14 @@ class TestZipfian:
         assert_allclose(zipfian.stats(a, n, moments="mvsk"),
                         [mean, var, skew, kurtosis])
 
+    def test_pmf_integer_k(self):
+        k = np.arange(0, 1000)
+        k_int32 = k.astype(np.int32)
+        dist = zipfian(111, 22)
+        pmf = dist.pmf(k)
+        pmf_k_int32 = dist.pmf(k_int32)
+        assert_equal(pmf, pmf_k_int32)
+
 
 class TestNCH:
     np.random.seed(2)  # seeds 0 and 1 had some xl = xu; randint failed
@@ -627,3 +635,14 @@ class TestBetaNBinom:
         #      return float(fourth_moment/var**2 - 3.)
         assert_allclose(betanbinom.stats(n, a, b, moments="k"),
                         ref, rtol=3e-15)
+
+
+class TestZipf:
+    def test_gh20692(self):
+        # test that int32 data for k generates same output as double
+        k = np.arange(0, 1000)
+        k_int32 = k.astype(np.int32)
+        dist = zipf(9)
+        pmf = dist.pmf(k)
+        pmf_k_int32 = dist.pmf(k_int32)
+        assert_equal(pmf, pmf_k_int32)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -13,7 +13,7 @@ import platform
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_almost_equal, assert_array_almost_equal,
                            assert_allclose, assert_, assert_warns,
-                           assert_array_less, suppress_warnings, IS_PYPY)
+                           assert_array_less, suppress_warnings)
 import pytest
 from pytest import raises as assert_raises
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4006,6 +4006,12 @@ class TestSkewNorm:
         fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
+    def test_ppf(self):
+        # gh-20124 reported that Boost's ppf was wrong for high skewness
+        # Reference value was calculated using
+        # N[InverseCDF[SkewNormalDistribution[0, 1, 500], 1/100], 14] in Wolfram Alpha.
+        assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-13)
+
 
 class TestExpon:
     def test_zero(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4460,7 +4460,7 @@ class TestBeta:
         assert_equal(stats.beta.pdf(1, a, b), 5)
         assert_equal(stats.beta.pdf(1-1e-310, a, b), 5)
 
-    @pytest.mark.xfail(IS_PYPY, reason="Does not convert boost warning")
+    @pytest.mark.xfail(reason="Does not warn on special codepath")
     def test_boost_eval_issue_14606(self):
         q, a, b = 0.995, 1.0e11, 1.0e13
         with pytest.warns(RuntimeWarning):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4006,12 +4006,6 @@ class TestSkewNorm:
         fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
-    def test_ppf(self):
-        # gh-20124 reported that Boost's ppf was wrong for high skewness
-        # Reference value was calculated using
-        # N[InverseCDF[SkewNormalDistribution[0, 1, 500], 1/100], 14] in Wolfram Alpha.
-        assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-13)
-
 
 class TestExpon:
     def test_zero(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1656,6 +1656,22 @@ class TestWilcoxon:
         assert_equal(np.round(res.pvalue, 2), res.pvalue)  # n_resamples used
         assert_equal(res.pvalue, ref.pvalue)  # random_state used
 
+    def test_method_auto_nan_propagate_ND_length_gt_50_gh20591(self):
+        # When method!='approx', nan_policy='propagate', and a slice of
+        # a >1 dimensional array input contained NaN, the result object of
+        # `wilcoxon` could (under yet other conditions) return `zstatistic`
+        # for some slices but not others. This resulted in an error because
+        # `apply_along_axis` would have to create a ragged array.
+        # Check that this is resolved.
+        rng = np.random.default_rng(235889269872456)
+        A = rng.normal(size=(51, 2))  # length along slice > exact threshold
+        A[5, 1] = np.nan
+        res = stats.wilcoxon(A)
+        ref = stats.wilcoxon(A, method='approx')
+        assert_allclose(res, ref)
+        assert hasattr(ref, 'zstatistic')
+        assert not hasattr(res, 'zstatistic')
+
 
 class TestKstat:
     def test_moments_normal_distribution(self):

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -289,9 +289,9 @@ def main():
                             cwd=os.getcwd())
         out, err = p.communicate()
         if not (p.returncode == 0):
-            raise RuntimeError(f"Writing {args.outfile} with f2py failed!\n"
-                            f"{out}\n"
-                            r"{err}")
+            raise RuntimeError(f"Processing {fname_pyf} with f2py failed!\n"
+                               f"{out.decode()}\n"
+                               f"{err.decode()}")
 
 
 if __name__ == "__main__":

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -11,7 +11,8 @@ target-version = "py39"
 # and `B028` which checks that warnings include the `stacklevel` keyword.
 # `B028` added in gh-19623.
 select = ["E", "F", "PGH004", "UP", "B028"]
-ignore = ["E741"]
+# UP031 should be enabled once someone fixes the errors.
+ignore = ["E741", "UP031"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -12,7 +12,7 @@ target-version = "py39"
 # `B028` added in gh-19623.
 select = ["E", "F", "PGH004", "UP", "B028"]
 # UP031 should be enabled once someone fixes the errors.
-ignore = ["E741", "UP031"]
+ignore = ["E741", "UP031", "UP032"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.26.dev'
-OPENBLAS_LONG = 'v0.3.26-382-gb1e8ba50'
+OPENBLAS_V = '0.3.27'
+OPENBLAS_LONG = 'v0.3.27'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 NIGHTLY_BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'


### PR DESCRIPTION
We're about 3.5 weeks from the planned branching for SciPy `1.14.x`. Since `1.13.0` was a bit rushed to support NumPy 2.x, and indeed I made a few oversights for backporting, it may make sense to at least assess how much work it would be to deliver `1.13.1`. I've cleaned up the backport labels a bit too, since there were almost 50 of them. Many were things I could have backported to `1.12.x`, but I think that would stretch me (and reviewers/support) too thin at this point.

Backports included here (so far):

1. gh-20322
2. gh-20333
3. gh-20401
4. gh-20435
5. gh-20437
6. gh-20449
7. gh-20473
8. gh-20474
9. gh-20484
10. gh-20505 (already covered by gh-20537)
11. gh-20516
12. gh-20527 (**danger: I applied the patch manually to the old version of the `special` code**; I did backport the new test though, and it did fail before/pass after my manual application of a slightly different patch)
13. gh-20530
14. gh-20569
15. gh-20573
16. gh-20607
17. gh-20611
18. gh-20633
19. gh-20653
20. gh-20654
21. gh-20444
22. gh-20687
23. gh-20280
24. gh-20601
25. gh-20629
26. gh-20644
27. gh-20727
28. gh-20533
29. gh-20592
30. gh-20702

Backports already merged to the release branch:
1. gh-20567
2. gh-20537

TODO:

- [x] perhaps deal with what I believe is NumPy copy semantics changes causing a few fails with pre-release (https://github.com/scipy/scipy/actions/runs/9102530687/job/25022358623?pr=20632), though I believe we don't really have to do that on the release branch and could also pin NumPy back a bit (maybe I'll evaluate size of patch needed locally...)
- [x] CI failure from https://github.com/scipy/scipy/issues/20714 (persists in `main` at time of writing)
- [x] https://github.com/scipy/scipy/issues/20576 (at least one of those is showing up here already I think)
- [x] there are a few 1.13.0 performance/hang-related tickets open to keep an eye on I think (OpenBLAS and/or Qhull thread contention?)
- [x] gradually running more of the CI here, including wheel build flush eventually because of i.e., OpenBLAS bump
- [x] check for more backport candidates from the last few days
- [x] update the release notes again
- [x] read the diff carefully
- [x] (minor) `doc/source/.jupyterlite.doit.db` isn't gitignored on this branch/PR when I do the doc build (which otherwise passes at the time of writing) locally
- [x] backport linter suppressions for stuff like `UP031 Use format specifiers ...` maybe?