### PR TITLE
MAINT: BUG: fixed issue where optimization method trust-constr evaluated bound constraint violating iterations

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -536,7 +536,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
             xtol, state, initial_barrier_parameter,
             initial_barrier_tolerance,
             initial_constr_penalty, initial_tr_radius,
-            factorization_method)
+            factorization_method, finite_diff_bounds)
 
     # Status 3 occurs when the callback function requests termination,
     # this is assumed to not be a success.

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -32,7 +32,7 @@ class BarrierSubproblem:
                  constr, jac, barrier_parameter, tolerance,
                  enforce_feasibility, global_stop_criteria,
                  xtol, fun0, grad0, constr_ineq0, jac_ineq0, constr_eq0,
-                 jac_eq0):
+                 jac_eq0, finite_diff_bounds):
         # Store parameters
         self.n_vars = n_vars
         self.x0 = x0
@@ -54,6 +54,8 @@ class BarrierSubproblem:
         self.constr0 = self._compute_constr(constr_ineq0, constr_eq0, s0)
         self.jac0 = self._compute_jacobian(jac_eq0, jac_ineq0, s0)
         self.terminate = False
+        self.lb = finite_diff_bounds[0]
+        self.ub = finite_diff_bounds[1]
 
     def update(self, barrier_parameter, tolerance):
         self.barrier_parameter = barrier_parameter
@@ -78,9 +80,21 @@ class BarrierSubproblem:
         # Get variables and slack variables
         x = self.get_variables(z)
         s = self.get_slack(z)
-        # Compute function and constraints
-        f = self.fun(x)
-        c_eq, c_ineq = self.constr(x)
+
+        # Compute function and constraints,
+        # making sure x is within any strict bounds
+        if np.any((x < self.lb) | (x > self.ub)):
+            # If x is out of the strict bounds, set f = inf,
+            # and just set both equality and inequality
+            # constraints to 0 since we can't evaluate
+            # them separately.
+            f = np.inf
+            c_eq = np.full(self.n_eq, 0.)
+            c_ineq = np.full(self.n_ineq, 0.)
+        else:
+            f = self.fun(x)
+            c_eq, c_ineq = self.constr(x)
+
         # Return objective function and constraints
         return (self._compute_function(f, c_ineq, s),
                 self._compute_constr(c_ineq, c_eq, s))
@@ -272,7 +286,8 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
                       initial_tolerance,
                       initial_penalty,
                       initial_trust_radius,
-                      factorization_method):
+                      factorization_method,
+                      finite_diff_bounds):
     """Trust-region interior points method.
 
     Solve problem:
@@ -305,7 +320,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
         x0, s0, fun, grad, lagr_hess, n_vars, n_ineq, n_eq, constr, jac,
         barrier_parameter, tolerance, enforce_feasibility,
         stop_criteria, xtol, fun0, grad0, constr_ineq0, jac_ineq0,
-        constr_eq0, jac_eq0)
+        constr_eq0, jac_eq0, finite_diff_bounds)
     # Define initial parameter for the first iteration.
     z = np.hstack((x0, s0))
     fun0_subprob, constr0_subprob = subprob.fun0, subprob.constr0

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 from numpy.testing import (assert_array_almost_equal,
-                           assert_array_less, assert_, assert_allclose,
+                           assert_array_less, assert_,
                            suppress_warnings)
 from scipy.optimize import (NonlinearConstraint,
                             LinearConstraint,

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -764,6 +764,37 @@ def test_gh20665_too_many_constraints():
                  options={'factorization_method': 'SVDFactorization'})
 
 
+def test_gh11649():
+    bnds = Bounds(lb=[-1, -1], ub=[1, 1], keep_feasible=True)
+
+    def assert_inbounds(x):
+        assert np.all(x >= bnds.lb)
+        assert np.all(x <= bnds.ub)
+
+    def obj(x):
+        assert_inbounds(x)
+        return np.exp(x[0])*(4*x[0]**2 + 2*x[1]**2 + 4*x[0]*x[1] + 2*x[1] + 1)
+
+    def nce(x):
+        assert_inbounds(x)
+        return x[0]**2 + x[1]
+
+    def nce_jac(x):
+        return np.array([2 * x[0], 1])
+
+    def nci(x):
+        assert_inbounds(x)
+        return x[0]*x[1]
+
+    x0 = np.array((0.99, -0.99))
+    nlcs = [NonlinearConstraint(nci, -10, np.inf),
+            NonlinearConstraint(nce, 1, 1, jac=nce_jac)]
+
+    res = minimize(fun=obj, x0=x0, method='trust-constr',
+                   bounds=bnds, constraints=nlcs)
+    assert res.success
+
+
 class TestBoundedNelderMead:
 
     @pytest.mark.parametrize('bounds, x_opt',


### PR DESCRIPTION
Re-adds the changes from #11712 to fix #21248, fix #11649.

The reason why that was originally backed out was [because of](https://github.com/scipy/scipy/pull/11712#issuecomment-1294734024):

> FAILED scipy/optimize/tests/test_minimize_constrained.py::test_gh11649 - UserWarning: delta_grad == 0.0. Check if the approximated function is linear. If the function is linear better results can be obtained by defining the Hessian as zero instead of using quasi-Newton approximations.

The warning arises because at various points during the optimisation the `HessianUpdateStrategy.update` method has a zero delta_grad between two `update` calls. These points are when the equality constraint is satisfied (and one is using the default finite difference for grad calculation and `hess=BFGS()`).
The warning is not due to the changes in this PR, this can be proven by altering the added test to do the minimisation without bounds.

The simple way to prevent the warning from being emitted in the test is to provide the jacobian/grad of the constraint.