### PR TITLE
DEP: special.perm: deprecate non-integer `N` and `k` with `exact=True`

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2792,25 +2792,24 @@ def perm(N, k, exact=False):
 
     """
     if exact:
+        N = np.squeeze(N)[()]  # for backward compatibility (accepted size 1 arrays)
+        k = np.squeeze(k)[()]
         if not (isscalar(N) and isscalar(k)):
             raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
+
+        floor_N, floor_k = int(N), int(k)
+        non_integral = not (floor_N == N and floor_k == k)
         if (k > N) or (N < 0) or (k < 0):
-            if (
-                (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
-                 or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
-            ):
+            if non_integral:
                 msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and "
                        "will raise an error in SciPy 1.16.0.")
                 warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return 0
-        if (
-            (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
-                or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
-        ):
+        if non_integral:
             raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
                              "supported.")
         val = 1
-        for i in range(N - k + 1, N + 1):
+        for i in range(floor_N - floor_k + 1, floor_N + 1):
             val *= i
         return val
     else:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2765,9 +2765,9 @@ def perm(N, k, exact=False):
     k : int, ndarray
         Number of elements taken.
     exact : bool, optional
-        If True, calculate the answer exactly using long integer arithmetic and
-        `N` and `k` must be scalar integers. If False, result is approximated in
-        floating point rapidly using `poch`. Default is False.
+        If ``True``, calculate the answer exactly using long integer arithmetic (`N`
+        and `k` must be scalar integers). If ``False``, result is approximated in
+        floating point rapidly using `poch`. Default is ``False``.
     Returns
     -------
     val : int, ndarray
@@ -2793,7 +2793,7 @@ def perm(N, k, exact=False):
     if exact:
         if not (isscalar(N) and isscalar(k)):
             raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
-        if not floor(N) == N and floor(k) == k:
+        if not (floor(N) == N and floor(k) == k):
             msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and will "
                    "raise an error in SciPy 1.17.0.")
             warnings.warn(msg, DeprecationWarning, stacklevel=2)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2766,8 +2766,8 @@ def perm(N, k, exact=False):
         Number of elements taken.
     exact : bool, optional
         If ``True``, calculate the answer exactly using long integer arithmetic (`N`
-        and `k` must be scalar integers). If ``False``, result is approximated in
-        floating point rapidly using `poch`. Default is ``False``.
+        and `k` must be scalar integers). If ``False``, a floating point approximation
+        is calculated (more rapidly) using `poch`. Default is ``False``.
     Returns
     -------
     val : int, ndarray

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2794,12 +2794,21 @@ def perm(N, k, exact=False):
     if exact:
         if not (isscalar(N) and isscalar(k)):
             raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
-        if not (floor(N) == N and floor(k) == k):
-            msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and will "
-                   "raise an error in SciPy 1.17.0.")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
         if (k > N) or (N < 0) or (k < 0):
+            if (
+                (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
+                 or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
+            ):
+                msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and "
+                       "will raise an error in SciPy 1.16.0.")
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return 0
+        if (
+            (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
+                or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
+        ):
+            raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
+                             "supported.")
         val = 1
         for i in range(N - k + 1, N + 1):
             val *= i

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2765,9 +2765,9 @@ def perm(N, k, exact=False):
     k : int, ndarray
         Number of elements taken.
     exact : bool, optional
-        If `exact` is False, then floating point precision is used, otherwise
-        exact long integer is computed.
-
+        If True, calculate the answer exactly using long integer arithmetic and
+        `N` and `k` must be scalar integers. If False, result is approximated in
+        floating point rapidly using `poch`. Default is False.
     Returns
     -------
     val : int, ndarray
@@ -2791,6 +2791,12 @@ def perm(N, k, exact=False):
 
     """
     if exact:
+        if not (isscalar(N) and isscalar(k)):
+            raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
+        if not floor(N) == N and floor(k) == k:
+            msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and will "
+                   "raise an error in SciPy 1.17.0.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
         if (k > N) or (N < 0) or (k < 0):
             return 0
         val = 1

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2768,6 +2768,7 @@ def perm(N, k, exact=False):
         If ``True``, calculate the answer exactly using long integer arithmetic (`N`
         and `k` must be scalar integers). If ``False``, a floating point approximation
         is calculated (more rapidly) using `poch`. Default is ``False``.
+
     Returns
     -------
     val : int, ndarray

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1459,7 +1459,7 @@ class TestCombinatorics:
         assert_equal(special.comb(2, -1, exact=True), 0)
         assert_equal(special.comb(2, -1, exact=False), 0)
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
-    
+
     def test_comb_exact_non_int_dep(self):
         msg = "`exact=True`"
         with pytest.deprecated_call(match=msg):
@@ -1490,13 +1490,11 @@ class TestCombinatorics:
             special.perm(-4.6, 3, exact=True)
         with pytest.deprecated_call(match="Non-integer"):
             special.perm(4, -3.9, exact=True)
-        
+
         # Non-integral scalars which aren't included in the cases above an raise an
         # error directly without deprecation as this code never worked
         with pytest.raises(ValueError, match="Non-integer"):
             special.perm(6.0, 4.6, exact=True)
-        with pytest.raises(ValueError, match="Non-integer"):
-            special.perm(6.0, 4.0, exact=True)
 
 
 class TestTrigonometric:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1477,11 +1477,26 @@ class TestCombinatorics:
         assert_equal(special.perm(2, -1, exact=False), 0)
         assert_allclose(special.perm([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 720.])
 
-    def test_perm_invalid_inputs(self):
+    def test_perm_iv(self):
+        # currently `exact=True` only support scalars
         with pytest.raises(ValueError, match="scalar integers"):
             special.perm([1, 2], [4, 5], exact=True)
+
+        # Non-integral scalars with N < k, or N,k < 0 used to return 0, this is now
+        # deprecated and will raise an error in SciPy 1.16.0
         with pytest.deprecated_call(match="Non-integer"):
             special.perm(4.6, 6, exact=True)
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(-4.6, 3, exact=True)
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(4, -3.9, exact=True)
+        
+        # Non-integral scalars which aren't included in the cases above an raise an
+        # error directly without deprecation as this code never worked
+        with pytest.raises(ValueError, match="Non-integer"):
+            special.perm(6.0, 4.6, exact=True)
+        with pytest.raises(ValueError, match="Non-integer"):
+            special.perm(6.0, 4.0, exact=True)
 
 
 class TestTrigonometric:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1477,6 +1477,12 @@ class TestCombinatorics:
         assert_equal(special.perm(2, -1, exact=False), 0)
         assert_allclose(special.perm([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 720.])
 
+    def test_perm_invalid_inputs(self):
+        with pytest.raises(ValueError, match="scalar integers"):
+            special.perm([1, 2], [4, 5], exact=True)
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(4.6, 6, exact=True)
+
 
 class TestTrigonometric:
     def test_cbrt(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/20780#pullrequestreview-2081429801
#### What does this implement/fix?
<!--Please explain your changes.-->
Currently the behaviour of perm with `exact=True` is inconsistent with the other combinatorial functions. Specifically, floats sometimes cause an error and sometimes produce an output:
```
In [4]: perm(4.6, 6, exact=True)
Out[4]: 0

In [5]: perm(4.6, 3, exact=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 1
----> 1 perm(4.6, 3, exact=True)

File ~/development/scipy/build-install/lib/python3.11/site-packages/scipy/special/_basic.py:2797, in perm(N, k, exact)
   2795     return 0
   2796 val = 1
-> 2797 for i in range(N - k + 1, N + 1):
   2798     val *= i
   2799 return val

TypeError: 'float' object cannot be interpreted as an integer
```

This pr deprecates floats with `exact=True`.
#### Additional information
<!--Any additional information you think is important.-->
