### PR TITLE
DOC/DEV: add docs for enabling interactive examples

### DIFF
--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -69,6 +69,26 @@ To render the documentation on your own machine:
    with ``index.html`` and browse, or you can jump straight to the file you’re
    interested in.
 
+Examples within docstrings can be made interactive using
+`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
+but the buttons for converting examples sections into embedded interactive
+notebooks are hidden by default on clean docs builds. To enable interactive
+examples locally, you can edit the ``ignore_patterns` list in the runtime
+configuration file ``scipy/doc/build/html/try_examples.json``. The initial
+version of this file on a clean documentation build is
+
+```
+{
+    "min_height": "400px",
+    "ignore_patterns": [".*"]
+}
+```
+
+The buttons that turn docstring examples into embedded notebooks are hidden
+for all url paths matching the JavaScript Regex patterns in the
+``ignore_patterns` list. Replacing ``[".*"]`` with the empty list ``[]``
+will enable interactive examples by unhiding all buttons.
+
 .. note::
 
    - Changes to certain documents do not take effect when Sphinx documentation

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -82,7 +82,7 @@ documentation build is
 .. code-block:: json
 
    {
-       "min_height": "400px",
+       "global_min_height": "400px",
        "ignore_patterns": [".*"]
    }
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -69,25 +69,29 @@ To render the documentation on your own machine:
    with ``index.html`` and browse, or you can jump straight to the file you’re
    interested in.
 
+**Interactive Examples**
+
 Examples within docstrings can be made interactive using
-`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
-but the buttons for converting examples sections into embedded interactive
+`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_.
+The buttons for converting examples sections into embedded interactive
 notebooks are hidden by default on clean docs builds. To enable interactive
-examples locally, you can edit the ``ignore_patterns` list in the runtime
-configuration file ``scipy/doc/build/html/try_examples.json``. The initial
-version of this file on a clean documentation build is
+examples after building the documentation locally, edit the
+``ignore_patterns`` list in the runtime configuration file ``try_examples.json``
+within ``scipy/doc/build/html/``. The initial version of this file in a clean
+documentation build is
 
-```
-{
-    "min_height": "400px",
-    "ignore_patterns": [".*"]
-}
-```
+.. code-block:: json
 
-The buttons that turn docstring examples into embedded notebooks are hidden
+   {
+       "min_height": "400px",
+       "ignore_patterns": [".*"]
+   }
+
+The buttons that turn docstring examples into embedded notebooks will be hidden
 for all url paths matching the JavaScript Regex patterns in the
-``ignore_patterns` list. Replacing ``[".*"]`` with the empty list ``[]``
-will enable interactive examples by unhiding all buttons.
+``ignore_patterns`` list. ``[".*"]`` includes a pattern which matches all url
+paths. Removing this pattern from the list will enable interactivity for all
+examples.
 
 .. note::
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -71,8 +71,7 @@ To render the documentation on your own machine:
 
 **Interactive Examples**
 
-Examples within docstrings can be made interactive using
-`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_.
+Examples within docstrings can be made interactive using ``jupyterlite-sphinx``.
 The buttons for converting examples sections into embedded interactive
 notebooks are hidden by default on clean docs builds. To enable interactive
 examples after building the documentation locally, edit the
@@ -91,7 +90,9 @@ The buttons that turn docstring examples into embedded notebooks will be hidden
 for all url paths matching the JavaScript Regex patterns in the
 ``ignore_patterns`` list. ``[".*"]`` includes a pattern which matches all url
 paths. Removing this pattern from the list will enable interactivity for all
-examples.
+examples. See the documentation for the ``jupyterlite-sphinx``
+`TryExamples directive <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
+for more information.
 
 .. note::
 

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -243,3 +243,9 @@ Enable interactive examples by editing the runtime configuration file,
 ``try_examples.json``, in the root folder of the uploaded documentation on the
 release server. One must remove the regular expression pattern ``".*"`` from
 the ``ignore_patterns`` list.
+
+.. code-block:: console
+
+  $ ssh your-username@docs.scipy.org
+  $ cd /srv/docs_scipy_org/doc/scipy-1.13.1
+  $ vim try_examples.json  # edit the ignore list to remove: ".*"

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -241,5 +241,5 @@ were only made on the maintenance branch to main.
 
 Enable interactive examples by editing the runtime configuration file,
 ``try_examples.json``, in the root folder of the uploaded documentation on the
-on the release server. One must remove the regular expression pattern ``".*"``
-from the ``ignore_patterns`` list.
+release server. One must remove the regular expression pattern ``".*"`` from
+the ``ignore_patterns`` list.

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -243,7 +243,7 @@ Enable interactive examples with
 `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
 by editing the runtime configuration file ``try_examples.json`` in the root
 folder of the uploaded documentation on the release server. The initial version
-of this file on a fresh documentation build is:
+of this file on a clean documentation build is
 
 ```
 {
@@ -252,7 +252,5 @@ of this file on a fresh documentation build is:
 }
 ```
 
-The buttons that turn docstring examples into embedded notebooks are hidden
-for all url paths matching the JavaScript Regex patterns in the list of
-``ignore_patterns``. Replace ``[".*"]`` with the empty list ``[]`` to unhide
+Replace ``[".*"]`` with the empty list ``[]`` to unhide
 these buttons and enable interactive examples.

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -239,18 +239,7 @@ After the final release is done, port relevant changes to release notes, build
 scripts, author name mapping in ``tools/authors.py`` and any other changes that
 were only made on the maintenance branch to main.
 
-Enable interactive examples with
-`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
-by editing the runtime configuration file ``try_examples.json`` in the root
-folder of the uploaded documentation on the release server. The initial version
-of this file on a clean documentation build is
-
-```
-{
-    "min_height": "400px",
-    "ignore_patterns": [".*"]
-}
-```
-
-Replace ``[".*"]`` with the empty list ``[]`` to unhide
-these buttons and enable interactive examples.
+Enable interactive examples by editing the runtime configuration file,
+``try_examples.json``, in the root folder of the uploaded documentation on the
+on the release server. One must remove the regular expression pattern ``".*"``
+from the ``ignore_patterns`` list.

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -238,3 +238,21 @@ and test against their own code) and report issues on Github or Discourse.
 After the final release is done, port relevant changes to release notes, build
 scripts, author name mapping in ``tools/authors.py`` and any other changes that
 were only made on the maintenance branch to main.
+
+Enable interactive examples with
+`jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html#>`_
+by editing the runtime configuration file ``try_examples.json`` in the root
+folder of the uploaded documentation on the release server. The initial version
+of this file on a fresh documentation build is:
+
+```
+{
+    "min_height": "400px",
+    "ignore_patterns": [".*"]
+}
+```
+
+The buttons that turn docstring examples into embedded notebooks are hidden
+for all url paths matching the JavaScript Regex patterns in the list of
+``ignore_patterns``. Replace ``[".*"]`` with the empty list ``[]`` to unhide
+these buttons and enable interactive examples.

--- a/doc/source/try_examples.json
+++ b/doc/source/try_examples.json
@@ -1,4 +1,4 @@
 {
-    "min_height": "400px",
+    "global_min_height": "400px",
     "ignore_patterns": [".*"]
 }


### PR DESCRIPTION
This PR adds information to the releasing section of the core developer guide and the "Rendering documentation locally with Sphinx" section of the contributor guide describing how to enable interactive documentation with [jupyterlite-sphinx](https://jupyterlite-sphinx.readthedocs.io/en/latest/).

The information I've added to the releasing section is terse, giving only a mechanical description of what steps to take. This seems in line to me with how `releasing.rst.inc` is structured. I've added these steps to the "Wrapping Up" subsection.

The information I've given in the contributor guide has more detail, giving some explanation of what is going on, and showing what `try_examples.json` looks like in a clean doc build. I think that some contributors may be curious about these things.

#### Additional information

[Pyodide 0.26](https://pyodide.org/en/stable/) was released recently, which updated the SciPy version to 1.12. My understanding is that the jump from 1.11 to 1.12 was rather large, and examples running with 1.12 should work well enough for the latest version of SciPy (now 1.13, soon to be 1.14). I think now is a good time for us to turn on the interactive examples. I suppose this should go through discourse.

cc @rgommers, @melissawm 


