### PR TITLE
DOC/MAINT: stats.gmean/gstd/hmean/pmean: document/treat invalid input consistently

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3213,7 +3213,7 @@ def gstd(a, axis=0, ddof=1):
     When an observation is infinite, the geometric standard deviation is
     NaN (undefined). Non-positive observations will also produce NaNs in the
     output because the *natural* logarithm (as opposed to the *complex*
-    logarithm) is defined only for positive reals.
+    logarithm) is defined and finite only for positive reals.
     The geometric standard deviation is sometimes confused with the exponential
     of the standard deviation, ``exp(std(a))``. Instead, the geometric standard
     deviation is ``exp(std(log(a)))``.
@@ -3261,8 +3261,14 @@ def gstd(a, axis=0, ddof=1):
         log = np.log
 
     with np.errstate(invalid='ignore', divide='ignore'):
-        return np.exp(np.std(log(a), axis=axis, ddof=ddof))
+        res = np.exp(np.std(log(a), axis=axis, ddof=ddof))
 
+    if (a <= 0).any():
+        message = ("The geometric standard deviation is only defined if all elements "
+                   "are greater than or equal to zero; otherwise, the result is NaN.")
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
+
+    return res
 
 # Private dictionary initialized only once at module level
 # See https://en.wikipedia.org/wiki/Robust_measures_of_scale

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -184,6 +184,14 @@ def gmean(a, axis=0, dtype=None, weights=None):
     numpy.average : Weighted average
     hmean : Harmonic mean
 
+    Notes
+    -----
+    The sample geometric mean is the exponential of the mean of the natural
+    logarithms of the observations.
+    Negative observations will produce NaNs in the output because the *natural*
+    logarithm (as opposed to the *complex* logarithm) is defined only for
+    non-negative reals.
+
     References
     ----------
     .. [1] "Weighted Geometric Mean", *Wikipedia*,
@@ -266,9 +274,14 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
 
     Notes
     -----
+    The sample harmonic mean is the reciprocal of the mean of the reciprocals
+    of the observations.
+
     The harmonic mean is computed over a single dimension of the input
     array, axis=0 by default, or all values in the array if axis=None.
     float64 intermediate and return values are used for integer inputs.
+
+    The harmonic mean is only defined for positive real observations.
 
     References
     ----------
@@ -364,6 +377,8 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     The power mean is computed over a single dimension of the input
     array, ``axis=0`` by default, or all values in the array if ``axis=None``.
     float64 intermediate and return values are used for integer inputs.
+
+    The power mean is only defined for positive real observations.
 
     .. versionadded:: 1.9
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -281,7 +281,8 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
     array, axis=0 by default, or all values in the array if axis=None.
     float64 intermediate and return values are used for integer inputs.
 
-    The harmonic mean is only defined for positive real observations.
+    The harmonic mean is only defined if all observations are non-negative;
+    otherwise, the result is NaN.
 
     References
     ----------
@@ -306,9 +307,13 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
     if weights is not None:
         weights = np.asarray(weights, dtype=dtype)
 
-    if not np.all(a >= 0):
-        message = ("The harmonic mean is only defined if all elements are greater "
-                   "than or equal to zero; otherwise, the result is NaN.")
+    negative_mask = a < 0
+    if np.any(negative_mask):
+        # `where` avoids having to be careful about dtypes and will work with
+        # JAX. This is the exceptional case, so it's OK to be a little slower.
+        a = np.where(negative_mask, np.nan, a)
+        message = ("The harmonic mean is only defined if all elements are "
+                   "non-negative; otherwise, the result is NaN.")
         warnings.warn(message, RuntimeWarning, stacklevel=2)
 
     with np.errstate(divide='ignore'):
@@ -378,7 +383,8 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     array, ``axis=0`` by default, or all values in the array if ``axis=None``.
     float64 intermediate and return values are used for integer inputs.
 
-    The power mean is only defined for positive real observations.
+    The power mean is only defined if all observations are non-negative;
+    otherwise, the result is NaN.
 
     .. versionadded:: 1.9
 
@@ -427,9 +433,13 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     if weights is not None:
         weights = np.asanyarray(weights, dtype=dtype)
 
-    if not np.all(a >= 0):
-        message = ("The power mean is only defined if all elements are greater "
-                   "than or equal to zero; otherwise, the result is NaN.")
+    negative_mask = a < 0
+    if np.any(negative_mask):
+        # `where` avoids having to be careful about dtypes and will work with
+        # JAX. This is the exceptional case, so it's OK to be a little slower.
+        a = np.where(negative_mask, np.nan, a)
+        message = ("The power mean is only defined if all elements are "
+                   "non-negative; otherwise, the result is NaN.")
         warnings.warn(message, RuntimeWarning, stacklevel=2)
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6778,7 +6778,7 @@ def check_equal_pmean(array_like, exp, desired, axis=None, dtype=None,
     assert_equal(x.dtype, dtype)
 
 
-class TestHarMean:
+class TestHMean:
     def test_0(self):
         a = [1, 0, 2]
         desired = 0
@@ -6809,7 +6809,8 @@ class TestHarMean:
         a = np.array([1, 0, -1])
         message = "The harmonic mean is only defined..."
         with pytest.warns(RuntimeWarning, match=message):
-            stats.hmean(a)
+            res = stats.hmean(a)
+        np.testing.assert_equal(res, np.nan)
 
     # Note the next tests use axis=None as default, not axis=0
     def test_2d_list(self):
@@ -6880,7 +6881,7 @@ class TestHarMean:
 
 
 @array_api_compatible
-class TestGeoMean:
+class TestGMean:
     def test_0(self, xp):
         a = [1, 0, 2]
         desired = 0
@@ -7004,7 +7005,7 @@ class TestGeoMean:
                           dtype=np.float64, xp=xp)
 
 
-class TestPowMean:
+class TestPMean:
 
     def pmean_reference(a, p):
         return (np.sum(a**p) / a.size)**(1/p)
@@ -7020,7 +7021,7 @@ class TestPowMean:
 
     def test_1d_list(self):
         a, p = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100], 3.5
-        desired = TestPowMean.pmean_reference(np.array(a), p)
+        desired = TestPMean.pmean_reference(np.array(a), p)
         check_equal_pmean(a, p, desired)
 
         a, p = [1, 2, 3, 4], 2
@@ -7029,7 +7030,7 @@ class TestPowMean:
 
     def test_1d_array(self):
         a, p = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]), -2.5
-        desired = TestPowMean.pmean_reference(a, p)
+        desired = TestPMean.pmean_reference(a, p)
         check_equal_pmean(a, p, desired)
 
     def test_1d_array_with_zero(self):
@@ -7041,7 +7042,8 @@ class TestPowMean:
         a, p = np.array([1, 0, -1]), 1.23
         message = "The power mean is only defined..."
         with pytest.warns(RuntimeWarning, match=message):
-            stats.pmean(a, p)
+            res = stats.pmean(a, p)
+        np.testing.assert_equal(res, np.nan)
 
     @pytest.mark.parametrize(
         ("a", "p"),
@@ -7049,7 +7051,7 @@ class TestPowMean:
          (np.array([[10, 20], [50, 60], [90, 100]]), 0.5)]
     )
     def test_2d_axisnone(self, a, p):
-        desired = TestPowMean.pmean_reference(np.array(a), p)
+        desired = TestPMean.pmean_reference(np.array(a), p)
         check_equal_pmean(a, p, desired)
 
     @pytest.mark.parametrize(
@@ -7059,7 +7061,7 @@ class TestPowMean:
     )
     def test_2d_list_axis0(self, a, p):
         desired = [
-            TestPowMean.pmean_reference(
+            TestPMean.pmean_reference(
                 np.array([a[i][j] for i in range(len(a))]), p
             )
             for j in range(len(a[0]))
@@ -7072,13 +7074,13 @@ class TestPowMean:
          ([[10, 0, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]], 0.5)]
     )
     def test_2d_list_axis1(self, a, p):
-        desired = [TestPowMean.pmean_reference(np.array(a_), p) for a_ in a]
+        desired = [TestPMean.pmean_reference(np.array(a_), p) for a_ in a]
         check_equal_pmean(a, p, desired, axis=1)
 
     def test_weights_1d_list(self):
         a, p = [2, 10, 6], -1.23456789
         weights = [10, 5, 3]
-        desired = TestPowMean.wpmean_reference(np.array(a), p, weights)
+        desired = TestPMean.wpmean_reference(np.array(a), p, weights)
         check_equal_pmean(a, p, desired, weights=weights, rtol=1e-5)
 
     def test_weights_masked_1d_array(self):
@@ -7096,7 +7098,7 @@ class TestPowMean:
     def test_weights_2d_array(self, axis, fun_name, p):
         if fun_name == 'wpmean_reference':
             def fun(a, axis, weights):
-                return TestPowMean.wpmean_reference(a, p, weights)
+                return TestPMean.wpmean_reference(a, p, weights)
         else:
             fun = getattr(stats, fun_name)
         a = np.array([[2, 5], [10, 5], [6, 5]])
@@ -7105,7 +7107,7 @@ class TestPowMean:
         check_equal_pmean(a, p, desired, axis=axis, weights=weights, rtol=1e-5)
 
 
-class TestGeometricStandardDeviation:
+class TestGSTD:
     # must add 1 as `gstd` is only defined for positive values
     array_1d = np.arange(2 * 3 * 4) + 1
     gstd_array_1d = 2.294407613602

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7124,10 +7124,16 @@ class TestGeometricStandardDeviation:
         with pytest.raises(TypeError, match="ufunc 'log' not supported"):
             stats.gstd('You cannot take the logarithm of a string.')
 
-    @pytest.mark.parametrize('bad_value', (0, -1, np.inf))
+    @pytest.mark.parametrize('bad_value', (0, -1, np.inf, np.nan))
     def test_returns_nan_invalid_value(self, bad_value):
         x = np.append(self.array_1d, [bad_value])
-        assert_equal(stats.gstd(x), np.nan)
+        if np.isfinite(bad_value):
+            message = "The geometric standard deviation is only defined..."
+            with pytest.warns(RuntimeWarning, match=message):
+                res = stats.gstd(x)
+        else:
+            res = stats.gstd(x)
+        assert_equal(res, np.nan)
 
     def test_propagates_nan_values(self):
         a = array([[1, 1, 1, 16], [np.nan, 1, 2, 3]])


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-20954

#### What does this implement/fix?
This makes the treatment of invalid input more consistent among the various mean/std functions. It also adds notes to `stats.gmean`, `stats.hmean`, and `stats.pmean` that document the conditions under which the function is defined and the result in other cases.

#### Additional information
The first commit can be backported if desired.

Failure is just gh-20963.