### PR TITLE
BUG: interpolate: make BSpline.integrate always return an array

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -662,7 +662,7 @@ class BSpline:
                 # Fast path: use FITPACK's routine
                 # (cf _fitpack_impl.splint).
                 integral = _fitpack_impl.splint(a, b, self.tck)
-                return integral * sign
+                return np.asarray(integral * sign)
 
         out = np.empty((2, prod(self.c.shape[1:])), dtype=self.c.dtype)
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -390,6 +390,14 @@ class TestBSpline:
             assert_allclose(b.integrate(x0, x1),
                             p.integrate(x0, x1))
 
+    def test_integrate_0D_always(self):
+        # make sure the result is always a 0D array (not a python scalar)
+        b = BSpline.basis_element([0, 1, 2])
+        for extrapolate in (True, False):
+            res = b.integrate(0, 1, extrapolate=extrapolate)
+            assert type(res) == np.ndarray
+            assert res.ndim == 0
+
     def test_subclassing(self):
         # classmethods should not decay to the base class
         class B(BSpline):


### PR DESCRIPTION
Previously, the return value was either an array (possibly 0D) or a python float. Given that `BSpline.__call__` always returns 0D arrays not python scalars, and so do `PPoly.__call__` and `PPoly.integrate`, there is really no fundamental reason for the dtype variation. (The actual reason is an oversight when adding a fast path).

Strictly speaking, this is a backwards compat break. Still I'd say it's a bug, and the break should not be too bad for users. 
