### PR TITLE
TST: linalg: failure in `test_delete_last_p_col`

### DIFF
--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -11,7 +11,7 @@ def assert_unitary(a, rtol=None, atol=None, assert_sqr=True):
     if rtol is None:
         rtol = 10.0 ** -(np.finfo(a.dtype).precision-2)
     if atol is None:
-        atol = 10*np.finfo(a.dtype).eps
+        atol = 20 * np.finfo(a.dtype).eps
 
     if assert_sqr:
         assert_(a.shape[0] == a.shape[1], 'unitary matrices must be square')


### PR DESCRIPTION
#### Reference issue
Closes gh-5117
Other issues mentioned below.

#### What does this implement/fix?
Failures in `test_delete_last_p_col` have been reported many times over the years. This PR would bump the tolerance a second time as suggested by https://github.com/scipy/scipy/issues/5117#issuecomment-1987202802.

However, it might not even be needed. A lot of these reports and the PR (gh-10955) did not link to one another, so it's possible that they all could have been closed by that PR. 

To help confirm: 
@andyfaff - you reported gh-10716, which I just closed as a duplicate. Are you able to get any failures in `scipy.linalg.tests.test_decomp_update` in `main`? That would add a little evidence that this problem no longer exists. If you do get it, is the bump in this PR enough?

@h-vetinari - you reported gh-19210, the only releatively recent report. Can you give the full report for the `linalg/tests/test_decomp_update.py::TestQRdelete_f::test_delete_last_p_col` failure? If they are all extremely wrong (as you suggest that many of the ~60 errors are), it sounds like a different problem than we've seen before.

If you're not able to reproduce this problem, I'd suggest that we just close this PR and gh-5117.

#### Additional information
All of the failures in `test_delete_last_p_col` are at:
https://github.com/scipy/scipy/blob/b7e45413a75c6dda6b8f914a4b262d6c456e516f/scipy/linalg/tests/test_decomp_update.py#L325-L328

which checks that the matrix multiplied by its conjugate transpose is the identity:
https://github.com/scipy/scipy/blob/b7e45413a75c6dda6b8f914a4b262d6c456e516f/scipy/linalg/tests/test_decomp_update.py#L18-L19

with some default `atol` and `rtol`. Originally, the `atol` was set at `2*eps` (twice the epsilon of the dtype).

It looks like the first report was gh-5117. The failure was in the context of type `D` (`np.complex128`), and two elements of a 12 x 12 matrix mismatched in the comparison, but it was unclear by how much. 
```
Not equal to tolerance rtol=1e-13, atol=4.44089e-16

(mismatch 1.3888888888888857%)
x: array([[ 1.000000e+00 +0.000000e+00j, 3.816392e-17 +5.898060e-17j,
4.163336e-17 +2.775558e-17j, 1.387779e-17 +2.775558e-17j,
6.938894e-17 -6.245005e-17j, 3.469447e-17 -2.341877e-17j,...
y: array([[ 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
[ 0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
[ 0., 0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0.],...
```

The OP was [asked](https://github.com/scipy/scipy/issues/5117#issuecomment-128378373) to make a slight change in tolerances, but [replied](https://github.com/scipy/scipy/issues/5117#issuecomment-128703596) only that a huge tolerance bump fixed the problem. There was [concern](https://github.com/scipy/scipy/issues/5117#issuecomment-147839930) that this massive tolerance bump represented a serious problem that would not be fixed by tolerance adjustments, but based on context (and other issues), it has been [suggested](https://github.com/scipy/scipy/issues/5117#issuecomment-1987202802) that this large tolerance bump may not have been *necessary*, just sufficient.

The next report was gh-5335 in the context of dtype `f` (`np.float32`). There we see:
```
    raise AssertionError(msg) AssertionError:  Not equal to tolerance rtol=0.0001, atol=2.38419e-07

(mismatch 100.0%)  x: array([[  9.999999e-01,   1.746230e-08, 
-1.490116e-08,   1.490116e-08,
         -6.146729e-08,  -6.332994e-08,   3.352761e-08,   7.450581e-08,
          3.352761e-08,   2.142042e-08,  -4.097819e-08,   4.656613e-08],...  y: array([[ 1.,  0.,  0.,  0.,      0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
       [ 0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],...
```
I'm not really understanding why it reports 100% mismatch. Many of the elements that should be zero are off by less than the `atol`. The OP re-installs SciPy, the problem disappears, and a new, unrelated problem appears. 

Toward the end of the issue (still gh-5335), a [new report](https://github.com/scipy/scipy/issues/5335#issuecomment-249364188) of the same test failure appears in the context of dtype `F` (`complex64`). 
```
Not equal to tolerance rtol=0.0001, atol=2.38419e-07

(mismatch 1.3888888888888857%)
 x: array([[  1.000000e+00 +0.000000e+00j,  -4.470348e-08 -1.490116e-08j,
         -5.587935e-08 +0.000000e+00j,  -2.793968e-08 +1.490116e-08j,
          7.450581e-09 -2.607703e-08j,  -4.656613e-09 +9.313226e-09j,...
 y: array([[ 1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
       [ 0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],...

----------------------------------------------------------------------
```
We see the same sorts of magnitudes as above, but 1.388% of elements (`2` out of `12*12`) are reported to mismatch - not the 100% from the previous report, the 1.388% of the original report..

Next comes gh-10550 in the context of dtype `F` again. Now we actually see the magnitude of the error in those 1.388% of elements:
```
>       assert_allclose(aTa, np.eye(a.shape[1]), rtol=rtol, atol=atol)
E       AssertionError: 
E       Not equal to tolerance rtol=0.0001, atol=2.38419e-07
E       
E       Mismatch: 1.39%
E       Max absolute difference: 3.57627869e-07
E       Max relative difference: inf
E        x: array([[ 1.000000e+00+0.000000e+00j, -1.676381e-08+1.490116e-08j,
E                0.000000e+00+1.490116e-08j, -2.793968e-08-2.980232e-08j,
E               -2.235174e-08-1.862645e-08j, -2.095476e-08+5.587935e-09j,...
E        y: array([[1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
E              [0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
E              [0., 0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0.],...
```
Only slightly more than the `atol`.

gh-10716 and gh-10952 are exact duplicates. 

So gh-10955 bumped the tolerance from `2*eps` to `10*eps`.

That was about five years ago, and afterwards, reports of the problem stop. We don't anything close until gh-19210, but that is listed with some 50+ other test failures, so it seems to be a distinct problem.