### PR TITLE
MAINT: io: fix premature setting of attributes in `HBInfo`

### DIFF
--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -211,8 +211,6 @@ class HBInfo:
             pointer_format_str, indices_format_str, values_format_str,
             right_hand_sides_nlines=0, nelementals=0):
         """Do not use this directly, but the class ctrs (from_* functions)."""
-        self.title = title
-        self.key = key
         if title is None:
             title = "No Title"
         if len(title) > 72:
@@ -223,6 +221,8 @@ class HBInfo:
         if len(key) > 8:
             warnings.warn("key is > 8 characters (key is %s)" % key,
                           LineOverflow, stacklevel=3)
+        self.title = title
+        self.key = key
 
         self.total_nlines = total_nlines
         self.pointer_nlines = pointer_nlines


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-20931.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR sets the `title` and `key` attributes of `HBInfo` to after checking that they are `None` which ensures that the types of both attributes are `str`.