### PR TITLE
MAINT: `stats.bootstrap`: emit `FutureWarning` about broadcasting

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1420,6 +1420,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    @pytest.mark.fail_slow(5)
     def test_L9(self):
         # Lampinen ([5]) test problem 9
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -185,9 +185,23 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     if n_samples == 0:
         raise ValueError("`data` must contain at least one sample.")
 
+    message = ("Ignoring the dimension specified by `axis`, arrays in `data` do not "
+               "have the same shape. Beginning in SciPy 1.16.0, `bootstrap` will "
+               "explicitly broadcast elements of `data` to the same shape (ignoring "
+               "`axis`) before performing the calculation. To avoid this warning in "
+               "the meantime, ensure that all samples have the same shape (except "
+               "potentially along `axis`).")
+    data = [np.atleast_1d(sample) for sample in data]
+    reduced_shapes = set()
+    for sample in data:
+        reduced_shape = list(sample.shape)
+        reduced_shape.pop(axis)
+        reduced_shapes.add(tuple(reduced_shape))
+    if len(reduced_shapes) != 1:
+        warnings.warn(message, FutureWarning, stacklevel=3)
+
     data_iv = []
     for sample in data:
-        sample = np.atleast_1d(sample)
         if sample.shape[axis_int] <= 1:
             raise ValueError("each sample in `data` must contain two or more "
                              "observations along `axis`.")
@@ -315,7 +329,17 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     Parameters
     ----------
     data : sequence of array-like
-         Each element of data is a sample from an underlying distribution.
+         Each element of `data` is a sample containing scalar observations from an
+         underlying distribution. Elements of `data` must be broadcastable to the
+         same shape (with the possible exception of the dimension specified by `axis`).
+
+         .. warning:: Beginning in SciPy 1.14.0, `bootstrap` will emit a `FutureWarning`
+                      if the shapes of the elements of `data` are not the same (with the
+                      exception of the dimension specified by `axis`).
+                      Beginning in SciPy 1.16.0, `bootstrap` will explicitly broadcast
+                      the elements to the same shape (except along `axis) before
+                      performing the calculation.
+
     statistic : callable
         Statistic for which the confidence interval is to be calculated.
         `statistic` must be a callable that accepts ``len(data)`` samples

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -333,12 +333,13 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
          underlying distribution. Elements of `data` must be broadcastable to the
          same shape (with the possible exception of the dimension specified by `axis`).
 
-         .. warning:: Beginning in SciPy 1.14.0, `bootstrap` will emit a `FutureWarning`
-                      if the shapes of the elements of `data` are not the same (with the
-                      exception of the dimension specified by `axis`).
-                      Beginning in SciPy 1.16.0, `bootstrap` will explicitly broadcast
-                      the elements to the same shape (except along `axis) before
-                      performing the calculation.
+         .. versionchanged:: 1.14.0
+             `bootstrap` will now emit a ``FutureWarning`` if the shapes of the
+             elements of `data` are not the same (with the exception of the dimension
+             specified by `axis`).
+             Beginning in SciPy 1.16.0, `bootstrap` will explicitly broadcast the
+             elements to the same shape (except along `axis`) before performing
+             the calculation.
 
     statistic : callable
         Statistic for which the confidence interval is to be calculated.

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -732,6 +732,27 @@ def test_vector_valued_statistic_gh17715():
                     ref.confidence_interval.high, atol=1e-15)
 
 
+def test_gh_20850():
+    rng = np.random.default_rng(2085020850)
+    x = rng.random((10, 2))
+    y = rng.random((11, 2))
+    def statistic(x, y, axis):
+        return stats.ttest_ind(x, y, axis=axis).statistic
+
+    # The shapes do *not* need to be the same along axis
+    stats.bootstrap((x, y), statistic)
+    stats.bootstrap((x.T, y.T), statistic, axis=1)
+    # But even when the shapes *are* the same along axis, the lengths
+    # along other dimensions have to be the same (or `bootstrap` warns).
+    message = "Ignoring the dimension specified by `axis`..."
+    with pytest.warns(FutureWarning, match=message):
+        stats.bootstrap((x, y[:10, 0]), statistic)  # this won't work after 1.16
+    with pytest.warns(FutureWarning, match=message):
+        stats.bootstrap((x, y[:10, 0:1]), statistic)  # this will
+    with pytest.warns(FutureWarning, match=message):
+        stats.bootstrap((x.T, y.T[0:1, :10]), statistic, axis=1)  # this will
+
+
 # --- Test Monte Carlo Hypothesis Test --- #
 
 class TestMonteCarloHypothesisTest:


### PR DESCRIPTION
#### Reference issue
Closes gh-20850

#### What does this implement/fix?
gh-20850 highlighted that `stats.bootstrap` does not explicitly broadcast arrays to the same shape (except along `axis`) as essentially all other reducing `stats` functions do. Since `bootstrap` assumes that the arguments are of the same shape (except along `axis`), I don't think there are any (correct) uses of the function that cannot be accomplished with this restriction, so `bootstrap` should add the broadcasting. There are currently some legitimate uses that *happen* to work even when the shapes are incompatible. To avoid breaking these uses without warning, this PR emits a `FutureWarning` if the shapes do not agree.

#### Additional information
@aangelopoulos I was tempted in this PR to add notes to the documentation about how to use `bootstrap` for samples that contain multidimensional observations. I'd be happy to incorporate such examples here, or you're welcome to submit a separate PR.