### PR TITLE
CI: Add Linux workflow to test on free-threaded Python builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -487,6 +487,12 @@ jobs:
     - name: Build and run tests
       env:
         PYTHON_GIL: 0
+      # TODO: For some reason the Meson installation path points to
+      # python3/site-packages as opposed to python3.13/site-packages,
+      # then the dev.py scripts do not work as expected.
       run: |
-        python dev.py build --with-scipy-openblas
-        python dev.py --no-build test -j2 --mode full
+        # python dev.py build --with-scipy-openblas
+        # python dev.py --no-build test -j2 --mode full
+        pip install . -vv --no-build-isolation
+        pushd $RUNNER_TEMP
+        python -m pytest --pyargs scipy -n2 --durations=10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -446,3 +446,43 @@ jobs:
           python3.11 -m pytest --pyargs scipy.cluster
           python3.11 -m pytest --pyargs scipy.linalg
           popd
+
+  free-threaded:
+    needs: get_commit_message
+    runs-on: ubuntu-latest
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+    # TODO: replace with setup-python when there is support
+    - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
+      with:
+          python-version: '3.13-dev'
+          nogil: true
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache gfortran
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      run: |
+        pip install git+https://github.com/cython/cython
+    - name: Install nightly NumPy
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    - name: Install Python dependencies
+      run: |
+        pip install git+https://github.com/serge-sans-paille/pythran
+        pip install ninja meson-python pybind11 click rich_click pydevtool
+        pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
+        pip install -r requirements/openblas.txt
+    - name: Build and run tests
+      env:
+        PYTHON_GIL: 0
+      run: |
+        python dev.py build --with-scipy-openblas
+        python dev.py --no-build test -j2 --mode full

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -482,7 +482,7 @@ jobs:
       run: |
         pip install git+https://github.com/serge-sans-paille/pythran
         pip install ninja meson-python pybind11 click rich_click pydevtool
-        pip install --pre --upgrade pytest pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
+        pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
     - name: Build and run tests
       env:
@@ -493,6 +493,7 @@ jobs:
       run: |
         # python dev.py build --with-scipy-openblas
         # python dev.py --no-build test -j2 --mode full
-        pip install . -vv --no-build-isolation
+        python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > scipy-openblas.pc
+        PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
         pushd $RUNNER_TEMP
-        python -m pytest --pyargs scipy -n2 --durations=10
+        PYTHON_GIL=0 python -m pytest --pyargs scipy -n2 --durations=10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -467,6 +467,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache gfortran
+    # TODO: remove pip pre-release install after Python 3.13 release
+    - name: Install pre-release pip
+      run: |
+        pip install -U --pre pip
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       run: |
@@ -478,10 +482,8 @@ jobs:
       run: |
         pip install git+https://github.com/serge-sans-paille/pythran
         pip install ninja meson-python pybind11 click rich_click pydevtool
-        pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
+        pip install --pre --upgrade pytest pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
     - name: Build and run tests
       env:
         PYTHON_GIL: 0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -480,6 +480,8 @@ jobs:
         pip install ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Build and run tests
       env:
         PYTHON_GIL: 0

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -72,6 +72,7 @@ def test_docformat():
 
 
 @pytest.mark.skipif(DOCSTRINGS_STRIPPED, reason="docstrings stripped")
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='it fails on Py3.13')
 def test_decorator():
     with suppress_warnings() as sup:
         sup.filter(category=DeprecationWarning)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See https://github.com/scipy/scipy/issues/20669

#### What does this implement/fix?
This PR enables testing SciPy against newer Python free-threaded builds

#### Additional information
Equivalent NumPy PRs: https://github.com/numpy/numpy/pull/26512, https://github.com/numpy/numpy/pull/26463
