### PR TITLE
ENH: Speed up sparse.csgraph.dijkstra 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,7 +247,7 @@ scipy/signal/_bspline_util.c
 scipy/sparse/_csparsetools.c
 scipy/sparse/_csparsetools.pyx
 scipy/sparse/csgraph/_min_spanning_tree.c
-scipy/sparse/csgraph/_shortest_path.c
+scipy/sparse/csgraph/_shortest_path.cxx
 scipy/sparse/csgraph/_tools.c
 scipy/sparse/csgraph/_traversal.c
 scipy/sparse/csgraph/_flow.c

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -20,7 +20,7 @@ class Dijkstra(Benchmark):
         rng = np.random.default_rng(1234)
         if format == 'random':
             # make a random connectivity matrix
-            data = scipy.sparse.rand(n, n, density=0.2, format='csc',
+            data = scipy.sparse.rand(n, n, density=0.2, format='lil',
                                      random_state=42, dtype=np.bool_)
             data.setdiag(np.zeros(n, dtype=np.bool_))
             self.data = data

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -27,6 +27,9 @@ cimport cython
 from libc.stdlib cimport malloc, free
 from libc.math cimport INFINITY
 
+from libcpp.queue cimport priority_queue
+from libcpp.pair cimport pair
+
 np.import_array()
 
 include 'parameters.pxi'
@@ -651,81 +654,48 @@ def dijkstra(csgraph, directed=True, indices=None,
     else:
         return dist_matrix.reshape(return_shape)
 
-@cython.boundscheck(False)
-cdef _dijkstra_setup_heap_multi(FibonacciHeap *heap,
-                                FibonacciNode* nodes,
-                                const int[:] source_indices,
-                                int[:] sources,
-                                double[:] dist_matrix,
-                                int return_pred):
-    cdef:
-        unsigned int Nind = source_indices.shape[0]
-        unsigned int N = dist_matrix.shape[0]
-        unsigned int i, k, j_source
-        FibonacciNode *current_node
 
-    for k in range(N):
-        initialize_node(&nodes[k], k)
-
-    heap.min_node = NULL
-    for i in range(Nind):
-        j_source = source_indices[i]
-        current_node = &nodes[j_source]
-        if current_node.state == SCANNED:
-            continue
-        dist_matrix[j_source] = 0
-        if return_pred:
-            sources[j_source] = j_source
-        current_node.state = SCANNED
-        current_node.source = j_source
-        insert_node(heap, &nodes[j_source])
+ctypedef unsigned int uint_t
+ctypedef pair[DTYPE_t, uint_t] dist_index_pair_t
+ctypedef priority_queue[dist_index_pair_t] dijkstra_queue_t
 
 @cython.boundscheck(False)
-cdef _dijkstra_scan_heap_multi(FibonacciHeap *heap,
-                               FibonacciNode *v,
-                               FibonacciNode* nodes,
-                               const double[:] csr_weights,
-                               const int[:] csr_indices,
-                               const int[:] csr_indptr,
-                               int[:] pred,
-                               int[:] sources,
-                               int return_pred,
-                               DTYPE_t limit):
-    cdef:
-        unsigned int j_current
-        ITYPE_t j
-        DTYPE_t next_val
-        FibonacciNode *current_node
-
-    for j in range(csr_indptr[v.index], csr_indptr[v.index + 1]):
-        j_current = csr_indices[j]
-        current_node = &nodes[j_current]
-        if current_node.state != SCANNED:
-            next_val = v.val + csr_weights[j]
-            if next_val <= limit:
-                if current_node.state == NOT_IN_HEAP:
-                    current_node.state = IN_HEAP
-                    current_node.val = next_val
-                    current_node.source = v.source
-                    insert_node(heap, current_node)
-                    if return_pred:
-                        pred[j_current] = v.index
-                        sources[j_current] = v.source
-                elif current_node.val > next_val:
-                    current_node.source = v.source
-                    decrease_val(heap, current_node,
-                                 next_val)
-                    if return_pred:
-                        pred[j_current] = v.index
-                        sources[j_current] = v.source
-
-@cython.boundscheck(False)
-cdef _dijkstra_scan_heap(FibonacciHeap *heap,
-                         FibonacciNode *v,
-                         FibonacciNode* nodes,
+cdef _dijkstra_scan_heap_multi(dijkstra_queue_t &heap,
+                         dist_index_pair_t v,
                          const double[:] csr_weights,
                          const int[:] csr_indices,
                          const int[:] csr_indptr,
+                         double[:] dist_matrix,
+                         int[:] pred,
+                         int[:] sources,
+                         int return_pred,
+                         DTYPE_t limit):
+    cdef:
+        unsigned int k, j_source, j_current
+        ITYPE_t j
+        DTYPE_t next_val
+
+    # v is a dist_index_pair_t poped from the queue
+    # v.first: the distance of the vertex
+    # v.second: index of the vertex
+    for j in range(csr_indptr[v.second], csr_indptr[v.second + 1]):
+        j_current = csr_indices[j]
+        next_val = v.first + csr_weights[j]
+        if next_val <= limit:
+            if dist_matrix[j_current] > next_val:
+                dist_matrix[j_current] = next_val
+                heap.push(dist_index_pair_t(-next_val, j_current))
+                if return_pred:
+                    pred[j_current] = v.second
+                    sources[j_current] = sources[v.second]
+
+@cython.boundscheck(False)
+cdef _dijkstra_scan_heap(dijkstra_queue_t &heap,
+                         dist_index_pair_t v,
+                         const double[:] csr_weights,
+                         const int[:] csr_indices,
+                         const int[:] csr_indptr,
+                         double[:, :] dist_matrix,
                          int[:, :] pred,
                          int return_pred,
                          DTYPE_t limit,
@@ -734,25 +704,21 @@ cdef _dijkstra_scan_heap(FibonacciHeap *heap,
         unsigned int j_current
         ITYPE_t j
         DTYPE_t next_val
-        FibonacciNode *current_node
 
-    for j in range(csr_indptr[v.index], csr_indptr[v.index + 1]):
+    # v is a dist_index_pair_t poped from the queue
+    # v.first: the distance of the vertex
+    # v.second: index of the vertex
+    for j in range(csr_indptr[v.second], csr_indptr[v.second + 1]):
         j_current = csr_indices[j]
-        current_node = &nodes[j_current]
-        if current_node.state != SCANNED:
-            next_val = v.val + csr_weights[j]
-            if next_val <= limit:
-                if current_node.state == NOT_IN_HEAP:
-                    current_node.state = IN_HEAP
-                    current_node.val = next_val
-                    insert_node(heap, current_node)
-                    if return_pred:
-                        pred[i, j_current] = v.index
-                elif current_node.val > next_val:
-                    decrease_val(heap, current_node,
-                                 next_val)
-                    if return_pred:
-                        pred[i, j_current] = v.index
+        next_val = v.first + csr_weights[j]
+        if next_val <= limit:
+            if dist_matrix[i, j_current] > next_val:
+                dist_matrix[i, j_current] = next_val
+				# The same vertex may be pushed multiple times to the queue, but anything
+                heap.push(dist_index_pair_t(-next_val, j_current))
+                if return_pred:
+                    pred[i, j_current] = v.second
+
 
 @cython.boundscheck(False)
 cdef int _dijkstra_directed(
@@ -766,37 +732,33 @@ cdef int _dijkstra_directed(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, k, j_source
+        unsigned int i, k, j_source, j_current
+        DTYPE_t next_val
         int return_pred = (pred.size > 0)
-        FibonacciHeap heap
-        FibonacciNode *v
-        FibonacciNode* nodes = <FibonacciNode*> malloc(N *
-                                                       sizeof(FibonacciNode))
-    if nodes == NULL:
-        raise MemoryError("Failed to allocate memory in _dijkstra_directed")
-
+        dijkstra_queue_t heap # pairs of {-distance, vertex index} will be pushed to this priority queue
+        dist_index_pair_t v
+    
     for i in range(Nind):
         j_source = source_indices[i]
-
-        for k in range(N):
-            initialize_node(&nodes[k], k)
-
+        
         dist_matrix[i, j_source] = 0
-        heap.min_node = NULL
-        insert_node(&heap, &nodes[j_source])
+        # priority_queue is max-heap, so negate the distance to make it min-heap
+        heap.push(dist_index_pair_t(-dist_matrix[i, j_source], j_source))
 
-        while heap.min_node:
-            v = remove_min(&heap)
-            v.state = SCANNED
-
-            _dijkstra_scan_heap(&heap, v, nodes,
-                                csr_weights, csr_indices, csr_indptr,
-                                pred, return_pred, limit, i)
-
-            # v has now been scanned: add the distance to the results
-            dist_matrix[i, v.index] = v.val
-
-    free(nodes)
+        while heap.size():
+            v = heap.top()
+            heap.pop()
+            v.first = -v.first
+            # Do not process v if its distance has been updated
+			# after v was pushed to the queue, in which case
+			# _dijkstra_scan_heap should have already been called with
+			# the vertex v.second
+            # This assures _dijkstra_scan_heap is only called once per vertex
+			# and the total complexity is O(Mlog(M)) per source
+            if dist_matrix[i, v.second] < v.first : continue
+            
+            _dijkstra_scan_heap(heap, v, csr_weights, csr_indices, csr_indptr,
+                                dist_matrix, pred, return_pred, limit, i)
     return 0
 
 @cython.boundscheck(False)
@@ -810,37 +772,32 @@ cdef int _dijkstra_directed_multi(
             int[:] sources,
             DTYPE_t limit) except -1:
     cdef:
+        unsigned int Nind = source_indices.shape[0]
         unsigned int N = dist_matrix.shape[0]
-
+        unsigned int i, k, j_source, j_current
+        DTYPE_t next_val
         int return_pred = (pred.size > 0)
 
-        FibonacciHeap heap
-        FibonacciNode *v
-        FibonacciNode* nodes = <FibonacciNode*> malloc(N *
-                                                       sizeof(FibonacciNode))
-    if nodes == NULL:
-        raise MemoryError("Failed to allocate memory in "
-                          "_dijkstra_directed_multi")
+        # pairs of {-distance, vertex index} will be pushed
+        # to treat it as a min-heap instead of max-heap
+        dijkstra_queue_t heap = dijkstra_queue_t()
+        dist_index_pair_t v
 
-    # initialize the heap with each of the starting
-    # nodes on the heap and in a scanned state with 0 values
-    # and their entry of the distance matrix = 0
-    # pred will lead back to one of the starting indices
-    _dijkstra_setup_heap_multi(&heap, nodes, source_indices,
-                               sources, dist_matrix, return_pred)
-
-    while heap.min_node:
-        v = remove_min(&heap)
-        v.state = SCANNED
-
-        _dijkstra_scan_heap_multi(&heap, v, nodes,
-                                  csr_weights, csr_indices, csr_indptr,
-                                  pred, sources, return_pred, limit)
-
-        # v has now been scanned: add the distance to the results
-        dist_matrix[v.index] = v.val
-
-    free(nodes)
+    for i in range(Nind):
+        j_source = source_indices[i]
+        dist_matrix[j_source] = 0
+        heap.push(dist_index_pair_t(-dist_matrix[j_source], j_source))
+        if return_pred:
+            sources[j_source] = j_source
+    
+    while heap.size():
+        v = heap.top()
+        heap.pop()
+        v.first = -v.first
+        if dist_matrix[v.second] < v.first : continue
+        
+        _dijkstra_scan_heap_multi(heap, v, csr_weights, csr_indices, csr_indptr,
+                                  dist_matrix, pred, sources, return_pred, limit)
     return 0
 
 @cython.boundscheck(False)
@@ -858,42 +815,31 @@ cdef int _dijkstra_undirected(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, k, j_source
+        unsigned int i, k, j_source, j_current
+        DTYPE_t next_val
         int return_pred = (pred.size > 0)
-        FibonacciHeap heap
-        FibonacciNode *v
-        FibonacciNode* nodes = <FibonacciNode*> malloc(N *
-                                                       sizeof(FibonacciNode))
-    if nodes == NULL:
-        raise MemoryError("Failed to allocate memory in _dijkstra_undirected")
-
+        dijkstra_queue_t heap
+        dist_index_pair_t v
+    
     for i in range(Nind):
         j_source = source_indices[i]
-
-        for k in range(N):
-            initialize_node(&nodes[k], k)
-
+        
         dist_matrix[i, j_source] = 0
-        heap.min_node = NULL
-        insert_node(&heap, &nodes[j_source])
+        heap.push(dist_index_pair_t(-dist_matrix[i, j_source], j_source))
 
-        while heap.min_node:
-            v = remove_min(&heap)
-            v.state = SCANNED
+        while heap.size():
+            v = heap.top()
+            heap.pop()
+            v.first = -v.first
+            if dist_matrix[i, v.second] < v.first : continue
+            
+            _dijkstra_scan_heap(heap, v, csr_weights, csr_indices, csr_indptr,
+                                dist_matrix, pred, return_pred, limit, i)
+            _dijkstra_scan_heap(heap, v, csrT_weights, csrT_indices, csrT_indptr,
+                                dist_matrix, pred, return_pred, limit, i)
 
-            _dijkstra_scan_heap(&heap, v, nodes,
-                                csr_weights, csr_indices, csr_indptr,
-                                pred, return_pred, limit, i)
-
-            _dijkstra_scan_heap(&heap, v, nodes,
-                                csrT_weights, csrT_indices, csrT_indptr,
-                                pred, return_pred, limit, i)
-
-            # v has now been scanned: add the distance to the results
-            dist_matrix[i, v.index] = v.val
-
-    free(nodes)
     return 0
+
 
 @cython.boundscheck(False)
 cdef int _dijkstra_undirected_multi(
@@ -909,35 +855,32 @@ cdef int _dijkstra_undirected_multi(
             int[:] sources,
             DTYPE_t limit) except -1:
     cdef:
+        unsigned int Nind = source_indices.shape[0]
         unsigned int N = dist_matrix.shape[0]
+        unsigned int i, k, j_source, j_current
+        DTYPE_t next_val
         int return_pred = (pred.size > 0)
-        FibonacciHeap heap
-        FibonacciNode *v
-        FibonacciNode* nodes = <FibonacciNode*> malloc(N *
-                                                       sizeof(FibonacciNode))
-    if nodes == NULL:
-        raise MemoryError("Failed to allocate memory in "
-                          "_dijkstra_undirected_multi")
+        dijkstra_queue_t heap
+        dist_index_pair_t v
 
-    _dijkstra_setup_heap_multi(&heap, nodes, source_indices,
-                               sources, dist_matrix, return_pred)
-
-    while heap.min_node:
-        v = remove_min(&heap)
-        v.state = SCANNED
-
-        _dijkstra_scan_heap_multi(&heap, v, nodes,
-                                  csr_weights, csr_indices, csr_indptr,
-                                  pred, sources, return_pred, limit)
-
-        _dijkstra_scan_heap_multi(&heap, v, nodes,
-                                  csrT_weights, csrT_indices, csrT_indptr,
-                                  pred, sources, return_pred, limit)
-
-        #v has now been scanned: add the distance to the results
-        dist_matrix[v.index] = v.val
-
-    free(nodes)
+    for i in range(Nind):
+        j_source = source_indices[i]
+        dist_matrix[j_source] = 0
+        heap.push(dist_index_pair_t(-dist_matrix[j_source], j_source))
+        if return_pred:
+            sources[j_source] = j_source
+    
+    while heap.size():
+        v = heap.top()
+        heap.pop()
+        v.first = -v.first
+        if dist_matrix[v.second] < v.first : continue
+        
+        _dijkstra_scan_heap_multi(heap, v, csr_weights, csr_indices, csr_indptr,
+                                  dist_matrix, pred, sources, return_pred, limit)
+        _dijkstra_scan_heap_multi(heap, v, csrT_weights, csrT_indices, csrT_indptr,
+                                  dist_matrix, pred, sources, return_pred, limit)
+    
     return 0
 
 
@@ -1101,7 +1044,8 @@ cdef int _bellman_ford_directed(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, j, k, j_source, count
+        unsigned int i, j, j_source, count
+        int k
         DTYPE_t d1, d2, w12
         int return_pred = (pred.size > 0)
 
@@ -1441,253 +1385,6 @@ cdef int _johnson_undirected(
     return -1
 
 
-######################################################################
-# FibonacciNode structure
-#  This structure and the operations on it are the nodes of the
-#  Fibonacci heap.
-#
-cdef enum FibonacciState:
-    SCANNED
-    NOT_IN_HEAP
-    IN_HEAP
-
-
-cdef struct FibonacciNode:
-    unsigned int index
-    unsigned int rank
-    unsigned int source
-    FibonacciState state
-    DTYPE_t val
-    FibonacciNode* parent
-    FibonacciNode* left_sibling
-    FibonacciNode* right_sibling
-    FibonacciNode* children
-
-
-cdef void initialize_node(FibonacciNode* node,
-                          unsigned int index,
-                          DTYPE_t val=0) noexcept:
-    # Assumptions: - node is a valid pointer
-    #              - node is not currently part of a heap
-    node.index = index
-    node.source = -9999
-    node.val = val
-    node.rank = 0
-    node.state = NOT_IN_HEAP
-
-    node.parent = NULL
-    node.left_sibling = NULL
-    node.right_sibling = NULL
-    node.children = NULL
-
-
-cdef FibonacciNode* leftmost_sibling(FibonacciNode* node) noexcept:
-    # Assumptions: - node is a valid pointer
-    cdef FibonacciNode* temp = node
-    while(temp.left_sibling):
-        temp = temp.left_sibling
-    return temp
-
-
-cdef void add_child(FibonacciNode* node, FibonacciNode* new_child) noexcept:
-    # Assumptions: - node is a valid pointer
-    #              - new_child is a valid pointer
-    #              - new_child is not the sibling or child of another node
-    new_child.parent = node
-
-    if node.children:
-        add_sibling(node.children, new_child)
-    else:
-
-        node.children = new_child
-        new_child.right_sibling = NULL
-        new_child.left_sibling = NULL
-        node.rank = 1
-
-
-cdef void add_sibling(FibonacciNode* node, FibonacciNode* new_sibling) noexcept:
-    # Assumptions: - node is a valid pointer
-    #              - new_sibling is a valid pointer
-    #              - new_sibling is not the child or sibling of another node
-
-    # Insert new_sibling between node and node.right_sibling
-    if node.right_sibling:
-        node.right_sibling.left_sibling = new_sibling
-    new_sibling.right_sibling = node.right_sibling
-    new_sibling.left_sibling = node
-    node.right_sibling = new_sibling
-
-    new_sibling.parent = node.parent
-    if new_sibling.parent:
-        new_sibling.parent.rank += 1
-
-
-cdef void remove(FibonacciNode* node) noexcept:
-    # Assumptions: - node is a valid pointer
-    if node.parent:
-        node.parent.rank -= 1
-        if node.parent.children == node:  # node is the leftmost sibling.
-            node.parent.children = node.right_sibling
-
-    if node.left_sibling:
-        node.left_sibling.right_sibling = node.right_sibling
-    if node.right_sibling:
-        node.right_sibling.left_sibling = node.left_sibling
-
-    node.left_sibling = NULL
-    node.right_sibling = NULL
-    node.parent = NULL
-
-
-######################################################################
-# FibonacciHeap structure
-#  This structure and operations on it use the FibonacciNode
-#  routines to implement a Fibonacci heap
-
-ctypedef FibonacciNode* pFibonacciNode
-
-
-cdef struct FibonacciHeap:
-    # In this representation, min_node is always at the leftmost end
-    # of the linked-list, hence min_node.left_sibling is always NULL.
-    FibonacciNode* min_node
-    pFibonacciNode[100] roots_by_rank  # maximum number of nodes is ~2^100.
-
-
-cdef void insert_node(FibonacciHeap* heap,
-                      FibonacciNode* node) noexcept:
-    # Assumptions: - heap is a valid pointer
-    #              - node is a valid pointer
-    #              - node is not the child or sibling of another node
-    if heap.min_node:
-        if node.val < heap.min_node.val:
-            # Replace heap.min_node with node, which is always
-            # at the leftmost end of the roots' linked-list.
-            node.left_sibling = NULL
-            node.right_sibling = heap.min_node
-            heap.min_node.left_sibling = node
-            heap.min_node = node
-        else:
-            add_sibling(heap.min_node, node)
-    else:
-        heap.min_node = node
-
-
-cdef void decrease_val(FibonacciHeap* heap,
-                       FibonacciNode* node,
-                       DTYPE_t newval) noexcept:
-    # Assumptions: - heap is a valid pointer
-    #              - newval <= node.val
-    #              - node is a valid pointer
-    #              - node is not the child or sibling of another node
-    #              - node is in the heap
-    node.val = newval
-    if node.parent and (node.parent.val >= newval):
-        remove(node)
-        insert_node(heap, node)
-    elif heap.min_node.val > node.val:
-        # Replace heap.min_node with node, which is always
-        # at the leftmost end of the roots' linked-list.
-        remove(node)
-        node.right_sibling = heap.min_node
-        heap.min_node.left_sibling = node
-        heap.min_node = node
-
-
-cdef void link(FibonacciHeap* heap, FibonacciNode* node) noexcept:
-    # Assumptions: - heap is a valid pointer
-    #              - node is a valid pointer
-    #              - node is already within heap
-
-    cdef FibonacciNode *linknode
-
-    if heap.roots_by_rank[node.rank] == NULL:
-        heap.roots_by_rank[node.rank] = node
-    else:
-        linknode = heap.roots_by_rank[node.rank]
-        heap.roots_by_rank[node.rank] = NULL
-
-        if node.val < linknode.val or node == heap.min_node:
-            remove(linknode)
-            add_child(node, linknode)
-            link(heap, node)
-        else:
-            remove(node)
-            add_child(linknode, node)
-            link(heap, linknode)
-
-
-cdef FibonacciNode* remove_min(FibonacciHeap* heap) noexcept:
-    # Assumptions: - heap is a valid pointer
-    #              - heap.min_node is a valid pointer
-    cdef:
-        FibonacciNode *temp
-        FibonacciNode *temp_right
-        FibonacciNode *out
-        unsigned int i
-
-    # make all min_node children into root nodes
-    temp = heap.min_node.children
-
-    while temp:
-        temp_right = temp.right_sibling
-        remove(temp)
-        add_sibling(heap.min_node, temp)
-        temp = temp_right
-
-    # remove min_root and choose another root as a preliminary min_root
-    out = heap.min_node
-    temp = heap.min_node.right_sibling
-    remove(heap.min_node)
-    heap.min_node = temp
-
-    if temp == NULL:
-        # There is a unique root in the tree, hence a unique node
-        # which is the minimum that we return here.
-        return out
-
-    # re-link the heap
-    for i in range(100):
-        heap.roots_by_rank[i] = NULL
-
-    while temp:
-        if temp.val < heap.min_node.val:
-            heap.min_node = temp
-        temp_right = temp.right_sibling
-        link(heap, temp)
-        temp = temp_right
-
-    # move heap.min_node to the leftmost end of the linked-list of roots
-    temp = leftmost_sibling(heap.min_node)
-    if heap.min_node != temp:
-        remove(heap.min_node)
-        heap.min_node.right_sibling = temp
-        temp.left_sibling = heap.min_node
-
-    return out
-
-
-######################################################################
-# Debugging: Functions for printing the Fibonacci heap
-#
-#cdef void print_node(FibonacciNode* node, int level=0) noexcept:
-#    print('%s(%i,%i) %i' % (level*' ', node.index, node.val, node.rank))
-#    if node.children:
-#        print_node(node.children, level+1)
-#    if node.right_sibling:
-#        print_node(node.right_sibling, level)
-#
-#
-#cdef void print_heap(FibonacciHeap* heap) noexcept:
-#    print("---------------------------------")
-#    if heap.min_node:
-#        print("min node: (%i, %i)" % (heap.min_node.index, heap.min_node.val))
-#        print_node(heap.min_node)
-#    else:
-#        print("[empty heap]")
-
-######################################################################
-
 # Author: Tomer Sery  -- <tomersery28@gmail.com>
 # License: BSD 3-clause ("New BSD License"), (C) 2024
 
@@ -1904,9 +1601,6 @@ cdef void _yen(
     if shortest_distances[0] == INFINITY:
         # No paths between source and sink
         return
-    if directed:
-        # Avoid copying a size 0 memory view
-        originalT_weights = original_weights
 
     cdef:
         # initialize candidate arrays
@@ -1916,10 +1610,16 @@ cdef void _yen(
         int[:, :] candidate_predecessors = np.full((K, N), NULL_IDX, dtype=ITYPE)
         # Store the original graph weights for restoring the graph
         double[:] csr_weights = original_weights.copy()
-        double[:] csrT_weights = originalT_weights.copy()
+        double[:] csrT_weights
 
         int k, i, spur_node, node, short_path_idx, tmp_i
         double root_path_distance, total_distance, tmp_d
+
+    # Avoid copying a size 0 memory view
+    if directed:
+        csrT_weights = np.empty(0, dtype=DTYPE)
+    else:
+        csrT_weights = originalT_weights.copy()
 
     # Copy shortest path to shortest_paths_predecessors
     node = sink

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -366,7 +366,7 @@ cdef void _floyd_warshall(
     # dist_matrix should be a [N,N] matrix, such that dist_matrix[i, j]
     # is the distance from point i to point j.  Zero-distances imply that
     # the points are not connected.
-    cdef int N = dist_matrix.shape[0]
+    cdef unsigned int N = dist_matrix.shape[0]
     assert dist_matrix.shape[1] == N
 
     cdef unsigned int i, j, k
@@ -722,7 +722,7 @@ cdef int _dijkstra(
     cdef:
         unsigned int Nind = source_indices.shape[0]
         unsigned int N = dist_matrix.shape[0]
-        unsigned int i, k, j_source, j_current
+        unsigned int i, j_source
         DTYPE_t next_val
         int return_pred = (pred.size > 0)
         int return_sources = (sources.size > 0)
@@ -957,7 +957,8 @@ cdef int _bellman_ford_directed(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, j, k, j_source, count
+        unsigned int i, j, j_source, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
         int return_pred = (pred.size > 0)
 
@@ -998,7 +999,8 @@ cdef int _bellman_ford_undirected(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, j, k, j_source, ind_k, count
+        unsigned int i, j, j_source, ind_k, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
         int return_pred = (pred.size > 0)
 
@@ -1230,7 +1232,9 @@ cdef void _johnson_add_weights(
             const int[:] csr_indptr,
             const double[:] dist_array) noexcept:
     # let w(u, v) = w(u, v) + h(u) - h(v)
-    cdef unsigned int j, k, N = dist_array.shape[0]
+    cdef:
+        unsigned int j, N = dist_array.shape[0]
+        ITYPE_t k
 
     for j in range(N):
         for k in range(csr_indptr[j], csr_indptr[j + 1]):
@@ -1246,7 +1250,8 @@ cdef int _johnson_directed(
     # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
-        unsigned int j, k, count
+        unsigned int j, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times
@@ -1279,7 +1284,8 @@ cdef int _johnson_undirected(
     # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
-        unsigned int j, k, ind_k, count
+        unsigned int j, ind_k, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -1,27 +1,47 @@
-pyx_files = [
+pyx_files_for_c = [
   ['_flow', '_flow.pyx'],
   ['_matching', '_matching.pyx'],
   ['_min_spanning_tree', '_min_spanning_tree.pyx'],
   ['_reordering', '_reordering.pyx'],
-  ['_shortest_path', '_shortest_path.pyx'],
   ['_tools', '_tools.pyx'],
   ['_traversal', '_traversal.pyx']
 ]
+pyx_files_for_cpp = [
+  ['_shortest_path', '_shortest_path.pyx'],
+]
 
-cython_gen_csgraph = generator(cython,
+cython_gen_csgraph_for_c = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
   depends : [_cython_tree, fs.copyfile('parameters.pxi')],
 )
 
-foreach pyx_file: pyx_files
+foreach pyx_file: pyx_files_for_c
   py3.extension_module(pyx_file[0],
-    cython_gen_csgraph.process(pyx_file[1]),
+    cython_gen_csgraph_for_c.process(pyx_file[1]),
     c_args: cython_c_args,
     dependencies: np_dep,
     link_args: version_link_args,
     install: true,
-    subdir: 'scipy/sparse/csgraph'
+    subdir: 'scipy/sparse/csgraph',
+  )
+endforeach
+
+cython_gen_csgraph_for_cpp = generator(cython,
+  arguments : cython_cplus_args,
+  output : '@BASENAME@.cpp',
+  depends : [_cython_tree],
+)
+
+foreach pyx_file: pyx_files_for_cpp
+  py3.extension_module(pyx_file[0],
+    cython_gen_csgraph_for_cpp.process(pyx_file[1]),
+    cpp_args: cython_cpp_args,
+    include_directories: inc_np,
+    dependencies: np_dep,
+    link_args: version_link_args,
+    install: true,
+    subdir: 'scipy/sparse/csgraph',
   )
 endforeach
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -429,6 +429,7 @@ def test_yen_undirected():
         source=0,
         sink=3,
         K=4,
+        directed=False,
     )
     assert_allclose(distances, [1., 4., 5., 8.])
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -221,6 +221,28 @@ def test_dijkstra_min_only_random(n):
             p = pred[p]
 
 
+@pytest.mark.parametrize('n', (10, 100))
+@pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
+@pytest.mark.parametrize('directed', (True, False))
+def test_star_graph(n, method, directed):
+    # Build the star graph
+    star_arr = np.zeros((n, n), dtype=float)
+    star_center_idx = 0
+    star_arr[star_center_idx, :] = star_arr[:, star_center_idx] = range(n)
+    G = scipy.sparse.csr_matrix(star_arr, shape=(n, n))
+    # Build the distances matrix
+    SP_solution = np.zeros((n, n), dtype=float)
+    SP_solution[:] = star_arr[star_center_idx]
+    for idx in range(1, n):
+        SP_solution[idx] += star_arr[idx, star_center_idx]
+    np.fill_diagonal(SP_solution, 0)
+
+    SP = shortest_path(G, method=method, directed=directed)
+    assert_allclose(
+        SP_solution, SP
+    )
+
+
 def test_dijkstra_random():
     # reproduces the hang observed in gh-17782
     n = 10
@@ -433,6 +455,7 @@ def test_yen_undirected():
     )
     assert_allclose(distances, [1., 4., 5., 8.])
 
+
 def test_yen_unweighted():
     # Ask for more paths than there are, verify only the available paths are returned
     distances, predecessors = yen(
@@ -446,6 +469,7 @@ def test_yen_unweighted():
     assert_allclose(distances, [2., 3.])
     assert_allclose(predecessors, directed_2SP_0_to_3)
 
+
 def test_yen_no_paths():
     distances = yen(
         directed_G,
@@ -454,6 +478,7 @@ def test_yen_no_paths():
         K=1,
     )
     assert distances.size == 0
+
 
 def test_yen_negative_weights():
     distances = yen(

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -16,6 +16,7 @@ directed_G = np.array([[0, 3, 3, 0, 0],
                        [1, 0, 0, 0, 0],
                        [2, 0, 0, 2, 0]], dtype=float)
 
+# Undirected version of directed_G
 undirected_G = np.array([[0, 3, 3, 1, 2],
                          [3, 0, 0, 2, 4],
                          [3, 0, 0, 0, 0],
@@ -24,6 +25,7 @@ undirected_G = np.array([[0, 3, 3, 1, 2],
 
 unweighted_G = (directed_G > 0).astype(float)
 
+# Correct shortest path lengths for directed_G and undirected_G
 directed_SP = [[0, 3, 3, 5, 7],
                [3, 0, 6, 2, 4],
                [np.inf, np.inf, 0, np.inf, np.inf],
@@ -33,6 +35,35 @@ directed_SP = [[0, 3, 3, 5, 7],
 directed_2SP_0_to_3 = [[-9999, 0, -9999, 1, -9999],
                        [-9999, 0, -9999, 4, 1]]
 
+undirected_SP = np.array([[0, 3, 3, 1, 2],
+                          [3, 0, 6, 2, 4],
+                          [3, 6, 0, 4, 5],
+                          [1, 2, 4, 0, 2],
+                          [2, 4, 5, 2, 0]], dtype=float)
+
+undirected_SP_limit_2 = np.array([[0, np.inf, np.inf, 1, 2],
+                                  [np.inf, 0, np.inf, 2, np.inf],
+                                  [np.inf, np.inf, 0, np.inf, np.inf],
+                                  [1, 2, np.inf, 0, 2],
+                                  [2, np.inf, np.inf, 2, 0]], dtype=float)
+
+undirected_SP_limit_0 = np.ones((5, 5), dtype=float) - np.eye(5)
+undirected_SP_limit_0[undirected_SP_limit_0 > 0] = np.inf
+
+# Correct predecessors for directed_G and undirected_G
+directed_pred = np.array([[-9999, 0, 0, 1, 1],
+                          [3, -9999, 0, 1, 1],
+                          [-9999, -9999, -9999, -9999, -9999],
+                          [3, 0, 0, -9999, 1],
+                          [4, 0, 0, 4, -9999]], dtype=float)
+
+undirected_pred = np.array([[-9999, 0, 0, 0, 0],
+                            [1, -9999, 0, 1, 1],
+                            [2, 0, -9999, 0, 0],
+                            [3, 3, 0, -9999, 3],
+                            [4, 4, 0, 4, -9999]], dtype=float)
+
+# Other graphs
 directed_sparse_zero_G = scipy.sparse.csr_array(
     (
         [0, 1, 2, 3, 1],
@@ -60,33 +91,6 @@ undirected_sparse_zero_SP = [[0, 0, 1, np.inf, np.inf],
                         [1, 1, 0, np.inf, np.inf],
                         [np.inf, np.inf, np.inf, 0, 1],
                         [np.inf, np.inf, np.inf, 1, 0]]
-
-directed_pred = np.array([[-9999, 0, 0, 1, 1],
-                          [3, -9999, 0, 1, 1],
-                          [-9999, -9999, -9999, -9999, -9999],
-                          [3, 0, 0, -9999, 1],
-                          [4, 0, 0, 4, -9999]], dtype=float)
-
-undirected_SP = np.array([[0, 3, 3, 1, 2],
-                          [3, 0, 6, 2, 4],
-                          [3, 6, 0, 4, 5],
-                          [1, 2, 4, 0, 2],
-                          [2, 4, 5, 2, 0]], dtype=float)
-
-undirected_SP_limit_2 = np.array([[0, np.inf, np.inf, 1, 2],
-                                  [np.inf, 0, np.inf, 2, np.inf],
-                                  [np.inf, np.inf, 0, np.inf, np.inf],
-                                  [1, 2, np.inf, 0, 2],
-                                  [2, np.inf, np.inf, 2, 0]], dtype=float)
-
-undirected_SP_limit_0 = np.ones((5, 5), dtype=float) - np.eye(5)
-undirected_SP_limit_0[undirected_SP_limit_0 > 0] = np.inf
-
-undirected_pred = np.array([[-9999, 0, 0, 0, 0],
-                            [1, -9999, 0, 1, 1],
-                            [2, 0, -9999, 0, 0],
-                            [3, 3, 0, -9999, 3],
-                            [4, 4, 0, 4, -9999]], dtype=float)
 
 directed_negative_weighted_G = np.array([[0, 0, 0],
                                          [-1, 0, 0],


### PR DESCRIPTION
### Introduction
Rebase, reorganization, and code review of [PR 17019](https://github.com/scipy/scipy/pull/17019).

#### Original description
Another pull request to speed up sparse.csgraph.dijkstra, succeeding https://github.com/scipy/scipy/pull/16696
Thank you @jjerphan for reviewing the previous pull request and giving me advice

* Replaces FibonacciHeap with std::priority_queue which makes sparse.csgraph.dijkstra faster
   * asymptotically due to the removal of a bug in FibonacciHeap implementation
   * with regard to the constant factor due to better memory usage(?)
* Unifies the four similar dijkstra functions into one
   * Performance overhead was negligible, probably because the priority_queue is the bottleneck
* Adds the star graph to the benchmark as the worst case for the previous version
* Fixes a typo in the test file name
* A part of the test file for dijkstra is modified for better readability, nothing really changed
( See benchmarks in [PR 17019](https://github.com/scipy/scipy/pull/17019)).

### Changes from original PR
* Squashed tiny commits into larger commits (e.g., [this](https://github.com/scipy/scipy/pull/17019/commits/90b5151b766f8d68c74fa0f8b5ca6ecd62eb7bf5)).
* Removing irrelevant commits due to changes in repo since the original PR was opened ( e.g., [this](https://github.com/scipy/scipy/pull/17019/commits/92b53181f1fcdb90ec8d3ef2285195e2271c2d55) one).
* Adapted Yen's algorithm to the new Dijkstra internal implementation (under [this](https://github.com/scipy/scipy/commit/24fddcd7f7d0e8bf65724583515f86361266e7ff) commit).
* Removed random testing ( as I agree with the comment [here](https://github.com/scipy/scipy/pull/17800#pullrequestreview-1251442515)), instead added a star-graph test.

