### PR TITLE
DOC: `find_simplex` no self

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2076,8 +2076,6 @@ class Delaunay(_QhullUser):
 
         Parameters
         ----------
-        tri : DelaunayInfo
-            Delaunay triangulation
         xi : ndarray of double, shape (..., ndim)
             Points to locate
         bruteforce : bool, optional


### PR DESCRIPTION
* As Evgeni and I discussed in gh-21286, the docstring of `find_simplex` is actively deceiving because it claims that a `Delaunay` instance is accepted as an argument, but this is silly because `find_simplex` is a method of `Delaunay`.

[docs only]

It turns out this deception was useful for finding a segfault, as described in the ticket, but I'll deal with that in a follow-up.