### PR TITLE
MAINT: `stats.geom.rvs`: ensure that output is not negative for small shape

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -508,7 +508,11 @@ class geom_gen(rv_discrete):
         return [_ShapeInfo("p", False, (0, 1), (True, True))]
 
     def _rvs(self, p, size=None, random_state=None):
-        return random_state.geometric(p, size=size)
+        res = random_state.geometric(p, size=size)
+        # RandomState.geometric can wrap around to negative values; make behavior
+        # consistent with Generator.geometric by replacing with maximum integer.
+        max_int = np.iinfo(res.dtype).max
+        return np.where(res < 0, max_int, res)
 
     def _argcheck(self, p):
         return (p <= 1) & (p > 0)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -494,6 +494,11 @@ class geom_gen(rv_discrete):
     where :math:`p` is the probability of a single success
     and :math:`1-p` is the probability of a single failure.
 
+    Note that when drawing random samples, the probability of observations that exceed
+    ``np.iinfo(np.int64).max`` increases rapidly as $p$ decreases below $10^{-17}$. For
+    $p < 10^{-20}$, almost all observations would exceed the maximum ``int64``; however,
+    the output dtype is always ``int64``, so these values are clipped to the maximum.
+
     %(after_notes)s
 
     See Also

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1063,6 +1063,10 @@ class TestGeom:
         h = stats.geom(0.0146).entropy()
         assert_allclose(h, 5.219397961962308, rtol=1e-15)
 
+    def test_rvs_gh18372(self):
+        # gh-18372 reported that `geom.rvs` could produce negative numbers,
+        # but the support is positive integers. Check that this is resolved.
+        assert stats.geom.rvs(1e-30, random_state=1234) > 0
 
 class TestPlanck:
     def setup_method(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1065,8 +1065,10 @@ class TestGeom:
 
     def test_rvs_gh18372(self):
         # gh-18372 reported that `geom.rvs` could produce negative numbers,
-        # but the support is positive integers. Check that this is resolved.
-        assert stats.geom.rvs(1e-30, random_state=1234) > 0
+        # with `RandomState` PRNG, but the support is positive integers.
+        # Check that this is resolved.
+        random_state = np.random.RandomState(294582935)
+        assert (stats.geom.rvs(1e-30, size=10, random_state=random_state) > 0).all()
 
 class TestPlanck:
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
gh-18372

#### What does this implement/fix?
gh-18372 reported that `stats.geom.rvs` could produce negative values, which are not in the support of the distribution. This fixes it by following the convention of `Generator.geometric` in recent NumPy versions: replace negative values with the maximum integer.

```python3
import numpy as np
np.random.RandomState(294582935).geometric(1e-30)  # -9223372036854775808
np.random.default_rng(294582935).geometric(1e-30)  # 9223372036854775807
np.iinfo(np.int64).max  # 9223372036854775807
```

Currently, it does the work regardless of whether `random_state` is a `Generator` or `RandomState`, but if there is a follow-up to emit the warning per the suggesition in gh-18372, I can check the `random_state` type (and NumPy version, if need be) before determining the maximum integer and doing `where`.
