### PR TITLE
BUG: interpolate: do not segfault on bad boundary conditions

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1453,6 +1453,12 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     deriv_r_ords, deriv_r_vals = _process_deriv_spec(deriv_r)
     nright = deriv_r_ords.shape[0]
 
+    if not all(0 <= i <= k for i in deriv_l_ords):
+        raise ValueError(f"Bad boundary conditions at {x[0]}.")
+
+    if not all(0 <= i <= k for i in deriv_r_ords):
+        raise ValueError(f"Bad boundary conditions at {x[-1]}.")
+
     # have `n` conditions for `nt` coefficients; need nt-n derivatives
     n = x.size
     nt = t.size - k - 1

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1349,7 +1349,7 @@ class TestInterp:
     def test_deriv_order_too_large(self):
         x = np.arange(7)
         y = x**2
-        l, r = [(1, 0)], [(-6, 0)]    # 6th derivative = 0 at x[-1] for k=3
+        l, r = [(1, 0)], [(6, 0)]    # 6th derivative = 0 at x[-1] for k=3
         with assert_raises(ValueError):
             # cannot fix 6th derivative at x[-1]: does not segfault
             make_interp_spline(x, y, bc_type=(l, r))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1346,6 +1346,19 @@ class TestInterp:
         with assert_raises(ValueError):
             make_interp_spline(x, y, bc_type=(l, r))
 
+    def test_deriv_order_too_large(self):
+        x = np.arange(7)
+        y = x**2
+        l, r = [(1, 0)], [(-6, 0)]    # 6th derivative = 0 at x[-1] for k=3
+        with assert_raises(ValueError):
+            # cannot fix 6th derivative at x[-1]: does not segfault
+            make_interp_spline(x, y, bc_type=(l, r))
+
+        l, r = [(1, 0)], [(-6, 0)]    # derivative order < 0 at x[-1]
+        with assert_raises(ValueError):
+            # does not segfault
+            make_interp_spline(x, y, bc_type=(l, r))
+
     def test_complex(self):
         k = 3
         xx = self.xx

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1351,7 +1351,7 @@ class TestInterp:
         y = x**2
         l, r = [(6, 0)], [(1, 0)]    # 6th derivative = 0 at x[0] for k=3
         with assert_raises(ValueError, match="Bad boundary conditions at 0."):
-            # cannot fix 6th derivative at x[-1]: does not segfault
+            # cannot fix 6th derivative at x[0]: does not segfault
             make_interp_spline(x, y, bc_type=(l, r))
 
         l, r = [(1, 0)], [(-6, 0)]    # derivative order < 0 at x[-1]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1349,7 +1349,7 @@ class TestInterp:
     def test_deriv_order_too_large(self):
         x = np.arange(7)
         y = x**2
-        l, r = [(1, 0)], [(6, 0)]    # 6th derivative = 0 at x[-1] for k=3
+        l, r = [(6, 0)], [(1, 0)]    # 6th derivative = 0 at x[0] for k=3
         with assert_raises(ValueError):
             # cannot fix 6th derivative at x[-1]: does not segfault
             make_interp_spline(x, y, bc_type=(l, r))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1350,12 +1350,12 @@ class TestInterp:
         x = np.arange(7)
         y = x**2
         l, r = [(6, 0)], [(1, 0)]    # 6th derivative = 0 at x[0] for k=3
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Bad boundary conditions at 0."):
             # cannot fix 6th derivative at x[-1]: does not segfault
             make_interp_spline(x, y, bc_type=(l, r))
 
         l, r = [(1, 0)], [(-6, 0)]    # derivative order < 0 at x[-1]
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Bad boundary conditions at 6."):
             # does not segfault
             make_interp_spline(x, y, bc_type=(l, r))
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Avoid a segfault when `make_interp_spline` receives too high derivative order for a boundary condition. 

The underlying issue is that the input falls through all the way down to a C routine, https://github.com/scipy/scipy/blob/main/scipy/interpolate/src/__fitpack.h#L48
and triggers a UB. (in that line, `k=3` is the spline order, and `m` is the user input)

#### Additional information
<!--Any additional information you think is important.-->

- CubicSpline explicitly checks that the boundary conditions only feature 1st or 2nd derivatives. 

- Checks added in this PR are likely on a loose side: orders 0 and k currently raise a ValueError for a different reason; fixing these would a nice enhancement; this PR is a pure bug fix.

- found while looking at https://stackoverflow.com/questions/78482220/fixing-boundary-values-on-a-spline; 