### PR TITLE
BUG: sparse.linalg: Update `SuperLU` to fix unfilterable output for singular matrices

### DIFF
--- a/scipy/sparse/linalg/_dsolve/SuperLU/README
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/README
@@ -79,14 +79,8 @@ are described below.
    To install the library, type:
         make install
 
-   To run the installation test, type:
+   To run the regression tests, type:
    	make test (or: ctest)
-
-   	The test results are in the files below:
-       	    build/TESTING/s_test.out   # single precision, real
-       	    build/TESTING/d_test.out   # double precision, real
-       	    build/TESTING/c_test.out   # single precision, complex
-       	    build/TESTING/z_test.out   # double precision, complex
 
 
 2. Manual installation with makefile.      

--- a/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
@@ -1,0 +1,6 @@
+This directory contains a bundled version of SuperLU from
+https://github.com/xiaoyeli/superlu at
+commit 18958c35006c63071813df6808d7809247caac89.
+We use all .c and .h files except `mc64ad.c` which is license
+incompatible from the SRC folder and applied
+the patches from `scipychanges.patch`.

--- a/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
@@ -1,0 +1,5 @@
+This directory contains a bundled version of SuperLU from
+https://github.com/xiaoyeli/superlu at
+commit 18958c35006c63071813df6808d7809247caac89.
+We use all .c and .h files from the SRC folder and applied
+the patches from `scipychanges.patch`.

--- a/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/README.scipy
@@ -1,5 +1,6 @@
 This directory contains a bundled version of SuperLU from
 https://github.com/xiaoyeli/superlu at
 commit 18958c35006c63071813df6808d7809247caac89.
-We use all .c and .h files from the SRC folder and applied
+We use all .c and .h files except `mc64ad.c` which is license
+incompatible from the SRC folder and applied
 the patches from `scipychanges.patch`.

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cdiagonal.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cdiagonal.c
@@ -44,7 +44,7 @@ int cfill_diag(int n, NCformat *Astore)
     }
     if (fill)
     {
-	nzval_new = complexMalloc(nnz + fill);
+	nzval_new = singlecomplexMalloc(nnz + fill);
 	rowind_new = intMalloc(nnz + fill);
 	fill = 0;
 	for (i = 0; i < n; i++)
@@ -94,7 +94,7 @@ int cdominate(int n, NCformat *Astore)
     }
     if (fill)
     {
-	nzval_new = complexMalloc(nnz + fill);
+	nzval_new = singlecomplexMalloc(nnz + fill);
 	rowind_new = intMalloc(nnz+ fill);
 	fill = 0;
 	for (i = 0; i < n; i++)

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgscon.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   CGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by CGETRF.   *
+ *   the LU factorization computed by CGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   
@@ -119,7 +119,7 @@ cgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
 	return;
     }
 
-    work = complexCalloc( 3*L->nrow );
+    work = singlecomplexCalloc( 3*L->nrow );
 
 
     if ( !work )

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsisx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsisx.c
@@ -21,8 +21,7 @@ at the top-level directory.
  */
 #include "slu_cdefs.h"
 
-/*!
- * Computes approximate solutions using the ILU factorization from cgsitrf()
+/*! \brief
  *
  * <pre>
  * Purpose
@@ -374,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\\U data structures.
+ *	     The amount of space used in bytes for L\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)
@@ -455,12 +454,12 @@ cgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     }
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) ||
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
 	*info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c
@@ -540,7 +540,7 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
 			tol_U = SUPERLU_MAX(drop_tol, tol_U * 0.5);
 		}
 
-		if (drop_sum.r != 0.0 && drop_sum.i != 0.0)
+		if (drop_sum.r != 0.0 || drop_sum.i != 0.0)
 		{
                     omega = SUPERLU_MIN(2.0*(1.0-alpha)/c_abs1(&drop_sum), 1.0);
                     cs_mult(&drop_sum, &drop_sum, omega);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsrfs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsrfs.c
@@ -227,7 +227,7 @@ cgsrfs(trans_t trans, SuperMatrix *A, SuperMatrix *L, SuperMatrix *U,
     colequ = strncmp(equed, "C", 1)==0 || strncmp(equed, "B", 1)==0;
     
     /* Allocate working space */
-    work = complexMalloc(2*A->nrow);
+    work = singlecomplexMalloc(2*A->nrow);
     rwork = (float *) SUPERLU_MALLOC( A->nrow * sizeof(float) );
     iwork = int32Malloc(A->nrow);
     if ( !work || !rwork || !iwork ) 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgssv.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgssv.c
@@ -232,9 +232,12 @@ cgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
         /* Solve the system A*X=B, overwriting B with X. */
 	int info1;
         cgstrs (trans, L, U, perm_c, perm_r, B, stat, &info1);
-    } else {
+    }
+#if ( PRNTlevel>=1 )
+     else {
         printf("cgstrf info %lld\n", (long long) *info); fflush(stdout);
     }
+#endif
     
     utime[SOLVE] = SuperLU_timer_() - t;
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgssvx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgssvx.c
@@ -21,9 +21,7 @@ at the top-level directory.
  */
 #include "slu_cdefs.h"
 
-/*!
- * Solves the system of linear equations using
- * the LU factorization from cgstrf()
+/*! \brief
  *
  * <pre>
  * Purpose
@@ -245,7 +243,7 @@ at the top-level directory.
  *         to hold data structures for factors L and U.
  *         On exit, if fact is not 'F', L and U point to this array.
  *
- * lwork   (input) int
+ * lwork   (input) int_t
  *         Specifies the size of work array in bytes.
  *         = 0:  allocate space internally by system malloc;
  *         > 0:  use user-supplied work array of length lwork in bytes,
@@ -326,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\\U data structures.
+ *           The amount of space used in bytes for L\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)
@@ -363,7 +361,6 @@ cgssvx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
        float *rcond, float *ferr, float *berr, 
        GlobalLU_t *Glu, mem_usage_t *mem_usage, SuperLUStat_t *stat, int_t *info )
 {
-
 
     DNformat  *Bstore, *Xstore;
     singlecomplex    *Bmat, *Xmat;
@@ -411,13 +408,13 @@ printf("dgssvx: Fact=%4d, Trans=%4d, equed=%c\n",
 #endif
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
-	*info = -1;
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) || 
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
+	 *info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||
 	      A->Dtype != SLU_C || A->Mtype != SLU_GE )

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgstrs.c
@@ -137,9 +137,9 @@ cgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     }
 
     n = L->nrow;
-    work = complexCalloc((size_t) n * (size_t) nrhs);
+    work = singlecomplexCalloc((size_t) n * (size_t) nrhs);
     if ( !work ) ABORT("Malloc fails for local work[].");
-    soln = complexMalloc((size_t) n);
+    soln = singlecomplexMalloc((size_t) n);
     if ( !soln ) ABORT("Malloc fails for local soln[].");
 
     Bmat = Bstore->nzval;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cldperm.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cldperm.c
@@ -116,7 +116,7 @@ cldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
     for (i = 0; i <= n; ++i) ++colptr[i];
     for (i = 0; i < nnz; ++i) ++adjncy[i];
 #if ( DEBUGlevel>=2 )
-    printf("LDPERM(): n %d, nnz %d\n", n, nnz);
+    printf("LDPERM(): n %d, nnz %lld\n", n, (long long) nnz);
     slu_PrintInt10("colptr", n+1, colptr);
     slu_PrintInt10("adjncy", nnz, adjncy);
 #endif
@@ -152,7 +152,7 @@ cldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
 
 #if ( DEBUGlevel>=2 )
     slu_PrintInt10("perm", n, perm);
-    printf(".. After MC64AD info %lld\tsize of matching %d\n", (long long)info[0], num);
+    printf(".. After MC64AD info %lld\tsize of matching %lld\n", (long long)info[0], (long long) num);
 #endif
     if ( info[0] == 1 ) { /* Structurally singular */
         printf(".. The last %d permutations:\n", (int)(n-num));

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cmemory.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cmemory.c
@@ -679,13 +679,13 @@ cStackCompress(GlobalLU_t *Glu)
 void
 callocateA(int n, int_t nnz, singlecomplex **a, int_t **asub, int_t **xa)
 {
-    *a    = (singlecomplex *) complexMalloc(nnz);
+    *a    = (singlecomplex *) singlecomplexMalloc(nnz);
     *asub = (int_t *) intMalloc(nnz);
     *xa   = (int_t *) intMalloc(n+1);
 }
 
 
-singlecomplex *complexMalloc(size_t n)
+singlecomplex *singlecomplexMalloc(size_t n)
 {
     singlecomplex *buf;
     buf = (singlecomplex *) SUPERLU_MALLOC(n * (size_t) sizeof(singlecomplex)); 
@@ -695,7 +695,7 @@ singlecomplex *complexMalloc(size_t n)
     return (buf);
 }
 
-singlecomplex *complexCalloc(size_t n)
+singlecomplex *singlecomplexCalloc(size_t n)
 {
     singlecomplex *buf;
     register size_t i;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/colamd.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/colamd.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,6 +8,11 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
+/*! \file
+ * \brief Approximate minimum degree column ordering algorithm
+ *
+ * \ingroup Common
+ */
 /* ========================================================================== */
 /* === colamd/symamd - a sparse matrix column ordering algorithm ============ */
 /* ========================================================================== */

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c
@@ -134,7 +134,13 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 1
+#if 0
+        // There is no valid pivot.
+        // jcol represents the rank of U, 
+        // report the rank, let dgstrf handle the pivot
+	*pivrow = lsub_ptr[pivptr];
+	perm_r[*pivrow] = jcol;
+#elif 1
 #if SCIPY_FIX
 	if (pivptr < nsupr) {
 	    *pivrow = lsub_ptr[pivptr];
@@ -142,12 +148,7 @@ if ( jcol == MIN_COL ) {
 	else {
 	    *pivrow = diagind;
 	}
-#else
-	*pivrow = lsub_ptr[pivptr];
 #endif
-	perm_r[*pivrow] = jcol;
-#else
-	perm_r[diagind] = jcol;
 #endif
 	*usepr = 0;
 	return (jcol+1);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/csp_blas2.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/csp_blas2.c
@@ -125,7 +125,7 @@ sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L,
     Uval = Ustore->nzval;
     solve_ops = 0;
 
-    if ( !(work = complexCalloc(L->nrow)) )
+    if ( !(work = singlecomplexCalloc(L->nrow)) )
 	ABORT("Malloc fails for work in sp_ctrsv().");
     
     if ( strncmp(trans, "N", 1)==0 ) {	/* Form x := inv(A)*x. */

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cutil.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cutil.c
@@ -169,7 +169,7 @@ cCompRow_to_CompCol(int m, int n, int_t nnz,
     int_t *marker;
 
     /* Allocate storage for another copy of the matrix. */
-    *at = (singlecomplex *) complexMalloc(nnz);
+    *at = (singlecomplex *) singlecomplexMalloc(nnz);
     *rowind = (int_t *) intMalloc(nnz);
     *colptr = (int_t *) intMalloc(n+1);
     marker = (int_t *) intCalloc(n);
@@ -389,7 +389,7 @@ cFillRHS(trans_t trans, int nrhs, singlecomplex *x, int ldx,
 
 }
 
-/*! \brief Fills a complex precision array with a given value.
+/*! \brief Fills a singlecomplex precision array with a given value.
  */
 void 
 cfill(singlecomplex *a, int alen, singlecomplex dval)
@@ -474,7 +474,7 @@ cPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 int
-print_complex_vec(char *what, int n, singlecomplex *vec)
+print_singlecomplex_vec(char *what, int n, singlecomplex *vec)
 {
     int i;
     printf("%s: n %d\n", what, n);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgscon.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   DGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by DGETRF.   *
+ *   the LU factorization computed by DGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsisx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\\U data structures.
+ *	     The amount of space used in bytes for L\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)
@@ -454,12 +454,12 @@ dgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     }
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) ||
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
 	*info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgssv.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgssv.c
@@ -232,9 +232,12 @@ dgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
         /* Solve the system A*X=B, overwriting B with X. */
 	int info1;
         dgstrs (trans, L, U, perm_c, perm_r, B, stat, &info1);
-    } else {
+    }
+#if ( PRNTlevel>=1 )
+     else {
         printf("dgstrf info %lld\n", (long long) *info); fflush(stdout);
     }
+#endif
     
     utime[SOLVE] = SuperLU_timer_() - t;
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgssvx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgssvx.c
@@ -243,7 +243,7 @@ at the top-level directory.
  *         to hold data structures for factors L and U.
  *         On exit, if fact is not 'F', L and U point to this array.
  *
- * lwork   (input) int
+ * lwork   (input) int_t
  *         Specifies the size of work array in bytes.
  *         = 0:  allocate space internally by system malloc;
  *         > 0:  use user-supplied work array of length lwork in bytes,
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\\U data structures.
+ *           The amount of space used in bytes for L\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)
@@ -361,7 +361,6 @@ dgssvx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
        double *rcond, double *ferr, double *berr, 
        GlobalLU_t *Glu, mem_usage_t *mem_usage, SuperLUStat_t *stat, int_t *info )
 {
-
 
     DNformat  *Bstore, *Xstore;
     double    *Bmat, *Xmat;
@@ -409,13 +408,13 @@ printf("dgssvx: Fact=%4d, Trans=%4d, equed=%c\n",
 #endif
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
-	*info = -1;
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) || 
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
+	 *info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||
 	      A->Dtype != SLU_D || A->Mtype != SLU_GE )

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dldperm.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dldperm.c
@@ -115,7 +115,7 @@ dldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
     for (i = 0; i <= n; ++i) ++colptr[i];
     for (i = 0; i < nnz; ++i) ++adjncy[i];
 #if ( DEBUGlevel>=2 )
-    printf("LDPERM(): n %d, nnz %d\n", n, nnz);
+    printf("LDPERM(): n %d, nnz %lld\n", n, (long long) nnz);
     slu_PrintInt10("colptr", n+1, colptr);
     slu_PrintInt10("adjncy", nnz, adjncy);
 #endif
@@ -150,7 +150,7 @@ dldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
 
 #if ( DEBUGlevel>=2 )
     slu_PrintInt10("perm", n, perm);
-    printf(".. After MC64AD info %lld\tsize of matching %d\n", (long long)info[0], num);
+    printf(".. After MC64AD info %lld\tsize of matching %lld\n", (long long)info[0], (long long) num);
 #endif
     if ( info[0] == 1 ) { /* Structurally singular */
         printf(".. The last %d permutations:\n", (int)(n-num));

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c
@@ -122,22 +122,24 @@ if ( jcol == MIN_COL ) {
     diag = EMPTY;
     old_pivptr = nsupc;
     for (isub = nsupc; isub < nsupr; ++isub) {
-	    rtemp = fabs (lu_col_ptr[isub]);
+	rtemp = fabs (lu_col_ptr[isub]);
 	if ( rtemp > pivmax ) {
-	        pivmax = rtemp;
-	        pivptr = isub;
-	    }
-    	if ( *usepr && lsub_ptr[isub] == *pivrow ) old_pivptr = isub;
-	    if ( lsub_ptr[isub] == diagind ) diag = isub;
+	    pivmax = rtemp;
+	    pivptr = isub;
+	}
+	if ( *usepr && lsub_ptr[isub] == *pivrow ) old_pivptr = isub;
+	if ( lsub_ptr[isub] == diagind ) diag = isub;
     }
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
 #if 0
-        // There is no valid pivot.  
-        // jcol represents the rank of U
-        // report the rank let dgstrf handle the pivot
-#if 1
+        // There is no valid pivot.
+        // jcol represents the rank of U, 
+        // report the rank, let dgstrf handle the pivot
+	*pivrow = lsub_ptr[pivptr];
+	perm_r[*pivrow] = jcol;
+#elif 1
 #if SCIPY_FIX
 	if (pivptr < nsupr) {
 	    *pivrow = lsub_ptr[pivptr];
@@ -145,16 +147,10 @@ if ( jcol == MIN_COL ) {
 	else {
 	    *pivrow = diagind;
 	}
-#else
-    *pivrow = lsub_ptr[pivptr];
-#endif
-    perm_r[*pivrow] = jcol;
-#else
-    perm_r[diagind] = jcol;
 #endif
 #endif
-	    *usepr = 0;
-	    return (jcol+1);
+	*usepr = 0;
+	return (jcol+1);
     }
 
     thresh = u * pivmax;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/get_perm_c.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/get_perm_c.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,16 +8,17 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file get_perm_c.c
- * \brief Matrix permutation operations
- *
- * <pre>
+/*
  * -- SuperLU routine (version 3.1) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
  * August 1, 2008
  * March 25, 2023  add METIS option
- * </pre>
+ */
+/*! \file
+ * \brief Matrix permutation operations
+ *
+ * \ingroup Common
  */
 #include "slu_ddefs.h"
 #include "colamd.h"
@@ -28,15 +29,18 @@ extern int genmmd_(int *neqns, int_t *xadj, int_t *adjncy,
 		   int_t *qsize, int_t *llist, int_t *marker, int_t *maxint, 
 		   int_t *nofsub);
 
-void
-get_colamd(
-	   const int m,  /* number of rows in matrix A. */
-	   const int n,  /* number of columns in matrix A. */
-	   const int_t nnz,/* number of nonzeros in matrix A. */
-	   int_t *colptr,  /* column pointer of size n+1 for matrix A. */
-	   int_t *rowind,  /* row indices of size nz for matrix A. */
-	   int *perm_c   /* out - the column permutation vector. */
-	   )
+/*!
+ * \brief Get COLAMD's permutation for matrix A
+ *
+ * \param[in]  m Number of rows in matrix A.
+ * \param[in]  n Number of columns in matrix A.
+ * \param[in]  nnz Number of nonzeros in matrix A.
+ * \param[in]  colptr Column pointer of size n+1 for matrix A.
+ * \param[in]  rowind Row indices of size nnz for matrix A.
+ * \param[out] perm_c Column permutation vector.
+ */
+void get_colamd(const int m, const int n, const int_t nnz,
+                int_t *colptr, int_t *rowind, int *perm_c)
 {
     size_t Alen;
     int_t *A, i, *p;
@@ -62,16 +66,19 @@ get_colamd(
 
     SUPERLU_FREE(A);
     SUPERLU_FREE(p);
-} /* end get_colamd */
+}
 
-void
-get_metis(
-	  int n,           /* dimension of matrix B */
-	  int_t bnz,       /* number of nonzeros in matrix A. */
-	  int_t *b_colptr, /* column pointer of size n+1 for matrix B. */
-	  int_t *b_rowind, /* row indices of size bnz for matrix B. */
-	  int *perm_c      /* out - the column permutation vector. */
-	  )
+/*!
+ * \brief Get METIS' permutation for matrix B
+ *
+ * \param[in]  n Number of columns in matrix B.
+ * \param[in]  bnz Number of nonzeros in matrix B.
+ * \param[in]  b_colptr Column pointer of size n+1 for matrix B.
+ * \param[in]  b_rowind Row indices of size bnz for matrix B.
+ * \param[out] perm_c Column permutation vector.
+ */
+void get_metis(int n, int_t bnz, int_t *b_colptr,
+               int_t *b_rowind, int *perm_c)
 {
 #ifdef HAVE_METIS
     /*#define METISOPTIONS 8*/
@@ -117,13 +124,10 @@ get_metis(
 #endif /* HAVE_METIS */
 }
 
-/*! \brief
+/*!
+ * \brief Form the structure of A'*A.
  *
- * <pre>
- * Purpose
- * =======
- *
- * Form the structure of A'*A. A is an m-by-n matrix in column oriented
+ * A is an m-by-n matrix in column oriented
  * format represented by (colptr, rowind). The output A'*A is in column
  * oriented format (symmetrically, also row oriented), represented by
  * (ata_colptr, ata_rowind).
@@ -132,24 +136,23 @@ get_metis(
  * The complexity of this algorithm is: SUM_{i=1,m} r(i)^2,
  * i.e., the sum of the square of the row counts.
  *
- * Questions
- * =========
- *     o  Do I need to withhold the *dense* rows?
- *     o  How do I know the number of nonzeros in A'*A?
- * </pre>
+ * Questions<br>
+ * <ul>
+ *     <li>Do I need to withhold the *dense* rows?
+ *     <li>How do I know the number of nonzeros in A'*A?
+ * </ul>
+ *
+ * \param[in]  m number of rows in matrix A.
+ * \param[in]  n number of columns in matrix A.
+ * \param[in]  nz number of nonzeros in matrix A
+ * \param[in]  colptr column pointer of size n+1 for matrix A.
+ * \param[in]  rowind row indices of size nz for matrix A.
+ * \param[out] atanz on exit, returns the actual number of nonzeros in matrix A'*A.
+ * \param[out] ata_colptr column pointer of size n+1 for matrix A'*A.
+ * \param[out] ata_rowind row indices of size atanz for matrix A'*A.
  */
-void
-getata(
-       const int m,      /* number of rows in matrix A. */
-       const int n,      /* number of columns in matrix A. */
-       const int_t nz,     /* number of nonzeros in matrix A */
-       int_t *colptr,      /* column pointer of size n+1 for matrix A. */
-       int_t *rowind,      /* row indices of size nz for matrix A. */
-       int_t *atanz,       /* out - on exit, returns the actual number of
-                            nonzeros in matrix A'*A. */
-       int_t **ata_colptr, /* out - size n+1 */
-       int_t **ata_rowind  /* out - size *atanz */
-       )
+void getata(const int m, const int n, const int_t nz, int_t *colptr, int_t *rowind,
+            int_t *atanz, int_t **ata_colptr, int_t **ata_rowind)
 {
     register int_t i, j, k, col, num_nz, ti, trow;
     int_t *marker, *b_colptr, *b_rowind;
@@ -258,32 +261,27 @@ getata(
     SUPERLU_FREE(marker);
     SUPERLU_FREE(t_colptr);
     SUPERLU_FREE(t_rowind);
-} /* end getata */
+}
 
 
-/*! \brief
+/*!
+ * \brief Form the structure of A'+A.
  *
- * <pre>
- * Purpose
- * =======
- *
- * Form the structure of A'+A. A is an n-by-n matrix in column oriented
+ * A is an n-by-n matrix in column oriented
  * format represented by (colptr, rowind). The output A'+A is in column
  * oriented format (symmetrically, also row oriented), represented by
  * (b_colptr, b_rowind).
- * </pre>
+ *
+ * \param[in]  n number of columns in matrix A.
+ * \param[in]  nz number of nonzeros in matrix A
+ * \param[in]  colptr column pointer of size n+1 for matrix A.
+ * \param[in]  rowind row indices of size nz for matrix A.
+ * \param[out] bnz on exit, returns the actual number of nonzeros in matrix A'*A.
+ * \param[out] b_colptr column pointer of size n+1 for matrix A'+A.
+ * \param[out] b_rowind row indices of size bnz for matrix A'+A.
  */
-void
-at_plus_a(
-	  const int n,      /* number of columns in matrix A. */
-	  const int_t nz,   /* number of nonzeros in matrix A */
-	  int_t *colptr,      /* column pointer of size n+1 for matrix A. */
-	  int_t *rowind,      /* row indices of size nz for matrix A. */
-	  int_t *bnz,         /* out - on exit, returns the actual number of
-                               nonzeros in matrix A'*A. */
-	  int_t **b_colptr,   /* out - size n+1 */
-	  int_t **b_rowind    /* out - size *bnz */
-	  )
+void at_plus_a(const int n, const int_t nz, int_t *colptr, int_t *rowind,
+               int_t *bnz, int_t **b_colptr, int_t **b_rowind)
 {
     register int_t i, j, k, col, num_nz;
     int_t *t_colptr, *t_rowind; /* a column oriented form of T = A' */
@@ -397,41 +395,33 @@ at_plus_a(
     SUPERLU_FREE(marker);
     SUPERLU_FREE(t_colptr);
     SUPERLU_FREE(t_rowind);
-} /* end at_plus_a */
+}
 
-/*! \brief
+/*!
+ * \brief Obtains a permutation matrix by applying the multiple
+ * minimum degree ordering code
  *
- * <pre>
- * Purpose
- * =======
- *
- * GET_PERM_C obtains a permutation matrix Pc, by applying the multiple
- * minimum degree ordering code by Joseph Liu to matrix A'*A or A+A'.
+ * Obtains a permutation matrix Pc by applying the multiple
+ * minimum degree ordering code by Joseph Liu to matrix A'*A or A+A'
  * or using approximate minimum degree column ordering by Davis et. al.
  * The LU factorization of A*Pc tends to have less fill than the LU 
  * factorization of A.
  *
- * Arguments
- * =========
- *
- * ispec   (input) int
- *         Specifies the type of column ordering to reduce fill:
- *         = 1: minimum degree on the structure of A^T * A
- *         = 2: minimum degree on the structure of A^T + A
- *         = 3: approximate minimum degree for unsymmetric matrices
+ * \param[in] ispec
+ *         Specifies the type of column ordering to reduce fill:<br>
+ *         = 1: minimum degree on the structure of A^T * A<br>
+ *         = 2: minimum degree on the structure of A^T + A<br>
+ *         = 3: approximate minimum degree for unsymmetric matrices<br>
  *         If ispec == 0, the natural ordering (i.e., Pc = I) is returned.
- * 
- * A       (input) SuperMatrix*
+ * \param[in] A
  *         Matrix A in A*X=B, of dimension (A->nrow, A->ncol). The number
  *         of the linear equations is A->nrow. Currently, the type of A 
  *         can be: Stype = NC; Dtype = _D; Mtype = GE. In the future,
  *         more general A can be handled.
- *
- * perm_c  (output) int*
- *	   Column permutation vector of size A->ncol, which defines the 
+ * \param[out] perm_c
+ *         Column permutation vector of size A->ncol, which defines the
  *         permutation matrix Pc; perm_c[i] = j means column i of A is 
  *         in position j in A*Pc.
- * </pre>
  */
 void
 get_perm_c(int ispec, SuperMatrix *A, int *perm_c)
@@ -481,7 +471,7 @@ get_perm_c(int ispec, SuperMatrix *A, int *perm_c)
 #endif
 	return;
 #ifdef HAVE_METIS
-        case METIS_ATA: /* METIS ordering on A'*A */
+    case METIS_ATA: /* METIS ordering on A'*A */
 	    getata(m, n, Astore->nnz, Astore->colptr, Astore->rowind,
 		     &bnz, &b_colptr, &b_rowind);
 
@@ -497,6 +487,23 @@ get_perm_c(int ispec, SuperMatrix *A, int *perm_c)
 	    printf(".. Use METIS ordering on A'*A\n");
 #endif
 	    return;
+    case METIS_AT_PLUS_A: /* METIS ordering on A'*A */
+	if ( m != n ) ABORT("Matrix is not square");
+	at_plus_a(n, Astore->nnz, Astore->colptr, Astore->rowind,
+		  &bnz, &b_colptr, &b_rowind);
+
+        if ( bnz ) { /* non-empty adjacency structure */
+	    get_metis(n, bnz, b_colptr, b_rowind, perm_c);
+        } else { /* e.g., diagonal matrix */
+	    for (i = 0; i < n; ++i) perm_c[i] = i;
+		SUPERLU_FREE(b_colptr);
+	    /* b_rowind is not allocated in this case */
+	}
+
+#if ( PRNTlevel>=1 )
+	printf(".. Use METIS ordering on A'+A\n");
+#endif
+	return;
 #endif
 	
     default:

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/heap_relax_snode.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/heap_relax_snode.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,10 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file heap_relax_snode.c
- * \brief Identify the initial relaxed supernodes
- *
- * <pre>
+/*
  * -- SuperLU routine (version 3.0) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
@@ -27,7 +24,11 @@ at the top-level directory.
  * Permission to modify the code and to distribute modified code is
  * granted, provided the above notices are retained, and a notice that
  * the code was modified is included with the above copyright notice.
- * </pre>
+ */
+/*! \file
+ * \brief Identify the initial relaxed supernodes
+ *
+ * \ingroup Common
  */
 
 #include "slu_ddefs.h"

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c
@@ -147,12 +147,13 @@ ilu_cpivotL(
     /* Test for singularity */
     if (pivmax < 0.0) {
 #if SCIPY_FIX
-	ABORT("[0]: matrix is singular");
-#else
-	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+		ABORT("[0]: matrix is singular");
+    /*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
 	fflush(stderr);
-	exit(1);
+	exit(1); */
 #endif
+	*usepr = 0;
+	return (jcol+1);
     }
     if ( pivmax == 0.0 ) {
 	if (diag != EMPTY)
@@ -168,9 +169,11 @@ ilu_cpivotL(
 #if SCIPY_FIX
 		ABORT("[1]: matrix is singular");
 #else
-		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
 		fflush(stderr);
-		exit(1);
+		exit(1); */
+   	        *usepr = 0;
+	        return (jcol+1);
 #endif
 	    }
 
@@ -188,8 +191,8 @@ ilu_cpivotL(
 	printf("[0] ZERO PIVOT: FILL (%d, %d).\n", *pivrow, jcol);
 	fflush(stdout);
 #endif
-	info =jcol + 1;
-    } /* if (*pivrow == 0.0) */
+	info = jcol + 1;
+    } /* end if (*pivrow == 0.0) */
     else {
 	thresh = u * pivmax;
 
@@ -251,7 +254,7 @@ ilu_cpivotL(
 		break;
 	}
 
-    } /* else */
+    } /* end else */
 
     /* Record pivot row */
     perm_r[*pivrow] = jcol;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c
@@ -147,9 +147,11 @@ ilu_dpivotL(
 #if SCIPY_FIX
 	ABORT("[0]: matrix is singular");
 #else
-	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
 	fflush(stderr);
-	exit(1);
+	exit(1); */
+	*usepr = 0;
+	return (jcol+1);
 #endif
     }
     if ( pivmax == 0.0 ) {
@@ -166,9 +168,11 @@ ilu_dpivotL(
 #if SCIPY_FIX
 		ABORT("[1]: matrix is singular");
 #else
-		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
 		fflush(stderr);
-		exit(1);
+		exit(1); */
+   	        *usepr = 0;
+	        return (jcol+1);
 #endif
 	    }
 
@@ -185,8 +189,8 @@ ilu_dpivotL(
 	printf("[0] ZERO PIVOT: FILL (%d, %d).\n", *pivrow, jcol);
 	fflush(stdout);
 #endif
-	info =jcol + 1;
-    } /* if (*pivrow == 0.0) */
+	info = jcol + 1;
+    } /* end if (*pivrow == 0.0) */
     else {
 	thresh = u * pivmax;
 
@@ -244,7 +248,7 @@ ilu_dpivotL(
 		break;
 	}
 
-    } /* else */
+    } /* end else */
 
     /* Record pivot row */
     perm_r[*pivrow] = jcol;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_relax_snode.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_relax_snode.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,14 +8,15 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file ilu_relax_snode.c
- * \brief Identify initial relaxed supernodes
- *
- * <pre>
+/*
  * -- SuperLU routine (version 4.0) --
  * Lawrence Berkeley National Laboratory
  * June 1, 2009
- * </pre>
+ */
+/*! \file
+ * \brief Identify initial relaxed supernodes
+ *
+ * \ingroup Common
  */
 
 #include "slu_ddefs.h"

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c
@@ -147,9 +147,11 @@ ilu_spivotL(
 #if SCIPY_FIX
 	ABORT("[0]: matrix is singular");
 #else
-	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
 	fflush(stderr);
-	exit(1);
+	exit(1); */
+	*usepr = 0;
+	return (jcol+1);
 #endif
     }
     if ( pivmax == 0.0 ) {
@@ -164,11 +166,13 @@ ilu_spivotL(
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
 #if SCIPY_FIX
-		ABORT("[1]: matrix is singular");
+	ABORT("[1]: matrix is singular");
 #else
-		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
 		fflush(stderr);
-		exit(1);
+		exit(1); */
+   	        *usepr = 0;
+	        return (jcol+1);
 #endif
 	    }
 
@@ -185,8 +189,8 @@ ilu_spivotL(
 	printf("[0] ZERO PIVOT: FILL (%d, %d).\n", *pivrow, jcol);
 	fflush(stdout);
 #endif
-	info =jcol + 1;
-    } /* if (*pivrow == 0.0) */
+	info = jcol + 1;
+    } /* end if (*pivrow == 0.0) */
     else {
 	thresh = u * pivmax;
 
@@ -244,7 +248,7 @@ ilu_spivotL(
 		break;
 	}
 
-    } /* else */
+    } /* end else */
 
     /* Record pivot row */
     perm_r[*pivrow] = jcol;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c
@@ -149,9 +149,11 @@ ilu_zpivotL(
 #if SCIPY_FIX
 	ABORT("[0]: matrix is singular");
 #else
-	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
 	fflush(stderr);
-	exit(1);
+	exit(1); */
+	*usepr = 0;
+	return (jcol+1);
 #endif
     }
     if ( pivmax == 0.0 ) {
@@ -166,11 +168,13 @@ ilu_zpivotL(
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
 #if SCIPY_FIX
-		ABORT("[1]: matrix is singular");
+	ABORT("[1]: matrix is singular");
 #else
-		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
 		fflush(stderr);
-		exit(1);
+		exit(1); */
+   	        *usepr = 0;
+	        return (jcol+1);
 #endif
 	    }
 
@@ -188,8 +192,8 @@ ilu_zpivotL(
 	printf("[0] ZERO PIVOT: FILL (%d, %d).\n", *pivrow, jcol);
 	fflush(stdout);
 #endif
-	info =jcol + 1;
-    } /* if (*pivrow == 0.0) */
+	info = jcol + 1;
+    } /* end if (*pivrow == 0.0) */
     else {
 	thresh = u * pivmax;
 
@@ -251,7 +255,7 @@ ilu_zpivotL(
 		break;
 	}
 
-    } /* else */
+    } /* end else */
 
     /* Record pivot row */
     perm_r[*pivrow] = jcol;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/memory.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/memory.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,18 +8,19 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file memory.c
- * \brief Precision-independent memory-related routines
- *
- * <pre>
+/*
  * -- SuperLU routine (version 2.0) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
  * November 15, 1997
- * </pre>
  */
-/** Precision-independent memory-related routines.
-    (Shared by [sdcz]memory.c) **/
+/*! \file
+ * \brief Precision-independent memory-related routines
+ *
+ * Shared by [sdcz]memory.c)
+ *
+ * \ingroup Common
+ */
 
 #include "slu_ddefs.h"
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/mmd.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/mmd.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,6 +8,11 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
+/*! \file
+ * \brief Minimum degree algorithm
+ *
+ * \ingroup Common
+ */
 #include "superlu_config.h"
 
 typedef int_t shortint;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/relax_snode.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/relax_snode.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,10 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file relax_snode.c
- * \brief Identify initial relaxed supernodes
- *
- * <pre>
+/*
  * -- SuperLU routine (version 2.0) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
@@ -27,7 +24,11 @@ at the top-level directory.
  * Permission to modify the code and to distribute modified code is
  * granted, provided the above notices are retained, and a notice that
  * the code was modified is included with the above copyright notice.
- * </pre>
+ */
+/*! \file
+ * \brief Identify initial relaxed supernodes
+ *
+ * \ingroup Common
  */
 
 #include "slu_ddefs.h"

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgscon.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   SGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by SGETRF.   *
+ *   the LU factorization computed by SGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsisx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\\U data structures.
+ *	     The amount of space used in bytes for L\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)
@@ -454,12 +454,12 @@ sgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     }
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) ||
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
 	*info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgssv.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgssv.c
@@ -232,9 +232,12 @@ sgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
         /* Solve the system A*X=B, overwriting B with X. */
 	int info1;
         sgstrs (trans, L, U, perm_c, perm_r, B, stat, &info1);
-    } else {
+    }
+#if ( PRNTlevel>=1 )
+     else {
         printf("sgstrf info %lld\n", (long long) *info); fflush(stdout);
     }
+#endif
     
     utime[SOLVE] = SuperLU_timer_() - t;
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgssvx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgssvx.c
@@ -243,7 +243,7 @@ at the top-level directory.
  *         to hold data structures for factors L and U.
  *         On exit, if fact is not 'F', L and U point to this array.
  *
- * lwork   (input) int
+ * lwork   (input) int_t
  *         Specifies the size of work array in bytes.
  *         = 0:  allocate space internally by system malloc;
  *         > 0:  use user-supplied work array of length lwork in bytes,
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\\U data structures.
+ *           The amount of space used in bytes for L\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)
@@ -361,7 +361,6 @@ sgssvx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
        float *rcond, float *ferr, float *berr, 
        GlobalLU_t *Glu, mem_usage_t *mem_usage, SuperLUStat_t *stat, int_t *info )
 {
-
 
     DNformat  *Bstore, *Xstore;
     float    *Bmat, *Xmat;
@@ -409,13 +408,13 @@ printf("dgssvx: Fact=%4d, Trans=%4d, equed=%c\n",
 #endif
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
-	*info = -1;
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) || 
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
+	 *info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||
 	      A->Dtype != SLU_S || A->Mtype != SLU_GE )

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sldperm.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sldperm.c
@@ -116,7 +116,7 @@ sldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
     for (i = 0; i <= n; ++i) ++colptr[i];
     for (i = 0; i < nnz; ++i) ++adjncy[i];
 #if ( DEBUGlevel>=2 )
-    printf("LDPERM(): n %d, nnz %d\n", n, nnz);
+    printf("LDPERM(): n %d, nnz %lld\n", n, (long long) nnz);
     slu_PrintInt10("colptr", n+1, colptr);
     slu_PrintInt10("adjncy", nnz, adjncy);
 #endif
@@ -152,7 +152,7 @@ sldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
 
 #if ( DEBUGlevel>=2 )
     slu_PrintInt10("perm", n, perm);
-    printf(".. After MC64AD info %lld\tsize of matching %d\n", (long long)info[0], num);
+    printf(".. After MC64AD info %lld\tsize of matching %lld\n", (long long)info[0], (long long) num);
 #endif
     if ( info[0] == 1 ) { /* Structurally singular */
         printf(".. The last %d permutations:\n", (int)(n-num));

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_cdefs.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_cdefs.h
@@ -234,8 +234,8 @@ extern void    cSetRWork (int, int, singlecomplex *, singlecomplex **, singlecom
 extern void    cLUWorkFree (int *, singlecomplex *, GlobalLU_t *);
 extern int_t   cLUMemXpand (int, int_t, MemType, int_t *, GlobalLU_t *);
 
-extern singlecomplex  *complexMalloc(size_t);
-extern singlecomplex  *complexCalloc(size_t);
+extern singlecomplex  *singlecomplexMalloc(size_t);
+extern singlecomplex  *singlecomplexCalloc(size_t);
 extern float  *floatMalloc(size_t);
 extern float  *floatCalloc(size_t);
 extern int_t   cmemory_usage(const int_t, const int_t, const int_t, const int);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h
@@ -30,6 +30,11 @@ at the top-level directory.
 
 typedef struct { float r, i; } singlecomplex;
 
+#if defined(SUPERLU_TYPEDEF_COMPLEX) || DOXYGEN
+//! \brief backward compatibility with older versions of SuperLU
+//! Add -D enable_compatibility_complex=ON to your CMake call
+typedef singlecomplex complex;
+#endif
 
 /* Macro definitions */
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_sdefs.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_sdefs.h
@@ -20,7 +20,7 @@ at the top-level directory.
  * 
  * Global data structures used in LU factorization -
  * 
- *   nsuper: \#supernodes = nsuper + 1, numbered [0, nsuper].
+ *   nsuper: #supernodes = nsuper + 1, numbered [0, nsuper].
  *   (xsup,supno): supno[i] is the supernode no to which i belongs;
  *	xsup(s) points to the beginning of the s-th supernode.
  *	e.g.   supno 0 1 2 2 3 3 3 4 4 4 4 4   (n=12)

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h
@@ -32,7 +32,6 @@ at the top-level directory.
 #include <assert.h>
 #include "superlu_enum_consts.h"
 
-
 #include "scipy_slu_config.h"
 
 /***********************************************************************
@@ -414,9 +413,9 @@ extern void    StatInit(SuperLUStat_t *);
 extern void    StatPrint (SuperLUStat_t *);
 extern void    StatFree(SuperLUStat_t *);
 extern void    print_panel_seg(int, int, int, int, int *, int *);
-extern int     print_int_vec(char *,int, int *);
-extern int     slu_PrintInt10(char *, int, int *);
-extern int     check_perm(char *what, int n, int *perm);
+extern void    print_int_vec(char *what, int n, int *vec);
+extern void    slu_PrintInt10(char *name, int len, int *x);
+extern void    check_perm(char *what, int n, int *perm);
 
 #ifdef __cplusplus
   }

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_zdefs.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_zdefs.h
@@ -20,7 +20,7 @@ at the top-level directory.
  * 
  * Global data structures used in LU factorization -
  * 
- *   nsuper: \#supernodes = nsuper + 1, numbered [0, nsuper].
+ *   nsuper: #supernodes = nsuper + 1, numbered [0, nsuper].
  *   (xsup,supno): supno[i] is the supernode no to which i belongs;
  *	xsup(s) points to the beginning of the s-th supernode.
  *	e.g.   supno 0 1 2 2 3 3 3 4 4 4 4 4   (n=12)

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_coletree.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_coletree.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,10 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file sp_coletree.c
- * \brief Tree layout and computation routines
- *
- *<pre>
+/*
  * -- SuperLU routine (version 3.1) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
@@ -27,8 +24,12 @@ at the top-level directory.
  * Permission to modify the code and to distribute modified code is
  * granted, provided the above notices are retained, and a notice that
  * the code was modified is included with the above copyright notice.
- * </pre>
 */
+/*! \file
+ * \brief Tree layout and computation routines
+ *
+ * \ingroup Common
+ */
 
 /*  Elimination tree computation and layout routines */
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_ienv.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_ienv.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,16 +8,17 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file SRC/sp_ienv.c
- * \brief Chooses machine-dependent parameters for the local environment.
- *
- * <pre>
+/*
  * -- SuperLU routine (version 4.1) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
  * November, 2010
- * </pre>
 */
+/*! \file
+ * \brief Chooses machine-dependent parameters for the local environment.
+ *
+ * \ingroup Common
+ */
 
 /*
  * File name:		sp_ienv.c

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_preorder.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sp_preorder.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,8 +8,10 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file sp_preorder.c
- * \brief Permute and performs functions on columns of orginal matrix
+/*! @file
+ * \brief Permute and performs functions on columns of original matrix
+ *
+ * \ingroup Common
  */
 #include "slu_ddefs.h"
 
@@ -76,7 +78,7 @@ sp_preorder(superlu_options_t *options,  SuperMatrix *A, int *perm_c,
     NCPformat *ACstore;
     int       *iwork, *post;
     register  int n, i;
-    extern int check_perm(char *what, int n, int *perm);
+    extern void check_perm(char *what, int n, int *perm);
 	
     n = A->ncol;
     

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
@@ -133,7 +133,13 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 1
+#if 0
+        // There is no valid pivot.
+        // jcol represents the rank of U, 
+        // report the rank, let dgstrf handle the pivot
+	*pivrow = lsub_ptr[pivptr];
+	perm_r[*pivrow] = jcol;
+#elif 1
 #if SCIPY_FIX
 	if (pivptr < nsupr) {
 	    *pivrow = lsub_ptr[pivptr];
@@ -142,11 +148,8 @@ if ( jcol == MIN_COL ) {
 	    *pivrow = diagind;
 	}
 #else
-	*pivrow = lsub_ptr[pivptr];
+ 	*pivrow = lsub_ptr[pivptr];
 #endif
-	perm_r[*pivrow] = jcol;
-#else
-	perm_r[diagind] = jcol;
 #endif
 	*usepr = 0;
 	return (jcol+1);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h
@@ -3,7 +3,7 @@
 #define SUPERLU_CONFIG_H
 
 /* Enable metis */
-/* #undef HAVE_METIS */
+/*#define HAVE_METIS FALSE */
 
 /* Enable colamd */
 /* #undef HAVE_COLAMD */
@@ -12,7 +12,7 @@
 /* #undef XSDK_INDEX_SIZE */
 
 /* Integer type for indexing sparse matrix meta structure */
-#if (XSDK_INDEX_SIZE == 64)
+#if defined(XSDK_INDEX_SIZE) && (XSDK_INDEX_SIZE == 64)
 #include <stdint.h>
 #define _LONGINT 1
 typedef int64_t int_t;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_timer.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_timer.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -9,18 +9,15 @@ The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
 
-/*! @file superlu_timer.c
- * \brief Returns the time used
+/*! \file
+ * \brief Timer functions to record the time used
  *
- * <pre>
- * Purpose
- * ======= 
- * 
  * Returns the time in seconds used by the process.
  *
- * Note: the timer function call is machine dependent. Use conditional
+ * \note the timer function call is machine dependent. Use conditional
  *       compilation to choose the appropriate function.
- * </pre>
+ *
+ * \ingroup Common
  */
 
 #undef USE_TIMES
@@ -58,6 +55,8 @@ double SuperLU_timer_()
 #endif
 
 /*! \brief Timer function
+ *
+ * \return The time in seconds used by the process.
  */ 
 double SuperLU_timer_()
 {
@@ -83,6 +82,8 @@ double SuperLU_timer_()
 #include <stdlib.h>
 
 /*! \brief Timer function
+ *
+ * \return The time in seconds used by the process.
  */ 
 double SuperLU_timer_(void)
 {
@@ -94,4 +95,3 @@ double SuperLU_timer_(void)
 }
 
 #endif
-

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/util.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/util.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -8,10 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file util.c
- * \brief Utility functions
- * 
- * <pre>
+/*
  * -- SuperLU routine (version 4.1) --
  * Univ. of California Berkeley, Xerox Palo Alto Research Center,
  * and Lawrence Berkeley National Lab.
@@ -27,16 +24,20 @@ at the top-level directory.
  * Permission to modify the code and to distribute modified code is
  * granted, provided the above notices are retained, and a notice that
  * the code was modified is included with the above copyright notice.
- * </pre>
  */
-
+/*! \file
+ * \brief Utility functions
+ *
+ * \ingroup Common
+ */
 
 #include <math.h>
 #include "slu_ddefs.h"
 
-/*! \brief Global statistics variale
+/*! \brief Print message to error stream and exit program
+ *
+ * \param[in] mgs Message that is printed to error stream.
  */
-
 void superlu_abort_and_exit(char* msg)
 {
     fprintf(stderr, "%s", msg);
@@ -44,6 +45,8 @@ void superlu_abort_and_exit(char* msg)
 }
 
 /*! \brief Set the default values for the options argument.
+ *
+ * \param[in,out] options Options struct that is filled with default values.
  */
 void set_default_options(superlu_options_t *options)
 {
@@ -60,6 +63,8 @@ void set_default_options(superlu_options_t *options)
 }
 
 /*! \brief Set the default values for the options argument for ILU.
+ *
+ * \param[out] options Options struct that is filled with default values.
  */
 void ilu_set_default_options(superlu_options_t *options)
 {
@@ -78,6 +83,8 @@ void ilu_set_default_options(superlu_options_t *options)
 }
 
 /*! \brief Print the options setting.
+ *
+ * \param[in] options Options struct that is printed.
  */
 void print_options(superlu_options_t *options)
 {
@@ -95,6 +102,8 @@ void print_options(superlu_options_t *options)
 }
 
 /*! \brief Print the options setting.
+ *
+ * \param[in] options Options struct that is printed.
  */
 void print_ilu_options(superlu_options_t *options)
 {
@@ -109,13 +118,24 @@ void print_ilu_options(superlu_options_t *options)
     printf("..\n");
 }
 
-/*! \brief Deallocate the structure pointing to the actual storage of the matrix. */
+/*! \brief Deallocate SuperMatrix
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix.
+ */
 void
 Destroy_SuperMatrix_Store(SuperMatrix *A)
 {
     SUPERLU_FREE ( A->Store );
 }
 
+/*! \brief Deallocate SuperMatrix of type NC
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix of type NC.
+ */
 void
 Destroy_CompCol_Matrix(SuperMatrix *A)
 {
@@ -125,6 +145,12 @@ Destroy_CompCol_Matrix(SuperMatrix *A)
     SUPERLU_FREE( A->Store );
 }
 
+/*! \brief Deallocate SuperMatrix of type NR
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix of type NR.
+ */
 void
 Destroy_CompRow_Matrix(SuperMatrix *A)
 {
@@ -134,6 +160,12 @@ Destroy_CompRow_Matrix(SuperMatrix *A)
     SUPERLU_FREE( A->Store );
 }
 
+/*! \brief Deallocate SuperMatrix of type SC
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix of type SC.
+ */
 void
 Destroy_SuperNode_Matrix(SuperMatrix *A)
 {
@@ -146,7 +178,12 @@ Destroy_SuperNode_Matrix(SuperMatrix *A)
     SUPERLU_FREE ( A->Store );
 }
 
-/*! \brief A is of type Stype==NCP */
+/*! \brief Deallocate SuperMatrix of type NCP
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix of type NCP.
+ */
 void
 Destroy_CompCol_Permuted(SuperMatrix *A)
 {
@@ -155,7 +192,12 @@ Destroy_CompCol_Permuted(SuperMatrix *A)
     SUPERLU_FREE ( A->Store );
 }
 
-/*! \brief A is of type Stype==DN */
+/*! \brief Deallocate SuperMatrix of type DN
+ *
+ * Deallocate the structure pointing to the actual storage of the matrix.
+ *
+ * \param[in,out] A Deallocate all memory of this SuperMatrix of type DN.
+ */
 void
 Destroy_Dense_Matrix(SuperMatrix *A)
 {
@@ -164,7 +206,7 @@ Destroy_Dense_Matrix(SuperMatrix *A)
     SUPERLU_FREE ( A->Store );
 }
 
-/*! \brief Reset repfnz[] for the current column 
+/*! \brief Reset repfnz[] for the current column
  */
 void
 resetrep_col (const int nseg, const int *segrep, int *repfnz)
@@ -177,8 +219,7 @@ resetrep_col (const int nseg, const int *segrep, int *repfnz)
     }
 }
 
-
-/*! \brief Count the total number of nonzeros in factors L and U,  and in the symmetrically reduced L. 
+/*! \brief Count the total number of nonzeros in factors L and U, and in the symmetrically reduced L.
  */
 void
 countnz(const int n, int_t *xprune, int_t *nnzL, int_t *nnzU, GlobalLU_t *Glu)
@@ -256,8 +297,10 @@ ilu_countnz(const int n, int_t *nnzL, int_t *nnzU, GlobalLU_t *Glu)
     }
 }
 
-
-/*! \brief Fix up the data storage lsub for L-subscripts. It removes the subscript sets for structural pruning,	and applies permuation to the remaining subscripts.
+/*! \brief Fix up the data storage lsub for L-subscripts.
+ *
+ * It removes the subscript sets for structural pruning,
+ * and applies permutation to the remaining subscripts.
  */
 void
 fixupL(const int n, const int *perm_r, GlobalLU_t *Glu)
@@ -294,7 +337,6 @@ fixupL(const int n, const int *perm_r, GlobalLU_t *Glu)
     xlsub[n] = nextl;
 }
 
-
 /*! \brief Diagnostic print of segment info after panel_dfs().
  */
 void print_panel_seg(int n, int w, int jcol, int nseg, 
@@ -311,7 +353,10 @@ void print_panel_seg(int n, int w, int jcol, int nseg,
 
 }
 
-
+/*! \brief Initialize SuperLU stat
+ *
+ * \param[in,out] stat SuperLU stat that is initialized.
+ */
 void
 StatInit(SuperLUStat_t *stat)
 {
@@ -345,7 +390,12 @@ StatInit(SuperLUStat_t *stat)
 #endif
 }
 
-
+/*! \brief Display SuperLU stat
+ *
+ * Print content of SuperLU stat to output.
+ *
+ * \param[in] stat Display this SuperLU stat
+ */
 void
 StatPrint(SuperLUStat_t *stat)
 {
@@ -368,7 +418,12 @@ StatPrint(SuperLUStat_t *stat)
 
 }
 
-
+/*! \brief Deallocate SuperLU stat
+ *
+ * Deallocate the structure pointing to the actual storage of SuperLU stat.
+ *
+ * \param[in,out] stat Deallocate all memory of this SuperLU stat
+ */
 void
 StatFree(SuperLUStat_t *stat)
 {
@@ -377,32 +432,45 @@ StatFree(SuperLUStat_t *stat)
     SUPERLU_FREE(stat->ops);
 }
 
-
+/*! \brief Get operations for LU factorization
+ *
+ * Read out number of operations (ops) needed for LU factorization.
+ *
+ * \param[in] stat SuperLU stat used to read out the opts.
+ *
+ * \return Number of operations needed for LU factorization.
+ */
 flops_t
 LUFactFlops(SuperLUStat_t *stat)
 {
     return (stat->ops[FACT]);
 }
 
+/*! \brief Get operations for LU solve
+ *
+ * Read out number of operations (ops) needed for LU solve.
+ *
+ * \param[in] stat SuperLU stat used to read out the opts.
+ *
+ * \return Number of operations needed for LU solve.
+ */
 flops_t
 LUSolveFlops(SuperLUStat_t *stat)
 {
     return (stat->ops[SOLVE]);
 }
 
-
-
-
-
 /*! \brief Fills an integer array with a given value.
+ *
+ * \param[in,out] a Integer array that is filled.
+ * \param[in]     alen Length of integer array \a a.
+ * \param[in]     ival Value to be filled in every element of \a a.
  */
 void ifill(int *a, int alen, int ival)
 {
     register int i;
     for (i = 0; i < alen; i++) a[i] = ival;
 }
-
-
 
 /*! \brief Get the statistics of the supernodes 
  */
@@ -444,7 +512,6 @@ void super_stats(int nsuper, int *xsup)
 
 }
 
-
 float SpaSize(int n, int np, float sum_npw)
 {
     return (sum_npw*8 + np*8 + n*4)/1024.;
@@ -452,10 +519,8 @@ float SpaSize(int n, int np, float sum_npw)
 
 float DenseSize(int n, float sum_nw)
 {
-    return (sum_nw*8 + n*8)/1024.;;
+    return (sum_nw*8 + n*8)/1024.;
 }
-
-
 
 /*! \brief Check whether repfnz[] == EMPTY after reset.
  */
@@ -472,8 +537,13 @@ void check_repfnz(int n, int w, int jcol, int *repfnz)
 	    }
 }
 
-
-/*! \brief Print a summary of the testing results. */
+/*! \brief Print a summary of the testing results.
+ *
+ * \param[in] type Array with three chars indicating the type for that the tests were run like "CGE" or "DGE".
+ * \param[in] nfail Number of failed tests.
+ * \param[in] nrun Number of tests run.
+ * \param[in] nerrs Number of error messages recorded.
+ */
 void
 PrintSumm(char *type, int nfail, int nrun, int nerrs)
 {
@@ -487,16 +557,29 @@ PrintSumm(char *type, int nfail, int nrun, int nerrs)
 	printf("%6d error messages recorded\n", nerrs);
 }
 
-
-int print_int_vec(char *what, int n, int *vec)
+/*! \brief Print content of int array
+ *
+ * \param[in] what Vector name that is printed first.
+ * \param[in] n Number of elements in array.
+ * \param[in] vec Array of ints to be printed
+ */
+void print_int_vec(char *what, int n, int *vec)
 {
     int i;
     printf("%s\n", what);
     for (i = 0; i < n; ++i) printf("%d\t%d\n", i, vec[i]);
-    return 0;
 }
 
-int slu_PrintInt10(char *name, int len, int *x)
+/*! \brief Print content of int array with index numbers after every tenth row
+ *
+ * Print all elements of an int array. After ten rows the index is printed to
+ * make it more readable for humans.
+ *
+ * \param[in] name Vector name that is printed first.
+ * \param[in] len Number of elements in array.
+ * \param[in] x Array of ints to be printed.
+ */
+void slu_PrintInt10(char *name, int len, int *x)
 {
     register int i;
     
@@ -507,10 +590,15 @@ int slu_PrintInt10(char *name, int len, int *x)
 	printf("%6d", x[i]);
     }
     printf("\n");
-    return 0;
 }
 
-int check_perm(char *what, int n, int *perm)
+/*! \brief Validity check of a permutation
+ *
+ * \param[in] what String to be printed as part of displayed text for success or error.
+ * \param[in] n Number of elements in permutation \a perm.
+ * \param[in] perm Array describing the permutation.
+ */
+void check_perm(char *what, int n, int *perm)
 {
     register int i;
     int          *marker;
@@ -529,5 +617,4 @@ int check_perm(char *what, int n, int *perm)
 
     SUPERLU_FREE(marker);
     printf("check_perm: %s: n %d\n", what, n);
-    return 0;
 }

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgscon.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   ZGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by ZGETRF.   *
+ *   the LU factorization computed by ZGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsisx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\\U data structures.
+ *	     The amount of space used in bytes for L\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)
@@ -454,12 +454,12 @@ zgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
     }
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) ||
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
 	*info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c
@@ -540,7 +540,7 @@ zgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
 			tol_U = SUPERLU_MAX(drop_tol, tol_U * 0.5);
 		}
 
-		if (drop_sum.r != 0.0 && drop_sum.i != 0.0)
+		if (drop_sum.r != 0.0 || drop_sum.i != 0.0)
 		{
                     omega = SUPERLU_MIN(2.0*(1.0-alpha)/z_abs1(&drop_sum), 1.0);
                     zd_mult(&drop_sum, &drop_sum, omega);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgssv.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgssv.c
@@ -232,9 +232,12 @@ zgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
         /* Solve the system A*X=B, overwriting B with X. */
 	int info1;
         zgstrs (trans, L, U, perm_c, perm_r, B, stat, &info1);
-    } else {
+    }
+#if ( PRNTlevel>=1 )
+     else {
         printf("zgstrf info %lld\n", (long long) *info); fflush(stdout);
     }
+#endif
     
     utime[SOLVE] = SuperLU_timer_() - t;
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgssvx.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgssvx.c
@@ -243,7 +243,7 @@ at the top-level directory.
  *         to hold data structures for factors L and U.
  *         On exit, if fact is not 'F', L and U point to this array.
  *
- * lwork   (input) int
+ * lwork   (input) int_t
  *         Specifies the size of work array in bytes.
  *         = 0:  allocate space internally by system malloc;
  *         > 0:  use user-supplied work array of length lwork in bytes,
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\\U data structures.
+ *           The amount of space used in bytes for L\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)
@@ -361,7 +361,6 @@ zgssvx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
        double *rcond, double *ferr, double *berr, 
        GlobalLU_t *Glu, mem_usage_t *mem_usage, SuperLUStat_t *stat, int_t *info )
 {
-
 
     DNformat  *Bstore, *Xstore;
     doublecomplex    *Bmat, *Xmat;
@@ -409,13 +408,13 @@ printf("dgssvx: Fact=%4d, Trans=%4d, equed=%c\n",
 #endif
 
     /* Test the input parameters */
-    if (options->Fact != DOFACT && options->Fact != SamePattern &&
-	options->Fact != SamePattern_SameRowPerm &&
-	options->Fact != FACTORED &&
-	options->Trans != NOTRANS && options->Trans != TRANS && 
-	options->Trans != CONJ &&
-	options->Equil != NO && options->Equil != YES)
-	*info = -1;
+    if ( (options->Fact != DOFACT && options->Fact != SamePattern &&
+	  options->Fact != SamePattern_SameRowPerm &&
+	  options->Fact != FACTORED) || 
+	 (options->Trans != NOTRANS && options->Trans != TRANS && 
+	  options->Trans != CONJ) ||
+	 (options->Equil != NO && options->Equil != YES) )
+	 *info = -1;
     else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	      (A->Stype != SLU_NC && A->Stype != SLU_NR) ||
 	      A->Dtype != SLU_Z || A->Mtype != SLU_GE )

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zldperm.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zldperm.c
@@ -116,7 +116,7 @@ zldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
     for (i = 0; i <= n; ++i) ++colptr[i];
     for (i = 0; i < nnz; ++i) ++adjncy[i];
 #if ( DEBUGlevel>=2 )
-    printf("LDPERM(): n %d, nnz %d\n", n, nnz);
+    printf("LDPERM(): n %d, nnz %lld\n", n, (long long) nnz);
     slu_PrintInt10("colptr", n+1, colptr);
     slu_PrintInt10("adjncy", nnz, adjncy);
 #endif
@@ -152,7 +152,7 @@ zldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
 
 #if ( DEBUGlevel>=2 )
     slu_PrintInt10("perm", n, perm);
-    printf(".. After MC64AD info %lld\tsize of matching %d\n", (long long)info[0], num);
+    printf(".. After MC64AD info %lld\tsize of matching %lld\n", (long long)info[0], (long long) num);
 #endif
     if ( info[0] == 1 ) { /* Structurally singular */
         printf(".. The last %d permutations:\n", (int)(n-num));

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
@@ -235,6 +235,12 @@ zpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #else
+#if SCIPY_FIX
+		   if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		   }
+#endif
 		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #endif
@@ -428,12 +434,6 @@ zpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #else
-#if SCIPY_FIX
-		   if (nsupr < segsze) {
-			/* Fail early rather than passing in invalid parameters to TRSV. */
-			ABORT("failed to factorize matrix");
-		   }
-#endif
 		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #endif

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
@@ -134,7 +134,13 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 1
+#if 0
+        // There is no valid pivot.
+        // jcol represents the rank of U, 
+        // report the rank, let dgstrf handle the pivot
+	*pivrow = lsub_ptr[pivptr];
+	perm_r[*pivrow] = jcol;
+#elif 1
 #if SCIPY_FIX
 	if (pivptr < nsupr) {
 	    *pivrow = lsub_ptr[pivptr];
@@ -142,12 +148,7 @@ if ( jcol == MIN_COL ) {
 	else {
 	    *pivrow = diagind;
 	}
-#else
-	*pivrow = lsub_ptr[pivptr];
 #endif
-	perm_r[*pivrow] = jcol;
-#else
-	perm_r[diagind] = jcol;
 #endif
 	*usepr = 0;
 	return (jcol+1);

--- a/scipy/sparse/linalg/_dsolve/SuperLU/scipychanges.patch
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/scipychanges.patch
@@ -16,13 +16,14 @@ index 8aeb6270a..7b9a611e8 100644
  			   &nsupr, tempv, &incx );
  #endif
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c
-index d12c2ee04..a43d070e6 100644
+index 3e48e0a7f..b8001a7e9 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cpivotL.c
-@@ -135,7 +135,16 @@ if ( jcol == MIN_COL ) {
-     /* Test for singularity */
-     if ( pivmax == 0.0 ) {
- #if 1
+@@ -140,6 +140,15 @@ if ( jcol == MIN_COL ) {
+         // report the rank, let dgstrf handle the pivot
+ 	*pivrow = lsub_ptr[pivptr];
+ 	perm_r[*pivrow] = jcol;
++#elif 1
 +#if SCIPY_FIX
 +	if (pivptr < nsupr) {
 +	    *pivrow = lsub_ptr[pivptr];
@@ -30,12 +31,10 @@ index d12c2ee04..a43d070e6 100644
 +	else {
 +	    *pivrow = diagind;
 +	}
-+#else
- 	*pivrow = lsub_ptr[pivptr];
 +#endif
- 	perm_r[*pivrow] = jcol;
- #else
- 	perm_r[diagind] = jcol;
+ #endif
+ 	*usepr = 0;
+ 	return (jcol+1);
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/csnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/csnode_bmod.c
 index 9b7399729..1dffacace 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/csnode_bmod.c
@@ -71,13 +70,14 @@ index a44039172..5202349ad 100644
  			   &nsupr, tempv, &incx );
  #endif
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c
-index a0f23c6ba..8ac2316a9 100644
+index 36b1a9b01..270aa4fe6 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dpivotL.c
-@@ -138,7 +138,16 @@ if ( jcol == MIN_COL ) {
-         // jcol represents the rank of U
-         // report the rank let dgstrf handle the pivot
- #if 1
+@@ -139,6 +139,15 @@ if ( jcol == MIN_COL ) {
+         // report the rank, let dgstrf handle the pivot
+ 	*pivrow = lsub_ptr[pivptr];
+ 	perm_r[*pivrow] = jcol;
++#elif 1
 +#if SCIPY_FIX
 +	if (pivptr < nsupr) {
 +	    *pivrow = lsub_ptr[pivptr];
@@ -85,12 +85,10 @@ index a0f23c6ba..8ac2316a9 100644
 +	else {
 +	    *pivrow = diagind;
 +	}
-+#else
-     *pivrow = lsub_ptr[pivptr];
 +#endif
-     perm_r[*pivrow] = jcol;
- #else
-     perm_r[diagind] = jcol;
+ #endif
+ 	*usepr = 0;
+ 	return (jcol+1);
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dsnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dsnode_bmod.c
 index ad9237c1c..e3cff55ab 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dsnode_bmod.c
@@ -109,133 +107,257 @@ index ad9237c1c..e3cff55ab 100644
  	      &lusup[ufirst], &incx );
  	dgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c
-index fe20e6e31..e171d0c62 100644
+index 55c456b80..2d6748be3 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_cpivotL.c
-@@ -146,9 +146,13 @@ ilu_cpivotL(
+@@ -146,9 +146,12 @@ ilu_cpivotL(
  
      /* Test for singularity */
      if (pivmax < 0.0) {
+-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
 +#if SCIPY_FIX
-+	ABORT("[0]: matrix is singular");
-+#else
- 	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
++		ABORT("[0]: matrix is singular");
++    /*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
  	fflush(stderr);
- 	exit(1);
+ 	exit(1); */
 +#endif
+ 	*usepr = 0;
+ 	return (jcol+1);
      }
-     if ( pivmax == 0.0 ) {
- 	if (diag != EMPTY)
-@@ -161,9 +165,13 @@ ilu_cpivotL(
+@@ -163,11 +166,15 @@ ilu_cpivotL(
  	    for (icol = jcol; icol < n; icol++)
  		if (marker[swap[icol]] <= jcol) break;
  	    if (icol >= n) {
 +#if SCIPY_FIX
 +		ABORT("[1]: matrix is singular");
 +#else
- 		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+ 		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
  		fflush(stderr);
- 		exit(1);
+ 		exit(1); */
+    	        *usepr = 0;
+ 	        return (jcol+1);
 +#endif
  	    }
  
  	    *pivrow = swap[icol];
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c
-index 44c3817b5..68efe5069 100644
+index be1dcb737..0f2c83341 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_dpivotL.c
-@@ -144,9 +144,13 @@ ilu_dpivotL(
+@@ -144,11 +144,15 @@ ilu_dpivotL(
  
      /* Test for singularity */
      if (pivmax < 0.0) {
 +#if SCIPY_FIX
 +	ABORT("[0]: matrix is singular");
 +#else
- 	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+     	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
  	fflush(stderr);
- 	exit(1);
+ 	exit(1); */
+ 	*usepr = 0;
+ 	return (jcol+1);
 +#endif
      }
      if ( pivmax == 0.0 ) {
  	if (diag != EMPTY)
-@@ -159,9 +163,13 @@ ilu_dpivotL(
+@@ -161,11 +165,15 @@ ilu_dpivotL(
  	    for (icol = jcol; icol < n; icol++)
  		if (marker[swap[icol]] <= jcol) break;
  	    if (icol >= n) {
 +#if SCIPY_FIX
 +		ABORT("[1]: matrix is singular");
 +#else
- 		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+ 		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
  		fflush(stderr);
- 		exit(1);
+ 		exit(1); */
+    	        *usepr = 0;
+ 	        return (jcol+1);
 +#endif
  	    }
  
  	    *pivrow = swap[icol];
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c
-index 39b6f0e6c..0669323cc 100644
+index 0b0937739..fd3c15ca5 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_spivotL.c
-@@ -144,9 +144,13 @@ ilu_spivotL(
+@@ -144,11 +144,15 @@ ilu_spivotL(
  
      /* Test for singularity */
      if (pivmax < 0.0) {
 +#if SCIPY_FIX
 +	ABORT("[0]: matrix is singular");
 +#else
- 	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+     	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
  	fflush(stderr);
- 	exit(1);
+ 	exit(1); */
+ 	*usepr = 0;
+ 	return (jcol+1);
 +#endif
      }
      if ( pivmax == 0.0 ) {
  	if (diag != EMPTY)
-@@ -159,9 +163,13 @@ ilu_spivotL(
+@@ -161,11 +165,15 @@ ilu_spivotL(
  	    for (icol = jcol; icol < n; icol++)
  		if (marker[swap[icol]] <= jcol) break;
  	    if (icol >= n) {
 +#if SCIPY_FIX
-+		ABORT("[1]: matrix is singular");
++	ABORT("[1]: matrix is singular");
 +#else
- 		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+ 		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
  		fflush(stderr);
- 		exit(1);
+ 		exit(1); */
+    	        *usepr = 0;
+ 	        return (jcol+1);
 +#endif
  	    }
  
  	    *pivrow = swap[icol];
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c
-index 63040bae0..47aa02ab2 100644
+index 3af7e760b..d2d8543f7 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zpivotL.c
-@@ -146,9 +146,13 @@ ilu_zpivotL(
+@@ -146,11 +146,15 @@ ilu_zpivotL(
  
      /* Test for singularity */
      if (pivmax < 0.0) {
 +#if SCIPY_FIX
 +	ABORT("[0]: matrix is singular");
 +#else
- 	fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
+     	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
  	fflush(stderr);
- 	exit(1);
+ 	exit(1); */
+ 	*usepr = 0;
+ 	return (jcol+1);
 +#endif
      }
      if ( pivmax == 0.0 ) {
  	if (diag != EMPTY)
-@@ -161,9 +165,13 @@ ilu_zpivotL(
+@@ -163,11 +167,15 @@ ilu_zpivotL(
  	    for (icol = jcol; icol < n; icol++)
  		if (marker[swap[icol]] <= jcol) break;
  	    if (icol >= n) {
 +#if SCIPY_FIX
-+		ABORT("[1]: matrix is singular");
++	ABORT("[1]: matrix is singular");
 +#else
- 		fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
+ 		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
  		fflush(stderr);
- 		exit(1);
+ 		exit(1); */
+    	        *usepr = 0;
+ 	        return (jcol+1);
 +#endif
  	    }
  
  	    *pivrow = swap[icol];
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
+index 9a2d8064a..77f585cca 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
+@@ -400,6 +400,12 @@ spanel_bmod (
+ 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
+ 			   &nsupr, tempv, &incx );
+ #else
++#if SCIPY_FIX
++		   if (nsupr < segsze) {
++			/* Fail early rather than passing in invalid parameters to TRSV. */
++			ABORT("failed to factorize matrix");
++		   }
++#endif
+ 		    strsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+ 			   &nsupr, tempv, &incx );
+ #endif
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
+index 4dca33d3a..435f123f4 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
+@@ -139,6 +139,17 @@ if ( jcol == MIN_COL ) {
+         // report the rank, let dgstrf handle the pivot
+ 	*pivrow = lsub_ptr[pivptr];
+ 	perm_r[*pivrow] = jcol;
++#elif 1
++#if SCIPY_FIX
++	if (pivptr < nsupr) {
++	    *pivrow = lsub_ptr[pivptr];
++	}
++	else {
++	    *pivrow = diagind;
++	}
++#else
++ 	*pivrow = lsub_ptr[pivptr];
++#endif
+ #endif
+ 	*usepr = 0;
+ 	return (jcol+1);
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
+index db761ca11..da1ee1dca 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
+@@ -104,6 +104,12 @@ ssnode_bmod (
+ 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
+ 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
+ #else
++#if SCIPY_FIX
++       if (nsupr < nsupc) {
++           /* Fail early rather than passing in invalid parameters to TRSV. */
++           ABORT("failed to factorize matrix");
++       }
++#endif
+ 	strsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+ 	      &lusup[ufirst], &incx );
+ 	sgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
+index a41bbcaaa..8390fcd5a 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
+@@ -235,6 +235,12 @@ zpanel_bmod (
+ 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
+ 			   &nsupr, TriTmp, &incx );
+ #else
++#if SCIPY_FIX
++		   if (nsupr < segsze) {
++			/* Fail early rather than passing in invalid parameters to TRSV. */
++			ABORT("failed to factorize matrix");
++		   }
++#endif
+ 		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+ 			   &nsupr, TriTmp, &incx );
+ #endif
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
+index 1d16652d1..da0a615cb 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
+@@ -140,6 +140,15 @@ if ( jcol == MIN_COL ) {
+         // report the rank, let dgstrf handle the pivot
+ 	*pivrow = lsub_ptr[pivptr];
+ 	perm_r[*pivrow] = jcol;
++#elif 1
++#if SCIPY_FIX
++	if (pivptr < nsupr) {
++	    *pivrow = lsub_ptr[pivptr];
++	}
++	else {
++	    *pivrow = diagind;
++	}
++#endif
+ #endif
+ 	*usepr = 0;
+ 	return (jcol+1);
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
+index 351e0ad62..4015b2380 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
+@@ -105,6 +105,12 @@ zsnode_bmod (
+ 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
+ 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
+ #else
++#if SCIPY_FIX
++       if (nsupr < nsupc) {
++           /* Fail early rather than passing in invalid parameters to TRSV. */
++           ABORT("failed to factorize matrix");
++       }
++#endif
+ 	ztrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+ 	      &lusup[ufirst], &incx );
+ 	zgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 diff --git a/scipy/sparse/linalg/dsolve/SuperLU/SRC/scipy_slu_config.h b/scipy/sparse/linalg/dsolve/SuperLU/SRC/scipy_slu_config.h
 new file mode 100644
 index 000000000..5afc93b5d
@@ -291,137 +413,27 @@ index b95c01830..97ba246cc 100644
  #define ADD_       0
  #define ADD__      1
 diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h
-index cd4c2fa29..358c2eda1 100644
+index 1afbdd0e7..61552b753 100644
 --- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h
 +++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_util.h
-@@ -33,6 +33,8 @@ at the top-level directory.
+@@ -32,6 +32,7 @@ at the top-level directory.
+ #include <assert.h>
  #include "superlu_enum_consts.h"
  
- 
 +#include "scipy_slu_config.h"
-+
+ 
  /***********************************************************************
   * Macros
-  ***********************************************************************/
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
-index 9a2d8064a..77f585cca 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spanel_bmod.c
-@@ -400,6 +400,12 @@ spanel_bmod (
- 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
- 			   &nsupr, tempv, &incx );
- #else
-+#if SCIPY_FIX
-+		   if (nsupr < segsze) {
-+			/* Fail early rather than passing in invalid parameters to TRSV. */
-+			ABORT("failed to factorize matrix");
-+		   }
-+#endif
- 		    strsv_( "L", "N", "U", &segsze, &lusup[luptr], 
- 			   &nsupr, tempv, &incx );
- #endif
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
-index 6821840d3..ac38bdbdf 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/spivotL.c
-@@ -134,7 +134,16 @@ if ( jcol == MIN_COL ) {
-     /* Test for singularity */
-     if ( pivmax == 0.0 ) {
- #if 1
-+#if SCIPY_FIX
-+	if (pivptr < nsupr) {
-+	    *pivrow = lsub_ptr[pivptr];
-+	}
-+	else {
-+	    *pivrow = diagind;
-+	}
-+#else
- 	*pivrow = lsub_ptr[pivptr];
-+#endif
- 	perm_r[*pivrow] = jcol;
- #else
- 	perm_r[diagind] = jcol;
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
-index db761ca11..da1ee1dca 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ssnode_bmod.c
-@@ -104,6 +104,12 @@ ssnode_bmod (
- 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
- 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
- #else
-+#if SCIPY_FIX
-+       if (nsupr < nsupc) {
-+           /* Fail early rather than passing in invalid parameters to TRSV. */
-+           ABORT("failed to factorize matrix");
-+       }
-+#endif
- 	strsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
- 	      &lusup[ufirst], &incx );
- 	sgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
-index a41bbcaaa..0dfcd3c39 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpanel_bmod.c
-@@ -428,6 +428,12 @@ zpanel_bmod (
- 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
- 			   &nsupr, tempv, &incx );
- #else
-+#if SCIPY_FIX
-+		   if (nsupr < segsze) {
-+			/* Fail early rather than passing in invalid parameters to TRSV. */
-+			ABORT("failed to factorize matrix");
-+		   }
-+#endif
- 		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
- 			   &nsupr, tempv, &incx );
- #endif
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
-index 882b9d258..1e9643927 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zpivotL.c
-@@ -135,7 +135,16 @@ if ( jcol == MIN_COL ) {
-     /* Test for singularity */
-     if ( pivmax == 0.0 ) {
- #if 1
-+#if SCIPY_FIX
-+	if (pivptr < nsupr) {
-+	    *pivrow = lsub_ptr[pivptr];
-+	}
-+	else {
-+	    *pivrow = diagind;
-+	}
-+#else
- 	*pivrow = lsub_ptr[pivptr];
-+#endif
- 	perm_r[*pivrow] = jcol;
- #else
- 	perm_r[diagind] = jcol;
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
-index 351e0ad62..4015b2380 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zsnode_bmod.c
-@@ -105,6 +105,12 @@ zsnode_bmod (
- 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
- 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
- #else
-+#if SCIPY_FIX
-+       if (nsupr < nsupc) {
-+           /* Fail early rather than passing in invalid parameters to TRSV. */
-+           ABORT("failed to factorize matrix");
-+       }
-+#endif
- 	ztrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
- 	      &lusup[ufirst], &incx );
- 	zgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
-diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h
-index 40c22924c..83be8c971 100644
---- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h
-+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_scomplex.h
-@@ -30,7 +30,6 @@ at the top-level directory.
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h
+index eeb2a1e43..c3e7bac1c 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/superlu_config.h
+@@ -3,7 +3,7 @@
+ #define SUPERLU_CONFIG_H
  
- typedef struct { float r, i; } singlecomplex;
+ /* Enable metis */
+-#define HAVE_METIS TRUE
++/*#define HAVE_METIS FALSE */
  
--#define complex singlecomplex  // backward compatibility
- 
- /* Macro definitions */
- 
+ /* Enable colamd */
+ /* #undef HAVE_COLAMD */

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -722,6 +722,17 @@ class TestSplu:
 
         assert_equal(len(oks), 20)
 
+    def test_singular_matrix(self):
+        # Test that SuperLU does not print to stdout when a singular matrix is
+        # passed. See gh-20993.
+        A = identity(10, format='csr').tocsr()
+        A[-1, -1] = 0
+        b = np.zeros(10)
+        with pytest.warns(MatrixRankWarning):
+            res = spsolve(A, b)
+            assert np.isnan(res).all()
+
+
 class TestGstrsErrors:
     def setup_method(self):
       self.A = array([[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]], dtype=np.float64)


### PR DESCRIPTION
#### Reference issue
Closes gh-20993

#### What does this implement/fix?
Updates SuperLU to the head of their master branch. A [recent commit](https://github.com/xiaoyeli/superlu/commit/6cecd12c4680ce77d6ee4ff9eb412b5f8fc0e5f6) should avoid printing to stdout for singular matrices.

#### Additional information
Locally, on WSL using Ubuntu and conda compilers, compilation fails due to a recent SuperLU [update](https://github.com/xiaoyeli/superlu/commit/c511e1ddc8a4b8837292ca0d2c6f04c5012a5761) regarding complex numbers. 

Edit: compilation also fails in CI. After some feedback, I will open an issue upstream.