### PR TITLE
TST: sparse.csgraph: simplify dtypes def in `test_graph_laplacian.py`

### DIFF
--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -164,7 +164,6 @@ def _check_laplacian_dtype(
 INT_DTYPES = (np.intc, np_long, np.longlong)
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
-# use sorted list to ensure fixed order of tests
 DTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES
 
 

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -161,11 +161,11 @@ def _check_laplacian_dtype(
                 _assert_allclose_sparse(L, mat)
 
 
-INT_DTYPES = {np.intc, np_long, np.longlong}
-REAL_DTYPES = {np.float32, np.float64, np.longdouble}
-COMPLEX_DTYPES = {np.complex64, np.complex128, np.clongdouble}
+INT_DTYPES = (np.intc, np_long, np.longlong)
+REAL_DTYPES = (np.float32, np.float64, np.longdouble)
+COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 # use sorted list to ensure fixed order of tests
-DTYPES = sorted(INT_DTYPES ^ REAL_DTYPES ^ COMPLEX_DTYPES, key=str)
+DTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES
 
 
 @pytest.mark.parametrize("dtype", DTYPES)


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
As proposed in https://github.com/scipy/scipy/issues/19442#issuecomment-1783687195
