### PR TITLE
MAINT: adapt to a scipy-doctests change

### DIFF
--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -231,9 +231,9 @@ example that follows.
 
    Notice that `sproot` may fail to find an obvious solution at the edge of the
    approximation interval, :math:`x = 0`. If we define the spline on a slightly
-   larger interval, we recover both roots :math:`x = 0` and :math:`x = 2\pi`:
+   larger interval, we recover both roots :math:`x = 0` and :math:`x = \pi`:
 
-   >>> x = np.linspace(-np.pi/4, 2.*np.pi + np.pi/4, 21)
+   >>> x = np.linspace(-np.pi/4, np.pi + np.pi/4, 51)
    >>> y = np.sin(x)
    >>> tck = interpolate.splrep(x, y, s=0)
    >>> interpolate.sproot(tck)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -267,7 +267,7 @@ if HAVE_SCPDT:
 
     # FIXME: populate the dict once
     @contextmanager
-    def warnings_errors_and_rng(test):
+    def warnings_errors_and_rng(test=None):
         """Temporarily turn (almost) all warnings to errors.
 
         Filter out known warnings which we allow.
@@ -337,11 +337,11 @@ if HAVE_SCPDT:
         with _fixed_default_rng():
             np.random.seed(None)
             with warnings.catch_warnings():
-                if test.name in known_warnings:
+                if test and test.name in known_warnings:
                     warnings.filterwarnings('ignore',
                                             **known_warnings[test.name])
                     yield
-                elif test.name in legit:
+                elif test and test.name in legit:
                     yield
                 else:
                     warnings.simplefilter('error', Warning)


### PR DESCRIPTION
Allow the filter-warnings context manager to not receive a (doc)test.

This is useful to filter out DeprecationWarnings which are emitted during test discovery. Which is needed, e.g. for numpy 1/2 transition where things deprecated in numpy 2 emit warnings on import.

