### PR TITLE
BUG: `ndimage.binary_erosion`: avoid divide by zero by capping `block_size` at size

### DIFF
--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -146,7 +146,11 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
         _false = 0;
     }
     if (coordinate_list) {
-        block_size = LIST_SIZE / PyArray_NDIM(input) / sizeof(int);
+	if(PyArray_NDIM(input) != 0) {
+            block_size = LIST_SIZE / PyArray_NDIM(input) / sizeof(int);
+	} else {
+	    block_size = size;
+	}
         if (block_size < 1)
             block_size = 1;
         if (block_size > size)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1694,6 +1694,12 @@ class TestNdimageMorphology:
                                       origin=(1, 1), border_value=1)
         assert_array_almost_equal(out, expected)
 
+    def test_binary_dilation36(self):
+        # gh-21009
+        data = np.zeros([], bool)
+        out = ndimage.binary_dilation(data, iterations=-1)
+        assert_array_almost_equal(out, 0)
+
     def test_binary_propagation01(self):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1750,6 +1756,13 @@ class TestNdimageMorphology:
         data = np.zeros(mask.shape, bool)
         out = ndimage.binary_propagation(data, struct,
                                          mask=mask, border_value=1)
+        assert_array_almost_equal(out, expected)
+
+    def test_binary_propagation03(self):
+        # gh-21009
+        data = np.zeros([], bool)
+        expected = np.zeros([], bool)
+        out = ndimage.binary_propagation(data)
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)


### PR DESCRIPTION
If the user passes a 0-dimensional input, a non-zero structuring element, and an iterations of -1, then the block_size calculation will have a divide by zero, causing a crash.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #21009

#### What does this implement/fix?

This change caps the maximum value of `block_size` at `size`, even when we have zero dimensions.

I also added two tests for this behavior.

My logic for doing this is the code right beneath this is also capping `block_size` at `size`:

```
        if (block_size < 1)
            block_size = 1;
        if (block_size > size)
            block_size = size;
```

So it should be safe to use `size` as `block_size`.

Here are two examples of code that crashes without this fix:

```
from scipy import ndimage

ndimage.binary_propagation(None)
```

```
from scipy import ndimage
import numpy

ndimage.binary_propagation(numpy.array(1))
```
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
