### PR TITLE
DEP: interpolate: deprecate complex dtypes in `{Akima1D, Pchip}Interpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import warnings
-
 import numpy as np
 
 from scipy.linalg import solve, solve_banded
@@ -249,11 +247,9 @@ class PchipInterpolator(CubicHermiteSpline):
         x, _, y, axis, _ = prepare_input(x, y, axis)
         if np.iscomplexobj(y):
             msg = ("`PchipInterpolator` only works with real values for `y`. "
-                   "Passing an array with a complex dtype for `y` is deprecated "
-                   "and will raise an error in SciPy 1.15.0. If you are trying to "
-                   "use the real components of the passed array, use `np.real` on "
-                   "the array before passing to `PchipInterpolator`.")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                   "If you are trying to use the real components of the passed array, "
+                   "use `np.real` on the array before passing to `PchipInterpolator`.")
+            raise TypeError(msg)
         xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
         dk = self._find_derivatives(xp, y)
         super().__init__(x, y, dk, axis=0, extrapolate=extrapolate)
@@ -520,11 +516,10 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
         if np.iscomplexobj(y):
             msg = ("`Akima1DInterpolator` only works with real values for `y`. "
-                   "Passing an array with a complex dtype for `y` is deprecated "
-                   "and will raise an error in SciPy 1.15.0. If you are trying to "
-                   "use the real components of the passed array, use `np.real` on "
-                   "the array before passing to `Akima1DInterpolator`.")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                   "If you are trying to use the real components of the passed array, "
+                   "use `np.real` on the array before passing to "
+                   "`Akima1DInterpolator`.")
+            raise TypeError(msg)
 
         # Akima extrapolation historically False; parent class defaults to True.
         extrapolate = False if extrapolate is None else extrapolate

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -178,12 +178,6 @@ class PchipInterpolator(CubicHermiteSpline):
         A N-D array of real values. ``y``'s length along the interpolation
         axis must be equal to the length of ``x``. Use the ``axis``
         parameter to select the interpolation axis.
-
-        .. deprecated:: 1.13.0
-            Complex data is deprecated and will raise an error in SciPy 1.15.0.
-            If you are trying to use the real components of the passed array,
-            use ``np.real`` on ``y``.
-
     axis : int, optional
         Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
         to ``axis=0``.
@@ -405,12 +399,6 @@ class Akima1DInterpolator(CubicHermiteSpline):
         N-D array of real values. The length of ``y`` along the interpolation axis
         must be equal to the length of ``x``. Use the ``axis`` parameter to
         select the interpolation axis.
-
-        .. deprecated:: 1.13.0
-            Complex data is deprecated and will raise an error in SciPy 1.15.0.
-            If you are trying to use the real components of the passed array,
-            use ``np.real`` on ``y``.
-
     axis : int, optional
         Axis in the ``y`` array corresponding to the x-coordinate values. Defaults
         to ``axis=0``.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -243,7 +243,7 @@ class PchipInterpolator(CubicHermiteSpline):
             msg = ("`PchipInterpolator` only works with real values for `y`. "
                    "If you are trying to use the real components of the passed array, "
                    "use `np.real` on the array before passing to `PchipInterpolator`.")
-            raise TypeError(msg)
+            raise ValueError(msg)
         xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
         dk = self._find_derivatives(xp, y)
         super().__init__(x, y, dk, axis=0, extrapolate=extrapolate)
@@ -507,7 +507,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
                    "If you are trying to use the real components of the passed array, "
                    "use `np.real` on the array before passing to "
                    "`Akima1DInterpolator`.")
-            raise TypeError(msg)
+            raise ValueError(msg)
 
         # Akima extrapolation historically False; parent class defaults to True.
         extrapolate = False if extrapolate is None else extrapolate

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -282,7 +282,7 @@ class RegularGridInterpolator:
             msg = ("`PchipInterpolator` only works with real values. If you are trying "
                    "to use the real components of the passed array, use `np.real` on "
                    "the array before passing to `RegularGridInterpolator`.")
-            raise TypeError(msg)
+            raise ValueError(msg)
         if method in self._SPLINE_METHODS_ndbspl:
             if solver_args is None:
                 solver_args = {}

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -69,12 +69,6 @@ class RegularGridInterpolator:
         The data on the regular grid in n dimensions. Complex data is
         accepted.
 
-        .. deprecated:: 1.13.0
-            Complex data is deprecated with ``method="pchip"`` and will raise an
-            error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
-            works with real values. If you are trying to use the real components of
-            the passed array, use ``np.real`` on ``values``.
-
     method : str, optional
         The method of interpolation to perform. Supported are "linear",
         "nearest", "slinear", "cubic", "quintic" and "pchip". This

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -1,7 +1,6 @@
 __all__ = ['RegularGridInterpolator', 'interpn']
 
 import itertools
-import warnings
 
 import numpy as np
 
@@ -286,12 +285,10 @@ class RegularGridInterpolator:
         if self._descending_dimensions:
             self.values = np.flip(values, axis=self._descending_dimensions)
         if self.method == "pchip" and np.iscomplexobj(self.values):
-            msg = ("`PchipInterpolator` only works with real values. Passing "
-                   "complex-dtyped `values` with `method='pchip'` is deprecated "
-                   "and will raise an error in SciPy 1.15.0. If you are trying to "
-                   "use the real components of the passed array, use `np.real` on "
+            msg = ("`PchipInterpolator` only works with real values. If you are trying "
+                   "to use the real components of the passed array, use `np.real` on "
                    "the array before passing to `RegularGridInterpolator`.")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            raise TypeError(msg)
         if method in self._SPLINE_METHODS_ndbspl:
             if solver_args is None:
                 solver_args = {}

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
         splrep, splev, splantider, splint, sproot, Akima1DInterpolator,
-        NdPPoly, BSpline)
+        NdPPoly, BSpline, PchipInterpolator)
 
 from scipy.special import poch, gamma
 
@@ -947,16 +947,16 @@ class TestAkima1DInterpolator:
         # Testing extrapoation to actual function.
         assert_allclose(y_ext, ak_true(x_ext), atol=1e-15)
 
-    def test_complex(self):
-        # Complex-valued data deprecated
-        x = np.arange(0., 11.)
-        y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
-        y = y - 2j*y
-        # actually raises ComplexWarning, which subclasses RuntimeWarning, see
-        # https://github.com/numpy/numpy/blob/main/numpy/exceptions.py
-        msg = "Passing an array with a complex.*|Casting complex values to real.*"
-        with pytest.warns((RuntimeWarning, DeprecationWarning), match=msg):
-            Akima1DInterpolator(x, y)
+
+@pytest.mark.parametrize("method", [Akima1DInterpolator, PchipInterpolator])
+def test_complex(method):
+    # Complex-valued data deprecated
+    x = np.arange(0., 11.)
+    y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+    y = y - 2j*y
+    msg = "real values"
+    with pytest.raises(TypeError, match=msg):
+        method(x, y)
 
 
 class TestPPolyCommon:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -955,7 +955,7 @@ def test_complex(method):
     y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
     y = y - 2j*y
     msg = "real values"
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         method(x, y)
 
 

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -947,7 +947,7 @@ class TestInterpN:
 
         sample = np.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
                            [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
-        with pytest.raises(TypeError, match='real'):
+        with pytest.raises(ValueError, match='real'):
             interpn(points, values, sample, method='pchip')
 
     def test_complex_spline2fd(self):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -947,7 +947,7 @@ class TestInterpN:
 
         sample = np.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
                            [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
-        with pytest.deprecated_call(match='complex'):
+        with pytest.raises(TypeError, match='real'):
             interpn(points, values, sample, method='pchip')
 
     def test_complex_spline2fd(self):


### PR DESCRIPTION
follow up to https://github.com/scipy/scipy/pull/19752, scheduled for this release