### PR TITLE
ENH: stats.tmin/tmax: add array API support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -710,20 +710,22 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     14
 
     """
-    dtype = a.dtype
-
     xp = array_namespace(a)
+
+    # remember original dtype; _put_val_to_limits might need to change it
+    dtype = a.dtype
     a, mask = _put_val_to_limits(a, (lowerlimit, None), (inclusive, None),
                                  val=xp.inf, xp=xp)
+
     min = xp.min(a, axis=axis)
     n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
-    min = xp.where(n != 0, min, xp.nan)
+    res = xp.where(n != 0, min, xp.nan)
 
-    if not xp.any(xp.isnan(min)):
+    if not xp.any(xp.isnan(res)):
         # needed if input is of integer dtype
-        min = xp.astype(min, dtype, copy=False)
+        res = xp.astype(res, dtype, copy=False)
 
-    return min[()] if min.ndim == 0 else min
+    return res[()] if res.ndim == 0 else res
 
 
 @_axis_nan_policy_factory(
@@ -770,13 +772,22 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     12
 
     """
+    xp = array_namespace(a)
+
+    # remember original dtype; _put_val_to_limits might need to change it
     dtype = a.dtype
-    a, _ = _put_val_to_limits(a, (None, upperlimit), (None, inclusive))
-    res = np.nanmax(a, axis=axis)
-    if not np.any(np.isnan(res)):
+    a, mask = _put_val_to_limits(a, (None, upperlimit), (None, inclusive),
+                                 val=-xp.inf, xp=xp)
+
+    max = xp.max(a, axis=axis)
+    n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
+    res = xp.where(n != 0, max, xp.nan)
+
+    if not xp.any(xp.isnan(res)):
         # needed if input is of integer dtype
-        return res.astype(dtype, copy=False)
-    return res
+        res = xp.astype(res, dtype, copy=False)
+
+    return res[()] if res.ndim == 0 else res
 
 
 @_axis_nan_policy_factory(

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -182,7 +182,8 @@ class TestTrimmedStats:
         xp_assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False), xp.asarray(1))
 
         x = xp.reshape(x, (5, 2))
-        xp_assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False), xp.asarray([2, 1]))
+        xp_assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False),
+                        xp.asarray([2, 1]))
         xp_assert_equal(stats.tmin(x, axis=1), xp.asarray([0, 2, 4, 6, 8]))
         xp_assert_equal(stats.tmin(x, axis=None), xp.asarray(0))
 
@@ -204,41 +205,57 @@ class TestTrimmedStats:
         with suppress_warnings() as sup:
             sup.record(RuntimeWarning, "invalid value*")
             assert_equal(stats.tmin(x, nan_policy='omit'), 0.)
-            assert_raises(ValueError, stats.tmin, x, nan_policy='raise')
-            assert_raises(ValueError, stats.tmin, x, nan_policy='foobar')
+            msg = "The input contains nan values"
+            with assert_raises(ValueError, match=msg):
+                stats.tmin(x, nan_policy='raise')
             msg = "nan_policy must be one of..."
             with assert_raises(ValueError, match=msg):
-                stats.tmin(x, nan_policy='foo')
+                stats.tmin(x, nan_policy='foobar')
 
-    def test_tmax(self):
+    @array_api_compatible
+    @skip_xp_backends('array_api_strict', 'jax.numpy',
+                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
+                               "accept Python floats. See data-apis/array-api#807.",
+                               "JAX doesn't allow item assignment."])
+    @pytest.mark.usefixtures("skip_xp_backends")
+    def test_tmax(self, xp):
+        x = xp.arange(10)
+        xp_assert_equal(stats.tmax(x), xp.asarray(9))
+        xp_assert_equal(stats.tmax(x, upperlimit=9), xp.asarray(9))
+        xp_assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), xp.asarray(8))
+
+        x = xp.reshape(x, (5, 2))
+        xp_assert_equal(stats.tmax(x, upperlimit=9, inclusive=False),
+                        xp.asarray([8, 7]))
+        xp_assert_equal(stats.tmax(x, axis=1), xp.asarray([1, 3, 5, 7, 9]))
+        xp_assert_equal(stats.tmax(x, axis=None), xp.asarray(9))
+
+        x = xp.arange(10.)
+        x[9] = xp.nan
+        xp_assert_equal(stats.tmax(x), xp.asarray(xp.nan))
+
+        # check that if a full slice is masked, the output returns a
+        # nan instead of a garbage value.
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "All-NaN slice encountered")
+            x = xp.reshape(xp.arange(16), (4, 4))
+            res = stats.tmax(x, upperlimit=11, axis=1)
+            xp_assert_equal(res, xp.asarray([3, 7, 11, np.nan]))
+
+    def test_tax_scalar_and_nanpolicy(self):
         assert_equal(stats.tmax(4), 4)
-
-        x = np.arange(10)
-        assert_equal(stats.tmax(x), 9)
-        assert_equal(stats.tmax(x, upperlimit=9), 9)
-        assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), 8)
-
-        x = x.reshape((5, 2))
-        assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), [8, 7])
-        assert_equal(stats.tmax(x, axis=1), [1, 3, 5, 7, 9])
-        assert_equal(stats.tmax(x, axis=None), 9)
 
         x = np.arange(10.)
         x[6] = np.nan
         with suppress_warnings() as sup:
             sup.record(RuntimeWarning, "invalid value*")
-            assert_equal(stats.tmax(x), np.nan)
             assert_equal(stats.tmax(x, nan_policy='omit'), 9.)
-            assert_raises(ValueError, stats.tmax, x, nan_policy='raise')
-            assert_raises(ValueError, stats.tmax, x, nan_policy='foobar')
-
-        # check that that if a full slice is masked, the output returns a
-        # nan instead of a garbage value.
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "All-NaN slice encountered")
-            x = np.arange(16).reshape(4, 4)
-            res = stats.tmax(x, upperlimit=11, axis=1)
-            assert_equal(res, [3, 7, 11, np.nan])
+            msg = "The input contains nan values"
+            with assert_raises(ValueError, match=msg):
+                stats.tmax(x, nan_policy='raise')
+            msg = "nan_policy must be one of..."
+            with assert_raises(ValueError, match=msg):
+                stats.tmax(x, nan_policy='foobar')
 
     def test_tsem(self):
         y = stats.tsem(X, limits=(3, 8), inclusive=(False, True))


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `tmin` and `tmax`.

#### Additional information
If this looks good, I'll do `tvar`, `tstd`, and `tsem` in one PR. Or I can add them to this PR if preferred.