### PR TITLE
DOC/DEV: add `pooch` to virtualenv dev quickstart guide

### DIFF
--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -71,7 +71,7 @@ following commands at the terminal from the base directory of your
             # Activate the environment
             source $HOME/.venvs/scipy-dev/bin/activate
             # Install python-level dependencies
-            python -m pip install numpy pytest cython pythran pybind11 meson ninja pydevtool rich-click hypothesis
+            python -m pip install numpy pytest cython pythran pybind11 meson ninja pydevtool rich-click hypothesis pooch
 
 Your command prompt now lists the name of your new environment, like so:
 ``(scipy-dev)$``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->
Small PR to add the pooch library to the installation command in the dev quickstart guide. 
#### Additional information
<!--Any additional information you think is important.-->
Previously, when running `python dev.py test`, an error would occur stating that Pooch was missing.

```bash
During handling of the above exception, another exception occurred:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
scipy/datasets/tests/test_data.py:12: in <module>
    raise ImportError("Missing optional dependency 'pooch' required "
E   ImportError: Missing optional dependency 'pooch' required for scipy.datasets module. Please use pip or conda to install 'pooch'.
```
