### PR TITLE
MAINT, DOC: bump jupyterlite-sphinx lower bound

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,9 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
+            # TODO: remove jupyterlite-sphinx pin when
+            # gh-21212 is resolved upstream
+            python -m pip install jupyterlite-sphinx==0.15.0
             python dev.py --no-build doc 2>&1 | tee sphinx_log.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,6 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
-            # TODO: remove jupyterlite-sphinx pin when
-            # gh-21212 is resolved upstream
-            python -m pip install jupyterlite-sphinx==0.15.0
             python dev.py --no-build doc 2>&1 | tee sphinx_log.txt
 
       - run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ doc = [
     "jupytext",
     "myst-nb",
     "pooch",
-    "jupyterlite-sphinx>=0.13.1",
+    "jupyterlite-sphinx>=0.16.2",
     "jupyterlite-pyodide-kernel",
 ]
 dev = [

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,5 +9,5 @@ numpydoc
 jupytext
 myst-nb
 pooch
-jupyterlite-sphinx>=0.13.1
+jupyterlite-sphinx>=0.16.2
 jupyterlite-pyodide-kernel


### PR DESCRIPTION
~~* Two versions of `jupyterlite-sphinx` were released in the last 5 hours, and neither one works with our doc build per gh-21212, so just pin for now. (I did confirm locally)~~

Update: just bump the lower bound for `jupyterlite-sphinx` now that there's an upstream fix.

[skip actions] [skip cirrus]