### PR TITLE
BUG: optimize.minimize: set `trust-constr` `success=False` when constraints are not satisfied

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -19,7 +19,7 @@ TERMINATION_MESSAGES = {
     1: "`gtol` termination condition is satisfied.",
     2: "`xtol` termination condition is satisfied.",
     3: "`callback` function requested termination.",
-    4: "Constraints are not satisfied."
+    4: "Constraint violation exceeds 'gtol'"
 }
 
 
@@ -300,7 +300,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         * 1 : `gtol` termination condition is satisfied.
         * 2 : `xtol` termination condition is satisfied.
         * 3 : `callback` function requested termination.
-        * 4 : Constraints are not satisfied.
+        * 4 : Constraint violation exceeds 'gtol'.
 
     cg_stop_cond : int
         Reason for CG subproblem termination at the last iteration:

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -18,7 +18,8 @@ TERMINATION_MESSAGES = {
     0: "The maximum number of function evaluations is exceeded.",
     1: "`gtol` termination condition is satisfied.",
     2: "`xtol` termination condition is satisfied.",
-    3: "`callback` function requested termination."
+    3: "`callback` function requested termination.",
+    4: "Constraints are not satisfied."
 }
 
 
@@ -292,13 +293,14 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         Total execution time.
     message : str
         Termination message.
-    status : {0, 1, 2, 3}
+    status : {0, 1, 2, 3, 4}
         Termination status:
 
         * 0 : The maximum number of function evaluations is exceeded.
         * 1 : `gtol` termination condition is satisfied.
         * 2 : `xtol` termination condition is satisfied.
         * 3 : `callback` function requested termination.
+        * 4 : Constraints are not satisfied.
 
     cg_stop_cond : int
         Reason for CG subproblem termination at the last iteration:
@@ -539,6 +541,10 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
             initial_barrier_tolerance,
             initial_constr_penalty, initial_tr_radius,
             factorization_method)
+
+    # Status 4 occurs when minimize is successful but constraints are not satisfied.
+    if result.status in (1, 2) and state.constr_violation > gtol:
+        result.status = 4
 
     # Status 3 occurs when the callback function requests termination,
     # this is assumed to not be a success.

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -763,6 +763,25 @@ def test_gh20665_too_many_constraints():
         minimize(rosen, x0, method='trust-constr', constraints=[g],
                  options={'factorization_method': 'SVDFactorization'})
 
+def test_issue_18882():
+    def lsf(u):
+        u1, u2 = u
+        a, b = [3.0, 4.0]
+        return 1.0 + u1**2 / a**2 - u2**2 / b**2
+
+    def of(u):
+        return np.sum(u**2)
+
+    with suppress_warnings() as sup:
+        sup.filter(UserWarning, "delta_grad == 0.0")
+        sup.filter(UserWarning, "Singular Jacobian matrix.")
+        res = minimize(
+            of,
+            [0.0, 0.0],
+            method="trust-constr",
+            constraints=NonlinearConstraint(lsf, 0, 0),
+        )
+    assert (not res.success) and (res.constr_violation > 1e-8)  
 
 class TestBoundedNelderMead:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #18882.

#### What does this implement/fix?
Previously trust-constr returned success=True (i.e. status equal to 1 or 2) even when the constraints were not satisfied.  Now trust-constr returns success=False and status=4 with message="Constraints are not satisfied."  A test is implemented in test_minimized_constrained.py to check success=False when constr_violation>gtol.

#### Additional information
This fix is based in part on the PR created by @ellieLitwack at https://github.com/scipy/scipy/pull/18890#issue-1806356775, but approaches the solution to the bug in a way that does not require a modification to the stop criteria.  The feedback from @andyfaff to this previous PR was also considered in the creation of this new fix.
