### PR TITLE
MAINT: clarify dual_annealing-minimizer_kwargs docstring. Closes #20614

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -478,11 +478,11 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         Keyword arguments to be passed to the local minimizer
         (`minimize`). An important option could be ``method`` for the minimizer
         method to use.
-        If no keyword arguments are provided the local minimizer defaults to
+        If no keyword arguments are provided, the local minimizer defaults to
         'L-BFGS-B' and uses the already supplied bounds. If `minimizer_kwargs`
         is specified, then the dict must contain all parameters required to
-        control the local minimization. Do not include `args` as this is passed
-        automatically. `bounds` is not automatically passed on to the local
+        control the local minimization except `args`. Do not include `args`, as this is
+        passed automatically. `bounds` is not automatically passed on to the local
         minimizer as the method may not support them.
     initial_temp : float, optional
         The initial temperature, use higher values to facilitates a wider

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -397,6 +397,7 @@ class LocalSearchWrapper:
         self.jac = self.kwargs.get('jac', None)
         self.hess = self.kwargs.get('hess', None)
         self.hessp = self.kwargs.get('hessp', None)
+        self.kwargs.pop("args")
         self.minimizer = minimize
         bounds_list = list(zip(*search_bounds))
         self.lower = np.array(bounds_list[0])
@@ -481,9 +482,9 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         If no keyword arguments are provided, the local minimizer defaults to
         'L-BFGS-B' and uses the already supplied bounds. If `minimizer_kwargs`
         is specified, then the dict must contain all parameters required to
-        control the local minimization except `args`. Do not include `args`, as this is
-        passed automatically. `bounds` is not automatically passed on to the local
-        minimizer as the method may not support them.
+        control the local minimization. `args` is ignored in this dict, as it is
+        passed automatically. `bounds` is not automatically passed on to the
+        local minimizer as the method may not support them.
     initial_temp : float, optional
         The initial temperature, use higher values to facilitates a wider
         search of the energy landscape, allowing dual_annealing to escape

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -397,7 +397,7 @@ class LocalSearchWrapper:
         self.jac = self.kwargs.get('jac', None)
         self.hess = self.kwargs.get('hess', None)
         self.hessp = self.kwargs.get('hessp', None)
-        self.kwargs.pop("args")
+        self.kwargs.pop("args", None)
         self.minimizer = minimize
         bounds_list = list(zip(*search_bounds))
         self.lower = np.array(bounds_list[0])

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -395,6 +395,8 @@ class LocalSearchWrapper:
         self.func_wrapper = func_wrapper
         self.kwargs = kwargs
         self.jac = self.kwargs.get('jac', None)
+        self.hess = self.kwargs.get('hess', None)
+        self.hessp = self.kwargs.get('hessp', None)
         self.minimizer = minimize
         bounds_list = list(zip(*search_bounds))
         self.lower = np.array(bounds_list[0])
@@ -411,10 +413,19 @@ class LocalSearchWrapper:
                 'maxiter': ls_max_iter,
             }
             self.kwargs['bounds'] = list(zip(self.lower, self.upper))
-        elif callable(self.jac):
-            def wrapped_jac(x):
-                return self.jac(x, *args)
-            self.kwargs['jac'] = wrapped_jac
+        else:
+            if callable(self.jac):
+                def wrapped_jac(x):
+                    return self.jac(x, *args)
+                self.kwargs['jac'] = wrapped_jac
+            if callable(self.hess):
+                def wrapped_hess(x):
+                    return self.hess(x, *args)
+                self.kwargs['hess'] = wrapped_hess
+            if callable(self.hessp):
+                def wrapped_hessp(x):
+                    return self.hessp(x, *args)
+                self.kwargs['hessp'] = wrapped_hessp
 
     def local_search(self, x, e):
         # Run local search from the given x location where energy value is e
@@ -464,10 +475,15 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     maxiter : int, optional
         The maximum number of global search iterations. Default value is 1000.
     minimizer_kwargs : dict, optional
-        Extra keyword arguments to be passed to the local minimizer
-        (`minimize`). Some important options could be:
-        ``method`` for the minimizer method to use and ``args`` for
-        objective function additional arguments.
+        Keyword arguments to be passed to the local minimizer
+        (`minimize`). An important option could be ``method`` for the minimizer
+        method to use.
+        If no keyword arguments are provided the local minimizer defaults to
+        'L-BFGS-B' and uses the  already supplied bounds. If `minimizer_kwargs`
+        is specified, then the dict must contain all parameters required to
+        control the local minimization. Do not include `args` as this is passed
+        automatically. `bounds` is not automatically passed on to the local
+        minimizer as the method may not support them.
     initial_temp : float, optional
         The initial temperature, use higher values to facilitates a wider
         search of the energy landscape, allowing dual_annealing to escape

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -424,8 +424,8 @@ class LocalSearchWrapper:
                     return self.hess(x, *args)
                 self.kwargs['hess'] = wrapped_hess
             if callable(self.hessp):
-                def wrapped_hessp(x):
-                    return self.hessp(x, *args)
+                def wrapped_hessp(x, p):
+                    return self.hessp(x, p, *args)
                 self.kwargs['hessp'] = wrapped_hessp
 
     def local_search(self, x, e):

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -479,7 +479,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         (`minimize`). An important option could be ``method`` for the minimizer
         method to use.
         If no keyword arguments are provided the local minimizer defaults to
-        'L-BFGS-B' and uses the  already supplied bounds. If `minimizer_kwargs`
+        'L-BFGS-B' and uses the already supplied bounds. If `minimizer_kwargs`
         is specified, then the dict must contain all parameters required to
         control the local minimization. Do not include `args` as this is passed
         automatically. `bounds` is not automatically passed on to the local

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -378,6 +378,7 @@ class TestDualAnnealing:
             return np.diag(
                 power * np.exp(x ** power) * x ** (power - 2) *
                 (power * x ** power + power - 1)
+            )
 
         def hessp(x, p, power):
             return hess(x, power) @ p

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -378,7 +378,9 @@ class TestDualAnnealing:
             return np.diag(
                 power * np.exp(x ** power) * x ** (power - 2) *
                 (power * x ** power + power - 1)
-            )
+
+        def hessp(x, p, power):
+            return hess(x, power) @ p
 
         res1 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
                               minimizer_kwargs=dict(method='L-BFGS-B'))
@@ -388,5 +390,9 @@ class TestDualAnnealing:
         res3 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
                               minimizer_kwargs=dict(method='newton-cg',
                                                     jac=jac, hess=hess))
+        res4 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
+                              minimizer_kwargs=dict(method='newton-cg',
+                                                    jac=jac, hessp=hessp))
         assert_allclose(res1.fun, res2.fun, rtol=1e-6)
         assert_allclose(res3.fun, res2.fun, rtol=1e-6)
+        assert_allclose(res4.fun, res2.fun, rtol=1e-6)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -361,9 +361,11 @@ class TestDualAnnealing:
         assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
         assert ret_bounds_list.nfev == ret_bounds_class.nfev
 
-    def test_callable_jac_with_args_gh11052(self):
+    def test_callable_jac_hess_with_args_gh11052(self):
         # dual_annealing used to fail when `jac` was callable and `args` were
         # used; check that this is resolved. Example is from gh-11052.
+
+        # extended to hess as part of closing gh20614
         rng = np.random.default_rng(94253637693657847462)
         def f(x, power):
             return np.sum(np.exp(x ** power))
@@ -371,9 +373,20 @@ class TestDualAnnealing:
         def jac(x, power):
             return np.exp(x ** power) * power * x ** (power - 1)
 
+        def hess(x, power):
+            # calculated using WolframAlpha as d^2/dx^2 e^(x^p)
+            return np.diag(
+                power * np.exp(x ** power) * x ** (power - 2) *
+                (power * x ** power + power - 1)
+            )
+
         res1 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
                               minimizer_kwargs=dict(method='L-BFGS-B'))
         res2 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
                               minimizer_kwargs=dict(method='L-BFGS-B',
                                                     jac=jac))
+        res3 = dual_annealing(f, args=(2, ), bounds=[[0, 1], [0, 1]], seed=rng,
+                              minimizer_kwargs=dict(method='newton-cg',
+                                                    jac=jac, hess=hess))
         assert_allclose(res1.fun, res2.fun, rtol=1e-6)
+        assert_allclose(res3.fun, res2.fun, rtol=1e-6)


### PR DESCRIPTION
Closes #20614

This PR explains more clearly how keyword arguments are passed to a local minimiser as part of `dual_annealing`.

As part of understanding how the minimizer_kwargs is passed to `minimize` I realised that if `args` are provided to the original `dual_annealing` call, then they were automatically provided to `func` and possibly `jac` using a wrapping approach, and therefore don't need to be specified in `minimizer_kwargs`. The PR therefore states not to include `args` in that dict. I then realised that the same wrapping mechanism should be implemented for `hess` and `hessp`, and did that as well.
