### PR TITLE
BUG: fix cstddef include

### DIFF
--- a/scipy/special/special/config.h
+++ b/scipy/special/special/config.h
@@ -59,7 +59,7 @@
 
 #include <cuda/std/cmath>
 #include <cuda/std/cstdint>
-#include <cuda/std/cstdef>
+#include <cuda/std/cstddef>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>


### PR DESCRIPTION
* Fixes #21228

* The `cstddef` include had a typo, preventing the tests failing in the above ticket from running properly.

[skip cirrus] [skip circle]

Note that while this gets me past the original problem described in the matching issue, I do still have a problem with `cuda_runtime.h` not being available, but I'll assume that's specific to my `spack`-based buildout of CUDA (it is there when I look for it manually). @mdhaber does this patch get you to the tests passing on your end? I'm guessing you installed CUDA another way so it may work for you just fine now?

@leofang @jakirkham does this look right? I don't see the original spelling of the file but this new one is there.