### PR TITLE
ENH: stats.mstats: add weighted Harrell Davis quantile estimation

### DIFF
--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -86,9 +86,9 @@ def hdquantiles(data, prob=list([.25,.5,.75]), axis=None, var=False, weights=Non
     >>> quantile_estimates = hdquantiles(data, prob=probabilities, weights=weights)
     >>> for i, quantile in enumerate(probabilities):
     ...     print(f"{int(quantile * 100)}th percentile: {quantile_estimates[i]}")
-    25th percentile: 15.02819625052742
-    50th percentile: 49.993761268123606
-    75th percentile: 84.96474577296154
+    25th percentile: 15.02819625052742 # may vary
+    50th percentile: 49.993761268123606 # may vary
+    75th percentile: 84.96474577296154 # may vary
 
     """
     def _kish_ess(weights):


### PR DESCRIPTION
#### **Reference Issue**

No issue

#### **What does this implement/fix?**

Updates the implementation of Harrell Davis quantile estimation, enabling weighted data. This changes assume equal weights as default, leaving the previous implementation invariant.

#### **Additional Information**

Referenced implementation on the work done by Andrey Akinshin @AndreyAkinshin  present in the reference material of https://doi.org/10.48550/arXiv.2304.07265. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
