### PR TITLE
TYP: ignore missing sphinx import in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -88,6 +88,9 @@ ignore_missing_imports = True
 [mypy-array_api_strict]
 ignore_missing_imports = True
 
+[mypy-sphinx.*]
+ignore_missing_imports = True
+
 #
 # Extension modules without stubs.
 #


### PR DESCRIPTION
Sphinx isn't required, and if it is missing we otherwise see:
```
scipy/_lib/_docscrape.py:632: error: Cannot find implementation or library stub for module named "sphinx.ext.autodoc"  [import-not-found]
```

[skip ci] (since no CI config is relevant here, we install `sphinx` in the Mypy job)
