### PR TITLE
DEP: `integrate.cumulative_trapezoid`: raise `ValueError` for values of `initial` other than `None` and `0`

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -478,12 +478,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
     if initial is not None:
         if initial != 0:
-            warnings.warn(
-                "The option for values for `initial` other than None or 0 is "
-                "deprecated as of SciPy 1.12.0 and will raise a value error in"
-                " SciPy 1.15.0.",
-                DeprecationWarning, stacklevel=2
-            )
+            raise ValueError("`initial` must be None or 0.")
         if not np.isscalar(initial):
             raise ValueError("`initial` parameter should be a scalar.")
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -473,7 +473,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
 
     if initial is not None:
         if initial != 0:
-            raise ValueError("`initial` must be None or 0.")
+            raise ValueError("`initial` must be `None` or `0`.")
         if not np.isscalar(initial):
             raise ValueError("`initial` parameter should be a scalar.")
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -412,11 +412,6 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
         0 or None are the only values accepted. Default is None, which means
         `res` has one element less than `y` along the axis of integration.
 
-        .. deprecated:: 1.12.0
-            The option for non-zero inputs for `initial` will be deprecated in
-            SciPy 1.15.0. After this time, a ValueError will be raised if
-            `initial` is not None or 0.
-
     Returns
     -------
     res : ndarray

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -324,12 +324,11 @@ class TestCumulative_trapezoid:
     @pytest.mark.parametrize(
         "initial", [1, 0.5]
     )
-    def test_initial_warning(self, initial):
+    def test_initial_error(self, initial):
         """If initial is not None or 0, a ValueError is raised."""
         y = np.linspace(0, 10, num=10)
-        with pytest.deprecated_call(match="`initial`"):
-            res = cumulative_trapezoid(y, initial=initial)
-        assert_allclose(res, [initial, *np.cumsum(y[1:] + y[:-1])/2])
+        with pytest.raises(ValueError, match="`initial`"):
+            cumulative_trapezoid(y, initial=initial)
 
     def test_zero_len_y(self):
         with pytest.raises(ValueError, match="At least one point is required"):


### PR DESCRIPTION
follow up to https://github.com/scipy/scipy/pull/18219, scheduled for this release