### PR TITLE
MAINT: stats.kruskal: fix no-arg behavior w/ SCIPY_ARRAY_API=1

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -16,6 +16,8 @@ def _broadcast_arrays(arrays, axis=None, xp=None):
     """
     Broadcast shapes of arrays, ignoring incompatibility of specified axes
     """
+    if not arrays:
+        return arrays
     xp = array_namespace(*arrays) if xp is None else xp
     arrays = [xp.asarray(arr) for arr in arrays]
     shapes = [arr.shape for arr in arrays]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7638,6 +7638,11 @@ class TestKruskal:
         expected = 0
         assert_approx_equal(p, expected)
 
+    def test_no_args_gh20661(self):
+        message = r"Need at least two groups in stats.kruskal\(\)"
+        with pytest.raises(ValueError, match=message):
+            stats.kruskal()
+
 
 class TestCombinePvalues:
 


### PR DESCRIPTION
#### Reference issue
Closes gh-20661

#### What does this implement/fix?
Fixes the failing test `test_axis_nan_policy_decorated_positional_args ` when `SCIPY_ARRAY_API=1`. Changes to low-level stats private methods have created the same sort failure twice (first due to adding array API support to `_get_nan`, now due to adding support to `_broadcast_arrays`), so I've added a similar test in `test_stats` that will run on the array API job regularly.
