### PR TITLE
ENH: spatial: remove redundant weight summing from hamming distance

### DIFF
--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -180,30 +180,26 @@ mahalanobis_distance(const double *u, const double *v, const double *covinv,
 }
 
 static inline double
-hamming_distance_double(const double *u, const double *v, const npy_intp n, const double *w)
+hamming_distance_double(const double *u, const double *v, const npy_intp n, const double *w, const double w_sum)
 {
     npy_intp i;
     double s = 0;
-    double w_sum = 0;
 
     for (i = 0; i < n; ++i) {
         s += ((double) (u[i] != v[i])) * w[i];
-        w_sum += w[i];
     }
 
     return s / w_sum;
 }
 
 static inline double
-hamming_distance_char(const char *u, const char *v, const npy_intp n, const double *w)
+hamming_distance_char(const char *u, const char *v, const npy_intp n, const double *w, const double w_sum)
 {
     npy_intp i;
     double s = 0;
-    double w_sum = 0;
 
     for (i = 0; i < n; ++i) {
         s += ((double) (u[i] != v[i])) * w[i];
-        w_sum += w[i];
     }
 
     return s / w_sum;
@@ -653,13 +649,18 @@ static inline int
 pdist_hamming_double(const double *X, double *dm, npy_intp num_rows,
                          const npy_intp num_cols, const double *w)
 {
-    npy_intp i, j;
+    npy_intp i, j, w_idx;
+
+    double w_sum = 0.0;
+    for (w_idx = 0; w_idx < num_cols; ++w_idx) {
+        w_sum += w[w_idx];
+    }
 
     for (i = 0; i < num_rows; ++i) {
         const double *u = X + (num_cols * i);
         for (j = i + 1; j < num_rows; ++j, ++dm) {
             const double *v = X + (num_cols * j);
-            *dm = hamming_distance_double(u, v, num_cols, w);
+            *dm = hamming_distance_double(u, v, num_cols, w, w_sum);
         }
     }
     return 0;
@@ -669,13 +670,18 @@ static inline int
 pdist_hamming_char(const char *X, double *dm, npy_intp num_rows,
                          const npy_intp num_cols, const double *w)
 {
-    npy_intp i, j;
+    npy_intp i, j, w_idx;
+
+    double w_sum = 0.0;
+    for (w_idx = 0; w_idx < num_cols; ++w_idx) {
+        w_sum += w[w_idx];
+    }
 
     for (i = 0; i < num_rows; ++i) {
         const char *u = X + (num_cols * i);
         for (j = i + 1; j < num_rows; ++j, ++dm) {
             const char *v = X + (num_cols * j);
-            *dm = hamming_distance_char(u, v, num_cols, w);
+            *dm = hamming_distance_char(u, v, num_cols, w, w_sum);
         }
     }
     return 0;
@@ -881,13 +887,18 @@ cdist_hamming_double(const double *XA, const double *XB, double *dm,
                          const npy_intp num_cols,
                          const double *w)
 {
-    npy_intp i, j;
+    npy_intp i, j, w_idx;
+
+    double w_sum = 0.0;
+    for (w_idx = 0; w_idx < num_cols; ++w_idx) {
+        w_sum += w[w_idx];
+    }
 
     for (i = 0; i < num_rowsA; ++i) {
         const double *u = XA + (num_cols * i);
         for (j = 0; j < num_rowsB; ++j, ++dm) {
             const double *v = XB + (num_cols * j);
-            *dm = hamming_distance_double(u, v, num_cols, w);
+            *dm = hamming_distance_double(u, v, num_cols, w, w_sum);
         }
     }
     return 0;
@@ -899,13 +910,18 @@ cdist_hamming_char(const char *XA, const char *XB, double *dm,
                          const npy_intp num_cols,
                          const double *w)
 {
-    npy_intp i, j;
+    npy_intp i, j, w_idx;
+
+    double w_sum = 0.0;
+    for (w_idx = 0; w_idx < num_cols; ++w_idx) {
+        w_sum += w[w_idx];
+    }
 
     for (i = 0; i < num_rowsA; ++i) {
         const char *u = XA + (num_cols * i);
         for (j = 0; j < num_rowsB; ++j, ++dm) {
             const char *v = XB + (num_cols * j);
-            *dm = hamming_distance_char(u, v, num_cols, w);
+            *dm = hamming_distance_char(u, v, num_cols, w, w_sum);
         }
     }
     return 0;


### PR DESCRIPTION
Instead of re-summing all the weights each time a pair of inputs is compared, sum the weights once and re-use the result. When I measured locally, trimming this extra work allowed about 25% more throughput on chars and 5% on doubles. I'll make this a draft to start, and seek review if the ci benchmarks corroborate.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
n/a

#### What does this implement/fix?
Moderate performance improvements to existing functionality.

#### Additional information
n/a
