### PR TITLE
MAINT:integrate: Fix an off-by-one error in QUADPACK

### DIFF
--- a/scipy/integrate/__quadpack.c
+++ b/scipy/integrate/__quadpack.c
@@ -553,7 +553,7 @@ dqagie(double(*fcn)(double* x), const double bound, const int inf,
         // decrease the sum of the errors over the larger intervals (erlarg)
         // and perform extrapolation.
         jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
-        for (k = nrmax; k <= jupbnd; k++) {
+        for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];
             errmax = elist[maxerr];
             if (fabs(blist[maxerr] - alist[maxerr]) > small) { goto LINE90; }
@@ -1105,7 +1105,7 @@ dqagpe(double(*fcn)(double* x), const double a, const double b, int npts2,
             // decrease the sum of the errors over the larger intervals (erlarg)
             // and perform extrapolation.
             jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
-            for (k = nrmax; k <= jupbnd; k++) {
+            for (k = nrmax; k < jupbnd; k++) {
                 maxerr = iord[nrmax];
                 errmax = elist[maxerr];
                 if (level[maxerr] +1 <= levmax) { goto LINE160; }  // break->continue
@@ -1532,7 +1532,7 @@ dqagse(double(*fcn)(double* x), const double a, const double b,
         // decrease the sum of the errors over the larger intervals (erlarg)
         // and perform extrapolation.
         jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
-        for (k = nrmax; k <= jupbnd; k++) {
+        for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];
             errmax = elist[maxerr];
             if (fabs(blist[maxerr] - alist[maxerr]) > small) { goto LINE90; } // break->continue
@@ -2717,7 +2717,7 @@ LINE70:
         // extrapolation.
         jupbnd = (*last > (limit/2 + 2) ? limit + 2 - *last : L);
 
-        for (k = nrmax; k <= jupbnd; k++) {
+        for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];
             errmax = elist[maxerr];
             if (fabs(blist[maxerr] - alist[maxerr]) > small) { goto LINE140; }

--- a/scipy/integrate/__quadpack.c
+++ b/scipy/integrate/__quadpack.c
@@ -552,7 +552,7 @@ dqagie(double(*fcn)(double* x), const double bound, const int inf,
         // The smallest interval has the largest error. Before bisecting
         // decrease the sum of the errors over the larger intervals (erlarg)
         // and perform extrapolation.
-        jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
+        jupbnd = (*last > 2 + (limit/2) ? limit + 3 - *last : *last);
         for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];
             errmax = elist[maxerr];
@@ -1104,7 +1104,7 @@ dqagpe(double(*fcn)(double* x), const double a, const double b, int npts2,
             // The smallest interval has the largest error. Before bisecting
             // decrease the sum of the errors over the larger intervals (erlarg)
             // and perform extrapolation.
-            jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
+            jupbnd = (*last > 2 + (limit/2) ? limit + 3 - *last : *last);
             for (k = nrmax; k < jupbnd; k++) {
                 maxerr = iord[nrmax];
                 errmax = elist[maxerr];
@@ -1531,7 +1531,7 @@ dqagse(double(*fcn)(double* x), const double a, const double b,
         // The smallest interval has the largest error. Before bisecting
         // decrease the sum of the errors over the larger intervals (erlarg)
         // and perform extrapolation.
-        jupbnd = (*last > 2 + (limit/2) ? limit + 2 - L : L);
+        jupbnd = (*last > 2 + (limit/2) ? limit + 3 - *last : *last);
         for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];
             errmax = elist[maxerr];
@@ -2715,7 +2715,7 @@ LINE70:
         // The smallest interval has the largest error. Before bisecting, decrease
         // the sum of the erorrs over the larger intervals (erlarg) and perform
         // extrapolation.
-        jupbnd = (*last > (limit/2 + 2) ? limit + 2 - *last : L);
+        jupbnd = (*last > 2 + (limit/2) ? limit + 3 - *last : *last);
 
         for (k = nrmax; k < jupbnd; k++) {
             maxerr = iord[nrmax];


### PR DESCRIPTION

#### Reference issue
#21201 

Addressing the small differences in certain integration results when compared to the QUADPACK Fortran code.

CC: @mdhaber 

I've checked the ones that are still left red in the excel and indeed most of them are not occurring on my Win10 machine. I did the same fix to all solvers that was copy pasted at some point and seems to be in accordance. There are still differences but they are much smaller now. 