### PR TITLE
MAINT: Specify SHELL=/bin/bash in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,6 +52,8 @@ clean:
 
 UPLOAD_DIR=/srv/docs_scipy_org/doc/scipy-$(RELEASE)
 
+# `set -o pipefail` is specific to bash
+SHELL = /bin/bash
 SCIPYVER:=$(shell $(PYTHON) -c "import scipy; print(scipy.version.git_revision[:10])" 2>/dev/null)
 GITVER ?= $(shell (cd ..; set -o pipefail && git rev-parse HEAD 2>/dev/null | cut -c1-10) || echo Unknown)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/21460

#### What does this implement/fix?
Adds a `SHELL=/bin/bash` to make sure that `set -o pipefail` works.

#### Additional information
It's slightly weird to have a bash specific command in the Makefile, but it should be okay given that most development environments have `/bin/bash`.