### PR TITLE
TST: add additional margin to `fail_slow`s

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -395,7 +395,7 @@ class TestLazywhere:
     p = strategies.floats(min_value=0, max_value=1)
     data = strategies.data()
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')  # overflows, etc.
     @skip_xp_backends('jax.numpy',
                       reasons=["JAX arrays do not support item assignment"])

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -8,7 +8,7 @@ from .test_public_api import PUBLIC_MODULES
 # Check that all modules are importable in a new Python process.
 # This is not necessarily true if there are import cycles present.
 
-@pytest.mark.fail_slow(20)
+@pytest.mark.fail_slow(40)
 @pytest.mark.slow
 def test_public_modules_importable():
     pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -95,7 +95,7 @@ def warning_calls():
     return bad_filters, bad_stacklevels
 
 
-@pytest.mark.fail_slow(20)
+@pytest.mark.fail_slow(40)
 @pytest.mark.slow
 def test_warning_calls_filters(warning_calls):
     bad_filters, bad_stacklevels = warning_calls

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -35,7 +35,7 @@ class TestDatasets:
 
         yield
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_existence_all(self):
         assert len(os.listdir(data_dir)) >= len(registry)
 

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -260,7 +260,7 @@ def test_integration_complex():
         assert np.all(e < 5)
 
 
-@pytest.mark.fail_slow(2)
+@pytest.mark.fail_slow(5)
 def test_integration_sparse_difference():
     n = 200
     t_span = [0, 20]

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -107,7 +107,7 @@ def _lorenzian(x):
     return 1 / (1 + x**2)
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_quad_vec_pool():
     f = _lorenzian
     res, err = quad_vec(f, -np.inf, np.inf, norm='max', epsabs=1e-4, workers=4)
@@ -124,7 +124,7 @@ def _func_with_args(x, a):
     return x * (x + a) * np.arange(3)
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 @pytest.mark.parametrize('extra_args', [2, (2,)])
 @pytest.mark.parametrize('workers', [1, 10])
 def test_quad_vec_pool_args(extra_args, workers):

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -541,7 +541,7 @@ class TestQuad:
 
 
 class TestNQuad:
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +
@@ -556,7 +556,7 @@ class TestNQuad:
         assert_quad(res[:-1], 1.5267454070738635)
         assert_(res[-1]['neval'] > 0 and res[-1]['neval'] < 4e5)
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_variable_limits(self):
         scale = .1
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1795,6 +1795,7 @@ class TestSmoothingSpline:
                         spline_interp(grid),
                         atol=1e-15)
 
+    @pytest.mark.fail_slow(2)
     def test_weighted_smoothing_spline(self):
         # create data sample
         np.random.seed(1234)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -359,7 +359,7 @@ class TestCloughTocher2DInterpolator:
         yi_rescale = interpnd.CloughTocher2DInterpolator(tri.points, y, rescale=True)(x)
         assert_almost_equal(yi, yi_rescale)
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_dense(self):
         # Should be more accurate for dense meshes
         funcs = [

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -467,7 +467,7 @@ class TestRegularGridInterpolator:
         assert_equal(res[i], np.nan)
         assert_equal(res[~i], interp(z[~i]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     @parametrize_rgi_interp_methods
     @pytest.mark.parametrize(("ndims", "func"), [
         (2, lambda x, y: 2 * x ** 3 + 3 * y ** 2),
@@ -527,7 +527,7 @@ class TestRegularGridInterpolator:
                                          method=method, bounds_error=False)
         assert np.isnan(interp([10]))
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     @parametrize_rgi_interp_methods
     def test_nonscalar_values(self, method):
 
@@ -851,7 +851,7 @@ class TestInterpN:
                      method=method, bounds_error=False)
         assert_allclose(v1, v2.reshape(v1.shape))
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     @parametrize_rgi_interp_methods
     def test_nonscalar_values(self, method):
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -127,7 +127,7 @@ class TestMMIOArray:
         a = np.random.random(sz)
         self.check(a, (20, 15, 300, 'array', 'real', 'general'))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_bad_number_of_array_header_fields(self):
         s = """\
             %%MatrixMarket matrix array real general

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1178,7 +1178,7 @@ class TestSVD_GESVD(TestSVD_GESDD):
     lapack_driver = 'gesvd'
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_svd_gesdd_nofegfault():
     # svd(a) with {U,VT}.size > INT_MAX does not segfault
     # cf https://github.com/scipy/scipy/issues/14001
@@ -2601,7 +2601,7 @@ class TestOrdQZ:
 
 
 class TestOrdQZWorkspaceSize:
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_decompose(self):
         rng = np.random.RandomState(12345)
         N = 202

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -9,7 +9,7 @@ from scipy.linalg.blas import cdotu  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
 
 
-@pytest.mark.fail_slow(60)
+@pytest.mark.fail_slow(120)
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -752,7 +752,7 @@ class TestExpM:
         a.flags.writeable = False
         expm(a)
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_gh18086(self):
         A = np.zeros((400, 400), dtype=float)
         rng = np.random.default_rng(100)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -199,7 +199,7 @@ class TestBasinHopping:
                            niter=self.niter, disp=self.disp)
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_all_minimizers(self):
         # Test 2-D minimizations with gradient. Nelder-Mead, Powell, COBYLA, and
         # COBYQA don't accept jac=True, so aren't included here.
@@ -213,7 +213,7 @@ class TestBasinHopping:
                                niter=self.niter, disp=self.disp)
             assert_almost_equal(res.x, self.sol[i], self.tol)
 
-    @pytest.mark.fail_slow(10)
+    @pytest.mark.fail_slow(20)
     def test_all_nograd_minimizers(self):
         # Test 2-D minimizations without gradient. Newton-CG requires jac=True,
         # so not included here.

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -722,7 +722,7 @@ class TestDifferentialEvolutionSolver:
                     pass
             assert s._updating == 'deferred'
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_parallel(self):
         # smoke test for parallelization with deferred updating
         bounds = [(0., 2.), (0., 2.)]
@@ -864,7 +864,7 @@ class TestDifferentialEvolutionSolver:
         assert constr_f(res.x) <= 1.9
         assert res.success
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_impossible_constraint(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -1021,7 +1021,7 @@ class TestDifferentialEvolutionSolver:
         xtrial = np.arange(4 * 5).reshape(4, 5)
         assert cw.violation(xtrial).shape == (2, 5)
 
-    @pytest.mark.fail_slow(10)
+    @pytest.mark.fail_slow(20)
     def test_L1(self):
         # Lampinen ([5]) test problem 1
 
@@ -1116,7 +1116,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_L2(self):
         # Lampinen ([5]) test problem 2
 
@@ -1156,7 +1156,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_L3(self):
         # Lampinen ([5]) test problem 3
 
@@ -1207,7 +1207,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_L4(self):
         # Lampinen ([5]) test problem 4
         def f(x):
@@ -1260,7 +1260,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_L5(self):
         # Lampinen ([5]) test problem 5
 
@@ -1291,7 +1291,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_L6(self):
         # Lampinen ([5]) test problem 6
         def f(x):
@@ -1450,7 +1450,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_integrality(self):
         # test fitting discrete distribution to data
         rng = np.random.default_rng(6519843218105)
@@ -1540,7 +1540,7 @@ class TestDifferentialEvolutionSolver:
             DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
                                         integrality=integrality)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_vectorized(self):
         def quadratic(x):
             return np.sum(x**2)
@@ -1632,7 +1632,7 @@ class TestDifferentialEvolutionSolver:
         # "MAXCV = 0.".
         assert "MAXCV = 0.4" in result.message
 
-    @pytest.mark.fail_slow(10)  # fail-slow exception by request - see gh-20806
+    @pytest.mark.fail_slow(20)  # fail-slow exception by request - see gh-20806
     def test_strategy_fn(self):
         # examines ability to customize strategy by mimicking one of the
         # in-built strategies

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -110,7 +110,7 @@ class TestDualAnnealing:
         assert_allclose(ret.fun, 0., atol=1e-12)
         assert ret.success
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_high_dim(self):
         ret = dual_annealing(self.func, self.hd_bounds, seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-12)
@@ -121,7 +121,7 @@ class TestDualAnnealing:
                              no_local_search=True, seed=self.seed)
         assert_allclose(ret.fun, 0., atol=1e-4)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_high_dim_no_ls(self):
         ret = dual_annealing(self.func, self.hd_bounds,
                              no_local_search=True, seed=self.seed)
@@ -140,7 +140,7 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.weirdfunc,
                       self.ld_bounds)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_reproduce(self):
         res1 = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
         res2 = dual_annealing(self.func, self.ld_bounds, seed=self.seed)
@@ -282,7 +282,7 @@ class TestDualAnnealing:
                              seed=self.seed)
         assert ret.njev == self.ngev
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_from_docstring(self):
         def func(x):
             return np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
@@ -338,7 +338,7 @@ class TestDualAnnealing:
 
         assert_allclose(rate, accept_rate)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_bounds_class(self):
         # test that result does not depend on the bounds type
         def func(x):
@@ -367,7 +367,7 @@ class TestDualAnnealing:
         assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
         assert ret_bounds_list.nfev == ret_bounds_class.nfev
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_callable_jac_hess_with_args_gh11052(self):
         # dual_annealing used to fail when `jac` was callable and `args` were
         # used; check that this is resolved. Example is from gh-11052.

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -470,7 +470,7 @@ class TestShgoSimplicialTestFunctions:
                  options=options, iters=1,
                  sampling_method='simplicial')
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_f5_3_cons_symmetry(self):
         """Assymmetrically constrained test function"""
         options = {'symmetry': [0, 0, 0, 3],
@@ -778,7 +778,7 @@ class TestShgoArguments:
         np.testing.assert_allclose(res_new_bounds.x, x_opt)
         np.testing.assert_allclose(res_new_bounds.x, res_old_bounds.x)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_19_parallelization(self):
         """Test the functionality to add custom sampling methods to shgo"""
 

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -61,7 +61,7 @@ class TestOldToNew:
 
 
 class TestNewToOld:
-
+    @pytest.mark.fail_slow(2)
     def test_multiple_constraint_objects(self):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2
@@ -90,7 +90,7 @@ class TestNewToOld:
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-4)
             assert_allclose(funs['cobyqa'], funs['trust-constr'], rtol=1e-4)
 
-    @pytest.mark.fail_slow(10)
+    @pytest.mark.fail_slow(20)
     def test_individual_constraint_objects(self):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2

--- a/scipy/optimize/tests/test_extending.py
+++ b/scipy/optimize/tests/test_extending.py
@@ -6,7 +6,7 @@ import pytest
 from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
 
 
-@pytest.mark.fail_slow(20)
+@pytest.mark.fail_slow(40)
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -468,7 +468,7 @@ class BoundsMixin:
                             bounds=Bounds(lb=[0.1, 0.1]))
         assert_allclose(res.x, [0.1, 0.1], atol=1e-5)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_rosenbrock_bounds(self):
         x0_1 = np.array([-2.0, 1.0])
         x0_2 = np.array([2.0, 2.0])
@@ -554,7 +554,7 @@ class SparseMixin:
             assert_allclose(res_dense.cost, 0, atol=1e-20)
             assert_allclose(res_sparse.cost, 0, atol=1e-20)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_with_bounds(self):
         p = BroydenTridiagonal()
         for jac, jac_sparsity in product(

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1802,7 +1802,7 @@ class LinprogHiGHSTests(LinprogCommonTests):
         # there should be nonzero crossover iterations for IPM (only)
         assert_equal(res.crossover_nit == 0, self.method != "highs-ipm")
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_marginals(self):
         # Ensure lagrange multipliers are correct by comparing the derivative
         # w.r.t. b_ub/b_eq/ub/lb to the reported duals.
@@ -2249,7 +2249,7 @@ class TestLinprogHiGHSMIP:
     method = "highs"
     options = {}
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     @pytest.mark.xfail(condition=(sys.maxsize < 2 ** 32 and
                        platform.system() == "Linux"),
                        run=False,

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -207,7 +207,7 @@ class SparseMixin:
         res = lsq_linear(A, b)
         assert_allclose(res.optimality, 0, atol=1e-6)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_sparse_bounds(self):
         m = 5000
         n = 1000

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1261,7 +1261,7 @@ class TestOptimizeSimple(CheckOptimize):
             assert func(sol1.x) < func(sol2.x), \
                    f"{method}: {func(sol1.x)} vs. {func(sol2.x)}"
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     @pytest.mark.filterwarnings('ignore::UserWarning')
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')  # See gh-18547
     @pytest.mark.parametrize('method',
@@ -2495,6 +2495,7 @@ class TestOptimizeResultAttributes:
         self.hessp = optimize.rosen_hess_prod
         self.bounds = [(0., 10.), (0., 10.)]
 
+    @pytest.mark.fail_slow(2)
     def test_attributes_present(self):
         attributes = ['nit', 'nfev', 'x', 'success', 'status', 'fun',
                       'message']
@@ -2584,7 +2585,7 @@ class TestBrute:
 
         optimize.brute(f, [(-1, 1)], Ns=3, finish=None)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_workers(self):
         # check that parallel evaluation works
         resbrute = optimize.brute(brute_func, self.rranges, args=self.params,
@@ -2615,7 +2616,7 @@ class TestBrute:
         assert_allclose(resbrute, 0)
 
 
-@pytest.mark.fail_slow(10)
+@pytest.mark.fail_slow(20)
 def test_cobyla_threadsafe():
 
     # Verify that cobyla is threadsafe. Will segfault if it is not.
@@ -2663,7 +2664,7 @@ class TestIterationLimits:
         r, t = np.sqrt(v[0]**2+v[1]**2), np.arctan2(v[0], v[1])
         return np.sin(r*20 + t)+r*0.5
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_neldermead_limit(self):
         self.check_limits("Nelder-Mead", 200)
 

--- a/scipy/optimize/tests/test_trustregion_exact.py
+++ b/scipy/optimize/tests/test_trustregion_exact.py
@@ -275,7 +275,7 @@ class TestIterativeSubproblem:
                                       -0.84954934])
         assert_array_almost_equal(hits_boundary, True)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_for_random_entries(self):
         # Seed
         np.random.seed(1)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2493,7 +2493,7 @@ class TestBessel:
         assert_raises(ValueError, _bessel_poly, -3)
         assert_raises(ValueError, _bessel_poly, 3.3)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_fs_param(self):
         for norm in ('phase', 'mag', 'delay'):
             for fs in (900, 900.1, 1234.567):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2441,7 +2441,7 @@ def check_filtfilt_gust(b, a, shape, axis, irlen=None):
     assert_allclose(zg2, zo2, rtol=1e-8, atol=1e-9)
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_choose_conv_method():
     for mode in ['valid', 'same', 'full']:
         for ndim in [1, 2]:
@@ -2473,7 +2473,7 @@ def test_choose_conv_method():
         assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_filtfilt_gust():
     # Design a filter.
     z, p, k = signal.ellip(3, 0.01, 120, 0.0875, output='zpk')

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -308,7 +308,7 @@ def test_precond_dummy(case):
 
 
 # Specific test for poisson1d and poisson2d cases
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 @pytest.mark.parametrize('case', [x for x in IterativeParams().cases
                                   if x.name in ('poisson1d', 'poisson2d')],
                          ids=['poisson1d', 'poisson2d'])
@@ -685,7 +685,7 @@ class TestGMRES:
         assert_allclose(r_x, x)
         assert r_info == info
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_atol_legacy(self):
 
         A = eye(2)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -179,7 +179,7 @@ class TestExpmActionSimple:
 
 class TestExpmActionInterval:
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(20)
     def test_sparse_expm_multiply_interval(self):
         np.random.seed(1234)
         start = 0.1
@@ -205,7 +205,7 @@ class TestExpmActionInterval:
                     for solution, t in zip(X, samples):
                         assert_allclose(solution, sp_expm(t*A).dot(target))
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(20)
     def test_expm_multiply_interval_vector(self):
         np.random.seed(1234)
         interval = {'start': 0.1, 'stop': 3.2, 'endpoint': True}
@@ -232,7 +232,7 @@ class TestExpmActionInterval:
                 assert_allclose(sol_given, correct)
                 assert_allclose(sol_wrong, correct)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(20)
     def test_expm_multiply_interval_matrix(self):
         np.random.seed(1234)
         interval = {'start': 0.1, 'stop': 3.2, 'endpoint': True}

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2580,6 +2580,7 @@ class _TestSlicing:
         assert_equal(A[s, :].toarray(), B[2:4, :])
         assert_equal(A[:, s].toarray(), B[:, 2:4])
 
+    @pytest.mark.fail_slow(2)
     def test_slicing_3(self):
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spcreator(B)
@@ -3383,7 +3384,7 @@ class _TestArithmetic:
         self.__Asp = self.spcreator(self.__A)
         self.__Bsp = self.spcreator(self.__B)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(20)
     def test_add_sub(self):
         self.__arith_init()
 
@@ -5153,6 +5154,7 @@ class Test64Bit:
     def test_resiliency_limit_10(self, cls, method_name):
         self._check_resiliency(cls, method_name, maxval_limit=10)
 
+    @pytest.mark.fail_slow(2)
     @pytest.mark.parametrize('cls,method_name', cases_64bit())
     def test_resiliency_random(self, cls, method_name):
         # bsr_matrix.eliminate_zeros relies on csr_matrix constructor
@@ -5168,6 +5170,7 @@ class Test64Bit:
     def test_resiliency_all_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int64)
 
+    @pytest.mark.fail_slow(5)
     @pytest.mark.parametrize('cls,method_name', cases_64bit())
     def test_no_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, assert_32bit=True)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -971,7 +971,7 @@ def test_kdtree_list_k(kdtree_type):
     assert_equal(dd, np.ravel(dd1))
     assert_equal(ii, np.ravel(ii1))
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_kdtree_box(kdtree_type):
     # check ckdtree periodic boundary
     n = 2000
@@ -1146,7 +1146,7 @@ def test_kdtree_weights(kdtree_type):
         assert_raises(ValueError, tree1.count_neighbors,
             tree2, np.linspace(0, 10, 100), weights=w1)
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(10)
 def test_kdtree_count_neighbous_multiple_r(kdtree_type):
     n = 2000
     m = 2

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -327,7 +327,7 @@ class TestUtilities:
             ok = (j != -1) | at_boundary
             assert_(ok.all(), f"{err_msg} {np.nonzero(~ok)}")
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     def test_degenerate_barycentric_transforms(self):
         # The triangulation should not produce invalid barycentric
         # transforms that stump the simplex finding
@@ -346,7 +346,7 @@ class TestUtilities:
         self._check_barycentric_transforms(tri)
 
     @pytest.mark.slow
-    @pytest.mark.fail_slow(10)
+    @pytest.mark.fail_slow(20)
     # OK per https://github.com/scipy/scipy/pull/20487#discussion_r1572684869
     def test_more_barycentric_transforms(self):
         # Triangulate some "nasty" grids
@@ -962,7 +962,7 @@ class TestVoronoi:
         vor = Voronoi(points,furthest_site=True)
         assert_equal(vor.furthest_site,True)
 
-    @pytest.mark.fail_slow(5)
+    @pytest.mark.fail_slow(10)
     @pytest.mark.parametrize("name", sorted(INCREMENTAL_DATASETS))
     def test_incremental(self, name):
         # Test incremental construction of the triangulation

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1063,7 +1063,7 @@ class TestAiry:
                                      array([0.5357]),
                                      array([0.7012])),4)
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_ai_zeros_big(self):
         z, zp, ai_zpx, aip_zx = special.ai_zeros(50000)
         ai_z, aip_z, _, _ = special.airy(z)
@@ -1088,7 +1088,7 @@ class TestAiry:
             [-1.0187929716, -3.2481975822, -4.8200992112,
              -6.1633073556, -7.3721772550, -8.4884867340], rtol=1e-10)
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     def test_bi_zeros_big(self):
         z, zp, bi_zpx, bip_zx = special.bi_zeros(50000)
         _, _, bi_z, bip_z = special.airy(z)

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -320,7 +320,7 @@ def test_cython_api_completeness():
                 raise RuntimeError(f"{name} missing from tests!")
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(20)
 @pytest.mark.parametrize("param", PARAMS, ids=IDS)
 def test_cython_api(param):
     pyfunc, cyfunc, specializations, knownfailure = param

--- a/scipy/special/tests/test_extending.py
+++ b/scipy/special/tests/test_extending.py
@@ -7,7 +7,7 @@ from scipy._lib._testutils import IS_EDITABLE,_test_cython_extension, cython
 from scipy.special import beta, gamma
 
 
-@pytest.mark.fail_slow(20)
+@pytest.mark.fail_slow(40)
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')

--- a/scipy/special/tests/test_round.py
+++ b/scipy/special/tests/test_round.py
@@ -4,14 +4,14 @@ import pytest
 from scipy.special import _test_internal
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(20)
 @pytest.mark.skipif(not _test_internal.have_fenv(), reason="no fenv()")
 def test_add_round_up():
     np.random.seed(1234)
     _test_internal.test_add_round(10**5, 'up')
 
 
-@pytest.mark.fail_slow(5)
+@pytest.mark.fail_slow(20)
 @pytest.mark.skipif(not _test_internal.have_fenv(), reason="no fenv()")
 def test_add_round_down():
     np.random.seed(1234)

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -47,7 +47,7 @@ def test_rel_entr_generic(dtype):
     xp_assert_close(res, xp.asarray(ref), xp=xp)
 
 
-@pytest.mark.fail_slow(2)
+@pytest.mark.fail_slow(5)
 @array_api_compatible
 @given(data=strategies.data())
 @pytest.mark.parametrize('f_name_n_args', array_special_func_map.items())

--- a/scipy/stats/tests/test_fast_gen_inversion.py
+++ b/scipy/stats/tests/test_fast_gen_inversion.py
@@ -142,6 +142,7 @@ def test_geninvgauss_uerror():
 
 
 # TODO: add more distributions
+@pytest.mark.fail_slow(5)
 @pytest.mark.parametrize(("distname, args"), [("beta", (0.11, 0.11))])
 def test_error_extreme_params(distname, args):
     # take extreme parameters where u-error might not be below the tolerance

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -589,6 +589,7 @@ class TestFit:
 
         assert_nlff_less_or_close(dist, data, res.params, shapes, **self.tols)
 
+    @pytest.mark.fail_slow(5)
     def test_truncweibull_min(self):
         # Can't guarantee that all distributions will fit all data with
         # arbitrary bounds. This distribution just happens to fail above.

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -194,7 +194,7 @@ class TestMGCStat:
         assert_approx_equal(stat_dist, 0.163, significant=1)
         assert_approx_equal(pvalue_dist, 0.001, significant=1)
 
-    @pytest.mark.fail_slow(10)  # all other tests are XSLOW; we need at least one to run
+    @pytest.mark.fail_slow(20)  # all other tests are XSLOW; we need at least one to run
     @pytest.mark.slow
     def test_pvalue_literature(self):
         np.random.seed(12345678)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1097,6 +1097,7 @@ class TestMonteCarloHypothesisTest:
         assert_allclose(res.statistic, ref.statistic)
         assert_allclose(res.pvalue, ref.pvalue, atol=1e-2)
 
+    @pytest.mark.fail_slow(2)
     @pytest.mark.xfail_on_32bit("Statistic may not depend on sample order on 32-bit")
     def test_finite_precision_statistic(self):
         # Some statistics return numerically distinct values when the values
@@ -1924,6 +1925,7 @@ class TestPermutationTest:
         got = list(_resampling._batch_generator(iterable, batch))
         assert got == expected
 
+    @pytest.mark.fail_slow(2)
     def test_finite_precision_statistic(self):
         # Some statistics return numerically distinct values when the values
         # should be equal in theory. Test that `permutation_test` accounts

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -588,7 +588,7 @@ class TestPearsonr:
         with pytest.raises(ValueError, match=message):
             res.confidence_interval(method="exact")
 
-    @pytest.mark.fail_slow(2)
+    @pytest.mark.fail_slow(5)
     @pytest.mark.skip_xp_backends(np_only=True)
     @pytest.mark.xfail_on_32bit("Monte Carlo method needs > a few kB of memory")
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))


### PR DESCRIPTION
#### Reference issue
gh-20806

#### What does this implement/fix?
False positives have already slowed down a lot, but this will hopefully make them rare. This:
1. Adds additional margin to tests that already have a `fail_slow` exception.
2. Adds a few new `fail_slow` exceptions to tests that were considered in the original PR but ultimately left out.

#### Additional information
This is only marked as draft to delay pinging all code owners. Feel free to mark as ready for review and merge.