### PR TITLE
BUG: `_lib`: ensure reasonable length `_deprecate_positional_args` messages

### DIFF
--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -213,14 +213,10 @@ def _deprecate_positional_args(func=None, *, version=None):
                 return f(*args, **kwargs)
 
             # extra_args > 0
-            args_msg = [
-                f"{name}={arg}"
-                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
-            ]
-            args_msg = ", ".join(args_msg)
+            args_msg = ", ".join(kwonly_args[:extra_args])
             warnings.warn(
                 (
-                    f"You are passing {args_msg} as a positional argument. "
+                    f"You are passing as positional arguments: {args_msg}. "
                     "Please change your invocation to use keyword arguments. "
                     f"From SciPy {version}, passing these as positional "
                     "arguments will result in an error."


### PR DESCRIPTION
#### Reference issue

Closes gh-20910.

#### What does this implement/fix?

This updates the `DeprecationWarning` message emitted by `_deprecate_positional_args()` not to show argument values. An example of the new message with this change:

> test.py:12: DeprecationWarning: You are passing as positional arguments: x, y. Please change your invocation to use keyword arguments. From SciPy 1.14, passing these as positional arguments will result in an error.
