### PR TITLE
MAINT: `stats.combine_pvalues`: fix native `axis` support for `method='stouffer'`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9375,7 +9375,10 @@ def combine_pvalues(pvalues, method='fisher', weights=None, *, axis=0):
 
         norm = _SimpleNormal()
         Zi = norm.isf(pvalues)
-        statistic = weights @ Zi / xp.linalg.vector_norm(weights, axis=axis)
+        # could use `einsum` or clever `matmul` for performance,
+        # but this is the most readable
+        statistic = (xp.sum(weights * Zi, axis=axis)
+                     / xp.linalg.vector_norm(weights, axis=axis))
         pval = _get_pvalue(statistic, norm, alternative="greater", xp=xp)
 
     else:

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -56,6 +56,11 @@ def xp_var(*args, **kwargs):
     return stats._stats_py._xp_var(*args, **kwargs)
 
 
+def combine_pvalues_weighted(*args, **kwargs):
+    return stats.combine_pvalues(args[0], *args[2:], weights=args[1],
+                                 method='stouffer', **kwargs)
+
+
 axis_nan_policy_cases = [
     # function, args, kwds, number of samples, number of outputs,
     # ... paired, unpacker function
@@ -131,6 +136,7 @@ axis_nan_policy_cases = [
     (stats.alexandergovern, tuple(), {}, 2, 2, False,
      lambda res: (res.statistic, res.pvalue)),
     (stats.combine_pvalues, tuple(), {}, 1, 2, False, None),
+    (combine_pvalues_weighted, tuple(), {}, 2, 2, True, None),
     (xp_mean_1samp, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (xp_mean_2samp, tuple(), dict(), 2, 1, True, lambda x: (x,)),
     (xp_var, tuple(), dict(), 1, 1, False, lambda x: (x,)),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8099,19 +8099,19 @@ class TestCombinePvalues:
         rng = np.random.default_rng(234892349810482)
         x = xp.asarray(rng.random(size=(2, 10)))
         x = x.T if (axis == 0) else x
-        res = stats.combine_pvalues(x, axis=axis)
+        res = stats.combine_pvalues(x, axis=axis, method=method)
 
         if axis is None:
             x = xp.reshape(x, (-1,))
-            ref = stats.combine_pvalues(x)
+            ref = stats.combine_pvalues(x, method=method)
             xp_assert_close(res.statistic, ref.statistic)
             xp_assert_close(res.pvalue, ref.pvalue)
             return
 
         x = x.T if (axis == 0) else x
         x0, x1 = x[0, :], x[1, :]
-        ref0 = stats.combine_pvalues(x0)
-        ref1 = stats.combine_pvalues(x1)
+        ref0 = stats.combine_pvalues(x0, method=method)
+        ref1 = stats.combine_pvalues(x1, method=method)
 
         xp_assert_close(res.statistic[0], ref0.statistic)
         xp_assert_close(res.statistic[1], ref1.statistic)


### PR DESCRIPTION
#### Reference issue
Closes gh-21106

#### What does this implement/fix?
gh-21106 reported that `stats.combine_pvalues` with `method='stouffer'` was not working properly for n-D inputs after `axis` support was added to the function itself (rather than relying on the `axis-nan_policy` decorator). The problem was that an `@`, which was used for vector-vector dot product in the original code, was left alone for n-D arrays, whereas it should have been changed to do batched vector-vector dot products. This wasn't caught by the tests: even though the test of `axis` was `parametrize`d over all methods, the `method` argument was not passed into `combine_pvalues`, so the test was being run multiple times with `method='fisher'`.

To fix this:
- I changed `@` to do an explicit elementwise products followed by `sum` along `axis`. `einsum` (and even a trick with `matmul` might be more efficient, but this is simple, readable, and far faster than the looping that was done in 1.14)
- I corrected the test of `axis` to pass `method` into `combine_pvalues`
- I added a test of `combine_pvalues` with `method='stouffer'` and explicit `weight` argument to `test_axis_nan_policy.py`, since the exist test does not check the behavior with explicit n-D `weight` arrays.

#### Additional information
Fortunately, no backport is needed since the problem is new in `main` only. Thanks for catching it early @michaelpradel!