### PR TITLE
DOC: signal: fix typos in `_short_time_fft.py` and `signal.rst`

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1081,7 +1081,7 @@ For real-valued signals the so-called "onesided" spectral representation is ofte
 It only uses the non-negative frequencies (due to :math:`X(-f)= \conj{X}(f)` if
 :math:`x(t)\in\IR`). Sometimes the values of the negative frequencies are added to their
 positive counterparts. Then the amplitude spectrum allows to read off the full (not
-half) amplitude sine  of :math:`x(t)` at :math:`f_z` and the area of an interval in
+half) amplitude sine  of :math:`x(t)` at :math:`f_x` and the area of an interval in
 the PSD represents its full (not half) power. Note that for amplitude spectral
 densities the positive values are not doubled but multiplied by :math:`\sqrt{2}`, since
 it is the square root of the PSD. Furthermore, there is no canonical way for naming a
@@ -1089,13 +1089,13 @@ doubled spectrum.
 
 The following plot shows three different spectral representations of four sine signals
 :math:`x(t)` of Eq. :math:numref:`eq_SpectA_sine` with different amplitudes :math:`a`
-and durations :math:`\tau`. For less clutter, the spectra are centered at :math:`f_z`
+and durations :math:`\tau`. For less clutter, the spectra are centered at :math:`f_x`
 and being are plotted next to each other:
 
 .. plot:: tutorial/examples/signal_SpectralAnalysis_ContinuousSpectralRepresentations.py
 
 Note that depending on the representation, the height of the peaks vary. Only the
-interpretation of the magnitude spectrum is straightforward: The peak at :math:`f_z` in
+interpretation of the magnitude spectrum is straightforward: The peak at :math:`f_x` in
 the second plot represents half the magnitude :math:`|a|` of the sine signal. For all other
 representations the duration :math:`\tau` needs to be taken into account to extract
 information about the signal's amplitude.
@@ -1478,7 +1478,7 @@ reformulate Eq. :math:numref:`eq_dSTFT` as a two-step process:
        x_p[m] = x\!\big[m - \lfloor M/2\rfloor + h p\big]\, \conj{w[m]}\ ,
                 \quad m = 0, \ldots M-1\ ,
 
-   where the integer :math:`\lfloor M/2\rfloor` represents ``M//2``, i.e, it is
+   where the integer :math:`\lfloor M/2\rfloor` represents ``M//2``, i.e., it is
    the mid point of the window (`m_num_mid`). For notational convenience,
    :math:`x[k]:=0` for :math:`k\not\in\{0, 1, \ldots, N-1\}` is assumed. In the
    subsection :ref:`tutorial_stft_sliding_win` the indexing of the slices is
@@ -1719,7 +1719,7 @@ due to :math:`\vb{F}` being unitary. Furthermore
 
 shows that :math:`\vb{D}_p` is a diagonal matrix with non-negative entries.
 Hence, summing :math:`\vb{D}_p` preserves that property. This allows to
-simplify Eq. :math:numref:`eq_STFT_MoorePenrose` further, i.e,
+simplify Eq. :math:numref:`eq_STFT_MoorePenrose` further, i.e.,
 
 .. math::
     :label: eq_STFT_istftM

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -861,11 +861,11 @@ class ShortTimeFFT:
             -> np.ndarray:
         r"""Calculate spectrogram or cross-spectrogram.
 
-        The spectrogram is the absolute square of the STFT, i.e, it is
+        The spectrogram is the absolute square of the STFT, i.e., it is
         ``abs(S[q,p])**2`` for given ``S[q,p]``  and thus is always
         non-negative.
         For two STFTs ``Sx[q,p], Sy[q,p]``, the cross-spectrogram is defined
-        as ``Sx[q,p] * np.conj(Sx[q,p])`` and is complex-valued.
+        as ``Sx[q,p] * np.conj(Sy[q,p])`` and is complex-valued.
         This is a convenience function for calling `~ShortTimeFFT.stft` /
         `stft_detrend`, hence all parameters are discussed there. If `y` is not
         ``None`` it needs to have the same shape as `x`.


### PR DESCRIPTION
[docs only]

Reported [here].

[here]: https://discuss.scientific-python.org/t/typo-in-signal-shorttimeffr-spectrogram-documentation/1363