### PR TITLE
MAINT: `stats.randint.pmf`: fix zero PMF values within the support

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1209,7 +1209,7 @@ class randint_gen(rv_discrete):
 
     def _pmf(self, k, low, high):
         # randint.pmf(k) = 1./(high - low)
-        p = np.ones_like(k) / (high - low)
+        p = np.ones_like(k) / (np.asarray(high, dtype=np.int64) - low)
         return np.where((k >= low) & (k < high), p, 0.)
 
     def _cdf(self, x, low, high):

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -646,3 +646,22 @@ class TestZipf:
         pmf = dist.pmf(k)
         pmf_k_int32 = dist.pmf(k_int32)
         assert_equal(pmf, pmf_k_int32)
+
+
+class TestRandInt:
+    def test_gh19759(self):
+        # test premature underflow reported in gh19759
+        a = -354
+        max_range = abs(a)
+
+        all_b_1 = [a + 2 ** 31 + i for i in range(max_range)]
+        assert not (randint.pmf(325, a, all_b_1) == 0).any()
+
+        all_b_2 = [a + 2 ** 31 + i for i in range(max_range + 1)]
+        assert not (randint.pmf(325, a, all_b_2) == 0).any()
+
+        all_b_3 = np.array(all_b_1)
+        assert not (randint.pmf(325, a, all_b_3) == 0).any()
+
+        all_b_4 = np.arange(a + 2 ** 31, 2 ** 31)
+        assert not (randint.pmf(325, a, all_b_4) == 0).any()

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -650,18 +650,11 @@ class TestZipf:
 
 class TestRandInt:
     def test_gh19759(self):
-        # test premature underflow reported in gh19759
+        # test zero PMF values within the support reported by gh-19759
         a = -354
         max_range = abs(a)
-
         all_b_1 = [a + 2 ** 31 + i for i in range(max_range)]
-        assert not (randint.pmf(325, a, all_b_1) == 0).any()
-
-        all_b_2 = [a + 2 ** 31 + i for i in range(max_range + 1)]
-        assert not (randint.pmf(325, a, all_b_2) == 0).any()
-
-        all_b_3 = np.array(all_b_1)
-        assert not (randint.pmf(325, a, all_b_3) == 0).any()
-
-        all_b_4 = np.arange(a + 2 ** 31, 2 ** 31)
-        assert not (randint.pmf(325, a, all_b_4) == 0).any()
+        res = randint.pmf(325, a, all_b_1)
+        assert (res > 0).all()
+        ref = 1 / (np.asarray(all_b_1, dtype=np.float64) - a)
+        assert_allclose(res, ref)


### PR DESCRIPTION
#### Reference issue
Closes gh-19759

#### What does this implement/fix?
gh-19759 reported that `randint.pmf` could produce zero values within the support. This occured on platforms for which `int32`  is the default integer type, the endpoints of the support are small enough to be stored as `int32`, but the width of the support is greater than `int32` can store. Subtraction to calculate the width of the support made the result wrap around to negative values, which caused the PMF to clip to zero. A MRE is:

```python3
import numpy as np
from scipy import stats
a = -1
b = 2 ** 31 - 1
stats.randint.pmf(1, a, b)  # 0 if `a` and `b` become `float32`
assert (np.asarray(b) - np.asarray(a)) < 0  # True on some platforms
```

This fixes the bug by ensuring that one of the operands is `int64` before subtraction is performed. This won't be necessary with NumPy 2.0 when `int64` seems to be the default on all platforms, but might as well fix it in the meantime.