### PR TITLE
DOC: linalg.hankel: emphasize that first element of `r` is ignored

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -123,8 +123,11 @@ def hankel(c, r=None):
     Construct a Hankel matrix.
 
     The Hankel matrix has constant anti-diagonals, with `c` as its
-    first column and `r` as its last row. If `r` is not given, then
-    `r = zeros_like(c)` is assumed.
+    first column and `r` as its last row. If the first element of `r`
+    differs from the last element of `c`, the first element of `r` is
+    replaced by the last element of `c` to ensure that anti-diagonals
+    remain constant. If `r` is not given, then `r = zeros_like(c)` is
+    assumed.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
Closes gh-14788

#### What does this implement/fix?
gh-14788 reported confusion about the fact that the first element of `r` was ignored. This PR emphasizes this fact, which is already present in the description of the `r` parameters, by including this information in the extended summary and documenting the rationale. 

#### Additional information
gh-14788 also reported unfamiliarity with non-square Hankel matrices, but I didn't see how this could be addressed with the documentation. This is not unusual for implementations like `hankel` (e.g. Matlab), there is already an example of a non-square Hankel matrix in the documentation, and the behavior seems straightforward enough. There was no follow-up from the OP, so I don't think this needs to be addressed further.
