### PR TITLE
BUG: interpolate: avoid OOB in the periodic spline constructor

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -302,7 +302,7 @@ def insert(double xval,
 
 
 @cython.wraparound(False)
-@cython.boundscheck(True)
+@cython.boundscheck(False)
 def _colloc(const double[::1] x, const double[::1] t, int k, double[::1, :] ab,
             int offset=0):
     """Build the B-spline collocation matrix.

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -302,7 +302,7 @@ def insert(double xval,
 
 
 @cython.wraparound(False)
-@cython.boundscheck(False)
+@cython.boundscheck(True)
 def _colloc(const double[::1] x, const double[::1] t, int k, double[::1, :] ab,
             int offset=0):
     """Build the B-spline collocation matrix.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1201,7 +1201,8 @@ def _make_periodic_spline(x, y, t, k, axis):
 
     # `offset` is made to shift all the non-zero elements to the end of the
     # matrix
-    _bspl._colloc(x, t, k, ab, offset=k)
+    # NB: drop the last element of `x` because `x[0] = x[-1] + T` & `y[0] == y[-1]`
+    _bspl._colloc(x[:-1], t, k, ab, offset=k)
 
     # remove zeros before the matrix
     ab = ab[-k - (k + 1) % 2:, :]


### PR DESCRIPTION
Fix the out-of-bounds access in `make_interp_spline(...., bc_type='periodic')`.

This is a curious case where a bugfix PR does not need new tests: just flipping the boundschecking to True (IOW, applying  2376efb72ebb823e10385e1f658d1c0f35c0c3c3 to main) is enough to observe a dozen of IndexErrors from Cython. 

The problem was masked for a long time because the boundschecking was switched off for the "production version".

I'm adding 2376efb72ebb823e10385e1f658d1c0f35c0c3c3 to make sure the full CI agrees it's the right fix, will remove before landing the PR.

My take-home message is that whatever it is, it's buggy until it's been run with boundschecking at least once.