### PR TITLE
ENH: stats: add array API support for `directional_stats`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -555,7 +555,7 @@ def xp_vector_norm(x: Array, /, *,
     xp = array_namespace(x) if xp is None else xp
 
 	# check for optional `linalg` extension
-    if hasattr(xp, 'linalg'):
+    if SCIPY_ARRAY_API and hasattr(xp, 'linalg'):
         return xp.linalg.vector_norm(x, axis=axis, keepdims=keepdims, ord=ord)
 
     else:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -554,12 +554,11 @@ def xp_vector_norm(x: Array, /, *,
                    xp: ModuleType | None = None) -> Array:
     xp = array_namespace(x) if xp is None else xp
 
-	# check for optional `linalg` extension
+    # check for optional `linalg` extension
     if SCIPY_ARRAY_API and hasattr(xp, 'linalg'):
         return xp.linalg.vector_norm(x, axis=axis, keepdims=keepdims, ord=ord)
 
     else:
-        # note: we do not currently validate that `ord` is not `inf` or `-inf`
         if ord != 2:
             raise ValueError(
                 "only the Euclidean norm (`ord=2`) is currently supported in "

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -545,3 +545,26 @@ def xp_sign(x: Array, /, *, xp: ModuleType | None = None) -> Array:
     sign = xp.where(x < 0, -one, sign)
     sign = xp.where(x == 0, 0*one, sign)
     return sign
+
+# maybe use `scipy.linalg` if/when array API support is added
+def xp_vector_norm(x: Array, /, *, 
+                   axis: int | tuple[int] | None = None,
+                   keepdims: bool = False,
+                   ord: int | float = 2,
+                   xp: ModuleType | None = None) -> Array:
+    xp = array_namespace(x) if xp is None else xp
+
+	# check for optional `linalg` extension
+    if hasattr(xp, 'linalg'):
+        return xp.linalg.vector_norm(x, axis=axis, keepdims=keepdims, ord=ord)
+
+    else:
+        # note: we do not currently validate that `ord` is not `inf` or `-inf`
+        if ord != 2:
+            raise ValueError(
+                "only the Euclidean norm (`ord=2`) is currently supported in "
+                "`xp_vector_norm` for backends not implementing the `linalg` extension."
+            )
+        # return (x @ x)**0.5 
+        # or to get the right behavior with nd, complex arrays
+        return xp.sum(xp.conj(x) * x, axis=axis, keepdims=keepdims)**0.5

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -11,8 +11,14 @@ from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
 from scipy import optimize, special, interpolate, stats
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
-from scipy._lib._array_api import (array_namespace, xp_minimum, size as xp_size,
-                                   xp_moveaxis_to_end)
+
+from scipy._lib._array_api import (
+    array_namespace,
+    size as xp_size,
+    xp_minimum,
+    xp_moveaxis_to_end,
+    xp_vector_norm,
+)
 
 from ._ansari_swilk_statistics import gscale, swilk
 from . import _stats_py, _wilcoxon
@@ -4793,10 +4799,10 @@ def directional_stats(samples, *, axis=0, normalize=True):
                          f"Instead samples has shape: {samples.shape!r}")
     samples = xp.moveaxis(samples, axis, 0)
     if normalize:
-        vectornorms = xp.linalg.vector_norm(samples, axis=-1, keepdims=True)
+        vectornorms = xp_vector_norm(samples, axis=-1, keepdims=True)
         samples = samples/vectornorms
     mean = xp.mean(samples, axis=0)
-    mean_resultant_length = xp.linalg.vector_norm(mean, axis=-1, keepdims=True)
+    mean_resultant_length = xp_vector_norm(mean, axis=-1, keepdims=True)
     mean_direction = mean / mean_resultant_length
     return DirectionalStats(mean_direction,
                             mean_resultant_length.squeeze(-1)[()])

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4785,16 +4785,18 @@ def directional_stats(samples, *, axis=0, normalize=True):
     >>> 1 - dirstats.mean_resultant_length
     0.13397459716167093
     """
-    samples = np.asarray(samples)
+    xp = array_namespace(samples)
+    samples = xp.asarray(samples)
+    
     if samples.ndim < 2:
         raise ValueError("samples must at least be two-dimensional. "
                          f"Instead samples has shape: {samples.shape!r}")
-    samples = np.moveaxis(samples, axis, 0)
+    samples = xp.moveaxis(samples, axis, 0)
     if normalize:
-        vectornorms = np.linalg.norm(samples, axis=-1, keepdims=True)
+        vectornorms = xp.linalg.vector_norm(samples, axis=-1, keepdims=True)
         samples = samples/vectornorms
-    mean = np.mean(samples, axis=0)
-    mean_resultant_length = np.linalg.norm(mean, axis=-1, keepdims=True)
+    mean = xp.mean(samples, axis=0)
+    mean_resultant_length = xp.linalg.vector_norm(mean, axis=-1, keepdims=True)
     mean_direction = mean / mean_resultant_length
     return DirectionalStats(mean_direction,
                             mean_resultant_length.squeeze(-1)[()])

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4796,7 +4796,7 @@ def directional_stats(samples, *, axis=0, normalize=True):
     
     if samples.ndim < 2:
         raise ValueError("samples must at least be two-dimensional. "
-                         f"Instead samples has shape: {samples.shape!r}")
+                         f"Instead samples has shape: {tuple(samples.shape)}")
     samples = xp.moveaxis(samples, axis, 0)
     if normalize:
         vectornorms = xp_vector_norm(samples, axis=-1, keepdims=True, xp=xp)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4799,13 +4799,14 @@ def directional_stats(samples, *, axis=0, normalize=True):
                          f"Instead samples has shape: {samples.shape!r}")
     samples = xp.moveaxis(samples, axis, 0)
     if normalize:
-        vectornorms = xp_vector_norm(samples, axis=-1, keepdims=True)
+        vectornorms = xp_vector_norm(samples, axis=-1, keepdims=True, xp=xp)
         samples = samples/vectornorms
     mean = xp.mean(samples, axis=0)
-    mean_resultant_length = xp_vector_norm(mean, axis=-1, keepdims=True)
+    mean_resultant_length = xp_vector_norm(mean, axis=-1, keepdims=True, xp=xp)
     mean_direction = mean / mean_resultant_length
-    return DirectionalStats(mean_direction,
-                            mean_resultant_length.squeeze(-1)[()])
+    mrl = xp.squeeze(mean_resultant_length, axis=-1)
+    mean_resultant_length = mrl[()] if mrl.ndim == 0 else mrl
+    return DirectionalStats(mean_direction, mean_resultant_length)
 
 
 def false_discovery_control(ps, *, axis=0, method='bh'):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3060,10 +3060,9 @@ class TestDirectionalStats:
         # test that directional stats calculations yield same results
         # for unnormalized input with normalize=True and normalized
         # input with normalize=False
-        dt = getattr(xp, dtype)
         data = np.array([[0.8660254, 0.5, 0.],
-                         [1.7320508, -1., 0.]])
-        res = stats.directional_stats(xp.asarray(data, dtype=dt), normalize=True)
+                         [1.7320508, -1., 0.]], dtype=dtype)
+        res = stats.directional_stats(xp.asarray(data), normalize=True)
         normalized_data = data / np.linalg.norm(data, axis=-1,
                                                 keepdims=True)
         ref = stats.directional_stats(normalized_data, normalize=False)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -33,7 +33,6 @@ from scipy._lib._array_api import (
     xp_assert_close,
     xp_assert_equal,
     xp_assert_less,
-    xp_vector_norm,
 )
 
 
@@ -3061,16 +3060,16 @@ class TestDirectionalStats:
         # test that directional stats calculations yield same results
         # for unnormalized input with normalize=True and normalized
         # input with normalize=False
-        data = xp.asarray([[0.8660254, 0.5, 0.],
-                           [1.7320508, -1., 0.]])
-        res = stats.directional_stats(data, normalize=True)
-        # get `xp.linalg.vector_norm` for `xp_vector_norm`
-        xp_test = array_namespace(data)
-        data_norm = xp_vector_norm(data, axis=-1, keepdims=True, xp=xp_test)
-        normalized_data = data / data_norm
+        data = np.array([[0.8660254, 0.5, 0.],
+                         [1.7320508, -1., 0.]])
+        res = stats.directional_stats(xp.asarray(data), normalize=True)
+        normalized_data = data / np.linalg.norm(data, axis=-1,
+                                                keepdims=True)
         ref = stats.directional_stats(normalized_data, normalize=False)
-        xp_assert_close(res.mean_direction, ref.mean_direction)
-        xp_assert_close(res.mean_resultant_length, ref.mean_resultant_length)
+        xp_assert_close(res.mean_direction,
+                        xp.asarray(ref.mean_direction))
+        xp_assert_close(res.mean_resultant_length,
+                        xp.asarray(ref.mean_resultant_length))
 
 
 class TestFDRControl:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2976,9 +2976,9 @@ class TestDirectionalStats:
                          np.sin(incl)),
                         axis=1)
         
-        decl = xp.asarray(decl)
-        incl = xp.asarray(incl)
-        data = xp.asarray(data)
+        decl = xp.asarray(decl.tolist())
+        incl = xp.asarray(incl.tolist())
+        data = xp.asarray(data.tolist())
 
         dirstats = stats.directional_stats(data)
         directional_mean = dirstats.mean_direction

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3026,7 +3026,7 @@ class TestDirectionalStats:
         # test that directional_stats works for higher dimensions
         # here a 4D array is reduced over axis = 2
         data = xp.asarray([[0.8660254, 0.5, 0.],
-                         [0.8660254, -0.5, 0.]])
+                           [0.8660254, -0.5, 0.]])
         full_array = xp.asarray(xp.tile(data, (2, 2, 2, 1)))
         expected = xp.asarray([[[1., 0., 0.],
                                 [1., 0., 0.]],

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2967,16 +2967,18 @@ class TestDirectionalStats:
         # Data from Fisher: Dispersion on a sphere, 1953 and
         # Mardia and Jupp, Directional Statistics.
         # angles were converted to radians
-        decl = xp.asarray([-5.98996999, -1.08210414, -0.64402649, -0.4712389,
-                           -6.26573201, -0.09948377, -0.87964594, -6.24129741,
-                           -0.76794487])
-        incl = xp.asarray([-1.15366264, -1.1990412 , -1.22347581, -1.43291532,
-                           -1.38753676, -1.27409035, -1.20951317, -1.0262536,
-                           -0.89709924])
-        data = xp.stack((xp.cos(incl) * xp.cos(decl),
-                         xp.cos(incl) * xp.sin(decl),
-                         xp.sin(incl)),
+        decl = -np.deg2rad(np.array([343.2, 62., 36.9, 27., 359.,
+                                     5.7, 50.4, 357.6, 44.]))
+        incl = -np.deg2rad(np.array([66.1, 68.7, 70.1, 82.1, 79.5,
+                                     73., 69.3, 58.8, 51.4]))
+        data = np.stack((np.cos(incl) * np.cos(decl),
+                         np.cos(incl) * np.sin(decl),
+                         np.sin(incl)),
                         axis=1)
+        
+        decl = xp.asarray(decl)
+        incl = xp.asarray(incl)
+        data = xp.asarray(data)
 
         dirstats = stats.directional_stats(data)
         directional_mean = dirstats.mean_direction

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3006,8 +3006,8 @@ class TestDirectionalStats:
                                    axis=1)
         dirstats = stats.directional_stats(testdata_vector)
         directional_mean = dirstats.mean_direction
-        directional_mean_angle = xp.atan2(directional_mean[1],
-                                          directional_mean[0])
+        directional_mean_angle = np.arctan2(directional_mean[1],
+                                            directional_mean[0])
         directional_mean_angle = directional_mean_angle % (2 * xp.pi)
         circmean = stats.circmean(testdata)
         xp_assert_close(circmean, directional_mean_angle)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2982,7 +2982,7 @@ class TestDirectionalStats:
         directional_mean = dirstats.mean_direction
 
         reference_mean = xp.asarray([0.2984, -0.1346, -0.9449])
-        xp_assert_close(directional_mean, reference_mean, atol=1e-4, rtol=1e-4)
+        xp_assert_close(directional_mean, reference_mean, atol=1e-4)
 
     @pytest.mark.parametrize('angles, ref', [
         ([-np.pi/2, np.pi/2], 1.),
@@ -3006,8 +3006,9 @@ class TestDirectionalStats:
                                    axis=1)
         dirstats = stats.directional_stats(testdata_vector)
         directional_mean = dirstats.mean_direction
-        directional_mean_angle = np.arctan2(directional_mean[1],
-                                            directional_mean[0])
+        xp_test = array_namespace(directional_mean)  # np needs atan2
+        directional_mean_angle = xp_test.arctan2(directional_mean[1],
+                                                 directional_mean[0])
         directional_mean_angle = directional_mean_angle % (2 * xp.pi)
         circmean = stats.circmean(testdata)
         xp_assert_close(circmean, directional_mean_angle)
@@ -3060,7 +3061,7 @@ class TestDirectionalStats:
                                       normalize=False)
         xp_assert_close(res.mean_direction, ref.mean_direction)
         xp_assert_close(res.mean_resultant_length,
-                           ref.mean_resultant_length)
+                        ref.mean_resultant_length)
 
 
 class TestFDRControl:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3007,7 +3007,7 @@ class TestDirectionalStats:
         dirstats = stats.directional_stats(testdata_vector)
         directional_mean = dirstats.mean_direction
         directional_mean_angle = xp.atan2(directional_mean[1],
-                                            directional_mean[0])
+                                          directional_mean[0])
         directional_mean_angle = directional_mean_angle % (2 * xp.pi)
         circmean = stats.circmean(testdata)
         xp_assert_close(circmean, directional_mean_angle)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2967,12 +2967,12 @@ class TestDirectionalStats:
         # Data from Fisher: Dispersion on a sphere, 1953 and
         # Mardia and Jupp, Directional Statistics.
         # angles were converted to radians
-        decl = xp.array([-5.98996999, -1.08210414, -0.64402649, -0.4712389,
-                         -6.26573201, -0.09948377, -0.87964594, -6.24129741,
-                         -0.76794487])
-        incl = xp.array([-1.15366264, -1.1990412 , -1.22347581, -1.43291532,
-                         -1.38753676, -1.27409035, -1.20951317, -1.0262536,
-                         -0.89709924])
+        decl = xp.asarray([-5.98996999, -1.08210414, -0.64402649, -0.4712389,
+                           -6.26573201, -0.09948377, -0.87964594, -6.24129741,
+                           -0.76794487])
+        incl = xp.asarray([-1.15366264, -1.1990412 , -1.22347581, -1.43291532,
+                           -1.38753676, -1.27409035, -1.20951317, -1.0262536,
+                           -0.89709924])
         data = xp.stack((xp.cos(incl) * xp.cos(decl),
                          xp.cos(incl) * xp.sin(decl),
                          xp.sin(incl)),
@@ -2981,7 +2981,7 @@ class TestDirectionalStats:
         dirstats = stats.directional_stats(data)
         directional_mean = dirstats.mean_direction
 
-        reference_mean = xp.array([0.2984, -0.1346, -0.9449])
+        reference_mean = xp.asarray([0.2984, -0.1346, -0.9449])
         xp_assert_close(directional_mean, reference_mean, atol=1e-4, rtol=1e-4)
 
     @pytest.mark.parametrize('angles, ref', [
@@ -3022,10 +3022,10 @@ class TestDirectionalStats:
         data = np.array([[0.8660254, 0.5, 0.],
                          [0.8660254, -0.5, 0.]])
         full_array = xp.asarray(np.tile(data, (2, 2, 2, 1)))
-        expected = xp.array([[[1., 0., 0.],
-                              [1., 0., 0.]],
-                             [[1., 0., 0.],
-                              [1., 0., 0.]]])
+        expected = xp.asarray([[[1., 0., 0.],
+                                [1., 0., 0.]],
+                               [[1., 0., 0.],
+                                [1., 0., 0.]]])
         dirstats = stats.directional_stats(full_array, axis=2)
         xp_assert_close(expected, dirstats.mean_direction)
 
@@ -3051,8 +3051,8 @@ class TestDirectionalStats:
         # test that directional stats calculations yield same results
         # for unnormalized input with normalize=True and normalized
         # input with normalize=False
-        data = xp.array([[0.8660254, 0.5, 0.],
-                         [1.7320508, -1., 0.]])
+        data = xp.asarray([[0.8660254, 0.5, 0.],
+                           [1.7320508, -1., 0.]])
         res = stats.directional_stats(data, normalize=True)
         normalized_data = data / xp.linalg.vector_norm(data, axis=-1,
                                                        keepdims=True)


### PR DESCRIPTION
#### Reference issue
Towards #20544

#### What does this implement/fix?
Adds array API support for `directional_stats`.

#### Additional information
This is the first time I look into array API stuff, any pointers are highly appreciated. I mostly checked what is available in the standard and adapted existing tests to what I saw for tests of other array API compatible functions. I do not have pytorch locally installed, so mostly relying on CI now.