### PR TITLE
BUG: optimize: Avoid sharing BFGS HessianUpdateStrategy between constraints

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -105,9 +105,11 @@ class NonlinearConstraint:
     >>> nlc = NonlinearConstraint(con, -np.inf, 1.9)
 
     """
-    def __init__(self, fun, lb, ub, jac='2-point', hess=BFGS(),
+    def __init__(self, fun, lb, ub, jac='2-point', hess=None,
                  keep_feasible=False, finite_diff_rel_step=None,
                  finite_diff_jac_sparsity=None):
+        if hess is None:
+            hess = BFGS()
         self.fun = fun
         self.lb = lb
         self.ub = ub

--- a/scipy/optimize/_trustregion_constr/tests/meson.build
+++ b/scipy/optimize/_trustregion_constr/tests/meson.build
@@ -3,7 +3,8 @@ py3.install_sources([
     'test_canonical_constraint.py',
     'test_projections.py',
     'test_qp_subproblem.py',
-    'test_report.py'
+    'test_report.py',
+    'test_nested_minimize.py'
   ],
   subdir: 'scipy/optimize/_trustregion_constr/tests',
   install_tag: 'tests'

--- a/scipy/optimize/_trustregion_constr/tests/test_nested_minimize.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_nested_minimize.py
@@ -1,0 +1,37 @@
+import pytest
+import numpy as np
+from scipy.optimize import minimize, NonlinearConstraint, rosen, rosen_der
+
+
+# Ignore this warning about inefficient use of Hessians
+# The bug only shows up with the default HUS
+@pytest.mark.filterwarnings("ignore:Check if the approximated function is linear")
+def test_gh21193():
+    # Test that nested minimization does not share Hessian objects
+    def identity(x):
+        return x[0]
+    def identity_jac(x):
+        a = np.zeros(len(x))
+        a[0] = 1
+        return a
+    constraint1 = NonlinearConstraint(identity, 0, 0, identity_jac)
+    constraint2 = NonlinearConstraint(identity, 0, 0, identity_jac)
+
+    # The default HUS for each should be distinct
+    assert constraint1.hess is not constraint2.hess
+
+    _ = minimize(
+        lambda x: minimize(
+            rosen,
+            x[1:],
+            jac=rosen_der,
+            constraints=constraint1,
+            method="trust-constr",
+            options={'maxiter': 2},
+        ).fun,
+        [1, 0, 0],
+        constraints=constraint2,
+        method="trust-constr",
+        options={'maxiter': 2},
+    )
+    # This test doesn't check that the output is correct, just that it doesn't crash

--- a/scipy/optimize/_trustregion_constr/tests/test_nested_minimize.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_nested_minimize.py
@@ -5,7 +5,9 @@ from scipy.optimize import minimize, NonlinearConstraint, rosen, rosen_der
 
 # Ignore this warning about inefficient use of Hessians
 # The bug only shows up with the default HUS
-@pytest.mark.filterwarnings("ignore:Check if the approximated function is linear")
+@pytest.mark.filterwarnings(
+    "ignore:delta_grad == 0.0. Check if the approximated function is linear."
+)
 def test_gh21193():
     # Test that nested minimization does not share Hessian objects
     def identity(x):


### PR DESCRIPTION
If default BFGS object is shared between constraints, it is possible for two nested minimizers to both update the same object. Construct a new BFGS object each time to avoid this.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #21193
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

If someone is using minimize() with a function which itself calls minimize(), using constraints and a different number of variables in each one, this can cause a crash.

I believe this issue is specific to trust-constr: as far as I know, it is the only optimizer which 1) supports constraints and 2) makes use of Hessian information within constraints, both of which are needed to trigger this issue.

However, the bug is not in trust-constr, but in NonlinearConstraint. Specifically, it use a mutable default argument for the hess function. This means that the BFGS object will be shared between two different minimization problems.

This is likely also a problem if multithreading is in use, though I did not test this.

#### Regression test

I tried to write a regression test, but I am unsure of two things.

1. Should I write a regression test that calls minimize() in a manner similar to the original bug report? Or should it just construct two NonlinearConstraints, and check that .hess points to a different object in each one?
2. Where should the test go? It could go with trust-constr, since this is a trust-constr specific bug. It could also go with the NonlinearConstraint tests, since the fix happens in NonlinearConstraint.

Example of end to end test:

```
def test_bfgs_update_no_shape_error():
    # Test that nested minimization does not share Hessian objects
    # gh-21193
    identity = lambda x: x[0]
    constraint1 = NonlinearConstraint(identity, 0, 0)
    constraint2 = NonlinearConstraint(identity, 0, 0)

    _ = minimize(
        lambda x: minimize(
            rosen,
            x[1:],
            constraints=constraint1,
            method="trust-constr",
            options={'maxiter': 2},
        ).fun,
        [1, 0, 0],
        constraints=constraint2,
        method="trust-constr",
        options={'maxiter': 2},
    )
```

Example of checking that hess is not shared:

```
import numpy as np
from scipy import optimize


def constraint_a(x):
    return x[0]


def constraint_b(x):
    return -x[0]


constraint1 = optimize.NonlinearConstraint(constraint_a, 0, 0)
constraint2 = optimize.NonlinearConstraint(constraint_b, 0, 0)
assert constraint1.hess is not constraint2.hess
```
<!--Any additional information you think is important.-->
