### PR TITLE
ENH: sparse: efficient arithmetic operations for DIA format

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -14,7 +14,7 @@ from ._sputils import (
     isdense, isscalarlike, isshape, upcast_char, getdtype, get_sum_dtype,
     validateaxis, check_shape
 )
-from ._sparsetools import dia_matmat, dia_matvec
+from ._sparsetools import dia_matmat, dia_matvec, dia_matvecs
 
 
 class _dia_base(_data_matrix):
@@ -296,6 +296,13 @@ class _dia_base(_data_matrix):
                    x.ravel(), y.ravel())
 
         return y
+
+    def _matmul_multivector(self, other):
+        res = np.zeros((self.shape[0], other.shape[1]),
+                       dtype=np.result_type(self.data, other))
+        dia_matvecs(*self.shape, *self.data.shape, self.offsets, self.data,
+                    other.shape[1], other, res)
+        return res
 
     def _matmul_sparse(self, other):
         # If other is not DIA format, use default handler.

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -112,6 +112,7 @@ coo_matvec_nd       v llIITT*T
 coo_matmat_dense    v llIITT*T
 coo_matmat_dense_nd v lllIIITT*T
 dia_matvec          v iiiiITT*T
+dia_matvecs         v iiiiITiT*T
 cs_graph_components i iII*I
 """
 

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -107,6 +107,7 @@ coo_tocsr           v iiiIIT*I*I*T
 coo_todense         v iilIIT*Ti
 coo_todense_nd      v IllIT*Ti
 coo_matvec          v lIITT*T
+dia_matmat          v iiiiITiiiIT*V*W
 coo_matvec_nd       v llIITT*T
 coo_matmat_dense    v llIITT*T
 coo_matmat_dense_nd v lllIIITT*T

--- a/scipy/sparse/sparsetools/dia.h
+++ b/scipy/sparse/sparsetools/dia.h
@@ -2,6 +2,120 @@
 #define __DIA_H__
 
 #include <algorithm>
+#include <vector>
+
+using std::min, std::max;
+
+template <class I, class T>
+T min_el(const T vec[], I len) {
+  return *std::min_element(vec, vec + len);
+}
+
+template <class I, class T>
+T max_el(const T vec[], I len) {
+  return *std::max_element(vec, vec + len);
+}
+
+
+/*
+ * Compute DIA matrix output = A * B for DIA matrices A, B
+ *
+ *
+ * Input Arguments:
+ *   I  A_rows               - number of rows in A
+ *   I  A_cols               - number of columns in A
+ *   I  A_diags              - number of diagonals in A
+ *   I  A_L                  - length of each diagonal in A
+ *   I  A_offsets[A_diags]   - diagonal offsets in A
+ *   T  A_data[A_diags,A_L]  - diagonals data of A
+ *   I  B_cols               - number of columns in B
+ *   I  B_diags              - number of diagonals in B
+ *   I  B_L                  - length of each diagonal in B
+ *   I  B_offsets[B_diags]   - diagonal offsets in B
+ *   T  B_data[B_diags,B_L]  - diagonals data of B
+ *
+ * Output Arguments:
+ *   V  offsets              - diagonal offsets
+ *   W  data                 - diagonals data
+ *
+ * Note:
+ *   Number of diagonals in output (diags) is the length of output offsets;
+ *   length of each diagonal (L) equals B_L; data dimensions are [diags,L]
+ *   Negative offsets correspond to lower diagonals
+ *   Positive offsets correspond to upper diagonals
+ *
+ */
+template <class I, class T>
+void dia_matmat(const I A_rows,
+                const I A_cols,
+                const I A_diags,
+                const I A_L,
+                const I A_offsets[],
+                const T A_data[],
+                const I B_cols,
+                const I B_diags,
+                const I B_L,
+                const I B_offsets[],
+                const T B_data[],
+                std::vector<I>* offsets,
+                std::vector<T>* data)
+{
+    const I B_rows = A_cols,
+            rows = A_rows, cols = B_cols,
+            L = min(cols, B_L);
+
+    // range of combinations of input offsets
+    const I min_map_ofs = min_el(A_offsets, A_diags) + min_el(B_offsets, B_diags),
+            max_map_ofs = max_el(A_offsets, A_diags) + max_el(B_offsets, B_diags);
+    // limits for output offsets
+    const I min_ofs = max(min_map_ofs, 1 - rows),
+            max_ofs = min(max_map_ofs, L - 1);
+    // mark output offsets
+    std::vector<I> buf(max_map_ofs - min_map_ofs + 1);
+    // (alias to buf indexable from [min_map_ofs] to [max_map_ofs];
+    //  only [min_ofs] to [max_ofs] will be used later)
+    I* ofs_map = buf.data() - min_map_ofs;
+    for (I i = 0; i < A_diags; ++i)
+        for (I j = 0; j < B_diags; ++j)
+            ofs_map[A_offsets[i] + B_offsets[j]] = I(true);
+    // enumerate marks
+    offsets->resize(max_ofs - min_ofs + 1);
+    I N_ofs = 0;
+    for (I ofs = min_ofs; ofs <= max_ofs; ++ofs)
+        if (ofs_map[ofs]) {
+            (*offsets)[N_ofs] = ofs;
+            ofs_map[ofs] = N_ofs;
+            ++N_ofs;
+        }
+    offsets->resize(N_ofs);
+
+    // allocate output diagonals, filled with zeros
+    data->resize(N_ofs * L);
+    // loop over diagonals in B
+    for (I B_i = 0; B_i < B_diags; ++B_i) {
+        const I B_ofs = B_offsets[B_i];
+        const T* B_diag_r = B_data + npy_intp(B_L) * B_i + B_ofs; // row-indexed
+        // span of data within current (row-indexed) B diagonal
+        const I B_j_beg = max(-B_ofs, I(0)),
+                B_j_end = min(min(B_cols, B_L) - B_ofs, B_rows);
+        // loop over diagonals in A
+        for (I A_i = 0; A_i < A_diags; ++A_i) {
+            const I A_ofs = A_offsets[A_i];
+            const T* A_diag_c = A_data + npy_intp(A_L) * A_i; // column-indexed
+            // output offset and corresponding diagonal
+            const I ofs = A_ofs + B_ofs;
+            if (ofs < min_ofs or ofs > max_ofs)
+                continue;
+            T* diag_r = data->data() + npy_intp(L) * ofs_map[ofs] + B_ofs; // row-indexed
+            // overlapping span of data within current B and A diagonals
+            const I j_beg = max(B_j_beg, A_ofs),
+                    j_end = min({B_j_end, min(A_cols, A_L), A_rows + A_ofs});
+            // add partial product to output
+            for (I j = j_beg; j < j_end; ++j)
+                diag_r[j] += A_diag_c[j] * B_diag_r[j];
+        }
+    }
+}
 
 
 /*

--- a/scipy/sparse/sparsetools/dia.h
+++ b/scipy/sparse/sparsetools/dia.h
@@ -119,7 +119,7 @@ void dia_matmat(const I A_rows,
 
 
 /*
- * Compute Y += A*X for DIA matrix A and dense vectors X,Y
+ * Compute Y += A * X for DIA matrix A and dense vectors X, Y
  *
  *
  * Input Arguments:
@@ -145,25 +145,25 @@ void dia_matvec(const I n_row,
                 const I n_col,
                 const I n_diags,
                 const I L,
-	            const I offsets[], 
-	            const T diags[], 
-	            const T Xx[],
-	                  T Yx[])
+                const I offsets[],
+                const T diags[],
+                const T Xx[],
+                      T Yx[])
 {
-    for(I i = 0; i < n_diags; i++){
+    for (I i = 0; i < n_diags; i++){
         const I k = offsets[i];  //diagonal offset
 
-        const I i_start = std::max<I>(0,-k);
-        const I j_start = std::max<I>(0, k);
-        const I j_end   = std::min<I>(std::min<I>(n_row + k, n_col),L);
+        const I i_start = max<I>(0, -k);
+        const I j_start = max<I>(0, k);
+        const I j_end   = min<I>(min<I>(n_row + k, n_col), L);
 
         const I N = j_end - j_start;  //number of elements to process
 
-        const T * diag = diags + (npy_intp)i*L + j_start;
+        const T * diag = diags + (npy_intp)i * L + j_start;
         const T * x = Xx + j_start;
               T * y = Yx + i_start;
 
-        for(I n = 0; n < N; n++){
+        for (I n = 0; n < N; n++) {
             y[n] += diag[n] * x[n]; 
         }
     }

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4985,6 +4985,21 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         csc = dia.tocsc()
         assert csc.indices.dtype == np.int32
 
+    def test_add_sparse(self):
+        # test format and cases not covered by common add tests
+        A = diag([1, 2])
+        B = A + diag([3], 1)
+        Asp = dia_matrix(A)
+        Bsp = dia_matrix(B)
+
+        Csp = Asp + Bsp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), A + B)
+
+        Csp = Bsp + Asp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), B + A)
+
     def test_mul_scalar(self):
         # repro for gh-20434
         m = self.dia_container([[1, 2], [0, 4]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -5000,6 +5000,25 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         assert isinstance(Csp, dia_matrix)
         assert_array_equal(Csp.toarray(), B + A)
 
+    def test_sub_sparse(self):
+        # test format and cases not covered by common sub tests
+        A = diag([1, 2])
+        B = A + diag([3], 1)
+        Asp = dia_matrix(A)
+        Bsp = dia_matrix(B)
+
+        Csp = Asp - Bsp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), A - B)
+
+        Csp = Bsp - Asp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), B - A)
+
+        Bsp = Bsp.asformat('csr')
+        assert_array_equal((Asp - Bsp).toarray(), A - B)
+        assert_array_equal((Bsp - Asp).toarray(), B - A)
+
     def test_mul_scalar(self):
         # repro for gh-20434
         m = self.dia_container([[1, 2], [0, 4]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -5030,6 +5030,50 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         assert isinstance(res2, m.__class__)
         assert_array_equal(res2.toarray(), [[3, 6], [0, 12]])
 
+    def test_matmul_dia(self):
+        # test DIA structure of DIA @ DIA:
+
+        # that all and only needed elements are used and produced
+        A = array([[1, 2, 3],
+                   [4, 5, 6]])
+        B = array([[11, 12],
+                   [13, 14],
+                   [15, 16]])
+        Asp = dia_matrix(A)
+        Bsp = dia_matrix(B)
+        Asp.data[Asp.data == 0] = -1  # poison outside elements
+        Bsp.data[Bsp.data == 0] = -1
+        assert_array_equal(Asp.toarray(), A)
+        assert_array_equal(Bsp.toarray(), B)
+
+        C = A @ B
+        Csp = Asp @ Bsp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), C)
+        assert_array_equal(Csp.offsets, [-1, 0, 1])
+        assert_array_equal(Csp.data, dia_matrix(C).data)
+
+        C = B @ A
+        Csp = Bsp @ Asp
+        assert isinstance(Csp, dia_matrix)
+        assert_array_equal(Csp.toarray(), C)
+        assert_array_equal(Csp.offsets, [-2, -1, 0, 1, 2])
+        assert_array_equal(Csp.data, dia_matrix(C).data)
+
+        # short data and that order of input offsets doesn't matter
+        Asp = dia_matrix(([[0., 1., 2.], [3., 4., 5.]], [1, -2]), (5, 5))
+        Bsp = dia_matrix(([[6., 7., 8.], [0., 0., 9.]], [-1, 2]), (5, 5))
+
+        Csp = Asp @ Bsp
+        assert_array_equal(Csp.offsets, array([-3, 0]))
+        assert_array_equal(Csp.data, [[24., 35., 0.],
+                                      [6., 14., 27.]])
+
+        Csp = Bsp @ Asp
+        assert_array_equal(Csp.offsets, array([-3, 0]))
+        assert_array_equal(Csp.data, [[24., 0., 0.],
+                                      [27., 6., 14.]])
+
 
 class TestDIAMatrix(_MatrixMixin, TestDIA):
     spcreator = dia_matrix


### PR DESCRIPTION
#### Reference issue
Partially addresses gh-21039.

#### What does this implement/fix?
Implements most important arithmetic operations with sparse arrays in DIA format. Previously most operations used fall-back conversion to CSR format with very poor overall efficiency.

For comparison, the standard benchmarks (``python dev.py bench -s sparse.Arithmetic``):

##### Before
```
sparse.Arithmetic.time_arithmetic                        
======== ==== ========== ========== ========== ==========
--                                 op                    
------------- -------------------------------------------
 format   XY   __add__    __sub__    multiply   __mul__  
======== ==== ========== ========== ========== ==========
  csr     AA   1.95±0ms   1.15±0ms   1.97±0ms   10.4±0ms 
  csr     AB   7.12±0ms   13.8±0ms   7.64±0ms   21.1±0ms 
  csr     BA   6.89±0ms   7.05±0ms   6.52±0ms   24.4±0ms 
  csr     BB   7.06±0ms   5.21±0ms   6.98±0ms   46.0±0ms 
  csc     AA   3.63±0ms   6.53±0ms   3.49±0ms   10.2±0ms 
  csc     AB   6.55±0ms   6.45±0ms   7.40±0ms   24.4±0ms 
  csc     BA   6.40±0ms   6.43±0ms   7.31±0ms   20.8±0ms 
  csc     BB   7.04±0ms   5.65±0ms   7.07±0ms   44.9±0ms 
  coo     AA   18.5±0ms   15.4±0ms   17.9±0ms   27.2±0ms 
  coo     AB   25.9±0ms   26.0±0ms   26.2±0ms   42.0±0ms 
  coo     BA   25.8±0ms   29.4±0ms   26.5±0ms   49.8±0ms 
  coo     BB   35.0±0ms   30.8±0ms   33.0±0ms   72.9±0ms 
  dia     AA   1.44±0ms   28.2±0ms   29.3±0ms   38.2±0ms 
  dia     AB   2.37±0ms   46.7±0ms   46.8±0ms   61.5±0ms 
  dia     BA   2.16±0ms   46.0±0ms   42.3±0ms   66.9±0ms 
  dia     BB   1.51±0ms   64.6±0ms   66.8±0ms   108±0ms  
======== ==== ========== ========== ========== ==========
```
(Only addition was implemented.)

##### After
```
sparse.Arithmetic.time_arithmetic                        
======== ==== ========== ========== ========== ==========
--                                 op                    
------------- -------------------------------------------
 format   XY   __add__    __sub__    multiply   __mul__  
======== ==== ========== ========== ========== ==========
  csr     AA   1.90±0ms   1.19±0ms   1.94±0ms   10.1±0ms 
  csr     AB   6.86±0ms   6.85±0ms   6.39±0ms   20.2±0ms 
  csr     BA   6.63±0ms   6.60±0ms   6.14±0ms   23.9±0ms 
  csr     BB   6.87±0ms   5.16±0ms   7.22±0ms   44.8±0ms 
  csc     AA   3.46±0ms   2.85±0ms   3.60±0ms   10.3±0ms 
  csc     AB   6.72±0ms   6.51±0ms   6.79±0ms   24.3±0ms 
  csc     BA   6.54±0ms   6.70±0ms   6.69±0ms   20.4±0ms 
  csc     BB   7.01±0ms   5.65±0ms   7.02±0ms   42.5±0ms 
  coo     AA   18.1±0ms   15.4±0ms   17.7±0ms   26.0±0ms 
  coo     AB   26.7±0ms   26.8±0ms   27.4±0ms   42.9±0ms 
  coo     BA   27.0±0ms   27.0±0ms   27.6±0ms   46.4±0ms 
  coo     BB   35.7±0ms   32.6±0ms   35.3±0ms   73.7±0ms 
  dia     AA   596±0μs    596±0μs    1.42±0ms   7.07±0ms 
  dia     AB   2.38±0ms   3.17±0ms   1.41±0ms   13.0±0ms 
  dia     BA   2.42±0ms   2.44±0ms   1.49±0ms   12.8±0ms 
  dia     BB   1.26±0ms   1.45±0ms   5.74±0ms   26.0±0ms 
======== ==== ========== ========== ========== ==========
```
(Now DIA is the most efficient in all respects, as expected.)

DIA @ dense is also implemented and has efficiency similar to CSR @ dense, so the overall performance is improved by avoiding the DIA → COO → CSR conversion.

#### Additional information
<!--Any additional information you think is important.-->
I'm not familiar with SciPy internals and didn't find technical notes about `scipy.sparse` in particular (please point out if they exist), so there are some details that might need attention:
* Are `dtype` promotions done correctly?
* Should indexing `dtype` be specified? (The existing code sometimes uses defaults and sometimes `intc`, even though `intp` should be more time-efficient under Windows, see [numpy 15513](https://github.com/numpy/numpy/issues/15513#event-13468943685).)
* Is `.ravel()` needed for arrays passed to wrapped C++ functions? (Again, seems to work without it, but some existing code uses it.)
* Should error messages be more informative and consistent? I mean, there's been some work in gh-21018, but to a very limited extent.

To complete gh-21039, divisions and comparisons also need to be implemented, but in order to do them, I need to know 
the conventions (what exactly should happen with operations on implicit zeros?).
