### PR TITLE
BUG: special: Fixes for pro_rad1

### DIFF
--- a/scipy/special/special/specfun/specfun.h
+++ b/scipy/special/special/specfun/specfun.h
@@ -4318,7 +4318,7 @@ inline int msta2(double x, int n, int mp) {
         n1 = nn;
         f1 = f;
     }
-    return nn;
+    return nn + 10;
 }
 
 

--- a/scipy/special/special/specfun/specfun.h
+++ b/scipy/special/special/specfun/specfun.h
@@ -4777,7 +4777,7 @@ inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
 
     cx = c * x;
     nm2 = 2 * nm + m;
-    sphj(static_cast<T>(nm2), cx, &nm2, sj, dj);
+    sphj(cx, nm2, &nm2, sj, dj);
 
     a0 = pow(1.0 - kd / (x * x), 0.5 * m) / suc;
     *r1f = 0.0;

--- a/scipy/special/special/specfun/specfun.h
+++ b/scipy/special/special/specfun/specfun.h
@@ -5597,7 +5597,7 @@ void sphj(T x, int n, int *nm, T *sj, T *dj) {
         }
         sj[0] = 1.0;
         if (n > 0) {
-            dj[0] = 1.0 / 3.0;
+            dj[1] = 1.0 / 3.0;
         }
         return;
     }
@@ -5621,7 +5621,7 @@ void sphj(T x, int n, int *nm, T *sj, T *dj) {
         f1 = 1e-100;
         for (k = m; k >= 0; k--) {
             f = (2.0*k + 3.0)*f1/x - f0;
-            if (k <= *nm) { sj[k - 1] = f; }
+            if (k <= *nm) { sj[k] = f; }
             f0 = f1;
             f1 = f;
         }
@@ -5631,7 +5631,7 @@ void sphj(T x, int n, int *nm, T *sj, T *dj) {
         }
     }
     for (k = 1; k <= *nm; k++) {
-        dj[k] = sj[k - 1] - (k + 1.0)*sj[k - 1]/x;
+        dj[k] = sj[k - 1] - (k + 1.0)*sj[k]/x;
     }
     return;
 }

--- a/scipy/special/tests/test_specfun.py
+++ b/scipy/special/tests/test_specfun.py
@@ -29,3 +29,12 @@ def test_hygfz_branches():
     """(cabs(z+1) < eps) && (fabs(c-a+b - 1.0) < eps)"""
     res = special.hyp2f1(5+5e-16, 2, 2, -1.0 + 5e-16j)
     assert_allclose(res, 0.031249999999999986+3.9062499999999994e-17j)
+
+
+def test_pro_rad1():
+    # https://github.com/scipy/scipy/issues/21058
+    # Reference values taken from WolframAlpha
+    # SpheroidalS1(1, 1, 30, 1.1)
+    # SpheroidalS1Prime(1, 1, 30, 1.1)
+    res = special.pro_rad1(1, 1, 30, 1.1)
+    assert_allclose(res, (0.009657872296166435, 3.253369651472877), rtol=1e-5)

--- a/scipy/special/tests/test_specfun.py
+++ b/scipy/special/tests/test_specfun.py
@@ -37,4 +37,4 @@ def test_pro_rad1():
     # SpheroidalS1(1, 1, 30, 1.1)
     # SpheroidalS1Prime(1, 1, 30, 1.1)
     res = special.pro_rad1(1, 1, 30, 1.1)
-    assert_allclose(res, (0.009657872296166435, 3.253369651472877), rtol=1e-5)
+    assert_allclose(res, (0.009657872296166435, 3.253369651472877), rtol=2e-5)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #21058 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes some mistakes that were made when `sphj` in `specfun` was translated from Fortran to C++. `sphj` is only used in `pro_rad1`,  and the existing test for `pro_rad1` did not cover the cases impacted by these mistakes. I've added a test using the failing example from #21058.

#### Additional information
<!--Any additional information you think is important.-->
The `rtol` for the test I've added is pretty high at `1e-5`, but the accuracy is now comparable (slightly better on my machine) to the old Fortran implementation.
