### PR TITLE
TST: adjust new array API test, slow tests

### DIFF
--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -9,7 +9,7 @@ from scipy.linalg.blas import cdotu  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
 
 
-@pytest.mark.fail_slow(30)
+@pytest.mark.fail_slow(60)
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -632,7 +632,7 @@ def test_diagonal_data_types(n, m):
             # This is one of the slower tests because there are >1,000 configs
             # to test here. Flip a biased coin to decide whether to run  each
             # test to get decent coverage in less time.
-            if rnd.random() < 0.95:
+            if rnd.random() < 0.98:
                 continue  # too many tests
             eigvals, _ = lobpcg(A, X, B=B, M=M, Y=Y, tol=1e-4,
                                 maxiter=100, largest=False)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1353,7 +1353,7 @@ class TestCvm_2samp:
         # The values are taken from Table 2, 3, 4 and 5
         assert_equal(_pval_cvm_2samp_exact(statistic, m, n), pval)
 
-    @pytest.mark.slow
+    @pytest.mark.xslow
     def test_large_sample(self):
         # for large samples, the statistic U gets very large
         # do a sanity check that p-value is not 0, 1 or nan

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2650,13 +2650,13 @@ class TestSEM:
         y = stats.sem(testcase)
         xp_assert_close(y, xp.asarray(0.6454972244))
         n = len(self.testcase)
-        assert_allclose(stats.sem(testcase, ddof=0) * (n/(n-2))**0.5,
+        xp_assert_close(stats.sem(testcase, ddof=0) * (n/(n-2))**0.5,
                         stats.sem(testcase, ddof=2))
 
         x = xp.arange(10.)
         x[9] = xp.nan
-        assert_equal(stats.sem(x), xp.asarray(xp.nan))
-    
+        xp_assert_equal(stats.sem(x), xp.asarray(xp.nan))
+
     @skip_xp_backends(np_only=True,
                       reasons=['`nan_policy` only supports NumPy backend'])
     def test_sem_nan_policy(self, xp):


### PR DESCRIPTION
#### Reference issue
gh-20631

#### What does this implement/fix?
A recently added test was missing using of `xp_` assertions, so tests failed with CuPy backend. This also adjusts the fail timer on some slow tests.