### PR TITLE
BUG: find_simplex shape () segfault

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2110,8 +2110,9 @@ class Delaunay(_QhullUser):
 
         xi = np.asanyarray(xi)
 
-        if xi.shape[-1] != self.ndim:
-            raise ValueError("wrong dimensionality in xi")
+        with cython.boundscheck(True):
+            if xi.shape[-1] != self.ndim:
+                raise ValueError("wrong dimensionality in xi")
 
         xi_shape = xi.shape
         xi = xi.reshape(-1, xi.shape[-1])

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1188,3 +1188,22 @@ def test_gh_20623(diagram_type):
     invalid_data = rng.random((4, 10, 3))
     with pytest.raises(ValueError, match="dimensions"):
         diagram_type(invalid_data)
+
+
+def test_gh_21286():
+    generators = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
+    tri = qhull.Delaunay(generators)
+    # verify absence of segfault reported in ticket:
+    with pytest.raises(IndexError):
+        tri.find_simplex(1)
+    with pytest.raises(IndexError):
+        # strikingly, Delaunay object has shape
+        # () just like np.asanyarray(1) above
+        tri.find_simplex(tri)
+
+
+def test_find_simplex_ndim_err():
+    generators = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
+    tri = qhull.Delaunay(generators)
+    with pytest.raises(ValueError):
+        tri.find_simplex([2, 2, 2])


### PR DESCRIPTION
* Fixes gh-21286

* `find_simplex` has Cython bounds checking disabled, which means that when it receives an argument for `xi` that `asanyarray` converts to a 0d NumPy array with shape `()`, the `shape[-1]` check segfaults before we can even check that the array has the correct dimensionality for the "point in simplex" algorithm that follows.

* My original reproducer in the ticket above is quite strange--it just so happens that a `Delaunay` object fed through `asanyarray` has shape `()`. While this makes basically no sense to me at all, this is why feeding the triangulation object itself to `find_simplex` behaves the same as feeding an integer value like `1`, and both segfaulted in the original ticket.

* Add a regression test for both cases described above/in the ticket, requiring that an error is raised instead of segfaulting. The tests are made to pass by using a context manager to locally re-enable Cython bounds checking for the input dimensionality check.

* Confusingly, the new error raised by Cython when `ndim` is zero is an `IndexError` (by default), while our custom error checking raises `ValueError` when `ndim` is too large relative to the generators used to produce the original triangulation for example. I might be convinced that we should unify these, though it would require a try/except to accomplish I believe. For now, I've just added an additional test for the original `ValueError` (there wasn't one prior to this patch).

[skip circle] [skip cirrus]