### PR TITLE
BLD: use release configuration in dev.py on windows by default

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -490,6 +490,9 @@ class Build(Task):
             cmd += ['-Db_coverage=true']
         if args.asan:
             cmd += ['-Db_sanitize=address,undefined']
+        if not args.debug and sys.platform == 'win32':
+            # Building in debug mode on windows is much slower
+            cmd += ['-Dbuildtype=release']
         if args.setup_args:
             cmd += [str(arg) for arg in args.setup_args]
         if args.with_accelerate:


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #20718 

#### What does this implement/fix?
<!--Please explain your changes.-->
It seems a debug build on windows is much slower than a release one.

#### Additional information
<!--Any additional information you think is important.-->
