### PR TITLE
MAINT: `stats.bartlett`: ensure statistic is non-negative

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -788,7 +788,6 @@ class TestBartlett:
         c = xp.asarray([10.05, 10.15, 10.25, 10.35], dtype=xp.float32)
         res = stats.bartlett(a, b, c)
         assert xp.all(res.statistic >= 0)
-        assert res.statistic.dtype == xp.float32
 
 
 class TestLevene:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -8,7 +8,6 @@ import sys
 from functools import partial
 
 import numpy as np
-import numpy.testing
 from numpy.random import RandomState
 from numpy.testing import (assert_array_equal, assert_almost_equal,
                            assert_array_less, assert_array_almost_equal,
@@ -782,6 +781,14 @@ class TestBartlett:
         NaN = xp.asarray(xp.nan)
         xp_assert_equal(res.statistic, NaN)
         xp_assert_equal(res.pvalue, NaN)
+
+    def test_negative_pvalue_gh21152(self, xp):
+        a = xp.asarray([10.1, 10.2, 10.3, 10.4], dtype=xp.float32)
+        b = xp.asarray([10.15, 10.25, 10.35, 10.45], dtype=xp.float32)
+        c = xp.asarray([10.05, 10.15, 10.25, 10.35], dtype=xp.float32)
+        res = stats.bartlett(a, b, c)
+        assert xp.all(res.statistic >= 0)
+        assert res.statistic.dtype == xp.float32
 
 
 class TestLevene:


### PR DESCRIPTION
#### Reference issue
Closes gh-21152

#### What does this implement/fix?
gh-21152 showed a case in which `stats.bartlett` produced a small, negative value of the statistic, which should always be positive. This PR ensures that the statistic is always non-negative.

#### Additional information
Also, per the 2023 standard, the dtype of the output of `sum` should be the same as the input. `array_api_compat` doesn't yet enforce the 2023 standard; until then, this manually specifies the `dtype` of `sum` in `bartlett`.