### PR TITLE
BUG: interpolate.LinearNDInterpolator: fix for precomputed triangulation

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -89,7 +89,8 @@ class NDInterpolatorBase:
             self.scale[~(self.scale > 0)] = 1.0  # avoid division by 0
             self.points /= self.scale
         
-        self._calculate_triangulation(self.points)
+        if self.tri is None:
+            self._calculate_triangulation(self.points)
         
         if need_values or values is not None:
             self._set_values(values, fill_value, need_contiguous, ndim)

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -88,10 +88,10 @@ class NDInterpolatorBase:
             self.scale = np.ptp(points, axis=0)
             self.scale[~(self.scale > 0)] = 1.0  # avoid division by 0
             self.points /= self.scale
-        
+
         if self.tri is None:
             self._calculate_triangulation(self.points)
-        
+
         if need_values or values is not None:
             self._set_values(values, fill_value, need_contiguous, ndim)
         else:

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -59,42 +59,9 @@ class TestLinearNDInterpolation:
         y = y - 3j*y
 
         tri = qhull.Delaunay(x)
-        yi = interpnd.LinearNDInterpolator(tri, y)(x)
-        assert_almost_equal(y, yi)
-
-    def test_tri2_input(self):
-        # be sur that Delaunay triangulation is not recompute.
-        #  the fake tri have a hole in the middle if recompute it will be "closed",
-        #  if not center get NAN value.
-        class FakeDelaunay(qhull.Delaunay):
-            def __init__(self):
-                self._points = np.array([(0,0), (0,1), (0,2),
-                                         (1,0), (1,1), (1,2),
-                                         (2,0), (2,1), (2,2)], dtype=np.float64)
-                self.simplices = np.array([(0,1,3),(1,2,5),(3,7,6), (5,8,7)],
-                                          dtype=np.int32)
-                self.neighbors = np.array([(-1,-1,-1),
-                                           (-1,-1,-1),
-                                           (-1,-1,-1),
-                                           (-1,-1,-1)], dtype=np.int32)
-                self.ndim = self._points.shape[1]
-                self.npoints = self._points.shape[0]
-                self.min_bound = self._points.min(axis=0)
-                self.max_bound = self._points.max(axis=0)
-                self.equations = np.zeros((9, 4), dtype=np.double)
-                self.paraboloid_scale = 1
-                self.paraboloid_shift = 0
-                self._transform = None
-
-        y = np.array([(1), (1), (1), (1), (1), (1), (1), (1), (1)], dtype=np.float64)
-        test_points = np.array([(0.1,0.1), (1.5,1.5)], dtype=np.float64)
-        test_res    = np.array([(1), (np.nan)], dtype=np.float64)
-
-        tri = FakeDelaunay()
         interpolator = interpnd.LinearNDInterpolator(tri, y)
-        res = interpolator(test_points)
-
-        assert_almost_equal(res, test_res)
+        yi = interpolator(x)
+        assert_almost_equal(y, yi)
         assert interpolator.tri is tri
 
     def test_square(self):


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/21043

#### Test
```
python dev.py test -s interpolate -m full
[...]
scipy/interpolate/tests/test_interpnd.py ......................                                                                                        [ 33%]
[...]
======================================================== 1023 passed, 17 skipped, 1 xfailed in 11.38s ========================================================
```
look no break on existing test.