### PR TITLE
MAINT/DOC: clean up `_lib._array_api`, update docs

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -10,7 +10,7 @@ Support for the array API standard
 This guide describes how to **use** and **add support for** the
 `Python array API standard <https://data-apis.org/array-api/latest/index.html>`_.
 This standard allows users to use any array API compatible array library
-with SciPy out of the box.
+with parts of SciPy out of the box.
 
 The `RFC`_ defines how SciPy implements support for the standard, with the main
 principle being *"array type in equals array type out"*. In addition, the
@@ -57,7 +57,7 @@ values:
 
 Note that the above example works for PyTorch CPU tensors. For GPU tensors or
 CuPy arrays, the expected result for ``vq`` is a ``TypeError``, because ``vq``
-is not a pure Python function and hence won't work on GPU.
+uses compiled code in its implementation, which won't work on GPU.
 
 More strict array input validation will reject ``np.matrix`` and
 ``np.ma.MaskedArray`` instances, as well as arrays with ``object`` dtype:
@@ -95,10 +95,12 @@ Currently supported functionality
 The following modules provide array API standard support when the environment
 variable is set:
 
-- `scipy.cluster.hierarchy`
-- `scipy.cluster.vq`
+- `scipy.cluster`
 - `scipy.constants`
+- `scipy.datasets`
 - `scipy.fft`
+- `scipy.io`
+- `scipy.ndimage`
 
 Support is provided in `scipy.special` for the following functions:
 `scipy.special.log_ndtr`, `scipy.special.ndtr`, `scipy.special.ndtri`,
@@ -119,6 +121,8 @@ Support is provided in `scipy.stats` for the following functions:
 `scipy.stats.jarque_bera`, `scipy.stats.bartlett`, `scipy.stats.power_divergence`,
 and `scipy.stats.monte_carlo_test`.
 
+Please see `the tracker issue`_ for updates.
+
 
 Implementation notes
 --------------------
@@ -126,22 +130,22 @@ Implementation notes
 A key part of the support for the array API standard and specific compatibility
 functions for Numpy, CuPy and PyTorch is provided through
 `array-api-compat <https://github.com/data-apis/array-api-compat>`_.
-This package is included in the SciPy code base via a git submodule (under
+This package is included in the SciPy codebase via a git submodule (under
 ``scipy/_lib``), so no new dependencies are introduced.
 
 ``array-api-compat`` provides generic utility functions and adds aliases such
-as ``xp.concat`` (which, for numpy, maps to ``np.concatenate``). This allows
-using a uniform API across NumPy, PyTorch, CuPy and JAX (with other libraries,
-such as Dask, coming in the future).
+as ``xp.concat`` (which, for numpy, mapped to ``np.concatenate`` before NumPy added
+``np.concat`` in NumPy 2.0). This allows using a uniform API across NumPy, PyTorch,
+CuPy and JAX (with other libraries, such as Dask, being worked on).
 
 When the environment variable isn't set and hence array API standard support in
-SciPy is disabled, we still use the "augmented" version of the NumPy namespace,
+SciPy is disabled, we still use the wrapped version of the NumPy namespace,
 which is ``array_api_compat.numpy``. That should not change behavior of SciPy
-functions, it's effectively the existing ``numpy`` namespace with a number of
+functions, as it's effectively the existing ``numpy`` namespace with a number of
 aliases added and a handful of functions amended/added for array API standard
-support. When support is enabled, depending on the type of arrays, ``xp`` will
-return the standard-compatible namespace matching the input array type to a
-function (e.g., if the input to `cluster.vq.kmeans` is a PyTorch array, then
+support. When support is enabled, ``xp = array_namespace(input)`` will
+be the standard-compatible namespace matching the input array type to a
+function (e.g., if the input to `cluster.vq.kmeans` is a PyTorch tensor, then
 ``xp`` is ``array_api_compat.torch``).
 
 
@@ -154,20 +158,9 @@ idioms for NumPy usage as well). By following the standard, effectively adding
 support for the array API standard is typically straightforward, and we ideally
 don't need to maintain any customization.
 
-Three helper functions are available:
-
-* ``array_namespace``: return the namespace based on input arrays and do some
-  input validation (like refusing to work with masked arrays, please see the
-  `RFC`_.)
-* ``_asarray``: a drop-in replacement for ``asarray`` with the additional
-  parameters ``check_finite`` and ``order``. As stated above, try to limit
-  the use of non-standard features. In the end we would want to upstream our
-  needs to the compatibility library. Passing ``xp=xp`` avoids duplicate calls
-  of ``array_namespace`` internally.
-* ``copy``: an alias for ``_asarray(x, copy=True)``.
-  The ``copy`` parameter was only introduced to ``np.asarray`` in NumPy 2.0,
-  so use of the helper is needed to support ``<2.0``. Passing ``xp=xp`` avoids
-  duplicate calls of ``array_namespace`` internally.
+Various helper functions are available in ``scipy._lib._array_api`` - please see
+the ``__all__`` in that module for a list of current helpers, and their docstrings
+for more information.
 
 To add support to a SciPy function which is defined in a ``.py`` file, what you
 have to change is:
@@ -183,11 +176,13 @@ Input array validation uses the following pattern::
    # alternatively, if there are multiple array inputs, include them all:
    xp = array_namespace(arr1, arr2)
 
+   # replace np.asarray with xp.asarray
+   arr = xp.asarray(arr)
    # uses of non-standard parameters of np.asarray can be replaced with _asarray
    arr = _asarray(arr, order='C', dtype=xp.float64, xp=xp)
 
-Note that if one input is a non-numpy array type, all array-like inputs have to
-be of that type; trying to mix non-numpy arrays with lists, Python scalars or
+Note that if one input is a non-NumPy array type, all array-like inputs have to
+be of that type; trying to mix non-NumPy arrays with lists, Python scalars or
 other arbitrary Python objects will raise an exception. For NumPy arrays, those
 types will continue to be accepted for backwards compatibility reasons.
 
@@ -218,7 +213,7 @@ You would convert this like so::
   def toto(a, b):
       xp = array_namespace(a, b)
       a = xp.asarray(a)
-      b = copy(b, xp=xp)  # our custom helper is needed for copy
+      b = xp_copy(b, xp=xp)  # our custom helper is needed for copy
 
       c = xp.sum(a) - xp.prod(b)
 
@@ -231,7 +226,7 @@ You would convert this like so::
 
 Going through compiled code requires going back to a NumPy array, because
 SciPy's extension modules only work with NumPy arrays (or memoryviews in the
-case of Cython), but not with other array types. For arrays on CPU, the
+case of Cython). For arrays on CPU, the
 conversions should be zero-copy, while on GPU and other devices the attempt at
 conversion will raise an exception. The reason for that is that silent data
 transfer between devices is considered bad practice, as it is likely to be a
@@ -245,13 +240,13 @@ The following pytest markers are available:
 
 * ``array_api_compatible -> xp``: use a parametrisation to run a test on
   multiple array backends.
-* ``skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False)``:
-  skip certain backends and/or devices. ``np_only`` skips tests for all backends
-  other than the default NumPy backend.
+* ``skip_xp_backends(*backends, reasons=None, np_only=False, cpu_only=False, exceptions=None)``:
+  skip certain backends and/or devices.
   ``@pytest.mark.usefixtures("skip_xp_backends")`` must be used alongside this
-  marker for the skipping to apply.
+  marker for the skipping to apply. See the fixture's docstring in ``scipy.conftest``
+  for information on how use this marker to skip tests.
 * ``skip_xp_invalid_arg`` is used to skip tests that use arguments which
-  are invalid when ``SCIPY_ARRAY_API`` is used. For instance, some tests of
+  are invalid when ``SCIPY_ARRAY_API`` is enabled. For instance, some tests of
   `scipy.stats` functions pass masked arrays to the function being tested, but
   masked arrays are incompatible with the array API. Use of the
   ``skip_xp_invalid_arg`` decorator allows these tests to protect against
@@ -263,40 +258,57 @@ The following pytest markers are available:
   default and only behavior, these tests (and the decorator itself) will be
   removed.
 
-The following is an example using the markers::
+``scipy._lib._array_api`` contains array-agnostic assertions such as ``xp_assert_close``
+which can be used to replace assertions from `numpy.testing`.
+
+The following examples demonstrate how to use the markers::
 
   from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
+  from scipy._lib._array_api import xp_assert_close
   ...
-  @pytest.mark.skip_xp_backends(np_only=True,
-                                 reasons=['skip reason'])
+  @pytest.mark.skip_xp_backends(np_only=True, reasons=['skip reason'])
   @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto1(self, xp):
       a = xp.asarray([1, 2, 3])
       b = xp.asarray([0, 2, 5])
-      toto(a, b)
+      xp_assert_close(toto(a, b), a)
   ...
   @pytest.mark.skip_xp_backends('array_api_strict', 'cupy',
-                                 reasons=['skip reason 1',
-                                          'skip reason 2',])
+                                reasons=['skip reason 1',
+                                         'skip reason 2',],)
   @pytest.mark.usefixtures("skip_xp_backends")
   @array_api_compatible
   def test_toto2(self, xp):
-      a = xp.asarray([1, 2, 3])
-      b = xp.asarray([0, 2, 5])
-      toto(a, b)
+      ...
   ...
   # Do not run when SCIPY_ARRAY_API is used
   @skip_xp_invalid_arg
   def test_toto_masked_array(self):
-      a = np.ma.asarray([1, 2, 3])
-      b = np.ma.asarray([0, 2, 5])
-      toto(a, b)
+      ...
 
 Passing a custom reason to ``reasons`` when ``cpu_only=True`` is unsupported
 since ``cpu_only=True`` can be used alongside passing ``backends``. Also,
 the reason for using ``cpu_only`` is likely just that compiled code is used
 in the function(s) being tested.
+
+Passing names of backends into ``exceptions`` means that they will not be skipped
+by ``cpu_only=True``. This is useful when delegation is implemented for some,
+but not all, non-CPU backends, and the CPU code path requires conversion to NumPy
+for compiled code::
+
+  # array-api-strict and CuPy will always be skipped, for the given reasons.
+  # All libraries using a non-CPU device will also be skipped, apart from
+  # JAX, for which delegation is implemented (hence non-CPU execution is supported).
+  @pytest.mark.skip_xp_backends('array_api_strict', 'cupy',
+                                reasons=['skip reason 1',
+                                         'skip reason 2',],
+                                cpu_only=True,
+                                exceptions=['jax.numpy'],)
+  @pytest.mark.usefixtures("skip_xp_backends")
+  @array_api_compatible
+  def test_toto(self, xp):
+      ...
 
 When every test function in a file has been updated for array API
 compatibility, one can reduce verbosity by telling ``pytest`` to apply the
@@ -309,9 +321,7 @@ markers to every test function using ``pytestmark``::
     ...
     @skip_xp_backends(np_only=True, reasons=['skip reason'])
     def test_toto1(self, xp):
-        a = xp.asarray([1, 2, 3])
-        b = xp.asarray([0, 2, 5])
-        toto(a, b)
+        ...
 
 After applying these markers, ``dev.py test`` can be used with the new option
 ``-b`` or ``--array-api-backend``::
@@ -321,12 +331,12 @@ After applying these markers, ``dev.py test`` can be used with the new option
 This automatically sets ``SCIPY_ARRAY_API`` appropriately. To test a library
 that has multiple devices with a non-default device, a second environment
 variable (``SCIPY_DEVICE``, only used in the test suite) can be set. Valid
-values depend on the array library under test, e.g. for PyTorch (currently the
-only library with multi-device support that is known to work) valid values are
-``"cpu", "cuda", "mps"``. So to run the test suite with the PyTorch MPS
+values depend on the array library under test, e.g. for PyTorch, valid values are
+``"cpu", "cuda", "mps"``. To run the test suite with the PyTorch MPS
 backend, use: ``SCIPY_DEVICE=mps python dev.py test -b pytorch``.
 
-Note that there is a GitHub Actions workflow which runs ``pytorch-cpu``.
+Note that there is a GitHub Actions workflow which tests with array-api-strict,
+PyTorch, and JAX on CPU.
 
 
 Additional information
@@ -346,3 +356,4 @@ helped during the development phase:
   `#25956 <https://github.com/scikit-learn/scikit-learn/pull/25956>`__
 
 .. _RFC: https://github.com/scipy/scipy/issues/18286
+.. _the tracker issue: https://github.com/scipy/scipy/issues/18867

--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -14,7 +14,7 @@
 import math
 import numpy as np
 from ._util import _RichResult, _call_callback_maybe_halt
-from ._array_api import array_namespace, size as xp_size
+from ._array_api import array_namespace, xp_size
 
 _ESIGNERR = -1
 _ECONVERR = -2

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 import numpy as np
-from scipy._lib._array_api import array_namespace, is_numpy, size as xp_size
+from scipy._lib._array_api import array_namespace, is_numpy, xp_size
 
 
 AxisError: type[Exception]

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -13,7 +13,7 @@ from hypothesis import given, strategies, reproduce_failure  # noqa: F401
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
 
 from scipy._lib._array_api import (xp_assert_equal, xp_assert_close, is_numpy,
-                                   copy as xp_copy, is_array_api_strict)
+                                   xp_copy, is_array_api_strict)
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
                               getfullargspec_no_self, FullArgSpec,
                               rng_integers, _validate_int, _rename_parameter,

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, _asarray, copy, xp_assert_equal, is_numpy
+    _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy
 )
 import scipy._lib.array_api_compat.numpy as np_compat
 
@@ -60,7 +60,7 @@ class TestArrayAPI:
     def test_copy(self, xp):
         for _xp in [xp, None]:
             x = xp.asarray([1, 2, 3])
-            y = copy(x, xp=_xp)
+            y = xp_copy(x, xp=_xp)
             # with numpy we'd want to use np.shared_memory, but that's not specified
             # in the array-api
             x[0] = 10

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -134,7 +134,7 @@ from collections import deque
 import numpy as np
 from . import _hierarchy, _optimal_leaf_ordering
 import scipy.spatial.distance as distance
-from scipy._lib._array_api import array_namespace, _asarray, copy, is_jax
+from scipy._lib._array_api import array_namespace, _asarray, xp_copy, is_jax
 from scipy._lib._disjoint_set import DisjointSet
 
 
@@ -1358,7 +1358,7 @@ def cut_tree(Z, n_clusters=None, height=None):
 
     for i, node in enumerate(nodes):
         idx = node.pre_order()
-        this_group = copy(last_group, xp=xp)
+        this_group = xp_copy(last_group, xp=xp)
         # TODO ARRAY_API complex indexing not supported
         this_group[idx] = xp.min(last_group[idx])
         this_group[this_group > xp.max(last_group[idx])] -= 1
@@ -1822,14 +1822,14 @@ def from_mlab_linkage(Z):
 
     # If it's empty, return it.
     if len(Zs) == 0 or (len(Zs) == 1 and Zs[0] == 0):
-        return copy(Z, xp=xp)
+        return xp_copy(Z, xp=xp)
 
     if len(Zs) != 2:
         raise ValueError("The linkage array must be rectangular.")
 
     # If it contains no rows, return it.
     if Zs[0] == 0:
-        return copy(Z, xp=xp)
+        return xp_copy(Z, xp=xp)
 
     if xp.min(Z[:, 0:2]) != 1.0 and xp.max(Z[:, 0:2]) != 2 * Zs[0]:
         raise ValueError('The format of the indices is not 1..N')
@@ -1925,7 +1925,7 @@ def to_mlab_linkage(Z):
     Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
     Zs = Z.shape
     if len(Zs) == 0 or (len(Zs) == 1 and Zs[0] == 0):
-        return copy(Z, xp=xp)
+        return xp_copy(Z, xp=xp)
     is_valid_linkage(Z, throw=True, name='Z')
 
     return xp.concat((Z[:, :2] + 1.0, Z[:, 2:3]), axis=1)

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -16,7 +16,7 @@ from scipy.conftest import array_api_compatible
 from scipy.sparse._sputils import matrix
 
 from scipy._lib._array_api import (
-    SCIPY_ARRAY_API, copy, cov, xp_assert_close, xp_assert_equal
+    SCIPY_ARRAY_API, xp_copy, xp_cov, xp_assert_close, xp_assert_equal
 )
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
@@ -307,7 +307,7 @@ class TestKMean:
         data1 = data[:, 0]
 
         initc = data1[:3]
-        code = copy(initc, xp=xp)
+        code = xp_copy(initc, xp=xp)
         kmeans2(data1, code, iter=1)[0]
         kmeans2(data1, code, iter=2)[0]
 
@@ -353,8 +353,8 @@ class TestKMean:
         for data in datas:
             rng = np.random.default_rng(1234)
             init = _krandinit(data, k, rng, xp)
-            orig_cov = cov(data.T)
-            init_cov = cov(init.T)
+            orig_cov = xp_cov(data.T)
+            init_cov = xp_cov(init.T)
             xp_assert_close(orig_cov, init_cov, atol=1.1e-2)
 
     def test_kmeans2_empty(self, xp):

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -68,7 +68,7 @@ import warnings
 import numpy as np
 from collections import deque
 from scipy._lib._array_api import (
-    _asarray, array_namespace, size, atleast_nd, copy, cov
+    _asarray, array_namespace, xp_size, xp_atleast_nd, xp_copy, xp_cov
 )
 from scipy._lib._util import check_random_state, rng_integers
 from scipy.spatial.distance import cdist
@@ -472,8 +472,8 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
         raise ValueError(f"iter must be at least 1, got {iter}")
 
     # Determine whether a count (scalar) or an initial guess (array) was passed.
-    if size(guess) != 1:
-        if size(guess) < 1:
+    if xp_size(guess) != 1:
+        if xp_size(guess) < 1:
             raise ValueError(f"Asked for 0 clusters. Initial book was {guess}")
         return _kmeans(obs, guess, thresh=thresh, xp=xp)
 
@@ -551,23 +551,23 @@ def _krandinit(data, k, rng, xp):
     k = np.asarray(k)
 
     if data.ndim == 1:
-        _cov = cov(data)
+        _cov = xp_cov(data)
         x = rng.standard_normal(size=k)
         x = xp.asarray(x)
         x *= xp.sqrt(_cov)
     elif data.shape[1] > data.shape[0]:
         # initialize when the covariance matrix is rank deficient
         _, s, vh = xp.linalg.svd(data - mu, full_matrices=False)
-        x = rng.standard_normal(size=(k, size(s)))
+        x = rng.standard_normal(size=(k, xp_size(s)))
         x = xp.asarray(x)
         sVh = s[:, None] * vh / xp.sqrt(data.shape[0] - xp.asarray(1.))
         x = x @ sVh
     else:
-        _cov = atleast_nd(cov(data.T), ndim=2)
+        _cov = xp_atleast_nd(xp_cov(data.T), ndim=2)
 
         # k rows, d cols (one row = one obs)
         # Generate k sample of a random variable ~ Gaussian(mu, cov)
-        x = rng.standard_normal(size=(k, size(mu)))
+        x = rng.standard_normal(size=(k, xp_size(mu)))
         x = xp.asarray(x)
         x = x @ xp.linalg.cholesky(_cov).T
 
@@ -782,7 +782,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
     else:
         xp = array_namespace(data, k)
     data = _asarray(data, xp=xp, check_finite=check_finite)
-    code_book = copy(k, xp=xp)
+    code_book = xp_copy(k, xp=xp)
     if data.ndim == 1:
         d = 1
     elif data.ndim == 2:
@@ -790,11 +790,11 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
     else:
         raise ValueError("Input of rank > 2 is not supported.")
 
-    if size(data) < 1 or size(code_book) < 1:
+    if xp_size(data) < 1 or xp_size(code_book) < 1:
         raise ValueError("Empty input is not supported.")
 
     # If k is not a single value, it should be compatible with data's shape
-    if minit == 'matrix' or size(code_book) > 1:
+    if minit == 'matrix' or xp_size(code_book) > 1:
         if data.ndim != code_book.ndim:
             raise ValueError("k array doesn't match data rank")
         nc = code_book.shape[0]

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -180,6 +180,8 @@ skip_xp_invalid_arg = pytest.mark.skipif(SCIPY_ARRAY_API,
 def skip_xp_backends(xp, request):
     """
     Skip based on the ``skip_xp_backends`` marker.
+    
+    See the "Support for the array API standard" docs page for usage examples.
 
     Parameters
     ----------

--- a/scipy/fft/_fftlog_backend.py
+++ b/scipy/fft/_fftlog_backend.py
@@ -3,7 +3,7 @@ from warnings import warn
 from ._basic import rfft, irfft
 from ..special import loggamma, poch
 
-from scipy._lib._array_api import array_namespace, copy
+from scipy._lib._array_api import array_namespace
 
 __all__ = ['fht', 'ifht', 'fhtoffset']
 
@@ -106,12 +106,12 @@ def fhtcoeff(n, dln, mu, offset=0.0, bias=0.0, inverse=False):
     if np.isinf(u[0]) and not inverse:
         warn('singular transform; consider changing the bias', stacklevel=3)
         # fix coefficient to obtain (potentially correct) transform anyway
-        u = copy(u)
+        u = np.copy(u)
         u[0] = 0
     elif u[0] == 0 and inverse:
         warn('singular inverse transform; consider changing the bias', stacklevel=3)
         # fix coefficient to obtain (potentially correct) inverse anyway
-        u = copy(u)
+        u = np.copy(u)
         u[0] = np.inf
 
     return u

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -9,7 +9,7 @@ from pytest import raises as assert_raises
 import scipy.fft as fft
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    array_namespace, size, xp_assert_close, xp_assert_equal
+    array_namespace, xp_size, xp_assert_close, xp_assert_equal
 )
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
@@ -123,7 +123,7 @@ class TestFFT:
 
     def test_rfft(self, xp):
         x = xp.asarray(random(29), dtype=xp.float64)
-        for n in [size(x), 2*size(x)]:
+        for n in [xp_size(x), 2*xp_size(x)]:
             for norm in [None, "backward", "ortho", "forward"]:
                 xp_assert_close(fft.rfft(x, n=n, norm=norm),
                                 fft.fft(xp.asarray(x, dtype=xp.complex128),
@@ -285,7 +285,7 @@ class TestFFT:
         x = xp.asarray(random(30), dtype=xp.float64)
         xp_test = array_namespace(x)
         x_norm = xp_test.linalg.vector_norm(x)
-        n = size(x) * 2
+        n = xp_size(x) * 2
         func_pairs = [(fft.rfft, fft.irfft),
                       # hfft: order so the first function takes x.size samples
                       #       (necessary for comparison to x_norm above)
@@ -297,7 +297,7 @@ class TestFFT:
             if forw == fft.fft:
                 x = xp.asarray(x, dtype=xp.complex128)
                 x_norm = xp_test.linalg.vector_norm(x)
-            for n in [size(x), 2*size(x)]:
+            for n in [xp_size(x), 2*xp_size(x)]:
                 for norm in ['backward', 'ortho', 'forward']:
                     tmp = forw(x, n=n, norm=norm)
                     tmp = back(tmp, n=n, norm=norm)

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -12,7 +12,7 @@ import numpy as np
 import sys
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    xp_assert_close, get_xp_devices, device, array_namespace
+    xp_assert_close, get_xp_devices, xp_device, array_namespace
 )
 from scipy import fft
 
@@ -537,7 +537,7 @@ class TestFFTFreq:
         for d in devices:
             y = fft.fftfreq(9, xp=xp, device=d)
             x = xp_test.empty(0, device=d)
-            assert device(y) == device(x)
+            assert xp_device(y) == xp_device(x)
 
 
 @skip_xp_backends("cupy", "jax.numpy",
@@ -569,4 +569,4 @@ class TestRFFTFreq:
         for d in devices:
             y = fft.rfftfreq(9, xp=xp, device=d)
             x = xp_test.empty(0, device=d)
-            assert device(y) == device(x)
+            assert xp_device(y) == xp_device(x)

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -7,7 +7,7 @@ from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
 import scipy.fft as fft
 from scipy import fftpack
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import copy, xp_assert_close
+from scipy._lib._array_api import xp_copy, xp_assert_close
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -43,7 +43,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize, xp):
 
 
 @skip_xp_backends(np_only=True,
-                   reasons=['`overwrite_x` only supported for NumPy backend.'])
+                  reasons=['`overwrite_x` only supported for NumPy backend.'])
 @pytest.mark.parametrize("forward, backward", [(dct, idct), (dst, idst)])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
@@ -199,7 +199,7 @@ def test_orthogonalize_noop(func, type, norm, xp):
 def test_orthogonalize_dct1(norm, xp):
     x = xp.asarray(np.random.rand(100))
 
-    x2 = copy(x, xp=xp)
+    x2 = xp_copy(x, xp=xp)
     x2[0] *= SQRT_2
     x2[-1] *= SQRT_2
 
@@ -232,7 +232,7 @@ def test_orthogonalize_dcst2(func, norm, xp):
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst3(func, norm, xp):
     x = xp.asarray(np.random.rand(100))
-    x2 = copy(x, xp=xp)
+    x2 = xp_copy(x, xp=xp)
     x2[0 if func == dct else -1] *= SQRT_2
 
     y1 = func(x, type=3, norm=norm, orthogonalize=True)

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy import special
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import (array_namespace, copy as xp_copy, xp_ravel,
+from scipy._lib._array_api import (array_namespace, xp_copy, xp_ravel,
                                    xp_real, is_numpy, is_cupy, is_torch,
                                    xp_take_along_axis)
 

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose, assert_equal
 from scipy.conftest import array_api_compatible
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._array_api import (array_namespace, xp_assert_close, xp_assert_equal,
-                                   size as xp_size, xp_ravel, copy as xp_copy)
+                                   xp_size, xp_ravel, xp_copy)
 from scipy import special, stats
 from scipy.integrate import quad_vec, nsum
 from scipy.integrate._tanhsinh import _tanhsinh, _pair_cache

--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import xp_sign, copy as xp_copy, xp_take_along_axis
+from scipy._lib._array_api import xp_sign, xp_copy, xp_take_along_axis
 
 # TODO:
 # - (maybe?) don't use fancy indexing assignment

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -3,7 +3,7 @@ import scipy.sparse as sps
 from ._numdiff import approx_derivative, group_columns
 from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy.sparse.linalg import LinearOperator
-from scipy._lib._array_api import atleast_nd, array_namespace
+from scipy._lib._array_api import xp_atleast_nd, array_namespace
 
 
 FD_METHODS = ('2-point', '3-point', 'cs')
@@ -183,7 +183,7 @@ class ScalarFunction:
                              "quasi-Newton strategies.")
 
         self.xp = xp = array_namespace(x0)
-        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -274,7 +274,7 @@ class ScalarFunction:
             # ensure that self.x is a copy of x. Don't store a reference
             # otherwise the memoization doesn't work properly.
 
-            _x = atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
             self.g_updated = False
@@ -283,7 +283,7 @@ class ScalarFunction:
         else:
             # ensure that self.x is a copy of x. Don't store a reference
             # otherwise the memoization doesn't work properly.
-            _x = atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
             self.g_updated = False
@@ -380,7 +380,7 @@ class VectorFunction:
                              "strategies.")
 
         self.xp = xp = array_namespace(x0)
-        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -557,7 +557,7 @@ class VectorFunction:
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
                 self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
@@ -565,7 +565,7 @@ class VectorFunction:
                 self._update_hess()
         else:
             def update_x(x):
-                _x = atleast_nd(x, ndim=1, xp=self.xp)
+                _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
                 self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
@@ -637,7 +637,7 @@ class LinearVectorFunction:
         self.m, self.n = self.J.shape
 
         self.xp = xp = array_namespace(x0)
-        _x = atleast_nd(x0, ndim=1, xp=xp)
+        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -654,7 +654,7 @@ class LinearVectorFunction:
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            _x = atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -6,7 +6,7 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, csc_matrix, csr_matrix, coo_matrix, find
 from ._group_columns import group_dense, group_sparse
-from scipy._lib._array_api import atleast_nd, array_namespace
+from scipy._lib._array_api import xp_atleast_nd, array_namespace
 
 
 def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
@@ -440,7 +440,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         raise ValueError(f"Unknown method '{method}'. ")
 
     xp = array_namespace(x0)
-    _x = atleast_nd(x0, ndim=1, xp=xp)
+    _x = xp_atleast_nd(x0, ndim=1, xp=xp)
     _dtype = xp.float64
     if xp.isdtype(_x.dtype, "real floating"):
         _dtype = _x.dtype

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -24,7 +24,7 @@ from ._optimize import (OptimizeResult, _check_unknown_options,
                         _check_clip_x)
 from ._numdiff import approx_derivative
 from ._constraints import old_bound_to_new, _arr_to_scalar
-from scipy._lib._array_api import atleast_nd, array_namespace
+from scipy._lib._array_api import xp_atleast_nd, array_namespace
 
 
 __docformat__ = "restructuredtext en"
@@ -250,7 +250,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
     # Transform x0 into an array.
     xp = array_namespace(x0)
-    x0 = atleast_nd(x0, ndim=1, xp=xp)
+    x0 = xp_atleast_nd(x0, ndim=1, xp=xp)
     dtype = xp.float64
     if xp.isdtype(x0.dtype, "real floating"):
         dtype = x0.dtype

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -36,7 +36,7 @@ from scipy.optimize import _moduleTNC as moduleTNC
 from ._optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._constraints import old_bound_to_new
-from scipy._lib._array_api import atleast_nd, array_namespace
+from scipy._lib._array_api import xp_atleast_nd, array_namespace
 
 from numpy import inf, array, zeros
 
@@ -356,7 +356,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     pgtol = gtol
 
     xp = array_namespace(x0)
-    x0 = atleast_nd(x0, ndim=1, xp=xp)
+    x0 = xp_atleast_nd(x0, ndim=1, xp=xp)
     dtype = xp.float64
     if xp.isdtype(x0.dtype, "real floating"):
         dtype = x0.dtype

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -7,7 +7,7 @@ import scipy._lib._elementwise_iterative_method as eim
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (array_namespace, xp_assert_close, xp_assert_equal,
                                    xp_assert_less, is_numpy, is_cupy,
-                                   xp_ravel, size as xp_size)
+                                   xp_ravel, xp_size,)
 
 from scipy.optimize.elementwise import find_minimum, find_root
 from scipy.optimize._tstutils import _CHANDRUPATLA_TESTS

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -14,7 +14,7 @@ from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
 
 from scipy._lib._array_api import (
     array_namespace,
-    size as xp_size,
+    xp_size,
     xp_moveaxis_to_end,
     xp_vector_norm,
 )

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -42,7 +42,6 @@ from scipy.optimize import milp, LinearConstraint
 from scipy._lib._util import (check_random_state, _get_nan,
                               _rename_parameter, _contains_nan,
                               AxisError, _lazywhere)
-from scipy._lib._array_api import _asarray as xp_asarray
 
 import scipy.special as special
 # Import unused here but needs to stay until end of deprecation periode
@@ -73,9 +72,9 @@ from scipy._lib._util import normalize_axis_index
 from scipy._lib._array_api import (
     _asarray,
     array_namespace,
-    atleast_nd,
+    xp_atleast_nd,
     is_numpy,
-    size as xp_size,
+    xp_size,
     xp_moveaxis_to_end,
     xp_sign,
     xp_vector_norm,
@@ -144,7 +143,7 @@ def _chk2_asarray(a, b, axis):
 
 def _convert_common_float(*arrays, xp=None):
     xp = array_namespace(*arrays) if xp is None else xp
-    arrays = [xp_asarray(array, subok=True) for array in arrays]
+    arrays = [_asarray(array, subok=True) for array in arrays]
     dtypes = [(xp.asarray(1.).dtype if xp.isdtype(array.dtype, 'integral')
                else array.dtype) for array in arrays]
     dtype = xp.result_type(*dtypes)
@@ -2594,7 +2593,7 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     if axis is None:
         a = xp.reshape(a, (-1,))
         axis = 0
-    a = atleast_nd(a, ndim=1, xp=xp)
+    a = xp_atleast_nd(a, ndim=1, xp=xp)
     n = a.shape[axis]
     s = xp.std(a, axis=axis, correction=ddof) / n**0.5
     return s

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -42,8 +42,8 @@ from scipy.stats._stats_py import (_permutation_distribution_t, _chk_asarray, _m
 from scipy._lib._util import AxisError
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
 from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, array_namespace,
-                                   copy, is_numpy, is_torch, SCIPY_ARRAY_API,
-                                   size as xp_size, copy as xp_copy)
+                                   is_numpy, is_torch, SCIPY_ARRAY_API,
+                                   xp_size, xp_copy)
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -711,7 +711,7 @@ class TestPearsonr:
 
         message = 'An input array is constant'
         with pytest.warns(stats.ConstantInputWarning, match=message):
-            x = copy(x0)
+            x = xp_copy(x0)
             x[0, ...] = 1
             res = stats.pearsonr(x, y0, axis=1)
             ci = res.confidence_interval()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Follow-up to gh-21294

#### What does this implement/fix?
- First commit improves the naming consistency in `_lib._array_api` and updates `__all__`.
- Second commit is a full sweep of updates on the docs page to accommodate the requested improvements in gh-21294.

#### Additional information
<!--Any additional information you think is important.-->
