### PR TITLE
ENH: interpolate: Add the ability to specify `k` in `NearestNDInterpolator`

### DIFF
--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -178,7 +178,8 @@ class NearestNDInterpolator(NDInterpolatorBase):
             if weights == 'uniform' and dist.ndim > 1:
                 interp_values = np.average(self.values[i], axis=1)
             elif weights == 'distance' and dist.ndim > 1:
-                interp_values = np.average(self.values[i], axis=1, weights=(1 - (dist / np.max(dist))))
+                power = 2
+                interp_values = np.average(self.values[i], axis=1, weights=( 1.0 / (dist ** power) ))
             else:
                 raise ValueError("Unknown value %r passed for weights,"
                                 "must be either 'uniform' or 'distance'" % (weights))


### PR DESCRIPTION
This commit allows you to specify k nearest neighbors in NearestNDInterpolator. This enables you to allow for averaging over the top closest neighbors rather than just the most similar.  It also allows you to specify the averaging method, either uniform or distance.

#### Reference issue
addresses gh-21138

#### What does this implement/fix?
allows you to specify k in NearestNDInterpolator


