### PR TITLE
TST: Use pytest-run-parallel against free-threaded CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -452,12 +452,14 @@ jobs:
     needs: get_commit_message
     strategy:
       matrix:
-        parallel: ['0', '1']
+        # Restore once parallel testing passes in CI
+        # parallel: ['0', '1']
+        parallel: ['0']
+
     runs-on: ubuntu-latest
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-      && false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -450,6 +450,9 @@ jobs:
 
   free-threaded:
     needs: get_commit_message
+    strategy:
+      matrix:
+        parallel: ['0', '1']
     runs-on: ubuntu-latest
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -481,6 +484,11 @@ jobs:
         pip install ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
+    - name: Install pytest-run-parallel
+      if: ${{ matrix.parallel == '1'}}
+      run: |
+        pip install git+https://github.com/Quansight-Labs/pytest-run-parallel
+        echo "EXTRA_PYTEST_ARGS=--parallel-threads=10" >> "$GITHUB_ENV"
     - name: Build and run tests
       env:
         PYTHON_GIL: 0
@@ -493,7 +501,7 @@ jobs:
         python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > scipy-openblas.pc
         PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
         pushd $RUNNER_TEMP
-        PYTHON_GIL=0 python -m pytest --pyargs scipy -n2 --durations=10
+        PYTHON_GIL=0 python -m pytest --pyargs scipy -n2 --durations=10 $EXTRA_PYTEST_ARGS
   #################################################################################
   clang-17-build-only:
     # Purpose is to check for warnings in builds with latest clang.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -483,8 +483,8 @@ jobs:
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
     - name: Install Python dependencies
       run: |
-        pip install git+https://github.com/serge-sans-paille/pythran
-        pip install ninja meson-python pybind11 click rich_click pydevtool
+        # pip install git+https://github.com/serge-sans-paille/pythran
+        pip install pythran ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
         echo "N_TEST_WORKERS=2" >> "$GITHUB_ENV"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -484,11 +484,13 @@ jobs:
         pip install ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
+        echo "N_TEST_WORKERS=2" >> "$GITHUB_ENV"
     - name: Install pytest-run-parallel
       if: ${{ matrix.parallel == '1'}}
       run: |
         pip install pytest-run-parallel
         echo "EXTRA_PYTEST_ARGS=--parallel-threads=5" >> "$GITHUB_ENV"
+        echo "N_TEST_WORKERS=1" >> "$GITHUB_ENV"
     - name: Build and run tests
       env:
         PYTHON_GIL: 0
@@ -501,7 +503,7 @@ jobs:
         python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > scipy-openblas.pc
         PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
         pushd $RUNNER_TEMP
-        PYTHON_GIL=0 python -m pytest --pyargs scipy -n1 --durations=10 $EXTRA_PYTEST_ARGS
+        PYTHON_GIL=0 python -m pytest --pyargs scipy -n$N_TEST_WORKERS --durations=10 $EXTRA_PYTEST_ARGS
   #################################################################################
   clang-17-build-only:
     # Purpose is to check for warnings in builds with latest clang.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -483,7 +483,6 @@ jobs:
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
     - name: Install Python dependencies
       run: |
-        # pip install git+https://github.com/serge-sans-paille/pythran
         pip install pythran ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -487,8 +487,8 @@ jobs:
     - name: Install pytest-run-parallel
       if: ${{ matrix.parallel == '1'}}
       run: |
-        pip install git+https://github.com/Quansight-Labs/pytest-run-parallel
-        echo "EXTRA_PYTEST_ARGS=--parallel-threads=10" >> "$GITHUB_ENV"
+        pip install pytest-run-parallel
+        echo "EXTRA_PYTEST_ARGS=--parallel-threads=5" >> "$GITHUB_ENV"
     - name: Build and run tests
       env:
         PYTHON_GIL: 0
@@ -501,7 +501,7 @@ jobs:
         python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > scipy-openblas.pc
         PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
         pushd $RUNNER_TEMP
-        PYTHON_GIL=0 python -m pytest --pyargs scipy -n2 --durations=10 $EXTRA_PYTEST_ARGS
+        PYTHON_GIL=0 python -m pytest --pyargs scipy -n1 --durations=10 $EXTRA_PYTEST_ARGS
   #################################################################################
   clang-17-build-only:
     # Purpose is to check for warnings in builds with latest clang.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -457,6 +457,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
+      && false
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -284,6 +284,9 @@ def _test_cython_extension(tmp_path, srcdir):
     except FileNotFoundError:
         pytest.skip("No usable 'meson' found")
 
+    # Make safe for being called by multiple threads within one test
+    tmp_path = tmp_path / str(threading.get_ident())
+
     # build the examples in a temporary directory
     mod_name = os.path.split(srcdir)[1]
     shutil.copytree(srcdir, tmp_path / mod_name)

--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -6,6 +6,7 @@ from . import _uarray
 import copyreg
 import pickle
 import contextlib
+import threading
 
 from ._uarray import (  # type: ignore
     BackendNotImplementedError,
@@ -266,15 +267,16 @@ def set_backend(backend, coerce=False, only=False):
     skip_backend: A context manager that allows skipping of backends.
     set_global_backend: Set a single, global backend for a domain.
     """
+    tid = threading.get_native_id()
     try:
-        return backend.__ua_cache__["set", coerce, only]
+        return backend.__ua_cache__[tid, "set", coerce, only]
     except AttributeError:
         backend.__ua_cache__ = {}
     except KeyError:
         pass
 
     ctx = _SetBackendContext(backend, coerce, only)
-    backend.__ua_cache__["set", coerce, only] = ctx
+    backend.__ua_cache__[tid, "set", coerce, only] = ctx
     return ctx
 
 
@@ -294,15 +296,16 @@ def skip_backend(backend):
     set_backend: A context manager that allows setting of backends.
     set_global_backend: Set a single, global backend for a domain.
     """
+    tid = threading.get_native_id()
     try:
-        return backend.__ua_cache__["skip"]
+        return backend.__ua_cache__[tid, "skip"]
     except AttributeError:
         backend.__ua_cache__ = {}
     except KeyError:
         pass
 
     ctx = _SkipBackendContext(backend)
-    backend.__ua_cache__["skip"] = ctx
+    backend.__ua_cache__[tid, "skip"] = ctx
     return ctx
 
 

--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -175,7 +175,7 @@ def generate_multimethod(
     argument_extractor: ArgumentExtractorType,
     argument_replacer: ArgumentReplacerType,
     domain: str,
-    default: typing.Optional[typing.Callable] = None,
+    default: typing.Callable | None = None,
 ):
     """
     Generates a multimethod.

--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -1,6 +1,7 @@
 """ Test for assert_deallocated context manager and gc utilities
 """
 import gc
+from threading import Lock
 
 from scipy._lib._gcutils import (set_gc_state, gc_state, assert_deallocated,
                                  ReferenceError, IS_PYPY)
@@ -10,59 +11,67 @@ from numpy.testing import assert_equal
 import pytest
 
 
-def test_set_gc_state():
-    gc_status = gc.isenabled()
-    try:
-        for state in (True, False):
-            gc.enable()
-            set_gc_state(state)
-            assert_equal(gc.isenabled(), state)
-            gc.disable()
-            set_gc_state(state)
-            assert_equal(gc.isenabled(), state)
-    finally:
-        if gc_status:
-            gc.enable()
+@pytest.fixture
+def gc_lock():
+    return Lock()
 
 
-def test_gc_state():
+def test_set_gc_state(gc_lock):
+    with gc_lock:
+        gc_status = gc.isenabled()
+        try:
+            for state in (True, False):
+                gc.enable()
+                set_gc_state(state)
+                assert_equal(gc.isenabled(), state)
+                gc.disable()
+                set_gc_state(state)
+                assert_equal(gc.isenabled(), state)
+        finally:
+            if gc_status:
+                gc.enable()
+
+
+def test_gc_state(gc_lock):
     # Test gc_state context manager
-    gc_status = gc.isenabled()
-    try:
-        for pre_state in (True, False):
-            set_gc_state(pre_state)
-            for with_state in (True, False):
-                # Check the gc state is with_state in with block
-                with gc_state(with_state):
-                    assert_equal(gc.isenabled(), with_state)
-                # And returns to previous state outside block
-                assert_equal(gc.isenabled(), pre_state)
-                # Even if the gc state is set explicitly within the block
-                with gc_state(with_state):
-                    assert_equal(gc.isenabled(), with_state)
-                    set_gc_state(not with_state)
-                assert_equal(gc.isenabled(), pre_state)
-    finally:
-        if gc_status:
-            gc.enable()
+    with gc_lock:
+        gc_status = gc.isenabled()
+        try:
+            for pre_state in (True, False):
+                set_gc_state(pre_state)
+                for with_state in (True, False):
+                    # Check the gc state is with_state in with block
+                    with gc_state(with_state):
+                        assert_equal(gc.isenabled(), with_state)
+                    # And returns to previous state outside block
+                    assert_equal(gc.isenabled(), pre_state)
+                    # Even if the gc state is set explicitly within the block
+                    with gc_state(with_state):
+                        assert_equal(gc.isenabled(), with_state)
+                        set_gc_state(not with_state)
+                    assert_equal(gc.isenabled(), pre_state)
+        finally:
+            if gc_status:
+                gc.enable()
 
 
 @pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
-def test_assert_deallocated():
+def test_assert_deallocated(gc_lock):
     # Ordinary use
     class C:
         def __init__(self, arg0, arg1, name='myname'):
             self.name = name
-    for gc_current in (True, False):
-        with gc_state(gc_current):
-            # We are deleting from with-block context, so that's OK
-            with assert_deallocated(C, 0, 2, 'another name') as c:
-                assert_equal(c.name, 'another name')
-                del c
-            # Or not using the thing in with-block context, also OK
-            with assert_deallocated(C, 0, 2, name='third name'):
-                pass
-            assert_equal(gc.isenabled(), gc_current)
+    with gc_lock:
+        for gc_current in (True, False):
+            with gc_state(gc_current):
+                # We are deleting from with-block context, so that's OK
+                with assert_deallocated(C, 0, 2, 'another name') as c:
+                    assert_equal(c.name, 'another name')
+                    del c
+                # Or not using the thing in with-block context, also OK
+                with assert_deallocated(C, 0, 2, name='third name'):
+                    pass
+                assert_equal(gc.isenabled(), gc_current)
 
 
 @pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -258,14 +258,21 @@ class TestRenameParameter:
         with pytest.raises(TypeError, match=message):
             self.old_keyword_still_accepted(new=10, old=10)
 
-    def test_old_keyword_deprecated(self):
+    @pytest.fixture
+    def kwarg_lock(self):
+        from threading import Lock
+        return Lock()
+
+    def test_old_keyword_deprecated(self, kwarg_lock):
         # positional argument and both keyword work identically,
         # but use of old keyword results in DeprecationWarning
         dep_msg = "Use of keyword argument `old` is deprecated"
         res1 = self.old_keyword_deprecated(10)
         res2 = self.old_keyword_deprecated(new=10)
-        with pytest.warns(DeprecationWarning, match=dep_msg):
-            res3 = self.old_keyword_deprecated(old=10)
+        # pytest warning filter is not thread-safe, enforce serialization
+        with kwarg_lock:
+            with pytest.warns(DeprecationWarning, match=dep_msg):
+                    res3 = self.old_keyword_deprecated(old=10)
         assert res1 == res2 == res3 == 10
 
         # unexpected keyword raises an error
@@ -278,12 +285,15 @@ class TestRenameParameter:
         message = re.escape("old_keyword_deprecated() got multiple")
         with pytest.raises(TypeError, match=message):
             self.old_keyword_deprecated(10, new=10)
-        with pytest.raises(TypeError, match=message), \
-                pytest.warns(DeprecationWarning, match=dep_msg):
-            self.old_keyword_deprecated(10, old=10)
-        with pytest.raises(TypeError, match=message), \
-                pytest.warns(DeprecationWarning, match=dep_msg):
-            self.old_keyword_deprecated(new=10, old=10)
+        with kwarg_lock:
+            with pytest.raises(TypeError, match=message), \
+                    pytest.warns(DeprecationWarning, match=dep_msg):
+                    # breakpoint()
+                    self.old_keyword_deprecated(10, old=10)
+        with kwarg_lock:
+            with pytest.raises(TypeError, match=message), \
+                    pytest.warns(DeprecationWarning, match=dep_msg):
+                    self.old_keyword_deprecated(new=10, old=10)
 
 
 class TestContainsNaNTest:
@@ -423,6 +433,7 @@ class TestLazywhere:
     @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @given(n_arrays=n_arrays, rng_seed=rng_seed, dtype=dtype, p=p, data=data)
+    @pytest.mark.parallel_threads(5)
     def test_basic(self, n_arrays, rng_seed, dtype, p, data, xp):
         mbs = npst.mutually_broadcastable_shapes(num_shapes=n_arrays+1,
                                                  min_side=0)

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -433,7 +433,7 @@ class TestLazywhere:
     @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @given(n_arrays=n_arrays, rng_seed=rng_seed, dtype=dtype, p=p, data=data)
-    @pytest.mark.parallel_threads(5)
+    @pytest.mark.parallel_threads(1)
     def test_basic(self, n_arrays, rng_seed, dtype, p, data, xp):
         mbs = npst.mutually_broadcastable_shapes(num_shapes=n_arrays+1,
                                                  min_side=0)

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -433,7 +433,7 @@ class TestLazywhere:
     @pytest.mark.usefixtures("skip_xp_backends")
     @array_api_compatible
     @given(n_arrays=n_arrays, rng_seed=rng_seed, dtype=dtype, p=p, data=data)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_basic(self, n_arrays, rng_seed, dtype, p, data, xp):
         mbs = npst.mutually_broadcastable_shapes(num_shapes=n_arrays+1,
                                                  min_side=0)

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,6 +1,8 @@
 import pytest
+from threading import Lock
 
 
+@pytest.mark.parallel_threads(1)
 def test_cython_api_deprecation():
     match = ("`scipy._lib._test_deprecation_def.foo_deprecated` "
              "is deprecated, use `foo` instead!\n"

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,6 +1,6 @@
 import pytest
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_cython_api_deprecation():
     match = ("`scipy._lib._test_deprecation_def.foo_deprecated` "
              "is deprecated, use `foo` instead!\n"

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,6 +1,4 @@
 import pytest
-from threading import Lock
-
 
 @pytest.mark.parallel_threads(1)
 def test_cython_api_deprecation():

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -10,6 +10,7 @@ from .test_public_api import PUBLIC_MODULES
 
 @pytest.mark.fail_slow(40)
 @pytest.mark.slow
+@pytest.mark.parallel_threads(1)
 def test_public_modules_importable():
     pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])
             for module in PUBLIC_MODULES]

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -10,7 +10,7 @@ from .test_public_api import PUBLIC_MODULES
 
 @pytest.mark.fail_slow(40)
 @pytest.mark.slow
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_public_modules_importable():
     pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])
             for module in PUBLIC_MODULES]

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -222,7 +222,7 @@ SKIP_LIST = [
 # while attempting to import each discovered package.
 # For now, `ignore_errors` only ignores what is necessary, but this could be expanded -
 # for example, to all errors from private modules or git subpackages - if desired.
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_all_modules_are_expected():
     """
     Test that we don't add anything that looks like a new public module by
@@ -339,7 +339,7 @@ def test_api_importable():
                              f"{module_names}")
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize(("module_name", "correct_module"),
                          [('scipy.constants.codata', None),
                           ('scipy.constants.constants', None),
@@ -465,7 +465,7 @@ def test_private_but_present_deprecation(module_name, correct_module):
         getattr(module, "ekki")
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_misc_doccer_deprecation():
     # gh-18279, gh-17572, gh-17771 noted that deprecation warnings
     # for imports from private modules were misleading.

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -222,6 +222,7 @@ SKIP_LIST = [
 # while attempting to import each discovered package.
 # For now, `ignore_errors` only ignores what is necessary, but this could be expanded -
 # for example, to all errors from private modules or git subpackages - if desired.
+@pytest.mark.parallel_threads(1)
 def test_all_modules_are_expected():
     """
     Test that we don't add anything that looks like a new public module by
@@ -338,6 +339,7 @@ def test_api_importable():
                              f"{module_names}")
 
 
+@pytest.mark.parallel_threads(1)
 @pytest.mark.parametrize(("module_name", "correct_module"),
                          [('scipy.constants.codata', None),
                           ('scipy.constants.constants', None),
@@ -463,6 +465,7 @@ def test_private_but_present_deprecation(module_name, correct_module):
         getattr(module, "ekki")
 
 
+@pytest.mark.parallel_threads(1)
 def test_misc_doccer_deprecation():
     # gh-18279, gh-17572, gh-17771 noted that deprecation warnings
     # for imports from private modules were misleading.

--- a/scipy/_lib/tests/test_tmpdirs.py
+++ b/scipy/_lib/tests/test_tmpdirs.py
@@ -13,7 +13,7 @@ MY_PATH = abspath(__file__)
 MY_DIR = dirname(MY_PATH)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_tempdir():
     with tempdir() as tmpdir:
         fname = pjoin(tmpdir, 'example_file.txt')
@@ -22,7 +22,7 @@ def test_tempdir():
     assert_(not exists(tmpdir))
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_in_tempdir():
     my_cwd = getcwd()
     with in_tempdir() as tmpdir:
@@ -34,7 +34,7 @@ def test_in_tempdir():
     assert_equal(getcwd(), my_cwd)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_given_directory():
     # Test InGivenDirectory
     cwd = getcwd()

--- a/scipy/_lib/tests/test_tmpdirs.py
+++ b/scipy/_lib/tests/test_tmpdirs.py
@@ -6,10 +6,14 @@ from scipy._lib._tmpdirs import tempdir, in_tempdir, in_dir
 
 from numpy.testing import assert_, assert_equal
 
+import pytest
+
+
 MY_PATH = abspath(__file__)
 MY_DIR = dirname(MY_PATH)
 
 
+@pytest.mark.parallel_threads(1)
 def test_tempdir():
     with tempdir() as tmpdir:
         fname = pjoin(tmpdir, 'example_file.txt')
@@ -18,6 +22,7 @@ def test_tempdir():
     assert_(not exists(tmpdir))
 
 
+@pytest.mark.parallel_threads(1)
 def test_in_tempdir():
     my_cwd = getcwd()
     with in_tempdir() as tmpdir:
@@ -29,6 +34,7 @@ def test_in_tempdir():
     assert_equal(getcwd(), my_cwd)
 
 
+@pytest.mark.parallel_threads(1)
 def test_given_directory():
     # Test InGivenDirectory
     cwd = getcwd()

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1017,6 +1017,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     elif y.ndim == 2:
         if (y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0) and
                 xp.all(y >= 0) and np.allclose(y, y.T)):
+            print('----------------------')
             warnings.warn('The symmetric non-negative hollow observation '
                           'matrix looks suspiciously like an uncondensed '
                           'distance matrix',

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1017,7 +1017,6 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     elif y.ndim == 2:
         if (y.shape[0] == y.shape[1] and np.allclose(np.diag(y), 0) and
                 xp.all(y >= 0) and np.allclose(y, y.T)):
-            print('----------------------')
             warnings.warn('The symmetric non-negative hollow observation '
                           'matrix looks suspiciously like an uncondensed '
                           'distance matrix',

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -51,6 +51,8 @@ from scipy.cluster._hierarchy import Heap
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 
+from threading import Lock
+
 from . import hierarchy_test_data
 
 
@@ -1071,20 +1073,26 @@ class TestDendrogram:
                          'leaves_color_list': ['C1', 'C1', 'C0', 'C0', 'C0'],
                          })
 
-    def test_dendrogram_colors(self, xp):
+    @pytest.fixture
+    def dendrogram_lock(self):
+        return Lock()
+
+    def test_dendrogram_colors(self, xp, dendrogram_lock):
         # Tests dendrogram plots with alternate colors
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')
 
-        set_link_color_palette(['c', 'm', 'y', 'k'])
-        R = dendrogram(Z, no_plot=True,
-                       above_threshold_color='g', color_threshold=250)
-        set_link_color_palette(['g', 'r', 'c', 'm', 'y', 'k'])
+        with dendrogram_lock:
+            # Global color palette might be changed concurrently
+            set_link_color_palette(['c', 'm', 'y', 'k'])
+            R = dendrogram(Z, no_plot=True,
+                        above_threshold_color='g', color_threshold=250)
+            set_link_color_palette(['g', 'r', 'c', 'm', 'y', 'k'])
 
-        color_list = R['color_list']
-        assert_equal(color_list, ['c', 'm', 'g', 'g', 'g'])
+            color_list = R['color_list']
+            assert_equal(color_list, ['c', 'm', 'g', 'g', 'g'])
 
-        # reset color palette (global list)
-        set_link_color_palette(None)
+            # reset color palette (global list)
+            set_link_color_palette(None)
 
     def test_dendrogram_leaf_colors_zero_dist(self, xp):
         # tests that the colors of leafs are correct for tree
@@ -1154,6 +1162,7 @@ def calculate_maximum_inconsistencies(Z, R, k=3, xp=np):
     return B
 
 
+@pytest.mark.parallel_threads(1)
 @skip_xp_backends(cpu_only=True)
 def test_unsupported_uncondensed_distance_matrix_linkage_warning(xp):
     assert_warns(ClusterWarning, linkage, xp.asarray([[0, 1], [1, 0]]))

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1162,7 +1162,7 @@ def calculate_maximum_inconsistencies(Z, R, k=3, xp=np):
     return B
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 @skip_xp_backends(cpu_only=True)
 def test_unsupported_uncondensed_distance_matrix_linkage_warning(xp):
     assert_warns(ClusterWarning, linkage, xp.asarray([[0, 1], [1, 0]]))

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -400,7 +400,7 @@ class TestKMean:
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), 2, minit='++', rng=rng)
         xp_assert_close(res, prev_res)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @skip_xp_backends('jax.numpy',
                       reason='jax arrays do not support item assignment')
     def test_kmeans2_kpp_high_dim(self, xp):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -400,6 +400,7 @@ class TestKMean:
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), 2, minit='++', rng=rng)
         xp_assert_close(res, prev_res)
 
+    @pytest.mark.parallel_threads(1)
     @skip_xp_backends('jax.numpy',
                       reason='jax arrays do not support item assignment')
     def test_kmeans2_kpp_high_dim(self, xp):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
     HAVE_SCPDT = False
 
 try:
-    import pytest_run_parallel
+    import pytest_run_parallel  # noqa:F401
     PARALLEL_RUN_AVAILABLE = True
 except Exception:
     PARALLEL_RUN_AVAILABLE = False

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -60,6 +60,10 @@ def pytest_configure(config):
             'markers',
             'parallel_threads(n): run the given test function in parallel '
             'using `n` threads.')
+        config.addinivalue_line(
+            "markers",
+            "thread_unsafe: mark the test function as single-threaded",
+        )
 
 
 def pytest_runtest_setup(item):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -49,6 +49,13 @@ def pytest_configure(config):
         "xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, "
         "exceptions=None): "
         "mark the desired xfail configuration for the `xfail_xp_backends` fixture.")
+    try:
+        import pytest_run_parallel
+    except Exception:
+        config.addinivalue_line(
+            'markers',
+            'parallel_threads(n): run the given test function in parallel '
+            'using `n` threads.')
 
 
 def pytest_runtest_setup(item):
@@ -244,12 +251,12 @@ def xfail_xp_backends(xp, request):
         return
     backends, kwargs = _backends_kwargs_from_request(request, skip_or_xfail='xfail')
     skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='xfail')
-    
+
 
 def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
     """
     Skip based on the ``skip_xp_backends`` or ``xfail_xp_backends`` marker.
-    
+
     See the "Support for the array API standard" docs page for usage examples.
 
     Parameters
@@ -285,7 +292,7 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
     np_only = kwargs.get("np_only", False)
     cpu_only = kwargs.get("cpu_only", False)
     exceptions = kwargs.get("exceptions", [])
-    
+
     if reasons := kwargs.get("reasons"):
         raise ValueError(f"provide a single `reason=` kwarg; got {reasons=} instead")
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -21,6 +21,12 @@ try:
 except ModuleNotFoundError:
     HAVE_SCPDT = False
 
+try:
+    import pytest_run_parallel
+    PARALLEL_RUN_AVAILABLE = True
+except Exception:
+    PARALLEL_RUN_AVAILABLE = False
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers",
@@ -49,9 +55,7 @@ def pytest_configure(config):
         "xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, "
         "exceptions=None): "
         "mark the desired xfail configuration for the `xfail_xp_backends` fixture.")
-    try:
-        import pytest_run_parallel
-    except Exception:
+    if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(
             'markers',
             'parallel_threads(n): run the given test function in parallel '
@@ -120,6 +124,12 @@ def check_fpu_mode(request):
         warnings.warn(f"FPU mode changed from {old_mode:#x} to {new_mode:#x} during "
                       "the test",
                       category=FPUModeChangeWarning, stacklevel=0)
+
+
+if not PARALLEL_RUN_AVAILABLE:
+    @pytest.fixture
+    def num_parallel_threads():
+        return 1
 
 
 # Array API backend handling

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -4,6 +4,7 @@ from scipy.datasets._utils import _clear_cache
 from scipy.datasets import ascent, face, electrocardiogram, download_all
 from numpy.testing import assert_equal, assert_almost_equal
 import os
+from threading import get_ident
 import pytest
 
 try:
@@ -68,7 +69,10 @@ class TestDatasets:
 
 def test_clear_cache(tmp_path):
     # Note: `tmp_path` is a pytest fixture, it handles cleanup
-    dummy_basepath = tmp_path / "dummy_cache_dir"
+    thread_basepath = tmp_path / str(get_ident())
+    thread_basepath.mkdir()
+
+    dummy_basepath = thread_basepath / "dummy_cache_dir"
     dummy_basepath.mkdir()
 
     # Create three dummy dataset files for dummy dataset methods

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -685,6 +685,7 @@ class TestHessian(JacobianHessianTest):
         # assert np.unique(res.nfev).size == 3
 
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.skip_xp_backends(np_only=True,
                                   reason='Python list input uses NumPy backend')
     def test_small_rtol_warning(self, xp):

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -685,7 +685,7 @@ class TestHessian(JacobianHessianTest):
         # assert np.unique(res.nfev).size == 3
 
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.skip_xp_backends(np_only=True,
                                   reason='Python list input uses NumPy backend')
     def test_small_rtol_warning(self, xp):

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -11,7 +11,6 @@ from scipy._lib._array_api import is_numpy, is_torch, array_namespace
 from scipy import stats, optimize, special
 from scipy.differentiate import derivative, jacobian, hessian
 from scipy.differentiate._differentiate import _EERRORINCREASE
-import threading
 
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -11,6 +11,8 @@ from scipy._lib._array_api import is_numpy, is_torch, array_namespace
 from scipy import stats, optimize, special
 from scipy.differentiate import derivative, jacobian, hessian
 from scipy.differentiate._differentiate import _EERRORINCREASE
+import threading
+
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
 
@@ -54,17 +56,19 @@ class TestDerivative:
         # input shapes.
         x = np.linspace(-0.05, 1.05, 12).reshape(shape) if shape else 0.6
         n = np.size(x)
+        state = {}
 
         @np.vectorize
         def _derivative_single(x):
             return derivative(self.f, x, order=order)
 
         def f(x, *args, **kwargs):
-            f.nit += 1
-            f.feval += 1 if (x.size == n or x.ndim <=1) else x.shape[-1]
+            state['nit'] += 1
+            state['feval'] += 1 if (x.size == n or x.ndim <=1) else x.shape[-1]
             return self.f(x, *args, **kwargs)
-        f.nit = -1
-        f.feval = 0
+
+        state['nit'] = -1
+        state['feval'] = 0
 
         res = derivative(f, xp.asarray(x, dtype=xp.float64), order=order)
         refs = _derivative_single(x).ravel()
@@ -88,12 +92,12 @@ class TestDerivative:
         ref_nfev = [np.int32(ref.nfev) for ref in refs]
         xp_assert_equal(xp.reshape(res.nfev, (-1,)), xp.asarray(ref_nfev))
         if is_numpy(xp):  # can't expect other backends to be exactly the same
-            assert xp.max(res.nfev) == f.feval
+            assert xp.max(res.nfev) == state['feval']
 
         ref_nit = [np.int32(ref.nit) for ref in refs]
         xp_assert_equal(xp.reshape(res.nit, (-1,)), xp.asarray(ref_nit))
         if is_numpy(xp):  # can't expect other backends to be exactly the same
-            assert xp.max(res.nit) == f.nit
+            assert xp.max(res.nit) == state['nit']
 
     def test_flags(self, xp):
         # Test cases that should produce different status flags; show that all

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -474,7 +474,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_size_accuracy_small(self, size):
-        x = np.random.rand(size, size) + 1j*np.random.rand(size, size)
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, size)) + 1j * rng.random((size, size))
         y1 = fftn(x.real.astype(np.float32))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -483,7 +484,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES)
     def test_size_accuracy_large(self, size):
-        x = np.random.rand(size, 3) + 1j*np.random.rand(size, 3)
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, 3)) + 1j * rng.random((size, 3))
         y1 = fftn(x.real.astype(np.float32))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -501,7 +503,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_float16_input_small(self, size):
-        x = np.random.rand(size, size) + 1j*np.random.rand(size, size)
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, size)) + 1j*rng.random((size, size))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -510,7 +513,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES)
     def test_float16_input_large(self, size):
-        x = np.random.rand(size, 3) + 1j*np.random.rand(size, 3)
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, 3)) + 1j*rng.random((size, 3))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -756,6 +760,7 @@ class TestIfftn:
                              [(np.float64, np.complex128, 2000),
                               (np.float32, np.complex64, 3500)])
     def test_definition(self, dtype, cdtype, maxnlp):
+        rng = np.random.default_rng(1234)
         x = np.array([[1, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]], dtype=dtype)
@@ -763,16 +768,17 @@ class TestIfftn:
         assert_equal(y.dtype, cdtype)
         assert_array_almost_equal_nulp(y, direct_idftn(x), maxnlp)
 
-        x = random((20, 26))
+        x = rng.random((20, 26))
         assert_array_almost_equal_nulp(ifftn(x), direct_idftn(x), maxnlp)
 
-        x = random((5, 4, 3, 20))
+        x = rng.random((5, 4, 3, 20))
         assert_array_almost_equal_nulp(ifftn(x), direct_idftn(x), maxnlp)
 
     @pytest.mark.parametrize('maxnlp', [2000, 3500])
     @pytest.mark.parametrize('size', [1, 2, 51, 32, 64, 92])
     def test_random_complex(self, maxnlp, size):
-        x = random([size, size]) + 1j*random([size, size])
+        rng = np.random.default_rng(1234)
+        x = rng.random([size, size]) + 1j * rng.random([size, size])
         assert_array_almost_equal_nulp(ifftn(fftn(x)), x, maxnlp)
         assert_array_almost_equal_nulp(fftn(ifftn(x)), x, maxnlp)
 
@@ -802,6 +808,7 @@ class TestRfftn:
                              [(np.float64, np.complex128, 2000),
                               (np.float32, np.complex64, 3500)])
     def test_definition(self, dtype, cdtype, maxnlp):
+        rng = np.random.default_rng(1234)
         x = np.array([[1, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]], dtype=dtype)
@@ -809,15 +816,16 @@ class TestRfftn:
         assert_equal(y.dtype, cdtype)
         assert_array_almost_equal_nulp(y, direct_rdftn(x), maxnlp)
 
-        x = random((20, 26))
+        x = rng.random((20, 26))
         assert_array_almost_equal_nulp(rfftn(x), direct_rdftn(x), maxnlp)
 
-        x = random((5, 4, 3, 20))
+        x = rng.random((5, 4, 3, 20))
         assert_array_almost_equal_nulp(rfftn(x), direct_rdftn(x), maxnlp)
 
     @pytest.mark.parametrize('size', [1, 2, 51, 32, 64, 92])
     def test_random(self, size):
-        x = random([size, size])
+        rng = np.random.default_rng(1234)
+        x = rng.random([size, size])
         assert_allclose(irfftn(rfftn(x), x.shape), x, atol=1e-10)
 
     @pytest.mark.parametrize('func', [rfftn, irfftn])

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,5 +1,6 @@
 from os.path import join, dirname
 from typing import Callable, Union
+from threading import Lock
 
 import numpy as np
 from numpy.testing import (
@@ -81,6 +82,11 @@ def mdata_xy(request, reference_data):
     y = reference_data['Y'][request.param]
     x = reference_data['X'][request.param]
     return x, y
+
+
+@pytest.fixture
+def ref_lock():
+    return Lock()
 
 
 def fftw_dct_ref(type, size, dt, reference_data):
@@ -266,8 +272,10 @@ for k,v in dec_map.copy().items():
 @pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
 class TestDCT:
-    def test_definition(self, rdt, type, fftwdata_size, reference_data):
-        x, yr, dt = fftw_dct_ref(type, fftwdata_size, rdt, reference_data)
+    def test_definition(self, rdt, type, fftwdata_size,
+                        reference_data, ref_lock):
+        with ref_lock:
+            x, yr, dt = fftw_dct_ref(type, fftwdata_size, rdt, reference_data)
         y = dct(x, type=type)
         assert_equal(y.dtype, dt)
         dec = dec_map[(dct, rdt, type)]
@@ -341,8 +349,9 @@ def test_dct4_definition_ortho(mdata_x, rdt):
 
 @pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
-def test_idct_definition(fftwdata_size, rdt, type, reference_data):
-    xr, yr, dt = fftw_dct_ref(type, fftwdata_size, rdt, reference_data)
+def test_idct_definition(fftwdata_size, rdt, type, reference_data, ref_lock):
+    with ref_lock:
+        xr, yr, dt = fftw_dct_ref(type, fftwdata_size, rdt, reference_data)
     x = idct(yr, type=type)
     dec = dec_map[(idct, rdt, type)]
     assert_equal(x.dtype, dt)
@@ -351,8 +360,9 @@ def test_idct_definition(fftwdata_size, rdt, type, reference_data):
 
 @pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
-def test_definition(fftwdata_size, rdt, type, reference_data):
-    xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt, reference_data)
+def test_definition(fftwdata_size, rdt, type, reference_data, ref_lock):
+    with ref_lock:
+        xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt, reference_data)
     y = dst(xr, type=type)
     dec = dec_map[(dst, rdt, type)]
     assert_equal(y.dtype, dt)
@@ -385,8 +395,9 @@ def test_dst4_definition_ortho(rdt, mdata_x):
 
 @pytest.mark.parametrize('rdt', [np.longdouble, np.float64, np.float32, int])
 @pytest.mark.parametrize('type', [1, 2, 3, 4])
-def test_idst_definition(fftwdata_size, rdt, type, reference_data):
-    xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt, reference_data)
+def test_idst_definition(fftwdata_size, rdt, type, reference_data, ref_lock):
+    with ref_lock:
+        xr, yr, dt = fftw_dst_ref(type, fftwdata_size, rdt, reference_data)
     x = idst(yr, type=type)
     dec = dec_map[(idst, rdt, type)]
     assert_equal(x.dtype, dt)

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,5 +1,5 @@
 from os.path import join, dirname
-from typing import Callable, Union
+from collections.abc import Callable
 from threading import Lock
 
 import numpy as np
@@ -203,7 +203,7 @@ def test_complex(transform, dtype):
 
 
 DecMapType = dict[
-    tuple[Callable[..., np.ndarray], Union[type[np.floating], type[int]], int],
+    tuple[Callable[..., np.ndarray], type[np.floating] | type[int], int],
     int,
 ]
 

--- a/scipy/fft/tests/mock_backend.py
+++ b/scipy/fft/tests/mock_backend.py
@@ -1,15 +1,20 @@
 import numpy as np
 import scipy.fft
+import threading
 
 class _MockFunction:
     def __init__(self, return_value = None):
-        self.number_calls = 0
+        self.number_calls = {}
         self.return_value = return_value
-        self.last_args = ([], {})
+        self.last_args = {}
 
     def __call__(self, *args, **kwargs):
-        self.number_calls += 1
-        self.last_args = (args, kwargs)
+        tid = threading.get_native_id()
+        if tid not in self.number_calls:
+            self.number_calls[tid] = 0
+
+        self.number_calls[tid] += 1
+        self.last_args[tid] = (args, kwargs)
         return self.return_value
 
 

--- a/scipy/fft/tests/mock_backend.py
+++ b/scipy/fft/tests/mock_backend.py
@@ -4,17 +4,16 @@ import threading
 
 class _MockFunction:
     def __init__(self, return_value = None):
-        self.number_calls = {}
+        self.number_calls = threading.local()
         self.return_value = return_value
-        self.last_args = {}
+        self.last_args = threading.local()
 
     def __call__(self, *args, **kwargs):
-        tid = threading.get_native_id()
-        if tid not in self.number_calls:
-            self.number_calls[tid] = 0
+        if not hasattr(self.number_calls, 'c'):
+            self.number_calls.c = 0
 
-        self.number_calls[tid] += 1
-        self.last_args[tid] = (args, kwargs)
+        self.number_calls.c += 1
+        self.last_args.l = (args, kwargs)
         return self.return_value
 
 

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -1,5 +1,4 @@
 from functools import partial
-import threading
 
 import numpy as np
 import scipy.fft

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -56,16 +56,15 @@ mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
 
 @pytest.mark.parametrize("func, np_func, mock", zip(funcs, np_funcs, mocks))
 def test_backend_call(func, np_func, mock):
-    tid = threading.get_native_id()
     x = np.arange(20).reshape((10,2))
     answer = np_func(x.astype(np.float64))
     assert_allclose(func(x), answer, atol=1e-10)
 
     with set_backend(mock_backend, only=True):
-        # mock.number_calls = {}
+        mock.number_calls.c = 0
         y = func(x)
         assert_equal(y, mock.return_value)
-        assert_equal(mock.number_calls[tid], 1)
+        assert_equal(mock.number_calls.c, 1)
 
     assert_allclose(func(x), answer, atol=1e-10)
 
@@ -87,14 +86,14 @@ plan_mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
 
 @pytest.mark.parametrize("func, mock", zip(plan_funcs, plan_mocks))
 def test_backend_plan(func, mock):
-    tid = threading.get_native_id()
     x = np.arange(20).reshape((10, 2))
 
     with pytest.raises(NotImplementedError, match='precomputed plan'):
         func(x, plan='foo')
 
     with set_backend(mock_backend, only=True):
+        mock.number_calls.c = 0
         y = func(x, plan='foo')
         assert_equal(y, mock.return_value)
-        assert_equal(mock.number_calls[tid], 1)
-        assert_equal(mock.last_args[tid][1]['plan'], 'foo')
+        assert_equal(mock.number_calls.c, 1)
+        assert_equal(mock.last_args.l[1]['plan'], 'foo')

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -1,4 +1,5 @@
 from functools import partial
+import threading
 
 import numpy as np
 import scipy.fft
@@ -55,15 +56,16 @@ mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
 
 @pytest.mark.parametrize("func, np_func, mock", zip(funcs, np_funcs, mocks))
 def test_backend_call(func, np_func, mock):
+    tid = threading.get_native_id()
     x = np.arange(20).reshape((10,2))
     answer = np_func(x.astype(np.float64))
     assert_allclose(func(x), answer, atol=1e-10)
 
     with set_backend(mock_backend, only=True):
-        mock.number_calls = 0
+        # mock.number_calls = {}
         y = func(x)
         assert_equal(y, mock.return_value)
-        assert_equal(mock.number_calls, 1)
+        assert_equal(mock.number_calls[tid], 1)
 
     assert_allclose(func(x), answer, atol=1e-10)
 
@@ -85,14 +87,14 @@ plan_mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
 
 @pytest.mark.parametrize("func, mock", zip(plan_funcs, plan_mocks))
 def test_backend_plan(func, mock):
+    tid = threading.get_native_id()
     x = np.arange(20).reshape((10, 2))
 
     with pytest.raises(NotImplementedError, match='precomputed plan'):
         func(x, plan='foo')
 
     with set_backend(mock_backend, only=True):
-        mock.number_calls = 0
         y = func(x, plan='foo')
         assert_equal(y, mock.return_value)
-        assert_equal(mock.number_calls, 1)
-        assert_equal(mock.last_args[1]['plan'], 'foo')
+        assert_equal(mock.number_calls[tid], 1)
+        assert_equal(mock.last_args[tid][1]['plan'], 'foo')

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -50,7 +50,7 @@ class TestFFT:
         for i in [1, 2, 16, 128, 512, 53, 149, 281, 397]:
             xp_assert_close(fft.ifft(fft.fft(x[0:i])), x[0:i])
             xp_assert_close(fft.irfft(fft.rfft(xr[0:i]), i), xr[0:i])
-    
+
     @skip_xp_backends(np_only=True, reason='significant overhead for some backends')
     def test_identity_extensive(self, xp):
         maxlen = 512
@@ -333,7 +333,8 @@ class TestFFT:
 
     @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
     def test_dtypes_complex(self, dtype, xp):
-        x = xp.asarray(random(30), dtype=getattr(xp, dtype))
+        rng = np.random.default_rng(1234)
+        x = xp.asarray(rng.random(30), dtype=getattr(xp, dtype))
 
         res_fft = fft.ifft(fft.fft(x))
         # Check both numerical results and exact dtype matches

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -3,7 +3,6 @@ import math
 
 import numpy as np
 import pytest
-import threading
 
 from scipy.fft._fftlog import fht, ifht, fhtoffset
 from scipy.special import poch

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -111,13 +111,10 @@ def test_fht_identity(n, bias, offset, optimal, xp):
     xp_assert_close(a_, a, rtol=1.5e-7)
 
 
-@pytest.fixture
-def fht_lock():
-    return threading.Lock()
 
 
 @pytest.mark.thread_unsafe
-def test_fht_special_cases(xp, fht_lock):
+def test_fht_special_cases(xp):
     rng = np.random.RandomState(3491349965)
 
     a = xp.asarray(rng.standard_normal(64))

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -116,7 +116,7 @@ def fht_lock():
     return threading.Lock()
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_fht_special_cases(xp, fht_lock):
     rng = np.random.RandomState(3491349965)
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -430,8 +430,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_size_accuracy_small(self, size):
-        rand = np.random.default_rng(1234)
-        x = rand.random((size, size)) + 1j*rand.random((size, size))
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, size)) + 1j*rng.random((size, size))
         y1 = fftn(x.real.astype(np.float32))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -459,8 +459,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_float16_input_small(self, size):
-        rand = np.random.default_rng(1234)
-        x = rand.random((size, size)) + 1j * rand.random((size, size))
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, size)) + 1j * rng.random((size, size))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -469,8 +469,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES)
     def test_float16_input_large(self, size):
-        rand = np.random.default_rng(1234)
-        x = rand.random((size, 3)) + 1j*rand.random((size, 3))
+        rng = np.random.default_rng(1234)
+        x = rng.random((size, 3)) + 1j*rng.random((size, 3))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -430,7 +430,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_size_accuracy_small(self, size):
-        x = np.random.rand(size, size) + 1j*np.random.rand(size, size)
+        rand = np.random.default_rng(1234)
+        x = rand.random((size, size)) + 1j*rand.random((size, size))
         y1 = fftn(x.real.astype(np.float32))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -439,7 +440,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES)
     def test_size_accuracy_large(self, size):
-        x = np.random.rand(size, 3) + 1j*np.random.rand(size, 3)
+        rand = np.random.default_rng(1234)
+        x = rand.random((size, 3)) + 1j*rand.random((size, 3))
         y1 = fftn(x.real.astype(np.float32))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -457,7 +459,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', SMALL_COMPOSITE_SIZES + SMALL_PRIME_SIZES)
     def test_float16_input_small(self, size):
-        x = np.random.rand(size, size) + 1j*np.random.rand(size, size)
+        rand = np.random.default_rng(1234)
+        x = rand.random((size, size)) + 1j * rand.random((size, size))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -466,7 +469,8 @@ class TestFftnSingle:
 
     @pytest.mark.parametrize('size', LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES)
     def test_float16_input_large(self, size):
-        x = np.random.rand(size, 3) + 1j*np.random.rand(size, 3)
+        rand = np.random.default_rng(1234)
+        x = rand.random((size, 3)) + 1j*rand.random((size, 3))
         y1 = fftn(x.real.astype(np.float16))
         y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
@@ -701,6 +705,7 @@ class TestIfftn:
                              [(np.float64, np.complex128, 2000),
                               (np.float32, np.complex64, 3500)])
     def test_definition(self, dtype, cdtype, maxnlp):
+        rng = np.random.default_rng(1234)
         x = np.array([[1, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]], dtype=dtype)
@@ -708,16 +713,17 @@ class TestIfftn:
         assert_equal(y.dtype, cdtype)
         assert_array_almost_equal_nulp(y, direct_idftn(x), maxnlp)
 
-        x = random((20, 26))
+        x = rng.random((20, 26))
         assert_array_almost_equal_nulp(ifftn(x), direct_idftn(x), maxnlp)
 
-        x = random((5, 4, 3, 20))
+        x = rng.random((5, 4, 3, 20))
         assert_array_almost_equal_nulp(ifftn(x), direct_idftn(x), maxnlp)
 
     @pytest.mark.parametrize('maxnlp', [2000, 3500])
     @pytest.mark.parametrize('size', [1, 2, 51, 32, 64, 92])
     def test_random_complex(self, maxnlp, size):
-        x = random([size, size]) + 1j*random([size, size])
+        rng = np.random.default_rng(1234)
+        x = rng.random([size, size]) + 1j * rng.random([size, size])
         assert_array_almost_equal_nulp(ifftn(fftn(x)), x, maxnlp)
         assert_array_almost_equal_nulp(fftn(ifftn(x)), x, maxnlp)
 

--- a/scipy/fftpack/tests/test_pseudo_diffs.py
+++ b/scipy/fftpack/tests/test_pseudo_diffs.py
@@ -154,9 +154,10 @@ class TestDiff:
         assert_array_almost_equal(diff(2*cos(2*x),-1),sin(2*x))
 
     def test_random_even(self):
+        rng = np.random.default_rng(1234)
         for k in [0,2,4,6]:
             for n in [60,32,64,56,55]:
-                f = random((n,))
+                f = rng.random((n,))
                 af = sum(f,axis=0)/n
                 f = f-af
                 # zeroing Nyquist mode:
@@ -166,9 +167,10 @@ class TestDiff:
                 assert_array_almost_equal(diff(diff(f,-k),k),f)
 
     def test_random_odd(self):
+        rng = np.random.default_rng(1234)
         for k in [0,1,2,3,4,5,6]:
             for n in [33,65,55]:
-                f = random((n,))
+                f = rng.random((n,))
                 af = sum(f,axis=0)/n
                 f = f-af
                 assert_almost_equal(sum(f,axis=0),0.0)
@@ -176,9 +178,10 @@ class TestDiff:
                 assert_array_almost_equal(diff(diff(f,-k),k),f)
 
     def test_zero_nyquist(self):
+        rng = np.random.default_rng(1234)
         for k in [0,1,2,3,4,5,6]:
             for n in [32,33,64,56,55]:
-                f = random((n,))
+                f = rng.random((n,))
                 af = sum(f,axis=0)/n
                 f = f-af
                 # zeroing Nyquist mode:
@@ -212,9 +215,10 @@ class TestTilbert:
                 assert_array_almost_equal(direct_tilbert(direct_itilbert(f,h),h),f)
 
     def test_random_odd(self):
+        rng = np.random.default_rng(1234)
         for h in [0.1,0.5,1,5.5,10]:
             for n in [33,65,55]:
-                f = random((n,))
+                f = rng.random((n,))
                 af = sum(f,axis=0)/n
                 f = f-af
                 assert_almost_equal(sum(f,axis=0),0.0)
@@ -259,8 +263,9 @@ class TestHilbert:
             assert_array_almost_equal(y,y2)
 
     def test_random_odd(self):
+        rng = np.random.default_rng(1234)
         for n in [33,65,55]:
-            f = random((n,))
+            f = rng.random((n,))
             af = sum(f,axis=0)/n
             f = f-af
             assert_almost_equal(sum(f,axis=0),0.0)
@@ -268,8 +273,9 @@ class TestHilbert:
             assert_array_almost_equal(hilbert(ihilbert(f)),f)
 
     def test_random_even(self):
+        rng = np.random.default_rng(1234)
         for n in [32,64,56]:
-            f = random((n,))
+            f = rng.random((n,))
             af = sum(f,axis=0)/n
             f = f-af
             # zeroing Nyquist mode:
@@ -335,11 +341,13 @@ class TestOverwrite:
         assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, *args, **kwargs):
-        np.random.seed(1234)
+        # rng = np.random.default_rng(1234)
+        rng = np.random.RandomState(1234)
+        # np.random.seed(1234)
         if np.issubdtype(dtype, np.complexfloating):
-            data = np.random.randn(*shape) + 1j*np.random.randn(*shape)
+            data = rng.randn(*shape) + 1j*rng.randn(*shape)
         else:
-            data = np.random.randn(*shape)
+            data = rng.randn(*shape)
         data = data.astype(dtype)
         self._check(data, routine, *args, **kwargs)
 

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -228,7 +228,7 @@ class _TestDCTBase:
 
 
 class _TestDCTIBase(_TestDCTBase):
-    def test_definition_ortho(self, dct_lock):
+    def test_definition_ortho(self):
         # Test orthornomal mode.
         dt = np.result_type(np.float32, self.rdt)
         for xr in X:

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -1,4 +1,5 @@
 from os.path import join, dirname
+import threading
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
@@ -192,9 +193,14 @@ class _TestDCTBase:
         self.dec = 14
         self.type = None
 
-    def test_definition(self):
+    @pytest.fixture
+    def dct_lock(self):
+        return threading.Lock()
+
+    def test_definition(self, dct_lock):
         for i in FFTWDATA_SIZES:
-            x, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
+            with dct_lock:
+                x, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
             y = dct(x, type=self.type)
             assert_equal(y.dtype, dt)
             # XXX: we divide by np.max(y) because the tests fail otherwise. We
@@ -206,8 +212,9 @@ class _TestDCTBase:
 
     def test_axis(self):
         nt = 2
+        rng = np.random.RandomState(1234)
         for i in [7, 8, 9, 16, 32, 64]:
-            x = np.random.randn(nt, i)
+            x = rng.randn(nt, i)
             y = dct(x, type=self.type)
             for j in range(nt):
                 assert_array_almost_equal(y[j], dct(x[j], type=self.type),
@@ -221,7 +228,7 @@ class _TestDCTBase:
 
 
 class _TestDCTIBase(_TestDCTBase):
-    def test_definition_ortho(self):
+    def test_definition_ortho(self, dct_lock):
         # Test orthornomal mode.
         dt = np.result_type(np.float32, self.rdt)
         for xr in X:
@@ -355,9 +362,14 @@ class _TestIDCTBase:
         self.dec = 14
         self.type = None
 
-    def test_definition(self):
+    @pytest.fixture
+    def idct_lock(self):
+        return threading.Lock()
+
+    def test_definition(self, idct_lock):
         for i in FFTWDATA_SIZES:
-            xr, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
+            with idct_lock:
+                xr, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
             x = idct(yr, type=self.type)
             if self.type == 1:
                 x /= 2 * (i-1)
@@ -460,9 +472,14 @@ class _TestDSTBase:
         self.dec = None  # number of decimals to match
         self.type = None  # dst type
 
-    def test_definition(self):
+    @pytest.fixture
+    def dst_lock(self):
+        return threading.Lock()
+
+    def test_definition(self, dst_lock):
         for i in FFTWDATA_SIZES:
-            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
+            with dst_lock:
+                xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
             y = dst(xr, type=self.type)
             assert_equal(y.dtype, dt)
             # XXX: we divide by np.max(y) because the tests fail otherwise. We
@@ -585,9 +602,14 @@ class _TestIDSTBase:
         self.dec = None
         self.type = None
 
-    def test_definition(self):
+    @pytest.fixture
+    def idst_lock(self):
+        return threading.Lock()
+
+    def test_definition(self, idst_lock):
         for i in FFTWDATA_SIZES:
-            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
+            with idst_lock:
+                xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
             x = idst(yr, type=self.type)
             if self.type == 1:
                 x /= 2 * (i+1)
@@ -701,11 +723,11 @@ class TestOverwrite:
             assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, axis):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         if np.issubdtype(dtype, np.complexfloating):
-            data = np.random.randn(*shape) + 1j*np.random.randn(*shape)
+            data = rng.randn(*shape) + 1j*rng.randn(*shape)
         else:
-            data = np.random.randn(*shape)
+            data = rng.randn(*shape)
         data = data.astype(dtype)
 
         for type in [1, 2, 3, 4]:

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -1,7 +1,6 @@
 from itertools import product
 from numpy.testing import (assert_, assert_allclose, assert_array_less,
                            assert_equal, assert_no_warnings, suppress_warnings)
-import threading
 import pytest
 from pytest import raises as assert_raises
 import numpy as np

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -1127,7 +1127,7 @@ def test_args():
     assert_allclose(zfinalevents[2], [zfinal])
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_array_rtol():
     # solve_ivp had a bug with array_like `rtol`; see gh-15482
     # check that it's fixed

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -7,6 +7,11 @@ from . import _odepack
 from copy import copy
 import warnings
 
+from threading import Lock
+
+
+ODE_LOCK = Lock()
+
 
 class ODEintWarning(Warning):
     """Warning raised during the execution of `odeint`."""
@@ -244,10 +249,12 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
 
     t = copy(t)
     y0 = copy(y0)
-    output = _odepack.odeint(func, y0, t, args, Dfun, col_deriv, ml, mu,
-                             full_output, rtol, atol, tcrit, h0, hmax, hmin,
-                             ixpr, mxstep, mxhnil, mxordn, mxords,
-                             int(bool(tfirst)))
+
+    with ODE_LOCK:
+        output = _odepack.odeint(func, y0, t, args, Dfun, col_deriv, ml, mu,
+                                full_output, rtol, atol, tcrit, h0, hmax, hmin,
+                                ixpr, mxstep, mxhnil, mxordn, mxords,
+                                int(bool(tfirst)))
     if output[-1] < 0:
         warning_msg = (f"{_msgs[output[-1]]} Run with full_output = 1 to "
                        f"get quantitative information.")

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -210,6 +210,8 @@ def test_points(a, b):
         j = np.searchsorted(sorted(points), tuple(p))
         assert np.all(j == j[0])
 
+
+@pytest.mark.parallel_threads(1)
 def test_trapz_deprecation():
     with pytest.deprecated_call(match="`quadrature='trapz'`"):
         quad_vec(lambda x: x, 0, 1, quadrature="trapz")

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -211,7 +211,7 @@ def test_points(a, b):
         assert np.all(j == j[0])
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_trapz_deprecation():
     with pytest.deprecated_call(match="`quadrature='trapz'`"):
         quad_vec(lambda x: x, 0, 1, quadrature="trapz")

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -125,7 +125,7 @@ def _analytical_solution(a, y0, t):
     return sol
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_banded_ode_solvers():
     # Test the "lsoda", "vode" and "zvode" solvers of the `ode` class
     # with a system that has a banded Jacobian matrix.

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -1,4 +1,5 @@
 import itertools
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from scipy.integrate import ode
@@ -124,6 +125,7 @@ def _analytical_solution(a, y0, t):
     return sol
 
 
+@pytest.mark.parallel_threads(1)
 def test_banded_ode_solvers():
     # Test the "lsoda", "vode" and "zvode" solvers of the `ode` class
     # with a system that has a banded Jacobian matrix.

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -691,7 +691,7 @@ def test_nonlin_bc():
     assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_verbose():
     # Smoke test that checks the printing does something and does not crash
     x = np.linspace(0, 1, 5)

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -16,6 +16,8 @@ from scipy.integrate._bvp import (modify_mesh, estimate_fun_jac,
                                   estimate_bc_jac, compute_jac_indices,
                                   construct_global_jac, solve_bvp)
 
+import pytest
+
 
 def exp_fun(x, y):
     return np.vstack((y[1], y[0]))
@@ -689,6 +691,7 @@ def test_nonlin_bc():
     assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
 
+@pytest.mark.parallel_threads(1)
 def test_verbose():
     # Smoke test that checks the printing does something and does not crash
     x = np.linspace(0, 1, 5)

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -92,7 +92,6 @@ class TestOde(TestODEClass):
 
     ode_class = ode
 
-    @pytest.mark.thread_unsafe
     def test_vode(self):
         # Check the vode solver
         for problem_cls in PROBLEMS:
@@ -103,7 +102,6 @@ class TestOde(TestODEClass):
                 self._do_problem(problem, 'vode', 'adams')
             self._do_problem(problem, 'vode', 'bdf')
 
-    @pytest.mark.thread_unsafe
     def test_zvode(self):
         # Check the zvode solver
         for problem_cls in PROBLEMS:
@@ -112,11 +110,8 @@ class TestOde(TestODEClass):
                 self._do_problem(problem, 'zvode', 'adams')
             self._do_problem(problem, 'zvode', 'bdf')
 
-    @pytest.mark.thread_unsafe
-    def test_lsoda(self, num_parallel_threads):
+    def test_lsoda(self):
         # Check the lsoda solver
-        if num_parallel_threads > 1:
-            pytest.skip(reason='LSODA does not allow for concurrent execution')
         for problem_cls in PROBLEMS:
             problem = problem_cls()
             if problem.cmplx:
@@ -206,7 +201,6 @@ class TestComplexOde(TestODEClass):
 
     ode_class = complex_ode
 
-    @pytest.mark.thread_unsafe
     def test_vode(self):
         # Check the vode solver
         for problem_cls in PROBLEMS:
@@ -216,10 +210,7 @@ class TestComplexOde(TestODEClass):
             else:
                 self._do_problem(problem, 'vode', 'bdf')
 
-    @pytest.mark.thread_unsafe
-    def test_lsoda(self, num_parallel_threads):
-        if num_parallel_threads > 1:
-            pytest.skip(reason='LSODA does not allow for concurrent execution')
+    def test_lsoda(self):
 
         # Check the lsoda solver
         for problem_cls in PROBLEMS:
@@ -615,21 +606,11 @@ class ODECheckParameterUse:
         solver.integrate(pi)
         assert_array_almost_equal(solver.y, [-1.0, 0.0])
 
-    def test_no_params(self, num_parallel_threads):
-        if (self.solver_name in {'vode', 'lsoda', 'zvode'} and
-                num_parallel_threads > 1):
-            pytest.skip(reason=f'{self.solver_name} does not allow for '
-                        'concurrent execution')
-
+    def test_no_params(self):
         solver = self._get_solver(f, jac)
         self._check_solver(solver)
 
-    def test_one_scalar_param(self, num_parallel_threads):
-        if (self.solver_name in {'vode', 'lsoda', 'zvode'} and
-                num_parallel_threads > 1):
-            pytest.skip(reason=f'{self.solver_name} does not allow for '
-                        'concurrent execution')
-
+    def test_one_scalar_param(self):
         solver = self._get_solver(f1, jac1)
         omega = 1.0
         solver.set_f_params(omega)
@@ -637,11 +618,7 @@ class ODECheckParameterUse:
             solver.set_jac_params(omega)
         self._check_solver(solver)
 
-    def test_two_scalar_params(self, num_parallel_threads):
-        if (self.solver_name in {'vode', 'lsoda', 'zvode'} and
-                num_parallel_threads > 1):
-            pytest.skip(reason=f'{self.solver_name} does not allow for '
-                        'concurrent execution')
+    def test_two_scalar_params(self):
         solver = self._get_solver(f2, jac2)
         omega1 = 1.0
         omega2 = 1.0
@@ -650,11 +627,7 @@ class ODECheckParameterUse:
             solver.set_jac_params(omega1, omega2)
         self._check_solver(solver)
 
-    def test_vector_param(self, num_parallel_threads):
-        if (self.solver_name in {'vode', 'lsoda', 'zvode'} and
-                num_parallel_threads > 1):
-            pytest.skip(reason=f'{self.solver_name} does not allow for '
-                        'concurrent execution')
+    def test_vector_param(self):
         solver = self._get_solver(fv, jacv)
         omega = [1.0, 1.0]
         solver.set_f_params(omega)

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -144,7 +144,7 @@ class TestOde(TestODEClass):
                 continue
             self._do_problem(problem, 'dop853')
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrent_fail(self):
         for sol in ('vode', 'zvode', 'lsoda'):
             def f(t, y):
@@ -657,7 +657,7 @@ class ODECheckParameterUse:
             solver.set_jac_params(omega)
         self._check_solver(solver)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_warns_on_failure(self):
         # Set nsteps small to ensure failure
         solver = self._get_solver(f, jac)

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -92,6 +92,7 @@ class TestOde(TestODEClass):
 
     ode_class = ode
 
+    @pytest.mark.thread_unsafe
     def test_vode(self):
         # Check the vode solver
         for problem_cls in PROBLEMS:
@@ -102,6 +103,7 @@ class TestOde(TestODEClass):
                 self._do_problem(problem, 'vode', 'adams')
             self._do_problem(problem, 'vode', 'bdf')
 
+    @pytest.mark.thread_unsafe
     def test_zvode(self):
         # Check the zvode solver
         for problem_cls in PROBLEMS:
@@ -110,6 +112,7 @@ class TestOde(TestODEClass):
                 self._do_problem(problem, 'zvode', 'adams')
             self._do_problem(problem, 'zvode', 'bdf')
 
+    @pytest.mark.thread_unsafe
     def test_lsoda(self, num_parallel_threads):
         # Check the lsoda solver
         if num_parallel_threads > 1:
@@ -203,6 +206,7 @@ class TestComplexOde(TestODEClass):
 
     ode_class = complex_ode
 
+    @pytest.mark.thread_unsafe
     def test_vode(self):
         # Check the vode solver
         for problem_cls in PROBLEMS:
@@ -212,6 +216,7 @@ class TestComplexOde(TestODEClass):
             else:
                 self._do_problem(problem, 'vode', 'bdf')
 
+    @pytest.mark.thread_unsafe
     def test_lsoda(self, num_parallel_threads):
         if num_parallel_threads > 1:
             pytest.skip(reason='LSODA does not allow for concurrent execution')

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -356,7 +356,7 @@ class TestTrapezoid:
 
 
 class TestQMCQuad:
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_input_validation(self):
         message = "`func` must be callable."
         with pytest.raises(TypeError, match=message):
@@ -433,7 +433,7 @@ class TestQMCQuad:
     def test_sign(self, signs):
         self.basic_test(signs=signs)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("log", [False, True])
     def test_zero(self, log):
         message = "A lower limit was equal to an upper limit, so"
@@ -616,7 +616,7 @@ class TestCumulativeSimpson:
         # `simpson` uses the trapezoidal rule
         return theoretical_difference
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(
@@ -647,7 +647,7 @@ class TestCumulativeSimpson:
             res[..., 1:], ref[..., 1:] + theoretical_difference[..., 1:]
         )
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -356,6 +356,7 @@ class TestTrapezoid:
 
 
 class TestQMCQuad:
+    @pytest.mark.parallel_threads(1)
     def test_input_validation(self):
         message = "`func` must be callable."
         with pytest.raises(TypeError, match=message):
@@ -432,6 +433,7 @@ class TestQMCQuad:
     def test_sign(self, signs):
         self.basic_test(signs=signs)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize("log", [False, True])
     def test_zero(self, log):
         message = "A lower limit was equal to an upper limit, so"
@@ -614,6 +616,7 @@ class TestCumulativeSimpson:
         # `simpson` uses the trapezoidal rule
         return theoretical_difference
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(
@@ -644,6 +647,7 @@ class TestCumulativeSimpson:
             res[..., 1:], ref[..., 1:] + theoretical_difference[..., 1:]
         )
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -553,7 +553,7 @@ class BSpline:
         splder, splantider
 
         """
-        c = self.c
+        c = self.c.copy()
         # pad the c array if needed
         ct = len(self.t) - len(c)
         if ct > 0:
@@ -2324,7 +2324,7 @@ def fpcheck(x, t, k):
 
     Return None if inputs are consistent, raises a ValueError otherwise.
     """
-    # This routine is a clone of the `fpchec` Fortran routine, 
+    # This routine is a clone of the `fpchec` Fortran routine,
     # https://github.com/scipy/scipy/blob/main/scipy/interpolate/fitpack/fpchec.f
     # which carries the following comment:
     #

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -587,7 +587,7 @@ class BSpline:
         splder, splantider
 
         """
-        c = self.c
+        c = self.c.copy()
         # pad the c array if needed
         ct = len(self.t) - len(c)
         if ct > 0:

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -20,6 +20,7 @@ __all__ = [
 
 
 import warnings
+from threading import Lock
 
 from numpy import zeros, concatenate, ravel, diff, array
 import numpy as np
@@ -29,6 +30,7 @@ from . import _dfitpack as dfitpack
 
 
 dfitpack_int = dfitpack.types.intvar.dtype
+FITPACK_LOCK = Lock()
 
 
 # ############### Univariate spline ####################
@@ -237,8 +239,9 @@ class UnivariateSpline:
                                                       check_finite)
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
-        data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
-                                xe=bbox[1], s=s)
+        with FITPACK_LOCK:
+            data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
+                                    xe=bbox[1], s=s)
         if data[-1] == 1:
             # nest too small, setting to maximum bound
             data = self._reset_nest(data)
@@ -337,7 +340,8 @@ class UnivariateSpline:
                                [8, 9, 11, 12])
 
         args = data[:8] + (t, c, n, fpint, nrdata, data[13])
-        data = dfitpack.fpcurf1(*args)
+        with FITPACK_LOCK:
+            data = dfitpack.fpcurf1(*args)
         return data
 
     def set_smoothing_factor(self, s):
@@ -354,7 +358,8 @@ class UnivariateSpline:
                           stacklevel=2)
             return
         args = data[:6] + (s,) + data[7:]
-        data = dfitpack.fpcurf1(*args)
+        with FITPACK_LOCK:
+            data = dfitpack.fpcurf1(*args)
         if data[-1] == 1:
             # nest too small, setting to maximum bound
             data = self._reset_nest(data)
@@ -397,7 +402,8 @@ class UnivariateSpline:
                 ext = _extrap_modes[ext]
             except KeyError as e:
                 raise ValueError(f"Unknown extrapolation mode {ext}.") from e
-        return _fitpack_impl.splev(x, self._eval_args, der=nu, ext=ext)
+        with FITPACK_LOCK:
+            return _fitpack_impl.splev(x, self._eval_args, der=nu, ext=ext)
 
     def get_knots(self):
         """ Return positions of interior knots of the spline.
@@ -461,7 +467,8 @@ class UnivariateSpline:
         0.0
 
         """
-        return _fitpack_impl.splint(a, b, self._eval_args)
+        with FITPACK_LOCK:
+            return _fitpack_impl.splint(a, b, self._eval_args)
 
     def derivatives(self, x):
         """ Return all derivatives of the spline at the point x.
@@ -487,7 +494,8 @@ class UnivariateSpline:
         array([2.25, 3.0, 2.0, 0])
 
         """
-        return _fitpack_impl.spalde(x, self._eval_args)
+        with FITPACK_LOCK:
+            return _fitpack_impl.spalde(x, self._eval_args)
 
     def roots(self):
         """ Return the zeros of the spline.
@@ -534,7 +542,8 @@ class UnivariateSpline:
         if k == 3:
             t = self._eval_args[0]
             mest = 3 * (len(t) - 7)
-            return _fitpack_impl.sproot(self._eval_args, mest=mest)
+            with FITPACK_LOCK:
+                return _fitpack_impl.sproot(self._eval_args, mest=mest)
         raise NotImplementedError('finding roots unsupported for '
                                   'non-cubic splines')
 
@@ -583,7 +592,8 @@ class UnivariateSpline:
         :math:`\\cos(x) = \\sin'(x)`.
 
         """
-        tck = _fitpack_impl.splder(self._eval_args, n)
+        with FITPACK_LOCK:
+            tck = _fitpack_impl.splder(self._eval_args, n)
         # if self.ext is 'const', derivative.ext will be 'zeros'
         ext = 1 if self.ext == 3 else self.ext
         return UnivariateSpline._from_tck(tck, ext=ext)
@@ -640,7 +650,8 @@ class UnivariateSpline:
         2.2572053268208538
 
         """
-        tck = _fitpack_impl.splantider(self._eval_args, n)
+        with FITPACK_LOCK:
+            tck = _fitpack_impl.splantider(self._eval_args, n)
         return UnivariateSpline._from_tck(tck, self.ext)
 
 
@@ -745,8 +756,9 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
             raise ValueError('x must be strictly increasing')
 
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
-        self._data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
-                                      xe=bbox[1], s=0)
+        with FITPACK_LOCK:
+            self._data = dfitpack.fpcurf0(x, y, k, w=w, xb=bbox[0],
+                                          xe=bbox[1], s=0)
         self._reset_class()
 
 
@@ -903,9 +915,10 @@ class LSQUnivariateSpline(UnivariateSpline):
         if not np.all(t[k+1:n-k]-t[k:n-k-1] > 0, axis=0):
             raise ValueError('Interior knots t must satisfy '
                              'Schoenberg-Whitney conditions')
-        if not dfitpack.fpchec(x, t, k) == 0:
-            raise ValueError(_fpchec_error_string)
-        data = dfitpack.fpcurfm1(x, y, k, t, w=w, xb=xb, xe=xe)
+        with FITPACK_LOCK:
+            if not dfitpack.fpchec(x, t, k) == 0:
+                raise ValueError(_fpchec_error_string)
+            data = dfitpack.fpcurfm1(x, y, k, t, w=w, xb=xb, xe=xe)
         self._data = data[:-3] + (None, None, data[-1])
         self._reset_class()
 
@@ -1045,11 +1058,13 @@ class _BivariateSplineBase:
                 raise ValueError("y must be strictly increasing when `grid` is True")
 
             if dx or dy:
-                z, ier = dfitpack.parder(tx, ty, c, kx, ky, dx, dy, x, y)
+                with FITPACK_LOCK:
+                    z, ier = dfitpack.parder(tx, ty, c, kx, ky, dx, dy, x, y)
                 if not ier == 0:
                     raise ValueError(f"Error code returned by parder: {ier}")
             else:
-                z, ier = dfitpack.bispev(tx, ty, c, kx, ky, x, y)
+                with FITPACK_LOCK:
+                    z, ier = dfitpack.bispev(tx, ty, c, kx, ky, x, y)
                 if not ier == 0:
                     raise ValueError(f"Error code returned by bispev: {ier}")
         else:
@@ -1065,11 +1080,13 @@ class _BivariateSplineBase:
                 return np.zeros(shape, dtype=self.tck[2].dtype)
 
             if dx or dy:
-                z, ier = dfitpack.pardeu(tx, ty, c, kx, ky, dx, dy, x, y)
+                with FITPACK_LOCK:
+                    z, ier = dfitpack.pardeu(tx, ty, c, kx, ky, dx, dy, x, y)
                 if not ier == 0:
                     raise ValueError(f"Error code returned by pardeu: {ier}")
             else:
-                z, ier = dfitpack.bispeu(tx, ty, c, kx, ky, x, y)
+                with FITPACK_LOCK:
+                    z, ier = dfitpack.bispeu(tx, ty, c, kx, ky, x, y)
                 if not ier == 0:
                     raise ValueError(f"Error code returned by bispeu: {ier}")
 
@@ -1110,7 +1127,8 @@ class _BivariateSplineBase:
                 raise ValueError("order of derivative must be less than"
                                  " degree of spline")
             tx, ty, c = self.tck[:3]
-            newc, ier = dfitpack.pardtc(tx, ty, c, kx, ky, dx, dy)
+            with FITPACK_LOCK:
+                newc, ier = dfitpack.pardtc(tx, ty, c, kx, ky, dx, dy)
             if ier != 0:
                 # This should not happen under normal conditions.
                 raise ValueError("Unexpected error code returned by"
@@ -1284,7 +1302,8 @@ class BivariateSpline(_BivariateSplineBase):
         """
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
-        return dfitpack.dblint(tx, ty, c, kx, ky, xa, xb, ya, yb)
+        with FITPACK_LOCK:
+            return dfitpack.dblint(tx, ty, c, kx, ky, xa, xb, ya, yb)
 
     @staticmethod
     def _validate_input(x, y, z, w, kx, ky, eps):
@@ -1414,18 +1433,13 @@ class SmoothBivariateSpline(BivariateSpline):
             raise ValueError("s should be s >= 0.0")
 
         xb, xe, yb, ye = bbox
-        nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(x, y, z, w,
-                                                                xb, xe, yb,
-                                                                ye, kx, ky,
-                                                                s=s, eps=eps,
-                                                                lwrk2=1)
-        if ier > 10:          # lwrk2 was to small, re-run
-            nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(x, y, z, w,
-                                                                    xb, xe, yb,
-                                                                    ye, kx, ky,
-                                                                    s=s,
-                                                                    eps=eps,
-                                                                    lwrk2=ier)
+        with FITPACK_LOCK:
+            nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(
+                x, y, z, w, xb, xe, yb, ye, kx, ky, s=s, eps=eps, lwrk2=1)
+            if ier > 10:          # lwrk2 was to small, re-run
+                nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(
+                    x, y, z, w, xb, xe, yb, ye, kx, ky, s=s, eps=eps,
+                    lwrk2=ier)
         if ier in [0, -1, -2]:  # normal return
             pass
         else:
@@ -1514,14 +1528,15 @@ class LSQBivariateSpline(BivariateSpline):
         ty1[ky+1:ny-ky-1] = ty
 
         xb, xe, yb, ye = bbox
-        tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z, nx, tx1, ny, ty1,
-                                                   w, xb, xe, yb, ye,
-                                                   kx, ky, eps, lwrk2=1)
-        if ier > 10:
-            tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z,
-                                                       nx, tx1, ny, ty1, w,
-                                                       xb, xe, yb, ye,
-                                                       kx, ky, eps, lwrk2=ier)
+        with FITPACK_LOCK:
+            tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z, nx, tx1, ny, ty1,
+                                                    w, xb, xe, yb, ye,
+                                                    kx, ky, eps, lwrk2=1)
+            if ier > 10:
+                tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z,
+                                                        nx, tx1, ny, ty1, w,
+                                                        xb, xe, yb, ye,
+                                                        kx, ky, eps, lwrk2=ier)
         if ier in [0, -1, -2]:  # normal return
             pass
         else:
@@ -1612,8 +1627,9 @@ class RectBivariateSpline(BivariateSpline):
 
         z = ravel(z)
         xb, xe, yb, ye = bbox
-        nx, tx, ny, ty, c, fp, ier = dfitpack.regrid_smth(x, y, z, xb, xe, yb,
-                                                          ye, kx, ky, s)
+        with FITPACK_LOCK:
+            nx, tx, ny, ty, c, fp, ier = dfitpack.regrid_smth(x, y, z, xb, xe, yb,
+                                                            ye, kx, ky, s)
 
         if ier not in [0, -1, -2]:
             msg = _surfit_messages.get(ier, f'ier={ier}')
@@ -1933,9 +1949,10 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
-        nt_, tt_, np_, tp_, c, fp, ier = dfitpack.spherfit_smth(theta, phi,
-                                                                r, w=w, s=s,
-                                                                eps=eps)
+        with FITPACK_LOCK:
+            nt_, tt_, np_, tp_, c, fp, ier = dfitpack.spherfit_smth(theta, phi,
+                                                                    r, w=w, s=s,
+                                                                    eps=eps)
         if ier not in [0, -1, -2]:
             message = _spherefit_messages.get(ier, f'ier={ier}')
             raise ValueError(message)
@@ -2088,8 +2105,9 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         tt_, tp_ = zeros((nt_,), float), zeros((np_,), float)
         tt_[4:-4], tp_[4:-4] = tt, tp
         tt_[-4:], tp_[-4:] = np.pi, 2. * np.pi
-        tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
-                                                     w=w, eps=eps)
+        with FITPACK_LOCK:
+            tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
+                                                        w=w, eps=eps)
         if ier > 0:
             message = _spherefit_messages.get(ier, f'ier={ier}')
             raise ValueError(message)
@@ -2351,11 +2369,12 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
             raise ValueError('s should be positive')
 
         r = np.ravel(r)
-        nu, tu, nv, tv, c, fp, ier = dfitpack.regrid_smth_spher(iopt, ider,
-                                                                u.copy(),
-                                                                v.copy(),
-                                                                r.copy(),
-                                                                r0, r1, s)
+        with FITPACK_LOCK:
+            nu, tu, nv, tv, c, fp, ier = dfitpack.regrid_smth_spher(iopt, ider,
+                                                                    u.copy(),
+                                                                    v.copy(),
+                                                                    r.copy(),
+                                                                    r0, r1, s)
 
         if ier not in [0, -1, -2]:
             msg = _spfit_messages.get(ier, f'ier={ier}')

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -745,7 +745,6 @@ def splder(tck, n=1):
         return splantider(tck, -n)
 
     t, c, k = tck
-    c = c.copy()
 
     if n > k:
         raise ValueError(f"Order of derivative (n = {n!r}) must be <= "
@@ -784,7 +783,6 @@ def splantider(tck, n=1):
         return splder(tck, -n)
 
     t, c, k = tck
-    c = c.copy()
 
     # Extra axes for the trailing dims of the `c` array:
     sh = (slice(None),) + (None,)*len(c.shape[1:])

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -745,6 +745,7 @@ def splder(tck, n=1):
         return splantider(tck, -n)
 
     t, c, k = tck
+    c = c.copy()
 
     if n > k:
         raise ValueError(f"Order of derivative (n = {n!r}) must be <= "
@@ -783,6 +784,7 @@ def splantider(tck, n=1):
         return splder(tck, -n)
 
     t, c, k = tck
+    c = c.copy()
 
     # Extra axes for the trailing dims of the `c` array:
     sh = (slice(None),) + (None,)*len(c.shape[1:])

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -92,7 +92,7 @@ class TestAAA:
         with pytest.raises(ValueError, match="greater"):
             AAA([1], [1], max_terms=-1)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_convergence_error(self):
         with pytest.warns(RuntimeWarning, match="AAA failed"):
             AAA(UNIT_INTERVAL, np.exp(UNIT_INTERVAL),  max_terms=1)
@@ -246,7 +246,7 @@ class TestAAA:
         r = AAA(z, np.tan(np.pi*z/2))
         assert_allclose(np.sort(np.abs(r.poles()))[:4], [1, 1, 3, 3], rtol=9e-7)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_spiral_cleanup(self):
         z = np.exp(np.linspace(-0.5, 0.5 + 15j*np.pi, num=1000))
         # here we set `rtol=0` to force froissart doublets, without cleanup there

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -92,6 +92,7 @@ class TestAAA:
         with pytest.raises(ValueError, match="greater"):
             AAA([1], [1], max_terms=-1)
 
+    @pytest.mark.parallel_threads(1)
     def test_convergence_error(self):
         with pytest.warns(RuntimeWarning, match="AAA failed"):
             AAA(UNIT_INTERVAL, np.exp(UNIT_INTERVAL),  max_terms=1)
@@ -245,6 +246,7 @@ class TestAAA:
         r = AAA(z, np.tan(np.pi*z/2))
         assert_allclose(np.sort(np.abs(r.poles()))[:4], [1, 1, 3, 3], rtol=9e-7)
 
+    @pytest.mark.parallel_threads(1)
     def test_spiral_cleanup(self):
         z = np.exp(np.linspace(-0.5, 0.5 + 15j*np.pi, num=1000))
         # here we set `rtol=0` to force froissart doublets, without cleanup there

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1087,12 +1087,13 @@ class TestInterop:
         for b in [self.b, self.b2]:
             # pad the c array (FITPACK convention)
             ct = len(b.t) - len(b.c)
+            b_c = b.c.copy()
             if ct > 0:
-                b.c = np.r_[b.c, np.zeros((ct,) + b.c.shape[1:])]
+                b_c = np.r_[b_c, np.zeros((ct,) + b_c.shape[1:])]
 
             for n in [1, 2, 3]:
                 bd = splder(b)
-                tck_d = _impl.splder((b.t.copy(), b.c, b.k))
+                tck_d = _impl.splder((b.t.copy(), b_c, b.k))
                 xp_assert_close(bd.t, tck_d[0], atol=1e-15)
                 xp_assert_close(bd.c, tck_d[1], atol=1e-15)
                 assert bd.k == tck_d[2]
@@ -1103,12 +1104,13 @@ class TestInterop:
         for b in [self.b, self.b2]:
             # pad the c array (FITPACK convention)
             ct = len(b.t) - len(b.c)
+            b_c = b.c.copy()
             if ct > 0:
-                b.c = np.r_[b.c, np.zeros((ct,) + b.c.shape[1:])]
+                b_c = np.r_[b_c, np.zeros((ct,) + b_c.shape[1:])]
 
             for n in [1, 2, 3]:
                 bd = splantider(b)
-                tck_d = _impl.splantider((b.t.copy(), b.c, b.k))
+                tck_d = _impl.splantider((b.t.copy(), b_c, b.k))
                 xp_assert_close(bd.t, tck_d[0], atol=1e-15)
                 xp_assert_close(bd.c, tck_d[1], atol=1e-15)
                 assert bd.k == tck_d[2]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1091,7 +1091,7 @@ class TestInterop:
 
             for n in [1, 2, 3]:
                 bd = splder(b)
-                tck_d = _impl.splder((b.t, b.c, b.k))
+                tck_d = _impl.splder((b.t.copy(), b.c, b.k))
                 xp_assert_close(bd.t, tck_d[0], atol=1e-15)
                 xp_assert_close(bd.c, tck_d[1], atol=1e-15)
                 assert bd.k == tck_d[2]
@@ -1107,7 +1107,7 @@ class TestInterop:
 
             for n in [1, 2, 3]:
                 bd = splantider(b)
-                tck_d = _impl.splantider((b.t, b.c, b.k))
+                tck_d = _impl.splantider((b.t.copy(), b.c, b.k))
                 xp_assert_close(bd.t, tck_d[0], atol=1e-15)
                 xp_assert_close(bd.c, tck_d[1], atol=1e-15)
                 assert bd.k == tck_d[2]
@@ -3240,6 +3240,7 @@ index 1afb1900f1..d817e51ad8 100644
 
         xp_assert_close(tt, t, atol=1e-15)
 
+    @pytest.mark.parallel_threads(1)
     def test_s_too_small(self):
         n = 14
         x = np.arange(n)
@@ -3470,6 +3471,7 @@ class TestMakeSplrep:
 
         xp_assert_close(spl.c, spl_i.c, atol=1e-15)
 
+    @pytest.mark.parallel_threads(1)
     def test_s_too_small(self):
         # both splrep and make_splrep warn that "s too small": ier=2
         n = 14

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -459,6 +459,7 @@ class TestBSpline:
         spl1 = BSpline(t, c[1], k)
         xp_assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
 
+    @pytest.mark.parallel_threads(1)
     def test_design_matrix_bc_types(self):
         '''
         Splines with different boundary conditions are built on different

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1584,13 +1584,8 @@ class TestInterp:
                     d[i, :j] = np.diagonal(a, offset=j)
                 else:
                     d[i, j:] = np.diagonal(a, offset=j)
-<<<<<<< HEAD
-            b = np.random.random(n)
-            xp_assert_close(_woodbury_algorithm(d, ur, ll, b, k),
-=======
             b = rng.random(n)
-            assert_allclose(_woodbury_algorithm(d, ur, ll, b, k),
->>>>>>> 006da0af8 (ENH: scipy.interpolate tests are now passing under concurrent loads)
+            xp_assert_close(_woodbury_algorithm(d, ur, ll, b, k),
                             np.linalg.solve(a, b), atol=1e-14)
 
 
@@ -1706,29 +1701,18 @@ class TestLSQ:
     @parametrize_lsq_methods
     def test_multiple_rhs(self, method):
         x, t, k, n = self.x, self.t, self.k, self.n
-<<<<<<< HEAD
-        y = np.random.random(size=(n, 5, 6, 7))
-        b = make_lsq_spline(x, y, t, k, method=method)
-        assert b.c.shape == (t.size-k-1, 5, 6, 7)
-=======
         rng = np.random.RandomState(1234)
         y = rng.random(size=(n, 5, 6, 7))
-        b = make_lsq_spline(x, y, t, k)
-        assert_equal(b.c.shape, (t.size-k-1, 5, 6, 7))
->>>>>>> 006da0af8 (ENH: scipy.interpolate tests are now passing under concurrent loads)
+        b = make_lsq_spline(x, y, t, k, method=method)
+        assert b.c.shape == (t.size-k-1, 5, 6, 7)
 
     @parametrize_lsq_methods
     def test_multiple_rhs_2(self, method):
         x, t, k, n = self.x, self.t, self.k, self.n
         nrhs = 3
-<<<<<<< HEAD
-        y = np.random.random(size=(n, nrhs))
-        b = make_lsq_spline(x, y, t, k, method=method)
-=======
         rng = np.random.RandomState(1234)
         y = rng.random(size=(n, nrhs))
-        b = make_lsq_spline(x, y, t, k)
->>>>>>> 006da0af8 (ENH: scipy.interpolate tests are now passing under concurrent loads)
+        b = make_lsq_spline(x, y, t, k, method=method)
 
         bb = [make_lsq_spline(x, y[:, i], t, k, method=method)
               for i in range(nrhs)]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -459,7 +459,7 @@ class TestBSpline:
         spl1 = BSpline(t, c[1], k)
         xp_assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_design_matrix_bc_types(self):
         '''
         Splines with different boundary conditions are built on different
@@ -634,7 +634,7 @@ class TestBSpline:
         b = BSpline(t=t, c=c, k=0)
         xp_assert_close(b(xx), np.ones_like(xx) * 3.0)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to BSpline
         b = _make_random_spline()
@@ -2721,7 +2721,7 @@ class TestNdBSpline:
         with assert_raises(ValueError, match="Data and knots*"):
             NdBSpline.design_matrix([[1, 2]], t3, [k]*3)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         rng = np.random.default_rng(12345)
         k = 3
@@ -3243,7 +3243,7 @@ index 1afb1900f1..d817e51ad8 100644
 
         xp_assert_close(tt, t, atol=1e-15)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_s_too_small(self):
         n = 14
         x = np.arange(n)
@@ -3474,7 +3474,7 @@ class TestMakeSplrep:
 
         xp_assert_close(spl.c, spl_i.c, atol=1e-15)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_s_too_small(self):
         # both splrep and make_splrep warn that "s too small": ier=2
         n = 14

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -78,16 +78,11 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_almost_equal(spl.roots()[0], 1.050290639101332)
 
-    @pytest.fixture
-    def univariate_lock(self):
-        return Lock()
-
-    def test_roots_length(self, univariate_lock): # for gh18335
+    def test_roots_length(self): # for gh18335
         x = np.linspace(0, 50 * np.pi, 1000)
         y = np.cos(x)
         spl = UnivariateSpline(x, y, s=0)
-        with univariate_lock:
-            assert len(spl.roots()) == 50
+        assert len(spl.roots()) == 50
 
     def test_derivatives(self):
         x = [1, 3, 5, 7, 9]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -376,7 +376,7 @@ class TestUnivariateSpline:
         xp_assert_close(spl1([0.1, 0.5, 0.9, 0.99]),
                         spl2([0.1, 0.5, 0.9, 0.99]))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_fpknot_oob_crash(self):
         # https://github.com/scipy/scipy/issues/3691
         x = range(109)
@@ -421,7 +421,7 @@ of squared residuals does not satisfy the condition abs\(fp-s\)/s < tol.""")
 
 class TestLSQBivariateSpline:
     # NOTE: The systems in this test class are rank-deficient
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_linear_constant(self):
         x = [1,1,1,2,2,2,3,3,3]
         y = [1,2,3,1,2,3,1,2,3]
@@ -461,7 +461,7 @@ class TestLSQBivariateSpline:
                               + lut(xb, yb)*t*s)
                         assert_almost_equal(lut(xp,yp), zp)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_integral(self):
         x = [1,1,1,2,2,2,8,8,8]
         y = [1,2,3,1,2,3,1,2,3]
@@ -482,7 +482,7 @@ class TestLSQBivariateSpline:
         assert_almost_equal(np.asarray(lut.integral(tx[0], tx[-1], ty[0], ty[-1])),
                             np.asarray(trpz))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_empty_input(self):
         # Test whether empty inputs returns an empty output. Ticket 1014
         x = [1,1,1,2,2,2,3,3,3]
@@ -542,7 +542,7 @@ class TestLSQBivariateSpline:
             LSQBivariateSpline(x, y, z, tx, ty, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_array_like_input(self):
         s = 0.1
         tx = np.array([1 + s, 3 - s])
@@ -564,7 +564,7 @@ class TestLSQBivariateSpline:
             xp_assert_close(spl1(2.0, 2.0), spl2(2.0, 2.0))
             assert len(r) == 2
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_unequal_length_of_knots(self):
         """Test for the case when the input knot-location arrays in x and y are
         of different lengths.
@@ -607,7 +607,7 @@ class TestSmoothBivariateSpline:
         assert abs(lut.get_residual()) < 1e-15
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_integral(self):
         x = [1,1,1,2,2,2,4,4,4]
         y = [1,2,3,1,2,3,1,2,3]

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -174,6 +174,7 @@ class TestLinearNDInterpolation:
         assert_almost_equal(ip(0.5, 0.5), ip2(0.5, 0.5))
 
     @pytest.mark.slow
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.skipif(_IS_32BIT, reason='it fails on 32-bit')
     def test_threading(self):
         # This test was taken from issue 8856
@@ -258,7 +259,8 @@ class TestCloughTocher2DInterpolator:
 
     def _check_accuracy(self, func, x=None, tol=1e-6, alternate=False,
                         rescale=False, **kw):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
+        # np.random.seed(1234)
         if x is None:
             x = np.array([(0, 0), (0, 1),
                           (1, 0), (1, 1), (0.25, 0.75), (0.6, 0.8),
@@ -273,7 +275,7 @@ class TestCloughTocher2DInterpolator:
                                                      func(x[:,0], x[:,1]),
                                                      tol=1e-6, rescale=rescale)
 
-        p = np.random.rand(50, 2)
+        p = rng.rand(50, 2)
 
         if not alternate:
             a = ip(p)
@@ -372,9 +374,9 @@ class TestCloughTocher2DInterpolator:
             lambda x, y: np.cos(2*np.pi*x)*np.sin(2*np.pi*y)
         ]
 
-        np.random.seed(4321)  # use a different seed than the check!
+        rng = np.random.RandomState(4321)  # use a different seed than the check!
         grid = np.r_[np.array([(0,0), (0,1), (1,0), (1,1)], dtype=float),
-                     np.random.rand(30*30, 2)]
+                     rng.rand(30*30, 2)]
 
         for j, func in enumerate(funcs):
             self._check_accuracy(func, x=grid, tol=1e-9, atol=5e-3, rtol=1e-2,
@@ -389,9 +391,9 @@ class TestCloughTocher2DInterpolator:
 
     def test_pickle(self):
         # Test at single points
-        np.random.seed(1234)
-        x = np.random.rand(30, 2)
-        y = np.random.rand(30) + 1j*np.random.rand(30)
+        rng = np.random.RandomState(1234)
+        x = rng.rand(30, 2)
+        y = rng.rand(30) + 1j*rng.rand(30)
 
         ip = interpnd.CloughTocher2DInterpolator(x, y)
         ip2 = pickle.loads(pickle.dumps(ip))
@@ -421,9 +423,9 @@ class TestCloughTocher2DInterpolator:
         xp_assert_close(v1, v2)
 
         # ... and affine invariant
-        np.random.seed(1)
-        A = np.random.randn(2, 2)
-        b = np.random.randn(2)
+        rng = np.random.RandomState(1)
+        A = rng.randn(2, 2)
+        b = rng.randn(2)
 
         points = A.dot(points.T).T + b[None,:]
         p1 = A.dot(p1) + b

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -174,7 +174,7 @@ class TestLinearNDInterpolation:
         assert_almost_equal(ip(0.5, 0.5), ip2(0.5, 0.5))
 
     @pytest.mark.slow
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.skipif(_IS_32BIT, reason='it fails on 32-bit')
     def test_threading(self):
         # This test was taken from issue 8856

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1216,12 +1216,12 @@ class TestPPoly:
             B = binom(n, k)
             return B[::-1, ::-1]
 
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
 
         power = 3
         for m in [10, 20, 30]:
-            x = np.sort(np.random.uniform(0, 10, m + 1))
-            ca = np.random.uniform(-2, 2, size=(power + 1, m))
+            x = np.sort(rng.uniform(0, 10, m + 1))
+            ca = rng.uniform(-2, 2, size=(power + 1, m))
 
             h = np.diff(x)
             h_powers = h[None, :] ** np.arange(power + 1)[::-1, None]
@@ -1233,7 +1233,7 @@ class TestPPoly:
             pa = PPoly(ca, x, extrapolate=True)
             pd = PPoly(cd[:, ::-1], x[::-1], extrapolate=True)
 
-            x_test = np.random.uniform(-10, 20, 100)
+            x_test = rng.uniform(-10, 20, 100)
             xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
             xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
@@ -1247,7 +1247,7 @@ class TestPPoly:
             # equal.
             pa_i = pa.antiderivative()
             pd_i = pd.antiderivative()
-            for a, b in np.random.uniform(-10, 20, (5, 2)):
+            for a, b in rng.uniform(-10, 20, (5, 2)):
                 int_a = pa.integrate(a, b)
                 int_d = pd.integrate(a, b)
                 xp_assert_close(int_a, int_d, rtol=1e-13)
@@ -1282,9 +1282,9 @@ class TestPPoly:
         xp_assert_close(p(0.7), np.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
 
     def test_vs_alternative_implementations(self):
-        np.random.seed(1234)
-        c = np.random.rand(3, 12, 22)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
+        rng = np.random.RandomState(1234)
+        c = rng.rand(3, 12, 22)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
 
         p = PPoly(c, x)
 
@@ -1296,9 +1296,9 @@ class TestPPoly:
         xp_assert_close(p(xp)[:, 0], expected)
 
     def test_from_spline(self):
-        np.random.seed(1234)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
-        y = np.random.rand(len(x))
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
 
         spl = splrep(x, y, s=0)
         pp = PPoly.from_spline(spl)
@@ -1333,9 +1333,9 @@ class TestPPoly:
         xp_assert_close(pp.derivative(2).c, ddpp.c)
 
     def test_derivative_eval(self):
-        np.random.seed(1234)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
-        y = np.random.rand(len(x))
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
 
         spl = splrep(x, y, s=0)
         pp = PPoly.from_spline(spl)
@@ -1345,9 +1345,9 @@ class TestPPoly:
             xp_assert_close(pp(xi, dx), splev(xi, spl, dx))
 
     def test_derivative(self):
-        np.random.seed(1234)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
-        y = np.random.rand(len(x))
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
         pp = PPoly.from_spline(spl)
@@ -1398,9 +1398,9 @@ class TestPPoly:
         xp_assert_close(iipp2.c.T, iic.T)
 
     def test_antiderivative_vs_derivative(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         x = np.linspace(0, 1, 30)**2
-        y = np.random.rand(len(x))
+        y = rng.rand(len(x))
         spl = splrep(x, y, s=0, k=5)
         pp = PPoly.from_spline(spl)
 
@@ -1422,9 +1422,9 @@ class TestPPoly:
                                 rtol=1e-7, err_msg="dx=%d k=%d" % (dx, k))
 
     def test_antiderivative_vs_spline(self):
-        np.random.seed(1234)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
-        y = np.random.rand(len(x))
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
         pp = PPoly.from_spline(spl)
@@ -1452,9 +1452,9 @@ class TestPPoly:
         xp_assert_close(p2.c, p.c)
 
     def test_integrate(self):
-        np.random.seed(1234)
-        x = np.sort(np.r_[0, np.random.rand(11), 1])
-        y = np.random.rand(len(x))
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
         pp = PPoly.from_spline(spl)
@@ -1587,17 +1587,17 @@ class TestPPoly:
 
     def test_roots_random(self):
         # Check high-order polynomials with random coefficients
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         num = 0
 
         for extrapolate in (True, False):
             for order in range(0, 20):
-                x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
-                c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
+                x = np.unique(np.r_[0, 10 * rng.rand(30), 10])
+                c = 2*rng.rand(order+1, len(x)-1, 2, 3) - 1
 
                 pp = PPoly(c, x)
-                for y in [0, np.random.random()]:
+                for y in [0, rng.random()]:
                     r = pp.solve(y, discontinuity=False, extrapolate=extrapolate)
 
                     for i in range(2):
@@ -1619,16 +1619,16 @@ class TestPPoly:
 
     def test_roots_croots(self):
         # Test the complex root finding algorithm
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         for k in range(1, 15):
-            c = np.random.rand(k, 1, 130)
+            c = rng.rand(k, 1, 130)
 
             if k == 3:
                 # add a case with zero discriminant
                 c[:,0,0] = 1, 2, 1
 
-            for y in [0, np.random.random()]:
+            for y in [0, rng.random()]:
                 w = np.empty(c.shape, dtype=complex)
                 _ppoly._croots_poly1(c, w, y)
 
@@ -1725,19 +1725,19 @@ class TestBPoly:
         xp_assert_close(bp(-1.3, 1), np.asarray(2 * (0.7/2)))
 
     def test_descending(self):
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
 
         power = 3
         for m in [10, 20, 30]:
-            x = np.sort(np.random.uniform(0, 10, m + 1))
-            ca = np.random.uniform(-0.1, 0.1, size=(power + 1, m))
+            x = np.sort(rng.uniform(0, 10, m + 1))
+            ca = rng.uniform(-0.1, 0.1, size=(power + 1, m))
             # We need only to flip coefficients to get it right!
             cd = ca[::-1].copy()
 
             pa = BPoly(ca, x, extrapolate=True)
             pd = BPoly(cd[:, ::-1], x[::-1], extrapolate=True)
 
-            x_test = np.random.uniform(-10, 20, 100)
+            x_test = rng.uniform(-10, 20, 100)
             xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
             xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
@@ -1751,7 +1751,7 @@ class TestBPoly:
             # equal.
             pa_i = pa.antiderivative()
             pd_i = pd.antiderivative()
-            for a, b in np.random.uniform(-10, 20, (5, 2)):
+            for a, b in rng.uniform(-10, 20, (5, 2)):
                 int_a = pa.integrate(a, b)
                 int_d = pd.integrate(a, b)
                 xp_assert_close(int_a, int_d, rtol=1e-12)
@@ -1759,13 +1759,14 @@ class TestBPoly:
                                 rtol=1e-12)
 
     def test_multi_shape(self):
-        c = np.random.rand(6, 2, 1, 2, 3)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(6, 2, 1, 2, 3)
         x = np.array([0, 0.5, 1])
         p = BPoly(c, x)
         assert p.x.shape == x.shape
         assert p.c.shape == c.shape
         assert p(0.3).shape == c.shape[2:]
-        assert p(np.random.rand(5, 6)).shape == (5, 6) + c.shape[2:]
+        assert p(rng.rand(5, 6)).shape == (5, 6) + c.shape[2:]
 
         dp = p.derivative()
         assert dp.c.shape == (5, 2, 1, 2, 3)
@@ -1823,10 +1824,10 @@ class TestBPolyCalculus:
 
     def test_derivative_ppoly(self):
         # make sure it's consistent w/ power basis
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
-        x = np.sort(np.random.random(m))
-        c = np.random.random((k, m-1))
+        x = np.sort(rng.random(m))
+        c = rng.random((k, m-1))
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
 
@@ -1837,10 +1838,10 @@ class TestBPolyCalculus:
             xp_assert_close(bp(xp), pp(xp))
 
     def test_deriv_inplace(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
-        x = np.sort(np.random.random(m))
-        c = np.random.random((k, m-1))
+        x = np.sort(rng.random(m))
+        c = rng.random((k, m-1))
 
         # test both real and complex coefficients
         for cc in [c.copy(), c*(1. + 2.j)]:
@@ -1870,9 +1871,9 @@ class TestBPolyCalculus:
                         atol=1e-12, rtol=1e-12)
 
     def test_der_antider(self):
-        np.random.seed(1234)
-        x = np.sort(np.random.random(11))
-        c = np.random.random((4, 10, 2, 3))
+        rng = np.random.RandomState(1234)
+        x = np.sort(rng.random(11))
+        c = rng.random((4, 10, 2, 3))
         bp = BPoly(c, x)
 
         xx = np.linspace(x[0], x[-1], 100)
@@ -1880,9 +1881,9 @@ class TestBPolyCalculus:
                         bp(xx), atol=1e-12, rtol=1e-12)
 
     def test_antider_ppoly(self):
-        np.random.seed(1234)
-        x = np.sort(np.random.random(11))
-        c = np.random.random((4, 10, 2, 3))
+        rng = np.random.RandomState(1234)
+        x = np.sort(rng.random(11))
+        c = rng.random((4, 10, 2, 3))
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
 
@@ -1892,9 +1893,9 @@ class TestBPolyCalculus:
                         pp.antiderivative(2)(xx), atol=1e-12, rtol=1e-12)
 
     def test_antider_continuous(self):
-        np.random.seed(1234)
-        x = np.sort(np.random.random(11))
-        c = np.random.random((4, 10))
+        rng = np.random.RandomState(1234)
+        x = np.sort(rng.random(11))
+        c = rng.random((4, 10))
         bp = BPoly(c, x).antiderivative()
 
         xx = bp.x[1:-1]
@@ -1902,9 +1903,9 @@ class TestBPolyCalculus:
                         bp(xx + 1e-14), atol=1e-12, rtol=1e-12)
 
     def test_integrate(self):
-        np.random.seed(1234)
-        x = np.sort(np.random.random(11))
-        c = np.random.random((4, 10))
+        rng = np.random.RandomState(1234)
+        x = np.sort(rng.random(11))
+        c = rng.random((4, 10))
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
         xp_assert_close(bp.integrate(0, 1),
@@ -1976,10 +1977,10 @@ class TestPolyConversions:
         xp_assert_close(pp(xp), pp1(xp))
 
     def test_bp_from_pp_random(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
-        x = np.sort(np.random.random(m))
-        c = np.random.random((k, m-1))
+        x = np.sort(rng.random(m))
+        c = rng.random((k, m-1))
         pp = PPoly(c, x)
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
@@ -2043,9 +2044,9 @@ class TestBPolyFromDerivatives:
         xp_assert_close(c3, [1., 5./3, 3., 4.])
 
     def test_make_poly_12(self):
-        np.random.seed(12345)
-        ya = np.r_[0, np.random.random(5)]
-        yb = np.r_[0, np.random.random(5)]
+        rng = np.random.RandomState(12345)
+        ya = np.r_[0, rng.random(5)]
+        yb = np.r_[0, rng.random(5)]
 
         c = BPoly._construct_from_derivatives(0, 1, ya, yb)
         pp = BPoly(c[:, None], [0, 1])
@@ -2055,10 +2056,10 @@ class TestBPolyFromDerivatives:
             pp = pp.derivative()
 
     def test_raise_degree(self):
-        np.random.seed(12345)
+        rng = np.random.RandomState(12345)
         x = [0, 1]
         k, d = 8, 5
-        c = np.random.random((k, 1, 2, 3, 4))
+        c = rng.random((k, 1, 2, 3, 4))
         bp = BPoly(c, x)
 
         c1 = BPoly._raise_degree(c, d)
@@ -2089,9 +2090,9 @@ class TestBPolyFromDerivatives:
 
     def _make_random_mk(self, m, k):
         # k derivatives at each breakpoint
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         xi = np.asarray([1. * j**2 for j in range(m+1)])
-        yi = [np.random.random(k) for j in range(m+1)]
+        yi = [rng.random(k) for j in range(m+1)]
         return xi, yi
 
     def test_random_12(self):
@@ -2154,9 +2155,10 @@ class TestBPolyFromDerivatives:
             assert not np.allclose(pp(x - 1e-12), pp(x + 1e-12))
 
     def test_yi_trailing_dims(self):
+        rng = np.random.RandomState(1234)
         m, k = 7, 5
-        xi = np.sort(np.random.random(m+1))
-        yi = np.random.random((m+1, k, 6, 7, 8))
+        xi = np.sort(rng.random(m+1))
+        yi = rng.random((m+1, k, 6, 7, 8))
         pp = BPoly.from_derivatives(xi, yi)
         assert pp.c.shape == (2*k, m, 6, 7, 8)
 
@@ -2180,12 +2182,12 @@ class TestBPolyFromDerivatives:
 
 class TestNdPPoly:
     def test_simple_1d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5)
+        c = rng.rand(4, 5)
         x = np.linspace(0, 1, 5+1)
 
-        xi = np.random.rand(200)
+        xi = rng.rand(200)
 
         p = NdPPoly(c, (x,))
         v1 = p((xi,))
@@ -2194,14 +2196,14 @@ class TestNdPPoly:
         xp_assert_close(v1, v2)
 
     def test_simple_2d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5, 6, 7)
+        c = rng.rand(4, 5, 6, 7)
         x = np.linspace(0, 1, 6+1)
         y = np.linspace(0, 1, 7+1)**2
 
-        xi = np.random.rand(200)
-        yi = np.random.rand(200)
+        xi = rng.rand(200)
+        yi = rng.rand(200)
 
         v1 = np.empty([len(xi), 1], dtype=c.dtype)
         v1.fill(np.nan)
@@ -2223,16 +2225,16 @@ class TestNdPPoly:
             xp_assert_close(v1, v2, err_msg=repr(nu))
 
     def test_simple_3d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5, 6, 7, 8, 9)
+        c = rng.rand(4, 5, 6, 7, 8, 9)
         x = np.linspace(0, 1, 7+1)
         y = np.linspace(0, 1, 8+1)**2
         z = np.linspace(0, 1, 9+1)**3
 
-        xi = np.random.rand(40)
-        yi = np.random.rand(40)
-        zi = np.random.rand(40)
+        xi = rng.rand(40)
+        yi = rng.rand(40)
+        zi = rng.rand(40)
 
         p = NdPPoly(c, (x, y, z))
 
@@ -2243,18 +2245,18 @@ class TestNdPPoly:
             xp_assert_close(v1, v2, err_msg=repr(nu))
 
     def test_simple_4d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5, 6, 7, 8, 9, 10, 11)
+        c = rng.rand(4, 5, 6, 7, 8, 9, 10, 11)
         x = np.linspace(0, 1, 8+1)
         y = np.linspace(0, 1, 9+1)**2
         z = np.linspace(0, 1, 10+1)**3
         u = np.linspace(0, 1, 11+1)**4
 
-        xi = np.random.rand(20)
-        yi = np.random.rand(20)
-        zi = np.random.rand(20)
-        ui = np.random.rand(20)
+        xi = rng.rand(20)
+        yi = rng.rand(20)
+        zi = rng.rand(20)
+        ui = rng.rand(20)
 
         p = NdPPoly(c, (x, y, z, u))
         v1 = p((xi, yi, zi, ui))
@@ -2263,9 +2265,9 @@ class TestNdPPoly:
         xp_assert_close(v1, v2)
 
     def test_deriv_1d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5)
+        c = rng.rand(4, 5)
         x = np.linspace(0, 1, 5+1)
 
         p = NdPPoly(c, (x,))
@@ -2283,9 +2285,9 @@ class TestNdPPoly:
         xp_assert_close(dp.c, dp1.c)
 
     def test_deriv_3d(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = np.random.rand(4, 5, 6, 7, 8, 9)
+        c = rng.rand(4, 5, 6, 7, 8, 9)
         x = np.linspace(0, 1, 7+1)
         y = np.linspace(0, 1, 8+1)**2
         z = np.linspace(0, 1, 9+1)**3
@@ -2315,6 +2317,7 @@ class TestNdPPoly:
 
     def test_deriv_3d_simple(self):
         # Integrate to obtain function x y**2 z**4 / (2! 4!)
+        rng = np.random.RandomState(1234)
 
         c = np.ones((1, 1, 1, 3, 4, 5))
         x = np.linspace(0, 1, 3+1)**1
@@ -2325,16 +2328,16 @@ class TestNdPPoly:
         ip = p.antiderivative((1, 0, 4))
         ip = ip.antiderivative((0, 2, 0))
 
-        xi = np.random.rand(20)
-        yi = np.random.rand(20)
-        zi = np.random.rand(20)
+        xi = rng.rand(20)
+        yi = rng.rand(20)
+        zi = rng.rand(20)
 
         xp_assert_close(ip((xi, yi, zi)),
                         xi * yi**2 * zi**4 / (gamma(3)*gamma(5)))
 
     def test_integrate_2d(self):
-        np.random.seed(1234)
-        c = np.random.rand(4, 5, 16, 17)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(4, 5, 16, 17)
         x = np.linspace(0, 1, 16+1)**1
         y = np.linspace(0, 1, 17+1)**2
 
@@ -2366,8 +2369,8 @@ class TestNdPPoly:
                             err_msg=repr(ranges))
 
     def test_integrate_1d(self):
-        np.random.seed(1234)
-        c = np.random.rand(4, 5, 6, 16, 17, 18)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(4, 5, 6, 16, 17, 18)
         x = np.linspace(0, 1, 16+1)**1
         y = np.linspace(0, 1, 17+1)**2
         z = np.linspace(0, 1, 18+1)**3
@@ -2375,8 +2378,8 @@ class TestNdPPoly:
         # Check 1-D integration
         p = NdPPoly(c, (x, y, z))
 
-        u = np.random.rand(200)
-        v = np.random.rand(200)
+        u = rng.rand(200)
+        v = rng.rand(200)
         a, b = 0.2, 0.7
 
         px = p.integrate_1d(a, b, axis=0)
@@ -2391,7 +2394,7 @@ class TestNdPPoly:
         paz = p.antiderivative((0, 0, 1))
         xp_assert_close(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
 
-
+    @pytest.mark.parallel_threads(1)
     def test_concurrency(self):
         rng = np.random.default_rng(12345)
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2394,7 +2394,7 @@ class TestNdPPoly:
         paz = p.antiderivative((0, 0, 1))
         xp_assert_close(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         rng = np.random.default_rng(12345)
 

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -246,7 +246,7 @@ class TestNearestNDInterpolator:
         with assert_raises(TypeError):
             NI([0.5, 0.5], query_options="not a dictionary")
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         npts, nd = 50, 3
         x = np.arange(npts * nd).reshape((npts, nd))

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -246,6 +246,7 @@ class TestNearestNDInterpolator:
         with assert_raises(TypeError):
             NI([0.5, 0.5], query_options="not a dictionary")
 
+    @pytest.mark.parallel_threads(1)
     def test_concurrency(self):
         npts, nd = 50, 3
         x = np.arange(npts * nd).reshape((npts, nd))
@@ -262,9 +263,9 @@ class TestNDInterpolators:
     @parametrize_interpolators
     def test_broadcastable_input(self, interpolator):
         # input data
-        np.random.seed(0)
-        x = np.random.random(10)
-        y = np.random.random(10)
+        rng = np.random.RandomState(0)
+        x = rng.random(10)
+        y = rng.random(10)
         z = np.hypot(x, y)
 
         # x-y grid for interpolation
@@ -291,13 +292,13 @@ class TestNDInterpolators:
     @parametrize_interpolators
     def test_read_only(self, interpolator):
         # input data
-        np.random.seed(0)
-        xy = np.random.random((10, 2))
+        rng = np.random.RandomState(0)
+        xy = rng.random((10, 2))
         x, y = xy[:, 0], xy[:, 1]
         z = np.hypot(x, y)
 
         # interpolation points
-        XY = np.random.random((50, 2))
+        XY = rng.random((50, 2))
 
         xy.setflags(write=False)
         z.setflags(write=False)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -21,16 +21,16 @@ def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
                 extra_args=None):
     if extra_args is None:
         extra_args = {}
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
 
     x = [-1, 0, 1, 2, 3, 4]
     s = list(range(1, len(y_shape)+1))
     s.insert(axis % (len(y_shape)+1), 0)
-    y = np.random.rand(*((6,) + y_shape)).transpose(s)
+    y = rng.rand(*((6,) + y_shape)).transpose(s)
 
     xi = np.zeros(x_shape)
     if interpolator_cls is CubicHermiteSpline:
-        dydx = np.random.rand(*((6,) + y_shape)).transpose(s)
+        dydx = rng.rand(*((6,) + y_shape)).transpose(s)
         yi = interpolator_cls(x, y, dydx, axis=axis, **extra_args)(xi)
     else:
         yi = interpolator_cls(x, y, axis=axis, **extra_args)(xi)
@@ -314,10 +314,12 @@ class TestKrogh:
                   1j*KroghInterpolator(x, y.imag).derivatives(0))
         xp_assert_close(cmplx, cmplx2, atol=1e-15)
 
+    @pytest.mark.parallel_threads(1)
     def test_high_degree_warning(self):
         with pytest.warns(UserWarning, match="40 degrees provided,"):
             KroghInterpolator(np.arange(40), np.ones(40))
 
+    @pytest.mark.parallel_threads(1)
     def test_concurrency(self):
         P = KroghInterpolator(self.xs, self.ys)
 
@@ -517,6 +519,7 @@ class TestBarycentric:
         # at the nodes
         assert_almost_equal(yi, P.yi.ravel())
 
+    @pytest.mark.parallel_threads(1)
     def test_repeated_node(self):
         # check that a repeated node raises a ValueError
         # (computing the weights requires division by xi[i] - xi[j])
@@ -526,6 +529,7 @@ class TestBarycentric:
                            match="Interpolation points xi must be distinct."):
             BarycentricInterpolator(xis, ys)
 
+    @pytest.mark.parallel_threads(1)
     def test_concurrency(self):
         P = BarycentricInterpolator(self.xs, self.ys)
 
@@ -537,9 +541,9 @@ class TestBarycentric:
 
 class TestPCHIP:
     def _make_random(self, npts=20):
-        np.random.seed(1234)
-        xi = np.sort(np.random.random(npts))
-        yi = np.random.random(npts)
+        rng = np.random.RandomState(1234)
+        xi = np.sort(rng.random(npts))
+        yi = rng.random(npts)
         return pchip(xi, yi), xi, yi
 
     def test_overshoot(self):
@@ -621,6 +625,7 @@ class TestPCHIP:
             for t in (x[0], x[-1]):
                 assert pp(t, 1) != 0
 
+    @pytest.mark.parallel_threads(1)
     def test_all_zeros(self):
         x = np.arange(10)
         y = np.zeros_like(x)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -314,12 +314,12 @@ class TestKrogh:
                   1j*KroghInterpolator(x, y.imag).derivatives(0))
         xp_assert_close(cmplx, cmplx2, atol=1e-15)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_high_degree_warning(self):
         with pytest.warns(UserWarning, match="40 degrees provided,"):
             KroghInterpolator(np.arange(40), np.ones(40))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         P = KroghInterpolator(self.xs, self.ys)
 
@@ -519,7 +519,7 @@ class TestBarycentric:
         # at the nodes
         assert_almost_equal(yi, P.yi.ravel())
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_repeated_node(self):
         # check that a repeated node raises a ValueError
         # (computing the weights requires division by xi[i] - xi[j])
@@ -529,7 +529,7 @@ class TestBarycentric:
                            match="Interpolation points xi must be distinct."):
             BarycentricInterpolator(xis, ys)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         P = BarycentricInterpolator(self.xs, self.ys)
 
@@ -625,7 +625,7 @@ class TestPCHIP:
             for t in (x[0], x[-1]):
                 assert pp(t, 1) != 0
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_all_zeros(self):
         x = np.arange(10)
         y = np.zeros_like(x)

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -231,7 +231,7 @@ def test_rbf_epsilon_none_collinear():
     assert rbf.epsilon > 0
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_rbf_concurrency():
     x = linspace(0, 10, 100)
     y0 = sin(x)

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -9,6 +9,8 @@ from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate._rbf import Rbf
 from scipy._lib._testutils import _run_concurrent_barrier
 
+import pytest
+
 
 FUNCTIONS = ('multiquadric', 'inverse multiquadric', 'gaussian',
              'cubic', 'quintic', 'thin-plate', 'linear')
@@ -26,8 +28,9 @@ def check_rbf1d_interpolation(function):
 
 def check_rbf2d_interpolation(function):
     # Check that the Rbf function interpolates through the nodes (2D).
-    x = random.rand(50,1)*4-2
-    y = random.rand(50,1)*4-2
+    rng = np.random.RandomState(1234)
+    x = rng.rand(50,1)*4-2
+    y = rng.rand(50,1)*4-2
     z = x*exp(-x**2-1j*y**2)
     rbf = Rbf(x, y, z, epsilon=2, function=function)
     zi = rbf(x, y)
@@ -37,9 +40,10 @@ def check_rbf2d_interpolation(function):
 
 def check_rbf3d_interpolation(function):
     # Check that the Rbf function interpolates through the nodes (3D).
-    x = random.rand(50, 1)*4 - 2
-    y = random.rand(50, 1)*4 - 2
-    z = random.rand(50, 1)*4 - 2
+    rng = np.random.RandomState(1234)
+    x = rng.rand(50, 1)*4 - 2
+    y = rng.rand(50, 1)*4 - 2
+    z = rng.rand(50, 1)*4 - 2
     d = x*exp(-x**2 - y**2)
     rbf = Rbf(x, y, z, d, epsilon=2, function=function)
     di = rbf(x, y, z)
@@ -68,8 +72,9 @@ def check_2drbf1d_interpolation(function):
 
 def check_2drbf2d_interpolation(function):
     # Check that the 2-D Rbf function interpolates through the nodes (2D).
-    x = random.rand(50, ) * 4 - 2
-    y = random.rand(50, ) * 4 - 2
+    rng = np.random.RandomState(1234)
+    x = rng.rand(50, ) * 4 - 2
+    y = rng.rand(50, ) * 4 - 2
     z0 = x * exp(-x ** 2 - 1j * y ** 2)
     z1 = y * exp(-y ** 2 - 1j * x ** 2)
     z = np.vstack([z0, z1]).T
@@ -81,9 +86,10 @@ def check_2drbf2d_interpolation(function):
 
 def check_2drbf3d_interpolation(function):
     # Check that the 2-D Rbf function interpolates through the nodes (3D).
-    x = random.rand(50, ) * 4 - 2
-    y = random.rand(50, ) * 4 - 2
-    z = random.rand(50, ) * 4 - 2
+    rng = np.random.RandomState(1234)
+    x = rng.rand(50, ) * 4 - 2
+    y = rng.rand(50, ) * 4 - 2
+    z = rng.rand(50, ) * 4 - 2
     d0 = x * exp(-x ** 2 - y ** 2)
     d1 = y * exp(-y ** 2 - x ** 2)
     d = np.vstack([d0, d1]).T
@@ -159,9 +165,9 @@ def check_rbf1d_stability(function):
     # to overshoot. Regression for issue #4523.
     #
     # Generate some data (fixed random seed hence deterministic)
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     x = np.linspace(0, 10, 50)
-    z = x + 4.0 * np.random.randn(len(x))
+    z = x + 4.0 * rng.randn(len(x))
 
     rbf = Rbf(x, z, function=function)
     xi = np.linspace(0, 10, 1000)
@@ -225,6 +231,7 @@ def test_rbf_epsilon_none_collinear():
     assert rbf.epsilon > 0
 
 
+@pytest.mark.parallel_threads(1)
 def test_rbf_concurrency():
     x = linspace(0, 10, 100)
     y0 = sin(x)

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from scipy._lib._array_api import assert_array_almost_equal, assert_almost_equal
 
-from numpy import linspace, sin, cos, random, exp, allclose
+from numpy import linspace, sin, cos, exp, allclose
 from scipy.interpolate._rbf import Rbf
 from scipy._lib._testutils import _run_concurrent_barrier
 

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -366,7 +366,7 @@ class _TestRBFInterpolator:
         with pytest.raises(ValueError, match=match):
             self.build(y, d, kernel='thin_plate_spline')
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_degree_warning(self):
         y = np.linspace(0, 1, 5)[:, None]
         d = np.zeros(5)

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -366,6 +366,7 @@ class _TestRBFInterpolator:
         with pytest.raises(ValueError, match=match):
             self.build(y, d, kernel='thin_plate_spline')
 
+    @pytest.mark.parallel_threads(1)
     def test_degree_warning(self):
         y = np.linspace(0, 1, 5)[:, None]
         d = np.zeros(5)

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -696,6 +696,7 @@ class TestRegularGridInterpolator:
                 (x, y), data, method='slinear',  solver_args={'woof': 42}
             )
 
+    @pytest.mark.parallel_threads(1)
     def test_concurrency(self):
         points, values = self._get_sample_4d()
         sample = np.array([[0.1 , 0.1 , 1.  , 0.9 ],
@@ -966,6 +967,7 @@ class TestInterpN:
 
         xp_assert_close(v1, v2)
 
+    @pytest.mark.parallel_threads(1)
     def test_complex_pchip(self):
         # Complex-valued data deprecated for pchip
         x, y, values = self._sample_2d_data()
@@ -977,6 +979,7 @@ class TestInterpN:
         with pytest.raises(ValueError, match='real'):
             interpn(points, values, sample, method='pchip')
 
+    @pytest.mark.parallel_threads(1)
     def test_complex_spline2fd(self):
         # Complex-valued data not supported by spline2fd
         x, y, values = self._sample_2d_data()

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -696,7 +696,7 @@ class TestRegularGridInterpolator:
                 (x, y), data, method='slinear',  solver_args={'woof': 42}
             )
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         points, values = self._get_sample_4d()
         sample = np.array([[0.1 , 0.1 , 1.  , 0.9 ],
@@ -967,7 +967,7 @@ class TestInterpN:
 
         xp_assert_close(v1, v2)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_complex_pchip(self):
         # Complex-valued data deprecated for pchip
         x, y, values = self._sample_2d_data()
@@ -979,7 +979,7 @@ class TestInterpN:
         with pytest.raises(ValueError, match='real'):
             interpn(points, values, sample, method='pchip')
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_complex_spline2fd(self):
         # Complex-valued data not supported by spline2fd
         x, y, values = self._sample_2d_data()

--- a/scipy/io/_harwell_boeing/_fortran_format_parser.py
+++ b/scipy/io/_harwell_boeing/_fortran_format_parser.py
@@ -7,6 +7,7 @@ FortranFormatParser can create *Format instances from raw Fortran format
 strings (e.g. '(3I4)', '(10I3)', etc...)
 """
 import re
+import threading
 
 import numpy as np
 
@@ -228,16 +229,19 @@ class FortranFormatParser:
     (integer format) for now.
     """
     def __init__(self):
-        self.tokenizer = Tokenizer()
+        self.tokenizer = threading.local()
 
     def parse(self, s):
-        self.tokenizer.input(s)
+        if not hasattr(self.tokenizer, 't'):
+            self.tokenizer.t = Tokenizer()
+
+        self.tokenizer.t.input(s)
 
         tokens = []
 
         try:
             while True:
-                t = self.tokenizer.next_token()
+                t = self.tokenizer.t.next_token()
                 if t is None:
                     break
                 else:

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -766,7 +766,7 @@ def test_to_writeable():
                  np.array([(2,)], dtype=[('f', '|O8')]))
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_recarray():
     # check roundtrip of structured array
     dt = [('f1', 'f8'),
@@ -794,7 +794,7 @@ def test_recarray():
     assert_equal(a21['f2'], 'not perl')
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_save_object():
     class C:
         pass

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -766,7 +766,6 @@ def test_to_writeable():
                  np.array([(2,)], dtype=[('f', '|O8')]))
 
 
-@pytest.mark.thread_unsafe
 def test_recarray():
     # check roundtrip of structured array
     dt = [('f1', 'f8'),
@@ -794,7 +793,6 @@ def test_recarray():
     assert_equal(a21['f2'], 'not perl')
 
 
-@pytest.mark.thread_unsafe
 def test_save_object():
     class C:
         pass

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -33,6 +33,7 @@ from scipy._lib._util import VisibleDeprecationWarning
 
 
 test_data_path = pjoin(dirname(__file__), 'data')
+pytestmark = pytest.mark.parallel_threads(1)
 
 
 def mlarr(*args, **kwargs):
@@ -765,6 +766,7 @@ def test_to_writeable():
                  np.array([(2,)], dtype=[('f', '|O8')]))
 
 
+@pytest.mark.parallel_threads(1)
 def test_recarray():
     # check roundtrip of structured array
     dt = [('f1', 'f8'),
@@ -792,6 +794,7 @@ def test_recarray():
     assert_equal(a21['f2'], 'not perl')
 
 
+@pytest.mark.parallel_threads(1)
 def test_save_object():
     class C:
         pass

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -2,8 +2,10 @@
 
 import tempfile
 import shutil
+import os
 from os import path
 from glob import iglob
+import threading
 import re
 
 from numpy.testing import assert_equal, assert_allclose
@@ -18,7 +20,12 @@ from . import _test_fortran
 DATA_PATH = path.join(path.dirname(__file__), 'data')
 
 
-def test_fortranfiles_read():
+@pytest.fixture
+def io_lock():
+    return threading.Lock()
+
+
+def test_fortranfiles_read(io_lock):
     for filename in iglob(path.join(DATA_PATH, "fortran-*-*x*x*.dat")):
         m = re.search(r'fortran-([^-]+)-(\d+)x(\d+)x(\d+).dat', filename, re.I)
         if not m:
@@ -28,18 +35,20 @@ def test_fortranfiles_read():
 
         dtype = m.group(1).replace('s', '<')
 
-        f = FortranFile(filename, 'r', '<u4')
-        data = f.read_record(dtype=dtype).reshape(dims, order='F')
-        f.close()
+        with io_lock:
+            f = FortranFile(filename, 'r', '<u4')
+            data = f.read_record(dtype=dtype).reshape(dims, order='F')
+            f.close()
 
         expected = np.arange(np.prod(dims)).reshape(dims).astype(dtype)
         assert_equal(data, expected)
 
 
-def test_fortranfiles_mixed_record():
+def test_fortranfiles_mixed_record(io_lock):
     filename = path.join(DATA_PATH, "fortran-mixed.dat")
-    with FortranFile(filename, 'r', '<u4') as f:
-        record = f.read_record('<i4,<f4,<i8,2<f8')
+    with io_lock:
+        with FortranFile(filename, 'r', '<u4') as f:
+            record = f.read_record('<i4,<f4,<i8,2<f8')
 
     assert_equal(record['f0'][0], 1)
     assert_allclose(record['f1'][0], 2.3)
@@ -59,7 +68,8 @@ def test_fortranfiles_write():
 
         tmpdir = tempfile.mkdtemp()
         try:
-            testFile = path.join(tmpdir,path.basename(filename))
+            testFile = path.join(str(threading.get_native_id()),
+                                 tmpdir,path.basename(filename))
             f = FortranFile(testFile, 'w','<u4')
             f.write_record(data.T)
             f.close()
@@ -73,7 +83,7 @@ def test_fortranfiles_write():
             shutil.rmtree(tmpdir)
 
 
-def test_fortranfile_read_mixed_record():
+def test_fortranfile_read_mixed_record(io_lock):
     # The data file fortran-3x3d-2i.dat contains the program that
     # produced it at the end.
     #
@@ -86,8 +96,9 @@ def test_fortranfile_read_mixed_record():
     #
 
     filename = path.join(DATA_PATH, "fortran-3x3d-2i.dat")
-    with FortranFile(filename, 'r', '<u4') as f:
-        record = f.read_record('(3,3)<f8', '2<i4')
+    with io_lock:
+        with FortranFile(filename, 'r', '<u4') as f:
+            record = f.read_record('(3,3)<f8', '2<i4')
 
     ax = np.arange(3*3).reshape(3, 3).astype(np.float64)
     bx = np.array([-1, -2], dtype=np.int32)
@@ -97,7 +108,8 @@ def test_fortranfile_read_mixed_record():
 
 
 def test_fortranfile_write_mixed_record(tmpdir):
-    tf = path.join(str(tmpdir), 'test.dat')
+    tf = path.join(str(tmpdir), str(threading.get_native_id()), 'test.dat')
+    os.makedirs(path.dirname(tf), exist_ok=True)
 
     r1 = (('f4', 'f4', 'i4'), (np.float32(2), np.float32(3), np.int32(100)))
     r2 = (('4f4', '(3,3)f4', '8i4'),
@@ -119,17 +131,21 @@ def test_fortranfile_write_mixed_record(tmpdir):
             assert_equal(bb, aa)
 
 
-def test_fortran_roundtrip(tmpdir):
-    filename = path.join(str(tmpdir), 'test.dat')
+def test_fortran_roundtrip(tmpdir, io_lock):
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         'test.dat')
+    os.makedirs(path.dirname(filename), exist_ok=True)
 
-    np.random.seed(1)
+    rng = np.random.RandomState(1)
 
     # double precision
     m, n, k = 5, 3, 2
-    a = np.random.randn(m, n, k)
+    a = rng.randn(m, n, k)
     with FortranFile(filename, 'w') as f:
         f.write_record(a.T)
-    a2 = _test_fortran.read_unformatted_double(m, n, k, filename)
+    with io_lock:
+        a2 = _test_fortran.read_unformatted_double(m, n, k, filename)
+
     with FortranFile(filename, 'r') as f:
         a3 = f.read_record('(2,3,5)f8').T
     assert_equal(a2, a)
@@ -137,10 +153,11 @@ def test_fortran_roundtrip(tmpdir):
 
     # integer
     m, n, k = 5, 3, 2
-    a = np.random.randn(m, n, k).astype(np.int32)
+    a = rng.randn(m, n, k).astype(np.int32)
     with FortranFile(filename, 'w') as f:
         f.write_record(a.T)
-    a2 = _test_fortran.read_unformatted_int(m, n, k, filename)
+    with io_lock:
+        a2 = _test_fortran.read_unformatted_int(m, n, k, filename)
     with FortranFile(filename, 'r') as f:
         a3 = f.read_record('(2,3,5)i4').T
     assert_equal(a2, a)
@@ -148,11 +165,12 @@ def test_fortran_roundtrip(tmpdir):
 
     # mixed
     m, n, k = 5, 3, 2
-    a = np.random.randn(m, n)
-    b = np.random.randn(k).astype(np.intc)
+    a = rng.randn(m, n)
+    b = rng.randn(k).astype(np.intc)
     with FortranFile(filename, 'w') as f:
         f.write_record(a.T, b.T)
-    a2, b2 = _test_fortran.read_unformatted_mixed(m, n, k, filename)
+    with io_lock:
+        a2, b2 = _test_fortran.read_unformatted_mixed(m, n, k, filename)
     with FortranFile(filename, 'r') as f:
         a3, b3 = f.read_record('(3,5)f8', '2i4')
         a3 = a3.T
@@ -163,11 +181,13 @@ def test_fortran_roundtrip(tmpdir):
 
 
 def test_fortran_eof_ok(tmpdir):
-    filename = path.join(str(tmpdir), "scratch")
-    np.random.seed(1)
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         "scratch")
+    os.makedirs(path.dirname(filename), exist_ok=True)
+    rng = np.random.RandomState(1)
     with FortranFile(filename, 'w') as f:
-        f.write_record(np.random.randn(5))
-        f.write_record(np.random.randn(3))
+        f.write_record(rng.randn(5))
+        f.write_record(rng.randn(3))
     with FortranFile(filename, 'r') as f:
         assert len(f.read_reals()) == 5
         assert len(f.read_reals()) == 3
@@ -176,11 +196,13 @@ def test_fortran_eof_ok(tmpdir):
 
 
 def test_fortran_eof_broken_size(tmpdir):
-    filename = path.join(str(tmpdir), "scratch")
-    np.random.seed(1)
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         "scratch")
+    os.makedirs(path.dirname(filename), exist_ok=True)
+    rng = np.random.RandomState(1)
     with FortranFile(filename, 'w') as f:
-        f.write_record(np.random.randn(5))
-        f.write_record(np.random.randn(3))
+        f.write_record(rng.randn(5))
+        f.write_record(rng.randn(3))
     with open(filename, "ab") as f:
         f.write(b"\xff")
     with FortranFile(filename, 'r') as f:
@@ -191,11 +213,13 @@ def test_fortran_eof_broken_size(tmpdir):
 
 
 def test_fortran_bogus_size(tmpdir):
-    filename = path.join(str(tmpdir), "scratch")
-    np.random.seed(1)
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         "scratch")
+    os.makedirs(path.dirname(filename), exist_ok=True)
+    rng = np.random.RandomState(1)
     with FortranFile(filename, 'w') as f:
-        f.write_record(np.random.randn(5))
-        f.write_record(np.random.randn(3))
+        f.write_record(rng.randn(5))
+        f.write_record(rng.randn(3))
     with open(filename, "w+b") as f:
         f.write(b"\xff\xff")
     with FortranFile(filename, 'r') as f:
@@ -204,11 +228,13 @@ def test_fortran_bogus_size(tmpdir):
 
 
 def test_fortran_eof_broken_record(tmpdir):
-    filename = path.join(str(tmpdir), "scratch")
-    np.random.seed(1)
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         "scratch")
+    os.makedirs(path.dirname(filename), exist_ok=True)
+    rng = np.random.RandomState(1)
     with FortranFile(filename, 'w') as f:
-        f.write_record(np.random.randn(5))
-        f.write_record(np.random.randn(3))
+        f.write_record(rng.randn(5))
+        f.write_record(rng.randn(3))
     with open(filename, "ab") as f:
         f.truncate(path.getsize(filename)-20)
     with FortranFile(filename, 'r') as f:
@@ -218,7 +244,9 @@ def test_fortran_eof_broken_record(tmpdir):
 
 
 def test_fortran_eof_multidimensional(tmpdir):
-    filename = path.join(str(tmpdir), "scratch")
+    filename = path.join(str(tmpdir), str(threading.get_native_id()),
+                         "scratch")
+    os.makedirs(path.dirname(filename), exist_ok=True)
     n, m, q = 3, 5, 7
     dt = np.dtype([("field", np.float64, (n, m))])
     a = np.zeros(q, dtype=dt)

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -278,7 +278,7 @@ class TestStructures:
         assert_identical(s.fc.r, np.array([0], dtype=np.int16))
         assert_identical(s.fc.c, np.array([4], dtype=np.int16))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_arrays_corrupt_idl80(self):
         # test byte arrays with missing nbyte information from IDL 8.0 .sav file
         with suppress_warnings() as sup:
@@ -455,7 +455,7 @@ def test_null_pointer():
     assert_identical(s.check, np.int16(5))
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_invalid_pointer():
     # Regression test for invalid pointers (gh-4613).
 

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -278,6 +278,7 @@ class TestStructures:
         assert_identical(s.fc.r, np.array([0], dtype=np.int16))
         assert_identical(s.fc.c, np.array([4], dtype=np.int16))
 
+    @pytest.mark.parallel_threads(1)
     def test_arrays_corrupt_idl80(self):
         # test byte arrays with missing nbyte information from IDL 8.0 .sav file
         with suppress_warnings() as sup:
@@ -454,6 +455,7 @@ def test_null_pointer():
     assert_identical(s.check, np.int16(5))
 
 
+@pytest.mark.parallel_threads(1)
 def test_invalid_pointer():
     # Regression test for invalid pointers (gh-4613).
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -58,13 +58,13 @@ class TestMMIOArray:
         b = mmread(self.fn)
         assert_equal(a, b)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('typeval, dtype', parametrize_args)
     def test_simple_integer(self, typeval, dtype):
         self.check_exact(array([[1, 2], [3, 4]], dtype=dtype),
                          (2, 2, 4, 'array', typeval, 'general'))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('typeval, dtype', parametrize_args)
     def test_32bit_integer(self, typeval, dtype):
         a = array([[2**31-1, 2**31-2], [2**31-3, 2**31-4]], dtype=dtype)

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -42,10 +42,6 @@ class TestMMIOArray:
     def teardown_method(self):
         shutil.rmtree(self.tmpdir)
 
-    @pytest.fixture
-    def lock(self):
-        return threading.Lock()
-
     def check(self, a, info):
         mmwrite(self.fn, a)
         assert_equal(mminfo(self.fn), info)

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
                            break_cycles, suppress_warnings, IS_PYPY)
+import pytest
 from pytest import raises as assert_raises
 
 from scipy.io import netcdf_file
@@ -20,6 +21,9 @@ TEST_DATA_PATH = pjoin(dirname(__file__), 'data')
 
 N_EG_ELS = 11  # number of elements for example variable
 VARTYPE_EG = 'b'  # var type for example variable
+
+
+pytestmark = pytest.mark.parallel_threads(1)
 
 
 @contextmanager

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -362,7 +362,7 @@ def test_read_unknown_wave_format():
                 wavfile.read(fp, mmap=mmap)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_read_early_eof_with_data():
     # File ends inside 'data' chunk, but we keep incomplete data
     for mmap in [False, True]:

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from io import BytesIO
+import threading
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_, assert_array_equal,
@@ -361,6 +362,7 @@ def test_read_unknown_wave_format():
                 wavfile.read(fp, mmap=mmap)
 
 
+@pytest.mark.parallel_threads(1)
 def test_read_early_eof_with_data():
     # File ends inside 'data' chunk, but we keep incomplete data
     for mmap in [False, True]:
@@ -414,7 +416,8 @@ def test_read_inconsistent_header():
 def test_write_roundtrip(realfile, mmap, rate, channels, dt_str, tmpdir):
     dtype = np.dtype(dt_str)
     if realfile:
-        tmpfile = str(tmpdir.join('temp.wav'))
+        tmpfile = str(tmpdir.join(str(threading.get_native_id()), 'temp.wav'))
+        os.makedirs(os.path.dirname(tmpfile), exist_ok=True)
     else:
         tmpfile = BytesIO()
     data = np.random.rand(100, channels)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -537,7 +537,7 @@ class TestSolve:
     def setup_method(self):
         np.random.seed(1234)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_20Feb04_bug(self):
         a = [[1, 1], [1.0, 0]]  # ok
         x0 = solve(a, [1, 0j])
@@ -773,7 +773,7 @@ class TestSolve:
         b = np.arange(9)[:, None]
         assert_raises(LinAlgError, solve, a, b)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('structure',
                              ('diagonal', 'tridiagonal', 'lower triangular',
                               'upper triangular', 'symmetric', 'hermitian',
@@ -865,7 +865,7 @@ class TestSolve:
                                 rtol=tol * size,
                                 err_msg=err_msg)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('dt_a', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt_a, dt_b):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -537,6 +537,7 @@ class TestSolve:
     def setup_method(self):
         np.random.seed(1234)
 
+    @pytest.mark.parallel_threads(1)
     def test_20Feb04_bug(self):
         a = [[1, 1], [1.0, 0]]  # ok
         x0 = solve(a, [1, 0j])
@@ -772,6 +773,7 @@ class TestSolve:
         b = np.arange(9)[:, None]
         assert_raises(LinAlgError, solve, a, b)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('structure',
                              ('diagonal', 'tridiagonal', 'lower triangular',
                               'upper triangular', 'symmetric', 'hermitian',
@@ -1903,9 +1905,9 @@ class TestSolveCirculant:
 
     def test_random_b_and_c(self):
         # Random b and c
-        np.random.seed(54321)
-        c = np.random.randn(50)
-        b = np.random.randn(50)
+        rng = np.random.RandomState(54321)
+        c = rng.randn(50)
+        b = rng.randn(50)
         x = solve_circulant(c, b)
         y = solve(circulant(c), b)
         assert_allclose(x, y)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -183,6 +183,7 @@ class TestSolveBanded:
         x = solve_banded((l, u), ab, b)
         assert_array_almost_equal(dot(a, x), b)
 
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
     @pytest.mark.parametrize('dt_ab', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt_ab, dt_b):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -865,6 +865,7 @@ class TestSolve:
                                 rtol=tol * size,
                                 err_msg=err_msg)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('dt_a', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt_a, dt_b):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -183,7 +183,7 @@ class TestSolveBanded:
         x = solve_banded((l, u), ab, b)
         assert_array_almost_equal(dot(a, x), b)
 
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     @pytest.mark.parametrize('dt_ab', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt_ab, dt_b):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -212,6 +212,9 @@ class TestFBLAS1Simple:
     # XXX: need tests for rot,rotm,rotg,rotmg
 
 
+# FORTRAN routines are in their most part, thread-unsafe, therefore they can
+# cause segmentation faults and other memory access errors.
+@pytest.mark.thread_unsafe
 class TestFBLAS2Simple:
 
     def test_gemv(self):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -4,7 +4,6 @@
 
 import math
 import pytest
-import threading
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_,
                            assert_array_almost_equal, assert_allclose)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -212,7 +212,7 @@ class TestFBLAS1Simple:
     # XXX: need tests for rot,rotm,rotg,rotmg
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 class TestFBLAS2Simple:
 
     def test_gemv(self):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -4,6 +4,7 @@
 
 import math
 import pytest
+import threading
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_,
                            assert_array_almost_equal, assert_allclose)
@@ -212,6 +213,7 @@ class TestFBLAS1Simple:
     # XXX: need tests for rot,rotm,rotg,rotmg
 
 
+@pytest.mark.parallel_threads(1)
 class TestFBLAS2Simple:
 
     def test_gemv(self):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -212,7 +212,6 @@ class TestFBLAS1Simple:
     # XXX: need tests for rot,rotm,rotg,rotmg
 
 
-@pytest.mark.thread_unsafe
 class TestFBLAS2Simple:
 
     def test_gemv(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2885,9 +2885,9 @@ def _check_orth(n, dtype, skip_big=False):
     assert_allclose(Y, Y.mean(), atol=tol)
 
     if n > 5 and not skip_big:
-        np.random.seed(1)
-        X = np.random.rand(n, 5) @ np.random.rand(5, n)
-        X = X + 1e-4 * np.random.rand(n, 1) @ np.random.rand(1, n)
+        rng = np.random.RandomState(1)
+        X = rng.rand(n, 5) @ rng.rand(5, n)
+        X = X + 1e-4 * rng.rand(n, 1) @ rng.rand(1, n)
         X = X.astype(dtype)
 
         Y = orth(X, rcond=1e-3)
@@ -2932,7 +2932,7 @@ def test_orth_empty(dt):
 
 class TestNullSpace:
     def test_null_space(self):
-        np.random.seed(1)
+        rng = np.random.RandomState(1)
 
         dtypes = [np.float32, np.float64, np.complex64, np.complex128]
         sizes = [1, 2, 3, 10, 100]
@@ -2951,15 +2951,15 @@ class TestNullSpace:
             assert_equal(Y.shape, (2, 1))
             assert_allclose(X.T @ Y, 0, atol=tol)
 
-            X = np.random.randn(1 + n//2, n)
+            X = rng.randn(1 + n//2, n)
             Y = null_space(X)
             assert_equal(Y.shape, (n, n - 1 - n//2))
             assert_allclose(X @ Y, 0, atol=tol)
 
             if n > 5:
-                np.random.seed(1)
-                X = np.random.rand(n, 5) @ np.random.rand(5, n)
-                X = X + 1e-4 * np.random.rand(n, 1) @ np.random.rand(1, n)
+                rng = np.random.RandomState(1)
+                X = rng.rand(n, 5) @ rng.rand(5, n)
+                X = X + 1e-4 * rng.rand(n, 1) @ rng.rand(1, n)
                 X = X.astype(dt)
 
                 Y = null_space(X, rcond=1e-3)

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import raises as assert_raises, warns
 
 
+@pytest.mark.parallel_threads(1)
 def test_args():
     A = eye(3)
     # Nonsquare array

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -9,7 +9,7 @@ import pytest
 from pytest import raises as assert_raises, warns
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_args():
     A = eye(3)
     # Nonsquare array

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -634,23 +634,24 @@ class BaseQRinsert(BaseQRdeltas):
         a, q, r = super().generate(type, mode)
 
         assert_(p > 0)
+        rng = np.random.RandomState(1234)
 
         # super call set the seed...
         if which == 'row':
             if p == 1:
-                u = np.random.random(a.shape[1])
+                u = rng.random(a.shape[1])
             else:
-                u = np.random.random((p, a.shape[1]))
+                u = rng.random((p, a.shape[1]))
         elif which == 'col':
             if p == 1:
-                u = np.random.random(a.shape[0])
+                u = rng.random(a.shape[0])
             else:
-                u = np.random.random((a.shape[0], p))
+                u = rng.random((a.shape[0], p))
         else:
             ValueError('which should be either "row" or "col"')
 
         if np.iscomplexobj(self.dtype.type(1)):
-            b = np.random.random(u.shape)
+            b = rng.random(u.shape)
             u = u + 1j * b
 
         u = u.astype(self.dtype)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -252,6 +252,7 @@ class TestLogM:
         assert log_a.shape == (0, 0)
         assert log_a.dtype == log_a0.dtype
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('dtype', [int, float, np.float32, complex, np.complex64])
     def test_no_ZeroDivisionError(self, dtype):
         # gh-17136 reported inconsistent behavior in `logm` depending on input dtype:
@@ -264,9 +265,9 @@ class TestLogM:
 
 class TestSqrtM:
     def test_round_trip_random_float(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         for n in range(1, 6):
-            M_unscaled = np.random.randn(n, n)
+            M_unscaled = rng.randn(n, n)
             for scale in np.logspace(-4, 4, 9):
                 M = M_unscaled * scale
                 M_sqrtm, info = sqrtm(M, disp=False)
@@ -274,9 +275,9 @@ class TestSqrtM:
                 assert_allclose(M_sqrtm_round_trip, M)
 
     def test_round_trip_random_complex(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
         for n in range(1, 6):
-            M_unscaled = np.random.randn(n, n) + 1j * np.random.randn(n, n)
+            M_unscaled = rng.randn(n, n) + 1j * rng.randn(n, n)
             for scale in np.logspace(-4, 4, 9):
                 M = M_unscaled * scale
                 M_sqrtm, info = sqrtm(M, disp=False)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -202,6 +202,7 @@ class TestLogM:
                 A_logm, info = logm(A, disp=False)
                 assert_(np.issubdtype(A_logm.dtype, np.complexfloating))
 
+    @pytest.mark.parallel_threads(1)
     def test_exactly_singular(self):
         A = np.array([[0, 0], [1j, 1j]])
         B = np.asarray([[1, 1], [0, 0]])
@@ -211,6 +212,7 @@ class TestLogM:
             E = expm(L)
             assert_allclose(E, M, atol=1e-14)
 
+    @pytest.mark.parallel_threads(1)
     def test_nearly_singular(self):
         M = np.array([[1e-100]])
         expected_warning = _matfuncs_inv_ssq.LogmNearlySingularWarning
@@ -762,6 +764,7 @@ class TestExpM:
         a.flags.writeable = False
         expm(a)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.fail_slow(5)
     def test_gh18086(self):
         A = np.zeros((400, 400), dtype=float)
@@ -953,12 +956,12 @@ class TestExpmConditionNumber:
 
     @pytest.mark.slow
     def test_expm_cond_fuzz(self):
-        np.random.seed(12345)
+        rng = np.random.RandomState(12345)
         eps = 1e-5
         nsamples = 10
         for i in range(nsamples):
-            n = np.random.randint(2, 5)
-            A = np.random.randn(n, n)
+            n = rng.randint(2, 5)
+            A = rng.randn(n, n)
             A_norm = scipy.linalg.norm(A)
             X = expm(A)
             X_norm = scipy.linalg.norm(X)
@@ -979,7 +982,7 @@ class TestExpmConditionNumber:
             # Check that the identified perturbation indeed gives greater
             # relative error than random perturbations with similar norms.
             for j in range(5):
-                p_rand = eps * _normalized_like(np.random.randn(*A.shape), A)
+                p_rand = eps * _normalized_like(rng.randn(*A.shape), A)
                 assert_allclose(norm(p_best), norm(p_rand))
                 p_rand_relerr = _relative_error(expm, A, p_rand)
                 assert_array_less(p_rand_relerr, p_best_relerr)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -202,7 +202,7 @@ class TestLogM:
                 A_logm, info = logm(A, disp=False)
                 assert_(np.issubdtype(A_logm.dtype, np.complexfloating))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_exactly_singular(self):
         A = np.array([[0, 0], [1j, 1j]])
         B = np.asarray([[1, 1], [0, 0]])
@@ -212,7 +212,7 @@ class TestLogM:
             E = expm(L)
             assert_allclose(E, M, atol=1e-14)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_nearly_singular(self):
         M = np.array([[1e-100]])
         expected_warning = _matfuncs_inv_ssq.LogmNearlySingularWarning
@@ -252,7 +252,7 @@ class TestLogM:
         assert log_a.shape == (0, 0)
         assert log_a.dtype == log_a0.dtype
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('dtype', [int, float, np.float32, complex, np.complex64])
     def test_no_ZeroDivisionError(self, dtype):
         # gh-17136 reported inconsistent behavior in `logm` depending on input dtype:
@@ -765,7 +765,7 @@ class TestExpM:
         a.flags.writeable = False
         expm(a)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.fail_slow(5)
     def test_gh18086(self):
         A = np.zeros((400, 400), dtype=float)

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -11,33 +11,33 @@ from scipy.sparse._sputils import matrix
 
 
 def test_orthogonal_procrustes_ndim_too_large():
-    np.random.seed(1234)
-    A = np.random.randn(3, 4, 5)
-    B = np.random.randn(3, 4, 5)
+    rng = np.random.RandomState(1234)
+    A = rng.randn(3, 4, 5)
+    B = rng.randn(3, 4, 5)
     assert_raises(ValueError, orthogonal_procrustes, A, B)
 
 
 def test_orthogonal_procrustes_ndim_too_small():
-    np.random.seed(1234)
-    A = np.random.randn(3)
-    B = np.random.randn(3)
+    rng = np.random.RandomState(1234)
+    A = rng.randn(3)
+    B = rng.randn(3)
     assert_raises(ValueError, orthogonal_procrustes, A, B)
 
 
 def test_orthogonal_procrustes_shape_mismatch():
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     shapes = ((3, 3), (3, 4), (4, 3), (4, 4))
     for a, b in permutations(shapes, 2):
-        A = np.random.randn(*a)
-        B = np.random.randn(*b)
+        A = rng.randn(*a)
+        B = rng.randn(*b)
         assert_raises(ValueError, orthogonal_procrustes, A, B)
 
 
 def test_orthogonal_procrustes_checkfinite_exception():
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     m, n = 2, 3
-    A_good = np.random.randn(m, n)
-    B_good = np.random.randn(m, n)
+    A_good = rng.randn(m, n)
+    B_good = rng.randn(m, n)
     for bad_value in np.inf, -np.inf, np.nan:
         A_bad = A_good.copy()
         A_bad[1, 2] = bad_value
@@ -48,23 +48,23 @@ def test_orthogonal_procrustes_checkfinite_exception():
 
 
 def test_orthogonal_procrustes_scale_invariance():
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     m, n = 4, 3
     for i in range(3):
-        A_orig = np.random.randn(m, n)
-        B_orig = np.random.randn(m, n)
+        A_orig = rng.randn(m, n)
+        B_orig = rng.randn(m, n)
         R_orig, s = orthogonal_procrustes(A_orig, B_orig)
-        for A_scale in np.square(np.random.randn(3)):
-            for B_scale in np.square(np.random.randn(3)):
+        for A_scale in np.square(rng.randn(3)):
+            for B_scale in np.square(rng.randn(3)):
                 R, s = orthogonal_procrustes(A_orig * A_scale, B_orig * B_scale)
                 assert_allclose(R, R_orig)
 
 
 def test_orthogonal_procrustes_array_conversion():
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     for m, n in ((6, 4), (4, 4), (4, 6)):
-        A_arr = np.random.randn(m, n)
-        B_arr = np.random.randn(m, n)
+        A_arr = rng.randn(m, n)
+        B_arr = rng.randn(m, n)
         As = (A_arr, A_arr.tolist(), matrix(A_arr))
         Bs = (B_arr, B_arr.tolist(), matrix(B_arr))
         R_arr, s = orthogonal_procrustes(A_arr, B_arr)
@@ -76,13 +76,13 @@ def test_orthogonal_procrustes_array_conversion():
 
 
 def test_orthogonal_procrustes():
-    np.random.seed(1234)
+    rng = np.random.RandomState(1234)
     for m, n in ((6, 4), (4, 4), (4, 6)):
         # Sample a random target matrix.
-        B = np.random.randn(m, n)
+        B = rng.randn(m, n)
         # Sample a random orthogonal matrix
         # by computing eigh of a sampled symmetric matrix.
-        X = np.random.randn(n, n)
+        X = rng.randn(n, n)
         w, V = eigh(X.T + X)
         assert_allclose(inv(V), V.T)
         # Compute a matrix with a known orthogonal transformation that gives B.
@@ -92,7 +92,7 @@ def test_orthogonal_procrustes():
         assert_allclose(inv(R), R.T)
         assert_allclose(A.dot(R), B)
         # Create a perturbed input matrix.
-        A_perturbed = A + 1e-2 * np.random.randn(m, n)
+        A_perturbed = A + 1e-2 * rng.randn(m, n)
         # Check that the orthogonal procrustes function can find an orthogonal
         # transformation that is better than the orthogonal transformation
         # computed from the original input matrix.

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -211,7 +211,7 @@ class TestBlockDiag:
 
 
 class TestKron:
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dep(self):
         with pytest.deprecated_call(match="`kron`"):
             kron(np.array([[1, 2],[3, 4]]),np.array([[1, 1, 1]]))
@@ -612,7 +612,7 @@ class TestConvolutionMatrix:
         assert_array_almost_equal(y1, y2)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 @pytest.mark.fail_slow(5)  # `leslie` has an import in the function
 @pytest.mark.parametrize('f, args', [(circulant, ()),
                                      (companion, ()),

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -211,6 +211,7 @@ class TestBlockDiag:
 
 
 class TestKron:
+    @pytest.mark.parallel_threads(1)
     def test_dep(self):
         with pytest.deprecated_call(match="`kron`"):
             kron(np.array([[1, 2],[3, 4]]),np.array([[1, 1, 1]]))
@@ -611,6 +612,7 @@ class TestConvolutionMatrix:
         assert_array_almost_equal(y1, y2)
 
 
+@pytest.mark.parallel_threads(1)
 @pytest.mark.fail_slow(5)  # `leslie` has an import in the function
 @pytest.mark.parametrize('f, args', [(circulant, ()),
                                      (companion, ()),

--- a/scipy/misc/tests/test_config.py
+++ b/scipy/misc/tests/test_config.py
@@ -18,7 +18,7 @@ class TestSciPyConfigs:
         "Python Information",
     ]
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @patch("scipy.__config__._check_pyyaml")
     def test_pyyaml_not_found(self, mock_yaml_importer):
         mock_yaml_importer.side_effect = ModuleNotFoundError()

--- a/scipy/misc/tests/test_config.py
+++ b/scipy/misc/tests/test_config.py
@@ -18,6 +18,7 @@ class TestSciPyConfigs:
         "Python Information",
     ]
 
+    @pytest.mark.parallel_threads(1)
     @patch("scipy.__config__._check_pyyaml")
     def test_pyyaml_not_found(self, mock_yaml_importer):
         mock_yaml_importer.side_effect = ModuleNotFoundError()

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -613,7 +613,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel(self, dtype_input, dtype_kernel,
                                       dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -633,7 +633,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     @pytest.mark.parametrize('mode', ['grid-constant', 'constant'])
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
                                            dtype_output, mode, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -655,7 +655,7 @@ class TestNdimageFilters:
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel_invalid_cval(self, dtype_input,
                                                    dtype_kernel, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -676,7 +676,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_kernel(self, dtype_input, dtype_kernel,
                                         dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -691,7 +691,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_kernel_cval(self, dtype_input, dtype_kernel,
                                              dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -707,7 +707,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_input(self, dtype_input, dtype_kernel,
                                      dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -724,7 +724,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input(self, dtype_input, dtype_kernel,
                                        dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -742,7 +742,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_cval(self, dtype_input, dtype_kernel,
                                             dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -757,7 +757,7 @@ class TestNdimageFilters:
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_input_and_kernel(self, dtype, dtype_output, xp):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
@@ -774,7 +774,7 @@ class TestNdimageFilters:
                       exceptions=['cupy'],)
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate_complex_input_and_kernel_cval(self, dtype,
                                                      dtype_output, xp):
         dtype = getattr(xp, dtype)
@@ -790,7 +790,7 @@ class TestNdimageFilters:
     @skip_xp_backends(np_only=True, reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output, xp):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
@@ -801,7 +801,7 @@ class TestNdimageFilters:
 
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_and_kernel_cval(self, dtype,
                                                        dtype_output, xp):
         if not (is_numpy(xp) or is_cupy(xp)):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -613,6 +613,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_kernel(self, dtype_input, dtype_kernel,
                                       dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -632,6 +633,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     @pytest.mark.parametrize('mode', ['grid-constant', 'constant'])
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
                                            dtype_output, mode, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -653,6 +655,7 @@ class TestNdimageFilters:
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_kernel_invalid_cval(self, dtype_input,
                                                    dtype_kernel, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -673,6 +676,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_kernel(self, dtype_input, dtype_kernel,
                                         dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -687,6 +691,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_kernel_cval(self, dtype_input, dtype_kernel,
                                              dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -702,6 +707,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_input(self, dtype_input, dtype_kernel,
                                      dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -718,6 +724,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_input(self, dtype_input, dtype_kernel,
                                        dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -735,6 +742,7 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_input_cval(self, dtype_input, dtype_kernel,
                                             dtype_output, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -749,6 +757,7 @@ class TestNdimageFilters:
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_input_and_kernel(self, dtype, dtype_output, xp):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
@@ -765,6 +774,7 @@ class TestNdimageFilters:
                       exceptions=['cupy'],)
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate_complex_input_and_kernel_cval(self, dtype,
                                                      dtype_output, xp):
         dtype = getattr(xp, dtype)
@@ -780,6 +790,7 @@ class TestNdimageFilters:
     @skip_xp_backends(np_only=True, reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output, xp):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
@@ -790,6 +801,7 @@ class TestNdimageFilters:
 
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parallel_threads(1)
     def test_correlate1d_complex_input_and_kernel_cval(self, dtype,
                                                        dtype_output, xp):
         if not (is_numpy(xp) or is_cupy(xp)):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -114,7 +114,8 @@ def _cases_axes_tuple_length_mismatch():
 
 class TestNdimageFilters:
 
-    def _validate_complex(self, xp, array, kernel, type2, mode='reflect', cval=0):
+    def _validate_complex(self, xp, array, kernel, type2, mode='reflect',
+                          cval=0, check_warnings=True):
         # utility for validating complex-valued correlations
         real_dtype = xp.real(xp.asarray([], dtype=type2)).dtype
         expected = _complex_correlate(
@@ -155,14 +156,17 @@ class TestNdimageFilters:
         assert_array_almost_equal(expected, output)
         assert output.dtype.type == type2
 
-        # warns if the output is not a complex dtype
-        with pytest.warns(UserWarning,
-                          match="promoting specified output dtype to complex"):
-            correlate(array, kernel, output=real_dtype)
+        if check_warnings:
+            # warns if the output is not a complex dtype
+            with pytest.warns(UserWarning,
+                              match="promoting specified output dtype to "
+                              "complex"):
+                correlate(array, kernel, output=real_dtype)
 
-        with pytest.warns(UserWarning,
-                          match="promoting specified output dtype to complex"):
-            convolve(array, kernel, output=real_dtype)
+            with pytest.warns(UserWarning,
+                              match="promoting specified output dtype to "
+                              "complex"):
+                convolve(array, kernel, output=real_dtype)
 
         # raises if output array is provided, but is not complex-valued
         output_real = xp.zeros_like(array, dtype=real_dtype)
@@ -613,9 +617,8 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel(self, dtype_input, dtype_kernel,
-                                      dtype_output, xp):
+                                      dtype_output, xp, num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
@@ -624,7 +627,8 @@ class TestNdimageFilters:
                              [0, 1 + 1j]], dtype=dtype_kernel)
         array = xp.asarray([[1, 2, 3],
                             [4, 5, 6]], dtype=dtype_input)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @xfail_xp_backends(np_only=True,
                        reason="output=dtype is numpy-specific",
@@ -633,9 +637,9 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     @pytest.mark.parametrize('mode', ['grid-constant', 'constant'])
-    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
-                                           dtype_output, mode, xp):
+                                           dtype_output, mode, xp,
+                                           num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
@@ -650,7 +654,8 @@ class TestNdimageFilters:
         array = xp.asarray([[1, 2, 3],
                             [4, 5, 6]], dtype=dtype_input)
         self._validate_complex(xp, array, kernel, dtype_output, mode=mode,
-                               cval=5.0)
+                               cval=5.0,
+                               check_warnings=num_parallel_threads == 1)
 
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
@@ -676,24 +681,24 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_kernel(self, dtype_input, dtype_kernel,
-                                        dtype_output, xp):
+                                        dtype_output, xp, num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
 
         kernel = xp.asarray([1, 1 + 1j], dtype=dtype_kernel)
         array = xp.asarray([1, 2, 3, 4, 5, 6], dtype=dtype_input)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_kernel_cval(self, dtype_input, dtype_kernel,
-                                             dtype_output, xp):
+                                             dtype_output, xp,
+                                             num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
@@ -701,15 +706,15 @@ class TestNdimageFilters:
         kernel = xp.asarray([1, 1 + 1j], dtype=dtype_kernel)
         array = xp.asarray([1, 2, 3, 4, 5, 6], dtype=dtype_input)
         self._validate_complex(xp, array, kernel, dtype_output, mode='constant',
-                               cval=5.0)
+                               cval=5.0,
+                               check_warnings=num_parallel_threads == 1)
 
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate_complex_input(self, dtype_input, dtype_kernel,
-                                     dtype_output, xp):
+                                     dtype_output, xp, num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
@@ -718,22 +723,23 @@ class TestNdimageFilters:
                              [0, 1]], dtype=dtype_kernel)
         array = xp.asarray([[1, 2j, 3],
                             [1 + 4j, 5, 6j]], dtype=dtype_input)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input(self, dtype_input, dtype_kernel,
-                                       dtype_output, xp):
+                                       dtype_output, xp, num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
 
         kernel = xp.asarray([1, 0, 1], dtype=dtype_kernel)
         array = xp.asarray([1, 2j, 3, 1 + 4j, 5, 6j], dtype=dtype_input)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @skip_xp_backends(np_only=True,
@@ -742,9 +748,9 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_cval(self, dtype_input, dtype_kernel,
-                                            dtype_output, xp):
+                                            dtype_output, xp,
+                                            num_parallel_threads):
         dtype_input = getattr(xp, dtype_input)
         dtype_kernel = getattr(xp, dtype_kernel)
         dtype_output = getattr(xp, dtype_output)
@@ -752,13 +758,14 @@ class TestNdimageFilters:
         kernel = xp.asarray([1, 0, 1], dtype=dtype_kernel)
         array = xp.asarray([1, 2j, 3, 1 + 4j, 5, 6j], dtype=dtype_input)
         self._validate_complex(xp, array, kernel, dtype_output, mode='constant',
-                               cval=5 - 3j)
+                               cval=5 - 3j,
+                               check_warnings=num_parallel_threads == 1)
 
     @skip_xp_backends(np_only=True, reason='output=dtype is numpy-specific')
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
-    def test_correlate_complex_input_and_kernel(self, dtype, dtype_output, xp):
+    def test_correlate_complex_input_and_kernel(self, dtype, dtype_output, xp,
+                                                num_parallel_threads):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
 
@@ -766,7 +773,8 @@ class TestNdimageFilters:
                              [0, 1 + 1j]], dtype=dtype)
         array = xp.asarray([[1, 2j, 3],
                             [1 + 4j, 5, 6j]], dtype=dtype)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @skip_xp_backends(np_only=True,
@@ -774,9 +782,9 @@ class TestNdimageFilters:
                       exceptions=['cupy'],)
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate_complex_input_and_kernel_cval(self, dtype,
-                                                     dtype_output, xp):
+                                                     dtype_output, xp,
+                                                     num_parallel_threads):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
 
@@ -785,25 +793,28 @@ class TestNdimageFilters:
         array = xp.asarray([[1, 2, 3],
                             [4, 5, 6]], dtype=dtype)
         self._validate_complex(xp, array, kernel, dtype_output, mode='constant',
-                               cval=5.0 + 2.0j)
+                               cval=5.0 + 2.0j,
+                               check_warnings=num_parallel_threads == 1)
 
     @skip_xp_backends(np_only=True, reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     @pytest.mark.thread_unsafe
-    def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output, xp):
+    def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output, xp,
+                                                  num_parallel_threads):
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
 
         kernel = xp.asarray([1, 1 + 1j], dtype=dtype)
         array = xp.asarray([1, 2j, 3, 1 + 4j, 5, 6j], dtype=dtype)
-        self._validate_complex(xp, array, kernel, dtype_output)
+        self._validate_complex(xp, array, kernel, dtype_output,
+                               check_warnings=num_parallel_threads == 1)
 
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_and_kernel_cval(self, dtype,
-                                                       dtype_output, xp):
+                                                       dtype_output, xp,
+                                                       num_parallel_threads):
         if not (is_numpy(xp) or is_cupy(xp)):
             pytest.xfail("output=dtype is numpy-specific")
 
@@ -816,7 +827,8 @@ class TestNdimageFilters:
         kernel = xp.asarray([1, 1 + 1j], dtype=dtype)
         array = xp.asarray([1, 2j, 3, 1 + 4j, 5, 6j], dtype=dtype)
         self._validate_complex(xp, array, kernel, dtype_output, mode='constant',
-                               cval=5.0 + 2.0j)
+                               cval=5.0 + 2.0j,
+                               check_warnings=num_parallel_threads == 1)
 
     def test_gauss01(self, xp):
         input = xp.asarray([[1, 2, 3],

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1306,7 +1306,7 @@ class TestZoom:
         )
 
     @pytest.mark.parametrize('mode', ['constant', 'wrap'])
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_zoom_grid_mode_warnings(self, mode, xp):
         # Warn on use of non-grid modes when grid_mode is True
         x = xp.reshape(xp.arange(9, dtype=xp.float64), (3, 3))

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -450,7 +450,7 @@ class TestGeometricTransformExtra:
         x = np.arange(144, dtype=float).reshape(12, 12)
         npad = 24
         pad_mode = ndimage_to_numpy_mode.get(mode)
-        x_padded = np.pad(x, npad, mode=pad_mode) 
+        x_padded = np.pad(x, npad, mode=pad_mode)
 
         x = xp.asarray(x)
         x_padded = xp.asarray(x_padded)
@@ -1306,6 +1306,7 @@ class TestZoom:
         )
 
     @pytest.mark.parametrize('mode', ['constant', 'wrap'])
+    @pytest.mark.parallel_threads(1)
     def test_zoom_grid_mode_warnings(self, mode, xp):
         # Warn on use of non-grid modes when grid_mode is True
         x = xp.reshape(xp.arange(9, dtype=xp.float64), (3, 3))

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -164,7 +164,7 @@ def test_label02(xp):
     assert n == 0
 
 
-@pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
+@pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
 def test_label03(xp):
     data = xp.ones([1])
     out, n = ndimage.label(data)

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -165,7 +165,7 @@ def test_label02(xp):
 
 
 def test_label03(xp):
-    data = xp.ones([1])
+    data = xp.ones([1], dtype=xp.int64)
     out, n = ndimage.label(data)
     assert_array_almost_equal(out, xp.asarray([1]))
     assert n == 1
@@ -823,7 +823,7 @@ def test_maximum04(xp):
 def test_maximum05(xp):
     # Regression test for ticket #501 (Trac)
     x = xp.asarray([-3, -2, -1])
-    assert ndimage.maximum(x) == -1 
+    assert ndimage.maximum(x) == -1
 
 
 def test_median01(xp):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -164,8 +164,9 @@ def test_label02(xp):
     assert n == 0
 
 
+@pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
 def test_label03(xp):
-    data = xp.ones([1], dtype=xp.int64)
+    data = xp.ones([1])
     out, n = ndimage.label(data)
     assert_array_almost_equal(out, xp.asarray([1]))
     assert n == 1

--- a/scipy/ndimage/tests/test_ni_support.py
+++ b/scipy/ndimage/tests/test_ni_support.py
@@ -39,7 +39,7 @@ def test_get_output_basic(dtype):
     assert result is output
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_get_output_complex():
     shape = (2, 3)
 

--- a/scipy/ndimage/tests/test_ni_support.py
+++ b/scipy/ndimage/tests/test_ni_support.py
@@ -39,6 +39,7 @@ def test_get_output_basic(dtype):
     assert result is output
 
 
+@pytest.mark.parallel_threads(1)
 def test_get_output_complex():
     shape = (2, 3)
 

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -28,6 +28,7 @@ class TestODR:
     def empty_data_func(self, B, x):
         return B[0]*x + B[1]
 
+    @pytest.mark.parallel_threads(1)
     def test_empty_data(self):
         beta0 = [0.02, 0.0]
         linear = Model(self.empty_data_func)

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -28,7 +28,7 @@ class TestODR:
     def empty_data_func(self, B, x):
         return B[0]*x + B[1]
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_empty_data(self):
         beta0 = [0.02, 0.0]
         linear = Model(self.empty_data_func)

--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -1,6 +1,10 @@
 import numpy as np
+from threading import Lock
 
 from ._optimize import _check_unknown_options
+
+
+COBYQA_LOCK = Lock()
 
 
 def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
@@ -64,4 +68,5 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
         'radius_final': float(final_tr_radius),
         'scale': bool(scale),
     }
-    return minimize(fun, x0, args, bounds, constraints, callback, options)
+    with COBYQA_LOCK:
+        return minimize(fun, x0, args, bounds, constraints, callback, options)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -391,7 +391,7 @@ class Test_RandomDisplacement:
         # note these tests are random, they will fail from time to time
         rng = np.random.RandomState(0)
         x0 = np.zeros([self.N])
-        displace = RandomDisplacement(stepsize=self.stepsize, random_gen=rng)
+        displace = RandomDisplacement(stepsize=self.stepsize, rng=rng)
         x = displace(x0)
         v = (2. * self.stepsize) ** 2 / 12
         assert_almost_equal(np.mean(x), 0., 1)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -224,7 +224,7 @@ class TestBasinHopping:
             minimizer_kwargs["method"] = method
             res = basinhopping(func2d_nograd, self.x0[i],
                                minimizer_kwargs=minimizer_kwargs,
-                               niter=niter, disp=self.disp)
+                               niter=niter, disp=self.disp, seed=1234)
             tol = self.tol
             if method == 'COBYLA':
                 tol = 2
@@ -344,6 +344,7 @@ class TestBasinHopping:
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
 
+@pytest.mark.parallel_threads(1)
 class Test_Storage:
     def setup_method(self):
         self.x0 = np.array(1)
@@ -382,15 +383,16 @@ class Test_Storage:
 class Test_RandomDisplacement:
     def setup_method(self):
         self.stepsize = 1.0
-        self.displace = RandomDisplacement(stepsize=self.stepsize)
         self.N = 300000
-        self.x0 = np.zeros([self.N])
 
     def test_random(self):
         # the mean should be 0
         # the variance should be (2*stepsize)**2 / 12
         # note these tests are random, they will fail from time to time
-        x = self.displace(self.x0)
+        rng = np.random.RandomState(0)
+        x0 = np.zeros([self.N])
+        displace = RandomDisplacement(stepsize=self.stepsize, random_gen=rng)
+        x = displace(x0)
         v = (2. * self.stepsize) ** 2 / 12
         assert_almost_equal(np.mean(x), 0., 1)
         assert_almost_equal(np.var(x), v, 1)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -344,7 +344,7 @@ class TestBasinHopping:
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 class Test_Storage:
     def setup_method(self):
         self.x0 = np.array(1)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -704,7 +704,7 @@ class TestDifferentialEvolutionSolver:
         )
         assert res.success
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_immediate_updating(self):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
@@ -850,7 +850,7 @@ class TestDifferentialEvolutionSolver:
             assert_almost_equal(cv, np.array([[0.0, 0.0, 0.], [2.1, 4.2, 0]]))
             assert cv.shape == (2, 3)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_constraint_solve(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -868,7 +868,7 @@ class TestDifferentialEvolutionSolver:
         assert res.success
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_impossible_constraint(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -1545,7 +1545,7 @@ class TestDifferentialEvolutionSolver:
             DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
                                         integrality=integrality)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.fail_slow(10)
     def test_vectorized(self):
         def quadratic(x):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -704,6 +704,7 @@ class TestDifferentialEvolutionSolver:
         )
         assert res.success
 
+    @pytest.mark.parallel_threads(1)
     def test_immediate_updating(self):
         # check setting of immediate updating, with default workers
         bounds = [(0., 2.), (0., 2.)]
@@ -849,6 +850,7 @@ class TestDifferentialEvolutionSolver:
             assert_almost_equal(cv, np.array([[0.0, 0.0, 0.], [2.1, 4.2, 0]]))
             assert cv.shape == (2, 3)
 
+    @pytest.mark.parallel_threads(1)
     def test_constraint_solve(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -866,6 +868,7 @@ class TestDifferentialEvolutionSolver:
         assert res.success
 
     @pytest.mark.fail_slow(10)
+    @pytest.mark.parallel_threads(1)
     def test_impossible_constraint(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -1542,6 +1545,7 @@ class TestDifferentialEvolutionSolver:
             DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
                                         integrality=integrality)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.fail_slow(10)
     def test_vectorized(self):
         def quadratic(x):

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -19,6 +19,8 @@ from numpy.testing import assert_equal, assert_allclose, assert_array_less
 from pytest import raises as assert_raises
 from scipy._lib._util import check_random_state
 
+import threading
+
 
 class TestDualAnnealing:
 
@@ -36,8 +38,8 @@ class TestDualAnnealing:
         self.qv = 2.62
         self.seed = 1234
         self.rng = check_random_state(self.seed)
-        self.nb_fun_call = 0
-        self.ngev = 0
+        self.nb_fun_call = threading.local()
+        self.ngev = threading.local()
 
     def callback(self, x, f, context):
         # For testing callback mechanism. Should stop for e <= 1 as
@@ -53,11 +55,15 @@ class TestDualAnnealing:
             shift = 0
         y = np.sum((x - shift) ** 2 - 10 * np.cos(2 * np.pi * (
             x - shift))) + 10 * np.size(x) + shift
-        self.nb_fun_call += 1
+        if not hasattr(self.nb_fun_call, 'c'):
+            self.nb_fun_call.c = 0
+        self.nb_fun_call.c += 1
         return y
 
     def rosen_der_wrapper(self, x, args=()):
-        self.ngev += 1
+        if not hasattr(self.ngev, 'c'):
+            self.ngev.c = 0
+        self.ngev.c += 1
         return rosen_der(x, *args)
 
     # FIXME: there are some discontinuities in behaviour as a function of `qv`,
@@ -128,13 +134,15 @@ class TestDualAnnealing:
         assert_allclose(ret.fun, 0., atol=1e-4)
 
     def test_nb_fun_call(self):
+        self.nb_fun_call.c = 0
         ret = dual_annealing(self.func, self.ld_bounds, rng=self.seed)
-        assert_equal(self.nb_fun_call, ret.nfev)
+        assert_equal(self.nb_fun_call.c, ret.nfev)
 
     def test_nb_fun_call_no_ls(self):
+        self.nb_fun_call.c = 0
         ret = dual_annealing(self.func, self.ld_bounds,
                              no_local_search=True, rng=self.seed)
-        assert_equal(self.nb_fun_call, ret.nfev)
+        assert_equal(self.nb_fun_call.c, ret.nfev)
 
     def test_max_reinit(self):
         assert_raises(ValueError, dual_annealing, self.weirdfunc,
@@ -179,6 +187,7 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.func,
                       invalid_bounds)
 
+    @pytest.mark.parallel_threads(1)
     def test_deprecated_local_search_options_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))
@@ -191,6 +200,7 @@ class TestDualAnnealing:
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
 
+    @pytest.mark.parallel_threads(1)
     def test_minimizer_kwargs_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))
@@ -280,7 +290,7 @@ class TestDualAnnealing:
         ret = dual_annealing(rosen, self.ld_bounds,
                              minimizer_kwargs=minimizer_opts,
                              rng=self.seed)
-        assert ret.njev == self.ngev
+        assert ret.njev == self.ngev.c
 
     @pytest.mark.fail_slow(10)
     def test_from_docstring(self):

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -187,7 +187,7 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.func,
                       invalid_bounds)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_deprecated_local_search_options_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))
@@ -200,7 +200,7 @@ class TestDualAnnealing:
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_minimizer_kwargs_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -85,7 +85,7 @@ class TestRoot:
         with assert_raises(ValueError):
             root(F, [0.1, 0.0], method='lm')
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_gh_10370(self):
         # gh-10370 reported that passing both `args` and `jac` to `root` with
         # `method='krylov'` caused a failure. Ensure that this is fixed whether

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -85,6 +85,7 @@ class TestRoot:
         with assert_raises(ValueError):
             root(F, [0.1, 0.0], method='lm')
 
+    @pytest.mark.parallel_threads(1)
     def test_gh_10370(self):
         # gh-10370 reported that passing both `args` and `jac` to `root` with
         # `method='krylov'` caused a failure. Ensure that this is fixed whether
@@ -110,7 +111,7 @@ class TestRoot:
         assert_equal(res1.x, ref.x)
         assert_equal(res2.x, ref.x)
         assert res1.success is res2.success is ref.success is True
-    
+
     @pytest.mark.parametrize("method", ["hybr", "lm", "broyden1", "broyden2",
                                         "anderson", "linearmixing",
                                         "diagbroyden", "excitingmixing",
@@ -118,6 +119,6 @@ class TestRoot:
     def test_method_in_result(self, method):
         def func(x):
             return x - 1
-        
+
         res = root(func, x0=[1], method=method)
         assert res.method == method

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1007,7 +1007,7 @@ class TestShgoFailures:
 
         np.testing.assert_equal(False, res.success)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_6_1_lower_known_f_min(self):
         """Test Global mode limiting local evaluations with f* too high"""
         options = {  # Specify known function value

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1007,6 +1007,7 @@ class TestShgoFailures:
 
         np.testing.assert_equal(False, res.success)
 
+    @pytest.mark.parallel_threads(1)
     def test_6_1_lower_known_f_min(self):
         """Test Global mode limiting local evaluations with f* too high"""
         options = {  # Specify known function value

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -61,9 +61,9 @@ class TestCobyla:
         )
 
     def test_minimize_constraint_violation(self):
-        np.random.seed(1234)
-        pb = np.random.rand(10, 10)
-        spread = np.random.rand(10)
+        rng = np.random.RandomState(1234)
+        pb = rng.rand(10, 10)
+        spread = rng.rand(10)
 
         def p(w):
             return pb.dot(w)

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -12,7 +12,6 @@ from scipy.optimize import (
 )
 
 
-# @pytest.mark.thread_unsafe
 class TestCOBYQA:
 
     def setup_method(self):
@@ -78,7 +77,7 @@ class TestCOBYQA:
         assert sol.fun < self.fun(solution) + 1e-3, sol
         assert sol.nfev == callback.n_calls, \
             "Callback is not called exactly once for every function eval."
-        assert_allclose(sol.x, sol_new.x, atol=1e-12, rtol=1e-12)
+        assert_equal(sol.x, sol_new.x)
         assert sol_new.success, sol_new.message
         assert sol.fun == sol_new.fun
         assert sol.maxcv == sol_new.maxcv

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -11,6 +11,7 @@ from scipy.optimize import (
 )
 
 
+@pytest.mark.parallel_threads(1)
 class TestCOBYQA:
 
     def setup_method(self):
@@ -42,6 +43,7 @@ class TestCOBYQA:
                 assert isinstance(intermediate_result, OptimizeResult)
                 self.n_calls += 1
 
+        x0 = [4.95, 0.66]
         callback = Callback()
         callback_new_syntax = CallbackNewSyntax()
 
@@ -49,7 +51,7 @@ class TestCOBYQA:
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
         sol = minimize(
             self.fun,
-            self.x0,
+            x0,
             method='cobyqa',
             constraints=constraints,
             callback=callback,
@@ -57,7 +59,7 @@ class TestCOBYQA:
         )
         sol_new = minimize(
             self.fun,
-            self.x0,
+            x0,
             method='cobyqa',
             constraints=constraints,
             callback=callback_new_syntax,

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -11,7 +11,7 @@ from scipy.optimize import (
 )
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 class TestCOBYQA:
 
     def setup_method(self):

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -206,7 +206,7 @@ class TestNewToOldSLSQP:
 
             assert_array_almost_equal(result.x, prob.x_opt, decimal=3)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_warn_mixed_constraints(self):
         # warns about inefficiency of mixed equality/inequality constraints
         def fun(x):
@@ -219,7 +219,7 @@ class TestNewToOldSLSQP:
             assert_warns(OptimizeWarning, minimize, fun, (2, 0, 1),
                          method=self.method, bounds=bnds, constraints=cons)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_warn_ignored_options(self):
         # warns about constraint options being ignored
         def fun(x):

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -62,7 +62,7 @@ class TestOldToNew:
 
 class TestNewToOld:
     @pytest.mark.fail_slow(2)
-    def test_multiple_constraint_objects(self):
+    def test_multiple_constraint_objects(self, num_parallel_threads):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2
         x0 = [2, 0, 1]
@@ -88,10 +88,12 @@ class TestNewToOld:
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-4)
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-4)
-            assert_allclose(funs['cobyqa'], funs['trust-constr'], rtol=1e-4)
+            if num_parallel_threads == 1:
+                assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                                rtol=1e-4)
 
     @pytest.mark.fail_slow(20)
-    def test_individual_constraint_objects(self):
+    def test_individual_constraint_objects(self, num_parallel_threads):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2
         x0 = [2, 0, 1]
@@ -158,7 +160,9 @@ class TestNewToOld:
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-3)
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-3)
-            assert_allclose(funs['cobyqa'], funs['trust-constr'], rtol=1e-3)
+            if num_parallel_threads == 1:
+                assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                                rtol=1e-3)
 
         for con in cone:
             funs = {}
@@ -168,7 +172,9 @@ class TestNewToOld:
                     result = minimize(fun, x0, method=method, constraints=con)
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-3)
-            assert_allclose(funs['cobyqa'], funs['trust-constr'], rtol=1e-3)
+            if num_parallel_threads == 1:
+                assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                                rtol=1e-3)
 
 
 class TestNewToOldSLSQP:
@@ -200,6 +206,7 @@ class TestNewToOldSLSQP:
 
             assert_array_almost_equal(result.x, prob.x_opt, decimal=3)
 
+    @pytest.mark.parallel_threads(1)
     def test_warn_mixed_constraints(self):
         # warns about inefficiency of mixed equality/inequality constraints
         def fun(x):
@@ -212,6 +219,7 @@ class TestNewToOldSLSQP:
             assert_warns(OptimizeWarning, minimize, fun, (2, 0, 1),
                          method=self.method, bounds=bnds, constraints=cons)
 
+    @pytest.mark.parallel_threads(1)
     def test_warn_ignored_options(self):
         # warns about constraint options being ignored
         def fun(x):

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -287,6 +287,7 @@ class TestScalarFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
+    @pytest.mark.parallel_threads(1)
     def test_x_storage_overlap(self):
         # Scalar_Function should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes
@@ -628,6 +629,7 @@ class TestVectorialFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
+    @pytest.mark.parallel_threads(1)
     def test_x_storage_overlap(self):
         # VectorFunction should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -287,7 +287,7 @@ class TestScalarFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # Scalar_Function should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes
@@ -629,7 +629,7 @@ class TestVectorialFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # VectorFunction should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -6,12 +6,13 @@ from numpy.testing import (assert_allclose,
 import pytest
 import numpy as np
 from scipy.optimize import direct, Bounds
+import threading
 
 
 class TestDIRECT:
 
     def setup_method(self):
-        self.fun_calls = 0
+        self.fun_calls = threading.local()
         self.bounds_sphere = 4*[(-2, 3)]
         self.optimum_sphere_pos = np.zeros((4, ))
         self.optimum_sphere = 0.0
@@ -20,7 +21,9 @@ class TestDIRECT:
 
     # test functions
     def sphere(self, x):
-        self.fun_calls += 1
+        if not hasattr(self.fun_calls, 'c'):
+            self.fun_calls.c = 0
+        self.fun_calls.c += 1
         return np.square(x).sum()
 
     def inv(self, x):
@@ -57,7 +60,7 @@ class TestDIRECT:
         # up to 500 evaluations in last iteration
         assert res.nfev <= 1000 * (len(self.bounds_sphere) + 1)
         # test that number of function evaluations is correct
-        assert res.nfev == self.fun_calls
+        assert res.nfev == self.fun_calls.c
 
         # test that number of iterations is below supplied maximum
         assert res.nit <= self.maxiter

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -77,7 +77,7 @@ def fun_bvp(x):
 
 class BroydenTridiagonal:
     def __init__(self, n=100, mode='sparse'):
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
 
         self.n = n
 
@@ -85,10 +85,10 @@ class BroydenTridiagonal:
         self.lb = np.linspace(-2, -1.5, n)
         self.ub = np.linspace(-0.8, 0.0, n)
 
-        self.lb += 0.1 * np.random.randn(n)
-        self.ub += 0.1 * np.random.randn(n)
+        self.lb += 0.1 * rng.randn(n)
+        self.ub += 0.1 * rng.randn(n)
 
-        self.x0 += 0.1 * np.random.randn(n)
+        self.x0 += 0.1 * rng.randn(n)
         self.x0 = make_strictly_feasible(self.x0, self.lb, self.ub)
 
         if mode == 'sparse':
@@ -132,7 +132,7 @@ class ExponentialFittingProblem:
 
     def __init__(self, a, b, noise, n_outliers=1, x_range=(-1, 1),
                  n_points=11, random_seed=None):
-        np.random.seed(random_seed)
+        rng = np.random.RandomState(random_seed)
         self.m = n_points
         self.n = 2
 
@@ -140,10 +140,10 @@ class ExponentialFittingProblem:
         self.x = np.linspace(x_range[0], x_range[1], n_points)
 
         self.y = a + np.exp(b * self.x)
-        self.y += noise * np.random.randn(self.m)
+        self.y += noise * rng.randn(self.m)
 
-        outliers = np.random.randint(0, self.m, n_outliers)
-        self.y[outliers] += 50 * noise * np.random.rand(n_outliers)
+        outliers = rng.randint(0, self.m, n_outliers)
+        self.y[outliers] += 50 * noise * rng.rand(n_outliers)
 
         self.p_opt = np.array([a, b])
 
@@ -798,10 +798,10 @@ def test_small_tolerances_for_lm():
 def test_fp32_gh12991():
     # checks that smaller FP sizes can be used in least_squares
     # this is the minimum working example reported for gh12991
-    np.random.seed(1)
+    rng = np.random.RandomState(1)
 
     x = np.linspace(0, 1, 100).astype("float32")
-    y = np.random.random(100).astype("float32")
+    y = rng.random(100).astype("float32")
 
     def func(p, x):
         return p[0] + p[1] * x

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -7,6 +7,8 @@ from numpy.testing import (assert_equal, assert_array_almost_equal,
 import scipy.optimize._linesearch as ls
 from scipy.optimize._linesearch import LineSearchWarning
 import numpy as np
+import pytest
+import threading
 
 
 def assert_wolfe(s, phi, derphi, c1=1e-4, c2=0.9, err_msg=""):
@@ -54,19 +56,25 @@ def assert_fp_equal(x, y, err_msg="", nulp=50):
 class TestLineSearch:
     # -- scalar functions; must have dphi(0.) < 0
     def _scalar_func_1(self, s):  # skip name check
-        self.fcount += 1
+        if not hasattr(self.fcount, 'c'):
+            self.fcount.c = 0
+        self.fcount.c += 1
         p = -s - s**3 + s**4
         dp = -1 - 3*s**2 + 4*s**3
         return p, dp
 
     def _scalar_func_2(self, s):  # skip name check
-        self.fcount += 1
+        if not hasattr(self.fcount, 'c'):
+            self.fcount.c = 0
+        self.fcount.c += 1
         p = np.exp(-4*s) + s**2
         dp = -4*np.exp(-4*s) + 2*s
         return p, dp
 
     def _scalar_func_3(self, s):  # skip name check
-        self.fcount += 1
+        if not hasattr(self.fcount, 'c'):
+            self.fcount.c = 0
+        self.fcount.c += 1
         p = -np.sin(10*s)
         dp = -10*np.cos(10*s)
         return p, dp
@@ -74,13 +82,17 @@ class TestLineSearch:
     # -- n-d functions
 
     def _line_func_1(self, x):  # skip name check
-        self.fcount += 1
+        if not hasattr(self.fcount, 'c'):
+            self.fcount.c = 0
+        self.fcount.c += 1
         f = np.dot(x, x)
         df = 2*x
         return f, df
 
     def _line_func_2(self, x):  # skip name check
-        self.fcount += 1
+        if not hasattr(self.fcount, 'c'):
+            self.fcount.c = 0
+        self.fcount.c += 1
         f = np.dot(x, np.dot(self.A, x)) + 1
         df = np.dot(self.A + self.A.T, x)
         return f, df
@@ -91,7 +103,7 @@ class TestLineSearch:
         self.scalar_funcs = []
         self.line_funcs = []
         self.N = 20
-        self.fcount = 0
+        self.fcount = threading.local()
 
         def bind_index(func, idx):
             # Remember Python's closure semantics!
@@ -116,16 +128,17 @@ class TestLineSearch:
                 yield name, phi, derphi, old_phi0
 
     def line_iter(self):
+        rng = np.random.RandomState(1234)
         for name, f, fprime in self.line_funcs:
             k = 0
             while k < 9:
-                x = np.random.randn(self.N)
-                p = np.random.randn(self.N)
+                x = rng.randn(self.N)
+                p = rng.randn(self.N)
                 if np.dot(p, fprime(x)) >= 0:
                     # always pick a descent direction
                     continue
                 k += 1
-                old_fv = float(np.random.randn())
+                old_fv = float(rng.randn())
                 yield name, f, fprime, x, p, old_fv
 
     # -- Generic scalar searches
@@ -197,11 +210,11 @@ class TestLineSearch:
         for name, f, fprime, x, p, old_f in self.line_iter():
             f0 = f(x)
             g0 = fprime(x)
-            self.fcount = 0
+            self.fcount.c = 0
             s, fc, gc, fv, ofv, gv = ls.line_search_wolfe1(f, fprime, x, p,
                                                            g0, f0, old_f,
                                                            amax=smax)
-            assert_equal(self.fcount, fc+gc)
+            assert_equal(self.fcount.c, fc+gc)
             assert_fp_equal(ofv, f(x))
             if s is None:
                 continue
@@ -219,7 +232,7 @@ class TestLineSearch:
         for name, f, fprime, x, p, old_f in self.line_iter():
             f0 = f(x)
             g0 = fprime(x)
-            self.fcount = 0
+            self.fcount.c = 0
             with suppress_warnings() as sup:
                 sup.filter(LineSearchWarning,
                            "The line search algorithm could not find a solution")
@@ -228,7 +241,7 @@ class TestLineSearch:
                 s, fc, gc, fv, ofv, gv = ls.line_search_wolfe2(f, fprime, x, p,
                                                                g0, f0, old_f,
                                                                amax=smax)
-            assert_equal(self.fcount, fc+gc)
+            assert_equal(self.fcount.c, fc+gc)
             assert_fp_equal(ofv, f(x))
             assert_fp_equal(fv, f(x + s*p))
             if gv is not None:
@@ -238,6 +251,7 @@ class TestLineSearch:
                 assert_line_wolfe(x, p, s, f, fprime, err_msg=name)
         assert c > 3  # check that the iterator really works...
 
+    @pytest.mark.parallel_threads(1)
     def test_line_search_wolfe2_bounds(self):
         # See gh-7475
 
@@ -271,10 +285,10 @@ class TestLineSearch:
         for name, f, fprime, x, p, old_f in self.line_iter():
             f0 = f(x)
             g0 = fprime(x)
-            self.fcount = 0
+            self.fcount.c = 0
             s, fc, fv = ls.line_search_armijo(f, x, p, g0, f0)
             c += 1
-            assert_equal(self.fcount, fc)
+            assert_equal(self.fcount.c, fc)
             assert_fp_equal(fv, f(x + s*p))
             assert_line_armijo(x, p, s, f, err_msg=name)
         assert c >= 9

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -251,7 +251,7 @@ class TestLineSearch:
                 assert_line_wolfe(x, p, s, f, fprime, err_msg=name)
         assert c > 3  # check that the iterator really works...
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_line_search_wolfe2_bounds(self):
         # See gh-7475
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -85,7 +85,7 @@ def magic_square(n):
     (or absence) of an integer 1 to n^2 in each position of the square.
     """
 
-    np.random.seed(0)
+    rng = np.random.RandomState(0)
     M = n * (n**2 + 1) / 2
 
     numbers = np.arange(n**4) // n**2 + 1
@@ -139,7 +139,7 @@ def magic_square(n):
 
     A = np.array(np.vstack(A_list), dtype=float)
     b = np.array(b_list, dtype=float)
-    c = np.random.rand(A.shape[1])
+    c = rng.rand(A.shape[1])
 
     return A, b, c, numbers, M
 
@@ -149,8 +149,8 @@ def lpgen_2d(m, n):
         row sums == n/m, col sums == 1
         https://gist.github.com/denis-bz/8647461
     """
-    np.random.seed(0)
-    c = - np.random.exponential(size=(m, n))
+    rng = np.random.RandomState(0)
+    c = - rng.exponential(size=(m, n))
     Arow = np.zeros((m, m * n))
     brow = np.zeros(m)
     for j in range(m):
@@ -172,17 +172,17 @@ def lpgen_2d(m, n):
 
 
 def very_random_gen(seed=0):
-    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
     m_eq, m_ub, n = 10, 20, 50
-    c = np.random.rand(n)-0.5
-    A_ub = np.random.rand(m_ub, n)-0.5
-    b_ub = np.random.rand(m_ub)-0.5
-    A_eq = np.random.rand(m_eq, n)-0.5
-    b_eq = np.random.rand(m_eq)-0.5
-    lb = -np.random.rand(n)
-    ub = np.random.rand(n)
-    lb[lb < -np.random.rand()] = -np.inf
-    ub[ub > np.random.rand()] = np.inf
+    c = rng.rand(n)-0.5
+    A_ub = rng.rand(m_ub, n)-0.5
+    b_ub = rng.rand(m_ub)-0.5
+    A_eq = rng.rand(m_eq, n)-0.5
+    b_eq = rng.rand(m_eq)-0.5
+    lb = -rng.rand(n)
+    ub = rng.rand(n)
+    lb[lb < -rng.rand()] = -np.inf
+    ub[ub > rng.rand()] = np.inf
     bounds = np.vstack((lb, ub)).T
     return c, A_ub, b_ub, A_eq, b_eq, bounds
 
@@ -211,11 +211,11 @@ def l1_regression_prob(seed=0, m=8, d=9, n=100):
     phi: feature map R^d -> R^m
     m: dimension of feature space
     '''
-    np.random.seed(seed)
-    phi = np.random.normal(0, 1, size=(m, d))  # random feature mapping
-    w_true = np.random.randn(m)
-    x = np.random.normal(0, 1, size=(d, n))  # features
-    y = w_true @ (phi @ x) + np.random.normal(0, 1e-5, size=n)  # measurements
+    rng = np.random.RandomState(seed)
+    phi = rng.normal(0, 1, size=(m, d))  # random feature mapping
+    w_true = rng.randn(m)
+    x = rng.normal(0, 1, size=(d, n))  # features
+    y = w_true @ (phi @ x) + rng.normal(0, 1e-5, size=n)  # measurements
 
     # construct the problem
     c = np.ones(m+n)
@@ -267,6 +267,7 @@ def generic_callback_test(self):
     assert_allclose(last_cb['slack'], res['slack'])
 
 
+@pytest.mark.parallel_threads(1)
 def test_unknown_solvers_and_options():
     c = np.array([-3, -2])
     A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -292,6 +293,7 @@ def test_choose_solver():
     _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
 
+@pytest.mark.parallel_threads(1)
 def test_deprecation():
     with pytest.warns(DeprecationWarning):
         linprog(1, method='interior-point')
@@ -444,6 +446,7 @@ class LinprogCommonTests:
                       method=self.method, options=self.options)
         _assert_success(res, desired_fun=2, desired_x=[2])
 
+    @pytest.mark.parallel_threads(1)
     def test_unknown_options(self):
         c = np.array([-3, -2])
         A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -460,6 +463,7 @@ class LinprogCommonTests:
         assert_warns(OptimizeWarning, f,
                      c, A_ub=A_ub, b_ub=b_ub, options=o)
 
+    @pytest.mark.parallel_threads(1)
     def test_integrality_without_highs(self):
         # ensure that using `integrality` parameter without `method='highs'`
         # raises warning and produces correct solution to relaxed problem
@@ -512,14 +516,14 @@ class LinprogCommonTests:
             linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                     method=self.method, options=self.options)
 
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
         m = 100
         n = 150
         A_eq = scipy.sparse.rand(m, n, 0.5)
-        x_valid = np.random.randn(n)
-        c = np.random.randn(n)
-        ub = x_valid + np.random.rand(n)
-        lb = x_valid - np.random.rand(n)
+        x_valid = rng.randn(n)
+        c = rng.randn(n)
+        ub = x_valid + rng.rand(n)
+        lb = x_valid - rng.rand(n)
         bounds = np.column_stack((lb, ub))
         b_eq = A_eq @ x_valid
 
@@ -609,6 +613,7 @@ class LinprogCommonTests:
         if do_presolve:
             assert_equal(res.nit, 0)
 
+    @pytest.mark.parallel_threads(1)
     def test_bounds_infeasible_2(self):
 
         # Test ill-valued bounds (lower inf, upper -inf)
@@ -805,12 +810,12 @@ class LinprogCommonTests:
 
     def test_zero_column_1(self):
         m, n = 3, 4
-        np.random.seed(0)
-        c = np.random.rand(n)
+        rng = np.random.RandomState(0)
+        c = rng.rand(n)
         c[1] = 1
-        A_eq = np.random.rand(m, n)
+        A_eq = rng.rand(m, n)
         A_eq[:, 1] = 0
-        b_eq = np.random.rand(m)
+        b_eq = rng.rand(m)
         A_ub = [[1, 0, 1, 1]]
         b_ub = 3
         bounds = [(-10, 10), (-10, 10), (-10, None), (None, None)]
@@ -823,17 +828,17 @@ class LinprogCommonTests:
             # See upstream issue https://github.com/ERGO-Code/HiGHS/issues/648
             pytest.xfail()
 
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
         m, n = 2, 4
-        c = np.random.rand(n)
+        c = rng.rand(n)
         c[1] = -1
-        A_eq = np.random.rand(m, n)
+        A_eq = rng.rand(m, n)
         A_eq[:, 1] = 0
-        b_eq = np.random.rand(m)
+        b_eq = rng.rand(m)
 
-        A_ub = np.random.rand(m, n)
+        A_ub = rng.rand(m, n)
         A_ub[:, 1] = 0
-        b_ub = np.random.rand(m)
+        b_ub = rng.rand(m)
         bounds = (None, None)
         res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                       method=self.method, options=self.options)
@@ -863,10 +868,11 @@ class LinprogCommonTests:
 
     def test_zero_row_3(self):
         m, n = 2, 4
-        c = np.random.rand(n)
-        A_eq = np.random.rand(m, n)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(n)
+        A_eq = rng.rand(m, n)
         A_eq[0, :] = 0
-        b_eq = np.random.rand(m)
+        b_eq = rng.rand(m)
         res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                       method=self.method, options=self.options)
         _assert_infeasible(res)
@@ -877,10 +883,11 @@ class LinprogCommonTests:
 
     def test_zero_row_4(self):
         m, n = 2, 4
-        c = np.random.rand(n)
-        A_ub = np.random.rand(m, n)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(n)
+        A_ub = rng.rand(m, n)
         A_ub[0, :] = 0
-        b_ub = -np.random.rand(m)
+        b_ub = -rng.rand(m)
         res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                       method=self.method, options=self.options)
         _assert_infeasible(res)
@@ -1062,9 +1069,10 @@ class LinprogCommonTests:
         # mostly a test of redundancy removal, which is carefully tested in
         # test__remove_redundancy.py
         m, n = 10, 10
-        c = np.random.rand(n)
-        A_eq = np.random.rand(m, n)
-        b_eq = np.random.rand(m)
+        rng = np.random.RandomState(0)
+        c = rng.rand(n)
+        A_eq = rng.rand(m, n)
+        b_eq = rng.rand(m)
         A_eq[-1, :] = 2 * A_eq[-2, :]
         b_eq[-1] *= -1
         with suppress_warnings() as sup:
@@ -1764,6 +1772,7 @@ class LinprogHiGHSTests(LinprogCommonTests):
         res = linprog(c, A_ub=A_ub, b_ub=b_ub, method=self.method)
         _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize("options",
                              [{"maxiter": -1},
                               {"disp": -1},
@@ -1950,7 +1959,8 @@ class TestLinprogSimplexDefault(LinprogSimplexTests):
         # even if the solution is wrong, the appropriate error is raised.
         pytest.skip("Simplex fails on this problem.")
 
-    def test_bug_8174_low_tol(self):
+    @pytest.mark.parallel_threads(1)
+    def test_bug_8174_low_tol(self, num_parallel_threads):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.
         self.options.update({'tol': 1e-12})
@@ -1966,6 +1976,7 @@ class TestLinprogSimplexBland(LinprogSimplexTests):
     def test_bug_5400(self):
         pytest.skip("Simplex fails on this problem.")
 
+    @pytest.mark.parallel_threads(1)
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate error is raised.
@@ -2001,6 +2012,7 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
     def test_bug_7237_low_tol(self):
         pytest.skip("Simplex fails on this problem.")
 
+    @pytest.mark.parallel_threads(1)
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -267,7 +267,7 @@ def generic_callback_test(self):
     assert_allclose(last_cb['slack'], res['slack'])
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_unknown_solvers_and_options():
     c = np.array([-3, -2])
     A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -293,7 +293,7 @@ def test_choose_solver():
     _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_deprecation():
     with pytest.warns(DeprecationWarning):
         linprog(1, method='interior-point')
@@ -446,7 +446,7 @@ class LinprogCommonTests:
                       method=self.method, options=self.options)
         _assert_success(res, desired_fun=2, desired_x=[2])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_unknown_options(self):
         c = np.array([-3, -2])
         A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -463,7 +463,7 @@ class LinprogCommonTests:
         assert_warns(OptimizeWarning, f,
                      c, A_ub=A_ub, b_ub=b_ub, options=o)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_integrality_without_highs(self):
         # ensure that using `integrality` parameter without `method='highs'`
         # raises warning and produces correct solution to relaxed problem
@@ -613,7 +613,7 @@ class LinprogCommonTests:
         if do_presolve:
             assert_equal(res.nit, 0)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_bounds_infeasible_2(self):
 
         # Test ill-valued bounds (lower inf, upper -inf)
@@ -1772,7 +1772,7 @@ class LinprogHiGHSTests(LinprogCommonTests):
         res = linprog(c, A_ub=A_ub, b_ub=b_ub, method=self.method)
         _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("options",
                              [{"maxiter": -1},
                               {"disp": -1},
@@ -1959,7 +1959,7 @@ class TestLinprogSimplexDefault(LinprogSimplexTests):
         # even if the solution is wrong, the appropriate error is raised.
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self, num_parallel_threads):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.
@@ -1976,7 +1976,7 @@ class TestLinprogSimplexBland(LinprogSimplexTests):
     def test_bug_5400(self):
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate error is raised.
@@ -2012,7 +2012,7 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
     def test_bug_7237_low_tol(self):
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1960,7 +1960,7 @@ class TestLinprogSimplexDefault(LinprogSimplexTests):
         pytest.skip("Simplex fails on this problem.")
 
     @pytest.mark.thread_unsafe
-    def test_bug_8174_low_tol(self, num_parallel_threads):
+    def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.
         self.options.update({'tol': 1e-12})

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -198,8 +198,9 @@ class SparseMixin:
     def test_sparse_and_LinearOperator(self):
         m = 5000
         n = 1000
-        A = rand(m, n, random_state=0)
-        b = self.rnd.randn(m)
+        rng = np.random.RandomState(0)
+        A = rand(m, n, random_state=rng)
+        b = rng.randn(m)
         res = lsq_linear(A, b)
         assert_allclose(res.optimality, 0, atol=1e-6)
 
@@ -211,9 +212,10 @@ class SparseMixin:
     def test_sparse_bounds(self):
         m = 5000
         n = 1000
-        A = rand(m, n, random_state=0)
-        b = self.rnd.randn(m)
-        lb = self.rnd.randn(n)
+        rng = np.random.RandomState(0)
+        A = rand(m, n, random_state=rng)
+        b = rng.randn(m)
+        lb = rng.randn(n)
         ub = lb + 1
         res = lsq_linear(A, b, (lb, ub))
         assert_allclose(res.optimality, 0.0, atol=1e-6)

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -294,7 +294,7 @@ def test_infeasible_prob_16609():
 _msg_time = "Time limit reached. (HiGHS Status 13:"
 _msg_iter = "Iteration limit reached. (HiGHS Status 14:"
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 # See https://github.com/scipy/scipy/pull/19255#issuecomment-1778438888
 @pytest.mark.xfail(reason="Often buggy, revisit with callbacks, gh-19255")
 @pytest.mark.skipif(np.intp(0).itemsize < 8,

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -294,6 +294,7 @@ def test_infeasible_prob_16609():
 _msg_time = "Time limit reached. (HiGHS Status 13:"
 _msg_iter = "Iteration limit reached. (HiGHS Status 14:"
 
+@pytest.mark.parallel_threads(1)
 # See https://github.com/scipy/scipy/pull/19255#issuecomment-1778438888
 @pytest.mark.xfail(reason="Often buggy, revisit with callbacks, gh-19255")
 @pytest.mark.skipif(np.intp(0).itemsize < 8,

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -471,7 +471,7 @@ class TestTrustRegionConstr:
     @pytest.mark.parametrize('hess', ("prob.hess", '3-point', SR1(),
                                       BFGS(exception_strategy='damp_update'),
                                       BFGS(exception_strategy='skip_update')))
-    def test_list_of_problems(self, prob, grad, hess, num_parallel_threads):
+    def test_list_of_problems(self, prob, grad, hess):
         grad = prob.grad if grad == "prob.grad" else grad
         hess = prob.hess if hess == "prob.hess" else hess
         # Remove exceptions

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -465,7 +465,7 @@ class TestTrustRegionConstr:
                         Elec(n_electrons=2, constr_jac='3-point',
                              constr_hess=SR1())]
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('prob', list_of_problems)
     @pytest.mark.parametrize('grad', ('prob.grad', '3-point', False))
     @pytest.mark.parametrize('hess', ("prob.hess", '3-point', SR1(),
@@ -779,7 +779,7 @@ def test_issue_18882():
             method="trust-constr",
             constraints=NonlinearConstraint(lsf, 0, 0),
         )
-    assert (not res.success) and (res.constr_violation > 1e-8)  
+    assert (not res.success) and (res.constr_violation > 1e-8)
 
 class TestBoundedNelderMead:
 

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -465,12 +465,13 @@ class TestTrustRegionConstr:
                         Elec(n_electrons=2, constr_jac='3-point',
                              constr_hess=SR1())]
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('prob', list_of_problems)
     @pytest.mark.parametrize('grad', ('prob.grad', '3-point', False))
     @pytest.mark.parametrize('hess', ("prob.hess", '3-point', SR1(),
                                       BFGS(exception_strategy='damp_update'),
                                       BFGS(exception_strategy='skip_update')))
-    def test_list_of_problems(self, prob, grad, hess):
+    def test_list_of_problems(self, prob, grad, hess, num_parallel_threads):
         grad = prob.grad if grad == "prob.grad" else grad
         hess = prob.hess if hess == "prob.hess" else hess
         # Remove exceptions

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -3,6 +3,7 @@ Unit tests for optimization routines from minpack.py.
 """
 import warnings
 import pytest
+import threading
 
 from numpy.testing import (assert_, assert_almost_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose,
@@ -260,8 +261,13 @@ class TestRootLM:
 
 
 class TestNfev:
+    def setup_method(self):
+        self.nfev = threading.local()
+
     def zero_f(self, y):
-        self.nfev += 1
+        if not hasattr(self.nfev, 'c'):
+            self.nfev.c = 0
+        self.nfev.c += 1
         return y**2-3
 
     @pytest.mark.parametrize('method', ['hybr', 'lm', 'broyden1',
@@ -270,14 +276,14 @@ class TestNfev:
                                         'excitingmixing', 'krylov',
                                         'df-sane'])
     def test_root_nfev(self, method):
-        self.nfev = 0
+        self.nfev.c = 0
         solution = optimize.root(self.zero_f, 100, method=method)
-        assert solution.nfev == self.nfev
+        assert solution.nfev == self.nfev.c
 
     def test_fsolve_nfev(self):
-        self.nfev = 0
+        self.nfev.c = 0
         x, info, ier, mesg = optimize.fsolve(self.zero_f, 100, full_output=True)
-        assert info['nfev'] == self.nfev
+        assert info['nfev'] == self.nfev.c
 
 
 class TestLeastSq:
@@ -557,6 +563,7 @@ class TestCurveFit:
         y = [3, 5, 7, 9]
         assert_allclose(curve_fit(f_linear, x, y)[0], [2, 1], atol=1e-10)
 
+    @pytest.mark.parallel_threads(1)
     def test_indeterminate_covariance(self):
         # Test that a warning is returned when pcov is indeterminate
         xdata = np.array([1, 2, 3, 4, 5, 6])
@@ -853,10 +860,10 @@ class TestCurveFit:
             e = np.exp(-b*x)
             return np.vstack((e, -a * x * e)).T
 
-        np.random.seed(0)
+        rng = np.random.RandomState(0)
         xdata = np.arange(1, 4)
         y = func(xdata, 2.5, 1.0)
-        ydata = y + 0.2 * np.random.normal(size=len(xdata))
+        ydata = y + 0.2 * rng.normal(size=len(xdata))
         sigma = np.zeros(len(xdata)) + 0.2
         covar = np.diag(sigma**2)
         # Get a rotation matrix, and obtain ydatap = R ydata

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -563,7 +563,7 @@ class TestCurveFit:
         y = [3, 5, 7, 9]
         assert_allclose(curve_fit(f_linear, x, y)[0], [2, 1], atol=1e-10)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_indeterminate_covariance(self):
         # Test that a warning is returned when pcov is indeterminate
         xdata = np.array([1, 2, 3, 4, 5, 6])

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -4,6 +4,7 @@ May 2007
 """
 from numpy.testing import assert_
 import pytest
+from functools import partial
 
 from scipy.optimize import _nonlin as nonlin, root
 from scipy.sparse import csr_array
@@ -212,7 +213,7 @@ class TestNonlin:
     def test_no_convergence(self):
         def wont_converge(x):
             return 1e3 + x
-        
+
         with pytest.raises(scipy.optimize.NoConvergence):
             nonlin.newton_krylov(wont_converge, xin=[0], maxiter=1)
 
@@ -367,18 +368,18 @@ class TestJacobianDotSolve:
     Check that solve/dot methods in Jacobian approximations are consistent
     """
 
-    def _func(self, x):
-        return x**2 - 1 + np.dot(self.A, x)
+    def _func(self, x, A=None):
+        return x**2 - 1 + np.dot(A, x)
 
     def _check_dot(self, jac_cls, complex=False, tol=1e-6, **kw):
-        np.random.seed(123)
+        rng = np.random.RandomState(123)
 
         N = 7
 
         def rand(*a):
-            q = np.random.rand(*a)
+            q = rng.rand(*a)
             if complex:
-                q = q + 1j*np.random.rand(*a)
+                q = q + 1j*rng.rand(*a)
             return q
 
         def assert_close(a, b, msg):
@@ -387,12 +388,12 @@ class TestJacobianDotSolve:
             if d > f:
                 raise AssertionError(f'{msg}: err {d:g}')
 
-        self.A = rand(N, N)
+        A = rand(N, N)
 
         # initialize
-        x0 = np.random.rand(N)
+        x0 = rng.rand(N)
         jac = jac_cls(**kw)
-        jac.setup(x0, self._func(x0), self._func)
+        jac.setup(x0, self._func(x0, A), partial(self._func, A=A))
 
         # check consistency
         for k in range(2*N):
@@ -428,7 +429,7 @@ class TestJacobianDotSolve:
                 assert_close(Jv, Jv2, 'rmatvec vs rsolve')
 
             x = rand(N)
-            jac.update(x, self._func(x))
+            jac.update(x, self._func(x, A))
 
     def test_broyden1(self):
         self._check_dot(nonlin.BroydenFirst, complex=False)
@@ -454,6 +455,7 @@ class TestJacobianDotSolve:
         self._check_dot(nonlin.ExcitingMixing, complex=False)
         self._check_dot(nonlin.ExcitingMixing, complex=True)
 
+    @pytest.mark.parallel_threads(1)
     def test_krylov(self):
         self._check_dot(nonlin.KrylovJacobian, complex=False, tol=1e-3)
         self._check_dot(nonlin.KrylovJacobian, complex=True, tol=1e-3)

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -455,7 +455,7 @@ class TestJacobianDotSolve:
         self._check_dot(nonlin.ExcitingMixing, complex=False)
         self._check_dot(nonlin.ExcitingMixing, complex=True)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_krylov(self):
         self._check_dot(nonlin.KrylovJacobian, complex=False, tol=1e-3)
         self._check_dot(nonlin.KrylovJacobian, complex=True, tol=1e-3)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -8,6 +8,7 @@ Authors:
 """
 import itertools
 import platform
+import threading
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
                            assert_almost_equal,
@@ -108,22 +109,32 @@ class CheckOptimize:
         self.startparams = np.zeros(3, np.float64)
         self.solution = np.array([0., -0.524869316, 0.487525860])
         self.maxiter = 1000
-        self.funccalls = 0
-        self.gradcalls = 0
-        self.trace = []
+        self.funccalls = threading.local()
+        self.gradcalls = threading.local()
+        self.trace = threading.local()
 
     def func(self, x):
-        self.funccalls += 1
-        if self.funccalls > 6000:
+        if not hasattr(self.funccalls, 'c'):
+            self.funccalls.c = 0
+
+        if not hasattr(self.gradcalls, 'c'):
+            self.gradcalls.c = 0
+
+        self.funccalls.c += 1
+        if self.funccalls.c > 6000:
             raise RuntimeError("too many iterations in optimization routine")
         log_pdot = np.dot(self.F, x)
         logZ = np.log(sum(np.exp(log_pdot)))
         f = logZ - np.dot(self.K, x)
-        self.trace.append(np.copy(x))
+        if not hasattr(self.trace, 't'):
+            self.trace.t = []
+        self.trace.t.append(np.copy(x))
         return f
 
     def grad(self, x):
-        self.gradcalls += 1
+        if not hasattr(self.gradcalls, 'c'):
+            self.gradcalls.c = 0
+        self.gradcalls.c += 1
         log_pdot = np.dot(self.F, x)
         logZ = np.log(sum(np.exp(log_pdot)))
         p = np.exp(log_pdot - logZ)
@@ -164,11 +175,11 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls == 9, self.funccalls
-        assert self.gradcalls == 7, self.gradcalls
+        assert self.funccalls.c == 9, self.funccalls.c
+        assert self.gradcalls.c == 7, self.gradcalls.c
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[2:4],
+        assert_allclose(self.trace.t[2:4],
                         [[0, -0.5, 0.5],
                          [0, -5.05700028e-01, 4.95985862e-01]],
                         atol=1e-14, rtol=1e-7)
@@ -209,11 +220,11 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls == 10, self.funccalls
-        assert self.gradcalls == 8, self.gradcalls
+        assert self.funccalls.c == 10, self.funccalls.c
+        assert self.gradcalls.c == 8, self.gradcalls.c
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[6:8],
+        assert_allclose(self.trace.t[6:8],
                         [[0, -5.25060743e-01, 4.87748473e-01],
                          [0, -5.24885582e-01, 4.87530347e-01]],
                         atol=1e-14, rtol=1e-7)
@@ -338,8 +349,8 @@ class CheckOptimizeParameterized(CheckOptimize):
         # machines, and when using e.g., MKL, data alignment
         # etc., affect the rounding error.
         #
-        assert self.funccalls <= 116 + 20, self.funccalls
-        assert self.gradcalls == 0, self.gradcalls
+        assert self.funccalls.c <= 116 + 20, self.funccalls.c
+        assert self.gradcalls.c == 0, self.gradcalls.c
 
     @pytest.mark.xfail(reason="This part of test_powell fails on some "
                        "platforms, but the solution returned by powell is "
@@ -388,7 +399,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                                     method='Powell', options=opts)
             params, func_calls = (res['x'], res['nfev'])
 
-            assert func_calls == self.funccalls
+            assert func_calls == self.funccalls.c
             assert_allclose(self.func(params), self.func(self.solution),
                             atol=1e-6, rtol=1e-5)
 
@@ -398,8 +409,8 @@ class CheckOptimizeParameterized(CheckOptimize):
             # affect the rounding error.
             # It takes 155 calls on my machine, but we can add the same +20
             # margin as is used in `test_powell`
-            assert self.funccalls <= 155 + 20
-            assert self.gradcalls == 0
+            assert self.funccalls.c <= 155 + 20
+            assert self.gradcalls.c == 0
 
     def test_neldermead(self):
         # Nelder-Mead simplex algorithm
@@ -423,11 +434,11 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls == 167, self.funccalls
-        assert self.gradcalls == 0, self.gradcalls
+        assert self.funccalls.c == 167, self.funccalls.c
+        assert self.gradcalls.c == 0, self.gradcalls.c
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[76:78],
+        assert_allclose(self.trace.t[76:78],
                         [[0.1928968, -0.62780447, 0.35166118],
                          [0.19572515, -0.63648426, 0.35838135]],
                         atol=1e-14, rtol=1e-7)
@@ -463,11 +474,11 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.17.0. Don't allow them to increase.
-        assert self.funccalls == 100, self.funccalls
-        assert self.gradcalls == 0, self.gradcalls
+        assert self.funccalls.c == 100, self.funccalls.c
+        assert self.gradcalls.c == 0, self.gradcalls.c
 
         # Ensure that the function behaves the same; this is from SciPy 0.15.0
-        assert_allclose(self.trace[50:52],
+        assert_allclose(self.trace.t[50:52],
                         [[0.14687474, -0.5103282, 0.48252111],
                          [0.14474003, -0.5282084, 0.48743951]],
                         atol=1e-14, rtol=1e-7)
@@ -573,14 +584,14 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls == 7, self.funccalls
-        assert self.gradcalls <= 22, self.gradcalls  # 0.13.0
+        assert self.funccalls.c == 7, self.funccalls.c
+        assert self.gradcalls.c <= 22, self.gradcalls.c  # 0.13.0
         # assert self.gradcalls <= 18, self.gradcalls  # 0.9.0
         # assert self.gradcalls == 18, self.gradcalls  # 0.8.0
         # assert self.gradcalls == 22, self.gradcalls  # 0.7.0
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[3:5],
+        assert_allclose(self.trace.t[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
@@ -608,13 +619,13 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls <= 7, self.funccalls  # gh10673
-        assert self.gradcalls <= 18, self.gradcalls  # 0.9.0
+        assert self.funccalls.c <= 7, self.funccalls.c  # gh10673
+        assert self.gradcalls.c <= 18, self.gradcalls.c  # 0.9.0
         # assert self.gradcalls == 18, self.gradcalls  # 0.8.0
         # assert self.gradcalls == 22, self.gradcalls  # 0.7.0
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[3:5],
+        assert_allclose(self.trace.t[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
@@ -642,13 +653,13 @@ class CheckOptimizeParameterized(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls <= 7, self.funccalls  # gh10673
-        assert self.gradcalls <= 18, self.gradcalls  # 0.9.0
+        assert self.funccalls.c <= 7, self.funccalls.c  # gh10673
+        assert self.gradcalls.c <= 18, self.gradcalls.c  # 0.9.0
         # assert self.gradcalls == 18, self.gradcalls  # 0.8.0
         # assert self.gradcalls == 22, self.gradcalls  # 0.7.0
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
-        assert_allclose(self.trace[3:5],
+        assert_allclose(self.trace.t[3:5],
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
@@ -670,7 +681,7 @@ class CheckOptimizeParameterized(CheckOptimize):
             # computations are not bit-for-bit reproducible across machines. It
             # takes 45 calls on my machine, but we can add the same +20 margin
             # as is used in `test_powell`
-            assert self.funccalls <= 45 + 20, self.funccalls
+            assert self.funccalls.c <= 45 + 20, self.funccalls.c
 
 
 def test_maxfev_test():
@@ -764,6 +775,7 @@ def test_neldermead_adaptive():
     assert_equal(res.success, True)
 
 
+@pytest.mark.parallel_threads(1)
 def test_bounded_powell_outsidebounds():
     # With the bounded Powell method if you start outside the bounds the final
     # should still be within the bounds (provided that the user doesn't make a
@@ -795,6 +807,7 @@ def test_bounded_powell_outsidebounds():
     assert_equal(res.status, 4)
 
 
+@pytest.mark.parallel_threads(1)
 def test_bounded_powell_vs_powell():
     # here we test an example where the bounded Powell method
     # will return a different result than the standard Powell
@@ -1049,12 +1062,12 @@ class TestOptimizeSimple(CheckOptimize):
 
         # Ensure that function call counts are 'known good'; these are from
         # SciPy 0.7.0. Don't allow them to increase.
-        assert self.funccalls == 7, self.funccalls
-        assert self.gradcalls == 5, self.gradcalls
+        assert self.funccalls.c == 7, self.funccalls.c
+        assert self.gradcalls.c == 5, self.gradcalls.c
 
         # Ensure that the function behaves the same; this is from SciPy 0.7.0
         # test fixed in gh10673
-        assert_allclose(self.trace[3:5],
+        assert_allclose(self.trace.t[3:5],
                         [[8.117083e-16, -5.196198e-01, 4.897617e-01],
                          [0., -0.52489628, 0.48753042]],
                         atol=1e-14, rtol=1e-7)
@@ -1117,23 +1130,23 @@ class TestOptimizeSimple(CheckOptimize):
                               options=opts)
         assert_allclose(self.func(r.x), self.func(self.solution),
                         atol=1e-6)
-        assert self.gradcalls == r.njev
+        assert self.gradcalls.c == r.njev
 
-        self.funccalls = self.gradcalls = 0
+        self.funccalls.c = self.gradcalls.c = 0
         # approximate jacobian
         ra = optimize.minimize(self.func, self.startparams,
                                method='L-BFGS-B', options=opts)
         # check that function evaluations in approximate jacobian are counted
         # assert_(ra.nfev > r.nfev)
-        assert self.funccalls == ra.nfev
+        assert self.funccalls.c == ra.nfev
         assert_allclose(self.func(ra.x), self.func(self.solution),
                         atol=1e-6)
 
-        self.funccalls = self.gradcalls = 0
+        self.funccalls.c = self.gradcalls.c = 0
         # approximate jacobian
         ra = optimize.minimize(self.func, self.startparams, jac='3-point',
                                method='L-BFGS-B', options=opts)
-        assert self.funccalls == ra.nfev
+        assert self.funccalls.c == ra.nfev
         assert_allclose(self.func(ra.x), self.func(self.solution),
                         atol=1e-6)
 
@@ -1413,6 +1426,7 @@ class TestOptimizeSimple(CheckOptimize):
         elif method == 'cobyqa':
             assert sol.status == 6  # Iteration limit reached
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('method', ['Nelder-Mead', 'Powell',
                                         'fmin', 'fmin_powell'])
     def test_runtime_warning(self, method):
@@ -1541,9 +1555,12 @@ class TestOptimizeSimple(CheckOptimize):
                                         'cobyla', 'cobyqa', 'slsqp',
                                         'trust-constr', 'dogleg', 'trust-ncg',
                                         'trust-exact', 'trust-krylov'])
-    def test_nan_values(self, method):
+    def test_nan_values(self, method, num_parallel_threads):
+        if num_parallel_threads > 1 and method == 'cobyqa':
+            pytest.skip('COBYQA does not support concurrent execution')
+
         # Check nan values result to failed exit status
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         count = [0]
 
@@ -1555,7 +1572,7 @@ class TestOptimizeSimple(CheckOptimize):
             if count[0] > 2:
                 return np.nan
             else:
-                return np.random.rand()
+                return rng.rand()
 
         def grad(x):
             return np.array([1.0])
@@ -1607,8 +1624,8 @@ class TestOptimizeSimple(CheckOptimize):
             optimize.minimize(self.func, self.startparams,
                               method=method, jac=jac, hess=hess)
 
-        for i in range(1, len(self.trace)):
-            if np.array_equal(self.trace[i - 1], self.trace[i]):
+        for i in range(1, len(self.trace.t)):
+            if np.array_equal(self.trace.t[i - 1], self.trace.t[i]):
                 raise RuntimeError(
                     f"Duplicate evaluations made by {method}")
 
@@ -1698,6 +1715,7 @@ class TestOptimizeSimple(CheckOptimize):
         with pytest.raises(ValueError, match=msg):
             optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('method', ['bfgs', 'cg', 'newton-cg', 'powell'])
     def test_minimize_warnings_gh1953(self, method):
         # test that minimize methods produce warnings rather than just using
@@ -2071,6 +2089,7 @@ class TestOptimizeScalar:
         res = optimize.minimize_scalar(f, **kwargs)
         assert res.x.shape == res.fun.shape == f(res.x).shape == fshape
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('method', ['bounded', 'brent', 'golden'])
     def test_minimize_scalar_warnings_gh1953(self, method):
         # test that minimize_scalar methods produce warnings rather than just
@@ -2628,6 +2647,7 @@ class TestBrute:
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
 
+    @pytest.mark.parallel_threads(1)
     def test_runtime_warning(self, capsys):
         rng = np.random.default_rng(1234)
 
@@ -2647,6 +2667,7 @@ class TestBrute:
         assert_allclose(resbrute, 0)
 
 
+@pytest.mark.parallel_threads(1)
 @pytest.mark.fail_slow(20)
 def test_cobyla_threadsafe():
 
@@ -2688,10 +2709,12 @@ class TestIterationLimits:
     # number of iterations or evaluations. And that it does not succeed
     # by exceeding the limits.
     def setup_method(self):
-        self.funcalls = 0
+        self.funcalls = threading.local()
 
     def slow_func(self, v):
-        self.funcalls += 1
+        if not hasattr(self.funcalls, 'c'):
+            self.funcalls.c = 0
+        self.funcalls.c += 1
         r, t = np.sqrt(v[0]**2+v[1]**2), np.arctan2(v[0], v[1])
         return np.sin(r*20 + t)+r*0.5
 
@@ -2705,11 +2728,11 @@ class TestIterationLimits:
     def check_limits(self, method, default_iters):
         for start_v in [[0.1, 0.1], [1, 1], [2, 2]]:
             for mfev in [50, 500, 5000]:
-                self.funcalls = 0
+                self.funcalls.c = 0
                 res = optimize.minimize(self.slow_func, start_v,
                                         method=method,
                                         options={"maxfev": mfev})
-                assert self.funcalls == res["nfev"]
+                assert self.funcalls.c == res["nfev"]
                 if res["success"]:
                     assert res["nfev"] < mfev
                 else:
@@ -2723,23 +2746,23 @@ class TestIterationLimits:
                 else:
                     assert res["nit"] >= mit
             for mfev, mit in [[50, 50], [5000, 5000], [5000, np.inf]]:
-                self.funcalls = 0
+                self.funcalls.c = 0
                 res = optimize.minimize(self.slow_func, start_v,
                                         method=method,
                                         options={"maxiter": mit,
                                                  "maxfev": mfev})
-                assert self.funcalls == res["nfev"]
+                assert self.funcalls.c == res["nfev"]
                 if res["success"]:
                     assert res["nfev"] < mfev and res["nit"] <= mit
                 else:
                     assert res["nfev"] >= mfev or res["nit"] >= mit
             for mfev, mit in [[np.inf, None], [None, np.inf]]:
-                self.funcalls = 0
+                self.funcalls.c = 0
                 res = optimize.minimize(self.slow_func, start_v,
                                         method=method,
                                         options={"maxiter": mit,
                                                  "maxfev": mfev})
-                assert self.funcalls == res["nfev"]
+                assert self.funcalls.c == res["nfev"]
                 if res["success"]:
                     if mfev is None:
                         assert res["nfev"] < default_iters*2
@@ -2777,10 +2800,12 @@ def test_result_x_shape_when_len_x_is_one():
 
 class FunctionWithGradient:
     def __init__(self):
-        self.number_of_calls = 0
+        self.number_of_calls = threading.local()
 
     def __call__(self, x):
-        self.number_of_calls += 1
+        if not hasattr(self.number_of_calls, 'c'):
+            self.number_of_calls.c = 0
+        self.number_of_calls.c += 1
         return np.sum(x**2), 2 * x
 
 
@@ -2794,17 +2819,17 @@ def test_memoize_jac_function_before_gradient(function_with_gradient):
 
     x0 = np.array([1.0, 2.0])
     assert_allclose(memoized_function(x0), 5.0)
-    assert function_with_gradient.number_of_calls == 1
+    assert function_with_gradient.number_of_calls.c == 1
 
     assert_allclose(memoized_function.derivative(x0), 2 * x0)
-    assert function_with_gradient.number_of_calls == 1, \
+    assert function_with_gradient.number_of_calls.c == 1, \
         "function is not recomputed " \
         "if gradient is requested after function value"
 
     assert_allclose(
         memoized_function(2 * x0), 20.0,
         err_msg="different input triggers new computation")
-    assert function_with_gradient.number_of_calls == 2, \
+    assert function_with_gradient.number_of_calls.c == 2, \
         "different input triggers new computation"
 
 
@@ -2813,17 +2838,17 @@ def test_memoize_jac_gradient_before_function(function_with_gradient):
 
     x0 = np.array([1.0, 2.0])
     assert_allclose(memoized_function.derivative(x0), 2 * x0)
-    assert function_with_gradient.number_of_calls == 1
+    assert function_with_gradient.number_of_calls.c == 1
 
     assert_allclose(memoized_function(x0), 5.0)
-    assert function_with_gradient.number_of_calls == 1, \
+    assert function_with_gradient.number_of_calls.c == 1, \
         "function is not recomputed " \
         "if function value is requested after gradient"
 
     assert_allclose(
         memoized_function.derivative(2 * x0), 4 * x0,
         err_msg="different input triggers new computation")
-    assert function_with_gradient.number_of_calls == 2, \
+    assert function_with_gradient.number_of_calls.c == 2, \
         "different input triggers new computation"
 
 
@@ -2839,13 +2864,13 @@ def test_memoize_jac_with_bfgs(function_with_gradient):
     x0 = np.array([1.0, 0.5])
     scalar_function = ScalarFunction(
         memoized_function, x0, (), jac, hess, None, None)
-    assert function_with_gradient.number_of_calls == 1
+    assert function_with_gradient.number_of_calls.c == 1
 
     scalar_function.fun(x0 + 0.1)
-    assert function_with_gradient.number_of_calls == 2
+    assert function_with_gradient.number_of_calls.c == 2
 
     scalar_function.fun(x0 + 0.2)
-    assert function_with_gradient.number_of_calls == 3
+    assert function_with_gradient.number_of_calls.c == 3
 
 
 def test_gh12696():
@@ -2859,8 +2884,8 @@ def test_gh12696():
 
 def setup_test_equal_bounds():
 
-    np.random.seed(0)
-    x0 = np.random.rand(4)
+    rng = np.random.RandomState(0)
+    x0 = rng.rand(4)
     lb = np.array([0, 2, -1, -1.0])
     ub = np.array([3, 2, 2, -1.0])
     i_eb = (lb == ub)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -775,7 +775,7 @@ def test_neldermead_adaptive():
     assert_equal(res.success, True)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_bounded_powell_outsidebounds():
     # With the bounded Powell method if you start outside the bounds the final
     # should still be within the bounds (provided that the user doesn't make a
@@ -807,7 +807,7 @@ def test_bounded_powell_outsidebounds():
     assert_equal(res.status, 4)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_bounded_powell_vs_powell():
     # here we test an example where the bounded Powell method
     # will return a different result than the standard Powell
@@ -1426,7 +1426,7 @@ class TestOptimizeSimple(CheckOptimize):
         elif method == 'cobyqa':
             assert sol.status == 6  # Iteration limit reached
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['Nelder-Mead', 'Powell',
                                         'fmin', 'fmin_powell'])
     def test_runtime_warning(self, method):
@@ -1715,7 +1715,7 @@ class TestOptimizeSimple(CheckOptimize):
         with pytest.raises(ValueError, match=msg):
             optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['bfgs', 'cg', 'newton-cg', 'powell'])
     def test_minimize_warnings_gh1953(self, method):
         # test that minimize methods produce warnings rather than just using
@@ -2089,7 +2089,7 @@ class TestOptimizeScalar:
         res = optimize.minimize_scalar(f, **kwargs)
         assert res.x.shape == res.fun.shape == f(res.x).shape == fshape
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['bounded', 'brent', 'golden'])
     def test_minimize_scalar_warnings_gh1953(self, method):
         # test that minimize_scalar methods produce warnings rather than just
@@ -2647,7 +2647,7 @@ class TestBrute:
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_runtime_warning(self, capsys):
         rng = np.random.default_rng(1234)
 
@@ -2667,7 +2667,7 @@ class TestBrute:
         assert_allclose(resbrute, 0)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 @pytest.mark.fail_slow(20)
 def test_cobyla_threadsafe():
 

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -144,14 +144,14 @@ class QAPCommonTests:
         seed_cost = np.array([4, 8, 10])
         seed = np.asarray([seed_cost, opt_perm[seed_cost]]).T
         res = quadratic_assignment(A, B, method=self.method,
-                                   options={'partial_match': seed})
+                                   options={'partial_match': seed, "rng": rng})
         assert_(11156 <= res.fun < 21000)
         assert_equal(res.col_ind[seed_cost], opt_perm[seed_cost])
 
         # check performance when partial match is the global optimum
         seed = np.asarray([np.arange(len(A)), opt_perm]).T
         res = quadratic_assignment(A, B, method=self.method,
-                                   options={'partial_match': seed})
+                                   options={'partial_match': seed, "rng": rng})
         assert_equal(res.col_ind, seed[:, 1].T)
         assert_equal(res.fun, 11156)
         assert_equal(res.nit, 0)
@@ -266,7 +266,6 @@ class TestFAQ(QAPCommonTests):
 class Test2opt(QAPCommonTests):
     method = "2opt"
 
-    @pytest.mark.thread_unsafe
     def test_deterministic(self):
         n = 20
         rng = default_rng(51982908)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -163,7 +163,7 @@ class QAPCommonTests:
         assert_equal(res.nit, 0)
         assert_equal(res.fun, 0)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_unknown_options(self):
         A, B, opt_perm = chr12c()
 
@@ -172,7 +172,7 @@ class QAPCommonTests:
                                  options={"ekki-ekki": True})
         assert_warns(OptimizeWarning, f)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_deprecation_future_warnings(self):
         # May be removed after SPEC-7 transition is complete in SciPy 1.17
         A = np.arange(16).reshape((4, 4))
@@ -266,7 +266,7 @@ class TestFAQ(QAPCommonTests):
 class Test2opt(QAPCommonTests):
     method = "2opt"
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_deterministic(self):
         n = 20
         rng = default_rng(51982908)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -172,6 +172,7 @@ class QAPCommonTests:
                                  options={"ekki-ekki": True})
         assert_warns(OptimizeWarning, f)
 
+    @pytest.mark.parallel_threads(1)
     def test_deprecation_future_warnings(self):
         # May be removed after SPEC-7 transition is complete in SciPy 1.17
         A = np.arange(16).reshape((4, 4))

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -163,6 +163,7 @@ class QAPCommonTests:
         assert_equal(res.nit, 0)
         assert_equal(res.fun, 0)
 
+    @pytest.mark.parallel_threads(1)
     def test_unknown_options(self):
         A, B, opt_perm = chr12c()
 
@@ -264,6 +265,7 @@ class TestFAQ(QAPCommonTests):
 class Test2opt(QAPCommonTests):
     method = "2opt"
 
+    @pytest.mark.parallel_threads(1)
     def test_deterministic(self):
         n = 20
         rng = default_rng(51982908)

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -592,6 +592,7 @@ class TestSLSQP:
         # The problem is infeasible, so it cannot succeed
         assert not res.success
 
+    @pytest.mark.parallel_threads(1)
     def test_parameters_stay_within_bounds(self):
         # gh11403. For some problems the SLSQP Fortran code suggests a step
         # outside one of the lower/upper bounds. When this happens

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -592,7 +592,7 @@ class TestSLSQP:
         # The problem is infeasible, so it cannot succeed
         assert not res.success
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_parameters_stay_within_bounds(self):
         # gh11403. For some problems the SLSQP Fortran code suggests a step
         # outside one of the lower/upper bounds. When this happens

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -51,7 +51,7 @@ class TestTrustRegionSolvers:
         assert_allclose(r['x'], r['allvecs'][-1])
         assert_allclose(sum(r['allvecs'][1:]), accumulator.accum)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dogleg_user_warning(self):
         with pytest.warns(RuntimeWarning,
                           match=r'Maximum number of iterations'):

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -51,6 +51,7 @@ class TestTrustRegionSolvers:
         assert_allclose(r['x'], r['allvecs'][-1])
         assert_allclose(sum(r['allvecs'][1:]), accumulator.accum)
 
+    @pytest.mark.parallel_threads(1)
     def test_dogleg_user_warning(self):
         with pytest.warns(RuntimeWarning,
                           match=r'Maximum number of iterations'):

--- a/scipy/optimize/tests/test_trustregion_krylov.py
+++ b/scipy/optimize/tests/test_trustregion_krylov.py
@@ -153,7 +153,7 @@ class TestKrylovQuadraticSubproblem:
                                       -0.84954934])
         assert_array_almost_equal(hits_boundary, True)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_disp(self, capsys):
         H = -np.eye(5)
         g = np.array([0, 0, 0, 0, 1e-6])

--- a/scipy/optimize/tests/test_trustregion_krylov.py
+++ b/scipy/optimize/tests/test_trustregion_krylov.py
@@ -2,6 +2,7 @@
 Unit tests for Krylov space trust-region subproblem solver.
 
 """
+import pytest
 import numpy as np
 from scipy.optimize._trlib import (get_trlib_quadratic_subproblem)
 from numpy.testing import (assert_,
@@ -152,6 +153,7 @@ class TestKrylovQuadraticSubproblem:
                                       -0.84954934])
         assert_array_almost_equal(hits_boundary, True)
 
+    @pytest.mark.parallel_threads(1)
     def test_disp(self, capsys):
         H = -np.eye(5)
         g = np.array([0, 0, 0, 0, 1e-6])

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -362,7 +362,7 @@ class TestNewton(TestScalarRootFinders):
         x = zeros.newton(lambda y, z: z - y ** 2, [4] * 2, args=([15, 17],))
         assert_allclose(x, (3.872983346207417, 4.123105625617661))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_array_newton_zero_der_failures(self):
         # test derivative zero warning
         assert_warns(RuntimeWarning, zeros.newton,
@@ -432,7 +432,7 @@ class TestNewton(TestScalarRootFinders):
                 with pytest.raises(RuntimeError, match=msg):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_deriv_zero_warning(self):
         def func(x):
             return x ** 2 - 2.0
@@ -604,7 +604,7 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_zero_der_nz_dp(capsys):
     """Test secant method with a non-zero dp, but an infinite newton step"""
     # pick a symmetrical functions and choose a point on the side that with dx
@@ -637,7 +637,7 @@ def test_zero_der_nz_dp(capsys):
         x = zeros.newton(lambda y: (y + 1.0) ** 2, x0=p0, disp=True)
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_array_newton_failures():
     """Test that array newton fails as expected"""
     # p = 0.68  # [MPa]
@@ -801,7 +801,7 @@ def test_gh9254_flag_if_maxiter_exceeded(maximum_iterations, flag_expected):
         assert result[1].iterations < maximum_iterations
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_gh9551_raise_error_if_disp_true():
     """Test that if disp is true then zero derivative raises RuntimeError"""
 
@@ -874,7 +874,7 @@ def test_function_calls(solver_name, rs_interface):
         assert res[1].function_calls == f.calls
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_gh_14486_converged_false():
     """Test that zero slope with secant method results in a converged=False"""
     def lhs(x):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -362,6 +362,7 @@ class TestNewton(TestScalarRootFinders):
         x = zeros.newton(lambda y, z: z - y ** 2, [4] * 2, args=([15, 17],))
         assert_allclose(x, (3.872983346207417, 4.123105625617661))
 
+    @pytest.mark.parallel_threads(1)
     def test_array_newton_zero_der_failures(self):
         # test derivative zero warning
         assert_warns(RuntimeWarning, zeros.newton,
@@ -431,6 +432,7 @@ class TestNewton(TestScalarRootFinders):
                 with pytest.raises(RuntimeError, match=msg):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
+    @pytest.mark.parallel_threads(1)
     def test_deriv_zero_warning(self):
         def func(x):
             return x ** 2 - 2.0
@@ -602,6 +604,7 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
+@pytest.mark.parallel_threads(1)
 def test_zero_der_nz_dp(capsys):
     """Test secant method with a non-zero dp, but an infinite newton step"""
     # pick a symmetrical functions and choose a point on the side that with dx
@@ -634,6 +637,7 @@ def test_zero_der_nz_dp(capsys):
         x = zeros.newton(lambda y: (y + 1.0) ** 2, x0=p0, disp=True)
 
 
+@pytest.mark.parallel_threads(1)
 def test_array_newton_failures():
     """Test that array newton fails as expected"""
     # p = 0.68  # [MPa]
@@ -797,6 +801,7 @@ def test_gh9254_flag_if_maxiter_exceeded(maximum_iterations, flag_expected):
         assert result[1].iterations < maximum_iterations
 
 
+@pytest.mark.parallel_threads(1)
 def test_gh9551_raise_error_if_disp_true():
     """Test that if disp is true then zero derivative raises RuntimeError"""
 
@@ -869,6 +874,7 @@ def test_function_calls(solver_name, rs_interface):
         assert res[1].function_calls == f.calls
 
 
+@pytest.mark.parallel_threads(1)
 def test_gh_14486_converged_false():
     """Test that zero slope with secant method results in a converged=False"""
     def lhs(x):

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -119,7 +119,7 @@ class TestBSplines:
                             np.asarray([0.15418033, 0.6909883, 0.15418033])
         )
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_cspline1d(self):
         np.random.seed(12462)
         xp_assert_equal(bsp.cspline1d(np.asarray([0])), [0.])

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -119,7 +119,6 @@ class TestBSplines:
                             np.asarray([0.15418033, 0.6909883, 0.15418033])
         )
 
-    @pytest.mark.thread_unsafe
     def test_cspline1d(self):
         np.random.seed(12462)
         xp_assert_equal(bsp.cspline1d(np.asarray([0])), [0.])

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -18,12 +18,11 @@ class TestBSplines:
     expressions (cf. Unser, Aldroubi, Eden, IEEE TSP 1993, Table 1)."""
 
     def test_spline_filter(self):
-        np.random.seed(12457)
+        rng = np.random.RandomState(12457)
         # Test the type-error branch
         raises(TypeError, bsp.spline_filter, np.asarray([0]), 0)
         # Test the real branch
-        np.random.seed(12457)
-        data_array_real = np.random.rand(12, 12)
+        data_array_real = rng.rand(12, 12)
         # make the magnitude exceed 1, and make some negative
         data_array_real = 10*(1-2*data_array_real)
         result_array_real = np.asarray(
@@ -67,8 +66,8 @@ class TestBSplines:
                         result_array_real)
 
     def test_spline_filter_complex(self):
-        np.random.seed(12457)
-        data_array_complex = np.random.rand(7, 7) + np.random.rand(7, 7)*1j
+        rng = np.random.RandomState(12457)
+        data_array_complex = rng.rand(7, 7) + rng.rand(7, 7)*1j
         # make the magnitude exceed 1, and make some negative
         data_array_complex = 10*(1+1j-2*data_array_complex)
         result_array_complex = np.asarray(
@@ -120,6 +119,7 @@ class TestBSplines:
                             np.asarray([0.15418033, 0.6909883, 0.15418033])
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_cspline1d(self):
         np.random.seed(12462)
         xp_assert_equal(bsp.cspline1d(np.asarray([0])), [0.])

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -13,7 +13,7 @@ from scipy.signal import tf2ss, impulse, dimpulse, step, dstep
 
 
 class TestC2D:
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     def test_zoh(self):
         ac = np.eye(2, dtype=np.float64)
         bc = np.full((2, 1), 0.5, dtype=np.float64)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -13,7 +13,7 @@ from scipy.signal import tf2ss, impulse, dimpulse, step, dstep
 
 
 class TestC2D:
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
     def test_zoh(self):
         ac = np.eye(2, dtype=np.float64)
         bc = np.full((2, 1), 0.5, dtype=np.float64)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -13,9 +13,10 @@ from scipy.signal import tf2ss, impulse, dimpulse, step, dstep
 
 
 class TestC2D:
+    @pytest.mark.parallel_threads(1)
     def test_zoh(self):
-        ac = np.eye(2)
-        bc = np.full((2, 1), 0.5)
+        ac = np.eye(2, dtype=np.float64)
+        bc = np.full((2, 1), 0.5, dtype=np.float64)
         cc = np.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
         dc = np.array([[0.0], [0.0], [-0.33]])
 

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -13,7 +13,7 @@ from scipy.signal import tf2ss, impulse, dimpulse, step, dstep
 
 
 class TestC2D:
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_zoh(self):
         ac = np.eye(2, dtype=np.float64)
         bc = np.full((2, 1), 0.5, dtype=np.float64)

--- a/scipy/signal/tests/test_czt.py
+++ b/scipy/signal/tests/test_czt.py
@@ -55,13 +55,13 @@ def check_zoom_fft(x):
 def test_1D():
     # Test of 1D version of the transforms
 
-    np.random.seed(0)  # Deterministic randomness
+    rng = np.random.RandomState(0)  # Deterministic randomness
 
     # Random signals
-    lengths = np.random.randint(8, 200, 20)
+    lengths = rng.randint(8, 200, 20)
     np.append(lengths, 1)
     for length in lengths:
-        x = np.random.random(length)
+        x = rng.random(length)
         check_zoom_fft(x)
         check_czt(x)
 
@@ -92,7 +92,7 @@ def test_1D():
     xp_assert_close(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
 
     # Random (not a test condition)
-    x = np.random.rand(101)
+    x = rng.rand(101)
     check_zoom_fft(x)
 
     # Spikes
@@ -111,9 +111,9 @@ def test_1D():
 
 
 def test_large_prime_lengths():
-    np.random.seed(0)  # Deterministic randomness
+    rng = np.random.RandomState(0)  # Deterministic randomness
     for N in (101, 1009, 10007):
-        x = np.random.rand(N)
+        x = rng.rand(N)
         y = fft(x)
         y1 = czt(x)
         xp_assert_close(y, y1, rtol=1e-12)
@@ -121,10 +121,10 @@ def test_large_prime_lengths():
 
 @pytest.mark.slow
 def test_czt_vs_fft():
-    np.random.seed(123)
-    random_lengths = np.random.exponential(100000, size=10).astype('int')
+    rng = np.random.RandomState(123)  # Deterministic randomness
+    random_lengths = rng.exponential(100000, size=10).astype('int')
     for n in random_lengths:
-        a = np.random.randn(n)
+        a = rng.randn(n)
         xp_assert_close(czt(a), fft(a), rtol=1e-11)
 
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -253,6 +253,7 @@ class TestSos2Zpk:
         xp_assert_close(_cplxpair(p2), p)
         assert k2 == k
 
+    @pytest.mark.parallel_threads(1)
     def test_fewer_zeros(self):
         """Test not the expected number of p/z (effectively at origin)."""
         sos = butter(3, 0.1, output='sos')
@@ -1561,7 +1562,7 @@ class TestButtord:
         b, a = butter(N, Wn, 'bandpass', False)
         w, h = freqz(b, a)
         w /= np.pi
- 
+
         assert np.all((-rp - 0.1) < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
 
         assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < (-rs + 0.1))
@@ -1636,6 +1637,7 @@ class TestButtord:
             buttord([20, 50], [14, 60], 1, -2)
         assert "gstop should be larger than 0.0" in str(exc_info.value)
 
+    @pytest.mark.parallel_threads(1)
     def test_runtime_warnings(self):
         msg = "Order is zero.*|divide by zero encountered"
         with pytest.warns(RuntimeWarning, match=msg):
@@ -4134,10 +4136,10 @@ class TestIIRFilter:
                       output='zpk')[2]
         k2 = 9.999999999999989e+47
         xp_assert_close(np.asarray(k),  np.asarray(k2))
-        # if fs is specified then the normalization of Wn to have 
+        # if fs is specified then the normalization of Wn to have
         # 0 <= Wn <= 1 should not cause an integer overflow
         # the following line should not raise an exception
-        iirfilter(20, [1000000000, 1100000000], btype='bp', 
+        iirfilter(20, [1000000000, 1100000000], btype='bp',
                       analog=False, fs=6250000000)
 
     def test_invalid_wn_size(self):
@@ -4177,7 +4179,7 @@ class TestIIRFilter:
         assert_array_almost_equal(sos, sos2)
 
     def test_wn1_ge_wn0(self):
-        # gh-15773: should raise error if Wn[0] >= Wn[1]
+        # gh-15773: should | error if Wn[0] >= Wn[1]
         with pytest.raises(ValueError,
                            match=r"Wn\[0\] must be less than Wn\[1\]"):
             iirfilter(2, [0.5, 0.5])
@@ -4216,6 +4218,7 @@ class TestGroupDelay:
                               0.229038045801298, 0.212185774208521])
         assert_array_almost_equal(gd, matlab_gd)
 
+    @pytest.mark.parallel_threads(1)
     def test_singular(self):
         # Let's create a filter with zeros and poles on the unit circle and
         # check if warnings are raised at those frequencies.

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -253,7 +253,7 @@ class TestSos2Zpk:
         xp_assert_close(_cplxpair(p2), p)
         assert k2 == k
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_fewer_zeros(self):
         """Test not the expected number of p/z (effectively at origin)."""
         sos = butter(3, 0.1, output='sos')
@@ -1637,7 +1637,7 @@ class TestButtord:
             buttord([20, 50], [14, 60], 1, -2)
         assert "gstop should be larger than 0.0" in str(exc_info.value)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_runtime_warnings(self):
         msg = "Order is zero.*|divide by zero encountered"
         with pytest.warns(RuntimeWarning, match=msg):
@@ -4218,7 +4218,7 @@ class TestGroupDelay:
                               0.229038045801298, 0.212185774208521])
         assert_array_almost_equal(gd, matlab_gd)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_singular(self):
         # Let's create a filter with zeros and poles on the unit circle and
         # check if warnings are raised at those frequencies.

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4179,7 +4179,7 @@ class TestIIRFilter:
         assert_array_almost_equal(sos, sos2)
 
     def test_wn1_ge_wn0(self):
-        # gh-15773: should | error if Wn[0] >= Wn[1]
+        # gh-15773: should raise error if Wn[0] >= Wn[1]
         with pytest.raises(ValueError,
                            match=r"Wn\[0\] must be less than Wn\[1\]"):
             iirfilter(2, [0.5, 0.5])

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -597,7 +597,7 @@ class TestFirls:
             firls(11, .1, 1, fs=np.array([10, 20]))
 
 class TestMinimumPhase:
-
+    @pytest.mark.parallel_threads(1)
     def test_bad_args(self):
         # not enough taps
         assert_raises(ValueError, minimum_phase, [1.])

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -597,7 +597,7 @@ class TestFirls:
             firls(11, .1, 1, fs=np.array([10, 20]))
 
 class TestMinimumPhase:
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_bad_args(self):
         # not enough taps
         assert_raises(ValueError, minimum_phase, [1.])

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -187,7 +187,7 @@ class TestPlacePoles:
         assert fsf.rtol == 0
         assert fsf.nb_iter == 0
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_errors(self):
         # Test input mistakes from user
         A = np.array([0,7,0,0,0,0,0,7/3.,0,0,0,0,0,0,0,0]).reshape(4,4)

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import suppress_warnings
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import(
     assert_almost_equal, xp_assert_equal, xp_assert_close
@@ -186,6 +187,7 @@ class TestPlacePoles:
         assert fsf.rtol == 0
         assert fsf.nb_iter == 0
 
+    @pytest.mark.parallel_threads(1)
     def test_errors(self):
         # Test input mistakes from user
         A = np.array([0,7,0,0,0,0,0,7/3.,0,0,0,0,0,0,0,0]).reshape(4,4)

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -429,6 +429,7 @@ class TestPeakProminences:
         with raises(ValueError, match='wlen'):
             peak_prominences(np.arange(10), [3, 5], wlen=1)
 
+    @pytest.mark.parallel_threads(1)
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.
@@ -525,6 +526,7 @@ class TestPeakWidths:
             # prominence data contains None
             peak_widths([1, 2, 1], [1], prominence_data=(None, None, None))
 
+    @pytest.mark.parallel_threads(1)
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.
@@ -861,8 +863,8 @@ class TestFindPeaksCwt:
         """
         noise_amp = 1.0
         num_points = 100
-        np.random.seed(181819141)
-        test_data = (np.random.rand(num_points) - 0.5)*(2*noise_amp)
+        rng = np.random.RandomState(181819141)
+        test_data = (rng.rand(num_points) - 0.5)*(2*noise_amp)
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
         assert len(found_locs) == 0
@@ -884,8 +886,8 @@ class TestFindPeaksCwt:
         test_data, act_locs = _gen_gaussians_even(sigmas, num_points)
         widths = np.arange(0.1, max(sigmas), 0.2)
         noise_amp = 0.05
-        np.random.seed(18181911)
-        test_data += (np.random.rand(num_points) - 0.5)*(2*noise_amp)
+        rng = np.random.RandomState(18181911)
+        test_data += (rng.rand(num_points) - 0.5)*(2*noise_amp)
 
         # Possibly contrived negative region to throw off peak finding
         # when window_size is too large

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -429,7 +429,7 @@ class TestPeakProminences:
         with raises(ValueError, match='wlen'):
             peak_prominences(np.arange(10), [3, 5], wlen=1)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.
@@ -526,7 +526,7 @@ class TestPeakWidths:
             # prominence data contains None
             peak_widths([1, 2, 1], [1], prominence_data=(None, None, None))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -193,9 +193,9 @@ class TestConvolve(_TestConvolve):
 
         # These are random arrays, which means test is much stronger than
         # convolving testing by convolving two np.ones arrays
-        np.random.seed(42)
-        array_types = {'i': np.random.choice([0, 1], size=n),
-                       'f': np.random.randn(n)}
+        rng = np.random.RandomState(42)
+        array_types = {'i': rng.choice([0, 1], size=n),
+                       'f': rng.randn(n)}
         array_types['b'] = array_types['u'] = array_types['i']
         array_types['c'] = array_types['f'] + 0.5j*array_types['f']
 
@@ -249,6 +249,7 @@ class TestConvolve(_TestConvolve):
         assert_raises(ValueError, convolve, [1], [[2]])
         assert_raises(ValueError, convolve, [3], 2)
 
+    @pytest.mark.parallel_threads(1)
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -803,6 +804,7 @@ class TestFFTConvolve:
         out = fftconvolve(a, b, 'full', axes=[0])
         assert_allclose(out, expected, atol=1e-10)
 
+    @pytest.mark.parallel_threads(1)
     def test_fft_nan(self):
         n = 1000
         rng = np.random.default_rng(43876432987)
@@ -1110,7 +1112,7 @@ class TestMedFilt:
         if (dtype in ["float96", "float128"]
                 and np.finfo(np.longdouble).dtype != dtype):
             pytest.skip(f"Platform does not support {dtype}")
-        
+
         in_typed = np.array(self.IN, dtype=dtype)
         with pytest.raises(ValueError, match="not supported"):
             signal.medfilt(in_typed)
@@ -1268,6 +1270,7 @@ class TestResample:
         y = signal.resample(x, ny)
         assert_allclose(y, [1] * ny)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype):
         # Test that a mutable window is not modified
@@ -1861,6 +1864,7 @@ class _TestLinearFilter:
             lfilter(np.array([1.0]), np.array([1.0]), data),
             lfilter(b, a, data))
 
+    @pytest.mark.parallel_threads(1)
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -2099,6 +2103,7 @@ class TestCorrelate:
         assert_allclose(correlate(a, b, mode='full'), [6, 17, 32, 23, 12])
         assert_allclose(correlate(a, b, mode='valid'), [32])
 
+    @pytest.mark.parallel_threads(1)
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -2508,6 +2513,8 @@ def test_choose_conv_method():
         h = x.copy()
         assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
 
+
+@pytest.mark.parallel_threads(1)
 def test_choose_conv_dtype_deprecation():
     # gh-21211
     a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1270,7 +1270,7 @@ class TestResample:
         y = signal.resample(x, ny)
         assert_allclose(y, [1] * ny)
 
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype):
         # Test that a mutable window is not modified

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3586,6 +3586,7 @@ class TestSOSFilt:
         _, zf = sosfilt(sos, np.ones(40, dt), zi=zi.tolist())
         assert_allclose_cast(zf, zi, rtol=1e-13)
 
+    @pytest.mark.parallel_threads(1)
     def test_dtype_deprecation(self, dt):
         # gh-21211
         sos = np.asarray([1, 2, 3, 1, 5, 3], dtype=object).reshape(1, 6)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1270,7 +1270,7 @@ class TestResample:
         y = signal.resample(x, ny)
         assert_allclose(y, [1] * ny)
 
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#xxxx
+    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype):
         # Test that a mutable window is not modified

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -249,7 +249,7 @@ class TestConvolve(_TestConvolve):
         assert_raises(ValueError, convolve, [1], [[2]])
         assert_raises(ValueError, convolve, [3], 2)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -804,7 +804,7 @@ class TestFFTConvolve:
         out = fftconvolve(a, b, 'full', axes=[0])
         assert_allclose(out, expected, atol=1e-10)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_fft_nan(self):
         n = 1000
         rng = np.random.default_rng(43876432987)
@@ -1270,7 +1270,7 @@ class TestResample:
         y = signal.resample(x, ny)
         assert_allclose(y, [1] * ny)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype):
         # Test that a mutable window is not modified
@@ -1864,7 +1864,7 @@ class _TestLinearFilter:
             lfilter(np.array([1.0]), np.array([1.0]), data),
             lfilter(b, a, data))
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -2103,7 +2103,7 @@ class TestCorrelate:
         assert_allclose(correlate(a, b, mode='full'), [6, 17, 32, 23, 12])
         assert_allclose(correlate(a, b, mode='valid'), [32])
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dtype_deprecation(self):
         # gh-21211
         a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -2514,7 +2514,7 @@ def test_choose_conv_method():
         assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
 
 
-@pytest.mark.parallel_threads(1)
+@pytest.mark.thread_unsafe
 def test_choose_conv_dtype_deprecation():
     # gh-21211
     a = np.asarray([1, 2, 3, 6, 5, 3], dtype=object)
@@ -3586,7 +3586,7 @@ class TestSOSFilt:
         _, zf = sosfilt(sos, np.ones(40, dt), zi=zi.tolist())
         assert_allclose_cast(zf, zi, rtol=1e-13)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_dtype_deprecation(self, dt):
         # gh-21211
         sos = np.asarray([1, 2, 3, 1, 5, 3], dtype=object).reshape(1, 6)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1025,8 +1025,8 @@ class TestLombscargle:
         p = 0.7  # Fraction of points to select
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times
@@ -1059,8 +1059,8 @@ class TestLombscargle:
         offset = 0.15  # Offset to be subtracted in pre-centering
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times
@@ -1097,8 +1097,8 @@ class TestLombscargle:
         p = 0.7  # Fraction of points to select
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times
@@ -1341,6 +1341,7 @@ class TestLombscargle:
 
 
 class TestSTFT:
+    @pytest.mark.parallel_threads(1)
     def test_input_validation(self):
 
         def chk_VE(match):
@@ -1471,8 +1472,8 @@ class TestSTFT:
             assert_equal(False, check_NOLA(*setting), err_msg=msg)
 
     def test_average_all_segments(self):
-        np.random.seed(1234)
-        x = np.random.randn(1024)
+        rng = np.random.RandomState(1234)
+        x = rng.randn(1024)
 
         fs = 1.0
         window = 'hann'
@@ -1491,8 +1492,8 @@ class TestSTFT:
         assert_allclose(np.mean(np.abs(Z)**2, axis=-1), Pw)
 
     def test_permute_axes(self):
-        np.random.seed(1234)
-        x = np.random.randn(1024)
+        rng = np.random.RandomState(1234)
+        x = rng.randn(1024)
 
         fs = 1.0
         window = 'hann'
@@ -1515,7 +1516,7 @@ class TestSTFT:
 
     @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
     def test_roundtrip_real(self, scaling):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [
                     ('boxcar', 100, 10, 0),           # Test no overlap
@@ -1528,7 +1529,7 @@ class TestSTFT:
 
         for window, N, nperseg, noverlap in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size)
+            x = 10*rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                             window=window, detrend=None, padded=False,
@@ -1541,8 +1542,9 @@ class TestSTFT:
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
 
+    @pytest.mark.parallel_threads(1)
     def test_roundtrip_not_nola(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         w_fail = np.ones(16)
         w_fail[::2] = 0
@@ -1556,7 +1558,7 @@ class TestSTFT:
             assert not check_NOLA(window, nperseg, noverlap), msg
 
             t = np.arange(N)
-            x = 10 * np.random.randn(t.size)
+            x = 10 * rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                             window=window, detrend=None, padded=True,
@@ -1569,7 +1571,7 @@ class TestSTFT:
             assert not np.allclose(x, xr[:len(x)]), msg
 
     def test_roundtrip_nola_not_cola(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [
                     ('boxcar', 100, 10, 3),           # NOLA True, COLA False
@@ -1585,7 +1587,7 @@ class TestSTFT:
             assert not check_COLA(window, nperseg, noverlap), msg
 
             t = np.arange(N)
-            x = 10 * np.random.randn(t.size)
+            x = 10 * rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                             window=window, detrend=None, padded=True,
@@ -1599,13 +1601,13 @@ class TestSTFT:
             assert_allclose(x, xr[:len(x)], err_msg=msg)
 
     def test_roundtrip_float32(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [('hann', 1024, 256, 128)]
 
         for window, N, nperseg, noverlap in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size)
+            x = 10*rng.randn(t.size)
             x = x.astype(np.float32)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
@@ -1619,9 +1621,10 @@ class TestSTFT:
             assert_allclose(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
             assert_(x.dtype == xr.dtype)
 
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
     def test_roundtrip_complex(self, scaling):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [
                     ('boxcar', 100, 10, 0),           # Test no overlap
@@ -1634,7 +1637,7 @@ class TestSTFT:
 
         for window, N, nperseg, noverlap in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size) + 10j*np.random.randn(t.size)
+            x = 10*rng.randn(t.size) + 10j*rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                             window=window, detrend=None, padded=False,
@@ -1664,7 +1667,7 @@ class TestSTFT:
         assert_allclose(x, xr, err_msg=msg)
 
     def test_roundtrip_boundary_extension(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         # Test against boxcar, since window is all ones, and thus can be fully
         # recovered with no boundary extension
@@ -1676,7 +1679,7 @@ class TestSTFT:
 
         for window, N, nperseg, noverlap in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size)
+            x = 10*rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                            window=window, detrend=None, padded=True,
@@ -1697,7 +1700,7 @@ class TestSTFT:
                 assert_allclose(x, xr_ext, err_msg=msg)
 
     def test_roundtrip_padded_signal(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [
                     ('boxcar', 101, 10, 0),
@@ -1706,7 +1709,7 @@ class TestSTFT:
 
         for window, N, nperseg, noverlap in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size)
+            x = 10*rng.randn(t.size)
 
             _, _, zz = stft(x, nperseg=nperseg, noverlap=noverlap,
                             window=window, detrend=None, padded=True)
@@ -1719,7 +1722,7 @@ class TestSTFT:
             assert_allclose(x, xr[:x.size], err_msg=msg)
 
     def test_roundtrip_padded_FFT(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         settings = [
                     ('hann', 1024, 256, 128, 512),
@@ -1730,7 +1733,7 @@ class TestSTFT:
 
         for window, N, nperseg, noverlap, nfft in settings:
             t = np.arange(N)
-            x = 10*np.random.randn(t.size)
+            x = 10*rng.randn(t.size)
             xc = x*np.exp(1j*np.pi/4)
 
             # real signal
@@ -1754,9 +1757,9 @@ class TestSTFT:
             assert_allclose(xc, xcr, err_msg=msg)
 
     def test_axis_rolling(self):
-        np.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        x_flat = np.random.randn(1024)
+        x_flat = rng.randn(1024)
         _, _, z_flat = stft(x_flat)
 
         for a in range(3):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1341,7 +1341,7 @@ class TestLombscargle:
 
 
 class TestSTFT:
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_input_validation(self):
 
         def chk_VE(match):
@@ -1542,7 +1542,7 @@ class TestSTFT:
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     def test_roundtrip_not_nola(self):
         rng = np.random.RandomState(1234)
 
@@ -1621,7 +1621,7 @@ class TestSTFT:
             assert_allclose(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
             assert_(x.dtype == xr.dtype)
 
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
     def test_roundtrip_complex(self, scaling):
         rng = np.random.RandomState(1234)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1273,8 +1273,8 @@ class TestLombscargle:
         offset = 2  # Large offset
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a cos wave for the selected times
@@ -1307,8 +1307,8 @@ class TestLombscargle:
         offset = 2.15  # Large offset
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See https://github.com/scipy/scipy/issues/20669

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds an additional CI job on top of the already-existing 3.13 free threaded one, this new CI pipeline runs the SciPy testsuite using the [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel/) plugin, which allows to run individual tests concurrently during a pytest session

#### Additional information
<!--Any additional information you think is important.-->

Several tests were using the global random number generator, via `np.random.seed`, which was causing numeric result mismatches when the tests were being run in parallel. Instead, all tests now use `np.random.RandomState`, which ensures that each thread gets its own independent random generator.