### PR TITLE
MAINT: signal: Don't redefine `PyArray_MIN` macro

### DIFF
--- a/scipy/signal/_splinemodule.cc
+++ b/scipy/signal/_splinemodule.cc
@@ -2,6 +2,7 @@
 #include "numpy/arrayobject.h"
 #include <complex>
 #include <cmath>
+#include <algorithm>
 #include "_splinemodule.h"
 
 
@@ -61,7 +62,7 @@ static PyObject *FIRsepsym2d(PyObject *NPY_UNUSED(dummy), PyObject *args) {
       return NULL;
 
   thetype = PyArray_ObjectType(image, NPY_FLOAT);
-  thetype = PyArray_MIN(thetype, NPY_CDOUBLE);
+  thetype = std::min(thetype, static_cast<int>(NPY_CDOUBLE));
   a_image = (PyArrayObject *)PyArray_FromObject(image, thetype, 2, 2);
   if (a_image == NULL)
       goto fail;
@@ -180,7 +181,7 @@ static PyObject *IIRsymorder1_ic(PyObject *NPY_UNUSED(dummy), PyObject *args) {
     return NULL;
 
   thetype = PyArray_ObjectType(sig, NPY_FLOAT);
-  thetype = PyArray_MIN(thetype, NPY_CDOUBLE);
+  thetype = std::min(thetype, static_cast<int>(NPY_CDOUBLE));
   a_sig = (PyArrayObject *)PyArray_FromObject(sig, thetype, 1, 2);
 
   if (a_sig == NULL) {
@@ -316,7 +317,7 @@ static PyObject *IIRsymorder2_ic_fwd(PyObject *NPY_UNUSED(dummy), PyObject *args
     return NULL;
 
   thetype = PyArray_ObjectType(sig, NPY_FLOAT);
-  thetype = PyArray_MIN(thetype, NPY_DOUBLE);
+  thetype = std::min(thetype, static_cast<int>(NPY_DOUBLE));
   a_sig = (PyArrayObject *)PyArray_FromObject(sig, thetype, 1, 2);
 
   if (a_sig == NULL) {
@@ -432,7 +433,7 @@ static PyObject *IIRsymorder2_ic_bwd(PyObject *NPY_UNUSED(dummy), PyObject *args
     return NULL;
 
   thetype = PyArray_ObjectType(sig, NPY_FLOAT);
-  thetype = PyArray_MIN(thetype, NPY_DOUBLE);
+  thetype = std::min(thetype, static_cast<int>(NPY_DOUBLE));
   a_sig = (PyArrayObject *)PyArray_FromObject(sig, thetype, 1, 2);
 
   if (a_sig == NULL) {

--- a/scipy/signal/_splinemodule.h
+++ b/scipy/signal/_splinemodule.h
@@ -10,7 +10,6 @@
         PyErr_SetString(PyExc_ValueError, message);                                                                    \
         goto fail;                                                                                                     \
     } while (0)
-#define PyArray_MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 
 /**


### PR DESCRIPTION
When building scipy with numpy 1.26.4, the following compiler warning is generated:

```
In file included from ../scipy/signal/_splinemodule.cc:5: ../scipy/signal/_splinemodule.h:13: warning: "PyArray_MIN" redefined
   13 | #define PyArray_MIN(a, b) (((a) < (b)) ? (a) : (b))
      |
In file included from ../../../../../py3.12.4/lib/python3.12/site-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                 from ../../../../../py3.12.4/lib/python3.12/site-packages/numpy/core/include/numpy/arrayobject.h:5,
                 from ../scipy/signal/_splinemodule.cc:2:
../../../../../py3.12.4/lib/python3.12/site-packages/numpy/core/include/numpy/ndarraytypes.h:964: note: this is the location of the previous definition
  964 | #define PyArray_MIN(a,b) (((a)<(b))?(a):(b))
```

In numpy 2.0.0, PyArray_MIN is defined in numpy/npy_math.h, so it doesn't result in the redefinition problem. In numpy 1.26.4, PyArray_MIN is defined in numpy/ndarraytypes.h, which is transitively included by the include of numpy/arrayobject.h in _splinemodule.cc, resulting in the redefinition warning.

To fix this, the PyArray_MIN macro is replaced with std::min.
