### PR TITLE
ENH: special.logsumexp: add array API standard support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Install PyTorch CPU
       run: |
-        python -m pip install "torch==2.3" --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
     - name: Install JAX
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -19,6 +19,7 @@ env:
     -t scipy.cluster
     -t scipy.constants
     -t scipy.fft
+    -t scipy.special.tests.test_logsumexp
     -t scipy.special.tests.test_support_alternative_backends
     -t scipy._lib.tests.test_array_api
     -t scipy._lib.tests.test__util

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -561,3 +561,40 @@ def xp_take_along_axis(arr: Array,
         raise NotImplementedError("Array API standard does not define take_along_axis")
     else:
         return xp.take_along_axis(arr, indices, axis)
+
+
+# utility to broadcast arrays and promote to common dtype
+def xp_broadcast_promote(*args, ensure_writeable=False, xp=None):
+    xp = array_namespace(*args) if xp is None else xp
+
+    args = [(xp.asarray(arg) if arg is not None else arg) for arg in args]
+    args_not_none = [arg for arg in args if arg is not None]
+
+    # determine minimum dtype
+    dtypes = [arg.dtype for arg in args_not_none
+              if not xp.isdtype(arg.dtype, 'integral')]
+    dtypes.append(xp.asarray(1.).dtype)
+    dtype = xp.result_type(*dtypes)
+
+    # determine result shape
+    shapes = {arg.shape for arg in args_not_none}
+    shape = np.broadcast_shapes(*shapes) if len(shapes) != 1 else args_not_none[0].shape
+
+    out = []
+    for arg in args:
+        if arg is None:
+            out.append(arg)
+            continue
+
+        # broadcast only if needed
+        # Even if two arguments need broadcasting, this is faster than
+        # `broadcast_arrays`, especially since we've already determined `shape`
+        if arg.shape != shape:
+            arg = xp.broadcast_to(arg, shape)
+
+        # convert dtype/copy only if needed
+        if (arg.dtype != dtype) or ensure_writeable:
+            arg = xp.astype(arg, dtype, copy=True)
+        out.append(arg)
+
+    return out

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -65,6 +65,15 @@ def _compliance_scipy(arrays: list[ArrayLike]) -> list[Array]:
     """
     for i in range(len(arrays)):
         array = arrays[i]
+
+        from scipy.sparse import issparse
+        # this comes from `_util._asarray_validated`
+        if issparse(array):
+            msg = ('Sparse arrays/matrices are not supported by this function. '
+                   'Perhaps one of the `scipy.sparse.linalg` functions '
+                   'would work instead.')
+            raise ValueError(msg)
+
         if isinstance(array, np.ma.MaskedArray):
             raise TypeError("Inputs of type `numpy.ma.MaskedArray` are not supported.")
         elif isinstance(array, np.matrix):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -78,7 +78,7 @@ def _compliance_scipy(arrays: list[ArrayLike]) -> list[Array]:
             raise TypeError("Inputs of type `numpy.ma.MaskedArray` are not supported.")
         elif isinstance(array, np.matrix):
             raise TypeError("Inputs of type `numpy.matrix` are not supported.")
-        if isinstance(array, (np.ndarray, np.generic)):
+        if isinstance(array, np.ndarray | np.generic):
             dtype = array.dtype
             if not (np.issubdtype(dtype, np.number) or np.issubdtype(dtype, np.bool_)):
                 raise TypeError(f"An argument has dtype `{dtype!r}`; "
@@ -573,7 +573,7 @@ def xp_take_along_axis(arr: Array,
 
 
 # utility to broadcast arrays and promote to common dtype
-def xp_broadcast_promote(*args, ensure_writeable=False, xp=None):
+def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp=None):
     xp = array_namespace(*args) if xp is None else xp
 
     args = [(xp.asarray(arg) if arg is not None else arg) for arg in args]
@@ -582,7 +582,8 @@ def xp_broadcast_promote(*args, ensure_writeable=False, xp=None):
     # determine minimum dtype
     dtypes = [arg.dtype for arg in args_not_none
               if not xp.isdtype(arg.dtype, 'integral')]
-    dtypes.append(xp.asarray(1.).dtype)
+    if force_floating:
+        dtypes.append(xp.asarray(1.).dtype)
     dtype = xp.result_type(*dtypes)
 
     # determine result shape

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -8,8 +8,6 @@ from collections import namedtuple
 import inspect
 import math
 from typing import (
-    Optional,
-    Union,
     TYPE_CHECKING,
     TypeVar,
 )
@@ -53,10 +51,10 @@ else:
     np_long = np.int_
     np_ulong = np.uint
 
-IntNumber = Union[int, np.integer]
-DecimalNumber = Union[float, np.floating, np.integer]
+IntNumber = int | np.integer
+DecimalNumber = float | np.floating | np.integer
 
-copy_if_needed: Optional[bool]
+copy_if_needed: bool | None
 
 if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
     copy_if_needed = None
@@ -73,10 +71,9 @@ else:
 # Since Generator was introduced in numpy 1.17, the following condition is needed for
 # backward compatibility
 if TYPE_CHECKING:
-    SeedType = Optional[Union[IntNumber, np.random.Generator,
-                              np.random.RandomState]]
-    GeneratorType = TypeVar("GeneratorType", bound=Union[np.random.Generator,
-                                                         np.random.RandomState])
+    SeedType = IntNumber | np.random.Generator | np.random.RandomState | None
+    GeneratorType = TypeVar("GeneratorType",
+                            bound=np.random.Generator|np.random.RandomState)
 
 try:
     from numpy.random import Generator as Generator
@@ -271,9 +268,9 @@ def check_random_state(seed):
     """
     if seed is None or seed is np.random:
         return np.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, np.integer)):
+    if isinstance(seed, numbers.Integral | np.integer):
         return np.random.RandomState(seed)
-    if isinstance(seed, (np.random.RandomState, np.random.Generator)):
+    if isinstance(seed, np.random.RandomState | np.random.Generator):
         return seed
 
     raise ValueError(f"'{seed}' cannot be used to seed a numpy.random.RandomState"

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -318,8 +318,8 @@ def _asarray_validated(a, check_finite=True,
     if not sparse_ok:
         import scipy.sparse
         if scipy.sparse.issparse(a):
-            msg = ('Sparse matrices are not supported by this function. '
-                   'Perhaps one of the scipy.sparse.linalg functions '
+            msg = ('Sparse arrays/matrices are not supported by this function. '
+                   'Perhaps one of the `scipy.sparse.linalg` functions '
                    'would work instead.')
             raise ValueError(msg)
     if not mask_ok:

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -5,8 +5,7 @@ from scipy import special
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
 from scipy._lib._array_api import (array_namespace, xp_copy, xp_ravel,
-                                   xp_real, is_numpy, is_cupy, is_torch,
-                                   xp_take_along_axis)
+                                   xp_real, xp_take_along_axis)
 
 
 __all__ = ['nsum']
@@ -412,7 +411,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
         fjwj, Sn = _euler_maclaurin_sum(fj, work, xp)
         if work.Sk.shape[-1]:
             Snm1 = work.Sk[:, -1]
-            Sn = (_logsumexp(xp.stack([Snm1 - math.log(2), Sn]), axis=0, xp=xp) if log
+            Sn = (special.logsumexp(xp.stack([Snm1 - math.log(2), Sn]), axis=0) if log
                   else Snm1 / 2 + Sn)
 
         work.fjwj = fjwj
@@ -691,7 +690,7 @@ def _euler_maclaurin_sum(fj, work, xp):
     fjwj = fj + xp.log(work.wj) if work.log else fj * work.wj
 
     # update integral estimate
-    Sn = (_logsumexp(fjwj + xp.log(work.h), axis=-1, xp=xp) if work.log
+    Sn = (special.logsumexp(fjwj + xp.log(work.h), axis=-1) if work.log
           else xp.sum(fjwj, axis=-1) * work.h)
 
     work.xr0, work.fr0, work.wr0 = xr0, fr0, wr0
@@ -726,7 +725,7 @@ def _estimate_error(work, xp):
         fjwj_rl = xp.reshape(work.fjwj, (n_active, 2, -1))
         fjwj = xp.reshape(fjwj_rl[:, :, :n_x], (n_active, 2*n_x))
         # Compute the Euler-Maclaurin sum at this level
-        Snm1 = (_logsumexp(fjwj, xp=xp, **axis_kwargs) + xp.log(h) if work.log
+        Snm1 = (special.logsumexp(fjwj, **axis_kwargs) + xp.log(h) if work.log
                 else xp.sum(fjwj, **axis_kwargs) * h)
         work.Sk = xp.concat((Snm1, work.Sk), axis=-1)
 
@@ -745,7 +744,7 @@ def _estimate_error(work, xp):
         fjwj_rl = xp.reshape(work.fjwj, (work.Sn.shape[0], 2, -1))
         fjwj = xp.reshape(fjwj_rl[..., :n_x], (n_active, 2*n_x))
         # Compute the Euler-Maclaurin sum at this level
-        Snm2 = (_logsumexp(fjwj, xp=xp, **axis_kwargs) + xp.log(h) if work.log
+        Snm2 = (special.logsumexp(fjwj, **axis_kwargs) + xp.log(h) if work.log
                 else xp.sum(fjwj, **axis_kwargs) * h)
         work.Sk = xp.concat((Snm2, work.Sk), axis=-1)
 
@@ -760,8 +759,8 @@ def _estimate_error(work, xp):
         # complex values have imaginary part in increments of pi*j, which just
         # carries sign information of the original integral, so use of
         # `xp.real` here is equivalent to absolute value in real scale.
-        d1 = xp_real(_logsumexp(xp.stack([work.Sn, Snm1 + work.pi*1j]), axis=0, xp=xp))
-        d2 = xp_real(_logsumexp(xp.stack([work.Sn, Snm2 + work.pi*1j]), axis=0, xp=xp))
+        d1 = xp_real(special.logsumexp(xp.stack([work.Sn, Snm1 + work.pi*1j]), axis=0))
+        d2 = xp_real(special.logsumexp(xp.stack([work.Sn, Snm2 + work.pi*1j]), axis=0))
         d3 = log_e1 + xp.max(xp_real(work.fjwj), axis=-1)
         d4 = work.d4
         ds = xp.stack([d1 ** 2 / d2, 2 * d1, d3, d4])
@@ -883,28 +882,6 @@ def _tanhsinh_iv(f, a, b, log, maxfun, maxlevel, minlevel,
 
     return (f, a, b, log, maxfun, maxlevel, minlevel,
             atol, rtol, args, preserve_shape, callback, xp)
-
-
-def _logsumexp(x, /, *, axis=0, keepdims=False, xp=None):
-    # Dispatcher for _logsumexp until scipy/scipy#21149 merges
-    # Also, logsumexp raises with empty array; don't do that.
-    xp = array_namespace(x) if xp is None else xp
-    x = xp.asarray(x)
-    shape = list(x.shape)
-    if shape[axis] == 0:
-        shape.pop(axis)
-        return xp.full(shape, fill_value=-xp.inf, dtype=x.dtype)
-
-    if is_numpy(xp):
-        return special.logsumexp(x, axis=axis, keepdims=keepdims)
-    elif is_cupy(xp):
-        from cupyx.scipy.special import logsumexp  # type: ignore[import-not-found]
-        return logsumexp(x, axis=axis, keepdims=keepdims)
-    elif is_torch(xp):
-        # Torch doesn't support complex
-        x = np.asarray(x)
-        y = special.logsumexp(x, axis=axis, keepdims=keepdims)[()]
-        return xp.asarray(y)
 
 
 def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
@@ -1251,7 +1228,7 @@ def _direct(f, a, b, step, args, constants, inclusive=True):
     # like this. This is an optimization that can be added later.
     fs[i_nan] = zero
     nfev = max_steps - i_nan.sum(axis=-1)
-    S = _logsumexp(fs, axis=-1) if log else np.sum(fs, axis=-1)
+    S = special.logsumexp(fs, axis=-1) if log else np.sum(fs, axis=-1)
     # Rough, non-conservative error estimate. See gh-19667 for improvement ideas.
     E = np.real(S) + np.log(eps) if log else eps * abs(S)
     return S, E, nfev
@@ -1265,7 +1242,10 @@ def _integral_bound(f, a, b, step, args, constants):
     # Get a lower bound on the sum and compute effective absolute tolerance
     lb = _tanhsinh(f, a, b, args=args, atol=atol, rtol=rtol, log=log)
     tol = np.broadcast_to(atol, lb.integral.shape)
-    tol = _logsumexp((tol, rtol + lb.integral)) if log else tol + rtol*lb.integral
+    if log:
+        tol = special.logsumexp((tol, rtol + lb.integral), axis=0)
+    else:
+        tol = tol + rtol*lb.integral
     i_skip = lb.status < 0  # avoid unnecessary f_evals if integral is divergent
     tol[i_skip] = np.nan
     status = lb.status
@@ -1323,9 +1303,9 @@ def _integral_bound(f, a, b, step, args, constants):
     if log:
         log_step = np.log(step)
         S_terms = (left, right.integral - log_step, fk - log2, fb - log2)
-        S = _logsumexp(S_terms, axis=0)
+        S = special.logsumexp(S_terms, axis=0)
         E_terms = (left_error, right.error - log_step, fk-log2, fb-log2+np.pi*1j)
-        E = _logsumexp(E_terms, axis=0).real
+        E = special.logsumexp(E_terms, axis=0).real
     else:
         S = left + right.integral/step + fk/2 + fb/2
         E = left_error + right.error/step + fk/2 - fb/2

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -496,6 +496,15 @@ class TestTanhSinh:
         assert res.success
         assert res.status == 0
 
+    @pytest.mark.skip_xp_backends(
+        'array_api_strict', 'jax.numpy', 'cupy', 'torch',
+        reasons=[
+            'Currently uses fancy indexing assignment.',
+            'JAX arrays do not support item assignment.',
+            'cupy/cupy#8391',
+            'https://github.com/scipy/scipy/pull/21149#issuecomment-2330477359',
+        ],
+    )
     @pytest.mark.parametrize('rtol', [1e-4, 1e-14])
     def test_log(self, rtol, xp):
         # Test equivalence of log-integration and regular integration

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -45,11 +45,12 @@ def _vectorize(xp):
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy', 'cupy',
-                              reasons=['Currently uses fancy indexing assignment.',
-                                       'JAX arrays do not support item assignment.',
-                                       'cupy/cupy#8391',],
-                              cpu_only=True,) # cpu only until gh-21149 merges
+@pytest.mark.skip_xp_backends(
+    'array_api_strict', 'jax.numpy', 'cupy',
+    reasons=['Currently uses fancy indexing assignment.',
+             'JAX arrays do not support item assignment.',
+             'cupy/cupy#8391',],
+)
 class TestTanhSinh:
 
     # Test problems from [1] Section 6

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy._lib._util import _asarray_validated
 from scipy._lib._array_api import (
     array_namespace,
-    size as xp_size,
+    xp_size,
     xp_broadcast_promote,
 )
 
@@ -99,7 +99,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     """
     xp = array_namespace(a, b)
-    a, b = xp_broadcast_promote(a, b, ensure_writeable=True, xp=xp)
+    a, b = xp_broadcast_promote(a, b, ensure_writeable=True, force_floating=True, xp=xp)
     axis = tuple(range(a.ndim)) if axis is None else axis
 
     if b is not None:

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -1,5 +1,10 @@
 import numpy as np
 from scipy._lib._util import _asarray_validated
+from scipy._lib._array_api import (
+    array_namespace,
+    size as xp_size,
+    xp_broadcast_promote,
+)
 
 __all__ = ["logsumexp", "softmax", "log_softmax"]
 
@@ -93,43 +98,49 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     1.6094379124341005, 1.6094379124341005
 
     """
-    a = _asarray_validated(a, check_finite=False)
+    xp = array_namespace(a, b)
+    a, b = xp_broadcast_promote(a, b, ensure_writeable=True, xp=xp)
+    axis = tuple(range(a.ndim)) if axis is None else axis
+
     if b is not None:
-        a, b = np.broadcast_arrays(a, b)
-        if np.any(b == 0):
-            a = a + 0.  # promote to at least float
-            a[b == 0] = -np.inf
+        a[b == 0] = -xp.inf
 
     # Scale by real part for complex inputs, because this affects
     # the magnitude of the exponential.
-    initial_value = -np.inf if np.size(a) == 0 else None
-    a_max = np.amax(a.real, axis=axis, keepdims=True, initial=initial_value)
+    if xp_size(a) == 0:
+        # because `xp.max` doesn't have `initial` argument...
+        shape = np.asarray(a.shape)  # NumPy is concise for scalar or tuple `axis`
+        shape[axis] = 1
+        a_max = xp.full(tuple(shape), -xp.inf, dtype=a.dtype)
+    else:
+        real = xp.real(a) if xp.isdtype(a.dtype, "complex floating") else a
+        a_max = xp.max(real, axis=axis, keepdims=True)
 
     if a_max.ndim > 0:
-        a_max[~np.isfinite(a_max)] = 0
-    elif not np.isfinite(a_max):
+        a_max[~xp.isfinite(a_max)] = 0
+    elif not xp.isfinite(a_max):
         a_max = 0
 
     if b is not None:
-        b = np.asarray(b)
-        tmp = b * np.exp(a - a_max)
+        b = xp.asarray(b)
+        tmp = b * xp.exp(a - a_max)
     else:
-        tmp = np.exp(a - a_max)
+        tmp = xp.exp(a - a_max)
 
     # suppress warnings about log of zero
     with np.errstate(divide='ignore'):
-        s = np.sum(tmp, axis=axis, keepdims=keepdims)
+        s = xp.sum(tmp, axis=axis, keepdims=keepdims)
         if return_sign:
             # For complex, use the numpy>=2.0 convention for sign.
-            if np.issubdtype(s.dtype, np.complexfloating):
-                sgn = s / np.where(s == 0, 1, abs(s))
+            if xp.isdtype(s.dtype, "complex floating"):
+                sgn = s / xp.where(s == 0, xp.asarray(1, dtype=s.dtype), xp.abs(s))
             else:
-                sgn = np.sign(s)
-            s = abs(s)
-        out = np.log(s)
+                sgn = xp.sign(s)
+            s = xp.abs(s)
+        out = xp.log(s)
 
     if not keepdims:
-        a_max = np.squeeze(a_max, axis=axis)
+        a_max = xp.squeeze(a_max, axis=axis)
     out += a_max
 
     if return_sign:

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -1,138 +1,136 @@
+import math
+import pytest
+
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_array_almost_equal)
+from numpy.testing import assert_allclose
+
+from scipy.conftest import array_api_compatible
+from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 
 from scipy.special import logsumexp, softmax
 
 
+@array_api_compatible
+@pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('jax.numpy',
+                              reasons=["JAX arrays do not support item assignment"])
 class TestLogSumExp:
-    def test_logsumexp(self):
+    def test_logsumexp(self, xp):
         # Test with zero-size array
-        a = []
-        desired = -np.inf
-        assert_equal(logsumexp(a), desired)
+        a = xp.asarray([])
+        desired = xp.asarray(-xp.inf)
+        xp_assert_equal(logsumexp(a), desired)
 
         # Test whether logsumexp() function correctly handles large inputs.
-        a = np.arange(200)
-        desired = np.log(np.sum(np.exp(a)))
-        assert_almost_equal(logsumexp(a), desired)
+        a = xp.arange(200., dtype=xp.float64)
+        desired = xp.log(xp.sum(xp.exp(a)))
+        xp_assert_close(logsumexp(a), desired)
 
         # Now test with large numbers
-        b = [1000, 1000]
-        desired = 1000.0 + np.log(2.0)
-        assert_almost_equal(logsumexp(b), desired)
+        b = xp.asarray([1000., 1000.])
+        desired = xp.asarray(1000.0 + math.log(2.0))
+        xp_assert_close(logsumexp(b), desired)
 
         n = 1000
-        b = np.full(n, 10000, dtype='float64')
-        desired = 10000.0 + np.log(n)
-        assert_almost_equal(logsumexp(b), desired)
+        b = xp.full((n,), 10000)
+        desired = xp.asarray(10000.0 + math.log(n))
+        xp_assert_close(logsumexp(b), desired)
 
-        x = np.array([1e-40] * 1000000)
-        logx = np.log(x)
-
-        X = np.vstack([x, x])
-        logX = np.vstack([logx, logx])
-        assert_array_almost_equal(np.exp(logsumexp(logX)), X.sum())
-        assert_array_almost_equal(np.exp(logsumexp(logX, axis=0)), X.sum(axis=0))
-        assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))
+        x = xp.asarray([1e-40] * 1000000)
+        logx = xp.log(x)
+        X = xp.stack([x, x])
+        logX = xp.stack([logx, logx])
+        xp_assert_close(xp.exp(logsumexp(logX)), xp.sum(X))
+        xp_assert_close(xp.exp(logsumexp(logX, axis=0)), xp.sum(X, axis=0))
+        xp_assert_close(xp.exp(logsumexp(logX, axis=1)), xp.sum(X, axis=1))
 
         # Handling special values properly
-        assert_equal(logsumexp(np.inf), np.inf)
-        assert_equal(logsumexp(-np.inf), -np.inf)
-        assert_equal(logsumexp(np.nan), np.nan)
-        assert_equal(logsumexp([-np.inf, -np.inf]), -np.inf)
+        inf = xp.asarray([xp.inf])
+        nan = xp.asarray([xp.nan])
+        xp_assert_equal(logsumexp(inf), inf[0])
+        xp_assert_equal(logsumexp(-inf), -inf[0])
+        xp_assert_equal(logsumexp(nan), nan[0])
+        xp_assert_equal(logsumexp(xp.asarray([-xp.inf, -xp.inf])), -inf[0])
 
         # Handling an array with different magnitudes on the axes
-        assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                            [-1e10, -np.inf]], axis=-1),
-                                [1e10, -1e10])
+        a = xp.asarray([[1e10, 1e-10],
+                        [-1e10, -np.inf]])
+        ref = xp.asarray([1e10, -1e10])
+        xp_assert_close(logsumexp(a, axis=-1), ref)
 
         # Test keeping dimensions
-        assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                            [-1e10, -np.inf]],
-                                            axis=-1,
-                                            keepdims=True),
-                                [[1e10], [-1e10]])
+        xp_test = array_namespace(a) # `torch` needs `expand_dims`
+        ref = xp_test.expand_dims(ref, axis=-1)
+        xp_assert_close(logsumexp(a, axis=-1, keepdims=True), ref)
 
         # Test multiple axes
-        assert_array_almost_equal(logsumexp([[1e10, 1e-10],
-                                            [-1e10, -np.inf]],
-                                            axis=(-1,-2)),
-                                1e10)
+        xp_assert_close(logsumexp(a, axis=(-1, -2)), xp.asarray(1e10))
 
+    def test_logsumexp_b(self, xp):
+        a = xp.arange(200., dtype=xp.float64)
+        b = xp.arange(200., 0., -1.)
+        desired = xp.log(xp.sum(b*xp.exp(a)))
+        xp_assert_close(logsumexp(a, b=b), desired)
 
-    def test_logsumexp_b(self):
-        a = np.arange(200)
-        b = np.arange(200, 0, -1)
-        desired = np.log(np.sum(b*np.exp(a)))
-        assert_almost_equal(logsumexp(a, b=b), desired)
+        a = xp.asarray([1000, 1000])
+        b = xp.asarray([1.2, 1.2])
+        desired = xp.asarray(1000 + math.log(2 * 1.2))
+        xp_assert_close(logsumexp(a, b=b), desired)
 
-        a = [1000, 1000]
-        b = [1.2, 1.2]
-        desired = 1000 + np.log(2 * 1.2)
-        assert_almost_equal(logsumexp(a, b=b), desired)
+        x = xp.asarray([1e-40] * 100000)
+        b = xp.linspace(1, 1000, 100000)
+        logx = xp.log(x)
+        X = xp.stack((x, x))
+        logX = xp.stack((logx, logx))
+        B = xp.stack((b, b))
+        xp_assert_close(xp.exp(logsumexp(logX, b=B)), xp.sum(B * X))
+        xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=0)), xp.sum(B * X, axis=0))
+        xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=1)), xp.sum(B * X, axis=1))
 
-        x = np.array([1e-40] * 100000)
-        b = np.linspace(1, 1000, 100000)
-        logx = np.log(x)
-
-        X = np.vstack((x, x))
-        logX = np.vstack((logx, logx))
-        B = np.vstack((b, b))
-        assert_array_almost_equal(np.exp(logsumexp(logX, b=B)), (B * X).sum())
-        assert_array_almost_equal(np.exp(logsumexp(logX, b=B, axis=0)),
-                                    (B * X).sum(axis=0))
-        assert_array_almost_equal(np.exp(logsumexp(logX, b=B, axis=1)),
-                                    (B * X).sum(axis=1))
-
-
-    def test_logsumexp_sign(self):
-        a = [1,1,1]
-        b = [1,-1,-1]
+    def test_logsumexp_sign(self, xp):
+        a = xp.asarray([1, 1, 1])
+        b = xp.asarray([1, -1, -1])
 
         r, s = logsumexp(a, b=b, return_sign=True)
-        assert_almost_equal(r,1)
-        assert_equal(s,-1)
+        xp_assert_close(r, xp.asarray(1.))
+        xp_assert_equal(s, xp.asarray(-1.))
 
-
-    def test_logsumexp_sign_zero(self):
-        a = [1,1]
-        b = [1,-1]
+    def test_logsumexp_sign_zero(self, xp):
+        a = xp.asarray([1, 1])
+        b = xp.asarray([1, -1])
 
         r, s = logsumexp(a, b=b, return_sign=True)
-        assert not np.isfinite(r)
-        assert not np.isnan(r)
+        assert not xp.isfinite(r)
+        assert not xp.isnan(r)
         assert r < 0
         assert s == 0
 
-
-    def test_logsumexp_sign_shape(self):
-        a = np.ones((1,2,3,4))
-        b = np.ones_like(a)
+    def test_logsumexp_sign_shape(self, xp):
+        a = xp.ones((1, 2, 3, 4))
+        b = xp.ones_like(a)
 
         r, s = logsumexp(a, axis=2, b=b, return_sign=True)
         assert r.shape == s.shape == (1, 2, 4)
 
-        r, s = logsumexp(a, axis=(1,3), b=b, return_sign=True)
-        assert r.shape == s.shape == (1, 3)
+        r, s = logsumexp(a, axis=(1, 3), b=b, return_sign=True)
+        assert r.shape == s.shape == (1,3)
 
-
-    def test_logsumexp_complex_sign(self):
-        a = np.array([1 + 1j, 2 - 1j, -2 + 3j])
+    def test_logsumexp_complex_sign(self, xp):
+        a = xp.asarray([1 + 1j, 2 - 1j, -2 + 3j])
 
         r, s = logsumexp(a, return_sign=True)
 
-        expected_sumexp = np.exp(a).sum()
+        expected_sumexp = xp.sum(xp.exp(a))
         # This is the numpy>=2.0 convention for np.sign
-        expected_sign = expected_sumexp / abs(expected_sumexp)
+        expected_sign = expected_sumexp / xp.abs(expected_sumexp)
 
-        assert_allclose(s, expected_sign)
-        assert_allclose(s * np.exp(r), expected_sumexp)
+        xp_assert_close(s, expected_sign)
+        xp_assert_close(s * xp.exp(r), expected_sumexp)
 
-
-    def test_logsumexp_shape(self):
-        a = np.ones((1, 2, 3, 4))
-        b = np.ones_like(a)
+    def test_logsumexp_shape(self, xp):
+        a = xp.ones((1, 2, 3, 4))
+        b = xp.ones_like(a)
 
         r = logsumexp(a, axis=2, b=b)
         assert r.shape == (1, 2, 4)
@@ -140,19 +138,22 @@ class TestLogSumExp:
         r = logsumexp(a, axis=(1, 3), b=b)
         assert r.shape == (1, 3)
 
+    def test_logsumexp_b_zero(self, xp):
+        a = xp.asarray([1, 10000])
+        b = xp.asarray([1, 0])
 
-    def test_logsumexp_b_zero(self):
-        a = [1,10000]
-        b = [1,0]
+        xp_assert_close(logsumexp(a, b=b), xp.asarray(1.))
 
-        assert_almost_equal(logsumexp(a, b=b), 1)
-
-
-    def test_logsumexp_b_shape(self):
-        a = np.zeros((4,1,2,1))
-        b = np.ones((3,1,5))
+    def test_logsumexp_b_shape(self, xp):
+        a = xp.zeros((4, 1, 2, 1))
+        b = xp.ones((3, 1, 5))
 
         logsumexp(a, b=b)
+
+    @pytest.mark.parametrize('arg', (1, [1, 2, 3]))
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_xp_invalid_input(self, arg, xp):
+        assert logsumexp(arg) == logsumexp(np.asarray(np.atleast_1d(arg)))
 
 
 class TestSoftmax:


### PR DESCRIPTION
#### Reference issue
Towards gh-18867. Take 2 of gh-20935.

#### What does this implement/fix?
By commit:
1. adds the `xp_broadcast_promote` utility, written by @mdhaber .
2. adds a `scipy.sparse` check to `compliance_scipy`, meaning that we can fully replace `_util._asarray_validated` by calls to `array_namespace` and `_asarray` (or in this case, `array_namespace` and `xp_broadcast_promote`).
3. adds inline array API standard support to `special.logsumexp`. This function is used in `integrate` and `stats`, so having full support here (as opposed to just dispatching via `_suport_alternative_backends`) unblocks other work. The alternative is to put this implementation in `_support_alternative_backends` as an agnostic implementation and leave the `np` implementation untouched. However, that duplication is undesirable to me.
4. adds `-t scipy.special.tests.test_logsumexp` to the array API CI job and converts the tests such that they test alternative backends too. No JAX yet, waiting on the discussion at the bottom of gh-20085 / https://github.com/data-apis/array-api-compat/issues/146.

#### Additional information
gh-21128 helped reduce the diff here. @rgommers does this meet the desired standards for clean diffs / commit structure?

---

@mdhaber I've added you as co-author for commits 3 and 4 since they are basically just what you wrote, but I did make a few small changes:
- added `sparse_ok=False` to the `array_namespace` call - addressed https://github.com/scipy/scipy/pull/20935#discussion_r1634452915
- added `xp=xp` to the `xp_broadcast_promote` call to reduce overhead ever so slightly.
- I replaced the `newaxis` indexing in the tests with `expand_dims` which I find a bit more readable. Since we need `xp_test` either way though, maybe we should just write out the full array?