### PR TITLE
TST: optimize: fix exception test on PyPy3.10

### DIFF
--- a/scipy/optimize/tests/test_hessian_update_strategy.py
+++ b/scipy/optimize/tests/test_hessian_update_strategy.py
@@ -100,9 +100,8 @@ class TestHessianUpdateStrategy(TestCase):
         ndims = 3
         # no complex allowed
         inits_msg_errtype = ((complex(3.14),
-                              re.escape("float() argument must be a "
-                                        "string or a real number, "
-                                        "not 'complex'"),
+                              r"float\(\) argument must be a string or a "
+                              r"(real )?number, not 'complex'",
                               TypeError),
 
                              (np.array([3.2, 2.3, 1.2]).astype(np.complex128),


### PR DESCRIPTION
#### Reference issue
Fixes #21045

#### What does this implement/fix?
Adjust the expected `float(complex())` conversion exception message to allow for the word "real" to be missing, as it is on PyPy3.10. This makes the test pass both with CPython and PyPy3, and also permits for PyPy3 to adjust the message in line with CPython in the future.