### PR TITLE
BUG: special: `cupy` import guard

### DIFF
--- a/scipy/special/tests/test_xsf_cuda.py
+++ b/scipy/special/tests/test_xsf_cuda.py
@@ -11,7 +11,7 @@ from scipy.special._testutils import MissingModule
 
 try:
     import cupy  # type: ignore
-except ImportError:
+except (ImportError, AttributeError):
     cupy = MissingModule('cupy')
 
 


### PR DESCRIPTION
* Fixes #21174

* Don't fail the SciPy testsuite when the wrong CuPy/NumPy combination is installed, since CuPy is an optional dep.

* Precedent is `scipy/stats/tests/test_morestats.py`, it catches the generic `Exception` for `matplotlib` import, which is even more aggressive.

[skip ci]