### PR TITLE
BUG: spatial.distance.correlation: fix complex input

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -105,7 +105,7 @@ __all__ = [
 ]
 
 
-import math
+import cmath
 import warnings
 import numpy as np
 import dataclasses
@@ -644,7 +644,9 @@ def correlation(u, v, w=None, centered=True):
     uv = np.dot(u, vw)
     uu = np.dot(u, uw)
     vv = np.dot(v, vw)
-    dist = 1.0 - uv / math.sqrt(uu * vv)
+    sqrt_uu_vv = cmath.sqrt(uu * vv)
+    sqrt_uu_vv = sqrt_uu_vv.real if sqrt_uu_vv.imag == 0 else sqrt_uu_vv
+    dist = 1.0 - uv / sqrt_uu_vv
     # Clip the result to avoid rounding error
     return np.clip(dist, 0.0, 2.0)
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1658,6 +1658,14 @@ class TestSomeDistanceFunctions:
             dist = mahalanobis(x, y, vi)
             assert_almost_equal(dist, np.sqrt(6.0))
 
+    def test_correlation_complex(self):
+        # Regression test for gh-20994
+        u = np.asarray([(1+2j), (3+4j)])
+        v = np.asarray([(5+6j), (7+8j)])
+        # should not raise a `ComplexWarning`
+        dist = correlation(u, v, centered=False)
+        assert_allclose(dist, (1.9780295711505111+0.011977004379304905j))
+
 
 class TestSquareForm:
     checked_dtypes = [np.float64, np.float32, np.int32, np.int8, bool]


### PR DESCRIPTION
#### Reference issue
Closes gh-20994

#### What does this implement/fix?
A regression was introduced for complex input when moving from `np.sqrt` to `math.sqrt`. This changes to `cmath.sqrt`.

#### Additional information
I had to include extra handling where the imaginary part is zero - not sure if this is the right way to do things.
