### PR TITLE
MAINT: interpolate.AAA: improve input validation of `max_terms`

### DIFF
--- a/scipy/interpolate/_aaa.py
+++ b/scipy/interpolate/_aaa.py
@@ -24,6 +24,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import warnings
+import operator
 
 import numpy as np
 import scipy
@@ -52,7 +53,7 @@ class AAA:
     rtol : float, optional
         Relative tolerance, defaults to ``eps**0.75``. If a small subset of the entries
         in `values` are much larger than the rest the default tolerance may be too
-        loose. 
+        loose.
     max_terms : int, optional
         Maximum number of terms in the barycentric representation, defaults to ``100``.
         Must be greater than or equal to one.
@@ -70,7 +71,7 @@ class AAA:
     errors : array
         Error :math:`|f(z) - r(z)|_\infty` over `points` in the successive iterations
         of AAA.
-    
+
     Warns
     -----
     RuntimeWarning
@@ -94,7 +95,7 @@ class AAA:
     where :math:`z_1,\dots,z_m` are real or complex support points selected from
     `points`, :math:`f_1,\dots,f_m` are the corresponding real or complex data values
     from `values`, and :math:`w_1,\dots,w_m` are real or complex weights.
-    
+
     Each iteration of the algorithm has two parts: the greedy selection the next support
     point and the computation of the weights. The first part of each iteration is to
     select the next support point to be added :math:`z_{m+1}` from the remaining
@@ -103,7 +104,7 @@ class AAA:
     when this maximum is less than ``rtol * np.linalg.norm(f, ord=np.inf)``. This means
     the interpolation property is only satisfied up to a tolerance, except at the
     support points where approximation exactly interpolates the supplied data.
-    
+
     In the second part of each iteration, the weights :math:`w_j` are selected to solve
     the least-squares problem
 
@@ -196,11 +197,12 @@ class AAA:
 
         if f.size != z.size:
             raise ValueError("`points` and `values` must be the same size.")
-        
+
         if not np.all(np.isfinite(z)):
             raise ValueError("`points` must be finite.")
-        
-        if max_terms < 1 or not np.issubdtype(type(max_terms), np.integer):
+
+        max_terms = operator.index(max_terms)
+        if max_terms < 1:
             raise ValueError("`max_terms` must be an integer value greater than or "
                              "equal to one.")
 

--- a/scipy/interpolate/_aaa.py
+++ b/scipy/interpolate/_aaa.py
@@ -55,6 +55,7 @@ class AAA:
         loose. 
     max_terms : int, optional
         Maximum number of terms in the barycentric representation, defaults to ``100``.
+        Must be greater than or equal to one.
 
     Attributes
     ----------
@@ -198,6 +199,10 @@ class AAA:
         
         if not np.all(np.isfinite(z)):
             raise ValueError("`points` must be finite.")
+        
+        if max_terms < 1 or not np.issubdtype(type(max_terms), np.integer):
+            raise ValueError("`max_terms` must be an integer value greater than or "
+                             "equal to one.")
 
         # Remove infinite or NaN function values and repeated entries
         to_keep = (np.isfinite(f)) & (~np.isnan(f))

--- a/scipy/interpolate/tests/test_aaa.py
+++ b/scipy/interpolate/tests/test_aaa.py
@@ -43,6 +43,10 @@ class TestAAA:
             AAA([[0], [0]], [[1], [1]])
         with pytest.raises(ValueError, match="finite"):
             AAA([np.inf], [1])
+        with pytest.raises(ValueError, match="integer"):
+            AAA([1], [1], max_terms=1.0)
+        with pytest.raises(ValueError, match="greater"):
+            AAA([1], [1], max_terms=-1)
     
     def test_convergence_error(self):
         with pytest.warns(RuntimeWarning, match="AAA failed"):

--- a/scipy/interpolate/tests/test_aaa.py
+++ b/scipy/interpolate/tests/test_aaa.py
@@ -43,7 +43,7 @@ class TestAAA:
             AAA([[0], [0]], [[1], [1]])
         with pytest.raises(ValueError, match="finite"):
             AAA([np.inf], [1])
-        with pytest.raises(ValueError, match="integer"):
+        with pytest.raises(TypeError):
             AAA([1], [1], max_terms=1.0)
         with pytest.raises(ValueError, match="greater"):
             AAA([1], [1], max_terms=-1)


### PR DESCRIPTION
Ensures `max_terms` is an integer greater than or equal to 1