### PR TITLE
MAINT: special: fix numpy initialization, avoid build warnings

### DIFF
--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -59,13 +59,15 @@ static PyModuleDef _gufuncs_def = {
 };
 
 PyMODINIT_FUNC PyInit__gufuncs() {
-    if (!SpecFun_Initialize()) {
-        return nullptr;
+    import_array();
+    import_umath();
+    if (PyErr_Occurred()) {
+        return NULL;
     }
 
     PyObject *_gufuncs = PyModule_Create(&_gufuncs_def);
     if (_gufuncs == nullptr) {
-        return nullptr;
+        return NULL;
     }
 
     PyObject *_lpn = SpecFun_NewGUFunc(

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -212,13 +212,15 @@ static PyModuleDef _special_ufuncs_def = {
 };
 
 PyMODINIT_FUNC PyInit__special_ufuncs() {
-    if (!SpecFun_Initialize()) {
-        return nullptr;
+    import_array();
+    import_umath();
+    if (PyErr_Occurred()) {
+        return NULL;
     }
 
     PyObject *_special_ufuncs = PyModule_Create(&_special_ufuncs_def);
     if (_special_ufuncs == nullptr) {
-        return nullptr;
+        return NULL;
     }
 
     PyObject *_cospi = SpecFun_NewUFunc(

--- a/scipy/special/ufunc.h
+++ b/scipy/special/ufunc.h
@@ -17,20 +17,6 @@
 #include "sf_error.h"
 #include "special/mdspan.h"
 
-// Initializes NumPy.
-inline bool SpecFun_Initialize() {
-    import_array();
-    if (PyErr_Occurred() != nullptr) {
-        return false; // import array failed
-    }
-
-    import_umath();
-    if (PyErr_Occurred() != nullptr) {
-        return false; // import umath failed
-    }
-
-    return true;
-}
 
 // This is std::accumulate, but that is not constexpr until C++20
 template <typename InputIt, typename T>


### PR DESCRIPTION
The warnings were:
```
[3/6] Compiling C++ object scipy/special/_gufuncs.cpython-310-darwin.so.p/_gufuncs.cpp.o
In file included from ../scipy/special/_gufuncs.cpp:1:
../scipy/special/ufunc.h:22:5: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
    import_array();
    ^~~~~~~~~~~~~~
../../../mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/_core/include/numpy/__multiarray_api.h:1583:12: note: expanded from macro 'import_array'
    return NULL; \
    ~~~~~~ ^
In file included from ../scipy/special/_gufuncs.cpp:1:
../scipy/special/ufunc.h:27:5: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
    import_umath();
    ^~~~~~~~~~~~~~
../../../mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/_core/include/numpy/__ufunc_api.h:294:20: note: expanded from macro 'import_umath'
            return NULL;\
            ~~~~~~ ^
2 warnings generated.
[5/6] Compiling C++ object scipy/special/_special_ufuncs.cpython-310-darwin.so.p/_special_ufuncs.cpp.o
In file included from ../scipy/special/_special_ufuncs.cpp:1:
../scipy/special/ufunc.h:22:5: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
    import_array();
    ^~~~~~~~~~~~~~
../../../mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/_core/include/numpy/__multiarray_api.h:1583:12: note: expanded from macro 'import_array'
    return NULL; \
    ~~~~~~ ^
In file included from ../scipy/special/_special_ufuncs.cpp:1:
../scipy/special/ufunc.h:27:5: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
    import_umath();
    ^~~~~~~~~~~~~~
../../../mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/_core/include/numpy/__ufunc_api.h:294:20: note: expanded from macro 'import_umath'
            return NULL;\
            ~~~~~~ ^
2 warnings generated.
```

This fix also makes the code more idiomatic; there are some `.cpp` files in numpy itself that use this pattern; the clearest docs are at https://pythonextensionpatterns.readthedocs.io/en/latest/cpp_and_numpy.html#initialising-numpy-in-a-cpython-module.