### PR TITLE
ENH: stats: end-to-end array-API support for NHSTs with chi-squared null distribution

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -810,7 +810,7 @@ from ._ufuncs import *
 # Replace some function definitions from _ufuncs to add Array API support
 from ._support_alternative_backends import (
     log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e, gammaln,
-    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy)
+    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy, chdtrc)
 
 from . import _basic
 from ._basic import *

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -94,7 +94,8 @@ def _chdtrc(xp, spx):
 
     def __chdtrc(v, x):
         res = xp.where(x >= 0, gammaincc(v/2, x/2), 1)
-        res = xp.where((x == 0) & (v == 0), xp.nan, res)
+        i_nan = ((x == 0) & (v == 0)) | xp.isnan(x) | xp.isnan(v)
+        res = xp.where(i_nan, xp.nan, res)
         return res
     return __chdtrc
 

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -11,8 +11,10 @@ from . import _ufuncs
 # These don't really need to be imported, but otherwise IDEs might not realize
 # that these are defined in this file / report an error in __init__.py
 from ._ufuncs import (
-    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e, gammaln, # noqa: F401
-    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy)  # noqa: F401
+    log_ndtr, ndtr, ndtri, erf, erfc, i0, i0e, i1, i1e, gammaln,  # noqa: F401
+    gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy,  # noqa: F401
+    chdtrc  # noqa: F401
+)
 
 _SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
 array_api_compat_prefix = "scipy._lib.array_api_compat"
@@ -33,19 +35,18 @@ def get_array_special_func(f_name, xp, n_array_args):
 
     # if generic array-API implementation is available, use that;
     # otherwise, fall back to NumPy/SciPy
-    # Use of ` _f=_f, _xp=xp` is to avoid late-binding gotcha
     if f_name in _generic_implementations:
-        _f = _generic_implementations[f_name]
-        def f(*args, _f=_f, _xp=xp, **kwargs):
-            return _f(*args, xp=_xp, **kwargs)
-    else:
-        _f = getattr(_ufuncs, f_name, None)
-        def f(*args, _f=_f, _xp=xp, **kwargs):
-            array_args = args[:n_array_args]
-            other_args = args[n_array_args:]
-            array_args = [np.asarray(arg) for arg in array_args]
-            out = _f(*array_args, *other_args, **kwargs)
-            return _xp.asarray(out)
+        _f = _generic_implementations[f_name](xp=xp, spx=spx)
+        if _f is not None:
+            return _f
+
+    _f = getattr(_ufuncs, f_name, None)
+    def f(*args, _f=_f, _xp=xp, **kwargs):
+        array_args = args[:n_array_args]
+        other_args = args[n_array_args:]
+        array_args = [np.asarray(arg) for arg in array_args]
+        out = _f(*array_args, *other_args, **kwargs)
+        return _xp.asarray(out)
 
     return f
 
@@ -60,24 +61,47 @@ def _get_shape_dtype(*args, xp):
     return args, shape, dtype
 
 
-def _rel_entr(x, y, *, xp):
-    args, shape, dtype = _get_shape_dtype(x, y, xp=xp)
-    x, y = args
-    res = xp.full(x.shape, xp.inf, dtype=dtype)
-    res[(x == 0) & (y >= 0)] = xp.asarray(0, dtype=dtype)
-    i = (x > 0) & (y > 0)
-    res[i] = x[i] * (xp.log(x[i]) - xp.log(y[i]))
-    return res
+def _rel_entr(xp, spx):
+    def __rel_entr(x, y, *, xp=xp):
+        args, shape, dtype = _get_shape_dtype(x, y, xp=xp)
+        x, y = args
+        res = xp.full(x.shape, xp.inf, dtype=dtype)
+        res[(x == 0) & (y >= 0)] = xp.asarray(0, dtype=dtype)
+        i = (x > 0) & (y > 0)
+        res[i] = x[i] * (xp.log(x[i]) - xp.log(y[i]))
+        return res
+    return __rel_entr
 
 
-def _xlogy(x, y, *, xp):
-    with np.errstate(divide='ignore', invalid='ignore'):
-        temp = x * xp.log(y)
-    return xp.where(x == 0., xp.asarray(0., dtype=temp.dtype), temp)
+def _xlogy(xp, spx):
+    def __xlogy(x, y, *, xp=xp):
+        with np.errstate(divide='ignore', invalid='ignore'):
+            temp = x * xp.log(y)
+        return xp.where(x == 0., xp.asarray(0., dtype=temp.dtype), temp)
+    return __xlogy
+
+
+def _chdtrc(xp, spx):
+    # The difference between this and just using `gammaincc`
+    # defined by `get_array_special_func` is that if `gammaincc`
+    # isn't found, we don't want to use the SciPy version; we'll
+    # return None here and use the SciPy version of `chdtrc`..
+    gammaincc = getattr(spx, 'gammaincc', None)  # noqa: F811
+    if gammaincc is None and hasattr(xp, 'special'):
+        gammaincc = getattr(xp.special, 'gammaincc', None)
+    if gammaincc is None:
+        return None
+
+    def __chdtrc(v, x):
+        res = xp.where(x >= 0, gammaincc(v/2, x/2), 1)
+        res = xp.where((x == 0) & (v == 0), xp.nan, res)
+        return res
+    return __chdtrc
 
 
 _generic_implementations = {'rel_entr': _rel_entr,
-                            'xlogy': _xlogy}
+                            'xlogy': _xlogy,
+                            'chdtrc': _chdtrc}
 
 
 # functools.wraps doesn't work because:
@@ -112,6 +136,7 @@ array_special_func_map = {
     'entr': 1,
     'rel_entr': 2,
     'xlogy': 2,
+    'chdtrc': 2,
 }
 
 for f_name, n_array_args in array_special_func_map.items():

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -8,7 +8,7 @@ import scipy.stats
 from scipy.optimize import shgo
 from . import distributions
 from ._common import ConfidenceInterval
-from ._continuous_distns import chi2, norm
+from ._continuous_distns import norm
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
 from ._stats_pythran import _a_ij_Aij_Dij2
@@ -141,7 +141,8 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
         corr = 1.0/(1.0 + n**(-0.45) + 10.1*(nx**(-1.7) + ny**(-1.7)))
         w = corr * w
 
-    p = chi2.sf(w, r)
+    chi2 = _stats_py._SimpleChi2(r)
+    p = _stats_py._get_pvalue(w, chi2, alternative='greater', xp=np)
 
     return Epps_Singleton_2sampResult(w, p)
 
@@ -693,8 +694,8 @@ def _somers_d(A, alternative='two-sided'):
     with np.errstate(divide='ignore'):
         Z = (PA - QA)/(4*(S))**0.5
 
-    norm = scipy.stats._stats_py._SimpleNormal()
-    p = scipy.stats._stats_py._get_pvalue(Z, norm, alternative)
+    norm = _stats_py._SimpleNormal()
+    p = _stats_py._get_pvalue(Z, norm, alternative, xp=np)
 
     return d, p
 

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -142,7 +142,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
         w = corr * w
 
     chi2 = _stats_py._SimpleChi2(r)
-    p = _stats_py._get_pvalue(w, chi2, alternative='greater', xp=np)
+    p = _stats_py._get_pvalue(w, chi2, alternative='greater', symmetric=False, xp=np)
 
     return Epps_Singleton_2sampResult(w, p)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -265,7 +265,7 @@ def kstat(data, n=2, *, axis=None):
     .. math::
 
         S_r \equiv \sum_{i=1}^n X_i^r,
-        
+
     and :math:`X_i` is the :math:`i` th data point.
 
     References
@@ -3083,7 +3083,8 @@ def bartlett(*samples, axis=0):
     denom = 1 + 1/(3*(k - 1)) * ((xp.sum(1/(Ni - 1), axis=0)) - 1/(Ntot - k))
     T = numer / denom
 
-    pvalue = _get_pvalue(T, _SimpleChi2(xp.asarray(k-1)), alternative='greater', xp=xp)
+    chi2 = _SimpleChi2(xp.asarray(k-1))
+    pvalue = _get_pvalue(T, chi2, alternative='greater', symmetric=False, xp=xp)
 
     T = T[()] if T.ndim == 0 else T
     pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
@@ -3658,9 +3659,10 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     Aibar = _apply_func(sample, g, np.sum) / Ni
     anbar = np.mean(sample, axis=0)
     varsq = np.var(sample, axis=0, ddof=1)
-    Xsq = np.sum(Ni * (asarray(Aibar) - anbar)**2.0, axis=0) / varsq
-    pval = _get_pvalue(Xsq, _SimpleChi2(k-1), alternative='greater', xp=np)
-    return FlignerResult(Xsq, pval)
+    statistic = np.sum(Ni * (asarray(Aibar) - anbar)**2.0, axis=0) / varsq
+    chi2 = _SimpleChi2(k-1)
+    pval = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=np)
+    return FlignerResult(statistic, pval)
 
 
 @_axis_nan_policy_factory(lambda x1: (x1,), n_samples=4, n_outputs=1)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -18,7 +18,7 @@ from ._ansari_swilk_statistics import gscale, swilk
 from . import _stats_py, _wilcoxon
 from ._fit import FitResult
 from ._stats_py import (find_repeats, _get_pvalue, SignificanceResult,  # noqa:F401
-                        _SimpleNormal)
+                        _SimpleNormal, _SimpleChi2)
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic
@@ -3083,9 +3083,8 @@ def bartlett(*samples, axis=0):
     denom = 1 + 1/(3*(k - 1)) * ((xp.sum(1/(Ni - 1), axis=0)) - 1/(Ntot - k))
     T = numer / denom
 
-    T_np = np.asarray(T)
-    pvalue = distributions.chi2.sf(T_np, k-1)
-    pvalue = xp.asarray(pvalue, dtype=T.dtype)
+    pvalue = _get_pvalue(T, _SimpleChi2(xp.asarray(k-1)), alternative='greater', xp=xp)
+
     T = T[()] if T.ndim == 0 else T
     pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
 
@@ -3660,7 +3659,7 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     anbar = np.mean(sample, axis=0)
     varsq = np.var(sample, axis=0, ddof=1)
     Xsq = np.sum(Ni * (asarray(Aibar) - anbar)**2.0, axis=0) / varsq
-    pval = distributions.chi2.sf(Xsq, k - 1)  # 1 - cdf
+    pval = _get_pvalue(Xsq, _SimpleChi2(k-1), alternative='greater', xp=np)
     return FlignerResult(Xsq, pval)
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1999,14 +1999,14 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 
     s, _ = skewtest(a, axis)
     k, _ = kurtosistest(a, axis)
-    X2 = s*s + k*k
+    x2 = s*s + k*k
 
-    pvalue = _get_pvalue(X2, _SimpleChi2(xp.asarray(2.)), alternative='greater', xp=xp)
+    pvalue = _get_pvalue(x2, _SimpleChi2(xp.asarray(2.)), alternative='greater', xp=xp)
 
-    X2 = X2[()] if X2.ndim == 0 else X2
+    x2 = x2[()] if x2.ndim == 0 else x2
     pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
 
-    return NormaltestResult(X2, pvalue)
+    return NormaltestResult(x2, pvalue)
 
 
 @_axis_nan_policy_factory(SignificanceResult, default_axis=None)
@@ -2168,14 +2168,14 @@ def jarque_bera(x, *, axis=None):
     diffx = x - mu
     s = skew(diffx, axis=axis, _no_deco=True)
     k = kurtosis(diffx, axis=axis, _no_deco=True)
-    X2 = n / 6 * (s**2 + k**2 / 4)
+    x2 = n / 6 * (s**2 + k**2 / 4)
 
-    pvalue = _get_pvalue(X2, _SimpleChi2(xp.asarray(2.)), alternative='greater', xp=xp)
+    pvalue = _get_pvalue(x2, _SimpleChi2(xp.asarray(2.)), alternative='greater', xp=xp)
 
-    X2 = X2[()] if X2.ndim == 0 else X2
+    x2 = x2[()] if x2.ndim == 0 else x2
     pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
 
-    return SignificanceResult(X2, pvalue)
+    return SignificanceResult(x2, pvalue)
 
 
 #####################################

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -736,8 +736,6 @@ class TestAnsari:
 
 
 @array_api_compatible
-@pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends(cpu_only=True, reasons=['Uses NumPy for pvalue'])
 class TestBartlett:
     def test_data(self, xp):
         # https://www.itl.nist.gov/div898/handbook/eda/section3/eda357.htm

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1085,6 +1085,7 @@ def test_plotting_positions():
     assert_array_almost_equal(pos.data, np.array([0.25, 0.5, 0.75]))
 
 
+@skip_xp_invalid_arg
 class TestNormalitytests:
 
     def test_vs_nonmasked(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4006,8 +4006,6 @@ power_div_empty_cases = [
 
 
 @array_api_compatible
-@pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends(cpu_only=True, reasons=['Uses NumPy for pvalue'])
 class TestPowerDivergence:
 
     def check_power_divergence(self, f_obs, f_exp, ddof, axis, lambda_,
@@ -4210,8 +4208,6 @@ class TestPowerDivergence:
 
 
 @array_api_compatible
-@pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends(cpu_only=True, reasons=['Uses NumPy for pvalue'])
 class TestChisquare:
     def test_gh_chisquare_12282(self, xp):
         # Currently `chisquare` is implemented via power_divergence
@@ -6322,8 +6318,6 @@ class TestRankSums:
             stats.ranksums(self.x, self.y, alternative='foobar')
 
 
-@pytest.mark.usefixtures("skip_xp_backends")
-@skip_xp_backends(cpu_only=True)
 @array_api_compatible
 class TestJarqueBera:
     def test_jarque_bera_against_R(self, xp):
@@ -6340,6 +6334,7 @@ class TestJarqueBera:
         xp_assert_close(res.pvalue, ref[1])
 
     @skip_xp_backends(np_only=True)
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_jarque_bera_array_like(self):
         # array-like only relevant for NumPy
         np.random.seed(987654321)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4204,7 +4204,7 @@ class TestPowerDivergence:
             lambda_, expected_stat = table5[i, 0], table5[i, 1]
             stat, p = stats.power_divergence(table4[:,0], table4[:,1],
                                              lambda_=lambda_)
-            assert_allclose(stat, expected_stat, rtol=5e-3)
+            xp_assert_close(stat, expected_stat, rtol=5e-3)
 
 
 @array_api_compatible


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Follow-up to gh-20777

#### What does this implement/fix?
Similar to gh-20777 but for hypothesis tests with a chi-squared null distribution.

#### Additional information
Technically I should probably be passing `symmetric=False` in all these calls to `_get_pvalue`, but `alternative='greater'` is specified explicitly, so it doesn't really matter.