### PR TITLE
DOC: signal.dbode: improve docstring

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3436,9 +3436,9 @@ def dbode(system, w=None, n=100):
             * 4 (A, B, C, D, dt)
 
     w : array_like, optional
-        Array of frequencies (in radians/sample). Magnitude and phase data is
-        calculated for every value in this array. If not given a reasonable
-        set will be calculated.
+        Array of frequencies (in radians/sample, i.e. 0 to pi covers up to the
+        Nyquist frequency). Magnitude and phase data is calculated for every
+        value in this array. If not given, a reasonable set will be calculated.
     n : int, optional
         Number of frequency points to compute if `w` is not given. The `n`
         frequencies are logarithmically spaced in an interval chosen to
@@ -3447,7 +3447,7 @@ def dbode(system, w=None, n=100):
     Returns
     -------
     w : 1D ndarray
-        Frequency array [rad/time_unit]
+        Frequency array [rad/s]
     mag : 1D ndarray
         Magnitude array [dB]
     phase : 1D ndarray


### PR DESCRIPTION
Unlike dfreqresp, which from context makes it clear what "radian/samples" means, dbode lacks such an example. This can be helpful for non-native speakers.

The unit for the returned frequency array w was wrong, since dt is specified to be in seconds.

[docs only]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->