### PR TITLE
ENH: linalg.exp: Improve performance for small matrices

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -287,7 +287,9 @@ def expm(A):
 
     if a.ndim < 2:
         raise LinAlgError('The input array must be at least two-dimensional')
-    if a.shape[-1] != a.shape[-2]:
+
+    n = a.shape[-1]
+    if n != a.shape[-2]:
         raise LinAlgError('Last 2 dimensions of the array must be square')
 
     # Empty array
@@ -308,7 +310,6 @@ def expm(A):
     # Kahan's method, numerical instabilities can occur (See gh-19584). Hence removed
     # here until we have a more stable implementation.
 
-    n = a.shape[-1]
     eA = np.empty(a.shape, dtype=a.dtype)
     # working memory to hold intermediate arrays
     Am = np.empty((5, n, n), dtype=a.dtype)

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -150,7 +150,6 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     np.matmul(absA, work_arr, out=work_arr)
     absA_pow4 = Am[1, :, :] # use the slice Am[1] as a working buffer
     np.matmul(absA, work_arr, absA_pow4)
-    del absA
     np.matmul(absA_pow4, work_arr, out=work_arr)
     temp = work_arr.max()
 

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -148,7 +148,8 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # 1-norm of A ** 7
     np.matmul(absA, work_arr, out=work_arr)
     np.matmul(absA, work_arr, out=work_arr)
-    absA_pow4 = np.matmul(absA, work_arr)
+    absA_pow4 = Am[1, :, :] # use the slice Am[1] as a working buffer
+    np.matmul(absA, work_arr, absA_pow4)
     del absA
     np.matmul(absA_pow4, work_arr, out=work_arr)
     temp = work_arr.max()

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -132,7 +132,7 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     absA = np.abs(Am[0, :, :])
 
     # First spin = normest(|A|, m=1), increase m when spun more
-    np.matmul(absA, work_arr, out=work_arr)
+    np.copyto(work_arr, absA)
     normA = work_arr.max()
 
     np.matmul(Am[0, :, :], Am[0, :, :], out=Am[1, :, :])
@@ -146,11 +146,11 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # m = 3
     # -------
     # 1-norm of A ** 7
-    for i in range(3):
-        np.matmul(absA, work_arr, out=work_arr)
-    absA_pow4 = work_arr.copy()
-    for i in range(3):
-        np.matmul(absA, work_arr, out=work_arr)
+    np.matmul(absA, work_arr, out=work_arr)
+    np.matmul(absA, work_arr, out=work_arr)
+    absA_pow4 = np.matmul(absA, work_arr)
+    del absA
+    np.matmul(absA_pow4, work_arr, out=work_arr)
     temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[0])/6), 0)
@@ -209,7 +209,7 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     s = max(<int>ceil(log2(eta4/theta[4])), 0)
     if s != 0:
         two_pow_s = 2.** (-s)
-        absA *= two_pow_s
+        absA_pow4 *= two_pow_s ** 4
 
         # work_arr has spun 19 times already
         two_pow_s = 2.** ((-s)*19.)

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -133,7 +133,7 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
 
     # First spin = normest(|A|, m=1), increase m when spun more
     np.matmul(absA, work_arr, out=work_arr)
-    normA = np.max(work_arr)
+    normA = work_arr.max()
 
     np.matmul(Am[0, :, :], Am[0, :, :], out=Am[1, :, :])
     np.matmul(Am[1, :, :], Am[1, :, :], out=Am[2, :, :])
@@ -146,9 +146,11 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # m = 3
     # -------
     # 1-norm of A ** 7
-    for i in range(6):
+    for i in range(4):
         np.matmul(absA, work_arr, out=work_arr)
-    temp = np.max(work_arr)
+    absA_pow4 = work_arr.copy()
+    np.matmul(absA_pow4, work_arr, out=work_arr)
+    temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[0])/6), 0)
     if eta0 < theta[0] and lm == 0:
@@ -157,9 +159,8 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # m = 5
     # -------
     # 1-norm of A ** 11
-    for i in range(4):
-        np.matmul(absA, work_arr, out=work_arr)
-    temp = np.max(work_arr)
+    np.matmul(absA_pow4, work_arr, out=work_arr)
+    temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[1])/10), 0)
     if eta1 < theta[1] and lm == 0:
@@ -176,9 +177,8 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     eta2 = max(d6, d8)
 
     # 1-norm of A ** 15
-    for i in range(4):
-        np.matmul(absA, work_arr, out=work_arr)
-    temp = np.max(work_arr)
+    np.matmul(absA_pow4, work_arr, out=work_arr)
+    temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[2])/14), 0)
     if eta2 < theta[2] and lm == 0:
@@ -187,9 +187,8 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # m = 9
     # -------
     # 1-norm of A ** 19
-    for i in range(4):
-        np.matmul(absA, work_arr, out=work_arr)
-    temp = np.max(work_arr)
+    np.matmul(absA_pow4, work_arr, out=work_arr)
+    temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[3])/18), 0)
     if eta2 < theta[3] and lm == 0:
@@ -217,9 +216,9 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
         normA *= 2.**(-s)
 
     # 1-norm of A ** 27
-    for i in range(8):
-        np.matmul(absA, work_arr, out=work_arr)
-    temp = np.max(work_arr)
+    for i in range(2):
+        np.matmul(absA_pow4, work_arr, out=work_arr)
+    temp = work_arr.max()
 
     s += max(<int>ceil(log2(temp/normA/coeff[4])/26), 0)
     return 13, s

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -146,10 +146,11 @@ def pick_pade_structure(cnp.ndarray[ndim=3, dtype=numpy_lapack_t] Am):
     # m = 3
     # -------
     # 1-norm of A ** 7
-    for i in range(4):
+    for i in range(3):
         np.matmul(absA, work_arr, out=work_arr)
     absA_pow4 = work_arr.copy()
-    np.matmul(absA_pow4, work_arr, out=work_arr)
+    for i in range(3):
+        np.matmul(absA, work_arr, out=work_arr)
     temp = work_arr.max()
 
     lm = max(<int>ceil(log2(temp/normA/coeff[0])/6), 0)


### PR DESCRIPTION
For small matrices the method `pick_pade_structure` can use a significant amount of time in `scipy.linalg.expm`. Part of the calculation inside `pick_pade_structure` is the calculation of the `absA**k` for various values of `k` (7, 11, 15, 19, 27) . Instead of calculating this power by repeated multiplication with `absA`, we calculate `absA**4` once and use that for calculation of higher order values. We also replace `np.max(work_arr)` with `work_arr.max()` (for small arrays the latter has significantly less overhead).

Benchmark:
```
import time
import scipy
from scipy.linalg import expm
import numpy as np
print(scipy, scipy.__version__)

for size in [2, 3, 4]:
    a=np.random.rand(5000, size, size)
    
    t0=time.perf_counter()
    
    for ii in range(len(a)):
        A = a[ii,:,:]
        expm(A)
        
    dt=time.perf_counter()-t0
    print(f'{size=} {dt:.3f} [s]')
```
Results on main:
```
<module 'scipy' from '/home/eendebakpt/sc/lib/python3.10/site-packages/scipy/__init__.py'> 1.15.0.dev0+git20240903.cd25eb1
size=2 0.567 [s]
size=3 0.649 [s]
size=4 0.689 [s]
```
Results on this PR:
```
<module 'scipy' from '/home/eendebakpt/sc/lib/python3.10/site-packages/scipy/__init__.py'> 1.15.0.dev0+git20240903.efde44b
size=2 0.401 [s]
size=3 0.430 [s]
size=4 0.447 [s]
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

None

#### What does this implement/fix?

The PR improves performance of `expm`

