### PR TITLE
BUG: sparse: fix 1D for vstack/hstack and Improve 1D error msgs in h/v-stacks/kron/kronsum

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -577,9 +577,9 @@ def kronsum(A, B, format=None):
     B = coo_sparse(B)
 
     if A.ndim != 2:
-        raise ValueError("A is not 2D")
+        raise ValueError(f"kronsum requires 2D inputs. `A` is {A.ndim}D.")
     if B.ndim != 2:
-        raise ValueError("B is not 2D")
+        raise ValueError(f"kronsum requires 2D inputs. `B` is {B.ndim}D.")
     if A.shape[0] != A.shape[1]:
         raise ValueError('A is not square')
     if B.shape[0] != B.shape[1]:

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -487,10 +487,14 @@ def kron(A, B, format=None):
         coo_sparse = coo_matrix
 
     B = coo_sparse(B)
+    if B.ndim != 2:
+        raise ValueError(f"kron requires 2D input arrays. `B` is {B.ndim}D.")
 
     # B is fairly dense, use BSR
     if (format is None or format == "bsr") and 2*B.nnz >= B.shape[0] * B.shape[1]:
         A = csr_sparse(A,copy=True)
+        if A.ndim != 2:
+            raise ValueError(f"kron requires 2D input arrays. `A` is {A.ndim}D.")
         output_shape = (A.shape[0]*B.shape[0], A.shape[1]*B.shape[1])
 
         if A.nnz == 0 or B.nnz == 0:
@@ -505,6 +509,8 @@ def kron(A, B, format=None):
     else:
         # use COO
         A = coo_sparse(A)
+        if A.ndim != 2:
+            raise ValueError(f"kron requires 2D input arrays. `A` is {A.ndim}D.")
         output_shape = (A.shape[0]*B.shape[0], A.shape[1]*B.shape[1])
 
         if A.nnz == 0 or B.nnz == 0:
@@ -570,9 +576,12 @@ def kronsum(A, B, format=None):
     A = coo_sparse(A)
     B = coo_sparse(B)
 
+    if A.ndim != 2:
+        raise ValueError("A is not 2D")
+    if B.ndim != 2:
+        raise ValueError("B is not 2D")
     if A.shape[0] != A.shape[1]:
         raise ValueError('A is not square')
-
     if B.shape[0] != B.shape[1]:
         raise ValueError('B is not square')
 
@@ -940,19 +949,19 @@ def _block(blocks, format, dtype, return_spmatrix=False):
                 block_mask[i,j] = True
 
                 if brow_lengths[i] == 0:
-                    brow_lengths[i] = A.shape[0]
-                elif brow_lengths[i] != A.shape[0]:
+                    brow_lengths[i] = A._shape_as_2d[0]
+                elif brow_lengths[i] != A._shape_as_2d[0]:
                     msg = (f'blocks[{i},:] has incompatible row dimensions. '
-                           f'Got blocks[{i},{j}].shape[0] == {A.shape[0]}, '
+                           f'Got blocks[{i},{j}].shape[0] == {A._shape_as_2d[0]}, '
                            f'expected {brow_lengths[i]}.')
                     raise ValueError(msg)
 
                 if bcol_lengths[j] == 0:
-                    bcol_lengths[j] = A.shape[1]
-                elif bcol_lengths[j] != A.shape[1]:
+                    bcol_lengths[j] = A._shape_as_2d[1]
+                elif bcol_lengths[j] != A._shape_as_2d[1]:
                     msg = (f'blocks[:,{j}] has incompatible column '
                            f'dimensions. '
-                           f'Got blocks[{i},{j}].shape[1] == {A.shape[1]}, '
+                           f'Got blocks[{i},{j}].shape[1] == {A._shape_as_2d[1]}, '
                            f'expected {bcol_lengths[j]}.')
                     raise ValueError(msg)
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -389,6 +389,14 @@ class TestConstructUtils:
         assert_array_equal(result.toarray(), expected)
         assert isinstance(result, spmatrix)
 
+    def test_kron_ndim_exceptions(self):
+        with pytest.raises(ValueError, match='requires 2D input'):
+            construct.kron([[0], [1]], csr_array([0, 1]))
+        with pytest.raises(ValueError, match='requires 2D input'):
+            construct.kron(csr_array([0, 1]), [[0], [1]])
+        # no exception if sparse arrays are not input (spmatrix inferred)
+        construct.kron([[0], [1]], [0, 1])
+
     def test_kron_large(self):
         n = 2**16
         a = construct.diags_array([1], shape=(1, n), offsets=n-1)
@@ -420,6 +428,14 @@ class TestConstructUtils:
         # check that spmatrix returned when both inputs are spmatrix
         result = construct.kronsum(csr_matrix(a), csr_matrix(b)).toarray()
         assert_array_equal(result, expected)
+
+    def test_kronsum_ndim_exceptions(self):
+        with pytest.raises(ValueError, match='is not 2D'):
+            construct.kronsum([[0], [1]], csr_array([0, 1]))
+        with pytest.raises(ValueError, match='is not 2D'):
+            construct.kronsum(csr_array([0, 1]), [[0], [1]])
+        # no exception if sparse arrays are not input (spmatrix inferred)
+        construct.kronsum([[0, 1], [1, 0]], [2])
 
     @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
     def test_vstack(self, coo_cls):
@@ -458,6 +474,19 @@ class TestConstructUtils:
         assert isinstance(construct.vstack([coo_array(A), coo_matrix(B)]), sparray)
         assert isinstance(construct.vstack([coo_matrix(A), coo_array(B)]), sparray)
         assert isinstance(construct.vstack([coo_matrix(A), coo_matrix(B)]), spmatrix)
+
+    def test_vstack_1d_with_2d(self):
+        # fixes gh-21064
+        arr = csr_array([[1, 0, 0], [0, 1, 0]])
+        arr1d = arr[0]
+        assert construct.vstack([arr, np.array([0, 0, 0])]).shape == (3, 3)
+        assert construct.hstack([arr1d, np.array([[0]])]).shape == (1, 4)
+        assert construct.vstack([arr1d, arr1d]).shape == (2, 3)
+
+        with pytest.raises(ValueError, match="incompatible row dimensions"):
+            construct.hstack([arr, np.array([0, 0])])
+        with pytest.raises(ValueError, match="incompatible column dimensions"):
+            construct.vstack([arr, np.array([0, 0])])
 
     @pytest.mark.parametrize("coo_cls", [coo_matrix, coo_array])
     def test_hstack(self, coo_cls):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -430,9 +430,9 @@ class TestConstructUtils:
         assert_array_equal(result, expected)
 
     def test_kronsum_ndim_exceptions(self):
-        with pytest.raises(ValueError, match='is not 2D'):
+        with pytest.raises(ValueError, match='requires 2D input'):
             construct.kronsum([[0], [1]], csr_array([0, 1]))
-        with pytest.raises(ValueError, match='is not 2D'):
+        with pytest.raises(ValueError, match='requires 2D input'):
             construct.kronsum(csr_array([0, 1]), [[0], [1]])
         # no exception if sparse arrays are not input (spmatrix inferred)
         construct.kronsum([[0, 1], [1, 0]], [2])


### PR DESCRIPTION
Fixes #21064 

Some construction functions (like hstack and vstack) do not handle 1D input well for some formats. The shape was assumed to be 2D and not checked for 1D. This PR:
- adds tests for these cases, 
- adds tests for better error messages in functions `kron` and `kronsum` when 1D input it used, 
- fixes ndim/shape related errors in `_construct.py` by using `_shape_as_2d` where needed

This might be too late, but if possible, it would be good to get this into 1.14.1. @tylerjereddy 