### PR TITLE
ENH: some micro-optimisations for differential_evolution

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1650,7 +1650,7 @@ class DifferentialEvolutionSolver:
         # trial either has shape (N, ) or (L, N), where L is the number of
         # solutions being scaled
         scaled = self.__scale_arg1 + (trial - 0.5) * self.__scale_arg2
-        if np.any(self.integrality):
+        if np.count_nonzero(self.integrality):
             i = np.broadcast_to(self.integrality, scaled.shape)
             scaled[i] = np.round(scaled[i])
         return scaled

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -963,6 +963,9 @@ class DifferentialEvolutionSolver:
         self.constraint_violation = np.zeros((self.num_population_members, 1))
         self.feasible = np.ones(self.num_population_members, bool)
 
+        # an array to shuffle when selecting candidates. Create it here
+        # rather than repeatedly creating it in _select_samples.
+        self._random_population_index = np.arange(self.num_population_members)
         self.disp = disp
 
     def init_population_lhs(self):
@@ -1658,8 +1661,9 @@ class DifferentialEvolutionSolver:
 
     def _ensure_constraint(self, trial):
         """Make sure the parameters lie between the limits."""
-        mask = np.where((trial > 1) | (trial < 0))
-        trial[mask] = self.random_number_generator.uniform(size=mask[0].shape)
+        mask = np.bitwise_or(trial > 1, trial < 0)
+        if oob := np.count_nonzero(mask):
+            trial[mask] = self.random_number_generator.uniform(size=oob)
 
     def _mutate(self, candidate):
         """Create a trial vector based on a mutation strategy."""
@@ -1762,17 +1766,9 @@ class DifferentialEvolutionSolver:
         obtain random integers from range(self.num_population_members),
         without replacement. You can't have the original candidate either.
         """
-        pool = np.arange(self.num_population_members)
-        self.random_number_generator.shuffle(pool)
-
-        idxs = []
-        while len(idxs) < number_samples and len(pool) > 0:
-            idx = pool[0]
-            pool = pool[1:]
-            if idx != candidate:
-                idxs.append(idx)
-        
-        return idxs
+        self.random_number_generator.shuffle(self._random_population_index)
+        idxs = self._random_population_index[:number_samples + 1]
+        return idxs[idxs != candidate][:number_samples]
 
 
 class _ConstraintWrapper:


### PR DESCRIPTION
Rationale:
`_select_samples` and `_ensure_constraint` are called repeatedly and they need to be efficient (hundreds of thousands of times). This PR makes some microoptimisations to make both those methods faster.
The changes to _ensure_constraint are based on:

```
a = rng.uniform(size=1000, low=-0.1, high=1.1)
msk = np.bitwise_or(a < 0, a > 1)
%timeit np.where((a < 0) | (a > 1))
%timeit np.bitwise_or(a < 0, a > 1)
%timeit rng.uniform(size=0)
%timeit np.count_nonzero(msk)
3.29 µs ± 6.57 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.19 µs ± 6.41 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
1.19 µs ± 35.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
235 ns ± 1.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

i.e. `bitwise_or` is faster than `np.where`, and that `rng.uniform(size=0)` has a cost. Most of the time `msk` has zero entries, so it's quicker to check how many entries that do need replacing, and only if there are entries is it worth calling the random number generator.

The changes to `_select_samples` are based on:

``` python
num_population_members = 200
rng = np.random.default_rng()
pool = np.arange(num_population_members)

def select_samples(candidate, number_samples):
    pool = np.arange(num_population_members)
    rng.shuffle(pool)

    idxs = []
    while len(idxs) < number_samples and len(pool) > 0:
        idx = pool[0]
        pool = pool[1:]
        if idx != candidate:
            idxs.append(idx)

    return idxs


def select_samples2(candidate, number_samples, pool):
    rng.shuffle(pool) # also tried rng.choice, but that's slower

    idxs = pool[:number_samples + 1]
    return idxs[idxs != candidate][:number_samples]

%timeit select_samples(5, 5)
%timeit select_samples2(5, 5, pool)
3.71 µs ± 10.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.23 µs ± 27 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```