### PR TITLE
DEP: signal.{correlate,convolve,lfilter}: deprecate object arrays and longdoubles

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -94,7 +94,7 @@ def _inputs_swap_needed(mode, shape1, shape2, axes=None):
 
 
 def _reject_objects(arr, name):
-    """Warn if arr.dtype is object or longdouble or float16.
+    """Warn if arr.dtype is object or longdouble.
     """
     dt = np.asarray(arr).dtype
     if not (np.issubdtype(dt, np.integer)
@@ -103,7 +103,7 @@ def _reject_objects(arr, name):
     ):
         msg = (
             f"dtype={dt} is not supported by {name} and will raise an error in "
-            f"SciPy 1.17.0. Supported dtypes are: boolean, integer, np.float16,"
+            f"SciPy 1.17.0. Supported dtypes are: boolean, integer, `np.float16`,"
             f"`np.float32`, `np.float64`, `np.complex64`, `np.complex128`."
         )
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -93,6 +93,18 @@ def _inputs_swap_needed(mode, shape1, shape2, axes=None):
     return not ok1
 
 
+def _reject_objects(arr, name):
+    """Warn if arr.dtype is object or longdouble or float16.
+    """
+    dt = np.asarray(arr).dtype
+    if not (np.issubdtype(dt, np.integer)
+            or dt in [np.bool_, np.float32, np.float64, np.complex64, np.complex128]
+    ):
+        warnings.warn(f"dtype={dt} is not supported by {name}",
+                      category=DeprecationWarning, stacklevel=2
+        )
+
+
 def correlate(in1, in2, mode='full', method='auto'):
     r"""
     Cross-correlate two N-dimensional arrays.
@@ -229,6 +241,8 @@ def correlate(in1, in2, mode='full', method='auto'):
     """
     in1 = np.asarray(in1)
     in2 = np.asarray(in2)
+    _reject_objects(in1, 'correlate')
+    _reject_objects(in1, 'correlate')
 
     if in1.ndim == in2.ndim == 0:
         return in1 * in2.conj()
@@ -1273,6 +1287,9 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     volume = np.asarray(in1)
     kernel = np.asarray(in2)
 
+    _reject_objects(in1, 'choose_conv_method')
+    _reject_objects(in1, 'choose_conv_method')
+
     if measure:
         times = {}
         for method in ['fft', 'direct']:
@@ -1401,6 +1418,9 @@ def convolve(in1, in2, mode='full', method='auto'):
     """
     volume = np.asarray(in1)
     kernel = np.asarray(in2)
+
+    _reject_objects(volume, 'correlate')
+    _reject_objects(kernel, 'correlate')
 
     if volume.ndim == kernel.ndim == 0:
         return volume * kernel
@@ -2077,6 +2097,11 @@ def lfilter(b, a, x, axis=-1, zi=None):
     """
     b = np.atleast_1d(b)
     a = np.atleast_1d(a)
+
+    _reject_objects(x, 'lfilter')
+    _reject_objects(a, 'lfilter')
+    _reject_objects(b, 'lfilter')
+
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
         # Any of b, a, x, or zi can set the dtype, but there is no default

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -98,11 +98,12 @@ def _reject_objects(arr, name):
     """
     dt = np.asarray(arr).dtype
     if not (np.issubdtype(dt, np.integer)
-            or dt in [np.bool_, np.float32, np.float64, np.complex64, np.complex128]
+            or dt in [np.bool_, np.float16, np.float32, np.float64,
+                      np.complex64, np.complex128]
     ):
         msg = (
             f"dtype={dt} is not supported by {name} and will raise an error in "
-            f"SciPy 1.17.0. Supported dtypes are: boolean, integer, "
+            f"SciPy 1.17.0. Supported dtypes are: boolean, integer, np.float16,"
             f"`np.float32`, `np.float64`, `np.complex64`, `np.complex128`."
         )
         warnings.warn(msg, category=DeprecationWarning, stacklevel=3)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -100,10 +100,12 @@ def _reject_objects(arr, name):
     if not (np.issubdtype(dt, np.integer)
             or dt in [np.bool_, np.float32, np.float64, np.complex64, np.complex128]
     ):
-        warnings.warn(f"dtype={dt} is not supported by {name} and will raise "
-                      f"an error in SciPy 1.17.0",
-                      category=DeprecationWarning, stacklevel=3
+        msg = (
+            f"dtype={dt} is not supported by {name} and will raise an error in "
+            f"SciPy 1.17.0. Supported dtypes are: boolean, integer, "
+            f"`np.float32`, `np.float64`, `np.complex64`, `np.complex128`."
         )
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
 
 
 def correlate(in1, in2, mode='full', method='auto'):

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1026,7 +1026,7 @@ def _numeric_arrays(arrays, kinds='buifc'):
         the ndarrays are not in this string the function returns False and
         otherwise returns True.
     """
-    if type(arrays) == np.ndarray:
+    if isinstance(arrays, np.ndarray):
         return arrays.dtype.kind in kinds
     for array_ in arrays:
         if array_.dtype.kind not in kinds:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -100,7 +100,8 @@ def _reject_objects(arr, name):
     if not (np.issubdtype(dt, np.integer)
             or dt in [np.bool_, np.float32, np.float64, np.complex64, np.complex128]
     ):
-        warnings.warn(f"dtype={dt} is not supported by {name}",
+        warnings.warn(f"dtype={dt} is not supported by {name} and will raise "
+                      f"an error in SciPy 1.17.0",
                       category=DeprecationWarning, stacklevel=2
         )
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -102,7 +102,7 @@ def _reject_objects(arr, name):
     ):
         warnings.warn(f"dtype={dt} is not supported by {name} and will raise "
                       f"an error in SciPy 1.17.0",
-                      category=DeprecationWarning, stacklevel=2
+                      category=DeprecationWarning, stacklevel=3
         )
 
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -185,7 +185,7 @@ class TestConvolve(_TestConvolve):
         # this types data structure was manually encoded instead of
         # using custom filters on the soon-to-be-removed np.sctypes
         types = {'uint16', 'uint64', 'int64', 'int32',
-                 'complex128', 'float64', 'float16',
+                 'complex128', 'float64',
                  'complex64', 'float32', 'int16',
                  'uint8', 'uint32', 'int8', 'bool'}
         args = [(t1, t2, mode) for t1 in types for t2 in types
@@ -200,8 +200,6 @@ class TestConvolve(_TestConvolve):
         array_types['c'] = array_types['f'] + 0.5j*array_types['f']
 
         for t1, t2, mode in args:
-            if t1 == 'float16' or t2 == 'float16':
-                pytest.skip("float16 is deprecated in correlate")
 
             x1 = array_types[np.dtype(t1).kind].astype(t1)
             x2 = array_types[np.dtype(t2).kind].astype(t2)
@@ -251,6 +249,13 @@ class TestConvolve(_TestConvolve):
         assert_raises(ValueError, convolve, 1, [2], method='fft')
         assert_raises(ValueError, convolve, [1], [[2]])
         assert_raises(ValueError, convolve, [3], 2)
+
+    def test_dtype_deprecation(self):
+        # gh-21211
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
+        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+            convolve(a, b)
 
 
 class _TestConvolve2d:
@@ -1848,6 +1853,13 @@ class _TestLinearFilter:
             lfilter(np.array([1.0]), np.array([1.0]), data),
             lfilter(b, a, data))
 
+    def test_dtype_deprecation(self):
+        # gh-21211
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
+        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+            lfilter(a, b, [1, 2, 3, 4])
+
 
 class TestLinearFilterFloat32(_TestLinearFilter):
     dtype = np.dtype('f')
@@ -2078,6 +2090,13 @@ class TestCorrelate:
         assert_allclose(correlate(a, b, mode='same'), [17, 32, 23])
         assert_allclose(correlate(a, b, mode='full'), [6, 17, 32, 23, 12])
         assert_allclose(correlate(a, b, mode='valid'), [32])
+
+    def test_dtype_deprecation(self):
+        # gh-21211
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
+        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+            correlate(a, b)
 
 
 @pytest.mark.parametrize("mode", ["valid", "same", "full"])
@@ -2475,6 +2494,13 @@ def test_choose_conv_method():
         x = np.array([2**51], dtype=np.int64)
         h = x.copy()
         assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
+
+def test_choose_conv_dtype_deprecation():
+    # gh-21211
+    a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
+    b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
+    with pytest.deprecated_call(match="dtype=float16 is not supported"):
+        choose_conv_method(a, b)
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -185,7 +185,7 @@ class TestConvolve(_TestConvolve):
         # this types data structure was manually encoded instead of
         # using custom filters on the soon-to-be-removed np.sctypes
         types = {'uint16', 'uint64', 'int64', 'int32',
-                 'complex128', 'float64',
+                 'complex128', 'float64', 'float16',
                  'complex64', 'float32', 'int16',
                  'uint8', 'uint32', 'int8', 'bool'}
         args = [(t1, t2, mode) for t1 in types for t2 in types
@@ -200,7 +200,6 @@ class TestConvolve(_TestConvolve):
         array_types['c'] = array_types['f'] + 0.5j*array_types['f']
 
         for t1, t2, mode in args:
-
             x1 = array_types[np.dtype(t1).kind].astype(t1)
             x2 = array_types[np.dtype(t2).kind].astype(t2)
 
@@ -252,9 +251,9 @@ class TestConvolve(_TestConvolve):
 
     def test_dtype_deprecation(self):
         # gh-21211
-        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
-        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
-        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=object)
+        with pytest.deprecated_call(match="dtype=object is not supported"):
             convolve(a, b)
 
 
@@ -1855,9 +1854,9 @@ class _TestLinearFilter:
 
     def test_dtype_deprecation(self):
         # gh-21211
-        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
-        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
-        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=object)
+        with pytest.deprecated_call(match="dtype=object is not supported"):
             lfilter(a, b, [1, 2, 3, 4])
 
 
@@ -2093,9 +2092,9 @@ class TestCorrelate:
 
     def test_dtype_deprecation(self):
         # gh-21211
-        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
-        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
-        with pytest.deprecated_call(match="dtype=float16 is not supported"):
+        a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
+        b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=object)
+        with pytest.deprecated_call(match="dtype=object is not supported"):
             correlate(a, b)
 
 
@@ -2497,9 +2496,9 @@ def test_choose_conv_method():
 
 def test_choose_conv_dtype_deprecation():
     # gh-21211
-    a = np.asarray([1, 2, 3, 6, 5, 3], dtype=np.float16)
-    b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=np.float16)
-    with pytest.deprecated_call(match="dtype=float16 is not supported"):
+    a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
+    b = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=object)
+    with pytest.deprecated_call(match="dtype=object is not supported"):
         choose_conv_method(a, b)
 
 


### PR DESCRIPTION
Following up on the discussion at https://github.com/scipy/scipy/pull/20772#issuecomment-2217614468, here is proposal to deprecate using object arrays and longdoubles in `scipy.signal.{correlate,convolve,lfilter}`. 

The intended use cases were, judging by tests, dealing with arrays of Decimals. The relevant C code has been there "forever" (since when multipack was a thing), and is very likely buggy since then (cf  this comment https://github.com/scipy/scipy/blob/main/scipy/signal/_lfilter.c.in#L679).

Whether these are used in the wild is a tough question to answer. A gut feeling is "not much", and as a  data point, we had no complaints when we recently (in the 1.11-1.14 timeframe) removed object and longdouble support in medfilt (https://github.com/scipy/scipy/pull/19673 and https://github.com/scipy/scipy/pull/18341). So most likely, it won't be a large loss if these are gone.

This PR is currently also removes float16 support. This might be a bit on a too-wide-sweep side, and I'm happy to roll it back. OTOH, the "support" currently seems to be just upcasting to wider float types, so this deprecation might be okay, too.