### PR TITLE
Fix typo in cont2discrete

### DIFF
--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -519,7 +519,7 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
 
     elif method == 'impulse':
         if not np.allclose(d, 0):
-            raise ValueError("Impulse method is only applicable"
+            raise ValueError("Impulse method is only applicable "
                              "to strictly proper systems")
 
         ad = linalg.expm(a * dt)


### PR DESCRIPTION
Fixed the missing blankspace in scipy.signal.cont2discrete() ValueError as per #20662 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #20662 

#### What does this implement/fix?
Fixed the missing blankspace in scipy.signal.cont2discrete().
