### PR TITLE
TST: `special.betainc`: add assumption to skip counterexample

### DIFF
--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -72,8 +72,7 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
     # Make exceptions for counterexamples
     if is_jax(xp):
         if f_name in {'gammainc', 'gammaincc'}:  # google/jax#20507
-            a = args_np[0]
-            assume(np.all(a != 0))
+            pytest.skip("google/jax#20507")
         if f_name == 'rel_entr':  # google/jax#21265
             x, y = args_np[0], args_np[1]
             assume(not np.any((x == 0) & (y == 1)))

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import given, strategies, reproduce_failure  # noqa: F401
+from hypothesis import given, strategies, reproduce_failure, assume  # noqa: F401
 import hypothesis.extra.numpy as npst
 
 from scipy.special._support_alternative_backends import (get_array_special_func,
@@ -79,6 +79,9 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
     # TypeError: can't convert np.ndarray of type numpy.object_.
     # So we extract the scalar from 0d arrays.
     args_xp = [xp.asarray(arg[()], dtype=dtype_xp) for arg in args_np]
+
+    if is_jax(xp) and f_name == 'betainc':
+        assume(np.all(args_xp[0] > 1e-30))
 
     ref = np.asarray(f(*args_np))
     res = f(*args_xp)

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -69,14 +69,11 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
     args_np = [np.asarray(data.draw(npst.arrays(dtype_np, shape, elements=elements)))
                for shape in shapes]
 
-    # Make exceptions for counter-examples
+    # Make exceptions for counterexamples
     if is_jax(xp):
-        if f_name == 'gammainc':  # google/jax#20507
-            a, x = args_np[0], args_np[1]
-            assume(not np.any((a == 0) & (x == 1)))
-        if f_name == 'gammaincc':  # google/jax#20507
-            a, x = args_np[0], args_np[1]
-            assume(not np.any((a == 0) & (x == 0)))
+        if f_name in {'gammainc', 'gammaincc'}:  # google/jax#20507
+            a = args_np[0]
+            assume(np.all(a != 0))
         if f_name == 'rel_entr':  # google/jax#21265
             x, y = args_np[0], args_np[1]
             assume(not np.any((x == 0) & (y == 1)))

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -78,7 +78,7 @@ def test_support_alternative_backends(xp, data, f_name_n_args):
             assume(not np.any((x == 0) & (y == 1)))
         if f_name == 'betainc':  # google/jax#21900
             a = args_np[0]
-            assume(np.all(a < 1e-30))
+            assume(np.all(a > 1e-30))
 
     # `torch.asarray(np.asarray(1.))` produces
     # TypeError: can't convert np.ndarray of type numpy.object_.


### PR DESCRIPTION
#### Reference issue
Closes gh-20963

#### What does this implement/fix?
An edge case that is problematic for `jax.scipy.special.betainc` is causing CI failures. In the meantime, add an `assume` condition to avoid this edge case. Alternative to gh-20966.

#### Additional information
If this works, this is the preferred approach, I think. In that case, let's close gh-20966 and convert the existing skips to `assume`s in this PR (with comments that link to the upstream issue).