### PR TITLE
MAINT: cleaner 0-D/scalar checks for `xp` assertions, round 2

### DIFF
--- a/scipy/_lib/_array_api_no_0d.py
+++ b/scipy/_lib/_array_api_no_0d.py
@@ -1,0 +1,104 @@
+"""
+Extra testing functions that forbid 0d-input, see #21044
+
+While the xp_assert_* functions generally aim to follow the conventions of the
+underlying `xp` library, NumPy in particular is inconsistent in its handling
+of scalars vs. 0d-arrays, see https://github.com/numpy/numpy/issues/24897.
+
+For example, this means that the following operations (as of v2.0.1) currently
+return scalars, even though a 0d-array would often be more appropriate:
+
+    import numpy as np
+    np.array(0) * 2     # scalar, not 0d array
+    - np.array(0)       # scalar, not 0d-array
+    np.sin(np.array(0)) # scalar, not 0d array
+    np.mean([1, 2, 3])  # scalar, not 0d array
+
+Libraries like CuPy tend to return a 0d-array in scenarios like those above,
+and even `xp.asarray(0)[()]` remains a 0d-array there. To deal with the reality
+of the inconsistencies present in NumPy, as well as 20+ years of code on top,
+the `xp_assert_*` functions here enforce consistency in the only way that
+doesn't go against the tide, i.e. by forbidding 0d-arrays as the return type.
+
+However, where possible, it remains preferable to use the assert functions from
+the `scipy._lib._array_api` module, which have less surprising behaviour.
+"""
+from __future__ import annotations
+
+from scipy._lib._array_api import array_namespace, is_numpy
+from scipy._lib._array_api import (xp_assert_close as xp_assert_close_base,
+                                   xp_assert_equal as xp_assert_equal_base,
+                                   xp_assert_less as xp_assert_less_base)
+
+__all__: list[str] = []
+
+
+def _check_scalar(actual, desired, *, xp=None, **kwargs):
+    __tracebackhide__ = True  # Hide traceback for py.test
+
+    if xp is None:
+        xp = array_namespace(actual)
+
+    # necessary to handle non-numpy scalars, e.g. bare `0.0` has no shape
+    desired = xp.asarray(desired)
+
+    # Only NumPy distinguishes between scalars and arrays;
+    # shape check in xp_assert_* is sufficient except for shape == ()
+    if not (is_numpy(xp) and desired.shape == ()):
+        return
+
+    _msg = ("Result is a NumPy 0d-array. Many SciPy functions intend to follow "
+            "the convention of many NumPy functions, returning a scalar when a "
+            "0d-array would be correct. The specialized `xp_assert_*` functions "
+            "in the `scipy._lib._array_api_no_0d` module err on the side of "
+            "caution and do not accept 0d-arrays by default. If the correct "
+            "result may legitimately be a 0d-array, pass `check_0d=True`, "
+            "or use the `xp_assert_*` functions from `scipy._lib._array_api`.")
+    assert xp.isscalar(actual), _msg
+
+
+def xp_assert_equal(actual, desired, *, check_0d=False, **kwargs):
+    # in contrast to xp_assert_equal_base, this defaults to check_0d=False,
+    # but will do an extra check in that case, which forbids 0d-arrays for `actual`
+    __tracebackhide__ = True  # Hide traceback for py.test
+
+    # array-ness (check_0d == True) is taken care of by the *_base functions
+    if not check_0d:
+        _check_scalar(actual, desired, **kwargs)
+    return xp_assert_equal_base(actual, desired, check_0d=check_0d, **kwargs)
+
+
+def xp_assert_close(actual, desired, *, check_0d=False, **kwargs):
+    # as for xp_assert_equal
+    __tracebackhide__ = True
+
+    if not check_0d:
+        _check_scalar(actual, desired, **kwargs)
+    return xp_assert_close_base(actual, desired, check_0d=check_0d, **kwargs)
+
+
+def xp_assert_less(actual, desired, *, check_0d=False, **kwargs):
+    # as for xp_assert_equal
+    __tracebackhide__ = True
+
+    if not check_0d:
+        _check_scalar(actual, desired, **kwargs)
+    return xp_assert_less_base(actual, desired, check_0d=check_0d, **kwargs)
+
+
+def assert_array_almost_equal(actual, desired, decimal=6, *args, **kwds):
+    """Backwards compatible replacement. In new code, use xp_assert_close instead.
+    """
+    rtol, atol = 0, 1.5*10**(-decimal)
+    return xp_assert_close(actual, desired,
+                           atol=atol, rtol=rtol, check_dtype=False, check_shape=False,
+                           *args, **kwds)
+
+
+def assert_almost_equal(actual, desired, decimal=7, *args, **kwds):
+    """Backwards compatible replacement. In new code, use xp_assert_close instead.
+    """
+    rtol, atol = 0, 1.5*10**(-decimal)
+    return xp_assert_close(actual, desired,
+                           atol=atol, rtol=rtol, check_dtype=False, check_shape=False,
+                           *args, **kwds)

--- a/scipy/_lib/_array_api_no_0d.py
+++ b/scipy/_lib/_array_api_no_0d.py
@@ -20,7 +20,8 @@ of the inconsistencies present in NumPy, as well as 20+ years of code on top,
 the `xp_assert_*` functions here enforce consistency in the only way that
 doesn't go against the tide, i.e. by forbidding 0d-arrays as the return type.
 
-However, where possible, it remains preferable to use the assert functions from
+However, when scalars are not generally the expected NumPy return type,
+it remains preferable to use the assert functions from
 the `scipy._lib._array_api` module, which have less surprising behaviour.
 """
 from __future__ import annotations

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -111,6 +111,7 @@ py3.extension_module('messagestream',
 python_sources = [
   '__init__.py',
   '_array_api.py',
+  '_array_api_no_0d.py',
   '_bunch.py',
   '_ccallback.py',
   '_disjoint_set.py',

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -445,7 +445,7 @@ class TestLazywhere:
             ref2 = ref2.reshape(result_shape)
             ref3 = ref3.reshape(result_shape)
 
-        xp_assert_close(res1, ref1, rtol=2e-16, check_0d=False)
-        xp_assert_equal(res2, ref2, check_0d=False)
+        xp_assert_close(res1, ref1, rtol=2e-16)
+        xp_assert_equal(res2, ref2)
         if not is_array_api_strict(xp):
-            xp_assert_equal(res3, ref3, check_0d=False)
+            xp_assert_equal(res3, ref3)

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -445,7 +445,7 @@ class TestLazywhere:
             ref2 = ref2.reshape(result_shape)
             ref3 = ref3.reshape(result_shape)
 
-        xp_assert_close(res1, ref1, rtol=2e-16, allow_0d=True)
-        xp_assert_equal(res2, ref2, allow_0d=True)
+        xp_assert_close(res1, ref1, rtol=2e-16, check_0d=False)
+        xp_assert_equal(res2, ref2, check_0d=False)
         if not is_array_api_strict(xp):
-            xp_assert_equal(res3, ref3, allow_0d=True)
+            xp_assert_equal(res3, ref3, check_0d=False)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -120,29 +120,32 @@ class TestArrayAPI:
 
         # identity always passes
         xp_assert_equal(xp.float64(0), xp.float64(0))
-        xp_assert_equal(xp.array(0.), xp.array(0.))
+        xp_assert_equal(xp.asarray(0.), xp.asarray(0.))
         xp_assert_equal(xp.float64(0), xp.float64(0), check_0d=False)
-        xp_assert_equal(xp.array(0.), xp.array(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), xp.asarray(0.), check_0d=False)
 
         # Check default convention: 0d-arrays are distinguished from scalars
         message = "Array-ness does not match:.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.array(0.), xp.float64(0))
+            xp_assert_equal(xp.asarray(0.), xp.float64(0))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.float64(0), xp.array(0.))
+            xp_assert_equal(xp.float64(0), xp.asarray(0.))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.array(42), xp.int64(42))
+            xp_assert_equal(xp.asarray(42), xp.int64(42))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.int64(42), xp.array(42))
+            xp_assert_equal(xp.int64(42), xp.asarray(42))
 
         # with `check_0d=False`, scalars-vs-0d passes (if values match)
-        xp_assert_equal(xp.array(0.), xp.float64(0), check_0d=False)
-        xp_assert_equal(xp.float64(0), xp.array(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), xp.float64(0), check_0d=False)
+        xp_assert_equal(xp.float64(0), xp.asarray(0.), check_0d=False)
         # also with regular python objects
-        xp_assert_equal(xp.array(0.), 0., check_0d=False)
-        xp_assert_equal(0., xp.array(0.), check_0d=False)
-        xp_assert_equal(xp.array(42), 42, check_0d=False)
-        xp_assert_equal(42, xp.array(42), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), 0., check_0d=False)
+        xp_assert_equal(0., xp.asarray(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(42), 42, check_0d=False)
+        xp_assert_equal(42, xp.asarray(42), check_0d=False)
+
+        # as an alternative to `check_0d=False`, explicitly expect scalar
+        xp_assert_equal(xp.float64(0), xp.asarray(0.)[()])
 
 
     @array_api_compatible
@@ -153,32 +156,32 @@ class TestArrayAPI:
         # identity passes, if first argument is not 0d (or check_0d=True)
         xp_assert_equal_no_0d(xp.float64(0), xp.float64(0))
         xp_assert_equal_no_0d(xp.float64(0), xp.float64(0), check_0d=True)
-        xp_assert_equal_no_0d(xp.array(0.), xp.array(0.), check_0d=True)
+        xp_assert_equal_no_0d(xp.asarray(0.), xp.asarray(0.), check_0d=True)
 
         # by default, 0d values are forbidden as the first argument
         message = "Result is a NumPy 0d-array.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.array(0.))
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.asarray(0.))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0))
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.float64(0))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(42), xp.int64(42))
+            xp_assert_equal_no_0d(xp.asarray(42), xp.int64(42))
 
         # Check default convention: 0d-arrays are NOT distinguished from scalars
-        xp_assert_equal_no_0d(xp.float64(0), xp.array(0.))
-        xp_assert_equal_no_0d(xp.int64(42), xp.array(42))
+        xp_assert_equal_no_0d(xp.float64(0), xp.asarray(0.))
+        xp_assert_equal_no_0d(xp.int64(42), xp.asarray(42))
 
         # opt in to 0d-check remains possible
         message = "Array-ness does not match:.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0), check_0d=True)
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.float64(0), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.float64(0), xp.array(0.), check_0d=True)
+            xp_assert_equal_no_0d(xp.float64(0), xp.asarray(0.), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(42), xp.int64(0), check_0d=True)
+            xp_assert_equal_no_0d(xp.asarray(42), xp.int64(0), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.int64(0), xp.array(42), check_0d=True)
+            xp_assert_equal_no_0d(xp.int64(0), xp.asarray(42), check_0d=True)
 
         # scalars-vs-0d passes (if values match) also with regular python objects
-        xp_assert_equal_no_0d(0., xp.array(0.))
-        xp_assert_equal_no_0d(42, xp.array(42))
+        xp_assert_equal_no_0d(0., xp.asarray(0.))
+        xp_assert_equal_no_0d(42, xp.asarray(42))

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -5,6 +5,7 @@ from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy
 )
+from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
 import scipy._lib.array_api_compat.numpy as np_compat
 
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -82,26 +83,34 @@ class TestArrayAPI:
         x = x if shape else x[()]
         y = np_compat.asarray(1)[()]
 
-        options = dict(check_namespace=True, check_dtype=False, check_shape=False)
+        kwarg_names = ["check_namespace", "check_dtype", "check_shape", "check_0d"]
+        options = dict(zip(kwarg_names, [True, False, False, False]))
         if xp == np:
             xp_assert_equal(x, y, **options)
         else:
             with pytest.raises(AssertionError, match="Namespaces do not match."):
                 xp_assert_equal(x, y, **options)
 
-        options = dict(check_namespace=False, check_dtype=True, check_shape=False)
+        options = dict(zip(kwarg_names, [False, True, False, False]))
         if y.dtype.name in str(x.dtype):
             xp_assert_equal(x, y, **options)
         else:
             with pytest.raises(AssertionError, match="dtypes do not match."):
                 xp_assert_equal(x, y, **options)
 
-        options = dict(check_namespace=False, check_dtype=False, check_shape=True)
+        options = dict(zip(kwarg_names, [False, False, True, False]))
         if x.shape == y.shape:
             xp_assert_equal(x, y, **options)
         else:
             with pytest.raises(AssertionError, match="Shapes do not match."):
-                xp_assert_equal(x, xp.asarray(y), allow_0d=True, **options)
+                xp_assert_equal(x, xp.asarray(y), **options)
+
+        options = dict(zip(kwarg_names, [False, False, False, True]))
+        if is_numpy(xp) and x.shape == y.shape:
+            xp_assert_equal(x, y, **options)
+        elif is_numpy(xp):
+            with pytest.raises(AssertionError, match="Array-ness does not match."):
+                xp_assert_equal(x, y, **options)
 
 
     @array_api_compatible
@@ -109,21 +118,67 @@ class TestArrayAPI:
         if not is_numpy(xp):
             pytest.skip("Scalars only exist in NumPy")
 
-        if is_numpy(xp):
-            # Check default convention: 0d arrays are not allowed
-            message = "Result is a NumPy 0d array. Many SciPy functions..."
-            with pytest.raises(AssertionError, match=message):
-                xp_assert_equal(xp.asarray(0.), xp.float64(0))
-            with pytest.raises(AssertionError, match=message):
-                xp_assert_equal(xp.asarray(0.), xp.asarray(0.))
-            xp_assert_equal(xp.float64(0), xp.asarray(0.))
-            xp_assert_equal(xp.float64(0), xp.float64(0))
+        # identity always passes
+        xp_assert_equal(xp.float64(0), xp.float64(0))
+        xp_assert_equal(xp.array(0.), xp.array(0.))
+        xp_assert_equal(xp.float64(0), xp.float64(0), check_0d=False)
+        xp_assert_equal(xp.array(0.), xp.array(0.), check_0d=False)
 
-            # Check `allow_0d`
-            message = "Types do not match:\n..."
-            with pytest.raises(AssertionError, match=message):
-                xp_assert_equal(xp.asarray(0.), xp.float64(0), allow_0d=True)
-            with pytest.raises(AssertionError, match=message):
-                xp_assert_equal(xp.float64(0), xp.asarray(0.), allow_0d=True)
-            xp_assert_equal(xp.float64(0), xp.float64(0), allow_0d=True)
-            xp_assert_equal(xp.asarray(0.), xp.asarray(0.), allow_0d=True)
+        # Check default convention: 0d-arrays are distinguished from scalars
+        message = "Array-ness does not match:.*"
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal(xp.array(0.), xp.float64(0))
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal(xp.float64(0), xp.array(0.))
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal(xp.array(42), xp.int64(42))
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal(xp.int64(42), xp.array(42))
+
+        # with `check_0d=False`, scalars-vs-0d passes (if values match)
+        xp_assert_equal(xp.array(0.), xp.float64(0), check_0d=False)
+        xp_assert_equal(xp.float64(0), xp.array(0.), check_0d=False)
+        # also with regular python objects
+        xp_assert_equal(xp.array(0.), 0., check_0d=False)
+        xp_assert_equal(0., xp.array(0.), check_0d=False)
+        xp_assert_equal(xp.array(42), 42, check_0d=False)
+        xp_assert_equal(42, xp.array(42), check_0d=False)
+
+
+    @array_api_compatible
+    def test_check_scalar_no_0d(self, xp):
+        if not is_numpy(xp):
+            pytest.skip("Scalars only exist in NumPy")
+
+        # identity passes, if first argument is not 0d (or check_0d=True)
+        xp_assert_equal_no_0d(xp.float64(0), xp.float64(0))
+        xp_assert_equal_no_0d(xp.float64(0), xp.float64(0), check_0d=True)
+        xp_assert_equal_no_0d(xp.array(0.), xp.array(0.), check_0d=True)
+
+        # by default, 0d values are forbidden as the first argument
+        message = "Result is a NumPy 0d-array.*"
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.array(0.), xp.array(0.))
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0))
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.array(42), xp.int64(42))
+
+        # Check default convention: 0d-arrays are NOT distinguished from scalars
+        xp_assert_equal_no_0d(xp.float64(0), xp.array(0.))
+        xp_assert_equal_no_0d(xp.int64(42), xp.array(42))
+
+        # opt in to 0d-check remains possible
+        message = "Array-ness does not match:.*"
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0), check_0d=True)
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.float64(0), xp.array(0.), check_0d=True)
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.array(42), xp.int64(0), check_0d=True)
+        with pytest.raises(AssertionError, match=message):
+            xp_assert_equal_no_0d(xp.int64(0), xp.array(42), check_0d=True)
+
+        # scalars-vs-0d passes (if values match) also with regular python objects
+        xp_assert_equal_no_0d(0., xp.array(0.))
+        xp_assert_equal_no_0d(42, xp.array(42))

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -13,7 +13,7 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 class TestConvertTemperature:
     def test_convert_temperature(self, xp):
         xp_assert_equal(sc.convert_temperature(xp.asarray(32.), 'f', 'Celsius'),
-                        xp.asarray(0.0), check_0d=False)
+                        xp.asarray(0.0)[()])
         xp_assert_equal(sc.convert_temperature(xp.asarray([0., 0.]),
                                                'celsius', 'Kelvin'),
                         xp.asarray([273.15, 273.15]))

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -13,7 +13,7 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 class TestConvertTemperature:
     def test_convert_temperature(self, xp):
         xp_assert_equal(sc.convert_temperature(xp.asarray(32.), 'f', 'Celsius'),
-                        xp.asarray(0.0))
+                        xp.asarray(0.0), check_0d=False)
         xp_assert_equal(sc.convert_temperature(xp.asarray([0., 0.]),
                                                'celsius', 'Kelvin'),
                         xp.asarray([273.15, 273.15]))

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -2,7 +2,7 @@ import pytest
 
 import scipy.constants as sc
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_equal, xp_assert_close
+from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from numpy.testing import assert_allclose
 
 
@@ -13,7 +13,7 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 class TestConvertTemperature:
     def test_convert_temperature(self, xp):
         xp_assert_equal(sc.convert_temperature(xp.asarray(32.), 'f', 'Celsius'),
-                        xp.asarray(0.0)[()])
+                        xp.asarray(0.0))
         xp_assert_equal(sc.convert_temperature(xp.asarray([0., 0.]),
                                                'celsius', 'Kelvin'),
                         xp.asarray([273.15, 273.15]))

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -5,8 +5,8 @@ from numpy.testing import assert_allclose
 
 from scipy.conftest import array_api_compatible
 import scipy._lib._elementwise_iterative_method as eim
-from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
-                                   is_numpy, is_torch, array_namespace)
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
+from scipy._lib._array_api import is_numpy, is_torch, array_namespace
 
 from scipy import stats, optimize, special
 from scipy.differentiate import differentiate, jacobian
@@ -30,7 +30,7 @@ class TestDifferentiate:
         default_dtype = xp.asarray(1.).dtype
         res = differentiate(self.f, xp.asarray(x, dtype=default_dtype))
         ref = xp.asarray(stats.norm().pdf(x), dtype=default_dtype)
-        xp_assert_close(res.df, ref[()])
+        xp_assert_close(res.df, ref)
         # This would be nice, but doesn't always work out. `error` is an
         # estimate, not a bound.
         if not is_torch(xp):
@@ -103,7 +103,7 @@ class TestDifferentiate:
             funcs = [lambda x: x - 2.5,  # converges
                      lambda x: xp.exp(x)*rng.random(),  # error increases
                      lambda x: xp.exp(x),  # reaches maxiter due to order=2
-                     lambda x: xp.full_like(x, xp.nan)[()]]  # stops due to NaN
+                     lambda x: xp.full_like(x, xp.nan)]  # stops due to NaN
             res = [funcs[int(j)](x) for x, j in zip(xs, xp.reshape(js, (-1,)))]
             return xp.stack(res)
         f.nit = 0
@@ -126,7 +126,7 @@ class TestDifferentiate:
             out = [x - 2.5,  # converges
                    xp.exp(x)*rng.random(),  # error increases
                    xp.exp(x),  # reaches maxiter due to order=2
-                   xp.full_like(x, xp.nan)[()]]  # stops due to NaN
+                   xp.full_like(x, xp.nan)]  # stops due to NaN
             return xp.stack(out)
 
         res = differentiate(f, xp.asarray(1, dtype=xp.float64),
@@ -286,7 +286,7 @@ class TestDifferentiate:
 
         # Test that dtypes are preserved
         dtype = getattr(xp, dtype)
-        x = xp.asarray(x, dtype=dtype)[()]
+        x = xp.asarray(x, dtype=dtype)
 
         def f(x):
             assert x.dtype == dtype
@@ -366,7 +366,7 @@ class TestDifferentiate:
         if not is_torch(xp):  # torch defaults to float32
             res = differentiate(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
             assert res.success
-            xp_assert_close(res.df, xp.asarray(99*7.**98)[()])
+            xp_assert_close(res.df, xp.asarray(99*7.**98))
 
         # Test that if success is achieved in the correct number
         # of iterations if function is a polynomial. Ideally, all polynomials
@@ -384,7 +384,7 @@ class TestDifferentiate:
 
             res = differentiate(f, x, maxiter=1, order=max(1, n))
             xp_assert_close(res.df, ref, rtol=1e-15)
-            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64)[()])
+            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64))
 
             res = differentiate(f, x, order=max(1, n))
             assert res.success
@@ -396,7 +396,7 @@ class TestDifferentiate:
             return c*x - 1
 
         res = differentiate(f, xp.asarray(2), args=xp.asarray(3))
-        xp_assert_close(res.df, xp.asarray(3.)[()])
+        xp_assert_close(res.df, xp.asarray(3.))
 
     # no need to run a test on multiple backends if it's xfailed
     @pytest.mark.skip_xp_backends(np_only=True)

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -30,7 +30,7 @@ class TestDifferentiate:
         default_dtype = xp.asarray(1.).dtype
         res = differentiate(self.f, xp.asarray(x, dtype=default_dtype))
         ref = xp.asarray(stats.norm().pdf(x), dtype=default_dtype)
-        xp_assert_close(res.df, ref, check_0d=False)
+        xp_assert_close(res.df, ref[()])
         # This would be nice, but doesn't always work out. `error` is an
         # estimate, not a bound.
         if not is_torch(xp):
@@ -366,7 +366,7 @@ class TestDifferentiate:
         if not is_torch(xp):  # torch defaults to float32
             res = differentiate(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
             assert res.success
-            xp_assert_close(res.df, xp.asarray(99*7.**98), check_0d=False)
+            xp_assert_close(res.df, xp.asarray(99*7.**98)[()])
 
         # Test that if success is achieved in the correct number
         # of iterations if function is a polynomial. Ideally, all polynomials
@@ -384,8 +384,7 @@ class TestDifferentiate:
 
             res = differentiate(f, x, maxiter=1, order=max(1, n))
             xp_assert_close(res.df, ref, rtol=1e-15)
-            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64),
-                            check_0d=False)
+            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64)[()])
 
             res = differentiate(f, x, order=max(1, n))
             assert res.success
@@ -397,7 +396,7 @@ class TestDifferentiate:
             return c*x - 1
 
         res = differentiate(f, xp.asarray(2), args=xp.asarray(3))
-        xp_assert_close(res.df, xp.asarray(3.), check_0d=False)
+        xp_assert_close(res.df, xp.asarray(3.)[()])
 
     # no need to run a test on multiple backends if it's xfailed
     @pytest.mark.skip_xp_backends(np_only=True)

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -30,7 +30,7 @@ class TestDifferentiate:
         default_dtype = xp.asarray(1.).dtype
         res = differentiate(self.f, xp.asarray(x, dtype=default_dtype))
         ref = xp.asarray(stats.norm().pdf(x), dtype=default_dtype)
-        xp_assert_close(res.df, ref)
+        xp_assert_close(res.df, ref, check_0d=False)
         # This would be nice, but doesn't always work out. `error` is an
         # estimate, not a bound.
         if not is_torch(xp):
@@ -366,7 +366,7 @@ class TestDifferentiate:
         if not is_torch(xp):  # torch defaults to float32
             res = differentiate(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
             assert res.success
-            xp_assert_close(res.df, xp.asarray(99*7.**98))
+            xp_assert_close(res.df, xp.asarray(99*7.**98), check_0d=False)
 
         # Test that if success is achieved in the correct number
         # of iterations if function is a polynomial. Ideally, all polynomials
@@ -384,7 +384,8 @@ class TestDifferentiate:
 
             res = differentiate(f, x, maxiter=1, order=max(1, n))
             xp_assert_close(res.df, ref, rtol=1e-15)
-            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64))
+            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64),
+                            check_0d=False)
 
             res = differentiate(f, x, order=max(1, n))
             assert res.success
@@ -396,7 +397,7 @@ class TestDifferentiate:
             return c*x - 1
 
         res = differentiate(f, xp.asarray(2), args=xp.asarray(3))
-        xp_assert_close(res.df, xp.asarray(3.))
+        xp_assert_close(res.df, xp.asarray(3.), check_0d=False)
 
     # no need to run a test on multiple backends if it's xfailed
     @pytest.mark.skip_xp_backends(np_only=True)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -227,10 +227,10 @@ class TestTanhSinh:
         ref = xp.asarray(ref, dtype=dtype)
 
         res = _tanhsinh(norm_pdf, *limits)
-        xp_assert_close(res.integral, ref, check_0d=False)
+        xp_assert_close(res.integral, ref[()])
 
         logres = _tanhsinh(norm_logpdf, *limits, log=True)
-        xp_assert_close(xp.exp(logres.integral), ref, check_0d=False, check_dtype=False)
+        xp_assert_close(xp.exp(logres.integral), ref[()], check_dtype=False)
         # Transformation should not make the result complex unnecessarily
         xp_test = array_namespace(*limits)  # we need xp.isdtype
         assert (xp_test.isdtype(logres.integral.dtype, "real floating") if ref > 0
@@ -540,7 +540,7 @@ class TestTanhSinh:
         a, b = xp.asarray(0.), xp.asarray(xp.pi/4)
         res = _tanhsinh(f, a, b)
         ref = math.sqrt(2)/2 + (1-math.sqrt(2)/2)*1j
-        xp_assert_close(res.integral, xp.asarray(ref), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(ref)[()])
 
         # Infinite limits
         def f(x):
@@ -548,7 +548,7 @@ class TestTanhSinh:
 
         a, b = xp.asarray(xp.inf), xp.asarray(-xp.inf)
         res = _tanhsinh(f, a, b)
-        xp_assert_close(res.integral, xp.asarray(-(1+1j)), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(-(1+1j))[()])
 
     @pytest.mark.parametrize("maxlevel", range(4))
     def test_minlevel(self, maxlevel, xp):
@@ -683,28 +683,28 @@ class TestTanhSinh:
 
         res = _tanhsinh(f, a, b)
         assert res.success
-        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5)[()])
 
         # Test levels 0 and 1; error is NaN
         res = _tanhsinh(f, a, b, maxlevel=0)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
+        xp_assert_equal(res.error, xp.asarray(xp.nan)[()])
         res = _tanhsinh(f, a, b, maxlevel=1)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
+        xp_assert_equal(res.error, xp.asarray(xp.nan)[()])
 
         # Test equal left and right integration limits
         res = _tanhsinh(f, b, b)
         assert res.success
         assert res.maxlevel == -1
-        xp_assert_close(res.integral, xp.asarray(0.), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.)[()])
 
         # Test scalar `args` (not in tuple)
         def f(x, c):
             return x**c
 
         res = _tanhsinh(f, a, b, args=29)
-        xp_assert_close(res.integral, xp.asarray(1/30), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(1/30)[()])
 
         # Test NaNs
         a = xp.asarray([xp.nan, 0, 0, 0])
@@ -728,9 +728,9 @@ class TestTanhSinh:
         _pair_cache.h0 = None
         a, b = xp.asarray(0), xp.asarray(1)
         res = _tanhsinh(lambda x: xp.asarray(x*1j), a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5*1j), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5*1j)[()])
         res = _tanhsinh(lambda x: x, a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5)[()])
 
         # Test zero-size
         shape = (0, 3)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -227,10 +227,10 @@ class TestTanhSinh:
         ref = xp.asarray(ref, dtype=dtype)
 
         res = _tanhsinh(norm_pdf, *limits)
-        xp_assert_close(res.integral, ref)
+        xp_assert_close(res.integral, ref, check_0d=False)
 
         logres = _tanhsinh(norm_logpdf, *limits, log=True)
-        xp_assert_close(xp.exp(logres.integral), ref, check_dtype=False)
+        xp_assert_close(xp.exp(logres.integral), ref, check_0d=False, check_dtype=False)
         # Transformation should not make the result complex unnecessarily
         xp_test = array_namespace(*limits)  # we need xp.isdtype
         assert (xp_test.isdtype(logres.integral.dtype, "real floating") if ref > 0
@@ -540,7 +540,7 @@ class TestTanhSinh:
         a, b = xp.asarray(0.), xp.asarray(xp.pi/4)
         res = _tanhsinh(f, a, b)
         ref = math.sqrt(2)/2 + (1-math.sqrt(2)/2)*1j
-        xp_assert_close(res.integral, xp.asarray(ref))
+        xp_assert_close(res.integral, xp.asarray(ref), check_0d=False)
 
         # Infinite limits
         def f(x):
@@ -548,7 +548,7 @@ class TestTanhSinh:
 
         a, b = xp.asarray(xp.inf), xp.asarray(-xp.inf)
         res = _tanhsinh(f, a, b)
-        xp_assert_close(res.integral, xp.asarray(-(1+1j)))
+        xp_assert_close(res.integral, xp.asarray(-(1+1j)), check_0d=False)
 
     @pytest.mark.parametrize("maxlevel", range(4))
     def test_minlevel(self, maxlevel, xp):
@@ -683,28 +683,28 @@ class TestTanhSinh:
 
         res = _tanhsinh(f, a, b)
         assert res.success
-        xp_assert_close(res.integral, xp.asarray(0.5))
+        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
 
         # Test levels 0 and 1; error is NaN
         res = _tanhsinh(f, a, b, maxlevel=0)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan))
+        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
         res = _tanhsinh(f, a, b, maxlevel=1)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan))
+        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
 
         # Test equal left and right integration limits
         res = _tanhsinh(f, b, b)
         assert res.success
         assert res.maxlevel == -1
-        xp_assert_close(res.integral, xp.asarray(0.))
+        xp_assert_close(res.integral, xp.asarray(0.), check_0d=False)
 
         # Test scalar `args` (not in tuple)
         def f(x, c):
             return x**c
 
         res = _tanhsinh(f, a, b, args=29)
-        xp_assert_close(res.integral, xp.asarray(1/30))
+        xp_assert_close(res.integral, xp.asarray(1/30), check_0d=False)
 
         # Test NaNs
         a = xp.asarray([xp.nan, 0, 0, 0])
@@ -728,9 +728,9 @@ class TestTanhSinh:
         _pair_cache.h0 = None
         a, b = xp.asarray(0), xp.asarray(1)
         res = _tanhsinh(lambda x: xp.asarray(x*1j), a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5*1j))
+        xp_assert_close(res.integral, xp.asarray(0.5*1j), check_0d=False)
         res = _tanhsinh(lambda x: x, a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5))
+        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
 
         # Test zero-size
         shape = (0, 3)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2621,7 +2621,7 @@ def test_uniform_filter1d_roundoff_errors(xp):
 
     for filter_size in range(3, 10):
         out = ndimage.uniform_filter1d(in_, filter_size)
-        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size), check_0d=False)
+        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size)[()])
 
 
 def test_footprint_all_zeros(xp):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2621,7 +2621,7 @@ def test_uniform_filter1d_roundoff_errors(xp):
 
     for filter_size in range(3, 10):
         out = ndimage.uniform_filter1d(in_, filter_size)
-        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size))
+        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size), check_0d=False)
 
 
 def test_footprint_all_zeros(xp):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2621,7 +2621,7 @@ def test_uniform_filter1d_roundoff_errors(xp):
 
     for filter_size in range(3, 10):
         out = ndimage.uniform_filter1d(in_, filter_size)
-        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size)[()])
+        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size), check_0d=False)
 
 
 def test_footprint_all_zeros(xp):

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -1,12 +1,12 @@
 import math
 import numpy as np
 
-from scipy._lib._array_api_no_0d import (
+from scipy._lib._array_api import (
     xp_assert_equal,
     assert_array_almost_equal,
     assert_almost_equal,
+    is_cupy,
 )
-from scipy._lib._array_api import is_cupy
 
 import pytest
 
@@ -34,7 +34,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_gaussian(a, [5.0, 2.5], shape[0], 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.irfft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(a), xp.asarray(1), decimal=dec)
+        assert_almost_equal(ndimage.sum(a), xp.asarray(1), decimal=dec,
+                            check_0d=False)
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 6), ("complex128", 14)])
@@ -50,7 +51,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_gaussian(a, [5.0, 2.5], -1, 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.ifft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec)
+        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec,
+                            check_0d=False)
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 6), ("float64", 14)])
@@ -66,7 +68,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_uniform(a, [5.0, 2.5], shape[0], 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.irfft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(a), xp.asarray(1.0), decimal=dec)
+        assert_almost_equal(ndimage.sum(a), xp.asarray(1.0), decimal=dec,
+                            check_0d=False)
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 6), ("complex128", 14)])
@@ -82,7 +85,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_uniform(a, [5.0, 2.5], -1, 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.ifft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec)
+        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec,
+                            check_0d=False)
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 4), ("float64", 11)])
@@ -129,7 +133,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_ellipsoid(a, [5.0, 2.5], shape[0], 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.irfft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(a), xp.asarray(1.0), decimal=dec)
+        assert_almost_equal(ndimage.sum(a), xp.asarray(1.0), decimal=dec,
+                            check_0d=False)
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 5), ("complex128", 14)])
@@ -145,7 +150,8 @@ class TestNdimageFourier:
         a = ndimage.fourier_ellipsoid(a, [5.0, 2.5], -1, 0)
         a = fft.ifft(a, n=shape[1], axis=1)
         a = fft.ifft(a, n=shape[0], axis=0)
-        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec)
+        assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec,
+                            check_0d=False)
 
     def test_fourier_ellipsoid_unimplemented_ndim(self, xp):
         # arrays with ndim > 3 raise NotImplementedError

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 
-from scipy._lib._array_api import (
+from scipy._lib._array_api_no_0d import (
     xp_assert_equal,
     assert_array_almost_equal,
     assert_almost_equal,

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -3,7 +3,7 @@ import os.path
 
 import numpy as np
 from numpy.testing import suppress_warnings
-from scipy._lib._array_api import (
+from scipy._lib._array_api_no_0d import (
     xp_assert_equal,
     xp_assert_close,
     assert_array_almost_equal,

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -3,13 +3,16 @@ import os.path
 
 import numpy as np
 from numpy.testing import suppress_warnings
-from scipy._lib._array_api_no_0d import (
+
+from scipy._lib._array_api import (
+    is_jax,
+    is_torch,
+    array_namespace,
     xp_assert_equal,
     xp_assert_close,
     assert_array_almost_equal,
     assert_almost_equal,
 )
-from scipy._lib._array_api import is_jax, is_torch, array_namespace
 
 import pytest
 from pytest import raises as assert_raises
@@ -592,7 +595,7 @@ def test_sum03(xp):
         dtype = getattr(xp, type)
         input = xp.ones([], dtype=dtype)
         output = ndimage.sum(input)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_sum04(xp):
@@ -600,7 +603,7 @@ def test_sum04(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1, 2], dtype=dtype)
         output = ndimage.sum(input)
-        assert_almost_equal(output, xp.asarray(3.0))
+        assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
 def test_sum05(xp):
@@ -608,7 +611,7 @@ def test_sum05(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.sum(input)
-        assert_almost_equal(output, xp.asarray(10.0))
+        assert_almost_equal(output, xp.asarray(10.0), check_0d=False)
 
 
 def test_sum06(xp):
@@ -648,7 +651,7 @@ def test_sum09(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.sum(input, labels=labels)
-        assert_almost_equal(output, xp.asarray(4.0))
+        assert_almost_equal(output, xp.asarray(4.0), check_0d=False)
 
 
 def test_sum10(xp):
@@ -658,7 +661,7 @@ def test_sum10(xp):
     labels = xp.asarray(labels)
     input = xp.asarray(input)
     output = ndimage.sum(input, labels=labels)
-    assert_almost_equal(output, xp.asarray(2.0))
+    assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
 def test_sum11(xp):
@@ -668,7 +671,7 @@ def test_sum11(xp):
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.sum(input, labels=labels,
                              index=2)
-        assert_almost_equal(output, xp.asarray(6.0))
+        assert_almost_equal(output, xp.asarray(6.0), check_0d=False)
 
 
 def test_sum12(xp):
@@ -700,7 +703,7 @@ def test_mean01(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.mean(input, labels=labels)
-        assert_almost_equal(output, xp.asarray(2.0))
+        assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
 def test_mean02(xp):
@@ -710,7 +713,7 @@ def test_mean02(xp):
     labels = xp.asarray(labels)
     input = xp.asarray(input)
     output = ndimage.mean(input, labels=labels)
-    assert_almost_equal(output, xp.asarray(1.0))
+    assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_mean03(xp):
@@ -720,7 +723,7 @@ def test_mean03(xp):
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.mean(input, labels=labels,
                               index=2)
-        assert_almost_equal(output, xp.asarray(3.0))
+        assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
 def test_mean04(xp):
@@ -745,7 +748,7 @@ def test_minimum01(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.minimum(input, labels=labels)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_minimum02(xp):
@@ -755,7 +758,7 @@ def test_minimum02(xp):
     labels = xp.asarray(labels)
     input = xp.asarray(input)
     output = ndimage.minimum(input, labels=labels)
-    assert_almost_equal(output, xp.asarray(1.0))
+    assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_minimum03(xp):
@@ -766,7 +769,7 @@ def test_minimum03(xp):
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.minimum(input, labels=labels,
                                  index=2)
-        assert_almost_equal(output, xp.asarray(2.0))
+        assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
 def test_minimum04(xp):
@@ -786,7 +789,7 @@ def test_maximum01(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.maximum(input, labels=labels)
-        assert_almost_equal(output, xp.asarray(3.0))
+        assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
 def test_maximum02(xp):
@@ -795,7 +798,7 @@ def test_maximum02(xp):
     labels = xp.asarray(labels)
     input = xp.asarray(input)
     output = ndimage.maximum(input, labels=labels)
-    assert_almost_equal(output, xp.asarray(1.0))
+    assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_maximum03(xp):
@@ -805,7 +808,7 @@ def test_maximum03(xp):
         input = xp.asarray([[1, 2], [3, 4]], dtype=dtype)
         output = ndimage.maximum(input, labels=labels,
                                  index=2)
-        assert_almost_equal(output, xp.asarray(4.0))
+        assert_almost_equal(output, xp.asarray(4.0), check_0d=False)
 
 
 def test_maximum04(xp):
@@ -843,7 +846,7 @@ def test_median02(xp):
                     [0, 0, 0, 7],
                     [9, 3, 0, 0]])
     output = ndimage.median(a)
-    assert_almost_equal(output, xp.asarray(1.0))
+    assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_median03(xp):
@@ -856,7 +859,7 @@ def test_median03(xp):
                          [0, 0, 0, 2],
                          [3, 3, 0, 0]])
     output = ndimage.median(a, labels=labels)
-    assert_almost_equal(output, xp.asarray(3.0))
+    assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
 def test_median_gh12836_bool(xp):
@@ -890,7 +893,7 @@ def test_variance02(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1], dtype=dtype)
         output = ndimage.variance(input)
-        assert_almost_equal(output, xp.asarray(0.0))
+        assert_almost_equal(output, xp.asarray(0.0), check_0d=False)
 
 
 def test_variance03(xp):
@@ -898,14 +901,14 @@ def test_variance03(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1, 3], dtype=dtype)
         output = ndimage.variance(input)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_variance04(xp):
     input = np.asarray([1, 0], dtype=bool)
     input = xp.asarray(input)
     output = ndimage.variance(input)
-    assert_almost_equal(output, xp.asarray(0.25))
+    assert_almost_equal(output, xp.asarray(0.25), check_0d=False)
 
 
 def test_variance05(xp):
@@ -915,7 +918,7 @@ def test_variance05(xp):
 
         input = xp.asarray([1, 3, 8], dtype=dtype)
         output = ndimage.variance(input, labels, 2)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_variance06(xp):
@@ -944,7 +947,7 @@ def test_standard_deviation02(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1], dtype=dtype)
         output = ndimage.standard_deviation(input)
-        assert_almost_equal(output, xp.asarray(0.0))
+        assert_almost_equal(output, xp.asarray(0.0), check_0d=False)
 
 
 def test_standard_deviation03(xp):
@@ -952,14 +955,14 @@ def test_standard_deviation03(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1, 3], dtype=dtype)
         output = ndimage.standard_deviation(input)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_standard_deviation04(xp):
     input = np.asarray([1, 0], dtype=bool)
     input = xp.asarray(input)
     output = ndimage.standard_deviation(input)
-    assert_almost_equal(output, xp.asarray(0.5))
+    assert_almost_equal(output, xp.asarray(0.5), check_0d=False)
 
 
 def test_standard_deviation05(xp):
@@ -968,7 +971,7 @@ def test_standard_deviation05(xp):
         dtype = getattr(xp, type)
         input = xp.asarray([1, 3, 8], dtype=dtype)
         output = ndimage.standard_deviation(input, labels, 2)
-        assert_almost_equal(output, xp.asarray(1.0))
+        assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
 def test_standard_deviation06(xp):

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -5,9 +5,9 @@ import numpy as np
 from scipy import stats, special
 import scipy._lib._elementwise_iterative_method as eim
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import (array_namespace, xp_assert_close, xp_assert_equal,
-                                   xp_assert_less, is_numpy, is_cupy,
-                                   xp_ravel, xp_size,)
+from scipy._lib._array_api import array_namespace, is_cupy, is_numpy, xp_ravel, xp_size
+from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
+                                         xp_assert_less)
 
 from scipy.optimize.elementwise import find_minimum, find_root
 from scipy.optimize._tstutils import _CHANDRUPATLA_TESTS

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -97,7 +97,7 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     ref = xp.asarray(f(*args_np), dtype=dtype_xp)
 
     eps = np.finfo(dtype_np).eps
-    xp_assert_close(res, ref, atol=10*eps)
+    xp_assert_close(res, ref, atol=10*eps, check_0d=False)
 
 
 @array_api_compatible

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -4,7 +4,8 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
                                                          array_special_func_map)
 from scipy.conftest import array_api_compatible
 from scipy import special
-from scipy._lib._array_api import xp_assert_close, is_jax, is_torch, SCIPY_DEVICE
+from scipy._lib._array_api_no_0d import xp_assert_close
+from scipy._lib._array_api import is_jax, is_torch, SCIPY_DEVICE
 from scipy._lib.array_api_compat import numpy as np
 
 try:
@@ -97,7 +98,6 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     ref = xp.asarray(f(*args_np), dtype=dtype_xp)
 
     eps = np.finfo(dtype_np).eps
-    ref = ref[()] if ref.ndim == 0 else ref
     xp_assert_close(res, ref, atol=10*eps)
 
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -97,7 +97,8 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     ref = xp.asarray(f(*args_np), dtype=dtype_xp)
 
     eps = np.finfo(dtype_np).eps
-    xp_assert_close(res, ref, atol=10*eps, check_0d=False)
+    ref = ref[()] if ref.ndim == 0 else ref
+    xp_assert_close(res, ref, atol=10*eps)
 
 
 @array_api_compatible

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -10,7 +10,7 @@ import numpy.ma.testutils as ma_npt
 from scipy._lib._util import (
     getfullargspec_no_self as _getfullargspec, np_long
 )
-from scipy._lib._array_api import xp_assert_equal
+from scipy._lib._array_api_no_0d import xp_assert_equal
 from scipy import stats
 
 

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -7,8 +7,9 @@ import numpy as np
 from scipy import stats
 from scipy.stats import norm, expon  # type: ignore[attr-defined]
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less,
-                                   is_jax, is_array_api_strict, array_namespace)
+from scipy._lib._array_api import array_namespace, is_array_api_strict, is_jax
+from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
+                                         xp_assert_less)
 
 class TestEntropy:
     @array_api_compatible

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -27,8 +27,11 @@ from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_nd_omit,
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import array_namespace, is_numpy
-from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
-                                         xp_assert_less)
+from scipy._lib._array_api_no_0d import (
+    xp_assert_close,
+    xp_assert_equal,
+    xp_assert_less,
+)
 
 
 skip_xp_backends = pytest.mark.skip_xp_backends

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -26,13 +26,9 @@ from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_nd_omit,
                                           too_small_1d_omit, too_small_1d_not_omit)
 
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import (
-    array_namespace,
-    is_numpy,
-    xp_assert_close,
-    xp_assert_equal,
-    xp_assert_less,
-)
+from scipy._lib._array_api import array_namespace, is_numpy
+from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
+                                         xp_assert_less)
 
 
 skip_xp_backends = pytest.mark.skip_xp_backends

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -5,8 +5,8 @@ from numpy.testing import assert_allclose, assert_equal, suppress_warnings
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._util import rng_integers
-from scipy._lib._array_api import (is_numpy, xp_assert_close,
-                                   xp_assert_equal, array_namespace)
+from scipy._lib._array_api import array_namespace, is_numpy
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy import stats, special
 from scipy.optimize import root
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -41,9 +41,9 @@ from scipy.stats._stats_py import (_permutation_distribution_t, _chk_asarray, _m
                                    LinregressResult, _xp_mean, _xp_var)
 from scipy._lib._util import AxisError
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
-from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, array_namespace,
-                                   is_numpy, is_torch, SCIPY_ARRAY_API,
-                                   xp_size, xp_copy)
+from scipy._lib._array_api import (array_namespace, xp_copy, is_numpy,
+                                   is_torch, xp_size, SCIPY_ARRAY_API)
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -7,7 +7,8 @@ from numpy.testing import suppress_warnings
 from scipy.stats import variation
 from scipy._lib._util import AxisError
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import xp_assert_equal, xp_assert_close, is_numpy
+from scipy._lib._array_api import is_numpy
+from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from scipy.stats._axis_nan_policy import (too_small_nd_omit, too_small_nd_not_omit,
                                           SmallSampleWarning)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-21044. Closes gh-21026.

---

The linked RFC discusses the problem of designing an API for these assertions which makes sense in various instances. Below I enumerate these instances and compare the proposed solutions of this PR's implementation to alternative solutions which have been suggested by others or thought of by me.

# Problem instances

## (1) Full module returning 0-D arrays

### Solution

```python
from scipy._lib._array_api import xp_assert_close
...
xp_assert_close(actual, desired) # `actual` and `desired` must match
xp_assert_close(actual, desired, check_0d=False) # no checks for 0-D vs scalar
```

**Pros:**
- clean solution, solves the problems from gh-21044

**Cons:**
- the keyword special-cases NumPy, hence the API isn't truly library-agnostic (but this is already the case before this PR)

*Remarks*:
- this seems like an obvious improvement 👍 the special-casing of NumPy seems to be necessary for us, however it does raise questions about how to generalise to a solution which would live upstream under the data-apis org *(would it be okay to treat NumPy as special or not?)*

## (2) Full module returning scalars

### Solution

```python
from scipy._lib._array_api_no_0d import xp_assert_close
...
xp_assert_close(actual, desired) # `actual` must be a scalar, regardless of the type of `desired`
xp_assert_close(actual, desired, check_0d=True) # `actual` must be 0-D if `desired` is 0-D
```

**Pros:**
- clean solution, doesn't increase verbosity while solving the problems from gh-21044

**Cons:**
- the "requiring scalar" semantics are abstracted away from the test functions to the import at the top of the module, so you have to scroll up to be aware of it

*Remarks*:
- I think the con is minor - it is already abstracted away before this PR, which is why some of the initial confusion arose

### Alternative (2A)

Require a keyword in every call to say that you expect a scalar. E.g.

```python
xp_assert_close(actual, desired, require_scalar=True)
```

**Pros:**
- more explicit and clear

**Cons:**
- very verbose when used in every call in a file

*Remarks*:
- I think that this is too verbose for the added clarity to be worth it

### Alternative (2B)

Cast `desired` to a scalar in every call via `[()]`.

**Pros:**
- more explicit (and clear?)

**Cons:**
- more verbose (unnecessarily?)
- See (3)

*Remarks*:
- I think that this is too verbose for any added clarity to be worth it

## (3) Module with some functions returning 0-D arrays, some returning scalars

### Solution

```python
from scipy._lib._array_api import xp_assert_close
...
xp_assert_close(actual, desired) # we want a 0-D array
xp_assert_close(actual, desired[()]) # we want a scalar
# XXX: would this be used?
xp_assert_close(actual, desired, check_0d=False) # we don't care either way
```

**Pros:**
- concise
- clear semantics for NumPy

**Cons:**
- while `[()]` works as a no-op for the alternative libraries which we test with[^1], it isn't standardised. See https://github.com/data-apis/array-api/issues/833. Hence this could be seen as semantically sketchy / a fudge for alternative backends rather than a watertight solution
- the `[()]` may be considered visually unappealing and less explicit/clear than a keyword

*Remarks:*

This seems like the best solution of the bunch to me, although I recognise that the problems described in the cons are real, hence it isn't an ideal solution

### Alternative (3A)

Like (2A), require a keyword for scalar checks:

```python
xp_assert_close(actual, desired) # we want a 0-D array
xp_assert_close(actual, desired, require_scalar=True) # we want a scalar
```

**Pros:**
- more explicit and clear

**Cons:**
- the special handling for NumPy arrays becomes built-in to the implementation of the assertion rather than handled by the user of the assertion at the call-point (or maybe this is a pro?)
- more verbose

*Remarks:*
- I would be happy with this alternative, even though it isn't my preference, if the concerns for the proposed solution here are deemed large

### Alternative (3B)

Just turn off the scalar/0-D check when a scalar is expected.

```python
xp_assert_close(actual, desired) # we want a 0-D array
xp_assert_close(actual, desired, check_0d=False) # we want a scalar
```

**Pros:**
- more explicit and clear

**Cons:**
- this is a regression in testing strictness - we no longer check that `actual` is a scalar, rather we just accept a scalar or a 0-D array

*Remarks:*
- this was the solution proposed in gh-21026. I think we want to avoid the regression in testing strictness, hence I didn't want to merge this solution

### Alternative (3C)

(3B) + do the scalar check separately. This could mean:

- a separate `assert_scalar_if_np` helper
- or, a separate test function in each instance of the problem (e.g. `test_func_returns_scalar`)

**Pros:**
- more explicit and clear
- avoids the regression for (3B)
- enables reduction of test redundancy, by only performing the scalar check once rather than in every use of the assertion
- a separate test is consistent with how we are checking behaviours for certain *inputs* elsewhere in the codebase, such as array-like input and empty array input

**Cons:**
- both options increase verbosity (the second especially would require a huge diff and a substantial amount of menial work to implement)
- this introduces the risk that performing the scalar check is forgotten about during development and thus gaps in the test coverage form - we no longer get the check "for free" just by using an assertion

*Remarks:*
- both cons seem quite serious for me, and I am of the opinion that they outweigh the pros here. But this is probably the most complex contest of ideas in this write-up

## (4) Module with functions varying behaviour based on `SCIPY_ARRAY_API`

### Solution

```python
from scipy._lib._array_api import xp_assert_close
...
actual = ndimage.sum_labels(input) # scalar without SCIPY_ARRAY_API, 0-D with SCIPY_ARRAY_API
xp_assert_close(actual, desired, check_0d=False) # just turn off the scalar/0-D check
```

**Pros:**
- simple
- does not reduce the strictness of the current tests - the scalar/0-D check was already turned off via `check_shape=False` in: https://github.com/scipy/scipy/blob/ada2bdb797b3e04d6b1f139971bca2612fd5bfce/scipy/_lib/_array_api.py#L390-L396

**Cons:**
- does not test for regressions (correctly returning scalar or 0-D based on if `SCIPY_ARRAY_API` is set)

*Remarks:*
- this seems fine since the check was turned off already, but I think it would be good to test for regressions in this situation too

 ### Alternative (4A)

Introduce a new kwarg to capture this behaviour, e.g.

```python
from scipy._lib._array_api import xp_assert_close
...
actual = ndimage.sum_labels(input) # scalar without SCIPY_ARRAY_API, 0-D with SCIPY_ARRAY_API
xp_assert_close(actual, desired, xp_now_0d=True) # check for 0-D with SCIPY_ARRAY_API, scalar without
```

**Pros:**
- introduces regression testing for this

**Cons:**
- I haven't thought of a good name for such a kwarg
- Makes the implementation a little more complex as it has to check the env var

*Remarks:*
- This seems like it would be an improvement to me, but could be saved for a follow-up

---

A follow-up to this PR could look at enabling some of the shape checks which are disabled across `ndimage`, now that instances (1), (3) and (4) are handled appropriately.

[^1]: it actually doesn't work for array-api-strict if a nonzero-dim array is passed. This can be easily worked around by guarding on `ndim == 0`, however. This is only a problem where a parameterised test results in a 0-dim array sometimes and a nonzero-dim array other times.