### PR TITLE
MAINT: remove pytest-fail-slow from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-timeout",
-    "pytest-fail-slow",
     "pytest-xdist",
     "asv",
     "mpmath",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,6 @@
 pytest
 pytest-cov
 pytest-timeout
-pytest-fail-slow
 pytest-xdist
 asv
 mpmath


### PR DESCRIPTION
#### Reference issue
Closes gh-20802

#### What does this implement/fix?
In gh-20480, `pytest-fail-slow` was added to `environment.yml` and `pyproject.toml` under the belief that it would not fail tests unless the `fail_slow` option was passed to `pytest`. Unfortunately, that wasn't the case - tests given an exception to the default time limit via `@pytest.mark.fail_slow` are subject to that higher limit on every test run if `pytest-fail-slow` is installed.

To ameliorate this, gh-20672 removed `pytest-fail-slow` from `environment.yml`, but I forgot to remove it from `pyproject.toml` at the same time. This PR removes `pytest-fail-slow` from `pyproject.toml` (and the auto-generated `requirements/test.txt`) to avoid unintentional installation/use.

#### Additional information
I'm looking into making pytest-fail-slow opt-in only (e.g. command line argument, environment variable, etc.).
*Update: jwodder/pytest-fail-slow#10*