### PR TITLE
BLD: Enable `open_memstream()` on newer glibc

### DIFF
--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -87,7 +87,7 @@ py3.extension_module('_test_deprecation_def',
 conf_memstream = configuration_data()
 
 if meson.get_compiler('c').has_function('open_memstream',
-                                        prefix: '#include <stdio.h>')
+                                        prefix: '#define _POSIX_C_SOURCE 200809L\n#include <stdio.h>')
   conf_memstream.set('has_openmemstream', '1')
 else
   conf_memstream.set('has_openmemstream', '0')


### PR DESCRIPTION
On glibc >= 2.10, if -std=c17 is set and no feature test macros are set, glibc will not define an open_memstream definition. musl has similar behavior. This causes SciPy to unnecessarily open a temporary file, when capturing the error stream could have been done in memory.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #19911 and #21079

#### What does this implement/fix?

This fixes a feature detection step within meson. By defining a feature test macro before importing stdio.h, `open_memstream()` will be available on platforms that support it.

#### Additional information
<!--Any additional information you think is important.-->

Issue #19911 suggests using `_DEFAULT_SOURCE`, however, I could not get the feature detection to work using that define. Alternatively, I could have used `_GNU_SOURCE`, but this seemed more conservative.