### PR TITLE
BLD: remove optional test dependencies from cibuildwheel config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,17 +125,15 @@ dodoFile = "dev.py"
 
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
-# gmpy2 and scikit-umfpack are usually added for testing. However, there are
-# currently wheels missing that make the test script fail.
+# We're only testing with essential test dependencies, not optional ones
+# Some of those require binary wheels (often missing for some platforms,
+# or they slow down the test suite runs too much or simply aren't necessary.
 test-requires = [
     "pytest",
-    "pytest-cov",
     "pytest-xdist",
-    "mpmath",
     "threadpoolctl",
     "pooch",
     "hypothesis",
-    "gmpy2",
 ]
 before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,8 @@ dodoFile = "dev.py"
 
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
-# We're only testing with essential test dependencies, not optional ones
-# Some of those require binary wheels (often missing for some platforms,
+# We're only testing with essential test dependencies, not optional ones.
+# Some of those require binary wheels (often missing for some platforms),
 # or they slow down the test suite runs too much or simply aren't necessary.
 test-requires = [
     "pytest",


### PR DESCRIPTION
This reverts the addition of gmpy2 from gh-21123, which broke wheels builds due to missing free-threaded and aarch64 wheels. It also adjusts the comment above the cibuildwheel test command to explain that we don't want these optional dependencies but only the essential ones. The full list of test dependencies is captured higher up in the `test` table under `[project.optional-dependencies]`.

The goal for wheel builds is reliability, not ultra-comprehensive testing. That's what we do for optional dependencies in one or a handful of CI jobs.