### PR TITLE
TST: stats.ttest_1samp: fix xslow test

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3559,10 +3559,12 @@ class TestKurtosis(SkewKurtosisTest):
 @hypothesis.strategies.composite
 def ttest_data_axis_strategy(draw):
     # draw an array under shape and value constraints
-    dtype = npst.floating_dtypes()
     elements = dict(allow_nan=False, allow_infinity=False)
     shape = npst.array_shapes(min_dims=1, min_side=2)
-    data = draw(npst.arrays(dtype=dtype, elements=elements, shape=shape))
+    # The test that uses this, `test_pvalue_ci`, uses `float64` to test
+    # extreme `alpha`. It could be adjusted to test a dtype-dependent
+    # range of `alpha` if this strategy is needed to generate other floats.
+    data = draw(npst.arrays(dtype=np.float64, elements=elements, shape=shape))
 
     # determine axes over which nonzero variance can be computed accurately
     ok_axes = []
@@ -3711,8 +3713,7 @@ class TestStudentTest:
     def test_pvalue_ci(self, alpha, data_axis, alternative, xp):
         # test relationship between one-sided p-values and confidence intervals
         data, axis = data_axis
-        data = data.astype(np.float64, copy=True)  # ensure byte order
-        data = xp.asarray(data, dtype=xp.float64)
+        data = xp.asarray(data)
         res = stats.ttest_1samp(data, 0.,
                                 alternative=alternative, axis=axis)
         l, u = res.confidence_interval(confidence_level=alpha)
@@ -3722,6 +3723,7 @@ class TestStudentTest:
         res = stats.ttest_1samp(data, popmean, alternative=alternative, axis=axis)
         shape = list(data.shape)
         shape.pop(axis)
+        # `float64` is used to correspond with extreme range of `alpha`
         ref = xp.broadcast_to(xp.asarray(1-alpha, dtype=xp.float64), shape)
         xp_assert_close(res.pvalue, ref)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3711,8 +3711,8 @@ class TestStudentTest:
     def test_pvalue_ci(self, alpha, data_axis, alternative, xp):
         # test relationship between one-sided p-values and confidence intervals
         data, axis = data_axis
-        data = data.astype(copy=True)  # ensure byte order
-        data = xp.asarray(data)
+        data = data.astype(np.float64, copy=True)  # ensure byte order
+        data = xp.asarray(data, dtype=xp.float64)
         res = stats.ttest_1samp(data, 0.,
                                 alternative=alternative, axis=axis)
         l, u = res.confidence_interval(confidence_level=alpha)
@@ -3722,7 +3722,7 @@ class TestStudentTest:
         res = stats.ttest_1samp(data, popmean, alternative=alternative, axis=axis)
         shape = list(data.shape)
         shape.pop(axis)
-        ref = xp.broadcast_to(xp.asarray(1-alpha), shape)
+        ref = xp.broadcast_to(xp.asarray(1-alpha, dtype=xp.float64), shape)
         xp_assert_close(res.pvalue, ref)
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-20641

#### What does this implement/fix?
Fixes the one test failure that occurs twice with each backend tested.

#### Additional information
```
[gh20641 aa257e0deb] TST: stats.ttest_1samp: fix xslow test
 1 file changed, 3 insertions(+), 3 deletions(-)
(scipy-dev) matthaberland@Matts-MacBook-Air scipy % git status
On branch gh20641
nothing to commit, working tree clean
(scipy-dev) matthaberland@Matts-MacBook-Air scipy % pytest scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci -v
========================================= test session starts =========================================
platform darwin -- Python 3.11.6, pytest-7.4.3, pluggy-1.5.0 -- /Users/matthaberland/miniforge3/envs/scipy-dev/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'deterministic' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=[HealthCheck.data_too_large, HealthCheck.filter_too_much, HealthCheck.too_slow, HealthCheck.large_base_example, HealthCheck.function_scoped_fixture, HealthCheck.differing_executors]
rootdir: /Users/matthaberland/Desktop/scipy
configfile: pytest.ini
plugins: fail-slow-0.5.0, hypothesis-6.88.1, anyio-4.3.0, cov-4.1.0, skip-slow-0.0.5, xdist-3.3.1
collected 6 items                                                                                     

scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[less-numpy] PASSED             [ 16%]
scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[less-array_api_strict] PASSED  [ 33%]
scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[less-torch] PASSED             [ 50%]
scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[greater-numpy] PASSED          [ 66%]
scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[greater-array_api_strict] PASSED [ 83%]
scipy/stats/tests/test_stats.py::TestStudentTest::test_pvalue_ci[greater-torch] PASSED          [100%]

========================================== 6 passed in 8.73s ==========================================
```