### PR TITLE
DEP: integrate.quad_vec: deprecate `quadrature="trapz"`

### DIFF
--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -298,7 +298,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
 
     if quadrature == "trapz":
         msg = ("`quadrature='trapz'` is deprecated in favour of "
-               "`quadrature='trapezoid' and will raise a error from SciPy 1.16.0 "
+               "`quadrature='trapezoid' and will raise an error from SciPy 1.16.0 "
                "onwards.")
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
 

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -3,6 +3,7 @@ import copy
 import heapq
 import collections
 import functools
+import warnings
 
 import numpy as np
 
@@ -294,6 +295,12 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
                        'trapezoid': _quadrature_trapezoid}[quadrature]
     except KeyError as e:
         raise ValueError(f"unknown quadrature {quadrature!r}") from e
+
+    if quadrature == "trapz":
+        msg = ("`quadrature='trapz'` is deprecated in favour of "
+               "`quadrature='trapezoid' and will raise a error from SciPy 1.16.0 "
+               "onwards.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     # Initial interval set
     if points is None:

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -207,3 +207,7 @@ def test_points(a, b):
     for p in interval_sets:
         j = np.searchsorted(sorted(points), tuple(p))
         assert np.all(j == j[0])
+
+def test_trapz_deprecation():
+    with pytest.deprecated_call(match="`quadrature='trapz'`"):
+        quad_vec(lambda x: x, 0, 1, quadrature="trapz")

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -134,9 +134,6 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\..*_roots',  # old aliases for scipy.special.*_roots
     r'scipy\.special\.jn',  # alias for jv
     r'scipy\.ndimage\.sum',   # alias for sum_labels
-    r'scipy\.integrate\.simps',   # alias for simpson
-    r'scipy\.integrate\.trapz',   # alias for trapezoid
-    r'scipy\.integrate\.cumtrapz',   # alias for cumulative_trapezoid
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
     r'scipy\.stats\.contingency\.chi2_contingency',
     r'scipy\.stats\.contingency\.expected_freq',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
towards #20486
#### What does this implement/fix?
<!--Please explain your changes.-->
Allows for cleaning up one of the final trapz references, which we have removed elsewhere as it is not an especially helpful acronym and can be interpreted as a slur.

Also tidies up some functions in the refguide check that no longer exist.
#### Additional information
<!--Any additional information you think is important.-->
Post to the development forum to follow once I do the other half of #20486