### PR TITLE
BUG: stats.mstats: fix `mstats.{ttest_rel, ttest_1samp}` when array API is enabled

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -100,8 +100,4 @@ jobs:
         python dev.py --no-build test -b all -t scipy.special.tests.test_support_alternative_backends -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test_array_api -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test__util -- --durations 3 --timeout=60
-        python dev.py --no-build test -b all -t scipy.stats.tests.test_stats -- --durations 3 --timeout=60
-        python dev.py --no-build test -b all -t scipy.stats.tests.test_morestats -- --durations 3 --timeout=60
-        python dev.py --no-build test -b all -t scipy.stats.tests.test_variation -- --durations 3 --timeout=60
-        python dev.py --no-build test -b all -t scipy.stats.tests.test_resampling -- --durations 3 --timeout=60
-        python dev.py --no-build test -b all -t scipy.optimize.tests.test_chandrupatla -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -s stats -- --durations 3 --timeout=60

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -92,11 +92,11 @@ def _ttest_finish(df, t, alternative):
     # We use ``stdtr`` directly here to preserve masked arrays
 
     if alternative == 'less':
-        pval = special.stdtr(df, t)
+        pval = special._ufuncs.stdtr(df, t)
     elif alternative == 'greater':
-        pval = special.stdtr(df, -t)
+        pval = special._ufuncs.stdtr(df, -t)
     elif alternative == 'two-sided':
-        pval = special.stdtr(df, -np.abs(t))*2
+        pval = special._ufuncs.stdtr(df, -np.abs(t))*2
     else:
         raise ValueError("alternative must be "
                          "'less', 'greater' or 'two-sided'")


### PR DESCRIPTION
supersedes #20905

addresses the failures reported in https://github.com/scipy/scipy/pull/20883#issuecomment-2149788033 by bypassing the dispatching mechanism since stats.mstats doesn't support array API.

Also enables testing with array API enabled for the whole submodule as requested in https://github.com/scipy/scipy/pull/20905#issuecomment-2150936496