### PR TITLE
TST: linalg.sqrtm: attempt to resolve test failure on some platforms

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -175,7 +175,8 @@ def sqrtm(A, disp=True, blocksize=64):
         d0 = np.diagonal(T)
         d1 = np.diagonal(T, -1)
         eps = np.finfo(T.dtype).eps
-        needs_conversion = abs(d1) > eps * (abs(d0[1:]) + abs(d0[:-1]))
+        # factor of 10 introduced to resolve gh-19816
+        needs_conversion = abs(d1) > 10 * eps * (abs(d0[1:]) + abs(d0[:-1]))
         if needs_conversion.any():
             T, Z = rsf2csf(T, Z)
     else:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -428,7 +428,6 @@ class TestSqrtM:
         assert_allclose(np.dot(R, R), M, atol=1e-14)
         assert_allclose(sqrtm(M), R, atol=1e-14)
 
-    @pytest.mark.xfail(reason="failing on macOS after gh-20212")
     def test_gh17918(self):
         M = np.empty((19, 19))
         M.fill(0.94)


### PR DESCRIPTION
#### Reference issue
Closes gh-20219

#### What does this implement/fix?
Attempts to resolve `linalg.sqrtm` test failure reported in gh-20219. I can't reproduce, even on my Mac, so this is a bit of a shot in the dark, but it looks like something a small tolerance bump might be able to solve since it is a heuristic anyway.

#### Additional information
I see in https://github.com/scipy/scipy/issues/19415#issuecomment-1985672674 that a tolerance will not resolve the underlying issue perfectly, but hopefully it is enough to close gh-20219 and make the `sqrtm` situation a little simpler.