### PR TITLE
ENH: stats: end-to-end array-API support for normality tests

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -460,10 +460,8 @@ def xp_minimum(x1: Array, x2: Array, /) -> Array:
     if hasattr(xp, 'minimum'):
         return xp.minimum(x1, x2)
     x1, x2 = xp.broadcast_arrays(x1, x2)
-    dtype = xp.result_type(x1.dtype, x2.dtype)
-    res = xp.asarray(x1, copy=True, dtype=dtype)
     i = (x2 < x1) | xp.isnan(x2)
-    res[i] = x2[i]
+    res = xp.where(i, x2, x1)
     return res[()] if res.ndim == 0 else res
 
 

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -693,7 +693,8 @@ def _somers_d(A, alternative='two-sided'):
     with np.errstate(divide='ignore'):
         Z = (PA - QA)/(4*(S))**0.5
 
-    p = scipy.stats._stats_py._get_pvalue(Z, distributions.norm, alternative)
+    norm = scipy.stats._stats_py._SimpleNormal()
+    p = scipy.stats._stats_py._get_pvalue(Z, norm, alternative)
 
     return d, p
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -17,7 +17,8 @@ from scipy._lib._array_api import (array_namespace, xp_minimum, size as xp_size,
 from ._ansari_swilk_statistics import gscale, swilk
 from . import _stats_py, _wilcoxon
 from ._fit import FitResult
-from ._stats_py import find_repeats, _get_pvalue, SignificanceResult  # noqa: F401
+from ._stats_py import (find_repeats, _get_pvalue, SignificanceResult,  # noqa:F401
+                        _SimpleNormal)
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic
@@ -2836,7 +2837,7 @@ def ansari(x, y, alternative='two-sided'):
     # Large values of AB indicate larger dispersion for the y sample.
     # This is opposite to the way we define the ratio of scales. see [1]_.
     z = (mnAB - AB) / sqrt(varAB)
-    pvalue = _get_pvalue(z, distributions.norm, alternative)
+    pvalue = _get_pvalue(z, _SimpleNormal(), alternative)
     return AnsariResult(AB[()], pvalue[()])
 
 
@@ -3879,7 +3880,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
         mnM = n * (N * N - 1.0) / 12
         varM = m * n * (N + 1.0) * (N + 2) * (N - 2) / 180
         z = (M - mnM) / sqrt(varM)
-    pval = _get_pvalue(z, distributions.norm, alternative)
+    pval = _get_pvalue(z, _SimpleNormal(), alternative)
 
     if res_shape == ():
         # Return scalars, not 0-D arrays

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6189,9 +6189,6 @@ class TestDescribe:
             stats.describe(xp.asarray([]))
 
 
-@pytest.mark.skip_xp_backends(cpu_only=True,
-                              reasons=['Uses NumPy for pvalue'])
-@pytest.mark.usefixtures("skip_xp_backends")
 @array_api_compatible
 class NormalityTests:
     def test_too_small(self, xp):


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
When adding array-API support to hypothesis tests, we've been computing p-values by converting the statistic to NumPy, evaluating the appropriate `cdf`/`sf` using a `stats.rv_continuous` distribution, and finally converting the result back to the desired array type. This PR avoids the back and forth conversion and the overhead of `stats.rv_continuous` for the normality tests. The approach is to define an array-API compatible `_SimpleNormal` class with just the required `cdf` and `sf` methods. These methods are implemented with `scipy.special.ndtr`, which already dispatches to the appropriate array library.

Incidentally, this also improves `xp_minimum`, replacing a call to `xp.result_type` and array mutation with `xp.where`, so it should work for JAX now.

I went ahead and used `_SimpleNormal` in non-array-API compatible functions, too, since eliminating the overhead of `stats.norm` is good for them, too.

#### Additional information
We can follow the same approach to define a `_SimpleStudentT` and `_SimpleChi2`, although we'd need to do some work to add the required special functions to `scipy.special._support_alternative_backends`. These three distributions would be enough to cover most of the hypothesis tests for which we can easily add array API support.