### PR TITLE
ENH: `linalg`/`signal`/`special`: unify approach for array API dispatching

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -97,7 +97,9 @@ jobs:
         python dev.py --no-build test -b all -s cluster -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -s constants -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -s fft -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -t scipy.signal.tests.test_support_alternative_backends -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy.special.tests.test_support_alternative_backends -- --durations 3 --timeout=60
+        python dev.py --no-build test -b all -t scipy.linalg.tests.test_support_alternative_backends -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test_array_api -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -t scipy._lib.tests.test__util -- --durations 3 --timeout=60
         python dev.py --no-build test -b all -s stats -- --durations 3 --timeout=60

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -600,7 +600,7 @@ def support_alternative_backends(func, n_array_args, subpackage, func_generic):
     return wrapped
 
 
-def xp_dispatch(n_array_args, subpackage, func_generic=None):
+def _xp_dispatch(n_array_args, subpackage, func_generic=None):
     # decorator version of `support_alternative_backends` with a name
     # I'd prefer for concision
     def wrapper(func):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -557,12 +557,13 @@ _SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
 array_api_compat_prefix = "scipy._lib.array_api_compat"
 
 
-def get_array_subpackage_func(f_name, xp, n_array_args, root_namespace,
+def get_array_subpackage_func(func, xp, n_array_args,
                               subpackage, generic_implementations):
     spx = scipy_namespace_for(xp)
     f = None
+    f_name = func.__name__
     if is_numpy(xp):
-        f = getattr(root_namespace, f_name, None)
+        f = func
     elif spx is not None:
         f = getattr(getattr(spx, subpackage, None), f_name, None)
         f = f or getattr(getattr(xp, subpackage, None), f_name, None)
@@ -577,7 +578,7 @@ def get_array_subpackage_func(f_name, xp, n_array_args, root_namespace,
         if _f is not None:
             return _f
 
-    _f = getattr(root_namespace, f_name, None)
+    _f = func
     def f(*args, _f=_f, _xp=xp, **kwargs):
         array_args = args[:n_array_args]
         other_args = args[n_array_args:]
@@ -588,14 +589,13 @@ def get_array_subpackage_func(f_name, xp, n_array_args, root_namespace,
     return f
 
 
-def support_alternative_backends(f_name, n_array_args, root_namespace,
+def support_alternative_backends(func, n_array_args,
                                  subpackage, generic_implementations):
-    func = getattr(root_namespace, f_name)
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         xp = array_namespace(*args[:n_array_args])
-        f = get_array_subpackage_func(f_name, xp, n_array_args, root_namespace,
+        f = get_array_subpackage_func(func, xp, n_array_args,
                                       subpackage, generic_implementations)
         return f(*args, **kwargs)
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -598,3 +598,12 @@ def support_alternative_backends(func, n_array_args, subpackage, func_generic):
         return f(*args, **kwargs)
 
     return wrapped
+
+
+def xp_dispatch(n_array_args, subpackage, func_generic=None):
+    # decorator version of `support_alternative_backends` with a name
+    # I'd prefer for concision
+    def wrapper(func):
+        return support_alternative_backends(func, n_array_args,
+                                            subpackage, func_generic)
+    return wrapper

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -558,7 +558,7 @@ array_api_compat_prefix = "scipy._lib.array_api_compat"
 
 
 def get_array_subpackage_func(func, xp, n_array_args,
-                              subpackage, generic_implementations):
+                              subpackage, func_generic):
     spx = scipy_namespace_for(xp)
     f = None
     f_name = func.__name__
@@ -573,8 +573,8 @@ def get_array_subpackage_func(func, xp, n_array_args,
 
     # if generic array-API implementation is available, use that;
     # otherwise, fall back to NumPy/SciPy
-    if f_name in generic_implementations:
-        _f = generic_implementations[f_name](xp=xp, spx=spx)
+    if func_generic is not None:
+        _f = func_generic(xp=xp, spx=spx)
         if _f is not None:
             return _f
 
@@ -589,14 +589,12 @@ def get_array_subpackage_func(func, xp, n_array_args,
     return f
 
 
-def support_alternative_backends(func, n_array_args,
-                                 subpackage, generic_implementations):
+def support_alternative_backends(func, n_array_args, subpackage, func_generic):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         xp = array_namespace(*args[:n_array_args])
-        f = get_array_subpackage_func(func, xp, n_array_args,
-                                      subpackage, generic_implementations)
+        f = get_array_subpackage_func(func, xp, n_array_args, subpackage, func_generic)
         return f(*args, **kwargs)
 
     return wrapped

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -565,6 +565,7 @@ def get_array_subpackage_func(f_name, xp, n_array_args, root_namespace,
         f = getattr(root_namespace, f_name, None)
     elif spx is not None:
         f = getattr(getattr(spx, subpackage, None), f_name, None)
+        f = f or getattr(getattr(xp, subpackage, None), f_name, None)
 
     if f is not None:
         return f

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -464,6 +464,11 @@ def scipy_namespace_for(xp: ModuleType) -> ModuleType | None:
 
     if is_cupy(xp):
         import cupyx  # type: ignore[import-not-found,import-untyped]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # Strange that this is needed. For now, filtering warnings
+            # to pass tests; we'll figure out a better strategy.
+            import cupyx.scipy.signal
         return cupyx.scipy
 
     if is_jax(xp):

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -121,6 +121,7 @@ def test_warning_calls_filters(warning_calls):
         os.path.join('stats', '_stats_py.py'),  # gh-20743
         os.path.join('stats', 'tests', 'test_axis_nan_policy.py'),  # gh-20694
         os.path.join('_lib', '_util.py'),  # gh-19341
+        os.path.join('_lib', '_array_api.py'),  # TBA
         os.path.join('sparse', 'linalg', '_dsolve', 'linsolve.py'),  # gh-17924
         "conftest.py",
     )

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -222,6 +222,11 @@ from ._decomp_update import *
 from ._sketches import *
 from ._decomp_cossin import *
 
+# Replace some function definitions from _ufuncs to add Array API support
+from ._support_alternative_backends import (
+    solve, inv, det, pinv
+)
+
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (
     decomp, decomp_cholesky, decomp_lu, decomp_qr, decomp_svd, decomp_schur,

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -22,7 +22,7 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
                    iscomplex, zeros, einsum, eye, inf)
 # Local imports
 from scipy._lib._util import _asarray_validated
-from scipy._lib._array_api import xp_dispatch
+from scipy._lib._array_api import _xp_dispatch
 from ._misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
 
@@ -281,7 +281,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
-@xp_dispatch(2,'linalg')
+@_xp_dispatch(2,'linalg')
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
          subset_by_value=None, driver=None):

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -22,6 +22,7 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
                    iscomplex, zeros, einsum, eye, inf)
 # Local imports
 from scipy._lib._util import _asarray_validated
+from scipy._lib._array_api import xp_dispatch
 from ._misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs, _compute_lwork
 
@@ -280,6 +281,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
+@xp_dispatch(2,'linalg')
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
          subset_by_value=None, driver=None):

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -281,7 +281,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
-@_xp_dispatch(2,'linalg')
+@_xp_dispatch(['a', 'b'], 'linalg')
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
          subset_by_value=None, driver=None):

--- a/scipy/linalg/_support_alternative_backends.py
+++ b/scipy/linalg/_support_alternative_backends.py
@@ -19,9 +19,9 @@ array_special_func_map = {
 
 for f_name, n_array_args in array_special_func_map.items():
     _f = getattr(_basic, f_name)
-    f = (support_alternative_backends(_f, n_array_args,'linalg',
-                                      _generic_implementations) if SCIPY_ARRAY_API
-         else _f)
+    _f_generic = _generic_implementations.get(f_name, None)
+    f = (support_alternative_backends(_f, n_array_args, 'linalg', _f_generic)
+         if SCIPY_ARRAY_API else getattr(_basic, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 
 __all__ = list(array_special_func_map)

--- a/scipy/linalg/_support_alternative_backends.py
+++ b/scipy/linalg/_support_alternative_backends.py
@@ -1,0 +1,26 @@
+import sys
+
+from scipy._lib._array_api import support_alternative_backends, SCIPY_ARRAY_API
+from . import _basic
+# These don't really need to be imported, but otherwise IDEs might not realize
+# that these are defined in this file / report an error in __init__.py
+from ._basic import (
+    solve, inv, det, pinv  # noqa: F401
+)
+
+_generic_implementations = {}
+
+array_special_func_map = {
+    'solve': 2,
+    'inv': 1,
+    'det': 1,
+    'pinv': 1,
+}
+
+for f_name, n_array_args in array_special_func_map.items():
+    f = (support_alternative_backends(f_name, n_array_args, _basic,
+                                      'linalg', _generic_implementations) if SCIPY_ARRAY_API
+         else getattr(_basic, f_name))
+    sys.modules[__name__].__dict__[f_name] = f
+
+__all__ = list(array_special_func_map)

--- a/scipy/linalg/_support_alternative_backends.py
+++ b/scipy/linalg/_support_alternative_backends.py
@@ -18,9 +18,10 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args, _basic,
-                                      'linalg', _generic_implementations) if SCIPY_ARRAY_API
-         else getattr(_basic, f_name))
+    _f = getattr(_basic, f_name)
+    f = (support_alternative_backends(_f, n_array_args,'linalg',
+                                      _generic_implementations) if SCIPY_ARRAY_API
+         else _f)
     sys.modules[__name__].__dict__[f_name] = f
 
 __all__ = list(array_special_func_map)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -288,6 +288,7 @@ python_sources = [
   '_sketches.py',
   '_solvers.py',
   '_special_matrices.py',
+  '_support_alternative_backends.py',
   '_testutils.py',
   'basic.py',
   'blas.py',

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -22,7 +22,8 @@ python_sources = [
   'test_sketches.py',
   'test_solve_toeplitz.py',
   'test_solvers.py',
-  'test_special_matrices.py'
+  'test_special_matrices.py',
+  'test_support_alternative_backends.py',
 ]
 
 

--- a/scipy/linalg/tests/test_support_alternative_backends.py
+++ b/scipy/linalg/tests/test_support_alternative_backends.py
@@ -3,14 +3,8 @@ import pytest
 from scipy.linalg._support_alternative_backends import array_special_func_map
 from scipy.conftest import array_api_compatible
 from scipy import linalg
-from scipy._lib._array_api import xp_assert_close, is_jax, get_array_subpackage_func
+from scipy._lib._array_api import xp_assert_close
 from scipy._lib.array_api_compat import numpy as np
-
-try:
-    import array_api_strict
-    HAVE_ARRAY_API_STRICT = True
-except ImportError:
-    HAVE_ARRAY_API_STRICT = False
 
 
 @pytest.mark.fail_slow(5)

--- a/scipy/linalg/tests/test_support_alternative_backends.py
+++ b/scipy/linalg/tests/test_support_alternative_backends.py
@@ -1,0 +1,40 @@
+import pytest
+
+from scipy.linalg._support_alternative_backends import array_special_func_map
+from scipy.conftest import array_api_compatible
+from scipy import linalg
+from scipy._lib._array_api import xp_assert_close, is_jax, get_array_subpackage_func
+from scipy._lib.array_api_compat import numpy as np
+
+try:
+    import array_api_strict
+    HAVE_ARRAY_API_STRICT = True
+except ImportError:
+    HAVE_ARRAY_API_STRICT = False
+
+
+@pytest.mark.fail_slow(5)
+@array_api_compatible
+# @pytest.mark.skip_xp_backends('numpy', reasons=['skip while debugging'])
+# @pytest.mark.usefixtures("skip_xp_backends")
+# `reversed` is for developer convenience: test new function first = less waiting
+@pytest.mark.parametrize('f_name_n_args', reversed(array_special_func_map.items()))
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('shapes', [[(10, 10), (10,)]])
+def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
+    f_name, n_args = f_name_n_args
+    shapes = shapes[:n_args]
+    f = getattr(linalg, f_name)
+
+    dtype_np = getattr(np, dtype)
+    dtype_xp = getattr(xp, dtype)
+
+    rng = np.random.default_rng(984254252920492019)
+    args_np = [rng.standard_normal(size=shape, dtype=dtype_np) for shape in shapes]
+    args_xp = [xp.asarray(arg[()], dtype=dtype_xp) for arg in args_np]
+
+    res = f(*args_xp)
+    ref = xp.asarray(f(*args_np), dtype=dtype_xp)
+
+    eps = np.finfo(dtype_np).eps
+    xp_assert_close(res, ref, atol=10*eps)

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -318,6 +318,11 @@ from . import (
     spectral, signaltools, waveforms, wavelets, spline
 )
 
+# Replace some function definitions from _ufuncs to add Array API support
+from ._support_alternative_backends import (
+    convolve, correlate, fftconvolve
+)
+
 __all__ = [
     s for s in dir() if not s.startswith("_")
 ]

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -18,9 +18,9 @@ array_special_func_map = {
 
 for f_name, n_array_args in array_special_func_map.items():
     _f = getattr(_signaltools, f_name)
-    f = (support_alternative_backends(_f, n_array_args,'signal',
-                                      _generic_implementations) if SCIPY_ARRAY_API
-         else getattr(_signaltools, f_name))
+    _f_generic = _generic_implementations.get(f_name, None)
+    f = (support_alternative_backends(_f, n_array_args, 'signal', _f_generic)
+         if SCIPY_ARRAY_API else getattr(_signaltools, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 
 __all__ = list(array_special_func_map)

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -17,8 +17,9 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args, _signaltools,
-                                      'signal', _generic_implementations) if SCIPY_ARRAY_API
+    _f = getattr(_signaltools, f_name)
+    f = (support_alternative_backends(_f, n_array_args,'signal',
+                                      _generic_implementations) if SCIPY_ARRAY_API
          else getattr(_signaltools, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -1,0 +1,25 @@
+import sys
+
+from scipy._lib._array_api import support_alternative_backends, SCIPY_ARRAY_API
+from . import _signaltools
+# These don't really need to be imported, but otherwise IDEs might not realize
+# that these are defined in this file / report an error in __init__.py
+from ._signaltools import (
+    convolve, correlate, fftconvolve,  # noqa: F401
+)
+
+_generic_implementations = {}
+
+array_special_func_map = {
+    'convolve': 2,
+    'correlate': 2,
+    'fftconvolve': 2,
+}
+
+for f_name, n_array_args in array_special_func_map.items():
+    f = (support_alternative_backends(f_name, n_array_args, _signaltools,
+                                      'signal', _generic_implementations) if SCIPY_ARRAY_API
+         else getattr(_signaltools, f_name))
+    sys.modules[__name__].__dict__[f_name] = f
+
+__all__ = list(array_special_func_map)

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -96,6 +96,7 @@ py3.install_sources([
     '_spectral_py.py',
     '_spline.pyi',
     '_splines.py',
+    '_support_alternative_backends.py',
     '_upfirdn.py',
     '_waveforms.py',
     '_wavelets.py',

--- a/scipy/signal/tests/meson.build
+++ b/scipy/signal/tests/meson.build
@@ -18,6 +18,7 @@ py3.install_sources([
     'test_signaltools.py',
     'test_spectral.py',
     'test_splines.py',
+    'test_support_alternative_backends.py',
     'test_upfirdn.py',
     'test_waveforms.py',
     'test_wavelets.py',

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -32,6 +32,7 @@ from scipy.signal._signaltools import (_filtfilt_gust, _compute_factors,
 from scipy.signal._upfirdn import _upfirdn_modes
 from scipy._lib import _testutils
 from scipy._lib._util import ComplexWarning, np_long, np_ulong
+from scipy._lib._array_api import SCIPY_ARRAY_API
 
 
 class _TestConvolve:
@@ -1102,7 +1103,7 @@ class TestMedFilt:
         if (dtype in ["float96", "float128"]
                 and np.finfo(np.longdouble).dtype != dtype):
             pytest.skip(f"Platform does not support {dtype}")
-        
+
         in_typed = np.array(self.IN, dtype=dtype)
         with pytest.raises(ValueError, match="not supported"):
             signal.medfilt(in_typed)
@@ -1895,10 +1896,16 @@ def test_lfilter_notimplemented_input():
     assert_raises(NotImplementedError, lfilter, [2,3], [4,5], [1,2,3,4,5])
 
 
-@pytest.mark.parametrize('dt', [np.ubyte, np.byte, np.ushort, np.short,
-                                np_ulong, np_long, np.ulonglong, np.ulonglong,
-                                np.float32, np.float64, np.longdouble,
-                                Decimal])
+def dtypes_TestCorrelateReal():
+    # Can't test with `Decimal` type when SCIPY_ARRAY_API=1
+    dtypes = [np.ubyte, np.byte, np.ushort, np.short,
+              np_ulong, np_long, np.ulonglong, np.ulonglong,
+              np.float32, np.float64, np.longdouble,
+              Decimal]
+    return dtypes[:-1] if SCIPY_ARRAY_API else dtypes
+
+
+@pytest.mark.parametrize('dt', dtypes_TestCorrelateReal())
 class TestCorrelateReal:
     def _setup_rank1(self, dt):
         a = np.linspace(0, 3, 4).astype(dt)

--- a/scipy/signal/tests/test_support_alternative_backends.py
+++ b/scipy/signal/tests/test_support_alternative_backends.py
@@ -1,0 +1,40 @@
+import pytest
+
+from scipy.signal._support_alternative_backends import array_special_func_map
+from scipy.conftest import array_api_compatible
+from scipy import signal
+from scipy._lib._array_api import xp_assert_close, is_jax, get_array_subpackage_func
+from scipy._lib.array_api_compat import numpy as np
+
+try:
+    import array_api_strict
+    HAVE_ARRAY_API_STRICT = True
+except ImportError:
+    HAVE_ARRAY_API_STRICT = False
+
+
+@pytest.mark.fail_slow(5)
+@array_api_compatible
+# @pytest.mark.skip_xp_backends('numpy', reasons=['skip while debugging'])
+# @pytest.mark.usefixtures("skip_xp_backends")
+# `reversed` is for developer convenience: test new function first = less waiting
+@pytest.mark.parametrize('f_name_n_args', reversed(array_special_func_map.items()))
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+@pytest.mark.parametrize('shapes', [[100, 150]])
+def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
+    f_name, n_args = f_name_n_args
+    shapes = shapes[:n_args]
+    f = getattr(signal, f_name)
+
+    dtype_np = getattr(np, dtype)
+    dtype_xp = getattr(xp, dtype)
+
+    rng = np.random.default_rng(984254252920492019)
+    args_np = [rng.standard_normal(size=shape, dtype=dtype_np) for shape in shapes]
+    args_xp = [xp.asarray(arg[()], dtype=dtype_xp) for arg in args_np]
+
+    res = f(*args_xp)
+    ref = xp.asarray(f(*args_np), dtype=dtype_xp)
+
+    eps = np.finfo(dtype_np).eps
+    xp_assert_close(res, ref, atol=10*eps)

--- a/scipy/signal/tests/test_support_alternative_backends.py
+++ b/scipy/signal/tests/test_support_alternative_backends.py
@@ -3,14 +3,8 @@ import pytest
 from scipy.signal._support_alternative_backends import array_special_func_map
 from scipy.conftest import array_api_compatible
 from scipy import signal
-from scipy._lib._array_api import xp_assert_close, is_jax, get_array_subpackage_func
+from scipy._lib._array_api import xp_assert_close
 from scipy._lib.array_api_compat import numpy as np
-
-try:
-    import array_api_strict
-    HAVE_ARRAY_API_STRICT = True
-except ImportError:
-    HAVE_ARRAY_API_STRICT = False
 
 
 @pytest.mark.fail_slow(5)

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -151,9 +151,9 @@ array_special_func_map = {
 
 for f_name, n_array_args in array_special_func_map.items():
     _f = getattr(_ufuncs, f_name)
-    f = (support_alternative_backends(_f, n_array_args, 'special',
-                                      _generic_implementations) if SCIPY_ARRAY_API
-         else getattr(_ufuncs, f_name))
+    _f_generic = _generic_implementations.get(f_name, None)
+    f = (support_alternative_backends(_f, n_array_args, 'special', _f_generic)
+         if SCIPY_ARRAY_API else getattr(_ufuncs, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 
 __all__ = list(array_special_func_map)

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -150,7 +150,8 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args, _ufuncs, 'special',
+    _f = getattr(_ufuncs, f_name)
+    f = (support_alternative_backends(_f, n_array_args, 'special',
                                       _generic_implementations) if SCIPY_ARRAY_API
          else getattr(_ufuncs, f_name))
     sys.modules[__name__].__dict__[f_name] = f

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -1,11 +1,7 @@
-import os
 import sys
-import functools
 
 import numpy as np
-from scipy._lib._array_api import (
-    array_namespace, scipy_namespace_for, is_numpy
-)
+from scipy._lib._array_api import support_alternative_backends, SCIPY_ARRAY_API
 from . import _ufuncs
 # These don't really need to be imported, but otherwise IDEs might not realize
 # that these are defined in this file / report an error in __init__.py
@@ -14,38 +10,6 @@ from ._ufuncs import (
     gammainc, gammaincc, logit, expit, entr, rel_entr, xlogy,  # noqa: F401
     chdtr, chdtrc, betainc, betaincc, stdtr  # noqa: F401
 )
-
-_SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
-array_api_compat_prefix = "scipy._lib.array_api_compat"
-
-
-def get_array_special_func(f_name, xp, n_array_args):
-    spx = scipy_namespace_for(xp)
-    f = None
-    if is_numpy(xp):
-        f = getattr(_ufuncs, f_name, None)
-    elif spx is not None:
-        f = getattr(spx.special, f_name, None)
-
-    if f is not None:
-        return f
-
-    # if generic array-API implementation is available, use that;
-    # otherwise, fall back to NumPy/SciPy
-    if f_name in _generic_implementations and spx is not None:
-        _f = _generic_implementations[f_name](xp=xp, spx=spx)
-        if _f is not None:
-            return _f
-
-    _f = getattr(_ufuncs, f_name, None)
-    def f(*args, _f=_f, _xp=xp, **kwargs):
-        array_args = args[:n_array_args]
-        other_args = args[n_array_args:]
-        array_args = [np.asarray(arg) for arg in array_args]
-        out = _f(*array_args, *other_args, **kwargs)
-        return _xp.asarray(out)
-
-    return f
 
 
 def _get_shape_dtype(*args, xp):
@@ -79,6 +43,8 @@ def _xlogy(xp, spx):
 
 
 def _chdtr(xp, spx):
+    if spx is None:
+        return None
     # The difference between this and just using `gammainc`
     # defined by `get_array_special_func` is that if `gammainc`
     # isn't found, we don't want to use the SciPy version; we'll
@@ -98,6 +64,8 @@ def _chdtr(xp, spx):
 
 
 def _chdtrc(xp, spx):
+    if spx is None:
+        return None
     # The difference between this and just using `gammaincc`
     # defined by `get_array_special_func` is that if `gammaincc`
     # isn't found, we don't want to use the SciPy version; we'll
@@ -117,6 +85,8 @@ def _chdtrc(xp, spx):
 
 
 def _betaincc(xp, spx):
+    if spx is None:
+        return None
     betainc = getattr(spx.special, 'betainc', None)  # noqa: F811
     if betainc is None and hasattr(xp, 'special'):
         betainc = getattr(xp.special, 'betainc', None)
@@ -130,6 +100,8 @@ def _betaincc(xp, spx):
 
 
 def _stdtr(xp, spx):
+    if spx is None:
+        return None
     betainc = getattr(spx.special, 'betainc', None)  # noqa: F811
     if betainc is None and hasattr(xp, 'special'):
         betainc = getattr(xp.special, 'betainc', None)
@@ -151,21 +123,6 @@ _generic_implementations = {'rel_entr': _rel_entr,
                             'betaincc': _betaincc,
                             'stdtr': _stdtr,
                             }
-
-
-# functools.wraps doesn't work because:
-# 'numpy.ufunc' object has no attribute '__module__'
-def support_alternative_backends(f_name, n_array_args):
-    func = getattr(_ufuncs, f_name)
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        xp = array_namespace(*args[:n_array_args])
-        f = get_array_special_func(f_name, xp, n_array_args)
-        return f(*args, **kwargs)
-
-    return wrapped
-
 
 array_special_func_map = {
     'log_ndtr': 1,
@@ -193,7 +150,8 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args) if _SCIPY_ARRAY_API
+    f = (support_alternative_backends(f_name, n_array_args, _ufuncs, 'special',
+                                      _generic_implementations) if SCIPY_ARRAY_API
          else getattr(_ufuncs, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -1,10 +1,9 @@
 import pytest
 
-from scipy.special._support_alternative_backends import (get_array_special_func,
-                                                         array_special_func_map)
+from scipy.special._support_alternative_backends import array_special_func_map
 from scipy.conftest import array_api_compatible
 from scipy import special
-from scipy._lib._array_api import xp_assert_close, is_jax
+from scipy._lib._array_api import xp_assert_close, is_jax, get_array_subpackage_func
 from scipy._lib.array_api_compat import numpy as np
 
 try:
@@ -18,7 +17,10 @@ except ImportError:
                     reason="`array_api_strict` not installed")
 def test_dispatch_to_unrecognize_library():
     xp = array_api_strict
-    f = get_array_special_func('ndtr', xp=xp, n_array_args=1)
+    f = get_array_subpackage_func('ndtr', xp=xp, n_array_args=1,
+                                  root_namespace=special._ufuncs,
+                                  subpackage='special',
+                                  generic_implementations={})
     x = [1, 2, 3]
     res = f(xp.asarray(x))
     ref = xp.asarray(special.ndtr(np.asarray(x)))
@@ -30,7 +32,10 @@ def test_dispatch_to_unrecognize_library():
                     reason="`array_api_strict` not installed")
 def test_rel_entr_generic(dtype):
     xp = array_api_strict
-    f = get_array_special_func('rel_entr', xp=xp, n_array_args=2)
+    f = get_array_subpackage_func('rel_entr', xp=xp, n_array_args=2,
+                                  root_namespace=special._ufuncs,
+                                  subpackage='special',
+                                  generic_implementations={})
     dtype_np = getattr(np, dtype)
     dtype_xp = getattr(xp, dtype)
     x, y = [-1, 0, 0, 1], [1, 0, 2, 3]

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -18,8 +18,7 @@ except ImportError:
 def test_dispatch_to_unrecognize_library():
     xp = array_api_strict
     f = get_array_subpackage_func(special._ufuncs.ndtr, xp=xp, n_array_args=1,
-                                  subpackage='special',
-                                  generic_implementations={})
+                                  subpackage='special', func_generic=None)
     x = [1, 2, 3]
     res = f(xp.asarray(x))
     ref = xp.asarray(special.ndtr(np.asarray(x)))
@@ -32,8 +31,7 @@ def test_dispatch_to_unrecognize_library():
 def test_rel_entr_generic(dtype):
     xp = array_api_strict
     f = get_array_subpackage_func(special._ufuncs.rel_entr, xp=xp, n_array_args=2,
-                                  subpackage='special',
-                                  generic_implementations={})
+                                  subpackage='special', func_generic=None)
     dtype_np = getattr(np, dtype)
     dtype_xp = getattr(xp, dtype)
     x, y = [-1, 0, 0, 1], [1, 0, 2, 3]

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -17,8 +17,7 @@ except ImportError:
                     reason="`array_api_strict` not installed")
 def test_dispatch_to_unrecognize_library():
     xp = array_api_strict
-    f = get_array_subpackage_func('ndtr', xp=xp, n_array_args=1,
-                                  root_namespace=special._ufuncs,
+    f = get_array_subpackage_func(special._ufuncs.ndtr, xp=xp, n_array_args=1,
                                   subpackage='special',
                                   generic_implementations={})
     x = [1, 2, 3]
@@ -32,8 +31,7 @@ def test_dispatch_to_unrecognize_library():
                     reason="`array_api_strict` not installed")
 def test_rel_entr_generic(dtype):
     xp = array_api_strict
-    f = get_array_subpackage_func('rel_entr', xp=xp, n_array_args=2,
-                                  root_namespace=special._ufuncs,
+    f = get_array_subpackage_func(special._ufuncs.rel_entr, xp=xp, n_array_args=2,
                                   subpackage='special',
                                   generic_implementations={})
     dtype_np = getattr(np, dtype)


### PR DESCRIPTION
#### Reference issue
gh-20772
gh-19260

#### What does this implement/fix?
As discussed in gh-20772 and gh-19260, this is an alternative approach to dispatching `linalg` and `signal` functions to the native backend of the input arrays.

Rather than adding separate approaches for dispatching to each SciPy subpackage, it proposes maintaining a single dispatch mechanism based on the existing code from `scipy.special` (with minor generalizations - see diff [here](https://www.diffchecker.com/8VsUNjf2/)).

Also, rather than translating the original test suites to use array API calls, this would only add property-based tests to confirm that the functions return similar results with each backend as they do for NumPy/SciPy. The philosophy is that we do not need to test the _quality_ of the alternative backend implementations to the same standards as we test the SciPy implementations; rather, we really just need to test the _"plumbing"_: for typical cases, when we pass an alternative-backend array into one of these dispatched functions, is type in == type out and do the numerical values agree with those of NumPy/SciPy? 
Of course, by adjusting the definition of "typical" in the tests, we can make the tests arbitrarily strong - for example, strong enough such that a function that passes the generic property based test would certainly pass all of SciPy's function-specific tests. (Note that this idea is orthogonal to the one above; we can certainly leverage the existing dispatch framework but not add these property-based tests, if we prefer to translate the test suites.)[^1]

The intent is to reduce author and review time for new functions and to minimize the diff/be non-invasive (i.e. to keep the original code readable/avoid introducing bugs in existing functions). We may find that additional generalizations are needed as we add more functions. That's OK. The intent here is to take care of low hanging fruit, and we can generalize when the time comes.

#### Additional information
The first commit moves the key `_support_alternative_backends` functions from `special` to `_lib/_array_api.py` and generalizes it slightly. GitHub shows this as a large diff (remove from one place, add to another), but all that has changed is adding some additional arguments to generalize from `special` to any sub-package. I'd suggest comparing the diff manually.

The next two commits add support and tests for a few functions in `signal` and `linalg`, respectively.

I'll make some additional notes inline.

[^1]: One might ask why we didn't do these things for `stats`. Let's separate this into implementation and testing:
**Implementation**: so far, we've been translating functions which don't have equivalents in other backends (for instance, `ttest_ind` is not implemented in JAX, CuPy, or Torch) and can be written efficiently in pure Python, array API standard calls (plus some dispatched `scipy.special` function calls). So in short, we can't just dispatch, and there would be little advantage to doing so. Instead, we translate.
**Testing**: TBH, we could have left the existing pure-NumPy tests alone and only added property-based tests. However, the difference in `stats` compared to say, `special`, is that because we are providing the whole implementation for other backends rather than just dispatching, it's no longer sufficient just to check the basic plumbing. We really do need to ensure full test coverage to ensure that all lines of code work as intended for all backends. It's possible to make the property-based tests sufficiently strong, and it might have been a bit simpler/faster to go this route... I'm not sure. The truth is that we just didn't try it. One advantage to translating the test functions is that it's given us a chance to improve SciPy's tests.