### PR TITLE
DEV: `gh_lists`: improve sanitization of backticks

### DIFF
--- a/tools/gh_lists.py
+++ b/tools/gh_lists.py
@@ -47,6 +47,7 @@ def main():
         print()
 
         def backtick_repl(matchobj):
+            """repl to add an escaped space following a code block if needed"""
             if matchobj.group(2) != ' ':
                 post = '\ ' + matchobj.group(2)
             else:
@@ -55,22 +56,36 @@ def main():
 
         for issue in items:
             msg = "* `#{0} <{1}>`__: {2}"
-            # sanitize whitespace, `, and *
+            # sanitize whitespace
             title = re.sub("\\s+", " ", issue.title.strip())
-            title = re.sub("([^`]|^)`([^`]|$)", "\g<1>``\g<2>", title)
+
+            # substitute any single backtick not adjacent to a backtick
+            # for a double backtick
+            title = re.sub("(?P<pre>(?:^|(?<=[^`])))`(?P<post>(?=[^`]|$))",
+                           "\g<pre>``\g<post>",
+                           title)
+            # add an escaped space if code block is not followed by a space
             title = re.sub("``(.*?)``(.)", backtick_repl, title)
+
+            # sanitize asterisks
             title = title.replace('*', '\\*')
+
             if len(title) > 60:
                 remainder = re.sub("\\s.*$", "...", title[60:])
                 if len(remainder) > 20:
-                    # this was previously bugged,
+                    # just use the first 80 characters, with ellipses.
+                    # note: this was previously bugged,
                     # assigning to `remainder` rather than `title`
                     title = title[:80] + "..."
                 else:
+                    # use the first 60 characters and the next word
                     title = title[:60] + remainder
+
                 if title.count('`') % 4 != 0:
-                    # ellipses have cut in the middle of a code block
+                    # ellipses have cut in the middle of a code block,
+                    # so finish the code block before the ellipses
                     title = title[:-3] + '``...'
+
             msg = msg.format(issue.id, issue.url, title)
             print(msg)
         print()


### PR DESCRIPTION
[skip ci]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-21030

#### What does this implement/fix?
- Improves the sanitization of backticks to fix the cases found in https://github.com/scipy/scipy/pull/20986#issuecomment-2185402086 and https://github.com/scipy/scipy/issues/21030#issuecomment-2263665593.
- Also adds code comments to help whoever has to read these regular expressions in the future :)

#### Additional information
2 of the problematic examples were caused by having 2 code blocks separated by only a single character. In a similar vein, the other was caused by having a code block containing only a single character.

The flaw was in my previous regular expression to expand single backticks to double backticks. Since `re.sub` only replaces non-overlapping patterns, these nearby code blocks were matched by overlapping patterns and hence only the first was replaced.

This PR fixes this by making use of [`re`](https://github.com/scipy/scipy/issues/21030#issuecomment-2263665593) *lookbehind* and *lookahead* assertions, which allow you to check behind/ahead of your pattern without consuming those parts of the string, hence fixing the problematic overlapping.