### PR TITLE
DOC: update distributing section

### DIFF
--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -32,10 +32,10 @@ There are some issues with how Python packaging tools handle
 dependencies reported by projects.  Because SciPy gets regular bug reports
 about this, we go in a bit of detail here.
 
-SciPy only reports its dependency on NumPy via ``install_requires`` if NumPy
-isn't installed at all on a system, or when building wheels with
-``bdist_wheel``. SciPy no longer uses ``setup_requires`` (which in the past
-invoked ``easy_install``); build dependencies are now handled only via
+SciPy reports its dependency on NumPy via ``pyproject.toml`` for build purposes,
+and SciPy also has a runtime check that an appropriate version of NumPy is
+available. SciPy no longer uses ``setup_requires`` (which in
+the past invoked ``easy_install``); build dependencies are now handled only via
 ``pyproject.toml``. ``pyproject.toml`` relies on PEP 517; ``pip`` has
 ``--no-use-pep517`` and ``--no-build-isolation`` flags that may ignore
 ``pyproject.toml`` or treat it differently - if users use those flags, they
@@ -50,13 +50,14 @@ For dependencies it's important to set lower and upper bounds on their
 versions. For *build-time* dependencies, they are specified in
 ``pyproject.toml`` and the versions will *only* apply to the SciPy build
 itself. It's fine to specify either a range or a specific version for a
-dependency like ``wheel`` or ``setuptools``. For NumPy we have to worry
-about ABI compatibility too, hence we specify the version with ``==``
-to the lowest supported version (because NumPy's ABI is backward but not
-forward compatible).
+dependency like ``meson-python`` or ``pybind11``. For NumPy we have to worry
+about ABI compatibility too. However, with NumPy ``>=2.0.0rc1`` backwards
+compatibility is guaranteed as far back as the NumPy ``1.19`` series so
+specification of a lowest supported version of NumPy at build time is no
+longer required in ``pyproject.toml``.
 
 For *run-time dependencies* (currently only ``numpy``), we specify the range
-of versions in ``pyproject.toml`` and in ``install_requires`` in ``setup.py``.
+of versions in ``pyproject.toml`` and in ``scipy/__init__.py``.
 Getting the upper bound right is slightly tricky.  If we don't set any bound, a
 too-new version will be pulled in a few years down the line, and NumPy may have
 deprecated and removed some API that SciPy depended on by then. On the other
@@ -64,8 +65,8 @@ hand if we set the upper bound to the newest already-released version, then as
 soon as a new NumPy version is released there will be no matching SciPy version
 that works with it. Given that NumPy and SciPy both release in a 6-monthly
 cadence and that features that get deprecated in NumPy should stay around for
-another two releases, we specify the upper bound as ``<1.xx+3.0`` (where ``xx``
-is the minor version of the latest already-released NumPy.
+another two releases, we specify the upper bound as ``<2.xx+3.0`` (where ``xx``
+is the minor version of the latest already-released NumPy).
 
 
 .. _supported-py-numpy-versions:
@@ -73,16 +74,16 @@ is the minor version of the latest already-released NumPy.
 Supported Python and NumPy versions
 -----------------------------------
 The Python_ versions that SciPy supports are listed in the list of PyPI
-classifiers in ``setup.py``, and mentioned in the release notes for each
+classifiers in ``pyproject.toml``, and mentioned in the release notes for each
 release.  All newly released Python versions will be supported as soon as
 possible.  For the general policy on dropping support for a Python or NumPy
 version, see :ref:`NEP 29 <NEP29>`.  The final decision on dropping support is
 always taken on the scipy-dev forum.
 
-The lowest supported Numpy_ version for a SciPy version is mentioned in the
-release notes and is encoded in ``pyproject.toml``, ``scipy/__init__.py`` and the
-``install_requires`` field of ``setup.py``.  Typically the latest SciPy release
-supports ~5-7 minor versions of NumPy: up to 2.5 years' old NumPy versions,
+The lowest supported NumPy_ version for a SciPy version is mentioned in the
+release notes and is encoded in ``pyproject.toml`` and ``scipy/__init__.py``.
+Typically the latest SciPy release supports ~5-7 minor versions of NumPy: up
+to 2.5 years' old NumPy versions,
 (given that the frequency of NumPy releases is about 2x/year at the time of
 writing) plus two versions into the future.
 
@@ -106,11 +107,12 @@ and distributing them on PyPI or elsewhere.
 
 **General**
 
-- A binary is specific for a single Python version (because different Python
-  versions aren't ABI-compatible, at least up to Python 3.4).
-- Build against the lowest NumPy version that you need to support, then it will
-  work for all NumPy versions with the same major version number (NumPy does
-  maintain backwards ABI compatibility).
+- A binary is specific for a single (major) Python version (because different
+  major Python versions aren't ABI-compatible, at least up to Python 3.12).
+- Build against the lowest NumPy 2.x version that you need to support, then it
+  will work for all NumPy versions with the same major version number (NumPy
+  does maintain backwards ABI compatibility), and as far back as NumPy ``1.19``
+  series at the time of writing.
 - The easiest available toolchain for building portable SciPy binaries
   is our ``cibuildwheel`` infrastructure for common platforms, with
   details available in our CI infrastructure code and available via the
@@ -152,7 +154,7 @@ Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 
 
 .. _`SciPy's configuration file`: https://github.com/scipy/scipy/blob/main/pyproject.toml
-.. _Numpy: https://numpy.org
+.. _NumPy: https://numpy.org
 .. _Python: https://www.python.org
 .. _nose: https://nose.readthedocs.io
 .. _asv: https://asv.readthedocs.org

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -109,8 +109,8 @@ and distributing them on PyPI or elsewhere.
 
 - A binary is specific for a single (major) Python version (because different
   major Python versions aren't ABI-compatible, at least up to Python 3.12).
-- Build against the lowest NumPy 2.x version that you need to support, then it
-  will work for all NumPy versions with the same major version number (NumPy
+- Build against NumPy ``2.0.0``, then it will work for all NumPy versions with
+  the same major version number (NumPy
   does maintain backwards ABI compatibility), and as far back as NumPy ``1.19``
   series at the time of writing.
 - The easiest available toolchain for building portable SciPy binaries


### PR DESCRIPTION
* Fixes gh-20552

* The above-linked issue requested an update to our docs about distributing SciPy, and this is an attempt to modernize the docs a bit to reflect recent changes.

[docs only]

There is still a bit of duplication in the docs, and I think the Windows specific distributing section might need some updates/tweaks. The way I describe the NumPy `2.x` backward/forward compat could be clearer perhaps, I may make an inline note or two about that.