### PR TITLE
BUG: sparse.linalg: fix shape mismatch in iterative linear system solvers

### DIFF
--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -27,39 +27,45 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     Parameters
     ----------
     A : {sparse matrix, ndarray, LinearOperator}
-        The real or complex N-by-N matrix of the linear system.
+        Real or complex N-by-N matrix of the linear system.
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` and ``A^T x`` using, e.g.,
         ``scipy.sparse.linalg.LinearOperator``.
     b : ndarray
-        Right hand side of the linear system. Has shape (N,) or (N,1).
-    x0 : ndarray
-        Starting guess for the solution.
+        Right hand side of the linear system with shape (N,) or (N,1).
+    x0 : ndarray, optional, default: None
+        Starting guess for the solution with shape (N,) or (N,1).
     rtol, atol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
         The default is ``atol=0.`` and ``rtol=1e-5``.
-    maxiter : integer
+    maxiter : integer, optional, default: None
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse matrix, ndarray, LinearOperator}, optional, default: None
         Preconditioner for A.  The preconditioner should approximate the
         inverse of A.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
         to reach a given error tolerance.
-    callback : function
+    callback : function, optional, default: None
         User-supplied function to call after each iteration.  It is called
         as callback(xk), where xk is the current solution vector.
 
     Returns
     -------
     x : ndarray
-        The converged solution.
+        The converged solution with shape (N,) or (N,1) consistent with
+        the shape of initial approximation ``x0`` if present or ``b``
     info : integer
         Provides convergence information:
             0  : successful exit
             >0 : convergence to tolerance not achieved, number of iterations
             <0 : parameter breakdown
+
+    Notes
+    -----
+    If the right hand side ``b`` is the zero vector, the code returns
+    the solution ``x`` also zero without iterating.
 
     Examples
     --------

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -42,7 +42,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}, optional, default: None
+    M : {sparse matrix, ndarray, LinearOperator}, optional
         Preconditioner for A.  The preconditioner should approximate the
         inverse of A.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -33,13 +33,13 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
         ``scipy.sparse.linalg.LinearOperator``.
     b : ndarray
         Right hand side of the linear system with shape (N,) or (N,1).
-    x0 : ndarray, optional, default: None
+    x0 : ndarray
         Starting guess for the solution with shape (N,) or (N,1).
     rtol, atol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(b - A @ x) <= max(rtol*norm(b), atol)`` should be satisfied.
         The default is ``atol=0.`` and ``rtol=1e-5``.
-    maxiter : integer, optional, default: None
+    maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
     M : {sparse matrix, ndarray, LinearOperator}, optional, default: None
@@ -47,7 +47,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
         inverse of A.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
         to reach a given error tolerance.
-    callback : function, optional, default: None
+    callback : function
         User-supplied function to call after each iteration.  It is called
         as callback(xk), where xk is the current solution vector.
 

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -55,7 +55,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     -------
     x : ndarray
         The converged solution with shape (N,) or (N,1) consistent with
-        the shape of the right hand side ``b``.
+        the shape of the right hand side `b`.
     info : integer
         Provides convergence information:
             0  : successful exit
@@ -64,7 +64,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
 
     Notes
     -----
-    If the right hand side ``b`` is the zero vector, the code returns
+    If the right hand side `b` is the zero vector, the code returns
     the solution ``x`` also zero without iterating.
 
     Examples

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -55,7 +55,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     -------
     x : ndarray
         The converged solution with shape (N,) or (N,1) consistent with
-        the shape of initial approximation ``x0`` if present or ``b``
+        the shape of the right hand side ``b``.
     info : integer
         Provides convergence information:
             0  : successful exit

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -552,7 +552,7 @@ def test_shape_consistency(solver, n):
             sol, _ = solver(mat, rhs)
             assert_array_equal(np.shape(sol), np.shape(rhs))
             sol, _ = solver(mat, rhs, x0)
-            assert_array_equal(np.shape(sol), np.shape(x0))
+            assert_array_equal(np.shape(sol), np.shape(rhs))
 
 
 # Specific tfqmr test

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -549,10 +549,10 @@ def test_shape_consistency(solver, n):
     vals2 = vals[:, np.newaxis]
     for rhs in [vals, 0. * vals, vals2, 0. * vals2]:
         for x0 in [vals, vals2]:
-            sol = solver(mat, rhs)
-            assert_array_equal(sol.shape, rhs.shape)
-            sol = solver(mat, rhs, x0)
-            assert_array_equal(sol.shape, x0.shape)
+            sol, _ = solver(mat, rhs)
+            assert_array_equal(np.shape(sol), np.shape(rhs))
+            sol, _ = solver(mat, rhs, x0)
+            assert_array_equal(np.shape(sol), np.shape(x0))
 
 
 # Specific tfqmr test

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -18,7 +18,7 @@ from scipy.sparse.linalg._isolve import (bicg, bicgstab, cg, cgs,
                                          gcrotmk, gmres, lgmres,
                                          minres, qmr, tfqmr)
 
-# TODO check that method preserve shape and type
+# TODO check that method preserve type
 # TODO test both preconditioner methods
 
 
@@ -536,6 +536,23 @@ def test_x0_solves_problem_exactly(solver):
     sol, info = solver(mat, rhs, x0=rhs)
     assert_allclose(sol, rhs)
     assert info == 0
+
+
+@pytest.mark.parametrize("solver", _SOLVERS)
+@pytest.mark.parametrize("n", [1, 3, 11])
+def test_shape_consistency(solver, n):
+    # See gh-21164
+    # 1D array
+    vals = np.arange(1, n + 1, dtype=float)
+    mat = np.diag(vals)
+    # 2D array
+    vals2 = vals[:, np.newaxis]
+    for rhs in [vals, 0. * vals, vals2, 0. * vals2]:
+        for x0 in [vals, vals2]:
+            sol = solver(mat, rhs)
+            assert_array_equal(sol.shape, rhs.shape)
+            sol = solver(mat, rhs, x0)
+            assert_array_equal(sol.shape, x0.shape)
 
 
 # Specific tfqmr test

--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -88,7 +88,7 @@ def make_system(A, M, x0, b):
     xtype = coerce(xtype, b.dtype.char)
 
     b = asarray(b,dtype=xtype)  # make b the same type as x
-    b = b.ravel()
+    # b = b.ravel()
 
     # process preconditioner
     if M is None:

--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -72,18 +72,15 @@ def make_system(A, M, x0, b):
     b = asanyarray(b)
     bshape = b.shape
 
-    if not (b.shape == (N,1) or b.shape == (N,)):
-        raise ValueError(f'shapes of A {A.shape} and b {b.shape} are '
+    if not (bshape == (N,1) or bshape == (N,)):
+        raise ValueError(f'shapes of A {A.shape} and b {bshape} are '
                          'incompatible')
 
     if b.dtype.char not in 'fdFD':
         b = b.astype('d')  # upcast non-FP types to double
 
     def postprocess(x):
-        if x0shape is None:
-            x = x.reshape(bshape)
-        else:
-            x = x.reshape(x0shape)
+        x = x.reshape(bshape)
         return x
 
     if hasattr(A,'dtype'):
@@ -116,7 +113,6 @@ def make_system(A, M, x0, b):
             raise ValueError('matrix and preconditioner have different shapes')
 
     # set initial guess
-    x0shape = None
     if x0 is None:
         x = zeros(N, dtype=xtype)
     elif isinstance(x0, str):
@@ -125,7 +121,6 @@ def make_system(A, M, x0, b):
             x = M.matvec(bCopy)
     else:
         x = array(x0, dtype=xtype)
-        x0shape = x.shape
         if not (x.shape == (N, 1) or x.shape == (N,)):
             raise ValueError(f'shapes of A {A.shape} and '
                              f'x0 {x.shape} are incompatible')

--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -70,6 +70,7 @@ def make_system(A, M, x0, b):
     N = A.shape[0]
 
     b = asanyarray(b)
+    bshape = b.shape
 
     if not (b.shape == (N,1) or b.shape == (N,)):
         raise ValueError(f'shapes of A {A.shape} and b {b.shape} are '
@@ -79,6 +80,10 @@ def make_system(A, M, x0, b):
         b = b.astype('d')  # upcast non-FP types to double
 
     def postprocess(x):
+        if x0shape is None:
+            x = x.reshape(bshape)
+        else:
+            x = x.reshape(x0shape)
         return x
 
     if hasattr(A,'dtype'):
@@ -88,7 +93,7 @@ def make_system(A, M, x0, b):
     xtype = coerce(xtype, b.dtype.char)
 
     b = asarray(b,dtype=xtype)  # make b the same type as x
-    # b = b.ravel()
+    b = b.ravel()
 
     # process preconditioner
     if M is None:
@@ -111,6 +116,7 @@ def make_system(A, M, x0, b):
             raise ValueError('matrix and preconditioner have different shapes')
 
     # set initial guess
+    x0shape = None
     if x0 is None:
         x = zeros(N, dtype=xtype)
     elif isinstance(x0, str):
@@ -119,6 +125,7 @@ def make_system(A, M, x0, b):
             x = M.matvec(bCopy)
     else:
         x = array(x0, dtype=xtype)
+        x0shape = x.shape
         if not (x.shape == (N, 1) or x.shape == (N,)):
             raise ValueError(f'shapes of A {A.shape} and '
                              f'x0 {x.shape} are incompatible')


### PR DESCRIPTION
#### Reference issue
Closes gh-16123.

#### What does this implement/fix?
fix shape mismatch in iterative linear system solvers by 
```
    def postprocess(x):
        x = x.reshape(bshape)
        return x
```

#### Additional information
Simply introduced actual postprocessing   in `utils.py`
