### PR TITLE
ENH: integrate.cubature: array API standard support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -25,6 +25,7 @@ env:
     -t scipy._lib.tests.test__util
     -t scipy.differentiate.tests.test_differentiate
     -t scipy.integrate.tests.test_tanhsinh
+    -t scipy.integrate.tests.test_cubature
     -t scipy.optimize.tests.test_chandrupatla
     -t scipy.stats
     -t scipy.ndimage

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -2,9 +2,9 @@ import heapq
 import itertools
 
 from dataclasses import dataclass
-from scipy._lib._util import MapWrapper
 
-import numpy as np
+from scipy._lib._array_api import array_namespace
+from scipy._lib._util import MapWrapper
 
 from scipy.integrate._rules import (
     ProductNestedFixed,
@@ -19,23 +19,27 @@ __all__ = ['cubature']
 
 @dataclass
 class CubatureRegion:
-    estimate: np.ndarray
-    error: np.ndarray
-    a: np.ndarray
-    b: np.ndarray
+    estimate: object
+    error: object
+    a: object
+    b: object
+    _xp: object
 
     def __lt__(self, other):
         # Consider regions with higher error estimates as being "less than" regions with
         # lower order estimates, so that regions with high error estimates are placed at
         # the top of the heap.
 
-        return np.max(np.abs(self.error)) > np.max(np.abs(other.error))
+        this_err = self._xp.max(self._xp.abs(self.error))
+        other_err = self._xp.max(self._xp.abs(other.error))
+
+        return this_err > other_err
 
 
 @dataclass
 class CubatureResult:
-    estimate: np.ndarray
-    error: np.ndarray
+    estimate: object
+    error: object
     status: str
     regions: list[CubatureRegion]
     subdivisions: int
@@ -207,28 +211,29 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
     # It is also possible to use a custom rule, but this is not yet part of the public
     # API. An example of this can be found in the class scipy.integrate._rules.Rule.
 
-    max_subdivisions = np.inf if max_subdivisions is None else max_subdivisions
+    xp = array_namespace(a, b)
+    max_subdivisions = float("inf") if max_subdivisions is None else max_subdivisions
 
-    # Convert a and b to arrays of at least 1D
-    a = np.array(a)
-    b = np.array(b)
+    # Convert a and b to arrays
+    a = xp.asarray(a)
+    b = xp.asarray(b)
 
     if a.ndim != 1 or b.ndim != 1:
         raise ValueError("`a` and `b` must be 1D arrays")
 
     # If the rule is a string, convert to a corresponding product rule
     if isinstance(rule, str):
-        ndim = len(a)
+        ndim = a.size
 
         if rule == "genz-malik":
-            rule = GenzMalikCubature(ndim)
+            rule = GenzMalikCubature(ndim, xp=xp)
         else:
             quadratues = {
-                "gauss-kronrod": GaussKronrodQuadrature(21),
+                "gauss-kronrod": GaussKronrodQuadrature(21, xp=xp),
 
                 # Also allow names quad_vec uses:
-                "gk21": GaussKronrodQuadrature(21),
-                "gk15": GaussKronrodQuadrature(15),
+                "gk21": GaussKronrodQuadrature(21, xp=xp),
+                "gk15": GaussKronrodQuadrature(15, xp=xp),
             }
 
             base_rule = quadratues.get(rule)
@@ -241,12 +246,12 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
     est = rule.estimate(f, a, b, args)
     err = rule.estimate_error(f, a, b, args)
 
-    regions = [CubatureRegion(est, err, a, b)]
+    regions = [CubatureRegion(est, err, a, b, xp)]
     subdivisions = 0
     success = True
 
     with MapWrapper(workers) as mapwrapper:
-        while np.any(err > atol + rtol * np.abs(est)):
+        while xp.any(err > atol + rtol * xp.abs(est)):
             # region_k is the region with highest estimated error
             region_k = heapq.heappop(regions)
 
@@ -283,7 +288,7 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
                 est += est_sub
                 err += err_sub
 
-                new_region = CubatureRegion(est_sub, err_sub, a_k_sub, b_k_sub)
+                new_region = CubatureRegion(est_sub, err_sub, a_k_sub, b_k_sub, xp)
 
                 heapq.heappush(regions, new_region)
 

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from dataclasses import dataclass
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_size
 from scipy._lib._util import MapWrapper
 
 from scipy.integrate._rules import (
@@ -230,7 +230,7 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     # If the rule is a string, convert to a corresponding product rule
     if isinstance(rule, str):
-        ndim = a.size
+        ndim = xp_size(a)
 
         if rule == "genz-malik":
             rule = GenzMalikCubature(ndim, xp=xp)

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -2,8 +2,10 @@ import heapq
 import itertools
 
 from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, TYPE_CHECKING
 
-from scipy._lib.array_api_compat import numpy as np
+from scipy._lib._array_api import np_compat
 from scipy._lib._array_api import array_namespace, xp_size
 from scipy._lib._util import MapWrapper
 
@@ -14,17 +16,21 @@ from scipy.integrate._rules import (
 )
 from scipy.integrate._rules._base import _subregion_coordinates
 
-
 __all__ = ['cubature']
+
+if TYPE_CHECKING:
+    Array = Any  # To be changed to a Protocol later (see array-api#589)
+else:
+    Array = object
 
 
 @dataclass
 class CubatureRegion:
-    estimate: object
-    error: object
-    a: object
-    b: object
-    _xp: object
+    estimate: Array
+    error: Array
+    a: Array
+    b: Array
+    _xp: ModuleType
 
     def __lt__(self, other):
         # Consider regions with higher error estimates as being "less than" regions with
@@ -39,8 +45,8 @@ class CubatureRegion:
 
 @dataclass
 class CubatureResult:
-    estimate: object
-    error: object
+    estimate: Array
+    error: Array
     status: str
     regions: list[CubatureRegion]
     subdivisions: int
@@ -214,8 +220,8 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     # If a and b are ordinary Python lists, default to NumPy
     if isinstance(a, list) and isinstance(b, list):
-        a = np.array(a)
-        b = np.array(b)
+        a = np_compat.array(a)
+        b = np_compat.array(b)
 
     xp = array_namespace(a, b)
     max_subdivisions = float("inf") if max_subdivisions is None else max_subdivisions

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -1,6 +1,8 @@
 import heapq
 import itertools
 
+import numpy as np
+
 from dataclasses import dataclass
 
 from scipy._lib._array_api import array_namespace
@@ -211,12 +213,17 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
     # It is also possible to use a custom rule, but this is not yet part of the public
     # API. An example of this can be found in the class scipy.integrate._rules.Rule.
 
+    # If a and b are ordinary Python lists, default to NumPy
+    if isinstance(a, list) and isinstance(b, list):
+        a = np.array(a)
+        b = np.array(b)
+
     xp = array_namespace(a, b)
     max_subdivisions = float("inf") if max_subdivisions is None else max_subdivisions
 
     # Convert a and b to arrays
-    a = xp.asarray(a)
-    b = xp.asarray(b)
+    a = xp.asarray(a, dtype=xp.float64)
+    b = xp.asarray(b, dtype=xp.float64)
 
     if a.ndim != 1 or b.ndim != 1:
         raise ValueError("`a` and `b` must be 1D arrays")

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, TYPE_CHECKING
 
-from scipy._lib._array_api import np_compat
 from scipy._lib._array_api import array_namespace, xp_size
 from scipy._lib._util import MapWrapper
 
@@ -217,11 +216,6 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     # It is also possible to use a custom rule, but this is not yet part of the public
     # API. An example of this can be found in the class scipy.integrate._rules.Rule.
-
-    # If a and b are ordinary Python lists, default to NumPy
-    if isinstance(a, list) and isinstance(b, list):
-        a = np_compat.array(a)
-        b = np_compat.array(b)
 
     xp = array_namespace(a, b)
     max_subdivisions = float("inf") if max_subdivisions is None else max_subdivisions

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -1,10 +1,9 @@
 import heapq
 import itertools
 
-import numpy as np
-
 from dataclasses import dataclass
 
+from scipy._lib.array_api_compat import numpy as np
 from scipy._lib._array_api import array_namespace, xp_size
 from scipy._lib._util import MapWrapper
 

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -1,6 +1,6 @@
 import itertools
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_size
 
 import numpy as np
 import math
@@ -434,7 +434,7 @@ def _cartesian_product(arrays):
 
     la = len(arrays)
     dtype = xp.result_type(*arrays)
-    arr = xp.empty([la] + [a.size for a in arrays], dtype=dtype)
+    arr = xp.empty([la] + [xp_size(a) for a in arrays], dtype=dtype)
 
     arrays_ix = xp.meshgrid(*arrays, indexing='ij')
 
@@ -476,8 +476,8 @@ def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
 
     rule_ndim = orig_nodes.shape[-1]
 
-    a_ndim = a.size
-    b_ndim = b.size
+    a_ndim = xp_size(a)
+    b_ndim = xp_size(b)
 
     if rule_ndim != a_ndim or rule_ndim != b_ndim:
         raise ValueError(f"rule and function are of incompatible dimension, nodes have"

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -338,8 +338,8 @@ class NestedFixedRule(FixedRule):
         if self.xp is None:
             self.xp = array_namespace(nodes)
 
-        error_nodes = _concat([nodes, lower_nodes], axis=0)
-        error_weights = _concat([weights, -lower_weights], axis=0)
+        error_nodes = self.xp.concat([nodes, lower_nodes], axis=0)
+        error_weights = self.xp.concat([weights, -lower_weights], axis=0)
 
         return self.xp.abs(
             _apply_fixed_rule(f, a, b, error_nodes, error_weights, args)
@@ -511,17 +511,3 @@ def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
     est = xp.sum(weights_reshaped * f_nodes, axis=0)
 
     return est
-
-
-def _concat(arrays, axis=0):
-    xp = array_namespace(*arrays)
-
-    if hasattr(xp, "concat"):
-        return xp.concat(arrays, axis=axis)
-    elif hasattr(xp, "concatenate"):
-        return xp.concatenate(arrays, axis=axis)
-    else:
-        return xp.asarray(np_compat.concatenate(
-            [np_compat.asarray(arr) for arr in arrays],
-            axis=axis,
-        ))

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -419,7 +419,7 @@ class ProductNestedFixed(NestedFixedRule):
             [cubature.lower_nodes_and_weights[0] for cubature in self.base_rules]
         )
 
-        weights = np.prod(
+        weights = self.xp.prod(
             _cartesian_product(
                 [cubature.lower_nodes_and_weights[1] for cubature in self.base_rules]
             ),
@@ -456,13 +456,14 @@ def _subregion_coordinates(a, b):
     """
 
     xp = array_namespace(a, b)
-    m = (a + b)/2
+    m = (a + b) * 0.5
 
+    # TODO: still relying on np
     for a_sub, b_sub in zip(
-        itertools.product(*xp.array([a, m]).T),
-        itertools.product(*xp.array([m, b]).T)
+        itertools.product(*np.asarray([a, m]).T),
+        itertools.product(*np.asarray([m, b]).T),
     ):
-        yield xp.array(a_sub), xp.array(b_sub)
+        yield xp.asarray(a_sub), xp.asarray(b_sub)
 
 
 def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
@@ -471,7 +472,7 @@ def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
     # Ensure orig_nodes are at least 2D, since 1D cubature methods can return arrays of
     # shape (npoints,) rather than (npoints, 1)
     if orig_nodes.ndim == 1:
-        orig_nodes = orig_nodes[:, np.newaxis]
+        orig_nodes = orig_nodes[:, xp.newaxis]
 
     rule_ndim = orig_nodes.shape[-1]
 

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -1,5 +1,4 @@
 from scipy._lib._array_api import array_namespace, xp_size
-from scipy._lib._array_api import np_compat
 
 import math
 

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,4 +1,4 @@
-from scipy._lib._array_api import is_numpy, np_compat
+from scipy._lib._array_api import np_compat, array_namespace
 
 from functools import cached_property
 
@@ -83,10 +83,10 @@ class GaussKronrodQuadrature(NestedFixedRule):
 
         self.npoints = npoints
 
-        if xp is None or is_numpy(xp):
+        if xp is None:
             xp = np_compat
 
-        self.xp = xp
+        self.xp = array_namespace(xp.empty(0))
 
         self.gauss = GaussLegendreQuadrature(npoints//2, xp=self.xp)
 

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,4 +1,4 @@
-from scipy._lib.array_api_compat import numpy as np
+from scipy._lib._array_api import np_compat
 
 from functools import cached_property
 
@@ -84,7 +84,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
         self.npoints = npoints
 
         if xp is None:
-            xp = np
+            xp = np_compat
 
         self.xp = xp
 

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -74,7 +74,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
      np.float64(2.220446049250313e-16)
     """
 
-    def __init__(self, npoints):
+    def __init__(self, npoints, xp=None):
         # TODO: nodes and weights are currently hard-coded for values 15 and 21, but in
         # the future it would be best to compute the Kronrod extension of the lower rule
         if npoints != 15 and npoints != 21:
@@ -82,12 +82,18 @@ class GaussKronrodQuadrature(NestedFixedRule):
                                       "supported for 15 or 21 nodes")
 
         self.npoints = npoints
-        self.gauss = GaussLegendreQuadrature(npoints//2)
+
+        if xp is None:
+            xp = np
+
+        self.xp = xp
+
+        self.gauss = GaussLegendreQuadrature(npoints//2, xp=self.xp)
 
     @cached_property
     def nodes_and_weights(self):
         if self.npoints == 21:
-            nodes = np.array([
+            nodes = self.xp.asarray([
                 0.995657163025808080735527280689003,
                 0.973906528517171720077964012084452,
                 0.930157491355708226001207180059508,
@@ -111,7 +117,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
                 -0.995657163025808080735527280689003,
             ])
 
-            weights = np.array([
+            weights = self.xp.asarray([
                 0.011694638867371874278064396062192,
                 0.032558162307964727478818972459390,
                 0.054755896574351996031381300244580,
@@ -135,7 +141,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
                 0.011694638867371874278064396062192,
             ])
         elif self.npoints == 15:
-            nodes = np.array([
+            nodes = self.xp.asarray([
                 0.991455371120812639206854697526329,
                 0.949107912342758524526189684047851,
                 0.864864423359769072789712788640926,
@@ -153,7 +159,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
                 -0.991455371120812639206854697526329,
             ])
 
-            weights = np.array([
+            weights = self.xp.asarray([
                 0.022935322010529224963732008058970,
                 0.063092092629978553290700663189204,
                 0.104790010322250183839876322541518,

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,4 +1,4 @@
-import numpy as np
+from scipy._lib.array_api_compat import numpy as np
 
 from functools import cached_property
 

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -1,4 +1,4 @@
-from scipy._lib._array_api import np_compat
+from scipy._lib._array_api import is_numpy, np_compat
 
 from functools import cached_property
 
@@ -83,7 +83,7 @@ class GaussKronrodQuadrature(NestedFixedRule):
 
         self.npoints = npoints
 
-        if xp is None:
+        if xp is None or is_numpy(xp):
             xp = np_compat
 
         self.xp = xp

--- a/scipy/integrate/_rules/_gauss_kronrod.py
+++ b/scipy/integrate/_rules/_gauss_kronrod.py
@@ -27,6 +27,10 @@ class GaussKronrodQuadrature(NestedFixedRule):
     npoints : int
         Number of nodes for the higher-order rule.
 
+    xp : array_namespace, optional
+        The namespace for the node and weight arrays. Default is None, where NumPy is
+        used.
+
     Attributes
     ----------
     lower : Rule

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,4 +1,4 @@
-from scipy._lib.array_api_compat import numpy as np
+from scipy._lib._array_api import np_compat
 
 from functools import cached_property
 
@@ -43,7 +43,7 @@ class GaussLegendreQuadrature(FixedRule):
         self.npoints = npoints
 
         if xp is None:
-            xp = np
+            xp = np_compat
 
         self.xp = xp
 

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,4 +1,4 @@
-from scipy._lib._array_api import np_compat
+from scipy._lib._array_api import is_numpy, np_compat
 
 from functools import cached_property
 
@@ -42,7 +42,7 @@ class GaussLegendreQuadrature(FixedRule):
 
         self.npoints = npoints
 
-        if xp is None:
+        if xp is None or is_numpy(xp):
             xp = np_compat
 
         self.xp = xp

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,4 +1,4 @@
-import numpy as np
+from scipy._lib.array_api_compat import numpy as np
 
 from functools import cached_property
 

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,4 +1,4 @@
-from scipy._lib._array_api import is_numpy, np_compat
+from scipy._lib._array_api import array_namespace, np_compat
 
 from functools import cached_property
 
@@ -42,10 +42,10 @@ class GaussLegendreQuadrature(FixedRule):
 
         self.npoints = npoints
 
-        if xp is None or is_numpy(xp):
+        if xp is None:
             xp = np_compat
 
-        self.xp = xp
+        self.xp = array_namespace(xp.empty(0))
 
     @cached_property
     def nodes_and_weights(self):

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -16,6 +16,10 @@ class GaussLegendreQuadrature(FixedRule):
     npoints : int
         Number of nodes for the higher-order rule.
 
+    xp : array_namespace, optional
+        The namespace for the node and weight arrays. Default is None, where NumPy is
+        used.
+
     Examples
     --------
     Evaluate a 1D integral. Note in this example that ``f`` returns an array, so the

--- a/scipy/integrate/_rules/_gauss_legendre.py
+++ b/scipy/integrate/_rules/_gauss_legendre.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from functools import cached_property
 
 from scipy.special import roots_legendre
@@ -32,7 +34,7 @@ class GaussLegendreQuadrature(FixedRule):
      array([1.11022302e-16])
     """
 
-    def __init__(self, npoints):
+    def __init__(self, npoints, xp=None):
         if npoints < 2:
             raise ValueError(
                 "At least 2 nodes required for Gauss-Legendre cubature"
@@ -40,6 +42,13 @@ class GaussLegendreQuadrature(FixedRule):
 
         self.npoints = npoints
 
+        if xp is None:
+            xp = np
+
+        self.xp = xp
+
     @cached_property
     def nodes_and_weights(self):
-        return roots_legendre(self.npoints)
+        # TODO: current converting to/from numpy
+        nodes, weights = roots_legendre(self.npoints)
+        return self.xp.asarray(nodes), self.xp.asarray(weights)

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -112,15 +112,14 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = self.xp.repeat(
-            self.xp.asarray([w_1, w_2, w_3, w_4, w_5]),
+        weights = self.xp.concat(
             self.xp.asarray([
-                1,
-                2 * self.ndim,
-                2*self.ndim,
-                2*(self.ndim - 1)*self.ndim,
-                2**self.ndim,
-            ]),
+                [w_1] * 1,
+                [w_2] * (2 * self.ndim),
+                [w_3] * (2 * self.ndim),
+                [w_4] * (2*(self.ndim - 1)*self.ndim),
+                [w_5] * (2**self.ndim),
+            ])
         )
 
         return nodes, weights
@@ -163,14 +162,13 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = self.xp.repeat(
-            self.xp.asarray([w_1, w_2, w_3, w_4]),
+        weights = self.xp.concat(
             self.xp.asarray([
-                1,
-                2 * self.ndim,
-                2*self.ndim,
-                2*(self.ndim - 1)*self.ndim,
-            ]),
+                [w_1] * 1,
+                [w_2] * (2 * self.ndim),
+                [w_3] * (2 * self.ndim),
+                [w_4] * (2*(self.ndim - 1)*self.ndim),
+            ])
         )
 
         return nodes, weights

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -3,10 +3,9 @@ import itertools
 
 from functools import cached_property
 
-from scipy._lib._array_api import np_compat
+from scipy._lib._array_api import is_numpy, np_compat
 
 from scipy.integrate._rules import NestedFixedRule
-from scipy.integrate._rules._base import _concat
 
 
 class GenzMalikCubature(NestedFixedRule):
@@ -65,7 +64,7 @@ class GenzMalikCubature(NestedFixedRule):
         self.degree = degree
         self.lower_degree = lower_degree
 
-        if xp is None:
+        if xp is None or is_numpy(xp):
             xp = np_compat
 
         self.xp = xp
@@ -113,7 +112,7 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = _concat([
+        weights = self.xp.concat([
             self.xp.asarray([w_1] * 1),
             self.xp.asarray([w_2] * (2 * self.ndim)),
             self.xp.asarray([w_3] * (2 * self.ndim)),
@@ -161,7 +160,7 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = _concat([
+        weights = self.xp.concat([
             self.xp.asarray([w_1] * 1),
             self.xp.asarray([w_2] * (2 * self.ndim)),
             self.xp.asarray([w_3] * (2 * self.ndim)),

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -112,15 +112,13 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = self.xp.concat(
-            self.xp.asarray([
-                [w_1] * 1,
-                [w_2] * (2 * self.ndim),
-                [w_3] * (2 * self.ndim),
-                [w_4] * (2*(self.ndim - 1)*self.ndim),
-                [w_5] * (2**self.ndim),
-            ])
-        )
+        weights = self.xp.concat([
+            [w_1] * 1,
+            [w_2] * (2 * self.ndim),
+            [w_3] * (2 * self.ndim),
+            [w_4] * (2 * (self.ndim - 1) * self.ndim),
+            [w_5] * (2**self.ndim),
+        ])
 
         return nodes, weights
 
@@ -162,14 +160,12 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = self.xp.concat(
-            self.xp.asarray([
-                [w_1] * 1,
-                [w_2] * (2 * self.ndim),
-                [w_3] * (2 * self.ndim),
-                [w_4] * (2*(self.ndim - 1)*self.ndim),
-            ])
-        )
+        weights = self.xp.concat([
+            [w_1] * 1,
+            [w_2] * (2 * self.ndim),
+            [w_3] * (2 * self.ndim),
+            [w_4] * (2 * (self.ndim - 1) * self.ndim),
+        ])
 
         return nodes, weights
 

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -94,10 +94,10 @@ class GenzMalikCubature(NestedFixedRule):
 
         nodes = self.xp.asarray(
             list(zip(*its)),
-            dtype=float,
+            dtype=self.xp.float64,
         )
 
-        nodes.shape = (self.ndim, nodes_size)
+        nodes = self.xp.reshape(nodes, (self.ndim, nodes_size))
 
         # It's convenient to generate the nodes as a sequence of evaluation points
         # as an array of shape (npoints, ndim), but nodes needs to have shape
@@ -113,14 +113,14 @@ class GenzMalikCubature(NestedFixedRule):
         w_5 = 6859 / 19683
 
         weights = self.xp.repeat(
-            [w_1, w_2, w_3, w_4, w_5],
-            [
+            self.xp.asarray([w_1, w_2, w_3, w_4, w_5]),
+            self.xp.asarray([
                 1,
                 2 * self.ndim,
                 2*self.ndim,
                 2*(self.ndim - 1)*self.ndim,
                 2**self.ndim,
-            ]
+            ]),
         )
 
         return nodes, weights
@@ -151,10 +151,10 @@ class GenzMalikCubature(NestedFixedRule):
 
         nodes = self.xp.asarray(
             list(zip(*its)),
-            dtype=float,
+            dtype=self.xp.float64,
         )
 
-        nodes.shape = (self.ndim, nodes_size)
+        nodes = self.xp.reshape(nodes, (self.ndim, nodes_size))
         nodes = nodes.T
 
         # Weights are different from those in the full rule.
@@ -164,8 +164,13 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (25 / 729)
 
         weights = self.xp.repeat(
-            [w_1, w_2, w_3, w_4],
-            [1, 2 * self.ndim, 2*self.ndim, 2*(self.ndim - 1)*self.ndim],
+            self.xp.asarray([w_1, w_2, w_3, w_4]),
+            self.xp.asarray([
+                1,
+                2 * self.ndim,
+                2*self.ndim,
+                2*(self.ndim - 1)*self.ndim,
+            ]),
         )
 
         return nodes, weights

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -1,8 +1,9 @@
 import math
 import itertools
-import numpy as np
 
 from functools import cached_property
+
+import numpy as np
 
 from scipy.integrate._rules import NestedFixedRule
 
@@ -51,7 +52,7 @@ class GenzMalikCubature(NestedFixedRule):
      np.float64(1.378269656626685e-06)
     """
 
-    def __init__(self, ndim, degree=7, lower_degree=5):
+    def __init__(self, ndim, degree=7, lower_degree=5, xp=None):
         if ndim < 2:
             raise ValueError("Genz-Malik cubature is only defined for ndim >= 2")
 
@@ -62,6 +63,11 @@ class GenzMalikCubature(NestedFixedRule):
         self.ndim = ndim
         self.degree = degree
         self.lower_degree = lower_degree
+
+        if xp is None:
+            xp = np
+
+        self.xp = xp
 
     @cached_property
     def nodes_and_weights(self):
@@ -85,12 +91,10 @@ class GenzMalikCubature(NestedFixedRule):
         )
 
         nodes_size = 1 + (2 * (self.ndim + 1) * self.ndim) + 2**self.ndim
-        count = nodes_size * self.ndim
 
-        nodes = np.fromiter(
-            itertools.chain.from_iterable(zip(*its)),
+        nodes = self.xp.asarray(
+            list(zip(*its)),
             dtype=float,
-            count=count,
         )
 
         nodes.shape = (self.ndim, nodes_size)
@@ -108,7 +112,7 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = np.repeat(
+        weights = self.xp.repeat(
             [w_1, w_2, w_3, w_4, w_5],
             [
                 1,
@@ -144,12 +148,10 @@ class GenzMalikCubature(NestedFixedRule):
         )
 
         nodes_size = 1 + (2 * (self.ndim + 1) * self.ndim)
-        count = nodes_size * self.ndim
 
-        nodes = np.fromiter(
-            itertools.chain.from_iterable(zip(*its)),
+        nodes = self.xp.asarray(
+            list(zip(*its)),
             dtype=float,
-            count=count,
         )
 
         nodes.shape = (self.ndim, nodes_size)
@@ -161,7 +163,7 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = np.repeat(
+        weights = self.xp.repeat(
             [w_1, w_2, w_3, w_4],
             [1, 2 * self.ndim, 2*self.ndim, 2*(self.ndim - 1)*self.ndim],
         )

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -19,6 +19,10 @@ class GenzMalikCubature(NestedFixedRule):
     ndim : int
         The spatial dimension of the integrand.
 
+    xp : array_namespace, optional
+        The namespace for the node and weight arrays. Default is None, where NumPy is
+        used.
+
     Attributes
     ----------
     higher : Cubature

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -3,7 +3,7 @@ import itertools
 
 from functools import cached_property
 
-import numpy as np
+from scipy._lib.array_api_compat import numpy as np
 
 from scipy.integrate._rules import NestedFixedRule
 

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from scipy._lib._array_api import np_compat
 
 from scipy.integrate._rules import NestedFixedRule
+from scipy.integrate._rules._base import _concat
 
 
 class GenzMalikCubature(NestedFixedRule):
@@ -112,12 +113,12 @@ class GenzMalikCubature(NestedFixedRule):
         w_4 = (2**self.ndim) * (200 / 19683)
         w_5 = 6859 / 19683
 
-        weights = self.xp.concat([
-            [w_1] * 1,
-            [w_2] * (2 * self.ndim),
-            [w_3] * (2 * self.ndim),
-            [w_4] * (2 * (self.ndim - 1) * self.ndim),
-            [w_5] * (2**self.ndim),
+        weights = _concat([
+            self.xp.asarray([w_1] * 1),
+            self.xp.asarray([w_2] * (2 * self.ndim)),
+            self.xp.asarray([w_3] * (2 * self.ndim)),
+            self.xp.asarray([w_4] * (2 * (self.ndim - 1) * self.ndim)),
+            self.xp.asarray([w_5] * (2**self.ndim)),
         ])
 
         return nodes, weights
@@ -160,11 +161,11 @@ class GenzMalikCubature(NestedFixedRule):
         w_3 = (2**self.ndim) * (265 - 100*self.ndim) / 1458
         w_4 = (2**self.ndim) * (25 / 729)
 
-        weights = self.xp.concat([
-            [w_1] * 1,
-            [w_2] * (2 * self.ndim),
-            [w_3] * (2 * self.ndim),
-            [w_4] * (2 * (self.ndim - 1) * self.ndim),
+        weights = _concat([
+            self.xp.asarray([w_1] * 1),
+            self.xp.asarray([w_2] * (2 * self.ndim)),
+            self.xp.asarray([w_3] * (2 * self.ndim)),
+            self.xp.asarray([w_4] * (2 * (self.ndim - 1) * self.ndim)),
         ])
 
         return nodes, weights

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -3,7 +3,7 @@ import itertools
 
 from functools import cached_property
 
-from scipy._lib.array_api_compat import numpy as np
+from scipy._lib._array_api import np_compat
 
 from scipy.integrate._rules import NestedFixedRule
 
@@ -65,7 +65,7 @@ class GenzMalikCubature(NestedFixedRule):
         self.lower_degree = lower_degree
 
         if xp is None:
-            xp = np
+            xp = np_compat
 
         self.xp = xp
 

--- a/scipy/integrate/_rules/_genz_malik.py
+++ b/scipy/integrate/_rules/_genz_malik.py
@@ -3,7 +3,7 @@ import itertools
 
 from functools import cached_property
 
-from scipy._lib._array_api import is_numpy, np_compat
+from scipy._lib._array_api import array_namespace, np_compat
 
 from scipy.integrate._rules import NestedFixedRule
 
@@ -64,10 +64,10 @@ class GenzMalikCubature(NestedFixedRule):
         self.degree = degree
         self.lower_degree = lower_degree
 
-        if xp is None or is_numpy(xp):
+        if xp is None:
             xp = np_compat
 
-        self.xp = xp
+        self.xp = array_namespace(xp.empty(0))
 
     @cached_property
     def nodes_and_weights(self):

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -67,9 +67,12 @@ def genz_malik_1980_f_1_exact(a, b, r, alphas, xp):
     a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
     b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-    return (-2)**ndim * 1/xp.prod(alphas, axis=-1) \
-        * xp.cos(2*math.pi*r + xp.sum(alphas * (a+b) * 0.5, axis=-1)) \
+    return (
+        (-2)**ndim
+        * 1/xp.prod(alphas, axis=-1)
+        * xp.cos(2*math.pi*r + xp.sum(alphas * (a+b) * 0.5, axis=-1))
         * xp.prod(xp.sin(alphas * (a-b)/2), axis=-1)
+    )
 
 
 def genz_malik_1980_f_1_random_args(rng, shape, xp):
@@ -110,11 +113,13 @@ def genz_malik_1980_f_2_exact(a, b, alphas, betas, xp):
     # `xp` is the unwrapped namespace, so `.atan` won't work for `xp = np` and np<2.
     xp_test = array_namespace(a)
 
-    return (-1)**ndim * 1/xp.prod(alphas, axis=-1) \
+    return (
+        (-1)**ndim * 1/xp.prod(alphas, axis=-1)
         * xp.prod(
             xp_test.atan((a - betas)/alphas) - xp_test.atan((b - betas)/alphas),
-            axis=-1
+            axis=-1,
         )
+    )
 
 
 def genz_malik_1980_f_2_random_args(rng, shape, xp):
@@ -125,9 +130,7 @@ def genz_malik_1980_f_2_random_args(rng, shape, xp):
     difficulty = 25.0
     products = xp.prod(alphas**xp.asarray(-2.0), axis=-1)
     normalisation_factors = (products**xp.asarray(1 / (2*ndim)))[..., None]
-    alphas = alphas \
-        * normalisation_factors \
-        / math.pow(difficulty, 1 / (2*ndim))
+    alphas = alphas * normalisation_factors * math.pow(difficulty, 1 / (2*ndim))
 
     # Adjust alphas from distribution used in Genz and Malik 1980 since denominator
     # is very small for high dimensions.
@@ -158,8 +161,10 @@ def genz_malik_1980_f_3_exact(a, b, alphas, xp):
     a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
     b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-    return (-1)**ndim * 1/xp.prod(alphas, axis=-1) \
+    return (
+        (-1)**ndim * 1/xp.prod(alphas, axis=-1)
         * xp.prod(xp.exp(alphas * a) - xp.exp(alphas * b), axis=-1)
+    )
 
 
 def genz_malik_1980_f_3_random_args(rng, shape, xp):
@@ -185,7 +190,7 @@ def genz_malik_1980_f_4(x, alphas, xp):
     alphas_reshaped = alphas[None, ...]
     x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return ((1 + xp.sum(alphas_reshaped * x_reshaped, axis=-1))**(-ndim-1))
+    return (1 + xp.sum(alphas_reshaped * x_reshaped, axis=-1))**(-ndim-1)
 
 
 def genz_malik_1980_f_4_exact(a, b, alphas, xp):
@@ -194,8 +199,10 @@ def genz_malik_1980_f_4_exact(a, b, alphas, xp):
     def F(x):
         x_reshaped = xp.reshape(x, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-        return (-1)**ndim/xp.prod(alphas, axis=-1) / (
-            math.factorial(ndim) * (1 + xp.sum(alphas * x_reshaped, axis=-1))
+        return (
+            (-1)**ndim/xp.prod(alphas, axis=-1)
+            / math.factorial(ndim)
+            / (1 + xp.sum(alphas * x_reshaped, axis=-1))
         )
 
     return _eval_indefinite_integral(F, a, b, xp)
@@ -258,13 +265,16 @@ def genz_malik_1980_f_5_exact(a, b, alphas, betas, xp):
     a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
     b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-    return (1/2)**ndim * 1/xp.prod(alphas, axis=-1) \
-        * (math.pi**(ndim/2)) \
+    return (
+        (1/2)**ndim
+        * 1/xp.prod(alphas, axis=-1)
+        * (math.pi**(ndim/2))
         * xp.prod(
             scipy.special.erf(alphas * (betas - a))
             + scipy.special.erf(alphas * (b - betas)),
             axis=-1,
         )
+    )
 
 
 def genz_malik_1980_f_5_random_args(rng, shape, xp):
@@ -272,9 +282,7 @@ def genz_malik_1980_f_5_random_args(rng, shape, xp):
     betas = xp.asarray(rng.random(shape))
 
     difficulty = 21.0
-    normalisation_factors = xp.sqrt(
-        xp.sum(alphas**xp.asarray(2.0), axis=-1)
-    )[..., None]
+    normalisation_factors = xp.sqrt(xp.sum(alphas**xp.asarray(2.0), axis=-1))[..., None]
     alphas = alphas / normalisation_factors * math.sqrt(difficulty)
 
     return alphas, betas
@@ -717,6 +725,13 @@ class TestRules:
             GaussKronrodQuadrature,
             (21,),
         ),
+        (
+            # 1D problem, 2D rule
+            [0],
+            [1],
+            GenzMalikCubature,
+            (2,),
+        )
     ])
     def test_incompatible_dimension_raises_error(self, problem, xp):
         a, b, quadrature, quadrature_args = problem

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -30,7 +30,7 @@ def basic_1d_integrand(x, n):
     x_reshaped = xp.reshape(x, (-1, 1, 1))
     n_reshaped = xp.reshape(n, (1, -1, 1))
 
-    return xp.pow(x_reshaped, n_reshaped)
+    return x_reshaped**n_reshaped
 
 
 def basic_1d_integrand_exact(n):
@@ -41,7 +41,7 @@ def basic_1d_integrand_exact(n):
 def basic_nd_integrand(x, n):
     xp = array_namespace(x, n)
 
-    return xp.pow(xp.reshape(xp.sum(x, axis=-1), (-1, 1)), xp.reshape(n, (1, -1)))
+    return xp.reshape(xp.sum(x, axis=-1), (-1, 1))**xp.reshape(n, (1, -1))
 
 
 def basic_nd_integrand_exact(n):
@@ -129,8 +129,8 @@ def genz_malik_1980_f_2_random_args(rng, shape, xp):
     betas = xp.asarray(rng.random(shape))
 
     difficulty = 25.0
-    products = xp.prod(xp.pow(alphas, xp.asarray(-2.0)), axis=-1)
-    normalisation_factors = xp.pow(products, xp.asarray(1 / (2*ndim)))[..., xp.newaxis]
+    products = xp.prod(alphas**xp.asarray(-2.0), axis=-1)
+    normalisation_factors = (products**xp.asarray(1 / (2*ndim)))[..., xp.newaxis]
     alphas = alphas \
         * normalisation_factors \
         / math.pow(difficulty, 1 / (2*ndim))
@@ -287,7 +287,7 @@ def genz_malik_1980_f_5_random_args(rng, shape, xp):
 
     difficulty = 21.0
     normalisation_factors = xp.sqrt(
-        xp.sum(xp.pow(alphas, xp.asarray(2.0)), axis=-1)
+        xp.sum(alphas**xp.asarray(2.0), axis=-1)
     )[..., xp.newaxis]
     alphas = alphas / normalisation_factors * math.sqrt(difficulty)
 
@@ -774,7 +774,7 @@ class TestRulesQuadrature:
             x_reshaped = xp.reshape(x, (-1, 1, 1))
             n_reshaped = xp.reshape(n, (1, -1, 1))
 
-            return xp.pow(x_reshaped, n_reshaped)
+            return x_reshaped**n_reshaped
 
         a = xp.asarray([0])
         b = xp.asarray([2])

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -57,30 +57,33 @@ def genz_malik_1980_f_1(x, r, alphas):
         genzMalik1980f1[x_List, r_, alphas_List] := Cos[2*Pi*r + Total[x*alphas]]
     """
 
+    xp = array_namespace(x, r, alphas)
     npoints, ndim = x.shape[0], x.shape[-1]
 
-    alphas_reshaped = alphas[np.newaxis, :]
-    x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    alphas_reshaped = alphas[xp.newaxis, ...]
+    x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return np.cos(2*np.pi*r + np.sum(alphas_reshaped * x_reshaped, axis=-1))
+    return xp.cos(2*math.pi*r + xp.sum(alphas_reshaped * x_reshaped, axis=-1))
 
 
 def genz_malik_1980_f_1_exact(a, b, r, alphas):
+    xp = array_namespace(a, b, r, alphas)
+
     ndim = a.size
-    a = np.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
-    b = np.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
+    a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
+    b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-    return (-2)**ndim * 1/np.prod(alphas, axis=-1) \
-        * np.cos(2*math.pi*r + np.sum(alphas * (a+b) * 0.5, axis=-1)) \
-        * np.prod(np.sin(alphas * (a-b)/2), axis=-1)
+    return (-2)**ndim * 1/xp.prod(alphas, axis=-1) \
+        * xp.cos(2*math.pi*r + xp.sum(alphas * (a+b) * 0.5, axis=-1)) \
+        * xp.prod(xp.sin(alphas * (a-b)/2), axis=-1)
 
 
-def genz_malik_1980_f_1_random_args(shape):
-    r = np.random.rand(*shape[:-1])
-    alphas = np.random.rand(*shape)
+def genz_malik_1980_f_1_random_args(rng, shape, xp):
+    r = xp.asarray(rng.random(shape[:-1]))
+    alphas = xp.asarray(rng.random(shape))
 
     difficulty = 9
-    normalisation_factors = np.expand_dims(np.sum(alphas, axis=-1), -1)
+    normalisation_factors = xp.expand_dims(xp.sum(alphas, axis=-1), axis=-1)
     alphas = difficulty * alphas / normalisation_factors
 
     return (r, alphas)
@@ -95,46 +98,44 @@ def genz_malik_1980_f_2(x, alphas, betas):
         genzMalik1980f2[x_List, alphas_List, betas_List] :=
             1/Times @@ ((alphas^2 + (x - betas)^2))
     """
+    xp = array_namespace(x, alphas, betas)
     npoints, ndim = x.shape[0], x.shape[-1]
 
-    alphas_reshaped = alphas[np.newaxis, :]
-    betas_reshaped = betas[np.newaxis, :]
+    alphas_reshaped = alphas[xp.newaxis, ...]
+    betas_reshaped = betas[xp.newaxis, ...]
 
-    x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return 1/np.prod(alphas_reshaped**2 + (x_reshaped-betas_reshaped)**2, axis=-1)
+    return 1/xp.prod(alphas_reshaped**2 + (x_reshaped-betas_reshaped)**2, axis=-1)
 
 
 def genz_malik_1980_f_2_exact(a, b, alphas, betas):
-    ndim = a.size
-    a = np.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
-    b = np.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
+    xp = array_namespace(a, b, alphas, betas)
 
-    return (-1)**ndim * 1/np.prod(alphas, axis=-1) \
-        * np.prod(
-            np.arctan((a - betas)/alphas) - np.arctan((b - betas)/alphas),
+    ndim = a.size
+    a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
+    b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
+
+    return (-1)**ndim * 1/xp.prod(alphas, axis=-1) \
+        * xp.prod(
+            xp.atan((a - betas)/alphas) - xp.atan((b - betas)/alphas),
             axis=-1
         )
 
 
-def genz_malik_1980_f_2_random_args(shape):
+def genz_malik_1980_f_2_random_args(rng, shape, xp):
     ndim = shape[-1]
-    alphas = np.random.rand(*shape)
-    betas = np.random.rand(*shape)
+    alphas = xp.asarray(rng.random(shape))
+    betas = xp.asarray(rng.random(shape))
 
     difficulty = 25.0
-    products = np.prod(np.power(alphas, -2), axis=-1)
-    normalisation_factors = np.expand_dims(np.power(products, 1 / (2*ndim)), axis=-1)
+    products = xp.prod(xp.pow(alphas, xp.asarray(-2.0)), axis=-1)
+    normalisation_factors = xp.expand_dims(
+        xp.pow(products, xp.asarray(1 / (2*ndim))), axis=-1
+    )
     alphas = alphas \
         * normalisation_factors \
-        / np.power(difficulty, 1 / (2*ndim))
-
-    xp_assert_close(
-        np.prod(np.power(alphas, -2), axis=-1),
-        difficulty,
-        check_shape=False,
-        check_0d=False,
-    )
+        / math.pow(difficulty, 1 / (2*ndim))
 
     # Adjust alphas from distribution used in Genz and Malik 1980 since denominator
     # is very small for high dimensions.
@@ -152,27 +153,30 @@ def genz_malik_1980_f_3(x, alphas):
         genzMalik1980f3[x_List, alphas_List] := Exp[Dot[x, alphas]]
     """
 
+    xp = array_namespace(x, alphas)
     npoints, ndim = x.shape[0], x.shape[-1]
 
-    alphas_reshaped = alphas[np.newaxis, :]
-    x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    alphas_reshaped = alphas[xp.newaxis, ...]
+    x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return np.exp(np.sum(alphas_reshaped * x_reshaped, axis=-1))
+    return xp.exp(xp.sum(alphas_reshaped * x_reshaped, axis=-1))
 
 
 def genz_malik_1980_f_3_exact(a, b, alphas):
-    ndim = len(a)
-    a = a.reshape(*([1]*(len(alphas.shape) - 1)), ndim)
-    b = b.reshape(*([1]*(len(alphas.shape) - 1)), ndim)
+    xp = array_namespace(a, b, alphas)
 
-    return (-1)**ndim * 1/np.prod(alphas, axis=-1) \
-        * np.prod(np.exp(alphas * a) - np.exp(alphas * b), axis=-1)
+    ndim = a.size
+    a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
+    b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
+
+    return (-1)**ndim * 1/xp.prod(alphas, axis=-1) \
+        * xp.prod(xp.exp(alphas * a) - xp.exp(alphas * b), axis=-1)
 
 
-def genz_malik_1980_f_3_random_args(shape):
-    alphas = np.random.rand(*shape)
-    normalisation_factors = np.expand_dims(np.sum(alphas, axis=-1), -1)
-    difficulty = 12
+def genz_malik_1980_f_3_random_args(rng, shape, xp):
+    alphas = xp.asarray(rng.random(shape))
+    normalisation_factors = xp.expand_dims(xp.sum(alphas, axis=-1), axis=-1)
+    difficulty = 12.0
     alphas = difficulty * alphas / normalisation_factors
 
     return (alphas,)
@@ -187,22 +191,24 @@ def genz_malik_1980_f_4(x, alphas):
             (1 + Dot[x, alphas])^(-Length[alphas] - 1)
     """
 
+    xp = array_namespace(x, alphas)
     npoints, ndim = x.shape[0], x.shape[-1]
 
-    alphas_reshaped = alphas[np.newaxis, :]
-    x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    alphas_reshaped = alphas[xp.newaxis, ...]
+    x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return ((1 + np.sum(alphas_reshaped * x_reshaped, axis=-1))**(-ndim-1))
+    return ((1 + xp.sum(alphas_reshaped * x_reshaped, axis=-1))**(-ndim-1))
 
 
 def genz_malik_1980_f_4_exact(a, b, alphas):
-    ndim = len(a)
+    xp = array_namespace(a, b, alphas)
+    ndim = a.size
 
     def F(x):
-        x_reshaped = x.reshape(*([1]*(len(alphas.shape) - 1)), ndim)
+        x_reshaped = xp.reshape(x, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-        return (-1)**ndim/np.prod(alphas, axis=-1) / (
-            math.factorial(ndim) * (1 + np.sum(alphas * x_reshaped, axis=-1))
+        return (-1)**ndim/xp.prod(alphas, axis=-1) / (
+            math.factorial(ndim) * (1 + xp.sum(alphas * x_reshaped, axis=-1))
         )
 
     return _eval_indefinite_integral(F, a, b)
@@ -214,23 +220,25 @@ def _eval_indefinite_integral(F, a, b):
     of the corresponding hyperrectangle.
     """
 
-    ndim = len(a)
-    points = np.stack([a, b], axis=0)
+    xp = array_namespace(a, b)
+    ndim = a.size
+    points = xp.stack([a, b], axis=0)
 
     out = 0
     for ind in itertools.product(range(2), repeat=ndim):
-        out += pow(-1, sum(ind) + ndim) * F(points[ind, tuple(range(ndim))])
+        selected_points = xp.asarray([points[i, j] for i, j in zip(ind, range(ndim))])
+        out += pow(-1, sum(ind) + ndim) * F(selected_points)
 
     return out
 
 
-def genz_malik_1980_f_4_random_args(shape):
+def genz_malik_1980_f_4_random_args(rng, shape, xp):
     ndim = shape[-1]
 
-    alphas = np.random.rand(*shape)
-    normalisation_factors = np.expand_dims(np.sum(alphas, axis=-1), -1)
-    difficulty = 14
-    alphas = (difficulty/ndim) * alphas / normalisation_factors
+    alphas = xp.asarray(rng.random(shape))
+    normalisation_factors = xp.expand_dims(xp.sum(alphas, axis=-1), axis=-1)
+    difficulty = 14.0
+    alphas = (difficulty / ndim) * alphas / normalisation_factors
 
     return (alphas,)
 
@@ -247,45 +255,49 @@ def genz_malik_1980_f_5(x, alphas, betas):
             Exp[-Total[alphas^2 * (x - betas)^2]]
     """
 
+    xp = array_namespace(x, alphas, betas)
     npoints, ndim = x.shape[0], x.shape[-1]
 
-    alphas_reshaped = alphas[np.newaxis, :]
-    betas_reshaped = betas[np.newaxis, :]
+    alphas_reshaped = alphas[xp.newaxis, ...]
+    betas_reshaped = betas[xp.newaxis, ...]
 
-    x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    x_reshaped = xp.reshape(x, (npoints, *([1]*(len(alphas.shape) - 1)), ndim))
 
-    return np.exp(
-        -np.sum(alphas_reshaped**2 * (x_reshaped - betas_reshaped)**2, axis=-1)
+    return xp.exp(
+        -xp.sum(alphas_reshaped**2 * (x_reshaped - betas_reshaped)**2, axis=-1)
     )
 
 
 def genz_malik_1980_f_5_exact(a, b, alphas, betas):
-    ndim = len(a)
-    a = a.reshape(*([1]*(len(alphas.shape) - 1)), ndim)
-    b = b.reshape(*([1]*(len(alphas.shape) - 1)), ndim)
+    xp = array_namespace(a, b, alphas, betas)
+    ndim = a.size
+    a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
+    b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
-    return (1/2)**ndim * 1/np.prod(alphas, axis=-1) \
-        * np.power(np.pi, ndim/2) \
-        * np.prod(
+    return (1/2)**ndim * 1/xp.prod(alphas, axis=-1) \
+        * (math.pi**(ndim/2)) \
+        * xp.prod(
             scipy.special.erf(alphas * (betas - a))
             + scipy.special.erf(alphas * (b - betas)),
-            axis=-1
+            axis=-1,
         )
 
 
-def genz_malik_1980_f_5_random_args(shape):
-    alphas = np.random.rand(*shape)
-    betas = np.random.rand(*shape)
+def genz_malik_1980_f_5_random_args(rng, shape, xp):
+    alphas = xp.asarray(rng.random(shape))
+    betas = xp.asarray(rng.random(shape))
 
-    difficulty = 21
-    normalisation_factors = np.expand_dims(
-        np.sqrt(np.sum(np.power(alphas, 2), axis=-1)), -1
+    difficulty = 21.0
+    normalisation_factors = xp.expand_dims(
+        xp.sqrt(xp.sum(xp.pow(alphas, xp.asarray(2.0)), axis=-1)),
+        axis=-1,
     )
-    alphas = alphas / normalisation_factors * np.sqrt(difficulty)
+    alphas = alphas / normalisation_factors * math.sqrt(difficulty)
 
     return alphas, betas
 
 
+@array_api_compatible
 class TestCubature:
     """
     Tests related to the interface of `cubature`.
@@ -297,10 +309,10 @@ class TestCubature:
         "gk21",
         "gk15",
     ])
-    def test_pass_str(self, rule_str):
-        n = np.arange(5)
-        a = np.asarray([0, 0])
-        b = np.asarray([2, 2])
+    def test_pass_str(self, rule_str, xp):
+        n = xp.arange(5, dtype=xp.float64)
+        a = xp.asarray([0, 0], dtype=xp.float64)
+        b = xp.asarray([2, 2], dtype=xp.float64)
 
         res = cubature(basic_nd_integrand, a, b, rule_str, args=(n,))
 
@@ -311,7 +323,9 @@ class TestCubature:
             atol=0,
         )
 
-    def test_pass_list_not_array(self):
+    def test_pass_list_not_array(self, xp):
+        # By default, cubature will default to using NumPy arrays if ordinary lists are
+        # passed.
         n = np.arange(5)
 
         a = [0]
@@ -331,9 +345,9 @@ class TestCubature:
             atol=0,
         )
 
-    def test_stops_after_max_subdivisions(self):
-        a = np.array([0])
-        b = np.array([1])
+    def test_stops_after_max_subdivisions(self, xp):
+        a = xp.asarray([0])
+        b = xp.asarray([1])
         rule = BadErrorRule()
 
         res = cubature(
@@ -342,15 +356,15 @@ class TestCubature:
             b,
             rule,
             max_subdivisions=10,
-            args=(np.arange(5),),
+            args=(xp.arange(5, dtype=xp.float64),),
         )
 
         assert res.subdivisions == 10
         assert res.status == "not_converged"
 
-    def test_a_and_b_must_be_1d(self):
-        a = np.array([[0]])
-        b = np.array([[1]])
+    def test_a_and_b_must_be_1d(self, xp):
+        a = xp.asarray([[0]], dtype=xp.float64)
+        b = xp.asarray([[1]], dtype=xp.float64)
 
         with pytest.raises(Exception, match="`a` and `b` must be 1D arrays"):
             cubature(basic_1d_integrand, a, b)
@@ -363,6 +377,7 @@ class TestCubature:
     "gk21",
     "genz-malik",
 ])
+@array_api_compatible
 class TestCubatureProblems:
     """
     Tests that `cubature` gives the correct answer.
@@ -378,45 +393,45 @@ class TestCubatureProblems:
             genz_malik_1980_f_1_exact,
 
             # Coordinates of `a`
-            np.array([0]),
+            [0],
 
             # Coordinates of `b`
-            np.array([10]),
+            [10],
 
             # Arguments to pass to `f` and `exact`
             (
                 1/4,
-                np.array([5]),
+                [5],
             )
         ),
         (
             genz_malik_1980_f_1,
             genz_malik_1980_f_1_exact,
-            np.array([0, 0]),
-            np.array([1, 1]),
+            [0, 0],
+            [1, 1],
             (
                 1/4,
-                np.array([2, 4]),
+                [2, 4],
             ),
         ),
         (
             genz_malik_1980_f_1,
             genz_malik_1980_f_1_exact,
-            np.array([0, 0]),
-            np.array([5, 5]),
+            [0, 0],
+            [5, 5],
             (
                 1/2,
-                np.array([2, 4]),
+                [2, 4],
             )
         ),
         (
             genz_malik_1980_f_1,
             genz_malik_1980_f_1_exact,
-            np.array([0, 0, 0]),
-            np.array([10, 10, 10]),
+            [0, 0, 0],
+            [10, 10, 10],
             (
                 1/2,
-                np.array([1, 1, 1]),
+                [1, 1, 1],
             )
         ),
 
@@ -424,62 +439,62 @@ class TestCubatureProblems:
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
-            np.array([-1]),
-            np.array([1]),
+            [-1],
+            [1],
             (
-                np.array([5]),
-                np.array([4]),
+                [5],
+                [4],
             )
         ),
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
 
-            np.array([10, 50]),
-            np.array([10, 50]),
+            [10, 50],
+            [10, 50],
             (
-                np.array([-3, 3]),
-                np.array([-2, 2])
+                [-3, 3],
+                [-2, 2],
             ),
         ),
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
-            np.array([0, 0, 0]),
-            np.array([1, 1, 1]),
+            [0, 0, 0],
+            [1, 1, 1],
             (
-                np.array([1, 1, 1]),
-                np.array([1, 1, 1]),
+                [1, 1, 1],
+                [1, 1, 1],
             )
         ),
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
-            np.array([0, 0, 0]),
-            np.array([1, 1, 1]),
+            [0, 0, 0],
+            [1, 1, 1],
             (
-                np.array([2, 3, 4]),
-                np.array([2, 3, 4]),
+                [2, 3, 4],
+                [2, 3, 4],
             )
         ),
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
-            np.array([-1, -1, -1]),
-            np.array([1, 1, 1]),
+            [-1, -1, -1],
+            [1, 1, 1],
             (
-                np.array([1, 1, 1]),
-                np.array([2, 2, 2]),
+                [1, 1, 1],
+                [2, 2, 2],
             )
         ),
         (
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
+            [-1, -1, -1, -1],
+            [1, 1, 1, 1],
             (
-                np.array([1, 1, 1, 1]),
-                np.array([1, 1, 1, 1]),
+                [1, 1, 1, 1],
+                [1, 1, 1, 1],
             )
         ),
 
@@ -487,28 +502,28 @@ class TestCubatureProblems:
         (
             genz_malik_1980_f_3,
             genz_malik_1980_f_3_exact,
-            np.array([-1]),
-            np.array([1]),
+            [-1],
+            [1],
             (
-                np.array([1/2]),
+                [1/2],
             ),
         ),
         (
             genz_malik_1980_f_3,
             genz_malik_1980_f_3_exact,
-            np.array([0, -1]),
-            np.array([1, 1]),
+            [0, -1],
+            [1, 1],
             (
-                np.array([5, 5]),
+                [5, 5],
             ),
         ),
         (
             genz_malik_1980_f_3,
             genz_malik_1980_f_3_exact,
-            np.array([-1, -1, -1]),
-            np.array([1, 1, 1]),
+            [-1, -1, -1],
+            [1, 1, 1],
             (
-                np.array([1, 1, 1]),
+                [1, 1, 1],
             ),
         ),
 
@@ -516,66 +531,66 @@ class TestCubatureProblems:
         (
             genz_malik_1980_f_4,
             genz_malik_1980_f_4_exact,
-            np.array([0]),
-            np.array([2]),
+            [0],
+            [2],
             (
-                np.array([1]),
+                [1],
             ),
         ),
         (
             genz_malik_1980_f_4,
             genz_malik_1980_f_4_exact,
-            np.array([0, 0]),
-            np.array([2, 1]),
-            (np.array([1, 1]),),
+            [0, 0],
+            [2, 1],
+            ([1, 1],),
         ),
         (
             genz_malik_1980_f_4,
             genz_malik_1980_f_4_exact,
-            np.array([0, 0, 0]),
-            np.array([1, 1, 1]),
-            (np.array([1, 1, 1]),),
+            [0, 0, 0],
+            [1, 1, 1],
+            ([1, 1, 1],),
         ),
 
         # -- f5 --
         (
             genz_malik_1980_f_5,
             genz_malik_1980_f_5_exact,
-            np.array([-1]),
-            np.array([1]),
+            [-1],
+            [1],
             (
-                np.array([-2]),
-                np.array([2]),
+                [-2],
+                [2],
             ),
         ),
         (
             genz_malik_1980_f_5,
             genz_malik_1980_f_5_exact,
-            np.array([-1, -1]),
-            np.array([1, 1]),
+            [-1, -1],
+            [1, 1],
             (
-                np.array([2, 3]),
-                np.array([4, 5]),
+                [2, 3],
+                [4, 5],
             ),
         ),
         (
             genz_malik_1980_f_5,
             genz_malik_1980_f_5_exact,
-            np.array([-1, -1]),
-            np.array([1, 1]),
+            [-1, -1],
+            [1, 1],
             (
-                np.array([-1, 1]),
-                np.array([0, 0]),
+                [-1, 1],
+                [0, 0],
             ),
         ),
         (
             genz_malik_1980_f_5,
             genz_malik_1980_f_5_exact,
-            np.array([-1, -1, -1]),
-            np.array([1, 1, 1]),
+            [-1, -1, -1],
+            [1, 1, 1],
             (
-                np.array([1, 1, 1]),
-                np.array([1, 1, 1]),
+                [1, 1, 1],
+                [1, 1, 1],
             ),
         ),
     ]
@@ -614,10 +629,14 @@ class TestCubatureProblems:
     ]
 
     @pytest.mark.parametrize("problem", problems_scalar_output)
-    def test_scalar_output(self, problem, rule, rtol, atol):
+    def test_scalar_output(self, problem, rule, rtol, atol, xp):
         f, exact, a, b, args = problem
 
-        ndim = len(a)
+        a = xp.asarray(a, dtype=xp.float64)
+        b = xp.asarray(b, dtype=xp.float64)
+        args = tuple(xp.asarray(arg, dtype=xp.float64) for arg in args)
+
+        ndim = a.size
 
         if rule == "genz-malik" and ndim < 2:
             pytest.skip("Genz-Malik cubature does not support 1D integrals")
@@ -657,8 +676,8 @@ class TestCubatureProblems:
         (3, 4, 2),
         (2, 1, 3),
     ])
-    def test_array_output(self, problem, rule, shape, rtol, atol):
-        np.random.seed(1)
+    def test_array_output(self, problem, rule, shape, rtol, atol, xp):
+        rng = np.random.default_rng(1)
         ndim = shape[-1]
 
         if rule == "genz-malik" and ndim < 2:
@@ -668,10 +687,10 @@ class TestCubatureProblems:
             pytest.mark.slow("Gauss-Kronrod is slow in >= 5 dim")
 
         f, exact, random_args = problem
-        args = random_args(shape)
+        args = random_args(rng, shape, xp)
 
-        a = np.array([0] * ndim)
-        b = np.array([1] * ndim)
+        a = xp.asarray([0] * ndim, dtype=xp.float64)
+        b = xp.asarray([1] * ndim, dtype=xp.float64)
 
         res = cubature(
             f,
@@ -696,7 +715,7 @@ class TestCubatureProblems:
 
         err_msg = (f"estimate_error={res.error}, "
                    f"subdivisions= {res.subdivisions}, "
-                   f"true_error={np.abs(res.estimate - exact(a, b, *args))}")
+                   f"true_error={xp.abs(res.estimate - exact(a, b, *args))}")
         assert res.status == "converged", err_msg
 
         assert res.estimate.shape == shape[:-1]
@@ -711,25 +730,18 @@ class TestRules:
     @pytest.mark.parametrize("problem", [
         (
             # 2D problem, 1D rule
-            np.array([0, 0]),
-            np.array([1, 1]),
-            GaussKronrodQuadrature(21),
-        ),
-        (
-            # 2D problem, 1D rule
-            np.array([0, 0]),
-            np.array([1, 1]),
-            NestedFixedRule(GaussKronrodQuadrature(21), GaussKronrodQuadrature(21)),
-        ),
-        (
-            # 1D problem, 2D rule
-            np.array([0]),
-            np.array([1]),
-            GenzMalikCubature(2),
+            [0, 0],
+            [1, 1],
+            GaussKronrodQuadrature,
+            (21,),
         ),
     ])
     def test_incompatible_dimension_raises_error(self, problem, xp):
-        a, b, rule = problem
+        a, b, quadrature, quadrature_args = problem
+        rule = quadrature(*quadrature_args, xp=xp)
+
+        a = xp.asarray(a, dtype=xp.float64)
+        b = xp.asarray(b, dtype=xp.float64)
 
         with pytest.raises(Exception, match="incompatible dimension"):
             rule.estimate(basic_1d_integrand, a, b)
@@ -786,8 +798,8 @@ class TestRulesQuadrature:
     def test_base_1d_quadratures_error_from_difference(self, rule_pair, rule_pair_args,
                                                        xp):
         n = xp.arange(5, dtype=xp.float64)
-        a = xp.asarray([0])
-        b = xp.asarray([2])
+        a = xp.asarray([0], dtype=xp.float64)
+        b = xp.asarray([2], dtype=xp.float64)
 
         higher = rule_pair[0](rule_pair_args[0], xp=xp)
         lower = rule_pair[1](rule_pair_args[1], xp=xp)
@@ -849,4 +861,5 @@ class BadErrorRule(Rule):
         return underlying.estimate(f, a, b, args)
 
     def estimate_error(self, f, a, b, args=()):
-        return 1e6
+        xp = array_namespace(a, b)
+        return xp.asarray(1e6, dtype=xp.float64)

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -107,9 +107,12 @@ def genz_malik_1980_f_2_exact(a, b, alphas, betas, xp):
     a = xp.reshape(a, (*([1]*(len(alphas.shape) - 1)), ndim))
     b = xp.reshape(b, (*([1]*(len(alphas.shape) - 1)), ndim))
 
+    # `xp` is the unwrapped namespace, so `.atan` won't work for `xp = np` and np<2.
+    xp_test = array_namespace(a)
+
     return (-1)**ndim * 1/xp.prod(alphas, axis=-1) \
         * xp.prod(
-            xp.atan((a - betas)/alphas) - xp.atan((b - betas)/alphas),
+            xp_test.atan((a - betas)/alphas) - xp_test.atan((b - betas)/alphas),
             axis=-1
         )
 


### PR DESCRIPTION
#### Reference issue
Builds on #21330 , towards gh-20930.

#### What does this implement/fix?
This adds support for the array API in `scipy.integrate.cubature` (currently in the open PR #21330). This means that functions returning arrays from any array API-compatible library can be used. The corresponding tests have been updated using the `@array_api_compatible` decorator.

#### Additional information
There are a few places where `np` is still used, such as in `integrate/_rules/_base.py::_subregion_coordinates`. Once CI shows whether the current changes work with other array APIs, I'll address these.

The first PR also introduced a (private) rules API, which allows different integration rules to be used with `cubature`. Rules need to know the correct array namespace to generate nodes and weights in, so these have been updated to accept an additional `xp` parameter on initialisation. This defaults to `np` if not set by the user. This is only a concern when using the rules API directly rather than using `cubature`, since `cubature` knows the array namespace being used by looking at the integration endpoints.

#### Acknowledgements
Thanks to @ev-br and @lucascolley for help with array API support.