### PR TITLE
ENH: Micro-optimizations for spatial.transform.Rotation methods

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2699,9 +2699,9 @@ cdef class Rotation:
             return self.inv()
         elif n == 1:
             if self._single:
-                return self.__class__(self._quat[0], copy=True)
+                return self.__class__(self._quat[0], normalize=False, copy=True)
             else:
-                return self.__class__(self._quat, copy=True)
+                return self.__class__(self._quat, normalize=False, copy=True)
         else:  # general scaling of rotation angle
             return Rotation.from_rotvec(n * self.as_rotvec())
 
@@ -2744,7 +2744,7 @@ cdef class Rotation:
         quat[:, 2] *= -1
         if self._single:
             quat = quat[0]
-        return self.__class__(quat, copy=False)
+        return self.__class__(quat, normalize=False, copy=False)
 
     @cython.embedsignature(True)
     @cython.boundscheck(False)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
Makes two small optimizations for Rotations, should hopefully speed up some of the basic operations:
* Skip normalization when inverting rotations.
* Skip normalization when raising to the first power and returning a copy of self

#### Additional information
N/A