### PR TITLE
ENH: stats.chisquare/power_divergence: add array API support

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -809,8 +809,8 @@ from ._ufuncs import *
 
 # Replace some function definitions from _ufuncs to add Array API support
 from ._support_alternative_backends import (
-    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e,
-    gammaln, gammainc, gammaincc, logit, expit, entr, rel_entr)
+    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e, gammaln,
+    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy)
 
 from . import _basic
 from ._basic import *

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -11,8 +11,8 @@ from . import _ufuncs
 # These don't really need to be imported, but otherwise IDEs might not realize
 # that these are defined in this file / report an error in __init__.py
 from ._ufuncs import (
-    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e,  # noqa: F401
-    gammaln, gammainc, gammaincc, logit, expit, entr, rel_entr)  # noqa: F401
+    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e, gammaln, # noqa: F401
+    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy)  # noqa: F401
 
 _SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
 array_api_compat_prefix = "scipy._lib.array_api_compat"
@@ -70,7 +70,14 @@ def _rel_entr(x, y, *, xp):
     return res
 
 
-_generic_implementations = {'rel_entr': _rel_entr}
+def _xlogy(x, y, *, xp):
+    with np.errstate(divide='ignore', invalid='ignore'):
+        temp = x * xp.log(y)
+    return xp.where(x == 0., xp.asarray(0., dtype=temp.dtype), temp)
+
+
+_generic_implementations = {'rel_entr': _rel_entr,
+                            'xlogy': _xlogy}
 
 
 # functools.wraps doesn't work because:
@@ -104,6 +111,7 @@ array_special_func_map = {
     'expit': 1,
     'entr': 1,
     'rel_entr': 2,
+    'xlogy': 2,
 }
 
 for f_name, n_array_args in array_special_func_map.items():

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8108,6 +8108,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
 
     """
     xp = array_namespace(f_obs)
+    default_float = xp.asarray(1.).dtype
 
     # Convert the input argument `lambda_` to a numerical value.
     if isinstance(lambda_, str):
@@ -8120,11 +8121,18 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         lambda_ = 1
 
     f_obs = f_obs if np.ma.isMaskedArray(f_obs) else xp.asarray(f_obs)
+    dtype = default_float if xp.isdtype(f_obs.dtype, 'integral') else f_obs.dtype
+    f_obs = (f_obs.astype(dtype) if np.ma.isMaskedArray(f_obs)
+             else xp.asarray(f_obs, dtype=dtype))
     f_obs_float = (f_obs.astype(np.float64) if hasattr(f_obs, 'mask')
                    else xp.asarray(f_obs, dtype=xp.float64))
 
     if f_exp is not None:
         f_exp = f_exp if np.ma.isMaskedArray(f_obs) else xp.asarray(f_exp)
+        dtype = default_float if xp.isdtype(f_exp.dtype, 'integral') else f_exp.dtype
+        f_exp = (f_exp.astype(dtype) if np.ma.isMaskedArray(f_exp)
+                 else xp.asarray(f_exp, dtype=dtype))
+
         bshape = _broadcast_shapes((f_obs_float.shape, f_exp.shape))
         f_obs_float = _m_broadcast_to(f_obs_float, bshape, xp=xp)
         f_exp = _m_broadcast_to(f_exp, bshape, xp=xp)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8154,7 +8154,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     # cases of lambda_.
     if lambda_ == 1:
         # Pearson's chi-squared statistic
-        terms = (f_obs_float - f_exp)**2 / f_exp
+        terms = (f_obs - f_exp)**2 / f_exp
     elif lambda_ == 0:
         # Log-likelihood ratio (i.e. G-test)
         terms = 2.0 * special.xlogy(f_obs, f_obs / f_exp)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `stats.chisquare` and `stats.power_divergence`. Preserves but deprecates support for masked arrays per generalization of the conversation about [`gstd`](https://discuss.scientific-python.org/t/deprecate-maskedarray-support-for-stats-gstd/1178/3).

#### Additional information
Consider reviewing diff with "Hide whitespace" checked. I moved some test functions into classes.