### PR TITLE
STY: `_lib._util`: address new mypy complaint in main

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -28,7 +28,7 @@ if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
         DTypePromotionError
     )
 else:
-    from numpy import (
+    from numpy import (  # type: ignore[attr-defined, no-redef]
         AxisError, ComplexWarning, VisibleDeprecationWarning  # noqa: F401
     )
     DTypePromotionError = TypeError  # type: ignore


### PR DESCRIPTION
#### Reference issue
e.g. gh-20976

#### What does this implement/fix?
mypy is reporting:
```
mypy.api.run --config-file /home/runner/work/scipy/scipy/mypy.ini scipy
scipy/_lib/_util.py:31: error: Module "numpy" has no attribute "AxisError"  [attr-defined]
scipy/_lib/_util.py:31: error: Name "AxisError" already defined on line 21  [no-redef]
scipy/_lib/_util.py:31: error: Module "numpy" has no attribute "ComplexWarning"  [attr-defined]
scipy/_lib/_util.py:31: error: Name "ComplexWarning" already defined on line 22  [no-redef]
scipy/_lib/_util.py:31: error: Module "numpy" has no attribute "VisibleDeprecationWarning"  [attr-defined]
scipy/_lib/_util.py:31: error: Name "VisibleDeprecationWarning" already defined on line 23  [no-redef]
Found 6 errors in 1 file (checked 889 source files)
```
in `main` now. This attempts to silence it, assuming that it has to with NumPy 2.0 and we will still need to support older NumPy versions for a while. The minimum support NumPy version is still 1.23.5 in main, so even if that will be updated before the next release, I assume we'll still be supporting 1.24. (According to SPEC 0, it would depend on whether SciPy 1.15 is released before or after December 18, since that appears to be the date 1.24 was release in 2022. I think we've been trying to catch up to the SPEC gradually.)