### PR TITLE
BUG: cluster: Avoid OOB write when distances are NaN in `centroid`

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -769,6 +769,12 @@ cdef Pair find_min_dist(int n, double[:] D, int[:] size, int x):
             current_min = dist
             y = i
 
+    if y == -1:
+        raise ValueError(
+            "find_min_dist cannot find any neighbors closer than inf away. "
+            "Check that distances contain no negative/infinite/NaN entries. "
+        )
+
     return Pair(y, current_min)
 
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1262,7 +1262,7 @@ def test_Heap(xp):
     assert_equal(pair['value'], 10)
 
 
-@skip_xp_backends(np_only=True, reasons=['scipy specific corner case'])
+@skip_xp_backends(cpu_only=True)
 def test_centroid_neg_distance(xp):
     # gh-21011
     values = xp.asarray([0, 0, -1])

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1260,3 +1260,12 @@ def test_Heap(xp):
     pair = heap.get_min()
     assert_equal(pair['key'], 1)
     assert_equal(pair['value'], 10)
+
+
+@skip_xp_backends(np_only=True, reasons=['scipy specific corner case'])
+def test_centroid_neg_distance(xp):
+    # gh-21011
+    values = xp.asarray([0, 0, -1])
+    with pytest.raises(ValueError):
+        # This is just checking that this doesn't crash
+        linkage(values, method='centroid')


### PR DESCRIPTION
If a distance matrix with negative distances is passed, to centroid or median linkage, this can result in NaN distances written back to the distance matrix. If this happens, none of those distances will be considered less than inf, so find_min_distance() will return -1, which will eventually be used to index into an array. This causes an OOB write and a crash. Forbid this and throw an exception if this ever happens.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #21011

#### What does this implement/fix?

Example test case:

```
from scipy.cluster.hierarchy import centroid

y = [0, 0, -1]
centroid(y)
```

Output:

```
double free or corruption (out)
Aborted (core dumped)
```
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
