### PR TITLE
MAINT: sparse: reformat str and repr for sparse arrays, correct 1D coords, improve dtype looks

### DIFF
--- a/doc/source/tutorial/sparse.rst
+++ b/doc/source/tutorial/sparse.rst
@@ -26,10 +26,10 @@ Sparse arrays are a special kind of array where only a few locations in the arra
        [0, 4, 1, 0],
        [0, 0, 5, 0]])
    >>> sparse
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-         with 5 stored elements in COOrdinate format>
+   <COOrdinate sparse array of dtype 'int64'
+        with 5 stored elements and shape (3, 4)>
 
-Note that in our dense array, we have five nonzero values. For example, ``2`` is at location ``0,3``, and ``4`` is at location ``1,1``. All of the other values are zero. The sparse array records these five values *explicitly* (see the ``5 stored elements in COOrdinate format``), and then represents all of the remaining zeros as *implicit* values. 
+Note that in our dense array, we have five nonzero values. For example, ``2`` is at location ``0,3``, and ``4`` is at location ``1,1``. All of the other values are zero. The sparse array records these five values *explicitly* (see the ``5 stored elements and shape (3, 4)``), and then represents all of the remaining zeros as *implicit* values. 
 
 Most sparse array methods work in a similar fashion to dense array methods: 
 
@@ -78,8 +78,8 @@ But, other formats, such as the Compressed Sparse Row (CSR) :func:`csr_array()` 
 Sometimes, `scipy.sparse` will return a different sparse matrix format than the input sparse matrix format. For example, the dot product of two sparse arrays in COO format will be a CSR format array: 
 
    >>> sparse @ sparse.T
-   <3x3 sparse array of type '<class 'numpy.int64'>'
-        with 5 stored elements in Compressed Sparse Row format>
+   <Compressed Sparse Row sparse array of dtype 'int64'
+        with 5 stored elements and shape (3, 3)>
 
 This change occurs because `scipy.sparse` will change the format of input sparse arrays in order to use the most efficient computational method. 
 
@@ -112,8 +112,8 @@ Using these, we can now define a sparse array without building a dense array fir
 
    >>> csr = sp.sparse.csr_array((data, (row, col)))
    >>> csr
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 5 stored elements in Compressed Sparse Row format>
+   <Compressed Sparse Row sparse array of dtype 'int64'
+        with 5 stored elements and shape (3, 4)>
 
 Different classes have different constructors, but the :func:`scipy.sparse.csr_array`, :func:`scipy.sparse.csc_array`, and :func:`scipy.sparse.coo_array` allow for this style of construction. 
 
@@ -132,8 +132,8 @@ Then, our sparse array will have *six* stored elements, not five:
 
    >>> csr = sp.sparse.csr_array((data, (row, col)))
    >>> csr
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 6 stored elements in Compressed Sparse Row format>
+   <Compressed Sparse Row sparse array of dtype 'int64'
+        with 6 stored elements and shape (3, 4)>
 
 The "extra" element is our *explicit zero*. The two are still identical when converted back into a dense array, because dense arrays represent *everything* explicitly: 
 
@@ -149,12 +149,12 @@ The "extra" element is our *explicit zero*. The two are still identical when con
 But, for sparse arithmetic, linear algebra, and graph methods, the value at ``2,3`` will be considered an *explicit zero*. To remove this explicit zero, we can use the ``csr.eliminate_zeros()`` method. This operates on the sparse array *in place*, and removes any zero-value stored elements: 
 
    >>> csr
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 6 stored elements in Compressed Sparse Row format>
+   <Compressed Sparse Row sparse array of dtype 'int64'
+        with 6 stored elements and shape (3, 4)>
    >>> csr.eliminate_zeros()
    >>> csr
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 5 stored elements in Compressed Sparse Row format>
+   <Compressed Sparse Row sparse array of dtype 'int64'
+        with 5 stored elements and shape (3, 4)>
 
 Before ``csr.eliminate_zeros()``, there were six stored elements. After, there are only five stored elements. 
 
@@ -168,8 +168,8 @@ In this case, we can see that there are *two* ``data`` values that correspond to
 
    >>> dupes = sp.sparse.coo_array((data, (row, col)))
    >>> dupes
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 6 stored elements in COOrdinate format>
+   <COOrdinate sparse array of dtype 'int64'
+        with 6 stored elements and shape (3, 4)>
 
 Note that there are six stored elements in this sparse array, despite only having five unique locations where data occurs. When these arrays are converted back to dense arrays, the duplicate values are summed. So, at location ``1,1``, the dense array will contain the sum of duplicate stored entries, ``1 + 3``: 
 
@@ -182,8 +182,8 @@ To remove duplicate values within the sparse array itself and thus reduce the nu
 
    >>> dupes.sum_duplicates()
    >>> dupes
-   <3x4 sparse array of type '<class 'numpy.int64'>'
-        with 5 stored elements in COOrdinate format>
+   <COOrdinate sparse array of dtype 'int64'
+        with 5 stored elements and shape (3, 4)>
 
 Now there are only five stored elements in our sparse array, and it is identical to the array we have been working with throughout this guide: 
    

--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -332,8 +332,8 @@ def mmread(source):
 
     >>> m = mmread(StringIO(text))
     >>> m
-    <5x5 sparse matrix of type '<class 'numpy.float64'>'
-    with 7 stored elements in COOrdinate format>
+    <COOrdinate sparse matrix of dtype 'float64'
+        with 7 stored elements and shape (5, 5)>
     >>> m.toarray()
     array([[0., 0., 0., 0., 0.],
            [0., 0., 1., 0., 0.],

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -499,6 +499,9 @@ def hb_read(path_or_open_file):
     >>> data = csr_matrix(eye(3))  # create a sparse matrix
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+        with 3 stored elements and shape (3, 3)>
+      Coords    Values
       (0, 0)	1.0
       (1, 1)	1.0
       (2, 2)	1.0
@@ -550,6 +553,9 @@ def hb_write(path_or_open_file, m, hb_info=None):
     >>> data = csr_matrix(eye(3))  # create a sparse matrix
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+        with 3 stored elements and shape (3, 3)>
+      Coords    Values
       (0, 0)	1.0
       (1, 1)	1.0
       (2, 2)	1.0

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -328,10 +328,9 @@ class _spbase:
     def __repr__(self):
         _, format_name = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        shape_str = 'x'.join(str(x) for x in self.shape)
         return (
-            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
-            f"\twith {self.nnz} stored elements in {format_name} format>"
+            f"<{format_name} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements and shape {self.shape}>"
         )
 
     def __str__(self):

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -338,19 +338,25 @@ class _spbase:
 
         A = self.tocoo()
 
+
         # helper function, outputs "(i,j)  v"
-        def tostr(row, col, data):
-            triples = zip(list(zip(row, col)), data)
+        def tostr(coords, data):
+            triples = zip(list(zip(*coords)), data)
             return '\n'.join([('  {}\t{}'.format(*t)) for t in triples])
 
+        out = repr(self)
+        if self.nnz == 0:
+            return out
+
+        out += '\n  Coords\tValues\n'
         if self.nnz > maxprint:
             half = maxprint // 2
-            out = tostr(A.row[:half], A.col[:half], A.data[:half])
+            out += tostr(tuple(c[:half] for c in A.coords), A.data[:half])
             out += "\n  :\t:\n"
             half = maxprint - maxprint//2
-            out += tostr(A.row[-half:], A.col[-half:], A.data[-half:])
+            out += tostr(tuple(c[-half:] for c in A.coords), A.data[-half:])
         else:
-            out = tostr(A.row, A.col, A.data)
+            out += tostr(A.coords, A.data)
 
         return out
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -329,7 +329,7 @@ class _spbase:
         _, format_name = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
         return (
-            f"<{format_name} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"<{format_name} sparse {sparse_cls} of dtype '{self.dtype}'\n"
             f"\twith {self.nnz} stored elements and shape {self.shape}>"
         )
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -342,6 +342,8 @@ class _spbase:
         def tostr(coords, data):
             pairs = zip(zip(*coords), data)
             return '\n'.join(f'  {idx}\t{val}' for idx, val in pairs)
+#            pairs = zip(zip(*(c.tolist() for c in coords)), data)
+#            return '\n'.join(f'  {idx}\t{val}' for idx, val in pairs)
 
         out = repr(self)
         if self.nnz == 0:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -338,11 +338,10 @@ class _spbase:
 
         A = self.tocoo()
 
-
         # helper function, outputs "(i,j)  v"
         def tostr(coords, data):
-            triples = zip(list(zip(*coords)), data)
-            return '\n'.join([('  {}\t{}'.format(*t)) for t in triples])
+            pairs = zip(zip(*coords), data)
+            return '\n'.join(f'  {idx}\t{val}' for idx, val in pairs)
 
         out = repr(self)
         if self.nnz == 0:
@@ -353,7 +352,7 @@ class _spbase:
             half = maxprint // 2
             out += tostr(tuple(c[:half] for c in A.coords), A.data[:half])
             out += "\n  :\t:\n"
-            half = maxprint - maxprint//2
+            half = maxprint - half
             out += tostr(tuple(c[-half:] for c in A.coords), A.data[-half:])
         else:
             out += tostr(A.coords, A.data)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -340,10 +340,8 @@ class _spbase:
 
         # helper function, outputs "(i,j)  v"
         def tostr(coords, data):
-            pairs = zip(zip(*coords), data)
+            pairs = zip(zip(*(c.tolist() for c in coords)), data)
             return '\n'.join(f'  {idx}\t{val}' for idx, val in pairs)
-#            pairs = zip(zip(*(c.tolist() for c in coords)), data)
-#            return '\n'.join(f'  {idx}\t{val}' for idx, val in pairs)
 
         out = repr(self)
         if self.nnz == 0:

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -220,11 +220,10 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
     def __repr__(self):
         _, fmt = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        shape_str = 'x'.join(str(x) for x in self.shape)
-        blksz = 'x'.join(str(x) for x in self.blocksize)
+        b = 'x'.join(str(x) for x in self.blocksize)
         return (
-            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
-            f"\twith {self.nnz} stored elements (blocksize = {blksz}) in {fmt} format>"
+            f"<{fmt} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements (blocksize={b}) and shape {self.shape}>"
         )
 
     def diagonal(self, k=0):

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -222,7 +222,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
         b = 'x'.join(str(x) for x in self.blocksize)
         return (
-            f"<{fmt} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"<{fmt} sparse {sparse_cls} of dtype '{self.dtype}'\n"
             f"\twith {self.nnz} stored elements (blocksize={b}) and shape {self.shape}>"
         )
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -312,11 +312,11 @@ def identity(n, dtype='d', format=None):
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
     >>> sp.sparse.identity(3, dtype='int8', format='dia')
-    <3x3 sparse matrix of type '<class 'numpy.int8'>'
-            with 3 stored elements (1 diagonals) in DIAgonal format>
+    <DIAgonal sparse matrix of dtype 'int8'
+        with 3 stored elements (1 diagonals) and shape (3, 3)>
     >>> sp.sparse.eye_array(3, dtype='int8', format='dia')
-    <3x3 sparse array of type '<class 'numpy.int8'>'
-            with 3 stored elements (1 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'int8'
+        with 3 stored elements (1 diagonals) and shape (3, 3)>
 
     """
     return eye(n, n, dtype=dtype, format=format)
@@ -351,8 +351,8 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
     >>> sp.sparse.eye_array(3, dtype=np.int8)
-    <3x3 sparse array of type '<class 'numpy.int8'>'
-            with 3 stored elements (1 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'int8'
+        with 3 stored elements (1 diagonals) and shape (3, 3)>
 
     """
     # TODO: delete next 15 lines [combine with _eye()] once spmatrix removed
@@ -430,8 +430,8 @@ def eye(m, n=None, k=0, dtype=float, format=None):
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.]])
     >>> sp.sparse.eye(3, dtype=np.int8)
-    <3x3 sparse matrix of type '<class 'numpy.int8'>'
-        with 3 stored elements (1 diagonals) in DIAgonal format>
+    <DIAgonal sparse matrix of dtype 'int8'
+        with 3 stored elements (1 diagonals) and shape (3, 3)>
 
     """
     return _eye(m, n, k, dtype, format, False)
@@ -1390,8 +1390,8 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
     >>> from scipy.sparse import rand
     >>> matrix = rand(3, 4, density=0.25, format="csr", random_state=42)
     >>> matrix
-    <3x4 sparse matrix of type '<class 'numpy.float64'>'
-       with 3 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'float64'
+        with 3 stored elements and shape (3, 4)>
     >>> matrix.toarray()
     array([[0.05641158, 0.        , 0.        , 0.65088847],  # random
            [0.        , 0.        , 0.        , 0.14286682],

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -98,7 +98,7 @@ class _dia_base(_data_matrix):
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
         d = self.data.shape[0]
         return (
-            f"<{fmt} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"<{fmt} sparse {sparse_cls} of dtype '{self.dtype}'\n"
             f"\twith {self.nnz} stored elements ({d} diagonals) and shape {self.shape}>"
         )
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -96,11 +96,10 @@ class _dia_base(_data_matrix):
     def __repr__(self):
         _, fmt = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
-        shape_str = 'x'.join(str(x) for x in self.shape)
-        ndiag = self.data.shape[0]
+        d = self.data.shape[0]
         return (
-            f"<{shape_str} sparse {sparse_cls} of type '{self.dtype.type}'\n"
-            f"\twith {self.nnz} stored elements ({ndiag} diagonals) in {fmt} format>"
+            f"<{fmt} sparse {sparse_cls} of type '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements ({d} diagonals) and shape {self.shape}>"
         )
 
     def _data_mask(self):

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -93,8 +93,8 @@ def tril(A, k=0, format=None):
            [4, 0, 0, 0, 0],
            [0, 0, 0, 0, 0]])
     >>> tril(A, format='csc')
-    <3x5 sparse array of type '<class 'numpy.int32'>'
-            with 4 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse array of dtype 'int32'
+        with 4 stored elements and shape (3, 5)>
 
     """
     coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix
@@ -161,8 +161,8 @@ def triu(A, k=0, format=None):
            [4, 5, 0, 6, 7],
            [0, 0, 8, 9, 0]])
     >>> triu(A, format='csc')
-    <3x5 sparse array of type '<class 'numpy.int32'>'
-            with 8 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse array of dtype 'int32'
+        with 8 stored elements and shape (3, 5)>
 
     """
     coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -111,17 +111,6 @@ class _lil_base(_spbase, IndexMixin):
     _getnnz.__doc__ = _spbase._getnnz.__doc__
     count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
-    def __str__(self):
-        val = repr(self)
-        if self.nnz == 0:
-            return val
-
-        val += '\n  Coords\tValue\n'
-        for i, row in enumerate(self.rows):
-            for pos, j in enumerate(row):
-                val += f"  {str((i, j))}\t{str(self.data[i][pos])}\n"
-        return val[:-1]
-
     def getrowview(self, i):
         """Returns a view of the 'i'th row (without copying).
         """

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -112,7 +112,11 @@ class _lil_base(_spbase, IndexMixin):
     count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
     def __str__(self):
-        val = ''
+        val = repr(self)
+        if self.nnz == 0:
+            return val
+
+        val += '\n  Coords\tValue\n'
         for i, row in enumerate(self.rows):
             for pos, j in enumerate(row):
                 val += f"  {str((i, j))}\t{str(self.data[i][pos])}\n"

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -38,8 +38,8 @@ def save_npz(file, matrix, compressed=True):
     >>> import scipy as sp
     >>> sparse_matrix = sp.sparse.csc_matrix([[0, 0, 3], [4, 0, 0]])
     >>> sparse_matrix
-    <2x3 sparse matrix of type '<class 'numpy.int64'>'
-       with 2 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse matrix of dtype 'int64'
+        with 2 stored elements and shape (2, 3)>
     >>> sparse_matrix.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
@@ -48,8 +48,8 @@ def save_npz(file, matrix, compressed=True):
     >>> sparse_matrix = sp.sparse.load_npz('/tmp/sparse_matrix.npz')
 
     >>> sparse_matrix
-    <2x3 sparse matrix of type '<class 'numpy.int64'>'
-       with 2 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse matrix of dtype 'int64'
+        with 2 stored elements and shape (2, 3)>
     >>> sparse_matrix.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
@@ -109,8 +109,8 @@ def load_npz(file):
     >>> import scipy as sp
     >>> sparse_array = sp.sparse.csc_array([[0, 0, 3], [4, 0, 0]])
     >>> sparse_array
-    <2x3 sparse array of type '<class 'numpy.int64'>'
-       with 2 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse array of dtype 'int64'
+        with 2 stored elements and shape (2, 3)>
     >>> sparse_array.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
@@ -119,8 +119,8 @@ def load_npz(file):
     >>> sparse_array = sp.sparse.load_npz('/tmp/sparse_array.npz')
 
     >>> sparse_array
-    <2x3 sparse array of type '<class 'numpy.int64'>'
-        with 2 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse array of dtype 'int64'
+        with 2 stored elements and shape (2, 3)>
     >>> sparse_array.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -59,6 +59,9 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -215,6 +218,9 @@ def structural_rank(graph):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 8 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 0)	1

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -148,6 +148,9 @@ def shortest_path(csgraph, method='auto',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -294,6 +297,9 @@ def floyd_warshall(csgraph, directed=True,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -519,6 +525,9 @@ def dijkstra(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -1004,6 +1013,9 @@ def bellman_ford(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -1241,6 +1253,9 @@ def johnson(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -1771,6 +1786,9 @@ def yen(
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
     (0, 1)	1
     (0, 2)	2
     (1, 3)	1

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -51,8 +51,8 @@ def csgraph_from_masked(graph):
     ... fill_value = 0)
 
     >>> csgraph_from_masked(graph_masked)
-    <4x4 sparse matrix of type '<class 'numpy.float64'>'
-        with 4 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'float64'
+        with 4 stored elements and shape (4, 4)>
 
     """
     # check that graph is a square matrix
@@ -209,8 +209,8 @@ def csgraph_from_dense(graph,
     ... ]
 
     >>> csgraph_from_dense(graph)
-    <4x4 sparse matrix of type '<class 'numpy.float64'>'
-        with 4 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'float64'
+        with 4 stored elements and shape (4, 4)>
 
     """
     return csgraph_from_masked(csgraph_masked_from_dense(graph,
@@ -303,8 +303,8 @@ def csgraph_to_dense(csgraph, null_value=0):
     ... [0, 0, 0, 0]
     ... ])
     >>> graph
-    <4x4 sparse matrix of type '<class 'numpy.int64'>'
-        with 4 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (4, 4)>
 
     >>> csgraph_to_dense(graph)
     array([[0., 1., 2., 0.],
@@ -367,8 +367,8 @@ def csgraph_to_masked(csgraph):
     ... [0, 0, 0, 0]
     ... ])
     >>> graph
-    <4x4 sparse matrix of type '<class 'numpy.int64'>'
-        with 4 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (4, 4)>
 
     >>> csgraph_to_masked(graph)
     masked_array(
@@ -453,6 +453,9 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1
@@ -562,6 +565,9 @@ def construct_dist_matrix(graph,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -75,6 +75,9 @@ def connected_components(csgraph, directed=True, connection='weak',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (5, 5)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	1
       (1, 2)	1
@@ -332,6 +335,9 @@ cpdef breadth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)    1
       (0, 2)    2
       (1, 3)    1
@@ -538,6 +544,9 @@ cpdef depth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 5 stored elements and shape (4, 4)>
+      Coords    Values
       (0, 1)	1
       (0, 2)	2
       (1, 3)	1

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -55,11 +55,11 @@ def inv(A):
     >>> A = csc_matrix([[1., 0.], [1., 2.]])
     >>> Ainv = inv(A)
     >>> Ainv
-    <2x2 sparse matrix of type '<class 'numpy.float64'>'
-        with 3 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+        with 3 stored elements and shape (2, 2)>
     >>> A.dot(Ainv)
-    <2x2 sparse matrix of type '<class 'numpy.float64'>'
-        with 2 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+        with 2 stored elements and shape (2, 2)>
     >>> A.dot(Ainv).toarray()
     array([[ 1.,  0.],
            [ 0.,  1.]])
@@ -581,8 +581,8 @@ def expm(A):
            [0, 0, 3]], dtype=int64)
     >>> Aexp = expm(A)
     >>> Aexp
-    <3x3 sparse matrix of type '<class 'numpy.float64'>'
-        with 3 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+        with 3 stored elements and shape (3, 3)>
     >>> Aexp.toarray()
     array([[  2.71828183,   0.        ,   0.        ],
            [  0.        ,   7.3890561 ,   0.        ],

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -92,8 +92,8 @@ of_the_second_derivative
     the default dtype for storing matrix representations.
 
     >>> lap.tosparse()
-    <6x6 sparse array of type '<class 'numpy.int8'>'
-        with 16 stored elements (3 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'int8'
+        with 16 stored elements (3 diagonals) and shape (6, 6)>
     >>> lap.toarray()
     array([[-1,  1,  0,  0,  0,  0],
            [ 1, -2,  1,  0,  0,  0],
@@ -165,8 +165,8 @@ of_the_second_derivative
 
     >>> lap = LaplacianNd(grid_shape, boundary_conditions='dirichlet')
     >>> lap.tosparse()
-    <6x6 sparse array of type '<class 'numpy.int8'>'
-        with 20 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse array of dtype 'int8'
+        with 20 stored elements and shape (6, 6)>
     >>> lap.toarray()
     array([[-4,  1,  0,  1,  0,  0],
            [ 1, -4,  1,  0,  1,  0],
@@ -192,8 +192,8 @@ of_the_second_derivative
 
     >>> lap = LaplacianNd(grid_shape, boundary_conditions='periodic')
     >>> lap.tosparse()
-    <6x6 sparse array of type '<class 'numpy.int8'>'
-        with 24 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse array of dtype 'int8'
+        with 24 stored elements and shape (6, 6)>
     >>> lap.toarray()
         array([[-4,  1,  1,  2,  0,  0],
                [ 1, -4,  1,  0,  2,  0],
@@ -218,8 +218,8 @@ of_the_second_derivative
 
     >>> lap = LaplacianNd(grid_shape, boundary_conditions='neumann')
     >>> lap.tosparse()
-    <6x6 sparse array of type '<class 'numpy.int8'>'
-        with 20 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse array of dtype 'int8'
+        with 20 stored elements and shape (6, 6)>
     >>> lap.toarray()
     array([[-2,  1,  0,  1,  0,  0],
            [ 1, -3,  1,  0,  1,  0],
@@ -589,8 +589,8 @@ class Sakurai(LinearOperator):
            [-4, -4, -4, -4, -4, -4],
            [ 5,  6,  6,  6,  6,  5]], dtype=int8)
     >>> sak.tosparse()
-    <6x6 sparse matrix of type '<class 'numpy.int8'>'
-        with 24 stored elements (5 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'int8'
+        with 24 stored elements (5 diagonals) and shape (6, 6)>
     >>> np.array_equal(sak.dot(np.eye(n)), sak.tosparse().toarray())
     True
     >>> sak.eigenvalues()
@@ -906,11 +906,11 @@ class MikotaPair:
     array([1.        , 0.5       , 0.33333333, 0.25      , 0.2       ,
         0.16666667])
     >>> mik_k.tosparse()
-    <6x6 sparse matrix of type '<class 'numpy.float64'>'
-        with 16 stored elements (3 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'float64'
+        with 20 stored elements (3 diagonals) and shape (6, 6)>
     >>> mik_m.tosparse()
-    <6x6 sparse matrix of type '<class 'numpy.float64'>'
-        with 6 stored elements (1 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'float64'
+        with 6 stored elements (1 diagonals) and shape (6, 6)>
     >>> np.array_equal(mik_k(np.eye(n)), mik_k.toarray())
     True
     >>> np.array_equal(mik_m(np.eye(n)), mik_m.toarray())

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -34,6 +34,7 @@ import scipy.sparse as sparse
 from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
         eye, issparse, SparseEfficiencyWarning, sparray)
+from scipy.sparse._base import _formats
 from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
                                    get_index_dtype, asmatrix, matrix)
 from scipy.sparse.linalg import splu, expm, inv
@@ -645,10 +646,37 @@ class _TestCommon:
         assert_raises(ValueError, self.spcreator, (-1,-1))
 
     def test_repr(self):
-        repr(self.datsp)
+        datsp = self.spcreator([[1, 0, 0], [0, 0, 0], [0, 0, -2]])
+        extra = (
+            "(1 diagonals) " if datsp.format == "dia"
+            else "(blocksize=1x1) " if datsp.format == "bsr"
+            else ""
+        )
+        _, fmt = _formats[datsp.format]
+        expected = (
+            f"<{fmt} sparse matrix of dtype '{datsp.dtype}'\n"
+            f"\twith {datsp.nnz} stored elements {extra}and shape {datsp.shape}>"
+        )
+        assert repr(datsp) == expected
 
     def test_str(self):
-        str(self.datsp)
+        datsp = self.spcreator([[1, 0, 0], [0, 0, 0], [0, 0, -2]])
+        if datsp.nnz != 2:
+            return
+        extra = (
+            "(1 diagonals) " if datsp.format == "dia"
+            else "(blocksize=1x1) " if datsp.format == "bsr"
+            else ""
+        )
+        _, fmt = _formats[datsp.format]
+        expected = (
+            f"<{fmt} sparse matrix of dtype '{datsp.dtype}'\n"
+            f"\twith {datsp.nnz} stored elements {extra}and shape {datsp.shape}>"
+            "\n  Coords\tValues"
+            "\n  (0, 0)\t1"
+            "\n  (2, 2)\t-2"
+        )
+        assert str(datsp) == expected
 
     def test_empty_arithmetic(self):
         # Test manipulating empty matrices. Fails in SciPy SVN <= r1768

--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -145,8 +145,8 @@ def crosstab(*args, levels=None, sparse=False):
 
     >>> res = crosstab(a, x, sparse=True)
     >>> res.count
-    <2x3 sparse matrix of type '<class 'numpy.int64'>'
-            with 4 stored elements in COOrdinate format>
+    <COOrdinate sparse matrix of dtype 'int64'
+        with 4 stored elements and shape (2, 3)>
     >>> res.count.toarray()
     array([[2, 3, 0],
            [1, 0, 4]])


### PR DESCRIPTION
Fixes #20378 
Fixes #20377 

Currently, `str(A)` for sparse A with no stored elements returns the empty string. 
In `repr(A)`, for 1D arrays, the shape does not appear nicely, e.g. "958 sparse array of type ...". 2D is "4x3 sparse array of type".

This PR puts in repr: `format` and `dtype` in first line, `nnz` and `shape` in 2nd line. 
For `str`, the text from repr is the start, followed by coord/value column titles followed by coord/value info as before, but now it works for 1D. Also, if no stored values exist, the `repr` text is returned.