### PR TITLE
BUG: special: remove type punning to avoid warnings in LTO builds

### DIFF
--- a/scipy/special/special_wrappers.cpp
+++ b/scipy/special/special_wrappers.cpp
@@ -107,19 +107,11 @@ using namespace std;
 namespace {
 
 complex<double> to_complex(npy_cdouble z) {
-    union {
-        npy_cdouble cvalue;
-        complex<double> value;
-    } z_union{z};
-    return z_union.value;
+    return {npy_creal(z), npy_cimag(z)};
 }
 
 npy_cdouble to_ccomplex(complex<double> z) {
-    union {
-        complex<double> value;
-        npy_cdouble cvalue;
-    } z_union{z};
-    return z_union.cvalue;
+    return {z.real(), z.imag()};
 }
 
 } // namespace


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #21065 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removes the use of type punning in `scipy.special`, which we were using for converting back and forth between `std::complex<double>`s and `npy_cdouble`s without needing to perform any copying. For now I propose we just copy the fields over. This will allow scipy to build without LTO errors.

#### Additional information
<!--Any additional information you think is important.-->
It was reported in #21065 that the type punning only started causing this issue after the update to NumPy 2.0, in which case it's likely that the complex type changes described [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#complex-types-underlying-type-changes) also play a role. It may still be possible to make things work without having to perform the copies and we can revisit that in the future.

~I've also added the strict compiler flags listed in #21065 to the clang build only CI job.~ I tried to add the strict compiler flags listed in #21065 to the clang build only CI job, but it seems those particular flags aren't all available in clang, https://github.com/llvm/llvm-project/issues/56487.
