### PR TITLE
MAINT: Fix broken links in `datasets._fetchers` module

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -36,8 +36,8 @@ def ascent():
     Get an 8-bit grayscale bit-depth, 512 x 512 derived image for easy
     use in demos.
 
-    The image is derived from accent-to-the-top.jpg at
-    http://www.public-domain-image.com/people-public-domain-images-pictures/
+    The image is derived from
+    https://pixnio.com/people/accent-to-the-top
 
     Parameters
     ----------
@@ -178,7 +178,8 @@ def face(gray=False):
     """
     Get a 1024 x 768, color image of a raccoon face.
 
-    raccoon-procyon-lotor.jpg at http://www.public-domain-image.com
+    The image is derived from
+    https://pixnio.com/fauna-animals/raccoons/raccoon-procyon-lotor
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
No issue.

#### What does this implement/fix?
In module `datasets._fetchers` two links based on <http://www.public-domain-image.com> are given.
The link <http://www.public-domain-image.com> is invalid and has been replaced by <https://pixnio.com>.
This PR updates the module.

#### Additional information
Both broken links are also contained in module `misc._common`.
But there the functions `face()` and `ascent()` are marked as deprecated.
Thus, I decided not to update this module as well.