### PR TITLE
CI: Make sure nightly free-threaded wheels are tested with GIL disabled

### DIFF
--- a/tools/wheels/cibw_before_test.sh
+++ b/tools/wheels/cibw_before_test.sh
@@ -7,9 +7,4 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
     python -m pip install git+https://github.com/cython/cython
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-
-    # TODO: delete when importing numpy no longer enables the GIL
-    # setting to zero ensures the GIL is disabled while running the
-    # tests under free-threaded python
-    export PYTHON_GIL=0
 fi

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -1,3 +1,11 @@
 set -xe
 
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    # TODO: delete when importing numpy no longer enables the GIL
+    # setting to zero ensures the GIL is disabled while running the
+    # tests under free-threaded python
+    export PYTHON_GIL=0
+fi
+
 python -c "import sys; import scipy; sys.exit(not scipy.test())"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See https://github.com/scipy/scipy/pull/20882#issuecomment-2150484149

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR ensures that free-threaded wheels are tested with the GIL disabled, i.e., `PYTHON_GIL=0`

#### Additional information
<!--Any additional information you think is important.-->
