### PR TITLE
DOC: special.ellipj: fix order of parameters in docstring

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2306,8 +2306,8 @@ add_newdoc("ellipj",
 
             sn(u|m), cn(u|m), dn(u|m)
 
-        The value `ph` is such that if `u = ellipkinc(ph, m)`,
-        then `sn(u|m) = sin(ph)` and `cn(u|m) = cos(ph)`.
+        The value `ph` is such that if ``u = ellipkinc(ph, m)``,
+        then ``sn(u|m) = sin(ph)`` and ``cn(u|m) = cos(ph)``.
 
     See Also
     --------
@@ -2316,18 +2316,18 @@ add_newdoc("ellipj",
 
     Notes
     -----
-    Wrapper for the Cephes [1]_ routine `ellpj`.
+    Wrapper for the Cephes [1]_ routine ``ellpj``.
 
     These functions are periodic, with quarter-period on the real axis
-    equal to the complete elliptic integral `ellipk(m)`.
+    equal to the complete elliptic integral ``ellipk(m)``.
 
-    Relation to incomplete elliptic integral: If `u = ellipkinc(phi,m)`, then
-    `sn(u|m) = sin(phi)`, and `cn(u|m) = cos(phi)`. The `phi` is called
-    the amplitude of `u`.
+    Relation to incomplete elliptic integral: If ``u = ellipkinc(phi,m)``, then
+    ``sn(u|m) = sin(phi)``, and ``cn(u|m) = cos(phi)``. The ``phi`` is called
+    the amplitude of ``u``.
 
     Computation is by means of the arithmetic-geometric mean algorithm,
     except when `m` is within 1e-9 of 0 or 1. In the latter case with `m`
-    close to 1, the approximation applies only for `phi < pi/2`.
+    close to 1, the approximation applies only for ``phi < pi/2``.
 
     References
     ----------

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2323,7 +2323,7 @@ add_newdoc("ellipj",
 
     Relation to incomplete elliptic integral: If ``u = ellipkinc(phi,m)``, then
     ``sn(u|m) = sin(phi)``, and ``cn(u|m) = cos(phi)``. The ``phi`` is called
-    the amplitude of ``u``.
+    the amplitude of `u`.
 
     Computation is by means of the arithmetic-geometric mean algorithm,
     except when `m` is within 1e-9 of 0 or 1. In the latter case with `m`

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2292,10 +2292,10 @@ add_newdoc("ellipj",
 
     Parameters
     ----------
-    m : array_like
-        Parameter.
     u : array_like
         Argument.
+    m : array_like
+        Parameter.
     out : tuple of ndarray, optional
         Optional output arrays for the function values
 


### PR DESCRIPTION
The updates parameters to be in the order of the function signature. Double-checked against the definition in `special_wrappers.h`.