### PR TITLE
[1.14.x] CI: Update to cibuildwheel 2.20.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -87,7 +87,7 @@ jobs:
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2019, win, AMD64, "", ""]
 
-        python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"]]
+        python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -173,7 +173,7 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.17.0
+    - python -m pip install cibuildwheel==2.20.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -83,23 +83,32 @@ def test_decorator():
             """ Docstring
             %(strtest3)s
             """
-        assert_equal(func.__doc__, """ Docstring
+
+        def expected():
+            """ Docstring
             Another test
                with some indent
-            """)
+            """
+        assert_equal(func.__doc__, expected.__doc__)
 
         # without unindentation of parameters
-        decorator = doccer.filldoc(doc_dict, False)
+
+        # The docstring should be unindented for Python 3.13+
+        # because of https://github.com/python/cpython/issues/81283
+        decorator = doccer.filldoc(doc_dict, False if \
+                                   sys.version_info < (3, 13) else True)
 
         @decorator
         def func():
             """ Docstring
             %(strtest3)s
             """
-        assert_equal(func.__doc__, """ Docstring
+        def expected():
+            """ Docstring
                 Another test
                    with some indent
-            """)
+            """
+        assert_equal(func.__doc__, expected.__doc__)
 
 
 @pytest.mark.skipif(DOCSTRINGS_STRIPPED, reason="docstrings stripped")

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -11,4 +11,4 @@ python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
 
 # delvewheel is the equivalent of delocate/auditwheel for windows.
-python -m pip install delvewheel
+python -m pip install delvewheel wheel


### PR DESCRIPTION
cibuildwheel [2.20.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0) uses the ABI stable Python 3.13.0rc1 and builds Python 3.13 wheels by default.

Backport of #21315. Part of tracking issue #20992.

Might needs some parts of https://github.com/scipy/scipy/pull/21000 also ported.