### PR TITLE
GitHub Action to show how to run SciPy on Python 3.13 prerelease

### DIFF
--- a/.github/workflows/scipy_on_py3_13.yml
+++ b/.github/workflows/scipy_on_py3_13.yml
@@ -1,0 +1,29 @@
+# A GitHub Action to demonstrate how to run SciPy on Python 3.13 before its release in Oct. 2024
+
+name: scipy_on_py3_13
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  scipy_on_py3_13:
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://docs.scipy.org/doc/scipy-1.13.0/building/index.html#building-from-source
+        os: [ubuntu-latest]  # , macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+          allow-prereleases: true
+      - if: runner.os == 'Linux'  # https://github.com/scipy/scipy/issues/16308#issuecomment-1140477372
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes libopenblas-dev
+      - run: pip install --upgrade pip
+      - run: pip install scipy
+      # Some packages that depend on SciPy
+      - run: pip install scikit-learn statsmodels xgboost


### PR DESCRIPTION
Add a GitHub Action to demonstrate how to run SciPy on Python 3.13 before its release in Oct. 2024
* https://www.python.org/downloads/release/python-3130b1/
* https://github.com/scipy/scipy/issues/16308#issuecomment-1140477372

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
