### PR TITLE
MAINT: "final" backports for 1.14.0

### DIFF
--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -205,7 +205,7 @@ Deprecated features
 - The option ``quadrature="trapz"`` in `scipy.integrate.quad_vec` has been
   deprecated in favour of ``quadrature="trapezoid"`` and will be removed in
   SciPy 1.16.0.
-- `scipy.special.comb` has deprecated support for use of ``exact=True`` in
+- ``scipy.special.{comb,perm}`` have deprecated support for use of ``exact=True`` in
   conjunction with non-integral ``N`` and/or ``k``.
 
 
@@ -294,13 +294,13 @@ Authors
 * Tim Beyer (1) +
 * Andrea Blengino (1) +
 * boatwrong (1)
-* Jake Bowhay (50)
+* Jake Bowhay (51)
 * Dietrich Brunn (2)
 * Evgeni Burovski (177)
 * Tim Butters (7) +
 * CJ Carey (5)
 * Sean Cheah (46)
-* Lucas Colley (72)
+* Lucas Colley (73)
 * Giuseppe "Peppe" Dilillo (1) +
 * DWesl (2)
 * Pieter Eendebak (5)
@@ -313,7 +313,7 @@ Authors
 * Rohit Goswami (28)
 * Ben Greiner (1) +
 * Lorenzo Gualniera (1) +
-* Matt Haberland (257)
+* Matt Haberland (260)
 * Shawn Hsu (1) +
 * Budjen Jovan (3) +
 * Jozsef Kutas (1)
@@ -339,7 +339,7 @@ Authors
 * pwcnorthrop (3) +
 * Bharat Raghunathan (1)
 * Tom M. Ragonneau (2) +
-* Tyler Reddy (96)
+* Tyler Reddy (101)
 * Pamphile Roy (18)
 * Atsushi Sakai (9)
 * Daniel Schmitz (5)
@@ -730,6 +730,7 @@ Pull requests for 1.14.0
 * `#20870 <https://github.com/scipy/scipy/pull/20870>`__: BLD: test delocate works by removing original lib [wheel build]
 * `#20881 <https://github.com/scipy/scipy/pull/20881>`__: DOC: mailing list to forum
 * `#20890 <https://github.com/scipy/scipy/pull/20890>`__: DOC: Write API reference titles in monospace font
+* `#20909 <https://github.com/scipy/scipy/pull/20909>`__: DEP: special.perm: deprecate non-integer \`N\` and \`k\` with...
 * `#20914 <https://github.com/scipy/scipy/pull/20914>`__: TST: linalg: bump tolerance in \`TestEig::test_singular\`
 * `#20919 <https://github.com/scipy/scipy/pull/20919>`__: BLD: optimize: use hidden visibility for static HiGHS libraries
 * `#20920 <https://github.com/scipy/scipy/pull/20920>`__: MAINT: special: fix msvc build by using \`new\` and \`delete\`...

--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -284,7 +284,7 @@ Other changes
 Authors
 *******
 * Name (commits)
-* h-vetinari (33)
+* h-vetinari (34)
 * Steven Adams (1) +
 * Max Aehle (1) +
 * Ataf Fazledin Ahamed (2) +
@@ -309,11 +309,11 @@ Authors
 * fancidev (2)
 * Anthony Frazier (1) +
 * Ilan Gold (1) +
-* Ralf Gommers (124)
+* Ralf Gommers (125)
 * Rohit Goswami (28)
 * Ben Greiner (1) +
 * Lorenzo Gualniera (1) +
-* Matt Haberland (256)
+* Matt Haberland (257)
 * Shawn Hsu (1) +
 * Budjen Jovan (3) +
 * Jozsef Kutas (1)
@@ -335,11 +335,11 @@ Authors
 * Jacob Ogle (1) +
 * Pearu Peterson (1)
 * Matti Picus (5)
-* Ilhan Polat (8)
+* Ilhan Polat (9)
 * pwcnorthrop (3) +
 * Bharat Raghunathan (1)
 * Tom M. Ragonneau (2) +
-* Tyler Reddy (84)
+* Tyler Reddy (96)
 * Pamphile Roy (18)
 * Atsushi Sakai (9)
 * Daniel Schmitz (5)
@@ -437,6 +437,7 @@ Issues closed for 1.14.0
 * `#20458 <https://github.com/scipy/scipy/issues/20458>`__: MAINT: more potential cleanups related to version bumps
 * `#20461 <https://github.com/scipy/scipy/issues/20461>`__: DOC: some likely changes to release process docs
 * `#20466 <https://github.com/scipy/scipy/issues/20466>`__: BUG: scipy.linalg.bandwidth returns incorrect upper bandwidth
+* `#20470 <https://github.com/scipy/scipy/issues/20470>`__: BUG: \`TestNNLS.test_nnls_inner_loop_case1\` fails with MKL
 * `#20486 <https://github.com/scipy/scipy/issues/20486>`__: DEP: deprecate and remove remaining usages of slur-adjacent "trapz"
 * `#20488 <https://github.com/scipy/scipy/issues/20488>`__: BUG: When given invalid bounds, \`_minimize_neldermead\` raises...
 * `#20492 <https://github.com/scipy/scipy/issues/20492>`__: DOC: linalg.solve_discrete_lyapunov: dead reference link
@@ -475,6 +476,7 @@ Issues closed for 1.14.0
 * `#20911 <https://github.com/scipy/scipy/issues/20911>`__: TST: TestEig.test_singular failing tolerance with generic BLAS...
 * `#20921 <https://github.com/scipy/scipy/issues/20921>`__: DOC: stats: wrong docstrings of \`\*Result\` classes
 * `#20938 <https://github.com/scipy/scipy/issues/20938>`__: TST: tolerance violations with SciPy 1.14.0rc1 on linux-{aarch64,ppc64le}
+* `#20943 <https://github.com/scipy/scipy/issues/20943>`__: TST: test failures on windows with SciPy 1.14.0rc1
 
 ************************
 Pull requests for 1.14.0
@@ -733,8 +735,13 @@ Pull requests for 1.14.0
 * `#20920 <https://github.com/scipy/scipy/pull/20920>`__: MAINT: special: fix msvc build by using \`new\` and \`delete\`...
 * `#20923 <https://github.com/scipy/scipy/pull/20923>`__: DOC: update doctests to satisfy scipy-doctests==1.2.0
 * `#20927 <https://github.com/scipy/scipy/pull/20927>`__: MAINT: adapt to a scipy-doctests change
+* `#20933 <https://github.com/scipy/scipy/pull/20933>`__: MAINT: 1.14.0rc2 backports
 * `#20936 <https://github.com/scipy/scipy/pull/20936>`__: DOC: \`array_api.rst\`: update 1.14 functions with array API...
 * `#20937 <https://github.com/scipy/scipy/pull/20937>`__: BUG/BLD: special: Ensure symbols in \`sf_error_state\` shared...
 * `#20945 <https://github.com/scipy/scipy/pull/20945>`__: TST: address tolerance violations with SciPy 1.14.0rc1 on linux-{aarch64,ppc64le}
 * `#20952 <https://github.com/scipy/scipy/pull/20952>`__: TST: loosen tolerance in test_x0_working to pass with alternate...
 * `#20953 <https://github.com/scipy/scipy/pull/20953>`__: TST: loosen tolerance in test_krandinit slightly to pass with...
+* `#20961 <https://github.com/scipy/scipy/pull/20961>`__: TST: robustify test_nnls_inner_loop_case1
+* `#20970 <https://github.com/scipy/scipy/pull/20970>`__: REL: set 1.14.0 rc3 unreleased
+* `#20973 <https://github.com/scipy/scipy/pull/20973>`__: TST:sparse.linalg: Skip test due to sensitivity to numerical...
+* `#20979 <https://github.com/scipy/scipy/pull/20979>`__: STY: \`_lib._util\`: address new mypy complaint in main

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -28,7 +28,7 @@ if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
         DTypePromotionError
     )
 else:
-    from numpy import (
+    from numpy import (  # type: ignore[attr-defined, no-redef]
         AxisError, ComplexWarning, VisibleDeprecationWarning  # noqa: F401
     )
     DTypePromotionError = TypeError  # type: ignore

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -97,7 +97,7 @@ class TestNNLS:
 
         # Small perturbations can already make the infinite loop go away (just
         # uncomment the next line)
-        # k = k + 1e-10 * np.random.normal(size=N)
+        k = k + 1e-10 * np.random.normal(size=N)
         dact, _ = nnls(W @ A, W @ k)
         assert_allclose(dact, d, rtol=0., atol=1e-10)
 

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -510,8 +510,12 @@ def test_x0_working(solver):
 
 
 def test_x0_equals_Mb(case):
+    if (case.solver is bicgstab) and (case.name == 'nonsymposdef-bicgstab'):
+        pytest.skip("Solver fails due to numerical noise "
+                    "on some architectures (see gh-15533).")
     if case.solver is tfqmr:
         pytest.skip("Solver does not support x0='Mb'")
+
     A = case.A
     b = case.b
     x0 = 'Mb'

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2765,8 +2765,9 @@ def perm(N, k, exact=False):
     k : int, ndarray
         Number of elements taken.
     exact : bool, optional
-        If `exact` is False, then floating point precision is used, otherwise
-        exact long integer is computed.
+        If ``True``, calculate the answer exactly using long integer arithmetic (`N`
+        and `k` must be scalar integers). If ``False``, a floating point approximation
+        is calculated (more rapidly) using `poch`. Default is ``False``.
 
     Returns
     -------
@@ -2791,10 +2792,24 @@ def perm(N, k, exact=False):
 
     """
     if exact:
+        N = np.squeeze(N)[()]  # for backward compatibility (accepted size 1 arrays)
+        k = np.squeeze(k)[()]
+        if not (isscalar(N) and isscalar(k)):
+            raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
+
+        floor_N, floor_k = int(N), int(k)
+        non_integral = not (floor_N == N and floor_k == k)
         if (k > N) or (N < 0) or (k < 0):
+            if non_integral:
+                msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and "
+                       "will raise an error in SciPy 1.16.0.")
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return 0
+        if non_integral:
+            raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
+                             "supported.")
         val = 1
-        for i in range(N - k + 1, N + 1):
+        for i in range(floor_N - floor_k + 1, floor_N + 1):
             val *= i
         return val
     else:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1459,7 +1459,7 @@ class TestCombinatorics:
         assert_equal(special.comb(2, -1, exact=True), 0)
         assert_equal(special.comb(2, -1, exact=False), 0)
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
-    
+
     def test_comb_exact_non_int_dep(self):
         msg = "`exact=True`"
         with pytest.deprecated_call(match=msg):
@@ -1476,6 +1476,25 @@ class TestCombinatorics:
         assert_equal(special.perm(2, -1, exact=True), 0)
         assert_equal(special.perm(2, -1, exact=False), 0)
         assert_allclose(special.perm([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 720.])
+
+    def test_perm_iv(self):
+        # currently `exact=True` only support scalars
+        with pytest.raises(ValueError, match="scalar integers"):
+            special.perm([1, 2], [4, 5], exact=True)
+
+        # Non-integral scalars with N < k, or N,k < 0 used to return 0, this is now
+        # deprecated and will raise an error in SciPy 1.16.0
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(4.6, 6, exact=True)
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(-4.6, 3, exact=True)
+        with pytest.deprecated_call(match="Non-integer"):
+            special.perm(4, -3.9, exact=True)
+
+        # Non-integral scalars which aren't included in the cases above an raise an
+        # error directly without deprecation as this code never worked
+        with pytest.raises(ValueError, match="Non-integer"):
+            special.perm(6.0, 4.6, exact=True)
 
 
 class TestTrigonometric:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6484,6 +6484,9 @@ def _t_confidence_interval(df, t, confidence_level, alternative, dtype=None, xp=
     dtype = t.dtype if dtype is None else dtype
     xp = array_namespace(t) if xp is None else xp
 
+    # stdtrit not dispatched yet; use NumPy
+    df, t = np.asarray(df), np.asarray(t)
+
     if confidence_level < 0 or confidence_level > 1:
         message = "`confidence_level` must be a number between 0 and 1."
         raise ValueError(message)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3227,7 +3227,7 @@ def gstd(a, axis=0, ddof=1):
     When an observation is infinite, the geometric standard deviation is
     NaN (undefined). Non-positive observations will also produce NaNs in the
     output because the *natural* logarithm (as opposed to the *complex*
-    logarithm) is defined only for positive reals.
+    logarithm) is defined and finite only for positive reals.
     The geometric standard deviation is sometimes confused with the exponential
     of the standard deviation, ``exp(std(a))``. Instead, the geometric standard
     deviation is ``exp(std(log(a)))``.
@@ -3275,8 +3275,14 @@ def gstd(a, axis=0, ddof=1):
         log = np.log
 
     with np.errstate(invalid='ignore', divide='ignore'):
-        return np.exp(np.std(log(a), axis=axis, ddof=ddof))
+        res = np.exp(np.std(log(a), axis=axis, ddof=ddof))
 
+    if (a <= 0).any():
+        message = ("The geometric standard deviation is only defined if all elements "
+                   "are greater than or equal to zero; otherwise, the result is NaN.")
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
+
+    return res
 
 # Private dictionary initialized only once at module level
 # See https://en.wikipedia.org/wiki/Robust_measures_of_scale

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -10,13 +10,16 @@ import numpy.ma.testutils as ma_npt
 from scipy._lib._util import (
     getfullargspec_no_self as _getfullargspec, np_long
 )
+from scipy._lib._array_api import xp_assert_equal
 from scipy import stats
 
 
-def check_named_results(res, attributes, ma=False):
+def check_named_results(res, attributes, ma=False, xp=None):
     for i, attr in enumerate(attributes):
         if ma:
             ma_npt.assert_equal(res[i], getattr(res, attr))
+        elif xp is not None:
+            xp_assert_equal(res[i], getattr(res, attr))
         else:
             npt.assert_equal(res[i], getattr(res, attr))
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -754,7 +754,7 @@ class TestBartlett:
         args = [xp.asarray(arg) for arg in args]
         res = stats.bartlett(*args)
         attributes = ('statistic', 'pvalue')
-        check_named_results(res, attributes)
+        check_named_results(res, attributes, xp=xp)
 
     @pytest.mark.skip_xp_backends(
         "jax.numpy", cpu_only=True,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7004,10 +7004,16 @@ class TestGeometricStandardDeviation:
         with pytest.raises(TypeError, match="ufunc 'log' not supported"):
             stats.gstd('You cannot take the logarithm of a string.')
 
-    @pytest.mark.parametrize('bad_value', (0, -1, np.inf))
+    @pytest.mark.parametrize('bad_value', (0, -1, np.inf, np.nan))
     def test_returns_nan_invalid_value(self, bad_value):
         x = np.append(self.array_1d, [bad_value])
-        assert_equal(stats.gstd(x), np.nan)
+        if np.isfinite(bad_value):
+            message = "The geometric standard deviation is only defined..."
+            with pytest.warns(RuntimeWarning, match=message):
+                res = stats.gstd(x)
+        else:
+            res = stats.gstd(x)
+        assert_equal(res, np.nan)
 
     def test_propagates_nan_values(self):
         a = array([[1, 1, 1, 16], [np.nan, 1, 2, 3]])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3770,7 +3770,7 @@ class TestStudentTest:
 
         res = stats.ttest_1samp(xp.asarray(self.X1), 0.)
         attributes = ('statistic', 'pvalue')
-        check_named_results(res, attributes)
+        check_named_results(res, attributes, xp=xp)
 
         t, p = stats.ttest_1samp(xp.asarray(self.X2), 0.)
 
@@ -4190,7 +4190,7 @@ class TestPowerDivergence:
         res = stats.power_divergence(f_obs=f_obs, f_exp=f_exp, ddof=ddof,
                                      axis=axis, lambda_="pearson")
         attributes = ('statistic', 'pvalue')
-        check_named_results(res, attributes)
+        check_named_results(res, attributes, xp=xp)
 
     def test_power_divergence_gh_12282(self, xp):
         # The sums of observed and expected frequencies must match
@@ -6189,9 +6189,10 @@ class TestDescribe:
         with pytest.raises(ValueError, match=message):
             stats.describe(x, nan_policy='foobar')
 
-    @array_api_compatible
-    def test_describe_result_attributes(self, xp):
-        actual = stats.describe(xp.arange(5.))
+    def test_describe_result_attributes(self):
+        # some result attributes are tuples, which aren't meant to be compared
+        # with `xp_assert_close`
+        actual = stats.describe(np.arange(5.))
         attributes = ('nobs', 'minmax', 'mean', 'variance', 'skewness', 'kurtosis')
         check_named_results(actual, attributes)
 
@@ -6290,7 +6291,7 @@ class NormalityTests:
         res_statistic, res_pvalue = res
         xp_assert_close(res_statistic, ref_statistic)
         xp_assert_close(res_pvalue, ref_pvalue)
-        check_named_results(res, ('statistic', 'pvalue'))
+        check_named_results(res, ('statistic', 'pvalue'), xp=xp)
 
     def test_nan(self, xp):
         # nan in input -> nan output (default nan_policy='propagate')


### PR DESCRIPTION
I think we're just about ready to go with `1.14.0` "final" now? The backports are pretty minor. I just did a scan through a pile of GitHub notifications and didn't catch any blockers I don't think.

Backports included (so far):

1. gh-20961
2. gh-20973
3. gh-20979
4. gh-20909
5. gh-20962 (first commit only, per Matt's comment and merge conflicts...)

TODO:

- [x] any regular CI failures to deal with?
- [x] any wheels build CI failures to deal with?
- [x] any objections to releasing SciPy `1.14.0` "final" before June 25th?
- [ ] remove the "is not released yet" part of the release notes, but probably just do that locally during rel process to be more consistent I suppose