### PR TITLE
ENH: interpolate: fix concurrency issues throughout

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import threading
 from importlib.util import module_from_spec, spec_from_file_location
 
 import numpy as np
@@ -323,3 +324,38 @@ def _test_cython_extension(tmp_path, srcdir):
 
     # test that the module can be imported
     return load("extending"), load("extending_cpp")
+
+
+def _run_concurrent_barrier(n_workers, fn, *args, **kwargs):
+    """
+    Run a given function concurrently across a given number of threads.
+
+    Arguments
+    ---------
+    n_workers: int
+        Number of concurrent threads to spawn.
+    fn: callable
+        Function closure to execute concurrently. Its first argument will
+        be the thread id.
+    *args: tuple
+        Variable number of positional arguments to pass to the function.
+    **kwargs: dict
+        Keyword arguments to pass to the function.
+    """
+    barrier = threading.Barrier(n_workers)
+
+    def closure(i, *args, **kwargs):
+        barrier.wait()
+        fn(i, *args, **kwargs)
+
+    workers = []
+    for i in range(0, n_workers):
+        workers.append(threading.Thread(
+            target=closure,
+            args=(i,) + args, kwargs=kwargs))
+
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join()

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -330,6 +330,11 @@ def _run_concurrent_barrier(n_workers, fn, *args, **kwargs):
     """
     Run a given function concurrently across a given number of threads.
 
+    This is equivalent to using a ThreadPoolExecutor, but using the threading
+    primitives instead. This function ensures that the closure passed by
+    parameter gets called concurrently by setting up a barrier before it gets
+    called before any of the threads.
+
     Arguments
     ---------
     n_workers: int

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,6 +1,7 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
 from math import prod
+import threading
 
 import numpy as np
 from numpy import array, asarray, intp, poly1d, searchsorted
@@ -578,6 +579,7 @@ class _PPolyBase:
     def __init__(self, c, x, extrapolate=None, axis=0):
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
+        self._c_lock = threading.RLock()
 
         if extrapolate is None:
             extrapolate = True
@@ -654,7 +656,8 @@ class _PPolyBase:
         if not self.x.flags.c_contiguous:
             self.x = self.x.copy()
         if not self.c.flags.c_contiguous:
-            self.c = self.c.copy()
+            with self._c_lock:
+                self.c = self.c.copy()
 
     def extend(self, c, x):
         """
@@ -689,51 +692,52 @@ class _PPolyBase:
         if c.size == 0:
             return
 
-        dx = np.diff(x)
-        if not (np.all(dx >= 0) or np.all(dx <= 0)):
-            raise ValueError("`x` is not sorted.")
+        with self._c_lock:
+            dx = np.diff(x)
+            if not (np.all(dx >= 0) or np.all(dx <= 0)):
+                raise ValueError("`x` is not sorted.")
 
-        if self.x[-1] >= self.x[0]:
-            if not x[-1] >= x[0]:
-                raise ValueError("`x` is in the different order "
-                                 "than `self.x`.")
+            if self.x[-1] >= self.x[0]:
+                if not x[-1] >= x[0]:
+                    raise ValueError("`x` is in the different order "
+                                    "than `self.x`.")
 
-            if x[0] >= self.x[-1]:
-                action = 'append'
-            elif x[-1] <= self.x[0]:
-                action = 'prepend'
+                if x[0] >= self.x[-1]:
+                    action = 'append'
+                elif x[-1] <= self.x[0]:
+                    action = 'prepend'
+                else:
+                    raise ValueError("`x` is neither on the left or on the right "
+                                    "from `self.x`.")
             else:
-                raise ValueError("`x` is neither on the left or on the right "
-                                 "from `self.x`.")
-        else:
-            if not x[-1] <= x[0]:
-                raise ValueError("`x` is in the different order "
-                                 "than `self.x`.")
+                if not x[-1] <= x[0]:
+                    raise ValueError("`x` is in the different order "
+                                    "than `self.x`.")
 
-            if x[0] <= self.x[-1]:
-                action = 'append'
-            elif x[-1] >= self.x[0]:
-                action = 'prepend'
-            else:
-                raise ValueError("`x` is neither on the left or on the right "
-                                 "from `self.x`.")
+                if x[0] <= self.x[-1]:
+                    action = 'append'
+                elif x[-1] >= self.x[0]:
+                    action = 'prepend'
+                else:
+                    raise ValueError("`x` is neither on the left or on the right "
+                                    "from `self.x`.")
 
-        dtype = self._get_dtype(c.dtype)
+            dtype = self._get_dtype(c.dtype)
 
-        k2 = max(c.shape[0], self.c.shape[0])
-        c2 = np.zeros((k2, self.c.shape[1] + c.shape[1]) + self.c.shape[2:],
-                      dtype=dtype)
+            k2 = max(c.shape[0], self.c.shape[0])
+            c2 = np.zeros((k2, self.c.shape[1] + c.shape[1]) + self.c.shape[2:],
+                        dtype=dtype)
 
-        if action == 'append':
-            c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
-            c2[k2-c.shape[0]:, self.c.shape[1]:] = c
-            self.x = np.r_[self.x, x]
-        elif action == 'prepend':
-            c2[k2-self.c.shape[0]:, :c.shape[1]] = c
-            c2[k2-c.shape[0]:, c.shape[1]:] = self.c
-            self.x = np.r_[x, self.x]
+            if action == 'append':
+                c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
+                c2[k2-c.shape[0]:, self.c.shape[1]:] = c
+                self.x = np.r_[self.x, x]
+            elif action == 'prepend':
+                c2[k2-self.c.shape[0]:, :c.shape[1]] = c
+                c2[k2-c.shape[0]:, c.shape[1]:] = self.c
+                self.x = np.r_[x, self.x]
 
-        self.c = c2
+            self.c = c2
 
     def __call__(self, x, nu=0, extrapolate=None):
         """
@@ -776,6 +780,9 @@ class _PPolyBase:
         if extrapolate == 'periodic':
             x = self.x[0] + (x - self.x[0]) % (self.x[-1] - self.x[0])
             extrapolate = False
+
+        with self._c_lock:
+            pass
 
         out = np.empty((len(x), prod(self.c.shape[2:])), dtype=self.c.dtype)
         self._ensure_c_contiguous()
@@ -880,6 +887,9 @@ class PPoly(_PPolyBase):
         if nu < 0:
             return self.antiderivative(-nu)
 
+        with self._c_lock:
+            pass
+
         # reduce order
         if nu == 0:
             c2 = self.c.copy()
@@ -929,6 +939,9 @@ class PPoly(_PPolyBase):
         """
         if nu <= 0:
             return self.derivative(-nu)
+
+        with self._c_lock:
+            pass
 
         c = np.zeros((self.c.shape[0] + nu, self.c.shape[1]) + self.c.shape[2:],
                      dtype=self.c.dtype)
@@ -983,6 +996,9 @@ class PPoly(_PPolyBase):
 
         range_int = np.empty((prod(self.c.shape[2:]),), dtype=self.c.dtype)
         self._ensure_c_contiguous()
+
+        with self._c_lock:
+            pass
 
         # Compute the integral.
         if extrapolate == 'periodic':
@@ -1087,6 +1103,9 @@ class PPoly(_PPolyBase):
 
         self._ensure_c_contiguous()
 
+        with self._c_lock:
+            pass
+
         if np.issubdtype(self.c.dtype, np.complexfloating):
             raise ValueError("Root finding is only for "
                              "real-valued polynomials")
@@ -1151,7 +1170,7 @@ class PPoly(_PPolyBase):
 
         Examples
         --------
-        Construct an interpolating spline and convert it to a `PPoly` instance 
+        Construct an interpolating spline and convert it to a `PPoly` instance
 
         >>> import numpy as np
         >>> from scipy.interpolate import splrep, PPoly
@@ -1341,6 +1360,9 @@ class BPoly(_PPolyBase):
     """  # noqa: E501
 
     def _evaluate(self, x, nu, extrapolate, out):
+        with self._c_lock:
+            pass
+
         _ppoly.evaluate_bernstein(
             self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
             self.x, x, nu, bool(extrapolate), out)
@@ -1370,6 +1392,9 @@ class BPoly(_PPolyBase):
             for k in range(nu):
                 bp = bp.derivative()
             return bp
+
+        with self._c_lock:
+            pass
 
         # reduce order
         if nu == 0:
@@ -1429,6 +1454,9 @@ class BPoly(_PPolyBase):
             for k in range(nu):
                 bp = bp.antiderivative()
             return bp
+
+        with self._c_lock:
+            pass
 
         # Construct the indefinite integrals on individual intervals
         c, x = self.c, self.x
@@ -1520,9 +1548,10 @@ class BPoly(_PPolyBase):
 
     def extend(self, c, x):
         k = max(self.c.shape[0], c.shape[0])
-        self.c = self._raise_degree(self.c, k - self.c.shape[0])
-        c = self._raise_degree(c, k - c.shape[0])
-        return _PPolyBase.extend(self, c, x)
+        with self._c_lock:
+            self.c = self._raise_degree(self.c, k - self.c.shape[0])
+            c = self._raise_degree(c, k - c.shape[0])
+            return _PPolyBase.extend(self, c, x)
     extend.__doc__ = _PPolyBase.extend.__doc__
 
     @classmethod

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -574,7 +574,7 @@ class interp1d(_Interpolator1D):
 
 class _PPolyBase:
     """Base class for piecewise polynomials."""
-    __slots__ = ('c', 'x', 'extrapolate', 'axis')
+    __slots__ = ('c', 'x', 'extrapolate', 'axis', '_c_lock')
 
     def __init__(self, c, x, extrapolate=None, axis=0):
         self.c = np.asarray(c)
@@ -643,6 +643,7 @@ class _PPolyBase:
         self.c = c
         self.x = x
         self.axis = axis
+        self._c_lock = threading.RLock()
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = extrapolate

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -621,7 +621,7 @@ class BarycentricInterpolator(_Interpolator1DWithDerivatives):
 
     def __init__(self, xi, yi=None, axis=0, *, wi=None, random_state=None):
         super().__init__(xi, yi, axis)
-        
+
         random_state = check_random_state(random_state)
 
         self.xi = np.asarray(xi, dtype=np.float64)

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -387,12 +387,13 @@ class RegularGridInterpolator:
         >>> interp([[1.5, 1.3], [0.3, 4.5]], method='linear')
         array([ 4.7, 24.3])
         """
+        _spline = self._spline
         method = self.method if method is None else method
         is_method_changed = self.method != method
         if method not in self._ALL_METHODS:
             raise ValueError(f"Method '{method}' is not defined")
         if is_method_changed and method in self._SPLINE_METHODS_ndbspl:
-            self._spline = self._construct_spline(method)
+            _spline = self._construct_spline(method)
 
         if nu is not None and method not in self._SPLINE_METHODS_ndbspl:
             raise ValueError(
@@ -428,7 +429,7 @@ class RegularGridInterpolator:
             if method in self._SPLINE_METHODS_recursive:
                 result = self._evaluate_spline(xi, method)
             else:
-                result = self._spline(xi, nu=nu)
+                result = _spline(xi, nu=nu)
 
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -271,6 +271,7 @@ class RegularGridInterpolator:
         elif method in self._SPLINE_METHODS:
             self._validate_grid_dimensions(points, method)
         self.method = method
+        self._spline = None
         self.bounds_error = bounds_error
         self.grid, self._descending_dimensions = _check_points(points)
         self.values = self._check_values(values)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -396,7 +396,7 @@ class TestBSpline:
         b = BSpline.basis_element([0, 1, 2])
         for extrapolate in (True, False):
             res = b.integrate(0, 1, extrapolate=extrapolate)
-            assert type(res) == np.ndarray
+            assert isinstance(res, np.ndarray)
             assert res.ndim == 0
 
     def test_subclassing(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1082,6 +1082,31 @@ class TestPPolyCommon:
 
             assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]], dtype=object))
 
+    def test_concurrency(self):
+        # Check that no segfaults appear with concurrent access to BPoly, PPoly
+        c = np.random.rand(8, 12, 5, 6, 7)
+        x = np.sort(np.random.rand(13))
+        xp = np.random.rand(3, 4)
+
+        for cls in (PPoly, BPoly):
+            interp = cls(c, x)
+
+            def worker_fn(interp, xp):
+                interp(xp)
+
+            workers = []
+            for _ in range(0, 10):
+                workers.append(threading.Thread(
+                    target=worker_fn,
+                    args=(interp, xp)))
+
+            for worker in workers:
+                worker.start()
+
+            for worker in workers:
+                worker.join()
+
+
     def test_complex_coef(self):
         np.random.seed(12345)
         x = np.sort(np.random.random(13))

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -1,5 +1,6 @@
 import warnings
 import io
+import threading
 import numpy as np
 
 from numpy.testing import (
@@ -315,6 +316,26 @@ class TestKrogh:
         with pytest.warns(UserWarning, match="40 degrees provided,"):
             KroghInterpolator(np.arange(40), np.ones(40))
 
+    def test_concurrency(self):
+        barrier = threading.Barrier(10)
+        P = KroghInterpolator(self.xs, self.ys)
+
+        def worker_fn(interp):
+            barrier.wait()
+            interp(self.xs)
+
+        workers = []
+        for _ in range(0, 10):
+            workers.append(threading.Thread(
+                target=worker_fn,
+                args=(P,)))
+
+        for worker in workers:
+            worker.start()
+
+        for worker in workers:
+            worker.join()
+
 
 class TestTaylor:
     def test_exponential(self):
@@ -513,6 +534,26 @@ class TestBarycentric:
         with pytest.raises(ValueError,
                            match="Interpolation points xi must be distinct."):
             BarycentricInterpolator(xis, ys)
+
+    def test_concurrency(self):
+        barrier = threading.Barrier(10)
+        P = BarycentricInterpolator(self.xs, self.ys)
+
+        def worker_fn(interp):
+            barrier.wait()
+            interp(self.xs)
+
+        workers = []
+        for _ in range(0, 10):
+            workers.append(threading.Thread(
+                target=worker_fn,
+                args=(P,)))
+
+        for worker in workers:
+            worker.start()
+
+        for worker in workers:
+            worker.join()
 
 
 class TestPCHIP:

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -6,8 +6,8 @@ from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_almost_equal)
 from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate._rbf import Rbf
+from scipy._lib._testutils import _run_concurrent_barrier
 
-import threading
 
 FUNCTIONS = ('multiquadric', 'inverse multiquadric', 'gaussian',
              'cubic', 'quintic', 'thin-plate', 'linear')
@@ -231,17 +231,7 @@ def test_rbf_concurrency():
     y = np.vstack([y0, y1]).T
     rbf = Rbf(x, y, mode='N-D')
 
-    def worker_fn(interp, xp):
+    def worker_fn(_, interp, xp):
         interp(xp)
 
-    workers = []
-    for _ in range(0, 10):
-        workers.append(threading.Thread(
-            target=worker_fn,
-            args=(rbf, x)))
-
-    for worker in workers:
-        worker.start()
-
-    for worker in workers:
-        worker.join()
+    _run_concurrent_barrier(10, worker_fn, rbf, x)

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -498,7 +498,8 @@ class TestRBFInterpolatorNeighbors20(_TestRBFInterpolator):
         assert_allclose(yitp1, yitp2, atol=1e-8)
 
     def test_concurrency(self):
-        # Check that no segfaults appear with concurrent access to BPoly, PPoly
+        # Check that no segfaults appear with concurrent access to
+        # RbfInterpolator
         seq = Halton(2, scramble=False, seed=np.random.RandomState())
         x = seq.random(100)
         xitp = seq.random(100)

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -500,7 +500,7 @@ class TestRBFInterpolatorNeighbors20(_TestRBFInterpolator):
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to
         # RbfInterpolator
-        seq = Halton(2, scramble=False, seed=np.random.RandomState())
+        seq = Halton(2, scramble=False, seed=np.random.RandomState(0))
         x = seq.random(100)
         xitp = seq.random(100)
 

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -697,19 +697,21 @@ class TestRegularGridInterpolator:
                            [0.5 , 0.5 , 0.5 , 0.5 ]])
         interp = RegularGridInterpolator(points, values, method="slinear")
 
+        # A call to RGI with a method different from the one specified on the
+        # constructor, should not mutate it.
         methods = ['slinear', 'cubic']
-        def worker_fn(interp):
+        def worker_fn(interp, tid):
             spline = interp._spline
             barrier.wait()
-            method = methods[threading.get_ident() % 2]
+            method = methods[tid % 2]
             interp(sample, method=method)
             assert interp._spline is spline
 
         workers = []
-        for _ in range(0, 10):
+        for i in range(0, 10):
             workers.append(threading.Thread(
                 target=worker_fn,
-                args=(interp,)))
+                args=(interp, i)))
 
         for worker in workers:
             worker.start()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See gh-20669

#### What does this implement/fix?
This PR will add concurrency tests for the main interpolation classes in SciPy. This is done in order to potentially discover any concurrency, race conditions or deadlocks that may appear when using multithreaded Python.

#### Additional information
- [x] `BSpline`: State is initialized in constructor, it shouldn't have any concurrency issues at first glance.
- [x] `PPoly` (and family): State (aka polynomial coefficients) can mutate under `extend` method, all other calls depend on the state  
- [x] `RbfInterpolator`: There are no functions that can mutate an instance state, thus is thread-safe, as long `KDTree` is safe: https://github.com/scipy/scipy/pull/20655
- [x] `Rbf`: There are no functions that can mutate an instance state.
- [x] `NdBSpline`: State is initialized in constructor, no concurrency issues found 
- [x] `NdPPoly`: State is initialized in constructor, no concurrency issues found 
- [x] `NearestNDInterpolator`: State is initialized in constructor, no mutation methods are available. It depends on `KDTree` being thread-safe:  https://github.com/scipy/scipy/pull/20655
- [x] `RegularGridInterpolator`: A wrapped `NdBSpline` instance can mutate during the call, introducing unwanted side effects on a concurrent scenario. Fixed on [7eb6d59](https://github.com/scipy/scipy/pull/20671/commits/7eb6d59c4d0912fa79cce1b792dfb8d27704f7c4) 
- [x] `LinearNDInterpolator/CloughTocherInterpolator`: The `NDInterpolatorBase` does not have any state mutation methods. Since they depend on QHull access, concurrent calls will be serialized https://github.com/scipy/scipy/pull/20619
- [x] `UnivariateSpline/_BivariateSplineBase` (and family): According to https://github.com/scipy/scipy/pull/16053#issuecomment-1113958708, all FORTRAN code that is declared with the `recursive` keyword is reentrant and thread safe, as long as there are not any variables declared with the `save` keyword. The port of FITPACK used by SciPy is not using `save`, and all routines are declared as recursive. Classes that use the FITPACK backend base classes (aka `UnivariateSpline` and `_BivariateSplineBase`) do not have any state-mutating public function different from the constructor, so they should be thread-safe in principle.