### PR TITLE
BUG: fix Vor/Delaunay segfaults

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1802,6 +1802,8 @@ class Delaunay(_QhullUser):
         if np.ma.isMaskedArray(points):
             raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
+        if points.ndim != 2:
+            raise ValueError("Input points array must have 2 dimensions.")
 
         if qhull_options is None:
             if not incremental:
@@ -2592,6 +2594,8 @@ class Voronoi(_QhullUser):
         if np.ma.isMaskedArray(points):
             raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
+        if points.ndim != 2:
+            raise ValueError("Input points array must have 2 dimensions.")
 
         if qhull_options is None:
             if not incremental:

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1178,3 +1178,11 @@ class Test_HalfspaceIntersection:
             assert set(a) == set(b)  # facet orientation can differ
 
         assert_allclose(hs.dual_points, qhalf_points)
+
+
+@pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
+def test_gh_20623(diagram_type):
+    rng = np.random.default_rng(123)
+    invalid_data = rng.random((4, 10, 3))
+    with pytest.raises(ValueError, match="dimensions"):
+        diagram_type(invalid_data)


### PR DESCRIPTION
* Deals with the `spatial` part of #20623 (`Voronoi` was also affected beyond the originally-reported `Delaunay` segfault).

* Both classes are documented to accept arrays with two dimensions only, so raise a `ValueError` in cases with other dimensions to avoid the segfault.

* Other potential points of confusion here are the differences between arrays with two dimensions and two dimensional arrays that represent generators with more than two dimensions via the number of columns, but this is just how things are for most array programming languages of course. Also, the docs don't explicitly say array-like for the generators I don't think, but this patch only worked if I placed it after the coercion to array type.

[skip circle]