### PR TITLE
ENH: special: add backward and two-way series evaluator

### DIFF
--- a/scipy/special/special/hyp2f1.h
+++ b/scipy/special/special/hyp2f1.h
@@ -630,8 +630,8 @@ SPECFUN_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, doubl
             return std::pow(1.0 - z, c - a - b) * result;
         }
         auto series_generator = detail::HypergeometricSeriesGenerator(a, b, c, z);
-        return detail::series_eval(series_generator, std::complex<double>{0.0, 0.0}, detail::hyp2f1_EPS,
-                                   detail::hyp2f1_MAXITER, "hyp2f1");
+        return detail::series_eval_two_way(series_generator, std::complex<double>{0.0, 0.0},
+                                           detail::hyp2f1_EPS, detail::hyp2f1_MAXITER, "hyp2f1");
     }
     /* Points near exp(iπ/3), exp(-iπ/3) not handled by any of the standard
      * transformations. Use series of López and Temme [5]. These regions


### PR DESCRIPTION
#### Reference issue
Toward gh-20223.

#### What does this implement/fix?
This PR adds the following C++ helper functions for series evaluation:

- `series_eval_backward_fixed_length` sums a finite series backward
- `series_eval_two_way` first sums the series forward to determine the number of terms required, and then sums the series backward to hopefully reduce round-off error.

#### Additional information
I modified two places in `hyp2f1.h` to illustrate what it looks like to use the new helper functions. One place is more explicit but lengthier; the other place is more concise. These changes are intended for illustration only.

One test case fails after the PR, where the error becomes `8e-16` versus test tolerance `5e-16`.