### PR TITLE
DOC: spatial: Fix typo in `seuclidean` docstring

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -915,7 +915,7 @@ def seuclidean(u, v, V):
         Input array.
     V : (N,) array_like
         `V` is an 1-D array of component variances. It is usually computed
-        among a larger collection vectors.
+        among a larger collection of vectors.
 
     Returns
     -------


### PR DESCRIPTION
"...collection _of_ vectors..."

[skip ci]
