### PR TITLE
TST: sparse.linalg: simplify dtypes def in `test_expm_multiply.py`

### DIFF
--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -17,11 +17,11 @@ from scipy._lib._util import np_long
 
 
 IMPRECISE = {np.single, np.csingle}
-REAL_DTYPES = {np.intc, np_long, np.longlong,
-               np.float32, np.float64, np.longdouble}
-COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
+REAL_DTYPES = (np.intc, np_long, np.longlong,
+               np.float32, np.float64, np.longdouble)
+COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 # use sorted list to ensure fixed order of tests
-DTYPES = sorted(REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
+DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
 def estimated(func):

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -20,7 +20,6 @@ IMPRECISE = {np.single, np.csingle}
 REAL_DTYPES = (np.intc, np_long, np.longlong,
                np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
-# use sorted list to ensure fixed order of tests
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 


### PR DESCRIPTION
use tuples directly

#### Reference issue
N/A

#### What does this implement/fix?
As proposed in https://github.com/scipy/scipy/issues/19442#issuecomment-1783687195
