### PR TITLE
DOC: `array_api.rst`: update 1.14 functions with array API support

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -105,10 +105,19 @@ Support is provided in `scipy.special` for the following functions:
 `scipy.special.erf`, `scipy.special.erfc`, `scipy.special.i0`,
 `scipy.special.i0e`, `scipy.special.i1`, `scipy.special.i1e`,
 `scipy.special.gammaln`, `scipy.special.gammainc`, `scipy.special.gammaincc`,
-`scipy.special.logit`, and `scipy.special.expit`.
+`scipy.special.logit`, `scipy.special.expit`, `scipy.special.entr`,
+`scipy.special.rel_entr`, `scipy.special.rel_entr`, `scipy.special.xlogy`,
+and `scipy.special.chdtrc`.
 
 Support is provided in `scipy.stats` for the following functions:
-`scipy.stats.pearsonr` and `scipy.stats.moment`.
+`scipy.stats.moment`, `scipy.stats.skew`, `scipy.stats.kurtosis`,
+`scipy.stats.kstat`, `scipy.stats.kstatvar`, `scipy.stats.circmean`,
+`scipy.stats.circvar`, `scipy.stats.circstd`, `scipy.stats.entropy`,
+`scipy.stats.variation` , `scipy.stats.sem`, `scipy.stats.ttest_1samp`,
+`scipy.stats.pearsonr`, `scipy.stats.chisquare`, `scipy.stats.skewtest`,
+`scipy.stats.kurtosistest`, `scipy.stats.normaltest`, `scipy.stats.jarque_bera`,
+`scipy.stats.bartlett`, `scipy.stats.power_divergence`, and
+`scipy.stats.monte_carlo_test`.
 
 
 Implementation notes

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -110,14 +110,14 @@ Support is provided in `scipy.special` for the following functions:
 and `scipy.special.chdtrc`.
 
 Support is provided in `scipy.stats` for the following functions:
-`scipy.stats.moment`, `scipy.stats.skew`, `scipy.stats.kurtosis`,
-`scipy.stats.kstat`, `scipy.stats.kstatvar`, `scipy.stats.circmean`,
-`scipy.stats.circvar`, `scipy.stats.circstd`, `scipy.stats.entropy`,
-`scipy.stats.variation` , `scipy.stats.sem`, `scipy.stats.ttest_1samp`,
-`scipy.stats.pearsonr`, `scipy.stats.chisquare`, `scipy.stats.skewtest`,
-`scipy.stats.kurtosistest`, `scipy.stats.normaltest`, `scipy.stats.jarque_bera`,
-`scipy.stats.bartlett`, `scipy.stats.power_divergence`, and
-`scipy.stats.monte_carlo_test`.
+`scipy.stats.describe`, `scipy.stats.moment`, `scipy.stats.skew`,
+`scipy.stats.kurtosis`, `scipy.stats.kstat`, `scipy.stats.kstatvar`,
+`scipy.stats.circmean`, `scipy.stats.circvar`, `scipy.stats.circstd`,
+`scipy.stats.entropy`, `scipy.stats.variation` , `scipy.stats.sem`,
+`scipy.stats.ttest_1samp`, `scipy.stats.pearsonr`, `scipy.stats.chisquare`,
+`scipy.stats.skewtest`, `scipy.stats.kurtosistest`, `scipy.stats.normaltest`,
+`scipy.stats.jarque_bera`, `scipy.stats.bartlett`, `scipy.stats.power_divergence`,
+and `scipy.stats.monte_carlo_test`.
 
 
 Implementation notes

--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -160,6 +160,7 @@ As of 1.14.0, there is support for
 
 - `scipy.stats`: (select functions)
 
+  - `scipy.stats.describe`
   - `scipy.stats.moment`
   - `scipy.stats.skew`
   - `scipy.stats.kurtosis`


### PR DESCRIPTION
#### Reference issue
As noted in gh-20935

#### What does this implement/fix?
Updates list of functions with array API support in SciPy 1.14.0.

#### Additional information
This is for backport; we'll need to update for `main` separately.