### PR TITLE
CI: Add MacOS to free-threaded wheel release CI

### DIFF
--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -156,7 +156,7 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@ba8be0d98853f5744f24e7f902c8adef7ae2e7f3  # v2.18.1
+        uses: pypa/cibuildwheel@a8d190a111314a07eb5116036c4b3fb26a4e3162  # v2.19.0
         env:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_FREE_THREADED_SUPPORT: True

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -179,18 +179,16 @@ jobs:
             ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
             ${{ matrix.buildplat[4] }}
 
-      - uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           # for installation of anaconda-client, required for upload to
           # anaconda.org
+          # default (and activated) environment name is test
           # Note that this step is *after* specific pythons have been used to
           # build and test the wheel
-          # for installation of anaconda-client, for upload to anaconda.org
-          # environment will be activated after creation, and in future bash steps
-          init-shell: bash
-          environment-name: upload-env
-          create-args: >-
-            anaconda-client
+          auto-update-conda: true
+          python-version: "3.10"
+          miniconda-version: "latest"
 
       - name: Upload wheels
         if: success()

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -84,7 +84,9 @@ jobs:
           - [ubuntu-22.04, musllinux, x86_64, "", ""]
           - [macos-12, macosx, x86_64, openblas, "10.9"]
           - [macos-13, macosx, x86_64, accelerate, "14.0"]
-          - [macos-14, macosx, arm64, openblas, "14.0"]
+          # OpenBLAS builds with deployment target set to 12 are failing due
+          # to relocation issues of gfortran dylibs
+          # - [macos-14, macosx, arm64, openblas, "12.0"]
           - [macos-14, macosx, arm64, accelerate, "14.0"]
           # TODO: build scipy and set up Windows and MacOS
           # cibuildwheel does not yet support Mac for free-threaded python

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -82,6 +82,10 @@ jobs:
         buildplat:
           - [ubuntu-22.04, manylinux, x86_64, "", ""]
           - [ubuntu-22.04, musllinux, x86_64, "", ""]
+          - [macos-12, macosx, x86_64, openblas, "10.9"]
+          - [macos-13, macosx, x86_64, accelerate, "14.0"]
+          - [macos-14, macosx, arm64, openblas, "12.0"]
+          - [macos-14, macosx, arm64, accelerate, "14.0"]
           # TODO: build scipy and set up Windows and MacOS
           # cibuildwheel does not yet support Mac for free-threaded python
           # windows is supported but numpy doesn't build on the image yet
@@ -103,6 +107,54 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Setup macOS
+        if: startsWith( matrix.buildplat[0], 'macos-' )
+        run: |
+          if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
+            echo CIBW_CONFIG_SETTINGS=\"setup-args=-Dblas=accelerate\" >> "$GITHUB_ENV"
+            # Always use preinstalled gfortran for Accelerate builds
+            ln -s $(which gfortran-13) gfortran
+            export PATH=$PWD:$PATH
+            echo "PATH=$PATH" >> "$GITHUB_ENV"
+            LIB_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
+          fi
+          if [[ ${{ matrix.buildplat[4] }} == '10.9' ]]; then
+            # Newest version of Xcode that supports macOS 10.9
+            XCODE_VER='13.4.1'
+          else
+            XCODE_VER='15.2'
+          fi
+          CIBW="sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app"
+          echo "CIBW_BEFORE_ALL=$CIBW" >> $GITHUB_ENV
+          # setting SDKROOT necessary when using the gfortran compiler
+          # installed in cibw_before_build_macos.sh
+          sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app
+          CIBW="MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[4] }}\
+            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)\
+            PKG_CONFIG_PATH=${{ github.workspace }}"
+          echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+          echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
+
+          PREFIX=DYLD_LIBRARY_PATH="\$(dirname \$(gfortran --print-file-name libgfortran.dylib))"
+          # remove libgfortran from location used for linking (if any), to
+          # check wheel has bundled things correctly and all tests pass without
+          # needing installed gfortran
+          POSTFIX=" sudo rm -rf /opt/gfortran-darwin-x86_64-native &&\
+                    sudo rm -rf /usr/local/gfortran/lib"
+          CIBW="$PREFIX delocate-listdeps -d {wheel} && echo "-----------" &&\
+            $PREFIX delocate-wheel -v $EXCLUDE --require-archs \
+            {delocate_archs} -w {dest_dir} {wheel} && echo "-----------" &&\
+            delocate-listdeps -d {dest_dir}/*.whl && echo "-----------" &&\
+            $POSTFIX"
+
+          # Rename x86 Accelerate wheel to test on macOS 13 runner
+          if [[ ${{ matrix.buildplat[0] }} == 'macos-13' && ${{ matrix.buildplat[4] }} == '14.0' ]]; then
+            CIBW+=" && mv {dest_dir}/\$(basename {wheel}) \
+              {dest_dir}/\$(echo \$(basename {wheel}) | sed 's/14_0/13_0/')"
+          fi
+          echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@ba8be0d98853f5744f24e7f902c8adef7ae2e7f3  # v2.18.1
         env:
@@ -113,6 +165,12 @@ jobs:
           # TODO: remove along with installing build deps in
           # cibw_before_build.sh when a released cython can build numpy
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+
+      - name: Rename after test (macOS x86 Accelerate only)
+        # Rename x86 Accelerate wheel back so it targets macOS >= 14
+        if: matrix.buildplat[0] == 'macos-13' && matrix.buildplat[4] == '14.0'
+        run: |
+          mv ./wheelhouse/*.whl $(find ./wheelhouse -type f -name '*.whl' | sed 's/13_0/14_0/')
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -84,7 +84,7 @@ jobs:
           - [ubuntu-22.04, musllinux, x86_64, "", ""]
           - [macos-12, macosx, x86_64, openblas, "10.9"]
           - [macos-13, macosx, x86_64, accelerate, "14.0"]
-          - [macos-14, macosx, arm64, openblas, "12.3"]
+          - [macos-14, macosx, arm64, openblas, "14.0"]
           - [macos-14, macosx, arm64, accelerate, "14.0"]
           # TODO: build scipy and set up Windows and MacOS
           # cibuildwheel does not yet support Mac for free-threaded python

--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -84,7 +84,7 @@ jobs:
           - [ubuntu-22.04, musllinux, x86_64, "", ""]
           - [macos-12, macosx, x86_64, openblas, "10.9"]
           - [macos-13, macosx, x86_64, accelerate, "14.0"]
-          - [macos-14, macosx, arm64, openblas, "12.0"]
+          - [macos-14, macosx, arm64, openblas, "12.3"]
           - [macos-14, macosx, arm64, accelerate, "14.0"]
           # TODO: build scipy and set up Windows and MacOS
           # cibuildwheel does not yet support Mac for free-threaded python

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -59,6 +59,16 @@ if [[ $PLATFORM == "arm64" ]]; then
   type -p gfortran
 fi
 
+# TODO: delete along with enabling build isolation by unsetting
+# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
+# python with a released version of cython
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    python -m pip install -U --pre pip
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
+    # python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11 pythran
+fi
 
 # Install Openblas
 python -m pip install -r requirements/openblas.txt


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See https://github.com/scipy/scipy/issues/20669

#### What does this implement/fix?
Since `cibuildwheel` now allows to build free-threaded Python wheels on MacOS, and NumPy is producing nightly wheels for such platform, SciPy could produce nightly free-threaded MacOS wheels as well. 

#### Additional information
<!--Any additional information you think is important.-->
See the corresponding PR in NumPy: https://github.com/numpy/numpy/pull/26664
