### PR TITLE
DEV/CI: add `gmpy2` back to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ test-requires = [
     "threadpoolctl",
     "pooch",
     "hypothesis",
+    "gmpy2",
 ]
 before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout
 pytest-xdist
 asv
 mpmath
-# gymp2  # does not yet support Python 3.12
+gmpy2
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -29,10 +29,6 @@ def generate_requirement_file(name, req_list, *, extra_list=None):
     comment = "# scikit-umfpack  # circular dependency issues"
     req_list = [comment if x == "scikit-umfpack" else x for x in req_list]
 
-    # remove once gmpy2 supports Python 3.12
-    comment = "# gymp2  # does not yet support Python 3.12"
-    req_list = [comment if x == "gmpy2" else x for x in req_list]
-
     if name == "build":
         req_list = [x for x in req_list if "numpy" not in x]
         req_list.append("ninja")


### PR DESCRIPTION
now that `gmpy2` 2.2.0 supports CPython 3.12 and 3.13

#### Reference issue
Closes gh-19782

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
