### PR TITLE
DOC: linalg.schur: update doc for the argument `sort`

### DIFF
--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -42,6 +42,9 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         Specifies whether the upper eigenvalues should be sorted. A callable
         may be passed that, given a eigenvalue, returns a boolean denoting
         whether the eigenvalue should be sorted to the top-left (True).
+        If output='real', the callable should have two arguments, the first
+        one being the real part of the eigenvalue, the second one being
+        the imaginary part.
         Alternatively, string parameters may be used::
 
             'lhp'   Left-hand plane (x.real < 0.0)


### PR DESCRIPTION
#### Reference issue
Closes #19791 

#### What does this implement/fix?
The documentation for `linalg.schur` explains now the arguments needed to be in `sort` when this is a callable.

#### Additional information
Would this be fine or should we also explicitly write that if output='complex' the callable should have only one argument being the argument a complex number?
