### PR TITLE
BUG: Fix incorrect brackets in cephes hyperg.h

### DIFF
--- a/scipy/special/special/cephes/hyperg.h
+++ b/scipy/special/special/cephes/hyperg.h
@@ -237,17 +237,15 @@ namespace cephes {
                 /* nan */
                 acanc = 1.0;
 
-            if (std::isinf(asum)) {
+            if (std::isinf(asum))
                 /* infinity */
                 acanc = 0;
 
-                acanc *= 30.0; /* fudge factor, since error of asymptotic formula
-                                * often seems this much larger than advertised */
-
-            adone:
-                *err = acanc;
-                return (asum);
-            }
+            acanc *= 30.0; /* fudge factor, since error of asymptotic formula
+                            * often seems this much larger than advertised */
+        adone:
+            *err = acanc;
+            return (asum);
         }
 
         /* Power series summation for confluent hypergeometric function */


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This is fixes one of the warnings mentioned in #20740, but would not be sufficient to close that issue.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes some incorrect bracketing in `hy1f1a` in `scipy/special/special/cephes/hyperg.h`.  While translating `cephes` into C++, in some places I added brackets in one line `if` blocks which omitted them, but in this case I added the opening bracket but not the closing bracket. I've simply removed this extraneous opening bracket to bring the code to it's original state.

#### Additional information
<!--Any additional information you think is important.-->
The `cephes` implementation of `hyp1f1` is not well tested because we use `Boost` for the `hyp1f1` ufunc. The `cephes` `hyp1f1` is only used in `orthogonal_eval.pxd` in the function `eval_genlaguerre`. I briefly tried to find a test case for `eval_genlaguerre` which would hit the control path without a return value, but couldn't find one. I think it's fine not to include a test case; one can compare this PR to the original cephes code.

https://github.com/scipy/scipy/blob/f133c27843a36c8fe1c2979b3a072ac4f5a00624/scipy/special/cephes/hyperg.c#L237-L247

Thanks @fancidev for bringing this to our attention in #20740 