### PR TITLE
CI: Update to cibuildwheel 2.20.0

### DIFF
--- a/.github/workflows/free_threaded_wheels.yml
+++ b/.github/workflows/free_threaded_wheels.yml
@@ -158,7 +158,7 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@7e5a838a63ac8128d71ab2dfd99e4634dd1bca09  # v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_FREE_THREADED_SUPPORT: True

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -207,7 +207,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV" 
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.19.1
+    - python -m pip install cibuildwheel==2.20.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:


### PR DESCRIPTION
cibuildwheel [2.20.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0) uses the ABI stable Python 3.13.0rc1 and build Python 3.13 wheels by default.

#### Reference issue
- #20992