### PR TITLE
TST: stats.nbinom: adjust cdf-ppf roundtrip test

### DIFF
--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -22,6 +22,8 @@ distdiscrete += [[stats.rv_discrete(values=vals), ()]]
 # For these distributions, test_discrete_basic only runs with test mode full
 distslow = {'zipfian', 'nhypergeom'}
 
+# Override number of ULPs adjustment for `check_cdf_ppf`
+roundtrip_cdf_ppf_exceptions = {'nbinom': 30}
 
 def cases_test_discrete_basic():
     seen = set()
@@ -193,8 +195,9 @@ def check_cdf_ppf(distfn, arg, supp, msg):
     cdf_supp = distfn.cdf(supp, *arg)
     # In very rare cases, the finite precision calculation of ppf(cdf(supp))
     # can produce an array in which an element is off by one.  We nudge the
-    # CDF values down by 15 ULPs help to avoid this.
-    cdf_supp0 = cdf_supp - 15*np.spacing(cdf_supp)
+    # CDF values down by a few ULPs help to avoid this.
+    n_ulps = roundtrip_cdf_ppf_exceptions.get(distfn.name, 15)
+    cdf_supp0 = cdf_supp - n_ulps*np.spacing(cdf_supp)
     npt.assert_array_equal(distfn.ppf(cdf_supp0, *arg),
                            supp, msg + '-roundtrip')
     # Repeat the same calculation, but with the CDF values decreased by 1e-8.


### PR DESCRIPTION
#### Reference issue
Closes gh-20801

#### What does this implement/fix?
Adjusts the cdf-ppf roundtrip test for `stats.nbinom` to fix a reported test failure.
