### PR TITLE
DEV/BENCH: asv: revert to `mamba` env type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,12 +150,12 @@ jobs:
           command: |
             export PYTHONPATH=$PWD/build-install/lib/python3.11/site-packages
             cd benchmarks
-            asv machine --machine CircleCI
+            asv machine --machine CircleCI --config asv.conf.jsonc
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
             export SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0
             export OPENBLAS_NUM_THREADS=1
-            time asv --config asv.conf.json run -m CircleCI --quick --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
-            asv --config asv.conf.json publish
+            time asv --config asv.conf.jsonc run -m CircleCI --quick --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
+            asv --config asv.conf.jsonc publish
 
       - store_artifacts:
           path: benchmarks/html

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,7 @@ tools/refguide_check.py  @ev-br
 tools/  @larsoner @rgommers
 pytest.ini  @larsoner
 .coveragerc  @larsoner
-benchmarks/asv.conf.json  @larsoner
+benchmarks/asv.conf.jsonc  @larsoner
 
 # CI config
 .circleci/  @larsoner

--- a/benchmarks/asv.conf.jsonc
+++ b/benchmarks/asv.conf.jsonc
@@ -13,7 +13,9 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
-    "branches": ["HEAD"],
+    "branches": [
+        "HEAD"
+    ],
 
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
@@ -23,7 +25,6 @@
     // "build_command": [
     //     "PIP_NO_BUILD_ISOLATION=false python -m pip install . --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
-
     "build_command": [
         "python -m build --wheel -o {build_cache_dir} {build_dir}"
     ],
@@ -40,12 +41,12 @@
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": [],
-        "Cython": [],
-        "pytest": [],
-        "pythran": [],
-        "pybind11": [],
-        "meson-python": [],
+        "numpy": [ ],
+        "Cython": [ ],
+        "pytest": [ ],
+        "pythran": [ ],
+        "pybind11": [ ],
+        "meson-python": [ ]
     },
 
     // The directory (relative to the current directory) that benchmarks are
@@ -61,8 +62,9 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "virtualenv",
-    // "environment_type": "mamba",
+    // "environment_type": "virtualenv",
+    "environment_type": "mamba",
+
     "build_cache_size": 10,
 
     // The directory (relative to the current directory) that raw benchmark
@@ -83,8 +85,7 @@
     // regressions.  The default is to start from the first commit
     // with results. If the commit is `null`, regression detection is
     // skipped for the matching benchmark.
-
     "regressions_first_commits": {
-       "io_matlab\\.StructArr\\..*": "67c089a6",  //  structarrs weren't properly implemented before this
+        "io_matlab\\.StructArr\\..*": "67c089a6" //  structarrs weren't properly implemented before this
     }
 }

--- a/dev.py
+++ b/dev.py
@@ -1004,7 +1004,8 @@ class Bench(Task):
             if not args.compare:
                 print(f"Running benchmarks for Scipy version {version} at {mod_path}")
                 cmd = ['asv', 'run', '--dry-run', '--show-stderr',
-                       '--python=same', '--quick'] + bench_args
+                       '--python=same', '--quick',
+                       '--config=asv.conf.jsonc',] + bench_args
                 retval = cls.run_asv(dirs, cmd)
                 sys.exit(retval)
             else:

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -136,6 +136,28 @@ To run only a single benchmark, such as ``KleeMinty`` from
 
    asv run --bench optimize_linprog.KleeMinty
 
+.. note::
+    Support for ``asv.conf.jsonc`` as a default config file path was added in
+    ``asv v0.6.4``. If developers must use an older version of ``asv``, they should
+    include ``--config=asv.conf.jsonc`` in their commands.
+
+.. note::
+
+    By default, the SciPy config uses ``mamba`` to manage ``asv`` environments,
+    which is preferable as explained in the ``asv`` docs:
+
+        ``libmambapy`` is the fastest for situations where non-pythonic dependencies are
+        required. Anaconda or miniconda is slower but still preferred if the project
+        involves a lot of compiled C/C++ extensions and are available in the conda
+        repository, since conda will be able to fetch precompiled binaries for these
+        dependencies in many cases. Using ``virtualenv``, dependencies without
+        precompiled wheels usually have to be compiled every time the environments are
+        set up.
+
+    However, developers may opt in to using ``virtualenv`` by uncommenting the line
+    ``"environment_type": "virtualenv",`` in ``asv.conf.jsonc``, and
+    commenting out ``"environment_type": "mamba",``.
+
 One great feature of ``asv`` is that it can automatically run a
 benchmark not just for the current commit, but for every commit in a
 range. ``linprog`` ``method='interior-point'`` was merged into SciPy


### PR DESCRIPTION
also fix `asv.conf` highlighting by using a `jsonc` file, newly supported in `asv v0.6.4`

[skip cirrus] [skip actions]

#### Reference issue
Closes gh-21372

#### What does this implement/fix?
- use a JSONC file to fix all the red highlighting on GitHub. This is supported by default upstream in the latest `asv` version
- Revert the change in gh-21243 to use `virtualenv` by default. This is less efficient than `mamba` which shouldn't cause issues if environments are set up correctly. The latest `asv` version adds a pointer to the `conda-build` dependency which is now needed in addition to `libmambapy`.
- Adds docs on both of these topics.

#### Additional information
@tylerjereddy @perimosocordiae please could one of you check that changing the env type to `virtualenv` works on this branch after upgrading to `asv v0.6.4`? If I am not mistaken, you shouldn't have to change any local `asv` invocations as it should now detect the `jsonc` file automatically.
