### PR TITLE
BUG: fft: fix real input to standard funcs

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -608,3 +608,17 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
         out.append(arg)
 
     return out
+
+
+def xp_float_to_complex(arr: Array, xp: ModuleType | None = None) -> Array:
+    xp = array_namespace(arr) if xp is None else xp
+    arr_dtype = arr.dtype
+    # The standard float dtypes are float32 and float64.
+    # Convert float32 to complex64,
+    # and float64 (and non-standard real dtypes) to complex128
+    if xp.isdtype(arr_dtype, xp.float32):
+        arr = xp.astype(arr, xp.complex64)
+    elif xp.isdtype(arr_dtype, 'real floating'):
+        arr = xp.astype(arr, xp.complex128)
+
+    return arr

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -489,3 +489,13 @@ def test_non_standard_params(func, xp):
         assert_raises(ValueError, func, x, workers=2)
         # `plan` param is not tested since SciPy does not use it currently
         # but should be tested if it comes into use
+
+
+@pytest.mark.parametrize("dtype", ['float32', 'float64'])
+@pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.irfft,
+                                  fft.fftn, fft.ifftn,
+                                  fft.irfftn, fft.hfft,])
+def test_real_input(func, dtype, xp):
+    x = xp.asarray([1, 2, 3], dtype=getattr(xp, dtype))
+    # func(x) should not raise an exception
+    func(x)


### PR DESCRIPTION
#### Reference issue
Closes gh-21507

#### What does this implement/fix?
Some of the fft standard extension functions expect complex input, but SciPy accepts real input also. This PR implements casting of real inputs to complex for these functions so that delegation to a standard extension implementation which only accepts complex input (e.g. array-api-strict) works.

#### Additional information
An alternative solution here is to delegate to the real algorithms (e.g. `rfft`?) instead so that no dtype casting is needed, suggested by @ilayn. That might be better, but here's a PR for discussion so we can compare.