### PR TITLE
DOC: sparse: 1.14.0 release notes additions

### DIFF
--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -84,6 +84,13 @@ New features
 
 `scipy.sparse` improvements
 ===========================
+- Sparse arrays now support 1D shapes in COO, DOK and CSR formats.
+  These are all the formats we currently intend to support 1D shapes.
+  Other sparse array formats raise an exception for 1D input.
+- Sparse array methods min/nanmin/argmin and max analogs now return 1D arrays.
+  Results are still COO format sparse arrays for min/nanmin and
+  dense ``np.ndarray`` for argmin.
+- Sparse matrix and array objects improve their ``repr`` and ``str`` output.
 - A special case has been added to handle multiplying a ``dia_array`` by a
   scalar, which avoids a potentially costly conversion to CSR format.
 - `scipy.sparse.csgraph.yen` has been added, allowing usage of Yen's K-Shortest


### PR DESCRIPTION
I didn't get release notes into the wiki, so I'm suggesting we add some via a PR to the maintenance 1.14.x branch.

These three bullets will help explain the status of the work toward sparse arrays.