### PR TITLE
CI: test cp313-dev

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/commit_message.yml
 
   test_meson:
-    name: mypy (py3.10) & dev deps (py3.12), fast, dev.py
+    name: mypy (py3.10) & dev deps (py3.13), fast, dev.py
     needs: get_commit_message
     # If using act to run CI locally the github object does not exist and
     # the usual skipping should not be enforced
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.12'] # this run will use python dev versions when available
+        python-version: ['3.10', '3.13-dev'] # this run will use python dev versions when available
         maintenance-branch:
           - ${{ contains(github.ref, 'maintenance/') || contains(github.base_ref, 'maintenance/') }}
         exclude:
@@ -54,6 +54,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: 'environment.yml'
+        allow-prereleases: true
 
     - name: Install Ubuntu dependencies
       run: |
@@ -67,7 +68,7 @@ jobs:
         python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
 
     - name: Install Python packages from repositories
-      if: matrix.python-version == '3.12' # this run will use python dev versions when available
+      if: matrix.python-version == '3.13-dev' # this run will use python dev versions when available
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
         python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"

--- a/scipy/special/_ellip_harm.pxd
+++ b/scipy/special/_ellip_harm.pxd
@@ -69,7 +69,7 @@ cdef inline double* lame_coefficients(double h2, double k2, int n, int p,
 
     cdef double s2, alpha, beta, gamma, lamba_romain, pp, psi, t1, tol, vl, vu
     cdef CBLAS_INT r, tp, j, size, i, info, lwork, liwork, c, iu
-    cdef Py_UNICODE t
+    cdef Py_UCS4 t
 
     r = n/2
     alpha = h2


### PR DESCRIPTION
Start testing on cp313 in the run up to its release. `Py_UNICODE` is deprecated in cp313, which necessitated one amendment.