### PR TITLE
DOC: `array`->`array_like` in a few functions

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -77,10 +77,10 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
         ``xi``. `f` must be an elementwise function: each scalar element ``f(xi)[j]``
         must equal ``f(xi[j])`` for valid indices ``j``. It must not mutate the array
         ``xi`` or the arrays in ``argsi``.
-    x : real number array
+    x : float array_like
         Abscissae at which to evaluate the derivative. Must be broadcastable with
         `args` and `step_direction`.
-    args : tuple of real number arrays, optional
+    args : tuple of array_like, optional
         Additional positional array arguments to be passed to `f`. Arrays
         must be broadcastable with one another and the arrays of `init`.
         If the callable for which the root is desired requires arguments that are
@@ -111,7 +111,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     maxiter : int, default: 10
         The maximum number of iterations of the algorithm to perform. See
         Notes.
-    step_direction : integer array
+    step_direction : integer array_like
         An array representing the direction of the finite difference steps (for
         use when `x` lies near to the boundary of the domain of the function.)
         Must be broadcastable with `x` and all `args`.
@@ -708,7 +708,7 @@ def jacobian(f, x, *, tolerances=None, maxiter=10,
         `functools.partial` or ``lambda``) and pass the wrapped callable
         into `jacobian`. `f` must not mutate the array ``xi``. See Notes
         regarding vectorization and the dimensionality of the input and output.
-    x : array_like
+    x : float array_like
         Points at which to evaluate the Jacobian. Must have at least one dimension.
         See Notes regarding the dimensionality and vectorization.
     tolerances : dictionary of floats, optional

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -53,10 +53,10 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
         If ``func`` returns a value with complex dtype when evaluated at
         either endpoint, subsequent arguments ``x`` will have complex dtype
         (but zero imaginary part).
-    a, b : array_like
+    a, b : float array_like
         Real lower and upper limits of integration. Must be broadcastable.
         Elements may be infinite.
-    args : tuple, optional
+    args : tuple of array_like, optional
         Additional positional arguments to be passed to `func`. Must be arrays
         broadcastable with `a` and `b`. If the callable to be integrated
         requires arguments that are not broadcastable with `a` and `b`, wrap
@@ -957,16 +957,16 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         function of `x` defined at *all reals* between `a` and `b`.          
         `nsum` performs no checks to verify that these conditions
         are met and may return erroneous results if they are violated.
-    a, b : real number array
+    a, b : float array_like
         Real lower and upper limits of summed terms. Must be broadcastable.
         Each element of `a` must be finite and less than the corresponding
         element in `b`, but elements of `b` may be infinite.
-    step : real number array
+    step : float array_like
         Finite, positive, real step between summed terms. Must be broadcastable
         with `a` and `b`. Note that the number of terms included in the sum will
         be ``floor((b - a) / step)`` + 1; adjust `b` accordingly to ensure
         that ``f(b)`` is included if intended.
-    args : tuple of real number arrays, optional
+    args : tuple of array_like, optional
         Additional positional arguments to be passed to `f`. Must be arrays
         broadcastable with `a`, `b`, and `step`. If the callable to be summed
         requires arguments that are not broadcastable with `a`, `b`, and `step`,

--- a/scipy/optimize/_elementwise.py
+++ b/scipy/optimize/_elementwise.py
@@ -35,12 +35,12 @@ def find_root(f, init, /, *, args=(), tolerances=None, maxiter=None, callback=No
         array ``x`` or the arrays in ``args``.
 
         `find_root` seeks an array ``x`` such that ``f(x)`` is an array of zeros.
-    init : 2-tuple of real number arrays
+    init : 2-tuple of float array_like
         The lower and upper endpoints of a bracket surrounding the desired root.
         A bracket is valid if arrays ``xl, xr = init`` satisfy ``xl < xr`` and
         ``sign(f(xl)) == -sign(f(xr))`` elementwise. Arrays be broadcastable with
         one another and `args`.
-    args : tuple of real number arrays, optional
+    args : tuple of array_like, optional
         Additional positional array arguments to be passed to `f`. Arrays
         must be broadcastable with one another and the arrays of `init`.
         If the callable for which the root is desired requires arguments that are
@@ -264,13 +264,13 @@ def find_minimum(f, init, /, *, args=(), tolerances=None, maxiter=100, callback=
 
         `find_minimum` seeks an array ``x`` such that ``f(x)`` is an array of
         local minima.
-    init : 3-tuple of real number arrays
+    init : 3-tuple of float array_like
         The abscissae of a standard scalar minimization bracket. A bracket is
         valid if arrays ``x1, x2, x3 = init`` satisfy ``x1 < x2 < x3`` and
         ``func(x1) >= func(x2) <= func(x3)``, where one of the inequalities
         is strict. Arrays must be broadcastable with one another and the arrays
         of `args`.
-    args : tuple of real number arrays, optional
+    args : tuple of array_like, optional
         Additional positional array arguments to be passed to `f`. Arrays
         must be broadcastable with one another and the arrays of `init`.
         If the callable for which the root is desired requires arguments that are
@@ -487,16 +487,16 @@ def bracket_root(f, xl0, xr0=None, *, xmin=None, xmax=None, factor=None, args=()
         `f` must be an elementwise function: each element ``f(x)[i]``
         must equal ``f(x[i])`` for all indices ``i``. It must not mutate the
         array ``x`` or the arrays in ``args``.
-    xl0, xr0: float array
+    xl0, xr0: float array_like
         Starting guess of bracket, which need not contain a root. If `xr0` is
         not provided, ``xr0 = xl0 + 1``. Must be broadcastable with all other
         array inputs.
-    xmin, xmax : float array, optional
+    xmin, xmax : float array_like, optional
         Minimum and maximum allowable endpoints of the bracket, inclusive. Must
         be broadcastable with all other array inputs.
-    factor : float array, default: 2
+    factor : float array_like, default: 2
         The factor used to grow the bracket. See Notes.
-    args : tuple of arrays, optional
+    args : tuple of array_like, optional
         Additional positional array arguments to be passed to `f`.
         If the callable for which the root is desired requires arguments that are
         not broadcastable with `x`, wrap that callable with `f` such that `f`
@@ -660,9 +660,9 @@ def bracket_minimum(f, xm0, *, xl0=None, xr0=None, xmin=None, xmax=None,
     xmin, xmax : float array_like, optional
         Minimum and maximum allowable endpoints of the bracket, inclusive. Must
         be broadcastable with all other array inputs.
-    factor : float array, default: 2
+    factor : float array_like, default: 2
         The factor used to grow the bracket. See Notes.
-    args : tuple of arrays, optional
+    args : tuple of array_like, optional
         Additional positional array arguments to be passed to `f`.
         If the callable for which the root is desired requires arguments that are
         not broadcastable with `x`, wrap that callable with `f` such that `f`


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/pull/20834#pullrequestreview-2175097036

#### What does this implement/fix?
Changes `array` to `array_like` in the documentation of a few functions.