### PR TITLE
ENH: `stats.tmean`: add array API support

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -229,16 +229,23 @@ def is_cupy(xp: ModuleType) -> bool:
 def is_torch(xp: ModuleType) -> bool:
     return xp.__name__ in ('torch', 'scipy._lib.array_api_compat.torch')
 
+
 def is_jax(xp):
     return xp.__name__ in ('jax.numpy', 'jax.experimental.array_api')
 
 
+def is_array_api_strict(xp):
+    return xp.__name__ == 'array_api_strict'
+
+
 def _strict_check(actual, desired, xp,
-                  check_namespace=True, check_dtype=True, check_shape=True):
+                  check_namespace=True, check_dtype=True, check_shape=True,
+                  allow_0d=False):
     __tracebackhide__ = True  # Hide traceback for py.test
     if check_namespace:
         _assert_matching_namespace(actual, desired)
 
+    was_scalar = np.isscalar(desired)
     desired = xp.asarray(desired)
 
     if check_dtype:
@@ -248,7 +255,7 @@ def _strict_check(actual, desired, xp,
     if check_shape:
         _msg = f"Shapes do not match.\nActual: {actual.shape}\nDesired: {desired.shape}"
         assert actual.shape == desired.shape, _msg
-        _check_scalar(actual, desired, xp)
+        _check_scalar(actual, desired, xp, allow_0d=allow_0d, was_scalar=was_scalar)
 
     desired = xp.broadcast_to(desired, actual.shape)
     return desired
@@ -266,7 +273,7 @@ def _assert_matching_namespace(actual, desired):
         assert arr_space == desired_space, _msg
 
 
-def _check_scalar(actual, desired, xp):
+def _check_scalar(actual, desired, xp, *, allow_0d, was_scalar):
     __tracebackhide__ = True  # Hide traceback for py.test
     # Shape check alone is sufficient unless desired.shape == (). Also,
     # only NumPy distinguishes between scalars and arrays.
@@ -285,19 +292,31 @@ def _check_scalar(actual, desired, xp):
     # array for `desired`, we would typically want the type of `actual` to be
     # the type of `desired[()]`. If the developer wants to override this
     # behavior, they can set `check_shape=False`.
-    desired = desired[()]
-    _msg = f"Types do not match:\n Actual: {type(actual)}\n Desired: {type(desired)}"
-    assert (xp.isscalar(actual) and xp.isscalar(desired)
-            or (not xp.isscalar(actual) and not xp.isscalar(desired))), _msg
+    if was_scalar:
+        desired = desired[()]
+
+    if allow_0d:
+        _msg = ("Types do not match:\n Actual: "
+                f"{type(actual)}\n Desired: {type(desired)}")
+        assert ((xp.isscalar(actual) and xp.isscalar(desired))
+                or (not xp.isscalar(actual) and not xp.isscalar(desired))), _msg
+    else:
+        _msg = ("Result is a NumPy 0d array. Many SciPy functions intend to follow "
+                "the convention of many NumPy functions, returning a scalar when a "
+                "0d array would be correct. `xp_assert_` functions err on the side of "
+                "caution and do not accept 0d arrays by default. If the correct result "
+                "may be a 0d NumPy array, pass `allow_0d=True`.")
+        assert xp.isscalar(actual), _msg
 
 
 def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
-                    check_shape=True, err_msg='', xp=None):
+                    check_shape=True, allow_0d=False, err_msg='', xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape)
+                            check_dtype=check_dtype, check_shape=check_shape,
+                            allow_0d=allow_0d)
     if is_cupy(xp):
         return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
     elif is_torch(xp):
@@ -311,12 +330,14 @@ def xp_assert_equal(actual, desired, check_namespace=True, check_dtype=True,
 
 
 def xp_assert_close(actual, desired, rtol=None, atol=0, check_namespace=True,
-                    check_dtype=True, check_shape=True, err_msg='', xp=None):
+                    check_dtype=True, check_shape=True, allow_0d=False,
+                    err_msg='', xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape)
+                            check_dtype=check_dtype, check_shape=check_shape,
+                            allow_0d=allow_0d)
 
     floating = xp.isdtype(actual.dtype, ('real floating', 'complex floating'))
     if rtol is None and floating:
@@ -340,12 +361,13 @@ def xp_assert_close(actual, desired, rtol=None, atol=0, check_namespace=True,
 
 
 def xp_assert_less(actual, desired, check_namespace=True, check_dtype=True,
-                   check_shape=True, err_msg='', verbose=True, xp=None):
+                   check_shape=True, allow_0d=False, err_msg='', verbose=True, xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape)
+                            check_dtype=check_dtype, check_shape=check_shape,
+                            allow_0d=allow_0d)
     if is_cupy(xp):
         return xp.testing.assert_array_less(actual, desired,
                                             err_msg=err_msg, verbose=verbose)
@@ -428,7 +450,7 @@ def get_xp_devices(xp: ModuleType) -> list[str] | list[None]:
 
     # given namespace is not known to have a list of available devices;
     # return `[None]` so that one can use this in tests for `device=None`.
-    return [None] 
+    return [None]
 
 
 def scipy_namespace_for(xp: ModuleType) -> ModuleType:

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -144,12 +144,9 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
         # If `fillvalue` is a Python scalar and we convert to `xp.asarray`, it gets the
         # default `int` or `float` type of `xp`, so `result_type` could be wrong.
         # `result_type` should/will handle mixed array/Python scalars
-        # (data-apis/array-api#805) but doesn't yet. So in the meantime, we need our
-        # own logic.
-        if type(fillvalue) in {int, float, complex, bool}:
-            dtype = (xp.asarray([0], dtype=temp1.dtype) * fillvalue).dtype
-        else:
-            dtype = xp.result_type(temp1.dtype, fillvalue.dtype)
+        # (data-apis/array-api#805) but doesn't yet. So in the meantime, this fails
+        # for array-api-strict.
+        dtype = xp.result_type(temp1.dtype, fillvalue)
         out = xp.full(cond.shape, fill_value=xp.asarray(fillvalue), dtype=dtype)
     else:
         ncond = ~cond

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -141,9 +141,16 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
     temp1 = xp.asarray(f(*(arr[cond] for arr in arrays)))
 
     if f2 is None:
-        fillvalue = xp.asarray(fillvalue)
-        dtype = xp.result_type(temp1.dtype, fillvalue.dtype)
-        out = xp.full(cond.shape, fill_value=fillvalue, dtype=dtype)
+        # If `fillvalue` is a Python scalar and we convert to `xp.asarray`, it gets the
+        # default `int` or `float` type of `xp`, so `result_type` could be wrong.
+        # `result_type` should/will handle mixed array/Python scalars
+        # (data-apis/array-api#805) but doesn't yet. So in the meantime, we need our
+        # own logic.
+        if type(fillvalue) in {int, float, complex, bool}:
+            dtype = (xp.asarray([0], dtype=temp1.dtype) * fillvalue).dtype
+        else:
+            dtype = xp.result_type(temp1.dtype, fillvalue.dtype)
+        out = xp.full(cond.shape, fill_value=xp.asarray(fillvalue), dtype=dtype)
     else:
         ncond = ~cond
         temp2 = xp.asarray(f2(*(arr[ncond] for arr in arrays)))

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -13,7 +13,7 @@ from hypothesis import given, strategies, reproduce_failure  # noqa: F401
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
 
 from scipy._lib._array_api import (xp_assert_equal, xp_assert_close, is_numpy,
-                                   copy as xp_copy)
+                                   copy as xp_copy, is_array_api_strict)
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
                               getfullargspec_no_self, FullArgSpec,
                               rng_integers, _validate_int, _rename_parameter,
@@ -407,7 +407,10 @@ class TestLazywhere:
                                                  min_side=0)
         input_shapes, result_shape = data.draw(mbs)
         cond_shape, *shapes = input_shapes
-        fillvalue = xp.asarray(data.draw(npst.arrays(dtype=dtype, shape=tuple())))
+        elements = {'allow_subnormal': False}  # cupy/cupy#8382
+        fillvalue = xp.asarray(data.draw(npst.arrays(dtype=dtype, shape=tuple(),
+                                                     elements=elements)))
+        float_fillvalue = float(fillvalue)
         arrays = [xp.asarray(data.draw(npst.arrays(dtype=dtype, shape=shape)))
                   for shape in shapes]
 
@@ -422,6 +425,8 @@ class TestLazywhere:
 
         res1 = _lazywhere(cond, arrays, f, fillvalue)
         res2 = _lazywhere(cond, arrays, f, f2=f2)
+        if not is_array_api_strict(xp):
+            res3 = _lazywhere(cond, arrays, f, float_fillvalue)
 
         # Ensure arrays are at least 1d to follow sane type promotion rules.
         if xp == np:
@@ -429,19 +434,17 @@ class TestLazywhere:
 
         ref1 = xp.where(cond, f(*arrays), fillvalue)
         ref2 = xp.where(cond, f(*arrays), f2(*arrays))
+        if not is_array_api_strict(xp):
+            # Array API standard doesn't currently define behavior when fillvalue is a
+            # Python scalar. When it does, test can be run with array_api_strict, too.
+            ref3 = xp.where(cond, f(*arrays), float_fillvalue)
 
         if xp == np:
             ref1 = ref1.reshape(result_shape)
             ref2 = ref2.reshape(result_shape)
-            res1 = xp.asarray(res1)[()]
-            res2 = xp.asarray(res2)[()]
+            ref3 = ref3.reshape(result_shape)
 
-        isinstance(res1, type(xp.asarray([])))
-        xp_assert_close(res1, ref1, rtol=2e-16)
-        assert_equal(res1.shape, ref1.shape)
-        assert_equal(res1.dtype, ref1.dtype)
-
-        isinstance(res2, type(xp.asarray([])))
-        xp_assert_equal(res2, ref2)
-        assert_equal(res2.shape, ref2.shape)
-        assert_equal(res2.dtype, ref2.dtype)
+        xp_assert_close(res1, ref1, rtol=2e-16, allow_0d=True)
+        xp_assert_equal(res2, ref2, allow_0d=True)
+        if not is_array_api_strict(xp):
+            xp_assert_equal(res3, ref3, allow_0d=True)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -101,7 +101,8 @@ class TestArrayAPI:
             xp_assert_equal(x, y, **options)
         else:
             with pytest.raises(AssertionError, match="Shapes do not match."):
-                xp_assert_equal(x, y, **options)
+                xp_assert_equal(x, xp.asarray(y), allow_0d=True, **options)
+
 
     @array_api_compatible
     def test_check_scalar(self, xp):
@@ -109,6 +110,20 @@ class TestArrayAPI:
             pytest.skip("Scalars only exist in NumPy")
 
         if is_numpy(xp):
-            with pytest.raises(AssertionError, match="Types do not match."):
+            # Check default convention: 0d arrays are not allowed
+            message = "Result is a NumPy 0d array. Many SciPy functions..."
+            with pytest.raises(AssertionError, match=message):
                 xp_assert_equal(xp.asarray(0.), xp.float64(0))
+            with pytest.raises(AssertionError, match=message):
+                xp_assert_equal(xp.asarray(0.), xp.asarray(0.))
             xp_assert_equal(xp.float64(0), xp.asarray(0.))
+            xp_assert_equal(xp.float64(0), xp.float64(0))
+
+            # Check `allow_0d`
+            message = "Types do not match:\n..."
+            with pytest.raises(AssertionError, match=message):
+                xp_assert_equal(xp.asarray(0.), xp.float64(0), allow_0d=True)
+            with pytest.raises(AssertionError, match=message):
+                xp_assert_equal(xp.float64(0), xp.asarray(0.), allow_0d=True)
+            xp_assert_equal(xp.float64(0), xp.float64(0), allow_0d=True)
+            xp_assert_equal(xp.asarray(0.), xp.asarray(0.), allow_0d=True)

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -3,6 +3,7 @@ import pytest
 import scipy.constants as sc
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_equal, xp_assert_close
+from numpy.testing import assert_allclose
 
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
@@ -53,7 +54,7 @@ class TestConvertTemperature:
 
     @skip_xp_backends(np_only=True, reasons=['Python list input uses NumPy backend'])
     def test_convert_temperature_array_like(self):
-        xp_assert_close(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
+        assert_allclose(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
                         [273.15, 0.], rtol=0., atol=1e-13)
 
 
@@ -73,7 +74,7 @@ class TestLambdaToNu:
 
     @skip_xp_backends(np_only=True, reasons=['Python list input uses NumPy backend'])
     def test_lambda_to_nu_array_like(self, xp):
-        xp_assert_equal(sc.lambda2nu([sc.speed_of_light, 1]),
+        assert_allclose(sc.lambda2nu([sc.speed_of_light, 1]),
                         [1, sc.speed_of_light])
 
 
@@ -84,6 +85,6 @@ class TestNuToLambda:
 
     @skip_xp_backends(np_only=True, reasons=['Python list input uses NumPy backend'])
     def test_nu_to_lambda_array_like(self, xp):
-        xp_assert_equal(sc.nu2lambda([sc.speed_of_light, 1]),
+        assert_allclose(sc.nu2lambda([sc.speed_of_light, 1]),
                         [1, sc.speed_of_light])
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -78,6 +78,10 @@ class TestTrimmedStats:
     dprec = np.finfo(np.float64).precision
 
     @array_api_compatible
+    @skip_xp_backends('array_api_strict',
+                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
+                               "accept Python floats. See data-apis/array-api#807."])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tmean(self, xp):
         x = xp.asarray(X)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -43,7 +43,7 @@ from scipy._lib._util import AxisError
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
 from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, array_namespace,
                                    copy, is_numpy, is_torch, SCIPY_ARRAY_API,
-                                   size as xp_size)
+                                   size as xp_size, copy as xp_copy)
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -77,52 +77,52 @@ class TestTrimmedStats:
     # TODO: write these tests to handle missing values properly
     dprec = np.finfo(np.float64).precision
 
-    def test_tmean(self):
-        y = stats.tmean(X, (2, 8), (True, True))
-        assert_approx_equal(y, 5.0, significant=self.dprec)
+    @array_api_compatible
+    def test_tmean(self, xp):
+        x = xp.asarray(X)
 
-        y1 = stats.tmean(X, limits=(2, 8), inclusive=(False, False))
-        y2 = stats.tmean(X, limits=None)
-        assert_approx_equal(y1, y2, significant=self.dprec)
+        y = stats.tmean(x, (2, 8), (True, True))
+        xp_assert_close(y, xp.asarray(5.0, dtype=x.dtype))
 
-        x_2d = arange(63, dtype=float64).reshape(9, 7)
+        y1 = stats.tmean(x, limits=(2, 8), inclusive=(False, False))
+        y2 = stats.tmean(x, limits=None)
+        xp_assert_close(y1, y2)
+
+        x_2d = xp.reshape(xp.arange(63.), (9, 7))
         y = stats.tmean(x_2d, axis=None)
-        assert_approx_equal(y, x_2d.mean(), significant=self.dprec)
+        xp_assert_close(y, xp.mean(x_2d))
 
         y = stats.tmean(x_2d, axis=0)
-        assert_array_almost_equal(y, x_2d.mean(axis=0), decimal=8)
+        xp_assert_close(y, xp.mean(x_2d, axis=0))
 
         y = stats.tmean(x_2d, axis=1)
-        assert_array_almost_equal(y, x_2d.mean(axis=1), decimal=8)
+        xp_assert_close(y, xp.mean(x_2d, axis=1))
 
         y = stats.tmean(x_2d, limits=(2, 61), axis=None)
-        assert_approx_equal(y, 31.5, significant=self.dprec)
+        xp_assert_close(y, xp.asarray(31.5))
 
         y = stats.tmean(x_2d, limits=(2, 21), axis=0)
         y_true = [14, 11.5, 9, 10, 11, 12, 13]
-        assert_array_almost_equal(y, y_true, decimal=8)
+        xp_assert_close(y, xp.asarray(y_true))
 
         y = stats.tmean(x_2d, limits=(2, 21), inclusive=(True, False), axis=0)
         y_true = [10.5, 11.5, 9, 10, 11, 12, 13]
-        assert_array_almost_equal(y, y_true, decimal=8)
+        xp_assert_close(y, xp.asarray(y_true))
 
-        x_2d_with_nan = np.array(x_2d)
-        x_2d_with_nan[-1, -3:] = np.nan
+        x_2d_with_nan = xp_copy(x_2d)
+        x_2d_with_nan[-1, -3:] = xp.nan
         y = stats.tmean(x_2d_with_nan, limits=(1, 13), axis=0)
-        y_true = [7, 4.5, 5.5, 6.5, np.nan, np.nan, np.nan]
-        assert_array_almost_equal(y, y_true, decimal=8)
+        y_true = [7, 4.5, 5.5, 6.5, xp.nan, xp.nan, xp.nan]
+        xp_assert_close(y, xp.asarray(y_true))
 
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Mean of empty slice")
+        y = stats.tmean(x_2d, limits=(2, 21), axis=1)
+        y_true = [4, 10, 17, 21, xp.nan, xp.nan, xp.nan, xp.nan, xp.nan]
+        xp_assert_close(y, xp.asarray(y_true))
 
-            y = stats.tmean(x_2d, limits=(2, 21), axis=1)
-            y_true = [4, 10, 17, 21, np.nan, np.nan, np.nan, np.nan, np.nan]
-            assert_array_almost_equal(y, y_true, decimal=8)
-
-            y = stats.tmean(x_2d, limits=(2, 21),
-                            inclusive=(False, True), axis=1)
-            y_true = [4.5, 10, 17, 21, np.nan, np.nan, np.nan, np.nan, np.nan]
-            assert_array_almost_equal(y, y_true, decimal=8)
+        y = stats.tmean(x_2d, limits=(2, 21),
+                        inclusive=(False, True), axis=1)
+        y_true = [4.5, 10, 17, 21, xp.nan, xp.nan, xp.nan, xp.nan, xp.nan]
+        xp_assert_close(y, xp.asarray(y_true))
 
     def test_tvar(self):
         y = stats.tvar(X, limits=(2, 8), inclusive=(True, True))


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `tmean` and paves the way for adding support to other trimmed statistics.

Along the way, I discovered that `_lazywhere` not always preserving `dtype` was one of several reasons that `tmean` wasn't preserving type, so I fixed that. I added associated tests to `_lazywhere`, which also led to me making the scalar check in `xp_assert` tests optional, since `_lazywhere` is (presumably) supposed to return 0-D arrays instead of scalars to follow the example of `where`.

#### Additional information
The diff would be smaller with this function if we were to just replace the use of `nanmean` with `xp_mean` with `nan_policy='omit'`, but that wouldn't help us with any of the other functions. Might as well keep the approach consistent unless we also want to add an `xp_var`, `xp_max`, `xp_min`, etc...

Looks like the failure is just gh-20963.