### PR TITLE
RFC/DEP: decorator to deprecate positional/keyword uses of arguments?

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -41,7 +41,7 @@ from scipy.spatial import distance_matrix
 from scipy.optimize import milp, LinearConstraint
 from scipy._lib._util import (check_random_state, _get_nan,
                               _rename_parameter, _contains_nan,
-                              AxisError, _lazywhere)
+                              AxisError, _lazywhere, _deprecate_pos_kwd_only_args)
 
 import scipy.special as special
 # Import unused here but needs to stay until end of deprecation periode
@@ -6753,6 +6753,10 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     return Ttest_indResult(*res)
 
 
+@_deprecate_pos_kwd_only_args(['a', 'b'],
+                              ['axis', 'equal_var', 'nan_policy', 'permutations',
+                               'random_state', 'alternative', 'trim'],
+                              "1.15.0")
 @_axis_nan_policy_factory(pack_TtestResult, default_axis=0, n_samples=2,
                           result_to_tuple=unpack_TtestResult, n_outputs=6)
 def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1094,7 +1094,7 @@ class TestMonteCarloHypothesisTest:
         data = rng.random(size=(2, 5)), rng.random(size=7)  # broadcastable
         rvs = rng.normal, rng.normal
         def statistic(x, y, axis):
-            return stats.ttest_ind(x, y, axis).statistic
+            return stats.ttest_ind(x, y, axis=axis).statistic
 
         res = stats.monte_carlo_test(data, rvs, statistic, axis=-1)
         ref = stats.ttest_ind(data[0], [data[1]], axis=-1)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5248,14 +5248,14 @@ def test_ttest_ind_nan_policy():
         return 1 - (p / 2)
     converter = np.vectorize(convert)
 
-    tr, pr = stats.ttest_ind(rvs1_3D, rvs2_3D, 0, nan_policy='omit')
+    tr, pr = stats.ttest_ind(rvs1_3D, rvs2_3D, axis=0, nan_policy='omit')
 
-    t, p = stats.ttest_ind(rvs1_3D, rvs2_3D, 0, nan_policy='omit',
+    t, p = stats.ttest_ind(rvs1_3D, rvs2_3D, axis=0, nan_policy='omit',
                            alternative='less')
     assert_allclose(t, tr, rtol=1e-14)
     assert_allclose(p, converter(tr, pr, 'less'), rtol=1e-14)
 
-    t, p = stats.ttest_ind(rvs1_3D, rvs2_3D, 0, nan_policy='omit',
+    t, p = stats.ttest_ind(rvs1_3D, rvs2_3D, axis=0, nan_policy='omit',
                            alternative='greater')
     assert_allclose(t, tr, rtol=1e-14)
     assert_allclose(p, converter(tr, pr, 'greater'), rtol=1e-14)


### PR DESCRIPTION
#### Reference issue
NA

#### What does this implement/fix?
Per [The Missing Bits](https://docs.scipy.org/doc/scipy/dev/missing-bits.html#required-keyword-names)

> For new functions or methods with more than a few arguments, all parameters after the first few "obvious" ones should *require* the use of the keyword when given.

I think we also know that names of required arguments like `a`/`b` are typically not very useful (and often just add inconsistency between similar functions). Presumably drawing from years of experience with API design, the array API standard seems to prefer most arguments to be either positional-only or keyword-only, not both.

So I thought I'd experiment with a decorator that will let us standardize existing signatures along these lines. 

(Besides helping us make the API more consistent, it is easier/faster to wrap large classes of functions - e.g. for array API dispatching - when it is known whether arguments will be passed by position or keyword.)

This PR also applies the decorator to `scipy.stats.ttest_ind`, making `a` and `b` positional-only and the rest of the arguments keyword only.

Again, this is just an experiment. It could be deemed too noisy for what we gain. An alternative might be to save this sort of thing for a SciPy 2.0 transition? But I thought I'd at least see if we could make it easy to implement.

#### Additional information
In the documentation, we will get a deprecation admonition in the Extended Summary of `ttest_ind`:

<img width="952" alt="image" src="https://github.com/scipy/scipy/assets/6570539/24184db6-c1d4-4593-938f-1458e1e5b3be">

And here is what the `DeprecationWarning`s look like:
```python3
import numpy as np
from scipy import stats

stats.ttest_ind(np.arange(10), np.arange(10), -1, True)
# DeprecationWarning: Argument(s) {'axis', 'equal_var'} of `ttest_ind` passed by position but will become keyword-only in SciPy 1.17.0.
#  stats.ttest_ind(np.arange(10), np.arange(10), -1, True)
# TtestResult(statistic=0.0, pvalue=1.0, df=18.0)

stats.ttest_ind(a=np.arange(10), b=np.arange(10), axis=-1)
# DeprecationWarning: Argument(s) {'a', 'b'} of `ttest_ind` passed by keyword but will become positional-only in SciPy 1.17.0.
#  stats.ttest_ind(a=np.arange(10), b=np.arange(10), axis=-1)
# TtestResult(statistic=0.0, pvalue=1.0, df=18.0)
```

I thought I'd get some feedback before putting the time into writing tests.