### PR TITLE
BUG: linalg: fix `solve_banded` raising `IndexError` when `m=1`

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -458,7 +458,15 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if a1.shape[-1] == 1:
         b2 = np.array(b1, copy=(not overwrite_b))
-        b2 /= a1[1, 0]
+        # Generally, m >= nlower + nupper + 1 (with m = a1.shape[-1])
+        # implies that nlower == nupper == 0 when m == 1,
+        # so that a1[0, 0] is the correct way to index the matrix.
+        # This may not always be the case (the GBSV documentation for Lapack
+        # https://netlib.org/lapack/explore-html/db/df8/group__gbsv_gaff55317eb
+        # 3aed2278a85919a488fec07.html#gaff55317eb3aed2278a85919a488fec07
+        # does not place a lower bound on the argument `N`),
+        # so we need to index the main diagonal by offsetting by nupper rows
+        b2 /= a1[nupper, 0]
         return b2
     if nlower == nupper == 1:
         overwrite_ab = overwrite_ab or _datacopied(a1, ab)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -458,14 +458,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if a1.shape[-1] == 1:
         b2 = np.array(b1, copy=(not overwrite_b))
-        # Generally, m >= nlower + nupper + 1 (with m = a1.shape[-1])
-        # implies that nlower == nupper == 0 when m == 1,
-        # so that a1[0, 0] is the correct way to index the matrix.
-        # This may not always be the case (the GBSV documentation for Lapack
-        # https://netlib.org/lapack/explore-html/db/df8/group__gbsv_gaff55317eb
-        # 3aed2278a85919a488fec07.html#gaff55317eb3aed2278a85919a488fec07
-        # does not place a lower bound on the argument `N`),
-        # so we need to index the main diagonal by offsetting by nupper rows
+        # a1.shape[-1] == 1 -> original matrix is 1x1. Typically, the user
+        # will pass u = l = 0 and `a1` will be 1x1. However, the rest of the
+        # function works with unnecessary rows in `a1` as long as
+        # `a1[u + i - j, j] == a[i,j]`. In the 1x1 case, we want i = j = 0,
+        # so the diagonal is in row `u` of `a1`. See gh-8906.
         b2 /= a1[nupper, 0]
         return b2
     if nlower == nupper == 1:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -154,11 +154,17 @@ class TestSolveBanded:
         assert_raises(ValueError, solve_banded, (1, 1), ab, [1.0, 2.0])
 
     def test_1x1(self):
+        # nupper == 1, nlower == 1
         b = array([[1., 2., 3.]])
         x = solve_banded((1, 1), [[0], [2], [0]], b)
         assert_array_equal(x, [[0.5, 1.0, 1.5]])
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
+
+        # nupper == nlower == 0
+        # NOTE: 3/2 is representable exactly in binary floating,
+        # so we use strict equality test instead of allmost_equal
+        assert_array_equal(solve_banded((0,0), [[2.0]], [3.0]), [1.5])
 
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -154,17 +154,22 @@ class TestSolveBanded:
         assert_raises(ValueError, solve_banded, (1, 1), ab, [1.0, 2.0])
 
     def test_1x1(self):
-        # nupper == 1, nlower == 1
+        # gh-8906 noted that the case of A@x = b with 1x1 A was handled
+        # incorrectly; check that this is resolved. Typical case:
+        # nupper == nlower == 0
+        # A = [[2]]
         b = array([[1., 2., 3.]])
+        ref = array([[0.5, 1.0, 1.5]])
+        x = solve_banded((0, 0), [[2]], b)
+        assert_array_equal(x, ref)
+
+        # However, the user *can* represent the same system with garbage rows
+        # in `ab`. Test the case with `nupper == 1, nlower == 1`.
         x = solve_banded((1, 1), [[0], [2], [0]], b)
-        assert_array_equal(x, [[0.5, 1.0, 1.5]])
+        assert_array_equal(x, ref)
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
 
-        # nupper == nlower == 0
-        # NOTE: 3/2 is representable exactly in binary floating,
-        # so we use strict equality test instead of allmost_equal
-        assert_array_equal(solve_banded((0,0), [[2.0]], [3.0]), [1.5])
 
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -161,15 +161,14 @@ class TestSolveBanded:
         b = array([[1., 2., 3.]])
         ref = array([[0.5, 1.0, 1.5]])
         x = solve_banded((0, 0), [[2]], b)
-        assert_array_equal(x, ref)
+        assert_allclose(x, ref, rtol=1e-15)
 
         # However, the user *can* represent the same system with garbage rows
         # in `ab`. Test the case with `nupper == 1, nlower == 1`.
         x = solve_banded((1, 1), [[0], [2], [0]], b)
-        assert_array_equal(x, ref)
+        assert_allclose(x, ref, rtol=1e-15)
         assert_equal(x.dtype, np.dtype('f8'))
         assert_array_equal(b, [[1.0, 2.0, 3.0]])
-
 
     def test_native_list_arguments(self):
         a = [[1.0, 20, 0, 0],


### PR DESCRIPTION
Solves gh-8906

Generally, `m >= nlower + nupper + 1` (with m = a1.shape[-1])
implies that `nlower == nupper == 0` when `m == 1`,
so that `a1[0, 0]` is the correct way to index the matrix.

This may not always be the case (the GBSV documentation for Lapack https://netlib.org/lapack/explore-html/db/df8/group__gbsv_gaff55317eb3aed2278a85919a488fec07.html#gaff55317eb3aed2278a85919a488fec07 does not place a lower bound on the argument `N`),
so we need to index the main diagonal by offsetting by `nupper` rows.

Example:

```py
>>> from scipy.linalg import solve_banded
# OLD
>>> solve_banded((0,0), [[2.0]], [3.0])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nicole/.miniconda3/envs/my/lib/python3.11/site-packages/scipy/linalg/_basic.py", line 444, in solve_banded
    b2 /= a1[1, 0]
          ~~^^^^^^
IndexError: index 1 is out of bounds for axis 0 with size 1
# NEW
>>> solve_banded((0,0), [[2.0]], [3.0])
array([1.5])
```