### PR TITLE
DOC: single to double backticks

### DIFF
--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -27,7 +27,7 @@ Fast Fourier transforms
 1-D discrete Fourier transforms
 ___________________________________________
 
-The FFT `y[k]` of length :math:`N` of the length-:math:`N` sequence `x[n]` is
+The FFT ``y[k]`` of length :math:`N` of the length-:math:`N` sequence ``x[n]`` is
 defined as
 
 .. math::
@@ -369,7 +369,7 @@ ____________
 
 
 The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up to a
-factor of `2N`. The orthonormalized DCT-III is exactly the inverse of the
+factor of ``2N``. The orthonormalized DCT-III is exactly the inverse of the
 orthonormalized DCT- II. The function :func:`idct` performs the mappings between
 the DCT and IDCT types, as well as the correct normalization.
 
@@ -485,7 +485,7 @@ definition of the unnormalized DST-I (``norm=None``):
     \right), \qquad 0 \le k < N.
 
 Note also that the DST-I is only supported for input size > 1. The
-(unnormalized) DST-I is its own inverse, up to a factor of `2(N+1)`.
+(unnormalized) DST-I is its own inverse, up to a factor of ``2(N+1)``.
 
 Type II DST
 ___________

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -466,7 +466,7 @@ has an exact solution using the matrix exponential:
 However, in this case, :math:`\mathbf{A}\left(t\right)` and its integral do not commute.
 
 This differential equation can be solved using the function :obj:`solve_ivp`.
-It requires the derivative, *fprime*, the time span `[t_start, t_end]`
+It requires the derivative, *fprime*, the time span ``[t_start, t_end]``
 and the initial conditions vector, *y0*, as input arguments and returns
 an object whose *y* field is an array with consecutive solution values as
 columns. The initial conditions are therefore given in the first output column.

--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -63,7 +63,7 @@ using each method.
    interpolation.
 
 If your data is such that spline methods produce ringing, you may consider
-using `method="pchip"`, which uses the tensor product of PCHIP interpolators,
+using ``method="pchip"``, which uses the tensor product of PCHIP interpolators,
 a `PchipInterpolator` per dimension.
 
 If you prefer a functional interface opposed to explicitly creating a class instance,

--- a/doc/source/tutorial/interpolate/splines_and_polynomials.rst
+++ b/doc/source/tutorial/interpolate/splines_and_polynomials.rst
@@ -260,7 +260,7 @@ at a given evaluation point, thus a design matrix built on b-splines has at most
 As an illustration, we consider a toy example. Suppose our data are
 one-dimensional and are confined to an interval :math:`[0, 6]`.
 We construct a 4-regular knot vector which corresponds to 7 data points and
-cubic, `k=3`, splines:
+cubic, ``k=3``, splines:
 
 >>> t = [0., 0., 0., 0., 2., 3., 4., 6., 6., 6., 6.]
 

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -84,7 +84,7 @@ def cluster_dist(const double[:, :] Z, int[:] T, double cutoff, int n):
         The linkage matrix.
     T : ndarray
         The array to store the cluster numbers. The i'th observation belongs to
-        cluster `T[i]`.
+        cluster ``T[i]``.
     cutoff : double
         Clusters are formed when distances are less than or equal to `cutoff`.
     n : int
@@ -107,7 +107,7 @@ def cluster_in(const double[:, :] Z, const double[:, :] R, int[:] T, double cuto
         The inconsistent matrix.
     T : ndarray
         The array to store the cluster numbers. The i'th observation belongs to
-        cluster `T[i]`.
+        cluster ``T[i]``.
     cutoff : double
         Clusters are formed when the inconsistent values are less than or
         or equal to `cutoff`.
@@ -129,7 +129,7 @@ def cluster_maxclust_dist(const double[:, :] Z, int[:] T, int n, int mc):
         The linkage matrix.
     T : ndarray
         The array to store the cluster numbers. The i'th observation belongs to
-        cluster `T[i]`.
+        cluster ``T[i]``.
     n : int
         The number of observations.
     mc : int
@@ -154,7 +154,7 @@ cpdef void cluster_maxclust_monocrit(const double[:, :] Z, const double[:] MC, i
         The monotonic criterion array.
     T : ndarray
         The array to store the cluster numbers. The i'th observation belongs to
-        cluster `T[i]`.
+        cluster ``T[i]``.
     n : int
         The number of observations.
     max_nc : int
@@ -240,7 +240,7 @@ cpdef void cluster_monocrit(const double[:, :] Z, const double[:] MC, int[:] T,
         The monotonic criterion array.
     T : ndarray
         The array to store the cluster numbers. The i'th observation belongs to
-        cluster `T[i]`.
+        cluster ``T[i]``.
     cutoff : double
         Clusters are formed when the MC values are less than or equal to
         `cutoff`.

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3672,7 +3672,7 @@ def lfilter_zi(b, a):
         A = scipy.linalg.companion(a).T
         B = b[1:] - a[1:]*b[0]
 
-    assuming `a[0]` is 1.0; if `a[0]` is not 1, `a` and `b` are first
+    assuming ``a[0]`` is 1.0; if ``a[0]`` is not 1, `a` and `b` are first
     divided by a[0].
 
     Examples
@@ -3700,7 +3700,7 @@ def lfilter_zi(b, a):
         0.44399389,  0.35505241])
 
     Note that the `zi` argument to `lfilter` was computed using
-    `lfilter_zi` and scaled by `x[0]`.  Then the output `y` has no
+    `lfilter_zi` and scaled by ``x[0]``.  Then the output `y` has no
     transient until the input drops from 0.5 to 0.0.
 
     """

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -127,8 +127,8 @@ Sparse tools:
 
 Identifying sparse arrays:
 
-- use `isinstance(A, sp.sparse.sparray)` to check whether an array or matrix.
-- use `A.format == 'csr'` to check the sparse format
+- use ``isinstance(A, sp.sparse.sparray)`` to check whether an array or matrix.
+- use ``A.format == 'csr'`` to check the sparse format
 
 Identifying sparse matrices:
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1156,7 +1156,7 @@ def canberra(u, v, w=None):
 
     Notes
     -----
-    When `u[i]` and `v[i]` are 0 for given i, then the fraction 0/0 = 0 is
+    When ``u[i]`` and ``v[i]`` are 0 for given i, then the fraction 0/0 = 0 is
     used in the calculation.
 
     Examples


### PR DESCRIPTION
A few more target that can't be in single backticks because they are not identifiers and woudl trigger issues if the default role was changed :any: or :py:obj: