### PR TITLE
DOC: optimize: make `lsq_linear` example smaller

### DIFF
--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -230,8 +230,8 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
     >>> from scipy.optimize import lsq_linear
     >>> rng = np.random.default_rng()
     ...
-    >>> m = 20000
-    >>> n = 10000
+    >>> m = 2000
+    >>> n = 1000
     ...
     >>> A = rand(m, n, density=1e-4, random_state=rng)
     >>> b = rng.standard_normal(m)
@@ -240,10 +240,9 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
     >>> ub = lb + 1
     ...
     >>> res = lsq_linear(A, b, bounds=(lb, ub), lsmr_tol='auto', verbose=1)
-    # may vary
     The relative change of the cost function is less than `tol`.
-    Number of iterations 16, initial cost 1.5039e+04, final cost 1.1112e+04,
-    first-order optimality 4.66e-08.
+    Number of iterations 10, initial cost 1.0070e+03, final cost 9.6602e+02,
+    first-order optimality 2.21e-09.        # may vary
     """
     if method not in ['trf', 'bvls']:
         raise ValueError("`method` must be 'trf' or 'bvls'")


### PR DESCRIPTION
Before the change, CircleCI periodically times out (in https://github.com/scipy/scipy/pull/21437), and

```
$ python smoke-docs -s optimize --durations 10
...
10.23s call     build-install/lib/python3.12/site-packages/scipy/optimize/__init__.py::scipy.optimize.lsq_linear
4.46s call     build-install/lib/python3.12/site-packages/scipy/optimize/__init__.py::scipy.optimize.differential_evolution
1.35s call     build-install/lib/python3.12/site-packages/scipy/optimize/__init__.py::scipy.optimize.least_squares
0.87s call     build-install/lib/python3.12/site-packages/scipy/optimize/__init__.py::scipy.optimize.dual_annealing
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
