### PR TITLE
ENH: `special.logsumexp`: add array API support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -98,6 +98,7 @@ jobs:
         python dev.py --no-build test -b all -s constants -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -s fft -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy.special.tests.test_support_alternative_backends -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -t scipy.special.tests.test_logsumexp -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test_array_api -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test__util -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -s stats -- --durations 3 --timeout=60

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -531,7 +531,7 @@ def xp_broadcast_promote(*args, ensure_writeable=False, xp=None):
             arg = xp.broadcast_to(arg, shape)
 
         # convert dtype/copy only if needed
-        if (arg.dtype != dtype) or ((arg.shape != shape) and ensure_writeable):
+        if (arg.dtype != dtype) or ensure_writeable:
             arg = xp.astype(arg, dtype, copy=True)
         out.append(arg)
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -97,9 +97,6 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     """
     xp = array_namespace(a, b)
-    if is_jax(xp):
-        return xp.special.logsumexp(a, axis=axis, b=b, keepdims=keepdims,
-                                    return_sign=return_sign)
     a, b = xp_broadcast_promote(a, b, ensure_writeable=True)
     axis = tuple(range(a.ndim)) if axis is None else axis
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -1,5 +1,8 @@
 import numpy as np
 from scipy._lib._util import _asarray_validated
+from scipy._lib._array_api import (array_namespace, size as xp_size,
+                                   xp_broadcast_promote)
+
 
 __all__ = ["logsumexp", "softmax", "log_softmax"]
 
@@ -93,43 +96,49 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     1.6094379124341005, 1.6094379124341005
 
     """
-    a = _asarray_validated(a, check_finite=False)
-    if b is not None:
-        a, b = np.broadcast_arrays(a, b)
-        if np.any(b == 0):
-            a = a + 0.  # promote to at least float
-            a[b == 0] = -np.inf
+    xp = array_namespace(a, b)
+    a, b = xp_broadcast_promote(a, b, ensure_writeable=True)
+    axis = tuple(range(a.ndim)) if axis is None else axis
+
+    if b is not None and xp.any(b==0):
+        a[b == 0] = -xp.inf
 
     # Scale by real part for complex inputs, because this affects
     # the magnitude of the exponential.
-    initial_value = -np.inf if np.size(a) == 0 else None
-    a_max = np.amax(a.real, axis=axis, keepdims=True, initial=initial_value)
+    if xp_size(a) == 0:
+        # because `xp.max` doesn't have `initial` argument...
+        shape = np.asarray(a.shape)  # NumPy is concise for scalar or tuple `axis`
+        shape[axis] = 1
+        a_max = xp.full(tuple(shape), -xp.inf, dtype=a.dtype)
+    else:
+        real = xp.real(a) if xp.isdtype(a.dtype, "complex floating") else a
+        a_max = xp.max(real, axis=axis, keepdims=True)
 
     if a_max.ndim > 0:
-        a_max[~np.isfinite(a_max)] = 0
-    elif not np.isfinite(a_max):
+        a_max[~xp.isfinite(a_max)] = 0
+    elif not xp.isfinite(a_max):
         a_max = 0
 
     if b is not None:
-        b = np.asarray(b)
-        tmp = b * np.exp(a - a_max)
+        b = xp.asarray(b)
+        tmp = b * xp.exp(a - a_max)
     else:
-        tmp = np.exp(a - a_max)
+        tmp = xp.exp(a - a_max)
 
     # suppress warnings about log of zero
     with np.errstate(divide='ignore'):
-        s = np.sum(tmp, axis=axis, keepdims=keepdims)
+        s = xp.sum(tmp, axis=axis, keepdims=keepdims)
         if return_sign:
             # For complex, use the numpy>=2.0 convention for sign.
-            if np.issubdtype(s.dtype, np.complexfloating):
-                sgn = s / np.where(s == 0, 1, abs(s))
+            if xp.isdtype(s.dtype, "complex floating"):
+                sgn = s / xp.where(s == 0, xp.asarray(1, dtype=s.dtype), xp.abs(s))
             else:
-                sgn = np.sign(s)
-            s = abs(s)
-        out = np.log(s)
+                sgn = xp.sign(s)
+            s = xp.abs(s)
+        out = xp.log(s)
 
     if not keepdims:
-        a_max = np.squeeze(a_max, axis=axis)
+        a_max = xp.squeeze(a_max, axis=axis)
     out += a_max
 
     if return_sign:

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy._lib._util import _asarray_validated
-from scipy._lib._array_api import (array_namespace, size as xp_size, is_jax,
+from scipy._lib._array_api import (array_namespace, size as xp_size,
                                    xp_broadcast_promote)
 
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy._lib._util import _asarray_validated
-from scipy._lib._array_api import (array_namespace, size as xp_size,
+from scipy._lib._array_api import (array_namespace, size as xp_size, is_jax,
                                    xp_broadcast_promote)
 
 
@@ -97,10 +97,13 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     """
     xp = array_namespace(a, b)
+    if is_jax(xp):
+        return xp.special.logsumexp(a, axis=axis, b=b, keepdims=keepdims,
+                                    return_sign=return_sign)
     a, b = xp_broadcast_promote(a, b, ensure_writeable=True)
     axis = tuple(range(a.ndim)) if axis is None else axis
 
-    if b is not None and xp.any(b==0):
+    if b is not None:
         a[b == 0] = -xp.inf
 
     # Scale by real part for complex inputs, because this affects

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -11,6 +11,8 @@ from scipy.special import logsumexp, softmax
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('jax.numpy',
+                              reasons=["JAX arrays do not support item assignment"])
 class TestLogSumExp:
     def test_logsumexp(self, xp):
         # Test with zero-size array

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -1,161 +1,168 @@
-import numpy as np
-from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_array_almost_equal, assert_)
+import math
+import pytest
 
+import numpy as np
+from numpy.testing import assert_allclose
+
+from scipy.conftest import array_api_compatible
+from scipy._lib._array_api import array_namespace, xp_assert_equal, xp_assert_close
 from scipy.special import logsumexp, softmax
 
 
-def test_logsumexp():
+@array_api_compatible
+def test_logsumexp(xp):
     # Test with zero-size array
-    a = []
-    desired = -np.inf
-    assert_equal(logsumexp(a), desired)
+    a = xp.asarray([])
+    desired = xp.asarray(-xp.inf)
+    xp_assert_equal(logsumexp(a), desired)
 
     # Test whether logsumexp() function correctly handles large inputs.
-    a = np.arange(200)
-    desired = np.log(np.sum(np.exp(a)))
-    assert_almost_equal(logsumexp(a), desired)
+    a = xp.arange(200., dtype=xp.float64)
+    desired = xp.log(xp.sum(xp.exp(a)))
+    xp_assert_close(logsumexp(a), desired)
 
     # Now test with large numbers
-    b = [1000, 1000]
-    desired = 1000.0 + np.log(2.0)
-    assert_almost_equal(logsumexp(b), desired)
+    b = xp.asarray([1000., 1000])
+    desired = xp.asarray(1000.0 + math.log(2.0))
+    xp_assert_close(logsumexp(b), desired)
 
     n = 1000
-    b = np.full(n, 10000, dtype='float64')
-    desired = 10000.0 + np.log(n)
-    assert_almost_equal(logsumexp(b), desired)
+    b = xp.full((n,), 10000)
+    desired = xp.asarray(10000.0 + math.log(n))
+    xp_assert_close(logsumexp(b), desired)
 
-    x = np.array([1e-40] * 1000000)
-    logx = np.log(x)
+    x = xp.asarray([1e-40] * 1000000)
+    logx = xp.log(x)
+    X = xp.stack([x, x])
+    logX = xp.stack([logx, logx])
+    xp_assert_close(xp.exp(logsumexp(logX)), xp.sum(X))
+    xp_assert_close(xp.exp(logsumexp(logX, axis=0)), xp.sum(X, axis=0))
+    xp_assert_close(xp.exp(logsumexp(logX, axis=1)), xp.sum(X, axis=1))
 
-    X = np.vstack([x, x])
-    logX = np.vstack([logx, logx])
-    assert_array_almost_equal(np.exp(logsumexp(logX)), X.sum())
-    assert_array_almost_equal(np.exp(logsumexp(logX, axis=0)), X.sum(axis=0))
-    assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))
-
-    # Handling special values properly
-    assert_equal(logsumexp(np.inf), np.inf)
-    assert_equal(logsumexp(-np.inf), -np.inf)
-    assert_equal(logsumexp(np.nan), np.nan)
-    assert_equal(logsumexp([-np.inf, -np.inf]), -np.inf)
+    # # Handling special values properly
+    inf = xp.asarray([xp.inf])
+    nan = xp.asarray([xp.nan])
+    xp_assert_equal(logsumexp(inf), inf[0])
+    xp_assert_equal(logsumexp(-inf), -inf[0])
+    xp_assert_equal(logsumexp(nan), nan[0])
+    xp_assert_equal(logsumexp(xp.asarray([-xp.inf, -xp.inf])), -inf[0])
 
     # Handling an array with different magnitudes on the axes
-    assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                         [-1e10, -np.inf]], axis=-1),
-                              [1e10, -1e10])
+    a = xp.asarray([[1e10, 1e-10],
+                    [-1e10, -np.inf]])
+    ref = xp.asarray([1e10, -1e10])
+    xp_assert_close(logsumexp(a, axis=-1), ref)
 
-    # Test keeping dimensions
-    assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                         [-1e10, -np.inf]],
-                                        axis=-1,
-                                        keepdims=True),
-                              [[1e10], [-1e10]])
+    # # Test keeping dimensions
+    xp_test = array_namespace(a)  # torch needs newaxis
+    xp_assert_close(logsumexp(a, axis=-1, keepdims=True), ref[:, xp_test.newaxis])
 
     # Test multiple axes
-    assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                         [-1e10, -np.inf]],
-                                        axis=(-1,-2)),
-                              1e10)
+    xp_assert_close(logsumexp(a, axis=(-1, -2)), xp.asarray(1e10))
 
 
-def test_logsumexp_b():
-    a = np.arange(200)
-    b = np.arange(200, 0, -1)
-    desired = np.log(np.sum(b*np.exp(a)))
-    assert_almost_equal(logsumexp(a, b=b), desired)
+@array_api_compatible
+def test_logsumexp_b(xp):
+    a = xp.arange(200., dtype=xp.float64)
+    b = xp.arange(200., 0, -1)
+    desired = xp.log(xp.sum(b*xp.exp(a)))
+    xp_assert_close(logsumexp(a, b=b), desired)
 
-    a = [1000, 1000]
-    b = [1.2, 1.2]
-    desired = 1000 + np.log(2 * 1.2)
-    assert_almost_equal(logsumexp(a, b=b), desired)
+    a = xp.asarray([1000, 1000])
+    b = xp.asarray([1.2, 1.2])
+    desired = xp.asarray(1000 + math.log(2 * 1.2))
+    xp_assert_close(logsumexp(a, b=b), desired)
 
-    x = np.array([1e-40] * 100000)
-    b = np.linspace(1, 1000, 100000)
-    logx = np.log(x)
-
-    X = np.vstack((x, x))
-    logX = np.vstack((logx, logx))
-    B = np.vstack((b, b))
-    assert_array_almost_equal(np.exp(logsumexp(logX, b=B)), (B * X).sum())
-    assert_array_almost_equal(np.exp(logsumexp(logX, b=B, axis=0)),
-                                (B * X).sum(axis=0))
-    assert_array_almost_equal(np.exp(logsumexp(logX, b=B, axis=1)),
-                                (B * X).sum(axis=1))
+    x = xp.asarray([1e-40] * 100000)
+    b = xp.linspace(1, 1000, 100000)
+    logx = xp.log(x)
+    X = xp.stack((x, x))
+    logX = xp.stack((logx, logx))
+    B = xp.stack((b, b))
+    xp_assert_close(xp.exp(logsumexp(logX, b=B)), xp.sum(B * X))
+    xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=0)), xp.sum(B * X, axis=0))
+    xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=1)), xp.sum(B * X, axis=1))
 
 
-def test_logsumexp_sign():
-    a = [1,1,1]
-    b = [1,-1,-1]
+@array_api_compatible
+def test_logsumexp_sign(xp):
+    a = xp.asarray([1, 1, 1])
+    b = xp.asarray([1, -1, -1])
 
     r, s = logsumexp(a, b=b, return_sign=True)
-    assert_almost_equal(r,1)
-    assert_equal(s,-1)
+    xp_assert_close(r, xp.asarray(1.))
+    xp_assert_equal(s, xp.asarray(-1.))
 
 
-def test_logsumexp_sign_zero():
-    a = [1,1]
-    b = [1,-1]
+@array_api_compatible
+def test_logsumexp_sign_zero(xp):
+    a = xp.asarray([1, 1])
+    b = xp.asarray([1, -1])
 
     r, s = logsumexp(a, b=b, return_sign=True)
-    assert_(not np.isfinite(r))
-    assert_(not np.isnan(r))
-    assert_(r < 0)
-    assert_equal(s,0)
+    assert not xp.isfinite(r)
+    assert not xp.isnan(r)
+    assert r < 0
+    assert s == 0
 
 
-def test_logsumexp_sign_shape():
-    a = np.ones((1,2,3,4))
-    b = np.ones_like(a)
+@array_api_compatible
+def test_logsumexp_sign_shape(xp):
+    a = xp.ones((1, 2, 3, 4))
+    b = xp.ones_like(a)
 
     r, s = logsumexp(a, axis=2, b=b, return_sign=True)
+    assert r.shape == s.shape == (1, 2, 4)
 
-    assert_equal(r.shape, s.shape)
-    assert_equal(r.shape, (1,2,4))
-
-    r, s = logsumexp(a, axis=(1,3), b=b, return_sign=True)
-
-    assert_equal(r.shape, s.shape)
-    assert_equal(r.shape, (1,3))
+    r, s = logsumexp(a, axis=(1, 3), b=b, return_sign=True)
+    assert r.shape == s.shape == (1,3)
 
 
-def test_logsumexp_complex_sign():
-    a = np.array([1 + 1j, 2 - 1j, -2 + 3j])
+@array_api_compatible
+def test_logsumexp_complex_sign(xp):
+    a = xp.asarray([1 + 1j, 2 - 1j, -2 + 3j])
 
     r, s = logsumexp(a, return_sign=True)
 
-    expected_sumexp = np.exp(a).sum()
+    expected_sumexp = xp.sum(xp.exp(a))
     # This is the numpy>=2.0 convention for np.sign
-    expected_sign = expected_sumexp / abs(expected_sumexp)
+    expected_sign = expected_sumexp / xp.abs(expected_sumexp)
 
-    assert_allclose(s, expected_sign)
-    assert_allclose(s * np.exp(r), expected_sumexp)
+    xp_assert_close(s, expected_sign)
+    xp_assert_close(s * xp.exp(r), expected_sumexp)
 
 
-def test_logsumexp_shape():
-    a = np.ones((1, 2, 3, 4))
-    b = np.ones_like(a)
+@array_api_compatible
+def test_logsumexp_shape(xp):
+    a = xp.ones((1, 2, 3, 4))
+    b = xp.ones_like(a)
 
     r = logsumexp(a, axis=2, b=b)
-    assert_equal(r.shape, (1, 2, 4))
+    assert r.shape == (1, 2, 4)
 
     r = logsumexp(a, axis=(1, 3), b=b)
-    assert_equal(r.shape, (1, 3))
+    assert r.shape == (1, 3)
 
 
-def test_logsumexp_b_zero():
-    a = [1,10000]
-    b = [1,0]
+@array_api_compatible
+def test_logsumexp_b_zero(xp):
+    a = xp.asarray([1, 10000])
+    b = xp.asarray([1, 0])
 
-    assert_almost_equal(logsumexp(a, b=b), 1)
+    xp_assert_close(logsumexp(a, b=b), xp.asarray(1.))
 
 
-def test_logsumexp_b_shape():
-    a = np.zeros((4,1,2,1))
-    b = np.ones((3,1,5))
+@array_api_compatible
+def test_logsumexp_b_shape(xp):
+    a = xp.zeros((4, 1, 2, 1))
+    b = xp.ones((3, 1, 5))
 
     logsumexp(a, b=b)
+
+
+@pytest.mark.parametrize('arg', (1, [1, 2, 3]))
+def test_xp_invalid_input(arg):
+    assert logsumexp(arg) == logsumexp(np.asarray(np.atleast_1d(arg)))
 
 
 def test_softmax_fixtures():


### PR DESCRIPTION
#### Reference issue
Toward gh-20930

#### What does this implement/fix?
Adds array API support to `special.logsumexp`. I'll need this for `integrate.qmc_quad`.

@lucascolley @j-bowhay the `xp_broadcast_promote` utility should replace the need for promoting dtypes manually.