### PR TITLE
CI: Use Cython nightly wheel on free-threaded CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -471,13 +471,9 @@ jobs:
     - name: Install pre-release pip
       run: |
         pip install -U --pre pip
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
+    - name: Install nightly NumPy and Cython
       run: |
-        pip install git+https://github.com/cython/cython
-    - name: Install nightly NumPy
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
     - name: Install Python dependencies
       run: |
         pip install git+https://github.com/serge-sans-paille/pythran

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -23,8 +23,7 @@ cat $PROJECT_DIR/tools/wheels/LICENSE_linux.txt >> $PROJECT_DIR/LICENSE.txt
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
-    python -m pip install git+https://github.com/cython/cython
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
     # python -m pip install git+https://github.com/serge-sans-paille/pythran
     python -m pip install ninja meson-python pybind11 pythran
 fi

--- a/tools/wheels/cibw_before_test.sh
+++ b/tools/wheels/cibw_before_test.sh
@@ -3,8 +3,6 @@ set -ex
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # TODO: delete when numpy is buildable under free-threaded python
-    # with a released version of cython
     python -m pip install -U --pre pip
-    python -m pip install git+https://github.com/cython/cython
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
 fi


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See https://github.com/scipy/scipy/issues/20669

#### What does this implement/fix?
Since Cython nightly wheels are now being published in the Scientific Python Anaconda channel, SciPy free-threaded CIs now can use them as opposed to building them in-place, this will reduce overall execution times.

#### Additional information
See https://github.com/scientific-python/upload-nightly-action/issues/80
