### PR TITLE
ENH: stats.tvar/tstd/tsem: add array API support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -687,12 +687,13 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
     """
     xp = array_namespace(a)
-    mean = tmean(a, limits=limits, inclusive=inclusive, axis=axis, _no_deco=True)
-    a, mask = _put_val_to_limits(a, limits, inclusive, val=mean, xp=xp)
-    n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
-    len_axis = xp_size(a) if axis is None else a.shape[axis]
-    res = xp.var(a, correction=ddof, axis=axis) * (len_axis - ddof)/(n - ddof)
-    return res[()] if res.ndim == 0 else res
+    a, _ = _put_val_to_limits(a, limits, inclusive, xp=xp)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SmallSampleWarning)
+        # Currently, this behaves like nan_policy='omit' for alternative array
+        # backends, but nan_policy='propagate' will be handled for other backends
+        # by the axis_nan_policy decorator shortly.
+        return _xp_var(a, correction=ddof, axis=axis, nan_policy='omit', xp=xp)
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -921,10 +921,18 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     1.1547005383792515
 
     """
-    a, _ = _put_val_to_limits(a, limits, inclusive)
-    sd = np.sqrt(np.nanvar(a, ddof=ddof, axis=axis))
-    n_obs = (~np.isnan(a)).sum(axis=axis)
-    return sd / np.sqrt(n_obs, dtype=sd.dtype)
+    xp = array_namespace(a)
+    a, _ = _put_val_to_limits(a, limits, inclusive, xp=xp)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SmallSampleWarning)
+        # Currently, this behaves like nan_policy='omit' for alternative array
+        # backends, but nan_policy='propagate' will be handled for other backends
+        # by the axis_nan_policy decorator shortly.
+        sd = _xp_var(a, correction=ddof, axis=axis, nan_policy='omit', xp=xp)**0.5
+
+    n_obs = xp.sum(~xp.isnan(a), axis=axis, dtype=sd.dtype)
+    return sd / n_obs**0.5
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -661,9 +661,13 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     20.0
 
     """
-    a, _ = _put_val_to_limits(a, limits, inclusive)
-    return np.nanvar(a, ddof=ddof, axis=axis)
-
+    xp = array_namespace(a)
+    mean = tmean(a, limits=limits, inclusive=inclusive, axis=axis, _no_deco=True)
+    a, mask = _put_val_to_limits(a, limits, inclusive, val=mean, xp=xp)
+    n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
+    len_axis = xp_size(a) if axis is None else a.shape[axis]
+    res = xp.var(a, correction=ddof, axis=axis) * (len_axis - ddof)/(n - ddof)
+    return res[()] if res.ndim == 0 else res
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -869,7 +869,7 @@ def tstd(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     4.4721359549995796
 
     """
-    return np.sqrt(tvar(a, limits, inclusive, axis, ddof, _no_deco=True))
+    return tvar(a, limits, inclusive, axis, ddof, _no_deco=True)**0.5
 
 
 @_axis_nan_policy_factory(

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -23,7 +23,7 @@ from numpy.testing import (assert_, assert_equal,
 import pytest
 from pytest import raises as assert_raises
 import numpy.ma.testutils as mat
-from numpy import array, arange, float32, float64, power
+from numpy import array, arange, float32, power
 import numpy as np
 
 import scipy.stats as stats
@@ -160,7 +160,7 @@ class TestTrimmedStats:
 
     def test_tstd(self, xp):
         x = xp.asarray(X)
-        xp_test = array_namespace(x)  # need array-api-compat var for `correction`
+        xp_test = array_namespace(x)  # need array-api-compat std for `correction`
 
         y = stats.tstd(x, (2, 8), (True, True))
         xp_assert_close(y, xp.asarray(2.1602468994692865))
@@ -250,7 +250,7 @@ class TestTrimmedStats:
 
     def test_tsem(self, xp):
         x = xp.asarray(X)
-        xp_test = array_namespace(x)  # need array-api-compat var for `correction`
+        xp_test = array_namespace(x)  # need array-api-compat std for `correction`
 
         y = stats.tsem(x, limits=(3, 8), inclusive=(False, True))
         y_ref = xp.asarray([4, 5, 6, 7, 8])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -166,12 +166,22 @@ class TestTrimmedStats:
         xp_assert_close(y[0], xp.asarray(4.666666666666667))
         xp_assert_equal(y[1], xp.asarray(xp.nan))
 
-    def test_tstd(self):
-        y = stats.tstd(X, (2, 8), (True, True))
-        assert_approx_equal(y, 2.1602468994692865, significant=self.dprec)
+    @array_api_compatible
+    @skip_xp_backends('array_api_strict', 'jax.numpy',
+                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
+                               "accept Python floats. See data-apis/array-api#807.",
+                               "JAX doesn't allow item assignment, and this  "
+                               "function uses _lazywhere."])
+    @pytest.mark.usefixtures("skip_xp_backends")
+    def test_tstd(self, xp):
+        x = xp.asarray(X)
+        xp_test = array_namespace(x)  # need array-api-compat var for `correction`
 
-        y = stats.tstd(X, limits=None)
-        assert_approx_equal(y, X.std(ddof=1), significant=self.dprec)
+        y = stats.tstd(x, (2, 8), (True, True))
+        xp_assert_close(y, xp.asarray(2.1602468994692865))
+
+        y = stats.tstd(x, limits=None)
+        xp_assert_close(y, xp_test.std(x, correction=1))
 
     @array_api_compatible
     @skip_xp_backends('array_api_strict', 'jax.numpy',

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -73,17 +73,16 @@ TINY = array([1e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12], float)
 ROUND = array([0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5], float)
 
 
+@array_api_compatible
+@skip_xp_backends('array_api_strict', 'jax.numpy',
+                  reasons=["`array_api_strict.where` `fillvalue` doesn't "
+                           "accept Python floats. See data-apis/array-api#807.",
+                           "JAX doesn't allow item assignment."])
+@pytest.mark.usefixtures("skip_xp_backends")
 class TestTrimmedStats:
     # TODO: write these tests to handle missing values properly
     dprec = np.finfo(np.float64).precision
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment, and this  "
-                               "function uses _lazywhere."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tmean(self, xp):
         x = xp.asarray(X)
 
@@ -130,13 +129,6 @@ class TestTrimmedStats:
         y_true = [4.5, 10, 17, 21, xp.nan, xp.nan, xp.nan, xp.nan, xp.nan]
         xp_assert_close(y, xp.asarray(y_true))
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment, and this  "
-                               "function uses _lazywhere."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tvar(self, xp):
         x = xp.asarray(X)
         xp_test = array_namespace(x)  # need array-api-compat var for `correction`
@@ -166,13 +158,6 @@ class TestTrimmedStats:
         xp_assert_close(y[0], xp.asarray(4.666666666666667))
         xp_assert_equal(y[1], xp.asarray(xp.nan))
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment, and this  "
-                               "function uses _lazywhere."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tstd(self, xp):
         x = xp.asarray(X)
         xp_test = array_namespace(x)  # need array-api-compat var for `correction`
@@ -183,12 +168,6 @@ class TestTrimmedStats:
         y = stats.tstd(x, limits=None)
         xp_assert_close(y, xp_test.std(x, correction=1))
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tmin(self, xp):
         x = xp.arange(10)
         xp_assert_equal(stats.tmin(x), xp.asarray(0))
@@ -211,7 +190,9 @@ class TestTrimmedStats:
         res = stats.tmin(x, lowerlimit=4, axis=1)
         xp_assert_equal(res, xp.asarray([np.nan, 4, 8, 12]))
 
-    def test_tmin_scalar_and_nanpolicy(self):
+    @skip_xp_backends(np_only=True,
+                      reasons=["Only NumPy arrays support scalar input/`nan_policy`."])
+    def test_tmin_scalar_and_nanpolicy(self, xp):
         assert_equal(stats.tmin(4), 4)
 
         x = np.arange(10.)
@@ -226,12 +207,6 @@ class TestTrimmedStats:
             with assert_raises(ValueError, match=msg):
                 stats.tmin(x, nan_policy='foobar')
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tmax(self, xp):
         x = xp.arange(10)
         xp_assert_equal(stats.tmax(x), xp.asarray(9))
@@ -256,7 +231,9 @@ class TestTrimmedStats:
             res = stats.tmax(x, upperlimit=11, axis=1)
             xp_assert_equal(res, xp.asarray([3, 7, 11, np.nan]))
 
-    def test_tax_scalar_and_nanpolicy(self):
+    @skip_xp_backends(np_only=True,
+                      reasons=["Only NumPy arrays support scalar input/`nan_policy`."])
+    def test_tax_scalar_and_nanpolicy(self, xp):
         assert_equal(stats.tmax(4), 4)
 
         x = np.arange(10.)
@@ -271,12 +248,6 @@ class TestTrimmedStats:
             with assert_raises(ValueError, match=msg):
                 stats.tmax(x, nan_policy='foobar')
 
-    @array_api_compatible
-    @skip_xp_backends('array_api_strict', 'jax.numpy',
-                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
-                               "accept Python floats. See data-apis/array-api#807.",
-                               "JAX doesn't allow item assignment."])
-    @pytest.mark.usefixtures("skip_xp_backends")
     def test_tsem(self, xp):
         x = xp.asarray(X)
         xp_test = array_namespace(x)  # need array-api-compat var for `correction`

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -84,10 +84,10 @@ class TestTrimmedStats:
     dprec = np.finfo(np.float64).precision
 
     def test_tmean(self, xp):
-        x = xp.asarray(X)
+        x = xp.asarray(X.tolist())  # use default dtype of xp
 
         y = stats.tmean(x, (2, 8), (True, True))
-        xp_assert_close(y, xp.asarray(5.0, dtype=x.dtype))
+        xp_assert_close(y, xp.asarray(5.0))
 
         y1 = stats.tmean(x, limits=(2, 8), inclusive=(False, False))
         y2 = stats.tmean(x, limits=None)
@@ -130,7 +130,7 @@ class TestTrimmedStats:
         xp_assert_close(y, xp.asarray(y_true))
 
     def test_tvar(self, xp):
-        x = xp.asarray(X)
+        x = xp.asarray(X.tolist())  # use default dtype of xp
         xp_test = array_namespace(x)  # need array-api-compat var for `correction`
 
         y = stats.tvar(x, limits=(2, 8), inclusive=(True, True))
@@ -139,15 +139,15 @@ class TestTrimmedStats:
         y = stats.tvar(x, limits=None)
         xp_assert_close(y, xp_test.var(x, correction=1))
 
-        x_2d = xp.reshape(xp.arange(63, dtype=xp.float64), (9, 7))
+        x_2d = xp.reshape(xp.arange(63.), (9, 7))
         y = stats.tvar(x_2d, axis=None)
         xp_assert_close(y, xp_test.var(x_2d, correction=1))
 
         y = stats.tvar(x_2d, axis=0)
-        xp_assert_close(y, xp.full(7, 367.5))
+        xp_assert_close(y, xp.full((7,), 367.5))
 
         y = stats.tvar(x_2d, axis=1)
-        xp_assert_close(y, xp.full(9, 4.66666667))
+        xp_assert_close(y, xp.full((9,), 4.66666667))
 
         # Limiting some values along one axis
         y = stats.tvar(x_2d, limits=(1, 5), axis=1, inclusive=(True, True))
@@ -159,7 +159,7 @@ class TestTrimmedStats:
         xp_assert_equal(y[1], xp.asarray(xp.nan))
 
     def test_tstd(self, xp):
-        x = xp.asarray(X)
+        x = xp.asarray(X.tolist())  # use default dtype of xp
         xp_test = array_namespace(x)  # need array-api-compat std for `correction`
 
         y = stats.tstd(x, (2, 8), (True, True))
@@ -249,12 +249,12 @@ class TestTrimmedStats:
                 stats.tmax(x, nan_policy='foobar')
 
     def test_tsem(self, xp):
-        x = xp.asarray(X)
+        x = xp.asarray(X.tolist())  # use default dtype of xp
         xp_test = array_namespace(x)  # need array-api-compat std for `correction`
 
         y = stats.tsem(x, limits=(3, 8), inclusive=(False, True))
-        y_ref = xp.asarray([4, 5, 6, 7, 8])
-        xp_assert_close(y, xp_test.std(y_ref, correction=1) / xp.sqrt(xp_size(y_ref)))
+        y_ref = xp.asarray([4., 5., 6., 7., 8.])
+        xp_assert_close(y, xp_test.std(y_ref, correction=1) / xp_size(y_ref)**0.5)
         xp_assert_close(stats.tsem(x, limits=[-1, 10]), stats.tsem(x, limits=None))
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -157,17 +157,14 @@ class TestTrimmedStats:
         y = stats.tvar(x_2d, axis=1)
         xp_assert_close(y, xp.full(9, 4.66666667))
 
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Degrees of freedom <= 0 for slice.")
+        # Limiting some values along one axis
+        y = stats.tvar(x_2d, limits=(1, 5), axis=1, inclusive=(True, True))
+        xp_assert_close(y[0], xp.asarray(2.5))
 
-            # Limiting some values along one axis
-            y = stats.tvar(x_2d, limits=(1, 5), axis=1, inclusive=(True, True))
-            xp_assert_close(y[0], xp.asarray(2.5))
-
-            # Limiting all values along one axis
-            y = stats.tvar(x_2d, limits=(0, 6), axis=1, inclusive=(True, True))
-            xp_assert_close(y[0], xp.asarray(4.666666666666667))
-            xp_assert_equal(y[1], xp.asarray(xp.nan))
+        # Limiting all values along one axis
+        y = stats.tvar(x_2d, limits=(0, 6), axis=1, inclusive=(True, True))
+        xp_assert_close(y[0], xp.asarray(4.666666666666667))
+        xp_assert_equal(y[1], xp.asarray(xp.nan))
 
     def test_tstd(self):
         y = stats.tstd(X, (2, 8), (True, True))


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `tvar`, `tstd`, and `tsem`.
