### PR TITLE
DOC: Remove outdated comment about macos/musl in Cirrus CI config

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -1,4 +1,4 @@
-# Regular CI for testing musllinux, linux_aarch64 and macosx_arm64 natively
+# Regular CI for testing linux_aarch64 natively
 # This only runs if cirrus is not building wheels. The rationale is that
 # cibuildwheel also runs tests during the wheel build process, so there's no need
 # to have duplication.


### PR DESCRIPTION
The macos/musl builds are now tested on GHA, not Cirrus, see commits c025587b9fbbabf7e6bbf10e2e7c76ae61d6395c and a146cd3e949abd22a34c667eee29a413c3c40818.

I thought this was kind of confusing, so I wrote a PR to remove the part of the comment referencing those.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
