### PR TITLE
BENCH: Update BlockDiagSparseConstruction to use a `coo_matrix` instead of a standard numpy array

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -206,14 +206,17 @@ class BlockDiagDenseConstruction(Benchmark):
 
 class BlockDiagSparseConstruction(Benchmark):
     param_names = ['num_matrices']
-    params = [100, 500, 1000, 1500, 2000]
+    params = [1000, 5000, 10000, 15000, 20000]
 
     def setup(self, num_matrices):
         self.matrices = []
         for i in range(num_matrices):
             rows = np.random.randint(1, 20)
             columns = np.random.randint(1, 20)
-            mat = np.random.randint(0, 10, (rows, columns))
+            density = 2e-3
+            nnz_per_row = int(density*columns)
+
+            mat = random_sparse(rows, columns, nnz_per_row)
             self.matrices.append(mat)
 
     def time_block_diag(self, num_matrices):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

[skip cirrus] [skip azp]

#### Reference issue
N/A

#### What does this implement/fix?
When needing to construct a sparse block diagonal matrix, we noticed that the benchmarking code appears to use a plain numpy array instead of a `spmatrix` subclass.

This PR updates the benchmark code to use a `coo_matrix`

#### Additional information
This is a speculative PR as we are aware that there is more context to this benchmark code that we might be missing. Please let us know if that's the case!
