### PR TITLE
DOC: add sphinx-copybutton

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
     'numpydoc',
+    'sphinx_copybutton',
     'sphinx_design',
     'scipyoptdoc',
     'doi_role',
@@ -267,6 +268,10 @@ html_file_suffix = '.html'
 htmlhelp_basename = 'scipy'
 
 mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
+
+# sphinx-copybutton configurations
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.{3,}: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # -----------------------------------------------------------------------------
 # Intersphinx configuration

--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,7 @@ dependencies:
   - setuptools<67.3  # avoid pkg_resources deprecation warnings from MPL/scikit-umfpack
   - matplotlib
   - pydata-sphinx-theme>=0.15.2
+  - sphinx-copybutton
   - sphinx-design
   - jupytext
   - myst-nb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ doc = [
     "sphinx>=5.0.0",
     "intersphinx_registry",
     "pydata-sphinx-theme>=0.15.2",
+    "sphinx-copybutton",
     "sphinx-design>=0.4.0",
     "matplotlib>=3.5",
     "numpydoc",

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -3,6 +3,7 @@
 sphinx>=5.0.0
 intersphinx_registry
 pydata-sphinx-theme>=0.15.2
+sphinx-copybutton
 sphinx-design>=0.4.0
 matplotlib>=3.5
 numpydoc


### PR DESCRIPTION
This PR adds a copy-button to all code blocks. If there are text prompts in the code block, the setting for the `copybutton_prompt_text` is configured to copy only the code and removes the text prompts. If there are no text prompts, the whole cell is copied.

- [ ] closes #21241