### PR TITLE
DOC: Fix type of ``html_sidebars`` value in ``conf.py``

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -195,7 +195,7 @@ html_logo = '_static/logo.svg'
 html_favicon = '_static/favicon.ico'
 
 html_sidebars = {
-    "index": "search-button-field",
+    "index": ["search-button-field"],
     "**": ["search-button-field", "sidebar-nav-bs"]
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -184,6 +184,10 @@ warnings.filterwarnings(
     message=r'There is no current event loop',
     category=DeprecationWarning,
 )
+# See https://github.com/sphinx-doc/sphinx/issues/12589
+suppress_warnings = [
+    'autosummary.import_cycle',
+]
 
 # -----------------------------------------------------------------------------
 # HTML output


### PR DESCRIPTION
#### Reference issue
* Resolves #21195

#### What does this implement/fix?
Support for string values in ``html_sidebars`` has been officially removed since Sphinx 2.0, but somehow seemed to work. Nevertheless, this resovlves the issue before a new version of Sphinx is resolved.

#### Additional information
* I intend to release a new version of Sphinx to make the error here more obvious, but it will still need fixing.
* See also https://github.com/sphinx-doc/sphinx/issues/12593#issuecomment-2231631067 for an in-depth explanation.

A