### PR TITLE
ENH: spatial: ensure thread-safety for KDTree

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -509,6 +509,7 @@ cdef class cKDTree:
         readonly np.ndarray      mins
         readonly np.ndarray      indices
         readonly object          boxsize
+        readonly object          _tree_lock
         np.ndarray               boxsize_data
 
     property n:

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1599,6 +1599,7 @@ cdef class cKDTree:
 
         # set raw pointers
         self._python_tree = None
+        self._tree_lock = threading.Lock()
         self._pre_init()
 
         # copy the tree data

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -783,6 +783,8 @@ cdef class cKDTree:
          [13 19]]
 
         """
+        with self._tree_lock:
+            pass
 
         cdef:
             np.intp_t n
@@ -931,6 +933,9 @@ cdef class cKDTree:
 
         """
 
+        with self._tree_lock:
+            pass
+
         cdef:
             object[::1] vout
             np.intp_t[::1] vlen
@@ -1053,6 +1058,8 @@ cdef class cKDTree:
         >>> plt.show()
 
         """
+        with self._tree_lock:
+            pass
 
         cdef:
             vector[vector[np.intp_t]] vvres
@@ -1143,6 +1150,8 @@ cdef class cKDTree:
         >>> plt.show()
 
         """
+        with self._tree_lock:
+            pass
 
         cdef ordered_pairs results
 
@@ -1349,6 +1358,9 @@ cdef class cKDTree:
         1
 
         """
+        with self._tree_lock:
+            pass
+
         cdef:
             int r_ndim
             np.intp_t n_queries, i

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -447,6 +447,7 @@ def test_query_ball_point_multithreading(kdtree_type):
             assert_array_equal(l1[i], l3[i])
 
 
+@pytest.mark.thread_unsafe
 def test_concurrent_access(kdtree_type):
     rng = np.random.default_rng(0)
     n = 10000
@@ -468,6 +469,7 @@ def test_concurrent_access(kdtree_type):
         worker.join()
 
 
+@pytest.mark.thread_unsafe
 def test_tree_concurrent_access(kdtree_type):
     barrier = threading.Barrier(10)
     rng = np.random.default_rng(0)
@@ -940,6 +942,8 @@ def test_kdtree_copy_data(kdtree_type):
     T2 = T.query(q, k=5)[-1]
     assert_array_equal(T1, T2)
 
+
+@pytest.mark.thread_unsafe
 def test_ckdtree_parallel(kdtree_type, monkeypatch):
     # check if parallel=True also generates correct query results
     np.random.seed(0)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -468,6 +468,35 @@ def test_concurrent_access(kdtree_type):
         worker.join()
 
 
+def test_tree_concurrent_access(kdtree_type):
+    barrier = threading.Barrier(10)
+    rng = np.random.default_rng(0)
+    n = 10000
+    k = 2
+    points = rng.random((n, k))
+    T = kdtree_type(points)
+    tree_ids = []
+
+    def closure():
+        barrier.wait()
+        tree_ids.append(id(T.tree))
+
+    workers = []
+    for _ in range(0, 10):
+        workers.append(threading.Thread(target=closure))
+
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join()
+
+    prev_id = tree_ids[0]
+    for i in range(1, 10):
+        assert prev_id == tree_ids[i]
+        prev_id = tree_ids[i]
+
+
 class two_trees_consistency:
 
     def distance(self, a, b, p):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -448,10 +448,10 @@ def test_query_ball_point_multithreading(kdtree_type):
 
 
 def test_concurrent_access(kdtree_type):
-    np.random.seed(0)
+    rng = np.random.default_rng(0)
     n = 10000
     k = 2
-    points = np.random.randn(n, k)
+    points = rng.random((n, k))
     T = kdtree_type(points)
 
     workers = []

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -479,7 +479,10 @@ def test_tree_concurrent_access(kdtree_type):
 
     def closure():
         barrier.wait()
-        tree_ids.append(id(T.tree))
+        tree = T.tree
+        if kdtree_type is KDTree:
+            tree = tree._node
+        tree_ids.append(id(tree))
 
     workers = []
     for _ in range(0, 10):


### PR DESCRIPTION
#### Reference issue
See gh-20669

#### What does this implement/fix?
This PR adds a quick check to ensure that concurrent calls to `KDTree` do not cause any unexpected errors. This is specially handy in the context of No-GIL CPython.

#### Additional information
In principle, concurrent access to `KDTree` is allowed out-of-the-box, since there are no methods that can mutate the state of the tree besides the constructor.
