### PR TITLE
DOC/MAINT: single to double backticks to remove improper linking

### DIFF
--- a/scipy/fftpack/_realtransforms.py
+++ b/scipy/fftpack/_realtransforms.py
@@ -333,7 +333,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
        \cos\left(\frac{\pi(2k+1)n}{2N}\right)
 
     The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
-    to a factor `2N`. The orthonormalized DCT-III is exactly the inverse of
+    to a factor ``2N``. The orthonormalized DCT-III is exactly the inverse of
     the orthonormalized DCT-II.
 
     **Type IV**
@@ -489,7 +489,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(k+1)(n+1)}{N+1}\right)
 
     Note that the DST-I is only supported for input size > 1.
-    The (unnormalized) DST-I is its own inverse, up to a factor `2(N+1)`.
+    The (unnormalized) DST-I is its own inverse, up to a factor ``2(N+1)``.
     The orthonormalized DST-I is exactly its own inverse.
 
     **Type II**
@@ -522,7 +522,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         \frac{\pi(2k+1)(n+1)}{2N}\right)
 
     The (unnormalized) DST-III is the inverse of the (unnormalized) DST-II, up
-    to a factor `2N`. The orthonormalized DST-III is exactly the inverse of the
+    to a factor ``2N``. The orthonormalized DST-III is exactly the inverse of the
     orthonormalized DST-II.
 
     .. versionadded:: 0.11.0
@@ -537,7 +537,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(2k+1)(2n+1)}{4N}\right)
 
-    The (unnormalized) DST-IV is its own inverse, up to a factor `2N`. The
+    The (unnormalized) DST-IV is its own inverse, up to a factor ``2N``. The
     orthonormalized DST-IV is exactly its own inverse.
 
     .. versionadded:: 1.2.0

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -709,8 +709,8 @@ def hstack(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block(hstack(blocks))` or convert one block
-        e.g. `blocks[0] = csr_array(blocks[0])`.
+        arrays, use ``block(hstack(blocks))`` or convert one block
+        e.g. ``blocks[0] = csr_array(blocks[0])``.
 
     See Also
     --------
@@ -756,7 +756,7 @@ def vstack(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block(vstack(blocks))` or convert one block
+        arrays, use ``block(vstack(blocks))`` or convert one block
         e.g. `blocks[0] = csr_array(blocks[0])`.
 
     See Also
@@ -815,7 +815,7 @@ def bmat(blocks, format=None, dtype=None):
         Otherwise return a sparse matrix.
 
         If you want a sparse array built from blocks that are not sparse
-        arrays, use `block_array()`.
+        arrays, use ``block_array()``.
 
     See Also
     --------
@@ -1116,7 +1116,7 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
         By default, uniform [0, 1) random values are used unless `dtype` is
         an integer (default uniform integers from that dtype) or
         complex (default uniform over the unit square in the complex plane).
-        For these, the `random_state` rng is used e.g. `rng.uniform(size=size)`.
+        For these, the `random_state` rng is used e.g. ``rng.uniform(size=size)``.
 
     Returns
     -------

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -112,7 +112,7 @@ class _data_matrix(_spbase):
         ------
         NotImplementedError : if n is a zero scalar
             If zero power is desired, special case it to use
-            `np.ones(A.shape, dtype=A.dtype)`
+            ``np.ones(A.shape, dtype=A.dtype)``
         """
         if not isscalarlike(n):
             raise NotImplementedError("input is not scalar")

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -422,7 +422,7 @@ class _dok_base(_spbase, IndexMixin, dict):
         .. deprecated:: 1.14.0
 
             `conjtransp` is deprecated and will be removed in v1.16.0.
-            Use `.T.conj()` instead.
+            Use ``.T.conj()`` instead.
         """
         msg = ("`conjtransp` is deprecated and will be removed in v1.16.0. "
                    "Use `.T.conj()` instead.")

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -573,7 +573,7 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=No
         convergence is tested with respect to the ``b - A @ x`` residual.
     callback : function
         User-supplied function to call after each iteration.  It is called
-        as `callback(args)`, where `args` are selected by `callback_type`.
+        as ``callback(args)``, where ``args`` are selected by `callback_type`.
     callback_type : {'x', 'pr_norm', 'legacy'}, optional
         Callback function argument requested:
           - ``x``: current iterate (ndarray), called on every restart

--- a/scipy/sparse/linalg/_isolve/lsmr.py
+++ b/scipy/sparse/linalg/_isolve/lsmr.py
@@ -155,7 +155,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     >>> x
     array([0., 0.])
 
-    The stopping code `istop=0` returned indicates that a vector of zeros was
+    The stopping code ``istop=0`` returned indicates that a vector of zeros was
     found as a solution. The returned solution `x` indeed contains
     ``[0., 0.]``. The next example has a non-trivial solution:
 
@@ -170,7 +170,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     >>> normr
     4.440892098500627e-16
 
-    As indicated by `istop=1`, `lsmr` found a solution obeying the tolerance
+    As indicated by ``istop=1``, `lsmr` found a solution obeying the tolerance
     limits. The given solution ``[1., -1.]`` obviously solves the equation. The
     remaining return values include information about the number of iterations
     (`itn=1`) and the remaining difference of left and right side of the solved

--- a/scipy/sparse/linalg/_isolve/lsqr.py
+++ b/scipy/sparse/linalg/_isolve/lsqr.py
@@ -282,7 +282,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     >>> x
     array([ 0.,  0.])
 
-    The stopping code `istop=0` returned indicates that a vector of zeros was
+    The stopping code ``istop=0`` returned indicates that a vector of zeros was
     found as a solution. The returned solution `x` indeed contains
     ``[0., 0.]``. The next example has a non-trivial solution:
 
@@ -297,7 +297,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     >>> r1norm
     4.440892098500627e-16
 
-    As indicated by `istop=1`, `lsqr` found a solution obeying the tolerance
+    As indicated by ``istop=1``, `lsqr` found a solution obeying the tolerance
     limits. The given solution ``[1., -1.]`` obviously solves the equation. The
     remaining return values include information about the number of iterations
     (`itn=1`) and the remaining difference of left and right side of the solved

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -38,7 +38,7 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
         error tolerance.  By default, no preconditioner is used.
     callback : function, optional
         User-supplied function to call after each iteration.  It is called
-        as `callback(xk)`, where `xk` is the current solution vector.
+        as ``callback(xk)``, where ``xk`` is the current solution vector.
     show : bool, optional
         Specify ``show = True`` to show the convergence, ``show = False`` is
         to close the output of the convergence.

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -127,7 +127,7 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         component larger than `eta` along the Lanczos vector will be purged.
         Default is set based on machine precision.
     anorm : float, optional
-        Estimate of ``||A||``.  Default is `0`.
+        Estimate of ``||A||``.  Default is ``0``.
     cgs : bool, optional
         If `True`, reorthogonalization is done using classical Gram-Schmidt.
         If `False` (default), it is done using modified Gram-Schmidt.
@@ -136,14 +136,14 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         when obtaining singular vectors.
     min_relgap : float, optional
         The smallest relative gap allowed between any shift in IRL mode.
-        Default is `0.001`.  Accessed only if ``irl_mode=True``.
+        Default is ``0.001``.  Accessed only if ``irl_mode=True``.
     shifts : int, optional
         Number of shifts per restart in IRL mode.  Default is determined
         to satisfy ``k <= min(kmax-shifts, m, n)``.  Must be
         >= 0, but choosing 0 might lead to performance degradation.
         Accessed only if ``irl_mode=True``.
     maxiter : int, optional
-        Maximum number of restarts in IRL mode.  Default is `1000`.
+        Maximum number of restarts in IRL mode.  Default is ``1000``.
         Accessed only if ``irl_mode=True``.
     random_state : {None, int, `numpy.random.Generator`,
                     `numpy.random.RandomState`}, optional

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -480,7 +480,7 @@ cdef class cKDTree:
         The n data points of dimension m to be indexed. This array is
         not copied unless this is necessary to produce a contiguous
         array of doubles. The data are also copied if the kd-tree is built
-        with `copy_data=True`.
+        with ``copy_data=True``.
     leafsize : positive int
         The number of points at which the algorithm switches over to
         brute-force.
@@ -1284,7 +1284,7 @@ cdef class cKDTree:
 
         where the brackets represents counting pairs between two data sets
         in a finite bin around ``r`` (distance), corresponding to setting
-        `cumulative=False`, and ``f = float(len(D)) / float(len(R))`` is the
+        ``cumulative=False``, and ``f = float(len(D)) / float(len(R))`` is the
         ratio between number of objects from data and random.
 
         The algorithm implemented here is loosely based on the dual-tree

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -267,7 +267,7 @@ class KDTree(cKDTree):
         The n data points of dimension m to be indexed. This array is
         not copied unless this is necessary to produce a contiguous
         array of doubles. The data are also copied if the kd-tree is built
-        with `copy_data=True`.
+        with ``copy_data=True``.
     leafsize : positive int
         The number of points at which the algorithm switches over to
         brute-force.

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -70,9 +70,9 @@ class SphericalVoronoi:
     -------
     calculate_areas
         Calculates the areas of the Voronoi regions. For 2D point sets, the
-        regions are circular arcs. The sum of the areas is `2 * pi * radius`.
+        regions are circular arcs. The sum of the areas is ``2 * pi * radius``.
         For 3D point sets, the regions are spherical polygons. The sum of the
-        areas is `4 * pi * radius**2`.
+        areas is ``4 * pi * radius**2``.
 
     Raises
     ------
@@ -321,10 +321,10 @@ class SphericalVoronoi:
         """Calculates the areas of the Voronoi regions.
 
         For 2D point sets, the regions are circular arcs. The sum of the areas
-        is `2 * pi * radius`.
+        is ``2 * pi * radius``.
 
         For 3D point sets, the regions are spherical polygons. The sum of the
-        areas is `4 * pi * radius**2`.
+        areas is ``4 * pi * radius**2``.
 
         .. versionadded:: 1.5.0
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -785,12 +785,12 @@ def jaccard(u, v, w=None):
 
     Notes
     -----
-    When both `u` and `v` lead to a `0/0` division i.e. there is no overlap
+    When both `u` and `v` lead to a ``0/0`` division i.e. there is no overlap
     between the items in the vectors the returned distance is 0. See the
     Wikipedia page on the Jaccard index [1]_, and this paper [2]_.
 
     .. versionchanged:: 1.2.0
-        Previously, when `u` and `v` lead to a `0/0` division, the function
+        Previously, when `u` and `v` lead to a ``0/0`` division, the function
         would return NaN. This was changed to return 0 instead.
 
     References

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5582,7 +5582,7 @@ add_newdoc("gdtrix",
     Parameters
     ----------
     a : array_like
-        `a` parameter values of ``gdtr(a, b, x)`. ``1/a`` is the "scale"
+        `a` parameter values of ``gdtr(a, b, x)``. ``1/a`` is the "scale"
         parameter of the gamma distribution.
     b : array_like
         `b` parameter values of ``gdtr(a, b, x)`. `b` is the "shape" parameter

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5457,7 +5457,7 @@ add_newdoc("gdtria",
     Returns
     -------
     a : scalar or ndarray
-        Values of the `a` parameter such that `p = gdtr(a, b, x)`.  `1/a`
+        Values of the `a` parameter such that ``p = gdtr(a, b, x)`.  ``1/a``
         is the "scale" parameter of the gamma distribution.
 
     See Also
@@ -5512,7 +5512,7 @@ add_newdoc("gdtrib",
     Parameters
     ----------
     a : array_like
-        `a` parameter values of `gdtr(a, b, x)`. `1/a` is the "scale"
+        `a` parameter values of ``gdtr(a, b, x)`. ``1/a`` is the "scale"
         parameter of the gamma distribution.
     p : array_like
         Probability values.
@@ -5582,10 +5582,10 @@ add_newdoc("gdtrix",
     Parameters
     ----------
     a : array_like
-        `a` parameter values of `gdtr(a, b, x)`. `1/a` is the "scale"
+        `a` parameter values of ``gdtr(a, b, x)`. ```1/a`` is the "scale"
         parameter of the gamma distribution.
     b : array_like
-        `b` parameter values of `gdtr(a, b, x)`. `b` is the "shape" parameter
+        `b` parameter values of ``gdtr(a, b, x)`. `b` is the "shape" parameter
         of the gamma distribution.
     p : array_like
         Probability values.
@@ -5602,8 +5602,8 @@ add_newdoc("gdtrix",
     See Also
     --------
     gdtr : CDF of the gamma distribution.
-    gdtria : Inverse with respect to `a` of `gdtr(a, b, x)`.
-    gdtrib : Inverse with respect to `b` of `gdtr(a, b, x)`.
+    gdtria : Inverse with respect to `a` of ``gdtr(a, b, x)``.
+    gdtrib : Inverse with respect to `b` of ``gdtr(a, b, x)``.
 
     Notes
     -----

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5582,7 +5582,7 @@ add_newdoc("gdtrix",
     Parameters
     ----------
     a : array_like
-        `a` parameter values of ``gdtr(a, b, x)`. ```1/a`` is the "scale"
+        `a` parameter values of ``gdtr(a, b, x)`. ``1/a`` is the "scale"
         parameter of the gamma distribution.
     b : array_like
         `b` parameter values of ``gdtr(a, b, x)`. `b` is the "shape" parameter

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5585,7 +5585,7 @@ add_newdoc("gdtrix",
         `a` parameter values of ``gdtr(a, b, x)``. ``1/a`` is the "scale"
         parameter of the gamma distribution.
     b : array_like
-        `b` parameter values of ``gdtr(a, b, x)`. `b` is the "shape" parameter
+        `b` parameter values of ``gdtr(a, b, x)``. `b` is the "shape" parameter
         of the gamma distribution.
     p : array_like
         Probability values.

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3248,9 +3248,9 @@ def stirling2(N, K, *, exact=False):
         Temme for larger entries  of `N` and `K` that allows trading speed for
         accuracy. See [2]_ for a description. Temme approximation is used for
         values `n>50`. The max error from the DP has max relative error
-        `4.5*10^-16` for `n<=50` and the max error from the Temme approximation
-        has max relative error `5*10^-5` for `51 <= n < 70` and
-        `9*10^-6` for `70 <= n < 101`. Note that these max relative errors will
+        ``4.5*10^-16`` for `n<=50` and the max error from the Temme approximation
+        has max relative error ``5*10^-5`` for ``51 <= n < 70`` and
+        ``9*10^-6`` for ``70 <= n < 101``. Note that these max relative errors will
         decrease further as `n` increases.
 
     Returns

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3248,7 +3248,7 @@ def stirling2(N, K, *, exact=False):
         Temme for larger entries  of `N` and `K` that allows trading speed for
         accuracy. See [2]_ for a description. Temme approximation is used for
         values `n>50`. The max error from the DP has max relative error
-        ``4.5*10^-16`` for `n<=50` and the max error from the Temme approximation
+        ``4.5*10^-16`` for ``n<=50`` and the max error from the Temme approximation
         has max relative error ``5*10^-5`` for ``51 <= n < 70`` and
         ``9*10^-6`` for ``70 <= n < 101``. Note that these max relative errors will
         decrease further as `n` increases.

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2607,8 +2607,8 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
 
     >>> a = np.array([10, 4, 9, 8, 5, 3, 7, 2, 1, 6])
 
-    The 10% of the lowest value (i.e., `1`) and the 20% of the highest
-    values (i.e., `9` and `10`) are replaced.
+    The 10% of the lowest value (i.e., ``1``) and the 20% of the highest
+    values (i.e., ``9`` and ``10``) are replaced.
 
     >>> winsorize(a, limits=[0.1, 0.2])
     masked_array(data=[8, 4, 8, 8, 5, 3, 7, 2, 2, 6],

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -653,7 +653,7 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_default_callparams)s
         maxpts : integer, optional
             The maximum number of points to use for integration
-            (default `1000000*dim`)
+            (default ``1000000*dim``)
         abseps : float, optional
             Absolute error tolerance (default 1e-5)
         releps : float, optional
@@ -698,7 +698,7 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_default_callparams)s
         maxpts : integer, optional
             The maximum number of points to use for integration
-            (default `1000000*dim`)
+            (default ``1000000*dim``)
         abseps : float, optional
             Absolute error tolerance (default 1e-5)
         releps : float, optional
@@ -877,7 +877,7 @@ class multivariate_normal_frozen(multi_rv_frozen):
             then that instance is used.
         maxpts : integer, optional
             The maximum number of points to use for integration of the
-            cumulative distribution function (default `1000000*dim`)
+            cumulative distribution function (default ``1000000*dim``)
         abseps : float, optional
             Absolute error tolerance for the cumulative distribution function
             (default 1e-5)
@@ -968,15 +968,15 @@ _matnorm_doc_default_callparams = """\
 mean : array_like, optional
     Mean of the distribution (default: `None`)
 rowcov : array_like, optional
-    Among-row covariance matrix of the distribution (default: `1`)
+    Among-row covariance matrix of the distribution (default: ``1``)
 colcov : array_like, optional
-    Among-column covariance matrix of the distribution (default: `1`)
+    Among-column covariance matrix of the distribution (default: ``1``)
 """
 
 _matnorm_doc_callparams_note = """\
 If `mean` is set to `None` then a matrix of zeros is used for the mean.
 The dimensions of this matrix are inferred from the shape of `rowcov` and
-`colcov`, if these are provided, or set to `1` if ambiguous.
+`colcov`, if these are provided, or set to ``1`` if ambiguous.
 
 `rowcov` and `colcov` can be two-dimensional array_likes specifying the
 covariance matrices directly. Alternatively, a one-dimensional array will
@@ -1329,9 +1329,9 @@ class matrix_normal_gen(multi_rv_generic):
         Parameters
         ----------
         rowcov : array_like, optional
-            Among-row covariance matrix of the distribution (default: `1`)
+            Among-row covariance matrix of the distribution (default: ``1``)
         colcov : array_like, optional
-            Among-column covariance matrix of the distribution (default: `1`)
+            Among-column covariance matrix of the distribution (default: ``1``)
 
         Returns
         -------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -704,10 +704,10 @@ def _van_der_corput_permutations(
     Notes
     -----
     In Algorithm 1 of Owen 2017, a permutation of `np.arange(base)` is
-    created for each positive integer `k` such that `1 - base**-k < 1`
+    created for each positive integer `k` such that ``1 - base**-k < 1``
     using floating-point arithmetic. For double precision floats, the
-    condition `1 - base**-k < 1` can also be written as `base**-k >
-    2**-54`, which makes it more apparent how many permutations we need
+    condition ``1 - base**-k < 1`` can also be written as ``base**-k >
+    2**-54``, which makes it more apparent how many permutations we need
     to create.
     """
     rng = check_random_state(random_state)

--- a/scipy/stats/tests/test_generation/reference_distributions.py
+++ b/scipy/stats/tests/test_generation/reference_distributions.py
@@ -35,7 +35,7 @@ class ReferenceDistribution:
     - moment accepts `order`, an integer that specifies the order of the (raw)
       moment, and `center`, which is the value about which the moment is
       taken. The default is to calculate the mean and use it to calculate
-      central moments; passing `0` results in a noncentral moment. For
+      central moments; passing ``0`` results in a noncentral moment. For
       efficiency, the mean can be passed explicitly if it is already known.
 
     Follow the example of SkewNormal to generate new reference distributions,


### PR DESCRIPTION
This fixes a few obviously improper usage of single backticks where the content cannot be a target.

This is part of an effort to uniformize the usage of single and doube backtick in order to have proper linking to all objects
