### PR TITLE
BUG: stats: Allow `betaprime._ppf` to accept scalars.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4884,7 +4884,7 @@ class invgauss_gen(rv_continuous):
     def fit(self, data, *args, **kwds):
         method = kwds.get('method', 'mle')
 
-        if (isinstance(data, CensoredData) or type(self) == wald_gen
+        if (isinstance(data, CensoredData) or isinstance(self, wald_gen)
                 or method.lower() == 'mm'):
             return super().fit(data, *args, **kwds)
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1035,16 +1035,20 @@ class betaprime_gen(rv_continuous):
 
     def _ppf(self, p, a, b):
         p, a, b = np.broadcast_arrays(p, a, b)
-        # by default, compute compute the ppf by solving the following:
+        # By default, compute the ppf by solving the following:
         # p = beta._cdf(x/(1+x), a, b). This implies x = r/(1-r) with
         # r = beta._ppf(p, a, b). This can cause numerical issues if r is
-        # very close to 1. in that case, invert the alternative expression of
+        # very close to 1. In that case, invert the alternative expression of
         # the cdf: p = beta._sf(1/(1+x), b, a).
         r = stats.beta._ppf(p, a, b)
         with np.errstate(divide='ignore'):
             out = r / (1 - r)
-        i = (r > 0.9999)
-        out[i] = 1/stats.beta._isf(p[i], b[i], a[i]) - 1
+        rnear1 = r > 0.9999
+        if np.isscalar(r):
+            if rnear1:
+                out = 1/stats.beta._isf(p, b, a) - 1
+        else:
+            out[rnear1] = 1/stats.beta._isf(p[rnear1], b[rnear1], a[rnear1]) - 1
         return out
 
     def _munp(self, n, a, b):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4635,6 +4635,13 @@ class TestBetaPrime:
     def test_ppf_gh_17631(self, x, a, b, p):
         assert_allclose(stats.betaprime.ppf(p, a, b), x, rtol=2e-14)
 
+    def test__ppf(self):
+        # Verify that _ppf supports scalar arrays.
+        a = np.array(1.0)
+        b = np.array(1.0)
+        p = np.array(0.5)
+        assert_allclose(stats.betaprime._ppf(p, a, b), 1.0, rtol=5e-16)
+
     @pytest.mark.parametrize(
         'x, a, b, expected',
         cdf_vals + [


### PR DESCRIPTION
Before this PR:

```
In [3]: stats.betaprime._ppf(np.array(0.5), np.array(1), np.array(1))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-249056a3ac64> in ?()
----> 1 stats.betaprime._ppf(np.array(0.5), np.array(1), np.array(1))

~/miniconda3/lib/python3.12/site-packages/scipy/stats/_continuous_distns.py in ?(self, p, a, b)
    976         r = stats.beta._ppf(p, a, b)
    977         with np.errstate(divide='ignore'):
    978             out = r / (1 - r)
    979         i = (r > 0.9999)
--> 980         out[i] = 1/stats.beta._isf(p[i], b[i], a[i]) - 1
    981         return out

TypeError: 'numpy.float64' object does not support item assignment
```

With this PR:

```
In [3]: stats.betaprime._ppf(np.array(0.5), np.array(1), np.array(1))
Out[3]: np.float64(1.0)
```