### PR TITLE
ENH: stats.cauchy: improve cdf and quantile accuracy in tail

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1447,7 +1447,7 @@ class cauchy_gen(rv_continuous):
 
     def _pdf(self, x):
         # cauchy.pdf(x) = 1 / (pi * (1 + x**2))
-        return 1.0 / np.pi / (1.0 + x * x)
+        return 1.0 / (np.pi * (1.0 + x * x))
 
     def _cdf(self, x):
         return _lazywhere(

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1447,19 +1447,29 @@ class cauchy_gen(rv_continuous):
 
     def _pdf(self, x):
         # cauchy.pdf(x) = 1 / (pi * (1 + x**2))
-        return 1.0/np.pi/(1.0+x*x)
+        return 1.0 / np.pi / (1.0 + x * x)
 
     def _cdf(self, x):
-        return 0.5 + 1.0/np.pi*np.arctan(x)
+        return _lazywhere(
+             x > -2.0, (x, ),
+             lambda x: 0.5 + np.arctan(x) / np.pi, 
+             f2=lambda x: -np.arctan(1.0 / x) / np.pi
+        )
 
     def _ppf(self, q):
-        return np.tan(np.pi*q-np.pi/2.0)
+        # return -1.0 / np.tan(q * np.pi)
+        return -np.cotPi(q)
 
     def _sf(self, x):
-        return 0.5 - 1.0/np.pi*np.arctan(x)
+        return _lazywhere(
+             x < 2.0, (x, ),
+             lambda x: 0.5 - np.arctan(x) / np.pi, 
+             f2=lambda x: np.arctan(1.0 / x) / np.pi
+        )
 
     def _isf(self, q):
-        return np.tan(np.pi/2.0-np.pi*q)
+        # return 1.0 / np.tan(q * np.pi)
+        return np.cotPi(q)
 
     def _stats(self):
         return np.nan, np.nan, np.nan, np.nan

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4902,11 +4902,13 @@ class TestCauchy:
     def test_cdf(self):
         assert_almost_equal(stats.cauchy.cdf(-100000), 3.18309886173180341999e-6,
                             decimal=15)
+        assert_equal(stats.cauchy.cdf(-1), 0.25)
         assert_equal(stats.cauchy.cdf(0), 0.5)
 
     def test_sf(self):
         assert_almost_equal(stats.cauchy.sf(100000), 3.18309886173180341999e-6,
                             decimal=15)
+        assert_equal(stats.cauchy.sf(1), 0.25)
         assert_equal(stats.cauchy.sf(0), 0.5)
 
     def test_ppf(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4924,10 +4924,16 @@ class TestCauchy:
                             decimal=15)
         assert_equal(stats.cauchy.ppf(0.5), 0)
 
+        assert np.isneginf(stats.cauchy.ppf(0))
+        assert np.isposinf(stats.cauchy.ppf(1))
+
     def test_isf(self):
         assert_almost_equal(stats.cauchy.isf(2**-32), 1.36713055115286317932e9,
                             decimal=15)
         assert_equal(stats.cauchy.isf(0.5), 0)
+
+        assert np.isposinf(stats.cauchy.isf(0))
+        assert np.isneginf(stats.cauchy.isf(1))
 
 class TestChi2:
     # regression tests after precision improvements, ticket:1041, not verified

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4898,6 +4898,26 @@ class TestDgamma:
         for i in range(len(y)):
             assert y[i] == stats.dgamma.entropy(x[i])
 
+class TestCauchy:
+    def test_cdf(self):
+        assert_almost_equal(stats.cauchy.cdf(-100000), 3.18309886173180341999e-6,
+                            decimal=15)
+        assert_equal(stats.cauchy.cdf(0), 0.5)
+
+    def test_sf(self):
+        assert_almost_equal(stats.cauchy.sf(100000), 3.18309886173180341999e-6,
+                            decimal=15)
+        assert_equal(stats.cauchy.sf(0), 0.5)
+
+    def test_ppf(self):
+        assert_almost_equal(stats.cauchy.ppf(2**-32), -1.36713055115286317932e9,
+                            decimal=15)
+        assert_equal(stats.cauchy.ppf(0.5), 0)
+
+    def test_isf(self):
+        assert_almost_equal(stats.cauchy.isf(2**-32), 1.36713055115286317932e9,
+                            decimal=15)
+        assert_equal(stats.cauchy.isf(0.5), 0)
 
 class TestChi2:
     # regression tests after precision improvements, ticket:1041, not verified

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4899,6 +4899,14 @@ class TestDgamma:
             assert y[i] == stats.dgamma.entropy(x[i])
 
 class TestCauchy:
+    def test_pdf(self):
+        assert_almost_equal(stats.cauchy.pdf(0), 3.18309886183790671538e-1,
+                            decimal=15)
+        assert_almost_equal(stats.cauchy.pdf(1), 1.59154943091895335769e-1,
+                            decimal=15)
+        assert_almost_equal(stats.cauchy.pdf(2), 6.36619772367581343076e-2,
+                            decimal=15)
+
     def test_cdf(self):
         assert_almost_equal(stats.cauchy.cdf(-100000), 3.18309886173180341999e-6,
                             decimal=15)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Toward https://github.com/scipy/scipy/issues/20761

#### What does this implement/fix?
<!--Please explain your changes.-->
Improve the accuracy of the cdf and quantile of the cauchy distribution with reference to the Boost implementation.

#### Additional information
<!--Any additional information you think is important.-->
**This implementation does not yet work because cotPi is not yet implemented in scipy.**
See also: https://discuss.scientific-python.org/t/rfc-add-sinpi-cospi-tanpi-and-cotpi-functions-to-special/1193