### PR TITLE
ENH: `integrate.solve_ivp`: add option to gracefully handle exceptions

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -358,6 +358,15 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     min_step : float, optional
         The minimum allowed step size for 'LSODA' method.
         By default `min_step` is zero.
+    catch_exceptions : bool, optional
+        Whether to catch exceptions raised during calls to `solver.step()`. 
+        Default is False.
+
+        If ``catch_exceptions`` is True, then any exceptions raised during a
+        step of the solver will be caught instead of raised. The output `status`
+        will be set to -2, and the exception will be included in the termination
+        message. By setting ``catch_exceptions=True``, this function will return
+        the solution up until the time when the exception was raised.
 
     Returns
     -------
@@ -383,7 +392,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         Number of LU decompositions.
     status : int
         Reason for algorithm termination:
-
+        
+            * -2: Other exception occured during integration step, and was caught.
             * -1: Integration step failed.
             *  0: The solver successfully reached the end of `tspan`.
             *  1: A termination event occurred.

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -658,7 +658,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
             if options.get('catch_exceptions', False):
                 solver.status = 'other_exception'
                 status = -2
-                message = f'Solver stopped with message: {e}'
+                message = f'Solver stopped with exception: {e}'
             else:
                 raise(e)
 

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -157,7 +157,8 @@ def find_active_events(g, g_new, direction):
 
 
 def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
-              events=None, vectorized=False, args=None, **options):
+              events=None, vectorized=False, args=None, catch_exceptions=False,
+              **options):
     """Solve an initial value problem for a system of ODEs.
 
     This function numerically integrates a system of ordinary differential
@@ -294,6 +295,15 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         So if, for example, `fun` has the signature ``fun(t, y, a, b, c)``,
         then `jac` (if given) and any event functions must have the same
         signature, and `args` must be a tuple of length 3.
+    catch_exceptions : bool, optional
+        Whether to catch exceptions raised during calls to ``solver.step()``. 
+        Default is False.
+
+        If `catch_exceptions` is True, then any exceptions raised during a
+        step of the solver will be caught. The output `status` will be set to
+        -2, and the exception will be included in the termination message.
+        By setting ``catch_exceptions=True``, this function will return
+        the solution up until the time when the exception was raised.
     **options
         Options passed to a chosen solver. All options available for already
         implemented solvers are listed below.
@@ -358,15 +368,6 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     min_step : float, optional
         The minimum allowed step size for 'LSODA' method.
         By default `min_step` is zero.
-    catch_exceptions : bool, optional
-        Whether to catch exceptions raised during calls to `solver.step()`. 
-        Default is False.
-
-        If ``catch_exceptions`` is True, then any exceptions raised during a
-        step of the solver will be caught instead of raised. The output `status`
-        will be set to -2, and the exception will be included in the termination
-        message. By setting ``catch_exceptions=True``, this function will return
-        the solution up until the time when the exception was raised.
 
     Returns
     -------
@@ -393,7 +394,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     status : int
         Reason for algorithm termination:
         
-            * -2: Other exception occured during integration step, and was caught.
+            * -2: Exception occured during integration step, and was caught.
             * -1: Integration step failed.
             *  0: The solver successfully reached the end of `tspan`.
             *  1: A termination event occurred.
@@ -665,8 +666,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         try:
             message = solver.step()
         except Exception as e:
-            if options.get('catch_exceptions', False):
-                solver.status = 'other_exception'
+            if catch_exceptions:
+                solver.status = 'exception_caught'
                 status = -2
                 message = f'Solver stopped with exception: {e}'
             else:

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -652,7 +652,12 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
 
     status = None
     while status is None:
-        message = solver.step()
+        try:
+            message = solver.step()
+        except Exception as e:
+            solver.status = 'other_exception'
+            status = -2
+            message = f'Solver stopped with exception: {e}'
 
         if solver.status == 'finished':
             status = 0

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -660,7 +660,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
                 status = -2
                 message = f'Solver stopped with exception: {e}'
             else:
-                raise(e)
+                raise e
 
         if solver.status == 'finished':
             status = 0

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -655,9 +655,12 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         try:
             message = solver.step()
         except Exception as e:
-            solver.status = 'other_exception'
-            status = -2
-            message = f'Solver stopped with exception: {e}'
+            if options.get('catch_exceptions', False):
+                solver.status = 'other_exception'
+                status = -2
+                message = f'Solver stopped with message: {e}'
+            else:
+                raise(e)
 
         if solver.status == 'finished':
             status = 0

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -157,7 +157,7 @@ def find_active_events(g, g_new, direction):
 
 
 def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
-              events=None, vectorized=False, args=None, catch_exceptions=False,
+              events=None, vectorized=False, args=None, *, catch_exceptions=False,
               **options):
     """Solve an initial value problem for a system of ODEs.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
This code allows the `solve_ivp` function catch any exceptions that might be thrown during the call to `solver.step()`. This is useful for the case where the function that calculates the RHS of the ODE runs into some issue and raises and exception. Rather than just failing entirely (and losing the solution up to the point of failure), the code stops the integration, and returns the solution up until the time that the exception was raised.

#### Additional information
The default behavior of `solve_ivp` is unchanged. In order to use the new exception-catching behavior, the user must pass the new optional parameter `catch_exceptions=True` when they call `solve_ivp`.
