### PR TITLE
MAINT: smoke-docs: add `special/_precompute` to --ignore list, improve the error message if scipy-doctest is not found

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -831,7 +831,8 @@ class SmokeDocs(Task):
         else:
             tests = None
 
-        # use strategy=api unless -t path/to/specific/file
+        # Request doctesting; use strategy=api unless -t path/to/specific/file
+        extra_argv += ["--doctest-modules",]
         if not args.tests:
             extra_argv += ['--doctest-collect=api']
 

--- a/dev.py
+++ b/dev.py
@@ -832,7 +832,8 @@ class SmokeDocs(Task):
             tests = None
 
         # Request doctesting; use strategy=api unless -t path/to/specific/file
-        extra_argv += ["--doctest-modules",]
+        # also switch off assertion rewriting: not useful for doctests
+        extra_argv += ["--doctest-modules", "--assert=plain"]
         if not args.tests:
             extra_argv += ['--doctest-collect=api']
 

--- a/dev.py
+++ b/dev.py
@@ -811,6 +811,10 @@ class SmokeDocs(Task):
         dirs.add_sys_path()
         print(f"SciPy from development installed path at: {dirs.site}")
 
+        # prevent obscure error later; cf https://github.com/numpy/numpy/pull/26691/
+        if not importlib.util.find_spec("scipy_doctest"):
+            raise ModuleNotFoundError("Please install scipy-doctest")
+
         # FIXME: support pos-args with doit
         extra_argv = list(pytest_args[:]) if pytest_args else []
         if extra_argv and extra_argv[0] == '--':

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -95,16 +95,7 @@ class PytestTester:
         pytest_args = ['--showlocals', '--tb=short']
 
         if doctests:
-            pytest_args += [
-                "--doctest-modules",
-                "--ignore=scipy/interpolate/_interpnd_info.py",
-                "--ignore=scipy/_lib/array_api_compat",
-                "--ignore=scipy/_lib/highs",
-                "--ignore=scipy/_lib/unuran",
-                "--ignore=scipy/_lib/_gcutils.py",
-                "--ignore=scipy/_lib/doccer.py",
-                "--ignore=scipy/_lib/_uarray",
-            ]
+            pytest_args += ["--doctest-modules",]
 
         if extra_argv:
             pytest_args += list(extra_argv)

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -94,9 +94,6 @@ class PytestTester:
 
         pytest_args = ['--showlocals', '--tb=short']
 
-        if doctests:
-            pytest_args += ["--doctest-modules",]
-
         if extra_argv:
             pytest_args += list(extra_argv)
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -389,6 +389,15 @@ if HAVE_SCPDT:
         "scipy.optimize.cython_optimize",
         "scipy.test",
         "scipy.show_config",
+        # equivalent to "pytest --ignore=path/to/file"
+        "scipy/special/_precompute",
+        "scipy/interpolate/_interpnd_info.py",
+        "scipy/_lib/array_api_compat",
+        "scipy/_lib/highs",
+        "scipy/_lib/unuran",
+        "scipy/_lib/_gcutils.py",
+        "scipy/_lib/doccer.py",
+        "scipy/_lib/_uarray",
     ]
 
     dt_config.pytest_extra_xfail = {

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -347,7 +347,6 @@ if HAVE_SCPDT:
                     warnings.simplefilter('error', Warning)
                     yield
 
-
     dt_config.user_context_mgr = warnings_errors_and_rng
     dt_config.skiplist = set([
         'scipy.linalg.LinAlgError',     # comes from numpy


### PR DESCRIPTION
Also move the ignore list from _testutils.py to conftest.py for viz

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Fix issues mentioned in  https://github.com/scipy/scipy/issues/20960#issuecomment-2175711767 : `dev.py smoke-docs` hard fails if mpmath is not available and the failure mode if `scipy-doctest` is not available is too obscure.

#### What does this implement/fix?
<!--Please explain your changes.-->

- add `scipy/special/_precompute` to the ignore list
- move the ignore list from `_lib/testutils` to conftest so that it is a little less well hidden.
- check existence `scipy-doctest`

#### Additional information
<!--Any additional information you think is important.-->

There's a minor piece of pytest voodoo to switch off rewriting of assertions for doctests: pytest by default marks all plugins for rewrting, and it is not useful for doctesting: the error messages are fixed by the doctesting machinery anyway. 
Unless something is done about the rewriting, attempts to import `scipy-doctest` fails with an obscure warning (which gets converted to an error by dev.py). 

This PR does the simplest thing and follows the recommendation from the pytest docs, see
 https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html for the gory details.