### PR TITLE
BUG: sparse: fix failing doctests in io and csgraph that print sparse

### DIFF
--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -499,11 +499,11 @@ def hb_read(path_or_open_file):
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
     <Compressed Sparse Column sparse matrix of dtype 'float64'
-    	with 3 stored elements and shape (3, 3)>
-    	Coords	Values
-    	(0, 0)	1.0
-    	(1, 1)	1.0
-    	(2, 2)	1.0
+        with 3 stored elements and shape (3, 3)>
+        Coords	Values
+        (0, 0)	1.0
+        (1, 1)	1.0
+        (2, 2)	1.0
     """
     def _get_matrix(fid):
         hb = HBFile(fid)
@@ -552,11 +552,11 @@ def hb_write(path_or_open_file, m, hb_info=None):
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
     <Compressed Sparse Column sparse matrix of dtype 'float64'
-    	with 3 stored elements and shape (3, 3)>
-    	Coords	Values
-    	(0, 0)	1.0
-    	(1, 1)	1.0
-    	(2, 2)	1.0
+        with 3 stored elements and shape (3, 3)>
+        Coords	Values
+        (0, 0)	1.0
+        (1, 1)	1.0
+        (2, 2)	1.0
     """
     m = m.tocsc(copy=False)
 

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -498,9 +498,12 @@ def hb_read(path_or_open_file):
     >>> data = csr_array(eye(3))  # create a sparse array
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
-    (np.int32(0), np.int32(0))	1.0
-    (np.int32(1), np.int32(1))	1.0
-    (np.int32(2), np.int32(2))	1.0
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+    	with 3 stored elements and shape (3, 3)>
+    	Coords	Values
+    	(0, 0)	1.0
+    	(1, 1)	1.0
+    	(2, 2)	1.0
     """
     def _get_matrix(fid):
         hb = HBFile(fid)
@@ -548,9 +551,12 @@ def hb_write(path_or_open_file, m, hb_info=None):
     >>> data = csr_array(eye(3))  # create a sparse array
     >>> hb_write("data.hb", data)  # write a hb file
     >>> print(hb_read("data.hb"))  # read a hb file
-    (np.int32(0), np.int32(0))	1.0
-    (np.int32(1), np.int32(1))	1.0
-    (np.int32(2), np.int32(2))	1.0
+    <Compressed Sparse Column sparse matrix of dtype 'float64'
+    	with 3 stored elements and shape (3, 3)>
+    	Coords	Values
+    	(0, 0)	1.0
+    	(1, 1)	1.0
+    	(2, 2)	1.0
     """
     m = m.tocsc(copy=False)
 

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -60,13 +60,13 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     >>> graph = csr_matrix(graph)
     >>> print(graph)
     <Compressed Sparse Row sparse matrix of dtype 'int64'
-    	with 5 stored elements and shape (4, 4)>
-    	Coords	Values
-    	(0, 1)	1
-    	(0, 2)	2
-    	(1, 3)	1
-    	(2, 0)	2
-    	(2, 3)	3
+        with 5 stored elements and shape (4, 4)>
+        Coords	Values
+        (0, 1)	1
+        (0, 2)	2
+        (1, 3)	1
+        (2, 0)	2
+        (2, 3)	3
 
     >>> reverse_cuthill_mckee(graph)
     array([3, 2, 1, 0], dtype=int32)
@@ -219,16 +219,16 @@ def structural_rank(graph):
     >>> graph = csr_matrix(graph)
     >>> print(graph)
     <Compressed Sparse Row sparse matrix of dtype 'int64'
-    	with 8 stored elements and shape (4, 4)>
-    	Coords	Values
-    	(0, 1)	1
-    	(0, 2)	2
-    	(1, 0)	1
-    	(1, 3)	1
-    	(2, 0)	2
-    	(2, 3)	3
-    	(3, 1)	1
-    	(3, 2)	3
+        with 8 stored elements and shape (4, 4)>
+        Coords	Values
+        (0, 1)	1
+        (0, 2)	2
+        (1, 0)	1
+        (1, 3)	1
+        (2, 0)	2
+        (2, 3)	3
+        (3, 1)	1
+        (3, 2)	3
 
     >>> structural_rank(graph)
     4

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -59,11 +59,14 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> reverse_cuthill_mckee(graph)
     array([3, 2, 1, 0], dtype=int32)
@@ -215,14 +218,17 @@ def structural_rank(graph):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(0))	1
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
-      (np.int32(3), np.int32(1))	1
-      (np.int32(3), np.int32(2))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 8 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 0)	1
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
+    	(3, 1)	1
+    	(3, 2)	3
 
     >>> structural_rank(graph)
     4

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -148,11 +148,14 @@ def shortest_path(csgraph, method='auto',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -296,11 +299,14 @@ def floyd_warshall(csgraph, directed=True,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> dist_matrix, predecessors = floyd_warshall(csgraph=graph, directed=False, return_predecessors=True)
     >>> dist_matrix
@@ -522,10 +528,13 @@ def dijkstra(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 4 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 3)	3
 
     >>> dist_matrix, predecessors = dijkstra(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1016,11 +1025,14 @@ def bellman_ford(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> dist_matrix, predecessors = bellman_ford(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1253,11 +1265,14 @@ def johnson(csgraph, directed=True, indices=None,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> dist_matrix, predecessors = johnson(csgraph=graph, directed=False, indices=0, return_predecessors=True)
     >>> dist_matrix
@@ -1783,11 +1798,14 @@ def yen(
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> dist_array, predecessors = yen(csgraph=graph, source=0, sink=3, K=2,
     ...                                directed=False, return_predecessors=True)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -453,10 +453,13 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-       (np.int32(0), np.int32(1))	1
-       (np.int32(0), np.int32(2))	2
-       (np.int32(1), np.int32(3))	1
-       (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 4 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 3)	3
 
     >>> pred = np.array([-9999, 0, 0, 1], dtype=np.int32)
 
@@ -570,10 +573,13 @@ def construct_dist_matrix(graph,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-       (np.int32(0), np.int32(1))	1
-       (np.int32(0), np.int32(2))	2
-       (np.int32(1), np.int32(3))	1
-       (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 4 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 3)	3
 
     >>> pred = np.array([[-9999, 0, 0, 2],
     ...                  [1, -9999, 0, 1],

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -75,10 +75,13 @@ def connected_components(csgraph, directed=True, connection='weak',
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	1
-      (np.int32(1), np.int32(2))	1
-      (np.int32(3), np.int32(4))	1
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 4 stored elements and shape (5, 5)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	1
+    	(1, 2)	1
+    	(3, 4)	1
 
     >>> n_components, labels = connected_components(csgraph=graph, directed=False, return_labels=True)
     >>> n_components
@@ -332,11 +335,14 @@ cpdef breadth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-      (np.int32(0), np.int32(1))	1
-      (np.int32(0), np.int32(2))	2
-      (np.int32(1), np.int32(3))	1
-      (np.int32(2), np.int32(0))	2
-      (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> breadth_first_order(graph,0)
     (array([0, 1, 2, 3], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))
@@ -538,11 +544,14 @@ cpdef depth_first_order(csgraph, i_start,
     ... ]
     >>> graph = csr_matrix(graph)
     >>> print(graph)
-    (np.int32(0), np.int32(1))	1
-    (np.int32(0), np.int32(2))	2
-    (np.int32(1), np.int32(3))	1
-    (np.int32(2), np.int32(0))	2
-    (np.int32(2), np.int32(3))	3
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+    	with 5 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 1)	1
+    	(0, 2)	2
+    	(1, 3)	1
+    	(2, 0)	2
+    	(2, 3)	3
 
     >>> depth_first_order(graph,0)
     (array([0, 1, 3, 2], dtype=int32), array([-9999,     0,     0,     1], dtype=int32))


### PR DESCRIPTION
A number of doctests in csgraph and io are making smoke-docs fail. They mismatch the output from `str(sparse)` due to crossing PRs #20649 and #20127. 

The fix involves changing the doctests to match the output of sparse's `__str__` method.

~~There is still an error in signal for the smoke-docs tests involving a determinant dividing by zero (that presumably wasn't a RunTimeWarning before numpy 2.0).  I didn't try to fix that here as the cause is different and it wasn't there 13 hours ago according to #21238~~

Some issues discussing this problem include:
Fixes #21238
It is also related to #20960 but there are other issues there too so other fixes may be needed there.