### PR TITLE
ENH: special: add `log_wright_bessel`

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -76,29 +76,30 @@ Bessel functions
 .. autosummary::
    :toctree: generated/
 
-   jv            -- Bessel function of the first kind of real order and \
-                    complex argument.
-   jve           -- Exponentially scaled Bessel function of order `v`.
-   yn            -- Bessel function of the second kind of integer order and \
-                    real argument.
-   yv            -- Bessel function of the second kind of real order and \
-                    complex argument.
-   yve           -- Exponentially scaled Bessel function of the second kind \
-                    of real order.
-   kn            -- Modified Bessel function of the second kind of integer \
-                    order `n`
-   kv            -- Modified Bessel function of the second kind of real order \
-                    `v`
-   kve           -- Exponentially scaled modified Bessel function of the \
-                    second kind.
-   iv            -- Modified Bessel function of the first kind of real order.
-   ive           -- Exponentially scaled modified Bessel function of the \
-                    first kind.
-   hankel1       -- Hankel function of the first kind.
-   hankel1e      -- Exponentially scaled Hankel function of the first kind.
-   hankel2       -- Hankel function of the second kind.
-   hankel2e      -- Exponentially scaled Hankel function of the second kind.
-   wright_bessel -- Wright's generalized Bessel function.
+   jv                -- Bessel function of the first kind of real order and \
+                        complex argument.
+   jve               -- Exponentially scaled Bessel function of order `v`.
+   yn                -- Bessel function of the second kind of integer order and \
+                        real argument.
+   yv                -- Bessel function of the second kind of real order and \
+                        complex argument.
+   yve               -- Exponentially scaled Bessel function of the second kind \
+                        of real order.
+   kn                -- Modified Bessel function of the second kind of integer \
+                        order `n`
+   kv                -- Modified Bessel function of the second kind of real order \
+                        `v`
+   kve               -- Exponentially scaled modified Bessel function of the \
+                        second kind.
+   iv                -- Modified Bessel function of the first kind of real order.
+   ive               -- Exponentially scaled modified Bessel function of the \
+                        first kind.
+   hankel1           -- Hankel function of the first kind.
+   hankel1e          -- Exponentially scaled Hankel function of the first kind.
+   hankel2           -- Hankel function of the second kind.
+   hankel2e          -- Exponentially scaled Hankel function of the second kind.
+   wright_bessel     -- Wright's generalized Bessel function.
+   log_wright_bessel -- Logarithm of Wright's generalized Bessel function.
 
 The following function does not accept NumPy arrays (it is not a
 universal function):

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -83,12 +83,12 @@ special_ufuncs = [
     'hankel1e', 'hankel2', 'hankel2e', 'hyp2f1', 'it2i0k0', 'it2j0y0', 'it2struve0',
     'itairy', 'iti0k0', 'itj0y0', 'itmodstruve0', 'itstruve0', 'iv', 'ive', 'jv',
     'jve', 'kei', 'keip', 'kelvin', 'ker', 'kerp', 'kv', 'kve', 'log_expit',
-    'loggamma', 'logit', 'mathieu_a', 'mathieu_b', 'mathieu_cem', 'mathieu_modcem1',
-    'mathieu_modcem2', 'mathieu_modsem1', 'mathieu_modsem2', 'mathieu_sem',
-    'modfresnelm', 'modfresnelp', 'obl_ang1', 'obl_ang1_cv', 'obl_cv', 'obl_rad1',
-    'obl_rad1_cv', 'obl_rad2', 'obl_rad2_cv', 'pbdv', 'pbvv', 'pbwa', 'pro_ang1',
-    'pro_ang1_cv', 'pro_cv', 'pro_rad1', 'pro_rad1_cv', 'pro_rad2', 'pro_rad2_cv',
-    'psi', 'rgamma', 'sph_harm', 'wright_bessel', 'yv', 'yve', '_zeta'
+    'log_wright_bessel', 'loggamma', 'logit', 'mathieu_a', 'mathieu_b', 'mathieu_cem',
+    'mathieu_modcem1', 'mathieu_modcem2', 'mathieu_modsem1', 'mathieu_modsem2',
+    'mathieu_sem', 'modfresnelm', 'modfresnelp', 'obl_ang1', 'obl_ang1_cv', 'obl_cv',
+    'obl_rad1', 'obl_rad1_cv', 'obl_rad2', 'obl_rad2_cv', 'pbdv', 'pbvv', 'pbwa',
+    'pro_ang1', 'pro_ang1_cv', 'pro_cv', 'pro_rad1', 'pro_rad1_cv', 'pro_rad2',
+    'pro_rad2_cv', 'psi', 'rgamma', 'sph_harm', 'wright_bessel', 'yv', 'yve', '_zeta'
 ]
 
 # -----------------------------------------------------------------------------

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -153,6 +153,7 @@ extern const char *lambertw_doc;
 extern const char *logit_doc;
 extern const char *loggamma_doc;
 extern const char *log_expit_doc;
+extern const char *log_wright_bessel_doc;
 extern const char *mathieu_a_doc;
 extern const char *mathieu_b_doc;
 extern const char *mathieu_cem_doc;
@@ -479,6 +480,12 @@ PyMODINIT_FUNC PyInit__special_ufuncs() {
         "log_expit", log_expit_doc
     );
     PyModule_AddObjectRef(_special_ufuncs, "log_expit", log_expit);
+
+    PyObject *log_wright_bessel = SpecFun_NewUFunc(
+        {static_cast<func_ddd_d_t>(special::log_wright_bessel), static_cast<func_fff_f_t>(special::log_wright_bessel)},
+        "log_wright_bessel", log_wright_bessel_doc
+    );
+    PyModule_AddObjectRef(_special_ufuncs, "log_wright_bessel", log_wright_bessel);
 
     PyObject *logit = SpecFun_NewUFunc(
         {static_cast<func_d_d_t>(special::logit), static_cast<func_f_f_t>(special::logit),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2754,6 +2754,41 @@ const char *log_expit_doc = R"(
     lose all precision and return 0.
     )";
 
+const char *log_wright_bessel_doc = R"(
+    log_wright_bessel(a, b, x, out=None)
+
+    Natural logarithm of Wright's generalized Bessel function, see `wright_bessel`.
+    This function comes in handy in particular for large values of x.
+
+    Parameters
+    ----------
+    a : array_like of float
+        a >= 0
+    b : array_like of float
+        b >= 0
+    x : array_like of float
+        x >= 0
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Value of the logarithm of Wright's generalized Bessel function
+
+    Notes
+    -----
+    Due to the complexity of the function with its three parameters, only
+    non-negative arguments are implemented.
+
+    Examples
+    --------
+    >>> from scipy.special import log_wright_bessel
+    >>> a, b, x = 1.5, 1.1, 2.5
+    >>> wright_bessel(a, b-1, x)
+    1.511041224929469
+    )";
+
 const char *mathieu_a_doc = R"(
     mathieu_a(m, q, out=None)
 

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2781,12 +2781,14 @@ const char *log_wright_bessel_doc = R"(
     Due to the complexity of the function with its three parameters, only
     non-negative arguments are implemented.
 
+    .. versionadded:: 1.14.0
+
     Examples
     --------
     >>> from scipy.special import log_wright_bessel
     >>> a, b, x = 1.5, 1.1, 2.5
-    >>> wright_bessel(a, b-1, x)
-    1.511041224929469
+    >>> log_wright_bessel(a, b, x)
+    1.1947654935299217
     )";
 
 const char *mathieu_a_doc = R"(
@@ -3934,6 +3936,8 @@ const char *wright_bessel_doc = R"(
     -----
     Due to the complexity of the function with its three parameters, only
     non-negative arguments are implemented.
+
+    .. versionadded:: 1.7.0
 
     References
     ----------

--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -151,6 +151,7 @@ __all__ = [
     'log1p',
     'log_expit',
     'log_ndtr',
+    'log_wright_bessel',
     'loggamma',
     'logit',
     'lpmv',
@@ -432,6 +433,7 @@ kve: np.ufunc
 log1p: np.ufunc
 log_expit: np.ufunc
 log_ndtr: np.ufunc
+log_wright_bessel: np.ufunc
 loggamma: np.ufunc
 logit: np.ufunc
 lpmv: np.ufunc

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -255,4 +255,5 @@ cpdef Dd_number_t yv(double x0, Dd_number_t x1) noexcept nogil
 cpdef Dd_number_t yve(double x0, Dd_number_t x1) noexcept nogil
 cpdef double zetac(double x0) noexcept nogil
 cpdef double wright_bessel(double x0, double x1, double x2) noexcept nogil
+cpdef double log_wright_bessel(double x0, double x1, double x2) noexcept nogil
 cpdef double ndtri_exp(double x0) noexcept nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1043,6 +1043,10 @@ Available functions
 
         double wright_bessel(double, double, double)
 
+- :py:func:`~scipy.special.log_wright_bessel`::
+
+        double log_wright_bessel(double, double, double)
+
 - :py:func:`~scipy.special.ndtri_exp`::
 
         double ndtri_exp(double)
@@ -1261,6 +1265,7 @@ cdef extern from r"special_wrappers.h":
     double _func_cephes_iv_wrap "cephes_iv_wrap"(double, double) nogil
 
     npy_double special_wright_bessel(npy_double, npy_double, npy_double) nogil
+    npy_double special_log_wright_bessel(npy_double, npy_double, npy_double) nogil
     double special_ellipk(double m) nogil
 
     double cephes_besselpoly(double a, double lmbda, double nu) nogil
@@ -3507,6 +3512,10 @@ cpdef double zetac(double x0) noexcept nogil:
 cpdef double wright_bessel(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.wright_bessel"""
     return special_wright_bessel(x0, x1, x2)
+
+cpdef double log_wright_bessel(double x0, double x1, double x2) noexcept nogil:
+    """See the documentation for scipy.special.log_wright_bessel"""
+    return special_log_wright_bessel(x0, x1, x2)
 
 cpdef double ndtri_exp(double x0) noexcept nogil:
     """See the documentation for scipy.special.ndtri_exp"""

--- a/scipy/special/special_wrappers.cpp
+++ b/scipy/special/special_wrappers.cpp
@@ -544,6 +544,7 @@ double cephes_p1evl_wrap(double x, const double coef[], int N) { return special:
 
 double gammaln_wrap(double x) { return special::gammaln(x); }
 double special_wright_bessel(double a, double b, double x) { return special::wright_bessel(a, b, x); }
+double special_log_wright_bessel(double a, double b, double x) { return special::log_wright_bessel(a, b, x); }
 
 double special_scaled_exp1(double x) { return special::scaled_exp1(x); }
 

--- a/scipy/special/special_wrappers.h
+++ b/scipy/special/special_wrappers.h
@@ -216,6 +216,7 @@ double cephes_yn_wrap(int n, double x);
 double cephes_polevl_wrap(double x, const double coef[], int N);
 double cephes_p1evl_wrap(double x, const double coef[], int N);
 double special_wright_bessel(double a, double b, double x);
+double special_log_wright_bessel(double a, double b, double x);
 
 double special_scaled_exp1(double x);
 

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -195,6 +195,7 @@ PARAMS: list[tuple[Callable, Callable, tuple[str, ...], str | None]] = [
     (special.log1p, cython_special.log1p, ('d', 'D'), None),
     (special.log_expit, cython_special.log_expit, ('f', 'd', 'g'), None),
     (special.log_ndtr, cython_special.log_ndtr, ('d', 'D'), None),
+    (special.log_wright_bessel, cython_special.log_wright_bessel, ('ddd',), None),
     (special.ndtri_exp, cython_special.ndtri_exp, ('d',), None),
     (special.loggamma, cython_special.loggamma, ('D',), None),
     (special.logit, cython_special.logit, ('f', 'd', 'g'), None),


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-20598

#### What does this implement/fix?
This PR adds the special function `log_wright_bessel`, i.e. the logarithm of Wright's Bessel function.

#### Additional information
Simply put, this might be (one of) the hardest to evaluate special function in scipy.special. Taking the logarithm makes the possible domain of the 3 parameters even larger.