### PR TITLE
TST: Fix bugs in various tests found via linter

### DIFF
--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -85,12 +85,12 @@ class TestDifferentiate:
 
         ref_nfev = [np.int32(ref.nfev) for ref in refs]
         xp_assert_equal(xp.reshape(res.nfev, (-1,)), xp.asarray(ref_nfev))
-        if not is_numpy(xp):  # can't expect other backends to be exactly the same
+        if is_numpy(xp):  # can't expect other backends to be exactly the same
             assert xp.max(res.nfev) == f.feval
 
         ref_nit = [np.int32(ref.nit) for ref in refs]
         xp_assert_equal(xp.reshape(res.nit, (-1,)), xp.asarray(ref_nit))
-        if not is_numpy(xp):  # can't expect other backends to be exactly the same
+        if is_numpy(xp):  # can't expect other backends to be exactly the same
             assert xp.max(res.nit) == f.nit
 
     def test_flags(self, xp):

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -86,12 +86,12 @@ class TestDifferentiate:
         ref_nfev = [np.int32(ref.nfev) for ref in refs]
         xp_assert_equal(xp.reshape(res.nfev, (-1,)), xp.asarray(ref_nfev))
         if not is_numpy(xp):  # can't expect other backends to be exactly the same
-            xp.max(res.nfev) == f.feval
+            assert xp.max(res.nfev) == f.feval
 
         ref_nit = [np.int32(ref.nit) for ref in refs]
         xp_assert_equal(xp.reshape(res.nit, (-1,)), xp.asarray(ref_nit))
         if not is_numpy(xp):  # can't expect other backends to be exactly the same
-            xp.max(res.nit) == f.nit
+            assert xp.max(res.nit) == f.nit
 
     def test_flags(self, xp):
         # Test cases that should produce different status flags; show that all

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1622,13 +1622,13 @@ class TestPPoly:
 
             for y in [0, np.random.random()]:
                 w = np.empty(c.shape, dtype=complex)
-                _ppoly._croots_poly1(c, w)
+                _ppoly._croots_poly1(c, w, y)
 
                 if k == 1:
                     assert_(np.isnan(w).all())
                     continue
 
-                res = 0
+                res = -y
                 cres = 0
                 for i in range(k):
                     res += c[i,None] * w**(k-1-i)

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -259,7 +259,7 @@ def test_64_bit_even_size():
     # 64-bit, 8 B container, 3 channels, 5 samples, 120 B data chunk
     for mmap in [False, True]:
         filename = 'test-8000Hz-le-3ch-5S-64bit.wav'
-        rate, data = wavfile.read(datafile(filename), mmap=False)
+        rate, data = wavfile.read(datafile(filename), mmap=mmap)
 
         assert_equal(rate, 8000)
         assert_(np.issubdtype(data.dtype, np.int64))

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -742,7 +742,7 @@ class TestEigTridiagonal:
 
         for driver in ('sterf', 'stev'):
             assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e,
-                          lapack_driver='stev', select='i',
+                          lapack_driver=driver, select='i',
                           select_range=(0, 1))
         for driver in ('stebz', 'stemr', 'auto'):
             # extracting eigenvalues with respect to the full index range

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2076,7 +2076,7 @@ def test_gttrf_gttrs(dtype):
         gttrf(dl, d, du[:-1])
 
     # test that matrix of size n=2 raises exception
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         gttrf(dl[0], d[:1], du[0])
 
     # test that singular (row of all zeroes) matrix fails via info

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -55,15 +55,14 @@ class TestClarksonWoodruffTransform:
                 assert_(sketch.shape == (self.n_sketch_rows, self.n_cols))
 
     def test_seed_returns_identical_transform_matrix(self):
-        for A in self.test_matrices:
-            for seed in self.seeds:
-                S1 = cwt_matrix(
-                    self.n_sketch_rows, self.n_rows, seed=seed
-                ).toarray()
-                S2 = cwt_matrix(
-                    self.n_sketch_rows, self.n_rows, seed=seed
-                ).toarray()
-                assert_equal(S1, S2)
+        for seed in self.seeds:
+            S1 = cwt_matrix(
+                self.n_sketch_rows, self.n_rows, seed=seed
+            ).toarray()
+            S2 = cwt_matrix(
+                self.n_sketch_rows, self.n_rows, seed=seed
+            ).toarray()
+            assert_equal(S1, S2)
 
     def test_seed_returns_identically(self):
         for A in self.test_matrices:

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -136,7 +136,7 @@ def test_dunder_reversed(d, Asp):
         with pytest.raises(TypeError):
             list(reversed(Asp))
     else:
-        list(reversed(Asp)) == list(reversed(d))
+        assert list(reversed(Asp)) == list(reversed(d))
 
 def test_dunder_ior(d, Asp):
     if isinstance(Asp, dok_array):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1390,7 +1390,7 @@ def test_kendalltau():
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.0, 1.0)
     for taux in variants:
-        res = stats.kendalltau(x, y)
+        res = stats.kendalltau(x, y, variant=taux)
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 
@@ -1401,7 +1401,7 @@ def test_kendalltau():
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.0, 1.0)
     for taux in variants:
-        res = stats.kendalltau(x, y)
+        res = stats.kendalltau(x, y, variant=taux)
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 
@@ -1412,7 +1412,7 @@ def test_kendalltau():
     # cor.test(x,y,method="kendall",exact=1)
     expected = (-0.14285714286, 0.77261904762)
     for taux in variants:
-        res = stats.kendalltau(x, y)
+        res = stats.kendalltau(x, y, variant=taux)
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 
@@ -1423,7 +1423,7 @@ def test_kendalltau():
     # cor.test(x,y,method="kendall",exact=1)
     expected = (0.047619047619, 1.0)
     for taux in variants:
-        res = stats.kendalltau(x, y)
+        res = stats.kendalltau(x, y, variant=taux)
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No issue was filed.

#### What does this implement/fix?
I was looking through the flake bugbear tests to see if any of them have value to the SciPy project. I found some warnings in the tests which look like bugs to me.

Specifically, I was looking at:

* B007: Loop control variable {name} not used within loop body
* B015: Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.
* B017: pytest.raises(Exception) should be considered evil

Many of the B007 warnings look like false positives, but some of them look like clear bugs to me. For example, in the test for kendalltau, a comment says that both variants of the kendalltau test should give the same result, and there is a loop over variants, but the variant is not passed to the function, so it just runs the same test twice.

For B015, there are tests which execute a statement like `a == b`, but do nothing with the result of that comparison. This looks like a bug to me, unless the intent was just to check that the equality check runs without error, and the result of the equality check is unimportant.

For B017, I found one place in the tests where a more specific exception can be expected, which makes the test more specific.

#### Additional information

I found one other thing that looks suspicious.

This test loops over two values of y: 0, and a random value. However, the variable y is never used. This looks like a bug to me. Either this shouldn't be a loop, or y should be involved in the check somehow. However, I'm unsure what the fix is.

```
    def test_roots_croots(self):
        # Test the complex root finding algorithm
        np.random.seed(1234)

        for k in range(1, 15):
            c = np.random.rand(k, 1, 130)

            if k == 3:
                # add a case with zero discriminant
                c[:,0,0] = 1, 2, 1

            for y in [0, np.random.random()]:
                w = np.empty(c.shape, dtype=complex)
                _ppoly._croots_poly1(c, w)

                if k == 1:
                    assert_(np.isnan(w).all())
                    continue

                res = 0
                cres = 0
                for i in range(k):
                    res += c[i,None] * w**(k-1-i)
                    cres += abs(c[i,None] * w**(k-1-i))
                with np.errstate(invalid='ignore'):
                    res /= cres
                res = res.ravel()
                res = res[~np.isnan(res)]
                assert_allclose(res, 0, atol=1e-10)
```

https://github.com/scipy/scipy/blob/main/scipy/interpolate/tests/test_interpolate.py#L1623