### PR TITLE
DOC: sparse.linalg.gcrotmk : Typeset code objects in docstring

### DIFF
--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -205,14 +205,14 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
     M : {sparse matrix, ndarray, LinearOperator}, optional
-        Preconditioner for A.  The preconditioner should approximate the
-        inverse of A. gcrotmk is a 'flexible' algorithm and the preconditioner
+        Preconditioner for ``A``.  The preconditioner should approximate the
+        inverse of ``A``. gcrotmk is a 'flexible' algorithm and the preconditioner
         can vary from iteration to iteration. Effective preconditioning
         dramatically improves the rate of convergence, which implies that
         fewer iterations are needed to reach a given error tolerance.
     callback : function, optional
         User-supplied function to call after each iteration.  It is called
-        as callback(xk), where xk is the current solution vector.
+        as ``callback(xk)``, where xk is the current solution vector.
     m : int, optional
         Number of inner FGMRES iterations per each outer iteration.
         Default: 20

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -212,7 +212,7 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
         fewer iterations are needed to reach a given error tolerance.
     callback : function, optional
         User-supplied function to call after each iteration.  It is called
-        as ``callback(xk)``, where xk is the current solution vector.
+        as ``callback(xk)``, where ``xk`` is the current solution vector.
     m : int, optional
         Number of inner FGMRES iterations per each outer iteration.
         Default: 20


### PR DESCRIPTION
Corrected the typesetting of code objects in the gcrotmk documentation. Ensured that 'A' in the parameter description for 'M' and 'callback(xk)' in the description of 'callback' are properly formatted as code.