### PR TITLE
TST: stats: refactor tests of normality tests

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -350,7 +350,7 @@ import warnings
 for key in (
         'interp2d` is deprecated',  # Deprecation of scipy.interpolate.interp2d
         'scipy.misc',  # scipy.misc deprecated in v1.10.0; use scipy.datasets
-        'kurtosistest only valid',  # intentionally "bad" excample in docstring
+        '`kurtosistest` p-value may be',  # intentionally "bad" excample in docstring
         'scipy.signal.daub is deprecated',
         'scipy.signal.qmf is deprecated',
         'scipy.signal.cascade is deprecated',

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1612,8 +1612,9 @@ def skewtest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     b2 = skew(a, axis)
     n = a.shape[axis]
     if n < 8:
-        raise ValueError(
-            f"skewtest is not valid with less than 8 samples; {n} samples were given.")
+        message = ("`skewtest` requires at least 8 observations; "
+                   f"{n} observations were given.")
+        raise ValueError(message)
     y = b2 * math.sqrt(((n + 1) * (n + 3)) / (6.0 * (n - 2)))
     beta2 = (3.0 * (n**2 + 27*n - 70) * (n+1) * (n+3) /
              ((n-2.0) * (n+5) * (n+7) * (n+9)))
@@ -1803,14 +1804,15 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     a, axis = _chk_asarray(a, axis, xp=xp)
 
     n = a.shape[axis]
+
     if n < 5:
-        raise ValueError(
-            "kurtosistest requires at least 5 observations; %i observations"
-            " were given." % int(n))
+        message = ("`kurtosistest` requires at least 5 observations; "
+                   f"only {n=} observations were given.")
+        raise ValueError(message)
     if n < 20:
-        warnings.warn("kurtosistest only valid for n>=20 ... continuing "
-                      "anyway, n=%i" % int(n),
-                      stacklevel=2)
+        message = ("`kurtosistest` p-value may be inaccurate with fewer than 20 "
+                   f"observations; only {n=} observations were given.")
+        warnings.warn(message, stacklevel=2)
     b2 = kurtosis(a, axis, fisher=False)
 
     E = 3.0*(n-1) / (n+1)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -135,8 +135,8 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "Window length (0) must be positive and less",
                       "Window length (1) must be positive and less",
                       "Window length (2) must be positive and less",
-                      "skewtest is not valid with less than",
-                      "kurtosistest requires at least 5",
+                      "`skewtest` requires at least",
+                      "`kurtosistest` requires at least",
                       "attempt to get argmax of an empty sequence",
                       "No array values within given limits",
                       "Input sample size must be greater than one.",}

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1840,6 +1840,7 @@ class TestCompareWithStats:
 
     def test_normaltest(self):
         with np.errstate(over='raise'), suppress_warnings() as sup:
+            sup.filter(UserWarning, "`kurtosistest` p-value may be inaccurate")
             sup.filter(UserWarning, "kurtosistest only valid for n>=20")
             for n in self.get_n():
                 if n > 8:


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-20597, gh-20715, gh-20736

#### What does this implement/fix?
As discussed in referenced issues, this PR refactors tests of `stats.skewtest`, `stats.kurtosistest`, and `stats.normaltest` to make them more maintainable.
