### PR TITLE
MAINT: stats: fix test that discrete distribution methods accept lists

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3369,7 +3369,8 @@ class rv_discrete(rv_generic):
         return self._cdf(k, *args) - self._cdf(k-1, *args)
 
     def _logpmf(self, k, *args):
-        return log(self._pmf(k, *args))
+        with np.errstate(divide='ignore'):
+            return log(self._pmf(k, *args))
 
     def _logpxf(self, k, *args):
         # continuous distributions have PDF, discrete have PMF, but sometimes

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -330,15 +330,16 @@ def test_methods_with_lists(method, distname, args):
         dist = getattr(stats, distname)
     except TypeError:
         return
+    dist_method = getattr(dist, method)
     if method in ['ppf', 'isf']:
         z = [0.1, 0.2]
     else:
         z = [0, 1]
     p2 = [[p]*2 for p in args]
     loc = [0, 1]
-    result = dist.pmf(z, *p2, loc=loc)
+    result = dist_method(z, *p2, loc=loc)
     npt.assert_allclose(result,
-                        [dist.pmf(*v) for v in zip(z, *p2, loc)],
+                        [dist_method(*v) for v in zip(z, *p2, loc)],
                         rtol=1e-15, atol=1e-15)
 
 


### PR DESCRIPTION
#### Reference issue
gh-12179

#### What does this implement/fix?
There is a test that checks whether distribution methods accept lists as arguments. The continuous version of the test looks OK, but the discrete version of the test did not test all the methods it intended to. This fixes the test. 

#### Additional information
A test failed, exposing that `_logpmf` does not silence `divide` warnings. All the other `_log...` methods to, so this resolves the failure by following suit.