### PR TITLE
ENH: speed up _row_norms in distance_impl.h

### DIFF
--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -39,11 +39,12 @@ _row_norms(const double *X, npy_intp num_rows, const npy_intp num_cols, double *
     /* Compute the row norms. */
     npy_intp i, j;
     for (i = 0; i < num_rows; ++i) {
-        for (j = 0; j < num_cols; ++j, ++X) {
-            const double curr_val = *X;
-            norms_buff[i] += curr_val * curr_val;
+        double accumulator = 0.0;
+        for (j = 0; j < num_cols; ++j) {
+            const double curr_val = X[(i * num_cols) + j];
+            accumulator += curr_val * curr_val;
         }
-        norms_buff[i] = sqrt(norms_buff[i]);
+        norms_buff[i] = sqrt(accumulator);
     }
 }
 


### PR DESCRIPTION
This PR is two small micro-optimizations to a helper function used in cdist and pdist. It's pretty miniscule (on GCC with O3 and the unsafe math pragma), 1-3% on something that's already a small proportion of the total time for any of the functions, but it's not zero and it's free.

1. Use a local accumulator for each row's sum, instead of hitting the output buffer repeatedly, to remove writes from the inner loop. This write seems to go away when ffast-math or similar are enabled, but it couldn't hurt to get rid of it for those compiling without that flag. As a knock-on, this means there's no longer a need to use calloc instead of malloc for the output buffer. I have not included the calloc->malloc change in this PR, but I wouldn't mind taking care of it if that change is desired.

2. Index into X, rather than incrementing it, to remove the incrementing instructions from the inner loop (which seem to sneak in on any compiler/arch/flags).

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
n/a

#### What does this implement/fix?
Small performance benefits for spatial.distance

#### Additional information
None
