### PR TITLE
TST: fix `boxcox_llf` test skips

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1924,6 +1924,7 @@ class TestPpccMax:
                             -0.71215366521264145, decimal=7)
 
 
+@pytest.mark.usefixtures("skip_xp_backends")
 @skip_xp_backends(cpu_only=True)
 @array_api_compatible
 class TestBoxcox_llf:


### PR DESCRIPTION
* Some test skips weren't being applied for array API testing infrastructure because a marker was missing. The changes here allow the following incantation to pass again locally with NVIDIA device:
`SCIPY_DEVICE=cuda python dev.py test -t scipy/stats/tests/test_morestats.py -b all`

[skip cirrus] [skip circle]