### PR TITLE
ENH: array types: add `dask.array` support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -116,5 +116,4 @@ jobs:
       run: |
         export OMP_NUM_THREADS=2
         # expand as more modules are supported by adding to `XP_TESTS` above
-        python dev.py --no-build test -b all $XP_TESTS -- --durations 3 --timeout=60
-
+        python dev.py --no-build test -b all $XP_TESTS -- --durations 3 --timeout=300

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -43,8 +43,8 @@ jobs:
     name: Get commit message
     uses: ./.github/workflows/commit_message.yml
 
-  pytorch_cpu:
-    name: Linux PyTorch/JAX/xp-strict CPU
+  xp_cpu:
+    name: Linux PyTorch/JAX/Dask/xp-strict CPU
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -85,6 +85,10 @@ jobs:
     - name: Install JAX
       run: |
         python -m pip install "jax[cpu]"
+
+    - name: Install Dask
+      run: |
+        python -m pip install git+https://github.com/dask/dask.git
 
     - name:  Prepare compiler cache
       id:    prep-ccache

--- a/dev.py
+++ b/dev.py
@@ -710,7 +710,8 @@ class Test(Task):
         multiple=True,
         help=(
             "Array API backend "
-            "('all', 'numpy', 'torch', 'cupy', 'array_api_strict', 'jax.numpy')."
+            "('all', 'numpy', 'torch', 'cupy', 'array_api_strict',"
+            " 'jax.numpy', 'dask.array')."
         )
     )
     # Argument can't have `help=`; used to consume all of `-- arg1 arg2 arg3`

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -24,6 +24,7 @@ from scipy._lib.array_api_compat import (
     is_cupy_namespace as is_cupy,
     is_torch_namespace as is_torch,
     is_jax_namespace as is_jax,
+    is_dask_namespace as is_dask,
     is_array_api_strict_namespace as is_array_api_strict
 )
 
@@ -246,6 +247,9 @@ def _strict_check(actual, desired, xp, *,
         assert actual.dtype == desired.dtype, _msg
 
     if check_shape:
+        if is_dask(xp):
+            actual.compute_chunk_sizes()
+            desired.compute_chunk_sizes()
         _msg = f"Shapes do not match.\nActual: {actual.shape}\nDesired: {desired.shape}"
         assert actual.shape == desired.shape, _msg
 

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -165,6 +165,7 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/cupy/__init__.py',
     'array_api_compat/array_api_compat/cupy/_aliases.py',
+    'array_api_compat/array_api_compat/cupy/_info.py',
     'array_api_compat/array_api_compat/cupy/_typing.py',
     'array_api_compat/array_api_compat/cupy/_info.py',
     'array_api_compat/array_api_compat/cupy/fft.py',
@@ -195,11 +196,11 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/numpy/__init__.py',
     'array_api_compat/array_api_compat/numpy/_aliases.py',
+    'array_api_compat/array_api_compat/numpy/_info.py',
     'array_api_compat/array_api_compat/numpy/_typing.py',
     'array_api_compat/array_api_compat/numpy/_info.py',
     'array_api_compat/array_api_compat/numpy/fft.py',
     'array_api_compat/array_api_compat/numpy/linalg.py',
-    'array_api_compat/array_api_compat/numpy/_info.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/numpy',
 )

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -199,6 +199,7 @@ py3.install_sources(
     'array_api_compat/array_api_compat/numpy/_info.py',
     'array_api_compat/array_api_compat/numpy/fft.py',
     'array_api_compat/array_api_compat/numpy/linalg.py',
+    'array_api_compat/array_api_compat/numpy/_info.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/numpy',
 )

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -4,7 +4,7 @@ import pytest
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
-    np_compat,
+    np_compat, is_dask
 )
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
@@ -76,6 +76,10 @@ class TestArrayAPI:
             x[0] = 10
             x[1] = 11
             x[2] = 12
+
+            if is_dask(xp):
+                x.compute()
+                y.compute()
 
             assert x[0] != y[0]
             assert x[1] != y[1]

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -4157,7 +4157,7 @@ def leaders(Z, T):
     if T.shape[0] != Z.shape[0] + 1:
         raise ValueError('Mismatch: len(T)!=Z.shape[0] + 1.')
 
-    n_clusters = int(xp.unique_values(T).shape[0])
+    n_clusters = int(np.asarray(xp.unique_values(T)).shape[0])
     n_obs = int(Z.shape[0] + 1)
     L = np.zeros(n_clusters, dtype=np.int32)
     M = np.zeros(n_clusters, dtype=np.int32)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -317,8 +317,9 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
         # recalc code_book as centroids of associated obs
         obs = np.asarray(obs)
         obs_code = np.asarray(obs_code)
+        code_book_len = np.asarray(code_book).shape[0]
         code_book, has_members = _vq.update_cluster_means(obs, obs_code,
-                                                          code_book.shape[0])
+                                                          code_book_len)
         obs = xp.asarray(obs)
         obs_code = xp.asarray(obs_code)
         code_book = xp.asarray(code_book)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -12,7 +12,7 @@ import hypothesis
 
 from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
-from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE
+from scipy._lib._array_api import SCIPY_ARRAY_API, SCIPY_DEVICE, xp_device
 from scipy._lib import _pep440
 
 try:
@@ -175,6 +175,12 @@ if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
         xp_available_backends.update({'jax.numpy': jax.numpy})
         jax.config.update("jax_enable_x64", True)
         jax.config.update("jax_default_device", jax.devices(SCIPY_DEVICE)[0])
+    except ImportError:
+        pass
+
+    try:
+        import dask.array  # type: ignore[import-not-found]
+        xp_available_backends.update({'dask.array': dask.array})
     except ImportError:
         pass
 
@@ -366,6 +372,9 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
                 for d in xp.empty(0).devices():
                     if 'cpu' not in d.device_kind:
                         skip_or_xfail(reason=reason)
+            elif xp.__name__ == 'dask.array':
+                if xp_device(xp.empty(0)) != 'cpu':
+                    skip_or_xfail(reason=reason)
 
 
 # Following the approach of NumPy's conftest.py...

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -21,6 +21,7 @@ jax_skip_reason = 'JAX arrays do not support item assignment.'
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
 @pytest.mark.skip_xp_backends('jax.numpy',reason=jax_skip_reason)
+@pytest.mark.skip_xp_backends('dask.array', reason='boolean indexing assignment')
 class TestDerivative:
 
     def f(self, x):

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -520,23 +520,24 @@ class TestFFTFreq:
 
         # default dtype varies across backends
 
-        y = 9 * fft.fftfreq(9, xp=xp)
+        wrapped_xp = array_namespace(x)
+        y = 9 * fft.fftfreq(9, xp=wrapped_xp)
         xp_assert_close(y, x, check_dtype=False, check_namespace=True)
 
-        y = 9 * xp.pi * fft.fftfreq(9, xp.pi, xp=xp)
+        y = 9 * xp.pi * fft.fftfreq(9, xp.pi, xp=wrapped_xp)
         xp_assert_close(y, x, check_dtype=False)
 
-        y = 10 * fft.fftfreq(10, xp=xp)
+        y = 10 * fft.fftfreq(10, xp=wrapped_xp)
         xp_assert_close(y, x2, check_dtype=False)
 
-        y = 10 * xp.pi * fft.fftfreq(10, xp.pi, xp=xp)
+        y = 10 * xp.pi * fft.fftfreq(10, xp.pi, xp=wrapped_xp)
         xp_assert_close(y, x2, check_dtype=False)
 
     def test_device(self, xp):
         xp_test = array_namespace(xp.empty(0))
         devices = get_xp_devices(xp)
         for d in devices:
-            y = fft.fftfreq(9, xp=xp, device=d)
+            y = fft.fftfreq(9, xp=xp_test, device=d)
             x = xp_test.empty(0, device=d)
             assert xp_device(y) == xp_device(x)
 
@@ -552,23 +553,23 @@ class TestRFFTFreq:
         x2 = xp.asarray([0, 1, 2, 3, 4, 5], dtype=xp.float64)
 
         # default dtype varies across backends
-        
-        y = 9 * fft.rfftfreq(9, xp=xp)
+        wrapped_xp = array_namespace(x)
+        y = 9 * fft.rfftfreq(9, xp=wrapped_xp)
         xp_assert_close(y, x, check_dtype=False, check_namespace=True)
 
-        y = 9 * xp.pi * fft.rfftfreq(9, xp.pi, xp=xp)
+        y = 9 * xp.pi * fft.rfftfreq(9, xp.pi, xp=wrapped_xp)
         xp_assert_close(y, x, check_dtype=False)
 
-        y = 10 * fft.rfftfreq(10, xp=xp)
+        y = 10 * fft.rfftfreq(10, xp=wrapped_xp)
         xp_assert_close(y, x2, check_dtype=False)
 
-        y = 10 * xp.pi * fft.rfftfreq(10, xp.pi, xp=xp)
+        y = 10 * xp.pi * fft.rfftfreq(10, xp.pi, xp=wrapped_xp)
         xp_assert_close(y, x2, check_dtype=False)
 
     def test_device(self, xp):
         xp_test = array_namespace(xp.empty(0))
         devices = get_xp_devices(xp)
         for d in devices:
-            y = fft.rfftfreq(9, xp=xp, device=d)
+            y = fft.rfftfreq(9, xp=xp_test, device=d)
             x = xp_test.empty(0, device=d)
             assert xp_device(y) == xp_device(x)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -49,6 +49,9 @@ def _vectorize(xp):
     'array_api_strict', reason='Currently uses fancy indexing assignment.'
 )
 @pytest.mark.skip_xp_backends(
+    'dask.array', reason='boolean indexing assignment'
+)
+@pytest.mark.skip_xp_backends(
     'jax.numpy', reason='JAX arrays do not support item assignment.'
 )
 class TestTanhSinh:

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -1803,6 +1803,7 @@ def morphological_laplace(input, size=None, footprint=None, structure=None,
         tmp2 = grey_erosion(input, size, footprint, structure, None, mode,
                             cval, origin, axes=axes)
         np.add(tmp1, tmp2, tmp2)
+        input = np.asarray(input)
         np.subtract(tmp2, input, tmp2)
         np.subtract(tmp2, input, tmp2)
         return tmp2

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -46,7 +46,7 @@ def delegate_xp(delegator, module_name):
                 # XXX: output arrays
                 result = func(*args, **kwds)
 
-                if isinstance(result, (np.ndarray, np.generic)):
+                if isinstance(result, np.ndarray | np.generic):
                     # XXX: np.int32->np.array_0D
                     return xp.asarray(result)
                 elif isinstance(result, int):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -195,6 +195,7 @@ class TestNdimageFilters:
 
     @xfail_xp_backends('cupy', reason="Differs by a factor of two?")
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_correlate01_overlap(self, xp):
         array = xp.reshape(xp.arange(256), (16, 16))
         weights = xp.asarray([2])
@@ -537,6 +538,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate23(self, dtype_array, dtype_output, xp):
@@ -556,6 +558,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate24(self, dtype_array, dtype_output, xp):
@@ -576,6 +579,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(output, tcov)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate25(self, dtype_array, dtype_output, xp):
@@ -881,6 +885,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(output1, output2)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_gauss_memory_overlap(self, xp):
         input = xp.arange(100 * 100, dtype=xp.float32)
         input = xp.reshape(input, (100, 100))
@@ -1227,6 +1232,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(t, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt02(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1289,6 +1295,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(t, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.",)
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel02(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1349,6 +1356,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only",)
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1379,6 +1387,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1395,6 +1404,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_generic_laplace01(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1420,6 +1430,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp, output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1441,6 +1452,7 @@ class TestNdimageFilters:
         xp_assert_close(output, expected, rtol=1e-6, atol=1e-6)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -2640,6 +2652,7 @@ def test_gaussian_radius_invalid(xp):
 
 
 @skip_xp_backends("jax.numpy", reason="output array is read-only")
+@skip_xp_backends("dask.array", reason="output array is read-only.")
 class TestThreading:
     def check_func_thread(self, n, fun, args, out):
         from threading import Thread

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -23,6 +23,7 @@ from . import types
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
               skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
@@ -365,10 +366,9 @@ def test_label_output_dtype(xp):
         assert output.dtype == t
 
 
+@xfail_xp_backends('dask.array', reason='Dask does not raise')
+@xfail_xp_backends('jax.numpy', reason='JAX does not raise')
 def test_label_output_wrong_size(xp):
-    if is_jax(xp):
-        pytest.xfail("JAX does not raise")
-
     data = xp.ones([5])
     for t in types:
         dtype = getattr(xp, t)
@@ -569,7 +569,7 @@ def test_value_indices03(xp):
         assert list(vi.keys()) == list(trueKeys)
         for k in [int(x) for x in trueKeys]:
             trueNdx = xp.nonzero(a == k, **nnz_kwd)
-            assert len(vi[k]) == len(trueNdx)
+            assert vi[k].shape[0] == trueNdx.shape[0]
             for vik, true_vik in zip(vi[k], trueNdx):
                 xp_assert_equal(vik, true_vik)
 
@@ -772,6 +772,7 @@ def test_minimum03(xp):
         assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_minimum04(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -811,6 +812,7 @@ def test_maximum03(xp):
         assert_almost_equal(output, xp.asarray(4.0), check_0d=False)
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_maximum04(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -1059,6 +1061,7 @@ def test_minimum_position06(xp):
         assert output == (0, 1)
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_minimum_position07(xp):
     labels = xp.asarray([1, 2, 3, 4])
     for type in types:
@@ -1124,6 +1127,7 @@ def test_maximum_position05(xp):
         assert output == (0, 0)
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_maximum_position06(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1188,6 +1192,7 @@ def test_extrema02(xp):
         assert output1 == (output2, output3, output4, output5)
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_extrema03(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -1216,6 +1221,7 @@ def test_extrema03(xp):
         assert output1[3] == output5
 
 
+@skip_xp_backends('dask.array', reason="no argsort in Dask")
 def test_extrema04(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1589,7 +1595,8 @@ class TestWatershedIft:
     @skip_xp_backends("cupy", reason="no watershed_ift on CuPy"	)
     def test_watershed_ift09(self, xp):
         # Test large cost. See gh-19575
-        data = xp.asarray([[xp.iinfo(xp.uint16).max, 0],
+        xp_test = array_namespace(xp.empty(0))  # dask.array needs iinfo
+        data = xp.asarray([[xp_test.iinfo(xp.uint16).max, 0],
                            [0, 0]], dtype=xp.uint16)
         markers = xp.asarray([[1, 0],
                               [0, 0]], dtype=xp.int8)

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import suppress_warnings
 
 from scipy._lib._array_api import (
-    is_jax,
     is_torch,
     array_namespace,
     xp_assert_equal,
@@ -569,7 +568,7 @@ def test_value_indices03(xp):
         assert list(vi.keys()) == list(trueKeys)
         for k in [int(x) for x in trueKeys]:
             trueNdx = xp.nonzero(a == k, **nnz_kwd)
-            assert vi[k].shape[0] == trueNdx.shape[0]
+            assert len(vi[k]) == len(trueNdx)
             for vik, true_vik in zip(vi[k], trueNdx):
                 xp_assert_equal(vik, true_vik)
 

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2303,6 +2303,7 @@ class TestNdimageMorphology:
                                               [5, 5, 3, 3, 1]]))
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8398")
     def test_grey_erosion01_overlap(self, xp):
 
@@ -2498,6 +2499,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_white_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2551,6 +2553,7 @@ class TestNdimageMorphology:
         xp_assert_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_white_tophat04(self, xp):
         array = np.eye(5, dtype=bool)
         structure = np.ones((3, 3), dtype=bool)
@@ -2563,6 +2566,7 @@ class TestNdimageMorphology:
         ndimage.white_tophat(array, structure=structure, output=output)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_black_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2616,6 +2620,7 @@ class TestNdimageMorphology:
         xp_assert_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("dask.array", reason="output array is read-only.")
     def test_black_tophat04(self, xp):
         array = xp.asarray(np.eye(5, dtype=bool))
         structure = xp.asarray(np.ones((3, 3), dtype=bool))

--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -134,7 +134,7 @@ def _chandrupatla(func, a, b, *, args=(), xatol=None, xrtol=None,
     func, xs, fs, args, shape, dtype, xp = temp
     x1, x2 = xs
     f1, f2 = fs
-    status = xp.full_like(x1, xp.asarray(eim._EINPROGRESS),
+    status = xp.full_like(x1, eim._EINPROGRESS,
                           dtype=xp.int32)  # in progress
     nit, nfev = 0, 2  # two function evaluations performed above
     finfo = xp.finfo(dtype)
@@ -219,7 +219,7 @@ def _chandrupatla(func, a, b, *, args=(), xatol=None, xrtol=None,
         j = ((1 - xp.sqrt(1 - xi1)) < phi1) & (phi1 < xp.sqrt(xi1))
 
         f1j, f2j, f3j, alphaj = work.f1[j], work.f2[j], work.f3[j], alpha[j]
-        t = xp.full_like(alpha, xp.asarray(0.5))
+        t = xp.full_like(alpha, 0.5)
         t[j] = (f1j / (f1j - f2j) * f3j / (f3j - f2j)
                 - alphaj * f1j / (f3j - f1j) * f2j / (f2j - f3j))
 
@@ -401,8 +401,7 @@ def _chandrupatla_minimize(func, x1, x2, x3, *, args=(), xatol=None,
     x1, x2, x3 = xs
     f1, f2, f3 = fs
     phi = xp.asarray(0.5 + 0.5*5**0.5, dtype=dtype)[()]  # golden ratio
-    status = xp.full_like(x1, xp.asarray(eim._EINPROGRESS),
-                          dtype=xp.int32)  # in progress
+    status = xp.full_like(x1, eim._EINPROGRESS, dtype=xp.int32)  # in progress
     nit, nfev = 0, 3  # three function evaluations performed above
     fatol = xp.finfo(dtype).smallest_normal if fatol is None else fatol
     frtol = xp.finfo(dtype).smallest_normal if frtol is None else frtol

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -187,6 +187,7 @@ cases = [
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('dask.array', reason='no argsort in Dask')
 @pytest.mark.skip_xp_backends('jax.numpy',
                               reason='JAX arrays do not support item assignment.')
 @pytest.mark.skip_xp_backends('array_api_strict',
@@ -553,6 +554,7 @@ class TestChandrupatlaMinimize:
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('dask.array', reason='boolean indexing assignment')
 @pytest.mark.skip_xp_backends('array_api_strict',
                               reason='Currently uses fancy indexing assignment.')
 @pytest.mark.skip_xp_backends('jax.numpy',

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -202,7 +202,10 @@ def _logsumexp(a, b, axis, return_sign, xp):
     a_max, i_max = _elements_and_indices_with_max_real(a, axis=axis, xp=xp)
 
     # for precision, these terms are separated out of the main sum.
-    a[i_max] = -xp.inf
+    # TODO: we shouldn't be mutating in-place here unless we make a copy
+    # dask arrays do not copy before this somehow
+    #a[i_max] = -xp.inf
+    a = xp.where(i_max, -xp.asarray(xp.inf, dtype=a.dtype), a)
     i_max_dt = xp.astype(i_max, a.dtype)
     # This is an inefficient way of getting `m` because it is the sum of a sparse
     # array; however, this is the simplest way I can think of to get the right shape.

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -69,7 +69,11 @@ class TestLogSumExp:
         nan = xp.asarray([xp.nan])
         xp_assert_equal(logsumexp(inf), inf[0])
         xp_assert_equal(logsumexp(-inf), -inf[0])
-        xp_assert_equal(logsumexp(nan), nan[0])
+        # catch warnings here for dasks state there's no way to suppress
+        # warnings just for dask
+        # https://github.com/dask/dask/issues/3245
+        with np.errstate(divide='ignore', invalid='ignore'):
+            xp_assert_equal(logsumexp(nan), nan[0])
         xp_assert_equal(logsumexp(xp.asarray([-xp.inf, -xp.inf])), -inf[0])
 
         # Handling an array with different magnitudes on the axes

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -5,7 +5,7 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
 from scipy.conftest import array_api_compatible
 from scipy import special
 from scipy._lib._array_api_no_0d import xp_assert_close
-from scipy._lib._array_api import is_jax, is_torch, SCIPY_DEVICE
+from scipy._lib._array_api import is_jax, is_torch, SCIPY_DEVICE, is_dask
 from scipy._lib.array_api_compat import numpy as np
 
 try:
@@ -64,6 +64,9 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     ):
         pytest.skip(f"`{f_name}` does not have an array-agnostic implementation "
                     f"and cannot delegate to PyTorch.")
+        
+    if is_dask(xp) and f_name == 'rel_entr':
+        pytest.skip("boolean index assignment")
 
     shapes = shapes[:n_args]
     f = getattr(special, f_name)

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -11,8 +11,11 @@ from scipy._lib._array_api import array_namespace, is_array_api_strict, is_jax
 from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
                                          xp_assert_less)
 
+@pytest.mark.skip_xp_backends("dask.array", reason="boolean index assignment")
+@pytest.mark.usefixtures("skip_xp_backends")
+@array_api_compatible
 class TestEntropy:
-    @array_api_compatible
+
     def test_entropy_positive(self, xp):
         # See ticket #497
         pk = xp.asarray([0.5, 0.2, 0.3])
@@ -22,7 +25,6 @@ class TestEntropy:
         xp_assert_equal(eself, xp.asarray(0.))
         xp_assert_less(-edouble, xp.asarray(0.))
 
-    @array_api_compatible
     def test_entropy_base(self, xp):
         pk = xp.ones(16)
         S = stats.entropy(pk, base=2.)
@@ -34,21 +36,18 @@ class TestEntropy:
         S2 = stats.entropy(pk, qk, base=2.)
         xp_assert_less(xp.abs(S/S2 - math.log(2.)), xp.asarray(1.e-5))
 
-    @array_api_compatible
     def test_entropy_zero(self, xp):
         # Test for PR-479
         x = xp.asarray([0., 1., 2.])
         xp_assert_close(stats.entropy(x),
                         xp.asarray(0.63651416829481278))
 
-    @array_api_compatible
     def test_entropy_2d(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
         xp_assert_close(stats.entropy(pk, qk),
                         xp.asarray([0.1933259, 0.18609809]))
 
-    @array_api_compatible
     def test_entropy_2d_zero(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.0, 0.1], [0.3, 0.6], [0.5, 0.3]])
@@ -59,20 +58,17 @@ class TestEntropy:
         xp_assert_close(stats.entropy(pk, qk),
                         xp.asarray([0.17403988, 0.18609809]))
 
-    @array_api_compatible
     def test_entropy_base_2d_nondefault_axis(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         xp_assert_close(stats.entropy(pk, axis=1),
                         xp.asarray([0.63651417, 0.63651417, 0.66156324]))
 
-    @array_api_compatible
     def test_entropy_2d_nondefault_axis(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
         xp_assert_close(stats.entropy(pk, qk, axis=1),
                         xp.asarray([0.23104906, 0.23104906, 0.12770641]))
 
-    @array_api_compatible
     def test_entropy_raises_value_error(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.1, 0.2], [0.6, 0.3]])
@@ -80,33 +76,28 @@ class TestEntropy:
         with pytest.raises(ValueError, match=message):
             stats.entropy(pk, qk)
 
-    @array_api_compatible
     def test_base_entropy_with_axis_0_is_equal_to_default(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         xp_assert_close(stats.entropy(pk, axis=0),
                         stats.entropy(pk))
 
-    @array_api_compatible
     def test_entropy_with_axis_0_is_equal_to_default(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
         xp_assert_close(stats.entropy(pk, qk, axis=0),
                         stats.entropy(pk, qk))
 
-    @array_api_compatible
     def test_base_entropy_transposed(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         xp_assert_close(stats.entropy(pk.T),
                         stats.entropy(pk, axis=1))
 
-    @array_api_compatible
     def test_entropy_transposed(self, xp):
         pk = xp.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
         qk = xp.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
         xp_assert_close(stats.entropy(pk.T, qk.T),
                         stats.entropy(pk, qk, axis=1))
 
-    @array_api_compatible
     def test_entropy_broadcasting(self, xp):
         rng = np.random.default_rng(74187315492831452)
         x = xp.asarray(rng.random(3))
@@ -115,7 +106,6 @@ class TestEntropy:
         xp_assert_equal(res[0], stats.entropy(x, y[0, ...]))
         xp_assert_equal(res[1], stats.entropy(x, y[1, ...]))
 
-    @array_api_compatible
     def test_entropy_shape_mismatch(self, xp):
         x = xp.ones((10, 1, 12))
         y = xp.ones((11, 2))
@@ -123,7 +113,6 @@ class TestEntropy:
         with pytest.raises(ValueError, match=message):
             stats.entropy(x, y)
 
-    @array_api_compatible
     def test_input_validation(self, xp):
         x = xp.ones(10)
         message = "`base` must be a positive number."
@@ -131,6 +120,7 @@ class TestEntropy:
             stats.entropy(x, base=-2)
 
 
+@pytest.mark.skip_xp_backends("dask.array", reason="No sorting in Dask")
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
 class TestDifferentialEntropy:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3709,8 +3709,8 @@ class TestSkew(SkewKurtosisTest):
             a[:, 0] = 1.01
             stats.skew(a)
 
-    @skip_xp_backends('jax.numpy',
-                      reason="JAX arrays do not support item assignment")
+    @skip_xp_backends('jax.numpy', reason="JAX arrays do not support item assignment")
+    @skip_xp_backends('dask.array', reason='boolean index assignment')
     @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @pytest.mark.parametrize('axis', [-1, 0, 2, None])
@@ -3809,8 +3809,8 @@ class TestKurtosis(SkewKurtosisTest):
             assert xp.isnan(stats.kurtosis(a / float(2**50), fisher=False))
             assert xp.isnan(stats.kurtosis(a, fisher=False, bias=False))
 
-    @skip_xp_backends('jax.numpy',
-                      reason='JAX arrays do not support item assignment')
+    @skip_xp_backends('jax.numpy', reason='JAX arrays do not support item assignment')
+    @skip_xp_backends('dask.array', reason='boolean index assignment')
     @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @pytest.mark.parametrize('axis', [-1, 0, 2, None])
@@ -8231,6 +8231,8 @@ class TestCombinePvalues:
 
     methods = ["fisher", "pearson", "tippett", "stouffer", "mudholkar_george"]
 
+    @skip_xp_backends('dask.array', reason='no sorting in Dask',
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'])
     @pytest.mark.parametrize("variant", ["single", "all", "random"])
     @pytest.mark.parametrize("method", methods)
     def test_monotonicity(self, variant, method, xp):
@@ -9553,7 +9555,9 @@ class TestXP_Mean:
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
 @skip_xp_backends('jax.numpy', reason='JAX arrays do not support item assignment')
+@skip_xp_backends('dask.array', reason='boolean index assignment')
 class TestXP_Var:
+
     @pytest.mark.parametrize('axis', [None, 1, -1, (-2, 2)])
     @pytest.mark.parametrize('keepdims', [False, True])
     @pytest.mark.parametrize('correction', [0, 1])
@@ -9632,7 +9636,8 @@ class TestXP_Var:
         xp_assert_equal(res, ref)
 
     def test_dtype(self, xp):
-        max = xp.finfo(xp.float32).max
+        xp_test = array_namespace(xp) # dask.array needs finfo
+        max = xp_test.finfo(xp.float32).max
         x_np = np.asarray([max, max/2], dtype=np.float32)
         x_xp = xp.asarray(x_np)
 


### PR DESCRIPTION
#### Reference issue
Towards gh-18867

#### What does this implement/fix?
Test with `dask.array` via array-api-compat.

#### Problems so far

Dask:
- dask/dask#11287
- https://github.com/dask/dask/pull/11288
- https://github.com/dask/dask/issues/4368
- https://github.com/dask/dask/issues/3245
- https://github.com/dask/dask/issues/11398

array-api-compat:
- data-apis/array-api-compat#176
- data-apis/array-api-compat#139
- No `sort` or `argsort`

SciPy:
- https://github.com/scipy/scipy/pull/20956#issuecomment-2276607897