### PR TITLE
DOC: `optimize.differential_evolution`: fix interval for `mutation`

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -111,7 +111,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     mutation : float or tuple(float, float), optional
         The mutation constant. In the literature this is also known as
         differential weight, being denoted by :math:`F`.
-        If specified as a float it should be in the range [0, 2].
+        If specified as a float it should be in the range [0, 2).
         If specified as a tuple ``(min, max)`` dithering is employed. Dithering
         randomly changes the mutation constant on a generation by generation
         basis. The mutation constant for that generation is taken from


### PR DESCRIPTION
#### Reference issue
<!--Modification in documentation-->

#### What does this implement/fix?
<!--Change in the documentation-->

#### Additional information
<!--In the diffrenetial_evolution algorithm, mutation should be between [0,2) not [0,2]-->
