### PR TITLE
BUG: interpolate.AAA: improve dtype consistency and test integer type promotion

### DIFF
--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -411,10 +411,10 @@ class AAA(_Barycentric_Rational):
         dtype = np.result_type(z, f, 1.0)
         rtol = np.finfo(dtype).eps**0.75 if rtol is None else rtol
         atol = rtol * np.linalg.norm(f, ord=np.inf)
-        zj = np.empty(max_terms, dtype=dtype)
+        zj = np.empty(max_terms, dtype=z.dtype)
         fj = np.empty(max_terms, dtype=dtype)
         # Cauchy matrix
-        C = np.empty((M, max_terms), dtype=dtype)
+        C = np.empty((M, max_terms), dtype=np.result_type(z, 1.0))
         # Loewner matrix
         A = np.empty((M, max_terms), dtype=dtype)
         errors = np.empty(max_terms, dtype=A.real.dtype)

--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -412,7 +412,7 @@ class AAA(_Barycentric_Rational):
         rtol = np.finfo(dtype).eps**0.75 if rtol is None else rtol
         atol = rtol * np.linalg.norm(f, ord=np.inf)
         zj = np.empty(max_terms, dtype=z.dtype)
-        fj = np.empty(max_terms, dtype=dtype)
+        fj = np.empty(max_terms, dtype=np.result_type(z, f))
         # Cauchy matrix
         C = np.empty((M, max_terms), dtype=np.result_type(z, 1.0))
         # Loewner matrix

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -83,7 +83,23 @@ class TestAAA:
         assert r.poles().dtype == np.result_type(z_dtype, f_dtype, 1j)
         assert r.residues().dtype == np.result_type(z_dtype, f_dtype, 1j)
         assert r.roots().dtype == np.result_type(z_dtype, f_dtype, 1j)
-    
+
+    @pytest.mark.parametrize("z_dtype,f_dtype",
+                             product([np.int16, np.int32, np.int64], repeat=2))
+    def test_int_dtypes(self, z_dtype, f_dtype):
+        z = np.arange(10, dtype=z_dtype)
+        f = z.astype(f_dtype)
+
+        r = AAA(z, f)
+        assert r(1).dtype == np.result_type(z_dtype, f_dtype, 1.0)
+        assert r.support_points.dtype == z_dtype
+        assert r.support_values.dtype == np.result_type(z_dtype, f_dtype)
+        assert r.weights.dtype == np.result_type(z_dtype, f_dtype, 1.0)
+        assert r.errors.dtype == np.result_type(z_dtype, f_dtype, 1.0)
+        assert r.poles().dtype == np.result_type(z_dtype, f_dtype, 1j)
+        assert r.residues().dtype == np.result_type(z_dtype, f_dtype, 1j)
+        assert r.roots().dtype == np.result_type(z_dtype, f_dtype, 1j)
+
     # The following tests are based on:
     # https://github.com/chebfun/chebfun/blob/master/tests/chebfun/test_aaa.m
     def test_exp(self):


### PR DESCRIPTION
Motivated by this example where there is no need to store support points as complex
```
In [1]: import numpy as np

In [2]: from scipy.interpolate import AAA

In [3]: z = np.linspace(-10,10,num=1000)

In [4]: r = AAA(z, z + 1j)

In [5]: r.support_points
Out[5]: array([-10.+0.j,  10.+0.j])
```

Also greatly strengthens tests by not assuming `z`, `f` and `z2` to have the same type

Secondly, adds tests defining integer type promotion as requested in https://github.com/scipy/scipy/pull/21497/files#r1741158461