### PR TITLE
BENCH: Corrections to benchmarks README and `sparse.Arithmetic` benchmark

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -19,11 +19,11 @@ development version of SciPy to your current Python environment.
 Run a benchmark against currently checked-out SciPy version (don't record the
 result)::
 
-    python dev.py bench sparse.Arithmetic
+    python dev.py bench --submodule sparse.Arithmetic
 
 Compare change in benchmark results with another branch::
 
-    python dev.py bench-compare main sparse.Arithmetic
+    python dev.py bench --compare main --submodule sparse.Arithmetic
 
 Run ASV commands directly (note, this will not set env vars for ``ccache``
 and disabling BLAS/LAPACK multi-threading, as ``dev.py`` does)::

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -57,8 +57,8 @@ class Arithmetic(Benchmark):
     ]
 
     def setup(self, format, XY, op):
-        matrices = dict(A=poisson2d(250, format=format),
-                        B=poisson2d(250, format=format)**2)
+        matrices = dict(A=poisson2d(250, format=format))
+        matrices['B'] = (matrices['A']**2).asformat(format)
 
         x = matrices[XY[0]]
         self.y = matrices[XY[1]]


### PR DESCRIPTION
#### Reference issue
None (discovered during work on #21039).

#### What does this implement/fix?
1. The outdated syntax for `dev.py` in benchmarks README is corrected.
2. `sparse.Arithmetic` benchmark was creating one of its test matrices my squaring the other one, which in case of COO and DIA formats implicitly converted it to CSR, thus rendering most results for these formats meaningless. Now it is explicitly cast to the original format.

#### Additional information
Example output before:
```
sparse.Arithmetic.time_arithmetic
======== ==== ========== ========== ========== ==========
--                                 op                    
------------- -------------------------------------------
 format   XY   __add__    __sub__    multiply   __mul__  
======== ==== ========== ========== ========== ==========
  csr     AA   2.01±0ms   1.15±0ms   2.05±0ms   10.1±0ms 
  csr     AB   7.00±0ms   6.99±0ms   6.76±0ms   20.2±0ms 
  csr     BA   6.98±0ms   6.79±0ms   6.51±0ms   24.1±0ms 
  csr     BB   7.08±0ms   5.26±0ms   7.11±0ms   44.9±0ms 
  csc     AA   3.57±0ms   2.80±0ms   3.55±0ms   10.1±0ms 
  csc     AB   6.55±0ms   6.74±0ms   7.39±0ms   24.2±0ms 
  csc     BA   6.56±0ms   6.53±0ms   7.10±0ms   20.5±0ms 
  csc     BB   7.17±0ms   5.71±0ms   7.18±0ms   42.9±0ms 
  coo     AA   18.1±0ms   16.5±0ms   18.1±0ms   27.7±0ms 
  coo     AB   15.5±0ms   15.5±0ms   14.9±0ms   26.8±0ms 
  coo     BA   15.3±0ms   15.1±0ms   14.2±0ms   30.5±0ms 
  coo     BB   7.39±0ms   5.90±0ms   7.41±0ms   45.3±0ms 
  dia     AA   1.47±0ms   28.8±0ms   27.1±0ms   35.5±0ms 
  dia     AB   17.7±0ms   17.9±0ms   17.6±0ms   31.1±0ms 
  dia     BA   17.5±0ms   17.4±0ms   17.0±0ms   34.9±0ms 
  dia     BB   6.05±0ms   5.19±0ms   6.07±0ms   44.5±0ms 
======== ==== ========== ========== ========== ==========
```
Notice how the results for `coo BB` and `dia BB` are the same as for `csr BB`.
And that most `coo` and `dia` results for `BB` are better that for `AA`, even though `B` has about twice more elements than `A`.

The output with the corrected format of `B`:
```
sparse.Arithmetic.time_arithmetic
======== ==== ========== ========== ========== ==========
--                                 op                    
------------- -------------------------------------------
 format   XY   __add__    __sub__    multiply   __mul__  
======== ==== ========== ========== ========== ==========
  csr     AA   1.93±0ms   1.34±0ms   2.07±0ms   9.67±0ms 
  csr     AB   7.33±0ms   7.35±0ms   6.87±0ms   20.2±0ms 
  csr     BA   7.13±0ms   7.09±0ms   6.54±0ms   24.0±0ms 
  csr     BB   6.80±0ms   5.20±0ms   6.82±0ms   44.5±0ms 
  csc     AA   3.37±0ms   2.79±0ms   3.37±0ms   10.8±0ms 
  csc     AB   7.08±0ms   7.01±0ms   7.73±0ms   24.2±0ms 
  csc     BA   7.00±0ms   7.00±0ms   7.68±0ms   20.5±0ms 
  csc     BB   7.68±0ms   5.89±0ms   7.85±0ms   43.3±0ms 
  coo     AA   18.3±0ms   15.4±0ms   18.0±0ms   26.9±0ms 
  coo     AB   26.7±0ms   26.3±0ms   27.2±0ms   42.5±0ms 
  coo     BA   26.9±0ms   27.3±0ms   27.7±0ms   46.8±0ms 
  coo     BB   37.7±0ms   32.7±0ms   36.0±0ms   72.7±0ms 
  dia     AA   1.41±0ms   28.3±0ms   30.2±0ms   38.7±0ms 
  dia     AB   2.39±0ms   47.9±0ms   48.0±0ms   62.0±0ms 
  dia     BA   2.42±0ms   46.9±0ms   42.8±0ms   67.5±0ms 
  dia     BB   1.50±0ms   65.6±0ms   67.4±0ms   107±0ms  
======== ==== ========== ========== ========== ==========
```
Makes more sense.
(And clearly demonstates that while `__add__` was implemented for DIA, `__sub__` was forgotten, which I plan to correct later.)
