### PR TITLE
ENH: optimize: improve `cobyqa` performance by reducing overhead in solver

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -159,8 +159,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     constraints : {Constraint, dict} or List of {Constraint, dict}, optional
         Constraints definition. Only for COBYLA, COBYQA, SLSQP and trust-constr.
 
-        Constraints for 'trust-constr' are defined as a single object or a
-        list of objects specifying constraints to the optimization problem.
+        Constraints for 'trust-constr' and 'cobyqa' are defined as a single object
+        or a list of objects specifying constraints to the optimization problem.
         Available constraints are:
 
             - `LinearConstraint`
@@ -182,7 +182,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         be zero whereas inequality means that it is to be non-negative.
         Note that COBYLA only supports inequality constraints.
 
-        Constraints for COBYQA are defined as any of the above.
     tol : float, optional
         Tolerance for termination. When `tol` is specified, the selected
         minimization algorithm sets some relevant solver-specific tolerance(s)
@@ -1060,7 +1059,7 @@ def standardize_constraints(constraints, x0, meth):
     else:
         constraints = list(constraints)  # ensure it's a mutable sequence
 
-    if meth in ['trust-constr', 'new']:
+    if meth in ['trust-constr', 'cobyqa', 'new']:
         for i, con in enumerate(constraints):
             if not isinstance(con, new_constraint_types):
                 constraints[i] = old_constraint_to_new(i, con)


### PR DESCRIPTION
This PR reduces the overhead inside the cobyqa minimiser. This pulls in the changes from the cobyqa submodule that implemented the improvements, https://github.com/cobyqa/cobyqa/pull/152 (I authored that PR).

Using the example given in #20724:
```
import time
from scipy.optimize import rosen, minimize
start = time.time()
res =  minimize(rosen, x0, method='cobyqa')
finish = time.time()
sftime = time.time()
_ = [rosen(res.x) for i in range(res.nfev)]
fftime = time.time()

print((fftime - sftime)/(finish - start), res.nfev, finish-start)
```

`0.00587003583427596 1198 0.9613449573516846`. 
Before this PR the output was
`0.0019886230044629835 1087 2.6466002464294434`

I.e. 2.64 s --> 0.96 s, a 64 % reduction in time.

@tylerjereddy I've added this to the 1.14 release milestone.

Lastly, I've amended the `minimize` docstring to tell the user that only NonlinearConstraint, LinearConstraint objects are accepted for cobyqa.


