### PR TITLE
BUG: sparse: fix two slow tests that fail in numpy 2 inside A.nnz

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -215,8 +215,8 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
         if axis is not None:
             raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for BSR format")
-        R,C = self.blocksize
-        return int(self.indptr[-1] * R * C)
+        R, C = self.blocksize
+        return int(self.indptr[-1]) * R * C
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 


### PR DESCRIPTION
As reported in #21144 two tests marked slow fail with numpy 2 due to overflow during `A.transpose()`, but the underlying overflow RunTimeWarning comes during `A.nnz` when we calculate `int(self.indptr[-1] * R * C)`.

In numpy 2 scalars overflow in arithmetic with python numbers. So we need to convert to `int` to protect against overflows.  This PR changes the faulty code to: `int(self.indptr[-1]) * R * C`.

Fixes #21144 