### PR TITLE
MAINT: numpy cleanup version bumps: fixes issue #20458

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -66,7 +66,7 @@ del _distributor_init
 
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
-np_minversion = '1.22.4'
+np_minversion = '2.0.0rc1'
 np_maxversion = '9.9.99'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -66,7 +66,7 @@ del _distributor_init
 
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
-np_minversion = '2.0.0rc1'
+np_minversion = '1.23.5'
 np_maxversion = '9.9.99'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -11,7 +11,6 @@ import hypothesis
 
 from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
-from scipy._lib import _pep440
 from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
 
 
@@ -39,16 +38,8 @@ def pytest_configure(config):
         "mark the desired skip configuration for the `skip_xp_backends` fixture.")
 
 
-def _get_mark(item, name):
-    if _pep440.parse(pytest.__version__) >= _pep440.Version("3.6.0"):
-        mark = item.get_closest_marker(name)
-    else:
-        mark = item.get_marker(name)
-    return mark
-
-
 def pytest_runtest_setup(item):
-    mark = _get_mark(item, "xslow")
+    mark = item.get_closest_marker("xslow")
     if mark is not None:
         try:
             v = int(os.environ.get('SCIPY_XSLOW', '0'))
@@ -57,7 +48,7 @@ def pytest_runtest_setup(item):
         if not v:
             pytest.skip("very slow test; "
                         "set environment variable SCIPY_XSLOW=1 to run it")
-    mark = _get_mark(item, 'xfail_on_32bit')
+    mark = item.get_closest_marker("xfail_on_32bit")
     if mark is not None and np.intp(0).itemsize < 8:
         pytest.xfail(f'Fails on our 32-bit test platform(s): {mark.args[0]}')
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -15,7 +15,6 @@ import operator
 import platform
 import itertools
 import sys
-from scipy._lib import _pep440
 
 import numpy as np
 from numpy import (arange, zeros, array, dot, asarray,
@@ -5032,15 +5031,10 @@ def cases_64bit():
                 if bool(msg):
                     marks += [pytest.mark.skip(reason=msg)]
 
-                if _pep440.parse(pytest.__version__) >= _pep440.Version("3.6.0"):
-                    markers = getattr(method, 'pytestmark', [])
-                    for mark in markers:
-                        if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):
-                            marks.append(mark)
-                else:
-                    for mname in ['skipif', 'skip', 'xfail', 'xslow']:
-                        if hasattr(method, mname):
-                            marks += [getattr(method, mname)]
+                markers = getattr(method, 'pytestmark', [])
+                for mark in markers:
+                    if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):
+                        marks.append(mark)
 
                 yield pytest.param(cls, method_name, marks=marks)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3775,10 +3775,6 @@ class TestDirichletMultinomial:
         assert_allclose(res, ref)
 
     def test_moments(self):
-        message = 'Needs NumPy 1.22.0 for multinomial broadcasting'
-        if Version(np.__version__) < Version("1.22.0"):
-            pytest.skip(reason=message)
-
         rng = np.random.default_rng(28469824356873456)
         dim = 5
         n = rng.integers(1, 100)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -32,7 +32,6 @@ from scipy import stats
 
 from scipy.integrate import romb, qmc_quad, tplquad
 from scipy.special import multigammaln
-from scipy._lib._pep440 import Version
 
 from .common_tests import check_random_state_property
 from .data._mvt import _qsimvtv


### PR DESCRIPTION
The minimum numpy version in `scipy/scipy/__init__.py` has been aligned to the minimum requirement of `pyproject.toml`. A numpy version check has been removed from test `test_moments` in `scipy/stats/tests/test_multivariate.py` because the check looked for a numpy version earlier than the minimum. This pull request does not fully solve #20458. I will come back at it after discussion.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Partially solves issue #20458 

#### What does this implement/fix?
This aligns a few numpy versions. Does not align the pytest version.

#### Additional information
I'm open to working on fixing the pytest versions too, as reported in #20458. However, it is not clear to me what is the exact pytest version we should report. Shall we find it ourselves or you already know? Tried grepping for it but didn't find anything useful.
