### PR TITLE
ENH: sparse: add dtype validation in `__init__` and `astype`

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike,
-                       matrix, validateaxis,)
+                       matrix, validateaxis, getdtype)
 
 from ._matrix import spmatrix
 
@@ -217,7 +217,7 @@ class _spbase:
             this array/matrix do not share any memory.
         """
 
-        dtype = np.dtype(dtype)
+        dtype = getdtype(dtype)
         if self.dtype != dtype:
             return self.tocsr().astype(
                 dtype, casting=casting, copy=copy).asformat(self.format)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -107,7 +107,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             self._shape = check_shape(self._swap((major_d, minor_d)), allow_1d=is_array)
 
         if dtype is not None:
-            self.data = self.data.astype(dtype, copy=False)
+            newdtype = getdtype(dtype)
+            self.data = self.data.astype(newdtype, copy=False)
 
         self.check_format(full_check=False)
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -94,7 +94,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 self.has_canonical_format = True
 
         if dtype is not None:
-            self.data = self.data.astype(dtype, copy=False)
+            newdtype = getdtype(dtype)
+            self.data = self.data.astype(newdtype, copy=False)
 
         self._check()
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -78,7 +78,8 @@ class _dia_base(_data_matrix):
             self._shape = check_shape(A.shape)
 
         if dtype is not None:
-            self.data = self.data.astype(dtype)
+            newdtype = getdtype(dtype)
+            self.data = self.data.astype(newdtype)
 
         #check format
         if self.offsets.ndim != 1:

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -37,7 +37,7 @@ class _dok_base(_spbase, IndexMixin, dict):
 
             self._dict = arg1._dict
             self._shape = check_shape(arg1.shape, allow_1d=is_array)
-            self.dtype = arg1.dtype
+            self.dtype = getdtype(arg1.dtype)
         else:  # Dense ctor
             try:
                 arg1 = np.asarray(arg1)
@@ -51,11 +51,11 @@ class _dok_base(_spbase, IndexMixin, dict):
                 if dtype is not None:
                     arg1 = arg1.astype(dtype)
                 self._dict = {i: v for i, v in enumerate(arg1) if v != 0}
-                self.dtype = arg1.dtype
+                self.dtype = getdtype(arg1.dtype)
             else:
                 d = self._coo_container(arg1, dtype=dtype).todok()
                 self._dict = d._dict
-                self.dtype = d.dtype
+                self.dtype = getdtype(d.dtype)
             self._shape = check_shape(arg1.shape, allow_1d=is_array)
 
     def update(self, val):

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -32,7 +32,8 @@ class _lil_base(_spbase, IndexMixin):
                 A = arg1.tolil()
 
             if dtype is not None:
-                A = A.astype(dtype, copy=False)
+                newdtype = getdtype(dtype)
+                A = A.astype(newdtype, copy=False)
 
             self._shape = check_shape(A.shape)
             self.dtype = A.dtype
@@ -62,7 +63,7 @@ class _lil_base(_spbase, IndexMixin):
             A = self._csr_container(A, dtype=dtype).tolil()
 
             self._shape = check_shape(A.shape)
-            self.dtype = A.dtype
+            self.dtype = getdtype(A.dtype)
             self.rows = A.rows
             self.data = A.data
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -4,6 +4,7 @@
 import sys
 from typing import Any, Literal, Optional, Union
 import operator
+from warnings import warn
 import numpy as np
 from math import prod
 import scipy.sparse as sp
@@ -130,7 +131,9 @@ def getdtype(dtype, a=None, default=None):
             raise ValueError(
                 "object dtype is not supported by sparse matrices"
             )
-
+    if newdtype not in supported_dtypes:
+        warn(f"dtype {newdtype} is not supported", stacklevel=3)
+    
     return newdtype
 
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -4,7 +4,6 @@
 import sys
 from typing import Any, Literal, Optional, Union
 import operator
-from warnings import warn
 import numpy as np
 from math import prod
 import scipy.sparse as sp
@@ -127,12 +126,11 @@ def getdtype(dtype, a=None, default=None):
                 raise TypeError("could not interpret data type") from e
     else:
         newdtype = np.dtype(dtype)
-        if newdtype == np.object_:
-            raise ValueError(
-                "object dtype is not supported by sparse matrices"
-            )
+
     if newdtype not in supported_dtypes:
-        warn(f"scipy.sparse does not support dtype {newdtype}", stacklevel=3)
+        supported_dtypes_fmt = ", ".join([t.__name__ for t in supported_dtypes])
+        raise ValueError(f"scipy.sparse does not support dtype {newdtype.name}. "
+                         f"The only supported types are: {supported_dtypes_fmt}.")
     
     return newdtype
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -128,7 +128,7 @@ def getdtype(dtype, a=None, default=None):
         newdtype = np.dtype(dtype)
 
     if newdtype not in supported_dtypes:
-        supported_dtypes_fmt = ", ".join([t.__name__ for t in supported_dtypes])
+        supported_dtypes_fmt = ", ".join(t.__name__ for t in supported_dtypes)
         raise ValueError(f"scipy.sparse does not support dtype {newdtype.name}. "
                          f"The only supported types are: {supported_dtypes_fmt}.")
     

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -132,7 +132,7 @@ def getdtype(dtype, a=None, default=None):
                 "object dtype is not supported by sparse matrices"
             )
     if newdtype not in supported_dtypes:
-        warn(f"dtype {newdtype} is not supported", stacklevel=3)
+        warn(f"scipy.sparse does not support dtype {newdtype}", stacklevel=3)
     
     return newdtype
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -23,9 +23,15 @@ class TestSparseUtils:
 
         with assert_raises(
             ValueError,
-            match="object dtype is not supported by sparse matrices",
+            match="scipy.sparse does not support dtype object. .*",
         ):
             sputils.getdtype("O")
+
+        with assert_raises(
+            ValueError,
+            match="scipy.sparse does not support dtype float16. .*",
+        ):
+            sputils.getdtype(None, default=np.float16)
 
     def test_isscalarlike(self):
         assert_equal(sputils.isscalarlike(3.0), True)


### PR DESCRIPTION
#### Reference issue
Fixes #20207 

#### What does this implement/fix?
Adds validation of dtype in sparse array/matrix creation (`__init__`) and type conversion (`astype`)
* `getdtype` function from `_sputils.py` raises a warning if dtype is not in `supported_dtypes` list
* Each sparse format's `__init__` method now uses `getdtype`
* `_spbase` sparse base class now uses `getdtype` in `astype` method

#### Additional information
