### PR TITLE
DOC: Fix version matching by extending the length of `GITVER`

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,7 +53,7 @@ clean:
 UPLOAD_DIR=/srv/docs_scipy_org/doc/scipy-$(RELEASE)
 
 SCIPYVER:=$(shell $(PYTHON) -c "import scipy; print(scipy.version.git_revision[:10])" 2>/dev/null)
-GITVER ?= $(shell (cd ..; set -o pipefail && git rev-parse HEAD 2>/dev/null | cut -c1-7) || echo Unknown)
+GITVER ?= $(shell (cd ..; set -o pipefail && git rev-parse HEAD 2>/dev/null | cut -c1-10) || echo Unknown)
 
 version-check:
 ifeq "$(GITVER)" "Unknown"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Fixes the following which happens on the `main` branch,

```zsh
(scipy-dev) 23:28:13:~/Quansight/scipy % python dev.py --no-build doc -j8
Skipping build
installed scipy 959d8da31d != current repo git version '149f9fd'
use "make dist" or "GITVER=959d8da31d make html ..."
make: *** [version-check] Error 1
```

#### Additional information
<!--Any additional information you think is important.-->
