### PR TITLE
MAINT: fix warnings about `noexcept` and `except *` in Cython code

### DIFF
--- a/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
+++ b/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
@@ -67,7 +67,7 @@ for _r in _ref_opts.records:
     _ref_opt_lookup[_r.name] = _r
 
 
-cdef str _opt_warning(string name, val, valid_set=None) noexcept:
+cdef str _opt_warning(string name, val, valid_set=None):
     cdef OptionRecord * r = _ref_opt_lookup[name]
 
     # BOOL
@@ -112,7 +112,7 @@ cdef str _opt_warning(string name, val, valid_set=None) noexcept:
            'See documentation for valid options. '
            'Using default.' % (name.decode(), str(val)))
 
-cdef apply_options(dict options, Highs & highs) noexcept:
+cdef void apply_options(dict options, Highs & highs):
     '''Take options from dictionary and apply to HiGHS object.'''
 
     # Initialize for error checking

--- a/scipy/stats/_stats.pxd
+++ b/scipy/stats/_stats.pxd
@@ -1,9 +1,10 @@
 # destined to be used in a LowLevelCallable
-cdef double _geninvgauss_pdf(double x, void *user_data) except * nogil
+
+cdef double _geninvgauss_pdf(double x, void *user_data) noexcept nogil
 cdef double _studentized_range_cdf(int n, double[2] x, void *user_data) noexcept nogil
 cdef double _studentized_range_cdf_asymptotic(double z, void *user_data) noexcept nogil
 cdef double _studentized_range_pdf(int n, double[2] x, void *user_data) noexcept nogil
 cdef double _studentized_range_pdf_asymptotic(double z, void *user_data) noexcept nogil
 cdef double _studentized_range_moment(int n, double[3] x_arg, void *user_data) noexcept nogil
-cdef double _genhyperbolic_pdf(double x, void *user_data) except * nogil
-cdef double _genhyperbolic_logpdf(double x, void *user_data) except * nogil
+cdef double _genhyperbolic_pdf(double x, void *user_data) noexcept nogil
+cdef double _genhyperbolic_logpdf(double x, void *user_data) noexcept nogil

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -509,7 +509,7 @@ cdef double _geninvgauss_logpdf_kernel(double x, double p, double b) noexcept no
     return c + (p - 1)*math.log(x) - b*(x + 1/x)/2
 
 
-cdef double _geninvgauss_pdf(double x, void *user_data) except * nogil:
+cdef double _geninvgauss_pdf(double x, void *user_data) noexcept nogil:
     # destined to be used in a LowLevelCallable
     cdef double p, b
 
@@ -645,7 +645,7 @@ cpdef double genhyperbolic_pdf(double x, double p, double a, double b) noexcept 
     return math.exp(_genhyperbolic_logpdf_kernel(x, p, a, b))
 
 
-cdef double _genhyperbolic_pdf(double x, void *user_data) except * nogil:
+cdef double _genhyperbolic_pdf(double x, void *user_data) noexcept nogil:
     # destined to be used in a LowLevelCallable
     cdef double p, a, b
 
@@ -662,7 +662,8 @@ cpdef double genhyperbolic_logpdf(
     return _genhyperbolic_logpdf_kernel(x, p, a, b)
 
 
-cdef double _genhyperbolic_logpdf(double x, void *user_data) except * nogil:
+# logpdf is always negative, so use positive exception value
+cdef double _genhyperbolic_logpdf(double x, void *user_data) noexcept nogil:
     # destined to be used in a LowLevelCallable
     cdef double p, a, b
 


### PR DESCRIPTION
The warnings were:
```
[4/12] Generating 'scipy/optimize/_highs/_highs_...on-311-x86_64-linux-gnu.so.p/_highs_wrapper.cpp'
warning: /home/rgommers/code/scipy/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx:70:21: noexcept clause is ignored for function returning Python object
warning: /home/rgommers/code/scipy/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx:115:18: noexcept clause is ignored for function returning Python object
[6/12] Generating 'scipy/stats/_stats.cpython-311-x86_64-linux-gnu.so.p/_stats.c'
performance hint: /home/rgommers/code/scipy/scipy/stats/_stats.pxd:2:28: No exception value declared for '_geninvgauss_pdf' in pxd file.
Users cimporting this function and calling it without the gil will always require an exception check.
Suggest adding an explicit exception value.
performance hint: /home/rgommers/code/scipy/scipy/stats/_stats.pxd:8:30: No exception value declared for '_genhyperbolic_pdf' in pxd file.
Users cimporting this function and calling it without the gil will always require an exception check.
Suggest adding an explicit exception value.
performance hint: /home/rgommers/code/scipy/scipy/stats/_stats.pxd:9:33: No exception value declared for '_genhyperbolic_logpdf' in pxd file.
Users cimporting this function and calling it without the gil will always require an exception check.
Suggest adding an explicit exception value.
```

Comments:
- for `_stats.pyx`/`_stats.pxd`: the pdf functions always return positive numbers, so use a negative number (-1) for an exception value. the `logpdf` function returns only negative numbers, so use a positive value (99).
- for `_highs_wrapper`: the `noexcept` annotations were wrong, because the first function returns a Python object (which implies `noexcept` should not be used), and the second one uses `warnings.warn` which certainly can cause an exception.

These warnings are new in Cython 3.0.9 (for `noexcept`) and 3.0.10 (for `except *`).