### PR TITLE
DOC: `integrate.quad_vec`: Add example when using `workers`

### DIFF
--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -222,7 +222,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     >>> plt.show()
 
     When using the argument ``workers``, one should ensure
-    the main module is import-safe, for instance
+    that the main module is import-safe, for instance
     by rewriting the example above as:
 
     .. code-block:: python

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -221,6 +221,23 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()
 
+    When using the argument ``workers``, one should ensure
+    the 'Safe importing of main module', for instance
+    by rewriting the example above as:
+
+    >>> from scipy.integrate import quad_vec
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> alpha = np.linspace(0.0, 2.0, num=30)
+    >>> x0, x1 = 0, 2
+    >>> def f(x):
+    ...     return x**alpha
+    >>> if __name__ == "__main__":
+    ...     y, err = quad_vec(f, x0, x1, workers=2)
+    ...     plt.plot(alpha, y)
+    ...     plt.xlabel(r"$\alpha$")
+    ...     plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
+    ...     plt.show()
     """
     a = float(a)
     b = float(b)

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -209,35 +209,43 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     --------
     We can compute integrations of a vector-valued function:
 
-    >>> from scipy.integrate import quad_vec
-    >>> import numpy as np
-    >>> import matplotlib.pyplot as plt
-    >>> alpha = np.linspace(0.0, 2.0, num=30)
-    >>> f = lambda x: x**alpha
-    >>> x0, x1 = 0, 2
-    >>> y, err = quad_vec(f, x0, x1)
-    >>> plt.plot(alpha, y)
-    >>> plt.xlabel(r"$\alpha$")
-    >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
-    >>> plt.show()
+    .. plot::
+        :context: close-figs
+
+        >>> from scipy.integrate import quad_vec
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> alpha = np.linspace(0.0, 2.0, num=30)
+        >>> f = lambda x: x**alpha
+        >>> x0, x1 = 0, 2
+        >>> y, err = quad_vec(f, x0, x1)
+        >>> plt.plot(alpha, y)
+        >>> plt.xlabel(r"$\alpha$")
+        >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
+        >>> plt.show()
 
     When using the argument ``workers``, one should ensure
     the 'Safe importing of main module', for instance
     by rewriting the example above as:
 
-    >>> from scipy.integrate import quad_vec
-    >>> import numpy as np
-    >>> import matplotlib.pyplot as plt
-    >>> alpha = np.linspace(0.0, 2.0, num=30)
-    >>> x0, x1 = 0, 2
-    >>> def f(x):
-    ...     return x**alpha
-    >>> if __name__ == "__main__":
-    ...     y, err = quad_vec(f, x0, x1, workers=2)
-    ...     plt.plot(alpha, y)
-    ...     plt.xlabel(r"$\alpha$")
-    ...     plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
-    ...     plt.show()
+    .. highlight:: python
+    .. code-block:: python
+
+        from scipy.integrate import quad_vec
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        alpha = np.linspace(0.0, 2.0, num=30)
+        x0, x1 = 0, 2
+        def f(x):
+            return x**alpha
+
+        if __name__ == "__main__":
+            y, err = quad_vec(f, x0, x1, workers=2)
+            plt.plot(alpha, y)
+            plt.xlabel(r"$\alpha$")
+            plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
+            plt.show()
     """
     a = float(a)
     b = float(b)

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -222,7 +222,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     >>> plt.show()
 
     When using the argument ``workers``, one should ensure
-    the 'Safe importing of main module', for instance
+    the main module is import-safe, for instance
     by rewriting the example above as:
 
     .. code-block:: python

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -221,7 +221,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()
 
-    When using the argument ``workers``, one should ensure
+    When using the argument `workers`, one should ensure
     that the main module is import-safe, for instance
     by rewriting the example above as:
 

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -209,26 +209,22 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
     --------
     We can compute integrations of a vector-valued function:
 
-    .. plot::
-        :context: close-figs
-
-        >>> from scipy.integrate import quad_vec
-        >>> import numpy as np
-        >>> import matplotlib.pyplot as plt
-        >>> alpha = np.linspace(0.0, 2.0, num=30)
-        >>> f = lambda x: x**alpha
-        >>> x0, x1 = 0, 2
-        >>> y, err = quad_vec(f, x0, x1)
-        >>> plt.plot(alpha, y)
-        >>> plt.xlabel(r"$\alpha$")
-        >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
-        >>> plt.show()
+    >>> from scipy.integrate import quad_vec
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> alpha = np.linspace(0.0, 2.0, num=30)
+    >>> f = lambda x: x**alpha
+    >>> x0, x1 = 0, 2
+    >>> y, err = quad_vec(f, x0, x1)
+    >>> plt.plot(alpha, y)
+    >>> plt.xlabel(r"$\alpha$")
+    >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
+    >>> plt.show()
 
     When using the argument ``workers``, one should ensure
     the 'Safe importing of main module', for instance
     by rewriting the example above as:
 
-    .. highlight:: python
     .. code-block:: python
 
         from scipy.integrate import quad_vec

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -238,10 +238,6 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
 
         if __name__ == "__main__":
             y, err = quad_vec(f, x0, x1, workers=2)
-            plt.plot(alpha, y)
-            plt.xlabel(r"$\alpha$")
-            plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
-            plt.show()
     """
     a = float(a)
     b = float(b)


### PR DESCRIPTION
#### Reference issue
An attempt to close #18879

#### What does this implement/fix?
Write a second code example where the argument ``workers`` is used.
