### PR TITLE
DOC: ndimage: improve grayscale morphology docstrings

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -1142,7 +1142,8 @@ def grey_erosion(input, size=None, footprint=None, structure=None,
         neighbors of the center over which the minimum is chosen.
     structure : array of ints, optional
         Structuring element used for the grayscale erosion. `structure`
-        may be a non-flat structuring element.
+        may be a non-flat structuring element. The `structure` array applies a
+        subtractive offset for each pixel in the neighborhood.
     output : array, optional
         An array used for storing the output of the erosion may be provided.
     mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
@@ -1253,7 +1254,8 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
         neighbors of the center over which the maximum is chosen.
     structure : array of ints, optional
         Structuring element used for the grayscale dilation. `structure`
-        may be a non-flat structuring element.
+        may be a non-flat structuring element. The `structure` array applies an
+        additive offset for each pixel in the neighborhood.
     output : array, optional
         An array used for storing the output of the dilation may be provided.
     mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
@@ -1399,7 +1401,9 @@ def grey_opening(input, size=None, footprint=None, structure=None,
         used for the grayscale opening.
     structure : array of ints, optional
         Structuring element used for the grayscale opening. `structure`
-        may be a non-flat structuring element.
+        may be a non-flat structuring element. The `structure` array applies
+        offsets to the pixels in a neighborhood (the offset is additive during
+        dilation and subtractive during erosion).
     output : array, optional
         An array used for storing the output of the opening may be provided.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
@@ -1484,7 +1488,9 @@ def grey_closing(input, size=None, footprint=None, structure=None,
         used for the grayscale closing.
     structure : array of ints, optional
         Structuring element used for the grayscale closing. `structure`
-        may be a non-flat structuring element.
+        may be a non-flat structuring element. The `structure` array applies
+        offsets to the pixels in a neighborhood (the offset is additive during
+        dilation and subtractive during erosion)
     output : array, optional
         An array used for storing the output of the closing may be provided.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
@@ -1570,8 +1576,10 @@ def morphological_gradient(input, size=None, footprint=None, structure=None,
         used for the morphology operations. Larger footprints
         give a more blurred morphological gradient.
     structure : array of ints, optional
-        Structuring element used for the morphology operations.
-        `structure` may be a non-flat structuring element.
+        Structuring element used for the morphology operations. `structure` may
+        be a non-flat structuring element. The `structure` array applies
+        offsets to the pixels in a neighborhood (the offset is additive during
+        dilation and subtractive during erosion)
     output : array, optional
         An array used for storing the output of the morphological gradient
         may be provided.
@@ -1673,12 +1681,18 @@ def morphological_laplace(input, size=None, footprint=None,
     ----------
     input : array_like
         Input.
-    size : int or sequence of ints, optional
-        See `structure`.
-    footprint : bool or ndarray, optional
-        See `structure`.
-    structure : structure, optional
-        Either `size`, `footprint`, or the `structure` must be provided.
+    size : tuple of ints
+        Shape of a flat and full structuring element used for the mathematical
+        morphology operations. Optional if `footprint` or `structure` is
+        provided.
+    footprint : array of ints, optional
+        Positions of non-infinite elements of a flat structuring element
+        used for the morphology operations.
+    structure : array of ints, optional
+        Structuring element used for the morphology operations. `structure` may
+        be a non-flat structuring element. The `structure` array applies
+        offsets to the pixels in a neighborhood (the offset is additive during
+        dilation and subtractive during erosion)
     output : ndarray, optional
         An output array can optionally be provided.
     mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
@@ -1730,8 +1744,10 @@ def white_tophat(input, size=None, footprint=None, structure=None,
         Positions of elements of a flat structuring element
         used for the white tophat filter.
     structure : array of ints, optional
-        Structuring element used for the filter. `structure`
-        may be a non-flat structuring element.
+        Structuring element used for the filter. `structure` may be a non-flat
+        structuring element. The `structure` array applies offsets to the
+        pixels in a neighborhood (the offset is additive during dilation and
+        subtractive during erosion)
     output : array, optional
         An array used for storing the output of the filter may be provided.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
@@ -1808,8 +1824,10 @@ def black_tophat(input, size=None, footprint=None,
         Positions of non-infinite elements of a flat structuring element
         used for the black tophat filter.
     structure : array of ints, optional
-        Structuring element used for the filter. `structure`
-        may be a non-flat structuring element.
+        Structuring element used for the filter. `structure` may be a non-flat
+        structuring element. The `structure` array applies offsets to the
+        pixels in a neighborhood (the offset is additive during dilation and
+        subtractive during erosion)
     output : array, optional
         An array used for storing the output of the filter may be provided.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional


### PR DESCRIPTION
The goal of this MR is to make the behavior of the `structure` argument clearer and avoid confusion as seen, for example, in #19384

