### PR TITLE
TST: interpolate: use `xp_assert` infrastructure

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -343,40 +343,43 @@ class TestBSpline:
 
     def test_integral(self):
         b = BSpline.basis_element([0, 1, 2])  # x for x < 1 else 2 - x
-        xp_assert_close(b.integrate(0, 1), 0.5)
-        xp_assert_close(b.integrate(1, 0), -1 * 0.5)
-        xp_assert_close(b.integrate(1, 0), -0.5)
+        xp_assert_close(b.integrate(0, 1), 0.5, check_0d=False)
+        xp_assert_close(b.integrate(1, 0), -1 * 0.5, check_0d=False)
+        xp_assert_close(b.integrate(1, 0), -0.5, check_0d=False)
 
         # extrapolate or zeros outside of [0, 2]; default is yes
-        xp_assert_close(b.integrate(-1, 1), 0.0)
-        xp_assert_close(b.integrate(-1, 1, extrapolate=True), 0.0)
-        xp_assert_close(b.integrate(-1, 1, extrapolate=False), 0.5)
-        xp_assert_close(b.integrate(1, -1, extrapolate=False), -1 * 0.5)
+        xp_assert_close(b.integrate(-1, 1), 0.0, check_0d=False)
+        xp_assert_close(b.integrate(-1, 1, extrapolate=True), 0.0, check_0d=False)
+        xp_assert_close(b.integrate(-1, 1, extrapolate=False), 0.5, check_0d=False)
+        xp_assert_close(b.integrate(1, -1, extrapolate=False), -1 * 0.5, check_0d=False)
 
         # Test ``_fitpack._splint()``
         xp_assert_close(b.integrate(1, -1, extrapolate=False),
-                        _impl.splint(1, -1, b.tck))
+                        _impl.splint(1, -1, b.tck), check_0d=False)
 
         # Test ``extrapolate='periodic'``.
         b.extrapolate = 'periodic'
         i = b.antiderivative()
         period_int = i(2) - i(0)
 
-        xp_assert_close(b.integrate(0, 2), period_int)
-        xp_assert_close(b.integrate(2, 0), -1 * period_int)
-        xp_assert_close(b.integrate(-9, -7), period_int)
-        xp_assert_close(b.integrate(-8, -4), 2 * period_int)
+        xp_assert_close(b.integrate(0, 2), period_int, check_0d=False)
+        xp_assert_close(b.integrate(2, 0), -1 * period_int, check_0d=False)
+        xp_assert_close(b.integrate(-9, -7), period_int, check_0d=False)
+        xp_assert_close(b.integrate(-8, -4), 2 * period_int, check_0d=False)
 
-        xp_assert_close(b.integrate(0.5, 1.5), i(1.5) - i(0.5))
-        xp_assert_close(b.integrate(1.5, 3), i(1) - i(0) + i(2) - i(1.5))
+        xp_assert_close(b.integrate(0.5, 1.5), i(1.5) - i(0.5), check_0d=False)
+        xp_assert_close(b.integrate(1.5, 3),
+                        i(1) - i(0) + i(2) - i(1.5), check_0d=False)
         xp_assert_close(b.integrate(1.5 + 12, 3 + 12),
-                        i(1) - i(0) + i(2) - i(1.5))
+                        i(1) - i(0) + i(2) - i(1.5), check_0d=False)
         xp_assert_close(b.integrate(1.5, 3 + 12),
-                        i(1) - i(0) + i(2) - i(1.5) + 6 * period_int)
+                        i(1) - i(0) + i(2) - i(1.5) + 6 * period_int, check_0d=False)
 
-        xp_assert_close(b.integrate(0, -1), i(0) - i(1))
-        xp_assert_close(b.integrate(-9, -10), i(0) - i(1))
-        xp_assert_close(b.integrate(0, -9), i(1) - i(2) - 4 * period_int)
+        xp_assert_close(b.integrate(0, -1), i(0) - i(1), check_0d=False)
+        xp_assert_close(b.integrate(-9, -10), i(0) - i(1), check_0d=False)
+        xp_assert_close(
+            b.integrate(0, -9), i(1) - i(2) - 4 * period_int, check_0d=False
+        )
 
     def test_integrate_ppoly(self):
         # test .integrate method to be consistent with PPoly.integrate
@@ -1051,10 +1054,11 @@ class TestInterop:
     def test_splint(self):
         # test that splint accepts BSpline objects
         b, b2 = self.b, self.b2
+
         xp_assert_close(splint(0, 1, b),
-                        splint(0, 1, b.tck), atol=1e-14)
+                        splint(0, 1, b.tck), atol=1e-14, check_0d=False)
         xp_assert_close(splint(0, 1, b),
-                        b.integrate(0, 1), atol=1e-14)
+                        b.integrate(0, 1), atol=1e-14, check_0d=False)
 
         # ... and deals with N-D arrays of coefficients
         with assert_raises(ValueError, match="Calling splint.. with BSpline"):
@@ -1283,12 +1287,16 @@ class TestInterp:
         # derivative at right-hand edge
         b = make_interp_spline(self.xx, self.yy, k=2, bc_type=(None, der))
         xp_assert_close(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
-        xp_assert_close(b(self.xx[-1], 1), der[0][1], atol=1e-14, rtol=1e-14)
+        xp_assert_close(
+            b(self.xx[-1], 1), der[0][1], atol=1e-14, rtol=1e-14, check_0d=False
+        )
 
         # derivative at left-hand edge
         b = make_interp_spline(self.xx, self.yy, k=2, bc_type=(der, None))
         xp_assert_close(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
-        xp_assert_close(b(self.xx[0], 1), der[0][1], atol=1e-14, rtol=1e-14)
+        xp_assert_close(
+            b(self.xx[0], 1), der[0][1], atol=1e-14, rtol=1e-14, check_0d=False
+        )
 
     def test_cubic_deriv(self):
         k = 3
@@ -1345,8 +1353,8 @@ class TestInterp:
                                bc_type=([(2, 0)], [(2, 0)]))
 
         xp_assert_close(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
-        xp_assert_close(b(self.xx[0], 2), 0.0, atol=1e-14)
-        xp_assert_close(b(self.xx[-1], 2), 0., atol=1e-14)
+        xp_assert_close(b(self.xx[0], 2), np.asarray(0.0), atol=1e-14)
+        xp_assert_close(b(self.xx[-1], 2), np.asarray(0.0), atol=1e-14)
 
     def test_minimum_points_and_deriv(self):
         # interpolation of f(x) = x**3 between 0 and 1. f'(x) = 3 * xx**2 and
@@ -1405,8 +1413,12 @@ class TestInterp:
         der_l, der_r = [(1, 3.j)], [(1, 4.+2.j)]
         b = make_interp_spline(xx, yy, k, bc_type=(der_l, der_r))
         xp_assert_close(b(xx), yy, atol=1e-14, rtol=1e-14)
-        xp_assert_close(b(xx[0], 1), der_l[0][1], atol=1e-14, rtol=1e-14)
-        xp_assert_close(b(xx[-1], 1), der_r[0][1], atol=1e-14, rtol=1e-14)
+        xp_assert_close(
+            b(xx[0], 1), der_l[0][1], atol=1e-14, rtol=1e-14, check_0d=False
+        )
+        xp_assert_close(
+            b(xx[-1], 1), der_r[0][1], atol=1e-14, rtol=1e-14, check_0d=False
+        )
 
         # also test zero and first order
         for k in (0, 1):
@@ -1895,8 +1907,9 @@ def bspline2(xy, t, c, k):
     assert (nx >= k+1)
     ny = len(ty) - k - 1
     assert (ny >= k+1)
-    return sum(c[ix, iy] * B(x, k, ix, tx) * B(y, k, iy, ty)
-               for ix in range(nx) for iy in range(ny))
+    res = sum(c[ix, iy] * B(x, k, ix, tx) * B(y, k, iy, ty)
+              for ix in range(nx) for iy in range(ny))
+    return np.asarray(res)
 
 
 def B(x, k, i, t):
@@ -1977,7 +1990,7 @@ class NdBSpline0:
             term = self.c[idx] * np.prod([B(x[d], self.k[d], idx[d], self.t[d])
                                           for d in range(ndim)])
             result += term
-        return result
+        return np.asarray(result)
 
 
 class TestNdBSpline:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -214,7 +214,7 @@ class TestBSpline:
         t, _, k = b.tck
         xx = [t[0] - 1, t[-1] + 1]
         yy = b(xx)
-        assert_(not np.all(np.isnan(yy)))
+        assert not np.all(np.isnan(yy))
 
     def test_periodic_extrap(self):
         np.random.seed(1234)
@@ -269,19 +269,17 @@ class TestBSpline:
         x = np.asarray([1, 3, 4, 6])
         assert_allclose(b(x[x != 6] - 1e-10),
                         b(x[x != 6] + 1e-10))
-        assert_(not np.allclose(b(6.-1e-10), b(6+1e-10)))
+        assert not np.allclose(b(6.-1e-10), b(6+1e-10))
 
         # 1st derivative jumps at double knots, 1 & 6:
         x0 = np.asarray([3, 4])
         assert_allclose(b(x0 - 1e-10, nu=1),
                         b(x0 + 1e-10, nu=1))
         x1 = np.asarray([1, 6])
-        assert_(not np.all(np.allclose(b(x1 - 1e-10, nu=1),
-                                       b(x1 + 1e-10, nu=1))))
+        assert not np.allclose(b(x1 - 1e-10, nu=1), b(x1 + 1e-10, nu=1))
 
         # 2nd derivative is not guaranteed to be continuous either
-        assert_(not np.all(np.allclose(b(x - 1e-10, nu=2),
-                                       b(x + 1e-10, nu=2))))
+        assert not np.allclose(b(x - 1e-10, nu=2), b(x + 1e-10, nu=2))
 
     def test_basis_element_quadratic(self):
         xx = np.linspace(-1, 4, 20)
@@ -318,7 +316,7 @@ class TestBSpline:
     def test_nan(self):
         # nan in, nan out.
         b = BSpline.basis_element([0, 1, 1, 2])
-        assert_(np.isnan(b(np.nan)))
+        assert np.isnan(b(np.nan))
 
     def test_derivative_method(self):
         b = _make_random_spline(k=5)
@@ -1086,8 +1084,8 @@ class TestInterop:
                 assert_allclose(bd.t, tck_d[0], atol=1e-15)
                 assert_allclose(bd.c, tck_d[1], atol=1e-15)
                 assert_equal(bd.k, tck_d[2])
-                assert_(isinstance(bd, BSpline))
-                assert_(isinstance(tck_d, tuple))  # back-compat: tck in and out
+                assert isinstance(bd, BSpline)
+                assert isinstance(tck_d, tuple)  # back-compat: tck in and out
 
     def test_splantider(self):
         for b in [self.b, self.b2]:
@@ -1102,8 +1100,8 @@ class TestInterop:
                 assert_allclose(bd.t, tck_d[0], atol=1e-15)
                 assert_allclose(bd.c, tck_d[1], atol=1e-15)
                 assert_equal(bd.k, tck_d[2])
-                assert_(isinstance(bd, BSpline))
-                assert_(isinstance(tck_d, tuple))  # back-compat: tck in and out
+                assert isinstance(bd, BSpline)
+                assert isinstance(tck_d, tuple)  # back-compat: tck in and out
 
     def test_insert(self):
         b, b2, xx = self.b, self.b2, self.xx
@@ -1114,8 +1112,8 @@ class TestInterop:
         bn, tck_n = insert(tn, b), insert(tn, (b.t, b.c, b.k))
         assert_allclose(splev(xx, bn),
                         splev(xx, tck_n), atol=1e-15)
-        assert_(isinstance(bn, BSpline))
-        assert_(isinstance(tck_n, tuple))   # back-compat: tck in, tck out
+        assert isinstance(bn, BSpline)
+        assert isinstance(tck_n, tuple)   # back-compat: tck in, tck out
 
         # for N-D array of coefficients, BSpline.c needs to be transposed
         # after that, the results are equivalent.
@@ -1128,8 +1126,8 @@ class TestInterop:
         # need a transpose for comparing the results, cf test_splev
         assert_allclose(np.asarray(splev(xx, tck_n2)).transpose(2, 0, 1),
                         bn2(xx), atol=1e-15)
-        assert_(isinstance(bn2, BSpline))
-        assert_(isinstance(tck_n2, tuple))   # back-compat: tck in, tck out
+        assert isinstance(bn2, BSpline)
+        assert isinstance(tck_n2, tuple)   # back-compat: tck in, tck out
 
 
 class TestInterp:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -148,7 +148,7 @@ class TestBSpline:
         b = _make_random_spline()
         b.c = np.ones_like(b.c)
         xx = np.linspace(b.t[b.k], b.t[-b.k-1], 100)
-        xp_assert_close(b(xx), 1., check_shape=False)
+        xp_assert_close(b(xx), np.ones_like(xx))
 
     def test_vectorization(self):
         n, k = 22, 3
@@ -348,8 +348,8 @@ class TestBSpline:
         xp_assert_close(b.integrate(1, 0), -0.5)
 
         # extrapolate or zeros outside of [0, 2]; default is yes
-        xp_assert_close(b.integrate(-1, 1), 0)
-        xp_assert_close(b.integrate(-1, 1, extrapolate=True), 0)
+        xp_assert_close(b.integrate(-1, 1), 0.0)
+        xp_assert_close(b.integrate(-1, 1, extrapolate=True), 0.0)
         xp_assert_close(b.integrate(-1, 1, extrapolate=False), 0.5)
         xp_assert_close(b.integrate(1, -1, extrapolate=False), -1 * 0.5)
 
@@ -736,9 +736,9 @@ class TestInsert:
         spl_1re = spl_re.insert_knot(xv)
         spl_1im = spl_im.insert_knot(xv)
 
-        assert_allclose(spl_1.t, spl_1re.t, atol=1e-15)
-        assert_allclose(spl_1.t, spl_1im.t, atol=1e-15)
-        assert_allclose(spl_1.c, spl_1re.c + 1j*spl_1im.c, atol=1e-15)
+        xp_assert_close(spl_1.t, spl_1re.t, atol=1e-15)
+        xp_assert_close(spl_1.t, spl_1im.t, atol=1e-15)
+        xp_assert_close(spl_1.c, spl_1re.c + 1j*spl_1im.c, atol=1e-15)
 
     def test_insert_periodic_too_few_internal_knots(self):
         # both FITPACK and spl.insert_knot raise when there's not enough
@@ -1065,7 +1065,7 @@ class TestInterop:
         integr = np.asarray(splint(0, 1, (b2.t, c2r, b2.k)))
         assert integr.shape == (3, 2)
         xp_assert_close(integr,
-                        splint(0, 1, b), atol=1e-14)
+                        splint(0, 1, b), atol=1e-14, check_shape=False)
 
     def test_splder(self):
         for b in [self.b, self.b2]:
@@ -1675,7 +1675,7 @@ class TestLSQ:
               for i in range(nrhs)]
         coefs = np.vstack([bb[i].c for i in range(nrhs)]).T
 
-        assert_allclose(coefs, b.c, atol=1e-15)
+        xp_assert_close(coefs, b.c, atol=1e-15)
 
     def test_complex(self):
         # cmplx-valued `y`
@@ -1699,7 +1699,7 @@ class TestLSQ:
         b_re = make_lsq_spline(x, yc.real, t, k)
         b_im = make_lsq_spline(x, yc.imag, t, k)
 
-        assert_allclose(b(x), b_re(x) + 1.j*b_im(x), atol=1e-15, rtol=1e-15)
+        xp_assert_close(b(x), b_re(x) + 1.j*b_im(x), atol=1e-15, rtol=1e-15)
 
         # repeat with num_trailing_dims > 1 : yc.shape[1:] = (2, 2)
         yc = np.stack((yc, yc), axis=1)
@@ -1708,7 +1708,7 @@ class TestLSQ:
         b_re = make_lsq_spline(x, yc.real, t, k)
         b_im = make_lsq_spline(x, yc.imag, t, k)
 
-        assert_allclose(b(x), b_re(x) + 1.j*b_im(x), atol=1e-15, rtol=1e-15)
+        xp_assert_close(b(x), b_re(x) + 1.j*b_im(x), atol=1e-15, rtol=1e-15)
 
     def test_int_xy(self):
         x = np.arange(10).astype(int)
@@ -2115,7 +2115,7 @@ class TestNdBSpline:
         result = bspl2_4(xy)
         val_single = NdBSpline(t2, c2, k)(xy)
         assert result.shape == (4,)
-        assert_allclose(result,
+        xp_assert_close(result,
                         [val_single, ]*4, atol=1e-14)
 
     def test_2D_random(self):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -343,43 +343,43 @@ class TestBSpline:
 
     def test_integral(self):
         b = BSpline.basis_element([0, 1, 2])  # x for x < 1 else 2 - x
-        xp_assert_close(b.integrate(0, 1), 0.5, check_0d=False)
-        xp_assert_close(b.integrate(1, 0), -1 * 0.5, check_0d=False)
-        xp_assert_close(b.integrate(1, 0), -0.5, check_0d=False)
+        xp_assert_close(b.integrate(0, 1), np.asarray(0.5))
+        xp_assert_close(b.integrate(1, 0), np.asarray(-1 * 0.5))
+        xp_assert_close(b.integrate(1, 0), np.asarray(-0.5))
 
         # extrapolate or zeros outside of [0, 2]; default is yes
-        xp_assert_close(b.integrate(-1, 1), 0.0, check_0d=False)
-        xp_assert_close(b.integrate(-1, 1, extrapolate=True), 0.0, check_0d=False)
-        xp_assert_close(b.integrate(-1, 1, extrapolate=False), 0.5, check_0d=False)
-        xp_assert_close(b.integrate(1, -1, extrapolate=False), -1 * 0.5, check_0d=False)
+        xp_assert_close(b.integrate(-1, 1), np.asarray(0.0))
+        xp_assert_close(b.integrate(-1, 1, extrapolate=True), np.asarray(0.0))
+        xp_assert_close(b.integrate(-1, 1, extrapolate=False), np.asarray(0.5))
+        xp_assert_close(b.integrate(1, -1, extrapolate=False), np.asarray(-1 * 0.5))
 
         # Test ``_fitpack._splint()``
         xp_assert_close(b.integrate(1, -1, extrapolate=False),
-                        _impl.splint(1, -1, b.tck), check_0d=False)
+                        np.asarray(_impl.splint(1, -1, b.tck)))
 
         # Test ``extrapolate='periodic'``.
         b.extrapolate = 'periodic'
         i = b.antiderivative()
-        period_int = i(2) - i(0)
+        period_int = np.asarray(i(2) - i(0))
 
-        xp_assert_close(b.integrate(0, 2), period_int, check_0d=False)
-        xp_assert_close(b.integrate(2, 0), -1 * period_int, check_0d=False)
-        xp_assert_close(b.integrate(-9, -7), period_int, check_0d=False)
-        xp_assert_close(b.integrate(-8, -4), 2 * period_int, check_0d=False)
+        xp_assert_close(b.integrate(0, 2), period_int)
+        xp_assert_close(b.integrate(2, 0), np.asarray(-1 * period_int))
+        xp_assert_close(b.integrate(-9, -7), period_int)
+        xp_assert_close(b.integrate(-8, -4), np.asarray(2 * period_int))
 
-        xp_assert_close(b.integrate(0.5, 1.5), i(1.5) - i(0.5), check_0d=False)
+        xp_assert_close(b.integrate(0.5, 1.5),
+                        np.asarray(i(1.5) - i(0.5)))
         xp_assert_close(b.integrate(1.5, 3),
-                        i(1) - i(0) + i(2) - i(1.5), check_0d=False)
+                        np.asarray(i(1) - i(0) + i(2) - i(1.5)))
         xp_assert_close(b.integrate(1.5 + 12, 3 + 12),
-                        i(1) - i(0) + i(2) - i(1.5), check_0d=False)
+                        np.asarray(i(1) - i(0) + i(2) - i(1.5)))
         xp_assert_close(b.integrate(1.5, 3 + 12),
-                        i(1) - i(0) + i(2) - i(1.5) + 6 * period_int, check_0d=False)
+                        np.asarray(i(1) - i(0) + i(2) - i(1.5) + 6 * period_int))
 
-        xp_assert_close(b.integrate(0, -1), i(0) - i(1), check_0d=False)
-        xp_assert_close(b.integrate(-9, -10), i(0) - i(1), check_0d=False)
-        xp_assert_close(
-            b.integrate(0, -9), i(1) - i(2) - 4 * period_int, check_0d=False
-        )
+        xp_assert_close(b.integrate(0, -1), np.asarray(i(0) - i(1)))
+        xp_assert_close(b.integrate(-9, -10), np.asarray(i(0) - i(1)))
+        xp_assert_close(b.integrate(0, -9),
+                        np.asarray(i(1) - i(2) - 4 * period_int))
 
     def test_integrate_ppoly(self):
         # test .integrate method to be consistent with PPoly.integrate

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -321,7 +321,7 @@ class TestSplint:
         # integrate directly: $\int_0^6 x^3 dx = 6^4 / 4$
         res = splint(0, 6, (t, c, k))
         expected = 6**4 / 4
-        assert abs(res - expected)  < 1e-13
+        assert abs(res - expected) < 1e-13
 
         # check that the coefficients past len(t) - k - 1 are ignored
         c0 = c.copy()

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -2,8 +2,9 @@ import itertools
 import os
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_allclose, assert_,
+from numpy.testing import (assert_allclose,
                            assert_almost_equal, assert_array_almost_equal)
+from scipy._lib._array_api import xp_assert_equal
 from pytest import raises as assert_raises
 import pytest
 from scipy._lib._testutils import check_free_memory
@@ -191,9 +192,9 @@ class TestSplev:
         y = [4,5,6,7,8]
         tck = splrep(x, y)
         z = splev([1], tck)
-        assert_equal(z.shape, (1,))
+        assert z.shape == (1,)
         z = splev(1, tck)
-        assert_equal(z.shape, ())
+        assert z.shape == ()
 
     def test_2d_shape(self):
         x = [1, 2, 3, 4, 5]
@@ -204,7 +205,7 @@ class TestSplev:
         z = splev(t, tck)
         z0 = splev(t[0], tck)
         z1 = splev(t[1], tck)
-        assert_equal(z, np.vstack((z0, z1)))
+        xp_assert_equal(z, np.vstack((z0, z1)))
 
     def test_extrapolation_modes(self):
         # test extrapolation modes
@@ -231,7 +232,7 @@ class TestSplder:
         self.spl = splrep(x, y)
 
         # double check that knots are non-uniform
-        assert_(np.ptp(np.diff(self.spl[0])) > 0)
+        assert np.ptp(np.diff(self.spl[0])) > 0
 
     def test_inverse(self):
         # Check that antiderivative + derivative is identity.
@@ -240,7 +241,7 @@ class TestSplder:
             spl3 = splder(spl2, n)
             assert_allclose(self.spl[0], spl3[0])
             assert_allclose(self.spl[1], spl3[1])
-            assert_equal(self.spl[2], spl3[2])
+            assert self.spl[2] == spl3[2]
 
     def test_splder_vs_splev(self):
         # Check derivative vs. FITPACK
@@ -304,7 +305,7 @@ class TestSplder:
 
             assert_allclose(t, spl3[0])
             assert_allclose(c2, spl3[1])
-            assert_equal(k, spl3[2])
+            assert k == spl3[2]
 
 
 class TestSplint:

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -2,9 +2,9 @@ import itertools
 import os
 
 import numpy as np
-from numpy.testing import (assert_allclose,
-                           assert_almost_equal, assert_array_almost_equal)
-from scipy._lib._array_api import xp_assert_equal
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal
+)
 from pytest import raises as assert_raises
 import pytest
 from scipy._lib._testutils import check_free_memory
@@ -100,7 +100,7 @@ class TestSmokeTests:
             d = 0
             for dr in r[1]:
                 tol = err_est(k, d)
-                assert_allclose(dr, f1(dx, d), atol=0, rtol=tol)
+                xp_assert_close(dr, f1(dx, d), atol=0, rtol=tol)
                 d = d+1
             k = k+1
 
@@ -138,8 +138,8 @@ class TestSmokeTests:
         k = 3
         tck = splrep(x, v, s=0, k=3)
         roots = sproot(tck)
-        assert_allclose(splev(roots, tck), 0, atol=1e-10, rtol=1e-10)
-        assert_allclose(roots, np.pi * np.array([1, 2, 3, 4]), rtol=1e-3)
+        xp_assert_close(splev(roots, tck), np.zeros(len(roots)), atol=1e-10, rtol=1e-10)
+        xp_assert_close(roots, np.pi * np.array([1, 2, 3, 4]), rtol=1e-3)
 
     @pytest.mark.parametrize('N', [20, 50])
     @pytest.mark.parametrize('k', [1, 2, 3, 4, 5])
@@ -239,8 +239,8 @@ class TestSplder:
         for n in range(5):
             spl2 = splantider(self.spl, n)
             spl3 = splder(spl2, n)
-            assert_allclose(self.spl[0], spl3[0])
-            assert_allclose(self.spl[1], spl3[1])
+            xp_assert_close(self.spl[0], spl3[0])
+            xp_assert_close(self.spl[1], spl3[1])
             assert self.spl[2] == spl3[2]
 
     def test_splder_vs_splev(self):
@@ -258,9 +258,9 @@ class TestSplder:
             spl2 = splder(self.spl, n)
             dy2 = splev(xx, spl2)
             if n == 1:
-                assert_allclose(dy, dy2, rtol=2e-6)
+                xp_assert_close(dy, dy2, rtol=2e-6)
             else:
-                assert_allclose(dy, dy2)
+                xp_assert_close(dy, dy2)
 
     def test_splantider_vs_splint(self):
         # Check antiderivative vs. FITPACK
@@ -274,7 +274,7 @@ class TestSplder:
             for x2 in xx:
                 y1 = splint(x1, x2, self.spl)
                 y2 = splev(x2, spl2) - splev(x1, spl2)
-                assert_allclose(y1, y2)
+                xp_assert_close(np.asarray(y1), np.asarray(y2))
 
     def test_order0_diff(self):
         assert_raises(ValueError, splder, self.spl, 4)
@@ -303,8 +303,8 @@ class TestSplder:
             spl2 = splantider((t, c2, k), n)
             spl3 = splder(spl2, n)
 
-            assert_allclose(t, spl3[0])
-            assert_allclose(c2, spl3[1])
+            xp_assert_close(t, spl3[0])
+            xp_assert_close(c2, spl3[1])
             assert k == spl3[2]
 
 
@@ -320,13 +320,14 @@ class TestSplint:
 
         # integrate directly: $\int_0^6 x^3 dx = 6^4 / 4$
         res = splint(0, 6, (t, c, k))
-        assert_allclose(res, 6**4 / 4, atol=1e-15)
+        expected = 6**4 / 4
+        assert abs(res - expected)  < 1e-13
 
         # check that the coefficients past len(t) - k - 1 are ignored
         c0 = c.copy()
-        c0[len(t)-k-1:] = np.nan
+        c0[len(t) - k - 1:] = np.nan
         res0 = splint(0, 6, (t, c0, k))
-        assert_allclose(res0, 6**4 / 4, atol=1e-15)
+        assert abs(res0 - expected) < 1e-13
 
         # however, all other coefficients *are* used
         c0[6] = np.nan
@@ -335,7 +336,8 @@ class TestSplint:
         # check that the coefficient array can have length `len(t) - k - 1`
         c1 = c[:len(t) - k - 1]
         res1 = splint(0, 6, (t, c1, k))
-        assert_allclose(res1, 6**4 / 4, atol=1e-15)
+        assert (res1 - expected) < 1e-13
+
 
         # however shorter c arrays raise. The error from f2py is a
         # `dftipack.error`, which is an Exception but not ValueError etc.
@@ -376,7 +378,7 @@ class TestBisplrep:
         x, y = np.meshgrid(x, y)
         z = np.zeros_like(x)
         tck = bisplrep(x, y, z, kx=3, ky=3, s=0)
-        assert_allclose(bisplev(0.5, 0.5, tck), 0.0)
+        xp_assert_close(bisplev(0.5, 0.5, tck), 0.0)
 
 
 def test_dblint():
@@ -389,10 +391,10 @@ def test_dblint():
     tck = list(rect.tck)
     tck.extend(rect.degrees)
 
-    assert_almost_equal(dblint(0, 1, 0, 1, tck), 1)
-    assert_almost_equal(dblint(0, 0.5, 0, 1, tck), 0.25)
-    assert_almost_equal(dblint(0.5, 1, 0, 1, tck), 0.75)
-    assert_almost_equal(dblint(-100, 100, -100, 100, tck), 1)
+    assert abs(dblint(0, 1, 0, 1, tck) - 1) < 1e-10
+    assert abs(dblint(0, 0.5, 0, 1, tck) - 0.25) < 1e-10
+    assert abs(dblint(0.5, 1, 0, 1, tck) - 0.75) < 1e-10
+    assert abs(dblint(-100, 100, -100, 100, tck) - 1) < 1e-10
 
 
 def test_splev_der_k():
@@ -407,8 +409,10 @@ def test_splev_der_k():
     x = np.array([-3, 0, 2.5, 3])
 
     # an explicit form of the linear spline
-    assert_allclose(splev(x, tck), c[0] + (c[1] - c[0]) * x/t[2])
-    assert_allclose(splev(x, tck, 1), (c[1]-c[0]) / t[2])
+    xp_assert_close(splev(x, tck), c[0] + (c[1] - c[0]) * x/t[2])
+    xp_assert_close(splev(x, tck, 1),
+                    np.ones_like(x) * (c[1] - c[0]) / t[2]
+    )
 
     # now check a random spline vs splder
     np.random.seed(1234)
@@ -418,7 +422,7 @@ def test_splev_der_k():
 
     x = [t[0] - 1., t[-1] + 1.]
     tck2 = splder((t, c, k), k)
-    assert_allclose(splev(x, (t, c, k), k), splev(x, tck2))
+    xp_assert_close(splev(x, (t, c, k), k), splev(x, tck2))
 
 
 def test_splprep_segfault():
@@ -500,5 +504,6 @@ def test_spalde_nc():
     k = 3
 
     res = spalde(x, (t, c, k))
+    res = np.vstack(res)
     res_splev = np.asarray([splev(x, (t, c, k), nu) for nu in range(4)])
-    assert_allclose(res, res_splev.T, atol=1e-15)
+    xp_assert_close(res, res_splev.T, atol=1e-15)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -420,7 +420,7 @@ class TestLSQBivariateSpline:
             lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
             assert len(r) == 1
 
-        assert_almost_equal(lut(2, 2), 3., check_shape=False)
+        assert_almost_equal(lut(2, 2), 3.)
 
     def test_bilinearity(self):
         x = [1,1,1,2,2,2,3,3,3]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -420,7 +420,7 @@ class TestLSQBivariateSpline:
             lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
             assert len(r) == 1
 
-        assert_almost_equal(lut(2, 2), 3.)
+        assert_almost_equal(lut(2, 2), np.asarray(3.))
 
     def test_bilinearity(self):
         x = [1,1,1,2,2,2,3,3,3]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,9 +1,11 @@
 # Created by Pearu Peterson, June 2003
 import itertools
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_array_equal,
-        assert_array_almost_equal, assert_allclose, suppress_warnings)
+from numpy.testing import suppress_warnings
 from pytest import raises as assert_raises
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal
+)
 
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
 from scipy.interpolate._fitpack_py import bisplrep, bisplev, splrep, spalde
@@ -21,10 +23,10 @@ class TestUnivariateSpline:
         x = [1,2,3]
         y = [3,3,3]
         lut = UnivariateSpline(x,y,k=1)
-        assert_array_almost_equal(lut.get_knots(),[1,3])
-        assert_array_almost_equal(lut.get_coeffs(),[3,3])
-        assert_almost_equal(lut.get_residual(),0.0)
-        assert_array_almost_equal(lut([1,1.5,2]),[3,3,3])
+        assert_array_almost_equal(lut.get_knots(), [1, 3])
+        assert_array_almost_equal(lut.get_coeffs(), [3, 3])
+        assert abs(lut.get_residual()) < 1e-10
+        assert_array_almost_equal(lut([1, 1.5, 2]), [3, 3, 3])
 
     def test_preserve_shape(self):
         x = [1, 2, 3]
@@ -43,7 +45,7 @@ class TestUnivariateSpline:
         lut = UnivariateSpline(x,y,k=1)
         assert_array_almost_equal(lut.get_knots(),[1,3])
         assert_array_almost_equal(lut.get_coeffs(),[0,4])
-        assert_almost_equal(lut.get_residual(),0.0)
+        assert abs(lut.get_residual()) < 1e-15
         assert_array_almost_equal(lut([1,1.5,2]),[0,1,2])
 
     def test_subclassing(self):
@@ -54,14 +56,14 @@ class TestUnivariateSpline:
                 return 0*array(x)
 
         sp = ZeroSpline([1,2,3,4,5], [3,2,3,2,3], k=2)
-        assert_array_equal(sp([1.5, 2.5]), [0., 0.])
+        xp_assert_equal(sp([1.5, 2.5]), [0., 0.])
 
     def test_empty_input(self):
         # Test whether empty input returns an empty output. Ticket 1014
         x = [1,3,5,7,9]
         y = [0,4,9,12,21]
         spl = UnivariateSpline(x, y, k=3)
-        assert_array_equal(spl([]), array([]))
+        xp_assert_equal(spl([]), array([]))
 
     def test_roots(self):
         x = [1, 3, 5, 7, 9]
@@ -88,13 +90,13 @@ class TestUnivariateSpline:
 
         tck = splrep(x, y, s=0)
         ders = spalde(3, tck)
-        assert_allclose(ders, [45.,   # 3**3 + 2*(3)**2
+        xp_assert_close(ders, [45.,   # 3**3 + 2*(3)**2
                                39.,   # 3*(3)**2 + 4*(3)
                                22.,   # 6*(3) + 4
                                6.],   # 6*3**0
                         atol=1e-15)
         spl = UnivariateSpline(x, y, s=0, k=3)
-        assert_allclose(spl.derivatives(3),
+        xp_assert_close(spl.derivatives(3),
                         ders,
                         atol=1e-15)
 
@@ -112,7 +114,7 @@ class TestUnivariateSpline:
              1.00000000e+12]
         spl = UnivariateSpline(x=x, y=y, w=w, s=None)
         desired = array([0.35100374, 0.51715855, 0.87789547, 0.98719344])
-        assert_allclose(spl([0.1, 0.5, 0.9, 0.99]), desired, atol=5e-4)
+        xp_assert_close(spl([0.1, 0.5, 0.9, 0.99]), desired, atol=5e-4)
 
     def test_out_of_range_regression(self):
         # Test different extrapolation modes. See ticket 3557
@@ -129,24 +131,24 @@ class TestUnivariateSpline:
         for cls in [UnivariateSpline, InterpolatedUnivariateSpline]:
             spl = cls(x=x, y=y)
             for ext in [0, 'extrapolate']:
-                assert_allclose(spl(xp, ext=ext), xp**3, atol=1e-16)
-                assert_allclose(cls(x, y, ext=ext)(xp), xp**3, atol=1e-16)
+                xp_assert_close(spl(xp, ext=ext), xp**3, atol=1e-16)
+                xp_assert_close(cls(x, y, ext=ext)(xp), xp**3, atol=1e-16)
             for ext in [1, 'zeros']:
-                assert_allclose(spl(xp, ext=ext), xp_zeros**3, atol=1e-16)
-                assert_allclose(cls(x, y, ext=ext)(xp), xp_zeros**3, atol=1e-16)
+                xp_assert_close(spl(xp, ext=ext), xp_zeros**3, atol=1e-16)
+                xp_assert_close(cls(x, y, ext=ext)(xp), xp_zeros**3, atol=1e-16)
             for ext in [2, 'raise']:
                 assert_raises(ValueError, spl, xp, **dict(ext=ext))
             for ext in [3, 'const']:
-                assert_allclose(spl(xp, ext=ext), xp_clip**3, atol=2e-16)
-                assert_allclose(cls(x, y, ext=ext)(xp), xp_clip**3, atol=2e-16)
+                xp_assert_close(spl(xp, ext=ext), xp_clip**3, atol=2e-16)
+                xp_assert_close(cls(x, y, ext=ext)(xp), xp_clip**3, atol=2e-16)
 
         # also test LSQUnivariateSpline [which needs explicit knots]
         t = spl.get_knots()[3:4]  # interior knots w/ default k=3
         spl = LSQUnivariateSpline(x, y, t)
-        assert_allclose(spl(xp, ext=0), xp**3, atol=1e-16)
-        assert_allclose(spl(xp, ext=1), xp_zeros**3, atol=1e-16)
+        xp_assert_close(spl(xp, ext=0), xp**3, atol=1e-16)
+        xp_assert_close(spl(xp, ext=1), xp_zeros**3, atol=1e-16)
         assert_raises(ValueError, spl, xp, **dict(ext=2))
-        assert_allclose(spl(xp, ext=3), xp_clip**3, atol=1e-16)
+        xp_assert_close(spl(xp, ext=3), xp_clip**3, atol=1e-16)
 
         # also make sure that unknown values for `ext` are caught early
         for ext in [-1, 'unknown']:
@@ -170,10 +172,10 @@ class TestUnivariateSpline:
 
         spl = UnivariateSpline(x, y, s=0)
         spl2 = spl.antiderivative(2).derivative(2)
-        assert_allclose(spl(0.3), spl2(0.3))
+        xp_assert_close(spl(0.3), spl2(0.3))
 
         spl2 = spl.antiderivative(1)
-        assert_allclose(spl2(0.6) - spl2(0.2),
+        xp_assert_close(spl2(0.6) - spl2(0.2),
                         spl.integral(0.2, 0.6))
 
     def test_derivative_extrapolation(self):
@@ -184,7 +186,7 @@ class TestUnivariateSpline:
         f = UnivariateSpline(x_values, y_values, ext='const', k=3)
 
         x = [-1, 0, -0.5, 9, 9.5, 10]
-        assert_allclose(f.derivative()(x), 0, atol=1e-15)
+        xp_assert_close(f.derivative()(x), np.zeros_like(x), atol=1e-15)
 
     def test_integral_out_of_bounds(self):
         # Regression test for gh-7906: .integral(a, b) is wrong if both
@@ -194,7 +196,7 @@ class TestUnivariateSpline:
             f = UnivariateSpline(x, x, s=0, ext=ext)
             for (a, b) in [(1, 1), (1, 5), (2, 5),
                            (0, 0), (-2, 0), (-2, -1)]:
-                assert_allclose(f.integral(a, b), 0, atol=1e-15)
+                assert abs(f.integral(a, b)) < 1e-15
 
     def test_nan(self):
         # bail out early if the input data contains nans
@@ -359,7 +361,7 @@ class TestUnivariateSpline:
         spl2 = UnivariateSpline(x=x_values.tolist(), y=y_values.tolist(),
                                 w=w_values.tolist(), bbox=bbox.tolist())
 
-        assert_allclose(spl1([0.1, 0.5, 0.9, 0.99]),
+        xp_assert_close(spl1([0.1, 0.5, 0.9, 0.99]),
                         spl2([0.1, 0.5, 0.9, 0.99]))
 
     def test_fpknot_oob_crash(self):
@@ -418,7 +420,7 @@ class TestLSQBivariateSpline:
             lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
             assert len(r) == 1
 
-        assert_almost_equal(lut(2,2), 3.)
+        assert_almost_equal(lut(2, 2), 3., check_shape=False)
 
     def test_bilinearity(self):
         x = [1,1,1,2,2,2,3,3,3]
@@ -462,8 +464,8 @@ class TestLSQBivariateSpline:
         trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
                     * (tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
 
-        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]),
-                            trpz)
+        assert_almost_equal(np.asarray(lut.integral(tx[0], tx[-1], ty[0], ty[-1])),
+                            np.asarray(trpz))
 
     def test_empty_input(self):
         # Test whether empty inputs returns an empty output. Ticket 1014
@@ -478,8 +480,8 @@ class TestLSQBivariateSpline:
             lut = LSQBivariateSpline(x, y, z, tx, ty, kx=1, ky=1)
             assert len(r) == 1
 
-        assert_array_equal(lut([], []), np.zeros((0,0)))
-        assert_array_equal(lut([], [], grid=False), np.zeros((0,)))
+        xp_assert_equal(lut([], []), np.zeros((0,0)))
+        xp_assert_equal(lut([], [], grid=False), np.zeros((0,)))
 
     def test_invalid_input(self):
         s = 0.1
@@ -542,7 +544,7 @@ class TestLSQBivariateSpline:
             spl2 = LSQBivariateSpline(x.tolist(), y.tolist(), z.tolist(),
                                       tx.tolist(), ty.tolist(), w=w.tolist(),
                                       bbox=bbox)
-            assert_allclose(spl1(2.0, 2.0), spl2(2.0, 2.0))
+            xp_assert_close(spl1(2.0, 2.0), spl2(2.0, 2.0))
             assert len(r) == 2
 
     def test_unequal_length_of_knots(self):
@@ -569,19 +571,22 @@ class TestSmoothBivariateSpline:
         y = [1,2,3,1,2,3,1,2,3]
         z = [3,3,3,3,3,3,3,3,3]
         lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1)
-        assert_array_almost_equal(lut.get_knots(),([1,1,3,3],[1,1,3,3]))
-        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
-        assert_almost_equal(lut.get_residual(),0.0)
-        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
+        for t in lut.get_knots():
+            assert_array_almost_equal(t, [1, 1, 3, 3])
+
+        assert_array_almost_equal(lut.get_coeffs(), [3, 3, 3, 3])
+        assert abs(lut.get_residual()) < 1e-15
+        assert_array_almost_equal(lut([1, 1.5, 2], [1, 1.5]), [[3, 3], [3, 3], [3, 3]])
 
     def test_linear_1d(self):
         x = [1,1,1,2,2,2,3,3,3]
         y = [1,2,3,1,2,3,1,2,3]
         z = [0,0,0,2,2,2,4,4,4]
         lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1)
-        assert_array_almost_equal(lut.get_knots(),([1,1,3,3],[1,1,3,3]))
-        assert_array_almost_equal(lut.get_coeffs(),[0,0,4,4])
-        assert_almost_equal(lut.get_residual(),0.0)
+        for t in lut.get_knots():
+            xp_assert_close(t, np.asarray([1.0, 1, 3, 3]))
+        assert_array_almost_equal(lut.get_coeffs(), [0, 0, 4, 4])
+        assert abs(lut.get_residual()) < 1e-15
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
 
     def test_integral(self):
@@ -600,16 +605,19 @@ class TestSmoothBivariateSpline:
         tz = lut(tx, ty)
         trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
                     * (tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
-        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
+        assert_almost_equal(np.asarray(lut.integral(tx[0], tx[-1], ty[0], ty[-1])),
+                            np.asarray(trpz))
 
         lut2 = SmoothBivariateSpline(x, y, z, kx=2, ky=2, s=0)
-        assert_almost_equal(lut2.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz,
+        assert_almost_equal(np.asarray(lut2.integral(tx[0], tx[-1], ty[0], ty[-1])),
+                            np.asarray(trpz),
                             decimal=0)  # the quadratures give 23.75 and 23.85
 
         tz = lut(tx[:-1], ty[:-1])
         trpz = .25*(diff(tx[:-1])[:,None]*diff(ty[:-1])[None,:]
                     * (tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
-        assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
+        assert_almost_equal(np.asarray(lut.integral(tx[0], tx[-2], ty[0], ty[-2])),
+                            np.asarray(trpz))
 
     def test_rerun_lwrk2_too_small(self):
         # in this setting, lwrk2 is too small in the default run. Here we
@@ -682,7 +690,7 @@ class TestSmoothBivariateSpline:
         spl2 = SmoothBivariateSpline(x.tolist(), y.tolist(), z.tolist(),
                                      bbox=bbox.tolist(), w=w.tolist(),
                                      kx=1, ky=1)
-        assert_allclose(spl1(0.1, 0.5), spl2(0.1, 0.5))
+        xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
 
 class TestLSQSphereBivariateSpline:
@@ -705,7 +713,7 @@ class TestLSQSphereBivariateSpline:
         self.new_lons, self.new_lats = knotsp, knotst
 
     def test_linear_constant(self):
-        assert_almost_equal(self.lut_lsq.get_residual(), 0.0)
+        assert abs(self.lut_lsq.get_residual()) < 1e-15
         assert_array_almost_equal(self.lut_lsq(self.new_lats, self.new_lons),
                                   self.data)
 
@@ -832,7 +840,7 @@ class TestSmoothSphereBivariateSpline:
         self.lut = SmoothSphereBivariateSpline(theta, phi, r, s=1E10)
 
     def test_linear_constant(self):
-        assert_almost_equal(self.lut.get_residual(), 0.)
+        assert abs(self.lut.get_residual()) < 1e-15
         assert_array_almost_equal(self.lut([1, 1.5, 2],[1, 1.5]),
                                   [[3, 3], [3, 3], [3, 3]])
 
@@ -1018,7 +1026,7 @@ class TestRectBivariateSpline:
         y = array([1,2,3,4,5])
         z = array([[1,2,1,2,1],[1,2,1,2,1],[1,2,3,2,1],[1,2,2,2,1],[1,2,1,2,1]])
         lut = RectBivariateSpline(x,y,z)
-        assert_allclose(lut(x, y), lut(x[:,None], y[None,:], grid=False))
+        xp_assert_close(lut(x, y), lut(x[:,None], y[None,:], grid=False))
 
     def test_invalid_input(self):
 
@@ -1180,26 +1188,26 @@ class TestRectSphereBivariateSpline:
         y = linspace(0.02, 2*pi-0.02, 7)
         x = linspace(0.02, pi-0.02, 7)
 
-        assert_allclose(lut(x, y, dtheta=1), _numdiff_2d(lut, x, y, dx=1),
+        xp_assert_close(lut(x, y, dtheta=1), _numdiff_2d(lut, x, y, dx=1),
                         rtol=1e-4, atol=1e-4)
-        assert_allclose(lut(x, y, dphi=1), _numdiff_2d(lut, x, y, dy=1),
+        xp_assert_close(lut(x, y, dphi=1), _numdiff_2d(lut, x, y, dy=1),
                         rtol=1e-4, atol=1e-4)
-        assert_allclose(lut(x, y, dtheta=1, dphi=1),
+        xp_assert_close(lut(x, y, dtheta=1, dphi=1),
                         _numdiff_2d(lut, x, y, dx=1, dy=1, eps=1e-6),
                         rtol=1e-3, atol=1e-3)
 
-        assert_array_equal(lut(x, y, dtheta=1),
+        xp_assert_equal(lut(x, y, dtheta=1),
                            lut.partial_derivative(1, 0)(x, y))
-        assert_array_equal(lut(x, y, dphi=1),
+        xp_assert_equal(lut(x, y, dphi=1),
                            lut.partial_derivative(0, 1)(x, y))
-        assert_array_equal(lut(x, y, dtheta=1, dphi=1),
+        xp_assert_equal(lut(x, y, dtheta=1, dphi=1),
                            lut.partial_derivative(1, 1)(x, y))
 
-        assert_array_equal(lut(x, y, dtheta=1, grid=False),
+        xp_assert_equal(lut(x, y, dtheta=1, grid=False),
                            lut.partial_derivative(1, 0)(x, y, grid=False))
-        assert_array_equal(lut(x, y, dphi=1, grid=False),
+        xp_assert_equal(lut(x, y, dphi=1, grid=False),
                            lut.partial_derivative(0, 1)(x, y, grid=False))
-        assert_array_equal(lut(x, y, dtheta=1, dphi=1, grid=False),
+        xp_assert_equal(lut(x, y, dtheta=1, dphi=1, grid=False),
                            lut.partial_derivative(1, 1)(x, y, grid=False))
 
     def test_derivatives(self):
@@ -1215,13 +1223,13 @@ class TestRectSphereBivariateSpline:
         x = linspace(0.02, pi-0.02, 7)
 
         assert lut(x, y, dtheta=1, grid=False).shape == x.shape
-        assert_allclose(lut(x, y, dtheta=1, grid=False),
+        xp_assert_close(lut(x, y, dtheta=1, grid=False),
                         _numdiff_2d(lambda x,y: lut(x,y,grid=False), x, y, dx=1),
                         rtol=1e-4, atol=1e-4)
-        assert_allclose(lut(x, y, dphi=1, grid=False),
+        xp_assert_close(lut(x, y, dphi=1, grid=False),
                         _numdiff_2d(lambda x,y: lut(x,y,grid=False), x, y, dy=1),
                         rtol=1e-4, atol=1e-4)
-        assert_allclose(lut(x, y, dtheta=1, dphi=1, grid=False),
+        xp_assert_close(lut(x, y, dtheta=1, dphi=1, grid=False),
                         _numdiff_2d(lambda x,y: lut(x,y,grid=False),
                                     x, y, dx=1, dy=1, eps=1e-6),
                         rtol=1e-3, atol=1e-3)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,7 +1,7 @@
 # Created by Pearu Peterson, June 2003
 import itertools
 import numpy as np
-from numpy.testing import (assert_equal, assert_almost_equal, assert_array_equal,
+from numpy.testing import (assert_almost_equal, assert_array_equal,
         assert_array_almost_equal, assert_allclose, suppress_warnings)
 from pytest import raises as assert_raises
 
@@ -31,11 +31,11 @@ class TestUnivariateSpline:
         y = [0, 2, 4]
         lut = UnivariateSpline(x, y, k=1)
         arg = 2
-        assert_equal(shape(arg), shape(lut(arg)))
-        assert_equal(shape(arg), shape(lut(arg, nu=1)))
+        assert shape(arg) == shape(lut(arg))
+        assert shape(arg) == shape(lut(arg, nu=1))
         arg = [1.5, 2, 2.5]
-        assert_equal(shape(arg), shape(lut(arg)))
-        assert_equal(shape(arg), shape(lut(arg, nu=1)))
+        assert shape(arg) == shape(lut(arg))
+        assert shape(arg) == shape(lut(arg, nu=1))
 
     def test_linear_1d(self):
         x = [1,2,3]
@@ -73,7 +73,7 @@ class TestUnivariateSpline:
         x = np.linspace(0, 50 * np.pi, 1000)
         y = np.cos(x)
         spl = UnivariateSpline(x, y, s=0)
-        assert_equal(len(spl.roots()), 50)
+        assert len(spl.roots()) == 50
 
     def test_derivatives(self):
         x = [1, 3, 5, 7, 9]
@@ -387,7 +387,7 @@ too small.
 There is an approximation returned but the corresponding weighted sum
 of squared residuals does not satisfy the condition abs\(fp-s\)/s < tol.""")
             UnivariateSpline(x, y, k=1)
-            assert_equal(len(r), 1)
+            assert len(r) == 1
 
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to
@@ -416,7 +416,7 @@ class TestLSQBivariateSpline:
         with suppress_warnings() as sup:
             r = sup.record(UserWarning, "\nThe coefficients of the spline")
             lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
-            assert_equal(len(r), 1)
+            assert len(r) == 1
 
         assert_almost_equal(lut(2,2), 3.)
 
@@ -456,7 +456,7 @@ class TestLSQBivariateSpline:
         with suppress_warnings() as sup:
             r = sup.record(UserWarning, "\nThe coefficients of the spline")
             lut = LSQBivariateSpline(x, y, z, tx, ty, kx=1, ky=1)
-            assert_equal(len(r), 1)
+            assert len(r) == 1
         tx, ty = lut.get_knots()
         tz = lut(tx, ty)
         trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
@@ -476,7 +476,7 @@ class TestLSQBivariateSpline:
         with suppress_warnings() as sup:
             r = sup.record(UserWarning, "\nThe coefficients of the spline")
             lut = LSQBivariateSpline(x, y, z, tx, ty, kx=1, ky=1)
-            assert_equal(len(r), 1)
+            assert len(r) == 1
 
         assert_array_equal(lut([], []), np.zeros((0,0)))
         assert_array_equal(lut([], [], grid=False), np.zeros((0,)))
@@ -543,7 +543,7 @@ class TestLSQBivariateSpline:
                                       tx.tolist(), ty.tolist(), w=w.tolist(),
                                       bbox=bbox)
             assert_allclose(spl1(2.0, 2.0), spl2(2.0, 2.0))
-            assert_equal(len(r), 2)
+            assert len(r) == 2
 
     def test_unequal_length_of_knots(self):
         """Test for the case when the input knot-location arrays in x and y are
@@ -558,7 +558,7 @@ class TestLSQBivariateSpline:
         with suppress_warnings() as sup:
             r = sup.record(UserWarning, "\nThe coefficients of the spline")
             lut = LSQBivariateSpline(x,y,z,tx,ty)
-            assert_equal(len(r), 1)
+            assert len(r) == 1
 
         assert_almost_equal(lut(x, y, grid=False), z)
 
@@ -1214,7 +1214,7 @@ class TestRectSphereBivariateSpline:
         y = linspace(0.02, 2*pi-0.02, 7)
         x = linspace(0.02, pi-0.02, 7)
 
-        assert_equal(lut(x, y, dtheta=1, grid=False).shape, x.shape)
+        assert lut(x, y, dtheta=1, grid=False).shape == x.shape
         assert_allclose(lut(x, y, dtheta=1, grid=False),
                         _numdiff_2d(lambda x,y: lut(x,y,grid=False), x, y, dx=1),
                         rtol=1e-4, atol=1e-4)
@@ -1344,21 +1344,21 @@ class Test_DerivedBivariateSpline:
             lut_der = self.lut_lsq.partial_derivative(nux, nuy)
             a = lut_der(3.5, 3.5, grid=False)
             b = self.lut_lsq(3.5, 3.5, dx=nux, dy=nuy, grid=False)
-            assert_equal(a, b)
+            assert a == b
 
     def test_creation_from_Smooth(self):
         for nux, nuy in self.orders:
             lut_der = self.lut_smooth.partial_derivative(nux, nuy)
             a = lut_der(5.5, 5.5, grid=False)
             b = self.lut_smooth(5.5, 5.5, dx=nux, dy=nuy, grid=False)
-            assert_equal(a, b)
+            assert a == b
 
     def test_creation_from_Rect(self):
         for nux, nuy in self.orders:
             lut_der = self.lut_rect.partial_derivative(nux, nuy)
             a = lut_der(0.5, 1.5, grid=False)
             b = self.lut_rect(0.5, 1.5, dx=nux, dy=nuy, grid=False)
-            assert_equal(a, b)
+            assert a == b
 
     def test_invalid_attribute_fp(self):
         der = self.lut_rect.partial_derivative(1, 1)

--- a/scipy/interpolate/tests/test_gil.py
+++ b/scipy/interpolate/tests/test_gil.py
@@ -3,7 +3,6 @@ import threading
 import time
 
 import numpy as np
-from scipy._lib._array_api import xp_assert_equal
 import pytest
 import scipy.interpolate
 

--- a/scipy/interpolate/tests/test_gil.py
+++ b/scipy/interpolate/tests/test_gil.py
@@ -3,7 +3,7 @@ import threading
 import time
 
 import numpy as np
-from numpy.testing import assert_equal
+from scipy._lib._array_api import xp_assert_equal
 import pytest
 import scipy.interpolate
 
@@ -55,11 +55,11 @@ class TestGIL:
             time.sleep(0.5)
             self.log('working')
         worker_thread.join()
-        assert_equal(self.messages, [
+        assert self.messages == [
             'interpolation started',
             'working',
             'working',
             'working',
             'interpolation complete',
-        ])
+        ]
 

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -2,10 +2,12 @@ import os
 import sys
 
 import numpy as np
-from numpy.testing import (assert_allclose, assert_almost_equal,
-                           suppress_warnings)
+from numpy.testing import suppress_warnings
 from pytest import raises as assert_raises
 import pytest
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_almost_equal,
+)
 
 from scipy._lib._testutils import check_free_memory
 import scipy.interpolate.interpnd as interpnd
@@ -237,7 +239,7 @@ class TestEstimateGradients2DGlobal:
             dz = interpnd.estimate_gradients_2d_global(tri, z, tol=1e-6)
 
             assert dz.shape, (6 == 2)
-            assert_allclose(dz, np.array(grad)[None,:] + 0*dz,
+            xp_assert_close(dz, np.array(grad)[None,:] + 0*dz,
                             rtol=1e-5, atol=1e-5, err_msg="item %d" % j)
 
     def test_regression_2359(self):
@@ -282,7 +284,7 @@ class TestCloughTocher2DInterpolator:
         b = func(p[:,0], p[:,1])
 
         try:
-            assert_allclose(a, b, **kw)
+            xp_assert_close(a, b, **kw)
         except AssertionError:
             print("_check_accuracy: abs(a-b):", abs(a - b))
             print("ip.grad:", ip.grad)
@@ -418,7 +420,7 @@ class TestCloughTocher2DInterpolator:
 
         v1 = ip(p1)
         v2 = ip(p2)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
         # ... and affine invariant
         np.random.seed(1)
@@ -434,5 +436,5 @@ class TestCloughTocher2DInterpolator:
 
         w1 = ip(p1)
         w2 = ip(p2)
-        assert_allclose(w1, v1)
-        assert_allclose(w2, v2)
+        xp_assert_close(w1, v1)
+        xp_assert_close(w2, v2)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_allclose, assert_almost_equal,
+from numpy.testing import (assert_allclose, assert_almost_equal,
                            suppress_warnings)
 from pytest import raises as assert_raises
 import pytest
@@ -236,7 +236,7 @@ class TestEstimateGradients2DGlobal:
             z = func(x[:,0], x[:,1])
             dz = interpnd.estimate_gradients_2d_global(tri, z, tol=1e-6)
 
-            assert_equal(dz.shape, (6, 2))
+            assert dz.shape, (6 == 2)
             assert_allclose(dz, np.array(grad)[None,:] + 0*dz,
                             rtol=1e-5, atol=1e-5, err_msg="item %d" % j)
 

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -5,9 +5,7 @@ import numpy as np
 from numpy.testing import suppress_warnings
 from pytest import raises as assert_raises
 import pytest
-from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_almost_equal,
-)
+from scipy._lib._array_api import xp_assert_close, assert_almost_equal
 
 from scipy._lib._testutils import check_free_memory
 import scipy.interpolate.interpnd as interpnd

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -236,7 +236,7 @@ class TestEstimateGradients2DGlobal:
             z = func(x[:,0], x[:,1])
             dz = interpnd.estimate_gradients_2d_global(tri, z, tol=1e-6)
 
-            assert dz.shape, (6 == 2)
+            assert dz.shape == (6, 2)
             xp_assert_close(dz, np.array(grad)[None,:] + 0*dz,
                             rtol=1e-5, atol=1e-5, err_msg="item %d" % j)
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1497,7 +1497,8 @@ class TestPPoly:
         xp_assert_close(P.integrate(-10, -4), 2 * period_int, check_0d=False)
 
         xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5), check_0d=False)
-        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5), check_0d=False)
+        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5),
+                        check_0d=False)
         xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
                         I(2) - I(1) + I(4) - I(3.5), check_0d=False)
         xp_assert_close(P.integrate(3.5, 5 + 12),
@@ -1505,7 +1506,8 @@ class TestPPoly:
 
         xp_assert_close(P.integrate(0, -1), I(2) - I(3), check_0d=False)
         xp_assert_close(P.integrate(-9, -10), I(2) - I(3), check_0d=False)
-        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int, check_0d=False)
+        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int,
+                        check_0d=False)
 
     def test_roots(self):
         x = np.linspace(0, 1, 31)**2
@@ -1605,7 +1607,8 @@ class TestPPoly:
                                 cmpval = pp(rr, nu=1,
                                             extrapolate=extrapolate)[:,i,j]
                                 msg = f"({extrapolate!r}) r = {repr(rr)}"
-                                xp_assert_close((val-y) / cmpval, np.asarray(0.0), atol=1e-7,
+                                xp_assert_close((val-y) / cmpval, np.asarray(0.0),
+                                                atol=1e-7,
                                                 err_msg=msg, check_shape=False)
 
         # Check that we checked a number of roots

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -151,7 +151,9 @@ class TestInterp1D:
         assert not interp1d(self.x10, self.y10, bounds_error=False).bounds_error
         assert np.isnan(interp1d(self.x10, self.y10).fill_value)
         assert interp1d(self.x10, self.y10, fill_value=3.0).fill_value == 3.0
-        assert interp1d(self.x10, self.y10, fill_value=(1.0, 2.0)).fill_value == (1.0, 2.0)
+        assert (interp1d(self.x10, self.y10, fill_value=(1.0, 2.0)).fill_value ==
+                (1.0, 2.0)
+        )
         assert interp1d(self.x10, self.y10).axis == 0
         assert interp1d(self.x10, self.y210).axis == 1
         assert interp1d(self.x10, self.y102, axis=0).axis == 0

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -497,8 +497,8 @@ class TestInterp1D:
     def _check_fill_value(self, kind):
         interp = interp1d(self.x10, self.y10, kind=kind,
                           fill_value=(-100, 100), bounds_error=False)
-        assert_array_almost_equal(interp(10), 100)
-        assert_array_almost_equal(interp(-10), -100)
+        assert_array_almost_equal(interp(10), np.asarray(100.))
+        assert_array_almost_equal(interp(-10), np.asarray(-100.))
         assert_array_almost_equal(interp([-10, 10]), [-100, 100])
 
         # Proper broadcasting:
@@ -509,15 +509,15 @@ class TestInterp1D:
         for y in (self.y235, self.y325, self.y225, self.y25):
             interp = interp1d(self.x5, y, kind=kind, axis=-1,
                               fill_value=100, bounds_error=False)
-            assert_array_almost_equal(interp(10), 100)
-            assert_array_almost_equal(interp(-10), 100)
-            assert_array_almost_equal(interp([-10, 10]), 100)
+            assert_array_almost_equal(interp(10), np.asarray(100.))
+            assert_array_almost_equal(interp(-10), np.asarray(100.))
+            assert_array_almost_equal(interp([-10, 10]), np.asarray(100.))
 
             # singleton lower, singleton upper
             interp = interp1d(self.x5, y, kind=kind, axis=-1,
                               fill_value=(-100, 100), bounds_error=False)
-            assert_array_almost_equal(interp(10), 100)
-            assert_array_almost_equal(interp(-10), -100)
+            assert_array_almost_equal(interp(10), np.asarray(100.))
+            assert_array_almost_equal(interp(-10), np.asarray(-100.))
             if y.ndim == 3:
                 result = [[[-100, 100]] * y.shape[1]] * y.shape[0]
             else:
@@ -561,7 +561,7 @@ class TestInterp1D:
                           axis=-1, fill_value=fill_value, bounds_error=False)
         interp = interp1d(self.x5, self.y235, kind=kind, axis=-1,
                           fill_value=fill_value, bounds_error=False)
-        assert_array_almost_equal(interp(10), 100)
+        assert_array_almost_equal(interp(10), np.asarray(100.))
         assert_array_almost_equal(interp(-10), [[-100, -200, -300]] * 2)
         assert_array_almost_equal(interp([-10, 10]), [[[-100, 100],
                                                        [-200, 100],
@@ -574,7 +574,7 @@ class TestInterp1D:
         for y in (self.y225, self.y325, self.y25):
             interp = interp1d(self.x5, y, kind=kind, axis=-1,
                               fill_value=fill_value, bounds_error=False)
-            assert_array_almost_equal(interp(10), 100)
+            assert_array_almost_equal(interp(10), np.asarray(100))
             result = [-100, -200]
             if y.ndim == 3:
                 result = [result] * y.shape[0]
@@ -1180,19 +1180,21 @@ class TestPPoly:
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
         p = PPoly(c, x)
-        xp_assert_close(p(0.3), 1*0.3**2 + 2*0.3 + 3)
-        xp_assert_close(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        xp_assert_close(p(0.3), np.asarray(1*0.3**2 + 2*0.3 + 3))
+        xp_assert_close(p(0.7), np.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
 
     def test_periodic(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
         p = PPoly(c, x, extrapolate='periodic')
 
-        xp_assert_close(p(1.3), 1 * 0.3 ** 2 + 2 * 0.3 + 3)
-        xp_assert_close(p(-0.3), 4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6)
+        xp_assert_close(p(1.3),
+                        np.asarray(1 * 0.3 ** 2 + 2 * 0.3 + 3))
+        xp_assert_close(p(-0.3),
+                        np.asarray(4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6))
 
-        xp_assert_close(p(1.3, 1), 2 * 0.3 + 2)
-        xp_assert_close(p(-0.3, 1), 8 * (0.7 - 0.5) + 5)
+        xp_assert_close(p(1.3, 1), np.asarray(2 * 0.3 + 2))
+        xp_assert_close(p(-0.3, 1), np.asarray(8 * (0.7 - 0.5) + 5))
 
     def test_read_only(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -1276,8 +1278,8 @@ class TestPPoly:
         c = np.array([[1, 4], [2, 5], [3, 6]], dtype=float)
         x = np.array([0, 0.5, 1])
         p = PPoly.construct_fast(c, x)
-        xp_assert_close(p(0.3), 1*0.3**2 + 2*0.3 + 3)
-        xp_assert_close(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        xp_assert_close(p(0.3), np.asarray(1*0.3**2 + 2*0.3 + 3))
+        xp_assert_close(p(0.7), np.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
 
     def test_vs_alternative_implementations(self):
         np.random.seed(1234)
@@ -1367,8 +1369,8 @@ class TestPPoly:
         q = p.antiderivative()
         xp_assert_equal(q.c, [[1, 0.5], [0, 1]])
         xp_assert_equal(q.x, [0.0, 1, 2])
-        xp_assert_close(p.integrate(0, 2), 1.5)
-        xp_assert_close(q(2) - q(0), 1.5)
+        xp_assert_close(p.integrate(0, 2), np.asarray(1.5))
+        xp_assert_close(q(2) - q(0), 1.5, check_0d=False)
 
     def test_antiderivative_simple(self):
         np.random.seed(1234)
@@ -1460,12 +1462,12 @@ class TestPPoly:
         ig = pp.integrate(a, b)
 
         ipp = pp.antiderivative()
-        xp_assert_close(ig, ipp(b) - ipp(a))
-        xp_assert_close(ig, splint(a, b, spl))
+        xp_assert_close(ig, ipp(b) - ipp(a), check_0d=False)
+        xp_assert_close(ig, splint(a, b, spl), check_0d=False)
 
         a, b = -0.3, 0.9
         ig = pp.integrate(a, b, extrapolate=True)
-        xp_assert_close(ig, ipp(b) - ipp(a))
+        xp_assert_close(ig, ipp(b) - ipp(a), check_0d=False)
 
         assert np.isnan(pp.integrate(a, b, extrapolate=False)).all()
 
@@ -1490,20 +1492,20 @@ class TestPPoly:
 
         period_int = I(4) - I(1)
 
-        xp_assert_close(P.integrate(1, 4), period_int)
-        xp_assert_close(P.integrate(-10, -7), period_int)
-        xp_assert_close(P.integrate(-10, -4), 2 * period_int)
+        xp_assert_close(P.integrate(1, 4), period_int, check_0d=False)
+        xp_assert_close(P.integrate(-10, -7), period_int, check_0d=False)
+        xp_assert_close(P.integrate(-10, -4), 2 * period_int, check_0d=False)
 
-        xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
-        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5), check_0d=False)
+        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5), check_0d=False)
         xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
-                        I(2) - I(1) + I(4) - I(3.5))
+                        I(2) - I(1) + I(4) - I(3.5), check_0d=False)
         xp_assert_close(P.integrate(3.5, 5 + 12),
-                        I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
+                        I(2) - I(1) + I(4) - I(3.5) + 4 * period_int, check_0d=False)
 
-        xp_assert_close(P.integrate(0, -1), I(2) - I(3))
-        xp_assert_close(P.integrate(-9, -10), I(2) - I(3))
-        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+        xp_assert_close(P.integrate(0, -1), I(2) - I(3), check_0d=False)
+        xp_assert_close(P.integrate(-9, -10), I(2) - I(3), check_0d=False)
+        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int, check_0d=False)
 
     def test_roots(self):
         x = np.linspace(0, 1, 31)**2
@@ -1603,7 +1605,7 @@ class TestPPoly:
                                 cmpval = pp(rr, nu=1,
                                             extrapolate=extrapolate)[:,i,j]
                                 msg = f"({extrapolate!r}) r = {repr(rr)}"
-                                xp_assert_close((val-y) / cmpval, 0.0, atol=1e-7,
+                                xp_assert_close((val-y) / cmpval, np.asarray(0.0), atol=1e-7,
                                                 err_msg=msg, check_shape=False)
 
         # Check that we checked a number of roots
@@ -1666,39 +1668,43 @@ class TestBPoly:
         x = [0, 1]
         c = [[3]]
         bp = BPoly(c, x)
-        xp_assert_close(bp(0.1), 3.)
+        xp_assert_close(bp(0.1), np.asarray(3.))
 
     def test_simple2(self):
         x = [0, 1]
         c = [[3], [1]]
         bp = BPoly(c, x)   # 3*(1-x) + 1*x
-        xp_assert_close(bp(0.1), 3*0.9 + 1.*0.1)
+        xp_assert_close(bp(0.1), np.asarray(3*0.9 + 1.*0.1))
 
     def test_simple3(self):
         x = [0, 1]
         c = [[3], [1], [4]]
         bp = BPoly(c, x)   # 3 * (1-x)**2 + 2 * x (1-x) + 4 * x**2
         xp_assert_close(bp(0.2),
-                3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2)
+                np.asarray(3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2))
 
     def test_simple4(self):
         x = [0, 1]
         c = [[1], [1], [1], [2]]
         bp = BPoly(c, x)
-        xp_assert_close(bp(0.3), 0.7**3 +
-                                 3 * 0.7**2 * 0.3 +
-                                 3 * 0.7 * 0.3**2 +
-                             2 * 0.3**3)
+        xp_assert_close(bp(0.3),
+                        np.asarray(    0.7**3 +
+                                   3 * 0.7**2 * 0.3 +
+                                   3 * 0.7 * 0.3**2 +
+                                   2 * 0.3**3)
+        )
 
     def test_simple5(self):
         x = [0, 1]
         c = [[1], [1], [8], [2], [1]]
         bp = BPoly(c, x)
-        xp_assert_close(bp(0.3), 0.7**4 +
+        xp_assert_close(bp(0.3),
+                        np.asarray(  0.7**4 +
                                  4 * 0.7**3 * 0.3 +
                              8 * 6 * 0.7**2 * 0.3**2 +
                              2 * 4 * 0.7 * 0.3**3 +
                                  0.3**4)
+        )
 
     def test_periodic(self):
         x = [0, 1, 3]
@@ -1706,11 +1712,11 @@ class TestBPoly:
         # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp = BPoly(c, x, extrapolate='periodic')
 
-        xp_assert_close(bp(3.4), 3 * 0.6**2)
-        xp_assert_close(bp(-1.3), 2 * (0.7/2)**2)
+        xp_assert_close(bp(3.4), np.asarray(3 * 0.6**2))
+        xp_assert_close(bp(-1.3), np.asarray(2 * (0.7/2)**2))
 
-        xp_assert_close(bp(3.4, 1), -6 * 0.6)
-        xp_assert_close(bp(-1.3, 1), 2 * (0.7/2))
+        xp_assert_close(bp(3.4, 1), np.asarray(-6 * 0.6))
+        xp_assert_close(bp(-1.3, 1), np.asarray(2 * (0.7/2)))
 
     def test_descending(self):
         np.random.seed(0)
@@ -1764,15 +1770,17 @@ class TestBPoly:
         bp = BPoly(c, x)
         xval = 0.1
         s = xval / 2  # s = (x - xa) / (xb - xa)
-        xp_assert_close(bp(xval), 3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+        xp_assert_close(bp(xval),
+                        np.asarray(3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+        )
 
     def test_two_intervals(self):
         x = [0, 1, 3]
         c = [[3, 0], [0, 0], [0, 2]]
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
 
-        xp_assert_close(bp(0.4), 3 * 0.6*0.6)
-        xp_assert_close(bp(1.7), 2 * (0.7/2)**2)
+        xp_assert_close(bp(0.4), np.asarray(3 * 0.6*0.6))
+        xp_assert_close(bp(1.7), np.asarray(2 * (0.7/2)**2))
 
     def test_extrapolate_attr(self):
         x = [0, 2]
@@ -1796,8 +1804,8 @@ class TestBPolyCalculus:
         c = [[3, 0], [0, 0], [0, 2]]
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp_der = bp.derivative()
-        xp_assert_close(bp_der(0.4), -6*(0.6))
-        xp_assert_close(bp_der(1.7), 0.7)
+        xp_assert_close(bp_der(0.4), np.asarray(-6*(0.6)))
+        xp_assert_close(bp_der(1.7), np.asarray(0.7))
 
         # derivatives in-place
         xp_assert_close(np.asarray([bp(0.4, nu) for nu in [1, 2, 3]]),
@@ -1894,7 +1902,7 @@ class TestBPolyCalculus:
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
         xp_assert_close(bp.integrate(0, 1),
-                        pp.integrate(0, 1), atol=1e-12, rtol=1e-12)
+                        pp.integrate(0, 1), atol=1e-12, rtol=1e-12, check_0d=False)
 
     def test_integrate_extrap(self):
         c = [[1]]
@@ -1902,7 +1910,7 @@ class TestBPolyCalculus:
         b = BPoly(c, x)
 
         # default is extrapolate=True
-        xp_assert_close(b.integrate(0, 2), 2., atol=1e-14)
+        xp_assert_close(b.integrate(0, 2), 2., atol=1e-14, check_0d=False)
 
         # .integrate argument overrides self.extrapolate
         b1 = BPoly(c, x, extrapolate=False)
@@ -2034,8 +2042,8 @@ class TestBPolyFromDerivatives:
         c = BPoly._construct_from_derivatives(0, 1, ya, yb)
         pp = BPoly(c[:, None], [0, 1])
         for j in range(6):
-            xp_assert_close(pp(0.), ya[j])
-            xp_assert_close(pp(1.), yb[j])
+            xp_assert_close(pp(0.), ya[j], check_0d=False)
+            xp_assert_close(pp(1.), yb[j], check_0d=False)
             pp = pp.derivative()
 
     def test_raise_degree(self):
@@ -2151,14 +2159,14 @@ class TestBPolyFromDerivatives:
         # one arbitrary precision integer type, so both should fail.
         orders = np.int32(1)
         p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
-        assert_almost_equal(p(0), 0)
+        assert_almost_equal(p(0), 0, check_0d=False)
         orders = np.int64(1)
         p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
-        assert_almost_equal(p(0), 0)
+        assert_almost_equal(p(0), 0, check_0d=False)
         orders = 1
         # This worked before; make sure it still works
         p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
-        assert_almost_equal(p(0), 0)
+        assert_almost_equal(p(0), 0, check_0d=False)
         orders = 1
 
 
@@ -2346,7 +2354,7 @@ class TestNdPPoly:
             ig = p.integrate(ranges)
             ig2, err2 = nquad(lambda x, y: p((x, y)), ranges,
                               opts=[dict(epsrel=1e-5, epsabs=1e-5)]*2)
-            xp_assert_close(ig, ig2, rtol=1e-5, atol=1e-5,
+            xp_assert_close(ig, ig2, rtol=1e-5, atol=1e-5, check_0d=False,
                             err_msg=repr(ranges))
 
     def test_integrate_1d(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,7 +1,6 @@
-from numpy.testing import (assert_almost_equal,
-                           assert_array_almost_equal, assert_array_equal,
-                           assert_allclose)
-from scipy._lib._array_api import xp_assert_equal, xp_assert_close
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal
+)
 from pytest import raises as assert_raises
 import pytest
 
@@ -156,9 +155,9 @@ class TestInterp1D:
         assert interp1d(self.x10, self.y10).axis == 0
         assert interp1d(self.x10, self.y210).axis == 1
         assert interp1d(self.x10, self.y102, axis=0).axis == 0
-        assert_array_equal(interp1d(self.x10, self.y10).x, self.x10)
-        assert_array_equal(interp1d(self.x10, self.y10).y, self.y10)
-        assert_array_equal(interp1d(self.x10, self.y210).y, self.y210)
+        xp_assert_equal(interp1d(self.x10, self.y10).x, self.x10)
+        xp_assert_equal(interp1d(self.x10, self.y10).y, self.y10)
+        xp_assert_equal(interp1d(self.x10, self.y210).y, self.y210)
 
     def test_assume_sorted(self):
         # Check for unsorted arrays
@@ -166,7 +165,7 @@ class TestInterp1D:
         interp10_unsorted = interp1d(self.x10[::-1], self.y10[::-1])
 
         assert_array_almost_equal(interp10_unsorted(self.x10), self.y10)
-        assert_array_almost_equal(interp10_unsorted(1.2), np.array([1.2]))
+        assert_array_almost_equal(interp10_unsorted(1.2), np.array(1.2))
         assert_array_almost_equal(interp10_unsorted([2.4, 5.6, 6.0]),
                                   interp10([2.4, 5.6, 6.0]))
 
@@ -194,14 +193,14 @@ class TestInterp1D:
         # Check the actual implementation of linear interpolation.
         interp10 = interp1d(self.x10, self.y10, kind=kind)
         assert_array_almost_equal(interp10(self.x10), self.y10)
-        assert_array_almost_equal(interp10(1.2), np.array([1.2]))
+        assert_array_almost_equal(interp10(1.2), np.array(1.2))
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2.4, 5.6, 6.0]))
 
         # test fill_value="extrapolate"
         extrapolator = interp1d(self.x10, self.y10, kind=kind,
                                 fill_value='extrapolate')
-        assert_allclose(extrapolator([-1., 0, 9, 11]),
+        xp_assert_close(extrapolator([-1., 0, 9, 11]),
                         [-1, 0, 9, 11], rtol=1e-14)
 
         opts = dict(kind=kind,
@@ -221,14 +220,14 @@ class TestInterp1D:
             y = x
             yp = interp1d(x, y, kind='linear')(x)
             assert yp.dtype == dtyp
-            assert_allclose(yp, y, atol=1e-15)
+            xp_assert_close(yp, y, atol=1e-15)
 
         # regression test for gh-14531, where 1D linear interpolation has been
         # has been extended to delegate to numpy.interp for integer dtypes
         x = [0, 1, 2]
         y = [np.nan, 0, 1]
         yp = interp1d(x, y)(x)
-        assert_allclose(yp, y, atol=1e-15)
+        xp_assert_close(yp, y, atol=1e-15)
 
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with
@@ -244,15 +243,16 @@ class TestInterp1D:
                     xnew = x.astype(dtn)
                     for kind in spline_kinds:
                         f = interp1d(x, y, kind=kind, bounds_error=False)
-                        assert_allclose(f(xnew), y, atol=1e-7,
+                        xp_assert_close(f(xnew), y, atol=1e-7,
+                                        check_dtype=False,
                                         err_msg=f"{dtx}, {dty} {dtn}")
 
     def test_cubic(self):
         # Check the actual implementation of spline interpolation.
         interp10 = interp1d(self.x10, self.y10, kind='cubic')
         assert_array_almost_equal(interp10(self.x10), self.y10)
-        assert_array_almost_equal(interp10(1.2), np.array([1.2]))
-        assert_array_almost_equal(interp10(1.5), np.array([1.5]))
+        assert_array_almost_equal(interp10(1.2), np.array(1.2))
+        assert_array_almost_equal(interp10(1.5), np.array(1.5))
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2.4, 5.6, 6.0]),)
 
@@ -269,7 +269,7 @@ class TestInterp1D:
         # test fill_value="extrapolate"
         extrapolator = interp1d(self.x10, self.y10, kind='nearest',
                                 fill_value='extrapolate')
-        assert_allclose(extrapolator([-1., 0, 9, 11]),
+        xp_assert_close(extrapolator([-1., 0, 9, 11]),
                         [0, 0, 9, 9], rtol=1e-14)
 
         opts = dict(kind='nearest',
@@ -290,7 +290,7 @@ class TestInterp1D:
         # test fill_value="extrapolate"
         extrapolator = interp1d(self.x10, self.y10, kind='nearest-up',
                                 fill_value='extrapolate')
-        assert_allclose(extrapolator([-1., 0, 9, 11]),
+        xp_assert_close(extrapolator([-1., 0, 9, 11]),
                         [0, 0, 9, 9], rtol=1e-14)
 
         opts = dict(kind='nearest-up',
@@ -310,24 +310,24 @@ class TestInterp1D:
         # test fill_value="extrapolate"
         extrapolator = interp1d(self.x10, self.y10, kind='previous',
                                 fill_value='extrapolate')
-        assert_allclose(extrapolator([-1., 0, 9, 11]),
+        xp_assert_close(extrapolator([-1., 0, 9, 11]),
                         [np.nan, 0, 9, 9], rtol=1e-14)
 
         # Tests for gh-9591
         interpolator1D = interp1d(self.x10, self.y10, kind="previous",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator1D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator1D([-1, -2, 5, 8, 12, 25]),
                         [np.nan, np.nan, 5, 8, 9, 9])
 
         interpolator2D = interp1d(self.x10, self.y210, kind="previous",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator2D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator2D([-1, -2, 5, 8, 12, 25]),
                         [[np.nan, np.nan, 5, 8, 9, 9],
                          [np.nan, np.nan, 15, 18, 19, 19]])
 
         interpolator2DAxis0 = interp1d(self.x10, self.y102, kind="previous",
                                        axis=0, fill_value='extrapolate')
-        assert_allclose(interpolator2DAxis0([-2, 5, 12]),
+        xp_assert_close(interpolator2DAxis0([-2, 5, 12]),
                         [[np.nan, np.nan],
                          [10, 11],
                          [18, 19]])
@@ -342,27 +342,27 @@ class TestInterp1D:
                                   [0, 1, -1], kind="previous",
                                   fill_value='extrapolate',
                                   assume_sorted=True)
-        assert_allclose(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
+        xp_assert_close(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
                         [np.nan, np.nan, 0, 1, -1, -1, -1])
 
         interpolator1D = interp1d([2, 0, 1],  # x is not ascending
                                   [-1, 0, 1], kind="previous",
                                   fill_value='extrapolate',
                                   assume_sorted=False)
-        assert_allclose(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
+        xp_assert_close(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
                         [np.nan, np.nan, 0, 1, -1, -1, -1])
 
         interpolator2D = interp1d(self.x10, self.y210_edge_updated,
                                   kind="previous",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator2D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator2D([-1, -2, 5, 8, 12, 25]),
                         [[np.nan, np.nan, 5, 8, -30, -30],
                          [np.nan, np.nan, 15, 18, -30, -30]])
 
         interpolator2DAxis0 = interp1d(self.x10, self.y102_edge_updated,
                                        kind="previous",
                                        axis=0, fill_value='extrapolate')
-        assert_allclose(interpolator2DAxis0([-2, 5, 12]),
+        xp_assert_close(interpolator2DAxis0([-2, 5, 12]),
                         [[np.nan, np.nan],
                          [10, 11],
                          [-30, -30]])
@@ -379,24 +379,24 @@ class TestInterp1D:
         # test fill_value="extrapolate"
         extrapolator = interp1d(self.x10, self.y10, kind='next',
                                 fill_value='extrapolate')
-        assert_allclose(extrapolator([-1., 0, 9, 11]),
+        xp_assert_close(extrapolator([-1., 0, 9, 11]),
                         [0, 0, 9, np.nan], rtol=1e-14)
 
         # Tests for gh-9591
         interpolator1D = interp1d(self.x10, self.y10, kind="next",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator1D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator1D([-1, -2, 5, 8, 12, 25]),
                         [0, 0, 5, 8, np.nan, np.nan])
 
         interpolator2D = interp1d(self.x10, self.y210, kind="next",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator2D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator2D([-1, -2, 5, 8, 12, 25]),
                         [[0, 0, 5, 8, np.nan, np.nan],
                          [10, 10, 15, 18, np.nan, np.nan]])
 
         interpolator2DAxis0 = interp1d(self.x10, self.y102, kind="next",
                                        axis=0, fill_value='extrapolate')
-        assert_allclose(interpolator2DAxis0([-2, 5, 12]),
+        xp_assert_close(interpolator2DAxis0([-2, 5, 12]),
                         [[0, 1],
                          [10, 11],
                          [np.nan, np.nan]])
@@ -411,27 +411,27 @@ class TestInterp1D:
                                   [0, 1, -1], kind="next",
                                   fill_value='extrapolate',
                                   assume_sorted=True)
-        assert_allclose(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
+        xp_assert_close(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
                         [0, 0, 0, 1, -1, np.nan, np.nan])
 
         interpolator1D = interp1d([2, 0, 1],  # x is not ascending
                                   [-1, 0, 1], kind="next",
                                   fill_value='extrapolate',
                                   assume_sorted=False)
-        assert_allclose(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
+        xp_assert_close(interpolator1D([-2, -1, 0, 1, 2, 3, 5]),
                         [0, 0, 0, 1, -1, np.nan, np.nan])
 
         interpolator2D = interp1d(self.x10, self.y210_edge_updated,
                                   kind="next",
                                   fill_value='extrapolate')
-        assert_allclose(interpolator2D([-1, -2, 5, 8, 12, 25]),
+        xp_assert_close(interpolator2D([-1, -2, 5, 8, 12, 25]),
                         [[30, 30, 5, 8, np.nan, np.nan],
                          [30, 30, 15, 18, np.nan, np.nan]])
 
         interpolator2DAxis0 = interp1d(self.x10, self.y102_edge_updated,
                                        kind="next",
                                        axis=0, fill_value='extrapolate')
-        assert_allclose(interpolator2DAxis0([-2, 5, 12]),
+        xp_assert_close(interpolator2DAxis0([-2, 5, 12]),
                         [[30, 30],
                          [10, 11],
                          [np.nan, np.nan]])
@@ -459,11 +459,11 @@ class TestInterp1D:
         extrap10 = interp1d(self.x10, self.y10, fill_value=self.fill_value,
                             bounds_error=False, kind=kind)
 
-        assert_array_equal(extrap10(11.2), np.array(self.fill_value))
-        assert_array_equal(extrap10(-3.4), np.array(self.fill_value))
-        assert_array_equal(extrap10([[[11.2], [-3.4], [12.6], [19.3]]]),
+        xp_assert_equal(extrap10(11.2), np.array(self.fill_value))
+        xp_assert_equal(extrap10(-3.4), np.array(self.fill_value))
+        xp_assert_equal(extrap10([[[11.2], [-3.4], [12.6], [19.3]]]),
                            np.array(self.fill_value),)
-        assert_array_equal(extrap10._check_bounds(
+        xp_assert_equal(extrap10._check_bounds(
                                np.array([-1.0, 0.0, 5.0, 9.0, 11.0])),
                            np.array([[True, False, False, False, False],
                                      [False, False, False, False, True]]))
@@ -709,8 +709,8 @@ class TestInterp1D:
 
             x2 = np.arange(2*3*1).reshape((2,3,1)) / 12.
             b = list(a)
-            b[n:n+1] = [2,3,1]
-            assert_array_almost_equal(z(x2).shape, b, err_msg=kind)
+            b[n:n+1] = [2, 3, 1]
+            assert z(x2).shape == tuple(b)
 
     def test_nd(self):
         for kind in ('linear', 'cubic', 'slinear', 'quadratic', 'nearest',
@@ -814,7 +814,7 @@ class TestInterp1D:
         # https://github.com/scipy/scipy/issues/4043
         f = interp1d([1.5], [6], kind=kind, bounds_error=False,
                      fill_value=(2, 10))
-        assert_array_equal(f([1, 1.5, 2]), [2, 6, 10])
+        xp_assert_equal(f([1, 1.5, 2]), np.asarray([2.0, 6, 10]))
         # check still error if bounds_error=True
         f = interp1d([1.5], [6], kind=kind, bounds_error=True)
         with assert_raises(ValueError, match="x_new is above"):
@@ -843,7 +843,7 @@ class TestAkima1DInterpolator:
             5.5067291516462386624652936, 5.2031367459745245795943447,
             4.1796554159017080820603951, 3.4110386597938129327189927,
             3.])
-        assert_allclose(ak(xi), yi)
+        xp_assert_close(ak(xi), yi)
 
     def test_eval_mod(self):
         # Reference values generated with the following MATLAB code:
@@ -860,7 +860,7 @@ class TestAkima1DInterpolator:
             0.0, 1.34471153846154, 2.0, 1.44375, 1.94375, 2.51939102564103,
             4.10366931918656, 5.98501550899192, 5.51756330960439, 5.1757231914014,
             4.12326636931311, 3.32931513157895, 3.0])
-        assert_allclose(ak(xi), yi)
+        xp_assert_close(ak(xi), yi)
 
     def test_eval_2d(self):
         x = np.arange(0., 11.)
@@ -877,7 +877,7 @@ class TestAkima1DInterpolator:
                        4.1796554159017080820603951,
                        3.4110386597938129327189927, 3.])
         yi = np.column_stack((yi, 2. * yi))
-        assert_allclose(ak(xi), yi)
+        xp_assert_close(ak(xi), yi)
 
     def test_eval_3d(self):
         x = np.arange(0., 11.)
@@ -902,7 +902,7 @@ class TestAkima1DInterpolator:
         yi[:, 1, 0] = 2. * yi_
         yi[:, 0, 1] = 3. * yi_
         yi[:, 1, 1] = 4. * yi_
-        assert_allclose(ak(xi), yi)
+        xp_assert_close(ak(xi), yi)
 
     def test_degenerate_case_multidimensional(self):
         # This test is for issue #5683.
@@ -911,7 +911,7 @@ class TestAkima1DInterpolator:
         ak = Akima1DInterpolator(x, y)
         x_eval = np.array([0.5, 1.5])
         y_eval = ak(x_eval)
-        assert_allclose(y_eval, np.vstack((x_eval, x_eval**2)).T)
+        xp_assert_close(y_eval, np.vstack((x_eval, x_eval**2)).T)
 
     def test_extend(self):
         x = np.arange(0., 11.)
@@ -939,13 +939,13 @@ class TestAkima1DInterpolator:
         ak_false = Akima1DInterpolator(x, y, extrapolate=False)
         ak_none = Akima1DInterpolator(x, y, extrapolate=None)
         # None should default to False; extrapolated points are NaN.
-        assert_allclose(ak_false(x_ext), ak_none(x_ext), equal_nan=True, atol=1e-15)
+        xp_assert_close(ak_false(x_ext), ak_none(x_ext), atol=1e-15)
         xp_assert_equal(ak_false(x_ext)[0:4], np.full(4, np.nan))
         xp_assert_equal(ak_false(x_ext)[-4:-1], np.full(3, np.nan))
         # Extrapolation on call and attribute should be equal.
-        assert_allclose(ak_false(x_ext, extrapolate=True), ak_true(x_ext), atol=1e-15)
+        xp_assert_close(ak_false(x_ext, extrapolate=True), ak_true(x_ext), atol=1e-15)
         # Testing extrapoation to actual function.
-        assert_allclose(y_ext, ak_true(x_ext), atol=1e-15)
+        xp_assert_close(y_ext, ak_true(x_ext), atol=1e-15)
 
 
 @pytest.mark.parametrize("method", [Akima1DInterpolator, PchipInterpolator])
@@ -1001,10 +1001,10 @@ class TestPPolyCommon:
 
             pp3 = cls(c, x)
 
-            assert_array_equal(pp.c, pp3.c)
-            assert_array_equal(pp.x, pp3.x)
-            assert_array_equal(pp2.c, pp3.c)
-            assert_array_equal(pp2.x, pp3.x)
+            xp_assert_equal(pp.c, pp3.c)
+            xp_assert_equal(pp.x, pp3.x)
+            xp_assert_equal(pp2.c, pp3.c)
+            xp_assert_equal(pp2.x, pp3.x)
 
     def test_extend_diff_orders(self):
         # Test extending polynomial with different order one
@@ -1028,8 +1028,8 @@ class TestPPolyCommon:
             xi1 = np.linspace(0, 1, 300, endpoint=False)
             xi2 = np.linspace(1, 2, 300)
 
-            assert_allclose(pp1(xi1), pp_comb(xi1))
-            assert_allclose(pp2(xi2), pp_comb(xi2))
+            xp_assert_close(pp1(xi1), pp_comb(xi1))
+            xp_assert_close(pp2(xi2), pp_comb(xi2))
 
     def test_extend_descending(self):
         np.random.seed(0)
@@ -1047,10 +1047,10 @@ class TestPPolyCommon:
             p2 = cls(c[:, 10:], x[10:])
             p2.extend(c[:, :10], x[:10])
 
-            assert_array_equal(p1.c, p.c)
-            assert_array_equal(p1.x, p.x)
-            assert_array_equal(p2.c, p.c)
-            assert_array_equal(p2.x, p.x)
+            xp_assert_equal(p1.c, p.c)
+            xp_assert_equal(p1.x, p.x)
+            xp_assert_equal(p2.c, p.c)
+            xp_assert_equal(p2.x, p.x)
 
     def test_shape(self):
         np.random.seed(1234)
@@ -1094,8 +1094,8 @@ class TestPPolyCommon:
         for cls in (PPoly, BPoly):
             p, p_re, p_im = cls(c, x), cls(c_re, x), cls(c_im, x)
             for nu in [0, 1, 2]:
-                assert_allclose(p(xp, nu).real, p_re(xp, nu))
-                assert_allclose(p(xp, nu).imag, p_im(xp, nu))
+                xp_assert_close(p(xp, nu).real, p_re(xp, nu))
+                xp_assert_close(p(xp, nu).imag, p_im(xp, nu))
 
     def test_axis(self):
         np.random.seed(12345)
@@ -1178,19 +1178,19 @@ class TestPPoly:
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
         p = PPoly(c, x)
-        assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
-        assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        xp_assert_close(p(0.3), 1*0.3**2 + 2*0.3 + 3)
+        xp_assert_close(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
 
     def test_periodic(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
         x = np.array([0, 0.5, 1])
         p = PPoly(c, x, extrapolate='periodic')
 
-        assert_allclose(p(1.3), 1 * 0.3 ** 2 + 2 * 0.3 + 3)
-        assert_allclose(p(-0.3), 4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6)
+        xp_assert_close(p(1.3), 1 * 0.3 ** 2 + 2 * 0.3 + 3)
+        xp_assert_close(p(-0.3), 4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6)
 
-        assert_allclose(p(1.3, 1), 2 * 0.3 + 2)
-        assert_allclose(p(-0.3, 1), 8 * (0.7 - 0.5) + 5)
+        xp_assert_close(p(1.3, 1), 2 * 0.3 + 2)
+        xp_assert_close(p(-0.3, 1), 8 * (0.7 - 0.5) + 5)
 
     def test_read_only(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -1230,13 +1230,13 @@ class TestPPoly:
             pd = PPoly(cd[:, ::-1], x[::-1], extrapolate=True)
 
             x_test = np.random.uniform(-10, 20, 100)
-            assert_allclose(pa(x_test), pd(x_test), rtol=1e-13)
-            assert_allclose(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
+            xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
+            xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
             pa_d = pa.derivative()
             pd_d = pd.derivative()
 
-            assert_allclose(pa_d(x_test), pd_d(x_test), rtol=1e-13)
+            xp_assert_close(pa_d(x_test), pd_d(x_test), rtol=1e-13)
 
             # Antiderivatives won't be equal because fixing continuity is
             # done in the reverse order, but surely the differences should be
@@ -1246,13 +1246,13 @@ class TestPPoly:
             for a, b in np.random.uniform(-10, 20, (5, 2)):
                 int_a = pa.integrate(a, b)
                 int_d = pd.integrate(a, b)
-                assert_allclose(int_a, int_d, rtol=1e-13)
-                assert_allclose(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
+                xp_assert_close(int_a, int_d, rtol=1e-13)
+                xp_assert_close(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
                                 rtol=1e-13)
 
             roots_d = pd.roots()
             roots_a = pa.roots()
-            assert_allclose(roots_a, np.sort(roots_d), rtol=1e-12)
+            xp_assert_close(roots_a, np.sort(roots_d), rtol=1e-12)
 
     def test_multi_shape(self):
         c = np.random.rand(6, 2, 1, 2, 3)
@@ -1274,8 +1274,8 @@ class TestPPoly:
         c = np.array([[1, 4], [2, 5], [3, 6]], dtype=float)
         x = np.array([0, 0.5, 1])
         p = PPoly.construct_fast(c, x)
-        assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
-        assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        xp_assert_close(p(0.3), 1*0.3**2 + 2*0.3 + 3)
+        xp_assert_close(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
 
     def test_vs_alternative_implementations(self):
         np.random.seed(1234)
@@ -1286,10 +1286,10 @@ class TestPPoly:
 
         xp = np.r_[0.3, 0.5, 0.33, 0.6]
         expected = _ppoly_eval_1(c, x, xp)
-        assert_allclose(p(xp), expected)
+        xp_assert_close(p(xp), expected)
 
         expected = _ppoly_eval_2(c[:,:,0], x, xp)
-        assert_allclose(p(xp)[:,0], expected)
+        xp_assert_close(p(xp)[:,0], expected)
 
     def test_from_spline(self):
         np.random.seed(1234)
@@ -1300,12 +1300,12 @@ class TestPPoly:
         pp = PPoly.from_spline(spl)
 
         xi = np.linspace(0, 1, 200)
-        assert_allclose(pp(xi), splev(xi, spl))
+        xp_assert_close(pp(xi), splev(xi, spl))
 
         # make sure .from_spline accepts BSpline objects
         b = BSpline(*spl)
         ppp = PPoly.from_spline(b)
-        assert_allclose(ppp(xi), b(xi))
+        xp_assert_close(ppp(xi), b(xi))
 
         # BSpline's extrapolate attribute propagates unless overridden
         t, c, k = spl
@@ -1325,8 +1325,8 @@ class TestPPoly:
         dpp = PPoly(dc, x)
         ddpp = PPoly(ddc, x)
 
-        assert_allclose(pp.derivative().c, dpp.c)
-        assert_allclose(pp.derivative(2).c, ddpp.c)
+        xp_assert_close(pp.derivative().c, dpp.c)
+        xp_assert_close(pp.derivative(2).c, ddpp.c)
 
     def test_derivative_eval(self):
         np.random.seed(1234)
@@ -1338,7 +1338,7 @@ class TestPPoly:
 
         xi = np.linspace(0, 1, 200)
         for dx in range(0, 3):
-            assert_allclose(pp(xi, dx), splev(xi, spl, dx))
+            xp_assert_close(pp(xi, dx), splev(xi, spl, dx))
 
     def test_derivative(self):
         np.random.seed(1234)
@@ -1350,7 +1350,7 @@ class TestPPoly:
 
         xi = np.linspace(0, 1, 200)
         for dx in range(0, 10):
-            assert_allclose(pp(xi, dx), pp.derivative(dx)(xi),
+            xp_assert_close(pp(xi, dx), pp.derivative(dx)(xi),
                             err_msg="dx=%d" % (dx,))
 
     def test_antiderivative_of_constant(self):
@@ -1365,8 +1365,8 @@ class TestPPoly:
         q = p.antiderivative()
         xp_assert_equal(q.c, [[1, 0.5], [0, 1]])
         xp_assert_equal(q.x, [0.0, 1, 2])
-        assert_allclose(p.integrate(0, 2), 1.5)
-        assert_allclose(q(2) - q(0), 1.5)
+        xp_assert_close(p.integrate(0, 2), 1.5)
+        xp_assert_close(q(2) - q(0), 1.5)
 
     def test_antiderivative_simple(self):
         np.random.seed(1234)
@@ -1387,10 +1387,10 @@ class TestPPoly:
         iipp = pp.antiderivative(2)
         iipp2 = ipp.antiderivative()
 
-        assert_allclose(ipp.x, x)
-        assert_allclose(ipp.c.T, ic.T)
-        assert_allclose(iipp.c.T, iic.T)
-        assert_allclose(iipp2.c.T, iic.T)
+        xp_assert_close(ipp.x, x)
+        xp_assert_close(ipp.c.T, ic.T)
+        xp_assert_close(iipp.c.T, iic.T)
+        xp_assert_close(iipp2.c.T, iic.T)
 
     def test_antiderivative_vs_derivative(self):
         np.random.seed(1234)
@@ -1404,7 +1404,7 @@ class TestPPoly:
 
             # check that derivative is inverse op
             pp2 = ipp.derivative(dx)
-            assert_allclose(pp.c, pp2.c)
+            xp_assert_close(pp.c, pp2.c)
 
             # check continuity
             for k in range(dx):
@@ -1413,7 +1413,7 @@ class TestPPoly:
                 r = 1e-13
                 endpoint = r*pp2.x[:-1] + (1 - r)*pp2.x[1:]
 
-                assert_allclose(pp2(pp2.x[1:]), pp2(endpoint),
+                xp_assert_close(pp2(pp2.x[1:]), pp2(endpoint),
                                 rtol=1e-7, err_msg="dx=%d k=%d" % (dx, k))
 
     def test_antiderivative_vs_spline(self):
@@ -1429,7 +1429,7 @@ class TestPPoly:
             spl2 = splantider(spl, dx)
 
             xi = np.linspace(0, 1, 200)
-            assert_allclose(pp2(xi), splev(xi, spl2),
+            xp_assert_close(pp2(xi), splev(xi, spl2),
                             rtol=1e-7)
 
     def test_antiderivative_continuity(self):
@@ -1440,11 +1440,11 @@ class TestPPoly:
         ip = p.antiderivative()
 
         # check continuity
-        assert_allclose(ip(0.5 - 1e-9), ip(0.5 + 1e-9), rtol=1e-8)
+        xp_assert_close(ip(0.5 - 1e-9), ip(0.5 + 1e-9), rtol=1e-8)
 
         # check that only lowest order coefficients were changed
         p2 = ip.derivative()
-        assert_allclose(p2.c, p.c)
+        xp_assert_close(p2.c, p.c)
 
     def test_integrate(self):
         np.random.seed(1234)
@@ -1458,12 +1458,12 @@ class TestPPoly:
         ig = pp.integrate(a, b)
 
         ipp = pp.antiderivative()
-        assert_allclose(ig, ipp(b) - ipp(a))
-        assert_allclose(ig, splint(a, b, spl))
+        xp_assert_close(ig, ipp(b) - ipp(a))
+        xp_assert_close(ig, splint(a, b, spl))
 
         a, b = -0.3, 0.9
         ig = pp.integrate(a, b, extrapolate=True)
-        assert_allclose(ig, ipp(b) - ipp(a))
+        xp_assert_close(ig, ipp(b) - ipp(a))
 
         assert np.isnan(pp.integrate(a, b, extrapolate=False)).all()
 
@@ -1488,20 +1488,20 @@ class TestPPoly:
 
         period_int = I(4) - I(1)
 
-        assert_allclose(P.integrate(1, 4), period_int)
-        assert_allclose(P.integrate(-10, -7), period_int)
-        assert_allclose(P.integrate(-10, -4), 2 * period_int)
+        xp_assert_close(P.integrate(1, 4), period_int)
+        xp_assert_close(P.integrate(-10, -7), period_int)
+        xp_assert_close(P.integrate(-10, -4), 2 * period_int)
 
-        assert_allclose(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
-        assert_allclose(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
-        assert_allclose(P.integrate(3.5 + 12, 5 + 12),
+        xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
+        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
                         I(2) - I(1) + I(4) - I(3.5))
-        assert_allclose(P.integrate(3.5, 5 + 12),
+        xp_assert_close(P.integrate(3.5, 5 + 12),
                         I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
 
-        assert_allclose(P.integrate(0, -1), I(2) - I(3))
-        assert_allclose(P.integrate(-9, -10), I(2) - I(3))
-        assert_allclose(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+        xp_assert_close(P.integrate(0, -1), I(2) - I(3))
+        xp_assert_close(P.integrate(-9, -10), I(2) - I(3))
+        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
 
     def test_roots(self):
         x = np.linspace(0, 1, 31)**2
@@ -1512,7 +1512,7 @@ class TestPPoly:
 
         r = pp.roots()
         r = r[(r >= 0 - 1e-15) & (r <= 1 + 1e-15)]
-        assert_allclose(r, sproot(spl), atol=1e-15)
+        xp_assert_close(r, sproot(spl), atol=1e-15)
 
     def test_roots_idzero(self):
         # Roots for piecewise polynomials with identically zero
@@ -1521,7 +1521,7 @@ class TestPPoly:
         x = np.array([0, 0.4, 0.6, 1.0])
 
         pp = PPoly(c, x)
-        assert_array_equal(pp.roots(),
+        xp_assert_equal(pp.roots(),
                            [0.25, 0.4, np.nan, 0.6 + 0.25])
 
         # ditto for p.solve(const) with sections identically equal const
@@ -1530,7 +1530,7 @@ class TestPPoly:
         c1[1, :] += const
         pp1 = PPoly(c1, x)
 
-        assert_array_equal(pp1.solve(const),
+        xp_assert_equal(pp1.solve(const),
                            [0.25, 0.4, np.nan, 0.6 + 0.25])
 
     def test_roots_all_zero(self):
@@ -1538,16 +1538,16 @@ class TestPPoly:
         c = [[0], [0]]
         x = [0, 1]
         p = PPoly(c, x)
-        assert_array_equal(p.roots(), [0, np.nan])
-        assert_array_equal(p.solve(0), [0, np.nan])
-        assert_array_equal(p.solve(1), [])
+        xp_assert_equal(p.roots(), [0, np.nan])
+        xp_assert_equal(p.solve(0), [0, np.nan])
+        xp_assert_equal(p.solve(1), [])
 
         c = [[0, 0], [0, 0]]
         x = [0, 1, 2]
         p = PPoly(c, x)
-        assert_array_equal(p.roots(), [0, np.nan, 1, np.nan])
-        assert_array_equal(p.solve(0), [0, np.nan, 1, np.nan])
-        assert_array_equal(p.solve(1), [])
+        xp_assert_equal(p.roots(), [0, np.nan, 1, np.nan])
+        xp_assert_equal(p.solve(0), [0, np.nan, 1, np.nan])
+        xp_assert_equal(p.solve(1), [])
 
     def test_roots_repeated(self):
         # Check roots repeated in multiple sections are reported only
@@ -1558,23 +1558,23 @@ class TestPPoly:
         x = np.array([-1, 0, 1])
 
         pp = PPoly(c, x)
-        assert_array_equal(pp.roots(), [-2, 0])
-        assert_array_equal(pp.roots(extrapolate=False), [0])
+        xp_assert_equal(pp.roots(), np.asarray([-2.0, 0.0]))
+        xp_assert_equal(pp.roots(extrapolate=False), np.asarray([0.0]))
 
     def test_roots_discont(self):
         # Check that a discontinuity across zero is reported as root
         c = np.array([[1], [-1]]).T
         x = np.array([0, 0.5, 1])
         pp = PPoly(c, x)
-        assert_array_equal(pp.roots(), [0.5])
-        assert_array_equal(pp.roots(discontinuity=False), [])
+        xp_assert_equal(pp.roots(), [0.5])
+        xp_assert_equal(pp.roots(discontinuity=False), [])
 
         # ditto for a discontinuity across y:
-        assert_array_equal(pp.solve(0.5), [0.5])
-        assert_array_equal(pp.solve(0.5, discontinuity=False), [])
+        xp_assert_equal(pp.solve(0.5), [0.5])
+        xp_assert_equal(pp.solve(0.5, discontinuity=False), [])
 
-        assert_array_equal(pp.solve(1.5), [])
-        assert_array_equal(pp.solve(1.5, discontinuity=False), [])
+        xp_assert_equal(pp.solve(1.5), [])
+        xp_assert_equal(pp.solve(1.5, discontinuity=False), [])
 
     def test_roots_random(self):
         # Check high-order polynomials with random coefficients
@@ -1601,8 +1601,8 @@ class TestPPoly:
                                 cmpval = pp(rr, nu=1,
                                             extrapolate=extrapolate)[:,i,j]
                                 msg = f"({extrapolate!r}) r = {repr(rr)}"
-                                assert_allclose((val-y) / cmpval, 0, atol=1e-7,
-                                                err_msg=msg)
+                                xp_assert_close((val-y) / cmpval, 0.0, atol=1e-7,
+                                                err_msg=msg, check_shape=False)
 
         # Check that we checked a number of roots
         assert num > 100, repr(num)
@@ -1635,7 +1635,7 @@ class TestPPoly:
                     res /= cres
                 res = res.ravel()
                 res = res[~np.isnan(res)]
-                assert_allclose(res, 0, atol=1e-10)
+                xp_assert_close(res, np.zeros_like(res), atol=1e-10)
 
     def test_extrapolate_attr(self):
         # [ 1 - x**2 ]
@@ -1653,10 +1653,10 @@ class TestPPoly:
                 assert np.isnan(pp_d([-0.1, 1.1])).all()
                 assert pp.roots() == [1]
             else:
-                assert_allclose(pp([-0.1, 1.1]), [1-0.1**2, 1-1.1**2])
+                xp_assert_close(pp([-0.1, 1.1]), [1-0.1**2, 1-1.1**2])
                 assert not np.isnan(pp_i([-0.1, 1.1])).any()
                 assert not np.isnan(pp_d([-0.1, 1.1])).any()
-                assert_allclose(pp.roots(), [1, -1])
+                xp_assert_close(pp.roots(), np.asarray([1.0, -1.0]))
 
 
 class TestBPoly:
@@ -1664,26 +1664,26 @@ class TestBPoly:
         x = [0, 1]
         c = [[3]]
         bp = BPoly(c, x)
-        assert_allclose(bp(0.1), 3.)
+        xp_assert_close(bp(0.1), 3.)
 
     def test_simple2(self):
         x = [0, 1]
         c = [[3], [1]]
         bp = BPoly(c, x)   # 3*(1-x) + 1*x
-        assert_allclose(bp(0.1), 3*0.9 + 1.*0.1)
+        xp_assert_close(bp(0.1), 3*0.9 + 1.*0.1)
 
     def test_simple3(self):
         x = [0, 1]
         c = [[3], [1], [4]]
         bp = BPoly(c, x)   # 3 * (1-x)**2 + 2 * x (1-x) + 4 * x**2
-        assert_allclose(bp(0.2),
+        xp_assert_close(bp(0.2),
                 3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2)
 
     def test_simple4(self):
         x = [0, 1]
         c = [[1], [1], [1], [2]]
         bp = BPoly(c, x)
-        assert_allclose(bp(0.3), 0.7**3 +
+        xp_assert_close(bp(0.3), 0.7**3 +
                                  3 * 0.7**2 * 0.3 +
                                  3 * 0.7 * 0.3**2 +
                              2 * 0.3**3)
@@ -1692,7 +1692,7 @@ class TestBPoly:
         x = [0, 1]
         c = [[1], [1], [8], [2], [1]]
         bp = BPoly(c, x)
-        assert_allclose(bp(0.3), 0.7**4 +
+        xp_assert_close(bp(0.3), 0.7**4 +
                                  4 * 0.7**3 * 0.3 +
                              8 * 6 * 0.7**2 * 0.3**2 +
                              2 * 4 * 0.7 * 0.3**3 +
@@ -1704,11 +1704,11 @@ class TestBPoly:
         # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp = BPoly(c, x, extrapolate='periodic')
 
-        assert_allclose(bp(3.4), 3 * 0.6**2)
-        assert_allclose(bp(-1.3), 2 * (0.7/2)**2)
+        xp_assert_close(bp(3.4), 3 * 0.6**2)
+        xp_assert_close(bp(-1.3), 2 * (0.7/2)**2)
 
-        assert_allclose(bp(3.4, 1), -6 * 0.6)
-        assert_allclose(bp(-1.3, 1), 2 * (0.7/2))
+        xp_assert_close(bp(3.4, 1), -6 * 0.6)
+        xp_assert_close(bp(-1.3, 1), 2 * (0.7/2))
 
     def test_descending(self):
         np.random.seed(0)
@@ -1724,13 +1724,13 @@ class TestBPoly:
             pd = BPoly(cd[:, ::-1], x[::-1], extrapolate=True)
 
             x_test = np.random.uniform(-10, 20, 100)
-            assert_allclose(pa(x_test), pd(x_test), rtol=1e-13)
-            assert_allclose(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
+            xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
+            xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
             pa_d = pa.derivative()
             pd_d = pd.derivative()
 
-            assert_allclose(pa_d(x_test), pd_d(x_test), rtol=1e-13)
+            xp_assert_close(pa_d(x_test), pd_d(x_test), rtol=1e-13)
 
             # Antiderivatives won't be equal because fixing continuity is
             # done in the reverse order, but surely the differences should be
@@ -1740,8 +1740,8 @@ class TestBPoly:
             for a, b in np.random.uniform(-10, 20, (5, 2)):
                 int_a = pa.integrate(a, b)
                 int_d = pd.integrate(a, b)
-                assert_allclose(int_a, int_d, rtol=1e-12)
-                assert_allclose(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
+                xp_assert_close(int_a, int_d, rtol=1e-12)
+                xp_assert_close(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
                                 rtol=1e-12)
 
     def test_multi_shape(self):
@@ -1762,15 +1762,15 @@ class TestBPoly:
         bp = BPoly(c, x)
         xval = 0.1
         s = xval / 2  # s = (x - xa) / (xb - xa)
-        assert_allclose(bp(xval), 3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+        xp_assert_close(bp(xval), 3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
 
     def test_two_intervals(self):
         x = [0, 1, 3]
         c = [[3, 0], [0, 0], [0, 2]]
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
 
-        assert_allclose(bp(0.4), 3 * 0.6*0.6)
-        assert_allclose(bp(1.7), 2 * (0.7/2)**2)
+        xp_assert_close(bp(0.4), 3 * 0.6*0.6)
+        xp_assert_close(bp(1.7), 2 * (0.7/2)**2)
 
     def test_extrapolate_attr(self):
         x = [0, 2]
@@ -1794,13 +1794,13 @@ class TestBPolyCalculus:
         c = [[3, 0], [0, 0], [0, 2]]
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp_der = bp.derivative()
-        assert_allclose(bp_der(0.4), -6*(0.6))
-        assert_allclose(bp_der(1.7), 0.7)
+        xp_assert_close(bp_der(0.4), -6*(0.6))
+        xp_assert_close(bp_der(1.7), 0.7)
 
         # derivatives in-place
-        assert_allclose([bp(0.4, nu=1), bp(0.4, nu=2), bp(0.4, nu=3)],
+        xp_assert_close([bp(0.4, nu=1), bp(0.4, nu=2), bp(0.4, nu=3)],
                         [-6*(1-0.4), 6., 0.])
-        assert_allclose([bp(1.7, nu=1), bp(1.7, nu=2), bp(1.7, nu=3)],
+        xp_assert_close([bp(1.7, nu=1), bp(1.7, nu=2), bp(1.7, nu=3)],
                         [0.7, 1., 0])
 
     def test_derivative_ppoly(self):
@@ -1816,7 +1816,7 @@ class TestBPolyCalculus:
             bp = bp.derivative()
             pp = pp.derivative()
             xp = np.linspace(x[0], x[-1], 21)
-            assert_allclose(bp(xp), pp(xp))
+            xp_assert_close(bp(xp), pp(xp))
 
     def test_deriv_inplace(self):
         np.random.seed(1234)
@@ -1829,7 +1829,7 @@ class TestBPolyCalculus:
             bp = BPoly(cc, x)
             xp = np.linspace(x[0], x[-1], 21)
             for i in range(k):
-                assert_allclose(bp(xp, i), bp.derivative(i)(xp))
+                xp_assert_close(bp(xp, i), bp.derivative(i)(xp))
 
     def test_antiderivative_simple(self):
         # f(x) = x        for x \in [0, 1),
@@ -1846,7 +1846,7 @@ class TestBPolyCalculus:
         bi = bp.antiderivative()
 
         xx = np.linspace(0, 3, 11)
-        assert_allclose(bi(xx),
+        xp_assert_close(bi(xx),
                         np.where(xx < 1, xx**2 / 2.,
                                          0.5 * xx * (xx/2. - 1) + 3./4),
                         atol=1e-12, rtol=1e-12)
@@ -1858,7 +1858,7 @@ class TestBPolyCalculus:
         bp = BPoly(c, x)
 
         xx = np.linspace(x[0], x[-1], 100)
-        assert_allclose(bp.antiderivative().derivative()(xx),
+        xp_assert_close(bp.antiderivative().derivative()(xx),
                         bp(xx), atol=1e-12, rtol=1e-12)
 
     def test_antider_ppoly(self):
@@ -1870,7 +1870,7 @@ class TestBPolyCalculus:
 
         xx = np.linspace(x[0], x[-1], 10)
 
-        assert_allclose(bp.antiderivative(2)(xx),
+        xp_assert_close(bp.antiderivative(2)(xx),
                         pp.antiderivative(2)(xx), atol=1e-12, rtol=1e-12)
 
     def test_antider_continuous(self):
@@ -1880,7 +1880,7 @@ class TestBPolyCalculus:
         bp = BPoly(c, x).antiderivative()
 
         xx = bp.x[1:-1]
-        assert_allclose(bp(xx - 1e-14),
+        xp_assert_close(bp(xx - 1e-14),
                         bp(xx + 1e-14), atol=1e-12, rtol=1e-12)
 
     def test_integrate(self):
@@ -1889,7 +1889,7 @@ class TestBPolyCalculus:
         c = np.random.random((4, 10))
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
-        assert_allclose(bp.integrate(0, 1),
+        xp_assert_close(bp.integrate(0, 1),
                         pp.integrate(0, 1), atol=1e-12, rtol=1e-12)
 
     def test_integrate_extrap(self):
@@ -1898,12 +1898,12 @@ class TestBPolyCalculus:
         b = BPoly(c, x)
 
         # default is extrapolate=True
-        assert_allclose(b.integrate(0, 2), 2., atol=1e-14)
+        xp_assert_close(b.integrate(0, 2), 2., atol=1e-14)
 
         # .integrate argument overrides self.extrapolate
         b1 = BPoly(c, x, extrapolate=False)
         assert np.isnan(b1.integrate(0, 2))
-        assert_allclose(b1.integrate(0, 2, extrapolate=True), 2., atol=1e-14)
+        xp_assert_close(b1.integrate(0, 2, extrapolate=True), 2., atol=1e-14)
 
     def test_integrate_periodic(self):
         x = np.array([1, 2, 4])
@@ -1914,20 +1914,20 @@ class TestBPolyCalculus:
 
         period_int = I(4) - I(1)
 
-        assert_allclose(P.integrate(1, 4), period_int)
-        assert_allclose(P.integrate(-10, -7), period_int)
-        assert_allclose(P.integrate(-10, -4), 2 * period_int)
+        xp_assert_close(P.integrate(1, 4), period_int)
+        xp_assert_close(P.integrate(-10, -7), period_int)
+        xp_assert_close(P.integrate(-10, -4), 2 * period_int)
 
-        assert_allclose(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
-        assert_allclose(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
-        assert_allclose(P.integrate(3.5 + 12, 5 + 12),
+        xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
+        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
                         I(2) - I(1) + I(4) - I(3.5))
-        assert_allclose(P.integrate(3.5, 5 + 12),
+        xp_assert_close(P.integrate(3.5, 5 + 12),
                         I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
 
-        assert_allclose(P.integrate(0, -1), I(2) - I(3))
-        assert_allclose(P.integrate(-9, -10), I(2) - I(3))
-        assert_allclose(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+        xp_assert_close(P.integrate(0, -1), I(2) - I(3))
+        xp_assert_close(P.integrate(-9, -10), I(2) - I(3))
+        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
 
     def test_antider_neg(self):
         # .derivative(-nu) ==> .andiderivative(nu) and vice versa
@@ -1937,9 +1937,9 @@ class TestBPolyCalculus:
 
         xx = np.linspace(0, 1, 21)
 
-        assert_allclose(b.derivative(-1)(xx), b.antiderivative()(xx),
+        xp_assert_close(b.derivative(-1)(xx), b.antiderivative()(xx),
                         atol=1e-12, rtol=1e-12)
-        assert_allclose(b.derivative(1)(xx), b.antiderivative(-1)(xx),
+        xp_assert_close(b.derivative(1)(xx), b.antiderivative(-1)(xx),
                         atol=1e-12, rtol=1e-12)
 
 
@@ -1952,8 +1952,8 @@ class TestPolyConversions:
         pp1 = PPoly.from_bernstein_basis(bp)
 
         xp = [0.1, 1.4]
-        assert_allclose(pp(xp), bp(xp))
-        assert_allclose(pp(xp), pp1(xp))
+        xp_assert_close(pp(xp), bp(xp))
+        xp_assert_close(pp(xp), pp1(xp))
 
     def test_bp_from_pp_random(self):
         np.random.seed(1234)
@@ -1965,8 +1965,8 @@ class TestPolyConversions:
         pp1 = PPoly.from_bernstein_basis(bp)
 
         xp = np.linspace(x[0], x[-1], 21)
-        assert_allclose(pp(xp), bp(xp))
-        assert_allclose(pp(xp), pp1(xp))
+        xp_assert_close(pp(xp), bp(xp))
+        xp_assert_close(pp(xp), pp1(xp))
 
     def test_pp_from_bp(self):
         x = [0, 1, 3]
@@ -1976,8 +1976,8 @@ class TestPolyConversions:
         bp1 = BPoly.from_power_basis(pp)
 
         xp = [0.1, 1.4]
-        assert_allclose(bp(xp), pp(xp))
-        assert_allclose(bp(xp), bp1(xp))
+        xp_assert_close(bp(xp), pp(xp))
+        xp_assert_close(bp(xp), bp1(xp))
 
     def test_broken_conversions(self):
         # regression test for gh-10597: from_power_basis only accepts PPoly etc.
@@ -1995,32 +1995,32 @@ class TestPolyConversions:
 class TestBPolyFromDerivatives:
     def test_make_poly_1(self):
         c1 = BPoly._construct_from_derivatives(0, 1, [2], [3])
-        assert_allclose(c1, [2., 3.])
+        xp_assert_close(c1, [2., 3.])
 
     def test_make_poly_2(self):
         c1 = BPoly._construct_from_derivatives(0, 1, [1, 0], [1])
-        assert_allclose(c1, [1., 1., 1.])
+        xp_assert_close(c1, [1., 1., 1.])
 
         # f'(0) = 3
         c2 = BPoly._construct_from_derivatives(0, 1, [2, 3], [1])
-        assert_allclose(c2, [2., 7./2, 1.])
+        xp_assert_close(c2, [2., 7./2, 1.])
 
         # f'(1) = 3
         c3 = BPoly._construct_from_derivatives(0, 1, [2], [1, 3])
-        assert_allclose(c3, [2., -0.5, 1.])
+        xp_assert_close(c3, [2., -0.5, 1.])
 
     def test_make_poly_3(self):
         # f'(0)=2, f''(0)=3
         c1 = BPoly._construct_from_derivatives(0, 1, [1, 2, 3], [4])
-        assert_allclose(c1, [1., 5./3, 17./6, 4.])
+        xp_assert_close(c1, [1., 5./3, 17./6, 4.])
 
         # f'(1)=2, f''(1)=3
         c2 = BPoly._construct_from_derivatives(0, 1, [1], [4, 2, 3])
-        assert_allclose(c2, [1., 19./6, 10./3, 4.])
+        xp_assert_close(c2, [1., 19./6, 10./3, 4.])
 
         # f'(0)=2, f'(1)=3
         c3 = BPoly._construct_from_derivatives(0, 1, [1, 2], [4, 3])
-        assert_allclose(c3, [1., 5./3, 3., 4.])
+        xp_assert_close(c3, [1., 5./3, 3., 4.])
 
     def test_make_poly_12(self):
         np.random.seed(12345)
@@ -2030,7 +2030,8 @@ class TestBPolyFromDerivatives:
         c = BPoly._construct_from_derivatives(0, 1, ya, yb)
         pp = BPoly(c[:, None], [0, 1])
         for j in range(6):
-            assert_allclose([pp(0.), pp(1.)], [ya[j], yb[j]])
+            xp_assert_close(pp(0.), ya[j])
+            xp_assert_close(pp(1.), yb[j])
             pp = pp.derivative()
 
     def test_raise_degree(self):
@@ -2044,7 +2045,7 @@ class TestBPolyFromDerivatives:
         bp1 = BPoly(c1, x)
 
         xp = np.linspace(0, 1, 11)
-        assert_allclose(bp(xp), bp1(xp))
+        xp_assert_close(bp(xp), bp1(xp))
 
     def test_xi_yi(self):
         assert_raises(ValueError, BPoly.from_derivatives, [0, 1], [0])
@@ -2062,7 +2063,9 @@ class TestBPolyFromDerivatives:
 
         ppd = pp.derivative()
         for xp in [0., 0.1, 1., 1.1, 1.9, 2., 2.5]:
-            assert_allclose([pp(xp), ppd(xp)], [0., 0.])
+            xp_assert_close(pp(xp), np.asarray(0.0))
+            xp_assert_close(ppd(xp), np.asarray(0.0))
+
 
     def _make_random_mk(self, m, k):
         # k derivatives at each breakpoint
@@ -2077,7 +2080,7 @@ class TestBPolyFromDerivatives:
         pp = BPoly.from_derivatives(xi, yi)
 
         for order in range(k//2):
-            assert_allclose(pp(xi), [yy[order] for yy in yi])
+            xp_assert_close(pp(xi), [yy[order] for yy in yi])
             pp = pp.derivative()
 
     def test_order_zero(self):
@@ -2104,7 +2107,7 @@ class TestBPolyFromDerivatives:
         pp = BPoly.from_derivatives(xi, yi, orders=order)
 
         for j in range(order//2+1):
-            assert_allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
+            xp_assert_close(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
         assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
 
@@ -2114,7 +2117,7 @@ class TestBPolyFromDerivatives:
         order = 6
         pp = BPoly.from_derivatives(xi, yi, orders=order)
         for j in range(order//2):
-            assert_allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
+            xp_assert_close(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
         assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
 
@@ -2126,7 +2129,7 @@ class TestBPolyFromDerivatives:
         for i, x in enumerate(xi[1:-1]):
             pp = BPoly.from_derivatives(xi, yi, orders=orders)
             for j in range(orders[i] // 2 + 1):
-                assert_allclose(pp(x - 1e-12), pp(x + 1e-12))
+                xp_assert_close(pp(x - 1e-12), pp(x + 1e-12))
                 pp = pp.derivative()
             assert not np.allclose(pp(x - 1e-12), pp(x + 1e-12))
 
@@ -2168,7 +2171,7 @@ class TestNdPPoly:
         v1 = p((xi,))
 
         v2 = _ppoly_eval_1(c[:,:,None], x, xi).ravel()
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_simple_2d(self):
         np.random.seed(1234)
@@ -2191,13 +2194,13 @@ class TestNdPPoly:
                            v1)
         v1 = v1.ravel()
         v2 = _ppoly2d_eval(c, (x, y), xi, yi)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
         p = NdPPoly(c, (x, y))
         for nu in (None, (0, 0), (0, 1), (1, 0), (2, 3), (9, 2)):
             v1 = p(np.c_[xi, yi], nu=nu)
             v2 = _ppoly2d_eval(c, (x, y), xi, yi, nu=nu)
-            assert_allclose(v1, v2, err_msg=repr(nu))
+            xp_assert_close(v1, v2, err_msg=repr(nu))
 
     def test_simple_3d(self):
         np.random.seed(1234)
@@ -2217,7 +2220,7 @@ class TestNdPPoly:
                    (6, 0, 2)):
             v1 = p((xi, yi, zi), nu=nu)
             v2 = _ppoly3d_eval(c, (x, y, z), xi, yi, zi, nu=nu)
-            assert_allclose(v1, v2, err_msg=repr(nu))
+            xp_assert_close(v1, v2, err_msg=repr(nu))
 
     def test_simple_4d(self):
         np.random.seed(1234)
@@ -2237,7 +2240,7 @@ class TestNdPPoly:
         v1 = p((xi, yi, zi, ui))
 
         v2 = _ppoly4d_eval(c, (x, y, z, u), xi, yi, zi, ui)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_deriv_1d(self):
         np.random.seed(1234)
@@ -2251,13 +2254,13 @@ class TestNdPPoly:
         dp = p.derivative(nu=[1])
         p1 = PPoly(c, x)
         dp1 = p1.derivative()
-        assert_allclose(dp.c, dp1.c)
+        xp_assert_close(dp.c, dp1.c)
 
         # antiderivative
         dp = p.antiderivative(nu=[2])
         p1 = PPoly(c, x)
         dp1 = p1.antiderivative(2)
-        assert_allclose(dp.c, dp1.c)
+        xp_assert_close(dp.c, dp1.c)
 
     def test_deriv_3d(self):
         np.random.seed(1234)
@@ -2273,21 +2276,21 @@ class TestNdPPoly:
         p1 = PPoly(c.transpose(0, 3, 1, 2, 4, 5), x)
         dp = p.derivative(nu=[2])
         dp1 = p1.derivative(2)
-        assert_allclose(dp.c,
+        xp_assert_close(dp.c,
                         dp1.c.transpose(0, 2, 3, 1, 4, 5))
 
         # antidifferentiate vs y
         p1 = PPoly(c.transpose(1, 4, 0, 2, 3, 5), y)
         dp = p.antiderivative(nu=[0, 1, 0])
         dp1 = p1.antiderivative(1)
-        assert_allclose(dp.c,
+        xp_assert_close(dp.c,
                         dp1.c.transpose(2, 0, 3, 4, 1, 5))
 
         # differentiate vs z
         p1 = PPoly(c.transpose(2, 5, 0, 1, 3, 4), z)
         dp = p.derivative(nu=[0, 0, 3])
         dp1 = p1.derivative(3)
-        assert_allclose(dp.c,
+        xp_assert_close(dp.c,
                         dp1.c.transpose(2, 3, 0, 4, 5, 1))
 
     def test_deriv_3d_simple(self):
@@ -2306,7 +2309,7 @@ class TestNdPPoly:
         yi = np.random.rand(20)
         zi = np.random.rand(20)
 
-        assert_allclose(ip((xi, yi, zi)),
+        xp_assert_close(ip((xi, yi, zi)),
                         xi * yi**2 * zi**4 / (gamma(3)*gamma(5)))
 
     def test_integrate_2d(self):
@@ -2339,7 +2342,7 @@ class TestNdPPoly:
             ig = p.integrate(ranges)
             ig2, err2 = nquad(lambda x, y: p((x, y)), ranges,
                               opts=[dict(epsrel=1e-5, epsabs=1e-5)]*2)
-            assert_allclose(ig, ig2, rtol=1e-5, atol=1e-5,
+            xp_assert_close(ig, ig2, rtol=1e-5, atol=1e-5,
                             err_msg=repr(ranges))
 
     def test_integrate_1d(self):
@@ -2358,15 +2361,15 @@ class TestNdPPoly:
 
         px = p.integrate_1d(a, b, axis=0)
         pax = p.antiderivative((1, 0, 0))
-        assert_allclose(px((u, v)), pax((b, u, v)) - pax((a, u, v)))
+        xp_assert_close(px((u, v)), pax((b, u, v)) - pax((a, u, v)))
 
         py = p.integrate_1d(a, b, axis=1)
         pay = p.antiderivative((0, 1, 0))
-        assert_allclose(py((u, v)), pay((u, b, v)) - pay((u, a, v)))
+        xp_assert_close(py((u, v)), pay((u, b, v)) - pay((u, a, v)))
 
         pz = p.integrate_1d(a, b, axis=2)
         paz = p.antiderivative((0, 0, 1))
-        assert_allclose(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
+        xp_assert_close(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
 
 
     def test_concurrency(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -145,11 +145,11 @@ class TestInterp1D:
     def test_init(self):
         # Check that the attributes are initialized appropriately by the
         # constructor.
-        assert_(interp1d(self.x10, self.y10).copy)
-        assert_(not interp1d(self.x10, self.y10, copy=False).copy)
-        assert_(interp1d(self.x10, self.y10).bounds_error)
-        assert_(not interp1d(self.x10, self.y10, bounds_error=False).bounds_error)
-        assert_(np.isnan(interp1d(self.x10, self.y10).fill_value))
+        assert interp1d(self.x10, self.y10).copy
+        assert not interp1d(self.x10, self.y10, copy=False).copy
+        assert interp1d(self.x10, self.y10).bounds_error
+        assert not interp1d(self.x10, self.y10, bounds_error=False).bounds_error
+        assert np.isnan(interp1d(self.x10, self.y10).fill_value)
         assert_equal(interp1d(self.x10, self.y10, fill_value=3.0).fill_value,
                      3.0)
         assert_equal(interp1d(self.x10, self.y10, fill_value=(1.0, 2.0)).fill_value,
@@ -484,7 +484,7 @@ class TestInterp1D:
         y = np.arange(10).astype(int)
         c = interp1d(x, y, kind=kind, fill_value=np.nan, bounds_error=False)
         yi = c(x - 1)
-        assert_(np.isnan(yi[0]))
+        assert np.isnan(yi[0])
         assert_array_almost_equal(yi, np.r_[np.nan, y[:-1]])
 
     def test_bounds(self):
@@ -676,7 +676,7 @@ class TestInterp1D:
                                   np.array([[3., 5.], [2., 7.]]))
 
         # Scalar input -> 0-dim scalar array output
-        assert_(isinstance(interp10(1.2), np.ndarray))
+        assert isinstance(interp10(1.2), np.ndarray)
         assert_equal(interp10(1.2).shape, ())
 
         # Multidimensional outputs.
@@ -767,7 +767,7 @@ class TestInterp1D:
         for kind in ('zero', 'slinear'):
             ir = interp1d(x, y, kind=kind)
             vals = ir([4.9, 7.0])
-            assert_(np.isfinite(vals).all())
+            assert np.isfinite(vals).all()
 
     def test_spline_nans(self):
         # Backwards compat: a single nan makes the whole spline interpolation
@@ -784,7 +784,7 @@ class TestInterp1D:
             for xnew in (6, [1, 6], [[1, 6], [3, 5]]):
                 xnew = np.asarray(xnew)
                 out, outn = ir(x), irn(x)
-                assert_(np.isnan(outn).all())
+                assert np.isnan(outn).all()
                 assert_equal(out.shape, outn.shape)
 
     def test_all_nans(self):
@@ -806,7 +806,7 @@ class TestInterp1D:
                          'cubic'):
                 f = interp1d(x, y, kind=kind)
                 vals = f(xnew)
-                assert_(np.isfinite(vals).all())
+                assert np.isfinite(vals).all()
 
     @pytest.mark.parametrize(
         "kind", ("linear", "nearest", "nearest-up", "previous", "next")
@@ -1205,7 +1205,7 @@ class TestPPoly:
             c.flags.writeable = writeable
             f = PPoly(c, x)
             vals = f(xnew)
-            assert_(np.isfinite(vals).all())
+            assert np.isfinite(vals).all()
 
     def test_descending(self):
         def binom_matrix(power):
@@ -1467,7 +1467,7 @@ class TestPPoly:
         ig = pp.integrate(a, b, extrapolate=True)
         assert_allclose(ig, ipp(b) - ipp(a))
 
-        assert_(np.isnan(pp.integrate(a, b, extrapolate=False)).all())
+        assert np.isnan(pp.integrate(a, b, extrapolate=False)).all()
 
     def test_integrate_readonly(self):
         x = np.array([1, 2, 4])
@@ -1479,7 +1479,7 @@ class TestPPoly:
             P = PPoly(c, x)
             vals = P.integrate(1, 4)
 
-            assert_(np.isfinite(vals).all())
+            assert np.isfinite(vals).all()
 
     def test_integrate_periodic(self):
         x = np.array([1, 2, 4])
@@ -1607,7 +1607,7 @@ class TestPPoly:
                                                 err_msg=msg)
 
         # Check that we checked a number of roots
-        assert_(num > 100, repr(num))
+        assert num > 100, repr(num)
 
     def test_roots_croots(self):
         # Test the complex root finding algorithm
@@ -1625,7 +1625,7 @@ class TestPPoly:
                 _ppoly._croots_poly1(c, w, y)
 
                 if k == 1:
-                    assert_(np.isnan(w).all())
+                    assert np.isnan(w).all()
                     continue
 
                 res = -y
@@ -1650,14 +1650,14 @@ class TestPPoly:
             pp_i = pp.antiderivative()
 
             if extrapolate is False:
-                assert_(np.isnan(pp([-0.1, 1.1])).all())
-                assert_(np.isnan(pp_i([-0.1, 1.1])).all())
-                assert_(np.isnan(pp_d([-0.1, 1.1])).all())
+                assert np.isnan(pp([-0.1, 1.1])).all()
+                assert np.isnan(pp_i([-0.1, 1.1])).all()
+                assert np.isnan(pp_d([-0.1, 1.1])).all()
                 assert_equal(pp.roots(), [1])
             else:
                 assert_allclose(pp([-0.1, 1.1]), [1-0.1**2, 1-1.1**2])
-                assert_(not np.isnan(pp_i([-0.1, 1.1])).any())
-                assert_(not np.isnan(pp_d([-0.1, 1.1])).any())
+                assert not np.isnan(pp_i([-0.1, 1.1])).any()
+                assert not np.isnan(pp_d([-0.1, 1.1])).any()
                 assert_allclose(pp.roots(), [1, -1])
 
 
@@ -1784,11 +1784,11 @@ class TestBPoly:
             bp = BPoly(c, x, extrapolate=extrapolate)
             bp_d = bp.derivative()
             if extrapolate is False:
-                assert_(np.isnan(bp([-0.1, 2.1])).all())
-                assert_(np.isnan(bp_d([-0.1, 2.1])).all())
+                assert np.isnan(bp([-0.1, 2.1])).all()
+                assert np.isnan(bp_d([-0.1, 2.1])).all()
             else:
-                assert_(not np.isnan(bp([-0.1, 2.1])).any())
-                assert_(not np.isnan(bp_d([-0.1, 2.1])).any())
+                assert not np.isnan(bp([-0.1, 2.1])).any()
+                assert not np.isnan(bp_d([-0.1, 2.1])).any()
 
 
 class TestBPolyCalculus:
@@ -1905,7 +1905,7 @@ class TestBPolyCalculus:
 
         # .integrate argument overrides self.extrapolate
         b1 = BPoly(c, x, extrapolate=False)
-        assert_(np.isnan(b1.integrate(0, 2)))
+        assert np.isnan(b1.integrate(0, 2))
         assert_allclose(b1.integrate(0, 2, extrapolate=True), 2., atol=1e-14)
 
     def test_integrate_periodic(self):
@@ -2061,7 +2061,7 @@ class TestBPolyFromDerivatives:
         xi = [0, 1, 2, 3]
         yi = [[0, 0], [0], [0, 0], [0, 0]]  # NB: will have to raise the degree
         pp = BPoly.from_derivatives(xi, yi)
-        assert_(pp.c.shape == (4, 3))
+        assert pp.c.shape == (4, 3)
 
         ppd = pp.derivative()
         for xp in [0., 0.1, 1., 1.1, 1.9, 2., 2.5]:
@@ -2109,7 +2109,7 @@ class TestBPolyFromDerivatives:
         for j in range(order//2+1):
             assert_allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
-        assert_(not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12)))
+        assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
 
         # now repeat with `order` being even: on each interval, it uses
         # order//2 'derivatives' @ the right-hand endpoint and
@@ -2119,7 +2119,7 @@ class TestBPolyFromDerivatives:
         for j in range(order//2):
             assert_allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
-        assert_(not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12)))
+        assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
 
     def test_orders_local(self):
         m, k = 7, 12
@@ -2131,7 +2131,7 @@ class TestBPolyFromDerivatives:
             for j in range(orders[i] // 2 + 1):
                 assert_allclose(pp(x - 1e-12), pp(x + 1e-12))
                 pp = pp.derivative()
-            assert_(not np.allclose(pp(x - 1e-12), pp(x + 1e-12)))
+            assert not np.allclose(pp(x - 1e-12), pp(x + 1e-12))
 
     def test_yi_trailing_dims(self):
         m, k = 7, 5
@@ -2400,7 +2400,7 @@ def _ppoly_eval_1(c, x, xps):
             continue
         j = np.searchsorted(x, xp) - 1
         d = xp - x[j]
-        assert_(x[j] <= xp < x[j+1])
+        assert x[j] <= xp < x[j+1]
         r = sum(c[k,j] * d**(c.shape[0]-k-1)
                 for k in range(c.shape[0]))
         out[i,:] = r

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -203,7 +203,7 @@ class TestInterp1D:
         extrapolator = interp1d(self.x10, self.y10, kind=kind,
                                 fill_value='extrapolate')
         xp_assert_close(extrapolator([-1., 0, 9, 11]),
-                        [-1, 0, 9, 11], rtol=1e-14)
+                        [-1.0, 0, 9, 11], rtol=1e-14)
 
         opts = dict(kind=kind,
                     fill_value='extrapolate',
@@ -272,7 +272,7 @@ class TestInterp1D:
         extrapolator = interp1d(self.x10, self.y10, kind='nearest',
                                 fill_value='extrapolate')
         xp_assert_close(extrapolator([-1., 0, 9, 11]),
-                        [0, 0, 9, 9], rtol=1e-14)
+                        [0.0, 0, 9, 9], rtol=1e-14)
 
         opts = dict(kind='nearest',
                     fill_value='extrapolate',
@@ -293,7 +293,7 @@ class TestInterp1D:
         extrapolator = interp1d(self.x10, self.y10, kind='nearest-up',
                                 fill_value='extrapolate')
         xp_assert_close(extrapolator([-1., 0, 9, 11]),
-                        [0, 0, 9, 9], rtol=1e-14)
+                        [0.0, 0, 9, 9], rtol=1e-14)
 
         opts = dict(kind='nearest-up',
                     fill_value='extrapolate',
@@ -464,7 +464,7 @@ class TestInterp1D:
         xp_assert_equal(extrap10(11.2), np.array(self.fill_value))
         xp_assert_equal(extrap10(-3.4), np.array(self.fill_value))
         xp_assert_equal(extrap10([[[11.2], [-3.4], [12.6], [19.3]]]),
-                           np.array(self.fill_value),)
+                           np.array(self.fill_value), check_shape=False)
         xp_assert_equal(extrap10._check_bounds(
                                np.array([-1.0, 0.0, 5.0, 9.0, 11.0])),
                            np.array([[True, False, False, False, False],
@@ -1800,10 +1800,12 @@ class TestBPolyCalculus:
         xp_assert_close(bp_der(1.7), 0.7)
 
         # derivatives in-place
-        xp_assert_close([bp(0.4, nu=1), bp(0.4, nu=2), bp(0.4, nu=3)],
-                        [-6*(1-0.4), 6., 0.])
-        xp_assert_close([bp(1.7, nu=1), bp(1.7, nu=2), bp(1.7, nu=3)],
-                        [0.7, 1., 0])
+        xp_assert_close(np.asarray([bp(0.4, nu) for nu in [1, 2, 3]]),
+                        [-6*(1-0.4), 6., 0.]
+        )
+        xp_assert_close(np.asarray([bp(1.7, nu) for nu in [1, 2, 3]]),
+                        [0.7, 1., 0]
+        )
 
     def test_derivative_ppoly(self):
         # make sure it's consistent w/ power basis

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -1,5 +1,7 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close
+)
 import pytest
 from pytest import raises as assert_raises
 
@@ -20,10 +22,10 @@ class TestGriddata:
         y = [1, 2, 3]
 
         yi = griddata(x, y, [(1,1), (1,2), (0,0)], fill_value=-1)
-        assert_array_equal(yi, [-1., -1, 1])
+        xp_assert_equal(yi, [-1., -1, 1])
 
         yi = griddata(x, y, [(1,1), (1,2), (0,0)])
-        assert_array_equal(yi, [np.nan, np.nan, 1])
+        xp_assert_equal(yi, [np.nan, np.nan, 1])
 
     def test_alternative_call(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -36,7 +38,7 @@ class TestGriddata:
                 msg = repr((method, rescale))
                 yi = griddata((x[:,0], x[:,1]), y, (x[:,0], x[:,1]), method=method,
                               rescale=rescale)
-                assert_allclose(y, yi, atol=1e-14, err_msg=msg)
+                xp_assert_close(y, yi, atol=1e-14, err_msg=msg)
 
     def test_multivalue_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -48,7 +50,7 @@ class TestGriddata:
             for rescale in (True, False):
                 msg = repr((method, rescale))
                 yi = griddata(x, y, x, method=method, rescale=rescale)
-                assert_allclose(y, yi, atol=1e-14, err_msg=msg)
+                xp_assert_close(y, yi, atol=1e-14, err_msg=msg)
 
     def test_multipoint_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -63,7 +65,7 @@ class TestGriddata:
                 yi = griddata(x, y, xi, method=method, rescale=rescale)
 
                 assert yi.shape == (5, 3)
-                assert_allclose(yi, np.tile(y[:,None], (1, 3)),
+                xp_assert_close(yi, np.tile(y[:,None], (1, 3)),
                                 atol=1e-14, err_msg=msg)
 
     def test_complex_2d(self):
@@ -80,7 +82,7 @@ class TestGriddata:
                 yi = griddata(x, y, xi, method=method, rescale=rescale)
 
                 assert yi.shape == (5, 3)
-                assert_allclose(yi, np.tile(y[:,None], (1, 3)),
+                xp_assert_close(yi, np.tile(y[:,None], (1, 3)),
                                 atol=1e-14, err_msg=msg)
 
     def test_1d(self):
@@ -88,11 +90,11 @@ class TestGriddata:
         y = np.array([1, 2, 0, 3.9, 2, 1])
 
         for method in ('nearest', 'linear', 'cubic'):
-            assert_allclose(griddata(x, y, x, method=method), y,
+            xp_assert_close(griddata(x, y, x, method=method), y,
                             err_msg=method, atol=1e-14)
-            assert_allclose(griddata(x.reshape(6, 1), y, x, method=method), y,
+            xp_assert_close(griddata(x.reshape(6, 1), y, x, method=method), y,
                             err_msg=method, atol=1e-14)
-            assert_allclose(griddata((x,), y, (x,), method=method), y,
+            xp_assert_close(griddata((x,), y, (x,), method=method), y,
                             err_msg=method, atol=1e-14)
 
     def test_1d_borders(self):
@@ -104,15 +106,15 @@ class TestGriddata:
         yi_should = np.array([1.0, 1.0])
 
         method = 'nearest'
-        assert_allclose(griddata(x, y, xi,
+        xp_assert_close(griddata(x, y, xi,
                                  method=method), yi_should,
                         err_msg=method,
                         atol=1e-14)
-        assert_allclose(griddata(x.reshape(6, 1), y, xi,
+        xp_assert_close(griddata(x.reshape(6, 1), y, xi,
                                  method=method), yi_should,
                         err_msg=method,
                         atol=1e-14)
-        assert_allclose(griddata((x, ), y, (xi, ),
+        xp_assert_close(griddata((x, ), y, (xi, ),
                                  method=method), yi_should,
                         err_msg=method,
                         atol=1e-14)
@@ -122,11 +124,11 @@ class TestGriddata:
         y = np.array([1, 2, 0, 3.9, 2, 1])
 
         for method in ('nearest', 'linear', 'cubic'):
-            assert_allclose(griddata(x, y, x, method=method), y,
+            xp_assert_close(griddata(x, y, x, method=method), y,
                             err_msg=method, atol=1e-10)
-            assert_allclose(griddata(x.reshape(6, 1), y, x, method=method), y,
+            xp_assert_close(griddata(x.reshape(6, 1), y, x, method=method), y,
                             err_msg=method, atol=1e-10)
-            assert_allclose(griddata((x,), y, (x,), method=method), y,
+            xp_assert_close(griddata((x,), y, (x,), method=method), y,
                             err_msg=method, atol=1e-10)
 
     def test_square_rescale_manual(self):
@@ -147,7 +149,7 @@ class TestGriddata:
                           method=method)
             zi_rescaled = griddata(points, values, xi, method=method,
                                    rescale=True)
-            assert_allclose(zi, zi_rescaled, err_msg=msg,
+            xp_assert_close(zi, zi_rescaled, err_msg=msg,
                             atol=1e-12)
 
     def test_xi_1d(self):
@@ -162,7 +164,7 @@ class TestGriddata:
         for method in ('nearest', 'linear', 'cubic'):
             p1 = griddata(x, y, xi, method=method)
             p2 = griddata(x, y, xi[None,:], method=method)
-            assert_allclose(p1, p2, err_msg=method)
+            xp_assert_close(p1, p2, err_msg=method)
 
             xi1 = np.array([0.5])
             xi3 = np.array([0.5, 0.5, 0.5])
@@ -182,7 +184,7 @@ class TestNearestNDInterpolator:
 
         opts = {'balanced_tree': False, 'compact_nodes': False}
         nndi_o = NearestNDInterpolator(x, y, tree_options=opts)
-        assert_allclose(nndi(x), nndi_o(x), atol=1e-14)
+        xp_assert_close(nndi(x), nndi_o(x), atol=1e-14)
 
     def test_nearest_list_argument(self):
         nd = np.array([[0, 0, 0, 0, 1, 0, 1],
@@ -192,11 +194,11 @@ class TestNearestNDInterpolator:
 
         # z is np.array
         NI = NearestNDInterpolator((d[0], d[1]), d[2])
-        assert_array_equal(NI([0.1, 0.9], [0.1, 0.9]), [0, 2])
+        xp_assert_equal(NI([0.1, 0.9], [0.1, 0.9]), [0.0, 2.0])
 
         # z is list
         NI = NearestNDInterpolator((d[0], d[1]), list(d[2]))
-        assert_array_equal(NI([0.1, 0.9], [0.1, 0.9]), [0, 2])
+        xp_assert_equal(NI([0.1, 0.9], [0.1, 0.9]), [0.0, 2.0])
 
     def test_nearest_query_options(self):
         nd = np.array([[0, 0.5, 0, 1],
@@ -209,22 +211,22 @@ class TestNearestNDInterpolator:
         # the query points' nearest distance to nd.
         NI = NearestNDInterpolator((nd[0], nd[1]), nd[2])
         distance_upper_bound = np.sqrt(delta ** 2 + delta ** 2) - 1e-7
-        assert_array_equal(NI(query_points, distance_upper_bound=distance_upper_bound),
+        xp_assert_equal(NI(query_points, distance_upper_bound=distance_upper_bound),
                            [np.nan, np.nan])
 
         # case 2 - query p is inf, will return [0, 2]
         distance_upper_bound = np.sqrt(delta ** 2 + delta ** 2) - 1e-7
         p = np.inf
-        assert_array_equal(
+        xp_assert_equal(
             NI(query_points, distance_upper_bound=distance_upper_bound, p=p),
-            [0, 2]
+            [0.0, 2.0]
         )
 
         # case 3 - query max_dist is larger, so should return non np.nan
         distance_upper_bound = np.sqrt(delta ** 2 + delta ** 2) + 1e-7
-        assert_array_equal(
+        xp_assert_equal(
             NI(query_points, distance_upper_bound=distance_upper_bound),
-            [0, 2]
+            [0.0, 2.0]
         )
 
     def test_nearest_query_valid_inputs(self):

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -64,7 +64,7 @@ class TestGriddata:
                 msg = repr((method, rescale))
                 yi = griddata(x, y, xi, method=method, rescale=rescale)
 
-                assert yi.shape == (5, 3)
+                assert yi.shape == (5, 3), msg
                 xp_assert_close(yi, np.tile(y[:,None], (1, 3)),
                                 atol=1e-14, err_msg=msg)
 

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal, assert_allclose
+from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 from pytest import raises as assert_raises
 
@@ -62,7 +62,7 @@ class TestGriddata:
                 msg = repr((method, rescale))
                 yi = griddata(x, y, xi, method=method, rescale=rescale)
 
-                assert_equal(yi.shape, (5, 3), err_msg=msg)
+                assert yi.shape == (5, 3)
                 assert_allclose(yi, np.tile(y[:,None], (1, 3)),
                                 atol=1e-14, err_msg=msg)
 
@@ -79,7 +79,7 @@ class TestGriddata:
                 msg = repr((method, rescale))
                 yi = griddata(x, y, xi, method=method, rescale=rescale)
 
-                assert_equal(yi.shape, (5, 3), err_msg=msg)
+                assert yi.shape == (5, 3)
                 assert_allclose(yi, np.tile(y[:,None], (1, 3)),
                                 atol=1e-14, err_msg=msg)
 
@@ -271,11 +271,11 @@ class TestNDInterpolators:
         interp_points3 = interp(X, Y)
         interp_points4 = interp(X, 0.0)
 
-        assert_equal(interp_points0.size ==
-                     interp_points1.size ==
-                     interp_points2.size ==
-                     interp_points3.size ==
-                     interp_points4.size, True)
+        assert (interp_points0.size ==
+                interp_points1.size ==
+                interp_points2.size ==
+                interp_points3.size ==
+                interp_points4.size)
 
     @parametrize_interpolators
     def test_read_only(self, interpolator):

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -1,14 +1,17 @@
-from numpy.testing import (assert_array_equal, assert_array_almost_equal)
+import numpy as np
 from scipy.interpolate import pade
+from scipy._lib._array_api import (
+    xp_assert_equal, assert_array_almost_equal
+)
 
 def test_pade_trivial():
     nump, denomp = pade([1.0], 0)
-    assert_array_equal(nump.c, [1.0])
-    assert_array_equal(denomp.c, [1.0])
+    xp_assert_equal(nump.c, np.asarray([1.0]))
+    xp_assert_equal(denomp.c, np.asarray([1.0]))
 
     nump, denomp = pade([1.0], 0, 0)
-    assert_array_equal(nump.c, [1.0])
-    assert_array_equal(denomp.c, [1.0])
+    xp_assert_equal(nump.c, np.asarray([1.0]))
+    xp_assert_equal(denomp.c, np.asarray([1.0]))
 
 
 def test_pade_4term_exp():
@@ -77,8 +80,8 @@ def test_pade_ints():
             nump_flt, denomp_flt = pade(an_flt, i, j)
 
             # Check that they are the same.
-            assert_array_equal(nump_int.c, nump_flt.c)
-            assert_array_equal(denomp_int.c, denomp_flt.c)
+            xp_assert_equal(nump_int.c, nump_flt.c)
+            xp_assert_equal(denomp_int.c, denomp_flt.c)
 
 
 def test_pade_complex():

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -644,14 +644,14 @@ class TestPCHIP:
     def test_pchip_interpolate(self):
         assert_array_almost_equal(
             pchip_interpolate([1,2,3], [4,5,6], [0.5], der=1),
-            [1.])
+            np.asarray([1.]))
 
         assert_array_almost_equal(
             pchip_interpolate([1,2,3], [4,5,6], [0.5], der=0),
-            [3.5])
+            np.asarray([3.5]))
 
         assert_array_almost_equal(
-            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1]),
+            np.asarray(pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1])),
             np.asarray([[3.5], [1]]))
 
     def test_roots(self):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -551,7 +551,7 @@ class TestPCHIP:
                 y1, y2 = y2, y1
             xp = np.linspace(x1, x2, 10)
             yp = p(xp)
-            assert_(((y1 <= yp + 1e-15) & (yp <= y2 + 1e-15)).all())
+            assert ((y1 <= yp + 1e-15) & (yp <= y2 + 1e-15)).all()
 
     def test_monotone(self):
         # PCHIP should preserve monotonicty
@@ -561,7 +561,7 @@ class TestPCHIP:
             y1, y2 = yi[i], yi[i+1]
             xp = np.linspace(x1, x2, 10)
             yp = p(xp)
-            assert_(((y2-y1) * (yp[1:] - yp[:1]) > 0).all())
+            assert ((y2-y1) * (yp[1:] - yp[:1]) > 0).all()
 
     def test_cast(self):
         # regression test for integer input data, see gh-3453
@@ -618,7 +618,7 @@ class TestPCHIP:
         y2 = np.array([279.35, 2.5e3, 1.50e3, 1.0e3])
         for pp in (pchip(x, y1), pchip(x, y2)):
             for t in (x[0], x[-1]):
-                assert_(pp(t, 1) != 0)
+                assert pp(t, 1) != 0
 
     def test_all_zeros(self):
         x = np.arange(10)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -703,7 +703,9 @@ class TestCubicSpline:
         elif bc_start == 'clamped':
             xp_assert_close(S(x[0], 1), np.asarray(0.0), rtol=tol, atol=tol)
         elif bc_start == 'natural':
-            xp_assert_close(S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol, check_dtype=False)
+            xp_assert_close(
+                S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol, check_dtype=False
+            )
         else:
             order, value = bc_start
             xp_assert_close(S(x[0], order), value, rtol=tol, atol=tol)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -169,8 +169,8 @@ class TestKrogh:
 
     def test_scalar(self):
         P = KroghInterpolator(self.xs,self.ys)
-        assert_almost_equal(self.true_poly(7),P(7))
-        assert_almost_equal(self.true_poly(np.array(7)), P(np.array(7)))
+        assert_almost_equal(self.true_poly(7),P(7), check_0d=False)
+        assert_almost_equal(self.true_poly(np.array(7)), P(np.array(7)), check_0d=False)
 
     def test_derivatives(self):
         P = KroghInterpolator(self.xs,self.ys)
@@ -350,8 +350,8 @@ class TestBarycentric:
 
     def test_scalar(self):
         P = BarycentricInterpolator(self.xs, self.ys)
-        xp_assert_close(P(7), self.true_poly(7))
-        xp_assert_close(P(np.array(7)), self.true_poly(np.array(7)))
+        xp_assert_close(P(7), self.true_poly(7), check_0d=False)
+        xp_assert_close(P(np.array(7)), self.true_poly(np.array(7)), check_0d=False)
 
     def test_derivatives(self):
         P = BarycentricInterpolator(self.xs, self.ys)
@@ -478,7 +478,7 @@ class TestBarycentric:
         x = 1000 * np.arange(1, 11)  # np.prod(x[-1] - x[:-1]) overflows
         y = np.arange(1, 11)
         value = barycentric_interpolate(x, y, 1000 * 9.5)
-        assert_almost_equal(value, 9.5)
+        assert_almost_equal(value, np.asarray(9.5))
 
     def test_large_chebyshev(self):
         # The weights for Chebyshev points of the second kind have analytically
@@ -683,7 +683,8 @@ class TestCubicSpline:
 
         # Check that we found a parabola, the third derivative is 0.
         if x.size == 3 and bc_start == 'not-a-knot' and bc_end == 'not-a-knot':
-            xp_assert_close(c[0], 0, rtol=tol, atol=tol)
+            xp_assert_close(c[0], 0.0, rtol=tol, atol=tol,
+                check_0d=False, check_shape=False)
             return
 
         # Check periodic boundary conditions.
@@ -697,32 +698,37 @@ class TestCubicSpline:
         if bc_start == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                xp_assert_close(S(x[0], 1), slope, rtol=tol, atol=tol)
+                xp_assert_close(S(x[0], 1), slope, rtol=tol, atol=tol, check_0d=False)
             else:
                 xp_assert_close(c[0, 0], c[0, 1], rtol=tol, atol=tol)
         elif bc_start == 'clamped':
-            xp_assert_close(S(x[0], 1), np.asarray(0.0), rtol=tol, atol=tol)
+            xp_assert_close(
+                S(x[0], 1), np.asarray(0.0), rtol=tol, atol=tol, check_shape=False
+            )
         elif bc_start == 'natural':
             xp_assert_close(
-                S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol, check_dtype=False
+                S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol,
+                check_dtype=False, check_shape=False,
             )
         else:
             order, value = bc_start
-            xp_assert_close(S(x[0], order), value, rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], order), value, rtol=tol, atol=tol, check_0d=False)
 
         if bc_end == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                xp_assert_close(S(x[1], 1), slope, rtol=tol, atol=tol)
+                xp_assert_close(S(x[1], 1), slope, rtol=tol, atol=tol, check_0d=False)
             else:
-                xp_assert_close(c[0, -1], c[0, -2], rtol=tol, atol=tol)
+                xp_assert_close(c[0, -1], c[0, -2], rtol=tol, atol=tol, check_0d=False)
         elif bc_end == 'clamped':
-            xp_assert_close(S(x[-1], 1), 0, rtol=tol, atol=tol)
+            xp_assert_close(S(x[-1], 1), 0.0, rtol=tol, atol=tol,
+                            check_0d=False, check_shape=False)
         elif bc_end == 'natural':
-            xp_assert_close(S(x[-1], 2), 0, rtol=2*tol, atol=2*tol)
+            xp_assert_close(S(x[-1], 2), 0.0, rtol=2*tol, atol=2*tol,
+                            check_0d=False, check_shape=False)
         else:
             order, value = bc_end
-            xp_assert_close(S(x[-1], order), value, rtol=tol, atol=tol)
+            xp_assert_close(S(x[-1], order), value, rtol=tol, atol=tol, check_0d=False)
 
     def check_all_bc(self, x, y, axis):
         deriv_shape = list(y.shape)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -2,9 +2,9 @@ import warnings
 import io
 import numpy as np
 
-from numpy.testing import (
-    assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_allclose )
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_array_almost_equal, assert_almost_equal
+)
 from pytest import raises as assert_raises
 import pytest
 
@@ -55,7 +55,7 @@ def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
         yv = yv.reshape(bs_shape)
 
         yi, y = np.broadcast_arrays(yi, yv)
-        assert_allclose(yi, y)
+        xp_assert_close(yi, y)
 
 
 SHAPES = [(), (0,), (1,), (6, 2, 5)]
@@ -148,12 +148,12 @@ def test_complex():
 
     for ip in [KroghInterpolator, BarycentricInterpolator, CubicSpline]:
         p = ip(x, y)
-        assert_allclose(y, p(x))
+        xp_assert_close(p(x), np.asarray(y))
 
     dydx = [0, -1j, 2, 3j]
     p = CubicHermiteSpline(x, y, dydx)
-    assert_allclose(y, p(x))
-    assert_allclose(dydx, p(x, 1))
+    xp_assert_close(p(x), np.asarray(y))
+    xp_assert_close(p(x, 1), np.asarray(dydx))
 
 
 class TestKrogh:
@@ -208,7 +208,7 @@ class TestKrogh:
         P = KroghInterpolator(self.xs, ys, axis=0)
         D = P.derivatives(self.test_xs)
         for i in range(D.shape[0]):
-            assert_allclose(D[i],
+            xp_assert_close(D[i],
                             np.stack((poly1.deriv(i)(self.test_xs),
                                       poly2.deriv(i)(self.test_xs),
                                       poly3.deriv(i)(self.test_xs)),
@@ -222,7 +222,7 @@ class TestKrogh:
 
         P = KroghInterpolator(self.xs, ys, axis=0)
         for i in range(P.n):
-            assert_allclose(P.derivative(self.test_xs, i),
+            xp_assert_close(P.derivative(self.test_xs, i),
                             np.stack((poly1.deriv(i)(self.test_xs),
                                       poly2.deriv(i)(self.test_xs),
                                       poly3.deriv(i)(self.test_xs)),
@@ -246,41 +246,41 @@ class TestKrogh:
 
     def test_empty(self):
         P = KroghInterpolator(self.xs,self.ys)
-        assert_array_equal(P([]), [])
+        xp_assert_equal(P([]), np.asarray([]))
 
     def test_shapes_scalarvalue(self):
         P = KroghInterpolator(self.xs,self.ys)
-        assert_array_equal(np.shape(P(0)), ())
-        assert_array_equal(np.shape(P(np.array(0))), ())
-        assert_array_equal(np.shape(P([0])), (1,))
-        assert_array_equal(np.shape(P([0,1])), (2,))
+        assert np.shape(P(0)) == ()
+        assert np.shape(P(np.array(0))) == ()
+        assert np.shape(P([0])) == (1,)
+        assert np.shape(P([0,1])) == (2,)
 
     def test_shapes_scalarvalue_derivative(self):
         P = KroghInterpolator(self.xs,self.ys)
         n = P.n
-        assert_array_equal(np.shape(P.derivatives(0)), (n,))
-        assert_array_equal(np.shape(P.derivatives(np.array(0))), (n,))
-        assert_array_equal(np.shape(P.derivatives([0])), (n,1))
-        assert_array_equal(np.shape(P.derivatives([0,1])), (n,2))
+        assert np.shape(P.derivatives(0)) == (n,)
+        assert np.shape(P.derivatives(np.array(0))) == (n,)
+        assert np.shape(P.derivatives([0])) == (n, 1)
+        assert np.shape(P.derivatives([0, 1])) == (n, 2)
 
     def test_shapes_vectorvalue(self):
         P = KroghInterpolator(self.xs,np.outer(self.ys,np.arange(3)))
-        assert_array_equal(np.shape(P(0)), (3,))
-        assert_array_equal(np.shape(P([0])), (1,3))
-        assert_array_equal(np.shape(P([0,1])), (2,3))
+        assert np.shape(P(0)) == (3,)
+        assert np.shape(P([0])) == (1, 3)
+        assert np.shape(P([0, 1])) == (2, 3)
 
     def test_shapes_1d_vectorvalue(self):
         P = KroghInterpolator(self.xs,np.outer(self.ys,[1]))
-        assert_array_equal(np.shape(P(0)), (1,))
-        assert_array_equal(np.shape(P([0])), (1,1))
-        assert_array_equal(np.shape(P([0,1])), (2,1))
+        assert np.shape(P(0)) == (1,)
+        assert np.shape(P([0])) == (1, 1)
+        assert np.shape(P([0,1])) == (2, 1)
 
     def test_shapes_vectorvalue_derivative(self):
         P = KroghInterpolator(self.xs,np.outer(self.ys,np.arange(3)))
         n = P.n
-        assert_array_equal(np.shape(P.derivatives(0)), (n,3))
-        assert_array_equal(np.shape(P.derivatives([0])), (n,1,3))
-        assert_array_equal(np.shape(P.derivatives([0,1])), (n,2,3))
+        assert np.shape(P.derivatives(0)) == (n, 3)
+        assert np.shape(P.derivatives([0])) == (n, 1, 3)
+        assert np.shape(P.derivatives([0,1])) == (n, 2, 3)
 
     def test_wrapper(self):
         P = KroghInterpolator(self.xs, self.ys)
@@ -301,8 +301,8 @@ class TestKrogh:
                                -0.12973574, -0.08582937, 0.05])
         f = KroghInterpolator(x, offset_cdf)
 
-        assert_allclose(abs((f(x) - offset_cdf) / f.derivative(x, 1)),
-                        0, atol=1e-10)
+        xp_assert_close(abs((f(x) - offset_cdf) / f.derivative(x, 1)),
+                        np.zeros_like(offset_cdf), atol=1e-10)
 
     def test_derivatives_complex(self):
         # regression test for gh-7381: krogh.derivatives(0) fails complex y
@@ -312,7 +312,7 @@ class TestKrogh:
 
         cmplx2 = (KroghInterpolator(x, y.real).derivatives(0) +
                   1j*KroghInterpolator(x, y.imag).derivatives(0))
-        assert_allclose(cmplx, cmplx2, atol=1e-15)
+        xp_assert_close(cmplx, cmplx2, atol=1e-15)
 
     def test_high_degree_warning(self):
         with pytest.warns(UserWarning, match="40 degrees provided,"):
@@ -346,24 +346,24 @@ class TestBarycentric:
 
     def test_lagrange(self):
         P = BarycentricInterpolator(self.xs, self.ys)
-        assert_allclose(P(self.test_xs), self.true_poly(self.test_xs))
+        xp_assert_close(P(self.test_xs), self.true_poly(self.test_xs))
 
     def test_scalar(self):
         P = BarycentricInterpolator(self.xs, self.ys)
-        assert_allclose(P(7), self.true_poly(7))
-        assert_allclose(P(np.array(7)), self.true_poly(np.array(7)))
+        xp_assert_close(P(7), self.true_poly(7))
+        xp_assert_close(P(np.array(7)), self.true_poly(np.array(7)))
 
     def test_derivatives(self):
         P = BarycentricInterpolator(self.xs, self.ys)
         D = P.derivatives(self.test_xs)
         for i in range(D.shape[0]):
-            assert_allclose(self.true_poly.deriv(i)(self.test_xs), D[i])
+            xp_assert_close(self.true_poly.deriv(i)(self.test_xs), D[i])
 
     def test_low_derivatives(self):
         P = BarycentricInterpolator(self.xs, self.ys)
         D = P.derivatives(self.test_xs, len(self.xs)+2)
         for i in range(D.shape[0]):
-            assert_allclose(self.true_poly.deriv(i)(self.test_xs),
+            xp_assert_close(self.true_poly.deriv(i)(self.test_xs),
                             D[i],
                             atol=1e-12)
 
@@ -372,12 +372,12 @@ class TestBarycentric:
         m = 10
         r = P.derivatives(self.test_xs, m)
         for i in range(m):
-            assert_allclose(P.derivative(self.test_xs, i), r[i])
+            xp_assert_close(P.derivative(self.test_xs, i), r[i])
 
     def test_high_derivative(self):
         P = BarycentricInterpolator(self.xs, self.ys)
         for i in range(len(self.xs), 5*len(self.xs)):
-            assert_allclose(P.derivative(self.test_xs, i),
+            xp_assert_close(P.derivative(self.test_xs, i),
                             np.zeros(len(self.test_xs)))
 
     def test_ndim_derivatives(self):
@@ -389,7 +389,7 @@ class TestBarycentric:
         P = BarycentricInterpolator(self.xs, ys, axis=0)
         D = P.derivatives(self.test_xs)
         for i in range(D.shape[0]):
-            assert_allclose(D[i],
+            xp_assert_close(D[i],
                             np.stack((poly1.deriv(i)(self.test_xs),
                                       poly2.deriv(i)(self.test_xs),
                                       poly3.deriv(i)(self.test_xs)),
@@ -404,7 +404,7 @@ class TestBarycentric:
 
         P = BarycentricInterpolator(self.xs, ys, axis=0)
         for i in range(P.n):
-            assert_allclose(P.derivative(self.test_xs, i),
+            xp_assert_close(P.derivative(self.test_xs, i),
                             np.stack((poly1.deriv(i)(self.test_xs),
                                       poly2.deriv(i)(self.test_xs),
                                       poly3.deriv(i)(self.test_xs)),
@@ -433,45 +433,45 @@ class TestBarycentric:
 
     def test_shapes_scalarvalue(self):
         P = BarycentricInterpolator(self.xs, self.ys)
-        assert_array_equal(np.shape(P(0)), ())
-        assert_array_equal(np.shape(P(np.array(0))), ())
-        assert_array_equal(np.shape(P([0])), (1,))
-        assert_array_equal(np.shape(P([0, 1])), (2,))
+        assert np.shape(P(0)) == ()
+        assert np.shape(P(np.array(0))) == ()
+        assert np.shape(P([0])) == (1,)
+        assert np.shape(P([0, 1])) == (2,)
 
     def test_shapes_scalarvalue_derivative(self):
         P = BarycentricInterpolator(self.xs,self.ys)
         n = P.n
-        assert_array_equal(np.shape(P.derivatives(0)), (n,))
-        assert_array_equal(np.shape(P.derivatives(np.array(0))), (n,))
-        assert_array_equal(np.shape(P.derivatives([0])), (n,1))
-        assert_array_equal(np.shape(P.derivatives([0,1])), (n,2))
+        assert np.shape(P.derivatives(0)) == (n,)
+        assert np.shape(P.derivatives(np.array(0))) == (n,)
+        assert np.shape(P.derivatives([0])) == (n,1)
+        assert np.shape(P.derivatives([0,1])) == (n,2)
 
     def test_shapes_vectorvalue(self):
         P = BarycentricInterpolator(self.xs, np.outer(self.ys, np.arange(3)))
-        assert_array_equal(np.shape(P(0)), (3,))
-        assert_array_equal(np.shape(P([0])), (1, 3))
-        assert_array_equal(np.shape(P([0, 1])), (2, 3))
+        assert np.shape(P(0)) == (3,)
+        assert np.shape(P([0])) == (1, 3)
+        assert np.shape(P([0, 1])) == (2, 3)
 
     def test_shapes_1d_vectorvalue(self):
         P = BarycentricInterpolator(self.xs, np.outer(self.ys, [1]))
-        assert_array_equal(np.shape(P(0)), (1,))
-        assert_array_equal(np.shape(P([0])), (1, 1))
-        assert_array_equal(np.shape(P([0,1])), (2, 1))
+        assert np.shape(P(0)) == (1,)
+        assert np.shape(P([0])) == (1, 1)
+        assert np.shape(P([0, 1])) == (2, 1)
 
     def test_shapes_vectorvalue_derivative(self):
         P = BarycentricInterpolator(self.xs,np.outer(self.ys,np.arange(3)))
         n = P.n
-        assert_array_equal(np.shape(P.derivatives(0)), (n,3))
-        assert_array_equal(np.shape(P.derivatives([0])), (n,1,3))
-        assert_array_equal(np.shape(P.derivatives([0,1])), (n,2,3))
+        assert np.shape(P.derivatives(0)) == (n, 3)
+        assert np.shape(P.derivatives([0])) == (n, 1, 3)
+        assert np.shape(P.derivatives([0, 1])) == (n, 2, 3)
 
     def test_wrapper(self):
         P = BarycentricInterpolator(self.xs, self.ys)
         bi = barycentric_interpolate
-        assert_allclose(P(self.test_xs), bi(self.xs, self.ys, self.test_xs))
-        assert_allclose(P.derivative(self.test_xs, 2),
+        xp_assert_close(P(self.test_xs), bi(self.xs, self.ys, self.test_xs))
+        xp_assert_close(P.derivative(self.test_xs, 2),
                             bi(self.xs, self.ys, self.test_xs, der=2))
-        assert_allclose(P.derivatives(self.test_xs, 2),
+        xp_assert_close(P.derivatives(self.test_xs, 2),
                             bi(self.xs, self.ys, self.test_xs, der=[0, 1]))
 
     def test_int_input(self):
@@ -573,7 +573,7 @@ class TestPCHIP:
         data1 = data * 1.0
         curve1 = pchip(data1[0], data1[1])(xx)
 
-        assert_allclose(curve, curve1, atol=1e-14, rtol=1e-14)
+        xp_assert_close(curve, curve1, atol=1e-14, rtol=1e-14)
 
     def test_nag(self):
         # Example from NAG C implementation,
@@ -608,7 +608,7 @@ class TestPCHIP:
           20.0000       1.0000
         '''
         result = np.loadtxt(io.StringIO(resultStr))
-        assert_allclose(result[:,1], pch(result[:,0]), rtol=0., atol=5e-5)
+        xp_assert_close(result[:,1], pch(result[:,0]), rtol=0., atol=5e-5)
 
     def test_endslopes(self):
         # this is a smoke test for gh-3453: PCHIP interpolator should not
@@ -639,7 +639,7 @@ class TestPCHIP:
         # Instead, it should construct a linear interpolator.
         x = np.linspace(0, 1, 11)
         p = pchip([0, 1], [0, 2])
-        assert_allclose(p(x), 2*x, atol=1e-15)
+        xp_assert_close(p(x), 2*x, atol=1e-15)
 
     def test_pchip_interpolate(self):
         assert_array_almost_equal(
@@ -652,13 +652,13 @@ class TestPCHIP:
 
         assert_array_almost_equal(
             pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1]),
-            [[3.5], [1]])
+            np.asarray([[3.5], [1]]))
 
     def test_roots(self):
         # regression test for gh-6357: .roots method should work
         p = pchip([0, 1], [-1, 1])
         r = p.roots()
-        assert_allclose(r, 0.5)
+        xp_assert_close(r, np.asarray([0.5]))
 
 
 class TestCubicSpline:
@@ -674,53 +674,53 @@ class TestCubicSpline:
         dxi = dx[:-1]
 
         # Check C2 continuity.
-        assert_allclose(c[3, 1:], c[0, :-1] * dxi**3 + c[1, :-1] * dxi**2 +
+        xp_assert_close(c[3, 1:], c[0, :-1] * dxi**3 + c[1, :-1] * dxi**2 +
                         c[2, :-1] * dxi + c[3, :-1], rtol=tol, atol=tol)
-        assert_allclose(c[2, 1:], 3 * c[0, :-1] * dxi**2 +
+        xp_assert_close(c[2, 1:], 3 * c[0, :-1] * dxi**2 +
                         2 * c[1, :-1] * dxi + c[2, :-1], rtol=tol, atol=tol)
-        assert_allclose(c[1, 1:], 3 * c[0, :-1] * dxi + c[1, :-1],
+        xp_assert_close(c[1, 1:], 3 * c[0, :-1] * dxi + c[1, :-1],
                         rtol=tol, atol=tol)
 
         # Check that we found a parabola, the third derivative is 0.
         if x.size == 3 and bc_start == 'not-a-knot' and bc_end == 'not-a-knot':
-            assert_allclose(c[0], 0, rtol=tol, atol=tol)
+            xp_assert_close(c[0], 0, rtol=tol, atol=tol)
             return
 
         # Check periodic boundary conditions.
         if bc_start == 'periodic':
-            assert_allclose(S(x[0], 0), S(x[-1], 0), rtol=tol, atol=tol)
-            assert_allclose(S(x[0], 1), S(x[-1], 1), rtol=tol, atol=tol)
-            assert_allclose(S(x[0], 2), S(x[-1], 2), rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], 0), S(x[-1], 0), rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], 1), S(x[-1], 1), rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], 2), S(x[-1], 2), rtol=tol, atol=tol)
             return
 
         # Check other boundary conditions.
         if bc_start == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                assert_allclose(S(x[0], 1), slope, rtol=tol, atol=tol)
+                xp_assert_close(S(x[0], 1), slope, rtol=tol, atol=tol)
             else:
-                assert_allclose(c[0, 0], c[0, 1], rtol=tol, atol=tol)
+                xp_assert_close(c[0, 0], c[0, 1], rtol=tol, atol=tol)
         elif bc_start == 'clamped':
-            assert_allclose(S(x[0], 1), 0, rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], 1), np.asarray(0.0), rtol=tol, atol=tol)
         elif bc_start == 'natural':
-            assert_allclose(S(x[0], 2), 0, rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol, check_dtype=False)
         else:
             order, value = bc_start
-            assert_allclose(S(x[0], order), value, rtol=tol, atol=tol)
+            xp_assert_close(S(x[0], order), value, rtol=tol, atol=tol)
 
         if bc_end == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                assert_allclose(S(x[1], 1), slope, rtol=tol, atol=tol)
+                xp_assert_close(S(x[1], 1), slope, rtol=tol, atol=tol)
             else:
-                assert_allclose(c[0, -1], c[0, -2], rtol=tol, atol=tol)
+                xp_assert_close(c[0, -1], c[0, -2], rtol=tol, atol=tol)
         elif bc_end == 'clamped':
-            assert_allclose(S(x[-1], 1), 0, rtol=tol, atol=tol)
+            xp_assert_close(S(x[-1], 1), 0, rtol=tol, atol=tol)
         elif bc_end == 'natural':
-            assert_allclose(S(x[-1], 2), 0, rtol=2*tol, atol=2*tol)
+            xp_assert_close(S(x[-1], 2), 0, rtol=2*tol, atol=2*tol)
         else:
             order, value = bc_end
-            assert_allclose(S(x[-1], order), value, rtol=tol, atol=tol)
+            xp_assert_close(S(x[-1], order), value, rtol=tol, atol=tol)
 
     def check_all_bc(self, x, y, axis):
         deriv_shape = list(y.shape)
@@ -798,7 +798,7 @@ class TestCubicSpline:
         y = np.array([1.0, 15.0, 1.0])
         S = CubicSpline(x, y, bc_type='periodic')
         self.check_correctness(S, 'periodic', 'periodic')
-        assert_allclose(S.derivative(1)(x), np.array([-48.0, -48.0, -48.0]))
+        xp_assert_close(S.derivative(1)(x), np.array([-48.0, -48.0, -48.0]))
 
     def test_periodic_three_points_multidim(self):
         # make sure one multidimensional interpolator does the same as multiple
@@ -810,8 +810,8 @@ class TestCubicSpline:
         S0 = CubicSpline(x, y[:, 0], bc_type="periodic")
         S1 = CubicSpline(x, y[:, 1], bc_type="periodic")
         q = np.linspace(0, 2, 5)
-        assert_allclose(S(q)[:, 0], S0(q))
-        assert_allclose(S(q)[:, 1], S1(q))
+        xp_assert_close(S(q)[:, 0], S0(q))
+        xp_assert_close(S(q)[:, 1], S1(q))
 
     def test_dtypes(self):
         x = np.array([0, 1, 2, 3], dtype=int)
@@ -883,8 +883,8 @@ def test_CubicHermiteSpline_correctness():
     y = [-1, 2, 3]
     dydx = [0, 3, 7]
     s = CubicHermiteSpline(x, y, dydx)
-    assert_allclose(s(x), y, rtol=1e-15)
-    assert_allclose(s(x, 1), dydx, rtol=1e-15)
+    xp_assert_close(s(x), y, check_shape=False, check_dtype=False, rtol=1e-15)
+    xp_assert_close(s(x, 1), dydx, check_shape=False, check_dtype=False,rtol=1e-15)
 
 
 def test_CubicHermiteSpline_error_handling():

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -169,7 +169,7 @@ class TestKrogh:
 
     def test_scalar(self):
         P = KroghInterpolator(self.xs,self.ys)
-        assert_almost_equal(self.true_poly(7),P(7), check_0d=False)
+        assert_almost_equal(self.true_poly(7), P(7), check_0d=False)
         assert_almost_equal(self.true_poly(np.array(7)), P(np.array(7)), check_0d=False)
 
     def test_derivatives(self):
@@ -643,15 +643,15 @@ class TestPCHIP:
 
     def test_pchip_interpolate(self):
         assert_array_almost_equal(
-            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=1),
+            pchip_interpolate([1, 2, 3], [4, 5, 6], [0.5], der=1),
             np.asarray([1.]))
 
         assert_array_almost_equal(
-            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=0),
+            pchip_interpolate([1, 2, 3], [4, 5, 6], [0.5], der=0),
             np.asarray([3.5]))
 
         assert_array_almost_equal(
-            np.asarray(pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1])),
+            np.asarray(pchip_interpolate([1, 2, 3], [4, 5, 6], [0.5], der=[0, 1])),
             np.asarray([[3.5], [1]]))
 
     def test_roots(self):
@@ -683,8 +683,7 @@ class TestCubicSpline:
 
         # Check that we found a parabola, the third derivative is 0.
         if x.size == 3 and bc_start == 'not-a-knot' and bc_end == 'not-a-knot':
-            xp_assert_close(c[0], 0.0, rtol=tol, atol=tol,
-                check_0d=False, check_shape=False)
+            xp_assert_close(c[0], np.zeros_like(c[0]), rtol=tol, atol=tol)
             return
 
         # Check periodic boundary conditions.
@@ -698,37 +697,36 @@ class TestCubicSpline:
         if bc_start == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                xp_assert_close(S(x[0], 1), slope, rtol=tol, atol=tol, check_0d=False)
+                slope = np.asarray(slope)
+                xp_assert_close(S(x[0], 1), slope, rtol=tol, atol=tol)
             else:
                 xp_assert_close(c[0, 0], c[0, 1], rtol=tol, atol=tol)
         elif bc_start == 'clamped':
             xp_assert_close(
-                S(x[0], 1), np.asarray(0.0), rtol=tol, atol=tol, check_shape=False
-            )
+                S(x[0], 1), np.zeros_like(S(x[0], 1)), rtol=tol, atol=tol)
         elif bc_start == 'natural':
             xp_assert_close(
-                S(x[0], 2), np.asarray(0.0), rtol=tol, atol=tol,
-                check_dtype=False, check_shape=False,
-            )
+                S(x[0], 2), np.zeros_like(S(x[0], 2)), rtol=tol, atol=tol)
         else:
             order, value = bc_start
-            xp_assert_close(S(x[0], order), value, rtol=tol, atol=tol, check_0d=False)
+            xp_assert_close(S(x[0], order), np.asarray(value), rtol=tol, atol=tol)
 
         if bc_end == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
-                xp_assert_close(S(x[1], 1), slope, rtol=tol, atol=tol, check_0d=False)
+                slope = np.asarray(slope)
+                xp_assert_close(S(x[1], 1), slope, rtol=tol, atol=tol)
             else:
-                xp_assert_close(c[0, -1], c[0, -2], rtol=tol, atol=tol, check_0d=False)
+                xp_assert_close(c[0, -1], c[0, -2], rtol=tol, atol=tol)
         elif bc_end == 'clamped':
-            xp_assert_close(S(x[-1], 1), 0.0, rtol=tol, atol=tol,
-                            check_0d=False, check_shape=False)
+            xp_assert_close(S(x[-1], 1), np.zeros_like(S(x[-1], 1)),
+                            rtol=tol, atol=tol)
         elif bc_end == 'natural':
-            xp_assert_close(S(x[-1], 2), 0.0, rtol=2*tol, atol=2*tol,
-                            check_0d=False, check_shape=False)
+            xp_assert_close(S(x[-1], 2), np.zeros_like(S(x[-1], 2)),
+                            rtol=2*tol, atol=2*tol)
         else:
             order, value = bc_end
-            xp_assert_close(S(x[-1], order), value, rtol=tol, atol=tol, check_0d=False)
+            xp_assert_close(S(x[-1], order), np.asarray(value), rtol=tol, atol=tol)
 
     def check_all_bc(self, x, y, axis):
         deriv_shape = list(y.shape)
@@ -892,7 +890,7 @@ def test_CubicHermiteSpline_correctness():
     dydx = [0, 3, 7]
     s = CubicHermiteSpline(x, y, dydx)
     xp_assert_close(s(x), y, check_shape=False, check_dtype=False, rtol=1e-15)
-    xp_assert_close(s(x, 1), dydx, check_shape=False, check_dtype=False,rtol=1e-15)
+    xp_assert_close(s(x, 1), dydx, check_shape=False, check_dtype=False, rtol=1e-15)
 
 
 def test_CubicHermiteSpline_error_handling():

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from numpy.testing import (
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_allclose, assert_equal, assert_)
+    assert_allclose )
 from pytest import raises as assert_raises
 import pytest
 
@@ -37,7 +37,7 @@ def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
 
     target_shape = ((deriv_shape or ()) + y.shape[:axis]
                     + x_shape + y.shape[axis:][1:])
-    assert_equal(yi.shape, target_shape)
+    assert yi.shape == target_shape
 
     # check it works also with lists
     if x_shape and y.size > 0:
@@ -630,7 +630,7 @@ class TestPCHIP:
             pch = pchip(x, y)
 
         xx = np.linspace(0, 9, 101)
-        assert_equal(pch(xx), 0.)
+        assert all(pch(xx) == 0.)
 
     def test_two_points(self):
         # regression test for gh-6222: pchip([0, 1], [0, 1]) fails because
@@ -906,8 +906,8 @@ def test_roots_extrapolate_gh_11185():
     # roots(extrapolate=True) for a polynomial with a single interval
     # should return all three real roots
     r = p.roots(extrapolate=True)
-    assert_equal(p.c.shape[1], 1)
-    assert_equal(r.size, 3)
+    assert p.c.shape[1] == 1
+    assert r.size == 3
 
 
 class TestZeroSizeArrays:

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -2,8 +2,11 @@
 """ Test functions for rbf module """
 
 import numpy as np
-from numpy.testing import (assert_, assert_array_almost_equal,
-                           assert_almost_equal)
+
+from scipy._lib._array_api import (
+    assert_array_almost_equal, assert_almost_equal, xp_assert_equal,
+)
+
 from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate._rbf import Rbf
 from scipy._lib._testutils import _run_concurrent_barrier
@@ -20,7 +23,7 @@ def check_rbf1d_interpolation(function):
     rbf = Rbf(x, y, function=function)
     yi = rbf(x)
     assert_array_almost_equal(y, yi)
-    assert_almost_equal(rbf(float(x[0])), y[0])
+    assert_almost_equal(rbf(float(x[0])), y[0], check_shape=False)
 
 
 def check_rbf2d_interpolation(function):

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -21,7 +21,7 @@ def check_rbf1d_interpolation(function):
     rbf = Rbf(x, y, function=function)
     yi = rbf(x)
     assert_array_almost_equal(y, yi)
-    assert_almost_equal(rbf(float(x[0])), y[0])
+    assert_almost_equal(rbf(float(x[0])), y[0], check_0d=False)
 
 
 def check_rbf2d_interpolation(function):

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -3,9 +3,7 @@
 
 import numpy as np
 
-from scipy._lib._array_api import (
-    assert_array_almost_equal, assert_almost_equal, xp_assert_equal,
-)
+from scipy._lib._array_api import assert_array_almost_equal, assert_almost_equal
 
 from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate._rbf import Rbf

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -108,7 +108,7 @@ def check_rbf1d_regularity(function, atol):
     xi = linspace(0, 10, 100)
     yi = rbf(xi)
     msg = f"abs-diff: {abs(yi - sin(xi)).max():f}"
-    assert_(allclose(yi, sin(xi), atol=atol), msg)
+    assert allclose(yi, sin(xi), atol=atol), msg
 
 
 def test_rbf_regularity():
@@ -136,7 +136,7 @@ def check_2drbf1d_regularity(function, atol):
     xi = linspace(0, 10, 100)
     yi = rbf(xi)
     msg = f"abs-diff: {abs(yi - np.vstack([sin(xi), cos(xi)]).T).max():f}"
-    assert_(allclose(yi, np.vstack([sin(xi), cos(xi)]).T, atol=atol), msg)
+    assert allclose(yi, np.vstack([sin(xi), cos(xi)]).T, atol=atol), msg
 
 
 def test_2drbf_regularity():
@@ -167,7 +167,7 @@ def check_rbf1d_stability(function):
     yi = rbf(xi)
 
     # subtract the linear trend and make sure there no spikes
-    assert_(np.abs(yi-xi).max() / np.abs(z-x).max() < 1.1)
+    assert np.abs(yi-xi).max() / np.abs(z-x).max() < 1.1
 
 def test_rbf_stability():
     for function in FUNCTIONS:
@@ -221,7 +221,7 @@ def test_rbf_epsilon_none_collinear():
     y = [4, 4, 4]
     z = [5, 6, 7]
     rbf = Rbf(x, y, z, epsilon=None)
-    assert_(rbf.epsilon > 0)
+    assert rbf.epsilon > 0
 
 
 def test_rbf_concurrency():
@@ -235,3 +235,4 @@ def test_rbf_concurrency():
         interp(xp)
 
     _run_concurrent_barrier(10, worker_fn, rbf, x)
+

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -21,7 +21,7 @@ def check_rbf1d_interpolation(function):
     rbf = Rbf(x, y, function=function)
     yi = rbf(x)
     assert_array_almost_equal(y, yi)
-    assert_almost_equal(rbf(float(x[0])), y[0], check_shape=False)
+    assert_almost_equal(rbf(float(x[0])), y[0])
 
 
 def check_rbf2d_interpolation(function):

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -2,7 +2,7 @@ import pickle
 import pytest
 import numpy as np
 from numpy.linalg import LinAlgError
-from numpy.testing import assert_allclose
+from scipy._lib._array_api import xp_assert_close
 from scipy.stats.qmc import Halton
 from scipy.spatial import cKDTree
 from scipy.interpolate._rbfinterp import (
@@ -91,7 +91,7 @@ class _TestRBFInterpolator:
         xitp = 3*seq.random(50)
         yitp1 = self.build(x, y, epsilon=1.0, kernel=kernel)(xitp)
         yitp2 = self.build(x, y, epsilon=2.0, kernel=kernel)(xitp)
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     @pytest.mark.parametrize('kernel', sorted(_SCALE_INVARIANT))
     def test_scale_invariance_2d(self, kernel):
@@ -103,7 +103,7 @@ class _TestRBFInterpolator:
         xitp = seq.random(100)
         yitp1 = self.build(x, y, epsilon=1.0, kernel=kernel)(xitp)
         yitp2 = self.build(x, y, epsilon=2.0, kernel=kernel)(xitp)
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     @pytest.mark.parametrize('kernel', sorted(_AVAILABLE))
     def test_extreme_domains(self, kernel):
@@ -131,7 +131,7 @@ class _TestRBFInterpolator:
                 kernel=kernel
                 )(xitp*scale + shift)
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     def test_polynomial_reproduction(self):
         # If the observed data comes from a polynomial, then the interpolant
@@ -153,7 +153,7 @@ class _TestRBFInterpolator:
         yitp1 = Pitp.dot(poly_coeffs)
         yitp2 = self.build(x, y, degree=degree)(xitp)
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     @pytest.mark.slow
     def test_chunking(self, monkeypatch):
@@ -185,7 +185,7 @@ class _TestRBFInterpolator:
 
         monkeypatch.setattr(interp, '_chunk_evaluator', _chunk_evaluator)
         yitp2 = interp(xitp)
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     def test_vector_data(self):
         # Make sure interpolating a vector field is the same as interpolating
@@ -202,8 +202,8 @@ class _TestRBFInterpolator:
         yitp2 = self.build(x, y[:, 0])(xitp)
         yitp3 = self.build(x, y[:, 1])(xitp)
 
-        assert_allclose(yitp1[:, 0], yitp2)
-        assert_allclose(yitp1[:, 1], yitp3)
+        xp_assert_close(yitp1[:, 0], yitp2)
+        xp_assert_close(yitp1[:, 1], yitp3)
 
     def test_complex_data(self):
         # Interpolating complex input should be the same as interpolating the
@@ -219,8 +219,8 @@ class _TestRBFInterpolator:
         yitp2 = self.build(x, y.real)(xitp)
         yitp3 = self.build(x, y.imag)(xitp)
 
-        assert_allclose(yitp1.real, yitp2)
-        assert_allclose(yitp1.imag, yitp3)
+        xp_assert_close(yitp1.real, yitp2)
+        xp_assert_close(yitp1.imag, yitp3)
 
     @pytest.mark.parametrize('kernel', sorted(_AVAILABLE))
     def test_interpolation_misfit_1d(self, kernel):
@@ -299,7 +299,7 @@ class _TestRBFInterpolator:
         smoothing[10] = 1000.0
         yitp = self.build(x, y_with_outlier, smoothing=smoothing)(x)
         # Should be able to reproduce the uncorrupted data almost exactly.
-        assert_allclose(yitp, y, atol=1e-4)
+        xp_assert_close(yitp, y, atol=1e-4)
 
     def test_inconsistent_x_dimensions_error(self):
         # ValueError should be raised if the observation points and evaluation
@@ -399,7 +399,7 @@ class _TestRBFInterpolator:
             y = np.zeros((1, dim))
             d = np.ones((1,))
             f = self.build(y, d, kernel='linear')(y)
-            assert_allclose(d, f)
+            xp_assert_close(d, f)
 
     def test_pickleable(self):
         # Make sure we can pickle and unpickle the interpolant without any
@@ -416,7 +416,7 @@ class _TestRBFInterpolator:
         yitp1 = interp(xitp)
         yitp2 = pickle.loads(pickle.dumps(interp))(xitp)
 
-        assert_allclose(yitp1, yitp2, atol=1e-16)
+        xp_assert_close(yitp1, yitp2, atol=1e-16)
 
 
 class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):
@@ -446,7 +446,7 @@ class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):
         Pitp = _vandermonde(xitp, degree)
         yitp2 = Pitp.dot(np.linalg.lstsq(P, y, rcond=None)[0])
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     def test_smoothing_limit_2d(self):
         # For large smoothing parameters, the interpolant should approach a
@@ -471,7 +471,7 @@ class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):
         Pitp = _vandermonde(xitp, degree)
         yitp2 = Pitp.dot(np.linalg.lstsq(P, y, rcond=None)[0])
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
 
 class TestRBFInterpolatorNeighbors20(_TestRBFInterpolator):
@@ -495,7 +495,7 @@ class TestRBFInterpolatorNeighbors20(_TestRBFInterpolator):
             _, nbr = tree.query(xi, 20)
             yitp2.append(RBFInterpolator(x[nbr], y[nbr])(xi[None])[0])
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)
 
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to
@@ -530,4 +530,4 @@ class TestRBFInterpolatorNeighborsInf(TestRBFInterpolatorNeighborsNone):
         yitp1 = self.build(x, y)(xitp)
         yitp2 = RBFInterpolator(x, y)(xitp)
 
-        assert_allclose(yitp1, yitp2, atol=1e-8)
+        xp_assert_close(yitp1, yitp2, atol=1e-8)

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -359,7 +359,7 @@ class TestRegularGridInterpolator:
         # check exrapolation w/ fill_value
         xp_assert_close(interp(np.array([1.1, 2.4])),
                         interp.fill_value,
-                        check_dtype=False, check_shape=False,
+                        check_dtype=False, check_shape=False, check_0d=False,
                         atol=1e-14)
 
         # check extrapolation: linear along the `y` axis, const along `x`

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from numpy.testing import (assert_allclose, assert_equal, assert_warns,
                            assert_array_almost_equal, assert_array_equal)
+from scipy._lib._array_api import xp_assert_equal
 from pytest import raises as assert_raises
 
 from scipy.interpolate import (RegularGridInterpolator, interpn,
@@ -419,8 +420,8 @@ class TestRegularGridInterpolator:
             # input) and we simply filter them out.
             res = f(x)
 
-        assert_equal(res[i], np.nan)
-        assert_equal(res[~i], f(x[~i]))
+        assert np.isnan(res[i]).all()
+        xp_assert_equal(res[~i], f(x[~i]))
 
         # also test the length-one axis f(nan)
         x = [1, 2, 3]
@@ -428,8 +429,8 @@ class TestRegularGridInterpolator:
         data = np.ones((3, 1))
         f = RegularGridInterpolator((x, y), data, fill_value=1,
                                     bounds_error=False, method=method)
-        assert np.isnan(f([np.nan, 1]))
-        assert np.isnan(f([1, np.nan]))
+        assert np.all(np.isnan(f([np.nan, 1])))
+        assert np.all(np.isnan(f([1, np.nan])))
 
     @pytest.mark.parametrize("method", ['nearest', 'linear'])
     def test_nan_x_2d(self, method):
@@ -465,8 +466,8 @@ class TestRegularGridInterpolator:
             # input) and we simply filter them out.
             res = interp(z)
 
-        assert_equal(res[i], np.nan)
-        assert_equal(res[~i], interp(z[~i]))
+        assert np.isnan(res[i]).all()
+        xp_assert_equal(res[~i], interp(z[~i]))
 
     @pytest.mark.fail_slow(10)
     @parametrize_rgi_interp_methods
@@ -547,7 +548,7 @@ class TestRegularGridInterpolator:
         interp = RegularGridInterpolator(points, values, method=method,
                                          bounds_error=False)
         v = interp(sample)
-        assert_equal(v.shape, (7, 3, 8), err_msg=method)
+        assert v.shape == (7, 3, 8)
 
         vs = []
         for j in range(8):
@@ -845,7 +846,7 @@ class TestInterpN:
 
         v1 = interpn(points, values, sample, method='nearest',
                      bounds_error=False)
-        assert_equal(v1.shape, (2, 3))
+        assert v1.shape, (2 == 3)
 
         v2 = interpn(points, values, sample.reshape(-1, 4),
                      method='nearest', bounds_error=False)
@@ -862,7 +863,7 @@ class TestInterpN:
 
         sample = (xi[:, None], yi[None, :])
         v1 = interpn(points, values, sample, method=method, bounds_error=False)
-        assert_equal(v1.shape, (2, 3))
+        assert v1.shape, (2 == 3)
 
         xx, yy = np.meshgrid(xi, yi)
         sample = np.c_[xx.T.ravel(), yy.T.ravel()]
@@ -889,7 +890,7 @@ class TestInterpN:
 
         v = interpn(points, values, sample, method=method,
                     bounds_error=False)
-        assert_equal(v.shape, (7, 3, 8), err_msg=method)
+        assert v.shape == (7, 3, 8)
 
         vs = [interpn(points, values[..., j], sample, method=method,
                       bounds_error=False) for j in range(8)]

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -3,9 +3,11 @@ import itertools
 import pytest
 import numpy as np
 
-from numpy.testing import (assert_allclose, assert_equal, assert_warns,
-                           assert_array_almost_equal, assert_array_equal)
-from scipy._lib._array_api import xp_assert_equal
+from numpy.testing import assert_warns
+from scipy._lib._array_api import (
+    xp_assert_equal, xp_assert_close, assert_array_almost_equal
+)
+
 from pytest import raises as assert_raises
 
 from scipy.interpolate import (RegularGridInterpolator, interpn,
@@ -81,7 +83,7 @@ class TestRegularGridInterpolator:
                                          values,
                                          method=method)
         v2 = interp(sample)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     @pytest.mark.parametrize('method', ['cubic', 'quintic', 'pchip'])
     def test_spline_dim_error(self, method):
@@ -119,7 +121,7 @@ class TestRegularGridInterpolator:
         v1 = interp(sample)
         interp = RegularGridInterpolator(points, values, method="slinear")
         v2 = interp(sample)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_derivatives(self):
         points, values = self._get_sample_4d()
@@ -132,14 +134,14 @@ class TestRegularGridInterpolator:
             # wrong number of derivatives (need 4)
             interp(sample, nu=1)
 
-        assert_allclose(interp(sample, nu=(1, 0, 0, 0)),
-                        [1, 1, 1], atol=1e-15)
-        assert_allclose(interp(sample, nu=(0, 1, 0, 0)),
-                        [10, 10, 10], atol=1e-15)
+        xp_assert_close(interp(sample, nu=(1, 0, 0, 0)),
+                        np.asarray([1.0, 1, 1]), atol=1e-15)
+        xp_assert_close(interp(sample, nu=(0, 1, 0, 0)),
+                        np.asarray([10.0, 10, 10]), atol=1e-15)
 
         # 2nd derivatives of a linear function are zero
-        assert_allclose(interp(sample, nu=(0, 1, 1, 0)),
-                        [0, 0, 0], atol=2e-12)
+        xp_assert_close(interp(sample, nu=(0, 1, 1, 0)),
+                        np.asarray([0.0, 0, 0]), atol=2e-12)
 
     @parametrize_rgi_interp_methods
     def test_complex(self, method):
@@ -156,7 +158,7 @@ class TestRegularGridInterpolator:
 
         v1 = interp(sample)
         v2 = rinterp(sample) + 1j*iinterp(sample)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_cubic_vs_pchip(self):
         x, y = [1, 2, 3, 4], [1, 2, 3, 4]
@@ -174,7 +176,7 @@ class TestRegularGridInterpolator:
         points, values = self._get_sample_4d_2()
         interp = RegularGridInterpolator(points, values)
         sample = np.asarray([0.1, 0.1, 10., 9.])
-        wanted = 1001.1
+        wanted = np.asarray([1001.1])
         assert_array_almost_equal(interp(sample), wanted)
 
     def test_linear_xi3d(self):
@@ -198,6 +200,7 @@ class TestRegularGridInterpolator:
     def test_nearest(self, sample, wanted):
         points, values = self._get_sample_4d()
         interp = RegularGridInterpolator(points, values, method="nearest")
+        wanted = np.asarray([wanted])
         assert_array_almost_equal(interp(sample), wanted)
 
     def test_linear_edges(self):
@@ -307,7 +310,7 @@ class TestRegularGridInterpolator:
 
         interp = RegularGridInterpolator((x, y), values._v, method=method)
         v2 = interp([0.4, 0.7])
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2, check_dtype=False)
 
     def test_invalid_fill_value(self):
         np.random.seed(1234)
@@ -344,33 +347,34 @@ class TestRegularGridInterpolator:
                                          bounds_error=False, fill_value=101)
 
         # check values at the grid
-        assert_allclose(interp(np.array([[1, 1], [1, 5], [1, 10]])),
-                        [2, 6, 11],
+        xp_assert_close(interp(np.array([[1, 1], [1, 5], [1, 10]])),
+                        np.asarray([2.0, 6, 11]),
                         atol=1e-14)
 
         # check off-grid interpolation is indeed linear
-        assert_allclose(interp(np.array([[1, 1.4], [1, 5.3], [1, 10]])),
+        xp_assert_close(interp(np.array([[1, 1.4], [1, 5.3], [1, 10]])),
                         [2.4, 6.3, 11],
                         atol=1e-14)
 
         # check exrapolation w/ fill_value
-        assert_allclose(interp(np.array([1.1, 2.4])),
+        xp_assert_close(interp(np.array([1.1, 2.4])),
                         interp.fill_value,
+                        check_dtype=False, check_shape=False,
                         atol=1e-14)
 
         # check extrapolation: linear along the `y` axis, const along `x`
         interp.fill_value = None
-        assert_allclose(interp([[1, 0.3], [1, 11.5]]),
+        xp_assert_close(interp([[1, 0.3], [1, 11.5]]),
                         [1.3, 12.5], atol=1e-15)
 
-        assert_allclose(interp([[1.5, 0.3], [1.9, 11.5]]),
+        xp_assert_close(interp([[1.5, 0.3], [1.9, 11.5]]),
                         [1.3, 12.5], atol=1e-15)
 
         # extrapolation with method='nearest'
         interp = RegularGridInterpolator((x, y), data, method="nearest",
                                          bounds_error=False, fill_value=None)
-        assert_allclose(interp([[1.5, 1.8], [-4, 5.1]]),
-                        [3, 6],
+        xp_assert_close(interp([[1.5, 1.8], [-4, 5.1]]),
+                        np.asarray([3.0, 6]),
                         atol=1e-15)
 
     @pytest.mark.parametrize("fill_value", [None, np.nan, np.pi])
@@ -391,15 +395,15 @@ class TestRegularGridInterpolator:
         # evaluated at provided y-value, fb should behave exactly as fa
         y1b = np.zeros(100)
         zb = fb(np.vstack([x1a, y1b]).T)
-        assert_allclose(zb, za)
+        xp_assert_close(zb, za)
 
         # evaluated at a different y-value, fb should return fill value
         y1b = np.ones(100)
         zb = fb(np.vstack([x1a, y1b]).T)
         if fill_value is None:
-            assert_allclose(zb, za)
+            xp_assert_close(zb, za)
         else:
-            assert_allclose(zb, fill_value)
+            xp_assert_close(zb, np.full_like(zb, fill_value))
 
     @pytest.mark.parametrize("method", ['nearest', 'linear'])
     def test_nan_x_1d(self, method):
@@ -446,7 +450,7 @@ class TestRegularGridInterpolator:
 
         with np.errstate(invalid='ignore'):
             res = interp([[1.5, np.nan], [1, 1]])
-        assert_allclose(res[1], 2, atol=1e-14)
+        xp_assert_close(res[1], 2.0, atol=1e-14)
         assert np.isnan(res[0])
 
         # test arbitrary nan pattern
@@ -467,7 +471,7 @@ class TestRegularGridInterpolator:
             res = interp(z)
 
         assert np.isnan(res[i]).all()
-        xp_assert_equal(res[~i], interp(z[~i]))
+        xp_assert_equal(res[~i], interp(z[~i]), check_dtype=False)
 
     @pytest.mark.fail_slow(10)
     @parametrize_rgi_interp_methods
@@ -508,7 +512,7 @@ class TestRegularGridInterpolator:
                                                     method=method)
         descending_result = descending_interp(test_points)
 
-        assert_array_equal(ascending_result, descending_result)
+        xp_assert_equal(ascending_result, descending_result)
 
     def test_invalid_points_order(self):
         def val_func_2d(x, y):
@@ -558,7 +562,7 @@ class TestRegularGridInterpolator:
             vs.append(interp(sample))
         v2 = np.array(vs).transpose(1, 2, 0)
 
-        assert_allclose(v, v2, atol=1e-14, err_msg=method)
+        xp_assert_close(v, v2, atol=1e-14, err_msg=method)
 
     @parametrize_rgi_interp_methods
     @pytest.mark.parametrize("flip_points", [False, True])
@@ -601,7 +605,7 @@ class TestRegularGridInterpolator:
                                                  bounds_error=False)
                 vs[i, j] = interp(sample).item()
         v2 = np.expand_dims(vs, axis=0)
-        assert_allclose(v, v2, atol=1e-14, err_msg=method)
+        xp_assert_close(v, v2, atol=1e-14, err_msg=method)
 
     def test_nonscalar_values_linear_2D(self):
         # Verify that non-scalar values work in the 2D fast path
@@ -632,7 +636,7 @@ class TestRegularGridInterpolator:
                                                  bounds_error=False)
                 vs[i, j] = interp(sample).item()
         v2 = np.expand_dims(vs, axis=0)
-        assert_allclose(v, v2, atol=1e-14, err_msg=method)
+        xp_assert_close(v, v2, atol=1e-14, err_msg=method)
 
     @pytest.mark.parametrize(
         "dtype",
@@ -660,7 +664,7 @@ class TestRegularGridInterpolator:
         # the values here are just what the call returns; the test checks that
         # that the call succeeds at all, instead of failing with cython not
         # having a float32 kernel
-        assert_allclose(interp(pts), [134.10469388, 153.40069388], atol=1e-7)
+        xp_assert_close(interp(pts), [134.10469388, 153.40069388], atol=1e-7, rtol=1e-7, check_dtype=False)
 
     def test_bad_solver(self):
         x = np.linspace(0, 3, 7)
@@ -764,7 +768,7 @@ class TestInterpN:
         v2 = interpn(
             (x.tolist(), y.tolist()), z.tolist(), xi.tolist(), method=method
         )
-        assert_allclose(v1, v2, err_msg=method)
+        xp_assert_close(v1, v2, err_msg=method)
 
     def test_spline_2d_outofbounds(self):
         x = np.array([.5, 2., 3., 4., 5.5])
@@ -807,7 +811,7 @@ class TestInterpN:
         # create a 4-D grid of 3 points in each dimension
         points, values = self._sample_4d_data()
         sample = np.asarray([[0.1, -0.1, 10.1, 9.]])
-        wanted = 999.99
+        wanted = np.asarray([999.99])
         actual = interpn(points, values, sample, method="linear",
                          bounds_error=False, fill_value=999.99)
         assert_array_almost_equal(actual, wanted)
@@ -824,7 +828,7 @@ class TestInterpN:
         # create a 4-D grid of 3 points in each dimension
         points, values = self._sample_4d_data()
         sample = np.asarray([[0.1, -0.1, 10.1, 9.]])
-        wanted = 999.99
+        wanted = np.asarray([999.99])
         actual = interpn(points, values, sample, method="nearest",
                          bounds_error=False, fill_value=999.99)
         assert_array_almost_equal(actual, wanted)
@@ -835,7 +839,7 @@ class TestInterpN:
         sample = np.asarray([0.1, 0.1, 10., 9.])
         v1 = interpn(points, values, sample, bounds_error=False)
         v2 = interpn(points, values, sample[None,:], bounds_error=False)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_xi_nd(self):
         # verify that higher-d xi works as expected
@@ -850,7 +854,7 @@ class TestInterpN:
 
         v2 = interpn(points, values, sample.reshape(-1, 4),
                      method='nearest', bounds_error=False)
-        assert_allclose(v1, v2.reshape(v1.shape))
+        xp_assert_close(v1, v2.reshape(v1.shape))
 
     @parametrize_rgi_interp_methods
     def test_xi_broadcast(self, method):
@@ -870,7 +874,7 @@ class TestInterpN:
 
         v2 = interpn(points, values, sample,
                      method=method, bounds_error=False)
-        assert_allclose(v1, v2.reshape(v1.shape))
+        xp_assert_close(v1, v2.reshape(v1.shape))
 
     @pytest.mark.fail_slow(5)
     @parametrize_rgi_interp_methods
@@ -896,7 +900,7 @@ class TestInterpN:
                       bounds_error=False) for j in range(8)]
         v2 = np.array(vs).transpose(1, 2, 0)
 
-        assert_allclose(v, v2, atol=1e-14, err_msg=method)
+        xp_assert_close(v, v2, atol=1e-14, err_msg=method)
 
     @parametrize_rgi_interp_methods
     def test_nonscalar_values_2(self, method):
@@ -929,7 +933,7 @@ class TestInterpN:
                         bounds_error=False) for i in range(values.shape[-2])
               ] for j in range(values.shape[-1])]
 
-        assert_allclose(v, np.asarray(vs).T, atol=1e-14, err_msg=method)
+        xp_assert_close(v, np.asarray(vs).T, atol=1e-14, err_msg=method)
 
     def test_non_scalar_values_splinef2d(self):
         # Vector-valued splines supported with fitpack
@@ -958,7 +962,7 @@ class TestInterpN:
         v2i = interpn(points, values.imag, sample, method=method)
         v2 = v2r + 1j*v2i
 
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2)
 
     def test_complex_pchip(self):
         # Complex-valued data deprecated for pchip
@@ -994,7 +998,7 @@ class TestInterpN:
 
         v1 = interpn((x, y), values, [0.4, 0.7], method=method)
         v2 = interpn((x, y), values._v, [0.4, 0.7], method=method)
-        assert_allclose(v1, v2)
+        xp_assert_close(v1, v2, check_dtype=False)
 
     @parametrize_rgi_interp_methods
     def test_matrix_input(self, method):
@@ -1009,9 +1013,9 @@ class TestInterpN:
         v2 = interpn((x, y), np.asarray(values), sample, method=method)
         if method == "quintic":
             # https://github.com/scipy/scipy/issues/20472
-            assert_allclose(v1, v2, atol=5e-5, rtol=2e-6)
+            xp_assert_close(v1, v2, atol=5e-5, rtol=2e-6)
         else:
-            assert_allclose(v1, v2)
+            xp_assert_close(v1, v2)
 
     def test_length_one_axis(self):
         # gh-5890, gh-9524 : length-1 axis is legal for method='linear'.
@@ -1026,14 +1030,14 @@ class TestInterpN:
                   9*0.2 + 1,       # on [3, 4] it's 9*(x-3) + 1
                   9*0.8 + 1]
 
-        assert_allclose(res, wanted, atol=1e-15)
+        xp_assert_close(res, wanted, atol=1e-15)
 
         # check extrapolation
         xi = np.array([[1.1, 2.2], [1.5, 3.2], [-2.3, 3.8]])
         res = interpn(([1], [2, 3, 4]), values, xi,
                       bounds_error=False, fill_value=None)
 
-        assert_allclose(res, wanted, atol=1e-15)
+        xp_assert_close(res, wanted, atol=1e-15)
 
     def test_descending_points(self):
         def value_func_4d(x, y, z, a):
@@ -1059,7 +1063,7 @@ class TestInterpN:
             *np.meshgrid(*points_shuffled, indexing='ij', sparse=True))
         test_result = interpn(points_shuffled, values_shuffled, pts)
 
-        assert_array_equal(correct_result, test_result)
+        xp_assert_equal(correct_result, test_result)
 
     def test_invalid_points_order(self):
         x = np.array([.5, 2., 0., 4., 5.5])  # not ascending or descending

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -552,7 +552,7 @@ class TestRegularGridInterpolator:
         interp = RegularGridInterpolator(points, values, method=method,
                                          bounds_error=False)
         v = interp(sample)
-        assert v.shape == (7, 3, 8)
+        assert v.shape == (7, 3, 8), method
 
         vs = []
         for j in range(8):
@@ -851,7 +851,7 @@ class TestInterpN:
 
         v1 = interpn(points, values, sample, method='nearest',
                      bounds_error=False)
-        assert v1.shape, (2 == 3)
+        assert v1.shape == (2, 3)
 
         v2 = interpn(points, values, sample.reshape(-1, 4),
                      method='nearest', bounds_error=False)
@@ -868,7 +868,7 @@ class TestInterpN:
 
         sample = (xi[:, None], yi[None, :])
         v1 = interpn(points, values, sample, method=method, bounds_error=False)
-        assert v1.shape, (2 == 3)
+        assert v1.shape == (2, 3)
 
         xx, yy = np.meshgrid(xi, yi)
         sample = np.c_[xx.T.ravel(), yy.T.ravel()]
@@ -895,7 +895,7 @@ class TestInterpN:
 
         v = interpn(points, values, sample, method=method,
                     bounds_error=False)
-        assert v.shape == (7, 3, 8)
+        assert v.shape == (7, 3, 8), method
 
         vs = [interpn(points, values[..., j], sample, method=method,
                       bounds_error=False) for j in range(8)]

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -664,7 +664,8 @@ class TestRegularGridInterpolator:
         # the values here are just what the call returns; the test checks that
         # that the call succeeds at all, instead of failing with cython not
         # having a float32 kernel
-        xp_assert_close(interp(pts), [134.10469388, 153.40069388], atol=1e-7, rtol=1e-7, check_dtype=False)
+        xp_assert_close(interp(pts), [134.10469388, 153.40069388],
+                        atol=1e-7, rtol=1e-7, check_dtype=False)
 
     def test_bad_solver(self):
         x = np.linspace(0, 3, 7)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

cross-ref https://github.com/scipy/scipy/issues/21031, https://github.com/scipy/scipy/issues/21044, https://github.com/scipy/scipy/pull/21091, 

#### What does this implement/fix?
<!--Please explain your changes.-->

Convert all `scipy.interpolate` tests to use `xp_*` style assertions instead of `numpy.testing.assert_*`.

#### Additional information
<!--Any additional information you think is important.-->
