### PR TITLE
BUG: stats: adapt to `np.floor` type promotion removal

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3392,7 +3392,7 @@ class rv_discrete(rv_generic):
         return np.sum(self._pmf(m, *args), axis=0)
 
     def _cdf(self, x, *args):
-        k = floor(x)
+        k = floor(x).astype(np.float64)
         return self._cdfvec(k, *args)
 
     # generic _logcdf, _sf, _logsf, _ppf, _isf, _rvs defined in rv_generic

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -549,3 +549,15 @@ def test_rv_sample():
     rng = np.random.default_rng(98430143469)
     rvs0 = dist.ppf(rng.random(size=100))
     assert_allclose(rvs, rvs0)
+
+def test__pmf_float_input():
+    # gh-21272
+    # test that `rvs()` can be computed when `_pmf` requires float input
+    
+    class rv_exponential(stats.rv_discrete):
+        def _pmf(self, i):
+            return (2/3)*3**(1 - i)
+    
+    rv = rv_exponential(a=0.0, b=float('inf'))
+    rvs = rv.rvs() # should not crash due to integer input to `_pmf`
+    assert_allclose(rvs, 0)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -559,5 +559,5 @@ def test__pmf_float_input():
             return (2/3)*3**(1 - i)
     
     rv = rv_exponential(a=0.0, b=float('inf'))
-    rvs = rv.rvs() # should not crash due to integer input to `_pmf`
+    rvs = rv.rvs(random_state=42)  # should not crash due to integer input to `_pmf`
     assert_allclose(rvs, 0)


### PR DESCRIPTION
`rv_discrete._cdf` relied on `np.floor` promoting its integer input to `np.float64`. This is no longer the case since numpy/numpy#26766.

[skip cirrus] [skip circle]

#### Reference issue
Closes gh-21272 @oscarbenjamin

#### What does this implement/fix?
Cast to `np.float64` ourselves after using `np.floor` as `np.floor` returns an integer in NumPy nightlies for integer input.

#### Additional information
I haven't tested locally with a NumPy nightly before/after this diff, but someone should. I can at some point if the reviewer would like me to.