### PR TITLE
ENH: `stats.combine_pvalues`: add native axis support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9168,7 +9168,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
 
 
 @_axis_nan_policy_factory(SignificanceResult, kwd_samples=['weights'], paired=True)
-def combine_pvalues(pvalues, method='fisher', weights=None, axis=0):
+def combine_pvalues(pvalues, method='fisher', weights=None, *, axis=0):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.
 
@@ -9292,6 +9292,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None, axis=0):
     xp = array_namespace(pvalues)
     pvalues = xp.asarray(pvalues)
     if xp_size(pvalues) == 0:
+        # This is really only needed for *testing* _axis_nan_policy decorator
+        # It won't happen when the decorator is used.
         NaN = _get_nan(pvalues)
         return SignificanceResult(NaN, NaN)
 
@@ -9326,7 +9328,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None, axis=0):
             weights = xp.ones_like(pvalues, dtype=pvalues.dtype)
         elif weights.shape[axis] != n:
             raise ValueError("pvalues and weights must be of the same "
-                             "size along `axis`.")
+                             "length along `axis`.")
 
         norm = _SimpleNormal()
         Zi = norm.isf(pvalues)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9168,7 +9168,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
 
 
 @_axis_nan_policy_factory(SignificanceResult, kwd_samples=['weights'], paired=True)
-def combine_pvalues(pvalues, method='fisher', weights=None):
+def combine_pvalues(pvalues, method='fisher', weights=None, axis=0):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.
 
@@ -9295,40 +9295,42 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         NaN = _get_nan(pvalues)
         return SignificanceResult(NaN, NaN)
 
-    n = pvalues.shape[0]
+    n = pvalues.shape[axis]
     # used to convert Python scalar to the right dtype
     one = xp.asarray(1, dtype=pvalues.dtype)
 
     if method == 'fisher':
-        statistic = -2 * xp.sum(xp.log(pvalues))
+        statistic = -2 * xp.sum(xp.log(pvalues), axis=axis)
         chi2 = _SimpleChi2(2*n*one)
         pval = _get_pvalue(statistic, chi2, alternative='greater',
                            symmetric=False, xp=xp)
     elif method == 'pearson':
-        statistic = 2 * xp.sum(xp.log1p(-pvalues))
+        statistic = 2 * xp.sum(xp.log1p(-pvalues), axis=axis)
         chi2 = _SimpleChi2(2*n*one)
         pval = _get_pvalue(-statistic, chi2, alternative='less', symmetric=False, xp=xp)
     elif method == 'mudholkar_george':
         normalizing_factor = math.sqrt(3/n)/xp.pi
-        statistic = -xp.sum(xp.log(pvalues)) + xp.sum(xp.log1p(-pvalues))
+        statistic = (-xp.sum(xp.log(pvalues), axis=axis)
+                     + xp.sum(xp.log1p(-pvalues), axis=axis))
         nu = 5*n  + 4
         approx_factor = math.sqrt(nu / (nu - 2))
         t = _SimpleStudentT(nu*one)
         pval = _get_pvalue(statistic * normalizing_factor * approx_factor, t,
                            alternative="greater", xp=xp)
     elif method == 'tippett':
-        statistic = xp.min(pvalues)
+        statistic = xp.min(pvalues, axis=axis)
         beta = _SimpleBeta(one, n*one)
         pval = _get_pvalue(statistic, beta, alternative='less', symmetric=False, xp=xp)
     elif method == 'stouffer':
         if weights is None:
             weights = xp.ones_like(pvalues, dtype=pvalues.dtype)
-        elif weights.shape[0] != n:
-            raise ValueError("pvalues and weights must be of the same size.")
+        elif weights.shape[axis] != n:
+            raise ValueError("pvalues and weights must be of the same "
+                             "size along `axis`.")
 
         norm = _SimpleNormal()
         Zi = norm.isf(pvalues)
-        statistic = weights @ Zi / xp.linalg.vector_norm(weights)
+        statistic = weights @ Zi / xp.linalg.vector_norm(weights, axis=axis)
         pval = _get_pvalue(statistic, norm, alternative="greater", xp=xp)
 
     else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8042,6 +8042,33 @@ class TestCombinePvalues:
         xp_assert_equal(res.statistic, res[0])
         xp_assert_equal(res.pvalue, res[1])
 
+    @pytest.mark.parametrize("method", methods)
+    # axis=None is currently broken for array API; will be handled when
+    # axis_nan_policy decorator is updated
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_axis(self, method, axis, xp):
+        rng = np.random.default_rng(234892349810482)
+        x = xp.asarray(rng.random(size=(2, 10)))
+        x = x.T if (axis == 0) else x
+        res = stats.combine_pvalues(x, axis=axis)
+
+        if axis is None:
+            x = xp.reshape(x, (-1,))
+            ref = stats.combine_pvalues(x)
+            xp_assert_close(res.statistic, ref.statistic)
+            xp_assert_close(res.pvalue, ref.pvalue)
+            return
+
+        x = x.T if (axis == 0) else x
+        x0, x1 = x[0, :], x[1, :]
+        ref0 = stats.combine_pvalues(x0)
+        ref1 = stats.combine_pvalues(x1)
+
+        xp_assert_close(res.statistic[0], ref0.statistic)
+        xp_assert_close(res.statistic[1], ref1.statistic)
+        xp_assert_close(res.pvalue[0], ref0.pvalue)
+        xp_assert_close(res.pvalue[1], ref1.pvalue)
+
 
 class TestCdfDistanceValidation:
     """


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/20934#issuecomment-2169077129
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds native axis support to `combine_pvalues`
#### Additional information
<!--Any additional information you think is important.-->
