### PR TITLE
DOC: fix documentation about verbose in minimize_trustregion_constr.py

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -211,7 +211,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         Relative step size for the finite difference approximation.
     maxiter : int, optional
         Maximum number of algorithm iterations. Default is 1000.
-    verbose : {0, 1, 2}, optional
+    verbose : {0, 1, 2, 3}, optional
         Level of algorithm's verbosity:
 
         * 0 (default) : work silently.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No issue

#### What does this implement/fix?
<!--Please explain your changes.-->
This is just a doc fix to make the range of verbose values consistent with the text below that explains each verbose level

#### Additional information
<!--Any additional information you think is important.-->
There is a codepath for verbose > 2, so this should be the right change (as opposed to removing the line about verbose=3)