### PR TITLE
ENH: `stats.differential_entropy`: add array API support

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -387,8 +387,8 @@ def _van_es_entropy(X, m, *, xp):
     n = X.shape[-1]
     difference = X[..., m:] - X[..., :-m]
     term1 = 1/(n-m) * xp.sum(xp.log((n+1)/m * difference), axis=-1)
-    k = xp.arange(m, n+1.)
-    return term1 + xp.sum(1./k) + math.log(m) - math.log(n+1)
+    k = xp.arange(m, n+1, dtype=term1.dtype)
+    return term1 + xp.sum(1/k) + math.log(m) - math.log(n+1)
 
 
 def _ebrahimi_entropy(X, m, *, xp):
@@ -399,7 +399,7 @@ def _ebrahimi_entropy(X, m, *, xp):
 
     differences = X[..., 2 * m:] - X[..., : -2 * m:]
 
-    i = xp.arange(1., n+1, dtype=X.dtype)
+    i = xp.arange(1, n+1, dtype=X.dtype)
     ci = xp.ones_like(i)*2
     ci[i <= m] = 1 + (i[i <= m] - 1)/m
     ci[i >= n - m + 1] = 1 + (n - i[i >= n-m+1])/m

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -366,9 +366,9 @@ def _pad_along_last_axis(X, m, *, xp):
     """Pad the data for computing the rolling window difference."""
     # scales a  bit better than method in _vasicek_like_entropy
     shape = X.shape[:-1] + (m,)
-    Xl = xp.broadcast_to(X[..., [0]], shape)  # [0] vs 0 to maintain shape
-    Xr = xp.broadcast_to(X[..., [-1]], shape)
-    return np.concatenate((Xl, X, Xr), axis=-1)
+    Xl = xp.broadcast_to(X[..., :1], shape)  # :1 vs 0 to maintain shape
+    Xr = xp.broadcast_to(X[..., -1:], shape)
+    return xp.concat((Xl, X, Xr), axis=-1)
 
 
 def _vasicek_entropy(X, m, *, xp):
@@ -387,8 +387,8 @@ def _van_es_entropy(X, m, *, xp):
     n = X.shape[-1]
     difference = X[..., m:] - X[..., :-m]
     term1 = 1/(n-m) * xp.sum(xp.log((n+1)/m * difference), axis=-1)
-    k = xp.arange(m, n+1)
-    return term1 + xp.sum(1/k) + xp.log(m) - xp.log(n+1)
+    k = xp.arange(m, n+1.)
+    return term1 + xp.sum(1./k) + math.log(m) - math.log(n+1)
 
 
 def _ebrahimi_entropy(X, m, *, xp):
@@ -399,7 +399,7 @@ def _ebrahimi_entropy(X, m, *, xp):
 
     differences = X[..., 2 * m:] - X[..., : -2 * m:]
 
-    i = xp.arange(1, n+1).astype(float)
+    i = xp.arange(1., n+1, dtype=X.dtype)
     ci = xp.ones_like(i)*2
     ci[i <= m] = 1 + (i[i <= m] - 1)/m
     ci[i >= n - m + 1] = 1 + (n - i[i >= n-m+1])/m

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 from scipy import special
 from ._axis_nan_policy import _axis_nan_policy_factory, _broadcast_arrays
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_moveaxis_to_end
 
 __all__ = ['entropy', 'differential_entropy']
 
@@ -317,8 +317,9 @@ def differential_entropy(
     >>> plt.title('Entropy Estimator Error (Exponential Distribution)')
 
     """
-    values = np.asarray(values)
-    values = np.moveaxis(values, axis, -1)
+    xp = array_namespace(values)
+    values = xp.asarray(values)
+    values = xp_moveaxis_to_end(values, axis, xp=xp)
     n = values.shape[-1]  # number of observations
 
     if window_length is None:
@@ -333,7 +334,7 @@ def differential_entropy(
     if base is not None and base <= 0:
         raise ValueError("`base` must be a positive number or `None`.")
 
-    sorted_data = np.sort(values, axis=-1)
+    sorted_data = xp.sort(values, axis=-1)
 
     methods = {"vasicek": _vasicek_entropy,
                "van es": _van_es_entropy,
@@ -353,74 +354,73 @@ def differential_entropy(
         else:
             method = 'vasicek'
 
-    res = methods[method](sorted_data, window_length)
+    res = methods[method](sorted_data, window_length, xp=xp)
 
     if base is not None:
-        res /= np.log(base)
+        res /= math.log(base)
 
     return res
 
 
-def _pad_along_last_axis(X, m):
+def _pad_along_last_axis(X, m, *, xp):
     """Pad the data for computing the rolling window difference."""
     # scales a  bit better than method in _vasicek_like_entropy
-    shape = np.array(X.shape)
-    shape[-1] = m
-    Xl = np.broadcast_to(X[..., [0]], shape)  # [0] vs 0 to maintain shape
-    Xr = np.broadcast_to(X[..., [-1]], shape)
+    shape = X.shape[:-1] + (m,)
+    Xl = xp.broadcast_to(X[..., [0]], shape)  # [0] vs 0 to maintain shape
+    Xr = xp.broadcast_to(X[..., [-1]], shape)
     return np.concatenate((Xl, X, Xr), axis=-1)
 
 
-def _vasicek_entropy(X, m):
+def _vasicek_entropy(X, m, *, xp):
     """Compute the Vasicek estimator as described in [6] Eq. 1.3."""
     n = X.shape[-1]
-    X = _pad_along_last_axis(X, m)
+    X = _pad_along_last_axis(X, m, xp=xp)
     differences = X[..., 2 * m:] - X[..., : -2 * m:]
-    logs = np.log(n/(2*m) * differences)
-    return np.mean(logs, axis=-1)
+    logs = xp.log(n/(2*m) * differences)
+    return xp.mean(logs, axis=-1)
 
 
-def _van_es_entropy(X, m):
+def _van_es_entropy(X, m, *, xp):
     """Compute the van Es estimator as described in [6]."""
     # No equation number, but referred to as HVE_mn.
     # Typo: there should be a log within the summation.
     n = X.shape[-1]
     difference = X[..., m:] - X[..., :-m]
-    term1 = 1/(n-m) * np.sum(np.log((n+1)/m * difference), axis=-1)
-    k = np.arange(m, n+1)
-    return term1 + np.sum(1/k) + np.log(m) - np.log(n+1)
+    term1 = 1/(n-m) * xp.sum(xp.log((n+1)/m * difference), axis=-1)
+    k = xp.arange(m, n+1)
+    return term1 + xp.sum(1/k) + xp.log(m) - xp.log(n+1)
 
 
-def _ebrahimi_entropy(X, m):
+def _ebrahimi_entropy(X, m, *, xp):
     """Compute the Ebrahimi estimator as described in [6]."""
     # No equation number, but referred to as HE_mn
     n = X.shape[-1]
-    X = _pad_along_last_axis(X, m)
+    X = _pad_along_last_axis(X, m, xp=xp)
 
     differences = X[..., 2 * m:] - X[..., : -2 * m:]
 
-    i = np.arange(1, n+1).astype(float)
-    ci = np.ones_like(i)*2
+    i = xp.arange(1, n+1).astype(float)
+    ci = xp.ones_like(i)*2
     ci[i <= m] = 1 + (i[i <= m] - 1)/m
     ci[i >= n - m + 1] = 1 + (n - i[i >= n-m+1])/m
 
-    logs = np.log(n * differences / (ci * m))
-    return np.mean(logs, axis=-1)
+    logs = xp.log(n * differences / (ci * m))
+    return xp.mean(logs, axis=-1)
 
 
-def _correa_entropy(X, m):
+def _correa_entropy(X, m, *, xp):
     """Compute the Correa estimator as described in [6]."""
     # No equation number, but referred to as HC_mn
     n = X.shape[-1]
-    X = _pad_along_last_axis(X, m)
+    X = _pad_along_last_axis(X, m, xp=xp)
 
-    i = np.arange(1, n+1)
-    dj = np.arange(-m, m+1)[:, None]
+    i = xp.arange(1, n+1)
+    dj = xp.arange(-m, m+1)[:, None]
     j = i + dj
     j0 = j + m - 1  # 0-indexed version of j
 
-    Xibar = np.mean(X[..., j0], axis=-2, keepdims=True)
+    Xibar = xp.mean(X[..., j0], axis=-2, keepdims=True)
     difference = X[..., j0] - Xibar
-    num = np.sum(difference*dj, axis=-2)  # dj is d-i
-    den = n*np.sum(difference**2, axis=-2)
-    return -np.mean(np.log(num/den), axis=-1)
+    num = xp.sum(difference*dj, axis=-2)  # dj is d-i
+    den = n*xp.sum(difference**2, axis=-2)
+    return -xp.mean(xp.log(num/den), axis=-1)

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -320,7 +320,7 @@ def differential_entropy(
     xp = array_namespace(values)
     values = xp.asarray(values)
     values = xp_moveaxis_to_end(values, axis, xp=xp)
-    n = values.shape[-1]  # number of observations
+    n = values.shape[-1]  # type: ignore[union-attr]
 
     if window_length is None:
         window_length = math.floor(math.sqrt(n) + 0.5)

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -129,6 +129,7 @@ class TestEntropy:
             stats.entropy(x, base=-2)
 
 
+@array_api_compatible
 class TestDifferentialEntropy:
     """
     Vasicek results are compared with the R package vsgoftest.
@@ -140,50 +141,47 @@ class TestDifferentialEntropy:
 
     """
 
-    def test_differential_entropy_vasicek(self):
+    def test_differential_entropy_vasicek(self, xp):
 
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal(100)
 
         entropy = stats.differential_entropy(values, method='vasicek')
-        assert_allclose(entropy, 1.342551, rtol=1e-6)
+        assert_allclose(entropy, 1.342551187000946)
 
         entropy = stats.differential_entropy(values, window_length=1,
                                              method='vasicek')
-        assert_allclose(entropy, 1.122044, rtol=1e-6)
+        assert_allclose(entropy, 1.122044177725947)
 
         entropy = stats.differential_entropy(values, window_length=8,
                                              method='vasicek')
-        assert_allclose(entropy, 1.349401, rtol=1e-6)
+        assert_allclose(entropy, 1.349401487550325)
 
-    def test_differential_entropy_vasicek_2d_nondefault_axis(self):
+    def test_differential_entropy_vasicek_2d_nondefault_axis(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
 
         entropy = stats.differential_entropy(values, axis=1, method='vasicek')
         assert_allclose(
             entropy,
-            [1.342551, 1.341826, 1.293775],
-            rtol=1e-6,
+            [1.342551187000946, 1.341825903922332, 1.293774601883585]
         )
 
         entropy = stats.differential_entropy(values, axis=1, window_length=1,
                                              method='vasicek')
         assert_allclose(
             entropy,
-            [1.122044, 1.102944, 1.129616],
-            rtol=1e-6,
+            [1.122044177725947, 1.10294413850758, 1.129615790292772]
         )
 
         entropy = stats.differential_entropy(values, axis=1, window_length=8,
                                              method='vasicek')
         assert_allclose(
             entropy,
-            [1.349401, 1.338514, 1.292332],
-            rtol=1e-6,
+            [1.349401487550325, 1.338514126301301, 1.292331889365405]
         )
 
-    def test_differential_entropy_raises_value_error(self):
+    def test_differential_entropy_raises_value_error(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
 
@@ -208,7 +206,7 @@ class TestDifferentialEntropy:
                     axis=1,
                 )
 
-    def test_base_differential_entropy_with_axis_0_is_equal_to_default(self):
+    def test_base_differential_entropy_with_axis_0_is_equal_to_default(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((100, 3))
 
@@ -216,7 +214,7 @@ class TestDifferentialEntropy:
         default_entropy = stats.differential_entropy(values)
         assert_allclose(entropy, default_entropy)
 
-    def test_base_differential_entropy_transposed(self):
+    def test_base_differential_entropy_transposed(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
 
@@ -225,7 +223,7 @@ class TestDifferentialEntropy:
             stats.differential_entropy(values, axis=1),
         )
 
-    def test_input_validation(self):
+    def test_input_validation(self, xp):
         x = np.random.rand(10)
 
         message = "`base` must be a positive number or `None`."
@@ -238,7 +236,7 @@ class TestDifferentialEntropy:
 
     @pytest.mark.parametrize('method', ['vasicek', 'van es',
                                         'ebrahimi', 'correa'])
-    def test_consistency(self, method):
+    def test_consistency(self, method, xp):
         # test that method is a consistent estimator
         n = 10000 if method == 'correa' else 1000000
         rvs = stats.norm.rvs(size=n, random_state=0)
@@ -256,7 +254,7 @@ class TestDifferentialEntropy:
 
     @pytest.mark.parametrize('method, expected',
                              list(norm_rmse_std_cases.items()))
-    def test_norm_rmse_std(self, method, expected):
+    def test_norm_rmse_std(self, method, expected, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also
         # tests vectorization.
@@ -280,7 +278,7 @@ class TestDifferentialEntropy:
 
     @pytest.mark.parametrize('method, expected',
                              list(expon_rmse_std_cases.items()))
-    def test_expon_rmse_std(self, method, expected):
+    def test_expon_rmse_std(self, method, expected, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also
         # tests vectorization.
@@ -297,7 +295,7 @@ class TestDifferentialEntropy:
     @pytest.mark.parametrize('n, method', [(8, 'van es'),
                                            (12, 'ebrahimi'),
                                            (1001, 'vasicek')])
-    def test_method_auto(self, n, method):
+    def test_method_auto(self, n, method, xp):
         rvs = stats.norm.rvs(size=(n,), random_state=0)
         res1 = stats.differential_entropy(rvs)
         res2 = stats.differential_entropy(rvs, method=method)

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -3,11 +3,11 @@ import pytest
 from pytest import raises as assert_raises
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from scipy import stats
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_close, xp_assert_equal, xp_assert_less
+from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
+                                   is_jax, is_array_api_strict, array_namespace)
 
 class TestEntropy:
     @array_api_compatible
@@ -130,6 +130,7 @@ class TestEntropy:
 
 
 @array_api_compatible
+@pytest.mark.usefixtures("skip_xp_backends")
 class TestDifferentialEntropy:
     """
     Vasicek results are compared with the R package vsgoftest.
@@ -145,45 +146,43 @@ class TestDifferentialEntropy:
 
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal(100)
+        values = xp.asarray(values.tolist())
 
         entropy = stats.differential_entropy(values, method='vasicek')
-        assert_allclose(entropy, 1.342551187000946)
+        xp_assert_close(entropy, xp.asarray(1.342551187000946))
 
         entropy = stats.differential_entropy(values, window_length=1,
                                              method='vasicek')
-        assert_allclose(entropy, 1.122044177725947)
+        xp_assert_close(entropy, xp.asarray(1.122044177725947))
 
         entropy = stats.differential_entropy(values, window_length=8,
                                              method='vasicek')
-        assert_allclose(entropy, 1.349401487550325)
+        xp_assert_close(entropy, xp.asarray(1.349401487550325))
 
     def test_differential_entropy_vasicek_2d_nondefault_axis(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
+        values = xp.asarray(values.tolist())
 
         entropy = stats.differential_entropy(values, axis=1, method='vasicek')
-        assert_allclose(
-            entropy,
-            [1.342551187000946, 1.341825903922332, 1.293774601883585]
-        )
+        ref = xp.asarray([1.342551187000946, 1.341825903922332, 1.293774601883585])
+        xp_assert_close(entropy, ref)
 
         entropy = stats.differential_entropy(values, axis=1, window_length=1,
                                              method='vasicek')
-        assert_allclose(
-            entropy,
-            [1.122044177725947, 1.10294413850758, 1.129615790292772]
-        )
+        ref = xp.asarray([1.122044177725947, 1.10294413850758, 1.129615790292772])
+        xp_assert_close(entropy, ref)
 
         entropy = stats.differential_entropy(values, axis=1, window_length=8,
                                              method='vasicek')
-        assert_allclose(
-            entropy,
-            [1.349401487550325, 1.338514126301301, 1.292331889365405]
-        )
+        ref = xp.asarray([1.349401487550325, 1.338514126301301, 1.292331889365405])
+        xp_assert_close(entropy, ref)
+
 
     def test_differential_entropy_raises_value_error(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
+        values = xp.asarray(values.tolist())
 
         error_str = (
             r"Window length \({window_length}\) must be positive and less "
@@ -206,25 +205,32 @@ class TestDifferentialEntropy:
                     axis=1,
                 )
 
+    @pytest.mark.skip_xp_backends('jax.numpy',
+                                  reason=["JAX doesn't support item assignment"])
     def test_base_differential_entropy_with_axis_0_is_equal_to_default(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((100, 3))
+        values = xp.asarray(values.tolist())
 
         entropy = stats.differential_entropy(values, axis=0)
         default_entropy = stats.differential_entropy(values)
-        assert_allclose(entropy, default_entropy)
+        xp_assert_close(entropy, default_entropy)
 
+    @pytest.mark.skip_xp_backends('jax.numpy',
+                                  reason=["JAX doesn't support item assignment"])
     def test_base_differential_entropy_transposed(self, xp):
         random_state = np.random.RandomState(0)
         values = random_state.standard_normal((3, 100))
+        values = xp.asarray(values.tolist())
 
-        assert_allclose(
-            stats.differential_entropy(values.T).T,
+        xp_assert_close(
+            stats.differential_entropy(values.T),
             stats.differential_entropy(values, axis=1),
         )
 
     def test_input_validation(self, xp):
         x = np.random.rand(10)
+        x = xp.asarray(x.tolist())
 
         message = "`base` must be a positive number or `None`."
         with pytest.raises(ValueError, match=message):
@@ -237,12 +243,17 @@ class TestDifferentialEntropy:
     @pytest.mark.parametrize('method', ['vasicek', 'van es',
                                         'ebrahimi', 'correa'])
     def test_consistency(self, method, xp):
+        if is_jax(xp) and method == 'ebrahimi':
+            pytest.xfail("Needs array assignment.")
+        elif is_array_api_strict(xp) and method == 'correa':
+            pytest.xfail("Needs fancy indexing.")
         # test that method is a consistent estimator
         n = 10000 if method == 'correa' else 1000000
         rvs = stats.norm.rvs(size=n, random_state=0)
-        expected = stats.norm.entropy()
+        rvs = xp.asarray(rvs.tolist())
+        expected = xp.asarray(float(stats.norm.entropy()))
         res = stats.differential_entropy(rvs, method=method)
-        assert_allclose(res, expected, rtol=0.005)
+        xp_assert_close(res, expected, rtol=0.005)
 
     # values from differential_entropy reference [6], table 1, n=50, m=7
     norm_rmse_std_cases = {  # method: (RMSE, STD)
@@ -252,22 +263,6 @@ class TestDifferentialEntropy:
                            'ebrahimi': (0.128, 0.109)
                            }
 
-    @pytest.mark.parametrize('method, expected',
-                             list(norm_rmse_std_cases.items()))
-    def test_norm_rmse_std(self, method, expected, xp):
-        # test that RMSE and standard deviation of estimators matches values
-        # given in differential_entropy reference [6]. Incidentally, also
-        # tests vectorization.
-        reps, n, m = 10000, 50, 7
-        rmse_expected, std_expected = expected
-        rvs = stats.norm.rvs(size=(reps, n), random_state=0)
-        true_entropy = stats.norm.entropy()
-        res = stats.differential_entropy(rvs, window_length=m,
-                                         method=method, axis=-1)
-        assert_allclose(np.sqrt(np.mean((res - true_entropy)**2)),
-                        rmse_expected, atol=0.005)
-        assert_allclose(np.std(res), std_expected, atol=0.002)
-
     # values from differential_entropy reference [6], table 2, n=50, m=7
     expon_rmse_std_cases = {  # method: (RMSE, STD)
                             'vasicek': (0.194, 0.148),
@@ -276,27 +271,41 @@ class TestDifferentialEntropy:
                             'ebrahimi': (0.151, 0.148)
                             }
 
-    @pytest.mark.parametrize('method, expected',
-                             list(expon_rmse_std_cases.items()))
-    def test_expon_rmse_std(self, method, expected, xp):
+    rmse_std_cases = {stats.norm: norm_rmse_std_cases,
+                      stats.expon: expon_rmse_std_cases}
+
+    @pytest.mark.parametrize('method', ['vasicek', 'van es', 'ebrahimi', 'correa'])
+    @pytest.mark.parametrize('dist', [stats.norm, stats.expon])
+    def test_norm_rmse_std(self, method, dist, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also
         # tests vectorization.
+        if is_jax(xp) and method == 'ebrahimi':
+            pytest.xfail("Needs array assignment.")
+        elif is_array_api_strict(xp) and method == 'correa':
+            pytest.xfail("Needs fancy indexing.")
+
         reps, n, m = 10000, 50, 7
-        rmse_expected, std_expected = expected
-        rvs = stats.expon.rvs(size=(reps, n), random_state=0)
-        true_entropy = stats.expon.entropy()
+        expected = self.rmse_std_cases[dist][method]
+        rmse_expected, std_expected = xp.asarray(expected[0]), xp.asarray(expected[1])
+        rvs = dist.rvs(size=(reps, n), random_state=0)
+        rvs = xp.asarray(rvs.tolist())
+        true_entropy = xp.asarray(float(dist.entropy()))
         res = stats.differential_entropy(rvs, window_length=m,
                                          method=method, axis=-1)
-        assert_allclose(np.sqrt(np.mean((res - true_entropy)**2)),
+        xp_assert_close(xp.sqrt(xp.mean((res - true_entropy)**2)),
                         rmse_expected, atol=0.005)
-        assert_allclose(np.std(res), std_expected, atol=0.002)
+        xp_test = array_namespace(res)
+        xp_assert_close(xp_test.std(res, correction=0), std_expected, atol=0.002)
 
     @pytest.mark.parametrize('n, method', [(8, 'van es'),
                                            (12, 'ebrahimi'),
                                            (1001, 'vasicek')])
     def test_method_auto(self, n, method, xp):
+        if is_jax(xp) and method == 'ebrahimi':
+            pytest.xfail("Needs array assignment.")
         rvs = stats.norm.rvs(size=(n,), random_state=0)
+        rvs = xp.asarray(rvs.tolist())
         res1 = stats.differential_entropy(rvs)
         res2 = stats.differential_entropy(rvs, method=method)
-        assert res1 == res2
+        xp_assert_equal(res1, res2)

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -276,7 +276,7 @@ class TestDifferentialEntropy:
 
     @pytest.mark.parametrize('method', ['vasicek', 'van es', 'ebrahimi', 'correa'])
     @pytest.mark.parametrize('dist', [stats.norm, stats.expon])
-    def test_norm_rmse_std(self, method, dist, xp):
+    def test_rmse_std(self, method, dist, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also
         # tests vectorization.

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -5,6 +5,7 @@ from pytest import raises as assert_raises
 import numpy as np
 
 from scipy import stats
+from scipy.stats import norm, expon  # type: ignore[attr-defined]
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
                                    is_jax, is_array_api_strict, array_namespace)
@@ -271,11 +272,11 @@ class TestDifferentialEntropy:
                             'ebrahimi': (0.151, 0.148)
                             }
 
-    rmse_std_cases = {stats.norm: norm_rmse_std_cases,
-                      stats.expon: expon_rmse_std_cases}
+    rmse_std_cases = {norm: norm_rmse_std_cases,
+                      expon: expon_rmse_std_cases}
 
     @pytest.mark.parametrize('method', ['vasicek', 'van es', 'ebrahimi', 'correa'])
-    @pytest.mark.parametrize('dist', [stats.norm, stats.expon])
+    @pytest.mark.parametrize('dist', [norm, expon])
     def test_rmse_std(self, method, dist, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `differential_entropy`. 

#### Additional information
Turned out pretty clean, I think.