### PR TITLE
DOC: stats: Convert `chisquare` example to notebook

### DIFF
--- a/doc/source/tutorial/stats/hypothesis_chisquare.md
+++ b/doc/source/tutorial/stats/hypothesis_chisquare.md
@@ -1,0 +1,67 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+```{eval-rst}
+.. jupyterlite:: ../../_contents/hypothesis_chisquare.ipynb
+   :new_tab: False
+```
+
+(hypothesis_chisquare)=
+# Hypothesis testing: Chi-square test
+
+The {class}`chi-square test <scipy.stats.chisquare>` tests the null hypothesis
+that the categorical data has the given frequencies.
+
+In [^1], bird foraging behavior was investigated in an old-growth forest of
+Oregon. In the forest, 44% of the canopy volume was Douglas fir, 24% was
+ponderosa pine, 29% was grand fir, and 3% was western larch. The authors
+observed the behavior of several species of birds, one of which was the
+red-breasted nuthatch. They made 189 observations of this species foraging,
+recording 43 ("23%") of observations in Douglas fir, 52 ("28%") in ponderosa
+pine, 54 ("29%") in grand fir, and 40 ("21%") in western larch.
+
+Using a chi-square test, we can test the null hypothesis that the proportions of
+foraging events are equal to the proportions of canopy volume. The authors of
+the paper considered a p-value less than 1% to be significant.
+
+Using the above proportions of canopy volume and observed events, we can infer
+expected frequencies.
+
+```{code-cell} ipython3
+import numpy as np
+f_exp = np.array([44, 24, 29, 3]) / 100 * 189
+```
+
+The observed frequencies of foraging were:
+
+```{code-cell} ipython3
+f_obs = np.array([43, 52, 54, 40])
+```
+
+We can now compare the observed frequencies with the expected frequencies.
+
+```{code-cell} ipython3
+from scipy.stats import chisquare
+chisquare(f_obs=f_obs, f_exp=f_exp)
+```
+
+The p-value is well below the chosen significance level. Hence, the authors
+considered the difference to be significant and concluded that the relative
+proportions of foraging events were not the same as the relative proportions of
+tree canopy volume.
+
+## References
+
+[^1]: Mannan, R. William and E. Charles. Meslow. "Bird populations and vegetation
+ characteristics in managed and old-growth forests, northeastern Oregon."
+ Journal of Wildlife Management 48, 1219-1238, :doi:`10.2307/3801783`, 1984.

--- a/doc/source/tutorial/stats/hypothesis_chisquare.md
+++ b/doc/source/tutorial/stats/hypothesis_chisquare.md
@@ -17,7 +17,7 @@ kernelspec:
 ```
 
 (hypothesis_chisquare)=
-# Hypothesis testing: Chi-square test
+# Chi-square test
 
 The {class}`chi-square test <scipy.stats.chisquare>` tests the null hypothesis
 that the categorical data has the given frequencies.

--- a/doc/source/tutorial/stats/hypothesis_tests.rst
+++ b/doc/source/tutorial/stats/hypothesis_tests.rst
@@ -10,5 +10,12 @@ Sample statistics and hypothesis tests
 
 Statistical hypothesis tests are used to decide whether data sufficiently
 support a particular hypothesis. SciPy defines a number of hypothesis tests,
-listed in :ref:`hypotests`. You can find examples to each test in the
-corresponding docstring.
+listed in :ref:`hypotests`.
+
+You can find simple examples to each test in the corresponding docstring. For
+more detailed examples, see the following sections.
+
+.. toctree::
+    :maxdepth: 1
+
+    hypothesis_chisquare.md

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7736,10 +7736,6 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
            in the case of a correlated system of variables is such that it can be reasonably
            supposed to have arisen from random sampling", Philosophical Magazine. Series 5. 50
            (1900), pp. 157-175.
-    .. [4] Mannan, R. William and E. Charles. Meslow. "Bird populations and
-           vegetation characteristics in managed and old-growth forests,
-           northeastern Oregon." Journal of Wildlife Management
-           48, 1219-1238, :doi:`10.2307/3801783`, 1984.
 
     Examples
     --------
@@ -7794,6 +7790,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     ...           axis=1)
     Power_divergenceResult(statistic=array([3.5 , 9.25]), pvalue=array([0.62338763, 0.09949846]))
 
+    For a more detailed example, see :ref:`hypothesis_chisquare`.
     """  # noqa: E501
     return power_divergence(f_obs, f_exp=f_exp, ddof=ddof, axis=axis,
                             lambda_="pearson")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7747,6 +7747,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     expected frequencies are uniform and given by the mean of the observed
     frequencies:
 
+    >>> import numpy as np
     >>> from scipy.stats import chisquare
     >>> chisquare([16, 18, 16, 14, 12, 12])
     Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7747,6 +7747,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     expected frequencies are uniform and given by the mean of the observed
     frequencies:
 
+    >>> from scipy.stats import chisquare
     >>> chisquare([16, 18, 16, 14, 12, 12])
     Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7703,6 +7703,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     scipy.stats.fisher_exact : Fisher exact test on a 2x2 contingency table.
     scipy.stats.barnard_exact : An unconditional exact test. An alternative
         to chi-squared test for small sample sizes.
+    :ref:`hypothesis_chisquare`
 
     Notes
     -----
@@ -7742,52 +7743,14 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
 
     Examples
     --------
-    In [4]_, bird foraging behavior was investigated in an old-growth forest
-    of Oregon.
-    In the forest, 44% of the canopy volume was Douglas fir,
-    24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
-    The authors observed the behavior of several species of birds, one of
-    which was the red-breasted nuthatch. They made 189 observations of this
-    species foraging, recording 43 ("23%") of observations in Douglas fir,
-    52 ("28%") in ponderosa pine, 54 ("29%") in grand fir, and 40 ("21%") in
-    western larch.
-
-    Using a chi-square test, we can test the null hypothesis that the
-    proportions of foraging events are equal to the proportions of canopy
-    volume. The authors of the paper considered a p-value less than 1% to be
-    significant.
-
-    Using the above proportions of canopy volume and observed events, we can
-    infer expected frequencies.
-
-    >>> import numpy as np
-    >>> f_exp = np.array([44, 24, 29, 3]) / 100 * 189
-
-    The observed frequencies of foraging were:
-
-    >>> f_obs = np.array([43, 52, 54, 40])
-
-    We can now compare the observed frequencies with the expected frequencies.
-
-    >>> from scipy.stats import chisquare
-    >>> chisquare(f_obs=f_obs, f_exp=f_exp)
-    Power_divergenceResult(statistic=228.23515947653874, pvalue=3.3295585338846486e-49)
-
-    The p-value is well below the chosen significance level. Hence, the
-    authors considered the difference to be significant and concluded
-    that the relative proportions of foraging events were not the same
-    as the relative proportions of tree canopy volume.
-
-    Following are other generic examples to demonstrate how the other
-    parameters can be used.
-
-    When just `f_obs` is given, it is assumed that the expected frequencies
-    are uniform and given by the mean of the observed frequencies.
+    When only the mandatory `f_obs` argument is given, it is assumed that the
+    expected frequencies are uniform and given by the mean of the observed
+    frequencies:
 
     >>> chisquare([16, 18, 16, 14, 12, 12])
     Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)
 
-    With `f_exp` the expected frequencies can be given.
+    The optional `f_exp` argument gives the expected frequencies.
 
     >>> chisquare([16, 18, 16, 14, 12, 12], f_exp=[16, 16, 16, 16, 16, 8])
     Power_divergenceResult(statistic=3.5, pvalue=0.62338762774958223)
@@ -7816,7 +7779,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     The calculation of the p-values is done by broadcasting the
     chi-squared statistic with `ddof`.
 
-    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0,1,2])
+    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0, 1, 2])
     Power_divergenceResult(statistic=2.0, pvalue=array([0.84914504, 0.73575888, 0.5724067 ]))
 
     `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has


### PR DESCRIPTION
#### Reference issue
--

#### What does this implement/fix?
This PR moves the narrative example from the chisquare hypothesis test docstring to a markdown-based notebook.

cc @mdhaber 
