### PR TITLE
MAINT: sparse.linalg: adjust `norm`, `eigs`, and `lsqr` to `pydata/sparse` input

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -40,7 +40,9 @@ import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
 from scipy.sparse import eye, issparse
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
-from scipy.sparse._sputils import isdense, is_pydata_spmatrix
+from scipy.sparse._sputils import (
+    convert_pydata_sparse_to_scipy, isdense, is_pydata_spmatrix,
+)
 from scipy.sparse.linalg import gmres, splu
 from scipy._lib._util import _aligned_zeros
 from scipy._lib._threadsafety import ReentrancyLock
@@ -1256,6 +1258,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     (13, 6)
 
     """
+    A = convert_pydata_sparse_to_scipy(A)
+    M = convert_pydata_sparse_to_scipy(M)
     if A.shape[0] != A.shape[1]:
         raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:

--- a/scipy/sparse/linalg/_isolve/lsqr.py
+++ b/scipy/sparse/linalg/_isolve/lsqr.py
@@ -54,6 +54,7 @@ __all__ = ['lsqr']
 import numpy as np
 from math import sqrt
 from scipy.sparse.linalg._interface import aslinearoperator
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 
 eps = np.finfo(np.float64).eps
 
@@ -319,6 +320,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     approximate solution to the corresponding least-squares problem. `r1norm`
     contains the norm of the minimal residual that was found.
     """
+    A = convert_pydata_sparse_to_scipy(A)
     A = aslinearoperator(A)
     b = np.atleast_1d(b)
     if b.ndim > 1:

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -4,6 +4,7 @@
 import numpy as np
 from scipy.sparse import issparse
 from scipy.sparse.linalg import svds
+from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 import scipy.sparse as sp
 
 from numpy import sqrt, abs
@@ -110,6 +111,7 @@ def norm(x, ord=None, axis=None):
     >>> norm(b, 2)
     1.9753...
     """
+    x = convert_pydata_sparse_to_scipy(x, target_format="csr")
     if not issparse(x):
         raise TypeError("input is not sparse. use numpy.linalg.norm")
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -212,6 +212,13 @@ def test_onenormest(matrices):
     assert_allclose(est, est0)
 
 
+def test_norm(matrices):
+    A_dense, A_sparse, b = matrices
+    norm0 = splin.norm(sp.csr_matrix(A_dense))
+    norm = splin.norm(A_sparse)
+    assert_allclose(norm, norm0)
+
+
 def test_inv(matrices):
     A_dense, A_sparse, b = matrices
     x0 = splin.inv(sp.csc_matrix(A_dense))


### PR DESCRIPTION
Hi @rgommers,

This small PR is connected to https://github.com/scipy/scipy/pull/20485 and adds similar dispatch for `pydata/sparse` input in `scipy.sparse.linalg.norm`, `scipy.sparse.linalg.lsqr`, and `scipy.sparse.linalg.eigs`. I didn't add a test for `lsqr`+`eigs` as they already exist. They worked without dispatch for Numba inputs but it breaks for Finch ones. 