### PR TITLE
API: Add `rng=` as suggested in SPEC 7 and use it for RatioUniforms

### DIFF
--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1426,7 +1426,8 @@ class TestRatioUniforms:
         gen1 = RatioUniforms(f, umax=umax, vmin=-v, vmax=v, random_state=1234)
         r1 = gen1.rvs(10)
         np.random.seed(1234)
-        gen2 = RatioUniforms(f, umax=umax, vmin=-v, vmax=v)
+        with pytest.warns(FutureWarning, match=".*The NumPy global rng"):
+            gen2 = RatioUniforms(f, umax=umax, vmin=-v, vmax=v)
         r2 = gen2.rvs(10)
         assert_equal(r1, r2)
 
@@ -1434,11 +1435,11 @@ class TestRatioUniforms:
         f = stats.norm.pdf
         # need vmin < vmax
         with assert_raises(ValueError, match="vmin must be smaller than vmax"):
-            RatioUniforms(pdf=f, umax=1, vmin=3, vmax=1)
+            RatioUniforms(pdf=f, umax=1, vmin=3, vmax=1, rng=123)
         with assert_raises(ValueError, match="vmin must be smaller than vmax"):
-            RatioUniforms(pdf=f, umax=1, vmin=1, vmax=1)
+            RatioUniforms(pdf=f, umax=1, vmin=1, vmax=1, rng=123)
         # need umax > 0
         with assert_raises(ValueError, match="umax must be positive"):
-            RatioUniforms(pdf=f, umax=-1, vmin=1, vmax=3)
+            RatioUniforms(pdf=f, umax=-1, vmin=1, vmax=3, rng=None)
         with assert_raises(ValueError, match="umax must be positive"):
-            RatioUniforms(pdf=f, umax=0, vmin=1, vmax=3)
+            RatioUniforms(pdf=f, umax=0, vmin=1, vmax=3, rng=None)


### PR DESCRIPTION
This implements a decorator to start the transition to `rng=`.  The big change is that it introduces a `FutureWarning` when `np.random.seed()` was ever called and the user is not passing `rng=` (or `random_state=`).

Further deprecation is not done here, since we want downstream to be able to switch to `rng=` directly without needing version specific changes (i.e. wait ~3 years unfortunately).

The new `rng=` is effectively identical to calling `rng = np.random.default_rng(rng)`.

See also the [SPEC PR](https://github.com/scientific-python/specs/pull/180) (EDIT Ralf: and gh-14322 as the canonical SciPy issue)

---

If merged, this PR needs to be followed up with introducing it wherever `check_random_state` is used.
