### PR TITLE
REL: set 1.14.0 rc3 unreleased

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.14.0rc2',
+  version: '1.14.0rc3',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.14.0rc2"
+version = "1.14.0rc3"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -7,9 +7,9 @@ import argparse
 MAJOR = 1
 MINOR = 14
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+VERSION = '%d.%d.%drc3' % (MAJOR, MINOR, MICRO)
 
 
 def get_version_info(source_root):


### PR DESCRIPTION
* Set SciPy version to `1.14.0rc3` unreleased.

[ci skip] [skip ci] [skip circle]

Some notes:

- CI has been skipped here, but I did check locally on ARM MacOS that full suite is still passing alongside NumPy `2.0.0`, and that the doc build and release notes render still look fine.
- The actual SciPy `1.14.0` "final" release is not slated until June 25, and whether we need an rc3 will of course depend on the issue tracker/problems discovered--I may adjust this PR if it turns out we need an RC3.
- The merged backport labels have been cleared out--we're down to just 1 at the moment--related to a testing shim.
- NumPy `2.0.0` "final" was just released, so there may be pressure to do a `1.13.2` release if something major crops up. I don't anticipate that changing the `1.14.0` scheduling, but it may require some dual backporting coordination.
