### PR TITLE
DOC: Write API reference titles in monospace font

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -83,3 +83,17 @@ div.admonition>.admonition-title {
 h1 {
   word-wrap: break-word;
 }
+
+/* Monospace titles for API docs */
+div.empty + section>h1 {
+  font-family: var(--pst-font-family-monospace);
+}
+
+.prename {
+  font-family: var(--pst-font-family-monospace);
+  font-size: var(--pst-font-size-h4);
+}
+
+.sig-prename {
+  display: none;
+}

--- a/doc/source/_templates/autosummary/attribute.rst
+++ b/doc/source/_templates/autosummary/attribute.rst
@@ -1,5 +1,10 @@
 :orphan:
 
+.. raw:: html
+
+   <div class="prename">{{ module }}.{{ class }}.</div>
+   <div class="empty"></div>
+
 {{ fullname }}
 {{ underline }}
 

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,4 +1,9 @@
-{{ fullname }}
+.. raw:: html
+
+   <div class="prename">{{ module }}.</div>
+   <div class="empty"></div>
+
+{{ name }}
 {{ underline }}
 
 .. currentmodule:: {{ module }}

--- a/doc/source/_templates/autosummary/function.rst
+++ b/doc/source/_templates/autosummary/function.rst
@@ -1,8 +1,6 @@
-:orphan:
-
 .. raw:: html
 
-   <div class="prename">{{ module }}.{{ class }}.</div>
+   <div class="prename">{{ module }}.</div>
    <div class="empty"></div>
 
 {{ name }}
@@ -10,4 +8,4 @@
 
 .. currentmodule:: {{ module }}
 
-.. automethod:: {{ objname }}
+.. autofunction:: {{ objname }}

--- a/doc/source/_templates/autosummary/ndarray_subclass.rst
+++ b/doc/source/_templates/autosummary/ndarray_subclass.rst
@@ -1,4 +1,9 @@
-{{ fullname }}
+.. raw:: html
+
+   <div class="prename">{{ module }}.</div>
+   <div class="empty"></div>
+
+{{ name }}
 {{ underline }}
 
 .. currentmodule:: {{ module }}

--- a/doc/source/_templates/autosummary/property.rst
+++ b/doc/source/_templates/autosummary/property.rst
@@ -1,5 +1,10 @@
 :orphan:
 
+.. raw:: html
+
+   <div class="prename">{{ module }}.{{ class }}.</div>
+   <div class="empty"></div>
+
 {{ fullname }}
 {{ underline }}
 


### PR DESCRIPTION
#### What does this implement/fix?
This is a cosmetic change to address two issues:
- The titles in API reference pages refer to code objects. To maintain consistency with the rest of the documentation, code should be formatted in monospace font.
- Some API reference pages have very long titles including the object's parent class and module. This PR splits the title to that the object's name is highlighted in larger font.

#### Additional information
Before:
![Captura de imagem_20240603_151447](https://github.com/scipy/scipy/assets/3949932/36907f42-ac76-4286-8baf-a4841f654e26)


After:
![Captura de imagem_20240603_151621](https://github.com/scipy/scipy/assets/3949932/e87b3f4d-d0f8-4b22-a0ed-b9041dacb604)

---

I believe this could be applied at the theme level, but that will require understanding if this is something SciPy (and maybe other projects) want, which is why I am submitting this PR here first.

cc @mdhaber 