### PR TITLE
MAINT: optimize: another fail_slow exception for COBYQA

### DIFF
--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -90,6 +90,7 @@ class TestNewToOld:
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-4)
             assert_allclose(funs['cobyqa'], funs['trust-constr'], rtol=1e-4)
 
+    @pytest.mark.fail_slow(10)
     def test_individual_constraint_objects(self):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2


### PR DESCRIPTION
#### Reference issue
gh-20721, for example

#### What does this implement/fix?
Makes another exception for COBYQA to make CI green.

#### Additional information
We'll track this in gh-20724 and remove the mark when COBYQA is faster.