### PR TITLE
MAINT: special.chdtr: fix generic chdtr

### DIFF
--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -90,10 +90,12 @@ def _chdtr(xp, spx):
         return None
 
     def __chdtr(v, x):
-        res = xp.where(x >= 0, gammainc(v/2, x/2), 0)
-        i_nan = ((x == 0) & (v == 0)) | xp.isnan(x) | xp.isnan(v)
-        res = xp.where(i_nan, xp.nan, res)
-        return res
+        res = gammainc(v / 2, x / 2)  # this is almost all we need
+        # The rest can be removed when google/jax#20507 is resolved
+        mask = (v == 0) & (x > 0)  # JAX returns NaN
+        res = xp.where(mask, 1., res)
+        mask = xp.isinf(v) & xp.isinf(x)  # JAX returns 1.0
+        return xp.where(mask, xp.nan, res)
     return __chdtr
 
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -98,3 +98,14 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
 
     eps = np.finfo(dtype_np).eps
     xp_assert_close(res, ref, atol=10*eps)
+
+
+@array_api_compatible
+def test_chdtr_gh21311(xp):
+    # the edge case behavior of generic chdtr was not right; see gh-21311
+    # make to test at least these cases
+    x = np.asarray([-np.inf, -1., 0., 1., np.inf])
+    v = x.reshape(-1, 1)
+    ref = special.chdtr(v, x)
+    res = special.chdtr(xp.asarray(v), xp.asarray(x))
+    xp_assert_close(res, xp.asarray(ref))

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -103,7 +103,8 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
 @array_api_compatible
 def test_chdtr_gh21311(xp):
     # the edge case behavior of generic chdtr was not right; see gh-21311
-    # make to test at least these cases
+    # be sure to test at least these cases
+    # should add `np.nan` into the mix when gh-21317 is resolved
     x = np.asarray([-np.inf, -1., 0., 1., np.inf])
     v = x.reshape(-1, 1)
     ref = special.chdtr(v, x)


### PR DESCRIPTION
#### Reference issue
Closes gh-21311

#### What does this implement/fix?
The edge case behavior of the array API version of `special.chdtr` (written in terms of the more common `gammainc`) was not correct. It wasn't caught because of a typo; now that it is fixed, we're getting errors in CI. This fixes the bug and adds a test.