### PR TITLE
DOC: add Stack Overflow link to readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,8 @@ ODE solvers, and more.
 - **Website:** https://scipy.org
 - **Documentation:** https://docs.scipy.org/doc/scipy/
 - **Development version of the documentation:** https://scipy.github.io/devdocs
-- **SciPy development forum:** https://discuss.scientific-python.org/c/contributor/scipy 
+- **SciPy development forum:** https://discuss.scientific-python.org/c/contributor/scipy
+- **Stack Overflow:** https://stackoverflow.com/questions/tagged/scipy
 - **Source code:** https://github.com/scipy/scipy
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues


### PR DESCRIPTION
#### Reference issue
No issue.

#### What does this implement/fix?
Since SciPy does not use an own GitHub discussion board, why not referring the users at least to the Stack Overflow area for SciPy?
This PR adds the link for it.
Other libs like scikit-learn support their link too.

I'm aware of the SciPy development forum at https://discuss.scientific-python.org/c/contributor/scipy, but at Stack Overflow there is by far more activity.
IMHO, it's worth to be mentioned in the readme file.

#### Additional information
