### PR TITLE
DOC: linalg: add # may vary to a linalg.schur example

### DIFF
--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -107,7 +107,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
            [ 0.        , -0.32948354+0.80225456j, -0.59877807+0.56192146j],
            [ 0.        ,  0.                    , -0.32948354-0.80225456j]])
     >>> eigvals(T2)
-    array([2.65896708, -0.32948354+0.80225456j, -0.32948354-0.80225456j])
+    array([2.65896708, -0.32948354+0.80225456j, -0.32948354-0.80225456j])   # may vary
 
     An arbitrary custom eig-sorting condition, having positive imaginary part,
     which is satisfied by only one eigenvalue


### PR DESCRIPTION
The ordering of complex conjugate pairs is not guaranteed and was reported to differ in https://github.com/scipy/scipy/issues/20960.
