### PR TITLE
TST:sparse.linalg: Skip test due to sensitivity to numerical noise

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -510,8 +510,12 @@ def test_x0_working(solver):
 
 
 def test_x0_equals_Mb(case):
+    if (case.solver is bicgstab) and (case.name == 'nonsymposdef-bicgstab'):
+        pytest.skip("Solver fails due to numerical noise "
+                    "on some architectures (see gh-15533).")
     if case.solver is tfqmr:
         pytest.skip("Solver does not support x0='Mb'")
+
     A = case.A
     b = case.b
     x0 = 'Mb'


### PR DESCRIPTION
#### Reference issue

Related #15533 

#### What does this implement/fix?
As we have noticed, the test passes through a very tight hole to succeed and on some architectures it fails. This skips that test that has been consistently failing on some architectures since version 1.8
