### PR TITLE
MAINT: sparse: Align matmul tests in `test_base.py` for spmatrix and sparray

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -56,8 +56,7 @@ class _data_matrix(_spbase):
         if isscalarlike(other):
             self.data *= other
             return self
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __itruediv__(self, other):  # self /= other
         if isscalarlike(other):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2304,7 +2304,7 @@ class _TestInplaceArithmetic:
             y @= b.T
             assert_array_equal(x, y)
 
-        # Matrix (non-elementwise) floor division is not defined
+        # Floor division is not supported
         with assert_raises(TypeError, match="unsupported operand"):
             x //= b
 
@@ -4243,11 +4243,11 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
     math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_mult(self):
-        A = dok_matrix((10,12))
-        A[0,3] = 10
-        A[5,6] = 20
-        D = A@A.T
-        E = A@A.T.conjugate()
+        A = dok_matrix((10, 12))
+        A[0, 3] = 10
+        A[5, 6] = 20
+        D = A @ A.T
+        E = A @ A.T.conjugate()
         assert_array_equal(D.toarray(), E.toarray())
 
     def test_add_nonzero(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2277,15 +2277,6 @@ class _TestInplaceArithmetic:
             x = x * a
             y *= b
             assert_array_equal(x, y)
-
-            # Now matrix product, from __rmatmul__
-            x = a.copy()
-            y = a.copy()
-            with assert_raises(ValueError, match="dimension mismatch"):
-                x @= b
-            x = x.dot(a.T)
-            y @= b.T
-            assert_array_equal(x, y)
         else:
             # Matrix Product from __rmul__
             x = a.copy()
@@ -2296,7 +2287,15 @@ class _TestInplaceArithmetic:
             y *= b.T
             assert_array_equal(x, y)
 
-            # Now matrix product, from __rmatmul__
+        # Now matrix product, from __rmatmul__
+        y = a.copy()
+        # skip this test if numpy doesn't support __imatmul__ yet.
+        # move out of the try/except once numpy 1.24 is no longer supported.
+        try:
+            y @= b.T
+        except TypeError:
+            pass
+        else:
             x = a.copy()
             y = a.copy()
             with assert_raises(ValueError, match="dimension mismatch"):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1685,7 +1685,7 @@ class _TestCommon:
         assert_equal(A @ np.ones((1, 1)), array([[1], [2], [3]]))
         assert_equal(A @ np.ones((1, 0)), np.ones((3, 0)))
 
-    def test_start_vs_at_sign_for_sparray_and_spmatrix(self):
+    def test_star_vs_at_sign_for_sparray_and_spmatrix(self):
         # test that * is matmul for spmatrix and mul for sparray
         A = self.spcreator([[1],[2],[3]])
 
@@ -1775,10 +1775,6 @@ class _TestCommon:
         assert_array_almost_equal(matmul(M, B).toarray(), (M @ B).toarray())
         assert_array_almost_equal(matmul(M.toarray(), B), (M @ B).toarray())
         assert_array_almost_equal(matmul(M, B.toarray()), (M @ B).toarray())
-        if not isinstance(M, sparray):
-            assert_array_almost_equal(matmul(M, B).toarray(), (M * B).toarray())
-            assert_array_almost_equal(matmul(M.toarray(), B), (M * B).toarray())
-            assert_array_almost_equal(matmul(M, B.toarray()), (M * B).toarray())
 
         # check error on matrix-scalar
         assert_raises(ValueError, matmul, M, 1)
@@ -1803,7 +1799,7 @@ class _TestCommon:
         bad_vecs = [array([1,2]), array([1,2,3,4]), array([[1],[2]]),
                     matrix([1,2,3]), matrix([[1],[2]])]
         for x in bad_vecs:
-            assert_raises(ValueError, M.__mul__, x)
+            assert_raises(ValueError, M.__matmul__, x)
 
         # The current relationship between sparse matrix products and array
         # products is as follows:
@@ -2275,14 +2271,25 @@ class _TestInplaceArithmetic:
         x = a.copy()
         y = a.copy()
         if isinstance(b, sparray):
+            # Elementwise multiply
             assert_raises(ValueError, operator.imul, x, b.T)
             x = x * a
             y *= b
-        else:
-            # This is matrix product, from __rmul__
-            assert_raises(ValueError, operator.imul, x, b)
+            # Now matrix product, from __rmatmul__
+            assert_raises(ValueError, operator.imatmul, x, b.T)
+            x = a.copy()
+            y = a.copy()
             x = x.dot(a.T)
+            y @= b.T
+        else:
+            # Elementwise multiply
+            assert_raises(ValueError, operator.imul, x, b)
+            x = x * a
             y *= b.T
+            # Now matrix product, from __rmatmul__
+            assert_raises(ValueError, operator.imatmul, x, b)
+            x = x.dot(a.T)
+            y @= b.T
         assert_array_equal(x, y)
 
         # Matrix (non-elementwise) floor division is not defined
@@ -2347,8 +2354,13 @@ class _TestInplaceArithmetic:
         bp = bp + a
         assert_allclose(b.toarray(), bp.toarray())
 
-        b *= a
-        bp = bp * a
+        if isinstance(b, sparray):
+            b *= a
+            bp = bp * a
+            assert_allclose(b.toarray(), bp.toarray())
+
+        b @= a
+        bp = bp @ a
         assert_allclose(b.toarray(), bp.toarray())
 
         b -= a
@@ -4217,11 +4229,11 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
     math_dtypes = [np.int_, np.float64, np.complex128]
 
     def test_mult(self):
-        A = dok_matrix((10,10))
+        A = dok_matrix((10,12))
         A[0,3] = 10
         A[5,6] = 20
-        D = A*A.T
-        E = A*A.T.conjugate()
+        D = A@A.T
+        E = A@A.T.conjugate()
         assert_array_equal(D.toarray(), E.toarray())
 
     def test_add_nonzero(self):
@@ -4328,9 +4340,9 @@ class TestLIL(sparse_test_class(minmax=False)):
 
         # TODO: properly handle this assertion on ppc64le
         if platform.machine() != 'ppc64le':
-            assert_array_equal(A @ A.T, (B * B.T).toarray())
+            assert_array_equal(A @ A.T, (B @ B.T).toarray())
 
-        assert_array_equal(A @ A.conjugate().T, (B * B.conjugate().T).toarray())
+        assert_array_equal(A @ A.conjugate().T, (B @ B.conjugate().T).toarray())
 
     def test_scalar_mul(self):
         x = lil_matrix((3, 3))
@@ -4804,12 +4816,12 @@ class TestBSR(sparse_test_class(getset=False,
     def test_bsr_matvec(self):
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]).reshape(-1,1)
-        assert_equal(A*x, A.toarray() @ x)
+        assert_equal(A @ x, A.toarray() @ x)
 
     def test_bsr_matvecs(self):
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]*6).reshape(-1,6)
-        assert_equal(A*x, A.toarray() @ x)
+        assert_equal(A @ x, A.toarray() @ x)
 
     @pytest.mark.xfail(run=False, reason='BSR does not have a __getitem__')
     def test_iterator(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2268,32 +2268,46 @@ class _TestInplaceArithmetic:
         y -= b
         assert_array_equal(x, y)
 
-        x = a.copy()
-        y = a.copy()
         if isinstance(b, sparray):
-            # Elementwise multiply
-            assert_raises(ValueError, operator.imul, x, b.T)
-            x = x * a
-            y *= b
-            # Now matrix product, from __rmatmul__
-            assert_raises(ValueError, operator.imatmul, x, b.T)
+            # Elementwise multiply from __rmul__
             x = a.copy()
             y = a.copy()
-            x = x.dot(a.T)
-            y @= b.T
-        else:
-            # Elementwise multiply
-            assert_raises(ValueError, operator.imul, x, b)
+            with assert_raises(ValueError, match="dimension mismatch"):
+                x *= b.T
             x = x * a
-            y *= b.T
+            y *= b
+            assert_array_equal(x, y)
+
             # Now matrix product, from __rmatmul__
-            assert_raises(ValueError, operator.imatmul, x, b)
+            x = a.copy()
+            y = a.copy()
+            with assert_raises(ValueError, match="dimension mismatch"):
+                x @= b
             x = x.dot(a.T)
             y @= b.T
-        assert_array_equal(x, y)
+            assert_array_equal(x, y)
+        else:
+            # Matrix Product from __rmul__
+            x = a.copy()
+            y = a.copy()
+            with assert_raises(ValueError, match="dimension mismatch"):
+                x *= b
+            x = x.dot(a.T)
+            y *= b.T
+            assert_array_equal(x, y)
+
+            # Now matrix product, from __rmatmul__
+            x = a.copy()
+            y = a.copy()
+            with assert_raises(ValueError, match="dimension mismatch"):
+                x @= b
+            x = x.dot(a.T)
+            y @= b.T
+            assert_array_equal(x, y)
 
         # Matrix (non-elementwise) floor division is not defined
-        assert_raises(TypeError, operator.ifloordiv, x, b)
+        with assert_raises(TypeError, match="unsupported operand"):
+            x //= b
 
     def test_imul_scalar(self):
         def check(dtype):
@@ -2367,7 +2381,8 @@ class _TestInplaceArithmetic:
         bp = bp - a
         assert_allclose(b.toarray(), bp.toarray())
 
-        assert_raises(TypeError, operator.ifloordiv, a, b)
+        with assert_raises(TypeError, match="unsupported operand"):
+            a //= b
 
 
 class _TestGetSet:


### PR DESCRIPTION
This PR is the first of three to get `test_base.py` able to easily switch from explicitly testing spmatrix to explicitly testing either sparray or spmatrix with easy changing back and forth. We don't expect `test_base.py` should ever test both frameworks in the same CI run. The short term goal is to make it easy to switch (so we can do it locally and in draft-PRs where needed). The long term goal is to have test_base act on sparray explicitly since that is the intended long term class suite.

Currently `test_base.py` tests the spmatrix classes directly and thus implicitly tests the sparray classes since almost all the code is shared between these two sets of classes. We'd like to switch the roles in `test_base.py` -- have it test sparray explicitly and thus implicitly test the spmatrix classes.

This first PR ensures that all matmul tests use `@` instead of `*`, and to expand the direct testing of operators * and @ so it depends on whether the class `spcreator` is an sparray or spmatrix.

The 2nd PR will change other aspects of tests that depend on whether spcreator is sparray or spmatrix so either can be tested. This is mostly changing `keepdims` args and switching tests of methods removed from sparray like `getrow` to the private versions `_getrow`.

The 3rd PR will switch all `*_matrix` to `*_object` and `asmatrix` to `asobject`. This also adds about 10 lines at the top to define `*_object` and `asobject` to allow easy switching via a one-line change: `test_arrays = True/False`.  This touches a lot, so I've isolated the mechanical changes into a separate PR.