### PR TITLE
ENH: spatial.distance: extending `_distance_pybind` with additional metrics

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1038,7 +1038,7 @@ class Bench(Task):
                 commit_a = out.strip()
                 cmd_compare = [
                     'asv', 'continuous', '--show-stderr', '--factor', '1.05',
-                    '--quick', commit_a, commit_b
+                    commit_a, commit_b
                 ] + bench_args
                 cls.run_asv(dirs, cmd_compare)
                 sys.exit(1)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1628,6 +1628,72 @@ _convert_to_bool = partial(_convert_to_type, out_type=bool)
 _distance_wrap.pdist_correlation_double_wrap = _correlation_pdist_wrap
 _distance_wrap.cdist_correlation_double_wrap = _correlation_cdist_wrap
 
+def _distance_pybind_cdist_cosine(XA, XB, *, out=None, **kwargs):
+    w = kwargs.pop('w', None)
+    if w is not None:
+        w = w / w.sum()
+
+    XA = XA.astype(np.float64)
+    XB = XB.astype(np.float64)
+    return _distance_pybind.cdist_cosine(XA, XB, w, out, **kwargs)
+
+def _distance_pybind_pdist_cosine(XA, *, out=None, **kwargs):
+    w = kwargs.pop('w', None)
+    if w is not None:
+        w = w / w.sum()
+
+    XA = XA.astype(np.float64)
+    return _distance_pybind.pdist_cosine(XA, w, out, **kwargs)
+
+def _distance_pybind_cdist_correlation(XA, XB, *, out=None, **kwargs):
+    w = kwargs.pop('w', None)
+    if w is not None:
+        w = w / w.sum()
+
+    XA = XA.astype(np.float64)
+    XB = XB.astype(np.float64)
+    return _distance_pybind.cdist_correlation(XA, XB, w, out, **kwargs)
+
+def _distance_pybind_pdist_correlation(XA, *, out=None, **kwargs):
+    w = kwargs.pop('w', None)
+    if w is not None:
+        w = w / w.sum()
+
+    XA = XA.astype(np.float64)
+    return _distance_pybind.pdist_correlation(XA, w, out, **kwargs)
+
+def _distance_pybind_cdist_seuclidean(XA, XB, *, out=None, **kwargs):
+    V = kwargs.pop('V', None)
+    w = None
+    if V is not None:
+        w = np.reciprocal(V)
+
+    return _distance_pybind.cdist_seuclidean(XA, XB, w, out, **kwargs)
+
+def _distance_pybind_pdist_seuclidean(X, *, out=None, **kwargs):
+    V = kwargs.pop('V', None)
+    w = None
+    if V is not None:
+        w = np.reciprocal(V)
+
+    return _distance_pybind.pdist_seuclidean(X, w, out, **kwargs)
+
+def _distance_pybind_pdist_jensenshannon(XA, *, out=None, **kwargs):
+    XA = XA.astype(np.float64)
+    return _distance_pybind.pdist_jensenshannon(XA, out, **kwargs)
+
+def _distance_pybind_cdist_jensenshannon(XA, XB, *, out=None, **kwargs):
+    XA = XA.astype(np.float64)
+    XB = XB.astype(np.float64)
+    return _distance_pybind.cdist_jensenshannon(XA, XB, out, **kwargs)
+
+def _distance_pybind_cdist_mahalanobis(XA, XB, *, out=None, **kwargs):
+    VI = kwargs.pop('VI', None)
+    return _distance_pybind.cdist_mahalanobis(XA, XB, VI, out, **kwargs)
+
+def _distance_pybind_pdist_mahalanobis(X, *, out=None, **kwargs):
+    VI = kwargs.pop('VI', None)
+    return _distance_pybind.pdist_mahalanobis(X, VI, out, **kwargs)
 
 @dataclasses.dataclass(frozen=True)
 class CDistMetricWrapper:
@@ -1738,15 +1804,15 @@ _METRIC_INFOS = [
         canonical_name='correlation',
         aka={'correlation', 'co'},
         dist_func=correlation,
-        cdist_func=CDistMetricWrapper('correlation'),
-        pdist_func=PDistMetricWrapper('correlation'),
+        cdist_func=_distance_pybind_cdist_correlation,
+        pdist_func=_distance_pybind_pdist_correlation,
     ),
     MetricInfo(
         canonical_name='cosine',
         aka={'cosine', 'cos'},
         dist_func=cosine,
-        cdist_func=CDistMetricWrapper('cosine'),
-        pdist_func=PDistMetricWrapper('cosine'),
+        cdist_func=_distance_pybind_cdist_cosine,
+        pdist_func=_distance_pybind_pdist_cosine,
     ),
     MetricInfo(
         canonical_name='dice',
@@ -1784,8 +1850,8 @@ _METRIC_INFOS = [
         canonical_name='jensenshannon',
         aka={'jensenshannon', 'js'},
         dist_func=jensenshannon,
-        cdist_func=CDistMetricWrapper('jensenshannon'),
-        pdist_func=PDistMetricWrapper('jensenshannon'),
+        cdist_func=_distance_pybind_cdist_jensenshannon,
+        pdist_func=_distance_pybind_pdist_jensenshannon,
     ),
     MetricInfo(
         canonical_name='kulczynski1',
@@ -1800,8 +1866,8 @@ _METRIC_INFOS = [
         aka={'mahalanobis', 'mahal', 'mah'},
         validator=_validate_mahalanobis_kwargs,
         dist_func=mahalanobis,
-        cdist_func=CDistMetricWrapper('mahalanobis'),
-        pdist_func=PDistMetricWrapper('mahalanobis'),
+        cdist_func=_distance_pybind_cdist_mahalanobis,
+        pdist_func=_distance_pybind_pdist_mahalanobis,
     ),
     MetricInfo(
         canonical_name='minkowski',
@@ -1832,8 +1898,8 @@ _METRIC_INFOS = [
         aka={'seuclidean', 'se', 's'},
         validator=_validate_seuclidean_kwargs,
         dist_func=seuclidean,
-        cdist_func=CDistMetricWrapper('seuclidean'),
-        pdist_func=PDistMetricWrapper('seuclidean'),
+        cdist_func=_distance_pybind_cdist_seuclidean,
+        pdist_func=_distance_pybind_pdist_seuclidean,
     ),
     MetricInfo(
         canonical_name='sokalmichener',
@@ -2574,7 +2640,7 @@ def num_obs_dm(d):
     --------
     Find the number of original observations corresponding
     to a square redundant distance matrix d.
-    
+
     >>> from scipy.spatial.distance import num_obs_dm
     >>> d = [[0, 100, 200], [100, 0, 150], [200, 150, 0]]
     >>> num_obs_dm(d)
@@ -2604,7 +2670,7 @@ def num_obs_y(Y):
     --------
     Find the number of original observations corresponding to a
     condensed distance matrix Y.
-    
+
     >>> from scipy.spatial.distance import num_obs_y
     >>> Y = [1, 2, 3.5, 7, 10, 4]
     >>> num_obs_y(Y)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1633,8 +1633,6 @@ def _distance_pybind_cdist_cosine(XA, XB, *, out=None, **kwargs):
     if w is not None:
         w = w / w.sum()
 
-    XA = XA.astype(np.float64)
-    XB = XB.astype(np.float64)
     return _distance_pybind.cdist_cosine(XA, XB, w, out, **kwargs)
 
 def _distance_pybind_pdist_cosine(XA, *, out=None, **kwargs):
@@ -1642,7 +1640,6 @@ def _distance_pybind_pdist_cosine(XA, *, out=None, **kwargs):
     if w is not None:
         w = w / w.sum()
 
-    XA = XA.astype(np.float64)
     return _distance_pybind.pdist_cosine(XA, w, out, **kwargs)
 
 def _distance_pybind_cdist_correlation(XA, XB, *, out=None, **kwargs):
@@ -1650,8 +1647,6 @@ def _distance_pybind_cdist_correlation(XA, XB, *, out=None, **kwargs):
     if w is not None:
         w = w / w.sum()
 
-    XA = XA.astype(np.float64)
-    XB = XB.astype(np.float64)
     return _distance_pybind.cdist_correlation(XA, XB, w, out, **kwargs)
 
 def _distance_pybind_pdist_correlation(XA, *, out=None, **kwargs):
@@ -1659,7 +1654,6 @@ def _distance_pybind_pdist_correlation(XA, *, out=None, **kwargs):
     if w is not None:
         w = w / w.sum()
 
-    XA = XA.astype(np.float64)
     return _distance_pybind.pdist_correlation(XA, w, out, **kwargs)
 
 def _distance_pybind_cdist_seuclidean(XA, XB, *, out=None, **kwargs):
@@ -1677,15 +1671,6 @@ def _distance_pybind_pdist_seuclidean(X, *, out=None, **kwargs):
         w = np.reciprocal(V)
 
     return _distance_pybind.pdist_seuclidean(X, w, out, **kwargs)
-
-def _distance_pybind_pdist_jensenshannon(XA, *, out=None, **kwargs):
-    XA = XA.astype(np.float64)
-    return _distance_pybind.pdist_jensenshannon(XA, out, **kwargs)
-
-def _distance_pybind_cdist_jensenshannon(XA, XB, *, out=None, **kwargs):
-    XA = XA.astype(np.float64)
-    XB = XB.astype(np.float64)
-    return _distance_pybind.cdist_jensenshannon(XA, XB, out, **kwargs)
 
 def _distance_pybind_cdist_mahalanobis(XA, XB, *, out=None, **kwargs):
     VI = kwargs.pop('VI', None)
@@ -1850,8 +1835,8 @@ _METRIC_INFOS = [
         canonical_name='jensenshannon',
         aka={'jensenshannon', 'js'},
         dist_func=jensenshannon,
-        cdist_func=_distance_pybind_cdist_jensenshannon,
-        pdist_func=_distance_pybind_pdist_jensenshannon,
+        cdist_func=_distance_pybind.cdist_jensenshannon,
+        pdist_func=_distance_pybind.pdist_jensenshannon,
     ),
     MetricInfo(
         canonical_name='kulczynski1',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1628,58 +1628,6 @@ _convert_to_bool = partial(_convert_to_type, out_type=bool)
 _distance_wrap.pdist_correlation_double_wrap = _correlation_pdist_wrap
 _distance_wrap.cdist_correlation_double_wrap = _correlation_cdist_wrap
 
-def _distance_pybind_cdist_cosine(XA, XB, *, out=None, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is not None:
-        w = w / w.sum()
-
-    return _distance_pybind.cdist_cosine(XA, XB, w, out, **kwargs)
-
-def _distance_pybind_pdist_cosine(XA, *, out=None, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is not None:
-        w = w / w.sum()
-
-    return _distance_pybind.pdist_cosine(XA, w, out, **kwargs)
-
-def _distance_pybind_cdist_correlation(XA, XB, *, out=None, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is not None:
-        w = w / w.sum()
-
-    return _distance_pybind.cdist_correlation(XA, XB, w, out, **kwargs)
-
-def _distance_pybind_pdist_correlation(XA, *, out=None, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is not None:
-        w = w / w.sum()
-
-    return _distance_pybind.pdist_correlation(XA, w, out, **kwargs)
-
-def _distance_pybind_cdist_seuclidean(XA, XB, *, out=None, **kwargs):
-    V = kwargs.pop('V', None)
-    w = None
-    if V is not None:
-        w = np.reciprocal(V)
-
-    return _distance_pybind.cdist_seuclidean(XA, XB, w, out, **kwargs)
-
-def _distance_pybind_pdist_seuclidean(X, *, out=None, **kwargs):
-    V = kwargs.pop('V', None)
-    w = None
-    if V is not None:
-        w = np.reciprocal(V)
-
-    return _distance_pybind.pdist_seuclidean(X, w, out, **kwargs)
-
-def _distance_pybind_cdist_mahalanobis(XA, XB, *, out=None, **kwargs):
-    VI = kwargs.pop('VI', None)
-    return _distance_pybind.cdist_mahalanobis(XA, XB, VI, out, **kwargs)
-
-def _distance_pybind_pdist_mahalanobis(X, *, out=None, **kwargs):
-    VI = kwargs.pop('VI', None)
-    return _distance_pybind.pdist_mahalanobis(X, VI, out, **kwargs)
-
 @dataclasses.dataclass(frozen=True)
 class CDistMetricWrapper:
     metric_name: str
@@ -1789,15 +1737,15 @@ _METRIC_INFOS = [
         canonical_name='correlation',
         aka={'correlation', 'co'},
         dist_func=correlation,
-        cdist_func=_distance_pybind_cdist_correlation,
-        pdist_func=_distance_pybind_pdist_correlation,
+        cdist_func=_distance_pybind.cdist_correlation,
+        pdist_func=_distance_pybind.pdist_correlation,
     ),
     MetricInfo(
         canonical_name='cosine',
         aka={'cosine', 'cos'},
         dist_func=cosine,
-        cdist_func=_distance_pybind_cdist_cosine,
-        pdist_func=_distance_pybind_pdist_cosine,
+        cdist_func=_distance_pybind.cdist_cosine,
+        pdist_func=_distance_pybind.pdist_cosine,
     ),
     MetricInfo(
         canonical_name='dice',
@@ -1851,8 +1799,8 @@ _METRIC_INFOS = [
         aka={'mahalanobis', 'mahal', 'mah'},
         validator=_validate_mahalanobis_kwargs,
         dist_func=mahalanobis,
-        cdist_func=_distance_pybind_cdist_mahalanobis,
-        pdist_func=_distance_pybind_pdist_mahalanobis,
+        cdist_func=_distance_pybind.cdist_mahalanobis,
+        pdist_func=_distance_pybind.pdist_mahalanobis,
     ),
     MetricInfo(
         canonical_name='minkowski',
@@ -1883,8 +1831,8 @@ _METRIC_INFOS = [
         aka={'seuclidean', 'se', 's'},
         validator=_validate_seuclidean_kwargs,
         dist_func=seuclidean,
-        cdist_func=_distance_pybind_cdist_seuclidean,
-        pdist_func=_distance_pybind_pdist_seuclidean,
+        cdist_func=_distance_pybind.cdist_seuclidean,
+        pdist_func=_distance_pybind.pdist_seuclidean,
     ),
     MetricInfo(
         canonical_name='sokalmichener',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -110,7 +110,7 @@ import warnings
 import numpy as np
 import dataclasses
 
-from typing import Optional, Callable
+from collections.abc import Callable
 
 from functools import partial
 from scipy._lib._util import _asarray_validated
@@ -1694,7 +1694,7 @@ class MetricInfo:
     pdist_func: Callable
     # function that checks kwargs and computes default values:
     # f(X, m, n, **kwargs)
-    validator: Optional[Callable] = None
+    validator: Callable | None = None
     # list of supported types:
     # X (pdist) and XA (cdist) are used to choose the type. if there is no
     # match the first type is used. Default double

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -319,7 +319,8 @@ struct NormaliseInput {
 
     template <typename T>
     void operator()(StridedView2D<T> x) {
-        T* rownorms = new T[x.shape[0]];
+        std::vector<T> rownorms_(x.shape[0]);
+        T* rownorms = rownorms_.data();
         transform_reduce_2d_(rownorms, x, [](T x) INLINE_LAMBDA {
             return x*x;
         },
@@ -330,13 +331,12 @@ struct NormaliseInput {
         transform_reduce_2d_(x, rownorms, [](T x, T y) INLINE_LAMBDA {
             return x/y;
         });
-
-        delete [] rownorms;
     }
 
     template <typename T>
     void operator()(StridedView2D<T> x, StridedView2D<const T> w) {
-        T* rownorms = new T[x.shape[0]];
+        std::vector<T> rownorms_(x.shape[0]);
+        T* rownorms = rownorms_.data();
         transform_reduce_2d_(rownorms, x, w, [](T x, T w) INLINE_LAMBDA {
             return w*x*x;
         },
@@ -347,8 +347,6 @@ struct NormaliseInput {
         transform_reduce_2d_(x, rownorms, [](T x, T y) INLINE_LAMBDA {
             return x/y;
         });
-
-        delete [] rownorms;
     }
 
 };
@@ -357,7 +355,8 @@ struct CentraliseInput {
 
     template <typename T>
     void operator()(StridedView2D<T> x) {
-        T* rowmeans = new T[x.shape[0]];
+        std::vector<T> rowmeans_(x.shape[0]);
+        T* rowmeans = rowmeans_.data();
         auto num_cols = x.shape[1];
         transform_reduce_2d_(rowmeans, x, [](T x) INLINE_LAMBDA {
             return x;
@@ -369,13 +368,12 @@ struct CentraliseInput {
         transform_reduce_2d_(x, rowmeans, [](T x, T y) INLINE_LAMBDA {
             return x - y;
         });
-
-        delete [] rowmeans;
     }
 
     template <typename T>
     void operator()(StridedView2D<T> x, StridedView2D<const T> w) {
-        T* rowmeans = new T[x.shape[0]];
+        std::vector<T> rowmeans_(x.shape[0]);
+        T* rowmeans = rowmeans_.data();
         transform_reduce_2d_(rowmeans, x, w, [](T x, T w) INLINE_LAMBDA {
             return w*x;
         });
@@ -383,8 +381,6 @@ struct CentraliseInput {
         transform_reduce_2d_(x, rowmeans, [](T x, T y) INLINE_LAMBDA {
             return x - y;
         });
-
-        delete [] rowmeans;
     }
 
 };
@@ -417,7 +413,8 @@ struct ScaleInputForJensenshannon {
 
     template <typename T>
     void operator()(StridedView2D<T> x) {
-        T* rowsums = new T[x.shape[0]];
+        std::vector<T> rowsums_(x.shape[0]);
+        T* rowsums = rowsums_.data();
         transform_reduce_2d_(rowsums, x, [](T x) INLINE_LAMBDA {
             return x < 0.0 ? NAN : x;
         },
@@ -428,8 +425,6 @@ struct ScaleInputForJensenshannon {
         transform_reduce_2d_(x, rowsums, [](T x, T y) INLINE_LAMBDA {
             return y == 0.0 ? NAN : x/y;
         });
-
-        delete [] rowsums;
     }
 
 };

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -169,6 +169,293 @@ void transform_reduce_2d_(
     }
 }
 
+template <int ilp_factor=4,
+          typename T,
+          typename TransformFunc,
+          typename ProjectFunc = Identity,
+          typename ReduceFunc = Plus>
+void transform_reduce_2d_(
+    T* out, StridedView2D<T> x,
+    const TransformFunc& map,
+    const ProjectFunc& project = Identity{},
+    const ReduceFunc& reduce = Plus{}) {
+    // Result type of calling map
+    using AccumulateType = typename std::decay<decltype(map(std::declval<T>()))>::type;
+    intptr_t xs = x.strides[1];
+
+    intptr_t i = 0;
+    if (xs == 1) {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            const T* x_rows[ilp_factor];
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                x_rows[k] = &x(i + k, 0);
+            });
+
+            AccumulateType dist[ilp_factor] = {};
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    auto val = map(x_rows[k][j]);
+                    dist[k] = reduce(dist[k], val);
+                });
+            }
+
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                out[i + k] = project(dist[k]);
+            });
+        }
+    } else {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            const T* x_rows[ilp_factor];
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                x_rows[k] = &x(i + k, 0);
+            });
+
+            AccumulateType dist[ilp_factor] = {};
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                auto x_offset = j * xs;
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    auto val = map(x_rows[k][x_offset]);
+                    dist[k] = reduce(dist[k], val);
+                });
+            }
+
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                out[i + k] = project(dist[k]);
+            });
+        }
+    }
+    for (; i < x.shape[0]; ++i) {
+        const T* x_row = &x(i, 0);
+        AccumulateType dist = {};
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            auto val = map(x_row[j * xs]);
+            dist = reduce(dist, val);
+        }
+        out[i] = project(dist);
+    }
+}
+
+template <int ilp_factor=2, typename T,
+          typename TransformFunc,
+          typename ProjectFunc = Identity,
+          typename ReduceFunc = Plus>
+void transform_reduce_2d_(
+    T* out, StridedView2D<T> x, StridedView2D<const T> w,
+    const TransformFunc& map,
+    const ProjectFunc& project = Identity{},
+    const ReduceFunc& reduce = Plus{}) {
+    intptr_t i = 0;
+    intptr_t xs = x.strides[1], ws = w.strides[1];
+    // Result type of calling map
+    using AccumulateType = typename std::decay<decltype(
+        map(std::declval<T>(), std::declval<T>()))>::type;
+
+    for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+        const T* x_rows[ilp_factor];
+        const T* w_rows[ilp_factor];
+        ForceUnroll<ilp_factor>{}([&](int k) {
+            x_rows[k] = &x(i + k, 0);
+            w_rows[k] = &w(i + k, 0);
+        });
+
+        AccumulateType dist[ilp_factor] = {};
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                auto val = map(x_rows[k][j * xs], w_rows[k][j * ws]);
+                dist[k] = reduce(dist[k], val);
+            });
+        }
+
+        ForceUnroll<ilp_factor>{}([&](int k) {
+            out[i + k] = project(dist[k]);
+        });
+    }
+    for (; i < x.shape[0]; ++i) {
+        const T* x_row = &x(i, 0);
+        const T* w_row = &w(i, 0);
+        AccumulateType dist = {};
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            auto val = map(x_row[j * xs], w_row[j * ws]);
+            dist = reduce(dist, val);
+        }
+        out[i] = project(dist);
+    }
+}
+
+template <int ilp_factor=4,
+          typename T,
+          typename TransformFunc>
+void transform_reduce_2d_(
+    StridedView2D<T> x, T* rowscales,
+    const TransformFunc& map) {
+    intptr_t xs = x.strides[1];
+
+    intptr_t i = 0;
+    if (xs == 1) {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    x(i + k, j) = map(x(i + k, j), rowscales[i + k]);
+                });
+            }
+        }
+    } else {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    x(i + k, j) = map(x(i + k, j), rowscales[i + k]);
+                });
+            }
+        }
+    }
+    for (; i < x.shape[0]; ++i) {
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            x(i, j) = map(x(i, j), rowscales[i]);
+        }
+    }
+}
+
+struct NormaliseInput {
+
+    template <typename T>
+    void operator()(StridedView2D<T> x) {
+        T* rownorms = new T[x.shape[0]];
+        transform_reduce_2d_(rownorms, x, [](T x) INLINE_LAMBDA {
+            return x*x;
+        },
+        [](T x) INLINE_LAMBDA {
+            return std::sqrt(x);
+        });
+
+        transform_reduce_2d_(x, rownorms, [](T x, T y) INLINE_LAMBDA {
+            return x/y;
+        });
+
+        delete [] rownorms;
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> x, StridedView2D<const T> w) {
+        T* rownorms = new T[x.shape[0]];
+        transform_reduce_2d_(rownorms, x, w, [](T x, T w) INLINE_LAMBDA {
+            return w*x*x;
+        },
+        [](T x) INLINE_LAMBDA {
+            return std::sqrt(x);
+        });
+
+        transform_reduce_2d_(x, rownorms, [](T x, T y) INLINE_LAMBDA {
+            return x/y;
+        });
+
+        delete [] rownorms;
+    }
+
+};
+
+struct CentraliseInput {
+
+    template <typename T>
+    void operator()(StridedView2D<T> x) {
+        T* rowmeans = new T[x.shape[0]];
+        auto num_cols = x.shape[1];
+        transform_reduce_2d_(rowmeans, x, [](T x) INLINE_LAMBDA {
+            return x;
+        },
+        [num_cols](T x) INLINE_LAMBDA {
+            return x/num_cols;
+        });
+
+        transform_reduce_2d_(x, rowmeans, [](T x, T y) INLINE_LAMBDA {
+            return x - y;
+        });
+
+        delete [] rowmeans;
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> x, StridedView2D<const T> w) {
+        T* rowmeans = new T[x.shape[0]];
+        transform_reduce_2d_(rowmeans, x, w, [](T x, T w) INLINE_LAMBDA {
+            return w*x;
+        });
+
+        transform_reduce_2d_(x, rowmeans, [](T x, T y) INLINE_LAMBDA {
+            return x - y;
+        });
+
+        delete [] rowmeans;
+    }
+
+};
+
+struct CosineDistance {
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        transform_reduce_2d_(out, x, y, [](T x, T y) INLINE_LAMBDA {
+            return x*y;
+        },
+        [](T cosine) INLINE_LAMBDA {
+            return std::clamp((T) 1. - cosine, (T) 0., (T) 2.0);
+        });
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
+            return (w * x) * y;
+        },
+        [](T cosine) INLINE_LAMBDA {
+            return std::clamp((T) 1. - cosine, (T) 0., (T) 2.0);
+        });
+    }
+
+};
+
+struct ScaleInputForJensenshannon {
+
+    template <typename T>
+    void operator()(StridedView2D<T> x) {
+        T* rowsums = new T[x.shape[0]];
+        transform_reduce_2d_(rowsums, x, [](T x) INLINE_LAMBDA {
+            return x < 0.0 ? NAN : x;
+        },
+        [](T x) INLINE_LAMBDA {
+            return x;
+        });
+
+        transform_reduce_2d_(x, rowsums, [](T x, T y) INLINE_LAMBDA {
+            return y == 0.0 ? NAN : x/y;
+        });
+
+        delete [] rowsums;
+    }
+
+};
+
+struct JensenshannonDistance {
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        transform_reduce_2d_(out, x, y, [](T x, T y) INLINE_LAMBDA {
+            if ( isnan(x) || isnan(y) ) {
+                return (T) NAN;
+            }
+
+            T m = (x + y)/2.0;
+            return ((x > 0.0) ? x * std::log(x/m) : 0.0) + ((y > 0.0) ? y * std::log(y/m) : 0.0);
+        },
+        [](T x) {
+            return isnan(x) ? HUGE_VAL : std::sqrt(x/2.0);
+        });
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> /*out*/, StridedView2D<const T> /*x*/, StridedView2D<const T> /*y*/, StridedView2D<const T> /*w*/) const {
+    }
+};
+
 struct MinkowskiDistance {
     double p_;
 

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -223,6 +223,15 @@ void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
 }
 
 template <typename T>
+ALWAYS_INLINE T reduce_loop(T* data, const intptr_t n) {
+    T sum = 0;
+    for( intptr_t i = 0; i < n; i++ ) {
+        sum += data[i];
+    }
+    return sum;
+}
+
+template <typename T>
 ALWAYS_INLINE void _compute_variance_across_rows(
     T* var, ArrayDescriptor x, const T* x_data,
     ArrayDescriptor y, const T* y_data) {
@@ -252,7 +261,8 @@ ALWAYS_INLINE void _compute_variance_across_rows(
             const intptr_t index = i * y.strides[0] + j * y.strides[1];
             sum[0] += y_data[index];
         }
-        var[j] = (sum[0] + sum[1] + sum[2] + sum[3])/(num_rowsX + num_rowsY);
+
+        var[j] = reduce_loop(sum, ilp_factor1)/(num_rowsX + num_rowsY);
     }
 
     const intptr_t ilp_factor2 = 2;
@@ -281,7 +291,8 @@ ALWAYS_INLINE void _compute_variance_across_rows(
             const intptr_t index = i * y.strides[0] + j * y.strides[1];
             sum[0] += (y_data[index] - mean) * (y_data[index] - mean);
         }
-        var[j] = (num_rowsX + num_rowsY - 1)/(sum[0] + sum[1]);
+
+        var[j] = (num_rowsX + num_rowsY - 1)/reduce_loop(sum, ilp_factor2);
     }
 }
 
@@ -291,42 +302,41 @@ ALWAYS_INLINE void _compute_variance_across_rows(
     const intptr_t num_rowsX = x.shape[0];
     const intptr_t num_cols = x.shape[1];
 
+    const intptr_t ilp_factor1 = 4;
     for( intptr_t j = 0; j < num_cols; j++ ) {
-        T sum[4] = {0, 0, 0, 0};
+        T sum[ilp_factor1];
+        std::memset(sum, 0, ilp_factor1 * sizeof(T));
         intptr_t i;
-        for( i = 0; i + 3 < num_rowsX; i += 4 ) {
-            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
-            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
-            const intptr_t index2 = (i + 2) * x.strides[0] + j * x.strides[1];
-            const intptr_t index3 = (i + 3) * x.strides[0] + j * x.strides[1];
-            sum[0] += x_data[index0];
-            sum[1] += x_data[index1];
-            sum[2] += x_data[index2];
-            sum[3] += x_data[index3];
+        for( i = 0; i + (ilp_factor1 - 1) < num_rowsX; i += ilp_factor1 ) {
+            ForceUnroll<ilp_factor1>{}([&](int k) {
+                sum[k] += x_data[(i + k) * x.strides[0] + j * x.strides[1]];
+            });
         }
         for( ; i < num_rowsX; i++ ) {
             const intptr_t index = i * x.strides[0] + j * x.strides[1];
             sum[0] += x_data[index];
         }
 
-        var[j] = (sum[0] + sum[1] + sum[2] + sum[3])/num_rowsX;
+        var[j] = reduce_loop(sum, ilp_factor1)/num_rowsX;
     }
 
+    const intptr_t ilp_factor2 = 2;
     for( intptr_t j = 0; j < num_cols; j++ ) {
-        T sum[2] = {0, 0};
+        T sum[ilp_factor2];
+        std::memset(sum, 0, ilp_factor2 * sizeof(T));
         T mean = var[j];
         intptr_t i;
         for( i = 0; i + 1 < num_rowsX; i += 2 ) {
-            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
-            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
-            sum[0] += (x_data[index0] - mean) * (x_data[index0] - mean);
-            sum[1] += (x_data[index1] - mean) * (x_data[index1] - mean);
+            ForceUnroll<ilp_factor2>{}([&](int k) {
+                const intptr_t index = (i + k) * x.strides[0] + j * x.strides[1];
+                sum[k] += (x_data[index] - mean) * (x_data[index] - mean);
+            });
         }
         for( ; i < num_rowsX; i++ ) {
             const intptr_t index = i * x.strides[0] + j * x.strides[1];
             sum[0] += (x_data[index] - mean) * (x_data[index] - mean);
         }
-        var[j] = (num_rowsX - 1)/(sum[0] + sum[1]);
+        var[j] = (num_rowsX - 1)/reduce_loop(sum, ilp_factor2);
     }
 }
 

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -1379,15 +1379,15 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("pdist_seuclidean",
-          [](py::object x, py::object w, py::object out) {
-              if( w.is_none() ) {
-                return pdist(out, x, w, EuclideanDistance{},
+          [](py::object x, py::object V, py::object out) {
+              if( V.is_none() ) {
+                return pdist(out, x, V, EuclideanDistance{},
                              PreprocessingType::ComputeVariance);
               } else {
-                return pdist(out, x, w, EuclideanDistance{});
+                return pdist(out, x, V, SeuclideanDistance{});
               }
           },
-          "x"_a, "w"_a, "out"_a=py::none());
+          "x"_a, "V"_a=py::none(), "out"_a=py::none());
     m.def("pdist_minkowski",
           [](py::object x, py::object w, py::object out, double p) {
               if (p == 1.0) {
@@ -1405,7 +1405,7 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
           [](py::object x, py::object vi, py::object out) {
               return pdist_mahalanobis(out, x, vi);
           },
-          "x"_a, "vi"_a=py::none(), "out"_a=py::none());
+          "x"_a, "VI"_a=py::none(), "out"_a=py::none());
     m.def("pdist_cosine",
           [](py::object x, py::object w, py::object out) {
               return pdist(out, x, w, CosineDistance{}, PreprocessingType::Normalise);
@@ -1499,20 +1499,20 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("cdist_seuclidean",
-          [](py::object x, py::object y, py::object w, py::object out) {
-              if( w.is_none() ) {
-                  return cdist(out, x, y, w, EuclideanDistance{},
+          [](py::object x, py::object y, py::object V, py::object out) {
+              if( V.is_none() ) {
+                  return cdist(out, x, y, V, EuclideanDistance{},
                                PreprocessingType::ComputeVariance);
               } else {
-                  return cdist(out, x, y, w, EuclideanDistance{});
+                  return cdist(out, x, y, V, SeuclideanDistance{});
               }
           },
-          "x"_a, "y"_a, "w"_a, "out"_a=py::none());
+          "x"_a, "y"_a, "V"_a=py::none(), "out"_a=py::none());
     m.def("cdist_mahalanobis",
           [](py::object x, py::object y, py::object vi, py::object out) {
               return cdist_mahalanobis(out, x, y, vi);
           },
-          "x"_a, "y"_a, "vi"_a=py::none(), "out"_a=py::none());
+          "x"_a, "y"_a, "VI"_a=py::none(), "out"_a=py::none());
     m.def("cdist_cosine",
           [](py::object x, py::object y, py::object w, py::object out) {
               return cdist(out, x, y, w, CosineDistance{},

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -24,6 +24,10 @@ using WeightedDistanceFunc = FunctionRef<
     void(StridedView2D<T>, StridedView2D<const T>,
          StridedView2D<const T>, StridedView2D<const T>)>;
 
+enum PreprocessingType {
+    None, Normalise, CentraliseAndNormalise, ComputeVariance, ScaleInputForJensenshannon_
+};
+
 // Validate weights are >= 0
 template <typename T>
 void validate_weights(const ArrayDescriptor& w, const T* w_data) {
@@ -68,10 +72,76 @@ void validate_weights(const ArrayDescriptor& w, const T* w_data) {
 }
 
 template <typename T>
+ALWAYS_INLINE void preprocess_inputs(
+    ArrayDescriptor x, const T* in_data, PreprocessingType type) {
+    if( type == PreprocessingType::None ) {
+        return ;
+    }
+
+    T* in_data_ = const_cast<T*>(in_data);
+
+    StridedView2D<T> x_view;
+    x_view.strides = {x.strides[0], x.strides[1]};
+    x_view.shape = {x.shape[0], x.shape[1]};
+    x_view.data = in_data_;
+
+    switch( type ) {
+        case PreprocessingType::Normalise: {
+            NormaliseInput{}(x_view);
+            break;
+        }
+        case PreprocessingType::CentraliseAndNormalise: {
+            CentraliseInput{}(x_view);
+            NormaliseInput{}(x_view);
+            break;
+        }
+        case PreprocessingType::ScaleInputForJensenshannon_: {
+            ScaleInputForJensenshannon{}(x_view);
+            break;
+        }
+        default: {
+        }
+    }
+}
+
+template <typename T>
+ALWAYS_INLINE void preprocess_inputs(
+    ArrayDescriptor x, const T* in_data,
+    StridedView2D<const T> w_view, PreprocessingType type) {
+    if( type == PreprocessingType::None ) {
+        return ;
+    }
+
+    T* in_data_ = const_cast<T*>(in_data);
+
+    StridedView2D<T> x_view;
+    x_view.strides = {x.strides[0], x.strides[1]};
+    x_view.shape = {x.shape[0], x.shape[1]};
+    x_view.data = in_data_;
+
+    switch( type ) {
+        case PreprocessingType::Normalise: {
+            NormaliseInput{}(x_view, w_view);
+            break;
+        }
+        case PreprocessingType::CentraliseAndNormalise: {
+            CentraliseInput{}(x_view, w_view);
+            NormaliseInput{}(x_view, w_view);
+            break;
+        }
+        default: {
+        }
+    }
+}
+
+template <typename T>
 void pdist_impl(ArrayDescriptor out, T* out_data,
                 ArrayDescriptor x, const T* in_data,
-                DistanceFunc<T> f) {
+                DistanceFunc<T> f,
+                PreprocessingType type) {
     const intptr_t num_rows = x.shape[0], num_cols = x.shape[1];
+
+    preprocess_inputs(x, in_data, type);
 
     StridedView2D<T> out_view;
     out_view.strides = {out.strides[0], 0};
@@ -103,10 +173,13 @@ template <typename T>
 void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
                          ArrayDescriptor x, const T* x_data,
                          ArrayDescriptor w, const T* w_data,
-                         WeightedDistanceFunc<T> f) {
+                         WeightedDistanceFunc<T> f,
+                         PreprocessingType type) {
     if (x.ndim != 2) {
         throw std::invalid_argument("x must be 2-dimensional");
     }
+
+    const intptr_t num_rows = x.shape[0];
 
     StridedView2D<T> out_view;
     out_view.strides = {out.strides[0], 0};
@@ -118,6 +191,8 @@ void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
     w_view.shape = out_view.shape;
     w_view.data = w_data;
 
+    preprocess_inputs(x, x_data, w_view, type);
+
     StridedView2D<const T> x_view;
     x_view.strides = {x.strides[0], x.strides[1]};
     x_view.shape = out_view.shape;
@@ -128,7 +203,6 @@ void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
     y_view.shape = out_view.shape;
     y_view.data = x_data;
 
-    const intptr_t num_rows = x.shape[0];
     for (intptr_t i = 0; i < num_rows - 1; ++i) {
         f(out_view, x_view, y_view, w_view);
 
@@ -141,14 +215,132 @@ void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
 }
 
 template <typename T>
+ALWAYS_INLINE void _compute_variance_across_rows(
+    T* var, ArrayDescriptor x, const T* x_data,
+    ArrayDescriptor y, const T* y_data) {
+    const intptr_t num_rowsX = x.shape[0], num_rowsY = y.shape[0];
+    const intptr_t num_cols = x.shape[1];
+
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        T sum[4] = {0, 0, 0, 0};
+        intptr_t i;
+        for( i = 0; i + 3 < num_rowsX; i += 4 ) {
+            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
+            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
+            const intptr_t index2 = (i + 2) * x.strides[0] + j * x.strides[1];
+            const intptr_t index3 = (i + 3) * x.strides[0] + j * x.strides[1];
+            sum[0] += x_data[index0];
+            sum[1] += x_data[index1];
+            sum[2] += x_data[index2];
+            sum[3] += x_data[index3];
+        }
+        for( ; i < num_rowsX; i++ ) {
+            const intptr_t index = i * x.strides[0] + j * x.strides[1];
+            sum[0] += x_data[index];
+        }
+
+        for( i = 0; i + 3 < num_rowsY; i += 4 ) {
+            const intptr_t index0 = i * y.strides[0] + j * y.strides[1];
+            const intptr_t index1 = (i + 1) * y.strides[0] + j * y.strides[1];
+            const intptr_t index2 = (i + 2) * y.strides[0] + j * y.strides[1];
+            const intptr_t index3 = (i + 3) * y.strides[0] + j * y.strides[1];
+            sum[0] += y_data[index0];
+            sum[1] += y_data[index1];
+            sum[2] += y_data[index2];
+            sum[3] += y_data[index3];
+        }
+        for( ; i < num_rowsY; i++ ) {
+            const intptr_t index = i * y.strides[0] + j * y.strides[1];
+            sum[0] += y_data[index];
+        }
+        var[j] = (sum[0] + sum[1] + sum[2] + sum[3])/(num_rowsX + num_rowsY);
+    }
+
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        T sum[2] = {0, 0};
+        T mean = var[j];
+        intptr_t i;
+        for( i = 0; i + 1 < num_rowsX; i += 2 ) {
+            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
+            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
+            sum[0] += (x_data[index0] - mean) * (x_data[index0] - mean);
+            sum[1] += (x_data[index1] - mean) * (x_data[index1] - mean);
+        }
+        for( ; i < num_rowsX; i++ ) {
+            const intptr_t index = i * x.strides[0] + j * x.strides[1];
+            sum[0] += (x_data[index] - mean) * (x_data[index] - mean);
+        }
+        for( i = 0; i + 1 < num_rowsY; i += 2 ) {
+            const intptr_t index0 = i * y.strides[0] + j * y.strides[1];
+            const intptr_t index1 = (i + 1) * y.strides[0] + j * y.strides[1];
+            sum[0] += (y_data[index0] - mean) * (y_data[index0] - mean);
+            sum[1] += (y_data[index1] - mean) * (y_data[index1] - mean);
+        }
+        for( ; i < num_rowsY; i++ ) {
+            const intptr_t index = i * y.strides[0] + j * y.strides[1];
+            sum[0] += (y_data[index] - mean) * (y_data[index] - mean);
+        }
+        var[j] = (num_rowsX + num_rowsY - 1)/(sum[0] + sum[1]);
+    }
+}
+
+template <typename T>
+ALWAYS_INLINE void _compute_variance_across_rows(
+    T* var, ArrayDescriptor x, const T* x_data) {
+    const intptr_t num_rowsX = x.shape[0];
+    const intptr_t num_cols = x.shape[1];
+
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        T sum[4] = {0, 0, 0, 0};
+        intptr_t i;
+        for( i = 0; i + 3 < num_rowsX; i += 4 ) {
+            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
+            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
+            const intptr_t index2 = (i + 2) * x.strides[0] + j * x.strides[1];
+            const intptr_t index3 = (i + 3) * x.strides[0] + j * x.strides[1];
+            sum[0] += x_data[index0];
+            sum[1] += x_data[index1];
+            sum[2] += x_data[index2];
+            sum[3] += x_data[index3];
+        }
+        for( ; i < num_rowsX; i++ ) {
+            const intptr_t index = i * x.strides[0] + j * x.strides[1];
+            sum[0] += x_data[index];
+        }
+
+        var[j] = (sum[0] + sum[1] + sum[2] + sum[3])/num_rowsX;
+    }
+
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        T sum[2] = {0, 0};
+        T mean = var[j];
+        intptr_t i;
+        for( i = 0; i + 1 < num_rowsX; i += 2 ) {
+            const intptr_t index0 = i * x.strides[0] + j * x.strides[1];
+            const intptr_t index1 = (i + 1) * x.strides[0] + j * x.strides[1];
+            sum[0] += (x_data[index0] - mean) * (x_data[index0] - mean);
+            sum[1] += (x_data[index1] - mean) * (x_data[index1] - mean);
+        }
+        for( ; i < num_rowsX; i++ ) {
+            const intptr_t index = i * x.strides[0] + j * x.strides[1];
+            sum[0] += (x_data[index] - mean) * (x_data[index] - mean);
+        }
+        var[j] = (num_rowsX - 1)/(sum[0] + sum[1]);
+    }
+}
+
+template <typename T>
 void cdist_impl(ArrayDescriptor out, T* out_data,
                 ArrayDescriptor x, const T* x_data,
                 ArrayDescriptor y, const T* y_data,
-                DistanceFunc<T> f) {
+                DistanceFunc<T> f, PreprocessingType type) {
 
     const auto num_rowsX = x.shape[0];
     const auto num_rowsY = y.shape[0];
     const auto num_cols = x.shape[1];
+
+    preprocess_inputs(x, x_data, type);
+    preprocess_inputs(y, y_data, type);
 
     StridedView2D<T> out_view;
     out_view.strides = {out.strides[1], 0};
@@ -178,11 +370,20 @@ void cdist_weighted_impl(ArrayDescriptor out, T* out_data,
                          ArrayDescriptor x, const T* x_data,
                          ArrayDescriptor y, const T* y_data,
                          ArrayDescriptor w, const T* w_data,
-                         WeightedDistanceFunc<T> f) {
+                         WeightedDistanceFunc<T> f,
+                         PreprocessingType type) {
 
     const auto num_rowsX = x.shape[0];
     const auto num_rowsY = y.shape[0];
     const auto num_cols = x.shape[1];
+
+    StridedView2D<const T> w_view;
+    w_view.strides = {0, w.strides[0]};
+    w_view.shape = {num_rowsY, num_cols};
+    w_view.data = w_data;
+
+    preprocess_inputs(x, x_data, w_view, type);
+    preprocess_inputs(y, y_data, w_view, type);
 
     StridedView2D<T> out_view;
     out_view.strides = {out.strides[1], 0};
@@ -198,11 +399,6 @@ void cdist_weighted_impl(ArrayDescriptor out, T* out_data,
     y_view.strides = {y.strides[0], y.strides[1]};
     y_view.shape = {num_rowsY, num_cols};
     y_view.data = y_data;
-
-    StridedView2D<const T> w_view;
-    w_view.strides = {0, w.strides[0]};
-    w_view.shape = {num_rowsY, num_cols};
-    w_view.data = w_data;
 
     for (intptr_t i = 0; i < num_rowsX; ++i) {
         f(out_view, x_view, y_view, w_view);
@@ -268,7 +464,8 @@ py::array npy_asarray(const py::handle& obj, int flags = 0) {
 
 template <typename scalar_t>
 py::array pdist_unweighted(const py::array& out_obj, const py::array& x_obj,
-                           DistanceFunc<scalar_t> f) {
+                           DistanceFunc<scalar_t> f,
+                           PreprocessingType type) {
     auto x = npy_asarray<scalar_t>(x_obj,
                                    NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
     auto out = py::cast<py::array_t<scalar_t>>(out_obj);
@@ -278,7 +475,7 @@ py::array pdist_unweighted(const py::array& out_obj, const py::array& x_obj,
     auto x_data = x.data();
     {
         py::gil_scoped_release guard;
-        pdist_impl(out_desc, out_data, x_desc, x_data, f);
+        pdist_impl(out_desc, out_data, x_desc, x_data, f, type);
     }
     return std::move(out);
 }
@@ -286,7 +483,8 @@ py::array pdist_unweighted(const py::array& out_obj, const py::array& x_obj,
 template <typename scalar_t>
 py::array pdist_weighted(
         const py::array& out_obj, const py::array& x_obj,
-        const py::array& w_obj, WeightedDistanceFunc<scalar_t> f) {
+        const py::array& w_obj, WeightedDistanceFunc<scalar_t> f,
+        PreprocessingType type) {
     auto x = npy_asarray<scalar_t>(x_obj,
                                    NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
     auto w = npy_asarray<scalar_t>(w_obj,
@@ -302,14 +500,45 @@ py::array pdist_weighted(
         py::gil_scoped_release guard;
         validate_weights(w_desc, w_data);
         pdist_weighted_impl(
-            out_desc, out_data, x_desc, x_data, w_desc, w_data, f);
+            out_desc, out_data, x_desc, x_data, w_desc, w_data, f, type);
     }
     return std::move(out);
 }
 
 template <typename scalar_t>
+py::array pdist_weighted(
+        const py::array& out_obj, const py::array& x_obj,
+        WeightedDistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                   NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+
+    scalar_t* w_data = new scalar_t[x_desc.shape[1]];
+    _compute_variance_across_rows(w_data, x_desc, x_data);
+    ArrayDescriptor w_desc(1);
+    w_desc.element_size = x_desc.element_size;
+    w_desc.shape[0] = x_desc.shape[1];
+    w_desc.strides[0] = 1;
+
+    {
+        py::gil_scoped_release guard;
+        pdist_weighted_impl(
+            out_desc, out_data, x_desc, x_data, w_desc,
+            w_data, f, PreprocessingType::None);
+    }
+
+    delete [] w_data;
+    return std::move(out);
+}
+
+template <typename scalar_t>
 py::array cdist_unweighted(const py::array& out_obj, const py::array& x_obj,
-                           const py::array& y_obj, DistanceFunc<scalar_t> f) {
+                           const py::array& y_obj, DistanceFunc<scalar_t> f,
+                           PreprocessingType type) {
     auto x = npy_asarray<scalar_t>(x_obj,
                                  NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
     auto y = npy_asarray<scalar_t>(y_obj,
@@ -324,7 +553,7 @@ py::array cdist_unweighted(const py::array& out_obj, const py::array& x_obj,
     auto y_data = y.data();
     {
         py::gil_scoped_release guard;
-        cdist_impl(out_desc, out_data, x_desc, x_data, y_desc, y_data, f);
+        cdist_impl(out_desc, out_data, x_desc, x_data, y_desc, y_data, f, type);
     }
     return std::move(out);
 }
@@ -333,7 +562,8 @@ template <typename scalar_t>
 py::array cdist_weighted(
         const py::array& out_obj, const py::array& x_obj,
         const py::array& y_obj, const py::array& w_obj,
-        WeightedDistanceFunc<scalar_t> f) {
+        WeightedDistanceFunc<scalar_t> f,
+        PreprocessingType type) {
     auto x = npy_asarray<scalar_t>(x_obj,
                                  NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
     auto y = npy_asarray<scalar_t>(y_obj,
@@ -354,8 +584,44 @@ py::array cdist_weighted(
         py::gil_scoped_release guard;
         validate_weights(w_desc, w_data);
         cdist_weighted_impl(
-            out_desc, out_data, x_desc, x_data, y_desc, y_data, w_desc, w_data, f);
+            out_desc, out_data, x_desc, x_data, y_desc, y_data,
+            w_desc, w_data, f, type);
     }
+    return std::move(out);
+}
+
+template <typename scalar_t>
+py::array cdist_weighted(
+        const py::array& out_obj, const py::array& x_obj,
+        const py::array& y_obj, WeightedDistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto y = npy_asarray<scalar_t>(y_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+    auto y_desc = get_descriptor(y);
+    auto y_data = y.data();
+
+    scalar_t* w_data = new scalar_t[x_desc.shape[1]];
+    _compute_variance_across_rows(w_data, x_desc, x_data, y_desc, y_data);
+    ArrayDescriptor w_desc(1);
+    w_desc.element_size = x_desc.element_size;
+    w_desc.shape[0] = x_desc.shape[1];
+    w_desc.strides[0] = 1;
+
+    {
+        py::gil_scoped_release guard;
+        cdist_weighted_impl(
+            out_desc, out_data, x_desc, x_data, y_desc, y_data,
+            w_desc, w_data, f, PreprocessingType::None);
+    }
+
+    delete [] w_data;
     return std::move(out);
 }
 
@@ -482,7 +748,8 @@ py::dtype promote_type_real(const py::dtype& dtype) {
 
 template <typename Func>
 py::array pdist(const py::object& out_obj, const py::object& x_obj,
-                const py::object& w_obj, Func&& f) {
+                const py::object& w_obj, Func&& f,
+                PreprocessingType type=PreprocessingType::None) {
     auto x = npy_asarray(x_obj);
     if (x.ndim() != 2) {
         throw std::invalid_argument("x must be 2-dimensional");
@@ -491,11 +758,21 @@ py::array pdist(const py::object& out_obj, const py::object& x_obj,
     const intptr_t m = x.shape(1);
     const intptr_t n = x.shape(0);
     std::array<intptr_t, 1> out_shape{{(n * (n - 1)) / 2}};
+
+    if( type == PreprocessingType::ComputeVariance ) {
+        auto dtype = promote_type_real(common_type(x.dtype()));
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            pdist_weighted<scalar_t>(out, x, f);
+        });
+        return out;
+    }
+
     if (w_obj.is_none()) {
         auto dtype = promote_type_real(x.dtype());
         auto out = prepare_out_argument(out_obj, dtype, out_shape);
         DISPATCH_DTYPE(dtype, [&]{
-            pdist_unweighted<scalar_t>(out, x, f);
+            pdist_unweighted<scalar_t>(out, x, f, type);
         });
         return out;
     }
@@ -504,14 +781,15 @@ py::array pdist(const py::object& out_obj, const py::object& x_obj,
     auto dtype = promote_type_real(common_type(x.dtype(), w.dtype()));
     auto out = prepare_out_argument(out_obj, dtype, out_shape);
     DISPATCH_DTYPE(dtype, [&]{
-        pdist_weighted<scalar_t>(out, x, w, f);
+        pdist_weighted<scalar_t>(out, x, w, f, type);
     });
     return out;
 }
 
 template <typename Func>
 py::array cdist(const py::object& out_obj, const py::object& x_obj,
-                const py::object& y_obj, const py::object& w_obj, Func&& f) {
+                const py::object& y_obj, const py::object& w_obj, Func&& f,
+                PreprocessingType type=PreprocessingType::None) {
     auto x = npy_asarray(x_obj);
     auto y = npy_asarray(y_obj);
     if (x.ndim() != 2) {
@@ -528,11 +806,21 @@ py::array cdist(const py::object& out_obj, const py::object& x_obj,
     }
 
     std::array<intptr_t, 2> out_shape{{x.shape(0), y.shape(0)}};
+
+    if( type == PreprocessingType::ComputeVariance ) {
+        auto dtype = promote_type_real(common_type(x.dtype(), y.dtype()));
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            cdist_weighted<scalar_t>(out, x, y, f);
+        });
+        return out;
+    }
+
     if (w_obj.is_none()) {
         auto dtype = promote_type_real(common_type(x.dtype(), y.dtype()));
         auto out = prepare_out_argument(out_obj, dtype, out_shape);
         DISPATCH_DTYPE(dtype, [&]{
-            cdist_unweighted<scalar_t>(out, x, y, f);
+            cdist_unweighted<scalar_t>(out, x, y, f, type);
         });
         return out;
     }
@@ -542,7 +830,461 @@ py::array cdist(const py::object& out_obj, const py::object& x_obj,
         common_type(x.dtype(), y.dtype(), w.dtype()));
     auto out = prepare_out_argument(out_obj, dtype, out_shape);
     DISPATCH_DTYPE(dtype, [&]{
-        cdist_weighted<scalar_t>(out, x, y, w, f);
+        cdist_weighted<scalar_t>(out, x, y, w, f, type);
+    });
+    return out;
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE void cdist_mahalanobis_impl(ArrayDescriptor x, const scalar_t* x_data,
+    ArrayDescriptor y, const scalar_t* y_data, ArrayDescriptor vi, const scalar_t* vi_data,
+    ArrayDescriptor out, scalar_t* out_data, intptr_t vi_col_offset) {
+    const intptr_t num_rowsX = x.shape[0], num_rowsY = y.shape[0];
+    const intptr_t num_cols = x.shape[1];
+    scalar_t* uv_diff1 = new scalar_t[2*num_cols];
+    scalar_t* uv_diff2 = uv_diff1 + num_cols;
+
+    for( intptr_t i = 0; i < num_rowsX; i++ ) {
+        const scalar_t* u = &x_data[i * x.strides[0]];
+        for( intptr_t j = 0; j < num_rowsY; j++ ) {
+            const scalar_t* v = &y_data[j * y.strides[0]];
+
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                uv_diff1[k] = u[k*x.strides[1]] - v[k*y.strides[1]];
+            }
+
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                uv_diff2[k] = 0;
+                for( intptr_t l = 0; l < num_cols; l++ ) {
+                    uv_diff2[k] += uv_diff1[l] * vi_data[k*vi.strides[0] + (l + vi_col_offset)*vi.strides[1]];
+                }
+            }
+
+            scalar_t s = 0;
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                s += uv_diff1[k] * uv_diff2[k];
+            }
+
+            out_data[i*out.strides[0] + j*out.strides[1]] = std::sqrt(s);
+        }
+    }
+
+    delete [] uv_diff1;
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE void _compute_inverse_matrix(ArrayDescriptor vi, scalar_t* vi_data) {
+
+    const intptr_t num_cols = vi.shape[0];
+
+    for( intptr_t i = 0; i < num_cols; i++ ) {
+        for( intptr_t j = num_cols; j < 2*num_cols; j++ ) {
+            vi_data[i*vi.strides[0] + j*vi.strides[1]] = 0;
+        }
+    }
+
+    for( intptr_t i = 0; i < num_cols; i++ ) {
+        for( intptr_t j = 0; j < 2*num_cols; j++ ) {
+            if( (j - i) == num_cols ) {
+                vi_data[i*vi.strides[0] + j*vi.strides[1]] = 1;
+            }
+        }
+    }
+
+    for( intptr_t i = num_cols - 1; i >= 1; i-- ) {
+        if( vi_data[(i - 1)*vi.strides[0]] < vi_data[i*vi.strides[0]] ) {
+            for( intptr_t j = 0; j < 2*num_cols; j++ ) {
+                scalar_t tmp = vi_data[i*vi.strides[0] + j*vi.strides[1]];
+                vi_data[i*vi.strides[0] + j*vi.strides[1]] = vi_data[(i - 1)*vi.strides[0] + j*vi.strides[1]];
+                vi_data[(i - 1)*vi.strides[0] + j*vi.strides[1]] = tmp;
+            }
+        }
+    }
+
+    for( intptr_t i = 0; i < num_cols; i++ ) {
+        for( intptr_t j = 0; j < num_cols; j++ ) {
+            if( j != i ) {
+                const intptr_t ji = j*vi.strides[0] + i*vi.strides[1];
+                const intptr_t ii = i*vi.strides[0] + i*vi.strides[1];
+                scalar_t factor = vi_data[ji] / vi_data[ii];
+                for( intptr_t k = 0; k < 2*num_cols; k++ ) {
+                    const intptr_t jk = j*vi.strides[0] + k*vi.strides[1];
+                    const intptr_t ik = i*vi.strides[0] + k*vi.strides[1];
+                    vi_data[jk] -= vi_data[ik] * factor;
+                }
+            }
+        }
+    }
+
+    for( intptr_t i = 0; i < num_cols; i++ ) {
+        const intptr_t ii = i*vi.strides[0] + i*vi.strides[1];
+        scalar_t factor = vi_data[ii];
+        for( intptr_t j = 0; j < 2*num_cols; j++ ) {
+            const intptr_t ij = i*vi.strides[0] + j*vi.strides[1];
+            vi_data[ij] /= factor;
+        }
+    }
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE scalar_t _compute_mean(
+    ArrayDescriptor x[], const scalar_t* x_data[], intptr_t nx, intptr_t j) {
+    scalar_t sum[4] = {0, 0, 0, 0};
+    intptr_t total_values = 0;
+
+    for( intptr_t ix = 0; ix < nx; ix++ ) {
+        const intptr_t num_rows = x[ix].shape[0];
+        total_values += num_rows;
+        intptr_t i;
+        for( i = 0; i + 3 < num_rows; i += 4 ) {
+            auto index0 = i*x[ix].strides[0] + j*x[ix].strides[1];
+            auto index1 = (i + 1)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto index2 = (i + 2)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto index3 = (i + 3)*x[ix].strides[0] + j*x[ix].strides[1];
+            sum[0] += x_data[ix][index0];
+            sum[1] += x_data[ix][index1];
+            sum[2] += x_data[ix][index2];
+            sum[3] += x_data[ix][index3];
+        }
+        for( ; i < num_rows; i++ ) {
+            auto index = i*x[ix].strides[0] + j*x[ix].strides[1];
+            sum[0] += x_data[ix][index];
+        }
+    }
+    return (sum[0] + sum[1] + sum[2] + sum[3])/total_values;
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE scalar_t _compute_covariance(
+    ArrayDescriptor x[], const scalar_t* x_data[],
+    intptr_t nx, intptr_t j, intptr_t k) {
+    scalar_t j_mean = _compute_mean(x, x_data, nx, j);
+    scalar_t k_mean = _compute_mean(x, x_data, nx, k);
+    scalar_t cov_jk[4] = {0, 0, 0, 0};
+    intptr_t total_values = 0;
+
+    for( intptr_t ix = 0; ix < nx; ix++ ) {
+        const intptr_t num_rows = x[ix].shape[0];
+        total_values += num_rows;
+        intptr_t i;
+        for( i = 0; i + 3 < num_rows; i += 4 ) {
+            auto jindex0 = i*x[ix].strides[0] + j*x[ix].strides[1];
+            auto kindex0 = i*x[ix].strides[0] + k*x[ix].strides[1];
+            auto jindex1 = (i + 1)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto kindex1 = (i + 1)*x[ix].strides[0] + k*x[ix].strides[1];
+            auto jindex2 = (i + 2)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto kindex2 = (i + 2)*x[ix].strides[0] + k*x[ix].strides[1];
+            auto jindex3 = (i + 3)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto kindex3 = (i + 3)*x[ix].strides[0] + k*x[ix].strides[1];
+            cov_jk[0] += (x_data[ix][jindex0] - j_mean)*(x_data[ix][kindex0] - k_mean);
+            cov_jk[1] += (x_data[ix][jindex1] - j_mean)*(x_data[ix][kindex1] - k_mean);
+            cov_jk[2] += (x_data[ix][jindex2] - j_mean)*(x_data[ix][kindex2] - k_mean);
+            cov_jk[3] += (x_data[ix][jindex3] - j_mean)*(x_data[ix][kindex3] - k_mean);
+        }
+        for( ; i < num_rows; i++ ) {
+            auto jindex = i*x[ix].strides[0] + j*x[ix].strides[1];
+            auto kindex = i*x[ix].strides[0] + k*x[ix].strides[1];
+            cov_jk[0] += (x_data[ix][jindex] - j_mean)*(x_data[ix][kindex] - k_mean);
+        }
+    }
+    return (cov_jk[0] + cov_jk[1] + cov_jk[2] + cov_jk[3])/(total_values - 1);
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE scalar_t _compute_covariance(
+    ArrayDescriptor x[], const scalar_t* x_data[],
+    intptr_t nx, intptr_t j) {
+    scalar_t j_mean = _compute_mean(x, x_data, nx, j);
+    scalar_t cov_jj[4] = {0, 0, 0, 0};
+    intptr_t total_values = 0;
+
+    for( intptr_t ix = 0; ix < nx; ix++ ) {
+        const intptr_t num_rows = x[ix].shape[0];
+        total_values += num_rows;
+        intptr_t i;
+        for( i = 0; i + 3 < num_rows; i += 4 ) {
+            auto jindex0 = i*x[ix].strides[0] + j*x[ix].strides[1];
+            auto jindex1 = (i + 1)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto jindex2 = (i + 2)*x[ix].strides[0] + j*x[ix].strides[1];
+            auto jindex3 = (i + 3)*x[ix].strides[0] + j*x[ix].strides[1];
+            cov_jj[0] += (x_data[ix][jindex0] - j_mean)*(x_data[ix][jindex0] - j_mean);
+            cov_jj[1] += (x_data[ix][jindex1] - j_mean)*(x_data[ix][jindex1] - j_mean);
+            cov_jj[2] += (x_data[ix][jindex2] - j_mean)*(x_data[ix][jindex2] - j_mean);
+            cov_jj[3] += (x_data[ix][jindex3] - j_mean)*(x_data[ix][jindex3] - j_mean);
+        }
+        for( ; i < num_rows; i++ ) {
+            auto jindex = i*x[ix].strides[0] + j*x[ix].strides[1];
+            cov_jj[0] += (x_data[ix][jindex] - j_mean)*(x_data[ix][jindex] - j_mean);
+        }
+    }
+    return (cov_jj[0] + cov_jj[1] + cov_jj[2] + cov_jj[3])/(total_values - 1);
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE void _compute_covariance_matrix(ArrayDescriptor x[], const scalar_t* x_data[],
+    intptr_t nx, ArrayDescriptor vi, scalar_t* vi_data) {
+    const intptr_t num_cols = x[0].shape[1];
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        for( intptr_t k = j + 1; k < num_cols; k++ ) {
+            scalar_t vi_ik_kj = _compute_covariance(x, x_data, nx, j, k);
+            vi_data[j*vi.strides[0] + k*vi.strides[1]] = vi_ik_kj;
+            vi_data[k*vi.strides[0] + j*vi.strides[1]] = vi_ik_kj;
+        }
+    }
+
+    for( intptr_t j = 0; j < num_cols; j++ ) {
+        scalar_t vi_ik_kj = _compute_covariance(x, x_data, nx, j);
+        vi_data[j*vi.strides[0] + j*vi.strides[1]] = vi_ik_kj;
+    }
+}
+
+template <typename scalar_t>
+py::array cdist_mahalanobis_without_vi(
+    const py::array& out_obj, const py::array& x_obj, const py::array& y_obj) {
+    auto x_array = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto y_array = npy_asarray<scalar_t>(y_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out_array = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto x = get_descriptor(x_array);
+    auto y = get_descriptor(y_array);
+    auto out = get_descriptor(out_array);
+    const scalar_t* x_data = static_cast<const scalar_t*>(x_array.data());
+    const scalar_t* y_data = static_cast<const scalar_t*>(y_array.data());
+    scalar_t* out_data = static_cast<scalar_t*>(out_array.mutable_data());
+
+    const intptr_t num_cols = x.shape[1];
+
+    ArrayDescriptor vi(2);
+    vi.element_size = x.element_size;
+    vi.shape = {num_cols, 2*num_cols};
+    vi.strides = {2*num_cols, 1};
+    scalar_t* vi_data = new scalar_t[2*num_cols*num_cols];
+
+    ArrayDescriptor X[2] = {x, y};
+    const scalar_t* X_data[2] = {x_data, y_data};
+
+    _compute_covariance_matrix(X, X_data, 2, vi, vi_data);
+    _compute_inverse_matrix(vi, vi_data);
+
+    cdist_mahalanobis_impl(x, x_data, y, y_data, vi, vi_data, out, out_data, num_cols);
+
+    delete [] vi_data;
+
+    return out_array;
+}
+
+template <typename scalar_t>
+py::array cdist_mahalanobis_with_vi(const py::array& out_obj, const py::array& x_obj,
+                                    const py::array& y_obj, const py::array& vi_obj) {
+    auto x_array = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto y_array = npy_asarray<scalar_t>(y_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto vi_array = npy_asarray<scalar_t>(vi_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out_array = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto x = get_descriptor(x_array);
+    auto y = get_descriptor(y_array);
+    auto vi = get_descriptor(vi_array);
+    auto out = get_descriptor(out_array);
+    const scalar_t* x_data = static_cast<const scalar_t*>(x_array.data());
+    const scalar_t* y_data = static_cast<const scalar_t*>(y_array.data());
+    const scalar_t* vi_data = static_cast<const scalar_t*>(vi_array.data());
+    scalar_t* out_data = static_cast<scalar_t*>(out_array.mutable_data());
+
+    cdist_mahalanobis_impl(x, x_data, y, y_data, vi, vi_data, out, out_data, 0);
+
+    return out_array;
+}
+
+py::array cdist_mahalanobis(py::object& out_obj, const py::object& x_obj,
+                const py::object& y_obj, const py::object& vi_obj) {
+    auto x = npy_asarray(x_obj);
+    auto y = npy_asarray(y_obj);
+    auto vi = npy_asarray(vi_obj);
+    if (x.ndim() != 2) {
+        throw std::invalid_argument("XA must be a 2-dimensional array.");
+    }
+    if (y.ndim() != 2) {
+        throw std::invalid_argument("XB must be a 2-dimensional array.");
+    }
+    const intptr_t m = x.shape(1);
+    if (m != y.shape(1)) {
+        throw std::invalid_argument(
+            "XA and XB must have the same number of columns "
+            "(i.e. feature dimension).");
+    }
+
+    std::array<intptr_t, 2> out_shape{{x.shape(0), y.shape(0)}};
+
+    if (vi_obj.is_none()) {
+        auto m = x.shape(0) + y.shape(0);
+        auto n = x.shape(1);
+        if( m <= n ) {
+            throw std::invalid_argument(
+                std::string("The number of observations (") +
+                std::to_string(m) + std::string(") is too ") +
+                "small; the covariance matrix is " +
+                "singular. For observations with " + std::to_string(n) +
+                " dimensions, at least " + std::to_string(n + 1) +
+                std::string(" observations are required."));
+        }
+        auto dtype = promote_type_real(common_type(x.dtype(), y.dtype()));
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            cdist_mahalanobis_without_vi<scalar_t>(out, x, y);
+        });
+        return out;
+    }
+
+    if( m != vi.shape(0) || m != vi.shape(1) ) {
+        throw std::invalid_argument(
+            "Inverse covariance matrix must have the same "
+            "number of columns as XA and XB "
+            "(i.e. feature dimension).");
+    }
+
+    auto dtype = promote_type_real(
+        common_type(x.dtype(), y.dtype(), vi.dtype()));
+    auto out = prepare_out_argument(out_obj, dtype, out_shape);
+    DISPATCH_DTYPE(dtype, [&]{
+        cdist_mahalanobis_with_vi<scalar_t>(out, x, y, vi);
+    });
+    return out;
+}
+
+template <typename scalar_t>
+ALWAYS_INLINE void pdist_mahalanobis_impl(
+    ArrayDescriptor x, const scalar_t* x_data,
+    ArrayDescriptor vi, const scalar_t* vi_data,
+    ArrayDescriptor out, scalar_t* out_data, intptr_t vi_col_offset) {
+    const intptr_t num_rowsX = x.shape[0];
+    const intptr_t num_cols = x.shape[1];
+    scalar_t* uv_diff1 = new scalar_t[2*num_cols];
+    scalar_t* uv_diff2 = uv_diff1 + num_cols;
+    intptr_t o = 0;
+
+    for( intptr_t i = 0; i < num_rowsX; i++ ) {
+        const scalar_t* u = &x_data[i * x.strides[0]];
+        for( intptr_t j = i + 1; j < num_rowsX; j++, o++ ) {
+            const scalar_t* v = &x_data[j * x.strides[0]];
+
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                uv_diff1[k] = u[k*x.strides[1]] - v[k*x.strides[1]];
+            }
+
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                uv_diff2[k] = 0;
+                for( intptr_t l = 0; l < num_cols; l++ ) {
+                    uv_diff2[k] += uv_diff1[l] * vi_data[k*vi.strides[0] + (l + vi_col_offset)*vi.strides[1]];
+                }
+            }
+
+            scalar_t s = 0;
+            for( intptr_t k = 0; k < num_cols; k++ ) {
+                s += uv_diff1[k] * uv_diff2[k];
+            }
+
+            out_data[o] = std::sqrt(s);
+        }
+    }
+
+    delete [] uv_diff1;
+}
+
+template <typename scalar_t>
+py::array pdist_mahalanobis_without_vi(
+    const py::array& out_obj, const py::array& x_obj) {
+    auto x_array = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out_array = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto x = get_descriptor(x_array);
+    auto out = get_descriptor(out_array);
+    const scalar_t* x_data = static_cast<const scalar_t*>(x_array.data());
+    scalar_t* out_data = static_cast<scalar_t*>(out_array.mutable_data());
+
+    const intptr_t num_cols = x.shape[1];
+
+    ArrayDescriptor vi(2);
+    vi.element_size = x.element_size;
+    vi.shape = {num_cols, 2*num_cols};
+    vi.strides = {2*num_cols, 1};
+    scalar_t* vi_data = new scalar_t[2*num_cols*num_cols];
+
+    ArrayDescriptor X[1] = {x};
+    const scalar_t* X_data[1] = {x_data};
+
+    _compute_covariance_matrix(X, X_data, 1, vi, vi_data);
+    _compute_inverse_matrix(vi, vi_data);
+
+    pdist_mahalanobis_impl(x, x_data, vi, vi_data, out, out_data, num_cols);
+
+    delete [] vi_data;
+
+    return out_array;
+}
+
+template <typename scalar_t>
+py::array pdist_mahalanobis_with_vi(
+    const py::array& out_obj, const py::array& x_obj, const py::array& vi_obj) {
+    auto x_array = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto vi_array = npy_asarray<scalar_t>(vi_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out_array = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto x = get_descriptor(x_array);
+    auto vi = get_descriptor(vi_array);
+    auto out = get_descriptor(out_array);
+    const scalar_t* x_data = static_cast<const scalar_t*>(x_array.data());
+    const scalar_t* vi_data = static_cast<const scalar_t*>(vi_array.data());
+    scalar_t* out_data = static_cast<scalar_t*>(out_array.mutable_data());
+
+    pdist_mahalanobis_impl(x, x_data, vi, vi_data, out, out_data, 0);
+
+    return out_array;
+}
+
+py::array pdist_mahalanobis(const py::object& out_obj,
+    const py::object& x_obj, const py::object& vi_obj) {
+    auto x = npy_asarray(x_obj);
+    auto vi = npy_asarray(vi_obj);
+    if (x.ndim() != 2) {
+        throw std::invalid_argument("x must be 2-dimensional");
+    }
+
+    const intptr_t n = x.shape(1);
+    const intptr_t m = x.shape(0);
+    std::array<intptr_t, 1> out_shape{{(m * (m - 1)) / 2}};
+
+    if (vi_obj.is_none()) {
+        if( m <= n ) {
+            throw std::invalid_argument(
+                std::string("The number of observations (") +
+                std::to_string(m) + std::string(") is too ") +
+                "small; the covariance matrix is " +
+                "singular. For observations with " + std::to_string(n) +
+                " dimensions, at least " + std::to_string(n + 1) +
+                std::string(" observations are required."));
+        }
+        auto dtype = promote_type_real(x.dtype());
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            pdist_mahalanobis_without_vi<scalar_t>(out, x);
+        });
+        return out;
+    }
+
+    if( n != vi.shape(0) || n != vi.shape(1) ) {
+        throw std::invalid_argument(
+            "Inverse covariance matrix must have the same "
+            "number of columns as X (i.e. feature dimension).");
+    }
+
+    auto dtype = promote_type_real(common_type(x.dtype(), vi.dtype()));
+    auto out = prepare_out_argument(out_obj, dtype, out_shape);
+    DISPATCH_DTYPE(dtype, [&]{
+        pdist_mahalanobis_with_vi<scalar_t>(out, x, vi);
     });
     return out;
 }
@@ -617,6 +1359,16 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return pdist(out, x, w, EuclideanDistance{});
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_seuclidean",
+          [](py::object x, py::object w, py::object out) {
+              if( w.is_none() ) {
+                return pdist(out, x, w, EuclideanDistance{},
+                             PreprocessingType::ComputeVariance);
+              } else {
+                return pdist(out, x, w, EuclideanDistance{});
+              }
+          },
+          "x"_a, "w"_a, "out"_a=py::none());
     m.def("pdist_minkowski",
           [](py::object x, py::object w, py::object out, double p) {
               if (p == 1.0) {
@@ -630,6 +1382,28 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               }
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+    m.def("pdist_mahalanobis",
+          [](py::object x, py::object vi, py::object out) {
+              return pdist_mahalanobis(out, x, vi);
+          },
+          "x"_a, "vi"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_cosine",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, CosineDistance{}, PreprocessingType::Normalise);
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_correlation",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, CosineDistance{},
+                           PreprocessingType::CentraliseAndNormalise);
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_jensenshannon",
+          [](py::object x, py::object out) {
+              return pdist(out, x, py::none(), JensenshannonDistance{},
+                           PreprocessingType::ScaleInputForJensenshannon_);
+          },
+          "x"_a, "out"_a=py::none());
     m.def("pdist_sqeuclidean",
           [](py::object x, py::object w, py::object out) {
               return pdist(out, x, w, SquareEuclideanDistance{});
@@ -705,6 +1479,39 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return cdist(out, x, y, w, EuclideanDistance{});
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_seuclidean",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              if( w.is_none() ) {
+                  return cdist(out, x, y, w, EuclideanDistance{},
+                               PreprocessingType::ComputeVariance);
+              } else {
+                  return cdist(out, x, y, w, EuclideanDistance{});
+              }
+          },
+          "x"_a, "y"_a, "w"_a, "out"_a=py::none());
+    m.def("cdist_mahalanobis",
+          [](py::object x, py::object y, py::object vi, py::object out) {
+              return cdist_mahalanobis(out, x, y, vi);
+          },
+          "x"_a, "y"_a, "vi"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_cosine",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, CosineDistance{},
+                           PreprocessingType::Normalise);
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_correlation",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, CosineDistance{},
+                           PreprocessingType::CentraliseAndNormalise);
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_jensenshannon",
+          [](py::object x, py::object y, py::object out) {
+              return cdist(out, x, y, py::none(), JensenshannonDistance{},
+                           PreprocessingType::ScaleInputForJensenshannon_);
+          },
+          "x"_a, "y"_a, "out"_a=py::none());
     m.def("cdist_minkowski",
           [](py::object x, py::object y, py::object w, py::object out,
              double p) {

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -517,7 +517,8 @@ py::array pdist_weighted(
     auto x_desc = get_descriptor(x);
     auto x_data = x.data();
 
-    scalar_t* w_data = new scalar_t[x_desc.shape[1]];
+    std::vector<scalar_t> w_data_(x_desc.shape[1]);
+    scalar_t* w_data = w_data_.data();
     _compute_variance_across_rows(w_data, x_desc, x_data);
     ArrayDescriptor w_desc(1);
     w_desc.element_size = x_desc.element_size;
@@ -531,7 +532,6 @@ py::array pdist_weighted(
             w_data, f, PreprocessingType::None);
     }
 
-    delete [] w_data;
     return std::move(out);
 }
 
@@ -607,7 +607,8 @@ py::array cdist_weighted(
     auto y_desc = get_descriptor(y);
     auto y_data = y.data();
 
-    scalar_t* w_data = new scalar_t[x_desc.shape[1]];
+    std::vector<scalar_t> w_data_(x_desc.shape[1]);
+    scalar_t* w_data = w_data_.data();
     _compute_variance_across_rows(w_data, x_desc, x_data, y_desc, y_data);
     ArrayDescriptor w_desc(1);
     w_desc.element_size = x_desc.element_size;
@@ -621,7 +622,6 @@ py::array cdist_weighted(
             w_desc, w_data, f, PreprocessingType::None);
     }
 
-    delete [] w_data;
     return std::move(out);
 }
 
@@ -841,7 +841,8 @@ ALWAYS_INLINE void cdist_mahalanobis_impl(ArrayDescriptor x, const scalar_t* x_d
     ArrayDescriptor out, scalar_t* out_data, intptr_t vi_col_offset) {
     const intptr_t num_rowsX = x.shape[0], num_rowsY = y.shape[0];
     const intptr_t num_cols = x.shape[1];
-    scalar_t* uv_diff1 = new scalar_t[2*num_cols];
+    std::vector<scalar_t> diffs(2*num_cols);
+    scalar_t* uv_diff1 = diffs.data();
     scalar_t* uv_diff2 = uv_diff1 + num_cols;
 
     for( intptr_t i = 0; i < num_rowsX; i++ ) {
@@ -868,8 +869,6 @@ ALWAYS_INLINE void cdist_mahalanobis_impl(ArrayDescriptor x, const scalar_t* x_d
             out_data[i*out.strides[0] + j*out.strides[1]] = std::sqrt(s);
         }
     }
-
-    delete [] uv_diff1;
 }
 
 template <typename scalar_t>
@@ -1059,7 +1058,8 @@ py::array cdist_mahalanobis_without_vi(
     vi.element_size = x.element_size;
     vi.shape = {num_cols, 2*num_cols};
     vi.strides = {2*num_cols, 1};
-    scalar_t* vi_data = new scalar_t[2*num_cols*num_cols];
+    std::vector<scalar_t> vi_data_(2*num_cols*num_cols);
+    scalar_t* vi_data = vi_data_.data();
 
     ArrayDescriptor X[2] = {x, y};
     const scalar_t* X_data[2] = {x_data, y_data};
@@ -1068,8 +1068,6 @@ py::array cdist_mahalanobis_without_vi(
     _compute_inverse_matrix(vi, vi_data);
 
     cdist_mahalanobis_impl(x, x_data, y, y_data, vi, vi_data, out, out_data, num_cols);
-
-    delete [] vi_data;
 
     return out_array;
 }
@@ -1161,7 +1159,8 @@ ALWAYS_INLINE void pdist_mahalanobis_impl(
     ArrayDescriptor out, scalar_t* out_data, intptr_t vi_col_offset) {
     const intptr_t num_rowsX = x.shape[0];
     const intptr_t num_cols = x.shape[1];
-    scalar_t* uv_diff1 = new scalar_t[2*num_cols];
+    std::vector<scalar_t> diffs(2*num_cols);
+    scalar_t* uv_diff1 = diffs.data();
     scalar_t* uv_diff2 = uv_diff1 + num_cols;
     intptr_t o = 0;
 
@@ -1189,8 +1188,6 @@ ALWAYS_INLINE void pdist_mahalanobis_impl(
             out_data[o] = std::sqrt(s);
         }
     }
-
-    delete [] uv_diff1;
 }
 
 template <typename scalar_t>
@@ -1210,7 +1207,8 @@ py::array pdist_mahalanobis_without_vi(
     vi.element_size = x.element_size;
     vi.shape = {num_cols, 2*num_cols};
     vi.strides = {2*num_cols, 1};
-    scalar_t* vi_data = new scalar_t[2*num_cols*num_cols];
+    std::vector<scalar_t> vi_data_(2*num_cols*num_cols);
+    scalar_t* vi_data = vi_data_.data();
 
     ArrayDescriptor X[1] = {x};
     const scalar_t* X_data[1] = {x_data};
@@ -1219,8 +1217,6 @@ py::array pdist_mahalanobis_without_vi(
     _compute_inverse_matrix(vi, vi_data);
 
     pdist_mahalanobis_impl(x, x_data, vi, vi_data, out, out_data, num_cols);
-
-    delete [] vi_data;
 
     return out_array;
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Continues https://github.com/scipy/scipy/pull/14611

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Performance differences with `main`,

```zsh
| Change   | Before [149f9fd3] <main>   | After [874e3e1c] <pybind11_dist>   |   Ratio | Benchmark (Parameter)                                   |
|----------|----------------------------|------------------------------------|---------|---------------------------------------------------------|
| +        | 2.26±0.01μs                | 2.65±0.02μs                        |    1.18 | spatial.Xdist.time_cdist(10, 'cosine')                  |
| +        | 2.11±0.02μs                | 2.38±0.02μs                        |    1.13 | spatial.Xdist.time_pdist(10, 'cosine')                  |
| +        | 2.17±0.04μs                | 2.36±0.02μs                        |    1.09 | spatial.Xdist.time_cdist(10, 'hamming')                 |
| +        | 1.86±0.02μs                | 1.99±0.02μs                        |    1.07 | spatial.Xdist.time_pdist(10, 'hamming')                 |
| -        | 196±2μs                    | 177±3μs                            |    0.9  | spatial.Xdist.time_pdist(100, 'jensenshannon')          |
| -        | 22.5±0.2ms                 | 19.8±0.2ms                         |    0.88 | spatial.Xdist.time_pdist(1000, 'jensenshannon')         |
| -        | 1.26±0.02ms                | 1.11±0.02ms                        |    0.88 | spatial.Xdist.time_pdist(1000, 'seuclidean')            |
| -        | 44.8±0.3ms                 | 38.1±0.3ms                         |    0.85 | spatial.Xdist.time_cdist(1000, 'jensenshannon')         |
| -        | 105±0.4μs                  | 84.9±0.3μs                         |    0.81 | spatial.Xdist.time_cdist(100, 'mahalanobis')            |
| -        | 2.62±0.03ms                | 2.13±0.03ms                        |    0.81 | spatial.Xdist.time_cdist(1000, 'seuclidean')            |
| -        | 423±7μs                    | 323±1μs                            |    0.76 | spatial.Xdist.time_cdist(100, 'jensenshannon')          |
| -        | 20.9±0.1μs                 | 14.8±0.04μs                        |    0.71 | spatial.Xdist.time_cdist(100, 'cosine')                 |
| -        | 1.15±0.03ms                | 817±20μs                           |    0.71 | spatial.Xdist.time_pdist(1000, 'correlation')           |
| -        | 1.14±0.01ms                | 794±20μs                           |    0.7  | spatial.Xdist.time_pdist(1000, 'cosine')                |
| -        | 62.4±1μs                   | 41.8±0.1μs                         |    0.67 | spatial.Xdist.time_pdist(100, 'mahalanobis')            |
| -        | 2.37±0.07ms                | 1.56±0.07ms                        |    0.66 | spatial.Xdist.time_cdist(1000, 'cosine')                |
| -        | 16.8±0.2μs                 | 11.0±0.06μs                        |    0.65 | spatial.Xdist.time_pdist(100, 'correlation')            |
| -        | 2.36±0.05ms                | 1.51±0.06ms                        |    0.64 | spatial.Xdist.time_cdist(1000, 'correlation')           |
| -        | 37.0±0.5μs                 | 21.6±0.09μs                        |    0.58 | spatial.Xdist.time_cdist(100, 'seuclidean')             |
| -        | 23.1±0.1μs                 | 12.5±0.06μs                        |    0.54 | spatial.Xdist.time_pdist(100, 'seuclidean')             |
| -        | 30.9±0.1μs                 | 15.3±0.2μs                         |    0.49 | spatial.Xdist.time_cdist(100, 'correlation')            |
| -        | 6.52±0.09μs                | 2.49±0.06μs                        |    0.38 | spatial.Xdist.time_pdist(10, 'correlation')             |
| -        | 10.5±0.06μs                | 2.74±0.02μs                        |    0.26 | spatial.Xdist.time_cdist(10, 'correlation')             |
| -        | 11.1±0.08μs                | 2.37±0.05μs                        |    0.21 | spatial.Xdist.time_pdist(10, 'seuclidean')              |
| -        | 13.2±0.2μs                 | 2.66±0.03μs                        |    0.2  | spatial.Xdist.time_cdist(10, 'seuclidean')              |
| -        | 22.5±0.2μs                 | 3.64±0.03μs                        |    0.16 | spatial.Xdist.time_cdist(10, 'mahalanobis')             |
| -        | 20.6±0.1μs                 | 2.98±0.1μs                         |    0.14 | spatial.Xdist.time_pdist(10, 'mahalanobis')             |
| -        | 474±2μs                    | 2.87±0.1μs                         |    0.01 | spatial.XdistWeighted.time_pdist(10, 'correlation')     |
| -        | 405±10μs                   | 2.84±0.05μs                        |    0.01 | spatial.XdistWeighted.time_pdist(10, 'cosine')          |
| -        | 1.04±0.01ms                | 3.30±0.03μs                        |    0    | spatial.XdistWeighted.time_cdist(10, 'correlation')     |
| -        | 879±8μs                    | 3.20±0.03μs                        |    0    | spatial.XdistWeighted.time_cdist(10, 'cosine')          |
| -        | 103±0.2ms                  | 24.7±0.5μs                         |    0    | spatial.XdistWeighted.time_cdist(100, 'correlation')    |
| -        | 86.6±0.2ms                 | 24.2±0.4μs                         |    0    | spatial.XdistWeighted.time_cdist(100, 'cosine')         |
| -        | 4.12±0.06ms                | 4.05±0.2μs                         |    0    | spatial.XdistWeighted.time_cdist(20, 'correlation')     |
| -        | 3.49±0.02ms                | 3.97±0.1μs                         |    0    | spatial.XdistWeighted.time_cdist(20, 'cosine')          |
| -        | 51.2±0.06ms                | 14.9±1μs                           |    0    | spatial.XdistWeighted.time_pdist(100, 'correlation')    |
| -        | 43.3±0.2ms                 | 14.6±1μs                           |    0    | spatial.XdistWeighted.time_pdist(100, 'cosine')         |
| -        | 1.99±0.01ms                | 3.40±0.2μs                         |    0    | spatial.XdistWeighted.time_pdist(20, 'correlation')     |
| -        | 1.66±0.01ms                | 3.27±0.2μs                         |    0    | spatial.XdistWeighted.time_pdist(20, 'cosine')          |
```

Performance difference between this branch and [`pybind11_dist_`](https://github.com/czgdp1807/scipy/tree/pybind11_dist_) (based on https://github.com/scipy/scipy/pull/21263#issuecomment-2251367073),

```zsh
| Change   | Before [5ae12deb] <pybind11_dist_>   | After [fa227c73] <pybind11_dist>   |   Ratio | Benchmark (Parameter)                           |
|----------|--------------------------------------|------------------------------------|---------|-------------------------------------------------|
| -        | 1.94±0ms                             | 1.74±0ms                           |    0.89 | spatial.Xdist.time_cdist(1000, 'cosine')        |
| -        | 87.9±0μs                             | 52.7±0μs                           |    0.6  | spatial.Xdist.time_cdist(100, 'cosine')         |
| -        | 91.2±0μs                             | 49.1±0μs                           |    0.54 | spatial.Xdist.time_cdist(10, 'cosine')          |
```

```zsh
| -        | 75.8±0μs                             | 67.5±0μs                           |    0.89 | spatial.XdistWeighted.time_cdist(20, 'cosine')          |
| -        | 106±0μs                              | 78.5±0μs                           |    0.74 | spatial.XdistWeighted.time_cdist(100, 'cosine')         |
| -        | 76.9±0μs                             | 67.0±0μs                           |    0.87 | spatial.XdistWeighted.time_cdist(10, 'cosine')          |
```

Performance difference between variance computation in C++ (`pybind11_dist_2`) and Python (`pybind11_dist`). The performance gains are significant.

```zsh
| Change   | Before [cbabc5a6] <pybind11_dist>   | After [7900364d] <pybind11_dist_2>   |   Ratio | Benchmark (Parameter)                            |
|----------|-------------------------------------|--------------------------------------|---------|--------------------------------------------------|
| -        | 2.50±0ms                            | 2.25±0ms                             |    0.9  | spatial.Xdist.time_cdist(1000, 'seuclidean')    |
| -        | 151±0μs                             | 56.4±0μs                             |    0.37 | spatial.Xdist.time_cdist(100, 'seuclidean')     |
| -        | 148±0μs                             | 37.8±0μs                             |    0.26 | spatial.Xdist.time_cdist(10, 'seuclidean')      |
```