### PR TITLE
TST: fix GPU failures

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -42,7 +42,8 @@ def pytest_configure(config):
         config.addinivalue_line(
             "markers", 'fail_slow: mark a test for a non-default timeout failure')
     config.addinivalue_line("markers",
-        "skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False): "
+        "skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False, "
+        "exceptions=None): "
         "mark the desired skip configuration for the `skip_xp_backends` fixture.")
 
 
@@ -202,6 +203,9 @@ def skip_xp_backends(xp, request):
         There is no need to provide any ``backends`` in this case,
         but any ``backends`` will also be skipped on the CPU.
         Default: ``False``.
+    exceptions : list, optional
+        A list of exceptions for use with `cpu_only`. This should be provided
+        when delegation is implemented for some, but not all, non-CPU backends.
     """
     if "skip_xp_backends" not in request.keywords:
         return
@@ -209,21 +213,34 @@ def skip_xp_backends(xp, request):
     kwargs = request.keywords["skip_xp_backends"].kwargs
     np_only = kwargs.get("np_only", False)
     cpu_only = kwargs.get("cpu_only", False)
+    exceptions = kwargs.get("exceptions", None)
+    
+    # input validation
+    if np_only and cpu_only:
+        raise ValueError("at most one of `np_only` and `cpu_only` should be provided")
+    if exceptions and not cpu_only:
+        raise ValueError("`exceptions` is only valid alongside `cpu_only`")
+
     if np_only:
         reasons = kwargs.get("reasons", ["do not run with non-NumPy backends."])
+        if len(reasons) > 1:
+            raise ValueError("please provide a singleton list to `reasons` "
+                             "when using `np_only`")
         reason = reasons[0]
         if xp.__name__ != 'numpy':
             pytest.skip(reason=reason)
         return
     if cpu_only:
-        reason = "do not run with `SCIPY_ARRAY_API` set and not on CPU"
+        reason = ("no array-agnostic implementation or delegation available "
+                  "for this backend and device")
+        exceptions = [] if exceptions is None else exceptions
         if SCIPY_ARRAY_API and SCIPY_DEVICE != 'cpu':
-            if xp.__name__ == 'cupy':
+            if xp.__name__ == 'cupy' and 'cupy' not in exceptions:
                 pytest.skip(reason=reason)
-            elif xp.__name__ == 'torch':
+            elif xp.__name__ == 'torch' and 'torch' not in exceptions:
                 if 'cpu' not in xp.empty(0).device.type:
                     pytest.skip(reason=reason)
-            elif xp.__name__ == 'jax.numpy':
+            elif xp.__name__ == 'jax.numpy' and 'jax.numpy' not in exceptions:
                 for d in xp.empty(0).devices():
                     if 'cpu' not in d.device_kind:
                         pytest.skip(reason=reason)

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -15,9 +15,10 @@ from scipy.differentiate._differentiate import _EERRORINCREASE
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy',
+@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy', 'cupy',
                               reasons=['Currently uses fancy indexing assignment.',
-                                       'JAX arrays do not support item assignment.'])
+                                       'JAX arrays do not support item assignment.',
+                                       'cupy/cupy#8391',],)
 class TestDifferentiate:
 
     def f(self, x):

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -449,6 +449,7 @@ class TestFFTShift:
             x = xp.asarray(np.random.random((n,)))
             xp_assert_close(fft.ifftshift(fft.fftshift(x)), x)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8393'])
     def test_axes_keyword(self, xp):
         freqs = xp.asarray([[0., 1, 2], [3, 4, -4], [-3, -2, -1]])
         shifted = xp.asarray([[-1., -3, -2], [2, 0, 1], [-4, 3, 4]])
@@ -460,6 +461,7 @@ class TestFFTShift:
         xp_assert_close(fft.fftshift(freqs), shifted)
         xp_assert_close(fft.ifftshift(shifted), freqs)
     
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8393'])
     def test_uneven_dims(self, xp):
         """ Test 2D input, which has uneven dimension sizes """
         freqs = xp.asarray([

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -45,9 +45,11 @@ def _vectorize(xp):
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy',
+@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy', 'cupy',
                               reasons=['Currently uses fancy indexing assignment.',
-                                       'JAX arrays do not support item assignment.'])
+                                       'JAX arrays do not support item assignment.',
+                                       'cupy/cupy#8391',],
+                              cpu_only=True,) # cpu only until gh-21149 merges
 class TestTanhSinh:
 
     # Test problems from [1] Section 6

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -21,7 +21,8 @@ from . import types, float_types, complex_types
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy']),]
 
 
 def sumsq(a, b, xp=None):
@@ -178,7 +179,8 @@ class TestNdimageFilters:
         output = ndimage.convolve1d(array, weights)
         assert_array_almost_equal(output, expected)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'])
     def test_correlate01_overlap(self, xp):
         if is_cupy(xp):
             pytest.xfail("Differs by a factor of two?")
@@ -531,7 +533,8 @@ class TestNdimageFilters:
                            mode='wrap', output=output)
         assert_array_almost_equal(output, expected)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate23(self, dtype_array, dtype_output, xp):
@@ -550,7 +553,8 @@ class TestNdimageFilters:
                            mode='nearest', output=output)
         assert_array_almost_equal(output, expected)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate24(self, dtype_array, dtype_output, xp):
@@ -570,7 +574,8 @@ class TestNdimageFilters:
                            mode='nearest', output=output, origin=-1)
         assert_array_almost_equal(output, tcov)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate25(self, dtype_array, dtype_output, xp):
@@ -868,7 +873,8 @@ class TestNdimageFilters:
         output2 = ndimage.gaussian_filter(input, 1.0, output=otype)
         assert_array_almost_equal(output1, output2)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_gauss_memory_overlap(self, xp):
         input = xp.arange(100 * 100, dtype=xp.float32)
         input = xp.reshape(input, (100, 100))
@@ -918,7 +924,8 @@ class TestNdimageFilters:
     kwargs_rank = dict(origin=(-1, 0, 1))
 
     @skip_xp_backends("array_api_strict",
-         reasons=["fancy indexing is only available in 2024 version"]
+         reasons=["fancy indexing is only available in 2024 version"],
+         cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     @pytest.mark.parametrize("filter_func, size0, size, kwargs",
                              [(ndimage.gaussian_filter, 0, 1.0, kwargs_gauss),
@@ -1092,7 +1099,8 @@ class TestNdimageFilters:
         output = ndimage.prewitt(array, 0)
         assert_array_almost_equal(t, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt02(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1154,7 +1162,8 @@ class TestNdimageFilters:
         output = ndimage.sobel(array, 0)
         assert_array_almost_equal(t, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel02(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1214,7 +1223,8 @@ class TestNdimageFilters:
         output = ndimage.laplace(array)
         assert_array_almost_equal(tmp1 + tmp2, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1244,7 +1254,8 @@ class TestNdimageFilters:
         output = ndimage.gaussian_laplace(array, 1.0)
         assert_array_almost_equal(tmp1 + tmp2, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1260,7 +1271,8 @@ class TestNdimageFilters:
         ndimage.gaussian_laplace(array, 1.0, output)
         assert_array_almost_equal(tmp1 + tmp2, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_generic_laplace01(self, dtype, xp):
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
@@ -1285,7 +1297,8 @@ class TestNdimageFilters:
         ndimage.gaussian_laplace(array, 1.0, output)
         assert_array_almost_equal(tmp, output)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1306,7 +1319,8 @@ class TestNdimageFilters:
         expected = astype(xp.sqrt(expected_float), dtype)
         xp_assert_close(output, expected, rtol=1e-6, atol=1e-6)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype',
                              ["int32", "float32", "float64",
                               "complex64", "complex128"])
@@ -1347,7 +1361,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1, tmp2)
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8430"])
+                      reasons=["https://github.com/cupy/cupy/pull/8430"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_uniform01(self, xp):
         array = xp.asarray([2, 4, 6])
         size = 2
@@ -1355,7 +1370,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([3, 5, 6]), output)
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8430"])
+                      reasons=["https://github.com/cupy/cupy/pull/8430"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_uniform01_complex(self, xp):
         array = xp.asarray([2 + 1j, 4 + 2j, 6 + 3j], dtype=xp.complex128)
         size = 2
@@ -1376,7 +1392,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(array, output)
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8430"])
+                      reasons=["https://github.com/cupy/cupy/pull/8430"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_uniform04(self, xp):
         array = xp.asarray([2, 4, 6])
         filter_shape = [2]
@@ -1390,7 +1407,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([]), output)
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8430"])
+                      reasons=["https://github.com/cupy/cupy/pull/8430"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_uniform06(self, dtype_array, dtype_output, xp):
@@ -1409,7 +1427,8 @@ class TestNdimageFilters:
         assert output.dtype.type == dtype_output
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8430"])
+                      reasons=["https://github.com/cupy/cupy/pull/8430"],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     @pytest.mark.parametrize('dtype_array', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     def test_uniform06_complex(self, dtype_array, dtype_output, xp):
@@ -1462,7 +1481,8 @@ class TestNdimageFilters:
                                               [5, 3, 3, 1, 1]]), output)
 
     @skip_xp_backends("jax.numpy",
-        reasons=["assignment destination is read-only"]
+        reasons=["assignment destination is read-only"],
+        cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_minimum_filter05_overlap(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -1695,7 +1715,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(expected, output)
 
     @skip_xp_backends("jax.numpy",
-        reasons=["assignment destination is read-only"]
+        reasons=["assignment destination is read-only"],
+        cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_rank06_overlap(self, xp):
         if is_cupy(xp):
@@ -2211,7 +2232,8 @@ def test_bad_convolve_and_correlate_origins(xp):
                   xp.ones((3, 5)), xp.ones((2, 2)), origin=[0, -2])
 
 @skip_xp_backends("cupy",
-                  reasons=["https://github.com/cupy/cupy/pull/8430"])
+                  reasons=["https://github.com/cupy/cupy/pull/8430"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 def test_multiple_modes(xp):
     # Test that the filters with multiple mode cababilities for different
     # dimensions give the same result as applying a single mode.
@@ -2242,9 +2264,11 @@ def test_multiple_modes(xp):
                  ndimage.uniform_filter(arr, 5, mode=mode2))
 
 
-@skip_xp_backends("jax.numpy", "cupy",
-                  reasons=["output array is read-only.",
-                           "https://github.com/cupy/cupy/pull/8430"]
+@skip_xp_backends(
+        "jax.numpy", "cupy",
+        reasons=["output array is read-only.",
+                 "https://github.com/cupy/cupy/pull/8430"],
+        cpu_only=True, exceptions=['cupy', 'jax.numpy'],
 )
 def test_multiple_modes_sequentially(xp):
     # Test that the filters with multiple mode cababilities for different
@@ -2361,7 +2385,8 @@ def test_multiple_modes_gaussian_gradient_magnitude(xp):
     assert_almost_equal(expected, calculated)
 
 @skip_xp_backends("cupy",
-                  reasons=["https://github.com/cupy/cupy/pull/8430"])
+                  reasons=["https://github.com/cupy/cupy/pull/8430"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 def test_multiple_modes_uniform(xp):
     # Test uniform filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2477,6 +2502,8 @@ def test_gaussian_radius_invalid(xp):
         ndimage.gaussian_filter1d(xp.zeros(8), sigma=1, radius=1.1)
 
 
+@skip_xp_backends("jax.numpy", reasons=["output array is read-only"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 class TestThreading:
     def check_func_thread(self, n, fun, args, out):
         from threading import Thread
@@ -2489,7 +2516,6 @@ class TestThreading:
         for i in range(n):
             fun(*args, output=out[i, ...])
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
     def test_correlate1d(self, xp):
         if is_cupy(xp):
             pytest.xfail("XXX thread exception; cannot repro outside of pytest")
@@ -2505,7 +2531,6 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate1d, (d, k), ot)
         xp_assert_equal(os, ot)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
     def test_correlate(self, xp):
         if is_cupy(xp):
             pytest.xfail("XXX thread exception; cannot repro outside of pytest")
@@ -2518,7 +2543,6 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate, (d, k), ot)
         xp_assert_equal(os, ot)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
     def test_median_filter(self, xp):
         if is_cupy(xp):
             pytest.xfail("XXX thread exception; cannot repro outside of pytest")
@@ -2530,7 +2554,6 @@ class TestThreading:
         self.check_func_thread(4, ndimage.median_filter, (d, 3), ot)
         xp_assert_equal(os, ot)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
     def test_uniform_filter1d(self, xp):
         if is_cupy(xp):
             pytest.xfail("XXX thread exception; cannot repro outside of pytest")
@@ -2545,7 +2568,6 @@ class TestThreading:
         self.check_func_thread(4, ndimage.uniform_filter1d, (d, 5), ot)
         xp_assert_equal(os, ot)
 
-    @skip_xp_backends("jax.numpy", reasons=["output array is read-only"])
     def test_minmax_filter(self, xp):
         if is_cupy(xp):
             pytest.xfail("XXX thread exception; cannot repro outside of pytest")

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -14,7 +14,8 @@ from scipy import ndimage
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 
 class TestNdimageFourier:

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -20,7 +20,8 @@ from . import types
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),]
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 IS_WINDOWS_AND_NP1 = os.name == 'nt' and np.__version__ < '2'
 
@@ -395,8 +396,9 @@ def test_label_structuring_elements(xp):
             xp_assert_equal(ndimage.label(d, s)[0], results[r, :, :], check_dtype=False)
             r += 1
 
-# cupyx.scipy.ndimage does not have find_objects
-@skip_xp_backends("cupy")
+@skip_xp_backends("cupy",
+                  reasons=["`cupyx.scipy.ndimage` does not have `find_objects`"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 def test_ticket_742(xp):
     def SE(img, thresh=.7, size=4):
         mask = img > thresh
@@ -427,7 +429,8 @@ def test_gh_issue_3025(xp):
     assert ndimage.label(d, xp.ones((3, 3)))[1] == 1
 
 
-@skip_xp_backends("cupy", reasons=["cupyx.scipy.ndimage does not have find_object"])
+@skip_xp_backends("cupy", reasons=["cupyx.scipy.ndimage does not have find_object"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 class TestFindObjects:
     def test_label_default_dtype(self, xp):
         test_array = np.random.rand(10, 10)
@@ -1364,7 +1367,8 @@ def test_stat_funcs_2d(xp):
     xp_assert_equal(max, xp.asarray([9, 5]), check_dtype=False)
 
 
-@skip_xp_backends("cupy", reasons=["no watershed_ift on CuPy"])
+@skip_xp_backends("cupy", reasons=["no watershed_ift on CuPy"],
+                  cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
 class TestWatershedIft:
 
     def test_watershed_ift01(self, xp):
@@ -1569,7 +1573,8 @@ class TestWatershedIft:
         assert_array_almost_equal(out, xp.asarray(expected))
 
     @skip_xp_backends(
-        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"]
+        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"],
+        cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_watershed_ift08(self, xp):
         # Test cost larger than uint8. See gh-10069.
@@ -1583,7 +1588,8 @@ class TestWatershedIft:
         assert_array_almost_equal(out, xp.asarray(expected))
 
     @skip_xp_backends(
-        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"]
+        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"],
+        cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_watershed_ift09(self, xp):
         # Test large cost. See gh-19575

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -12,7 +12,8 @@ from . import types
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),]
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 
 class TestNdimageMorphology:
@@ -1935,7 +1936,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @skip_xp_backends(
-	np_only=True, reasons=['inplace output= arrays are numpy-specific']
+        np_only=True, reasons=['inplace output= arrays are numpy-specific'],
     )
     def test_binary_dilation34(self, xp):
         if is_cupy(xp):
@@ -2265,7 +2266,8 @@ class TestNdimageMorphology:
                                               [2, 3, 1, 3, 1],
                                               [5, 5, 3, 3, 1]]))
 
-    @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_grey_erosion01_overlap(self, xp):
         if is_cupy(xp):
             pytest.xfail("https://github.com/cupy/cupy/issues/8398")
@@ -2461,7 +2463,8 @@ class TestNdimageMorphology:
                                                structure=structure)
         assert_array_almost_equal(expected, output)
 
-    @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_white_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2515,7 +2518,8 @@ class TestNdimageMorphology:
         output = ndimage.white_tophat(array, structure=structure)
         xp_assert_equal(expected, output)
 
-    @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_white_tophat04(self, xp):
         array = np.eye(5, dtype=bool)
         structure = np.ones((3, 3), dtype=bool)
@@ -2527,7 +2531,8 @@ class TestNdimageMorphology:
         output = xp.empty_like(array, dtype=xp.float64)
         ndimage.white_tophat(array, structure=structure, output=output)
 
-    @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_black_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2581,7 +2586,8 @@ class TestNdimageMorphology:
         output = ndimage.black_tophat(array, structure=structure)
         xp_assert_equal(expected, output)
 
-    @skip_xp_backends("jax.numpy", reason="output array is read-only.")
+    @skip_xp_backends("jax.numpy", reasons=["output array is read-only."],
+                      cpu_only=True, exceptions=['cupy', 'jax.numpy'],)
     def test_black_tophat04(self, xp):
         array = xp.asarray(np.eye(5, dtype=bool))
         structure = xp.asarray(np.ones((3, 3), dtype=bool))

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -8,7 +8,8 @@ from scipy import ndimage
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),]
+pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 
 def get_spline_knot_values(order):

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -531,9 +531,10 @@ class TestChandrupatlaMinimize:
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")
-@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy',
+@pytest.mark.skip_xp_backends('array_api_strict', 'jax.numpy', 'cupy',
                               reasons=['Currently uses fancy indexing assignment.',
-                                       'JAX arrays do not support item assignment.'])
+                                       'JAX arrays do not support item assignment.',
+                                       'cupy/cupy#8391',],)
 class TestChandrupatla(TestScalarRootFinders):
 
     def f(self, q, p):

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -146,7 +146,7 @@ def _stdtr(xp, spx):
 
 _generic_implementations = {'rel_entr': _rel_entr,
                             'xlogy': _xlogy,
-                            'chdtr,': _chdtr,
+                            'chdtr': _chdtr,
                             'chdtrc': _chdtrc,
                             'betaincc': _betaincc,
                             'stdtr': _stdtr,

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -4,7 +4,7 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
                                                          array_special_func_map)
 from scipy.conftest import array_api_compatible
 from scipy import special
-from scipy._lib._array_api import xp_assert_close, is_jax
+from scipy._lib._array_api import xp_assert_close, is_jax, is_torch, SCIPY_DEVICE
 from scipy._lib.array_api_compat import numpy as np
 
 try:
@@ -56,6 +56,14 @@ def test_rel_entr_generic(dtype):
                                     [(10,), (11, 1), (12, 1, 1), (13, 1, 1, 1)]])
 def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     f_name, n_args = f_name_n_args
+
+    if (SCIPY_DEVICE != 'cpu'
+        and is_torch(xp)
+        and f_name in {'stdtr', 'betaincc', 'betainc'}
+    ):
+        pytest.skip(f"`{f_name}` does not have an array-agnostic implementation "
+                    f"and cannot delegate to PyTorch.")
+
     shapes = shapes[:n_args]
     f = getattr(special, f_name)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2681,6 +2681,7 @@ class TestCircFuncs:
         x = xp.asarray([355, 5, 2, 359, 10, 350, np.nan])
         xp_assert_equal(test_func(x, high=360), xp.asarray(xp.nan))
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
     @pytest.mark.parametrize("test_func,expected",
                              [(stats.circmean,
                                {None: np.nan, 0: 355.66582264, 1: 0.28725053}),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -129,6 +129,11 @@ class TestTrimmedStats:
         y_true = [4.5, 10, 17, 21, xp.nan, xp.nan, xp.nan, xp.nan, xp.nan]
         xp_assert_close(y, xp.asarray(y_true))
 
+    @skip_xp_backends('array_api_strict', 'jax.numpy', 'cupy',
+                      reasons=["`array_api_strict.where` `fillvalue` doesn't "
+                               "accept Python floats. See data-apis/array-api#807.",
+                               "JAX doesn't allow item assignment.",
+                               "cupy/cupy#8391",])
     def test_tvar(self, xp):
         x = xp.asarray(X.tolist())  # use default dtype of xp
         xp_test = array_namespace(x)  # need array-api-compat var for `correction`
@@ -2888,6 +2893,8 @@ class TestZmapZscore:
         xp_assert_close(z[0, :], z0_expected)
         xp_assert_close(z[1, :], z1_expected)
 
+    @skip_xp_backends('cupy', 'jax.numpy',
+                      reasons=["cupy/cupy#8391", "JAX can't do item assignment"])
     def test_zscore_nan_propagate(self, xp):
         x = xp.asarray([1, 2, np.nan, 4, 5])
         z = stats.zscore(x, nan_policy='propagate')
@@ -2918,6 +2925,8 @@ class TestZmapZscore:
         with pytest.raises(ValueError, match="The input contains nan..."):
             stats.zscore(x, nan_policy='raise')
 
+    @skip_xp_backends('cupy', 'jax.numpy',
+                      reasons=["cupy/cupy#8391", "JAX can't do item assignment"])
     def test_zscore_constant_input_1d(self, xp):
         x = xp.asarray([-0.087] * 3)
         with pytest.warns(RuntimeWarning, match="Precision loss occurred..."):
@@ -2972,6 +2981,8 @@ class TestZmapZscore:
         xp_assert_close(z, xp.asarray([[np.nan, np.nan, np.nan, np.nan],
                                        [-1.0, -1.0, 1.0, 1.0]]))
 
+    @skip_xp_backends('cupy', 'jax.numpy',
+                      reasons=["cupy/cupy#8391", "JAX can't do item assignment"])
     def test_zscore_2d_all_nan(self, xp):
         # The entire 2d array is nan, and we use axis=None.
         y = xp.full((2, 3), xp.nan)
@@ -3453,6 +3464,8 @@ class TestMoments:
         assert_raises(ValueError, stats.moment, x, nan_policy='raise')
         assert_raises(ValueError, stats.moment, x, nan_policy='foobar')
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @pytest.mark.parametrize('dtype', ['float32', 'float64', 'complex128'])
     @pytest.mark.parametrize('expect, order', [(0, 1), (1, 0)])
@@ -6015,6 +6028,8 @@ def test_ttest_ind_empty_1d_returns_nan(xp):
     xp_assert_equal(res.pvalue, NaN)
 
 
+@skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+@pytest.mark.usefixtures("skip_xp_backends")
 @array_api_compatible
 @pytest.mark.parametrize('b, expected_shape',
                          [(np.empty((1, 5, 0)), (3, 5)),
@@ -6271,6 +6286,8 @@ class TestDescribe:
         xp_assert_equal(sk, xp.asarray(xp.nan))
         xp_assert_equal(kurt, xp.asarray(xp.nan))
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     def test_describe_numbers(self, xp):
         xp_test = array_namespace(xp.asarray(1.))  # numpy needs `concat`
@@ -6353,6 +6370,8 @@ class TestDescribe:
         attributes = ('nobs', 'minmax', 'mean', 'variance', 'skewness', 'kurtosis')
         check_named_results(actual, attributes)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     def test_describe_ddof(self, xp):
         xp_test = array_namespace(xp.asarray(1.))  # numpy needs `concat`
@@ -6372,6 +6391,8 @@ class TestDescribe:
         xp_assert_close(sk, skc)
         xp_assert_close(kurt, kurtc)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     def test_describe_axis_none(self, xp):
         xp_test = array_namespace(xp.asarray(1.))  # numpy needs `concat`
@@ -6420,6 +6441,8 @@ class NormalityTests:
             with pytest.raises(ValueError, match=message):
                 test_fun(x)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     @pytest.mark.parametrize("alternative", ['two-sided', 'less', 'greater'])
     def test_against_R(self, alternative, xp):
         # testa against R `dagoTest` from package `fBasics`
@@ -6451,6 +6474,8 @@ class NormalityTests:
         xp_assert_close(res_pvalue, ref_pvalue)
         check_named_results(res, ('statistic', 'pvalue'), xp=xp)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_nan(self, xp):
         # nan in input -> nan output (default nan_policy='propagate')
         test_fun = getattr(stats, self.test_name)
@@ -6495,6 +6520,8 @@ class TestKurtosisTest(NormalityTests):
     test_name = 'kurtosistest'
     case_ref = (-0.01403734404759738, 0.98880018772590561)  # statistic, pvalue
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_intuitive(self, xp):
         # intuitive tests; see gh-13549. excess kurtosis of laplace is 3 > 0
         a2 = stats.laplace.rvs(size=10000, random_state=123)
@@ -6502,6 +6529,8 @@ class TestKurtosisTest(NormalityTests):
         pval = stats.kurtosistest(a2_xp, alternative='greater').pvalue
         xp_assert_close(pval, xp.asarray(0.0, dtype=a2_xp.dtype), atol=1e-15)
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_gh9033_regression(self, xp):
         # regression test for issue gh-9033: x clearly non-normal but power of
         # negative denom needs to be handled correctly to reject normality
@@ -6510,6 +6539,8 @@ class TestKurtosisTest(NormalityTests):
         x = xp.asarray(x, dtype=xp.float64)
         assert stats.kurtosistest(x)[1] < 0.01
 
+    @skip_xp_backends('cupy', reasons=['cupy/cupy#8391'])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_kurtosistest_too_few_observations(self, xp):
         # kurtosistest requires at least 5 observations; 4 should raise a ValueError.
         # At least 20 are needed to avoid warning
@@ -8057,6 +8088,11 @@ class TestKruskal:
             stats.kruskal()
 
 
+@skip_xp_backends(cpu_only=True,
+                  exceptions=['cupy', 'jax.numpy'],
+                  reasons=['Delegation for `special.stdtr` only implemented '
+                           'for CuPy and JAX.'])
+@pytest.mark.usefixtures("skip_xp_backends")
 @array_api_compatible
 class TestCombinePvalues:
     # Reference values computed using the following R code:


### PR DESCRIPTION
#### Reference issue
Closes gh-21227, closes gh-21292, closes gh-20957.

#### What does this implement/fix?
This PR makes `SCIPY_DEVICE=cuda python dev.py test -b all` pass for me locally, in an environment with CuPy, PyTorch and JAX.

#### Additional information

Please take a look at any parts you wrote and let me know if the modifications look okay!

This diff is longer than it would be if we figured out how to "stack" `skip_xp_backends` decorators. But I haven't given that any thought recently, it seems difficult.