### PR TITLE
MAINT: odr: fix a refcounting issue in `__odrpack.c`

### DIFF
--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -50,8 +50,6 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
   PyArrayObject *pyXplusD;
   void *beta_dst;
 
-  arg01 = PyTuple_New(2);
-
   if (*m != 1)
     {
       npy_intp dim2[2];
@@ -68,21 +66,18 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
       memcpy(PyArray_DATA(pyXplusD), (void *)xplusd, (*n) * sizeof(double));
     }
 
-  PyTuple_SetItem(arg01, 0, odr_global.pyBeta);
-  Py_INCREF(odr_global.pyBeta);
-  PyTuple_SetItem(arg01, 1, (PyObject *) pyXplusD);
-  Py_INCREF((PyObject *) pyXplusD);
+  arg01 = PyTuple_Pack(2, odr_global.pyBeta, (PyObject *) pyXplusD);
+  Py_DECREF(pyXplusD);
+  if (arg01 == NULL) {
+    return;
+  }
 
   if (odr_global.extra_args != NULL)
-    {
       arglist = PySequence_Concat(arg01, odr_global.extra_args);
-    }
   else
-    {
       arglist = PySequence_Tuple(arg01);        /* make a copy */
-    }
-
   Py_DECREF(arg01);
+
   *istop = 0;
 
   beta_dst = (PyArray_DATA((PyArrayObject *) odr_global.pyBeta));
@@ -255,14 +250,12 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
 
   Py_DECREF(result);
   Py_DECREF(arglist);
-  Py_DECREF(pyXplusD);
 
   return;
 
 fail:
   Py_XDECREF(result);
   Py_XDECREF(arglist);
-  Py_XDECREF(pyXplusD);
   *istop = -1;
   return;
 }


### PR DESCRIPTION
Looks like a minor issue, but was reported as a potential use-after-free bug found by a static analysis tool.

Closes gh-18014

The main change is replacing `PyTuple_SetItem` with `PyTuple_Pack`, which is a safer API (so no need to think about whether the incref in the old code is actually incorrect or not). The rest is just cleanups to make the code easier to read/understand.