### PR TITLE
BUG: ndimage.value_indices: deal with unfixed types

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -999,6 +999,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
         case NPY_UINT32: CASE_VALUEINDICES_SET_MINMAX(npy_uint32); break;
         case NPY_INT64:  CASE_VALUEINDICES_SET_MINMAX(npy_int64); break;
         case NPY_UINT64: CASE_VALUEINDICES_SET_MINMAX(npy_uint64); break;
+        default:
+            switch(arrType) {
+            case NPY_UINT: CASE_VALUEINDICES_SET_MINMAX(npy_uint); break;
+            case NPY_INT: CASE_VALUEINDICES_SET_MINMAX(npy_int); break;
+            }
         }
         NI_ITERATOR_NEXT(ndiIter, arrData);
     }
@@ -1016,6 +1021,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
         case NPY_UINT32: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint32); break;
         case NPY_INT64:  CASE_VALUEINDICES_MAKEHISTOGRAM(npy_int64); break;
         case NPY_UINT64: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint64); break;
+        default:
+            switch(arrType) {
+            case NPY_INT:  CASE_VALUEINDICES_MAKEHISTOGRAM(npy_int); break;
+            case NPY_UINT: CASE_VALUEINDICES_MAKEHISTOGRAM(npy_uint); break;
+            }
         }
     }
 
@@ -1047,6 +1057,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
                 case NPY_UINT32: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint32, ii); break;
                 case NPY_INT64:  CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_int64, ii); break;
                 case NPY_UINT64: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint64, ii); break;
+                default:
+                    switch(arrType) {
+                    case NPY_INT:  CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_int, ii); break;
+                    case NPY_UINT: CASE_VALUEINDICES_MAKE_VALUEOBJ_FROMOFFSET(npy_uint, ii); break;
+                    }
                 }
                 /* Create a tuple of <ndim> index arrays */
                 t = PyTuple_New(ndim);
@@ -1093,6 +1108,11 @@ static PyObject *NI_ValueIndices(PyObject *self, PyObject *args)
                 case NPY_UINT32: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint32); break;
                 case NPY_INT64:  CASE_VALUEINDICES_GET_VALUEOFFSET(npy_int64); break;
                 case NPY_UINT64: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint64); break;
+                default:
+                    switch(arrType) {
+                    case NPY_INT:  CASE_VALUEINDICES_GET_VALUEOFFSET(npy_int); break;
+                    case NPY_UINT: CASE_VALUEINDICES_GET_VALUEOFFSET(npy_uint); break;
+                    }
                 }
 
                 if (ignoreValIsNone || (!valueIsIgnore)) {

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -10,6 +10,7 @@ from numpy.testing import (
     assert_equal,
     suppress_warnings,
 )
+import pytest
 from pytest import raises as assert_raises
 
 import scipy.ndimage as ndimage
@@ -1407,3 +1408,12 @@ class TestWatershedIft:
         expected = [[1, 1],
                     [1, 1]]
         assert_allclose(out, expected)
+
+
+@pytest.mark.parametrize("dt", [np.intc, np.uintc])
+def test_gh_19423(dt):
+    rng = np.random.default_rng(123)
+    max_val = 8
+    image = rng.integers(low=0, high=max_val, size=(10, 12)).astype(dtype=dt)
+    val_idx = ndimage.value_indices(image)
+    assert len(val_idx.keys()) == max_val


### PR DESCRIPTION
* Fixes gh-19423

* Add a few more `case` statements to account for the (i.e., Windows) data types that don't have a fixed width, and add a regression test.

[skip circle] [skip cirrus]