### PR TITLE
ENH: `special.rel_entr`: Avoid overflow before computing log

### DIFF
--- a/scipy/special/_convex_analysis.pxd
+++ b/scipy/special/_convex_analysis.pxd
@@ -27,23 +27,21 @@ cdef inline double rel_entr(double x, double y) noexcept nogil:
     cdef double ratio
     if isnan(x) or isnan(y):
         return NAN
-    elif x > 0 and y > 0:
-        ratio = x / y
-        if 0.5 < ratio < 2:
-            # When x and y are close, this is more accurate
-            return x * log1p((x - y) / y)
-        if DBL_MIN < ratio < INFINITY:
-            # There are no underflow/overflow issues
-            return x * log(ratio)
-        else:
-            # x and y are so far apart that taking x / y
-            # results in either an underflow, overflow,
-            # or subnormal number. Do the logarithm first
-            return x * (log(x) - log(y))
-    elif x == 0 and y >= 0:
-        return 0
-    else:
+    if x <= 0 or y <= 0:
+        if x == 0 and y >= 0:
+            return 0
         return INFINITY
+    ratio = x / y
+    if 0.5 < ratio < 2:
+        # When x and y are close, this is more accurate
+        return x * log1p((x - y) / y)
+    if DBL_MIN < ratio < INFINITY:
+        # There are no underflow/overflow issues
+        return x * log(ratio)
+    # x and y are so far apart that taking x / y
+    # results in either an underflow, overflow,
+    # or subnormal number. Do the logarithm first
+    return x * (log(x) - log(y))
 
 cdef inline double huber(double delta, double r) noexcept nogil:
     if delta < 0:

--- a/scipy/special/_convex_analysis.pxd
+++ b/scipy/special/_convex_analysis.pxd
@@ -1,4 +1,5 @@
 from libc.math cimport log, fabs, expm1, log1p, isnan, NAN, INFINITY
+import cython
 
 cdef inline double entr(double x) noexcept nogil:
     if isnan(x):
@@ -20,11 +21,26 @@ cdef inline double kl_div(double x, double y) noexcept nogil:
     else:
         return INFINITY
 
+@cython.cdivision(True)
 cdef inline double rel_entr(double x, double y) noexcept nogil:
+    cdef double ratio
+    # Smallest non-subnormal number, aka np.finfo(np.float64).tiny
+    cdef double tiny = 2.2250738585072014e-308
     if isnan(x) or isnan(y):
         return NAN
     elif x > 0 and y > 0:
-        return x * log(x / y)
+        ratio = x / y
+        if 0.5 < ratio < 2:
+            # When x and y are close, this is more accurate
+            return x * log1p((x - y) / y)
+        if tiny < ratio < INFINITY:
+            # There are no underflow/overflow issues
+            return x * log(ratio)
+        else:
+            # x and y are so far apart that taking x / y
+            # results in either an underflow, overflow,
+            # or subnormal number. Do the logarithm first
+            return x * (log(x) - log(y))
     elif x == 0 and y >= 0:
         return 0
     else:

--- a/scipy/special/_convex_analysis.pxd
+++ b/scipy/special/_convex_analysis.pxd
@@ -1,4 +1,5 @@
 from libc.math cimport log, fabs, expm1, log1p, isnan, NAN, INFINITY
+from libc.float cimport DBL_MIN
 import cython
 
 cdef inline double entr(double x) noexcept nogil:
@@ -24,8 +25,6 @@ cdef inline double kl_div(double x, double y) noexcept nogil:
 @cython.cdivision(True)
 cdef inline double rel_entr(double x, double y) noexcept nogil:
     cdef double ratio
-    # Smallest non-subnormal number, aka np.finfo(np.float64).tiny
-    cdef double tiny = 2.2250738585072014e-308
     if isnan(x) or isnan(y):
         return NAN
     elif x > 0 and y > 0:
@@ -33,7 +32,7 @@ cdef inline double rel_entr(double x, double y) noexcept nogil:
         if 0.5 < ratio < 2:
             # When x and y are close, this is more accurate
             return x * log1p((x - y) / y)
-        if tiny < ratio < INFINITY:
+        if DBL_MIN < ratio < INFINITY:
             # There are no underflow/overflow issues
             return x * log(ratio)
         else:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4152,6 +4152,46 @@ def test_rel_entr():
     assert_func_equal(special.rel_entr, w, z, rtol=1e-13, atol=1e-13)
 
 
+def test_rel_entr_gh_20710_near_zero():
+    # Check accuracy of inputs which are very close
+    inputs = np.array([
+        # x, y
+        (0.9456657713430001, 0.9456657713430094),
+        (0.48066098564791515, 0.48066098564794774),
+        (0.786048657854401, 0.7860486578542367),
+    ])
+    # Known values produced using `x * mpmath.log(x / y)` with dps=30
+    expected = [
+        -9.325873406851269e-15,
+        -3.258504577274724e-14,
+        1.6431300764454033e-13,
+    ]
+    x = inputs[:, 0]
+    y = inputs[:, 1]
+    assert_allclose(special.rel_entr(x, y), expected, rtol=1e-13, atol=0)
+
+
+def test_rel_entr_gh_20710_overflow():
+    inputs = np.array([
+        # x, y
+        # Overflow
+        (4, 2.22e-308),
+        # Underflow
+        (1e-200, 1e+200),
+        # Subnormal
+        (2.22e-308, 1e15),
+    ])
+    # Known values produced using `x * mpmath.log(x / y)` with dps=30
+    expected = [
+        2839.139983229607,
+        -9.210340371976183e-198,
+        -1.6493212008074475e-305,
+    ]
+    x = inputs[:, 0]
+    y = inputs[:, 1]
+    assert_allclose(special.rel_entr(x, y), expected, rtol=1e-13, atol=1e-13)
+
+
 def test_huber():
     assert_equal(special.huber(-1, 1.5), np.inf)
     assert_allclose(special.huber(2, 1.5), 0.5 * np.square(1.5))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4189,7 +4189,7 @@ def test_rel_entr_gh_20710_overflow():
     ]
     x = inputs[:, 0]
     y = inputs[:, 1]
-    assert_allclose(special.rel_entr(x, y), expected, rtol=1e-13, atol=1e-13)
+    assert_allclose(special.rel_entr(x, y), expected, rtol=1e-13, atol=0)
 
 
 def test_huber():

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -124,7 +124,7 @@ def entropy(pk: np.typing.ArrayLike,
     >>> D = entropy(pk, qk, base=base)
     >>> D
     0.7369655941662062
-    >>> D == np.sum(pk * np.log(pk/qk)) / np.log(base)
+    >>> np.isclose(D, np.sum(pk * np.log(pk/qk)) / np.log(base), rtol=1e-15, atol=0)
     True
 
     The cross entropy can be calculated as the sum of the entropy and

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -123,9 +123,9 @@ def entropy(pk: np.typing.ArrayLike,
 
     >>> D = entropy(pk, qk, base=base)
     >>> D
-    0.736965594166206
-    >>> np.sum(pk * np.log(pk/qk)) / np.log(base)
-    0.736965594166206
+    0.7369655941662062
+    >>> D == np.sum(pk * np.log(pk/qk)) / np.log(base)
+    True
 
     The cross entropy can be calculated as the sum of the entropy and
     relative entropy`:

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -124,7 +124,7 @@ def entropy(pk: np.typing.ArrayLike,
     >>> D = entropy(pk, qk, base=base)
     >>> D
     0.7369655941662062
-    >>> np.isclose(D, np.sum(pk * np.log(pk/qk)) / np.log(base), rtol=1e-15, atol=0)
+    >>> np.isclose(D, np.sum(pk * np.log(pk/qk)) / np.log(base), rtol=4e-16, atol=0)
     True
 
     The cross entropy can be calculated as the sum of the entropy and

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -123,9 +123,9 @@ def entropy(pk: np.typing.ArrayLike,
 
     >>> D = entropy(pk, qk, base=base)
     >>> D
-    0.7369655941662062
-    >>> D == np.sum(pk * np.log(pk/qk)) / np.log(base)
-    True
+    0.736965594166206
+    >>> np.sum(pk * np.log(pk/qk)) / np.log(base)
+    0.736965594166206
 
     The cross entropy can be calculated as the sum of the entropy and
     relative entropy`:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #20710

#### What does this implement/fix?
This PR improves the accuracy of `rel_entr()` in two ways:

1. If x / y overflows, underflows, or results in a subnormal number, the result is computed with the formula `x * (log(x) - log(y))`.
2. If x / y is close to 1, then a formula based on log1p is used instead. This improves accuracy for small rel_entr() values.

#### Performance regression

This is slower than the original `rel_entr()`.

Example benchmark script:

```
from scipy.special import rel_entr
import numpy as np
import timeit

x = np.random.rand(1_000_000)
y = np.random.rand(1_000_000)

def func():
    rel_entr(x, y)

print(timeit.timeit(func, number=100))
```

Prints 1.958 on main vs 3.587 on my branch.

#### Additional information

The log1p formula was contributed by @fancidev. 

I didn't understand why it worked, so here's a derivation of the formula:

```
rel_entry(x, y) = x * log(x / y)
rel_entry(x, y) = x * log((x - y + y) / y)
rel_entry(x, y) = x * log(1 + (x - y) / y)
rel_entry(x, y) = x * log1p((x - y) / y)
```

cc @mdhaber 