### PR TITLE
BLD: optimize: use hidden visibility for static HiGHS libraries

### DIFF
--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -51,7 +51,8 @@ basiclu_lib = static_library('basiclu',
     '../../_lib/highs/src',
     '../../_lib/highs/src/ipm/basiclu/include'
   ],
-  c_args: [Wno_unused_variable, highs_define_macros]
+  c_args: [Wno_unused_variable, highs_define_macros],
+  gnu_symbol_visibility: 'inlineshidden',
 )
 
 highs_flags = [
@@ -109,7 +110,8 @@ ipx_lib = static_library('ipx',
     'cython/src/'
   ],
   dependencies: thread_dep,
-  cpp_args: [highs_flags, highs_define_macros]
+  cpp_args: [highs_flags, highs_define_macros],
+  gnu_symbol_visibility: 'inlineshidden',
 )
 
 highs_lib = static_library('highs',
@@ -226,7 +228,8 @@ highs_lib = static_library('highs',
     '../../_lib/highs/src/util/',
   ],
   dependencies: thread_dep,
-  cpp_args: [highs_flags, highs_define_macros]
+  cpp_args: [highs_flags, highs_define_macros],
+  gnu_symbol_visibility: 'inlineshidden',
 )
 
 _highs_wrapper = py3.extension_module('_highs_wrapper',


### PR DESCRIPTION
This is a follow-up to gh-20477, where HiGHS wasn't touched on purpose to avoid a merge conflict in another PR.

Minor useful side benefit: it shrinks the size of `_highs_wrapper.so` by 0.4%

Closes gh-20256

After this, on macOS:
```
dyld_info -exports build/scipy/optimize/_highs/_highs_wrapper.cpython-310-darwin.so
build/scipy/optimize/_highs/_highs_wrapper.cpython-310-darwin.so [arm64]:
    -exports:
        offset      symbol
        0x0000273C  _PyInit__highs_wrapper
```


Before:
```
dyld_info -exports build/scipy/optimize/_highs/_highs_wrapper.cpython-310-darwin.so
build/scipy/optimize/_highs/_highs_wrapper.cpython-310-darwin.so [arm64]:
    -exports:
        offset      symbol
        0x0000467C  _PyInit__highs_wrapper
        0x0013B7AC  __Z10callICrashRK7HighsLpRK13ICrashOptionsR10ICrashInfo
        0x001ED6A0  __Z10first_wordRNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEi
        0x00085964  __Z10getLpCostsRK7HighsLpiiPd
...
(a ton of symbols)
```
