### PR TITLE
MAINT: stats.yulesimon: fix kurtosis

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1666,7 +1666,7 @@ class yulesimon_gen(rv_discrete):
                       np.inf)
         g1 = np.where(alpha <= 2, np.nan, g1)
         g2 = np.where(alpha > 4,
-                      alpha + 3 + ((alpha**3 - 49 * alpha - 22) /
+                      alpha + 3 + ((11 * alpha**3 - 49 * alpha - 22) /
                                    (alpha * (alpha - 4) * (alpha - 3))),
                       np.inf)
         g2 = np.where(alpha <= 2, np.nan, g2)

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -142,7 +142,7 @@ distdiscrete = [
     ['poisson', (0.6,)],
     ['randint', (7, 31)],
     ['skellam', (15, 8)],
-    ['zipf', (6.5,)],
+    ['zipf', (6.6,)],
     ['zipfian', (0.75, 15)],
     ['zipfian', (1.25, 10)],
     ['yulesimon', (11.0,)],

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -92,9 +92,9 @@ def test_moments(distname, arg):
     check_mean_expect(distfn, arg, m, distname)
     check_var_expect(distfn, arg, m, v, distname)
     check_skew_expect(distfn, arg, m, v, s, distname)
-    with warnings.catch_warnings():
+    with np.testing.suppress_warnings() as sup:
         if distname in ['zipf', 'betanbinom']:
-            warnings.simplefilter("ignore", category=RuntimeWarning)
+            sup.filter(RuntimeWarning)
         check_kurt_expect(distfn, arg, m, v, k, distname)
 
     # frozen distr moments

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy.testing as npt
 from numpy.testing import assert_allclose
 
@@ -91,7 +92,9 @@ def test_moments(distname, arg):
     check_mean_expect(distfn, arg, m, distname)
     check_var_expect(distfn, arg, m, v, distname)
     check_skew_expect(distfn, arg, m, v, s, distname)
-    if distname not in ['zipf', 'betanbinom']:
+    with warnings.catch_warnings():
+        if distname in ['zipf', 'betanbinom']:
+            warnings.simplefilter("ignore", category=RuntimeWarning)
         check_kurt_expect(distfn, arg, m, v, k, distname)
 
     # frozen distr moments

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -91,7 +91,7 @@ def test_moments(distname, arg):
     check_mean_expect(distfn, arg, m, distname)
     check_var_expect(distfn, arg, m, v, distname)
     check_skew_expect(distfn, arg, m, v, s, distname)
-    if distname not in ['zipf', 'yulesimon', 'betanbinom']:
+    if distname not in ['zipf', 'betanbinom']:
         check_kurt_expect(distfn, arg, m, v, k, distname)
 
     # frozen distr moments

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy.testing as npt
 from numpy.testing import assert_allclose
 


### PR DESCRIPTION
#### Reference issue
Closes gh-20648

#### What does this implement/fix?
Fixes a typo in the the `yulesimon` implementation of the kurtosis. Removed its exemption from generic kurtosis test that is sensitive to the bug. Changed the test to filter warnings rather than exempt distributions.

#### Additional information
The parameters chosen for the [`zipf` distribution plot](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.zipf.html) does not produce a great plot - basically just a point mass. This doesn't (/can't) make it any worse, though, and I'd rather not do a deep dive to fix that right now. (Better parameters cause warnings elsewhere.)