### PR TITLE
DEP: special.factorial: raise error for non-integer scalars and `exact=True`

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3020,8 +3020,8 @@ def factorial(n, exact=False):
             return math.factorial(n)
         elif exact:
             msg = ("Non-integer values of `n` together with `exact=True` are "
-                   "deprecated. Either ensure integer `n` or use `exact=False`.")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                   "not supported. Either ensure integer `n` or use `exact=False`.")
+            raise ValueError(msg)
         return _factorialx_approx_core(n, k=1)
 
     # arrays & array-likes

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2202,10 +2202,9 @@ class TestFactorialFunctions:
         def _check(n, expected):
             assert_allclose(special.factorial(n), expected)
             assert_allclose(special.factorial([n])[0], expected)
-            # using floats with exact=True is deprecated for scalars...
-            with pytest.deprecated_call(match="Non-integer values.*"):
+            # using floats with exact=True raises and error for scalars and arrays
+            with pytest.raises(ValueError, match="Non-integer values.*"):
                 assert_allclose(special.factorial(n, exact=True), expected)
-            # ... and already an error for arrays
             with pytest.raises(ValueError, match="factorial with `exact=Tr.*"):
                 special.factorial([n], exact=True)
 
@@ -2270,15 +2269,14 @@ class TestFactorialFunctions:
     def test_factorial_scalar_corner_cases(self, n, exact):
         if (n is None or n is np.nan or np.issubdtype(type(n), np.integer)
                 or np.issubdtype(type(n), np.floating)):
-            # no error
             if (np.issubdtype(type(n), np.floating) and exact
                     and n is not np.nan):
-                with pytest.deprecated_call(match="Non-integer values.*"):
-                    result = special.factorial(n, exact=exact)
+                with pytest.raises(ValueError, match="Non-integer values.*"):
+                    special.factorial(n, exact=exact)
             else:
                 result = special.factorial(n, exact=exact)
-            exp = np.nan if n is np.nan or n is None else special.factorial(n)
-            assert_equal(result, exp)
+                exp = np.nan if n is np.nan or n is None else special.factorial(n)
+                assert_equal(result, exp)
         else:
             with pytest.raises(ValueError, match="Unsupported datatype*"):
                 special.factorial(n, exact=exact)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2202,7 +2202,7 @@ class TestFactorialFunctions:
         def _check(n, expected):
             assert_allclose(special.factorial(n), expected)
             assert_allclose(special.factorial([n])[0], expected)
-            # using floats with exact=True raises and error for scalars and arrays
+            # using floats with `exact=True` raises an error for scalars and arrays
             with pytest.raises(ValueError, match="Non-integer values.*"):
                 assert_allclose(special.factorial(n, exact=True), expected)
             with pytest.raises(ValueError, match="factorial with `exact=Tr.*"):


### PR DESCRIPTION
follow up to https://github.com/scipy/scipy/commit/18bb04b95df98d5264bd3e522b8adde916f17e05, scheduled for this release 