### PR TITLE
BUG: `optimize.root_scalar`: let bracket be passed as a NumPy array

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -246,7 +246,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
     # Pick a method if not specified.
     # Use the "best" method available for the situation.
     if not method:
-        if bracket:
+        if bracket is not None:
             method = 'brentq'
         elif x0 is not None:
             if fprime:

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -191,6 +191,21 @@ class TestBracketMethods(TestScalarRootFinders):
         assert_allclose(root, 1.0, atol=self.xtol, rtol=self.rtol)
 
     @pytest.mark.parametrize('method', bracket_methods)
+    @pytest.mark.parametrize('function', tstutils_functions)
+    def test_bracket_is_array(self, method, function):
+        # Test bracketing root finders called via `root_scalar` on a small set
+        # of simple problems, each of which has a root at `x=1`. Check that
+        # passing `bracket` as a `ndarray` is accepted and leads to finding the
+        # correct root.
+        a, b = .5, sqrt(3)
+        r = root_scalar(function, method=method.__name__,
+                        bracket=np.array([a, b]), x0=a, xtol=self.xtol,
+                        rtol=self.rtol)
+        assert r.converged
+        assert_allclose(r.root, 1.0, atol=self.xtol, rtol=self.rtol)
+        assert r.method == method.__name__
+
+    @pytest.mark.parametrize('method', bracket_methods)
     def test_aps_collection(self, method):
         self.run_collection('aps', method, method.__name__, smoothness=1)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?

The method used by `root_scalar` depends on the optional arguments passed to the function. Whether `bracket` is passed is tested by evaluating its truthiness. That raises a `ValueError` if `bracket` is passed as a numpy array:
`ValueError: The truth value of an array with more than one element is ambiguous`.

This commit fixes this by testing `bracket` against `None`, and adds a simple test to check that the root obtained when passing `bracket` as an array is correct.

#### Additional information
<!--Any additional information you think is important.-->
A check was already in place within `root_scalar` to verify `bracket` is a list, tuple, or np.ndarray, which led me to believe passing the parameter as a np.ndarray should be accepted by this function.