### PR TITLE
MAINT: stats.gstd: return result rather than raising

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3147,25 +3147,25 @@ def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
 
 
 def gstd(a, axis=0, ddof=1):
-    """
+    r"""
     Calculate the geometric standard deviation of an array.
 
     The geometric standard deviation describes the spread of a set of numbers
     where the geometric mean is preferred. It is a multiplicative factor, and
     so a dimensionless quantity.
 
-    It is defined as the exponent of the standard deviation of ``log(a)``.
-    Mathematically the population geometric standard deviation can be
-    evaluated as::
-
-        gstd = exp(std(log(a)))
-
-    .. versionadded:: 1.3.0
+    It is defined as the exponential of the standard deviation of the
+    natural logarithms of the observations.
 
     Parameters
     ----------
     a : array_like
-        An array like object containing the sample data.
+        An array containing finite, strictly positive, real numbers.
+
+        .. deprecated:: 1.14.0
+            Support for masked array input was deprecated in
+            SciPy 1.14.0 and will be removed in version 1.16.0.
+
     axis : int, tuple or None, optional
         Axis along which to operate. Default is 0. If None, compute over
         the whole array `a`.
@@ -3187,14 +3187,28 @@ def gstd(a, axis=0, ddof=1):
 
     Notes
     -----
-    As the calculation requires the use of logarithms the geometric standard
-    deviation only supports strictly positive values. Any non-positive or
-    infinite values will raise a `ValueError`.
-    The geometric standard deviation is sometimes confused with the exponent of
-    the standard deviation, ``exp(std(a))``. Instead the geometric standard
+    Mathematically, the sample geometric standard deviation :math:`s_G` can be
+    defined in terms of the natural logarithms of the observations
+    :math:`y_i = \log(x_i)`:
+
+    .. math::
+
+        s_G = \exp(s_y), s_y = \sqrt{ \frac{1}{n - 1} \sum_{i=1}^n (y_i - \bar y)^2 }
+
+    where :math:`n` is the number of observations and :math:`\bar y` denotes the
+    mean of the natural logarithms of the observations.
+
+    Note that the default ``ddof=1``, which corresponds with the :math:`n - 1` term
+    above, is different from the default value used by similar functions, such as
+    `numpy.std` and `numpy.var`.
+
+    When an observation is infinite, the geometric standard deviation is
+    NaN (undefined). Non-positive observations will also produce NaNs in the
+    output because the *natural* logarithm (as opposed to the *complex*
+    logarithm) is defined only for positive reals.
+    The geometric standard deviation is sometimes confused with the exponential
+    of the standard deviation, ``exp(std(a))``. Instead, the geometric standard
     deviation is ``exp(std(log(a)))``.
-    The default value for `ddof` is different to the default value (0) used
-    by other ddof containing functions, such as ``np.std`` and ``np.nanstd``.
 
     References
     ----------
@@ -3206,7 +3220,7 @@ def gstd(a, axis=0, ddof=1):
     Examples
     --------
     Find the geometric standard deviation of a log-normally distributed sample.
-    Note that the standard deviation of the distribution is one, on a
+    Note that the standard deviation of the distribution is one; on a
     log scale this evaluates to approximately ``exp(1)``.
 
     >>> import numpy as np
@@ -3228,66 +3242,18 @@ def gstd(a, axis=0, ddof=1):
     >>> gstd(a, axis=(1,2))
     array([2.12939215, 1.22120169])
 
-    The geometric standard deviation further handles masked arrays.
-
-    >>> a = np.arange(1, 25).reshape(2, 3, 4)
-    >>> ma = np.ma.masked_where(a > 16, a)
-    >>> ma
-    masked_array(
-      data=[[[1, 2, 3, 4],
-             [5, 6, 7, 8],
-             [9, 10, 11, 12]],
-            [[13, 14, 15, 16],
-             [--, --, --, --],
-             [--, --, --, --]]],
-      mask=[[[False, False, False, False],
-             [False, False, False, False],
-             [False, False, False, False]],
-            [[False, False, False, False],
-             [ True,  True,  True,  True],
-             [ True,  True,  True,  True]]],
-      fill_value=999999)
-    >>> gstd(ma, axis=2)
-    masked_array(
-      data=[[1.8242475707663655, 1.2243686572447428, 1.1318311657788478],
-            [1.0934830582350938, --, --]],
-      mask=[[False, False, False],
-            [False,  True,  True]],
-      fill_value=999999)
-
     """
     a = np.asanyarray(a)
-    log = ma.log if isinstance(a, ma.MaskedArray) else np.log
+    if isinstance(a, ma.MaskedArray):
+        message = ("`gstd` support for masked array input was deprecated in "
+                   "SciPy 1.14.0 and will be removed in version 1.16.0.")
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        log = ma.log
+    else:
+        log = np.log
 
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", RuntimeWarning)
-            return np.exp(np.std(log(a), axis=axis, ddof=ddof))
-    except RuntimeWarning as w:
-        if np.isinf(a).any():
-            raise ValueError(
-                'Infinite value encountered. The geometric standard deviation '
-                'is defined for strictly positive values only.'
-            ) from w
-        a_nan = np.isnan(a)
-        a_nan_any = a_nan.any()
-        # exclude NaN's from negativity check, but
-        # avoid expensive masking for arrays with no NaN
-        if ((a_nan_any and np.less_equal(np.nanmin(a), 0)) or
-                (not a_nan_any and np.less_equal(a, 0).any())):
-            raise ValueError(
-                'Non positive value encountered. The geometric standard '
-                'deviation is defined for strictly positive values only.'
-            ) from w
-        elif 'Degrees of freedom <= 0 for slice' == str(w):
-            raise ValueError(w) from w
-        else:
-            #  Remaining warnings don't need to be exceptions.
-            return np.exp(np.std(log(a, where=~a_nan), axis=axis, ddof=ddof))
-    except TypeError as e:
-        raise ValueError(
-            'Invalid array input. The inputs could not be '
-            'safely coerced to any supported types') from e
+    with np.errstate(invalid='ignore', divide='ignore'):
+        return np.exp(np.std(log(a), axis=axis, ddof=ddof))
 
 
 # Private dictionary initialized only once at module level

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3193,14 +3193,12 @@ def gstd(a, axis=0, ddof=1):
 
     .. math::
 
-        s_G = \exp(s_y), s_y = \sqrt{ \frac{1}{n - 1} \sum_{i=1}^n (y_i - \bar y)^2 }
+        s_G = \exp(s), \quad s = \sqrt{\frac{1}{n - d} \sum_{i=1}^n (y_i - \bar y)^2}
 
-    where :math:`n` is the number of observations and :math:`\bar y` denotes the
-    mean of the natural logarithms of the observations.
-
-    Note that the default ``ddof=1``, which corresponds with the :math:`n - 1` term
-    above, is different from the default value used by similar functions, such as
-    `numpy.std` and `numpy.var`.
+    where :math:`n` is the number of observations, :math:`d` is the adjustment `ddof`
+    to the degrees of freedom, and :math:`\bar y` denotes the mean of the natural
+    logarithms of the observations. Note that the default ``ddof=1`` is different from
+    the default value used by similar functions, such as `numpy.std` and `numpy.var`.
 
     When an observation is infinite, the geometric standard deviation is
     NaN (undefined). Non-positive observations will also produce NaNs in the

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6828,21 +6828,15 @@ class TestGeometricStandardDeviation:
         gstd_actual = stats.gstd(tuple(self.array_1d))
         assert_allclose(gstd_actual, self.gstd_array_1d)
 
-    def test_raises_value_error_non_array_like_input(self):
-        with pytest.raises(ValueError, match='Invalid array input'):
-            stats.gstd('This should fail as it can not be cast to an array.')
+    def test_raises_value_error_non_numeric_input(self):
+        # this is raised by NumPy, but it's quite interpretable
+        with pytest.raises(TypeError, match="ufunc 'log' not supported"):
+            stats.gstd('You cannot take the logarithm of a string.')
 
-    def test_raises_value_error_zero_entry(self):
-        with pytest.raises(ValueError, match='Non positive value'):
-            stats.gstd(np.append(self.array_1d, [0]))
-
-    def test_raises_value_error_negative_entry(self):
-        with pytest.raises(ValueError, match='Non positive value'):
-            stats.gstd(np.append(self.array_1d, [-1]))
-
-    def test_raises_value_error_inf_entry(self):
-        with pytest.raises(ValueError, match='Infinite value'):
-            stats.gstd(np.append(self.array_1d, [np.inf]))
+    @pytest.mark.parametrize('bad_value', (0, -1, np.inf))
+    def test_returns_nan_invalid_value(self, bad_value):
+        x = np.append(self.array_1d, [bad_value])
+        assert_equal(stats.gstd(x), np.nan)
 
     def test_propagates_nan_values(self):
         a = array([[1, 1, 1, 16], [np.nan, 1, 2, 3]])
@@ -6850,7 +6844,7 @@ class TestGeometricStandardDeviation:
         assert_allclose(gstd_actual, np.array([4, np.nan]))
 
     def test_ddof_equal_to_number_of_observations(self):
-        with pytest.raises(ValueError, match='Degrees of freedom <= 0'):
+        with pytest.warns(RuntimeWarning, match='Degrees of freedom <= 0'):
             stats.gstd(self.array_1d, ddof=self.array_1d.size)
 
     def test_3d_array(self):
@@ -6888,7 +6882,9 @@ class TestGeometricStandardDeviation:
 
     def test_masked_3d_array(self):
         ma = np.ma.masked_where(self.array_3d > 16, self.array_3d)
-        gstd_actual = stats.gstd(ma, axis=2)
+        message = "`gstd` support for masked array input was deprecated in..."
+        with pytest.warns(DeprecationWarning, match=message):
+            gstd_actual = stats.gstd(ma, axis=2)
         gstd_desired = stats.gstd(self.array_3d, axis=2)
         mask = [[0, 0, 0], [0, 1, 1]]
         assert_allclose(gstd_actual, gstd_desired)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6845,7 +6845,7 @@ class TestGeometricStandardDeviation:
 
     def test_ddof_equal_to_number_of_observations(self):
         with pytest.warns(RuntimeWarning, match='Degrees of freedom <= 0'):
-            stats.gstd(self.array_1d, ddof=self.array_1d.size)
+            assert_equal(stats.gstd(self.array_1d, ddof=self.array_1d.size), np.inf)
 
     def test_3d_array(self):
         gstd_actual = stats.gstd(self.array_3d, axis=None)


### PR DESCRIPTION
#### Reference issue
gh-20285

#### What does this implement/fix?
gh-20285 noted changes to `stats.gstd` that would make it more amenable to the addition of array API support. This implements those changes. It also deprecates support for masked arrays, since `gstd` seems to be unique among `stats` functions in that it advertises support for masked arrays such that it *returns* a masked array with no masked elements (many handle them, but other functions return regular arrays).

#### Additional information 
See https://github.com/scipy/scipy/pull/20285#issuecomment-2015706838 for context and additional rationale.