### PR TITLE
MAINT: Add local resources for smoke-tutorials

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -435,5 +435,11 @@ if HAVE_SCPDT:
 
     # tutorials
     dt_config.pseudocode = set(['integrate.nquad(func,'])
-    dt_config.local_resources = {'io.rst': ["octave_a.mat", "octave_cells.mat", "octave_struct.mat"]}
+    dt_config.local_resources = {
+        'io.rst': [
+            "octave_a.mat",
+            "octave_cells.mat",
+            "octave_struct.mat"
+        ]
+    }
 ############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -426,7 +426,6 @@ if HAVE_SCPDT:
 
     dt_config.pytest_extra_xfail = {
         # name: reason
-        "io.rst": "",
         "ND_regular_grid.rst": "ReST parser limitation",
         "extrapolation_examples.rst": "ReST parser limitation",
         "sampling_pinv.rst": "__cinit__ unexpected argument",
@@ -436,5 +435,5 @@ if HAVE_SCPDT:
 
     # tutorials
     dt_config.pseudocode = set(['integrate.nquad(func,'])
-    dt_config.local_resources = {'io.rst': ["octave_a.mat"]}
+    dt_config.local_resources = {'io.rst': ["octave_a.mat", "octave_cells.mat", "octave_struct.mat"]}
 ############################################################################


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping
[docs only]
Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Related to https://github.com/scipy/scipy_doctest/issues/154

#### What does this implement/fix?
<!--Please explain your changes.-->
This update adds all the necessary local files that `scipy_doctest` requires to successfully run `python dev.py smoke-tutorials` on [`io.rst`](https://github.com/scipy/scipy/blob/main/doc/source/tutorial/io.rst). As a result, doctests for `io.rst` that previously failed due to missing local resources are now passing. The `xfail` marker for the test has therefore been removed.
