### PR TITLE
DOC: Fix bug with parallel doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
-            python dev.py --no-build doc 2>&1 | tee sphinx_log.txt
+            python dev.py --no-build doc -j2 2>&1 | tee sphinx_log.txt
 
       - run:
           name: Check sphinx log for warnings (which are treated as errors)

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -94,7 +94,6 @@ Compiled code
     development_workflow
     pep8
     ../gitwash/gitwash
-    ../../reference/index
     reviewing_prs
     ../triage
     adding_new


### PR DESCRIPTION
@tupui @melissawm @drammock I think I finally sorted out the core issue from #16660. In #17889 (which was merged first), the hidden `:toctree:` is nicely used to set the forward/backward page order for the contributing guide. However, having `reference/index` -- which is a top-level page -- in there is problematic. It's also not totally necessary I think, so this PR removes it!

In the parallel build case, having that top-level page in there messing things up *sometimes*. I think this is because pages are read in simultaneously in separate forks, and sometimes the fork processing `contributor_toc.rst` finishes first, and other times the fork processing `reference/index.rst` finishes first -- and then Sphinx [merges the read results](https://github.com/sphinx-doc/sphinx/blob/f0dc8239cd291176f2421d08f2b3c096cb5785c1/sphinx/builders/__init__.py#L462-L464), and how it does this is affected by the completion order. This in turn affects `env.toctree_includes`, which says which pages are parents of which. In the parallel case, `reference/index` sometimes gets seen as a child of `contributor_toc`. In the serial build, it never is. So that's probably a bug with Sphinx.

There is perhaps also a bug to be fixed in pydata-sphinx-theme where it should detect this bad cyclic condition / multiple-inclusion and resolve it better (or at least warn about it).

In the meantime, pydata-sphinx-theme should be able to reenable parallel writing, since the core problem occurs when *reading* in parallel (when resolving doc order) anyway, and that isn't affected by pydata-sphinx-theme.

Marking as draft until PST can cut a release reenabling parallel writes, and then the warning that's going to be problematic for CircleCI will go away.