### PR TITLE
DOC/DEV: mention `-b` option in contributor guide on testing

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -1,3 +1,5 @@
+.. _dev-arrayapi:
+
 Support for the array API standard
 ==================================
 

--- a/doc/source/dev/contributor/devpy_test.rst
+++ b/doc/source/dev/contributor/devpy_test.rst
@@ -87,6 +87,9 @@ Other useful options include:
 
 -  ``-v`` or ``--verbose``, which activates the verbose option for more
    detailed output. 
+-  ``-b`` or ``--array-api-backend`` *backend* to include alternative
+   array backends in array-api-compatible tests. See :ref:`dev-arrayapi`
+   for details.
 -  ``--coverage`` to generate a test coverage report in
    ``scipy/build/coverage/index.html``. *Note:* |pytest-cov|_ *must be
    installed.*


### PR DESCRIPTION
#### Reference issue
Toward gh-20844.

#### What does this implement/fix?
In the [contributor guide on testing](https://docs.scipy.org/doc/scipy/dev/contributor/devpy_test.html), advertise the `-b backend` option.