### PR TITLE
MAINT: itemsize pybind cleanup

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -221,8 +221,7 @@ ArrayDescriptor get_descriptor(const py::array& arr) {
     const auto arr_shape = arr.shape();
     desc.shape.assign(arr_shape, arr_shape + ndim);
 
-    // TODO: Replace the following with `arr.itemsize()` this is a temporary workaround:
-    desc.element_size = PyArray_ITEMSIZE(reinterpret_cast<PyArrayObject *>(arr.ptr()));
+    desc.element_size = arr.itemsize();
     const auto arr_strides = arr.strides();
     desc.strides.assign(arr_strides, arr_strides + ndim);
     for (intptr_t i = 0; i < ndim; ++i) {


### PR DESCRIPTION
* Related to some of the complex discussion at: https://github.com/pybind/pybind11/issues/5009

* It seems we are lower bounded by a recent enough `pybind11` in `pyproject.toml` that it should now be safe to clean this up. Full testsuite passed locally with NumPy 1.x and 2.x from clean build slate.

[skip circle] [skip cirrus]