### PR TITLE
BUG: sparse: Fix argmin/max shape diff between axis 0/1. And min/max can now return 1D shapes when axis set.

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -272,6 +272,9 @@ class _minmax_mixin:
                 else:
                     ret[i] = zero_ind
 
+        if isinstance(self, sparray):
+            return ret
+
         if axis == 1:
             ret = ret.reshape(-1, 1)
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -9,7 +9,7 @@
 import math
 import numpy as np
 
-from ._base import _spbase, _ufuncs_with_fixed_point_at_zero
+from ._base import _spbase, sparray, _ufuncs_with_fixed_point_at_zero
 from ._sputils import isscalarlike, validateaxis
 
 __all__ = []
@@ -194,6 +194,11 @@ class _minmax_mixin:
         mask = value != 0
         major_index = np.compress(mask, major_index)
         value = np.compress(mask, value)
+
+        if isinstance(self, sparray):
+            coords = (major_index,)
+            shape = (M,)
+            return self._coo_container((value, coords), shape=shape, dtype=self.dtype)
 
         if axis == 0:
             return self._coo_container(

--- a/scipy/sparse/tests/test_minmax1d.py
+++ b/scipy/sparse/tests/test_minmax1d.py
@@ -17,11 +17,11 @@ def toarray(a):
     return a.toarray()
 
 
-formats_for_minmax_1d = [coo_array, csr_array]
-formats_for_minmax_not1d = [csc_array, bsr_array]
+formats_for_minmax = [bsr_array, coo_array, csc_array, csr_array]
+formats_for_minmax_supporting_1d = [coo_array, csr_array]
 
 
-@pytest.mark.parametrize("spcreator", formats_for_minmax_1d)
+@pytest.mark.parametrize("spcreator", formats_for_minmax_supporting_1d)
 class Test_MinMaxMixin1D:
     def test_minmax(self, spcreator):
         D = np.arange(5)
@@ -82,7 +82,7 @@ class Test_MinMaxMixin1D:
                 mat.argmax(axis=axis)
 
 
-@pytest.mark.parametrize("spcreator", formats_for_minmax_1d + formats_for_minmax_not1d)
+@pytest.mark.parametrize("spcreator", formats_for_minmax)
 class Test_ShapeMinMax2DWithAxis:
     def test_minmax(self, spcreator):
         dat = np.array([[-1, 5, 0, 3], [0, 0, -1, -2], [0, 0, 1, 2]])

--- a/scipy/sparse/tests/test_minmax1d.py
+++ b/scipy/sparse/tests/test_minmax1d.py
@@ -93,13 +93,15 @@ class Test_ShapeMinMax2DWithAxis:
             (datsp.max, np.max),
             (datsp.nanmin, np.nanmin),
             (datsp.nanmax, np.nanmax),
-            (datsp.argmin, np.argmin),
-            (datsp.argmax, np.argmax),
         ]:
-            assert_equal(toarray(spminmax(axis=0)), npminmax(dat, axis=0))
-            assert_equal(toarray(spminmax(axis=1)), npminmax(dat, axis=1))
-            assert_equal(spminmax(axis=0).shape, (4,))
-            assert_equal(spminmax(axis=1).shape, (3,))
+            for ax, result_shape in [(0, (4,)), (1, (3,))]:
+                assert_equal(toarray(spminmax(axis=ax)), npminmax(dat, axis=ax))
+                assert_equal(spminmax(axis=ax).shape, result_shape)
+                assert spminmax(axis=ax).format == "coo"
+
+        for spminmax in [datsp.argmin, datsp.argmax]:
+            for ax in [0, 1]:
+                assert isinstance(spminmax(axis=ax), np.ndarray)
 
         # verify spmatrix behavior
         spmat_form = {
@@ -110,28 +112,17 @@ class Test_ShapeMinMax2DWithAxis:
         }
         datspm = spmat_form[datsp.format](dat)
 
-        for (spminax, npminax) in [
+        for spm, npm in [
             (datspm.min, np.min),
             (datspm.max, np.max),
             (datspm.nanmin, np.nanmin),
             (datspm.nanmax, np.nanmax),
-            (datspm.argmin, np.argmin),
-            (datspm.argmax, np.argmax),
         ]:
-            assert_equal(toarray(spminax(axis=0)), npminax(dat, axis=0, keepdims=True))
-            assert_equal(toarray(spminax(axis=1)), npminax(dat, axis=1, keepdims=True))
-            assert_equal(spminax(axis=0).shape, (1, 4))
-            assert_equal(spminax(axis=1).shape, (3, 1))
+            for ax, result_shape in [(0, (1, 4)), (1, (3, 1))]:
+                assert_equal(toarray(spm(axis=ax)), npm(dat, axis=ax, keepdims=True))
+                assert_equal(spm(axis=ax).shape, result_shape)
+                assert spm(axis=ax).format == "coo"
 
-        assert datspm.min(axis=0).format == "coo"
-        assert datspm.min(axis=1).format == "coo"
-        assert datspm.max(axis=0).format == "coo"
-        assert datspm.max(axis=1).format == "coo"
-        assert datspm.nanmin(axis=0).format == "coo"
-        assert datspm.nanmin(axis=1).format == "coo"
-        assert datspm.nanmax(axis=0).format == "coo"
-        assert datspm.nanmax(axis=1).format == "coo"
-        assert isinstance(datspm.argmin(axis=0), np.ndarray)
-        assert isinstance(datspm.argmin(axis=1), np.ndarray)
-        assert isinstance(datspm.argmax(axis=0), np.ndarray)
-        assert isinstance(datspm.argmax(axis=1), np.ndarray)
+        for spminmax in [datspm.argmin, datspm.argmax]:
+            for ax in [0, 1]:
+                assert isinstance(spminmax(axis=ax), np.ndarray)


### PR DESCRIPTION
Thus, this PR should go in before the 1.14 release or be backported if that doesn't happen.

This PR stems from an overview of the shapes returned by reduction methods (other than indexing).
Specifically, I've looked at `sum`, `mean`, `argmin`, `argmax`, `min`, `max`, `nanmin`, `nanmax` because they have an `axis` parameter. Let me know if there are others I should include (in another PR). Any reduction operation should be explored in light of the availability of 1D sparse to match the array-api.

For the default `axis=None`, all such functions return scalars for 1D, 2D sparray and 2D spmatrix. So that's good. But `argmin` and `argmax` return Python `int` rather than a numpy scalar. I have left that in place since the argmin should be an index. 

The methods `sum`, `mean`, `argmin`, and `argmax` return dense numpy objects when a valid `axis` is provided. For `spmatrix` the return is a 2D row or column depending on the axis value 0/1. For `sparray` the return is a 1D array. (The current release has `argmax(axis=0)` return 2D while `argmax(axis=1)` returns 1D. This PR fixes that for argmax and argmin.)

The other methods `min`, `max`, `nanmin`, `nanmax` return sparse matrix/array when `axis` is provided. For `spmatrix` they return a 2D row or column depending on the axis value 0/1. For `sparray` the return is a 1D object. (The current main returns a 2D row/column which breaks the array api. So this PR changes it to return 1D.)

Change summary:
- argmin/argmax now return 1D dense for axis=0/1/-1/-2 when input is a sparray.
- min/max/nanmin/nanmax now return 1D sparse for axis=0/1/-1/-2 when input is a sparray.
- tests are added to ensure this behavior is tracked and to adjust existing tests where needed. (I put these tests in `test_minmax1d.py` even though the input is 2D because the output is 1D.)

We've been wanting an overview of the current status of these functions, so I include a table here for discussion in case there are other aspects we wish to change (e.g. whether all these methods should return dense arrays).

This table shows the output of each method with given axis value as it depends on the input type/shape.
Note: All these methods return 0D numpy scalars when `axis=None` except `argmin/argmax` which return a Python `int` scalar.


Axis | Method | 1D-sparray   | 2D-sparray      | 2D-spmatrix
---  | --- | --- | --- | ---
0  |  sum   |  0D scalar  | 1D **np.ndarray** | 2D **np.matrix** row
0  |  mean |   0D scalar  | 1D **np.ndarray** | 2D **np.matrix** row
0  |  argmin | 0D python int | 1D **np.ndarray** | 2D **np.matrix** row
0  |  argmax | 0D python int | 1D **np.ndarray** | 2D **np.matrix** row
0  |  min    | 0D scalar   | 1D **sparray**  | 2D **spmatrix** row
0  |  max   |  0D scalar   | 1D **sparray** | 2D **spmatrix** row
0  |  nanmin | 0D scalar   | 1D **sparray** | 2D **spmatrix** row 
0  |  nanmax | 0D scalar   | 1D **sparray** | 2D **spmatrix** row 
1  |  sum     |  --       | 1D **np.ndarray** | 2D **np.matrix** col
1  |  mean   |   --       | 1D **np.ndarray** | 2D **np.matrix** col
1   | argmin   | --       | 1D **np.ndarray** | 2D **np.matrix** col
1  |  argmax  |  --       | 1D **np.ndarray** | 2D **np.matrix** col
1   | min     |  --       | 1D **sparray** | 2D **spmatrix** col
1   | max    |   --       | 1D **sparray** | 2D **spmatrix** col
1   | nanmin |   --       | 1D **sparray** | 2D **spmatrix** col
1   | nanmax  |  --       | 1D **sparray** | 2D **spmatrix** col
