### PR TITLE
ENH: special: Improve precision of special.logit.

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -8,8 +8,8 @@ files '_ufuncs.c' and '_ufuncs_cxx.c' by first producing Cython.
 This will generate both calls to PyUFunc_FromFuncAndData and the
 required ufunc inner loops.
 
-The functions signatures are contained in 'functions.json', the syntax
-for a function signature is
+The functions' signatures are contained in 'functions.json'.
+The syntax for a function signature is
 
     <function>:       <name> ':' <input> '*' <output>
                         '->' <retval> '*' <ignored_retval>

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2636,7 +2636,6 @@ const char *loggamma_doc = R"(
     )";
 
 const char *logit_doc = R"(
-    """
     logit(x, out=None)
 
     Logit ufunc for ndarrays.

--- a/scipy/special/xsf/log_exp.h
+++ b/scipy/special/xsf/log_exp.h
@@ -27,7 +27,18 @@ inline float exprel(float x) { return exprel(static_cast<double>(x)); }
 
 template <typename T>
 T logit(T x) {
-    return std::log(x / (1 - x));
+    // The standard formula is log(x/(1 - x)), but this expression
+    // loses precision near x=0.5, as does log(x) - log1p(-x).
+    // We use the latter just for small x, and otherwise use
+    // log1p(2*(x - 0.5)) - log1p(-2*(x - 0.5)), which provides
+    // very good precision for all x outside of an interval near 0.
+    if (x < 0.25) {
+        return std::log(x) - std::log1p(-x);
+    }
+    else {
+        T s = 2*(x - 0.5);
+        return std::log1p(s) - std::log1p(-s);
+    }
 };
 
 //

--- a/scipy/special/xsf/log_exp.h
+++ b/scipy/special/xsf/log_exp.h
@@ -29,11 +29,11 @@ template <typename T>
 T logit(T x) {
     // The standard formula is log(x/(1 - x)), but this expression
     // loses precision near x=0.5, as does log(x) - log1p(-x).
-    // We use the latter just for small x, and otherwise use
-    // log1p(2*(x - 0.5)) - log1p(-2*(x - 0.5)), which provides
-    // very good precision for all x outside of an interval near 0.
-    if (x < 0.25) {
-        return std::log(x) - std::log1p(-x);
+    // We use the standard formula away from p=0.5, and use
+    // log1p(2*(x - 0.5)) - log1p(-2*(x - 0.5)) around p=0.5, which
+    // provides very good precision in this interval.
+    if (x < 0.3 || x > 0.65) {
+        return std::log(x/(1 - x));
     }
     else {
         T s = 2*(x - 0.5);


### PR DESCRIPTION
Another "low hanging fruit" precision improvement: use formulations of `log(p/(1 - p))` that avoid loss of precision.

I refactored the tests of `logit`, and updated the reference values with values computed with mpmath.

Here's a script that uses mpmath to plot the relative error of logit over the interval (0, 1):

```python
from mpmath import mp
import numpy as np
import scipy
from scipy.special import logit
import matplotlib.pyplot as plt


mp.dps = 200

p = np.linspace(0, 1, 8000)[1:-1]
y = logit(p)
ref = np.array([float(mp.log(t) - mp.log1p(-t)) for t in p])
relerr = abs((y - ref)/ref)

plt.plot(p, relerr)
plt.grid()
plt.xlabel('p')
plt.title('Relative error of scipy.special.logit')

# plt.show()
plt.savefig(f'logit-relerr-{scipy.__version__}.png')
```
With the main development branch, the plot shows the spike in the relative error around p = 0.5:

![logit-relerr-1 15 0 dev0+1389 bfaef27](https://github.com/user-attachments/assets/5cddde1f-47eb-40b2-9e27-0a416546fe52)

With this PR, the relative error for this sample is less than 2.5e-16 over the entire interval:

![logit-relerr-1 15 0 dev0+1392 779bb9b](https://github.com/user-attachments/assets/b6c2e51e-e0ef-4a51-8ff9-ac8025f48f54)

