### PR TITLE
BLD/DEV: special: Fix warning due to mixed initializers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -497,3 +497,40 @@ jobs:
         PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
         pushd $RUNNER_TEMP
         PYTHON_GIL=0 python -m pytest --pyargs scipy -n2 --durations=10
+  #################################################################################
+  clang-17-build-only:
+    # Purpose is to check for warnings in builds with latest clang.
+    # We do not run the test suite here.
+    name: Clang-17 build-only (-Werror)
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup system dependencies
+        run: |
+          sudo apt-get -y update
+          wget https://apt.llvm.org/llvm.sh
+          chmod u+x llvm.sh
+          sudo ./llvm.sh 17
+          sudo apt install -y libopenblas-dev liblapack-dev
+
+      - name: Setup Python build deps
+        run: |
+          pip install -r requirements/build.txt
+          pip install build
+
+      - name: Build wheel, check for compiler warnings
+        run: |
+          # specify which compilers to use using environment variables
+          CC=clang-17 CXX=clang++-17 FC=gfortran python -m build -wnx -Csetup-args=--werror

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -53,7 +53,7 @@ extern const char *sph_harm_all_doc;
 extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
 
 static PyModuleDef _gufuncs_def = {
-    PyModuleDef_HEAD_INIT,
+    .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_gufuncs",
     .m_size = -1,
 };

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -206,7 +206,7 @@ extern const char *yve_doc;
 extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
 
 static PyModuleDef _special_ufuncs_def = {
-    PyModuleDef_HEAD_INIT,
+    .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_special_ufuncs",
     .m_size = -1,
 };


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Removes 2 of the 3 warnings in #20740 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes two instances in `special` C++ code where a mix of designated and non-designated initializers were used. Being able to use such a mix is a C99 extension and results in a warning on Clang. I've attempted to add a GitHub workflow to CI which builds with clang-17 using `--werror`.

#### Additional information
<!--Any additional information you think is important.-->
The new GitHub workflow can likely be improved a lot. I just took the `gcc9` workflow and edited it until it did what I wanted. It's using a wheel build because that's what the gcc9 job is doing, but there's probably no reason to be doing that. It doesn't actually run the test suite, just builds with clang-17 to check for warnings. I can update it to run the test suite if people think that's a good idea. I'd appreciate advice on a better way to write this workflow. Also, has anyone found a good way to get GitHub actions workflows to run locally? If I could do that, I could have written this workflow in a better way. I'd prefer not to have to debug by pushing commits here until that job works as expected.
