### PR TITLE
DOC: interpolate: mention default kinds in interp2d transition guide

### DIFF
--- a/doc/source/tutorial/interpolate/interp_transition_guide.md
+++ b/doc/source/tutorial/interpolate/interp_transition_guide.md
@@ -83,6 +83,22 @@ interpolation function.](plots/output_12_0.png)
 >>> assert_allclose(znew_i, znew_r, atol=1e-14)
 ```
 
+#### Interpolation order: linear, cubic etc
+
+
+`interp2d` defaults to `kind="linear"`, which is linear in both directions, `x-` and `y-`.
+`RectBivariateSpline`, on the other hand, defaults to cubic interpolation,
+`kx=3, ky=3`.
+
+Here is the exact equivalence:
+
+| interp2d | RectBivariateSpline |
+|----------|--------------------|
+| no kwargs   | kx = 1, ky = 1 |
+| kind='linear' | kx = 1, ky = 1 |
+| kind='cubic' | kx = 3, ky = 3 |
+
+
 ### 1.2. `interp2d` with full coordinates of points (scattered interpolation)
 
 Here, we flatten the meshgrid from the previous exercise to illustrate the functionality.
@@ -130,6 +146,22 @@ interpolation function.](plots/output_20_0.png)
 ```
 >>> assert_allclose(znew_i, znew_b, atol=1e-15)
 ```
+
+#### Interpolation order: linear, cubic etc
+
+
+`interp2d` defaults to `kind="linear"`, which is linear in both directions, `x-` and `y-`.
+`bisplrep`, on the other hand, defaults to cubic interpolation,
+`kx=3, ky=3`.
+
+Here is the exact equivalence:
+
+| `interp2d` | `bisplrep` |
+|----------|--------------------|
+| no kwargs   | kx = 1, ky = 1 |
+| kind='linear' | kx = 1, ky = 1 |
+| kind='cubic' | kx = 3, ky = 3 |
+
 
 ## 2. Alternative to `interp2d`: regular grid
 


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-20620

#### What does this implement/fix?
<!--Please explain your changes.-->

Mention the equivalence of interpolation kinds between the now-removed `interp2d` and its FITPACK replacements.

#### Additional information
<!--Any additional information you think is important.-->

While not critical for the 1.14 release of course, it'd be nice to have it included in the docs right away.