### PR TITLE
BUG: sparse: fix sparray errors found by applying `test_base` to sparray directly

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1165,8 +1165,13 @@ class _spbase:
                 np.ones((N, 1), dtype=res_dtype)
             )
 
-        if out is not None and out.shape != ret.shape:
-            raise ValueError("dimensions do not match")
+        if out is not None:
+            if isinstance(self, sparray):
+                if out.shape != ret.squeeze().shape:
+                    raise ValueError("dimensions do not match")
+            else:
+                if out.shape != ret.shape:
+                    raise ValueError("dimensions do not match")
 
         return ret.sum(axis=axis, dtype=dtype, out=out)
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1167,11 +1167,11 @@ class _spbase:
 
         if out is not None:
             if isinstance(self, sparray):
-                if out.shape != ret.squeeze().shape:
-                    raise ValueError("dimensions do not match")
+                ret_shape = ret.shape[:axis] + ret.shape[axis + 1:]
             else:
-                if out.shape != ret.shape:
-                    raise ValueError("dimensions do not match")
+                ret_shape = ret.shape
+            if out.shape != ret_shape:
+                raise ValueError("dimensions do not match")
 
         return ret.sum(axis=axis, dtype=dtype, out=out)
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -227,7 +227,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if axes is None:
             axes = range(self.ndim)[::-1]
         elif isinstance(self, sparray):
-            if len(axes) != self.ndim:
+            if (not isinstance(axes, (tuple, list))) or len(axes) != self.ndim:
                 raise ValueError("axes don't match matrix dimensions")
             if len(set(axes)) != self.ndim:
                 raise ValueError("repeated axis in transpose")

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -227,7 +227,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if axes is None:
             axes = range(self.ndim)[::-1]
         elif isinstance(self, sparray):
-            if (not isinstance(axes, (tuple, list))) or len(axes) != self.ndim:
+            if not hasattr(axes, "__len__") or len(axes) != self.ndim:
                 raise ValueError("axes don't match matrix dimensions")
             if len(set(axes)) != self.ndim:
                 raise ValueError("repeated axis in transpose")

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -172,19 +172,18 @@ class IndexMixin:
             raise IndexError('number of row and column indices differ')
 
         if issparse(x):
+            if 0 in x.shape:
+                return
             if i.ndim == 1:
                 # Inner indexing, so treat them like row vectors.
                 i = i[None]
                 j = j[None]
-            xM, xN = x._shape_as_2d
-            broadcast_row = xM == 1 and i.shape[0] != 1
-            broadcast_col = xN == 1 and i.shape[1] != 1
-            if not ((broadcast_row or xM == i.shape[0]) and
-                    (broadcast_col or xN == i.shape[1])):
-                raise ValueError('shape mismatch in assignment')
-            if 0 in x.shape:
-                return
             x = x.tocoo(copy=True).reshape(x._shape_as_2d)
+            broadcast_row = x.shape[0] == 1 and i.shape[0] != 1
+            broadcast_col = x.shape[1] == 1 and i.shape[1] != 1
+            if not ((broadcast_row or x.shape[0] == i.shape[0]) and
+                    (broadcast_col or x.shape[1] == i.shape[1])):
+                raise ValueError('shape mismatch in assignment')
             x.sum_duplicates()
             self._set_arrayXarray_sparse(i, j, x)
         else:

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -178,7 +178,7 @@ class IndexMixin:
                 # Inner indexing, so treat them like row vectors.
                 i = i[None]
                 j = j[None]
-            x = x.tocoo(copy=True).reshape(x._shape_as_2d)
+            x = x.tocoo(copy=False).reshape(x._shape_as_2d, copy=True)
             broadcast_row = x.shape[0] == 1 and i.shape[0] != 1
             broadcast_col = x.shape[1] == 1 and i.shape[1] != 1
             if not ((broadcast_row or x.shape[0] == i.shape[0]) and


### PR DESCRIPTION
This PR splits #gh-20894 with this PR containing the bug-fixes for sparrays found while moving the tests in `test_base.py` to directly test sparray and spmatrix.  Hopefully this is easier to review and we can get it merged -- since this code actually fixes bugs.

The two PRs #gh-20894 and #gh-20895 do the work of changing the tests in test_base.py to directly test both sparray and spmatrix. The first is ready for review and the second builds on the first (containing the mass-change types of changes).

But this PR acts on the bugs found during the creation of those two -- and can be reviewed/merged now without the tests updated.