### PR TITLE
DEP: special.comb: deprecate `exact=True` for non-integer intputs

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2734,6 +2734,9 @@ def comb(N, k, *, exact=False, repetition=False):
             return _comb_int(N, k)
         # otherwise, we disregard `exact=True`; it makes no sense for
         # non-integral arguments
+        msg = ("`exact=True` is deprecated for non-integers and will raise and error "
+               "in SciPy 1.16.0")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return comb(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2692,6 +2692,10 @@ def comb(N, k, *, exact=False, repetition=False):
     exact : bool, optional
         For integers, if `exact` is False, then floating point precision is
         used, otherwise the result is computed exactly.
+
+        .. deprecated:: 1.14.0
+            ``exact=True`` is deprecated for non-integer `N` and `k` and will raise an
+            error in SciPy 1.16.0
     repetition : bool, optional
         If `repetition` is True, then the number of combinations with
         repetition is computed.
@@ -2734,8 +2738,8 @@ def comb(N, k, *, exact=False, repetition=False):
             return _comb_int(N, k)
         # otherwise, we disregard `exact=True`; it makes no sense for
         # non-integral arguments
-        msg = ("`exact=True` is deprecated for non-integers and will raise and error "
-               "in SciPy 1.16.0")
+        msg = ("`exact=True` is deprecated for non-integer `N` and `k` and will raise "
+               "an error in SciPy 1.16.0")
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return comb(N, k)
     else:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1457,6 +1457,11 @@ class TestCombinatorics:
         assert_equal(special.comb(2, -1, exact=True), 0)
         assert_equal(special.comb(2, -1, exact=False), 0)
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
+    
+    def test_comb_exact_non_int_dep(self):
+        msg = "`exact=True`"
+        with pytest.deprecated_call(match=msg):
+            special.comb(3.4, 4, exact=True)
 
     def test_perm(self):
         assert_allclose(special.perm([10, 10], [3, 4]), [720., 5040.])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes https://github.com/scipy/scipy/issues/15722
#### What does this implement/fix?
<!--Please explain your changes.-->
Passing non-integers with `exact=True` silently returns the result as if `exact=False`. This PR deprecated this behaviour.
#### Additional information
<!--Any additional information you think is important.-->
