### PR TITLE
TST: bump tolerance to address local `test_axis_nan_policy` failures

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -255,22 +255,23 @@ def test_axis_nan_policy_fast(hypotest, args, kwds, n_samples, n_outputs,
                           unpacker, nan_policy, axis, data_generator)
 
 
-@pytest.mark.slow
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
-@pytest.mark.filterwarnings('ignore::UserWarning')
-@pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
-                          "paired", "unpacker"), axis_nan_policy_cases)
-@pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
-@pytest.mark.parametrize(("axis"), range(-3, 3))
-@pytest.mark.parametrize(("data_generator"),
-                         ("all_nans", "all_finite", "mixed"))
-def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
-                              paired, unpacker, nan_policy, axis,
-                              data_generator):
-    if hypotest in {stats.cramervonmises_2samp} and not SCIPY_XSLOW:
-        pytest.skip("Too slow.")
-    _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
-                          unpacker, nan_policy, axis, data_generator)
+if SCIPY_XSLOW:
+    # Takes O(1 min) to run, and even skipping with the `xslow` decorator takes
+    # about 3 sec because this is >3,000 tests. So ensure pytest doesn't see
+    # them at all unless `SCIPY_XSLOW` is defined.
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    @pytest.mark.filterwarnings('ignore::UserWarning')
+    @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
+                              "paired", "unpacker"), axis_nan_policy_cases)
+    @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
+    @pytest.mark.parametrize(("axis"), range(-3, 3))
+    @pytest.mark.parametrize(("data_generator"),
+                             ("all_nans", "all_finite", "mixed"))
+    def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
+                                  paired, unpacker, nan_policy, axis,
+                                  data_generator):
+        _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
+                              unpacker, nan_policy, axis, data_generator)
 
 
 def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -385,11 +385,11 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                                     "approximation.")
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))
-        assert_allclose(res[0], statistics, rtol=1e-15)
+        assert_allclose(res[0], statistics, rtol=1e-14)
         assert_equal(res[0].dtype, statistics.dtype)
 
         if len(res) == 2:
-            assert_allclose(res[1], pvalues, rtol=1e-15)
+            assert_allclose(res[1], pvalues, rtol=1e-14)
             assert_equal(res[1].dtype, pvalues.dtype)
 
 


### PR DESCRIPTION
The `normaltest` tests need 4e-15 to pass in my x86-64 linux conda-forge environment; the `kurtosistest` tests need 6e-15. These tolerances don't need to be this tight and my setup is unlikely to be worst-case, so add a bit of margin on top.

Failures:
```
E   AssertionError:
E   Not equal to tolerance rtol=1e-15, atol=0
E
E   Mismatched elements: 3 / 6 (50%)
E   Max absolute difference: 7.99360578e-15
E   Max relative difference: 3.95721074e-15
E    x: array([[5.141364, 0.673337],
E          [4.039859, 2.172997],
E          [4.832018, 5.96047 ]])
E    y: array([[5.141364, 0.673337],
E          [4.039859, 2.172997],
E          [4.832018, 5.96047 ]])
        args       = (<function assert_allclose.<locals>.compare at 0x7ef45c1d6e80>, array([[5.14136359, 0.67333671],
       [4.03985923, 2...18, 5.96046984]]), array([[5.14136359, 0.67333671],
       [4.03985923, 2.17299682],
       [4.83201818, 5.96046984]]))
        func       = <function assert_array_compare at 0x7ef488122f20>
        kwds       = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-15, atol=0', 'verbose': True}
        self       = <contextlib._GeneratorContextManager object at 0x7ef48811bc50>
========================================================= short test summary info ==========================================================
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-propagate-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-propagate-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-omit-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-omit-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-raise-kurtosistest-args41-kwds41-1-2-False-None] - AssertionError:
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-raise-normaltest-args42-kwds42-1-2-False-None] - AssertionError:
========================================== 36 failed, 3096 passed, 54 skipped in 66.33s (0:01:06) ==========================================
```

Also skip these tests unless `SCIPY_XSLOW` is set. This one parametrized test takes about a minute to run.