### PR TITLE
MAINT:update boost to fix `skewnorm.ppf`

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4011,8 +4011,8 @@ class TestSkewNorm:
 
     def test_ppf(self):
         # gh-20124 reported that Boost's ppf was wrong for high skewness
-        # Reference CDF value was calculated using
-        # CDF[SkewNormalDistribution[0, 1, 500], 0.01] in Wolfram Alpha.
+        # Reference value was calculated using
+        # N[InverseCDF[SkewNormalDistribution[0, 1, 500], 1/100], 14] in Wolfram Alpha.
         assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-13)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4009,6 +4009,12 @@ class TestSkewNorm:
         fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
+    def test_ppf(self):
+        # gh20124 reported that Boost's ppf was wrong for high skewness values
+        # Reference CDF value was calculated using
+        # CDF[SkewNormalDistribution[0, 1, a], x] in Wolfram Alpha.
+        assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-8)
+
 
 class TestExpon:
     def test_zero(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4012,8 +4012,8 @@ class TestSkewNorm:
     def test_ppf(self):
         # gh20124 reported that Boost's ppf was wrong for high skewness values
         # Reference CDF value was calculated using
-        # CDF[SkewNormalDistribution[0, 1, a], x] in Wolfram Alpha.
-        assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-8)
+        # CDF[SkewNormalDistribution[0, 1, 500], 0.01] in Wolfram Alpha.
+        assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-13)
 
 
 class TestExpon:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4010,7 +4010,7 @@ class TestSkewNorm:
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
     def test_ppf(self):
-        # gh20124 reported that Boost's ppf was wrong for high skewness values
+        # gh-20124 reported that Boost's ppf was wrong for high skewness
         # Reference CDF value was calculated using
         # CDF[SkewNormalDistribution[0, 1, 500], 0.01] in Wolfram Alpha.
         assert_allclose(stats.skewnorm.ppf(0.01, 500), 0.012533469508013, rtol=1e-13)


### PR DESCRIPTION
#### Reference issue
Supersedes #20125 
Closes #20124

#### What does this implement/fix?
The skewnorm quantile calculation was fixed upstream, so this updates boost to the latest commit of the development branch.

#### Additional information
CC @maresb in case you have more stress tests for the skewnorm distribution.

I added the backport-candidate label as this is a bug fix but feel free to ignore @tylerjereddy as boost had many moving parts lately. Might be worth to run wheel tests as boost was prone to subtle bugs, will leave the decision to people more involved in that though.