### PR TITLE
TST: Implement a `run_in_parallel` decorator for test functions

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -635,7 +635,7 @@ class TestBSpline:
         c = np.random.random(n)
         return BSpline.construct_fast(t, c, k)
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, random_spline):
         # Check that no segfaults appear with concurrent access to BSpline
         t, _, k = random_spline.tck
@@ -2438,7 +2438,7 @@ class TestNdBSpline:
         spl = NdBSpline((tx, ty, tz), c, k=k)
         return spl
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, random_3d_ndbspline):
         xi = np.c_[[1, 1.5, 2],
                    [1.1, 1.6, 2.1],

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -399,7 +399,7 @@ of squared residuals does not satisfy the condition abs\(fp-s\)/s < tol.""")
         spl = UnivariateSpline(xx, yy, check_finite=True)
         return spl, x
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, concurrent_spline):
         # Check that no segfaults appear with concurrent access to
         # UnivariateSpline

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -956,7 +956,7 @@ class TestAkima1DInterpolator:
         ak = Akima1DInterpolator(x, y, extrapolate=True)
         return ak, x_ext
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, concurrent_akima):
         # Check that no segfaults appear with concurrent access to Akima1D
         ak, x_ext = concurrent_akima
@@ -1082,7 +1082,7 @@ class TestPPolyCommon:
 
     @pytest.mark.parametrize('concurrent_inputs', [PPoly, BPoly],
                              indirect=['concurrent_inputs'])
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, concurrent_inputs):
         # Check that no segfaults appear with concurrent access to BPoly, PPoly
         interp, xp = concurrent_inputs
@@ -2389,7 +2389,7 @@ class TestNdPPoly:
         zi = rng.uniform(size=40)
         return p, (xi, yi, zi)
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, random_ndppoly):
         spl, inputs = random_ndppoly
         return spl(inputs)

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -242,7 +242,7 @@ class TestNearestNDInterpolator:
         nndi = NearestNDInterpolator(x, y)
         return nndi, x
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, concurrent_interp):
         spl, x = concurrent_interp
         return spl(x)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -14,7 +14,7 @@ from scipy.interpolate import (
     approximate_taylor_polynomial, CubicHermiteSpline, pchip,
     PchipInterpolator, pchip_interpolate, Akima1DInterpolator, CubicSpline,
     make_interp_spline)
-from scipy._lib._testutils import _run_concurrent_barrier
+from scipy._lib._testutils import run_in_parallel
 
 
 def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
@@ -318,13 +318,13 @@ class TestKrogh:
         with pytest.warns(UserWarning, match="40 degrees provided,"):
             KroghInterpolator(np.arange(40), np.ones(40))
 
-    def test_concurrency(self):
-        P = KroghInterpolator(self.xs, self.ys)
+    @pytest.fixture
+    def default_krogh(self):
+        return KroghInterpolator(self.xs, self.ys)
 
-        def worker_fn(_, interp):
-            interp(self.xs)
-
-        _run_concurrent_barrier(10, worker_fn, P)
+    @run_in_parallel
+    def test_concurrency(self, default_krogh):
+        return default_krogh(self.xs)
 
 
 class TestTaylor:
@@ -525,13 +525,13 @@ class TestBarycentric:
                            match="Interpolation points xi must be distinct."):
             BarycentricInterpolator(xis, ys)
 
-    def test_concurrency(self):
-        P = BarycentricInterpolator(self.xs, self.ys)
+    @pytest.fixture
+    def default_barycentric(self):
+        return BarycentricInterpolator(self.xs, self.ys)
 
-        def worker_fn(_, interp):
-            interp(self.xs)
-
-        _run_concurrent_barrier(10, worker_fn, P)
+    @run_in_parallel
+    def test_concurrency(self, default_barycentric):
+        return default_barycentric(self.xs)
 
 
 class TestPCHIP:

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -322,7 +322,7 @@ class TestKrogh:
     def default_krogh(self):
         return KroghInterpolator(self.xs, self.ys)
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, default_krogh):
         return default_krogh(self.xs)
 
@@ -529,7 +529,7 @@ class TestBarycentric:
     def default_barycentric(self):
         return BarycentricInterpolator(self.xs, self.ys)
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, default_barycentric):
         return default_barycentric(self.xs)
 

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -235,7 +235,7 @@ def default_rbf():
     return rbf, x
 
 
-@run_in_parallel
+@run_in_parallel(assert_all_close=True)
 def test_rbf_concurrency(default_rbf):
     rbf, x = default_rbf
     return rbf(x)

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -507,7 +507,7 @@ class TestRBFInterpolatorNeighbors20(_TestRBFInterpolator):
         interp = self.build(x, y)
         return interp, xitp
 
-    @run_in_parallel
+    @run_in_parallel(assert_all_close=True)
     def test_concurrency(self, random_rbf):
         # Check that no segfaults appear with concurrent access to
         # RbfInterpolator

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -699,7 +699,7 @@ class TestRegularGridInterpolator:
         interp = RegularGridInterpolator(points, values, method="slinear")
         return interp, sample
 
-    @run_in_parallel(pass_thread_id=True, assert_all_equal=False)
+    @run_in_parallel(pass_thread_id=True)
     def test_concurrency(self, rgi_4d, thread_id=0):
         # A call to RGI with a method different from the one specified on the
         # constructor, should not mutate it.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See https://github.com/Quansight-Labs/free-threaded-compatibility/issues/56

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR replaces the `_run_concurrent_barrier` introduced in #20671 by an unified decorator that supports pytest fixtures and markers, making it more idiomatic whilst reducing the amount of boilerplate code. This will enable easier concurrency and parallel testing of functions, classes and methods

#### Additional information
<!--Any additional information you think is important.-->
