### PR TITLE
DOC: optimize: Mark `x1` as optional for secant root finding

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -420,8 +420,9 @@ def _root_scalar_secant_doc():
         Maximum number of iterations.
     x0 : float, required
         Initial guess.
-    x1 : float, required
-        A second guess.
+    x1 : float, optional
+        A second guess. Must be different from x0. If not specified,
+        a value near x0 will be chosen.
     options: dict, optional
         Specifies any method-specific options not covered above.
 

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -421,8 +421,8 @@ def _root_scalar_secant_doc():
     x0 : float, required
         Initial guess.
     x1 : float, optional
-        A second guess. Must be different from x0. If not specified,
-        a value near x0 will be chosen.
+        A second guess. Must be different from `x0`. If not specified,
+        a value near `x0` will be chosen.
     options: dict, optional
         Specifies any method-specific options not covered above.
 


### PR DESCRIPTION
Since gh-17691, it is no longer required to provide x1. Document this.

I also documented the conditions x1 must obey.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue


Closes #21178 
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

The documentation [here](https://scipy.github.io/devdocs/reference/optimize.root_scalar-secant.html) is misleading - x1 is not actually required.
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
