### PR TITLE
DOC: add release note for 1.14 sparse section about sparse array iteration

### DIFF
--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -88,6 +88,7 @@ New features
 - Sparse array methods min/nanmin/argmin and max analogs now return 1D arrays.
   Results are still COO format sparse arrays for min/nanmin and
   dense ``np.ndarray`` for argmin.
+- Iterating over ``csr_array`` or ``csc_array`` yields 1D (CSC) arrays.
 - Sparse matrix and array objects improve their ``repr`` and ``str`` output.
 - A special case has been added to handle multiplying a ``dia_array`` by a
   scalar, which avoids a potentially costly conversion to CSR format.


### PR DESCRIPTION
In the release notes for v1.14, this PR adds an item regarding iterating over csr_arrays.
I've been asked about that issue so figured others might look for a note about it here.
