### PR TITLE
DOC: special: prolate spheroidal docs wrong

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -3204,7 +3204,7 @@ const char *obl_rad1_doc = R"(
 
     Computes the oblate spheroidal radial function of the first kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
+    and n>=m, spheroidal parameter `c` and ``x >= 0.0``.
 
     Parameters
     ----------
@@ -3239,7 +3239,7 @@ const char *obl_rad1_cv_doc = R"(
 
     Computes the oblate spheroidal radial function of the first kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
+    and n>=m, spheroidal parameter `c` and ``x >= 0.0``. Requires
     pre-computed characteristic value.
 
     Parameters
@@ -3277,7 +3277,7 @@ const char *obl_rad2_doc = R"(
 
     Computes the oblate spheroidal radial function of the second kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
+    and n>=m, spheroidal parameter `c` and ``x >= 0.0``.
 
     Parameters
     ----------
@@ -3312,7 +3312,7 @@ const char *obl_rad2_cv_doc = R"(
 
     Computes the oblate spheroidal radial function of the second kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
+    and n>=m, spheroidal parameter `c` and ``x >= 0.0``. Requires
     pre-computed characteristic value.
 
     Parameters
@@ -3531,7 +3531,7 @@ const char *pro_rad1_doc = R"(
 
     Computes the prolate spheroidal radial function of the first kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
+    and n>=m, spheroidal parameter `c` and ``x > 1.0``.
 
     Parameters
     ----------
@@ -3561,7 +3561,7 @@ const char *pro_rad1_cv_doc = R"(
 
     Computes the prolate spheroidal radial function of the first kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
+    and n>=m, spheroidal parameter `c` and ``x > 1.0``. Requires
     pre-computed characteristic value.
 
     Parameters
@@ -3594,7 +3594,7 @@ const char *pro_rad2_doc = R"(
 
     Computes the prolate spheroidal radial function of the second kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
+    and n>=m, spheroidal parameter `c` and ``x > 1.0``.
 
     Parameters
     ----------
@@ -3624,7 +3624,7 @@ const char *pro_rad2_cv_doc = R"(
 
     Computes the prolate spheroidal radial function of the second kind
     and its derivative (with respect to `x`) for mode parameters m>=0
-    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
+    and n>=m, spheroidal parameter `c` and ``x > 1.0``. Requires
     pre-computed characteristic value.
 
     Parameters

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -3215,7 +3215,7 @@ const char *obl_rad1_doc = R"(
     c : array_like
         Spheroidal parameter
     x : array_like
-        Parameter x (``|x| < 1.0``)
+        Parameter x (``x >= 0.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3253,7 +3253,7 @@ const char *obl_rad1_cv_doc = R"(
     cv : array_like
         Characteristic value
     x : array_like
-        Parameter x (``|x| < 1.0``)
+        Parameter x (``x >= 0.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3288,7 +3288,7 @@ const char *obl_rad2_doc = R"(
     c : array_like
         Spheroidal parameter
     x : array_like
-        Parameter x (``|x| < 1.0``)
+        Parameter x (``x >= 0.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3326,7 +3326,7 @@ const char *obl_rad2_cv_doc = R"(
     cv : array_like
         Characteristic value
     x : array_like
-        Parameter x (``|x| < 1.0``)
+        Parameter x (``x >= 0.0``)
     out : ndarray, optional
         Optional output array for the function results
 

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -3542,7 +3542,7 @@ const char *pro_rad1_doc = R"(
     c : array_like
         Spheroidal parameter
     x : array_like
-        Real parameter (``|x| < 1.0``)
+        Real parameter (``x > 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3575,7 +3575,7 @@ const char *pro_rad1_cv_doc = R"(
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (``|x| < 1.0``)
+        Real parameter (``x > 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3604,10 +3604,8 @@ const char *pro_rad2_doc = R"(
         Mode parameter n (>= m)
     c : array_like
         Spheroidal parameter
-    cv : array_like
-        Characteristic value
     x : array_like
-        Real parameter (``|x| < 1.0``)
+        Real parameter (``x > 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -3640,7 +3638,7 @@ const char *pro_rad2_cv_doc = R"(
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (``|x| < 1.0``)
+        Real parameter (``x > 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 


### PR DESCRIPTION
* Fixes gh-20991

* Looking at the original Fortran code: https://people.math.sc.edu/Burkardt/f_src/special_functions/special_functions.f90 it is clear that the "argument of the radial function" (`x`) should be strictly `> 1`. See subroutine `rswfp` over there. Furthermore, we enforce this in the C translation of the code in our codebase--see the `prolate_radial1` and `prolate_radial2` function error checking in `sphd_wave.h`.

* While in the neighborhood, fix up other docstring problems related to these functions, like copy-pase of characteristic value for functions that don't accept it.

[docs only]

Naturally, I spent quite some time looking for an actual bug first by comparing with the original Fortran, and didn't find one. While the literature related to these functions is untenably complex for me to read, and I see no modern implementation I can compare against, I would note that if you assume that I'm wrong and the F90 code is wrong, and you change the input validation in our code to enforce what the docs currently suggest on `main`, you'll still get `NaN` output because you end up with the square root of a negative number at: https://github.com/scipy/scipy/blob/8542c166eb1b0e3845fb7d9a3572af902e4e9b83/scipy/special/xsf/specfun/specfun.h#L4782

as `x` decreases the likelihood of a negative operand increases there, and when `m` is 1, you have sqrt of negative number.