### PR TITLE
DEV: `gh_lists`: single -> double backticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,10 @@ doc/source/.jupyterlite.doit.db
 .cache/
 .pytest_cache/
 
+# github cache #
+################
+gh_cache.json
+
 # mypy cache #
 ##############
 .mypy_cache/

--- a/tools/gh_lists.py
+++ b/tools/gh_lists.py
@@ -46,17 +46,31 @@ def main():
         print("-"*len(title))
         print()
 
+        def backtick_repl(matchobj):
+            if matchobj.group(2) != ' ':
+                post = '\ ' + matchobj.group(2)
+            else:
+                post = matchobj.group(2)
+            return '``' + matchobj.group(1) + '``' + post
+
         for issue in items:
             msg = "* `#{0} <{1}>`__: {2}"
             # sanitize whitespace, `, and *
             title = re.sub("\\s+", " ", issue.title.strip())
-            title = title.replace('`', '\\`').replace('*', '\\*')
+            title = re.sub("([^`]|^)`([^`]|$)", "\g<1>``\g<2>", title)
+            title = re.sub("``(.*?)``(.)", backtick_repl, title)
+            title = title.replace('*', '\\*')
             if len(title) > 60:
                 remainder = re.sub("\\s.*$", "...", title[60:])
                 if len(remainder) > 20:
-                    remainder = title[:80] + "..."
+                    # this was previously bugged,
+                    # assigning to `remainder` rather than `title`
+                    title = title[:80] + "..."
                 else:
                     title = title[:60] + remainder
+                if title.count('`') % 4 != 0:
+                    # ellipses have cut in the middle of a code block
+                    title = title[:-3] + '``...'
             msg = msg.format(issue.id, issue.url, title)
             print(msg)
         print()


### PR DESCRIPTION
Currently, the tool turns single backticks into escaped single backticks. This helps avoid syntax errors, but it doesn't help rst render the code blocks as intended.

I've adjusted the string replacement to instead turn single backticks into double backticks.

Sample output:

```
Issues closed for 1.15.0
------------------------

* `#19042 <https://github.com/scipy/scipy/issues/19042>`__: DOC: Scipy Sparse BSR does not support slicing: __getitem__ not...
* `#19405 <https://github.com/scipy/scipy/issues/19405>`__: ENH: keep axis functionality in sparse.csr_array.getnnz()
* `#19791 <https://github.com/scipy/scipy/issues/19791>`__: DOC: linalg.schur: unclear signature for ``sort`` callable when...
* `#20196 <https://github.com/scipy/scipy/issues/20196>`__: Audit usage of cython memoryviews, add ``const`` to allow readonly...
* `#20207 <https://github.com/scipy/scipy/issues/20207>`__: ENH: sparse: Validate dtype on sparse array/matrix creation
* `#20239 <https://github.com/scipy/scipy/issues/20239>`__: DOC: Sparse arrays: todense() does not return numpy.matrix
* `#20240 <https://github.com/scipy/scipy/issues/20240>`__: ENH: multiple small improvements to scipy.stats.circmean
* `#20370 <https://github.com/scipy/scipy/issues/20370>`__: DOC: ndimage.convolve: clarify origin parameter description
* `#20552 <https://github.com/scipy/scipy/issues/20552>`__: DOC/DEV/MAINT: review distributing section of core-dev guide
* `#20635 <https://github.com/scipy/scipy/issues/20635>`__: DOC: Titles of long function names in API Reference truncated...
* `#20710 <https://github.com/scipy/scipy/issues/20710>`__: ENH: ``special.rel_entr``: avoid premature overflow
* `#20763 <https://github.com/scipy/scipy/issues/20763>`__: BUG: sparse.csgraph, array types: some functions should expect...
* `#20844 <https://github.com/scipy/scipy/issues/20844>`__: DOC: update testing docs for alternative backends
* `#20893 <https://github.com/scipy/scipy/issues/20893>`__: DOC/DEV: Developer docs should mention Accelerate support
* `#20904 <https://github.com/scipy/scipy/issues/20904>`__: BUG: sparse.csgraph.dijkstra errors on inputs with int64 or no...
* `#20910 <https://github.com/scipy/scipy/issues/20910>`__: BUG: positional argument ``DeprecationWarning`` message is overly...
* `#20931 <https://github.com/scipy/scipy/issues/20931>`__: MAINT: Premature setting of attributes in ``HBInfo`` in ``scipy.io._harwell_boeing``.


Pull requests for 1.15.0
------------------------

* `#19255 <https://github.com/scipy/scipy/pull/19255>`__: ENH: Use ``highspy`` in ``linprog``
* `#20242 <https://github.com/scipy/scipy/pull/20242>`__: DOC: sparse: Correct ``todense`` documentation
* `#20303 <https://github.com/scipy/scipy/pull/20303>`__: DOC: stats: Convert sampling tutorial to MyST-md
* `#20408 <https://github.com/scipy/scipy/pull/20408>`__: DOC: ndimage.convolve: modify ``origin`` param description
* `#20719 <https://github.com/scipy/scipy/pull/20719>`__: MAINT: sparse: fix ``__init__`` func sig to allow ``maxprint``...
* `#20743 <https://github.com/scipy/scipy/pull/20743>`__: ENH: ``stats._xp_mean``, an array API compatible ``mean`` with...
* `#20754 <https://github.com/scipy/scipy/pull/20754>`__: ENH: sparse: add dtype validation in ``__init__`` and ``astype``
* `#20759 <https://github.com/scipy/scipy/pull/20759>`__: MAINT: sparse.linalg: adjust ``norm``, ``eigs``, and ``lsqr``...
* `#20766 <https://github.com/scipy/scipy/pull/20766>`__: MAINT: stats: minor numerical improvements to circular statistics
* `#20771 <https://github.com/scipy/scipy/pull/20771>`__: ENH: ``stats.ttest_ind``: add array API support
* `#20773 <https://github.com/scipy/scipy/pull/20773>`__: BUG: sparse.csgraph, array types: support non-zero ``fill_value``s
* `#20793 <https://github.com/scipy/scipy/pull/20793>`__: ENH: stats: end-to-end array-API support for NHSTs with beta...
* `#20816 <https://github.com/scipy/scipy/pull/20816>`__: ENH: ``special.rel_entr``: Avoid overflow before computing log
* `#20822 <https://github.com/scipy/scipy/pull/20822>`__: CI: Add Linux workflow to test on free-threaded Python builds
* `#20827 <https://github.com/scipy/scipy/pull/20827>`__: REL: set version to 1.15.0.dev0
* `#20829 <https://github.com/scipy/scipy/pull/20829>`__: MAINT: special: fix typo in ``four_gammas`` used by ``hyp2f1``
* `#20830 <https://github.com/scipy/scipy/pull/20830>`__: DOC: ``optimize.differential_evolution``: change convergence...
* `#20833 <https://github.com/scipy/scipy/pull/20833>`__: BUG: interpolate: make BSpline.integrate always return an array
* `#20837 <https://github.com/scipy/scipy/pull/20837>`__: MAINT: linalg: add ``const`` to Cython function signatures
* `#20843 <https://github.com/scipy/scipy/pull/20843>`__: DOC/DEV: add docs for enabling interactive examples
* `#20846 <https://github.com/scipy/scipy/pull/20846>`__: DOC: Wrap long titles in docs pages
* `#20849 <https://github.com/scipy/scipy/pull/20849>`__: DOC/DEV: mention ``-b`` option in contributor guide on testing
* `#20855 <https://github.com/scipy/scipy/pull/20855>`__: TST: add additional margin to ``fail_slow``s
* `#20857 <https://github.com/scipy/scipy/pull/20857>`__: ENH: sparse: add axis parameter to ``count_nonzero`` method
* `#20859 <https://github.com/scipy/scipy/pull/20859>`__: DEP: signal: remove ``cmplx_sort``
* `#20862 <https://github.com/scipy/scipy/pull/20862>`__: MAINT: special: Add kokkos ``mdspan``
* `#20864 <https://github.com/scipy/scipy/pull/20864>`__: DEP: integrate: remove quadrature and romberg
* `#20865 <https://github.com/scipy/scipy/pull/20865>`__: DEP: signal: remove wavelet functions
* `#20866 <https://github.com/scipy/scipy/pull/20866>`__: DEP: stats: remove ``rvs_ratio_uniforms``
* `#20867 <https://github.com/scipy/scipy/pull/20867>`__: DEP: ``integrate.cumulative_trapezoid``: raise ``ValueError``...
* `#20868 <https://github.com/scipy/scipy/pull/20868>`__: DEP: interpolate: deprecate complex dtypes in ``{Akima1D, Pchip}Interpolator``
* `#20869 <https://github.com/scipy/scipy/pull/20869>`__: DEP: special.factorial: raise error for non-integer scalars and...
* `#20872 <https://github.com/scipy/scipy/pull/20872>`__: MAINT: interpolate: add ``const`` to Cython function signatures
* `#20873 <https://github.com/scipy/scipy/pull/20873>`__: MAINT: sparse: add ``const`` to Cython function signatures
* `#20874 <https://github.com/scipy/scipy/pull/20874>`__: MAINT: spatial: add ``const`` to Cython function signatures
* `#20875 <https://github.com/scipy/scipy/pull/20875>`__: BLD/DEV: special: Fix warning due to mixed initializers
* `#20876 <https://github.com/scipy/scipy/pull/20876>`__: DOC: use ``intersphinx_registry`` for easier intersphinx mapping...
* `#20882 <https://github.com/scipy/scipy/pull/20882>`__: CI: Add workflow to build and upload free-threaded wheels
* `#20883 <https://github.com/scipy/scipy/pull/20883>`__: ENH: stats: rewrite ``ttest_rel`` in terms of ``ttest_1samp``
* `#20884 <https://github.com/scipy/scipy/pull/20884>`__: ENH: stats: end-to-end array-API support for NHSTs with Student's...
* `#20885 <https://github.com/scipy/scipy/pull/20885>`__: BUG: fix incorrect intersphinx-registry entry in environment.yml
* `#20886 <https://github.com/scipy/scipy/pull/20886>`__: CI/DEV: fix Node.js 16 warnings by bumping actions
* `#20887 <https://github.com/scipy/scipy/pull/20887>`__: MAINT: signal: add ``const`` to Cython function signatures
* `#20889 <https://github.com/scipy/scipy/pull/20889>`__: MAINT: sparse: Align matmul tests in ``test_base.py`` for spmatrix...
* `#20891 <https://github.com/scipy/scipy/pull/20891>`__: MAINT: stats: add ``const`` to Cython function signatures
* `#20900 <https://github.com/scipy/scipy/pull/20900>`__: ENH: stats: add array API support to combine_pvalues
* `#20906 <https://github.com/scipy/scipy/pull/20906>`__: DOC: linalg.schur: update doc for the argument ``sort``
* `#20907 <https://github.com/scipy/scipy/pull/20907>`__: CI: Make sure nightly free-threaded wheels are tested with GIL...
* `#20912 <https://github.com/scipy/scipy/pull/20912>`__: DOC: Add more information about how to use Accelerate
* `#20913 <https://github.com/scipy/scipy/pull/20913>`__: BUG: sparse.csgraph.dijkstra: fix dtype and shape bugs
* `#20916 <https://github.com/scipy/scipy/pull/20916>`__: DOC: Mention that ``sparse.bsr_array`` does not support slicing.
* `#20922 <https://github.com/scipy/scipy/pull/20922>`__: BUG: stats.mstats: fix ``mstats.{ttest_rel, ttest_1samp}`` when...
* `#20924 <https://github.com/scipy/scipy/pull/20924>`__: BUG: ``_lib``: ensure reasonable length ``_deprecate_positional_args``...
* `#20932 <https://github.com/scipy/scipy/pull/20932>`__: MAINT: io: fix premature setting of attributes in ``HBInfo``
* `#20934 <https://github.com/scipy/scipy/pull/20934>`__: TST: stats.combine_pvalues: parameterise tests and update reference...
* `#20941 <https://github.com/scipy/scipy/pull/20941>`__: DOC/MAINT: single to double backticks to remove improper linking
* `#20942 <https://github.com/scipy/scipy/pull/20942>`__: CI: Use Cython nightly wheel on free-threaded CI
* `#20944 <https://github.com/scipy/scipy/pull/20944>`__: DOC: update distributing section
* `#20946 <https://github.com/scipy/scipy/pull/20946>`__: ENH: stats.gmean: add array API support
* `#20951 <https://github.com/scipy/scipy/pull/20951>`__: CI: Add MacOS to free-threaded wheel release CI
* `#20954 <https://github.com/scipy/scipy/pull/20954>`__: MAINT: stats.hmean/pmean: simplify prior to array API conversion
* `#20955 <https://github.com/scipy/scipy/pull/20955>`__: DOC: Single to double backticks for non-targets
* `#20968 <https://github.com/scipy/scipy/pull/20968>`__: MAINT: fix some misspellings
* `#20969 <https://github.com/scipy/scipy/pull/20969>`__: DOC: linalg: add # may vary to a linalg.schur example
* `#20973 <https://github.com/scipy/scipy/pull/20973>`__: TST:sparse.linalg: Skip test due to sensitivity to numerical...
* `#20974 <https://github.com/scipy/scipy/pull/20974>`__: ENH: stats.combine_pvalues: add native axis support
* `#20975 <https://github.com/scipy/scipy/pull/20975>`__: DOC: single to double backticks
* `#20976 <https://github.com/scipy/scipy/pull/20976>`__: BUG: Update scipy-optimise directive in view of new default role
* `#20977 <https://github.com/scipy/scipy/pull/20977>`__: DOC: More single to double backtick
* `#20979 <https://github.com/scipy/scipy/pull/20979>`__: STY: ``_lib._util``: address new mypy complaint in main
* `#20980 <https://github.com/scipy/scipy/pull/20980>`__: CI, MAINT: ``test_plot_iv`` NumPy 2 shim
```