### PR TITLE
BUG: sparse: Fix 1D specialty hstack codes

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -602,23 +602,23 @@ def _compressed_sparse_stack(blocks, axis, return_spmatrix):
     """
     other_axis = 1 if axis == 0 else 0
     data = np.concatenate([b.data for b in blocks])
-    constant_dim = blocks[0].shape[other_axis]
+    constant_dim = blocks[0]._shape_as_2d[other_axis]
     idx_dtype = get_index_dtype(arrays=[b.indptr for b in blocks],
                                 maxval=max(data.size, constant_dim))
     indices = np.empty(data.size, dtype=idx_dtype)
-    indptr = np.empty(sum(b.shape[axis] for b in blocks) + 1, dtype=idx_dtype)
+    indptr = np.empty(sum(b._shape_as_2d[axis] for b in blocks) + 1, dtype=idx_dtype)
     last_indptr = idx_dtype(0)
     sum_dim = 0
     sum_indices = 0
     for b in blocks:
-        if b.shape[other_axis] != constant_dim:
+        if b._shape_as_2d[other_axis] != constant_dim:
             raise ValueError(f'incompatible dimensions for axis {other_axis}')
         indices[sum_indices:sum_indices+b.indices.size] = b.indices
         sum_indices += b.indices.size
-        idxs = slice(sum_dim, sum_dim + b.shape[axis])
+        idxs = slice(sum_dim, sum_dim + b._shape_as_2d[axis])
         indptr[idxs] = b.indptr[:-1]
         indptr[idxs] += last_indptr
-        sum_dim += b.shape[axis]
+        sum_dim += b._shape_as_2d[axis]
         last_indptr += b.indptr[-1]
     indptr[-1] = last_indptr
     # TODO remove this if-structure when sparse matrices removed
@@ -652,7 +652,7 @@ def _stack_along_minor_axis(blocks, axis):
 
     # check for incompatible dimensions
     other_axis = 1 if axis == 0 else 0
-    other_axis_dims = {b.shape[other_axis] for b in blocks}
+    other_axis_dims = {b._shape_as_2d[other_axis] for b in blocks}
     if len(other_axis_dims) > 1:
         raise ValueError(f'Mismatching dimensions along axis {other_axis}: '
                          f'{other_axis_dims}')
@@ -668,10 +668,10 @@ def _stack_along_minor_axis(blocks, axis):
     # - The max value in indptr is the number of non-zero entries. This is
     #   exceedingly unlikely to require int64, but is checked out of an
     #   abundance of caution.
-    sum_dim = sum(b.shape[axis] for b in blocks)
+    sum_dim = sum(b._shape_as_2d[axis] for b in blocks)
     nnz = sum(len(b.indices) for b in blocks)
     idx_dtype = get_index_dtype(maxval=max(sum_dim - 1, nnz))
-    stack_dim_cat = np.array([b.shape[axis] for b in blocks], dtype=idx_dtype)
+    stack_dim_cat = np.array([b._shape_as_2d[axis] for b in blocks], dtype=idx_dtype)
     if data_cat.size > 0:
         indptr_cat = np.concatenate(indptr_list).astype(idx_dtype)
         indices_cat = (np.concatenate([b.indices for b in blocks])

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -478,10 +478,20 @@ class TestConstructUtils:
     def test_vstack_1d_with_2d(self):
         # fixes gh-21064
         arr = csr_array([[1, 0, 0], [0, 1, 0]])
-        arr1d = arr[0]
+        arr1d = csr_array([1, 0, 0])
+        arr1dcoo = coo_array([1, 0, 0])
         assert construct.vstack([arr, np.array([0, 0, 0])]).shape == (3, 3)
         assert construct.hstack([arr1d, np.array([[0]])]).shape == (1, 4)
+        assert construct.hstack([arr1d, arr1d]).shape == (1, 6)
         assert construct.vstack([arr1d, arr1d]).shape == (2, 3)
+
+        # check csr specialty stacking code like _stack_along_minor_axis
+        assert construct.hstack([arr, arr]).shape == (2, 6)
+        assert construct.hstack([arr1d, arr1d]).shape == (1, 6)
+
+        assert construct.hstack([arr1d, arr1dcoo]).shape == (1, 6)
+        assert construct.vstack([arr, arr1dcoo]).shape == (3, 3)
+        assert construct.vstack([arr1d, arr1dcoo]).shape == (2, 3)
 
         with pytest.raises(ValueError, match="incompatible row dimensions"):
             construct.hstack([arr, np.array([0, 0])])


### PR DESCRIPTION
In working on backporting #21108 I added tests of both coo and csr formats and found some more bugs with 1D arrays.
I believe I have now identified and fixed all uses of `shape` attributes in `_construct.py` module. 

The test of 1D and 2D hstack and vstack now explicitly build 1d arrays, both csr and coo, and test more combinations of arrays in the hstack/vstack calls. 

This builds on #21108 and is due to work to help #21362 
