### PR TITLE
MAINT: `test_maxiter_worsening` cleanup

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -309,11 +309,6 @@ class Dirs:
         else:
             self.installed = self.build.parent / (self.build.stem + "-install")
 
-        if sys.platform == 'win32' and sys.version_info < (3, 10):
-            # Work around a pathlib bug; these must be absolute paths
-            self.build = Path(os.path.abspath(self.build))
-            self.installed = Path(os.path.abspath(self.installed))
-
         # relative path for site-package with py version
         # i.e. 'lib/python3.10/site-packages'
         self.site = self.get_site_packages()

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -3,7 +3,6 @@
 
 import itertools
 import platform
-import sys
 import pytest
 
 import numpy as np
@@ -451,9 +450,6 @@ def test_maxiter_worsening(solver):
     # This can occur due to the solvers hitting close to breakdown,
     # which they should detect and halt as necessary.
     # cf. gh-9100
-    if (solver is gmres and platform.machine() == 'aarch64'
-            and sys.version_info[1] == 9):
-        pytest.xfail(reason="gh-13019")
     if (solver is lgmres and
             platform.machine() not in ['x86_64' 'x86', 'aarch64', 'arm64']):
         # see gh-17839


### PR DESCRIPTION
* Fixes gh-13019

* Remove an inactive `xfail` from `test_maxiter_worsening`, since we no longer support Python `3.9.x` on `main`. Caution: I do see a user report of a Python `3.10` problem in the linked issue as well, so perhaps we might want to check the wheel builds before merging if Cirrus/whatever we have for ARM Linux testing doesn't have us covered. That said, the issue is almost 4 years old, and referred to the old macpython wheel builds, so many things have changed since then.

* While cleaning up old version checks, remove another stale check from `dev.py`, which cannot be satisfied with our current supported version bounds.

[skip circle]