### PR TITLE
MAINT: `linalg.schur`: fix `sort='iuc'/'ouc'`, correct documentation, and add tests

### DIFF
--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -40,17 +40,20 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         Whether to overwrite data in a (may improve performance).
     sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
         Specifies whether the upper eigenvalues should be sorted. A callable
-        may be passed that, given a eigenvalue, returns a boolean denoting
+        may be passed that, given an eigenvalue, returns a boolean denoting
         whether the eigenvalue should be sorted to the top-left (True).
-        If output='real', the callable should have two arguments, the first
-        one being the real part of the eigenvalue, the second one being
-        the imaginary part.
+
+        - If ``output='complex'`` OR the dtype of `a` is complex, the callable
+          should have one argument: the eigenvalue expressed as a complex number.
+        - If ``output='real'`` AND the dtype of `a` is real, the callable should have
+          two arguments: the real and imaginary parts of the eigenvalue, respectively.
+
         Alternatively, string parameters may be used::
 
-            'lhp'   Left-hand plane (x.real < 0.0)
-            'rhp'   Right-hand plane (x.real > 0.0)
-            'iuc'   Inside the unit circle (x*x.conjugate() <= 1.0)
-            'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+            'lhp'   Left-hand plane (real(eigenvalue) < 0.0)
+            'rhp'   Right-hand plane (real(eigenvalue) >= 0.0)
+            'iuc'   Inside the unit circle (abs(eigenvalue) <= 1.0)
+            'ouc'   Outside the unit circle (abs(eigenvalue) > 1.0)
 
         Defaults to None (no sorting).
     check_finite : bool, optional
@@ -68,6 +71,8 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
     sdim : int
         If and only if sorting was requested, a third return value will
         contain the number of eigenvalues satisfying the sort condition.
+        Note that complex conjugate pairs for which the condition is true
+        for either eigenvalue count as 2.
 
     Raises
     ------
@@ -109,12 +114,23 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
     >>> eigvals(T2)
     array([2.65896708, -0.32948354+0.80225456j, -0.32948354-0.80225456j])   # may vary
 
-    An arbitrary custom eig-sorting condition, having positive imaginary part,
-    which is satisfied by only one eigenvalue
+    A custom eigenvalue-sorting condition that sorts by positive imaginary part
+    is satisfied by only one eigenvalue.
 
-    >>> T3, Z3, sdim = schur(A, output='complex', sort=lambda x: x.imag > 0)
+    >>> _, _, sdim = schur(A, output='complex', sort=lambda x: x.imag > 1e-15)
     >>> sdim
     1
+
+    When ``output='real'`` and the array `a` is real, the `sort` callable must accept
+    the real and imaginary parts as separate arguments. Note that now the complex
+    eigenvalues ``-0.32948354+0.80225456j`` and ``-0.32948354-0.80225456j`` will be
+    treated as a complex conjugate pair, and according to the `sdim` documentation,
+    complex conjugate pairs for which the condition is True for *either* eigenvalue
+    increase `sdim` by *two*.
+
+    >>> _, _, sdim = schur(A, output='real', sort=lambda x, y: y > 1e-15)
+    >>> sdim
+    2
 
     """
     if output not in ['real', 'complex', 'r', 'c']:
@@ -161,17 +177,19 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         if callable(sort):
             sfunction = sort
         elif sort == 'lhp':
-            def sfunction(x):
+            def sfunction(x, y=None):
                 return x.real < 0.0
         elif sort == 'rhp':
-            def sfunction(x):
+            def sfunction(x, y=None):
                 return x.real >= 0.0
         elif sort == 'iuc':
-            def sfunction(x):
-                return abs(x) <= 1.0
+            def sfunction(x, y=None):
+                z = x if y is None else x + y*1j
+                return abs(z) <= 1.0
         elif sort == 'ouc':
-            def sfunction(x):
-                return abs(x) > 1.0
+            def sfunction(x, y=None):
+                z = x if y is None else x + y*1j
+                return abs(z) > 1.0
         else:
             raise ValueError("'sort' parameter must either be 'None', or a "
                              "callable, or one of ('lhp','rhp','iuc','ouc')")

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -173,7 +173,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
 
     if sort is None:
         sort_t = 0
-        def sfunction(x):
+        def sfunction(x, y=None):
             return None
     else:
         sort_t = 1

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -33,7 +33,10 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
     a : (M, M) array_like
         Matrix to decompose
     output : {'real', 'complex'}, optional
-        Construct the real or complex Schur decomposition (for real matrices).
+        When the dtype of `a` is real, this specifies whether to compute
+        the real or complex Schur decomposition.
+        When the dtype of `a` is complex, this argument is ignored, and the
+        complex Schur decomposition is computed.
     lwork : int, optional
         Work array size. If None or -1, it is automatically computed.
     overwrite_a : bool, optional

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2127,6 +2127,62 @@ class TestSchur:
         assert t.dtype == t0.dtype
         assert z.dtype == z0.dtype
 
+    @pytest.mark.parametrize('sort', ['iuc', 'ouc'])
+    @pytest.mark.parametrize('output', ['real', 'complex'])
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64,
+                                       np.complex64, np.complex128])
+    def test_gh_13137_sort_str(self, sort, output, dtype):
+        # gh-13137 reported that sort values 'iuc' and 'ouc' were not
+        # correct because the callables assumed that the eigenvalues would
+        # always be expressed as a single complex number.
+        # In fact, when `output='real'` and the dtype is real, the
+        # eigenvalues are passed as separate real and imaginary components
+        # (yet no error is raised if the callable accepts only one argument).
+        #
+        # This tests these sort values by counting the number of eigenvalues
+        # `schur` reports as being inside/outside the unit circle.
+
+        # Real matrix with eigenvalues 0.1 +- 2j
+        A = np.asarray([[0.1, -2], [2, 0.1]])
+
+        # Previously, this would fail for `output='real'` with real dtypes
+        sdim = schur(A.astype(dtype), sort=sort, output=output)[-1]
+        assert sdim == 0 if sort == 'iuc' else sdim == 2
+
+    @pytest.mark.parametrize('output', ['real', 'complex'])
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64,
+                                       np.complex64, np.complex128])
+    def test_gh_13137_sort_custom(self, output, dtype):
+        # This simply tests our understanding of how eigenvalues are
+        # passed to a sort callable. If `output='real'` and the dtype is real,
+        # real and imaginary parts are passed as separate real arguments;
+        # otherwise, they are passed a single complex argument.
+        # Also, if `output='real'` and the dtype is real, when either
+        # eigenvalue in a complex conjugate pair satisfies the sort condition,
+        # `sdim` is incremented by TWO.
+
+        # Real matrix with eigenvalues 0.1 +- 2j
+        A = np.asarray([[0.1, -2], [2, 0.1]])
+
+        all_real = output=='real' and dtype in {np.float32, np.float64}
+
+        def sort(x, y=None):
+            if all_real:
+                assert not np.iscomplexobj(x)
+                assert y is not None and np.isreal(y)
+                z = x + y*1j
+            else:
+                assert np.iscomplexobj(x)
+                assert y is None
+                z = x
+            return z.imag > 1e-15
+
+        # Only one complex eigenvalue satisfies the condition, but when
+        # `all_real` applies, both eigenvalues in the complex conjugate pair
+        # are counted.
+        sdim = schur(A.astype(dtype), sort=sort, output=output)[-1]
+        assert sdim == 2 if all_real else sdim == 1
+
 
 class TestHessenberg:
 


### PR DESCRIPTION
#### Reference issue
Closes gh-13137
Closes gh-15016
gh-19791
gh-20906

#### What does this implement/fix?
gh-19791 reported that the documentation of `linalg.schur`'s `sort` parameter did not mention that (under certain conditions) the eigenvalue can be passed to the `sort` callable as two separate arguments. 

gh-20906 added this information to the documentation, stating that the `sort` parameter should accept both arguments when `output='real'`. Technically, however, the matrix must be real for `output` to have an effect. Therefore, this needed to be updated to state that two arguments are needed when `output='real'` AND the input dtype is real. Also, it was worth noting that `output` is ignored when the input dtype is complex.

It turns out this issue had been reported before in both gh-15016 and gh-13137. In addition, gh-13137 pointed out that these fine points were overlooked even in the internal definitions of the 'iuc' and 'ouc' `sort` callables.

This PR:
- fixes the bug in the 'iuc' and 'ouc' sort callables,
- enhances the documentation surrounding these (very confusing) points, 
- notes that the `output` argument is ignored when the input is complex, and
- adds regression tests that confirm the 'iuc', 'ouc', and custom sort callable behavior.

#### Additional information
Two other possible improvements:
- Emit a warning when `a` is real, `output='real'`, and `sort` is a callable that accepts only one argument. (Would use introspection and add a few microseconds of overhead.)
- Emit a warning or error when `a` is complex and `output='real'`, since `output` will be ignored.

From the documentation of [ZGEES](https://netlib.org/lapack/explore-html//d5/d38/group__gees_gac426d99ddc8ac986de2a17e7ad3f2512.html), used whenever `output='complex'` or the dtype is complex:
```
SELECT is a LOGICAL FUNCTION of one COMPLEX*16 argument
```

From the documentation of [`DGEES`](https://netlib.org/lapack/explore-html//d5/d38/group__gees_gab48df0b5c60d7961190d868087f485bc.html#gab48df0b5c60d7961190d868087f485bc), used when `output='real'` and the dtype is real:
```
SELECT is a LOGICAL FUNCTION of two DOUBLE PRECISION arguments
```
Also:
```
          SDIM is INTEGER
          If SORT = 'N', SDIM = 0.
          If SORT = 'S', SDIM = number of eigenvalues (after sorting)
                         for which SELECT is true. (Complex conjugate
                         pairs for which SELECT is true for either
                         eigenvalue count as 2.)
```

