### PR TITLE
MAINT: sparse: fix `__init__` func sig to allow `maxprint` to be set

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -110,7 +110,7 @@ class _spbase:
         from ._lil import lil_array
         return lil_array
 
-    def __init__(self, arg1, maxprint=MAXPRINT):
+    def __init__(self, arg1, *, maxprint=None):
         self._shape = None
         if self.__class__.__name__ == '_spbase':
             raise ValueError("This class is not intended"
@@ -119,7 +119,7 @@ class _spbase:
             raise ValueError(
                 "scipy sparse array classes do not support instantiation from a scalar"
             )
-        self.maxprint = maxprint
+        self.maxprint = MAXPRINT if maxprint is None else maxprint
 
     @property
     def shape(self):

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -24,8 +24,9 @@ from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_maxnnz,
 class _bsr_base(_cs_matrix, _minmax_mixin):
     _format = 'bsr'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):
-        _data_matrix.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False,
+                 blocksize=None, *, maxprint=None):
+        _data_matrix.__init__(self, arg1, maxprint=maxprint)
 
         if issparse(arg1):
             if arg1.format == self.format and copy:

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -24,8 +24,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     base array/matrix class for compressed row- and column-oriented arrays/matrices
     """
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        _data_matrix.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
+        _data_matrix.__init__(self, arg1, maxprint=maxprint)
         is_array = isinstance(self, sparray)
 
         if issparse(arg1):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -24,8 +24,8 @@ import operator
 class _coo_base(_data_matrix, _minmax_mixin):
     _format = 'coo'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        _data_matrix.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
+        _data_matrix.__init__(self, arg1, maxprint=maxprint)
         is_array = isinstance(self, sparray)
         if not copy:
             copy = copy_if_needed

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -18,8 +18,8 @@ __all__ = []
 # TODO implement all relevant operations
 # use .data.__methods__() instead of /=, *=, etc.
 class _data_matrix(_spbase):
-    def __init__(self, arg1):
-        _spbase.__init__(self, arg1)
+    def __init__(self, arg1, *, maxprint=None):
+        _spbase.__init__(self, arg1, maxprint=maxprint)
 
     @property
     def dtype(self):

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -19,8 +19,8 @@ from ._sparsetools import dia_matvec
 class _dia_base(_data_matrix):
     _format = 'dia'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        _data_matrix.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
+        _data_matrix.__init__(self, arg1, maxprint=maxprint)
 
         if issparse(arg1):
             if arg1.format == "dia":

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -18,8 +18,8 @@ from ._sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
 class _dok_base(_spbase, IndexMixin, dict):
     _format = 'dok'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        _spbase.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
+        _spbase.__init__(self, arg1, maxprint=maxprint)
 
         is_array = isinstance(self, sparray)
         if isinstance(arg1, tuple) and isshape(arg1, allow_1d=is_array):

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -20,8 +20,8 @@ from . import _csparsetools
 class _lil_base(_spbase, IndexMixin):
     _format = 'lil'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        _spbase.__init__(self, arg1)
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
+        _spbase.__init__(self, arg1, maxprint=maxprint)
         self.dtype = getdtype(dtype, arg1, default=float)
 
         # First get the shape


### PR DESCRIPTION
arg `maxprint` in `_spbase.__init__()` doesn't appear in subclasses so setting maxprint during construction is not possible. See #20490

This PR adds tests of setting maxprint, and tests that the new `__str__` format works with maxprint set. Fixes `__init__` function signatures to work with maxprint being set.

I set up `maxprint` to be a keyword-only parameter so it doesn't disrupt the positional parameters for subclasses (in e.g. BSR where number of position-keyword parameters is one more than the other subclasses).