### PR TITLE
MAINT: special: Make fixes needed for ellipkinc and ellipeinc to work on CUDA

### DIFF
--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -326,7 +326,11 @@ special_cephes_sources = [
   'special/cephes/chdtr.h',
   'special/cephes/igami.h',
   'special/cephes/hyperg.h',
-  'special/cephes/expn.h'
+  'special/cephes/expn.h',
+  'special/cephes/ellie.h',
+  'special/cephes/ellik.h',
+  'special/cephes/ellpe.h',
+  'special/cephes/ellpk.h'
 ]
 
 py3.install_sources(special_sources, subdir: 'scipy/special/special')

--- a/scipy/special/special/cephes/ellie.h
+++ b/scipy/special/special/cephes/ellie.h
@@ -58,6 +58,7 @@
 #include "../config.h"
 #include "const.h"
 #include "ellpe.h"
+#include "ellpk.h"
 #include "unity.h"
 
 namespace special {
@@ -246,7 +247,7 @@ namespace cephes {
             e = 1.0 / (b * t);
             /* ... but avoid multiple recursions.  */
             if (std::abs(e) < 10.0) {
-                e = atan(e);
+                e = std::atan(e);
                 temp = E + m * std::sin(lphi) * std::sin(e) - ellie(e, m);
                 goto done;
             }

--- a/scipy/special/special/cephes/ellik.h
+++ b/scipy/special/special/cephes/ellik.h
@@ -131,7 +131,7 @@ namespace cephes {
             z1 = z;
             /* Carlson gives 1/pow(3*r, 1.0/6.0) for this constant. if r == eps,
              * it is ~338.38. */
-            Q = 400.0 * std::max(std::abs(A0 - x), std::max(std::abs(A0 - y), std::abs(A0 - z)));
+            Q = 400.0 * std::fmax(std::abs(A0 - x), std::fmax(std::abs(A0 - y), std::abs(A0 - z)));
 
             while (Q > std::abs(A) && n <= 100) {
                 double sx = std::sqrt(x1);

--- a/scipy/special/tests/test_xsf_cuda.py
+++ b/scipy/special/tests/test_xsf_cuda.py
@@ -17,13 +17,15 @@ except ImportError:
 
 def get_test_cases():
     cases_source = [
-        (sc.beta, "cephes/beta.h", "out0 = special::cephes::beta(in0, in1)"),
-        (sc.binom, "binom.h", "out0 = special::binom(in0, in1)"),
-        (sc.digamma, "digamma.h", "special::digamma(in0)"),
-        (sc.expn, "cephes/expn.h", "out0 = special::cephes::expn(in0, in1)"),
-        (sc.hyp2f1, "hyp2f1.h", "out0 = special::hyp2f1(in0, in1, in2, in3)"),
-        (sc._ufuncs._lambertw, "lambertw.h", "out0 = special::lambertw(in0, in1, in2)"),
-        (sc._ufuncs._iv_ratio, "iv_ratio.h", "out0 = special::iv_ratio(in0, in1)"),
+        # (sc.beta, "cephes/beta.h", "out0 = special::cephes::beta(in0, in1)"),
+        # (sc.binom, "binom.h", "out0 = special::binom(in0, in1)"),
+        # (sc.digamma, "digamma.h", "special::digamma(in0)"),
+        # (sc.expn, "cephes/expn.h", "out0 = special::cephes::expn(in0, in1)"),
+        # (sc.hyp2f1, "hyp2f1.h", "out0 = special::hyp2f1(in0, in1, in2, in3)"),
+        # (sc._ufuncs._lambertw, "lambertw.h", "out0 = special::lambertw(in0, in1, in2)"),
+        # (sc._ufuncs._iv_ratio, "iv_ratio.h", "out0 = special::iv_ratio(in0, in1)"),
+        (sc.ellipkinc, "cephes/ellik.h", "out0 = special::cephes::ellik(in0, in1)"),
+        (sc.ellipeinc, "cephes/ellie.h", "out0 = special::cephes::ellie(in0, in1)"),
     ]
 
     cases = []

--- a/scipy/special/tests/test_xsf_cuda.py
+++ b/scipy/special/tests/test_xsf_cuda.py
@@ -17,13 +17,13 @@ except ImportError:
 
 def get_test_cases():
     cases_source = [
-        # (sc.beta, "cephes/beta.h", "out0 = special::cephes::beta(in0, in1)"),
-        # (sc.binom, "binom.h", "out0 = special::binom(in0, in1)"),
-        # (sc.digamma, "digamma.h", "special::digamma(in0)"),
-        # (sc.expn, "cephes/expn.h", "out0 = special::cephes::expn(in0, in1)"),
-        # (sc.hyp2f1, "hyp2f1.h", "out0 = special::hyp2f1(in0, in1, in2, in3)"),
-        # (sc._ufuncs._lambertw, "lambertw.h", "out0 = special::lambertw(in0, in1, in2)"),
-        # (sc._ufuncs._iv_ratio, "iv_ratio.h", "out0 = special::iv_ratio(in0, in1)"),
+        (sc.beta, "cephes/beta.h", "out0 = special::cephes::beta(in0, in1)"),
+        (sc.binom, "binom.h", "out0 = special::binom(in0, in1)"),
+        (sc.digamma, "digamma.h", "special::digamma(in0)"),
+        (sc.expn, "cephes/expn.h", "out0 = special::cephes::expn(in0, in1)"),
+        (sc.hyp2f1, "hyp2f1.h", "out0 = special::hyp2f1(in0, in1, in2, in3)"),
+        (sc._ufuncs._lambertw, "lambertw.h", "out0 = special::lambertw(in0, in1, in2)"),
+        (sc._ufuncs._iv_ratio, "iv_ratio.h", "out0 = special::iv_ratio(in0, in1)"),
         (sc.ellipkinc, "cephes/ellik.h", "out0 = special::cephes::ellik(in0, in1)"),
         (sc.ellipeinc, "cephes/ellie.h", "out0 = special::cephes::ellie(in0, in1)"),
     ]


### PR DESCRIPTION
This PR adds tests for `ellipkinc` and `ellipeinc` to `special/tests/test_xsf_cuda.py` and makes some fixes that are needed for these functions to work on CUDA through CuPy. I plan to also make a PR to CuPy to add these two functions. 

cc @rlucas7