### PR TITLE
MAINT: sparse.linalg: `spsolve` simplification

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -313,11 +313,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             row_segs = []
             col_segs = []
             for j in range(b.shape[1]):
-                # TODO: replace this with
-                # bj = b[:, j].toarray().ravel()
-                # once 1D sparse arrays are supported.
-                # That is a slightly faster code path.
-                bj = b[:, [j]].toarray().ravel()
+                bj = b[:, j].toarray().ravel()
                 xj = Afactsolve(bj)
                 w = np.flatnonzero(xj)
                 segment_length = w.shape[0]


### PR DESCRIPTION
* A minor simplification in `spsolve`--it seems the `sparse` 1D support has reached the point where we can do this. If not, there's a gap in the testing (tests pass locally at least).

[skip circle] [skip cirrus]
