### PR TITLE
DEV/MAINT: Add `±` and `∞` to the extra set of allowed Unicode characters of linter

### DIFF
--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -11,7 +11,8 @@ import argparse
 # allow in the source code.
 latin1_letters = set(chr(cp) for cp in range(192, 256))
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
-extra_symbols = set(['®', 'ő', 'λ', 'π', 'ω', '∫', '≠', '≥', '≤', 'μ'])
+extra_symbols = set(['®', 'ő', 'λ', 'π', 'ω', '∫', '≠', '≥', '≤', 'μ',
+                     '±', '∞'])
 allowed = latin1_letters | box_drawing_chars | extra_symbols
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-21447.

#### What does this implement/fix?
Adds `±` and `∞` to the “extra” set of allowed Unicode characters of the linter (`unicode_checker.py`).

After this PR, the linter will no longer complain if any Python source in the repo contains these characters.

#### Additional information
<!--Any additional information you think is important.-->
