### PR TITLE
MAINT: ensure Python.h is included first in __minpack.c

### DIFF
--- a/scipy/optimize/__minpack.c
+++ b/scipy/optimize/__minpack.c
@@ -110,9 +110,10 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include "__minpack.h"
 #include <stdlib.h>
 #include <math.h>
-#include "__minpack.h"
+
 
 // Internal routines
 static void dogleg(const int,const double*,const double*,const double*,const double*,double*,double*,double*);

--- a/scipy/optimize/__minpack.h
+++ b/scipy/optimize/__minpack.h
@@ -7,6 +7,7 @@
   {"_lmder", minpack_lmder, METH_VARARGS, doc_lmder},
   {"_chkder", minpack_chkder, METH_VARARGS, doc_chkder},
  */
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "ccallback.h"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/02591ba5-a1b5-4c1c-ba46-f6e9d11bee88)
This came up running `python dev.py lint`, not sure why CI didn't fail?