### PR TITLE
MAINT/DEV: pin sphinx in `environment.yml`, bump `jupyterlite-sphinx`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - typing_extensions
   - types-psutil
   # For building docs
-  - sphinx
+  - sphinx<8.0.0
   - intersphinx-registry
   - numpydoc
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - sphinx-design
   - jupytext
   - myst-nb
-  - jupyterlite-sphinx>=0.13.1
+  - jupyterlite-sphinx>=0.16.5
   - jupyterlite-pyodide-kernel
   # Some optional test dependencies
   - mpmath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ doc = [
     "jupytext",
     "myst-nb",
     "pooch",
-    "jupyterlite-sphinx>=0.16.2",
+    "jupyterlite-sphinx>=0.16.5",
     "jupyterlite-pyodide-kernel",
 ]
 dev = [

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,5 +10,5 @@ numpydoc
 jupytext
 myst-nb
 pooch
-jupyterlite-sphinx>=0.16.2
+jupyterlite-sphinx>=0.16.5
 jupyterlite-pyodide-kernel


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
gh-21324 for `environment.yml` too. @agriyakhetarpal how are we looking for removing these pins after https://github.com/jupyterlite/jupyterlite-sphinx/pull/201 ?

#### Additional information
@gertingold bumped into this at the EuroSciPy 2024 sprint!