### PR TITLE
BUG: cluster: Fix `fcluster` `"maxclust"` binary search logic

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -135,7 +135,7 @@ def cluster_maxclust_dist(const double[:, :] Z, int[:] T, int n, int mc):
     mc : int
         The maximum number of clusters.
     """
-    cdef double[:] max_dists = np.ndarray(n, dtype=np.float64)
+    cdef double[:] max_dists = np.ndarray(n - 1, dtype=np.float64)
     get_max_dist_for_each_cluster(Z, max_dists, n)
     # should use an O(n) algorithm
     cluster_maxclust_monocrit(Z, max_dists, T, n, mc)
@@ -160,7 +160,13 @@ cpdef void cluster_maxclust_monocrit(const double[:, :] Z, const double[:] MC, i
     max_nc : int
         The maximum number of clusters.
     """
-    cdef int i, k, i_lc, i_rc, root, nc, lower_idx, upper_idx
+    cdef int i
+    if max_nc >= n:
+        for i in range(n):
+            T[i] = i + 1
+        return
+
+    cdef int k, i_lc, i_rc, root, nc, lower_idx, upper_idx
     cdef double thresh
     cdef int[:] curr_node = np.ndarray(n, dtype=np.intc)
 
@@ -169,7 +175,8 @@ cpdef void cluster_maxclust_monocrit(const double[:, :] Z, const double[:] MC, i
     if not visited:
         raise MemoryError
 
-    lower_idx = 0
+    # This index corresponds to "-INFINITY". `MC` is never evaluated at this index.
+    lower_idx = -1
     upper_idx = n - 1
     while upper_idx - lower_idx > 1:
         i = (lower_idx + upper_idx) >> 1

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -32,7 +32,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal, assert_, assert_warns
+from numpy.testing import (assert_allclose, assert_equal, assert_array_equal, assert_,
+                           assert_warns)
 import pytest
 from pytest import raises as assert_raises
 
@@ -282,6 +283,18 @@ class TestFcluster:
         Z = single(xp.asarray(hierarchy_test_data.Q_X))
         T = fcluster(Z, t, criterion='maxclust_monocrit', monocrit=maxdists(Z))
         assert_(is_isomorphic(T, expectedT))
+
+    def test_fcluster_maxclust_gh_12651(self, xp):
+        y = xp.asarray([[1], [4], [5]])
+        Z = single(y)
+        assert_array_equal(fcluster(Z, t=1, criterion="maxclust"),
+                           xp.asarray([1, 1, 1]))
+        assert_array_equal(fcluster(Z, t=2, criterion="maxclust"),
+                           xp.asarray([2, 1, 1]))
+        assert_array_equal(fcluster(Z, t=3, criterion="maxclust"),
+                           xp.asarray([1, 2, 3]))
+        assert_array_equal(fcluster(Z, t=5, criterion="maxclust"),
+                           xp.asarray([1, 2, 3]))
 
 
 @skip_xp_backends(cpu_only=True)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #12651

#### What does this implement/fix?

The `fcluster` algorithms with "maxclust" first search the threshold for which the number of formed clusters is not greater than the given value. But as was implemented the binary search can never select the first threshold value. The proper implementation must assure that the left bound does not satisfy the criterion and the right bound does and at the end the right bound is returned as the sought minimum. To achieve that we must consider a formal starting left bound of -1 which by convention does not satisfy the criterion. This is quite well known approach to correctly implement a binary search.

But this change alone is not enough. Because even if the minimum threshold is selected, it already might correspond to a cluster merge. Basically we need to have another lower threshold value which would correspond to "nothing merged" situation. But it's easier to just consider this as a special case. When the allowed maximum number of clusters is greater or equal than the number of original points, we can put each point into a separate cluster and be done with it.

The first change fixes the test with `t=2` (before the change all points were assigned to a single cluster) and the second change fixes the test with `t=3` (originally reported).