### PR TITLE
MAINT: Fix missing whitespace in signal.iirdesign, spacing consistency fix

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2392,7 +2392,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     fs = _validate_fs(fs, allow_none=True)
 
     if wp.shape[0] != ws.shape[0] or wp.shape not in [(1,), (2,)]:
-        raise ValueError("wp and ws must have one or two elements each, and"
+        raise ValueError("wp and ws must have one or two elements each, and "
                          f"the same shape, got {wp.shape} and {ws.shape}")
 
     if any(wp <= 0) or any(ws <= 0):
@@ -2403,14 +2403,14 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             if any(wp >= 1) or any(ws >= 1):
                 raise ValueError("Values for wp, ws must be less than 1")
         elif any(wp >= fs/2) or any(ws >= fs/2):
-            raise ValueError("Values for wp, ws must be less than fs/2"
-                             f" (fs={fs} -> fs/2={fs/2})")
+            raise ValueError("Values for wp, ws must be less than fs/2 "
+                             f"(fs={fs} -> fs/2={fs/2})")
 
     if wp.shape[0] == 2:
         if not ((ws[0] < wp[0] and wp[1] < ws[1]) or
                (wp[0] < ws[0] and ws[1] < wp[1])):
-            raise ValueError("Passband must lie strictly inside stopband"
-                             " or vice versa")
+            raise ValueError("Passband must lie strictly inside stopband "
+                             "or vice versa")
 
     band_type = 2 * (len(wp) - 1)
     band_type += 1


### PR DESCRIPTION
As per #20683, added the missing whitespace, and moved existing whitespace separators to the end of first strings for consistency

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #20683 

#### What does this implement/fix?
Added a missing whitespace as per the mentioned issue, I also moved around a couple of existing spaces to make the spacing convention consistent across the board. I used the convention of adding the whitespace to the end of the first string, as I have seen that convention being used in other filter functions I looked at.

