### PR TITLE
BLD: use OpenBLAS v0.3.28 with fewer kernels, fix OpenBLAS licences

### DIFF
--- a/requirements/openblas.txt
+++ b/requirements/openblas.txt
@@ -1,1 +1,1 @@
-scipy-openblas32==0.3.28.0.1
+scipy-openblas32==0.3.28.0.2

--- a/requirements/openblas.txt
+++ b/requirements/openblas.txt
@@ -1,1 +1,1 @@
-scipy-openblas32==0.3.27.63.1
+scipy-openblas32==0.3.28.0.1

--- a/tools/wheels/LICENSE_linux.txt
+++ b/tools/wheels/LICENSE_linux.txt
@@ -5,7 +5,7 @@ This binary distribution of SciPy also bundles the following software:
 
 
 Name: OpenBLAS
-Files: scipy.libs/libopenblas*.so
+Files: scipy.libs/libscipy_openblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution
@@ -41,7 +41,7 @@ License: BSD-3-Clause-Attribution
 
 
 Name: LAPACK
-Files: scipy.libs/libopenblas*.so
+Files: scipy.libs/libscipy_openblas*.so
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution

--- a/tools/wheels/LICENSE_linux.txt
+++ b/tools/wheels/LICENSE_linux.txt
@@ -1,7 +1,8 @@
 
 ----
 
-This binary distribution of SciPy also bundles the following software:
+This binary distribution of SciPy can also bundle the following software
+(depending on the build):
 
 
 Name: OpenBLAS

--- a/tools/wheels/LICENSE_osx.txt
+++ b/tools/wheels/LICENSE_osx.txt
@@ -5,7 +5,7 @@ This binary distribution of SciPy also bundles the following software:
 
 
 Name: OpenBLAS
-Files: scipy/.dylibs/libopenblas*.so
+Files: scipy/.dylibs/libscipy_openblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution
@@ -41,7 +41,7 @@ License: BSD-3-Clause-Attribution
 
 
 Name: LAPACK
-Files: scipy/.dylibs/libopenblas*.so
+Files: scipy/.dylibs/libscipy_openblas*.so
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution

--- a/tools/wheels/LICENSE_osx.txt
+++ b/tools/wheels/LICENSE_osx.txt
@@ -1,7 +1,8 @@
 
 ----
 
-This binary distribution of SciPy also bundles the following software:
+This binary distribution of SciPy can also bundle the following software
+(depending on the build):
 
 
 Name: OpenBLAS

--- a/tools/wheels/LICENSE_win32.txt
+++ b/tools/wheels/LICENSE_win32.txt
@@ -5,7 +5,7 @@ This binary distribution of SciPy also bundles the following software:
 
 
 Name: OpenBLAS
-Files: scipy.libs\libopenblas*.dll
+Files: scipy.libs\libscipy_openblas*.dll
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution
@@ -41,7 +41,7 @@ License: BSD-3-Clause-Attribution
 
 
 Name: LAPACK
-Files: scipy.libs\libopenblas*.dll
+Files: scipy.libs\libscipy_openblas*.dll
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause-Attribution
@@ -96,7 +96,7 @@ License: BSD-3-Clause-Attribution
 
 
 Name: GCC runtime library
-Files: scipy.libs\libopenblas*.dll
+Files: scipy.libs\libscipy_openblas*.dll
 Description: statically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
 License: GPL-3.0-with-GCC-exception
@@ -879,26 +879,3 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
-
-
-Name: libquadmath
-Files: scipy.libs\libopenblas*.dll
-Description: statically linked to files compiled with gcc
-Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libquadmath
-License: LGPL-2.1-or-later
-
-    GCC Quad-Precision Math Library
-    Copyright (C) 2010-2019 Free Software Foundation, Inc.
-    Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
-
-    This file is part of the libquadmath library.
-    Libquadmath is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Library General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    Libquadmath is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-    https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html

--- a/tools/wheels/LICENSE_win32.txt
+++ b/tools/wheels/LICENSE_win32.txt
@@ -1,7 +1,8 @@
 
 ----
 
-This binary distribution of SciPy also bundles the following software:
+This binary distribution of SciPy can also bundle the following software
+(depending on the build):
 
 
 Name: OpenBLAS


### PR DESCRIPTION
Update to the newly released OpenBLAS 0.3.28. Note this uses the "shrunk" x86_64 and i686 OpenBLAS shared object with fewer kernels. The full shared object is available in the scipy-openblas 0.3.28.0.0 wheels.

For the OpenBLAS changelog see https://github.com/OpenMathLib/OpenBLAS/blob/develop/Changelog.txt. This PR also fixes up the bundled licenses:
- fix the `File:` to the correct name
- remove mention of `quadmath` from windows, it is no longer linked in, and the lack of linking is verified in the scipy-openblas wheel build via checking the linker map.