### PR TITLE
ENH: optimize.approx_fprime: avoid quadratic memory usage

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -581,16 +581,16 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
     m = f0.size
     n = x0.size
     J_transposed = np.empty((n, m))
+    x1 = x0.copy()
+    x2 = x0.copy()
+    xc = x0.astype(complex, copy=True)
 
     for i in range(h.size):
         if method == '2-point':
-            x = x0.copy()
-            x[i] += h[i]
-            dx = x[i] - x0[i]  # Recompute dx as exactly representable number.
-            df = fun(x) - f0
+            x1[i] += h[i]
+            dx = x1[i] - x0[i]  # Recompute dx as exactly representable number.
+            df = fun(x1) - f0
         elif method == '3-point' and use_one_sided[i]:
-            x1 = x0.copy()
-            x2 = x0.copy()
             x1[i] += h[i]
             x2[i] += 2 * h[i]
             dx = x2[i] - x0[i]
@@ -598,24 +598,22 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
             f2 = fun(x2)
             df = -3.0 * f0 + 4 * f1 - f2
         elif method == '3-point' and not use_one_sided[i]:
-            x1 = x0.copy()
             x1[i] -= h[i]
-            x2 = x0.copy()
             x2[i] += h[i]
             dx = x2[i] - x1[i]
             f1 = fun(x1)
             f2 = fun(x2)
             df = f2 - f1
         elif method == 'cs':
-            x1 = x0.astype(complex, copy=True)
-            x1[i] += h[i] * 1.j
-            f1 = fun(x1)
+            xc[i] += h[i] * 1.j
+            f1 = fun(xc)
             df = f1.imag
             dx = h[i]
         else:
             raise RuntimeError("Never be here.")
 
         J_transposed[i] = df / dx
+        x1[i] = x2[i] = xc[i] = x0[i]
 
     if m == 1:
         J_transposed = np.ravel(J_transposed)

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -581,31 +581,37 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
     m = f0.size
     n = x0.size
     J_transposed = np.empty((n, m))
-    h_vecs = np.diag(h)
 
     for i in range(h.size):
         if method == '2-point':
-            x = x0 + h_vecs[i]
+            x = x0.copy()
+            x[i] += h[i]
             dx = x[i] - x0[i]  # Recompute dx as exactly representable number.
             df = fun(x) - f0
         elif method == '3-point' and use_one_sided[i]:
-            x1 = x0 + h_vecs[i]
-            x2 = x0 + 2 * h_vecs[i]
+            x1 = x0.copy()
+            x2 = x0.copy()
+            x1[i] += h[i]
+            x2[i] += 2 * h[i]
             dx = x2[i] - x0[i]
             f1 = fun(x1)
             f2 = fun(x2)
             df = -3.0 * f0 + 4 * f1 - f2
         elif method == '3-point' and not use_one_sided[i]:
-            x1 = x0 - h_vecs[i]
-            x2 = x0 + h_vecs[i]
+            x1 = x0.copy()
+            x1[i] -= h[i]
+            x2 = x0.copy()
+            x2[i] += h[i]
             dx = x2[i] - x1[i]
             f1 = fun(x1)
             f2 = fun(x2)
             df = f2 - f1
         elif method == 'cs':
-            f1 = fun(x0 + h_vecs[i]*1.j)
+            x1 = x0.astype(complex, copy=True)
+            x1[i] += h[i] * 1.j
+            f1 = fun(x1)
             df = f1.imag
-            dx = h_vecs[i, i]
+            dx = h[i]
         else:
             raise RuntimeError("Never be here.")
 


### PR DESCRIPTION
Currently, the code generates all possible vectors to change x0 by at once. When optimizing a function in many dimensions, this uses a quadratic amount of memory, which is wasteful. Reduce this by computing those vectors one at a time.

This is my first change to SciPy; I appreciate any feedback.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

There is no previously filed issue for this problem.

#### What does this implement/fix?

Here are two examples that I've seen on StackOverflow of users running into this problem:

https://stackoverflow.com/questions/77867437/scipy-minimize-returns-an-array-too-big

https://stackoverflow.com/questions/78399838/when-using-scipy-minimize-a-large-array-appears-which-was-not-originally-there

To summarize, both of these people are trying to minimize a function of ~90000 variables, and SciPy then asks to allocate an array which is N ** 2 * 8 bytes in size to compute the derivative. This seems strange, since this derivative can be computed in linear amounts of memory. There is also a solver, L-BFGS-B, which is capable of minimizing a function this large, so doing this in linear amounts of memory is not just of academic interest.

#### Memory usage benchmarks

I have two goals for this change:

* Reduce memory use
* Avoid a regression in CPU usage

Here is a benchmark showing the difference in memory usage:

```
import numpy as np
from scipy.optimize import rosen, minimize
import resource
import time


def get_peak_mem():
    kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
    mb = kb / 1024
    return mb

def func(x, target):
    return np.mean((target - x)**2)


x0 = np.zeros(10000)
target = np.ones_like(x0)
start = time.time()
res = minimize(
    func,
    x0,
    method='L-BFGS-B',
    options=dict(maxfun=np.inf),
    args=(target),
)
end = time.time()
print(res)
print(f"Usage: {get_peak_mem():.2f} MiB")
print(f"Duration: {end - start:.2f}s")
```

(Warning: memory usage will be wrong on OS X.)

Result, running on this branch

```
  message: CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL
  success: True
   status: 0
      fun: 2.5149038026498236e-10
        x: [ 1.000e+00  1.000e+00 ...  1.000e+00  1.000e+00]
      nit: 2
      jac: [-3.171e-09 -3.171e-09 ... -3.171e-09 -3.171e-09]
     nfev: 50005
     njev: 5
 hess_inv: <10000x10000 LbfgsInvHessProduct with dtype=float64>
Usage: 81.21 MiB
Duration: 2.00s
```

Result, running on current main (4a537b736203190a5bca1d00f7e2659a507e1ad3)

```
  message: CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL
  success: True
   status: 0
      fun: 2.5149038026498236e-10
        x: [ 1.000e+00  1.000e+00 ...  1.000e+00  1.000e+00]
      nit: 2
      jac: [-3.171e-09 -3.171e-09 ... -3.171e-09 -3.171e-09]
     nfev: 50005
     njev: 5
 hess_inv: <10000x10000 LbfgsInvHessProduct with dtype=float64>
Usage: 120.34 MiB
Duration: 3.67s
```

(Interestingly, this is less memory than predicted by the formula N ** 2 * 8 bytes. I believe this is because Linux lazily allocates memory. Each row in the matrix is roughly twenty 4K pages long, but only one of those pages must be allocated, since there is only one non-zero value per row.)

#### CPU Benchmarks

I also attempted to benchmark this with the built-in benchmarks, but could not figure out how to use `--compare`. (See https://github.com/airspeed-velocity/asv/issues/1401) Benchmarking without `--compare`, it seems on benchmarks where no derivative is supplied, this method is either faster, or only slower by ~1%.

Optimize benchmarks, my branch:

```
               rosenbrock_nograd        COBYLA       mean_nfev            1000.0         
               rosenbrock_nograd        COBYLA       mean_time     0.01873011589050293   
               rosenbrock_nograd        Powell       mean_nfev            887.2          
               rosenbrock_nograd        Powell       mean_time     0.01709756851196289   
               rosenbrock_nograd     nelder-mead     mean_nfev            310.2          
               rosenbrock_nograd     nelder-mead     mean_time    0.0070003032684326175  
               rosenbrock_nograd       L-BFGS-B      mean_nfev            148.4          
               rosenbrock_nograd       L-BFGS-B      mean_time     0.00667574405670166   
               rosenbrock_nograd         BFGS        mean_nfev            176.8          
               rosenbrock_nograd         BFGS        mean_time      0.0107954740524292   
               rosenbrock_nograd          CG         mean_nfev             n/a           
               rosenbrock_nograd          CG         mean_time             n/a           
               rosenbrock_nograd         TNC         mean_nfev             n/a           
               rosenbrock_nograd         TNC         mean_time             n/a           
               rosenbrock_nograd        SLSQP        mean_nfev            155.1          
               rosenbrock_nograd        SLSQP        mean_time     0.008312082290649414  
               rosenbrock_nograd      Newton-CG      mean_nfev             n/a           
               rosenbrock_nograd      Newton-CG      mean_time             n/a           
               rosenbrock_nograd        dogleg       mean_nfev             n/a           
               rosenbrock_nograd        dogleg       mean_time             n/a           
               rosenbrock_nograd      trust-ncg      mean_nfev             n/a           
               rosenbrock_nograd      trust-ncg      mean_time             n/a           
               rosenbrock_nograd     trust-exact     mean_nfev             n/a           
               rosenbrock_nograd     trust-exact     mean_time             n/a           
               rosenbrock_nograd     trust-krylov    mean_nfev             n/a           
               rosenbrock_nograd     trust-krylov    mean_time             n/a           
               rosenbrock_nograd     trust-constr    mean_nfev            216.0          
               rosenbrock_nograd     trust-constr    mean_time     0.07394084930419922   
```

Main branch

```
               rosenbrock_nograd        COBYLA       mean_nfev            1000.0         
               rosenbrock_nograd        COBYLA       mean_time     0.01912097930908203   
               rosenbrock_nograd        Powell       mean_nfev            887.2          
               rosenbrock_nograd        Powell       mean_time     0.018049192428588868  
               rosenbrock_nograd     nelder-mead     mean_nfev            310.2          
               rosenbrock_nograd     nelder-mead     mean_time     0.007235574722290039  
               rosenbrock_nograd       L-BFGS-B      mean_nfev            148.4          
               rosenbrock_nograd       L-BFGS-B      mean_time     0.00679473876953125   
               rosenbrock_nograd         BFGS        mean_nfev            176.8          
               rosenbrock_nograd         BFGS        mean_time     0.010858583450317382  
               rosenbrock_nograd          CG         mean_nfev             n/a           
               rosenbrock_nograd          CG         mean_time             n/a           
               rosenbrock_nograd         TNC         mean_nfev             n/a           
               rosenbrock_nograd         TNC         mean_time             n/a           
               rosenbrock_nograd        SLSQP        mean_nfev            155.1          
               rosenbrock_nograd        SLSQP        mean_time     0.009046149253845216  
               rosenbrock_nograd      Newton-CG      mean_nfev             n/a           
               rosenbrock_nograd      Newton-CG      mean_time             n/a           
               rosenbrock_nograd        dogleg       mean_nfev             n/a           
               rosenbrock_nograd        dogleg       mean_time             n/a           
               rosenbrock_nograd      trust-ncg      mean_nfev             n/a           
               rosenbrock_nograd      trust-ncg      mean_time             n/a           
               rosenbrock_nograd     trust-exact     mean_nfev             n/a           
               rosenbrock_nograd     trust-exact     mean_time             n/a           
               rosenbrock_nograd     trust-krylov    mean_nfev             n/a           
               rosenbrock_nograd     trust-krylov    mean_time             n/a           
               rosenbrock_nograd     trust-constr    mean_nfev            216.0          
               rosenbrock_nograd     trust-constr    mean_time     0.07378766536712647   
```
