### PR TITLE
ENH: stats: add F-test of equality of variances

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -409,6 +409,7 @@ Others are generalized to multiple samples.
    fligner
    levene
    bartlett
+   f_equality_test
    median_test
    friedmanchisquare
    anderson_ksamp


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/19646

The F-test of equality of variances is a statistical test for the
null hypothesis that two normal samples have the same variance.
This function has three alternatives to calculate the p-value
corresponding to the lower ('less') or upper ('greater') one-tailed
and two-tailed ('two-sided').

Co-Authored-By: Tomás Silva <tomas.g.silva@tecnico.ulisboa.pt>
