### PR TITLE
MAINT: sparse: better error message on `matmul` mismatch

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -644,7 +644,7 @@ class _spbase:
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector
-            if other.shape[0] != N:  # other.shape == (N,) or (N, 1)
+            if other.shape[0] != N:
                 raise ValueError(
                     f"{err_prefix} (n,k),(k,1?)->(n,1?) "
                     f"(size {N} is different from {other.shape[0]})"

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -620,9 +620,13 @@ class _spbase:
             # scalar value
             return self._mul_scalar(other)
 
+        err_prefix = "matmul: dimension mismatch with signature"
         if issparse(other):
-            if self.shape[-1] != other.shape[0]:
-                raise ValueError('dimension mismatch')
+            if N != other.shape[0]:
+                raise ValueError(
+                    f"{err_prefix} (n,k),(k,m)->(n,m) "
+                    f"(size {N} is different from {other.shape[0]})"
+                )
             return self._matmul_sparse(other)
 
         # If it's a list or whatever, treat it like an array
@@ -640,8 +644,11 @@ class _spbase:
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector
-            if other.shape != (N,) and other.shape != (N, 1):
-                raise ValueError('dimension mismatch')
+            if other.shape[0] != N:  # other.shape == (N,) or (N, 1)
+                raise ValueError(
+                    f"{err_prefix} (n,k),(k,1?)->(n,1?) "
+                    f"(size {N} is different from {other.shape[0]})"
+                )
 
             result = self._matmul_vector(np.ravel(other))
 
@@ -659,7 +666,10 @@ class _spbase:
             # dense 2D array or matrix ("multivector")
 
             if other.shape[0] != N:
-                raise ValueError('dimension mismatch')
+                raise ValueError(
+                    f"{err_prefix} (n,k),(k,m)->(n,m) "
+                    f"(size {N} is different from {other.shape[0]})"
+                )
 
             result = self._matmul_multivector(np.asarray(other))
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -624,8 +624,7 @@ class _spbase:
         if issparse(other):
             if N != other.shape[0]:
                 raise ValueError(
-                    f"{err_prefix} (n,k),(k,m)->(n,m) "
-                    f"(size {N} is different from {other.shape[0]})"
+                    f"{err_prefix} (n,k={N}),(k={other.shape[0]},m)->(n,m)"
                 )
             return self._matmul_sparse(other)
 
@@ -646,8 +645,7 @@ class _spbase:
             # dense row or column vector
             if other.shape[0] != N:
                 raise ValueError(
-                    f"{err_prefix} (n,k),(k,1?)->(n,1?) "
-                    f"(size {N} is different from {other.shape[0]})"
+                    f"{err_prefix} (n,k={N}),(k={other.shape[0]},1?)->(n,1?)"
                 )
 
             result = self._matmul_vector(np.ravel(other))
@@ -667,8 +665,7 @@ class _spbase:
 
             if other.shape[0] != N:
                 raise ValueError(
-                    f"{err_prefix} (n,k),(k,m)->(n,m) "
-                    f"(size {N} is different from {other.shape[0]})"
+                    f"{err_prefix} (n,k={N}),(k={other.shape[0]},m)->(n,m)"
                 )
 
             result = self._matmul_multivector(np.asarray(other))


### PR DESCRIPTION
The error message I saw in https://github.com/scipy/scipy/issues/21016 was just:
```
mne/morph.py:1401: in _surf_upsampling_mat
    data = use_e @ data
/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/scipy/sparse/_base.py:715: in __matmul__
    return self._matmul_dispatch(other)
/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/scipy/sparse/_base.py:625: in _matmul_dispatch
    raise ValueError('dimension mismatch')
E   ValueError: dimension mismatch
```
which was not as helpful as I would have liked. This PR tries to move toward having a similar message as NumPy:
```Python
>>> import numpy as np
>>> np.eye(2) @ np.ones(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 3 is different from 2)
>>> from scipy import sparse
>>> sparse.eye_array(2) @ sparse.eye_array(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/larsoner/python/scipy/scipy/sparse/_base.py", line 725, in __matmul__
    return self._matmul_dispatch(other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/larsoner/python/scipy/scipy/sparse/_base.py", line 626, in _matmul_dispatch
    raise ValueError(
ValueError: matmul: dimension mismatch with signature (n,k),(k,m)->(n,m) (size 2 is different from 3)
>>> sparse.eye_array(2) @ np.ones(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/larsoner/python/scipy/scipy/sparse/_base.py", line 725, in __matmul__
    return self._matmul_dispatch(other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/larsoner/python/scipy/scipy/sparse/_base.py", line 648, in _matmul_dispatch
    raise ValueError(
ValueError: matmul: dimension mismatch with signature (n,k),(k,1?)->(n,1?) (size 2 is different from 3)

```
Happy to adjust the message a bit more if people would prefer something different. My thinking was to try to be NumPy-like but simplify the language a little bit.