### PR TITLE
BUG: Update scipy-optimise directive in view of new default role

### DIFF
--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -30,7 +30,7 @@ if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from numpydoc.numpydoc import mangle_docstrings
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from sphinx.domains.python import PythonDomain
 from scipy._lib._util import getfullargspec_no_self
 
@@ -149,7 +149,8 @@ def wrap_mangling_directive(base_directive):
                     new_lines.append(':Options:')
                 else:
                     new_lines.append(line)
-            self.content = ViewList(new_lines, self.content.parent)
+
+            self.content = StringList(new_lines, parent=self.content.parent)
             return base_directive.run(self)
 
         option_spec = dict(base_directive.option_spec)


### PR DESCRIPTION
There is some work being done to update the default role from autolink to something more generic like py:obj or any, this is not yet possible as those do not yet cross-reference function parameters.

Nonetheless if one tries to change the default role, sphinx choke on some docutils node sources as the parent was improperly set.

This small patch should fix it by using the parent kwarg, and also using a  more specific subclass.

See https://github.com/sphinx-doc/sphinx/issues/12429