### PR TITLE
MAINT: remove unused variable in special

### DIFF
--- a/scipy/special/special/tools.h
+++ b/scipy/special/special/tools.h
@@ -41,7 +41,7 @@ namespace detail {
          *     of non-convergence.
          */
         T result = init_val;
-        T term, previous;
+        T term;
         for (std::uint64_t i = 0; i < max_terms; ++i) {
             term = g();
             result += term;


### PR DESCRIPTION
Whilst building on macOS I see several warnings of the type:
```
../scipy/special/special/hyp2f1.h:639:31: note: in instantiation of function template specialization 'special::detail::series_eval<special::detail::LopezTemmeSeriesGenerator, std::complex<double>>' requested here
            result *= detail::series_eval(series_generator, std::complex<double>{0.0, 0.0}, detail::hyp2f1_EPS,
                              ^
In file included from ../scipy/special/_special_ufuncs.cpp:16:
In file included from ../scipy/special/special/hyp2f1.h:44:
../scipy/special/special/tools.h:44:17: warning: unused variable 'previous' [-Wunused-variable]
        T term, previous;
                ^
```

This PR removes the unused variable.