### PR TITLE
MAINT: stats.wilcoxon: make `method='exact'` symmetric w/ ties

### DIFF
--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -215,12 +215,20 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
         p = _get_pvalue(z, stats.norm, alternative)
     elif method == 'exact':
         dist = WilcoxonDistribution(count)
+        # The null distribution in `dist` is exact only if there are no ties
+        # or zeros. If there are ties or zeros, the statistic can be non-
+        # integral, but the null distribution is only defined for integral
+        # values of the statistic. Therefore, we're conservative: round
+        # non-integral statistic up before computing CDF and down before
+        # computing SF. This preserves symmetry w.r.t. alternatives and
+        # order of the input arguments. See gh-19872.
         if alternative == 'less':
-            p = dist.cdf(r_plus)
+            p = dist.cdf(np.ceil(r_plus))
         elif alternative == 'greater':
-            p = dist.sf(r_plus)
+            p = dist.sf(np.floor(r_plus))
         else:
-            p = 2 * np.minimum(dist.sf(r_plus), dist.cdf(r_plus))
+            p = 2 * np.minimum(dist.sf(np.floor(r_plus)),
+                               dist.cdf(np.ceil(r_plus)))
             p = np.clip(p, 0, 1)
     else:  # `PermutationMethod` instance (already validated)
         p = stats.permutation_test(

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1684,6 +1684,19 @@ class TestWilcoxon:
         assert hasattr(ref, 'zstatistic')
         assert not hasattr(res, 'zstatistic')
 
+    @pytest.mark.parametrize('method', ['exact', 'approx'])
+    def test_symmetry_gh19872_gh20752(self, method):
+        # Check that one-sided exact tests obey required symmetry. Bug reported
+        # in gh-19872 and again in gh-20752; example from gh-19872 is more concise:
+        var1 = [62, 66, 61, 68, 74, 62, 68, 62, 55, 59]
+        var2 = [71, 71, 69, 61, 75, 71, 77, 72, 62, 65]
+        ref = stats.wilcoxon(var1, var2, alternative='less', method=method)
+        res = stats.wilcoxon(var2, var1, alternative='greater', method=method)
+        max_statistic = len(var1) * (len(var1) + 1) / 2
+        assert int(res.statistic) != res.statistic
+        assert_allclose(max_statistic - res.statistic, ref.statistic, rtol=1e-15)
+        assert_allclose(res.pvalue, ref.pvalue, rtol=1e-15)
+
 
 # data for k-statistics tests from
 # https://cran.r-project.org/web/packages/kStatistics/kStatistics.pdf


### PR DESCRIPTION
#### Reference issue
Closes gh-19872
Closes gh-20752 (duplicate)

#### What does this implement/fix?
The referenced issues reported that `wilcoxon` was not symmetric with respect to one-sided alternatives and ordering of the input arguments; i.e., these should produce identical p-values, but don't in `main`:
```python3
stats.wilcoxon(x, y, alternative = 'less', method='exact')
stats.wilcoxon(y, x, alternative = 'greater', method='exact')
```
This fixes the issue, adds a comment about why the approach is reasonable, and adds a test.

#### Additional information
@schekroud  @hengzhe-zhang Let me know if this looks OK to you. For reference, gh-19770 added a direct permutation method that will be available in SciPy 1.14.0.  Looks like it's a good thing to round in the conservative direction here because the permutation p-value for this case is in-between the two rounded p-values. In main:

```python3
from scipy import stats
var1 = [62, 66, 61, 68, 74, 62, 68, 62, 55, 59]
var2 = [71, 71, 69, 61, 75, 71, 77, 72, 62, 65]
print(stats.wilcoxon(var1, var2, alternative = 'less', method='exact'))
print(stats.wilcoxon(var2, var1, alternative = 'greater', method='exact'))
print(stats.wilcoxon(var1, var2, alternative = 'less', method=stats.PermutationMethod()))
print(stats.wilcoxon(var2, var1, alternative = 'greater', method=stats.PermutationMethod()))
# WilcoxonResult(statistic=4.5, pvalue=0.0068359375)
# WilcoxonResult(statistic=50.5, pvalue=0.009765625)
# WilcoxonResult(statistic=4.5, pvalue=0.0078125)
# WilcoxonResult(statistic=50.5, pvalue=0.0078125)
```
I would make this the default method in certain situations ([among other things](https://github.com/scipy/scipy/pull/19770#issuecomment-1880158299)), but I need to bring up the proposed changes on the discussion forum because they would change behavior. 