### PR TITLE
CI: remove `fetch-depth: 0` from wheel build jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
       with:
-        fetch-depth: 0
+        fetch-depth: 0  # previous commits used in tools/lint.py
         submodules: recursive
 
     - name: Setup Python

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,7 +101,6 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           submodules: true
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
We shouldn't need the whole commit history and all tags, we haven't used that in a long time. This reduces the time of the `actions/checkout` step from 40s-2min (depends on GitHub rate limiting) to 10s-30s, with the median time for each being around 44s vs. 15s.