### PR TITLE
CI: pin Python for MacOS conda

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -110,6 +110,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
+        mamba install python=${{ matrix.python-version}}
 
         # optional test dependencies
         mamba install scikit-umfpack scikit-sparse


### PR DESCRIPTION
Fixes #20714

* We're seeing CI failures related to an undesirable bump to Python `3.12` in this job, when the intention was clearly to respect the Python version specified in the GHA matrix. I didn't check too closely why exactly it suddenly started happening, but some packages weren't ready for `3.12` yet on this job (`scikit-umfpack` in particular) and I don't see too much harm in adding an extra pin to respect the intention for the Python version.

* I tried checking on my fork but it gets skipped unless I mod the GHA branch checks I think. If this turns into a bunch of shenanigans I'll make another branch and iterate on my fork.

[skip cirrus] [skip circle]