### PR TITLE
TST: linalg: skip `svd_gesdd` test for large matrices for/in WebAssembly

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1,5 +1,6 @@
 import itertools
 import platform
+import sys
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
@@ -36,6 +37,8 @@ try:
     from scipy.__config__ import CONFIG
 except ImportError:
     CONFIG = None
+
+IS_WASM = (sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"])
 
 
 def _random_hermitian_matrix(n, posdef=False, dtype=float):
@@ -1179,6 +1182,9 @@ class TestSVD_GESVD(TestSVD_GESDD):
     lapack_driver = 'gesvd'
 
 
+# Allocating an array of such a size leads to _ArrayMemoryError(s)
+# since the maximum memory that can be in 32-bit (WASM) is 4GB
+@pytest.mark.skipif(IS_WASM, reason="out of memory in WASM")
 @pytest.mark.fail_slow(10)
 def test_svd_gesdd_nofegfault():
     # svd(a) with {U,VT}.size > INT_MAX does not segfault


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This PR is related to a test introduced in gh-20349, that introduced an early `MemoryError` when trying to compute the SVD for matrices that are too big to compute it for on machines that don't have enough memory size.

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR skips the above test (xref: https://github.com/pyodide/pyodide/pull/4719) for Pyodide in a WebAssembly environment, where SciPy is being upgraded to v1.13.0. The bitness for WASM is 32-bit, which means that there are issues with allocating enough memory for arrays such as the one used to validate the test (since the total available memory is 4 GiB).

The `IS_WASM` constant has been included in the same file instead of adding a new file for these because it is the only place where it is required to be used.

#### Additional information
<!--Any additional information you think is important.-->

See also: gh-17413
