### PR TITLE
MAINT: Unskip `scipy.misc.test.test_decorator` for Python 3.13+

### DIFF
--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -72,7 +72,6 @@ def test_docformat():
 
 
 @pytest.mark.skipif(DOCSTRINGS_STRIPPED, reason="docstrings stripped")
-@pytest.mark.skipif(sys.version_info >= (3, 13), reason='it fails on Py3.13')
 def test_decorator():
     with suppress_warnings() as sup:
         sup.filter(category=DeprecationWarning)
@@ -84,23 +83,31 @@ def test_decorator():
             """ Docstring
             %(strtest3)s
             """
-        assert_equal(func.__doc__, """ Docstring
+
+        def expected():
+            """ Docstring
             Another test
                with some indent
-            """)
+            """
+        assert_equal(func.__doc__, expected.__doc__)
 
         # without unindentation of parameters
-        decorator = doccer.filldoc(doc_dict, False)
+
+        # The docstring should be unindented for Python 3.13+
+        # because of https://github.com/python/cpython/issues/81283
+        decorator = doccer.filldoc(doc_dict, False if sys.version_info < (3, 13) else True)
 
         @decorator
         def func():
             """ Docstring
             %(strtest3)s
             """
-        assert_equal(func.__doc__, """ Docstring
+        def expected():
+            """ Docstring
                 Another test
                    with some indent
-            """)
+            """
+        assert_equal(func.__doc__, expected.__doc__)
 
 
 @pytest.mark.skipif(DOCSTRINGS_STRIPPED, reason="docstrings stripped")

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -95,7 +95,8 @@ def test_decorator():
 
         # The docstring should be unindented for Python 3.13+
         # because of https://github.com/python/cpython/issues/81283
-        decorator = doccer.filldoc(doc_dict, False if sys.version_info < (3, 13) else True)
+        decorator = doccer.filldoc(doc_dict, False if \
+                                   sys.version_info < (3, 13) else True)
 
         @decorator
         def func():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/19572

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
