### PR TITLE
CI: Add workflow to build and upload free-threaded wheels

### DIFF
--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -80,8 +80,8 @@ jobs:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
-          - [ubuntu-20.04, manylinux_x86_64, ""]
-          - [ubuntu-20.04, musllinux_x86_64, ""]
+          - [ubuntu-22.04, manylinux, x86_64, "", ""]
+          - [ubuntu-22.04, musllinux, x86_64, "", ""]
           # TODO: build scipy and set up Windows and MacOS
           # cibuildwheel does not yet support Mac for free-threaded python
           # windows is supported but numpy doesn't build on the image yet
@@ -98,66 +98,10 @@ jobs:
         with:
           submodules: true
 
-      - name: win_amd64 - install rtools
-        run: |
-          # mingw-w64
-          choco install rtools -y --no-progress --force --version=4.0.0.20220206
-          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
-        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
-
       # Used to push the built wheels
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.x"
-
-      - name: Setup macOS
-        if: startsWith( matrix.buildplat[0], 'macos-' )
-        run: |
-          if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
-            echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
-            # Always use preinstalled gfortran for Accelerate builds
-            ln -s $(which gfortran-13) gfortran
-            export PATH=$PWD:$PATH
-            echo "PATH=$PATH" >> "$GITHUB_ENV"
-            LIB_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
-          fi
-          # Add libraries installed by cibw_before_build_macos.sh to path
-          if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
-            LIB_PATH=$LIB_PATH:/opt/arm64-builds/lib
-          else
-            LIB_PATH=$LIB_PATH:/usr/local/lib
-          fi
-          if [[ ${{ matrix.buildplat[4] }} == '10.9' ]]; then
-            # Newest version of Xcode that supports macOS 10.9
-            XCODE_VER='13.4.1'
-          else
-            XCODE_VER='15.2'
-          fi
-          CIBW="sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app"
-          echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
-          # setting SDKROOT necessary when using the gfortran compiler
-          # installed in cibw_before_build_macos.sh
-          sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app
-          CIBW="MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[4] }}\
-            LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH\
-            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
-            PIP_PRE=1\
-            PIP_NO_BUILD_ISOLATION=false\
-            PKG_CONFIG_PATH=$LIB_PATH/pkgconfig\
-            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
-          echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
-
-          echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
-          GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
-          CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-listdeps {wheel} &&\
-            DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-wheel --require-archs \
-            {delocate_archs} -w {dest_dir} {wheel}"
-          # Rename x86 Accelerate wheel to test on macOS 13 runner
-          if [[ ${{ matrix.buildplat[0] }} == 'macos-13' && ${{ matrix.buildplat[4] }} == '14.0' ]]; then
-            CIBW+=" && mv {dest_dir}/\$(basename {wheel}) \
-              {dest_dir}/\$(echo \$(basename {wheel}) | sed 's/14_0/13_0/')"
-          fi
-          echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@ba8be0d98853f5744f24e7f902c8adef7ae2e7f3  # v2.18.1
@@ -169,12 +113,6 @@ jobs:
           # TODO: remove along with installing build deps in
           # cibw_before_build.sh when a released cython can build numpy
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-
-      - name: Rename after test (macOS x86 Accelerate only)
-        # Rename x86 Accelerate wheel back so it targets macOS >= 14
-        if: matrix.buildplat[0] == 'macos-13' && matrix.buildplat[4] == '14.0'
-        run: |
-          mv ./wheelhouse/*.whl $(find ./wheelhouse -type f -name '*.whl' | sed 's/13_0/14_0/')
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -1,0 +1,222 @@
+# Workflow to build and test wheels for the free-threaded Python build.
+#
+# This should be merged back into wheels.yml when free-threaded wheel
+# builds can be uploaded to pypi along with the rest of scipy's release
+# artifacts.
+#
+# To work on the wheel building infrastructure on a fork, comment out:
+#
+# if: github.repository == 'scipy/scipy'
+#
+# in the get_commit_message job. Be sure to include [wheel build] in your commit
+# message to trigger the build. All files related to wheel building are located
+# at tools/wheels/
+name: Free-Threaded Wheel Builder
+
+on:
+    schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    - cron: "9  9 * * *"
+    push:
+      branches:
+        - maintenance/**
+    pull_request:
+      branches:
+        - main
+        - maintenance/**
+    workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  get_commit_message:
+    name: Get commit message
+    runs-on: ubuntu-latest
+    if: github.repository == 'scipy/scipy'
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout scipy
+        uses: actions/checkout@v4.1.1
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_MSG=$(git log --no-merges -1)
+          RUN="0"
+          if [[ "$COMMIT_MSG" == *"[wheel build]"* ]]; then
+              RUN="1"
+          fi
+          echo "message=$RUN" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
+
+  build_wheels:
+    name: Wheel, ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+      ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
+      ${{ matrix.buildplat[4] }}
+    needs: get_commit_message
+    if: >-
+      contains(needs.get_commit_message.outputs.message, '1') ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        # Github Actions doesn't support pairing matrix values together, let's improvise
+        # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64, ""]
+          - [ubuntu-20.04, musllinux_x86_64, ""]
+          # TODO: build scipy and set up Windows and MacOS
+          # cibuildwheel does not yet support Mac for free-threaded python
+          # windows is supported but numpy doesn't build on the image yet
+        python: [["cp313t", '3.13']]
+    env:
+      IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
+      # upload to staging if it's a push to a maintenance branch and the last
+      # commit message contains '[wheel build]'
+      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/maintenance') && contains(needs.get_commit_message.outputs.message, '1') }}
+      IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout scipy
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: true
+
+      - name: win_amd64 - install rtools
+        run: |
+          # mingw-w64
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
+          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
+
+      # Used to push the built wheels
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.x"
+
+      - name: Setup macOS
+        if: startsWith( matrix.buildplat[0], 'macos-' )
+        run: |
+          if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
+            echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
+            # Always use preinstalled gfortran for Accelerate builds
+            ln -s $(which gfortran-13) gfortran
+            export PATH=$PWD:$PATH
+            echo "PATH=$PATH" >> "$GITHUB_ENV"
+            LIB_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
+          fi
+          # Add libraries installed by cibw_before_build_macos.sh to path
+          if [[ ${{ matrix.buildplat[2] }} == 'arm64' ]]; then
+            LIB_PATH=$LIB_PATH:/opt/arm64-builds/lib
+          else
+            LIB_PATH=$LIB_PATH:/usr/local/lib
+          fi
+          if [[ ${{ matrix.buildplat[4] }} == '10.9' ]]; then
+            # Newest version of Xcode that supports macOS 10.9
+            XCODE_VER='13.4.1'
+          else
+            XCODE_VER='15.2'
+          fi
+          CIBW="sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app"
+          echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
+          # setting SDKROOT necessary when using the gfortran compiler
+          # installed in cibw_before_build_macos.sh
+          sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app
+          CIBW="MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[4] }}\
+            LD_LIBRARY_PATH=$LIB_PATH:$LD_LIBRARY_PATH\
+            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
+            PIP_PRE=1\
+            PIP_NO_BUILD_ISOLATION=false\
+            PKG_CONFIG_PATH=$LIB_PATH/pkgconfig\
+            PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+          echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
+          GFORTRAN_LIB="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
+          CIBW="DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-listdeps {wheel} &&\
+            DYLD_LIBRARY_PATH=$GFORTRAN_LIB:$LIB_PATH delocate-wheel --require-archs \
+            {delocate_archs} -w {dest_dir} {wheel}"
+          # Rename x86 Accelerate wheel to test on macOS 13 runner
+          if [[ ${{ matrix.buildplat[0] }} == 'macos-13' && ${{ matrix.buildplat[4] }} == '14.0' ]]; then
+            CIBW+=" && mv {dest_dir}/\$(basename {wheel}) \
+              {dest_dir}/\$(echo \$(basename {wheel}) | sed 's/14_0/13_0/')"
+          fi
+          echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@ba8be0d98853f5744f24e7f902c8adef7ae2e7f3  # v2.18.1
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_FREE_THREADED_SUPPORT: True
+          CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
+          CIBW_ARCHS: ${{ matrix.buildplat[2] }}
+          # TODO: remove along with installing build deps in
+          # cibw_before_build.sh when a released cython can build numpy
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+
+      - name: Rename after test (macOS x86 Accelerate only)
+        # Rename x86 Accelerate wheel back so it targets macOS >= 14
+        if: matrix.buildplat[0] == 'macos-13' && matrix.buildplat[4] == '14.0'
+        run: |
+          mv ./wheelhouse/*.whl $(find ./wheelhouse -type f -name '*.whl' | sed 's/13_0/14_0/')
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+            ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
+            ${{ matrix.buildplat[4] }}
+
+      - uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
+        with:
+          # for installation of anaconda-client, required for upload to
+          # anaconda.org
+          # Note that this step is *after* specific pythons have been used to
+          # build and test the wheel
+          # for installation of anaconda-client, for upload to anaconda.org
+          # environment will be activated after creation, and in future bash steps
+          init-shell: bash
+          environment-name: upload-env
+          create-args: >-
+            anaconda-client
+
+      - name: Upload wheels
+        if: success()
+        shell: bash -el {0}
+        # see https://github.com/marketplace/actions/setup-miniconda for why
+        # `-el {0}` is required.
+        env:
+          SCIPY_STAGING_UPLOAD_TOKEN: ${{ secrets.SCIPY_STAGING_UPLOAD_TOKEN }}
+          SCIPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
+        run: |
+          conda install -y anaconda-client
+          source tools/wheels/upload_wheels.sh
+          set_upload_vars
+          # For cron jobs (restricted to main branch) or "Run workflow" trigger
+          # an upload to:
+          #
+          # https://anaconda.org/scientific-python-nightly-wheels/scipy
+          #
+          # Pushes to a maintenance branch that contain '[wheel build]' will
+          # cause wheels to be built and uploaded to:
+          #
+          # https://anaconda.org/multibuild-wheels-staging/scipy
+          #
+          # The tokens were originally generated at anaconda.org
+          upload_wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ test-requires = [
     "pooch",
     "hypothesis",
 ]
+before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -25,8 +25,8 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
     python -m pip install git+https://github.com/cython/cython
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
+    # python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11 pythran
 fi
 
 # Install Openblas

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -17,6 +17,18 @@ printenv
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_linux.txt >> $PROJECT_DIR/LICENSE.txt
 
+# TODO: delete along with enabling build isolation by unsetting
+# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
+# python with a released version of cython
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    python -m pip install -U --pre pip
+    python -m pip install git+https://github.com/cython/cython
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11
+fi
+
 # Install Openblas
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc

--- a/tools/wheels/cibw_before_test.sh
+++ b/tools/wheels/cibw_before_test.sh
@@ -1,0 +1,15 @@
+set -ex
+
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    # TODO: delete when numpy is buildable under free-threaded python
+    # with a released version of cython
+    python -m pip install -U --pre pip
+    python -m pip install git+https://github.com/cython/cython
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+
+    # TODO: delete when importing numpy no longer enables the GIL
+    # setting to zero ensures the GIL is disabled while running the
+    # tests under free-threaded python
+    export PYTHON_GIL=0
+fi


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See #20669 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds a GitHub actions workflow to release free-threaded nightly wheels on the Scientific Python Anaconda wheel channel

#### Additional information
<!--Any additional information you think is important.-->
Corresponding PR in NumPy: https://github.com/numpy/numpy/pull/26512