### PR TITLE
DOC: use `https` URLs in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
 <!-- 
 Thanks for contributing a pull request! Please ensure that
 your PR satisfies the checklist before submitting:
-http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr
+https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr
 
 Also, please name and describe your PR as you would write a
 commit message:
-http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
+https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
 However, please only include an issue number in the description, not the title,
 and please ensure that any code names containing underscores are enclosed in backticks.
 
 Depending on your changes, you can skip CI operations and save time and energy: 
-http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping
+https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping
 
 Note that we are a team of volunteers; we appreciate your
 patience during the review process.


### PR DESCRIPTION
#### What does this implement/fix?
This converts the URLs in the pull request template to use HTTPS rather than HTTP. Previously they pointed to <http://scipy.github.io> rather than <https://scipy.github.io>.