### PR TITLE
BLD: optimize: silence build warnings coming from HiGHS

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -369,9 +369,11 @@ Wno_unused_result = cc.get_supported_arguments('-Wno-unused-result')
 Wno_unused_variable = cc.get_supported_arguments('-Wno-unused-variable')
 
 # C++ warning flags
+_cpp_Wno_bitwise_instead_of_logical = cpp.get_supported_arguments('-Wno-bitwise-instead-of-logical')
 _cpp_Wno_cpp = cpp.get_supported_arguments('-Wno-cpp')
-_cpp_Wno_deprecated_declarations = cpp.get_supported_arguments('-Wno-deprecated-declarations')
 _cpp_Wno_class_memaccess = cpp.get_supported_arguments('-Wno-class-memaccess')
+_cpp_Wno_deprecated_declarations = cpp.get_supported_arguments('-Wno-deprecated-declarations')
+_cpp_Wno_deprecated_builtins = cpp.get_supported_arguments('-Wno-deprecated-builtins')
 _cpp_Wno_format_truncation = cpp.get_supported_arguments('-Wno-format-truncation')
 _cpp_Wno_non_virtual_dtor = cpp.get_supported_arguments('-Wno-non-virtual-dtor')
 _cpp_Wno_sign_compare = cpp.get_supported_arguments('-Wno-sign-compare')

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -55,7 +55,10 @@ basiclu_lib = static_library('basiclu',
 )
 
 highs_flags = [
+  _cpp_Wno_bitwise_instead_of_logical,
   _cpp_Wno_class_memaccess,
+  _cpp_Wno_deprecated_builtins,
+  _cpp_Wno_deprecated_declarations,
   _cpp_Wno_format_truncation,
   _cpp_Wno_non_virtual_dtor,
   _cpp_Wno_sign_compare,


### PR DESCRIPTION
This got annoying, and the PR that would pull in the upstream fix was reverted. Since we're close to the 1.14.x branch point, let's silence these warnings.

Closes gh-19734