### PR TITLE
MAINT, TST: CuPy skip ndimage test

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -922,6 +922,8 @@ class TestNdimageFilters:
         expected = filter_func(array, *extra_args, all_sizes)
         xp_assert_close(output, expected)
 
+    @skip_xp_backends("cupy",
+                      reasons=["https://github.com/cupy/cupy/pull/8339"])
     @pytest.mark.parametrize('func', [ndimage.correlate, ndimage.convolve])
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64, np.complex64, np.complex128]


### PR DESCRIPTION
* Fixes gh-21486

* `scipy/ndimage/tests/test_filters.py::TestNdimageFilters::test_correlate_convolve_axes` was causing 240 test failures on `main` with CuPy backend because the CuPy `ndimage` equivalents of `convolve` and `correlate` don't have an `axes` kwarg, even in the latest stable release.

* So, skip these tests with CuPy for now.

[skip cirrus] [skip circle]