### PR TITLE
DEV: don't add `sparse` label for submodules

### DIFF
--- a/.github/label-globs.yml
+++ b/.github/label-globs.yml
@@ -73,8 +73,11 @@ scipy.signal:
 
 scipy.sparse:
 - changed-files:
-  - any-glob-to-any-file:
+  - all-globs-to-any-file:
     - scipy/sparse/**
+    # don't match the `csgraph` or `linalg` submodules
+    - '!scipy/sparse/csgraph/**'
+    - '!scipy/sparse/linalg/**'
 
 scipy.sparse.csgraph:
 - changed-files:


### PR DESCRIPTION
@rgommers I noticed you removed the label in gh-21096. This was something I wasn't sure about when adding the globs, but happy to change it now.