### PR TITLE
ENH: linalg: add Python wrapper of ?trcon

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -545,26 +545,49 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
 
 end subroutine <prefix>trtrs
 
-subroutine <prefix>trcon(norm, uplo, diag, n, a, lda, rcond, work, iwork, info)
+subroutine <prefix2>trcon(norm, uplo, diag, n, a, lda, rcond, work, iwork, info)
 
     ! ?TRCON estimates the reciprocal of the condition number of a
     ! triangular matrix A, in either the 1-norm or the infinity-norm.
 
     callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,iwork,&info);
-    callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
+    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
 
     character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
     character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
     character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
-    <ftype> intent(in), dimension(lda, n) :: a
+    <ftype2> intent(in), dimension(lda, n) :: a
     integer intent(hide), depend(a) :: n = shape(a, 1)
     integer intent(hide), depend(n) :: lda = MAX(1, n)
-    <ftype> intent(hide), dimension(3*n), depend(n) :: work
+    <ftype2> intent(hide), dimension(3*n), depend(n) :: work
     integer intent(hide), dimension(n), depend(n) :: iwork
-    <ftype> intent(out) :: rcond
+    <ftype2> intent(out) :: rcond
     integer intent(out) :: info
 
-end subroutine <prefix>trcon
+end subroutine <prefix2>trcon
+
+
+subroutine <prefix2c>trcon(norm, uplo, diag, n, a, lda, rcond, work, irwork, info)
+
+    ! ?TRCON estimates the reciprocal of the condition number of a
+    ! triangular matrix A, in either the 1-norm or the infinity-norm.
+
+    callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,irwork,&info);
+    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,<ctype2>*,F_INT*
+
+    character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
+    character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
+    character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
+    <ftype2c> intent(in), dimension(lda, n) :: a
+    integer intent(hide), depend(a) :: n = shape(a, 1)
+    integer intent(hide), depend(n) :: lda = MAX(1, n)
+    <ftype2c> intent(hide), dimension(2*n), depend(n) :: work
+    <ftype2> intent(hide), dimension(n), depend(n) :: irwork
+    <ftype2> intent(out) :: rcond
+    integer intent(out) :: info
+
+end subroutine <prefix2c>trcon
+
 
 subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     ! x, info  = tbtrs(ab, b, uplo="U", trans="N", diag="N", overwrite_b=0)

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -545,48 +545,27 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
 
 end subroutine <prefix>trtrs
 
-subroutine <prefix2>trcon(norm, uplo, diag, n, a, lda, rcond, work, iwork, info)
+
+subroutine <prefix>trcon(norm, uplo, diag, n, a, lda, rcond, work, irwork, info)
 
     ! ?TRCON estimates the reciprocal of the condition number of a
     ! triangular matrix A, in either the 1-norm or the infinity-norm.
 
     callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,iwork,&info);
-    callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
+    callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
 
     character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
     character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
     character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
-    <ftype2> intent(in), dimension(lda, n) :: a
+    <ftype> intent(in), dimension(lda, n) :: a
     integer intent(hide), depend(a) :: n = shape(a, 1)
     integer intent(hide), depend(n) :: lda = MAX(1, n)
-    <ftype2> intent(hide), dimension(3*n), depend(n) :: work
-    integer intent(hide), dimension(n), depend(n) :: iwork
-    <ftype2> intent(out) :: rcond
+    <ftype> intent(hide), dimension(3*n), depend(n) :: work
+    <integer, integer, real, double precision> intent(hide), dimension(n), depend(n) :: irwork
+    <ftypereal> intent(out) :: rcond
     integer intent(out) :: info
 
-end subroutine <prefix2>trcon
-
-
-subroutine <prefix2c>trcon(norm, uplo, diag, n, a, lda, rcond, work, irwork, info)
-
-    ! ?TRCON estimates the reciprocal of the condition number of a
-    ! triangular matrix A, in either the 1-norm or the infinity-norm.
-
-    callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,irwork,&info);
-    callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,<ctype2>*,F_INT*
-
-    character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
-    character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
-    character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
-    <ftype2c> intent(in), dimension(lda, n) :: a
-    integer intent(hide), depend(a) :: n = shape(a, 1)
-    integer intent(hide), depend(n) :: lda = MAX(1, n)
-    <ftype2c> intent(hide), dimension(2*n), depend(n) :: work
-    <ftype2> intent(hide), dimension(n), depend(n) :: irwork
-    <ftype2> intent(out) :: rcond
-    integer intent(out) :: info
-
-end subroutine <prefix2c>trcon
+end subroutine <prefix>trcon
 
 
 subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -551,7 +551,7 @@ subroutine <prefix>trcon(norm, uplo, diag, n, a, lda, rcond, work, irwork, info)
     ! ?TRCON estimates the reciprocal of the condition number of a
     ! triangular matrix A, in either the 1-norm or the infinity-norm.
 
-    callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,iwork,&info);
+    callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,irwork,&info);
     callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
 
     character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -545,6 +545,26 @@ subroutine <prefix>trtrs(lower, trans, unitdiag, n, nrhs, a, lda, b, ldb, info)
 
 end subroutine <prefix>trtrs
 
+subroutine <prefix>trcon(norm, uplo, diag, n, a, lda, rcond, work, iwork, info)
+
+    ! ?TRCON estimates the reciprocal of the condition number of a
+    ! triangular matrix A, in either the 1-norm or the infinity-norm.
+
+    callstatement (*f2py_func)(norm,uplo,diag,&n,a,&lda,&rcond,work,iwork,&info);
+    callprotoargument char*,char*,char*,F_INT*,<ctype>*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
+
+    character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
+    character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
+    character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
+    <ftype> intent(in), dimension(lda, n) :: a
+    integer intent(hide), depend(a) :: n = shape(a, 1)
+    integer intent(hide), depend(n) :: lda = MAX(1, n)
+    <ftype> intent(hide), dimension(3*n), depend(n) :: work
+    integer intent(hide), dimension(n), depend(n) :: iwork
+    <ftype> intent(out) :: rcond
+    integer intent(out) :: info
+
+end subroutine <prefix>trcon
 
 subroutine <prefix>tbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
     ! x, info  = tbtrs(ab, b, uplo="U", trans="N", diag="N", overwrite_b=0)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -708,6 +708,11 @@ All functions
    ctpttr
    ztpttr
 
+   strcon
+   dtrcon
+   ctrcon
+   ztrcon
+
    strexc
    dtrexc
    ctrexc

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -651,13 +651,13 @@ class TestTbtrs:
 
 
 
-@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype', DTYPES)
 @pytest.mark.parametrize('norm', ['I', '1', 'O'])
 @pytest.mark.parametrize('uplo', ['U', 'L'])
 @pytest.mark.parametrize('diag', ['N', 'U'])
 @pytest.mark.parametrize('n', [3, 10])
 def test_trcon(dtype, norm, uplo, diag, n):
-    rng = np.random.default_rng(23498324)
+    rng = np.random.default_rng(76563598)
 
     A = rng.random(size=(n, n)) + rng.random(size=(n, n))*1j
     A = A.real if np.issubdtype(dtype, np.floating) else A


### PR DESCRIPTION
#### Reference issue
gh-12824

#### What does this implement/fix?
gh-12824 could use a wrapper of ?trcon, a LAPACK routine that estimates the reciprocal condition number of a triangular matrix. This adds the wrapper and tests it.

#### Additional information
Hopefully I got it mostly right after learning from gh-21328, but no need to review until that one is merged (in case there are similar things to fix here).

When the reviewer does take a look, please run the tests locally - most of the tests pass, but a few fail, and I can't tell if there's any pattern. I also noticed that `gecon` did not work as a reference for `norm == 'I'`, so I replaced it with the definition. I'm hoping there's something obvious that might explain the problem. If not, can it be attributed to this being an "estimate" of the reciprocal condition number? (Probably not; the routine is usually very accurate.).