### PR TITLE
MAINT: stats.hmean/pmean: simplify prior to array API conversion

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -288,25 +288,18 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
     1.9029126213592233
 
     """
-    if not isinstance(a, np.ndarray):
-        a = np.array(a, dtype=dtype)
-    elif dtype:
-        # Must change the default dtype allowing array type
-        if isinstance(a, np.ma.MaskedArray):
-            a = np.ma.asarray(a, dtype=dtype)
-        else:
-            a = np.asarray(a, dtype=dtype)
+    a = np.asarray(a, dtype=dtype)
 
-    if np.all(a >= 0):
-        # Harmonic mean only defined if greater than or equal to zero.
-        if weights is not None:
-            weights = np.asanyarray(weights, dtype=dtype)
+    if weights is not None:
+        weights = np.asarray(weights, dtype=dtype)
 
-        with np.errstate(divide='ignore'):
-            return 1.0 / np.average(1.0 / a, axis=axis, weights=weights)
-    else:
-        raise ValueError("Harmonic mean only defined if all elements greater "
-                         "than or equal to zero")
+    if not np.all(a >= 0):
+        message = ("The harmonic mean is only defined if all elements are greater "
+                   "than or equal to zero; otherwise, the result is NaN.")
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
+
+    with np.errstate(divide='ignore'):
+        return 1.0 / _xp_mean(1.0 / a, axis=axis, weights=weights)
 
 
 @_axis_nan_policy_factory(
@@ -414,27 +407,18 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     if p == 0:
         return gmean(a, axis=axis, dtype=dtype, weights=weights)
 
-    if not isinstance(a, np.ndarray):
-        a = np.array(a, dtype=dtype)
-    elif dtype:
-        # Must change the default dtype allowing array type
-        if isinstance(a, np.ma.MaskedArray):
-            a = np.ma.asarray(a, dtype=dtype)
-        else:
-            a = np.asarray(a, dtype=dtype)
+    a = np.asarray(a, dtype=dtype)
 
-    if np.all(a >= 0):
-        # Power mean only defined if greater than or equal to zero
-        if weights is not None:
-            weights = np.asanyarray(weights, dtype=dtype)
+    if not np.all(a >= 0):
+        message = ("The power mean is only defined if all elements are greater "
+                   "than or equal to zero; otherwise, the result is NaN.")
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
 
-        with np.errstate(divide='ignore'):
-            return np.float_power(
-                np.average(np.float_power(a, p), axis=axis, weights=weights),
-                1/p)
-    else:
-        raise ValueError("Power mean only defined if all elements greater "
-                         "than or equal to zero")
+    if weights is not None:
+        weights = np.asanyarray(weights, dtype=dtype)
+
+    with np.errstate(divide='ignore'):
+        return _xp_mean(a**float(p), axis=axis, weights=weights)**(1/p)
 
 
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -409,15 +409,15 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
 
     a = np.asarray(a, dtype=dtype)
 
+    if weights is not None:
+        weights = np.asanyarray(weights, dtype=dtype)
+
     if not np.all(a >= 0):
         message = ("The power mean is only defined if all elements are greater "
                    "than or equal to zero; otherwise, the result is NaN.")
         warnings.warn(message, RuntimeWarning, stacklevel=2)
 
-    if weights is not None:
-        weights = np.asanyarray(weights, dtype=dtype)
-
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         return _xp_mean(a**float(p), axis=axis, weights=weights)**(1/p)
 
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1239,10 +1239,6 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name, unpacker):
     a_masked3 = np.ma.masked_array(a, mask=(mask_a1 | mask_a2))
     b_masked3 = np.ma.masked_array(b, mask=(mask_b1 | mask_b2))
 
-    mask_all = (mask_a1 | mask_a2 | mask_b1 | mask_b2)
-    a_masked4 = np.ma.masked_array(a, mask=mask_all)
-    b_masked4 = np.ma.masked_array(b, mask=mask_all)
-
     with np.testing.suppress_warnings() as sup:
         message = 'invalid value encountered'
         sup.filter(RuntimeWarning, message)
@@ -1251,21 +1247,11 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name, unpacker):
         res2 = func(a_masked2, weights=b_masked2, nan_policy="omit", axis=axis)
         res3 = func(a_masked3, weights=b_masked3, nan_policy="raise", axis=axis)
         res4 = func(a_masked3, weights=b_masked3, nan_policy="propagate", axis=axis)
-        # Would test with a_masked3/b_masked3, but there is a bug in np.average
-        # that causes a bug in _no_deco mean with masked weights. Would use
-        # np.ma.average, but that causes other problems. See numpy/numpy#7330.
-        if weighted_fun_name in {"hmean"}:
-            weighted_fun_ma = getattr(stats.mstats, weighted_fun_name)
-            res5 = weighted_fun_ma(a_masked4, weights=b_masked4,
-                                   axis=axis, _no_deco=True)
 
     np.testing.assert_array_equal(res1, res)
     np.testing.assert_array_equal(res2, res)
     np.testing.assert_array_equal(res3, res)
     np.testing.assert_array_equal(res4, res)
-    if weighted_fun_name in {"hmean"}:
-        # _no_deco mean returns masked array, last element was masked
-        np.testing.assert_allclose(res5.compressed(), res[~np.isnan(res)])
 
 
 def test_raise_invalid_args_g17713():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6804,7 +6804,9 @@ class TestHarMean:
 
     def test_1d_array_with_negative_value(self):
         a = np.array([1, 0, -1])
-        assert_raises(ValueError, stats.hmean, a)
+        message = "The harmonic mean is only defined..."
+        with pytest.warns(RuntimeWarning, match=message):
+            stats.hmean(a)
 
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
@@ -7020,7 +7022,8 @@ class TestPowMean:
 
     def test_1d_array_with_negative_value(self):
         a, p = np.array([1, 0, -1]), 1.23
-        with pytest.raises(ValueError, match='Power mean only defined if all'):
+        message = "The power mean is only defined..."
+        with pytest.warns(RuntimeWarning, match=message):
             stats.pmean(a, p)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue
gh-20696

#### What does this implement/fix?
Simplifies the implementation of the `hmean` and `pmean` functions to reduce the apparent diff when they are converted to array API. The decorator handles much of what is removed.

#### Additional information
Also follows the example of gh-20696 and returns NaN rather than raising in the case of negative observations. A negative observation in one slice of an N-d array should not cause the whole calculation to fail, and NaN is an appropriate result where the operation is undefined.

gh-20696 didn't emit a warning in such cases, though; it only added a note to the documentation.
> ...Non-positive observations will also produce NaNs in the output because the *natural* logarithm (as opposed to the *complex* logarithm) is defined only for positive reals.

Either way, I think we should add the note to the documentation; I'll let the reviewer decide whether we should warn or not. Whatever is decided will be made consistent throughout the `gstd`/`gmean`/`hmean`/`pmean` family of functions in this PR.

*Update: interesting that I didn't get the failure in `TestPowMean` locally. Everything should be easy to fix, though.*
*Update 2: done.*