### PR TITLE
MAINT: Check for all submodule paths in `check_installation`

### DIFF
--- a/tools/check_installation.py
+++ b/tools/check_installation.py
@@ -28,30 +28,18 @@ ROOT_DIR = os.path.dirname(CUR_DIR)
 SCIPY_DIR = os.path.join(ROOT_DIR, 'scipy')
 
 
+# Get the submodule paths so that we can ignore any tests in them or their submodules
+with open(os.path.join(ROOT_DIR, '.gitmodules')) as gitmodules:
+    data = gitmodules.read().split('\n')
+    submodule_paths = [datum.split(' = ')[1] for datum in data if \
+                       datum.startswith('\tpath = ')]
+
+
 # Files whose installation path will be different from original one
 changed_installed_path = {
     'scipy/_build_utils/tests/test_scipy_version.py':
         'scipy/_lib/tests/test_scipy_version.py'
 }
-
-# We do not want the following tests to be checked.
-# Note: only 3 subdirs are listed here, due to how `get_test_files` is
-# implemented.
-# If this list gets too annoying, we should implement excluding directories
-# rather than (or in addition to) files.
-exception_list_test_files = [
-    "_lib/array_api_compat/tests/test_all.py",
-    "_lib/array_api_compat/tests/test_array_namespace.py",
-    "_lib/array_api_compat/tests/test_common.py",
-    "_lib/array_api_compat/tests/test_isdtype.py",
-    "_lib/array_api_compat/tests/test_no_dependencies.py",
-    "_lib/array_api_compat/tests/test_vendoring.py",
-    "cobyqa/cobyqa/tests/test_main.py",
-    "cobyqa/cobyqa/tests/test_models.py",
-    "cobyqa/cobyqa/tests/test_problem.py",
-    "cobyqa/utils/tests/test_exceptions.py",
-    "cobyqa/utils/tests/test_math.py",
-]
 
 
 def main(install_dir, no_tests):
@@ -76,9 +64,6 @@ def main(install_dir, no_tests):
 
     # Check test files detected in repo are installed
     for test_file in scipy_test_files.keys():
-        if test_file in exception_list_test_files:
-            continue
-
         if no_tests:
             if test_file in installed_test_files:
                 raise Exception(f"{test_file} should not be installed but "
@@ -120,10 +105,11 @@ def get_test_files(dir, ext="py"):
     test_files = dict()
     underscore = "_" if ext == "so" else ""
     for path in glob.glob(f'{dir}/**/{underscore}test_*.{ext}', recursive=True):
+        if any(submodule_path in path for submodule_path in submodule_paths):
+            continue
         suffix_path = get_suffix_path(path, 3)
         suffix_path = changed_installed_path.get(suffix_path, suffix_path)
-        if "highspy" not in suffix_path:
-            test_files[suffix_path] = path
+        test_files[suffix_path] = path
 
     return test_files
 


### PR DESCRIPTION
As the comment said, the list was getting too annoying, particularly with the number of tests that would have to be ignored due to the prima submodule having pybind11 as a submodule (being added in #20964).

It seemed like the ones we want to ignore are the ones in submodules, since SciPy has no interest in running the tests of its submodules, so I just implemented some code to find and ignore all submodule paths. At first it seemed like there might be a bit of trickery with relative paths, but since CUR_DIR starts as an absolute path, the glob function returns absolute paths and the `submodule_path in path` check works as one would expect.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
N/A

#### What does this implement/fix?
<!--Please explain your changes.-->
See above

#### Additional information
<!--Any additional information you think is important.-->
None
