### PR TITLE
DOC: Wrap long titles in docs pages

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -78,3 +78,8 @@ div.admonition>.admonition-title {
     gap: 10px;
     margin-bottom: 20px;
 }
+
+/* Wrap long titles in pages */
+h1 {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
#### Reference issue
Closes #20635

#### What does this implement/fix?
After discussion with accessibility folks, changing the width proportion on the 3-column layout is not the best option for readability purposes. This PR just allows titles to wrap so they are at least legible if they overflow.

