### PR TITLE
BUG: special: remove redundant `Py_Initialize`

### DIFF
--- a/scipy/special/ufunc.h
+++ b/scipy/special/ufunc.h
@@ -17,10 +17,8 @@
 #include "sf_error.h"
 #include "special/mdspan.h"
 
-// Initializes Python and NumPy.
+// Initializes NumPy.
 inline bool SpecFun_Initialize() {
-    Py_Initialize();
-
     import_array();
     if (PyErr_Occurred() != nullptr) {
         return false; // import array failed


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #20783

#### What does this implement/fix?
<!--Please explain your changes.-->
The use of `Py_Initialize` in `SpecFun_Initialize` is redundant. This function is called in two places, both are the initialization functions called at module import time (thus the use of `PyMODINIT_FUNC`). Python must have been initialized for the import function to be called. What is more: PyPy does not implement `Py_Initialize`, so including it here needlessly breaks building SciPy on PyPy.

#### Additional information
<!--Any additional information you think is important.-->

Here are the calls to `SpecFun_Initialize`: 
https://github.com/scipy/scipy/blob/cdc251d1b7c4827e67c7432e37cdf1eaaebca654/scipy/special/_gufuncs.cpp#L61-L63

https://github.com/scipy/scipy/blob/cdc251d1b7c4827e67c7432e37cdf1eaaebca654/scipy/special/_special_ufuncs.cpp#L214-L216