### PR TITLE
MAINT: uarray: fix typo in `small_dynamic_array.h`

### DIFF
--- a/scipy/_lib/_uarray/small_dynamic_array.h
+++ b/scipy/_lib/_uarray/small_dynamic_array.h
@@ -142,7 +142,7 @@ public:
 
     clear();
 
-    size_ = copy.size;
+    size_ = copy.size_;
     try {
       allocate();
     } catch (...) {


### PR DESCRIPTION
on clang-19, this causes:
```
../scipy/_lib/_uarray/small_dynamic_array.h(145,18): error: reference to non-static member function must be called
  145 |     size_ = copy.size;
      |             ~~~~~^~~~
1 error generated.
```

I'm not sure how previous versions (much less other compilers) dealt with this, as it seems to me that the `SmallDynamicArray` class has no `size` member or field at all.

With this PR, I can build SciPy 1.14 with flang 19: https://github.com/conda-forge/scipy-feedstock/pull/269

CC @AnirudhDagar @rgommers @peterbell10 