### PR TITLE
MAINT: `special.betainc`: skip test with JAX backend

### DIFF
--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -56,6 +56,8 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
     f_name, n_args = f_name_n_args
 
     if is_jax(xp):
+        if f_name in ['betainc']:
+            pytest.skip("google/jax#21900")
         if f_name in ['gammainc', 'gammaincc']:
             pytest.skip("google/jax#20507")
         if f_name == 'rel_entr':


### PR DESCRIPTION
#### Reference issue
Closes gh-20963

#### What does this implement/fix?
An edge case that is problematic for `jax.scipy.special.betainc` is causing CI failures. In the meantime, skip this edge case.

#### Additional information
It would be good if we could get Hypothesis to skip the particular class of counter-examples rather than skipping JAX completely ~~, but that is an enhancement for another day~~ see gh-20967.