### PR TITLE
MAINT: sparse: clean up `_sputils.getdtype` docstring

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -15,7 +15,7 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
                     np.uintc, np_long, np_ulong, np.longlong, np.ulonglong,
-                    np.float32, np.float64, np.longdouble, 
+                    np.float32, np.float64, np.longdouble,
                     np.complex64, np.complex128, np.clongdouble]
 
 _upcast_memo = {}
@@ -109,12 +109,15 @@ def to_native(A):
 
 
 def getdtype(dtype, a=None, default=None):
-    """Function used to simplify argument processing. If 'dtype' is not
-    specified (is None), returns a.dtype. If 'dtype' and 'a'
-    are both None, return a numpy data type using the 'default' parameter.
-    Furthermore, 'dtype' must not be a np object and must be in supported_dtypes.
+    """Function used to simplify dtype argument processing.
+    If `dtype` is not specified (is None), returns ``a.dtype``. If `dtype`
+    and `a` are both None, return a numpy data type using `default`.
+
+    Furthermore, `dtype` must be in `supported_dtypes`:
+        bool_, int8, uint8, int16, uint16, int32, uint32,
+        int64, uint64, longlong, ulonglong, float32, float64,
+        longdouble, complex64, complex128, clongdouble
     """
-    # TODO is this really what we want?
     if dtype is None:
         try:
             newdtype = a.dtype
@@ -130,7 +133,6 @@ def getdtype(dtype, a=None, default=None):
         supported_dtypes_fmt = ", ".join(t.__name__ for t in supported_dtypes)
         raise ValueError(f"scipy.sparse does not support dtype {newdtype.name}. "
                          f"The only supported types are: {supported_dtypes_fmt}.")
-    
     return newdtype
 
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -109,11 +109,13 @@ def to_native(A):
 
 
 def getdtype(dtype, a=None, default=None):
-    """Function used to simplify dtype argument processing.
-    If `dtype` is not specified (is None), returns ``a.dtype``. If `dtype`
-    and `a` are both None, return a numpy data type using `default`.
+    """Form a supported numpy dtype based on input arguments.
 
-    Furthermore, `dtype` must be in `supported_dtypes`:
+    Returns a valid ``numpy.dtype`` from `dtype` if not None,
+    or else ``a.dtype`` if possible, or else the given `default`
+    if not None, or else raise a ``TypeError``.
+
+    The resulting ``dtype`` must be in ``supported_dtypes``:
         bool_, int8, uint8, int16, uint16, int32, uint32,
         int64, uint64, longlong, ulonglong, float32, float64,
         longdouble, complex64, complex128, clongdouble

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -110,10 +110,9 @@ def to_native(A):
 
 def getdtype(dtype, a=None, default=None):
     """Function used to simplify argument processing. If 'dtype' is not
-    specified (is None), returns a.dtype; otherwise returns a np.dtype
-    object created from the specified dtype argument. If 'dtype' and 'a'
-    are both None, construct a data type out of the 'default' parameter.
-    Furthermore, 'dtype' must be in 'allowed' set.
+    specified (is None), returns a.dtype. If 'dtype' and 'a'
+    are both None, return a numpy data type using the 'default' parameter.
+    Furthermore, 'dtype' must not be a np object and must be in supported_dtypes.
     """
     # TODO is this really what we want?
     if dtype is None:


### PR DESCRIPTION
Some changes to the docstring of getdtype function and adding a Value error if dtype not among the supported types list.
#### Reference issue

#### What does this implement/fix?

Closes #20879 

#### Additional information
