### PR TITLE
TST: loosen tolerance in test_x0_working to pass with alternate BLAS backends

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -506,7 +506,7 @@ def test_x0_working(solver):
 
     x, info = solver(A, b, x0=x0, **kw)
     assert info == 0
-    assert norm(A @ x - b) <= 2e-6*norm(b)
+    assert norm(A @ x - b) <= 3e-6*norm(b)
 
 
 def test_x0_equals_Mb(case):


### PR DESCRIPTION
Addressing a failure with blis resp. accelerate (c.f. #20472) which looks as follows:
```
____________________________ test_x0_working[tfqmr] ____________________________
[gw1] linux -- Python 3.9.19 $PREFIX/bin/python
$PREFIX/lib/python3.9/site-packages/scipy/sparse/linalg/_isolve/tests/test_iterative.py:507: in test_x0_working
    assert norm(A @ x - b) <= 2e-6*norm(b)
E   assert 3.5355292454346426e-06 <= (2e-06 * 1.240298651028214)
```
