### PR TITLE
ENH: stats.qmc: add bounds parameters to PoissonDisk

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -655,8 +655,8 @@ class BenchQMCSobol(Benchmark):
 class BenchPoissonDisk(Benchmark):
     param_names = ['d', 'radius', 'ncandidates', 'n']
     params = [
-        [1, 5, 10],
-        [1, 10, 50],
+        [1, 3, 5],
+        [0.2, 0.1, 0.05],
         [30, 60, 120],
         [30, 100, 300]
     ]

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -652,6 +652,21 @@ class BenchQMCSobol(Benchmark):
         seq = stats.qmc.Sobol(d, scramble=False, bits=32, seed=self.rng)
         seq.random_base2(base2)
 
+class BenchPoissonDisk(Benchmark):
+    param_names = ['d', 'radius', 'ncandidates', 'n']
+    params = [
+        [1, 5, 10],
+        [1, 10, 50],
+        [30, 60, 120],
+        [30, 100, 300]
+    ]
+
+    def setup(self, d, radius, ncandidates, n):
+        self.rng = np.random.default_rng(168525179735951991038384544)
+
+    def time_poisson_disk(self, d, radius, ncandidates, n):
+        seq = stats.qmc.PoissonDisk(d, radius=radius, ncandidates=ncandidates, seed=self.rng)
+        seq.random(n)
 
 class DistanceFunctions(Benchmark):
     param_names = ['n_size']

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -665,7 +665,8 @@ class BenchPoissonDisk(Benchmark):
         self.rng = np.random.default_rng(168525179735951991038384544)
 
     def time_poisson_disk(self, d, radius, ncandidates, n):
-        seq = stats.qmc.PoissonDisk(d, radius=radius, ncandidates=ncandidates, seed=self.rng)
+        seq = stats.qmc.PoissonDisk(d, radius=radius, ncandidates=ncandidates,
+                                    seed=self.rng)
         seq.random(n)
 
 class DistanceFunctions(Benchmark):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2018,7 +2018,7 @@ class PoissonDisk(QMCEngine):
         with np.errstate(divide='ignore'):
             self.cell_size = self.radius / np.sqrt(self.d)
             self.grid_size = (
-                np.ceil(self.u_bounds / self.cell_size)
+                np.ceil((self.u_bounds - self.l_bounds) / self.cell_size)
             ).astype(int)
 
         self._initialize_grid_pool()
@@ -2068,7 +2068,7 @@ class PoissonDisk(QMCEngine):
             Check if there are samples closer than ``radius_squared`` to the
             `candidate` sample.
             """
-            indices = (candidate / self.cell_size).astype(int)
+            indices = ((candidate - self.l_bounds) / self.cell_size).astype(int)
             ind_min = np.maximum(indices - n, self.l_bounds.astype(int))
             ind_max = np.minimum(indices + n + 1, self.grid_size)
 
@@ -2093,7 +2093,7 @@ class PoissonDisk(QMCEngine):
 
         def add_sample(candidate: np.ndarray) -> None:
             self.sample_pool.append(candidate)
-            indices = (candidate / self.cell_size).astype(int)
+            indices = ((candidate - self.l_bounds) / self.cell_size).astype(int)
             self.sample_grid[tuple(indices)] = candidate
             curr_sample.append(candidate)
 
@@ -2101,7 +2101,7 @@ class PoissonDisk(QMCEngine):
 
         if len(self.sample_pool) == 0:
             # the pool is being initialized with a single random sample
-            add_sample(self.rng.random(self.d))
+            add_sample(self.rng.uniform(self.l_bounds, self.u_bounds))
             num_drawn = 1
         else:
             num_drawn = 0

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -960,8 +960,16 @@ class TestPoisson(QMCEngineTests):
 
     def test_inconsistent_bounds(self):
         radius = 0.2
-        l_bounds=[-1, -2, -1]
-        u_bounds=[3, 2]
+        l_bounds = [-1, -2, -1]
+        u_bounds = [3, 2]
+        with pytest.raises(
+            ValueError, 
+            match="'l_bounds' and 'u_bounds' must be broadcastable and respect" 
+            " the sample dimension"):
+            self.qmce(d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
+        
+        l_bounds = [-1, -2]
+        u_bounds = [3, 2]
         with pytest.raises(
             ValueError, 
             match="'l_bounds' and 'u_bounds' must be broadcastable and respect" 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -938,10 +938,23 @@ class TestPoisson(QMCEngineTests):
         # circle packing problem is np complex
         assert l2_norm(sample) >= radius
 
-    def test_sample_inside_bounds(self):
+    @pytest.mark.parametrize("l_bounds", [[-1, -2, -1], [1, 2, 1]])
+    def test_sample_inside_lower_bounds(self, l_bounds):
         radius = 0.2
-        l_bounds=[-1, -2, -1]
-        u_bounds=[3, 2, 1]
+        u_bounds=[3, 3, 2]
+        engine = self.qmce(
+            d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds
+        )
+        sample = engine.random(30)
+
+        for point in sample:
+            assert_array_less(point, u_bounds) 
+            assert_array_less(l_bounds, point) 
+
+    @pytest.mark.parametrize("u_bounds", [[-1, -2, -1], [1, 2, 1]])
+    def test_sample_inside_upper_bounds(self, u_bounds):
+        radius = 0.2
+        l_bounds=[-3, -3, -2]
         engine = self.qmce(
             d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds
         )

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -942,7 +942,9 @@ class TestPoisson(QMCEngineTests):
         radius = 0.2
         l_bounds=[-1, -2, -1]
         u_bounds=[3, 2, 1]
-        engine = self.qmce(d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
+        engine = self.qmce(
+            d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds
+        )
         sample = engine.random(30)
 
         for point in sample:
@@ -958,23 +960,18 @@ class TestPoisson(QMCEngineTests):
             match="Bounds are not consistent 'l_bounds' < 'u_bounds'"):
             self.qmce(d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
 
-    def test_inconsistent_bounds(self):
+    @pytest.mark.parametrize("u_bounds", [[-1, -2, -1], [-1, -2]])
+    @pytest.mark.parametrize("l_bounds", [[3, 2]])
+    def test_inconsistent_bounds(self, u_bounds, l_bounds):
         radius = 0.2
-        l_bounds = [-1, -2, -1]
-        u_bounds = [3, 2]
         with pytest.raises(
             ValueError, 
             match="'l_bounds' and 'u_bounds' must be broadcastable and respect" 
             " the sample dimension"):
-            self.qmce(d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
-        
-        l_bounds = [-1, -2]
-        u_bounds = [3, 2]
-        with pytest.raises(
-            ValueError, 
-            match="'l_bounds' and 'u_bounds' must be broadcastable and respect" 
-            " the sample dimension"):
-            self.qmce(d=3, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
+            self.qmce(
+                d=3, radius=radius, 
+                l_bounds=l_bounds, u_bounds=u_bounds
+            )
         
     def test_raises(self):
         message = r"'toto' is not a valid hypersphere sampling"


### PR DESCRIPTION
#### Reference issue
Closes gh-20288

#### What does this implement/fix?
Add optional lower bounds and upper bounds parameters to scipy.stats.qmc.PoissonDisk, to allow for equal scaling in target sample. Only points that are inside the specified bounds are accepted and added to the target sample.