### PR TITLE
DOC/DEV: update commit message guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,9 @@ http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checkli
 
 Also, please name and describe your PR as you would write a
 commit message:
-http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message
+http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
+However, please only include an issue number in the description, not the title,
+and please ensure that any code names containing underscores are enclosed in backticks.
 
 Depending on your changes, you can skip CI operations and save time and energy: 
 http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -225,8 +225,7 @@ Example::
    Then a blank line, then more text if needed.
    References to code names should be enclosed in backticks.
    If changes are limited to certain submodules or functions, they should be
-   included after the acronym(s) - backticks are not needed here unless the code names
-   contain an underscore.
+   included after the acronym(s) - backticks are not needed here.
 
 Example::
 

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -214,15 +214,29 @@ been added to ``upstream`` that affect your work. In this case, follow the
 Writing the commit message
 --------------------------
 
-Commit messages should be clear and follow a few basic rules.  Example::
+Commit messages should be clear and follow a few basic rules.
 
-   ENH: add functionality X to SciPy.<submodule>.
+Example::
+
+   MAINT/TST: fft: remove xp backend skips, test `fftfreq` `device`
 
    The first line of the commit message starts with a capitalized acronym
-   (options listed below) indicating what type of commit this is. Then a blank
-   line, then more text if needed.  Lines shouldn't be longer than 72
-   characters.  If the commit is related to a ticket, indicate that with
-   "See #3456", "See ticket 3456", "Closes #3456", or similar.
+   (or multiple, options listed below) indicating what type of commit this is.
+   Then a blank line, then more text if needed.
+   References to code names should be enclosed in backticks.
+   If changes are limited to certain submodules or functions, they should be
+   included after the acronym(s) - backticks are not needed here unless the code names
+   contain an underscore.
+
+Example::
+
+   BUG:sparse.linalg.gmres: add early exit when `x0` already solves problem
+
+   Lines shouldn't be longer than 72 characters. If the commit is related to an issue,
+   indicate that with "See gh-3456", "Closes gh-3456", or similar,
+   in the extended description.
+   However, if you are pushing many commits to a PR, you should avoid including
+   this in every commit message as it will clutter the linked issue.
 
 Describing the motivation for a change, the nature of a bug for bug fixes or
 some details on what an enhancement does are also good to include in a commit


### PR DESCRIPTION
#### Reference issue
Closes gh-20739

#### What does this implement/fix?
<img width="751" alt="image" src="https://github.com/scipy/scipy/assets/51488791/5750b2a9-dd7c-4500-9e5d-2b34df8725d4">

#### Additional information
I'm sure this could be improved, open to suggestions.
