### PR TITLE
MAINT: `optimize.root_scalar`: ensure user function gets scalar argument

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -308,7 +308,12 @@ def root_scalar(f, args=(), method=None, bracket=None,
                 # use of `newton`. In that case, `approx_derivative` will
                 # always get scalar input. Nonetheless, it always returns an
                 # array, so we extract the element to produce scalar output.
-                return approx_derivative(f, x, method='2-point', args=args)[0]
+                # Similarly, `approx_derivative` always passes array input, so
+                # we extract the element to ensure the user's function gets
+                # scalar input.
+                def f_wrapped(x, *args):
+                    return f(x[0], *args)
+                return approx_derivative(f_wrapped, x, method='2-point', args=args)[0]
 
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -437,18 +437,23 @@ class TestNewton(TestScalarRootFinders):
         # to secant. When x1 was not specified, secant failed.
         # Check that without fprime, the default is secant if x1 is specified
         # and newton otherwise.
-        res_newton_default = root_scalar(f1, method='newton', x0=3, xtol=1e-6)
-        res_secant_default = root_scalar(f1, method='secant', x0=3, x1=2,
+        # Also confirm that `x` is always a scalar (gh-21148)
+        def f(x):
+            assert np.isscalar(x)
+            return f1(x)
+
+        res_newton_default = root_scalar(f, method='newton', x0=3, xtol=1e-6)
+        res_secant_default = root_scalar(f, method='secant', x0=3, x1=2,
                                          xtol=1e-6)
         # `newton` uses the secant method when `x1` and `x2` are specified
-        res_secant = newton(f1, x0=3, x1=2, tol=1e-6, full_output=True)[1]
+        res_secant = newton(f, x0=3, x1=2, tol=1e-6, full_output=True)[1]
 
         # all three found a root
-        assert_allclose(f1(res_newton_default.root), 0, atol=1e-6)
+        assert_allclose(f(res_newton_default.root), 0, atol=1e-6)
         assert res_newton_default.root.shape == tuple()
-        assert_allclose(f1(res_secant_default.root), 0, atol=1e-6)
+        assert_allclose(f(res_secant_default.root), 0, atol=1e-6)
         assert res_secant_default.root.shape == tuple()
-        assert_allclose(f1(res_secant.root), 0, atol=1e-6)
+        assert_allclose(f(res_secant.root), 0, atol=1e-6)
         assert res_secant.root.shape == tuple()
 
         # Defaults are correct


### PR DESCRIPTION
#### Reference issue
Closes gh-21148

#### What does this implement/fix?
gh-21148 reported that `root_scalar` sometimes passes an array of shape `(1,)` to the user callable. This occurs when `approx_derivative` is used to estimate the derivative. This PR fixes the problem by wrapping the user callable to ensure that it receives a scalar.

#### Additional information
@nickodell Can you confirm that `approx_derivative` *always* passes an array of shape `(1,)` (i.e. never a scalar or 0d array), at least in this context?
If not, the safer way to do this would be to `x.ravel()` before extracting the element. If it could be a Python scalar, then `np.ravel(x)`.