### PR TITLE
MAINT: interpolate: vectorize `_coeff_of_divided_diff`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2020,14 +2020,13 @@ def _coeff_of_divided_diff(x):
     No checks are performed.
 
     """
-    n = x.shape[0]
-    res = np.zeros(n)
-    for i in range(n):
-        pp = 1.
-        for k in range(n):
-            if k != i:
-                pp *= (x[i] - x[k])
-        res[i] = 1. / pp
+    # x.reshape((-1, 1)) Convert to column vector
+    res = x.reshape((-1, 1)) - x
+
+    # ~np.eye(res.shape[0], dtype=bool) mask of non-diagonal elements
+    res = res[~np.eye(res.shape[0], dtype=bool)].reshape(res.shape[0], -1)
+    res = 1. / np.prod(res, axis=1)
+
     return res
 
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2020,11 +2020,8 @@ def _coeff_of_divided_diff(x):
     No checks are performed.
 
     """
-    # x.reshape((-1, 1)) Convert to column vector
-    res = x.reshape((-1, 1)) - x
-
-    # ~np.eye(res.shape[0], dtype=bool) mask of non-diagonal elements
-    res = res[~np.eye(res.shape[0], dtype=bool)].reshape(res.shape[0], -1)
+    res = np.subtract.outer(x, x)
+    np.fill_diagonal(res, 1)
     res = 1. / np.prod(res, axis=1)
 
     return res


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Hi everyone!

This PR replaces loops with vector operations. Instead of iterative difference, the difference between a column vector and an array is used: `res = x.reshape((-1, 1)) - x`
Then the diagonal elements are eliminated: `~np.eye(res.shape[0], dtype=bool)`  and the products of the elements are calculated.
The calculation speed is better starting from an array size of 12 elements.

To compare the old and new algorithms, I made a code that outputs: the array size, the calculation time in seconds of the old and new algorithms, the ratio of time_old/time_new and compares the obtained results for equality.

Since the values ​​of `(x[i] - x[k])` can be quite small, `1. / pp` yields a huge number. Therefore, my for comparison code may generate warnings: `overflow encountered in scalar multiply` and `overflow encountered in scalar multiply`
Below in the drop-down list is the code for comparison.

#### Additional information
<details>

<summary>code for comparison</summary>

```
import numpy as np
import datetime



def old_coeff_of_divided_diff(x):
    n = x.shape[0]
    res = np.zeros(n)
    for i in range(n):
        pp = 1.
        for k in range(n):
            if k != i:
                pp *= (x[i] - x[k])
        res[i] = 1. / pp

    return res

def new_coeff_of_divided_diff(x):
    # x.reshape((-1, 1)) Convert to column vector
    res = x.reshape((-1, 1)) - x

    # ~np.eye(res.shape[0], dtype=bool) mask of non-diagonal elements
    res = res[~np.eye(res.shape[0], dtype=bool)].reshape(res.shape[0], -1)
    res = 1. / np.prod(res, axis=1)

    return res


for n in [5, 12, 25, 125, 625, 3125, 5000]:
    arr_sample = np.random.uniform(low=-5, high=5, size=(n))
    len_unique = len(np.unique(arr_sample))
    if len_unique != n:
        print('the number of unique is not equal n =', n, 'len unique', len_unique)
    #'''
    now = datetime.datetime.now()
    result_old = old_coeff_of_divided_diff(arr_sample)
    time_old = datetime.datetime.now() - now
    #'''
    now = datetime.datetime.now()
    result_new = new_coeff_of_divided_diff(arr_sample)
    time_new = datetime.datetime.now() - now
    #'''
    #'''
    word = ('array size n {0} time_old {1} time_new {2}'
            ' difference in time {3} comparison result array {4}'
            .format(n, time_old.total_seconds(), time_new.total_seconds(),
                    round(time_old / time_new, 2), np.all(result_new == result_old)))

    print(word)
    #'''
```

</details>

Output:
```
array size n 5 time_old 5.1e-05 time_new 0.000132 difference in time 0.39 comparison result array True
array size n 12 time_old 6.9e-05 time_new 5.6e-05 difference in time 1.23 comparison result array True
array size n 25 time_old 0.000285 time_new 7.2e-05 difference in time 3.96 comparison result array True
array size n 125 time_old 0.014494 time_new 0.000527 difference in time 27.5 comparison result array True
array size n 625 time_old 0.177522 time_new 0.014717 difference in time 12.06 comparison result array True
array size n 3125 time_old 4.223619 time_new 0.095541 difference in time 44.21 comparison result array True
array size n 5000 time_old 10.958876 time_new 0.267512 difference in time 40.97 comparison result array True
array size n 7000 time_old 20.973275 time_new 0.503466 difference in time 41.66 comparison result array True
array size n 10000 time_old 42.713791 time_new 2.56348 difference in time 16.66 comparison result array True
array size n 12500 time_old 67.414496 time_new 6.646003 difference in time 10.14 comparison result array True
array size n 14000 time_old 84.624646 time_new 26.281584 difference in time 3.22 comparison result array True
array size n 16000 time_old 111.502049 time_new 59.70884 difference in time 1.87 comparison result array True
```