### PR TITLE
MAINT: special: fix typo in `four_gammas` used by `hyp2f1`

### DIFF
--- a/scipy/special/special/hyp2f1.h
+++ b/scipy/special/special/hyp2f1.h
@@ -196,8 +196,8 @@ namespace detail {
     SPECFUN_HOST_DEVICE inline double four_gammas(double u, double v, double w, double x) {
         double result;
 
-        // Without loss of generality, assume |u| >= |v| and |w| >= |x|.
-        if (std::abs(u) > std::abs(v)) {
+        // Without loss of generality, ensure |u| >= |v| and |w| >= |x|.
+        if (std::abs(v) > std::abs(u)) {
             std::swap(u, v);
         }
         if (std::abs(x) > std::abs(w)) {


### PR DESCRIPTION
#### Reference issue
Addresses [this comment](https://github.com/scipy/scipy/pull/20089#issuecomment-2135314692)

#### What does this implement/fix?
There is a typo in the `four_gammas` function used by `hyp2f1`, which flipped the order of two variables in a commutative expression. 

#### Additional information
The typo has no effect on the mathematical value of the expression, but could affect the numerical accuracy for certain arguments.
