### PR TITLE
ENH: speed up for differential_evolution updating='deferred'

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -7,7 +7,8 @@ import warnings
 import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize._optimize import _status_message, _wrap_callback
-from scipy._lib._util import check_random_state, MapWrapper, _FunctionWrapper
+from scipy._lib._util import (check_random_state, MapWrapper, _FunctionWrapper,
+                              rng_integers)
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
@@ -1567,7 +1568,7 @@ class DifferentialEvolutionSolver:
                 # number of candidates that were mutated.
                 # For `immediate` S = 1. For `deferred` this will
                 # probably be the entire population, S = num_population_members
-                parameters = self._scale_parameters(trial)[0]
+                parameters = self._scale_parameters(trial)
 
                 # determine the energy of the objective function
                 if self._wrapped_constraints:
@@ -1610,7 +1611,9 @@ class DifferentialEvolutionSolver:
 
             # 'deferred' approach, vectorised form.
             # create trial solutions
-            trial_pop = self._mutate(np.arange(self.num_population_members))
+            trial_pop = self._mutate_many(
+                np.arange(self.num_population_members)
+            )
 
             # enforce bounds
             self._ensure_constraint(trial_pop)
@@ -1668,39 +1671,45 @@ class DifferentialEvolutionSolver:
         if oob := np.count_nonzero(mask):
             trial[mask] = self.random_number_generator.uniform(size=oob)
 
-    def _mutate(self, candidate):
-        """Create a trial vector based on a mutation strategy."""
+    def _mutate_custom(self, candidate):
         rng = self.random_number_generator
-
-        candidate = np.atleast_1d(candidate)
-        S = len(candidate)
-
-        if callable(self.strategy):
-            _population = self._scale_parameters(self.population)
+        msg = (
+            "strategy must have signature"
+            " f(candidate: int, population: np.ndarray, rng=None) returning an"
+            " array of shape (N,)"
+        )
+        _population = self._scale_parameters(self.population)
+        if not len(np.shape(candidate)):
+            # single entry in population
+            trial = self.strategy(candidate, _population, rng=rng)
+            if trial.shape != (self.parameter_count,):
+                raise RuntimeError(msg)
+        else:
             trial = np.array(
                 [self.strategy(c, _population, rng=rng) for c in candidate],
                 dtype=float
             )
             if trial.shape != (S, self.parameter_count):
-                raise RuntimeError(
-                    "strategy must have signature"
-                    " f(candidate: int, population: np.ndarray, rng=None)"
-                    " returning an array of shape (N,)"
-                )
-            return self._unscale_parameters(trial)
+                raise RuntimeError(msg)
+        return self._unscale_parameters(trial)
 
-        # trial should be at least 2-D, (S, N), because len(candidate) >= 1
-        trial = np.copy(self.population[candidate])
-        fill_point = rng.choice(self.parameter_count, size=S)
+    def _mutate_many(self, candidates):
+        """Create trial vectors based on a mutation strategy."""
+        rng = self.random_number_generator
 
-        # (S, 5)
-        samples = np.array([self._select_samples(c, 5) for c in candidate])
+        S = len(candidates)
+        if callable(self.strategy):
+            return self._mutate_custom(candidates)
+
+        trial = np.copy(self.population[candidates])
+        samples = np.array([self._select_samples(c, 5) for c in candidates])
 
         if self.strategy in ['currenttobest1exp', 'currenttobest1bin']:
-            bprime = self.mutation_func(candidate, samples)
+            bprime = self.mutation_func(candidates, samples)
         else:
             bprime = self.mutation_func(samples)
 
+        fill_point = rng_integers(rng, self.parameter_count, size=S)
         crossovers = rng.uniform(size=(S, self.parameter_count))
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
@@ -1708,13 +1717,13 @@ class DifferentialEvolutionSolver:
             # If you fill in modulo with a loop you have to set the last one to
             # true. If you don't use a loop then you can have any random entry
             # be True.
-            idx = np.arange(S)
-            crossovers[idx, fill_point[idx]] = True
+            i = np.arange(S)
+            crossovers[i, fill_point[i]] = True
             trial = np.where(crossovers, bprime, trial)
             return trial
 
         elif self.strategy in self._exponential:
-            crossovers[:, 0] = True
+            crossovers[..., 0] = True
             for j in range(S):
                 i = 0
                 init_fill = fill_point[j]
@@ -1725,22 +1734,62 @@ class DifferentialEvolutionSolver:
 
             return trial
 
+    def _mutate(self, candidate):
+        """Create a trial vector based on a mutation strategy."""
+        rng = self.random_number_generator
+
+        if callable(self.strategy):
+            return self._mutate_custom(candidate)
+
+        fill_point = rng_integers(rng, self.parameter_count)
+        samples = self._select_samples(candidate, 5)
+
+        trial = np.copy(self.population[candidate])
+
+        if self.strategy in ['currenttobest1exp', 'currenttobest1bin']:
+            bprime = self.mutation_func(candidate, samples)
+        else:
+            bprime = self.mutation_func(samples)
+
+        crossovers = rng.uniform(size=self.parameter_count)
+        crossovers = crossovers < self.cross_over_probability
+        if self.strategy in self._binomial:
+            # the last one is always from the bprime vector for binomial
+            # If you fill in modulo with a loop you have to set the last one to
+            # true. If you don't use a loop then you can have any random entry
+            # be True.
+            crossovers[fill_point] = True
+            trial = np.where(crossovers, bprime, trial)
+            return trial
+
+        elif self.strategy in self._exponential:
+            i = 0
+            crossovers[0] = True
+            while i < self.parameter_count and crossovers[i]:
+                trial[fill_point] = bprime[fill_point]
+                fill_point = (fill_point + 1) % self.parameter_count
+                i += 1
+
+            return trial
+
     def _best1(self, samples):
         """best1bin, best1exp"""
         # samples.shape == (S, 5)
-        r0, r1 = samples.T[:2]
+        # or
+        # samples.shape(5,)
+        r0, r1 = samples[..., :2].T
         return (self.population[0] + self.scale *
                 (self.population[r0] - self.population[r1]))
 
     def _rand1(self, samples):
         """rand1bin, rand1exp"""
-        r0, r1, r2 = samples.T[:3]
+        r0, r1, r2 = samples[..., :3].T
         return (self.population[r0] + self.scale *
                 (self.population[r1] - self.population[r2]))
 
     def _randtobest1(self, samples):
         """randtobest1bin, randtobest1exp"""
-        r0, r1, r2 = samples.T[:3]
+        r0, r1, r2 = samples[..., :3].T
         bprime = np.copy(self.population[r0])
         bprime += self.scale * (self.population[0] - bprime)
         bprime += self.scale * (self.population[r1] -
@@ -1749,7 +1798,7 @@ class DifferentialEvolutionSolver:
 
     def _currenttobest1(self, candidate, samples):
         """currenttobest1bin, currenttobest1exp"""
-        r0, r1 = samples.T[:2]
+        r0, r1 = samples[..., :2].T
         bprime = (self.population[candidate] + self.scale *
                   (self.population[0] - self.population[candidate] +
                    self.population[r0] - self.population[r1]))
@@ -1757,7 +1806,7 @@ class DifferentialEvolutionSolver:
 
     def _best2(self, samples):
         """best2bin, best2exp"""
-        r0, r1, r2, r3 = samples.T[:4]
+        r0, r1, r2, r3 = samples[..., :4].T
         bprime = (self.population[0] + self.scale *
                   (self.population[r0] + self.population[r1] -
                    self.population[r2] - self.population[r3]))
@@ -1766,7 +1815,7 @@ class DifferentialEvolutionSolver:
 
     def _rand2(self, samples):
         """rand2bin, rand2exp"""
-        r0, r1, r2, r3, r4 = samples.T[:5]
+        r0, r1, r2, r3, r4 = samples[..., :5].T
         bprime = (self.population[r0] + self.scale *
                   (self.population[r1] + self.population[r2] -
                    self.population[r3] - self.population[r4]))

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1564,10 +1564,6 @@ class DifferentialEvolutionSolver:
                 self._ensure_constraint(trial)
 
                 # scale from [0, 1) to the actual parameter value
-                # _mutate should return an array (S, N) where S is the
-                # number of candidates that were mutated.
-                # For `immediate` S = 1. For `deferred` this will
-                # probably be the entire population, S = num_population_members
                 parameters = self._scale_parameters(trial)
 
                 # determine the energy of the objective function

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1681,6 +1681,7 @@ class DifferentialEvolutionSolver:
             if trial.shape != (self.parameter_count,):
                 raise RuntimeError(msg)
         else:
+            S = candidate.shape[0]
             trial = np.array(
                 [self.strategy(c, _population, rng=rng) for c in candidate],
                 dtype=float

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -126,11 +126,11 @@ class TestDifferentialEvolutionSolver:
     def test__mutate1(self):
         # strategies */1/*, i.e. rand/1/bin, best/1/exp, etc.
         result = np.array([0.05])
-        trial = self.dummy_solver2._best1((2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._best1(np.array([2, 3, 4, 5, 6]))
         assert_allclose(trial, result)
 
         result = np.array([0.25])
-        trial = self.dummy_solver2._rand1((2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._rand1(np.array([2, 3, 4, 5, 6]))
         assert_allclose(trial, result)
 
     def test__mutate2(self):
@@ -138,23 +138,26 @@ class TestDifferentialEvolutionSolver:
         # [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
 
         result = np.array([-0.1])
-        trial = self.dummy_solver2._best2((2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._best2(np.array([2, 3, 4, 5, 6]))
         assert_allclose(trial, result)
 
         result = np.array([0.1])
-        trial = self.dummy_solver2._rand2((2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._rand2(np.array([2, 3, 4, 5, 6]))
         assert_allclose(trial, result)
 
     def test__randtobest1(self):
         # strategies randtobest/1/*
         result = np.array([0.15])
-        trial = self.dummy_solver2._randtobest1((2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._randtobest1(np.array([2, 3, 4, 5, 6]))
         assert_allclose(trial, result)
 
     def test__currenttobest1(self):
         # strategies currenttobest/1/*
         result = np.array([0.1])
-        trial = self.dummy_solver2._currenttobest1(1, (2, 3, 4, 5, 6))
+        trial = self.dummy_solver2._currenttobest1(
+            1,
+            np.array([2, 3, 4, 5, 6])
+        )
         assert_allclose(trial, result)
 
     def test_can_init_with_dithering(self):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -694,7 +694,14 @@ class TestDifferentialEvolutionSolver:
         solver = DifferentialEvolutionSolver(rosen, bounds, updating='deferred')
         assert_(solver._updating == 'deferred')
         assert_(solver._mapwrapper._mapfunc is map)
-        solver.solve()
+        res = solver.solve()
+        assert res.success
+
+        # check that deferred updating works with an exponential crossover
+        res = differential_evolution(
+            rosen, bounds, updating='deferred', strategy='best1exp'
+        )
+        assert res.success
 
     def test_immediate_updating(self):
         # check setting of immediate updating, with default workers

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1663,6 +1663,12 @@ class TestDifferentialEvolutionSolver:
         solver.solve()
         assert calls[0] > 0
 
+        # check custom strategy works with updating='deferred'
+        res = differential_evolution(
+            rosen, bounds, strategy=custom_strategy_fn, updating='deferred'
+        )
+        assert res.success
+
         def custom_strategy_fn(candidate, population, rng=None):
             return np.array([1.0, 2.0])
 
@@ -1672,3 +1678,4 @@ class TestDifferentialEvolutionSolver:
                 bounds,
                 strategy=custom_strategy_fn
             )
+


### PR DESCRIPTION
This PR reduces the overhead of the differential evolution solver by vectorising the `optimize._differential_evolution.DifferentialEvolutionSolver._mutate` method. This will only have an effect when `updating='deferred'` because the entire population is mutated at once. When `_mutate='immediate` mutation still occurs for each candidate individually. For the latter case solver speed is no faster.

Note: that bitwise equivalence of solver pathway is not maintained before/after this PR. This is because the random number streams are consumed in different orders. 
i.e. setting a seed still results in a reproducible minimisation. However, using the same seed before/after this PR will not give a bitwise equivalent solution. I believe that's an acceptable tradeoff for a faster solve.

For this example:
```python
from scipy.optimize import differential_evolution
import numpy as np

N = 10
bounds=[(-10, 10)]*N

%timeit differential_evolution(rosen, bounds, updating='deferred', vectorized=True)
```

Before PR:

`2.1 s ± 24.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

After PR:

`623 ms ± 3.82 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

@mdhaber this should improve performance in the areas of stats where DE is used.