### PR TITLE
TST: optimize: fix failing tests for `_bracket_minimum`

### DIFF
--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -778,7 +778,6 @@ class TestBracketMinimum:
             return -((log_b - log_a)*x)**-1
 
         result = _bracket_minimum(f, 0.5535723499480897, xmin=xmin, xmax=xmax)
-        assert not result.success
         assert xmin == result.xl
 
     def test_gh_20562_right(self):
@@ -791,5 +790,4 @@ class TestBracketMinimum:
             return ((log_b - log_a)*x)**-1
 
         result = _bracket_minimum(f, -0.5535723499480897, xmin=xmin, xmax=xmax)
-        assert not result.success
         assert xmax == result.xr


### PR DESCRIPTION
Follows up on failures reported in https://github.com/scipy/scipy/pull/20563#issuecomment-2119210627. The solution coincides with an endpoint, so it looks to me like it is valid - hence asserting `success` must be False seems incorrect.