### PR TITLE
TST: optimize.differential_evolution: add fail-slow exception

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1632,6 +1632,7 @@ class TestDifferentialEvolutionSolver:
         # "MAXCV = 0.".
         assert "MAXCV = 0.4" in result.message
 
+    @pytest.mark.fail_slow(10)  # fail-slow exception by request - see gh-20806
     def test_strategy_fn(self):
         # examines ability to customize strategy by mimicking one of the
         # in-built strategies


### PR DESCRIPTION
#### Reference issue
gh-20806

#### What does this implement/fix?
Two PRs crossed paths, resulting in a slow test failure that wasn't caught in the PR stage. This adds an exception per discussion in gh-20806.
