### PR TITLE
BUG: odr: fix pickling

### DIFF
--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -286,7 +286,7 @@ class Data:
     def __getattr__(self, attr):
         """ Dispatch attribute access to the metadata dictionary.
         """
-        if attr in self.meta:
+        if attr != "meta" and attr in self.meta:
             return self.meta[attr]
         else:
             raise AttributeError(f"'{attr}' not in metadata")
@@ -408,17 +408,18 @@ class RealData(Data):
             return weights
 
     def __getattr__(self, attr):
-        lookup_tbl = {('wd', 'sx'): (self._sd2wt, self.sx),
-                      ('wd', 'covx'): (self._cov2wt, self.covx),
-                      ('we', 'sy'): (self._sd2wt, self.sy),
-                      ('we', 'covy'): (self._cov2wt, self.covy)}
-
+    
         if attr not in ('wd', 'we'):
-            if attr in self.meta:
+            if attr != "meta" and attr in self.meta:
                 return self.meta[attr]
             else:
                 raise AttributeError(f"'{attr}' not in metadata")
         else:
+            lookup_tbl = {('wd', 'sx'): (self._sd2wt, self.sx),
+                      ('wd', 'covx'): (self._cov2wt, self.covx),
+                      ('we', 'sy'): (self._sd2wt, self.sy),
+                      ('we', 'covy'): (self._cov2wt, self.covy)}
+            
             func, arg = lookup_tbl[(attr, self._ga_flags[attr])]
 
             if arg is not None:
@@ -533,7 +534,7 @@ class Model:
         """ Dispatch attribute access to the metadata.
         """
 
-        if attr in self.meta:
+        if attr != "meta" and attr in self.meta:
             return self.meta[attr]
         else:
             raise AttributeError(f"'{attr}' not in metadata")

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -565,8 +565,6 @@ class TestODR:
             # Just make sure that it runs without raising an exception.
             odr_obj.run()
 
-    # Test pickling
-
     def test_pickling_data(self):
         x = np.linspace(0.0, 5.0)
         y = 1.0 * x + 2.0
@@ -575,22 +573,19 @@ class TestODR:
         obj_pickle = pickle.dumps(data)
         del data
         pickle.loads(obj_pickle)
-        
 
     def test_pickling_real_data(self):
         x = np.linspace(0.0, 5.0)
         y = 1.0 * x + 2.0
         data = RealData(x, y)
-        
+
         obj_pickle = pickle.dumps(data)
         del data
         pickle.loads(obj_pickle)
-        
 
     def test_pickling_model(self):
         obj_pickle = pickle.dumps(unilinear)
         pickle.loads(obj_pickle)
-        
 
     def test_pickling_odr(self):
         x = np.linspace(0.0, 5.0)
@@ -600,7 +595,6 @@ class TestODR:
         obj_pickle = pickle.dumps(odr_obj)
         del odr_obj
         pickle.loads(obj_pickle)
-        
 
     def test_pickling_output(self):
         x = np.linspace(0.0, 5.0)
@@ -610,4 +604,3 @@ class TestODR:
         obj_pickle = pickle.dumps(output)
         del output
         pickle.loads(obj_pickle)
-        

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -1,3 +1,4 @@
+import pickle
 import tempfile
 import shutil
 import os
@@ -563,3 +564,50 @@ class TestODR:
             odr_obj.set_job(fit_type=0, del_init=1)
             # Just make sure that it runs without raising an exception.
             odr_obj.run()
+
+    # Test pickling
+
+    def test_pickling_data(self):
+        x = np.linspace(0.0, 5.0)
+        y = 1.0 * x + 2.0
+        data = Data(x, y)
+
+        obj_pickle = pickle.dumps(data)
+        del data
+        pickle.loads(obj_pickle)
+        
+
+    def test_pickling_real_data(self):
+        x = np.linspace(0.0, 5.0)
+        y = 1.0 * x + 2.0
+        data = RealData(x, y)
+        
+        obj_pickle = pickle.dumps(data)
+        del data
+        pickle.loads(obj_pickle)
+        
+
+    def test_pickling_model(self):
+        obj_pickle = pickle.dumps(unilinear)
+        pickle.loads(obj_pickle)
+        
+
+    def test_pickling_odr(self):
+        x = np.linspace(0.0, 5.0)
+        y = 1.0 * x + 2.0
+        odr_obj = ODR(Data(x, y), unilinear)
+
+        obj_pickle = pickle.dumps(odr_obj)
+        del odr_obj
+        pickle.loads(obj_pickle)
+        
+
+    def test_pickling_output(self):
+        x = np.linspace(0.0, 5.0)
+        y = 1.0 * x + 2.0
+        output = ODR(Data(x, y), unilinear).run
+
+        obj_pickle = pickle.dumps(output)
+        del output
+        pickle.loads(obj_pickle)
+        


### PR DESCRIPTION
The `__getattr__` method of the `odr` objects led to a recursion error when unpickling. This is because, when unpickling, the instance is checked for a `__setstate__` method, before the any attributes are added.
The implementation before assumed that the attributes are already set. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-21306.

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes pickling behavior of the `scipy.odr` objects. To be specific, this fixes an issue while unpickling: The instance is checked for a `__setstate__` method. As the odr object don't have this method, the `__getattr__` method is called. At this stage, the instance does not have any attributes attached yet.
This enters an infinite recursion loop, as the `__getattr__` implementation assumes that all attributes are present and accesses the `meta` attribute. As this does not exist yet, the `__getattr__` method is called with again, to find the `meta` attribute, entering the recursion loop.

#### Additional information
<!--Any additional information you think is important.-->
Only the pickling and unpickling of the most important odr objects is tested. The other should pickle normally anyway.
Also the tests only confirm the pickling and unpickling works without errors and don't check the correctness of the resulting object. I did not see a reason to test for this.