### PR TITLE
MAINT: `stats.differential_entropy`: fix results with integer input and `method='ebrahimi'`

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -319,7 +319,7 @@ def differential_entropy(
     """
     xp = array_namespace(values)
     values = xp.asarray(values)
-    if xp.isdtype(values.dtype, "integral"):
+    if xp.isdtype(values.dtype, "integral"):  # type: ignore[union-attr]
         values = xp.astype(values, xp.asarray(1.).dtype)
     values = xp_moveaxis_to_end(values, axis, xp=xp)
     n = values.shape[-1]  # type: ignore[union-attr]
@@ -363,7 +363,7 @@ def differential_entropy(
 
     # avoid dtype changes due to data-apis/array-api-compat#152
     # can be removed when data-apis/array-api-compat#152 is resolved
-    return xp.astype(res, values.dtype)
+    return xp.astype(res, values.dtype)  # type: ignore[union-attr]
 
 
 def _pad_along_last_axis(X, m, *, xp):

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -319,6 +319,8 @@ def differential_entropy(
     """
     xp = array_namespace(values)
     values = xp.asarray(values)
+    if xp.isdtype(values.dtype, "integral"):
+        values = xp.astype(values, xp.asarray(1.).dtype)
     values = xp_moveaxis_to_end(values, axis, xp=xp)
     n = values.shape[-1]  # type: ignore[union-attr]
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -361,7 +361,9 @@ def differential_entropy(
     if base is not None:
         res /= math.log(base)
 
-    return res
+    # avoid dtype changes due to data-apis/array-api-compat#152
+    # can be removed when data-apis/array-api-compat#152 is resolved
+    return xp.astype(res, values.dtype)
 
 
 def _pad_along_last_axis(X, m, *, xp):

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -8,7 +8,8 @@ from scipy import stats
 from scipy.stats import norm, expon  # type: ignore[attr-defined]
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
-                                   is_jax, is_array_api_strict, array_namespace)
+                                   is_jax, is_array_api_strict, array_namespace,
+                                   is_numpy)
 
 class TestEntropy:
     @array_api_compatible
@@ -310,3 +311,20 @@ class TestDifferentialEntropy:
         res1 = stats.differential_entropy(rvs)
         res2 = stats.differential_entropy(rvs, method=method)
         xp_assert_equal(res1, res2)
+
+    @pytest.mark.skip_xp_backends('jax.numpy',
+                                  reason=["JAX doesn't support item assignment"])
+    @pytest.mark.parametrize('method', ["vasicek", "van es", "correa", "ebrahimi"])
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_dtypes_gh21192(self, xp, method, dtype):
+        # gh-21192 noted a change in the output of method='ebrahimi'
+        # with integer input. Check that the output is consistent regardless
+        # of input dtype.
+        if is_array_api_strict(xp) and method == 'correa':
+            pytest.xfail("Needs fancy indexing.")
+        x = [1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11]
+        dtype_in = getattr(xp, str(dtype), None)
+        dtype_out = getattr(xp, str(dtype), xp.asarray(1.).dtype)
+        res = stats.differential_entropy(xp.asarray(x, dtype=dtype_in), method=method)
+        ref = stats.differential_entropy(xp.asarray(x, dtype=xp.float64), method=method)
+        xp_assert_close(res, xp.asarray(ref, dtype=dtype_out)[()])

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -8,8 +8,7 @@ from scipy import stats
 from scipy.stats import norm, expon  # type: ignore[attr-defined]
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
-                                   is_jax, is_array_api_strict, array_namespace,
-                                   is_numpy)
+                                   is_jax, is_array_api_strict, array_namespace)
 
 class TestEntropy:
     @array_api_compatible


### PR DESCRIPTION
#### Reference issue
Closes gh-21192

#### What does this implement/fix?
gh-21192 reported that the result of `stats.differential_entropy` with `method='ebrahimi'` changed with integer input after the release of SciPy 1.14.0. 

Although integer input is unexpected since the function is documented to accept samples from a continuous distribution, integer input is not rejected, so this PR fixes the discrepancy. 

While testing, I noticed that data-apis/array-api-compat#152 could cause trouble, and output dtypes would change when the array API 2023.12 rules kick in. In the meantime, enforce the dtype so that there is no sudden change.