### PR TITLE
BUG: interpolate: FITPACK: remove `fpchec.f` in-line `if-then-endif` constructs

### DIFF
--- a/scipy/interpolate/fitpack/fpchec.f
+++ b/scipy/interpolate/fitpack/fpchec.f
@@ -29,36 +29,58 @@ c  ..
       nk2 = nk1+1
       ier = 10
 c  check condition no 1
-      if(nk1.lt.k1 .or. nk1.gt.m)then; ier=10; go to 80; endif
+      if (nk1.lt.k1 .or. nk1.gt.m) then
+          ier = 10
+          go to 80
+      endif
 c  check condition no 2
       j = n
       do 20 i=1,k
-        if(t(i).gt.t(i+1))then; ier=20; go to 80; endif
-        if(t(j).lt.t(j-1))then; ier=20; go to 80; endif
+        if (t(i) .gt. t(i+1)) then
+            ier = 20
+            go to 80
+        endif
+        if (t(j) .lt. t(j-1)) then
+            ier = 20
+            go to 80
+        endif
         j = j-1
   20  continue
 c  check condition no 3
       do 30 i=k2,nk2
-        if(t(i).le.t(i-1))then; ier=30; go to 80; endif
+        if (t(i) .le. t(i-1)) then
+            ier = 30
+            go to 80
+        endif
   30  continue
 c  check condition no 4
-      if(x(1).lt.t(k1) .or. x(m).gt.t(nk2))then; ier=40; go to 80;
+      if (x(1).lt.t(k1) .or. x(m).gt.t(nk2)) then
+          ier = 40
+          go to 80
       endif
 c  check condition no 5
-      if(x(1).ge.t(k2) .or. x(m).le.t(nk1))then; ier=50; go to 80;
+      if (x(1).ge.t(k2) .or. x(m).le.t(nk1)) then
+          ier = 50
+          go to 80
       endif
       i = 1
       l = k2
       nk3 = nk1-1
-      if(nk3.lt.2) go to 70
+      if (nk3 .lt. 2) go to 70
       do 60 j=2,nk3
         tj = t(j)
         l = l+1
         tl = t(l)
   40    i = i+1
-        if(i.ge.m)then; ier=50; go to 80; endif
-        if(x(i).le.tj) go to 40
-        if(x(i).ge.tl)then; ier=50; go to 80; endif
+        if (i .ge. m) then
+            ier = 50
+            go to 80
+        endif
+        if (x(i) .le. tj) go to 40
+        if (x(i) .ge. tl) then
+            ier = 50
+            go to 80
+        endif
   60  continue
   70  ier = 0
   80  return


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Filed as suggested in [gh-21349 (comment)](https://github.com/scipy/scipy/pull/21349#issuecomment-2282896549).

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR removes the single-line if-then-endif constructs in `fpchec.f` that were causing syntactical errors when compiling with `f2c` as part of building SciPy with the Emscripten toolchain, possibly because `fpchec` uses some dated, punch-card FORTRAN syntax. It converts them to statements split over multiple lines.

#### Additional information
<!--Any additional information you think is important.-->

This PR is part of a list of patches being upstreamed to Pyodide from compiling SciPy, which was recently updated to v1.13.0 in-tree: pyodide/pyodide#4719. This way, the patch can be removed in-tree if this code gets refactored/rewritten in C in a later version of SciPy or simply when SciPy is being updated to v1.15.0 if this file is left untouched after this gets merged.