### PR TITLE
BUG: special: Fix bug in beta ppf by setting correct Boost policy

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -6,11 +6,6 @@
 #include "sf_error.h"
 
 
-// Override some default BOOST policies.
-// These are required to ensure that the Boost function ibeta_inv
-// handles extremely small p values with precision comparable to the
-// Cephes incbi function.
-
 #include "boost/math/special_functions/beta.hpp"
 #include "boost/math/special_functions/erf.hpp"
 #include "boost/math/special_functions/powm1.hpp"

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -536,7 +536,7 @@ Real beta_ppf_wrap(const Real x, const Real a, const Real b)
         boost::math::policies::domain_error<boost::math::policies::ignore_error >,
         boost::math::policies::overflow_error<boost::math::policies::user_error >,
         boost::math::policies::evaluation_error<boost::math::policies::user_error >,
-        boost::math::policies::promote_float<false > > BetaPolicyForStats;
+        boost::math::policies::promote_double<false > > BetaPolicyForStats;
 
     return ibeta_inv_wrap(a, b, x, BetaPolicyForStats());
 }

--- a/scipy/special/tests/test_boost_ufuncs.py
+++ b/scipy/special/tests/test_boost_ufuncs.py
@@ -19,6 +19,7 @@ test_data = [
     (scu._beta_pdf, (0.5, 2, 3), 1.5),
     (scu._beta_pdf, (0, 1, 5), 5.0),
     (scu._beta_pdf, (1, 5, 1), 5.0),
+    (scu._beta_ppf, (0.5, 5., 5.), 0.5),  # gh-21303
     (scu._binom_cdf, (1, 3, 0.5), 0.5),
     (scu._binom_pmf, (1, 4, 0.5), 0.25),
     (scu._hypergeom_cdf, (2, 3, 5, 6), 0.5),


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-21303

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes `stats.beta.ppf` for the case `stats.beta(5., 5.).ppf(0.5)` by adjusting the Boost policies as suggested by @WarrenWeckesser here, https://github.com/scipy/scipy/issues/21303#issuecomment-2267563656.

#### Additional information
<!--Any additional information you think is important.-->
Thanks @WarrenWeckesser for investigating this and opening an issue upstream, https://github.com/boostorg/math/issues/1169. It's still not entirely clear to me what the underlying issue is and why the policies need to be set this way, but I've verified that the fix works.
