### PR TITLE
BUG: sparse.csgraph, array types: support non-zero `fill_value`s

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -399,7 +399,10 @@ def convert_pydata_sparse_to_scipy(
     pass through anything else.
     """
     if is_pydata_spmatrix(arg):
-        arg = arg.to_scipy_sparse(accept_fv=accept_fv)
+        try:
+            arg = arg.to_scipy_sparse(accept_fv=accept_fv)
+        except TypeError:
+            arg = arg.to_scipy_sparse()
         if target_format is not None:
             arg = arg.asformat(target_format)
         elif arg.format not in ("csc", "csr"):

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -399,6 +399,8 @@ def convert_pydata_sparse_to_scipy(
     pass through anything else.
     """
     if is_pydata_spmatrix(arg):
+        # The `accept_fv` keyword is new in PyData Sparse 0.15.4 (May 2024),
+        # remove the `except` once the minimum supported version is >=0.15.4
         try:
             arg = arg.to_scipy_sparse(accept_fv=accept_fv)
         except TypeError:

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -390,14 +390,16 @@ def is_pydata_spmatrix(m) -> bool:
 
 
 def convert_pydata_sparse_to_scipy(
-    arg: Any, target_format: Optional[Literal["csc", "csr"]] = None
+    arg: Any,
+    target_format: Optional[Literal["csc", "csr"]] = None,
+    accept_fv: Any = None,
 ) -> Union[Any, "sp.spmatrix"]:
     """
     Convert a pydata/sparse array to scipy sparse matrix,
     pass through anything else.
     """
     if is_pydata_spmatrix(arg):
-        arg = arg.to_scipy_sparse()
+        arg = arg.to_scipy_sparse(accept_fv=accept_fv)
         if target_format is not None:
             arg = arg.asformat(target_format)
         elif arg.format not in ("csc", "csr"):

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -97,6 +97,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     is_pydata_sparse = is_pydata_spmatrix(csgraph)
     if is_pydata_sparse:
         pydata_sparse_cls = csgraph.__class__
+        pydata_sparse_fill_value = csgraph.fill_value
     csgraph = validate_graph(csgraph, True, DTYPE, dense_output=False,
                              copy_if_sparse=not overwrite)
     cdef int N = csgraph.shape[0]
@@ -120,7 +121,9 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     sp_tree.eliminate_zeros()
 
     if is_pydata_sparse:
-        sp_tree = pydata_sparse_cls.from_scipy_sparse(sp_tree)
+        sp_tree = pydata_sparse_cls.from_scipy_sparse(
+            sp_tree, fill_value=pydata_sparse_fill_value
+        )
     return sp_tree
 
 

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -121,6 +121,8 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     sp_tree.eliminate_zeros()
 
     if is_pydata_sparse:
+        # The `fill_value` keyword is new in PyData Sparse 0.15.4 (May 2024),
+        # remove the `except` once the minimum supported version is >=0.15.4
         try:
             sp_tree = pydata_sparse_cls.from_scipy_sparse(
                 sp_tree, fill_value=pydata_sparse_fill_value

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -121,9 +121,12 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     sp_tree.eliminate_zeros()
 
     if is_pydata_sparse:
-        sp_tree = pydata_sparse_cls.from_scipy_sparse(
-            sp_tree, fill_value=pydata_sparse_fill_value
-        )
+        try:
+            sp_tree = pydata_sparse_cls.from_scipy_sparse(
+                sp_tree, fill_value=pydata_sparse_fill_value
+            )
+        except TypeError:
+            sp_tree = pydata_sparse_cls.from_scipy_sparse(sp_tree)
     return sp_tree
 
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -161,6 +161,8 @@ def shortest_path(csgraph, method='auto',
     array([-9999,     0,     0,     1], dtype=int32)
 
     """
+    csgraph = convert_pydata_sparse_to_scipy(csgraph, accept_fv=[0, np.inf, np.nan])
+
     # validate here to catch errors early but don't store the result;
     # we'll validate again later
     validate_graph(csgraph, directed, DTYPE,

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -472,6 +472,7 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     is_pydata_sparse = is_pydata_spmatrix(csgraph)
     if is_pydata_sparse:
         pydata_sparse_cls = csgraph.__class__
+        pydata_sparse_fill_value = csgraph.fill_value
     csgraph = validate_graph(csgraph, directed, dense_output=False)
 
     N = csgraph.shape[0]
@@ -502,7 +503,9 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     sctree = csr_matrix((data, indices, indptr), shape=(N, N))
     if is_pydata_sparse:
-        sctree = pydata_sparse_cls.from_scipy_sparse(sctree)
+        sctree = pydata_sparse_cls.from_scipy_sparse(
+            sctree, fill_value=pydata_sparse_fill_value
+        )
     return sctree
 
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -503,6 +503,8 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     sctree = csr_matrix((data, indices, indptr), shape=(N, N))
     if is_pydata_sparse:
+        # The `fill_value` keyword is new in PyData Sparse 0.15.4 (May 2024),
+        # remove the `except` once the minimum supported version is >=0.15.4
         try:
             sctree = pydata_sparse_cls.from_scipy_sparse(
                 sctree, fill_value=pydata_sparse_fill_value

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -503,9 +503,12 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     sctree = csr_matrix((data, indices, indptr), shape=(N, N))
     if is_pydata_sparse:
-        sctree = pydata_sparse_cls.from_scipy_sparse(
-            sctree, fill_value=pydata_sparse_fill_value
-        )
+        try:
+            sctree = pydata_sparse_cls.from_scipy_sparse(
+                sctree, fill_value=pydata_sparse_fill_value
+            )
+        except TypeError:
+            sctree = pydata_sparse_cls.from_scipy_sparse(sctree)
     return sctree
 
 

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -18,7 +18,12 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
     if not (csr_output or dense_output):
         raise ValueError("Internal: dense or csr output must be true")
 
-    csgraph = convert_pydata_sparse_to_scipy(csgraph)
+    accept_fv = []
+    if infinity_null:
+        accept_fv.append(np.inf)
+    if nan_null:
+        accept_fv.append(np.nan)
+    csgraph = convert_pydata_sparse_to_scipy(csgraph, accept_fv=accept_fv or None)
 
     # if undirected and csc storage, then transposing in-place
     # is quicker than later converting to csr.

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -18,12 +18,12 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
     if not (csr_output or dense_output):
         raise ValueError("Internal: dense or csr output must be true")
 
-    accept_fv = []
+    accept_fv = [null_value_in]
     if infinity_null:
         accept_fv.append(np.inf)
     if nan_null:
         accept_fv.append(np.nan)
-    csgraph = convert_pydata_sparse_to_scipy(csgraph, accept_fv=accept_fv or None)
+    csgraph = convert_pydata_sparse_to_scipy(csgraph, accept_fv=accept_fv)
 
     # if undirected and csc storage, then transposing in-place
     # is quicker than later converting to csr.

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -162,7 +162,7 @@ def test_min_weight_full_bipartite_matching(graphs):
 )
 @pytest.mark.parametrize(
     "fill_value, comp_func",
-    [(np.inf, np.isinf), (np.nan, np.isnan)],
+    [(np.inf, np.isposinf), (np.nan, np.isnan)],
 )
 def test_nonzero_fill_value(graphs, func, fill_value, comp_func):
     A_dense, A_sparse = graphs

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -147,3 +147,31 @@ def test_min_weight_full_bipartite_matching(graphs):
     desired = func(sp.csc_matrix(A_dense)[0:2, 1:3])
 
     assert_equal(actual, desired)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        spgraph.shortest_path,
+        spgraph.dijkstra,
+        spgraph.floyd_warshall,
+        spgraph.bellman_ford,
+        spgraph.johnson,
+        spgraph.minimum_spanning_tree,
+    ]
+)
+@pytest.mark.parametrize("fill_value", [0, np.inf])
+def test_fill_value(graphs, func, fill_value):
+    A_dense, A_sparse = graphs
+    sparse_cls = type(A_sparse)
+    A_sparse = sparse_cls(A_sparse, fill_value=fill_value)
+
+    actual = func(A_sparse)
+    desired = func(sp.csc_matrix(A_dense))
+
+    if func == spgraph.minimum_spanning_tree:
+        assert isinstance(actual, sparse_cls)
+        assert actual.fill_value == fill_value
+        assert_equal(actual.todense(), desired.todense())
+    else:
+        assert_equal(actual, desired)


### PR DESCRIPTION
Connected to: https://github.com/scipy/scipy/issues/20763, https://github.com/pydata/sparse/pull/685, https://github.com/willow-ahrens/finch-tensor/pull/59

Hi @hameerabbasi,

This PR allows to pass `pydata/sparse` arrays with `np.inf` fill-values to the selected `scipy.sparse.csgraph` functions. 

