### PR TITLE
ENH: sparse: add axis parameter to `count_nonzero` method

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -266,7 +266,7 @@ class _spbase:
     def count_nonzero(self, axis=None):
         """Number of non-zero entries, equivalent to
 
-        np.count_nonzero(a.toarray())
+        np.count_nonzero(a.toarray(), axis=axis)
 
         Unlike the nnz property, which return the number of stored
         entries (the length of the data attribute), this method counts the

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -280,6 +280,43 @@ class _spbase:
             Count nonzeros for the whole array, or along a specified axis.
 
             .. versionadded:: 1.15.0
+
+        Returns
+        -------
+        numpy array
+            A reduced array (no axis `axis`) holding the number of nonzero values
+            for each of the indices of the nonaxis dimensions.
+
+        Notes
+        -----
+        If you want to count nonzero and explicit zero stored values (e.g. nnz)
+        along an axis, two fast idioms are provided by `numpy` functions for the
+        common CSR, CSC, COO formats.
+
+        For the major axis in CSR (rows) and CSC (cols) use `np.diff`:
+
+            >>> import numpy as np
+            >>> import scipy as sp
+            >>> A = sp.sparse.csr_array([[4, 5, 0], [7, 0, 0]])
+            >>> major_axis_stored_values = np.diff(A.indptr)  # -> np.array([2, 1])
+
+        For the minor axis in CSR (cols) and CSC (rows) use `numpy.bincount` with
+        minlength ``A.shape[1]`` for CSR and ``A.shape[0]`` for CSC:
+
+            >>> csr_minor_stored_values = np.bincount(A.indices, minlength=A.shape[1])
+
+        For COO, use the minor axis approach for either `axis`:
+
+            >>> A = A.tocoo()
+            >>> coo_axis0_stored_values = np.bincount(A.coords[0], minlength=A.shape[1])
+            >>> coo_axis1_stored_values = np.bincount(A.coords[1], minlength=A.shape[0])
+
+        Examples
+        --------
+
+            >>> A = sp.sparse.csr_array([[4, 5, 0], [7, 0, 0]])
+            >>> A.count_nonzero(axis=0)
+            array([2, 1, 0])
         """
         clsname = self.__class__.__name__
         raise NotImplementedError(f"count_nonzero not implemented for {clsname}.")

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -263,7 +263,7 @@ class _spbase:
         """Maximum number of elements to display when printed."""
         return self.maxprint
 
-    def count_nonzero(self):
+    def count_nonzero(self, axis=None):
         """Number of non-zero entries, equivalent to
 
         np.count_nonzero(a.toarray())
@@ -271,18 +271,26 @@ class _spbase:
         Unlike the nnz property, which return the number of stored
         entries (the length of the data attribute), this method counts the
         actual number of non-zero entries in data.
+
+        Duplicate entries are summed before counting.
+
+        Parameters
+        ----------
+        axis : {-2, -1, 0, 1, None} optional
+            Count nonzeros for the whole array, or along a specified axis.
+
+            .. versionadded:: 1.15.0
         """
-        raise NotImplementedError("count_nonzero not implemented for %s." %
-                                  self.__class__.__name__)
+        clsname = self.__class__.__name__
+        raise NotImplementedError(f"count_nonzero not implemented for {clsname}.")
 
     def _getnnz(self, axis=None):
         """Number of stored values, including explicit zeros.
 
         Parameters
         ----------
-        axis : None, 0, or 1
-            Select between the number of values across the whole array, in
-            each column, or in each row.
+        axis : {-2, -1, 0, 1, None} optional
+            Report stored values for the whole array, or along a specified axis.
 
         See also
         --------

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -219,6 +219,15 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
+    def count_nonzero(self, axis=None):
+        if axis is not None:
+            raise NotImplementedError(
+                "count_nonzero over axis is not implemented for BSR format."
+            )
+        return np.count_nonzero(self._deduped_data())
+
+    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
+
     def __repr__(self):
         _, fmt = _formats[self.format]
         sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -2,7 +2,6 @@
 __all__ = []
 
 from warnings import warn
-import itertools
 import operator
 
 import numpy as np
@@ -153,9 +152,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif axis == 1:
             if self.data.all():
                 return np.diff(self.indptr)
-            x, y = itertools.tee(self.indptr)
-            next(y)
-            return np.array([np.count_nonzero(self.data[i:j]) for i, j in zip(x, y)])
+            # Todo: use itertools.pairwise after Python 3.9 support is dropped
+            # pairs = itertools.pairwise(self.indptr)
+            # return np.array([np.count_nonzero(self.data[i:j]) for i, j in pairs])
+            idx = iter(self.indptr)
+            i = next(idx, None)
+            return np.array([np.count_nonzero(self.data[i:(i:=j)]) for j in idx])
         else:
             raise ValueError('axis out of bounds')
 

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -2,6 +2,7 @@
 __all__ = []
 
 from warnings import warn
+import itertools
 import operator
 
 import numpy as np
@@ -124,13 +125,41 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             axis, _ = self._swap((axis, 1 - axis))
             _, N = self._swap(self.shape)
             if axis == 0:
-                return np.bincount(downcast_intp_index(self.indices),
-                                   minlength=N)
+                return np.bincount(downcast_intp_index(self.indices), minlength=N)
             elif axis == 1:
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
+
+    def count_nonzero(self, axis=None):
+        self.sum_duplicates()
+        if axis is None:
+            return np.count_nonzero(self.data)
+
+        if self.ndim == 1:
+            if axis not in (0, -1):
+                raise ValueError('axis out of bounds')
+            return np.count_nonzero(self.data)
+
+        if axis < 0:
+            axis += 2
+        axis, _ = self._swap((axis, 1 - axis))
+        if axis == 0:
+            _, N = self._swap(self.shape)
+            mask = self.data != 0
+            idx = self.indices if mask.all() else self.indices[mask]
+            return np.bincount(downcast_intp_index(idx), minlength=N)
+        elif axis == 1:
+            if self.data.all():
+                return np.diff(self.indptr)
+            x, y = itertools.tee(self.indptr)
+            next(y)
+            return np.array([np.count_nonzero(self.data[i:j]) for i, j in zip(x, y)])
+        else:
+            raise ValueError('axis out of bounds')
+
+    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
     def check_format(self, full_check=True):
         """Check whether the array/matrix respects the CSR or CSC format.

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -2,6 +2,7 @@
 __all__ = []
 
 from warnings import warn
+import itertools
 import operator
 
 import numpy as np
@@ -152,12 +153,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif axis == 1:
             if self.data.all():
                 return np.diff(self.indptr)
-            # Todo: use itertools.pairwise after Python 3.9 support is dropped
-            # pairs = itertools.pairwise(self.indptr)
-            # return np.array([np.count_nonzero(self.data[i:j]) for i, j in pairs])
-            idx = iter(self.indptr)
-            i = next(idx, None)
-            return np.array([np.count_nonzero(self.data[i:(i:=j)]) for j in idx])
+            pairs = itertools.pairwise(self.indptr)
+            return np.array([np.count_nonzero(self.data[i:j]) for i, j in pairs])
         else:
             raise ValueError('axis out of bounds')
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -189,7 +189,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         if axis < 0:
             axis += self.ndim
-        if axis >= self.ndim:
+        if axis < 0 or axis >= self.ndim:
             raise ValueError('axis out of bounds')
         mask = self.data != 0
         coord = self.coords[1 - axis][mask]

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -182,6 +182,21 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
+    def count_nonzero(self, axis=None):
+        self.sum_duplicates()
+        if axis is None:
+            return np.count_nonzero(self.data)
+
+        if axis < 0:
+            axis += self.ndim
+        if axis >= self.ndim:
+            raise ValueError('axis out of bounds')
+        mask = self.data != 0
+        coord = self.coords[1 - axis][mask]
+        return np.bincount(coord, minlength=self.shape[1 - axis])
+
+    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
+
     def _check(self):
         """ Checks data structure for consistency """
         if self.ndim != len(self.coords):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -193,7 +193,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             raise ValueError('axis out of bounds')
         mask = self.data != 0
         coord = self.coords[1 - axis][mask]
-        return np.bincount(coord, minlength=self.shape[1 - axis])
+        return np.bincount(downcast_intp_index(coord), minlength=self.shape[1 - axis])
 
     count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -97,11 +97,6 @@ class _data_matrix(_spbase):
 
     copy.__doc__ = _spbase.copy.__doc__
 
-    def count_nonzero(self):
-        return np.count_nonzero(self._deduped_data())
-
-    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
-
     def power(self, n, dtype=None):
         """
         This function performs element-wise power.

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -115,9 +115,15 @@ class _dia_base(_data_matrix):
         mask &= (offset_inds < num_cols)
         return mask
 
-    def count_nonzero(self):
+    def count_nonzero(self, axis=None):
+        if axis is not None:
+            raise NotImplementedError(
+                "count_nonzero over an axis is not implemented for DIA format"
+            )
         mask = self._data_mask()
         return np.count_nonzero(self.data[mask])
+
+    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
     def _getnnz(self, axis=None):
         if axis is not None:
@@ -133,7 +139,6 @@ class _dia_base(_data_matrix):
         return int(nnz)
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
-    count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
     def sum(self, axis=None, dtype=None, out=None):
         validateaxis(axis)

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -69,7 +69,11 @@ class _dok_base(_spbase, IndexMixin, dict):
             )
         return len(self._dict)
 
-    def count_nonzero(self):
+    def count_nonzero(self, axis=None):
+        if axis is not None:
+            raise NotImplementedError(
+                "count_nonzero over an axis is not implemented for DOK format."
+            )
         return sum(x != 0 for x in self.values())
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -106,10 +106,27 @@ class _lil_base(_spbase, IndexMixin):
         else:
             raise ValueError('axis out of bounds')
 
-    def count_nonzero(self):
-        return sum(np.count_nonzero(rowvals) for rowvals in self.data)
-
     _getnnz.__doc__ = _spbase._getnnz.__doc__
+
+    def count_nonzero(self, axis=None):
+        if axis is None:
+            return sum(np.count_nonzero(rowvals) for rowvals in self.data)
+
+        if axis < 0:
+            axis += 2
+        if axis == 0:
+            out = np.zeros(self.shape[1], dtype=np.intp)
+            for row, data in zip(self.rows, self.data):
+                mask = [c for c, d in zip(row, data) if d != 0]
+                out[mask] += 1
+            return out
+        elif axis == 1:
+            return np.array(
+                [np.count_nonzero(rowvals) for rowvals in self.data], dtype=np.intp,
+            )
+        else:
+            raise ValueError('axis out of bounds')
+
     count_nonzero.__doc__ = _spbase.count_nonzero.__doc__
 
     def getrowview(self, i):


### PR DESCRIPTION
The sparse matrix/array method `count_nonzero()` mimics `np.count_nonzero` but currently does not support the axis parameter.  This PR adds support for the axis parameter in COO, CSR, CSC, and LIL formats. The other formats add the parameter but raise if not the default value `axis=None`. This mimics the support format pattern for an axis parameter in the private `_getnnz` method.

This PR sums duplicate entries as part of the computation, and it does not eliminate explicit zeros. For CSC, CSR formats, faster methods work if no explicit zeros are stored, so we check for explicit zeros before deciding which method to use. 

The incentive for this feature (see #19405) is a way to provide `axis` level nonzero counts recently lost during the move from `getnnz` to  a property `nnz`. That dropped feature counted stored values while this counts nonzero values.

Tests and docs are added.

Closes: #19405
