### PR TITLE
BUG: sparse: Fix advanced indexing using both slice and array

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -260,6 +260,11 @@ class IndexMixin:
             idx_arrays = _broadcast_arrays(*(index[i] for i in array_indices))
             if any(idx_arrays[0].shape != ix.shape for ix in idx_arrays[1:]):
                 raise IndexError('array indices after broadcast differ in shape')
+            idx_shape = list(idx_arrays[0].shape) + idx_shape
+        if len(array_indices) == 1:
+            arr_index = array_indices[0]
+            arr_shape = list(index[arr_index].shape)
+            idx_shape = idx_shape[:arr_index] + arr_shape + idx_shape[arr_index:]
 
         # add slice(None) (which is colon) to fill out full index
         nslice = self.ndim - index_ndim
@@ -270,8 +275,6 @@ class IndexMixin:
             mid_shape = list(self.shape[ellps_pos : ellps_pos + nslice])
             idx_shape = idx_shape[:ellps_pos] + mid_shape + idx_shape[ellps_pos:]
 
-        if array_indices:
-            idx_shape = list(index[array_indices[0]].shape) + idx_shape
         if (ndim := len(idx_shape)) > 2:
             raise IndexError(f'Only 1D or 2D arrays allowed. Index makes {ndim}D')
         return tuple(index), tuple(idx_shape)

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -261,7 +261,7 @@ class IndexMixin:
             if any(idx_arrays[0].shape != ix.shape for ix in idx_arrays[1:]):
                 raise IndexError('array indices after broadcast differ in shape')
             idx_shape = list(idx_arrays[0].shape) + idx_shape
-        if len(array_indices) == 1:
+        elif len(array_indices) == 1:
             arr_index = array_indices[0]
             arr_shape = list(index[arr_index].shape)
             idx_shape = idx_shape[:arr_index] + arr_shape + idx_shape[arr_index:]

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -330,6 +330,100 @@ class TestSlicingAndFancy1D:
         ):
             A.__getitem__((2, "foo"))
 
+    def test_fancy_indexing_2darray(self, spcreator):
+        B = np.arange(50).reshape((5, 10))
+        A = spcreator(B)
+
+        # [i]
+        assert_equal(A[[1, 3]].toarray(), B[[1, 3]])
+
+        # [i,[1,2]]
+        assert_equal(A[3, [1, 3]].toarray(), B[3, [1, 3]])
+        assert_equal(A[-1, [2, -5]].toarray(), B[-1, [2, -5]])
+        assert_equal(A[np.array(-1), [2, -5]].toarray(), B[-1, [2, -5]])
+        assert_equal(A[-1, np.array([2, -5])].toarray(), B[-1, [2, -5]])
+        assert_equal(A[np.array(-1), np.array([2, -5])].toarray(), B[-1, [2, -5]])
+
+        # [1:2,[1,2]]
+        assert_equal(A[:, [2, 8, 3, -1]].toarray(), B[:, [2, 8, 3, -1]])
+        assert_equal(A[3:4, [9]].toarray(), B[3:4, [9]])
+        assert_equal(A[1:4, [-1, -5]].toarray(), B[1:4, [-1, -5]])
+        assert_equal(A[1:4, np.array([-1, -5])].toarray(), B[1:4, [-1, -5]])
+
+        # [[1,2],j]
+        assert_equal(A[[1, 3], 3].toarray(), B[[1, 3], 3])
+        assert_equal(A[[2, -5], -4].toarray(), B[[2, -5], -4])
+        assert_equal(A[np.array([2, -5]), -4].toarray(), B[[2, -5], -4])
+        assert_equal(A[[2, -5], np.array(-4)].toarray(), B[[2, -5], -4])
+        assert_equal(A[np.array([2, -5]), np.array(-4)].toarray(), B[[2, -5], -4])
+
+        # [[1,2],1:2]
+        assert_equal(A[[1, 3], :].toarray(), B[[1, 3], :])
+        assert_equal(A[[2, -5], 8:-1].toarray(), B[[2, -5], 8:-1])
+        assert_equal(A[np.array([2, -5]), 8:-1].toarray(), B[[2, -5], 8:-1])
+
+        # [[1,2],[1,2]]
+        assert_equal(toarray(A[[1, 3], [2, 4]]), B[[1, 3], [2, 4]])
+        assert_equal(toarray(A[[-1, -3], [2, -4]]), B[[-1, -3], [2, -4]])
+        assert_equal(
+            toarray(A[np.array([-1, -3]), [2, -4]]), B[[-1, -3], [2, -4]]
+        )
+        assert_equal(
+            toarray(A[[-1, -3], np.array([2, -4])]), B[[-1, -3], [2, -4]]
+        )
+        assert_equal(
+            toarray(A[np.array([-1, -3]), np.array([2, -4])]), B[[-1, -3], [2, -4]]
+        )
+
+        # [[[1],[2]],[1,2]]
+        assert_equal(A[[[1], [3]], [2, 4]].toarray(), B[[[1], [3]], [2, 4]])
+        assert_equal(
+            A[[[-1], [-3], [-2]], [2, -4]].toarray(),
+            B[[[-1], [-3], [-2]], [2, -4]]
+        )
+        assert_equal(
+            A[np.array([[-1], [-3], [-2]]), [2, -4]].toarray(),
+            B[[[-1], [-3], [-2]], [2, -4]]
+        )
+        assert_equal(
+            A[[[-1], [-3], [-2]], np.array([2, -4])].toarray(),
+            B[[[-1], [-3], [-2]], [2, -4]]
+        )
+        assert_equal(
+            A[np.array([[-1], [-3], [-2]]), np.array([2, -4])].toarray(),
+            B[[[-1], [-3], [-2]], [2, -4]]
+        )
+
+        # [[1,2]]
+        assert_equal(A[[1, 3]].toarray(), B[[1, 3]])
+        assert_equal(A[[-1, -3]].toarray(), B[[-1, -3]])
+        assert_equal(A[np.array([-1, -3])].toarray(), B[[-1, -3]])
+
+        # [[1,2],:][:,[1,2]]
+        assert_equal(
+            A[[1, 3], :][:, [2, 4]].toarray(), B[[1, 3], :][:, [2, 4]]
+        )
+        assert_equal(
+            A[[-1, -3], :][:, [2, -4]].toarray(), B[[-1, -3], :][:, [2, -4]]
+        )
+        assert_equal(
+            A[np.array([-1, -3]), :][:, np.array([2, -4])].toarray(),
+            B[[-1, -3], :][:, [2, -4]]
+        )
+
+        # [:,[1,2]][[1,2],:]
+        assert_equal(
+            A[:, [1, 3]][[2, 4], :].toarray(), B[:, [1, 3]][[2, 4], :]
+        )
+        assert_equal(
+            A[:, [-1, -3]][[2, -4], :].toarray(), B[:, [-1, -3]][[2, -4], :]
+        )
+        assert_equal(
+            A[:, np.array([-1, -3])][np.array([2, -4]), :].toarray(),
+            B[:, [-1, -3]][[2, -4], :]
+        )
+
+
     def test_fancy_indexing(self, spcreator):
         B = np.arange(50)
         A = spcreator(B)

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -423,7 +423,6 @@ class TestSlicingAndFancy1D:
             B[:, [-1, -3]][[2, -4], :]
         )
 
-
     def test_fancy_indexing(self, spcreator):
         B = np.arange(50)
         A = spcreator(B)


### PR DESCRIPTION
Fixes #21016 

Advanced indexing with both slice and array indices provides incorrect shapes for examples such as `csr_array(np.arange(15).reshape((5, 3)))[:, [1, 2]]`. This is due to a bug introduced in #20120 and caught via nightly builds. 

This PR provides a test showing the problem (it copies a test function from `test_base.py` and adapts it to 2d sparse arrays). A fix is also included. The fix involves adding a case for when only one dimension's index-value is an array while the index also contains a slice in a separate dimension. The result should now mimic numpy's indexing behavior for [advanced fancy indexing using both slices and arrays](https://numpy.org/doc/stable/user/basics.indexing.html#combining-advanced-and-basic-indexing)).

This unfortunate bug would have been easier to find (and the PR introducing it easier to review) if we converted the `test_base.py` module to directly and fully test sparray methods as well as spmatrix (as is developing in #20894 and #20895). In the meantime, this example shows the power of quick feedback based on nightly builds. And hopefully this PR allows the tests run on nightly builds to pass.