### PR TITLE
REL, MAINT: prep for 1.14.2

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.14.2-notes
    release/1.14.1-notes
    release/1.14.0-notes
    release/1.13.1-notes

--- a/doc/source/release/1.14.2-notes.rst
+++ b/doc/source/release/1.14.2-notes.rst
@@ -1,0 +1,23 @@
+==========================
+SciPy 1.14.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.14.2 is a bug-fix release with no new features
+compared to 1.14.1.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+Issues closed for 1.14.2
+------------------------
+
+
+
+Pull requests for 1.14.2
+------------------------

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.14.1',
+  version: '1.14.2.dev0',
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.14.1"
+version = "1.14.2.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -6,8 +6,8 @@ import argparse
 
 MAJOR = 1
 MINOR = 14
-MICRO = 1
-ISRELEASED = True
+MICRO = 2
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
* Prepare for SciPy `1.14.2`, just in case.

[skip cirrus]