### PR TITLE
TST: special: Fix two XSLOW tests.

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1528,6 +1528,7 @@ class TestSystematic:
             mp_igam_fac,
             [Arg(0, 1e14, inclusive_a=False), Arg(0, 1e14)],
             rtol=1e-10,
+            dps=29,
         )
 
     def test_j0(self):
@@ -2032,7 +2033,7 @@ class TestSystematic:
                 # larger DPS needed for correct results
                 old_dps = mpmath.mp.dps
                 try:
-                    mpmath.mp.dps = 300
+                    mpmath.mp.dps = 500
                     return mpmath.struvel(v, z)
                 finally:
                     mpmath.mp.dps = old_dps


### PR DESCRIPTION
Two of the XSLOW tests in special were failing because not enough digits of precision were being used in the mpmath-based functions that compute the reference values.

See https://github.com/scipy/scipy/issues/15384. This PR fixes the tests `test_igam_fac` and `test_struvel`.

We don't run the XSLOW tests in CI, so only the linter is enabled for this PR.