### PR TITLE
ENH: stats.kstat/kstatvar: add native support for `axis`

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -291,6 +291,7 @@ def kstat(data, n=2, *, axis=None):
     if n > 4 or n < 1:
         raise ValueError("k-statistics only supported for 1<=n<=4")
     n = int(n)
+    data = np.asarray(data)
     if axis is None:
         data = ravel(data)
         axis = 0
@@ -319,7 +320,7 @@ def kstat(data, n=2, *, axis=None):
 @_axis_nan_policy_factory(
     lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, default_axis=None
 )
-def kstatvar(data, n=2):
+def kstatvar(data, n=2, *, axis=None):
     r"""Return an unbiased estimator of the variance of the k-statistic.
 
     See `kstat` for more details of the k-statistic.
@@ -330,6 +331,11 @@ def kstatvar(data, n=2):
         Input array. Note that n-D input gets flattened.
     n : int, {1, 2}, optional
         Default is equal to 2.
+    axis : int or None, default: None
+        If an int, the axis of the input along which to compute the statistic.
+        The statistic of each axis-slice (e.g. row) of the input will appear
+        in a corresponding element of the output. If ``None``, the input will
+        be raveled before computing the statistic.
 
     Returns
     -------
@@ -359,13 +365,17 @@ def kstatvar(data, n=2):
                      \frac{144 n \kappa_{2} \kappa^2_{3}}{(n - 1) (n - 2)} +
                      \frac{24 (n + 1) n \kappa^4_{2}}{(n - 1) (n - 2) (n - 3)}
     """  # noqa: E501
-    data = ravel(data)
-    N = len(data)
+    data = np.asarray(data)
+    if axis is None:
+        data = ravel(data)
+        axis = 0
+    N = data.shape[axis]
+
     if n == 1:
-        return kstat(data, n=2) * 1.0/N
+        return kstat(data, n=2, axis=axis) * 1.0/N
     elif n == 2:
-        k2 = kstat(data, n=2)
-        k4 = kstat(data, n=4)
+        k2 = kstat(data, n=2, axis=axis)
+        k4 = kstat(data, n=4, axis=axis)
         return (2*N*k2**2 + (N-1)*k4) / (N*(N+1))
     else:
         raise ValueError("Only n=1 or n=2 supported.")

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -228,7 +228,7 @@ def kstat(data, n=2, *, axis=None):
     Parameters
     ----------
     data : array_like
-        Input array. Note that n-D input gets flattened.
+        Input array.
     n : int, {1, 2, 3, 4}, optional
         Default is equal to 2.
     axis : int or None, default: None
@@ -328,7 +328,7 @@ def kstatvar(data, n=2, *, axis=None):
     Parameters
     ----------
     data : array_like
-        Input array. Note that n-D input gets flattened.
+        Input array.
     n : int, {1, 2}, optional
         Default is equal to 2.
     axis : int or None, default: None

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1695,9 +1695,10 @@ class TestKstat:
         ref = stats.kstat(x.ravel(), n)
         assert_allclose(res, ref)
 
-
     def test_empty_input(self):
-        assert_raises(ValueError, stats.kstat, [])
+        message = 'Data input must not be empty'
+        with pytest.raises(ValueError, match=message):
+            stats.kstat([])
 
     def test_nan_input(self):
         data = np.arange(10.)
@@ -1705,11 +1706,13 @@ class TestKstat:
 
         assert_equal(stats.kstat(data), np.nan)
 
-    def test_kstat_bad_arg(self):
+    @pytest.mark.parametrize('n', [0, 4.001])
+    def test_kstat_bad_arg(self, n):
         # Raise ValueError if n > 4 or n < 1.
         data = np.arange(10)
-        for n in [0, 4.001]:
-            assert_raises(ValueError, stats.kstat, data, n=n)
+        message = 'k-statistics only supported for 1<=n<=4'
+        with pytest.raises(ValueError, match=message):
+            stats.kstat(data, n=n)
 
 
 class TestKstatVar:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1676,6 +1676,26 @@ class TestKstat:
         m3 = stats.moment(data, order=3)
         assert_allclose((m1, m2, m3), expected[:-1], atol=0.02, rtol=1e-2)
 
+    @pytest.mark.parametrize('n', [1, 2, 3, 4])
+    def test_axis(self, n):
+        # more thorough testing of `axis` in `test_axis_nan_policy`,
+        # but that isn't run for array API yet
+        rng = np.random.default_rng(24598245982345)
+        x = rng.random((6, 7))
+
+        res = stats.kstat(x, n, axis=0)
+        ref = [stats.kstat(x[:, i], n) for i in range(x.shape[1])]
+        assert_allclose(res, ref)
+
+        res = stats.kstat(x, n, axis=1)
+        ref = [stats.kstat(x[i, :], n) for i in range(x.shape[0])]
+        assert_allclose(res, ref)
+
+        res = stats.kstat(x, n, axis=None)
+        ref = stats.kstat(x.ravel(), n)
+        assert_allclose(res, ref)
+
+
     def test_empty_input(self):
         assert_raises(ValueError, stats.kstat, [])
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1661,6 +1661,14 @@ class TestWilcoxon:
         assert_equal(res.pvalue, ref.pvalue)  # random_state used
 
 
+# data for k-statistics tests from
+# https://cran.r-project.org/web/packages/kStatistics/kStatistics.pdf
+# see nKS "Examples"
+x_kstat = [16.34, 10.76, 11.84, 13.55, 15.85, 18.20, 7.51, 10.22, 12.52, 14.68,
+           16.08, 19.43, 8.12, 11.20, 12.95, 14.77, 16.83, 19.80, 8.55, 11.58,
+           12.10, 15.02, 16.83, 16.98, 19.92, 9.47, 11.68, 13.41, 15.35, 19.11]
+
+
 class TestKstat:
     def test_moments_normal_distribution(self):
         np.random.seed(32149)
@@ -1675,25 +1683,6 @@ class TestKstat:
         m2 = stats.moment(data, order=2)
         m3 = stats.moment(data, order=3)
         assert_allclose((m1, m2, m3), expected[:-1], atol=0.02, rtol=1e-2)
-
-    @pytest.mark.parametrize('n', [1, 2, 3, 4])
-    def test_axis(self, n):
-        # more thorough testing of `axis` in `test_axis_nan_policy`,
-        # but that isn't run for array API yet
-        rng = np.random.default_rng(24598245982345)
-        x = rng.random((6, 7))
-
-        res = stats.kstat(x, n, axis=0)
-        ref = [stats.kstat(x[:, i], n) for i in range(x.shape[1])]
-        assert_allclose(res, ref)
-
-        res = stats.kstat(x, n, axis=1)
-        ref = [stats.kstat(x[i, :], n) for i in range(x.shape[0])]
-        assert_allclose(res, ref)
-
-        res = stats.kstat(x, n, axis=None)
-        ref = stats.kstat(x.ravel(), n)
-        assert_allclose(res, ref)
 
     def test_empty_input(self):
         message = 'Data input must not be empty'
@@ -1714,10 +1703,30 @@ class TestKstat:
         with pytest.raises(ValueError, match=message):
             stats.kstat(data, n=n)
 
+    @pytest.mark.parametrize('case', [(1, 14.02166666666667),
+                                      (2, 12.65006954022974),
+                                      (3, -1.447059503280798),
+                                      (4, -141.6682291883626)])
+    def test_against_R(self, case):
+        # Test against reference values computed with R kStatistics, e.g.
+        # options(digits=16)
+        # library(kStatistics)
+        # data <-c (16.34, 10.76, 11.84, 13.55, 15.85, 18.20, 7.51, 10.22,
+        #           12.52, 14.68, 16.08, 19.43, 8.12, 11.20, 12.95, 14.77,
+        #           16.83, 19.80, 8.55, 11.58, 12.10, 15.02, 16.83, 16.98,
+        #           19.92, 9.47, 11.68, 13.41, 15.35, 19.11)
+        # nKS(4, data)
+        n, ref = case
+        res = stats.kstat(x_kstat, n)
+        assert_allclose(res, ref)
+
+
 
 class TestKstatVar:
     def test_empty_input(self):
-        assert_raises(ValueError, stats.kstatvar, [])
+        message = 'Data input must not be empty'
+        with pytest.raises(ValueError, match=message):
+            stats.kstatvar([])
 
     def test_nan_input(self):
         data = np.arange(10.)
@@ -1729,7 +1738,27 @@ class TestKstatVar:
         # Raise ValueError is n is not 1 or 2.
         data = [1]
         n = 10
-        assert_raises(ValueError, stats.kstatvar, data, n=n)
+        message = 'Only n=1 or n=2 supported.'
+        with pytest.raises(ValueError, match=message):
+            stats.kstatvar(data, n=n)
+
+    def test_against_R_mathworld(self):
+        # Test against reference values computed using formulas exactly as
+        # they appear at https://mathworld.wolfram.com/k-Statistic.html
+        # This is *really* similar to how they appear in the implementation,
+        # but that could change, and this should not.
+        n = len(x_kstat)
+        k2 = 12.65006954022974  # see source code in TestKstat
+        k4 = -141.6682291883626
+
+        res = stats.kstatvar(x_kstat, 1)
+        ref = k2 / n
+        assert_allclose(res, ref)
+
+        res = stats.kstatvar(x_kstat, 2)
+        # *unbiased estimator* for var(k2)
+        ref = (2*k2**2*n + (n-1)*k4) / (n * (n+1))
+        assert_allclose(res, ref)
 
 
 class TestPpccPlot:
@@ -2980,3 +3009,31 @@ class TestFDRControl:
         assert_array_equal(stats.false_discovery_control([0.25]), [0.25])
         assert_array_equal(stats.false_discovery_control(0.25), 0.25)
         assert_array_equal(stats.false_discovery_control([]), [])
+
+
+class TestCommonAxis:
+    # More thorough testing of `axis` in `test_axis_nan_policy`,
+    # but those testa aren't run with array API yet. This class
+    # is in `test_morestats` instead of `test_axis_nan_policy`
+    # because there is no reason to run `test_axis_nan_policy`
+    # with the array API CI job right now.
+
+    @pytest.mark.parametrize('case', [(stats.sem, {}),
+                                      (stats.kstat, {'n': 4}),
+                                      (stats.kstat, {'n': 2})])
+    def test_axis(self, case):
+        fun, kwargs = case
+        rng = np.random.default_rng(24598245982345)
+        x = rng.random((6, 7))
+
+        res = fun(x, **kwargs, axis=0)
+        ref = [fun(x[:, i], **kwargs) for i in range(x.shape[1])]
+        assert_allclose(res, ref)
+
+        res = fun(x, **kwargs, axis=1)
+        ref = [fun(x[i, :], **kwargs) for i in range(x.shape[0])]
+        assert_allclose(res, ref)
+
+        res = fun(x, **kwargs, axis=None)
+        ref = fun(x.ravel(), **kwargs)
+        assert_allclose(res, ref)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
gh-20544 listed `kstat`/`kstatvar` as functions that were ready for array API conversion, but they weren't quite ready, since their `axis` argument is implemented with a Python loop. This PR adds native `axis` support and strengthens tests.

#### Additional information
These functions could use input validation, and the `n` argument should probably be renamed to `order` to match `moment`.