### PR TITLE
DEP: deprecate trapz alias of `stats.trapezoid` distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -35,6 +35,19 @@ from scipy.optimize import root_scalar
 from scipy.stats._warnings_errors import FitError
 import scipy.stats as stats
 
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    # deprecated, but we want it because it can wrap entire functions
+    try:
+        from numpy.lib._utils_impl import deprecate
+    except ImportError:
+        # since we're ignoring numpy's DeprecationWarning below, we risk breaking
+        # before the usual 2.{N+3} that we have as an upper bound; fall back to
+        # empty decorator otherwise
+        def deprecate(*args, **kwargs):
+            return args[0]
+else:
+    from numpy import deprecate
+
 
 def _remove_optimizer_parameters(kwds):
     """
@@ -9713,10 +9726,14 @@ _method_names = [
     "std", "var"
 ]
 for m in _method_names:
-    wrapper = np.deprecate(getattr(trapz, m), f"trapz.{m}", f"trapz.{m}",
-                           "Please replace all uses of the distribution class "
-                           "`trapz` with `trapezoid`. "
-                           "`trapz` will be removed in SciPy 1.16.")
+    with warnings.catch_warnings():
+        # oh the irony...
+        warnings.filterwarnings("ignore", message="`deprecate` is deprecated",
+                                category=DeprecationWarning)
+        wrapper = deprecate(getattr(trapz, m), f"trapz.{m}", f"trapezoid.{m}",
+                            "Please replace all uses of the distribution class "
+                            "`trapz` with `trapezoid`. "
+                            "`trapz` will be removed in SciPy 1.16.")
     setattr(trapz, m, wrapper)
 
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9727,7 +9727,7 @@ class _DeprecationWrapper:
 
 
 for m in _method_names:
-    setattr(trapz, m, _deprecation_wrapper(m))
+    setattr(trapz, m, _DeprecationWrapper(m))
 
 
 class triang_gen(rv_continuous):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9683,12 +9683,41 @@ class trapezoid_gen(rv_continuous):
         return 0.5 * (1.0-d+c) / (1.0+d-c) + np.log(0.5 * (1.0+d-c))
 
 
+# deprecation of trapz, see #20486
+deprmsg = ("`trapz` is deprecated in favour of `trapezoid` "
+           "and will be removed in SciPy 1.16.0.")
+
+
+class trapz_gen(trapezoid_gen):
+    # override __call__ protocol from rv_generic to also
+    # deprecate instantiation of frozen distributions
+    """
+
+    .. deprecated:: 1.14.0
+        `trapz` is deprecated and will be removed in SciPy 1.16.
+        Plese use `trapezoid` instead!
+    """
+    def __call__(self, *args, **kwds):
+        warnings.warn(deprmsg, DeprecationWarning, stacklevel=2)
+        return self.freeze(*args, **kwds)
+
+
 trapezoid = trapezoid_gen(a=0.0, b=1.0, name="trapezoid")
-# Note: alias kept for backwards compatibility. Rename was done
-# because trapz is a slur in colloquial English (see gh-12924).
-trapz = trapezoid_gen(a=0.0, b=1.0, name="trapz")
-if trapz.__doc__:
-    trapz.__doc__ = "trapz is an alias for `trapezoid`"
+trapz = trapz_gen(a=0.0, b=1.0, name="trapz")
+
+# since the deprecated class gets intantiated upon import (and we only want to
+# warn upon use), add the deprecation to each class method
+_method_names = [
+    "cdf", "entropy", "expect", "fit", "interval", "isf", "logcdf", "logpdf",
+    "logsf", "mean", "median", "moment", "pdf", "ppf", "rvs", "sf", "stats",
+    "std", "var"
+]
+for m in _method_names:
+    wrapper = np.deprecate(getattr(trapz, m), f"trapz.{m}", f"trapz.{m}",
+                           "Please replace all uses of the distribution class "
+                           "`trapz` with `trapezoid`. "
+                           "`trapz` will be removed in SciPy 1.16.")
+    setattr(trapz, m, wrapper)
 
 
 class triang_gen(rv_continuous):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7347,9 +7347,8 @@ class TestTrapezoid:
     def test_trapz_deprecation(self, method):
         c, d = 0.2, 0.8
         expected = getattr(stats.trapezoid, method)(1, c, d)
-        with pytest.warns(
-            DeprecationWarning,
-            match=rf"\s*`trapz\.{method}` is deprecated,.*",
+        with pytest.deprecated_call(
+            match=f"`trapz.{method}` is deprecated",
         ):
             result = getattr(stats.trapz, method)(1, c, d)
         assert result == expected

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7338,7 +7338,21 @@ class TestTrapezoid:
     def test_trapz(self):
         # Basic test for alias
         x = np.linspace(0, 1, 10)
-        assert_almost_equal(stats.trapz.pdf(x, 0, 1), stats.uniform.pdf(x))
+        with pytest.deprecated_call(match="`trapz.pdf` is deprecated"):
+            result = stats.trapz.pdf(x, 0, 1)
+        assert_almost_equal(result, stats.uniform.pdf(x))
+
+    @pytest.mark.parametrize('method', ['pdf', 'logpdf', 'cdf', 'logcdf',
+                                        'sf', 'logsf', 'ppf', 'isf'])
+    def test_trapz_deprecation(self, method):
+        c, d = 0.2, 0.8
+        expected = getattr(stats.trapezoid, method)(1, c, d)
+        with pytest.warns(
+            DeprecationWarning,
+            match=rf"\s*`trapz\.{method}` is deprecated,.*",
+        ):
+            result = getattr(stats.trapz, method)(1, c, d)
+        assert result == expected
 
 
 class TestTriang:


### PR DESCRIPTION
Fixes #20486

Needs to go into 1.14, but can land after rc1