### PR TITLE
DOC: stats.ecdf: fix example plot

### DIFF
--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -391,7 +391,7 @@ def ecdf(sample: npt.ArrayLike | CensoredData) -> ECDFResult:
     To plot the result as a step function:
 
     >>> ax = plt.subplot()
-    >>> res.cdf.plot(ax)
+    >>> res.sf.plot(ax)
     >>> ax.set_xlabel('Fanbelt Survival Time (thousands of miles)')
     >>> ax.set_ylabel('Empirical SF')
     >>> plt.show()


### PR DESCRIPTION
#### What does this implement/fix?

Hi, this fixes a typo in the example of the documentation.
The survival function should be decreasing (the more time passes, the more the probability of survival is close to 0); moreover, the context of the example uses the empirical survival (sf) data and not cdf.

Thanks