### PR TITLE
TST: signal: convert to `xp_assert_*` infrastructure (pt. 1)

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -312,6 +312,13 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
+
+    if (isinstance(actual, (int, float, complex)) and
+        isinstance(desired, (int, float, complex))
+    ):
+        actual = xp.asarray(actual)
+        desired = xp.asarray(desired)
+
     desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
                             check_dtype=check_dtype, check_shape=check_shape,
                             check_0d=check_0d)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -271,7 +271,7 @@ def _strict_check(actual, desired, xp, *,
         assert actual.shape == desired.shape, _msg
 
     desired = xp.broadcast_to(desired, actual.shape)
-    return desired
+    return actual, desired
 
 
 def _assert_matching_namespace(actual, desired):
@@ -291,9 +291,13 @@ def xp_assert_equal(actual, desired, *, check_namespace=True, check_dtype=True,
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
-    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape,
-                            check_0d=check_0d)
+
+    actual, desired = _strict_check(
+        actual, desired, xp, check_namespace=check_namespace,
+        check_dtype=check_dtype, check_shape=check_shape,
+        check_0d=check_0d
+    )
+
     if is_cupy(xp):
         return xp.testing.assert_array_equal(actual, desired, err_msg=err_msg)
     elif is_torch(xp):
@@ -313,15 +317,11 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
     if xp is None:
         xp = array_namespace(actual)
 
-    if (isinstance(actual, (int, float, complex)) and
-        isinstance(desired, (int, float, complex))
-    ):
-        actual = xp.asarray(actual)
-        desired = xp.asarray(desired)
-
-    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape,
-                            check_0d=check_0d)
+    actual, desired = _strict_check(
+        actual, desired, xp,
+        check_namespace=check_namespace, check_dtype=check_dtype,
+        check_shape=check_shape, check_0d=check_0d
+    )
 
     floating = xp.isdtype(actual.dtype, ('real floating', 'complex floating'))
     if rtol is None and floating:
@@ -349,9 +349,13 @@ def xp_assert_less(actual, desired, *, check_namespace=True, check_dtype=True,
     __tracebackhide__ = True  # Hide traceback for py.test
     if xp is None:
         xp = array_namespace(actual)
-    desired = _strict_check(actual, desired, xp, check_namespace=check_namespace,
-                            check_dtype=check_dtype, check_shape=check_shape,
-                            check_0d=check_0d)
+
+    actual, desired = _strict_check(
+        actual, desired, xp, check_namespace=check_namespace,
+        check_dtype=check_dtype, check_shape=check_shape,
+        check_0d=check_0d
+    )
+
     if is_cupy(xp):
         return xp.testing.assert_array_less(actual, desired,
                                             err_msg=err_msg, verbose=verbose)

--- a/scipy/signal/tests/test_array_tools.py
+++ b/scipy/signal/tests/test_array_tools.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numpy.testing import assert_array_equal
+from scipy._lib._array_api import xp_assert_equal
 from pytest import raises as assert_raises
 
 from scipy.signal._arraytools import (axis_slice, axis_reverse,
@@ -13,31 +13,31 @@ class TestArrayTools:
         a = np.arange(12).reshape(3, 4)
 
         s = axis_slice(a, start=0, stop=1, axis=0)
-        assert_array_equal(s, a[0:1, :])
+        xp_assert_equal(s, a[0:1, :])
 
         s = axis_slice(a, start=-1, axis=0)
-        assert_array_equal(s, a[-1:, :])
+        xp_assert_equal(s, a[-1:, :])
 
         s = axis_slice(a, start=0, stop=1, axis=1)
-        assert_array_equal(s, a[:, 0:1])
+        xp_assert_equal(s, a[:, 0:1])
 
         s = axis_slice(a, start=-1, axis=1)
-        assert_array_equal(s, a[:, -1:])
+        xp_assert_equal(s, a[:, -1:])
 
         s = axis_slice(a, start=0, step=2, axis=0)
-        assert_array_equal(s, a[::2, :])
+        xp_assert_equal(s, a[::2, :])
 
         s = axis_slice(a, start=0, step=2, axis=1)
-        assert_array_equal(s, a[:, ::2])
+        xp_assert_equal(s, a[:, ::2])
 
     def test_axis_reverse(self):
         a = np.arange(12).reshape(3, 4)
 
         r = axis_reverse(a, axis=0)
-        assert_array_equal(r, a[::-1, :])
+        xp_assert_equal(r, a[::-1, :])
 
         r = axis_reverse(a, axis=1)
-        assert_array_equal(r, a[:, ::-1])
+        xp_assert_equal(r, a[:, ::-1])
 
     def test_odd_ext(self):
         a = np.array([[1, 2, 3, 4, 5],
@@ -46,14 +46,14 @@ class TestArrayTools:
         odd = odd_ext(a, 2, axis=1)
         expected = np.array([[-1, 0, 1, 2, 3, 4, 5, 6, 7],
                              [11, 10, 9, 8, 7, 6, 5, 4, 3]])
-        assert_array_equal(odd, expected)
+        xp_assert_equal(odd, expected)
 
         odd = odd_ext(a, 1, axis=0)
         expected = np.array([[-7, -4, -1, 2, 5],
                              [1, 2, 3, 4, 5],
                              [9, 8, 7, 6, 5],
                              [17, 14, 11, 8, 5]])
-        assert_array_equal(odd, expected)
+        xp_assert_equal(odd, expected)
 
         assert_raises(ValueError, odd_ext, a, 2, axis=0)
         assert_raises(ValueError, odd_ext, a, 5, axis=1)
@@ -65,14 +65,14 @@ class TestArrayTools:
         even = even_ext(a, 2, axis=1)
         expected = np.array([[3, 2, 1, 2, 3, 4, 5, 4, 3],
                              [7, 8, 9, 8, 7, 6, 5, 6, 7]])
-        assert_array_equal(even, expected)
+        xp_assert_equal(even, expected)
 
         even = even_ext(a, 1, axis=0)
         expected = np.array([[9, 8, 7, 6, 5],
                              [1, 2, 3, 4, 5],
                              [9, 8, 7, 6, 5],
                              [1, 2, 3, 4, 5]])
-        assert_array_equal(even, expected)
+        xp_assert_equal(even, expected)
 
         assert_raises(ValueError, even_ext, a, 2, axis=0)
         assert_raises(ValueError, even_ext, a, 5, axis=1)
@@ -84,14 +84,14 @@ class TestArrayTools:
         const = const_ext(a, 2, axis=1)
         expected = np.array([[1, 1, 1, 2, 3, 4, 5, 5, 5],
                              [9, 9, 9, 8, 7, 6, 5, 5, 5]])
-        assert_array_equal(const, expected)
+        xp_assert_equal(const, expected)
 
         const = const_ext(a, 1, axis=0)
         expected = np.array([[1, 2, 3, 4, 5],
                              [1, 2, 3, 4, 5],
                              [9, 8, 7, 6, 5],
                              [9, 8, 7, 6, 5]])
-        assert_array_equal(const, expected)
+        xp_assert_equal(const, expected)
 
     def test_zero_ext(self):
         a = np.array([[1, 2, 3, 4, 5],
@@ -100,12 +100,12 @@ class TestArrayTools:
         zero = zero_ext(a, 2, axis=1)
         expected = np.array([[0, 0, 1, 2, 3, 4, 5, 0, 0],
                              [0, 0, 9, 8, 7, 6, 5, 0, 0]])
-        assert_array_equal(zero, expected)
+        xp_assert_equal(zero, expected)
 
         zero = zero_ext(a, 1, axis=0)
         expected = np.array([[0, 0, 0, 0, 0],
                              [1, 2, 3, 4, 5],
                              [9, 8, 7, 6, 5],
                              [0, 0, 0, 0, 0]])
-        assert_array_equal(zero, expected)
+        xp_assert_equal(zero, expected)
 

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -1,8 +1,9 @@
 # pylint: disable=missing-docstring
 import numpy as np
-from numpy import array
-from numpy.testing import (assert_allclose, assert_array_equal,
-                           assert_almost_equal)
+
+from scipy._lib._array_api import (
+    assert_almost_equal, xp_assert_close, xp_assert_equal
+)
 import pytest
 from pytest import raises
 
@@ -19,13 +20,13 @@ class TestBSplines:
     def test_spline_filter(self):
         np.random.seed(12457)
         # Test the type-error branch
-        raises(TypeError, bsp.spline_filter, array([0]), 0)
+        raises(TypeError, bsp.spline_filter, np.asarray([0]), 0)
         # Test the real branch
         np.random.seed(12457)
         data_array_real = np.random.rand(12, 12)
         # make the magnitude exceed 1, and make some negative
         data_array_real = 10*(1-2*data_array_real)
-        result_array_real = array(
+        result_array_real = np.asarray(
             [[-.463312621, 8.33391222, .697290949, 5.28390836,
               5.92066474, 6.59452137, 9.84406950, -8.78324188,
               7.20675750, -8.17222994, -4.38633345, 9.89917069],
@@ -62,7 +63,7 @@ class TestBSplines:
              [9.86326886, 1.05134482, -7.75950607, -3.64429655,
               7.81848957, -9.02270373, 3.73399754, -4.71962549,
               -7.71144306, 3.78263161, 6.46034818, -4.43444731]])
-        assert_allclose(bsp.spline_filter(data_array_real, 0),
+        xp_assert_close(bsp.spline_filter(data_array_real, 0),
                         result_array_real)
 
     def test_spline_filter_complex(self):
@@ -70,7 +71,7 @@ class TestBSplines:
         data_array_complex = np.random.rand(7, 7) + np.random.rand(7, 7)*1j
         # make the magnitude exceed 1, and make some negative
         data_array_complex = 10*(1+1j-2*data_array_complex)
-        result_array_complex = array(
+        result_array_complex = np.asarray(
             [[-4.61489230e-01-1.92994022j, 8.33332443+6.25519943j,
               6.96300745e-01-9.05576038j, 5.28294849+3.97541356j,
               5.92165565+7.68240595j, 6.59493160-1.04542804j,
@@ -102,86 +103,95 @@ class TestBSplines:
         # FIXME: for complex types, the computations are done in
         # single precision (reason unclear). When this is changed,
         # this test needs updating.
-        assert_allclose(bsp.spline_filter(data_array_complex, 0),
+        xp_assert_close(bsp.spline_filter(data_array_complex, 0),
                         result_array_complex, rtol=1e-6)
 
     def test_gauss_spline(self):
         np.random.seed(12459)
         assert_almost_equal(bsp.gauss_spline(0, 0), 1.381976597885342)
-        assert_allclose(bsp.gauss_spline(array([1.]), 1), array([0.04865217]))
+        xp_assert_close(bsp.gauss_spline(np.asarray([1.]), 1),
+                        np.asarray([0.04865217]), atol=1e-9
+        )
 
     def test_gauss_spline_list(self):
         # regression test for gh-12152 (accept array_like)
         knots = [-1.0, 0.0, -1.0]
         assert_almost_equal(bsp.gauss_spline(knots, 3),
-                            array([0.15418033, 0.6909883, 0.15418033]))
+                            np.asarray([0.15418033, 0.6909883, 0.15418033])
+        )
 
     def test_cspline1d(self):
         np.random.seed(12462)
-        assert_array_equal(bsp.cspline1d(array([0])), [0.])
-        c1d = array([1.21037185, 1.86293902, 2.98834059, 4.11660378,
-                     4.78893826])
+        xp_assert_equal(bsp.cspline1d(np.asarray([0])), [0.])
+        c1d = np.asarray([1.21037185, 1.86293902, 2.98834059, 4.11660378,
+                          4.78893826])
         # test lamda != 0
-        assert_allclose(bsp.cspline1d(array([1., 2, 3, 4, 5]), 1), c1d)
-        c1d0 = array([0.78683946, 2.05333735, 2.99981113, 3.94741812,
-                      5.21051638])
-        assert_allclose(bsp.cspline1d(array([1., 2, 3, 4, 5])), c1d0)
+        xp_assert_close(bsp.cspline1d(np.asarray([1., 2, 3, 4, 5]), 1), c1d)
+        c1d0 = np.asarray([0.78683946, 2.05333735, 2.99981113, 3.94741812,
+                           5.21051638])
+        xp_assert_close(bsp.cspline1d(np.asarray([1., 2, 3, 4, 5])), c1d0)
 
     def test_qspline1d(self):
         np.random.seed(12463)
-        assert_array_equal(bsp.qspline1d(array([0])), [0.])
+        xp_assert_equal(bsp.qspline1d(np.asarray([0])), [0.])
         # test lamda != 0
-        raises(ValueError, bsp.qspline1d, array([1., 2, 3, 4, 5]), 1.)
-        raises(ValueError, bsp.qspline1d, array([1., 2, 3, 4, 5]), -1.)
-        q1d0 = array([0.85350007, 2.02441743, 2.99999534, 3.97561055,
-                      5.14634135])
-        assert_allclose(bsp.qspline1d(array([1., 2, 3, 4, 5])), q1d0)
+        raises(ValueError, bsp.qspline1d, np.asarray([1., 2, 3, 4, 5]), 1.)
+        raises(ValueError, bsp.qspline1d, np.asarray([1., 2, 3, 4, 5]), -1.)
+        q1d0 = np.asarray([0.85350007, 2.02441743, 2.99999534, 3.97561055,
+                           5.14634135])
+        xp_assert_close(bsp.qspline1d(np.asarray([1., 2, 3, 4, 5])), q1d0)
 
     def test_cspline1d_eval(self):
         np.random.seed(12464)
-        assert_allclose(bsp.cspline1d_eval(array([0., 0]), [0.]), array([0.]))
-        assert_array_equal(bsp.cspline1d_eval(array([1., 0, 1]), []),
-                           array([]))
+        xp_assert_close(bsp.cspline1d_eval(np.asarray([0., 0]), [0.]),
+                        np.asarray([0.])
+        )
+        xp_assert_equal(bsp.cspline1d_eval(np.asarray([1., 0, 1]), []),
+                        np.asarray([])
+        )
         x = [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6]
-        dx = x[1]-x[0]
+        dx = x[1] - x[0]
         newx = [-6., -5.5, -5., -4.5, -4., -3.5, -3., -2.5, -2., -1.5, -1.,
                 -0.5, 0., 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.,
                 6.5, 7., 7.5, 8., 8.5, 9., 9.5, 10., 10.5, 11., 11.5, 12.,
                 12.5]
-        y = array([4.216, 6.864, 3.514, 6.203, 6.759, 7.433, 7.874, 5.879,
-                   1.396, 4.094])
+        y = np.asarray([4.216, 6.864, 3.514, 6.203, 6.759, 7.433, 7.874, 5.879,
+                        1.396, 4.094])
         cj = bsp.cspline1d(y)
-        newy = array([6.203, 4.41570658, 3.514, 5.16924703, 6.864, 6.04643068,
-                      4.21600281, 6.04643068, 6.864, 5.16924703, 3.514,
-                      4.41570658, 6.203, 6.80717667, 6.759, 6.98971173, 7.433,
-                      7.79560142, 7.874, 7.41525761, 5.879, 3.18686814, 1.396,
-                      2.24889482, 4.094, 2.24889482, 1.396, 3.18686814, 5.879,
-                      7.41525761, 7.874, 7.79560142, 7.433, 6.98971173, 6.759,
-                      6.80717667, 6.203, 4.41570658])
-        assert_allclose(bsp.cspline1d_eval(cj, newx, dx=dx, x0=x[0]), newy)
+        newy = np.asarray([6.203, 4.41570658, 3.514, 5.16924703, 6.864, 6.04643068,
+                           4.21600281, 6.04643068, 6.864, 5.16924703, 3.514,
+                           4.41570658, 6.203, 6.80717667, 6.759, 6.98971173, 7.433,
+                           7.79560142, 7.874, 7.41525761, 5.879, 3.18686814, 1.396,
+                           2.24889482, 4.094, 2.24889482, 1.396, 3.18686814, 5.879,
+                           7.41525761, 7.874, 7.79560142, 7.433, 6.98971173, 6.759,
+                           6.80717667, 6.203, 4.41570658])
+        xp_assert_close(bsp.cspline1d_eval(cj, newx, dx=dx, x0=x[0]), newy)
 
     def test_qspline1d_eval(self):
         np.random.seed(12465)
-        assert_allclose(bsp.qspline1d_eval(array([0., 0]), [0.]), array([0.]))
-        assert_array_equal(bsp.qspline1d_eval(array([1., 0, 1]), []),
-                           array([]))
+        xp_assert_close(bsp.qspline1d_eval(np.asarray([0., 0]), [0.]),
+                        np.asarray([0.])
+        )
+        xp_assert_equal(bsp.qspline1d_eval(np.asarray([1., 0, 1]), []),
+                        np.asarray([])
+        )
         x = [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6]
         dx = x[1]-x[0]
         newx = [-6., -5.5, -5., -4.5, -4., -3.5, -3., -2.5, -2., -1.5, -1.,
                 -0.5, 0., 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.,
                 6.5, 7., 7.5, 8., 8.5, 9., 9.5, 10., 10.5, 11., 11.5, 12.,
                 12.5]
-        y = array([4.216, 6.864, 3.514, 6.203, 6.759, 7.433, 7.874, 5.879,
-                   1.396, 4.094])
+        y = np.asarray([4.216, 6.864, 3.514, 6.203, 6.759, 7.433, 7.874, 5.879,
+                        1.396, 4.094])
         cj = bsp.qspline1d(y)
-        newy = array([6.203, 4.49418159, 3.514, 5.18390821, 6.864, 5.91436915,
-                      4.21600002, 5.91436915, 6.864, 5.18390821, 3.514,
-                      4.49418159, 6.203, 6.71900226, 6.759, 7.03980488, 7.433,
-                      7.81016848, 7.874, 7.32718426, 5.879, 3.23872593, 1.396,
-                      2.34046013, 4.094, 2.34046013, 1.396, 3.23872593, 5.879,
-                      7.32718426, 7.874, 7.81016848, 7.433, 7.03980488, 6.759,
-                      6.71900226, 6.203, 4.49418159])
-        assert_allclose(bsp.qspline1d_eval(cj, newx, dx=dx, x0=x[0]), newy)
+        newy = np.asarray([6.203, 4.49418159, 3.514, 5.18390821, 6.864, 5.91436915,
+                           4.21600002, 5.91436915, 6.864, 5.18390821, 3.514,
+                           4.49418159, 6.203, 6.71900226, 6.759, 7.03980488, 7.433,
+                           7.81016848, 7.874, 7.32718426, 5.879, 3.23872593, 1.396,
+                           2.34046013, 4.094, 2.34046013, 1.396, 3.23872593, 5.879,
+                           7.32718426, 7.874, 7.81016848, 7.433, 7.03980488, 6.759,
+                           6.71900226, 6.203, 4.49418159])
+        xp_assert_close(bsp.qspline1d_eval(cj, newx, dx=dx, x0=x[0]), newy)
 
 
 # i/o dtypes with scipy 1.9.1, likely fixed by backwards compat
@@ -231,21 +241,19 @@ class TestSepfir2d:
         h1 = [0.5, 1, 0.5]
         h2 = [1]
         result = signal.sepfir2d(a, h1, h2)
-        expected = array([[2.5, 4. , 5.5, 5.5, 4. , 2.5],
-                          [2.5, 4. , 5.5, 5.5, 4. , 2.5],
-                          [2.5, 4. , 5.5, 5.5, 4. , 2.5],
-                          [2.5, 4. , 5.5, 5.5, 4. , 2.5]])
-
-        assert_allclose(result, expected, atol=1e-16)
-        assert result.dtype == sepfir_dtype_map[dtyp]
+        dt = sepfir_dtype_map[dtyp]
+        expected = np.asarray([[2.5, 4. , 5.5, 5.5, 4. , 2.5],
+                               [2.5, 4. , 5.5, 5.5, 4. , 2.5],
+                               [2.5, 4. , 5.5, 5.5, 4. , 2.5],
+                               [2.5, 4. , 5.5, 5.5, 4. , 2.5]], dtype=dt)
+        xp_assert_close(result, expected, atol=1e-16)
 
         result = signal.sepfir2d(a, h2, h1)
-        expected = array([[2., 4., 6., 6., 4., 2.],
-                          [2., 4., 6., 6., 4., 2.],
-                          [2., 4., 6., 6., 4., 2.],
-                          [2., 4., 6., 6., 4., 2.]])
-        assert_allclose(result, expected, atol=1e-16)
-        assert result.dtype == sepfir_dtype_map[dtyp]
+        expected = np.asarray([[2., 4., 6., 6., 4., 2.],
+                               [2., 4., 6., 6., 4., 2.],
+                               [2., 4., 6., 6., 4., 2.],
+                               [2., 4., 6., 6., 4., 2.]], dtype=dt)
+        xp_assert_close(result, expected, atol=1e-16)
 
     @pytest.mark.parametrize('dtyp',
         [np.uint8, int, np.float32, float, np.complex64, complex]
@@ -258,7 +266,7 @@ class TestSepfir2d:
         h1, h2 = [0.5, 1, 0.5], [1]
         result_strided = signal.sepfir2d(a[:, ::2], h1, h2)
         result_contig = signal.sepfir2d(a[:, ::2].copy(), h1, h2)
-        assert_allclose(result_strided, result_contig, atol=1e-15)
+        xp_assert_close(result_strided, result_contig, atol=1e-15)
         assert result_strided.dtype == result_contig.dtype
 
     @pytest.mark.xfail(reason="XXX: filt.size > image.shape: flaky")
@@ -269,11 +277,11 @@ class TestSepfir2d:
         filt = np.array([1.0, 2.0, 4.0, 2.0, 1.0, 3.0, 2.0])
         image = np.random.rand(4, 4)
 
-        expected = np.array([[36.018162, 30.239061, 38.71187 , 43.878183],
-                             [38.180999, 35.824583, 43.525247, 43.874945],
-                             [43.269533, 40.834018, 46.757772, 44.276423],
-                             [49.120928, 39.681844, 43.596067, 45.085854]])
-        assert_allclose(signal.sepfir2d(image, filt, filt[::3]), expected)
+        expected = np.asarray([[36.018162, 30.239061, 38.71187 , 43.878183],
+                                [38.180999, 35.824583, 43.525247, 43.874945],
+                                [43.269533, 40.834018, 46.757772, 44.276423],
+                                [49.120928, 39.681844, 43.596067, 45.085854]])
+        xp_assert_close(signal.sepfir2d(image, filt, filt[::3]), expected)
 
     @pytest.mark.xfail(reason="XXX: flaky. pointers OOB on some platforms")
     @pytest.mark.parametrize('dtyp',
@@ -284,28 +292,30 @@ class TestSepfir2d:
         # unsafe casting errors for many combinations. Historically, dtype handling
         # in `sepfir2d` is a tad baroque; fixing it is an enhancement.
         filt = np.array([1, 2, 4, 2, 1, 3, 2], dtype=dtyp)
-        image = np.array([[0, 3, 0, 1, 2],
-                          [2, 2, 3, 3, 3],
-                          [0, 1, 3, 0, 3],
-                          [2, 3, 0, 1, 3],
-                          [3, 3, 2, 1, 2]], dtype=dtyp)
+        image = np.asarray([[0, 3, 0, 1, 2],
+                            [2, 2, 3, 3, 3],
+                            [0, 1, 3, 0, 3],
+                            [2, 3, 0, 1, 3],
+                            [3, 3, 2, 1, 2]], dtype=dtyp)
 
-        expected = array([[123., 101.,  91., 136., 127.],
-             [133., 125., 126., 152., 160.],
-             [136., 137., 150., 162., 177.],
-             [133., 124., 132., 148., 147.],
-             [173., 158., 152., 164., 141.]])
+        expected = [[123., 101.,  91., 136., 127.],
+                    [133., 125., 126., 152., 160.],
+                    [136., 137., 150., 162., 177.],
+                    [133., 124., 132., 148., 147.],
+                    [173., 158., 152., 164., 141.]]
+        expected = np.asarray(expected)
         result = signal.sepfir2d(image, filt, filt[::3])
-        assert_allclose(result, expected, atol=1e-15)
+        xp_assert_close(result, expected, atol=1e-15)
         assert result.dtype == sepfir_dtype_map[dtyp]
 
-        expected = array([[22., 35., 41., 31., 47.],
-             [27., 39., 48., 47., 55.],
-             [33., 42., 49., 53., 59.],
-             [39., 44., 41., 36., 48.],
-             [67., 62., 47., 34., 46.]])
+        expected = [[22., 35., 41., 31., 47.],
+                    [27., 39., 48., 47., 55.],
+                    [33., 42., 49., 53., 59.],
+                    [39., 44., 41., 36., 48.],
+                    [67., 62., 47., 34., 46.]]
+        expected = np.asarray(expected)
         result = signal.sepfir2d(image, filt[::3], filt[::3])
-        assert_allclose(result, expected, atol=1e-15)
+        xp_assert_close(result, expected, atol=1e-15)
         assert result.dtype == sepfir_dtype_map[dtyp]
 
 

--- a/scipy/signal/tests/test_czt.py
+++ b/scipy/signal/tests/test_czt.py
@@ -4,7 +4,7 @@
 A unit test module for czt.py
 '''
 import pytest
-from numpy.testing import assert_allclose
+from scipy._lib._array_api import xp_assert_close
 from scipy.fft import fft
 from scipy.signal import (czt, zoom_fft, czt_points, CZT, ZoomFFT)
 import numpy as np
@@ -14,42 +14,42 @@ def check_czt(x):
     # Check that czt is the equivalent of normal fft
     y = fft(x)
     y1 = czt(x)
-    assert_allclose(y1, y, rtol=1e-13)
+    xp_assert_close(y1, y, rtol=1e-13)
 
     # Check that interpolated czt is the equivalent of normal fft
     y = fft(x, 100*len(x))
     y1 = czt(x, 100*len(x))
-    assert_allclose(y1, y, rtol=1e-12)
+    xp_assert_close(y1, y, rtol=1e-12)
 
 
 def check_zoom_fft(x):
     # Check that zoom_fft is the equivalent of normal fft
     y = fft(x)
     y1 = zoom_fft(x, [0, 2-2./len(y)], endpoint=True)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    xp_assert_close(y1, y, rtol=1e-11, atol=1e-14)
     y1 = zoom_fft(x, [0, 2])
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    xp_assert_close(y1, y, rtol=1e-11, atol=1e-14)
 
     # Test fn scalar
     y1 = zoom_fft(x, 2-2./len(y), endpoint=True)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    xp_assert_close(y1, y, rtol=1e-11, atol=1e-14)
     y1 = zoom_fft(x, 2)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    xp_assert_close(y1, y, rtol=1e-11, atol=1e-14)
 
     # Check that zoom_fft with oversampling is equivalent to zero padding
     over = 10
     yover = fft(x, over*len(x))
     y2 = zoom_fft(x, [0, 2-2./len(yover)], m=len(yover), endpoint=True)
-    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
+    xp_assert_close(y2, yover, rtol=1e-12, atol=1e-10)
     y2 = zoom_fft(x, [0, 2], m=len(yover))
-    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
+    xp_assert_close(y2, yover, rtol=1e-12, atol=1e-10)
 
     # Check that zoom_fft works on a subrange
     w = np.linspace(0, 2-2./len(x), len(x))
     f1, f2 = w[3], w[6]
     y3 = zoom_fft(x, [f1, f2], m=3*over+1, endpoint=True)
     idx3 = slice(3*over, 6*over+1)
-    assert_allclose(y3, yover[idx3], rtol=1e-13)
+    xp_assert_close(y3, yover[idx3], rtol=1e-13)
 
 
 def test_1D():
@@ -85,11 +85,11 @@ def test_1D():
     x = np.reshape(np.arange(3*2*28), (3, 2, 28))
     y1 = zoom_fft(x, [0, 2-2./28])
     y2 = zoom_fft(x[2, 0, :], [0, 2-2./28])
-    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
+    xp_assert_close(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
 
     y1 = zoom_fft(x, [0, 2], endpoint=False)
     y2 = zoom_fft(x[2, 0, :], [0, 2], endpoint=False)
-    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
+    xp_assert_close(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
 
     # Random (not a test condition)
     x = np.random.rand(101)
@@ -116,7 +116,7 @@ def test_large_prime_lengths():
         x = np.random.rand(N)
         y = fft(x)
         y1 = czt(x)
-        assert_allclose(y, y1, rtol=1e-12)
+        xp_assert_close(y, y1, rtol=1e-12)
 
 
 @pytest.mark.slow
@@ -125,7 +125,7 @@ def test_czt_vs_fft():
     random_lengths = np.random.exponential(100000, size=10).astype('int')
     for n in random_lengths:
         a = np.random.randn(n)
-        assert_allclose(czt(a), fft(a), rtol=1e-11)
+        xp_assert_close(czt(a), fft(a), rtol=1e-11)
 
 
 def test_empty_input():
@@ -152,34 +152,36 @@ def test_0_rank_input():
 @pytest.mark.parametrize('w', (None, 0.98534 + 0.17055j))
 def test_czt_math(impulse, m, w, a):
     # z-transform of an impulse is 1 everywhere
-    assert_allclose(czt(impulse[2:], m=m, w=w, a=a),
-                    np.ones(m), rtol=1e-10)
+    xp_assert_close(czt(impulse[2:], m=m, w=w, a=a),
+                    np.ones(m, dtype=np.complex128), rtol=1e-10)
 
     # z-transform of a delayed impulse is z**-1
-    assert_allclose(czt(impulse[1:], m=m, w=w, a=a),
+    xp_assert_close(czt(impulse[1:], m=m, w=w, a=a),
                     czt_points(m=m, w=w, a=a)**-1, rtol=1e-10)
 
     # z-transform of a 2-delayed impulse is z**-2
-    assert_allclose(czt(impulse, m=m, w=w, a=a),
+    xp_assert_close(czt(impulse, m=m, w=w, a=a),
                     czt_points(m=m, w=w, a=a)**-2, rtol=1e-10)
 
 
 def test_int_args():
     # Integer argument `a` was producing all 0s
-    assert_allclose(abs(czt([0, 1], m=10, a=2)), 0.5*np.ones(10), rtol=1e-15)
-    assert_allclose(czt_points(11, w=2), 1/(2**np.arange(11)), rtol=1e-30)
+    xp_assert_close(abs(czt([0, 1], m=10, a=2)), 0.5*np.ones(10), rtol=1e-15)
+    xp_assert_close(czt_points(11, w=2),
+                    1/(2**np.arange(11, dtype=np.complex128)), rtol=1e-30)
 
 
 def test_czt_points():
     for N in (1, 2, 3, 8, 11, 100, 101, 10007):
-        assert_allclose(czt_points(N), np.exp(2j*np.pi*np.arange(N)/N),
+        xp_assert_close(czt_points(N), np.exp(2j*np.pi*np.arange(N)/N),
                         rtol=1e-30)
 
-    assert_allclose(czt_points(7, w=1), np.ones(7), rtol=1e-30)
-    assert_allclose(czt_points(11, w=2.), 1/(2**np.arange(11)), rtol=1e-30)
+    xp_assert_close(czt_points(7, w=1), np.ones(7, dtype=np.complex128), rtol=1e-30)
+    xp_assert_close(czt_points(11, w=2.),
+                    1/(2**np.arange(11, dtype=np.complex128)), rtol=1e-30)
 
     func = CZT(12, m=11, w=2., a=1)
-    assert_allclose(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
+    xp_assert_close(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
 
 
 @pytest.mark.parametrize('cls, args', [(CZT, (100,)), (ZoomFFT, (100, 0.2))])

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -2,11 +2,12 @@
 # April 4, 2011
 
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_array_almost_equal, assert_array_equal,
-                           assert_allclose, assert_, assert_almost_equal,
-                           suppress_warnings)
+from numpy.testing import suppress_warnings
 from pytest import raises as assert_raises
+from scipy._lib._array_api import (
+    assert_array_almost_equal, assert_almost_equal, xp_assert_close, xp_assert_equal,
+)
+
 from scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
                           StateSpace, TransferFunction, ZerosPolesGain,
                           dfreqresp, dbode, BadCoefficients)
@@ -59,7 +60,7 @@ class TestDLTI:
 
         assert_array_almost_equal(yout_truth, yout)
         assert_array_almost_equal(xout_truth, xout)
-        assert_equal(len(tout), yout.shape[0])
+        assert len(tout) == len(yout)
 
         # Transfer functions (assume dt = 0.5)
         num = np.asarray([1.0, -0.1])
@@ -122,22 +123,22 @@ class TestDLTI:
 
         tout, yout = dstep((a, b, c, d, dt), n=10)
 
-        assert_equal(len(yout), 3)
+        assert len(yout) == 3
 
         for i in range(0, len(yout)):
-            assert_equal(yout[i].shape[0], 10)
+            assert yout[i].shape[0] == 10
             assert_array_almost_equal(yout[i].flatten(), yout_step_truth[i])
 
         # Check that the other two inputs (tf, zpk) will work as well
         tfin = ([1.0], [1.0, 1.0], 0.5)
         yout_tfstep = np.asarray([0.0, 1.0, 0.0])
         tout, yout = dstep(tfin, n=3)
-        assert_equal(len(yout), 1)
+        assert len(yout) == 1
         assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
 
         zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
         tout, yout = dstep(zpkin, n=3)
-        assert_equal(len(yout), 1)
+        assert len(yout) == 1
         assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
 
         # Raise an error for continuous-time systems
@@ -166,22 +167,22 @@ class TestDLTI:
 
         tout, yout = dimpulse((a, b, c, d, dt), n=10)
 
-        assert_equal(len(yout), 3)
+        assert len(yout) == 3
 
         for i in range(0, len(yout)):
-            assert_equal(yout[i].shape[0], 10)
+            assert yout[i].shape[0] == 10
             assert_array_almost_equal(yout[i].flatten(), yout_imp_truth[i])
 
         # Check that the other two inputs (tf, zpk) will work as well
         tfin = ([1.0], [1.0, 1.0], 0.5)
         yout_tfimpulse = np.asarray([0.0, 1.0, -1.0])
         tout, yout = dimpulse(tfin, n=3)
-        assert_equal(len(yout), 1)
+        assert len(yout) == 1
         assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
 
         zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
         tout, yout = dimpulse(zpkin, n=3)
-        assert_equal(len(yout), 1)
+        assert len(yout) == 1
         assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
 
         # Raise an error for continuous-time systems
@@ -196,9 +197,9 @@ class TestDLTI:
         n = 5
         u = np.zeros(n).reshape(-1, 1)
         tout, yout, xout = dlsim((a, b, c, d, 1), u)
-        assert_array_equal(tout, np.arange(float(n)))
-        assert_array_equal(yout, np.zeros((n, 1)))
-        assert_array_equal(xout, np.zeros((n, 1)))
+        xp_assert_equal(tout, np.arange(float(n)))
+        xp_assert_equal(yout, np.zeros((n, 1)))
+        xp_assert_equal(xout, np.zeros((n, 1)))
 
     def test_dlsim_simple1d(self):
         a = np.array([[0.5]])
@@ -208,10 +209,10 @@ class TestDLTI:
         n = 5
         u = np.zeros(n).reshape(-1, 1)
         tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
-        assert_array_equal(tout, np.arange(float(n)))
+        xp_assert_equal(tout, np.arange(float(n)))
         expected = (0.5 ** np.arange(float(n))).reshape(-1, 1)
-        assert_array_equal(yout, expected)
-        assert_array_equal(xout, expected)
+        xp_assert_equal(yout, expected)
+        xp_assert_equal(xout, expected)
 
     def test_dlsim_simple2d(self):
         lambda1 = 0.5
@@ -227,12 +228,12 @@ class TestDLTI:
         n = 5
         u = np.zeros(n).reshape(-1, 1)
         tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
-        assert_array_equal(tout, np.arange(float(n)))
+        xp_assert_equal(tout, np.arange(float(n)))
         # The analytical solution:
         expected = (np.array([lambda1, lambda2]) **
                                 np.arange(float(n)).reshape(-1, 1))
-        assert_array_equal(yout, expected)
-        assert_array_equal(xout, expected)
+        xp_assert_equal(yout, expected)
+        xp_assert_equal(xout, expected)
 
     def test_more_step_and_impulse(self):
         lambda1 = 0.5
@@ -253,8 +254,8 @@ class TestDLTI:
         stp0 = (1.0 / (1 - lambda1)) * (1.0 - lambda1 ** np.arange(n))
         stp1 = (1.0 / (1 - lambda2)) * (1.0 - lambda2 ** np.arange(n))
 
-        assert_allclose(ys[0][:, 0], stp0)
-        assert_allclose(ys[1][:, 0], stp1)
+        xp_assert_close(ys[0][:, 0], stp0)
+        xp_assert_close(ys[1][:, 0], stp1)
 
         # Check an impulse response with an initial condition.
         x0 = np.array([1.0, 1.0])
@@ -268,17 +269,17 @@ class TestDLTI:
         y0 = imp[:n, 0] + np.dot(imp[1:n + 1, :], x0)
         y1 = imp[:n, 1] + np.dot(imp[1:n + 1, :], x0)
 
-        assert_allclose(yi[0][:, 0], y0)
-        assert_allclose(yi[1][:, 0], y1)
+        xp_assert_close(yi[0][:, 0], y0)
+        xp_assert_close(yi[1][:, 0], y1)
 
         # Check that dt=0.1, n=3 gives 3 time values.
         system = ([1.0], [1.0, -0.5], 0.1)
         t, (y,) = dstep(system, n=3)
-        assert_allclose(t, [0, 0.1, 0.2])
-        assert_array_equal(y.T, [[0, 1.0, 1.5]])
+        xp_assert_close(t, [0, 0.1, 0.2])
+        xp_assert_equal(y.T, [[0, 1.0, 1.5]])
         t, (y,) = dimpulse(system, n=3)
-        assert_allclose(t, [0, 0.1, 0.2])
-        assert_array_equal(y.T, [[0, 1, 0.5]])
+        xp_assert_close(t, [0, 0.1, 0.2])
+        xp_assert_equal(y.T, [[0, 1, 0.5]])
 
 
 class TestDlti:
@@ -288,24 +289,24 @@ class TestDlti:
         dt = 0.05
         # TransferFunction
         s = dlti([1], [-1], dt=dt)
-        assert_(isinstance(s, TransferFunction))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        assert isinstance(s, TransferFunction)
+        assert isinstance(s, dlti)
+        assert not isinstance(s, lti)
+        assert s.dt == dt
 
         # ZerosPolesGain
         s = dlti(np.array([]), np.array([-1]), 1, dt=dt)
-        assert_(isinstance(s, ZerosPolesGain))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        assert isinstance(s, ZerosPolesGain)
+        assert isinstance(s, dlti)
+        assert not isinstance(s, lti)
+        assert s.dt == dt
 
         # StateSpace
         s = dlti([1], [-1], 1, 3, dt=dt)
-        assert_(isinstance(s, StateSpace))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        assert isinstance(s, StateSpace)
+        assert isinstance(s, dlti)
+        assert not isinstance(s, lti)
+        assert s.dt == dt
 
         # Number of inputs
         assert_raises(ValueError, dlti, 1)
@@ -325,13 +326,13 @@ class TestStateSpaceDisc:
     def test_conversion(self):
         # Check the conversion functions
         s = StateSpace(1, 2, 3, 4, dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(StateSpace(s) is not s)
-        assert_(s.to_ss() is not s)
+        assert StateSpace(s) is not s
+        assert s.to_ss() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
@@ -339,8 +340,8 @@ class TestStateSpaceDisc:
 
         # Getters
         s = StateSpace(1, 1, 1, 1, dt=0.05)
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
+        xp_assert_equal(s.poles, [1.])
+        xp_assert_equal(s.zeros, [0.])
 
 
 class TestTransferFunction:
@@ -355,13 +356,13 @@ class TestTransferFunction:
     def test_conversion(self):
         # Check the conversion functions
         s = TransferFunction([1, 0], [1, -1], dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(TransferFunction(s) is not s)
-        assert_(s.to_tf() is not s)
+        assert TransferFunction(s) is not s
+        assert s.to_tf() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
@@ -369,8 +370,8 @@ class TestTransferFunction:
 
         # Getters
         s = TransferFunction([1, 0], [1, -1], dt=0.05)
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
+        xp_assert_equal(s.poles, [1.])
+        xp_assert_equal(s.zeros, [0.])
 
 
 class TestZerosPolesGain:
@@ -385,13 +386,13 @@ class TestZerosPolesGain:
     def test_conversion(self):
         # Check the conversion functions
         s = ZerosPolesGain(1, 2, 3, dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(ZerosPolesGain(s) is not s)
-        assert_(s.to_zpk() is not s)
+        assert ZerosPolesGain(s) is not s
+        assert s.to_zpk() is not s
 
 
 class Test_dfreqresp:
@@ -447,7 +448,7 @@ class Test_dfreqresp:
             sup.filter(RuntimeWarning, message="divide by zero")
             sup.filter(RuntimeWarning, message="invalid value encountered")
             w, H = dfreqresp(system, n=2)
-        assert_equal(w[0], 0.)  # a fail would give not-a-number
+        assert w[0] == 0.   # a fail would give not-a-number
 
     def test_error(self):
         # Raise an error for continuous-time systems
@@ -504,7 +505,7 @@ class Test_bode:
         assert_almost_equal(phase, expected_phase, decimal=4)
 
         # Test frequency
-        assert_equal(np.array(w) / dt, w2)
+        xp_assert_equal(np.array(w) / dt, w2)
 
     def test_auto(self):
         # Test bode() magnitude calculation.
@@ -543,7 +544,7 @@ class Test_bode:
             sup.filter(RuntimeWarning, message="divide by zero")
             sup.filter(RuntimeWarning, message="invalid value encountered")
             w, mag, phase = dbode(system, n=2)
-        assert_equal(w[0], 0.)  # a fail would give not-a-number
+        assert w[0] == 0.  # a fail would give not-a-number
 
     def test_imaginary(self):
         # bode() should not fail on a system with pure imaginary poles.
@@ -562,37 +563,37 @@ class TestTransferFunctionZConversion:
 
     def test_full(self):
         # Numerator and denominator same order
-        num = [2, 3, 4]
-        den = [5, 6, 7]
+        num = np.asarray([2.0, 3, 4])
+        den = np.asarray([5.0, 6, 7])
         num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal(num, num2)
-        assert_equal(den, den2)
+        xp_assert_equal(num, num2)
+        xp_assert_equal(den, den2)
 
         num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal(num, num2)
-        assert_equal(den, den2)
+        xp_assert_equal(num, num2)
+        xp_assert_equal(den, den2)
 
     def test_numerator(self):
         # Numerator lower order than denominator
-        num = [2, 3]
-        den = [5, 6, 7]
+        num = np.asarray([2.0, 3])
+        den = np.asarray([50, 6, 7])
         num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal([0, 2, 3], num2)
-        assert_equal(den, den2)
+        xp_assert_equal([0.0, 2, 3], num2)
+        xp_assert_equal(den, den2)
 
         num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal([2, 3, 0], num2)
-        assert_equal(den, den2)
+        xp_assert_equal([2.0, 3, 0], num2)
+        xp_assert_equal(den, den2)
 
     def test_denominator(self):
         # Numerator higher order than denominator
-        num = [2, 3, 4]
-        den = [5, 6]
+        num = np.asarray([2., 3, 4])
+        den = np.asarray([5.0, 6])
         num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal(num, num2)
-        assert_equal([0, 5, 6], den2)
+        xp_assert_equal(num, num2)
+        xp_assert_equal([0.0, 5, 6], den2)
 
         num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal(num, num2)
-        assert_equal([5, 6, 0], den2)
+        xp_assert_equal(num, num2)
+        xp_assert_equal([5.0, 6, 0], den2)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -6,9 +6,10 @@ from numpy.testing import (assert_array_almost_equal,
                            assert_array_almost_equal_nulp,
                            assert_array_equal, assert_array_less,
                            assert_equal, assert_,
-                           assert_allclose, assert_warns, suppress_warnings)
+                           assert_warns, suppress_warnings)
 import pytest
 from pytest import raises as assert_raises
+from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less)
 
 from numpy import array, spacing, sin, pi, sort, sqrt
 from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bilinear,
@@ -45,21 +46,21 @@ class TestCplxPair:
         assert_equal(_cplxpair(1), 1)
 
     def test_output_order(self):
-        assert_allclose(_cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
+        xp_assert_close(_cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
 
         a = [1+1j, 1+1j, 1, 1-1j, 1-1j, 2]
         b = [1-1j, 1+1j, 1-1j, 1+1j, 1, 2]
-        assert_allclose(_cplxpair(a), b)
+        xp_assert_close(_cplxpair(a), b)
 
         # points spaced around the unit circle
         z = np.exp(2j*pi*array([4, 3, 5, 2, 6, 1, 0])/7)
         z1 = np.copy(z)
         np.random.shuffle(z)
-        assert_allclose(_cplxpair(z), z1)
+        xp_assert_close(_cplxpair(z), z1)
         np.random.shuffle(z)
-        assert_allclose(_cplxpair(z), z1)
+        xp_assert_close(_cplxpair(z), z1)
         np.random.shuffle(z)
-        assert_allclose(_cplxpair(z), z1)
+        xp_assert_close(_cplxpair(z), z1)
 
         # Should be able to pair up all the conjugates
         x = np.random.rand(10000) + 1j * np.random.rand(10000)
@@ -70,24 +71,24 @@ class TestCplxPair:
         c = _cplxpair(x)
 
         # Every other element of head should be conjugates:
-        assert_allclose(c[0:20000:2], np.conj(c[1:20000:2]))
+        xp_assert_close(c[0:20000:2], np.conj(c[1:20000:2]))
         # Real parts of head should be in sorted order:
-        assert_allclose(c[0:20000:2].real, np.sort(c[0:20000:2].real))
+        xp_assert_close(c[0:20000:2].real, np.sort(c[0:20000:2].real))
         # Tail should be sorted real numbers:
-        assert_allclose(c[20000:], np.sort(c[20000:]))
+        xp_assert_close(c[20000:], np.sort(c[20000:]))
 
     def test_real_integer_input(self):
         assert_array_equal(_cplxpair([2, 0, 1]), [0, 1, 2])
 
     def test_tolerances(self):
         eps = spacing(1)
-        assert_allclose(_cplxpair([1j, -1j, 1+1j*eps], tol=2*eps),
+        xp_assert_close(_cplxpair([1j, -1j, 1+1j*eps], tol=2*eps),
                         [-1j, 1j, 1+1j*eps])
 
         # sorting close to 0
-        assert_allclose(_cplxpair([-eps+1j, +eps-1j]), [-1j, +1j])
-        assert_allclose(_cplxpair([+eps+1j, -eps-1j]), [-1j, +1j])
-        assert_allclose(_cplxpair([+1j, -1j]), [-1j, +1j])
+        xp_assert_close(_cplxpair([-eps+1j, +eps-1j]), [-1j, +1j])
+        xp_assert_close(_cplxpair([+eps+1j, -eps-1j]), [-1j, +1j])
+        xp_assert_close(_cplxpair([+1j, -1j]), [-1j, +1j])
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
@@ -116,7 +117,7 @@ class TestCplxReal:
 
     def test_output_order(self):
         zc, zr = _cplxreal(np.roots(array([1, 0, 0, 1])))
-        assert_allclose(np.append(zc, zr), [1/2 + 1j*sin(pi/3), -1])
+        xp_assert_close(np.append(zc, zr), [1/2 + 1j*sin(pi/3), -1])
 
         eps = spacing(1)
 
@@ -127,18 +128,18 @@ class TestCplxReal:
              3+1j, 3+1j, 3+1j, 3-1j, 3-1j, 3-1j,
              2-3j, 2+3j]
         zc, zr = _cplxreal(a)
-        assert_allclose(zc, [1j, 1j, 1j, 1+1j, 1+2j, 2+3j, 2+3j, 3+1j, 3+1j,
+        xp_assert_close(zc, [1j, 1j, 1j, 1+1j, 1+2j, 2+3j, 2+3j, 3+1j, 3+1j,
                              3+1j])
-        assert_allclose(zr, [0, 0, 1, 2, 3, 4])
+        xp_assert_close(zr, [0.0, 0, 1, 2, 3, 4])
 
         z = array([1-eps + 1j, 1+2j, 1-2j, 1+eps - 1j, 1+eps+3j, 1-2*eps-3j,
                    0+1j, 0-1j, 2+4j, 2-4j, 2+3j, 2-3j, 3+7j, 3-7j, 4-eps+1j,
                    4+eps-2j, 4-1j, 4-eps+2j])
 
         zc, zr = _cplxreal(z)
-        assert_allclose(zc, [1j, 1+1j, 1+2j, 1+3j, 2+3j, 2+4j, 3+7j, 4+1j,
+        xp_assert_close(zc, [1j, 1+1j, 1+2j, 1+3j, 2+3j, 2+4j, 3+7j, 4+1j,
                              4+2j])
-        assert_equal(zr, [])
+        assert_equal(zr, np.asarray([], dtype=zr.dtype))
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
@@ -243,9 +244,9 @@ class TestSos2Zpk:
                   -0.1 - 0.538516480713450j, -0.1 + 0.538516480713450j])
         k = 4
         z2, p2, k2 = sos2zpk(sos)
-        assert_allclose(_cplxpair(z2), z)
-        assert_allclose(_cplxpair(p2), p)
-        assert_allclose(k2, k)
+        xp_assert_close(_cplxpair(z2), z)
+        xp_assert_close(_cplxpair(p2), p)
+        assert k2 == k
 
     def test_fewer_zeros(self):
         """Test not the expected number of p/z (effectively at origin)."""
@@ -402,7 +403,7 @@ class TestZpk2Sos:
                     [1, 1.25, 1.5, 1, 0.4, 0.5]]  # MATLAB
             # sos2 = [[4, 8, 12, 1, 0.4, 0.5],
             #         [1, 1.25, 1.5, 1, 0.2, 0.3]]  # octave
-            assert_allclose(sos, sos2, rtol=1e-4, atol=1e-4)
+            xp_assert_close(sos, sos2, rtol=1e-4, atol=1e-4)
 
             z = []
             p = [0.2, -0.5+0.25j, -0.5-0.25j]
@@ -598,8 +599,8 @@ class TestFreqs_zpk:
 
         w1, h1 = freqs(b, a)
         w2, h2 = freqs_zpk(z, p, k)
-        assert_allclose(w1, w2)
-        assert_allclose(h1, h2, rtol=1e-6)
+        xp_assert_close(w1, w2)
+        xp_assert_close(h1, h2, rtol=1e-6)
 
     def test_backward_compat(self):
         # For backward compatibility, test if None act as a wrapper for default
@@ -759,8 +760,8 @@ class TestFreqz:
                     bk = b[:, k, 0]
                     ak = a[:, 0]
                     ww, hh = freqz(bk, ak, worN=worN, whole=whole)
-                    assert_allclose(ww, w)
-                    assert_allclose(hh, h[k])
+                    xp_assert_close(ww, w)
+                    xp_assert_close(hh, h[k])
 
     def test_broadcasting2(self):
         # Test broadcasting with worN an integer or a 1-D array,
@@ -773,8 +774,8 @@ class TestFreqz:
                 for k in range(b.shape[1]):
                     bk = b[:, k, 0]
                     ww, hh = freqz(bk, worN=worN, whole=whole)
-                    assert_allclose(ww, w)
-                    assert_allclose(hh, h[k])
+                    xp_assert_close(ww, w)
+                    xp_assert_close(hh, h[k])
 
     def test_broadcasting3(self):
         # Test broadcasting where b.shape[-1] is the same length
@@ -789,8 +790,8 @@ class TestFreqz:
                 for k in range(N):
                     bk = b[:, k]
                     ww, hh = freqz(bk, worN=w[k], whole=whole)
-                    assert_allclose(ww, w[k])
-                    assert_allclose(hh, h[k])
+                    xp_assert_close(ww, np.asarray(w[k])[None])
+                    xp_assert_close(hh, np.asarray(h[k])[None])
 
     def test_broadcasting4(self):
         # Test broadcasting with worN a 2-D array.
@@ -800,14 +801,14 @@ class TestFreqz:
         for whole in [False, True]:
             for worN in [np.random.rand(6, 7), np.empty((6, 0))]:
                 w, h = freqz(b, a, worN=worN, whole=whole)
-                assert_allclose(w, worN, rtol=1e-14)
+                xp_assert_close(w, worN, rtol=1e-14)
                 assert_equal(h.shape, (2,) + worN.shape)
                 for k in range(2):
                     ww, hh = freqz(b[:, k, 0, 0], a[:, k, 0, 0],
                                    worN=worN.ravel(),
                                    whole=whole)
-                    assert_allclose(ww, worN.ravel(), rtol=1e-14)
-                    assert_allclose(hh, h[k, :, :].ravel())
+                    xp_assert_close(ww, worN.ravel(), rtol=1e-14)
+                    xp_assert_close(hh, h[k, :, :].ravel())
 
     def test_backward_compat(self):
         # For backward compatibility, test if None act as a wrapper for default
@@ -826,34 +827,34 @@ class TestFreqz:
         # N = None, whole=False
         w1, h1 = freqz(b, a, fs=fs)
         w2, h2 = freqz(b, a)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 512, endpoint=False))
 
         # N = None, whole=True
         w1, h1 = freqz(b, a, whole=True, fs=fs)
         w2, h2 = freqz(b, a, whole=True)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False
         w1, h1 = freqz(b, a, 5, fs=fs)
         w2, h2 = freqz(b, a, 5)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 5, endpoint=False))
 
         # N = 5, whole=True
         w1, h1 = freqz(b, a, 5, whole=True, fs=fs)
         w2, h2 = freqz(b, a, 5, whole=True)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs, 5, endpoint=False))
 
         # w is an array_like
         for w in ([123], (123,), np.array([123]), (50, 123, 230),
                   np.array([50, 123, 230])):
             w1, h1 = freqz(b, a, w, fs=fs)
             w2, h2 = freqz(b, a, 2*pi*np.array(w)/fs)
-            assert_allclose(h1, h2)
-            assert_allclose(w, w1)
+            xp_assert_close(h1, h2)
+            xp_assert_close(np.asarray(w), w1, check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 7 (polyval) or 8 (fft) equally-spaced points
@@ -911,7 +912,7 @@ class TestFreqz:
         d = [0, 1]
         w, Drfft = freqz(d, worN=32, whole=whole, include_nyquist=nyquist)
         _, Dpoly = freqz(d, worN=w)
-        assert_allclose(Drfft, Dpoly)
+        xp_assert_close(Drfft, Dpoly)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
@@ -934,14 +935,14 @@ class Testfreqz_sos:
         w, h = freqz(b, a, worN=N)
         w2, h2 = freqz_sos(sos, worN=N)
         assert_equal(w2, w)
-        assert_allclose(h2, h, rtol=1e-10, atol=1e-14)
+        xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
 
         b, a = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass')
         sos = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass', output='sos')
         w, h = freqz(b, a, worN=N)
         w2, h2 = freqz_sos(sos, worN=N)
         assert_equal(w2, w)
-        assert_allclose(h2, h, rtol=1e-10, atol=1e-14)
+        xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
         # must have at least one section
         assert_raises(ValueError, freqz_sos, sos[:0])
 
@@ -965,17 +966,21 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        assert_allclose(20 * np.log10(h[w <= 0.1]), 0, atol=3.01)
-        assert_allclose(20 * np.log10(h[w >= 0.6]), 0., atol=3.01)
-        assert_allclose(h[(w >= 0.2) & (w <= 0.5)], 0., atol=1e-3)  # <= -60 dB
+        xp_assert_close(20 * np.log10(h[w <= 0.1]), np.asarray(0.), atol=3.01,
+                        check_shape=False)
+        xp_assert_close(20 * np.log10(h[w >= 0.6]), np.asarray(0.), atol=3.01,
+                        check_shape=False)
+        xp_assert_close(h[(w >= 0.2) & (w <= 0.5)],
+                        np.asarray(0.), atol=1e-3,
+                        check_shape=False)  # <= -60 dB
 
         N, Wn = cheb2ord([0.1, 0.6], [0.2, 0.5], 3, 150)
         sos = cheby2(N, 150, Wn, 'stop', output='sos')
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
-        assert_allclose(dB[w <= 0.1], 0, atol=3.01)
-        assert_allclose(dB[w >= 0.6], 0., atol=3.01)
+        xp_assert_close(dB[w <= 0.1], 0.0, atol=3.01, check_0d=False, check_shape=False)
+        xp_assert_close(dB[w >= 0.6], 0.0, atol=3.01, check_0d=False, check_shape=False)
         assert_array_less(dB[(w >= 0.2) & (w <= 0.5)], -149.9)
 
         # from cheb1ord
@@ -984,15 +989,18 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        assert_allclose(20 * np.log10(h[w <= 0.2]), 0, atol=3.01)
-        assert_allclose(h[w >= 0.3], 0., atol=1e-2)  # <= -40 dB
+        xp_assert_close(20 * np.log10(h[w <= 0.2]), 0.0, atol=3.01,
+                        check_0d=False, check_shape=False)
+        xp_assert_close(h[w >= 0.3], 0., atol=1e-2,
+                        check_0d=False, check_shape=False)  # <= -40 dB
 
         N, Wn = cheb1ord(0.2, 0.3, 1, 150)
         sos = cheby1(N, 1, Wn, 'low', output='sos')
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
-        assert_allclose(dB[w <= 0.2], 0, atol=1.01)
+        xp_assert_close(dB[w <= 0.2], 0.0, atol=1.01,
+                        check_0d=False, check_shape=False)
         assert_array_less(dB[w >= 0.3], -149.9)
 
         # adapted from ellipord
@@ -1001,8 +1009,10 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        assert_allclose(20 * np.log10(h[w >= 0.3]), 0, atol=3.01)
-        assert_allclose(h[w <= 0.1], 0., atol=1.5e-3)  # <= -60 dB (approx)
+        xp_assert_close(20 * np.log10(h[w >= 0.3]), 0.0, atol=3.01,
+                        check_0d=False, check_shape=False)
+        xp_assert_close(h[w <= 0.1], 0., atol=1.5e-3,
+                        check_0d=False, check_shape=False)  # <= -60 dB (approx)
 
         # adapted from buttord
         N, Wn = buttord([0.2, 0.5], [0.14, 0.6], 3, 40)
@@ -1010,19 +1020,26 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        assert_allclose(h[w <= 0.14], 0., atol=1e-2)  # <= -40 dB
-        assert_allclose(h[w >= 0.6], 0., atol=1e-2)  # <= -40 dB
-        assert_allclose(20 * np.log10(h[(w >= 0.2) & (w <= 0.5)]),
-                        0, atol=3.01)
+
+        h014 = h[w <= 0.14]
+        xp_assert_close(h014, np.zeros_like(h014), atol=1e-2)  # <= -40 dB
+        h06 = h[w >= 0.6]
+        xp_assert_close(h06, np.zeros_like(h06), atol=1e-2)  # <= -40 dB
+        h0205 = 20 * np.log10(h[(w >= 0.2) & (w <= 0.5)])
+        xp_assert_close(h0205, np.zeros_like(h0205), atol=3.01)
 
         N, Wn = buttord([0.2, 0.5], [0.14, 0.6], 3, 100)
         sos = butter(N, Wn, 'band', output='sos')
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
-        assert_array_less(dB[(w > 0) & (w <= 0.14)], -99.9)
-        assert_array_less(dB[w >= 0.6], -99.9)
-        assert_allclose(dB[(w >= 0.2) & (w <= 0.5)], 0, atol=3.01)
+
+        db014 = dB[(w > 0) & (w <= 0.14)]
+        xp_assert_less(db014, np.ones_like(db014) * (-99.9))
+        db06 = dB[w >= 0.6]
+        xp_assert_less(db06, np.ones_like(db06) * (-99.9))
+        db0205 = dB[(w >= 0.2) & (w <= 0.5)]
+        xp_assert_close(db0205, np.zeros_like(db0205), atol=3.01)
 
     def test_freqz_sos_design_ellip(self):
         N, Wn = ellipord(0.3, 0.1, 3, 60)
@@ -1030,15 +1047,20 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        assert_allclose(20 * np.log10(h[w >= 0.3]), 0, atol=3.01)
-        assert_allclose(h[w <= 0.1], 0., atol=1.5e-3)  # <= -60 dB (approx)
+
+        h03 = 20 * np.log10(h[w >= 0.3])
+        xp_assert_close(h03, np.zeros_like(h03), atol=3.01)
+        h01 = h[w <= 0.1]
+        xp_assert_close(h01, np.zeros_like(h01), atol=1.5e-3)  # <= -60 dB (approx)
 
         N, Wn = ellipord(0.3, 0.2, .5, 150)
         sos = ellip(N, .5, 150, Wn, 'high', output='sos')
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
-        assert_allclose(dB[w >= 0.3], 0, atol=.55)
+
+        db03 = dB[w >= 0.3]
+        xp_assert_close(db03, np.zeros_like(db03), atol=.55)
         # Allow some numerical slop in the upper bound -150, so this is
         # a check that dB[w <= 0.2] is less than or almost equal to -150.
         assert dB[w <= 0.2].max() < -150*(1 - 1e-12)
@@ -1060,8 +1082,8 @@ class Testfreqz_sos:
 
         sos = butter(order, Wn, output='sos')
         w, h = freqz_sos(sos, worN=N)
-        assert_allclose(w, w_mp, rtol=1e-12, atol=1e-14)
-        assert_allclose(h, h_mp, rtol=1e-12, atol=1e-14)
+        xp_assert_close(w, w_mp, rtol=1e-12, atol=1e-14)
+        xp_assert_close(h, h_mp, rtol=1e-12, atol=1e-14)
 
     def test_fs_param(self):
         fs = 900
@@ -1072,34 +1094,34 @@ class Testfreqz_sos:
         # N = None, whole=False
         w1, h1 = freqz_sos(sos, fs=fs)
         w2, h2 = freqz_sos(sos)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 512, endpoint=False))
 
         # N = None, whole=True
         w1, h1 = freqz_sos(sos, whole=True, fs=fs)
         w2, h2 = freqz_sos(sos, whole=True)
-        assert_allclose(h1, h2, atol=1e-27)
-        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+        xp_assert_close(h1, h2, atol=1e-27)
+        xp_assert_close(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False
         w1, h1 = freqz_sos(sos, 5, fs=fs)
         w2, h2 = freqz_sos(sos, 5)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 5, endpoint=False))
 
         # N = 5, whole=True
         w1, h1 = freqz_sos(sos, 5, whole=True, fs=fs)
         w2, h2 = freqz_sos(sos, 5, whole=True)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs, 5, endpoint=False))
 
         # w is an array_like
         for w in ([123], (123,), np.array([123]), (50, 123, 230),
                   np.array([50, 123, 230])):
             w1, h1 = freqz_sos(sos, w, fs=fs)
             w2, h2 = freqz_sos(sos, 2*pi*np.array(w)/fs)
-            assert_allclose(h1, h2)
-            assert_allclose(w, w1)
+            xp_assert_close(h1, h2)
+            xp_assert_close(np.asarray(w), np.asarray(w1), check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 7 (polyval) or 8 (fft) equally-spaced points
@@ -1156,8 +1178,8 @@ class TestFreqz_zpk:
 
         w1, h1 = freqz(b, a)
         w2, h2 = freqz_zpk(z, p, k)
-        assert_allclose(w1, w2)
-        assert_allclose(h1, h2, rtol=1e-6)
+        xp_assert_close(w1, w2)
+        xp_assert_close(h1, h2, rtol=1e-6)
 
     def test_backward_compat(self):
         # For backward compatibility, test if None act as a wrapper for default
@@ -1176,34 +1198,34 @@ class TestFreqz_zpk:
         # N = None, whole=False
         w1, h1 = freqz_zpk(z, p, k, whole=False, fs=fs)
         w2, h2 = freqz_zpk(z, p, k, whole=False)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 512, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 512, endpoint=False))
 
         # N = None, whole=True
         w1, h1 = freqz_zpk(z, p, k, whole=True, fs=fs)
         w2, h2 = freqz_zpk(z, p, k, whole=True)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs, 512, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs, 512, endpoint=False))
 
         # N = 5, whole=False
         w1, h1 = freqz_zpk(z, p, k, 5, fs=fs)
         w2, h2 = freqz_zpk(z, p, k, 5)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs/2, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs/2, 5, endpoint=False))
 
         # N = 5, whole=True
         w1, h1 = freqz_zpk(z, p, k, 5, whole=True, fs=fs)
         w2, h2 = freqz_zpk(z, p, k, 5, whole=True)
-        assert_allclose(h1, h2)
-        assert_allclose(w1, np.linspace(0, fs, 5, endpoint=False))
+        xp_assert_close(h1, h2)
+        xp_assert_close(w1, np.linspace(0, fs, 5, endpoint=False))
 
         # w is an array_like
         for w in ([123], (123,), np.array([123]), (50, 123, 230),
                   np.array([50, 123, 230])):
             w1, h1 = freqz_zpk(z, p, k, w, fs=fs)
             w2, h2 = freqz_zpk(z, p, k, 2*pi*np.array(w)/fs)
-            assert_allclose(h1, h2)
-            assert_allclose(w, w1)
+            xp_assert_close(h1, h2)
+            xp_assert_close(np.asarray(w), w1, check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 8 equally-spaced points
@@ -1308,8 +1330,8 @@ class TestLp2hp:
         b = [0.25059432325190018]
         a = [1, 0.59724041654134863, 0.92834805757524175, 0.25059432325190018]
         b_hp, a_hp = lp2hp(b, a, 2*np.pi*5000)
-        assert_allclose(b_hp, [1, 0, 0, 0])
-        assert_allclose(a_hp, [1, 1.1638e5, 2.3522e9, 1.2373e14], rtol=1e-4)
+        xp_assert_close(b_hp, [1.0, 0, 0, 0])
+        xp_assert_close(a_hp, [1, 1.1638e5, 2.3522e9, 1.2373e14], rtol=1e-4)
 
 
 class TestLp2bp:
@@ -1318,8 +1340,8 @@ class TestLp2bp:
         b = [1]
         a = [1, 2, 2, 1]
         b_bp, a_bp = lp2bp(b, a, 2*np.pi*4000, 2*np.pi*2000)
-        assert_allclose(b_bp, [1.9844e12, 0, 0, 0], rtol=1e-6)
-        assert_allclose(a_bp, [1, 2.5133e4, 2.2108e9, 3.3735e13,
+        xp_assert_close(b_bp, [1.9844e12, 0, 0, 0], rtol=1e-6)
+        xp_assert_close(a_bp, [1, 2.5133e4, 2.2108e9, 3.3735e13,
                                1.3965e18, 1.0028e22, 2.5202e26], rtol=1e-4)
 
 
@@ -1369,17 +1391,17 @@ class TestLp2lp_zpk:
         k = 1
         z_lp, p_lp, k_lp = lp2lp_zpk(z, p, k, 5)
         assert_array_equal(z_lp, [])
-        assert_allclose(sort(p_lp), sort(p)*5)
-        assert_allclose(k_lp, 25)
+        xp_assert_close(sort(p_lp), sort(p)*5)
+        xp_assert_close(k_lp, 25.)
 
         # Pseudo-Chebyshev with both poles and zeros
         z = [-2j, +2j]
         p = [-0.75, -0.5-0.5j, -0.5+0.5j]
         k = 3
         z_lp, p_lp, k_lp = lp2lp_zpk(z, p, k, 20)
-        assert_allclose(sort(z_lp), sort([-40j, +40j]))
-        assert_allclose(sort(p_lp), sort([-15, -10-10j, -10+10j]))
-        assert_allclose(k_lp, 60)
+        xp_assert_close(sort(z_lp), sort([-40j, +40j]))
+        xp_assert_close(sort(p_lp), sort([-15, -10-10j, -10+10j]))
+        xp_assert_close(float(k_lp), 60.)
 
     def test_fs_validation(self):
         z = [-2j, +2j]
@@ -1402,16 +1424,16 @@ class TestLp2hp_zpk:
 
         z_hp, p_hp, k_hp = lp2hp_zpk(z, p, k, 5)
         assert_array_equal(z_hp, [0, 0])
-        assert_allclose(sort(p_hp), sort(p)*5)
-        assert_allclose(k_hp, 1)
+        xp_assert_close(sort(p_hp), sort(p)*5)
+        xp_assert_close(k_hp, 1.0)
 
         z = [-2j, +2j]
         p = [-0.75, -0.5-0.5j, -0.5+0.5j]
         k = 3
         z_hp, p_hp, k_hp = lp2hp_zpk(z, p, k, 6)
-        assert_allclose(sort(z_hp), sort([-3j, 0, +3j]))
-        assert_allclose(sort(p_hp), sort([-8, -6-6j, -6+6j]))
-        assert_allclose(k_hp, 32)
+        xp_assert_close(sort(z_hp), sort([-3j, 0, +3j]))
+        xp_assert_close(sort(p_hp), sort([-8, -6-6j, -6+6j]))
+        xp_assert_close(k_hp, 32.0)
 
 
 class TestLp2bp_zpk:
@@ -1421,14 +1443,14 @@ class TestLp2bp_zpk:
         p = [-0.75, -0.5-0.5j, -0.5+0.5j]
         k = 3
         z_bp, p_bp, k_bp = lp2bp_zpk(z, p, k, 15, 8)
-        assert_allclose(sort(z_bp), sort([-25j, -9j, 0, +9j, +25j]))
-        assert_allclose(sort(p_bp), sort([-3 + 6j*sqrt(6),
+        xp_assert_close(sort(z_bp), sort([-25j, -9j, 0, +9j, +25j]))
+        xp_assert_close(sort(p_bp), sort([-3 + 6j*sqrt(6),
                                           -3 - 6j*sqrt(6),
                                           +2j+sqrt(-8j-225)-2,
                                           -2j+sqrt(+8j-225)-2,
                                           +2j-sqrt(-8j-225)-2,
                                           -2j-sqrt(+8j-225)-2, ]))
-        assert_allclose(k_bp, 24)
+        xp_assert_close(k_bp, 24.0)
 
 
 class TestLp2bs_zpk:
@@ -1440,18 +1462,18 @@ class TestLp2bs_zpk:
 
         z_bs, p_bs, k_bs = lp2bs_zpk(z, p, k, 35, 12)
 
-        assert_allclose(sort(z_bs), sort([+35j, -35j,
+        xp_assert_close(sort(z_bs), sort([+35j, -35j,
                                           +3j+sqrt(1234)*1j,
                                           -3j+sqrt(1234)*1j,
                                           +3j-sqrt(1234)*1j,
                                           -3j-sqrt(1234)*1j]))
-        assert_allclose(sort(p_bs), sort([+3j*sqrt(129) - 8,
+        xp_assert_close(sort(p_bs), sort([+3j*sqrt(129) - 8,
                                           -3j*sqrt(129) - 8,
                                           (-6 + 6j) - sqrt(-1225 - 72j),
                                           (-6 - 6j) - sqrt(-1225 + 72j),
                                           (-6 + 6j) + sqrt(-1225 - 72j),
                                           (-6 - 6j) + sqrt(-1225 + 72j), ]))
-        assert_allclose(k_bs, 32)
+        xp_assert_close(k_bs, 32.0)
 
 
 class TestBilinear_zpk:
@@ -1463,12 +1485,12 @@ class TestBilinear_zpk:
 
         z_d, p_d, k_d = bilinear_zpk(z, p, k, 10)
 
-        assert_allclose(sort(z_d), sort([(20-2j)/(20+2j), (20+2j)/(20-2j),
+        xp_assert_close(sort(z_d), sort([(20-2j)/(20+2j), (20+2j)/(20-2j),
                                          -1]))
-        assert_allclose(sort(p_d), sort([77/83,
+        xp_assert_close(sort(p_d), sort([77/83,
                                          (1j/2 + 39/2) / (41/2 - 1j/2),
                                          (39/2 - 1j/2) / (1j/2 + 41/2), ]))
-        assert_allclose(k_d, 9696/69803)
+        xp_assert_close(k_d, 9696/69803)
 
 
 class TestPrototypeType:
@@ -1483,8 +1505,8 @@ class TestPrototypeType:
                      lambda N: ellipap(N, 1, 20)):
             for N in range(7):
                 z, p, k = func(N)
-                assert_(isinstance(z, np.ndarray))
-                assert_(isinstance(p, np.ndarray))
+                assert isinstance(z, np.ndarray)
+                assert isinstance(p, np.ndarray)
 
 
 def dB(x):
@@ -1507,8 +1529,9 @@ class TestButtord:
         assert_array_less(-rp, dB(h[w <= wp]))
         assert_array_less(dB(h[ws <= w]), -rs)
 
-        assert_equal(N, 16)
-        assert_allclose(Wn, 2.0002776782743284e-01, rtol=1e-15)
+        xp_assert_equal(N, 16)
+        xp_assert_close(Wn,
+                        2.0002776782743284e-01, rtol=1e-15)
 
     def test_highpass(self):
         wp = 0.3
@@ -1522,8 +1545,9 @@ class TestButtord:
         assert_array_less(-rp, dB(h[wp <= w]))
         assert_array_less(dB(h[w <= ws]), -rs)
 
-        assert_equal(N, 18)
-        assert_allclose(Wn, 2.9996603079132672e-01, rtol=1e-15)
+        xp_assert_equal(N, 18)
+        xp_assert_close(Wn,
+                        2.9996603079132672e-01, rtol=1e-15)
 
     def test_bandpass(self):
         wp = [0.2, 0.5]
@@ -1540,7 +1564,7 @@ class TestButtord:
                           -rs + 0.1)
 
         assert_equal(N, 18)
-        assert_allclose(Wn, [1.9998742411409134e-01, 5.0002139595676276e-01],
+        xp_assert_close(Wn, [1.9998742411409134e-01, 5.0002139595676276e-01],
                         rtol=1e-15)
 
     def test_bandstop(self):
@@ -1558,7 +1582,7 @@ class TestButtord:
                           -rs)
 
         assert_equal(N, 20)
-        assert_allclose(Wn, [1.4759432329294042e-01, 5.9997365985276407e-01],
+        xp_assert_close(Wn, [1.4759432329294042e-01, 5.9997365985276407e-01],
                         rtol=1e-6)
 
     def test_analog(self):
@@ -1573,11 +1597,11 @@ class TestButtord:
         assert_array_less(dB(h[ws <= w]), -rs)
 
         assert_equal(N, 7)
-        assert_allclose(Wn, 2.0006785355671877e+02, rtol=1e-15)
+        xp_assert_close(Wn, 2.0006785355671877e+02, rtol=1e-15)
 
         n, Wn = buttord(1, 550/450, 1, 26, analog=True)
         assert_equal(n, 19)
-        assert_allclose(Wn, 1.0361980524629517, rtol=1e-15)
+        xp_assert_close(Wn, 1.0361980524629517, rtol=1e-15)
 
         assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
 
@@ -1596,7 +1620,7 @@ class TestButtord:
                           -rs + 0.1)
 
         assert_equal(N, 18)
-        assert_allclose(Wn, [4409.722701715714, 11025.47178084662],
+        xp_assert_close(Wn, [4409.722701715714, 11025.47178084662],
                         rtol=1e-15)
 
     def test_invalid_input(self):
@@ -1649,7 +1673,7 @@ class TestCheb1ord:
         assert_array_less(dB(h[ws <= w]), -rs + 0.1)
 
         assert_equal(N, 8)
-        assert_allclose(Wn, 0.2, rtol=1e-15)
+        xp_assert_close(Wn, 0.2, rtol=1e-15)
 
     def test_highpass(self):
         wp = 0.3
@@ -1664,7 +1688,7 @@ class TestCheb1ord:
         assert_array_less(dB(h[w <= ws]), -rs + 0.1)
 
         assert_equal(N, 9)
-        assert_allclose(Wn, 0.3, rtol=1e-15)
+        xp_assert_close(Wn, 0.3, rtol=1e-15)
 
     def test_bandpass(self):
         wp = [0.2, 0.5]
@@ -1681,7 +1705,7 @@ class TestCheb1ord:
                           -rs + 0.1)
 
         assert_equal(N, 9)
-        assert_allclose(Wn, [0.2, 0.5], rtol=1e-15)
+        xp_assert_close(Wn, [0.2, 0.5], rtol=1e-15)
 
     def test_bandstop(self):
         wp = [0.1, 0.6]
@@ -1698,7 +1722,7 @@ class TestCheb1ord:
                           -rs + 0.1)
 
         assert_equal(N, 10)
-        assert_allclose(Wn, [0.14758232569947785, 0.6], rtol=1e-5)
+        xp_assert_close(Wn, [0.14758232569947785, 0.6], rtol=1e-5)
 
     def test_analog(self):
         wp = 700
@@ -1712,7 +1736,7 @@ class TestCheb1ord:
         assert_array_less(dB(h[w <= ws]), -rs + 0.1)
 
         assert_equal(N, 4)
-        assert_allclose(Wn, 700, rtol=1e-15)
+        xp_assert_close(Wn, 700.0, rtol=1e-15)
 
         assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
 
@@ -1729,7 +1753,7 @@ class TestCheb1ord:
         assert_array_less(dB(h[ws <= w]), -rs + 0.1)
 
         assert_equal(N, 8)
-        assert_allclose(Wn, 4800, rtol=1e-15)
+        xp_assert_close(Wn, 4800.0, rtol=1e-15)
 
     def test_invalid_input(self):
         with pytest.raises(ValueError) as exc_info:
@@ -1779,7 +1803,7 @@ class TestCheb2ord:
         assert_array_less(dB(h[ws <= w]), -rs + 0.1)
 
         assert_equal(N, 8)
-        assert_allclose(Wn, 0.28647639976553163, rtol=1e-15)
+        xp_assert_close(Wn, 0.28647639976553163, rtol=1e-15)
 
     def test_highpass(self):
         wp = 0.3
@@ -1794,7 +1818,7 @@ class TestCheb2ord:
         assert_array_less(dB(h[w <= ws]), -rs + 0.1)
 
         assert_equal(N, 9)
-        assert_allclose(Wn, 0.20697492182903282, rtol=1e-15)
+        xp_assert_close(Wn, 0.20697492182903282, rtol=1e-15)
 
     def test_bandpass(self):
         wp = [0.2, 0.5]
@@ -1811,7 +1835,7 @@ class TestCheb2ord:
                           -rs + 0.1)
 
         assert_equal(N, 9)
-        assert_allclose(Wn, [0.14876937565923479, 0.59748447842351482],
+        xp_assert_close(Wn, [0.14876937565923479, 0.59748447842351482],
                         rtol=1e-15)
 
     def test_bandstop(self):
@@ -1829,7 +1853,7 @@ class TestCheb2ord:
                           -rs + 0.1)
 
         assert_equal(N, 10)
-        assert_allclose(Wn, [0.19926249974781743, 0.50125246585567362],
+        xp_assert_close(Wn, [0.19926249974781743, 0.50125246585567362],
                         rtol=1e-6)
 
     def test_analog(self):
@@ -1846,7 +1870,7 @@ class TestCheb2ord:
                           -rs + 0.1)
 
         assert_equal(N, 11)
-        assert_allclose(Wn, [1.673740595370124e+01, 5.974641487254268e+01],
+        xp_assert_close(Wn, [1.673740595370124e+01, 5.974641487254268e+01],
                         rtol=1e-15)
 
     def test_fs_param(self):
@@ -1862,7 +1886,7 @@ class TestCheb2ord:
         assert_array_less(dB(h[w <= ws]), -rs + 0.1)
 
         assert_equal(N, 9)
-        assert_allclose(Wn, 103.4874609145164, rtol=1e-15)
+        xp_assert_close(Wn, 103.4874609145164, rtol=1e-15)
 
     def test_invalid_input(self):
         with pytest.raises(ValueError) as exc_info:
@@ -1912,7 +1936,7 @@ class TestEllipord:
         assert_array_less(dB(h[ws <= w]), -rs + 0.1)
 
         assert_equal(N, 5)
-        assert_allclose(Wn, 0.2, rtol=1e-15)
+        xp_assert_close(Wn, 0.2, rtol=1e-15)
 
     def test_lowpass_1000dB(self):
         # failed when ellipkm1 wasn't used in ellipord and ellipap
@@ -1940,7 +1964,7 @@ class TestEllipord:
         assert_array_less(dB(h[w <= ws]), -rs + 0.1)
 
         assert_equal(N, 6)
-        assert_allclose(Wn, 0.3, rtol=1e-15)
+        xp_assert_close(Wn, 0.3, rtol=1e-15)
 
     def test_bandpass(self):
         wp = [0.2, 0.5]
@@ -1957,7 +1981,7 @@ class TestEllipord:
                           -rs + 0.1)
 
         assert_equal(N, 6)
-        assert_allclose(Wn, [0.2, 0.5], rtol=1e-15)
+        xp_assert_close(Wn, [0.2, 0.5], rtol=1e-15)
 
     def test_bandstop(self):
         wp = [0.1, 0.6]
@@ -1974,7 +1998,7 @@ class TestEllipord:
                           -rs + 0.1)
 
         assert_equal(N, 7)
-        assert_allclose(Wn, [0.14758232794342988, 0.6], rtol=1e-5)
+        xp_assert_close(Wn, [0.14758232794342988, 0.6], rtol=1e-5)
 
     def test_analog(self):
         wp = [1000, 6000]
@@ -1990,7 +2014,7 @@ class TestEllipord:
                           -rs + 0.1)
 
         assert_equal(N, 8)
-        assert_allclose(Wn, [1666.6666, 6000])
+        xp_assert_close(Wn, [1666.6666, 6000])
 
         assert_equal(ellipord(1, 1.2, 1, 80, analog=True)[0], 9)
 
@@ -2009,7 +2033,7 @@ class TestEllipord:
                           -rs + 0.1)
 
         assert_equal(N, 7)
-        assert_allclose(Wn, [590.3293117737195, 2400], rtol=1e-5)
+        xp_assert_close(Wn, [590.3293117737195, 2400], rtol=1e-5)
 
     def test_invalid_input(self):
         with pytest.raises(ValueError) as exc_info:
@@ -2052,13 +2076,13 @@ class TestBessel:
 
             # 1-order filter is same for all types
             b, a = bessel(1, 1, analog=True, norm=norm)
-            assert_allclose(b, [1], rtol=1e-15)
-            assert_allclose(a, [1, 1], rtol=1e-15)
+            xp_assert_close(b, np.asarray([1.0]), rtol=1e-15)
+            xp_assert_close(a, np.asarray([1.0, 1]), rtol=1e-15)
 
             z, p, k = bessel(1, 0.3, analog=True, output='zpk', norm=norm)
-            assert_array_equal(z, [])
-            assert_allclose(p, [-0.3], rtol=1e-14)
-            assert_allclose(k, 0.3, rtol=1e-14)
+            assert_array_equal(z, np.asarray([]))
+            xp_assert_close(p, np.asarray([-0.3+0j]), rtol=1e-14)
+            xp_assert_close(k, 0.3, rtol=1e-14)
 
     def test_high_order(self):
         # high even order, 'phase'
@@ -2080,9 +2104,9 @@ class TestBessel:
              ]
         k2 = 9.999999999999989e+47
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
-        assert_allclose(k, k2, rtol=1e-14)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(k, k2, rtol=1e-14)
 
         # high odd order, 'phase'
         z, p, k = bessel(23, 1000, analog=True, output='zpk')
@@ -2102,9 +2126,9 @@ class TestBessel:
              -9.066732476324988e+02]
         k2 = 9.999999999999983e+68
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
-        assert_allclose(k, k2, rtol=1e-14)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(k, k2, rtol=1e-14)
 
         # high even order, 'delay' (Orchard 1965 "The Roots of the
         # Maximally Flat-Delay Polynomials" Table 1)
@@ -2126,8 +2150,8 @@ class TestBessel:
               - 8.005600 + 25.875019j,
               - 4.792045 + 28.406037j,
               ]
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
 
         # high odd order, 'delay'
         z, p, k = bessel(30, 1, analog=True, output='zpk', norm='delay')
@@ -2147,17 +2171,17 @@ class TestBessel:
               - 7.901170 + 24.924391j,
               - 4.734679 + 27.435615j,
               ]
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
 
     def test_refs(self):
         # Compare to http://www.crbond.com/papers/bsf2.pdf
         # "Delay Normalized Bessel Polynomial Coefficients"
-        bond_b = 10395
-        bond_a = [1, 21, 210, 1260, 4725, 10395, 10395]
+        bond_b = np.asarray([10395.0])
+        bond_a = np.asarray([1.0, 21, 210, 1260, 4725, 10395, 10395])
         b, a = bessel(6, 1, norm='delay', analog=True)
-        assert_allclose(bond_b, b)
-        assert_allclose(bond_a, a)
+        xp_assert_close(bond_b, b)
+        xp_assert_close(bond_a, a)
 
         # "Delay Normalized Bessel Pole Locations"
         bond_poles = {
@@ -2215,29 +2239,29 @@ class TestBessel:
 
         # Compare to https://www.ranecommercial.com/legacy/note147.html
         # "Table 1 - Bessel Crossovers of Second, Third, and Fourth-Order"
-        a = [1, 1, 1/3]
+        a = np.asarray([1, 1, 1/3])
         b2, a2 = bessel(2, 1, norm='delay', analog=True)
-        assert_allclose(a[::-1], a2/b2)
+        xp_assert_close(a[::-1], a2/b2)
 
-        a = [1, 1, 2/5, 1/15]
+        a = np.asarray([1, 1, 2/5, 1/15])
         b2, a2 = bessel(3, 1, norm='delay', analog=True)
-        assert_allclose(a[::-1], a2/b2)
+        xp_assert_close(a[::-1], a2/b2)
 
-        a = [1, 1, 9/21, 2/21, 1/105]
+        a = np.asarray([1, 1, 9/21, 2/21, 1/105])
         b2, a2 = bessel(4, 1, norm='delay', analog=True)
-        assert_allclose(a[::-1], a2/b2)
+        xp_assert_close(a[::-1], a2/b2)
 
-        a = [1, np.sqrt(3), 1]
+        a = np.asarray([1, np.sqrt(3), 1])
         b2, a2 = bessel(2, 1, norm='phase', analog=True)
-        assert_allclose(a[::-1], a2/b2)
+        xp_assert_close(a[::-1], a2/b2)
 
         # TODO: Why so inaccurate?  Is reference flawed?
-        a = [1, 2.481, 2.463, 1.018]
+        a = np.asarray([1, 2.481, 2.463, 1.018])
         b2, a2 = bessel(3, 1, norm='phase', analog=True)
         assert_array_almost_equal(a[::-1], a2/b2, decimal=1)
 
         # TODO: Why so inaccurate?  Is reference flawed?
-        a = [1, 3.240, 4.5, 3.240, 1.050]
+        a = np.asarray([1, 3.240, 4.5, 3.240, 1.050])
         b2, a2 = bessel(4, 1, norm='phase', analog=True)
         assert_array_almost_equal(a[::-1], a2/b2, decimal=1)
 
@@ -2434,7 +2458,8 @@ class TestBessel:
             p1 = sorted(np.union1d(originals[N],
                                    np.conj(originals[N])), key=np.imag)
             p2 = sorted(besselap(N)[1], key=np.imag)
-            assert_allclose(p1, p2, rtol=1e-14)
+            xp_assert_close(np.asarray(p1),
+                            np.asarray(p2), rtol=1e-14, check_dtype=False)
 
     def test_norm_phase(self):
         # Test some orders and frequencies and see that they have the right
@@ -2445,7 +2470,7 @@ class TestBessel:
                 w = np.linspace(0, w0, 100)
                 w, h = freqs(b, a, w)
                 phase = np.unwrap(np.angle(h))
-                assert_allclose(phase[[0, -1]], (0, -N*pi/4), rtol=1e-1)
+                xp_assert_close(phase[[0, -1]], (0, -N*pi/4), rtol=1e-1)
 
     def test_norm_mag(self):
         # Test some orders and frequencies and see that they have the right
@@ -2456,7 +2481,7 @@ class TestBessel:
                 w = (0, w0)
                 w, h = freqs(b, a, w)
                 mag = abs(h)
-                assert_allclose(mag, (1, 1/np.sqrt(2)))
+                xp_assert_close(mag, (1, 1/np.sqrt(2)))
 
     def test_norm_delay(self):
         # Test some orders and frequencies and see that they have the right
@@ -2467,11 +2492,11 @@ class TestBessel:
                 w = np.linspace(0, 10*w0, 1000)
                 w, h = freqs(b, a, w)
                 delay = -np.diff(np.unwrap(np.angle(h)))/np.diff(w)
-                assert_allclose(delay[0], 1/w0, rtol=1e-4)
+                xp_assert_close(delay[0], 1/w0, rtol=1e-4)
 
     def test_norm_factor(self):
         mpmath_values = {
-            1: 1, 2: 1.361654128716130520, 3: 1.755672368681210649,
+            1: 1.0, 2: 1.361654128716130520, 3: 1.755672368681210649,
             4: 2.113917674904215843, 5: 2.427410702152628137,
             6: 2.703395061202921876, 7: 2.951722147038722771,
             8: 3.179617237510651330, 9: 3.391693138911660101,
@@ -2487,7 +2512,7 @@ class TestBessel:
             }
         for N in mpmath_values:
             z, p, k = besselap(N, 'delay')
-            assert_allclose(mpmath_values[N], _norm_factor(p, k), rtol=1e-13)
+            xp_assert_close(mpmath_values[N], _norm_factor(p, k), rtol=1e-13)
 
     def test_bessel_poly(self):
         assert_array_equal(_bessel_poly(5), [945, 945, 420, 105, 15, 1])
@@ -2512,14 +2537,16 @@ class TestBessel:
                         for btype in ('lp', 'hp'):
                             ba1 = bessel(N, fc, btype, norm=norm, fs=fs)
                             ba2 = bessel(N, fc/(fs/2), btype, norm=norm)
-                            assert_allclose(ba1, ba2)
+                            for ba1_, ba2_ in zip(ba1, ba2):
+                                xp_assert_close(ba1_, ba2_)
                     for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                         for btype in ('bp', 'bs'):
                             ba1 = bessel(N, fc, btype, norm=norm, fs=fs)
                             for seq in (list, tuple, array):
                                 fcnorm = seq([f/(fs/2) for f in fc])
                                 ba2 = bessel(N, fcnorm, btype, norm=norm)
-                                assert_allclose(ba1, ba2)
+                                for ba1_, ba2_ in zip(ba1, ba2):
+                                    xp_assert_close(ba1_, ba2_)
 
 
 class TestButter:
@@ -2537,8 +2564,8 @@ class TestButter:
 
         z, p, k = butter(1, 0.3, output='zpk')
         assert_array_equal(z, [-1])
-        assert_allclose(p, [3.249196962329063e-01], rtol=1e-14)
-        assert_allclose(k, 3.375401518835469e-01, rtol=1e-14)
+        xp_assert_close(p, [3.249196962329063e-01 + 0j], rtol=1e-14)
+        xp_assert_close(k, 3.375401518835469e-01, rtol=1e-14)
 
     def test_basic(self):
         # analog s-plane
@@ -2624,9 +2651,9 @@ class TestButter:
             ]
         k2 = 1.446671081817286e-06
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-7)
-        assert_allclose(k, k2, rtol=1e-10)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-7)
+        xp_assert_close(k, k2, rtol=1e-10)
 
         # highpass, high odd order
         z, p, k = butter(27, 0.56, 'high', output='zpk')
@@ -2662,9 +2689,9 @@ class TestButter:
             ]
         k2 = 9.585686688851069e-09
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-8)
-        assert_allclose(k, k2)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-8)
+        xp_assert_close(k, k2)
 
     def test_bandpass(self):
         z, p, k = butter(8, [0.25, 0.33], 'band', output='zpk')
@@ -2690,9 +2717,9 @@ class TestButter:
             ]
         k2 = 3.398854055800844e-08
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=1e-13)
 
         # bandpass analog
         z, p, k = butter(4, [90.5, 110.5], 'bp', analog=True, output='zpk')
@@ -2709,8 +2736,9 @@ class TestButter:
             ]
         k2 = 1.600000000000001e+05
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag), sorted(p2, key=np.imag))
-        assert_allclose(k, k2, rtol=1e-15)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)))
+        xp_assert_close(k, k2, rtol=1e-15)
 
     def test_bandstop(self):
         z, p, k = butter(7, [0.45, 0.56], 'stop', output='zpk')
@@ -2743,9 +2771,11 @@ class TestButter:
               -1.357545000491310e-02 + 8.382287744986582e-01j,
               -1.357545000491310e-02 - 8.382287744986582e-01j]
         k2 = 4.577122512960063e-01
-        assert_allclose(sorted(z, key=np.imag), sorted(z2, key=np.imag))
-        assert_allclose(sorted(p, key=np.imag), sorted(p2, key=np.imag))
-        assert_allclose(k, k2, rtol=1e-14)
+        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
+                        np.asarray(sorted(z2, key=np.imag)))
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)))
+        xp_assert_close(k, k2, rtol=1e-14)
 
     def test_ba_output(self):
         b, a = butter(4, [100, 300], 'bandpass', analog=True)
@@ -2755,8 +2785,8 @@ class TestButter:
               1.519411254969542e+10, 2.038238225207147e+12,
               2.309116882454312e+14, 1.411088002066486e+16,
               8.099999999999991e+17]
-        assert_allclose(b, b2, rtol=1e-14)
-        assert_allclose(a, a2, rtol=1e-14)
+        xp_assert_close(b, b2, rtol=1e-14)
+        xp_assert_close(a, a2, rtol=1e-14)
 
     def test_fs_param(self):
         for fs in (900, 900.1, 1234.567):
@@ -2765,14 +2795,16 @@ class TestButter:
                     for btype in ('lp', 'hp'):
                         ba1 = butter(N, fc, btype, fs=fs)
                         ba2 = butter(N, fc/(fs/2), btype)
-                        assert_allclose(ba1, ba2)
+                        for ba1_, ba2_ in zip(ba1, ba2):
+                            xp_assert_close(ba1_, ba2_)
                 for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                     for btype in ('bp', 'bs'):
                         ba1 = butter(N, fc, btype, fs=fs)
                         for seq in (list, tuple, array):
                             fcnorm = seq([f/(fs/2) for f in fc])
                             ba2 = butter(N, fcnorm, btype)
-                            assert_allclose(ba1, ba2)
+                            for ba1_, ba2_ in zip(ba1, ba2):
+                                xp_assert_close(ba1_, ba2_)
 
 
 class TestCheby1:
@@ -2791,8 +2823,8 @@ class TestCheby1:
 
         z, p, k = cheby1(1, 0.1, 0.3, output='zpk')
         assert_array_equal(z, [-1])
-        assert_allclose(p, [-5.390126972799615e-01], rtol=1e-14)
-        assert_allclose(k, 7.695063486399808e-01, rtol=1e-14)
+        xp_assert_close(p, [-5.390126972799615e-01 + 0j], rtol=1e-14)
+        xp_assert_close(k, 7.695063486399808e-01, rtol=1e-14)
 
     def test_basic(self):
         for N in range(25):
@@ -2889,9 +2921,9 @@ class TestCheby1:
               8.069756417293870e-01 - 5.862214589217275e-01j]
         k2 = 6.190427617192018e-04
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-10)
-        assert_allclose(k, k2, rtol=1e-10)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
+        xp_assert_close(k, k2, rtol=1e-10)
 
         # high odd order
         z, p, k = cheby1(23, 0.8, 0.3, 'high', output='zpk')
@@ -2921,9 +2953,9 @@ class TestCheby1:
               5.688812849391721e-01 - 8.086497795114683e-01j]
         k2 = 1.941697029206324e-05
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-10)
-        assert_allclose(k, k2, rtol=1e-10)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
+        xp_assert_close(k, k2, rtol=1e-10)
 
         z, p, k = cheby1(10, 1, 1000, 'high', analog=True, output='zpk')
         z2 = np.zeros(10)
@@ -2939,9 +2971,9 @@ class TestCheby1:
               -2.250315039031946e+01 - 1.001723931471477e+03j]
         k2 = 8.912509381337453e-01
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-15)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=1e-15)
 
     def test_bandpass(self):
         z, p, k = cheby1(8, 1, [0.3, 0.4], 'bp', output='zpk')
@@ -2964,9 +2996,9 @@ class TestCheby1:
               5.615189063336070e-01 - 8.100667803850766e-01j]
         k2 = 5.007028718074307e-09
         assert_array_equal(z, z2)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=1e-13)
 
     def test_bandstop(self):
         z, p, k = cheby1(7, 1, [0.5, 0.6], 'stop', output='zpk')
@@ -2999,11 +3031,11 @@ class TestCheby1:
               -3.072658345097743e-01 + 9.443589759799366e-01j,
               -3.072658345097743e-01 - 9.443589759799366e-01j]
         k2 = 3.619438310405028e-01
-        assert_allclose(sorted(z, key=np.imag),
-                        sorted(z2, key=np.imag), rtol=1e-13)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-13)
-        assert_allclose(k, k2, rtol=0, atol=5e-16)
+        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
+                        np.asarray(sorted(z2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=0, atol=5e-16)
 
     def test_ba_output(self):
         # with transfer function conversion,  without digital conversion
@@ -3022,8 +3054,8 @@ class TestCheby1:
               1.114411200988328e+20, 8.316815934908471e+21,
               1.169243442282517e+24
               ]
-        assert_allclose(b, b2, rtol=1e-14)
-        assert_allclose(a, a2, rtol=1e-14)
+        xp_assert_close(b, b2, rtol=1e-14)
+        xp_assert_close(a, a2, rtol=1e-14)
 
     def test_fs_param(self):
         for fs in (900, 900.1, 1234.567):
@@ -3032,15 +3064,16 @@ class TestCheby1:
                     for btype in ('lp', 'hp'):
                         ba1 = cheby1(N, 1, fc, btype, fs=fs)
                         ba2 = cheby1(N, 1, fc/(fs/2), btype)
-                        assert_allclose(ba1, ba2)
+                        for ba1_, ba2_ in zip(ba1, ba2):
+                            xp_assert_close(ba1_, ba2_)
                 for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                     for btype in ('bp', 'bs'):
                         ba1 = cheby1(N, 1, fc, btype, fs=fs)
                         for seq in (list, tuple, array):
                             fcnorm = seq([f/(fs/2) for f in fc])
                             ba2 = cheby1(N, 1, fcnorm, btype)
-                            assert_allclose(ba1, ba2)
-
+                            for ba1_, ba2_ in zip(ba1, ba2):
+                                xp_assert_close(ba1_, ba2_)
 
 class TestCheby2:
 
@@ -3058,8 +3091,8 @@ class TestCheby2:
 
         z, p, k = cheby2(1, 50, 0.3, output='zpk')
         assert_array_equal(z, [-1])
-        assert_allclose(p, [9.967826460175649e-01], rtol=1e-14)
-        assert_allclose(k, 1.608676991217512e-03, rtol=1e-14)
+        xp_assert_close(p, [9.967826460175649e-01 + 0j], rtol=1e-14)
+        xp_assert_close(k, 1.608676991217512e-03, rtol=1e-14)
 
     def test_basic(self):
         for N in range(25):
@@ -3147,11 +3180,11 @@ class TestCheby2:
               5.747812938519067e-01 + 6.643001536914696e-01j,
               5.747812938519067e-01 - 6.643001536914696e-01j]
         k2 = 9.932997786497189e-02
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-13)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-12)
-        assert_allclose(k, k2, rtol=1e-11)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-12)
+        xp_assert_close(k, k2, rtol=1e-11)
 
         # high odd order
         z, p, k = cheby2(25, 80, 0.5, 'high', output='zpk')
@@ -3206,11 +3239,11 @@ class TestCheby2:
               6.857277464483946e-03 + 8.383275456264492e-01j,
               6.857277464483946e-03 - 8.383275456264492e-01j]
         k2 = 6.507068761705037e-03
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-13)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-12)
-        assert_allclose(k, k2, rtol=1e-11)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-12)
+        xp_assert_close(k, k2, rtol=1e-11)
 
     def test_bandpass(self):
         z, p, k = cheby2(9, 40, [0.07, 0.2], 'pass', output='zpk')
@@ -3251,11 +3284,11 @@ class TestCheby2:
               9.438104703725529e-01 + 2.193509900269860e-01j,
               9.438104703725529e-01 - 2.193509900269860e-01j]
         k2 = 9.345352824659604e-03
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-13)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-11)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=1e-11)
 
     def test_bandstop(self):
         z, p, k = cheby2(6, 55, [0.1, 0.9], 'stop', output='zpk')
@@ -3284,11 +3317,11 @@ class TestCheby2:
                8.715844103386721e-01 + 1.370665039509331e-01j,
                8.715844103386721e-01 - 1.370665039509331e-01j]
         k2 = 2.917823332763358e-03
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-13)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-11)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(k, k2, rtol=1e-11)
 
     def test_ba_output(self):
         # with transfer function conversion, without digital conversion
@@ -3305,8 +3338,8 @@ class TestCheby2:
               7.535048322653831e+20, 5.567966191263037e+22,
               1.589246884221346e+27, 5.871210648525566e+28,
               1.339913493808590e+33]
-        assert_allclose(b, b2, rtol=1e-14)
-        assert_allclose(a, a2, rtol=1e-14)
+        xp_assert_close(b, b2, rtol=1e-14)
+        xp_assert_close(a, a2, rtol=1e-14)
 
     def test_fs_param(self):
         for fs in (900, 900.1, 1234.567):
@@ -3315,14 +3348,16 @@ class TestCheby2:
                     for btype in ('lp', 'hp'):
                         ba1 = cheby2(N, 20, fc, btype, fs=fs)
                         ba2 = cheby2(N, 20, fc/(fs/2), btype)
-                        assert_allclose(ba1, ba2)
+                        for ba1_, ba2_ in zip(ba1, ba2):
+                            xp_assert_close(ba1_, ba2_)
                 for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                     for btype in ('bp', 'bs'):
                         ba1 = cheby2(N, 20, fc, btype, fs=fs)
                         for seq in (list, tuple, array):
                             fcnorm = seq([f/(fs/2) for f in fc])
                             ba2 = cheby2(N, 20, fcnorm, btype)
-                            assert_allclose(ba1, ba2)
+                            for ba1_, ba2_ in zip(ba1, ba2):
+                                xp_assert_close(ba1_, ba2_)
 
 class TestEllip:
 
@@ -3340,9 +3375,9 @@ class TestEllip:
         assert_array_almost_equal(a, [1, 1])
 
         z, p, k = ellip(1, 1, 55, 0.3, output='zpk')
-        assert_allclose(z, [-9.999999999999998e-01], rtol=1e-14)
-        assert_allclose(p, [-6.660721153525525e-04], rtol=1e-10)
-        assert_allclose(k, 5.003330360576763e-01, rtol=1e-14)
+        xp_assert_close(z, [-9.999999999999998e-01], rtol=1e-14)
+        xp_assert_close(p, [-6.660721153525525e-04], rtol=1e-10)
+        xp_assert_close(k, 5.003330360576763e-01, rtol=1e-14)
 
     def test_basic(self):
         for N in range(25):
@@ -3420,11 +3455,11 @@ class TestEllip:
                5.877753105317594e-01 + 8.090050577978136e-01j,
                5.877753105317594e-01 - 8.090050577978136e-01j]
         k2 = 4.918081266957108e-02
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-4)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-4)
-        assert_allclose(k, k2, rtol=1e-3)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(k, k2, rtol=1e-3)
 
         # high odd order
         z, p, k = ellip(23, 1, 70, 0.5, 'high', output='zpk')
@@ -3475,11 +3510,11 @@ class TestEllip:
               -6.948417068525226e-07 + 9.999882737700173e-01j,
               -6.948417068525226e-07 - 9.999882737700173e-01j]
         k2 = 1.220910020289434e-02
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-4)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-4)
-        assert_allclose(k, k2, rtol=1e-3)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(k, k2, rtol=1e-3)
 
     def test_bandpass(self):
         z, p, k = ellip(7, 1, 40, [0.07, 0.2], 'pass', output='zpk')
@@ -3512,11 +3547,11 @@ class TestEllip:
               9.747235066273385e-01 + 2.178937926146544e-01j,
               9.747235066273385e-01 - 2.178937926146544e-01j]
         k2 = 8.354782670263239e-03
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-4)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-4)
-        assert_allclose(k, k2, rtol=1e-3)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(k, k2, rtol=1e-3)
 
         z, p, k = ellip(5, 1, 75, [90.5, 110.5], 'pass', True, 'zpk')
         z2 = [-5.583607317695175e-14 + 1.433755965989225e+02j,
@@ -3539,11 +3574,11 @@ class TestEllip:
               -7.230484977485752e-01 + 9.056598800801140e+01j,
               -7.230484977485752e-01 - 9.056598800801140e+01j]
         k2 = 3.774571622827070e-02
-        assert_allclose(sorted(z, key=np.imag),
-                        sorted(z2, key=np.imag), rtol=1e-4)
-        assert_allclose(sorted(p, key=np.imag),
-                        sorted(p2, key=np.imag), rtol=1e-6)
-        assert_allclose(k, k2, rtol=1e-3)
+        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
+                        np.asarray(sorted(z2, key=np.imag)), rtol=1e-4)
+        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
+                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-6)
+        xp_assert_close(k, k2, rtol=1e-3)
 
     def test_bandstop(self):
         z, p, k = ellip(8, 1, 65, [0.2, 0.4], 'stop', output='zpk')
@@ -3581,11 +3616,11 @@ class TestEllip:
                8.062787978834571e-01 + 5.855780880424964e-01j,
                8.062787978834571e-01 - 5.855780880424964e-01j]
         k2 = 2.068622545291259e-01
-        assert_allclose(sorted(z, key=np.angle),
-                        sorted(z2, key=np.angle), rtol=1e-6)
-        assert_allclose(sorted(p, key=np.angle),
-                        sorted(p2, key=np.angle), rtol=1e-5)
-        assert_allclose(k, k2, rtol=1e-5)
+        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
+                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-6)
+        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
+                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-5)
+        xp_assert_close(k, k2, rtol=1e-5)
 
     def test_ba_output(self):
         # with transfer function conversion,  without digital conversion
@@ -3606,8 +3641,8 @@ class TestEllip:
              2.791577695211466e+19, 7.241811142725384e+20,
              2.612380874940182e+23
              ]
-        assert_allclose(b, b2, rtol=1e-6)
-        assert_allclose(a, a2, rtol=1e-4)
+        xp_assert_close(b, b2, rtol=1e-6)
+        xp_assert_close(a, a2, rtol=1e-4)
 
     def test_fs_param(self):
         for fs in (900, 900.1, 1234.567):
@@ -3616,14 +3651,16 @@ class TestEllip:
                     for btype in ('lp', 'hp'):
                         ba1 = ellip(N, 1, 20, fc, btype, fs=fs)
                         ba2 = ellip(N, 1, 20, fc/(fs/2), btype)
-                        assert_allclose(ba1, ba2)
+                        for ba1_, ba2_ in zip(ba1, ba2):
+                            xp_assert_close(ba1_, ba2_)
                 for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                     for btype in ('bp', 'bs'):
                         ba1 = ellip(N, 1, 20, fc, btype, fs=fs)
                         for seq in (list, tuple, array):
                             fcnorm = seq([f/(fs/2) for f in fc])
                             ba2 = ellip(N, 1, 20, fcnorm, btype)
-                            assert_allclose(ba1, ba2)
+                            for ba1_, ba2_ in zip(ba1, ba2):
+                                xp_assert_close(ba1_, ba2_)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
@@ -3646,15 +3683,15 @@ def test_sos_consistency():
 
         b, a = func(2, *args, output='ba')
         sos = func(2, *args, output='sos')
-        assert_allclose(sos, [np.hstack((b, a))], err_msg=f"{name}(2,...)")
+        xp_assert_close(sos, [np.hstack((b, a))], err_msg=f"{name}(2,...)")
 
         zpk = func(3, *args, output='zpk')
         sos = func(3, *args, output='sos')
-        assert_allclose(sos, zpk2sos(*zpk), err_msg=f"{name}(3,...)")
+        xp_assert_close(sos, zpk2sos(*zpk), err_msg=f"{name}(3,...)")
 
         zpk = func(4, *args, output='zpk')
         sos = func(4, *args, output='sos')
-        assert_allclose(sos, zpk2sos(*zpk), err_msg=f"{name}(4,...)")
+        xp_assert_close(sos, zpk2sos(*zpk), err_msg=f"{name}(4,...)")
 
 
 class TestIIRNotch:
@@ -3672,8 +3709,8 @@ class TestIIRNotch:
              9.9373647e-01
              ]
 
-        assert_allclose(b, b2, rtol=1e-8)
-        assert_allclose(a, a2, rtol=1e-8)
+        xp_assert_close(b, b2, rtol=1e-8)
+        xp_assert_close(a, a2, rtol=1e-8)
 
     def test_frequency_response(self):
         # Get filter coefficients
@@ -3695,17 +3732,17 @@ class TestIIRNotch:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 0.3 and should be close to 1
-        assert_allclose(abs(hp[0]), 1, rtol=1e-2)
-        assert_allclose(abs(hp[4]), 1, rtol=1e-2)
+        xp_assert_close(abs(hp[0]), 1., rtol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[4]), 1., rtol=1e-2, check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to -3dB
-        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
-        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
 
         # hp[2] correspond to the frequency that should be removed
         # the frequency response should be very close to 0
-        assert_allclose(abs(hp[2]), 0, atol=1e-10)
+        xp_assert_close(abs(hp[2]), 0.0, atol=1e-10, check_0d=False)
 
     def test_errors(self):
         # Exception should be raised if w0 > 1 or w0 <0
@@ -3737,17 +3774,17 @@ class TestIIRNotch:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 1500 and should be close to 1
-        assert_allclose(abs(hp[0]), 1, rtol=1e-2)
-        assert_allclose(abs(hp[4]), 1, rtol=1e-2)
+        xp_assert_close(abs(hp[0]), np.ones_like(abs(hp[0])), rtol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[4]), np.ones_like(abs(hp[4])), rtol=1e-2, check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to -3dB
-        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
-        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
 
         # hp[2] correspond to the frequency that should be removed
         # the frequency response should be very close to 0
-        assert_allclose(abs(hp[2]), 0, atol=1e-10)
+        xp_assert_close(abs(hp[2]), 0., atol=1e-10, check_0d=False)
 
 
 class TestIIRPeak:
@@ -3764,8 +3801,8 @@ class TestIIRPeak:
              1.0000000e+00, -1.958421917e+00,
              9.9373647e-01
              ]
-        assert_allclose(b, b2, rtol=1e-8)
-        assert_allclose(a, a2, rtol=1e-8)
+        xp_assert_close(b, b2, rtol=1e-8)
+        xp_assert_close(a, a2, rtol=1e-8)
 
     def test_frequency_response(self):
         # Get filter coefficients
@@ -3787,17 +3824,19 @@ class TestIIRPeak:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 0.3 and should be close to 0
-        assert_allclose(abs(hp[0]), 0, atol=1e-2)
-        assert_allclose(abs(hp[4]), 0, atol=1e-2)
+        xp_assert_close(abs(hp[0]),
+                        np.zeros_like(abs(hp[0])), atol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[4]),
+                        np.zeros_like(abs(hp[4])), atol=1e-2, check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to 10**(-3/20)
-        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
-        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
 
         # hp[2] correspond to the frequency that should be retained and
         # the frequency response should be very close to 1
-        assert_allclose(abs(hp[2]), 1, rtol=1e-10)
+        xp_assert_close(abs(hp[2]), 1.0, rtol=1e-10, check_0d=False)
 
     def test_errors(self):
         # Exception should be raised if w0 > 1 or w0 <0
@@ -3829,17 +3868,20 @@ class TestIIRPeak:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 1200 and should be close to 0
-        assert_allclose(abs(hp[0]), 0, atol=1e-2)
-        assert_allclose(abs(hp[4]), 0, atol=1e-2)
+        xp_assert_close(abs(hp[0]),
+                        np.zeros_like(abs(hp[0])), atol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[4]),
+                        np.zeros_like(abs(hp[4])), atol=1e-2, check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to 10**(-3/20)
-        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
-        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        xp_assert_close(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
 
         # hp[2] correspond to the frequency that should be retained and
         # the frequency response should be very close to 1
-        assert_allclose(abs(hp[2]), 1, rtol=1e-10)
+        xp_assert_close(abs(hp[2]),
+                        np.ones_like(abs(hp[2])), rtol=1e-10, check_0d=False)
 
 
 class TestIIRComb:
@@ -3885,7 +3927,7 @@ class TestIIRComb:
 
         # Verify that the first notch sits at 1000 Hz
         comb1 = comb_points[0]
-        assert_allclose(freqs[comb1], 1000)
+        xp_assert_close(freqs[comb1], np.asarray(1000.), check_0d=False)
 
     # Verify pass_zero parameter
     @pytest.mark.parametrize('ftype,pass_zero,peak,notch',
@@ -3913,8 +3955,8 @@ class TestIIRComb:
     def test_iir_symmetry(self):
         b, a = iircomb(400, 30, fs=24000)
         z, p, k = tf2zpk(b, a)
-        assert_array_equal(sorted(z), sorted(z.conj()))
-        assert_array_equal(sorted(p), sorted(p.conj()))
+        assert_array_equal(np.asarray(sorted(z)), np.asarray(sorted(z.conj())))
+        assert_array_equal(np.asarray(sorted(p)), np.asarray(sorted(p.conj())))
         assert_equal(k, np.real(k))
 
         assert issubclass(b.dtype.type, np.floating)
@@ -3927,16 +3969,16 @@ class TestIIRComb:
                     0.0, 0.0, 0.0, 0.0, -0.957020174408697]
         a_notch2 = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0, 0.0, 0.0, -0.914040348817395]
-        assert_allclose(b_notch, b_notch2)
-        assert_allclose(a_notch, a_notch2)
+        xp_assert_close(b_notch, b_notch2)
+        xp_assert_close(a_notch, a_notch2)
 
         b_peak, a_peak = iircomb(60, 35, ftype='peak', fs=600)
         b_peak2 = [0.0429798255913026, 0.0, 0.0, 0.0, 0.0, 0.0,
                    0.0, 0.0, 0.0, 0.0, -0.0429798255913026]
         a_peak2 = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                    0.0, 0.0, 0.0, 0.0, 0.914040348817395]
-        assert_allclose(b_peak, b_peak2)
-        assert_allclose(a_peak, a_peak2)
+        xp_assert_close(b_peak, b_peak2)
+        xp_assert_close(a_peak, a_peak2)
 
     # Verify that https://github.com/scipy/scipy/issues/14043 is fixed
     def test_nearest_divisor(self):
@@ -4090,8 +4132,10 @@ class TestIIRFilter:
             for ftype in ('butter', 'bessel', 'cheby1', 'cheby2', 'ellip'):
                 z, p, k = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='zpk')
-                assert_array_equal(sorted(z), sorted(z.conj()))
-                assert_array_equal(sorted(p), sorted(p.conj()))
+                assert_array_equal(np.asarray(sorted(z)),
+                                   np.asarray(sorted(z.conj())))
+                assert_array_equal(np.asarray(sorted(p)),
+                                   np.asarray(sorted(p.conj())))
                 assert_equal(k, np.real(k))
 
                 b, a = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
@@ -4105,7 +4149,7 @@ class TestIIRFilter:
         k = iirfilter(24, 100, btype='low', analog=True, ftype='bessel',
                       output='zpk')[2]
         k2 = 9.999999999999989e+47
-        assert_allclose(k, k2)
+        xp_assert_close(np.asarray(k),  np.asarray(k2))
         # if fs is specified then the normalization of Wn to have 
         # 0 <= Wn <= 1 should not cause an integer overflow
         # the following line should not raise an exception
@@ -4173,7 +4217,7 @@ class TestGroupDelay:
         N = 100
         b = firwin(N + 1, 0.1)
         w, gd = group_delay((b, 1))
-        assert_allclose(gd, 0.5 * N)
+        xp_assert_close(gd, np.ones_like(gd)*(0.5 * N))
 
     def test_iir(self):
         # Let's design Butterworth filter and test the group delay at
@@ -4319,8 +4363,10 @@ class TestGammatone:
             freq_hz = freqs[np.argmax(np.abs(response))] / ((2 * np.pi) / fs)
 
             # Check that the peak magnitude is 1 and the frequency is 1000 Hz.
-            assert_allclose(response_max, 1, rtol=1e-2)
-            assert_allclose(freq_hz, 1000, rtol=1e-2)
+            xp_assert_close(response_max,
+                            np.ones_like(response_max), rtol=1e-2, check_0d=False)
+            xp_assert_close(freq_hz,
+                            1000*np.ones_like(freq_hz), rtol=1e-2, check_0d=False)
 
     # All built-in IIR filters are real, so should have perfectly
     # symmetrical poles and zeros. Then ba representation (using
@@ -4348,7 +4394,7 @@ class TestGammatone:
               2.9293319149544e-02, 2.852976858014e-02,
               2.6176557156294e-02, 2.2371510270395e-02,
               1.7332485267759e-02]
-        assert_allclose(b, b2)
+        xp_assert_close(b, b2)
 
     # Verify IIR filter coefficients with the paper's MATLAB implementation
     def test_iir_ba_output(self):
@@ -4361,8 +4407,8 @@ class TestGammatone:
               60.2667361289181, -46.9399590980486,
               22.9474798808461, -6.43799381299034,
               0.793651554625368]
-        assert_allclose(b, b2)
-        assert_allclose(a, a2)
+        xp_assert_close(b, b2)
+        xp_assert_close(a, a2)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
@@ -4383,7 +4429,7 @@ class TestOrderFilter:
              [0., 10., 11., 12., 0.],
              [0., 0., 0., 0., 0.]],
         )
-        assert_allclose(order_filter(x, domain, 0), expected)
+        xp_assert_close(order_filter(x, domain, 0), expected, check_dtype=False)
 
         # maximum of elements 1,3,9 (zero-padded) on phone pad
         # 7,5,3 on numpad
@@ -4394,7 +4440,7 @@ class TestOrderFilter:
              [21., 22., 23., 24., 19.],
              [20., 21., 22., 23., 24.]],
         )
-        assert_allclose(order_filter(x, domain, 2), expected)
+        xp_assert_close(order_filter(x, domain, 2), expected, check_dtype=False)
 
         # and, just to complete the set, median of zero-padded elements
         expected = np.array(
@@ -4404,7 +4450,7 @@ class TestOrderFilter:
              [15, 16, 17, 18, 13],
              [0, 15, 16, 17, 18]],
         )
-        assert_allclose(order_filter(x, domain, 1), expected)
+        xp_assert_close(order_filter(x, domain, 1), expected)
 
     def test_medfilt_order_filter(self):
         x = np.arange(25).reshape(5, 5)
@@ -4418,9 +4464,9 @@ class TestOrderFilter:
              [11, 16, 17, 18, 14],
              [0, 16, 17, 18, 0]],
         )
-        assert_allclose(medfilt(x, 3), expected)
+        xp_assert_close(medfilt(x, 3), expected)
 
-        assert_allclose(
+        xp_assert_close(
             order_filter(x, np.ones((3, 3)), 4),
             expected
         )
@@ -4440,7 +4486,7 @@ class TestOrderFilter:
              [0, 10, 11, 12, 13],
              [0, 15, 16, 17, 18]]
         )
-        assert_allclose(order_filter(x, domain, 0), expected)
+        xp_assert_close(order_filter(x, domain, 0), expected)
 
         expected = np.array(
             [[0, 0, 0, 0, 0],
@@ -4449,4 +4495,4 @@ class TestOrderFilter:
              [10, 11, 12, 13, 14],
              [15, 16, 17, 18, 19]]
         )
-        assert_allclose(order_filter(x, domain, 1), expected)
+        xp_assert_close(order_filter(x, domain, 1), expected)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2,14 +2,15 @@ import warnings
 
 from scipy._lib import _pep440
 import numpy as np
-from numpy.testing import (assert_array_almost_equal,
-                           assert_array_almost_equal_nulp,
-                           assert_array_equal, assert_array_less,
-                           assert_equal, assert_,
-                           assert_warns, suppress_warnings)
+from numpy.testing import (
+    assert_array_almost_equal_nulp, assert_warns, suppress_warnings
+)
 import pytest
 from pytest import raises as assert_raises
-from scipy._lib._array_api import (xp_assert_close, xp_assert_equal, xp_assert_less)
+from scipy._lib._array_api import (
+    xp_assert_close, xp_assert_equal, xp_assert_less,
+    assert_array_almost_equal,
+)
 
 from numpy import array, spacing, sin, pi, sort, sqrt
 from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bilinear,
@@ -42,8 +43,8 @@ def mpmath_check(min_ver):
 class TestCplxPair:
 
     def test_trivial_input(self):
-        assert_equal(_cplxpair([]).size, 0)
-        assert_equal(_cplxpair(1), 1)
+        assert _cplxpair([]).size == 0
+        assert _cplxpair(1) == 1
 
     def test_output_order(self):
         xp_assert_close(_cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
@@ -78,7 +79,7 @@ class TestCplxPair:
         xp_assert_close(c[20000:], np.sort(c[20000:]))
 
     def test_real_integer_input(self):
-        assert_array_equal(_cplxpair([2, 0, 1]), [0, 1, 2])
+        xp_assert_equal(_cplxpair([2, 0, 1]), [0, 1, 2])
 
     def test_tolerances(self):
         eps = spacing(1)
@@ -112,8 +113,12 @@ class TestCplxPair:
 class TestCplxReal:
 
     def test_trivial_input(self):
-        assert_equal(_cplxreal([]), ([], []))
-        assert_equal(_cplxreal(1), ([], [1]))
+        assert all(x.size ==0 for x in _cplxreal([]))
+
+        x = _cplxreal(1)
+        assert x[0].size == 0
+        xp_assert_equal(x[1], np.asarray([1]))
+
 
     def test_output_order(self):
         zc, zr = _cplxreal(np.roots(array([1, 0, 0, 1])))
@@ -139,7 +144,7 @@ class TestCplxReal:
         zc, zr = _cplxreal(z)
         xp_assert_close(zc, [1j, 1+1j, 1+2j, 1+3j, 2+3j, 2+4j, 3+7j, 4+1j,
                              4+2j])
-        assert_equal(zr, np.asarray([], dtype=zr.dtype))
+        xp_assert_equal(zr, np.asarray([]))
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
@@ -157,8 +162,8 @@ class TestCplxReal:
 
     def test_real_integer_input(self):
         zc, zr = _cplxreal([2, 0, 1, 4])
-        assert_array_equal(zc, [])
-        assert_array_equal(zr, [0, 1, 2, 4])
+        xp_assert_equal(zc, [])
+        xp_assert_equal(zr, [0, 1, 2, 4])
 
 
 class TestTf2zpk:
@@ -205,10 +210,10 @@ class TestZpk2Tf:
         # The test for the *type* of the return values is a regression
         # test for ticket #1095. In the case p=[], zpk2tf used to
         # return the scalar 1.0 instead of array([1.0]).
-        assert_array_equal(b, b_r)
-        assert_(isinstance(b, np.ndarray))
-        assert_array_equal(a, a_r)
-        assert_(isinstance(a, np.ndarray))
+        xp_assert_equal(b, b_r)
+        assert isinstance(b, np.ndarray)
+        xp_assert_equal(a, a_r)
+        assert isinstance(a, np.ndarray)
 
 
 class TestSos2Zpk:
@@ -553,7 +558,7 @@ class TestFreqs:
         for N in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
                   np.array(8)):
             w, h = freqs([1.0], [1.0], worN=N)
-            assert_equal(len(w), 8)
+            assert len(w) == 8
             assert_array_almost_equal(h, np.ones(8))
 
         # Measure at frequency 8 rad/sec
@@ -614,7 +619,7 @@ class TestFreqs_zpk:
         for N in (8, np.int8(8), np.int16(8), np.int32(8), np.int64(8),
                   np.array(8)):
             w, h = freqs_zpk([], [], 1, worN=N)
-            assert_equal(len(w), 8)
+            assert len(w) == 8
             assert_array_almost_equal(h, np.ones(8))
 
         # Measure at frequency 8 rad/sec
@@ -633,7 +638,7 @@ class TestFreqz:
         # requested.
         N = 100000
         w, h = freqz([1.0], worN=N)
-        assert_equal(w.shape, (N,))
+        assert w.shape == (N,)
 
     def test_basic(self):
         w, h = freqz([1.0], worN=8)
@@ -645,9 +650,9 @@ class TestFreqz:
 
         for a in [1, np.ones(2)]:
             w, h = freqz(np.ones(2), a, worN=0)
-            assert_equal(w.shape, (0,))
-            assert_equal(h.shape, (0,))
-            assert_equal(h.dtype, np.dtype('complex128'))
+            assert w.shape == (0,)
+            assert h.shape == (0,)
+            assert h.dtype == np.dtype('complex128')
 
         t = np.linspace(0, 1, 4, endpoint=False)
         for b, a, h_whole in zip(
@@ -786,7 +791,7 @@ class TestFreqz:
         for whole in [False, True]:
             for worN in [N, np.linspace(0, 1, N)]:
                 w, h = freqz(b, worN=worN, whole=whole)
-                assert_equal(w.size, N)
+                assert w.size == N
                 for k in range(N):
                     bk = b[:, k]
                     ww, hh = freqz(bk, worN=w[k], whole=whole)
@@ -802,7 +807,7 @@ class TestFreqz:
             for worN in [np.random.rand(6, 7), np.empty((6, 0))]:
                 w, h = freqz(b, a, worN=worN, whole=whole)
                 xp_assert_close(w, worN, rtol=1e-14)
-                assert_equal(h.shape, (2,) + worN.shape)
+                assert h.shape == (2,) + worN.shape
                 for k in range(2):
                     ww, hh = freqz(b[:, k, 0, 0], a[:, k, 0, 0],
                                    worN=worN.ravel(),
@@ -888,9 +893,9 @@ class TestFreqz:
 
         for a in [1, np.ones(2)]:
             w, h = freqz(np.ones(2), a, worN=0, include_nyquist=True)
-            assert_equal(w.shape, (0,))
-            assert_equal(h.shape, (0,))
-            assert_equal(h.dtype, np.dtype('complex128'))
+            assert w.shape == (0,)
+            assert h.shape == (0,)
+            assert h.dtype == np.dtype('complex128')
 
         w1, h1 = freqz([1.0], worN=8, whole = True, include_nyquist=True)
         w2, h2 = freqz([1.0], worN=8, whole = True, include_nyquist=False)
@@ -934,14 +939,14 @@ class Testfreqz_sos:
         sos = butter(4, 0.2, output='sos')
         w, h = freqz(b, a, worN=N)
         w2, h2 = freqz_sos(sos, worN=N)
-        assert_equal(w2, w)
+        xp_assert_equal(w2, w)
         xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
 
         b, a = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass')
         sos = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass', output='sos')
         w, h = freqz(b, a, worN=N)
         w2, h2 = freqz_sos(sos, worN=N)
-        assert_equal(w2, w)
+        xp_assert_equal(w2, w)
         xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
         # must have at least one section
         assert_raises(ValueError, freqz_sos, sos[:0])
@@ -981,7 +986,7 @@ class Testfreqz_sos:
         w /= np.pi
         xp_assert_close(dB[w <= 0.1], 0.0, atol=3.01, check_0d=False, check_shape=False)
         xp_assert_close(dB[w >= 0.6], 0.0, atol=3.01, check_0d=False, check_shape=False)
-        assert_array_less(dB[(w >= 0.2) & (w <= 0.5)], -149.9)
+        assert np.all(dB[(w >= 0.2) & (w <= 0.5)] < -149.9)
 
         # from cheb1ord
         N, Wn = cheb1ord(0.2, 0.3, 3, 40)
@@ -1001,7 +1006,7 @@ class Testfreqz_sos:
         w /= np.pi
         xp_assert_close(dB[w <= 0.2], 0.0, atol=1.01,
                         check_0d=False, check_shape=False)
-        assert_array_less(dB[w >= 0.3], -149.9)
+        assert np.all(dB[w >= 0.3] < -149.9)
 
         # adapted from ellipord
         N, Wn = ellipord(0.3, 0.2, 3, 60)
@@ -1034,10 +1039,8 @@ class Testfreqz_sos:
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
 
-        db014 = dB[(w > 0) & (w <= 0.14)]
-        xp_assert_less(db014, np.ones_like(db014) * (-99.9))
-        db06 = dB[w >= 0.6]
-        xp_assert_less(db06, np.ones_like(db06) * (-99.9))
+        assert np.all(dB[(w > 0) & (w <= 0.14)] < -99.9)
+        assert np.all(dB[w >= 0.6] < -99.9)
         db0205 = dB[(w >= 0.2) & (w <= 0.5)]
         xp_assert_close(db0205, np.zeros_like(db0205), atol=3.01)
 
@@ -1160,7 +1163,7 @@ class TestFreqz_zpk:
         # requested.
         N = 100000
         w, h = freqz_zpk([0.5], [0.5], 1.0, worN=N)
-        assert_equal(w.shape, (N,))
+        assert w.shape == (N,)
 
     def test_basic(self):
         w, h = freqz_zpk([0.5], [0.5], 1.0, worN=8)
@@ -1390,7 +1393,7 @@ class TestLp2lp_zpk:
         p = [(-1+1j)/np.sqrt(2), (-1-1j)/np.sqrt(2)]
         k = 1
         z_lp, p_lp, k_lp = lp2lp_zpk(z, p, k, 5)
-        assert_array_equal(z_lp, [])
+        xp_assert_equal(z_lp, [])
         xp_assert_close(sort(p_lp), sort(p)*5)
         xp_assert_close(k_lp, 25.)
 
@@ -1423,9 +1426,9 @@ class TestLp2hp_zpk:
         k = 1
 
         z_hp, p_hp, k_hp = lp2hp_zpk(z, p, k, 5)
-        assert_array_equal(z_hp, [0, 0])
+        xp_assert_equal(z_hp, np.asarray([0.0, 0.0]))
         xp_assert_close(sort(p_hp), sort(p)*5)
-        xp_assert_close(k_hp, 1.0)
+        xp_assert_close(np.asarray(k_hp), np.asarray(1.0))
 
         z = [-2j, +2j]
         p = [-0.75, -0.5-0.5j, -0.5+0.5j]
@@ -1526,10 +1529,10 @@ class TestButtord:
         b, a = butter(N, Wn, 'lowpass', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs)
+        assert np.all(-rp < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs)
 
-        xp_assert_equal(N, 16)
+        assert N == 16
         xp_assert_close(Wn,
                         2.0002776782743284e-01, rtol=1e-15)
 
@@ -1542,10 +1545,10 @@ class TestButtord:
         b, a = butter(N, Wn, 'highpass', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs)
+        assert np.all(-rp < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs)
 
-        xp_assert_equal(N, 18)
+        assert N == 18
         xp_assert_close(Wn,
                         2.9996603079132672e-01, rtol=1e-15)
 
@@ -1558,12 +1561,12 @@ class TestButtord:
         b, a = butter(N, Wn, 'bandpass', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+ 
+        assert np.all((-rp - 0.1) < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
 
-        assert_equal(N, 18)
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < (-rs + 0.1))
+
+        assert N == 18
         xp_assert_close(Wn, [1.9998742411409134e-01, 5.0002139595676276e-01],
                         rtol=1e-15)
 
@@ -1576,12 +1579,11 @@ class TestButtord:
         b, a = butter(N, Wn, 'bandstop', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs)
 
-        assert_equal(N, 20)
+        assert np.all(-rp < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs)
+
+        assert N == 20
         xp_assert_close(Wn, [1.4759432329294042e-01, 5.9997365985276407e-01],
                         rtol=1e-6)
 
@@ -1593,17 +1595,18 @@ class TestButtord:
         N, Wn = buttord(wp, ws, rp, rs, True)
         b, a = butter(N, Wn, 'lowpass', True)
         w, h = freqs(b, a)
-        assert_array_less(-rp, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs)
+        dbb = dB(h[w <= wp])
+        assert np.all(-rp < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs)
 
-        assert_equal(N, 7)
+        assert N == 7
         xp_assert_close(Wn, 2.0006785355671877e+02, rtol=1e-15)
 
         n, Wn = buttord(1, 550/450, 1, 26, analog=True)
-        assert_equal(n, 19)
+        assert n == 19
         xp_assert_close(Wn, 1.0361980524629517, rtol=1e-15)
 
-        assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
+        xp_assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
 
     def test_fs_param(self):
         wp = [4410, 11025]
@@ -1614,12 +1617,10 @@ class TestButtord:
         N, Wn = buttord(wp, ws, rp, rs, False, fs=fs)
         b, a = butter(N, Wn, 'bandpass', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
-        assert_equal(N, 18)
+        assert N == 18
         xp_assert_close(Wn, [4409.722701715714, 11025.47178084662],
                         rtol=1e-15)
 
@@ -1669,10 +1670,10 @@ class TestCheb1ord:
         b, a = cheby1(N, rp, Wn, 'low', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
-        assert_equal(N, 8)
+        assert N == 8
         xp_assert_close(Wn, 0.2, rtol=1e-15)
 
     def test_highpass(self):
@@ -1684,10 +1685,10 @@ class TestCheb1ord:
         b, a = cheby1(N, rp, Wn, 'high', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
-        assert_equal(N, 9)
+        assert N == 9
         xp_assert_close(Wn, 0.3, rtol=1e-15)
 
     def test_bandpass(self):
@@ -1699,12 +1700,10 @@ class TestCheb1ord:
         b, a = cheby1(N, rp, Wn, 'band', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
-        assert_equal(N, 9)
+        assert N == 9
         xp_assert_close(Wn, [0.2, 0.5], rtol=1e-15)
 
     def test_bandstop(self):
@@ -1716,12 +1715,10 @@ class TestCheb1ord:
         b, a = cheby1(N, rp, Wn, 'stop', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
-        assert_equal(N, 10)
+        assert N == 10
         xp_assert_close(Wn, [0.14758232569947785, 0.6], rtol=1e-5)
 
     def test_analog(self):
@@ -1732,13 +1729,13 @@ class TestCheb1ord:
         N, Wn = cheb1ord(wp, ws, rp, rs, True)
         b, a = cheby1(N, rp, Wn, 'high', True)
         w, h = freqs(b, a)
-        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
-        assert_equal(N, 4)
+        assert N == 4
         xp_assert_close(Wn, 700.0, rtol=1e-15)
 
-        assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
+        xp_assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
 
     def test_fs_param(self):
         wp = 4800
@@ -1749,10 +1746,10 @@ class TestCheb1ord:
         N, Wn = cheb1ord(wp, ws, rp, rs, False, fs=fs)
         b, a = cheby1(N, rp, Wn, 'low', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
-        assert_equal(N, 8)
+        assert N == 8
         xp_assert_close(Wn, 4800.0, rtol=1e-15)
 
     def test_invalid_input(self):
@@ -1799,10 +1796,10 @@ class TestCheb2ord:
         b, a = cheby2(N, rs, Wn, 'lp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
-        assert_equal(N, 8)
+        assert N == 8
         xp_assert_close(Wn, 0.28647639976553163, rtol=1e-15)
 
     def test_highpass(self):
@@ -1814,10 +1811,10 @@ class TestCheb2ord:
         b, a = cheby2(N, rs, Wn, 'hp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
-        assert_equal(N, 9)
+        assert N == 9
         xp_assert_close(Wn, 0.20697492182903282, rtol=1e-15)
 
     def test_bandpass(self):
@@ -1829,12 +1826,10 @@ class TestCheb2ord:
         b, a = cheby2(N, rs, Wn, 'bp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
-        assert_equal(N, 9)
+        assert N == 9
         xp_assert_close(Wn, [0.14876937565923479, 0.59748447842351482],
                         rtol=1e-15)
 
@@ -1847,12 +1842,10 @@ class TestCheb2ord:
         b, a = cheby2(N, rs, Wn, 'bs', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
-        assert_equal(N, 10)
+        assert N == 10
         xp_assert_close(Wn, [0.19926249974781743, 0.50125246585567362],
                         rtol=1e-6)
 
@@ -1864,12 +1857,10 @@ class TestCheb2ord:
         N, Wn = cheb2ord(wp, ws, rp, rs, True)
         b, a = cheby2(N, rs, Wn, 'bp', True)
         w, h = freqs(b, a)
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
-        assert_equal(N, 11)
+        assert N == 11
         xp_assert_close(Wn, [1.673740595370124e+01, 5.974641487254268e+01],
                         rtol=1e-15)
 
@@ -1882,10 +1873,10 @@ class TestCheb2ord:
         N, Wn = cheb2ord(wp, ws, rp, rs, False, fs=fs)
         b, a = cheby2(N, rs, Wn, 'hp', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
-        assert_equal(N, 9)
+        assert N == 9
         xp_assert_close(Wn, 103.4874609145164, rtol=1e-15)
 
     def test_invalid_input(self):
@@ -1932,10 +1923,10 @@ class TestEllipord:
         b, a = ellip(N, rp, rs, Wn, 'lp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
-        assert_equal(N, 5)
+        assert N == 5
         xp_assert_close(Wn, 0.2, rtol=1e-15)
 
     def test_lowpass_1000dB(self):
@@ -1948,8 +1939,8 @@ class TestEllipord:
         sos = ellip(N, rp, rs, Wn, 'lp', False, output='sos')
         w, h = freqz_sos(sos)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[w <= wp]))
-        assert_array_less(dB(h[ws <= w]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
     def test_highpass(self):
         wp = 0.3
@@ -1960,10 +1951,10 @@ class TestEllipord:
         b, a = ellip(N, rp, rs, Wn, 'hp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1, dB(h[wp <= w]))
-        assert_array_less(dB(h[w <= ws]), -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
-        assert_equal(N, 6)
+        assert N == 6
         xp_assert_close(Wn, 0.3, rtol=1e-15)
 
     def test_bandpass(self):
@@ -1975,12 +1966,10 @@ class TestEllipord:
         b, a = ellip(N, rp, rs, Wn, 'bp', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert_array_less(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
-        assert_equal(N, 6)
+        assert N == 6
         xp_assert_close(Wn, [0.2, 0.5], rtol=1e-15)
 
     def test_bandstop(self):
@@ -1992,12 +1981,10 @@ class TestEllipord:
         b, a = ellip(N, rp, rs, Wn, 'bs', False)
         w, h = freqz(b, a)
         w /= np.pi
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
-        assert_equal(N, 7)
+        assert N == 7
         xp_assert_close(Wn, [0.14758232794342988, 0.6], rtol=1e-5)
 
     def test_analog(self):
@@ -2008,15 +1995,13 @@ class TestEllipord:
         N, Wn = ellipord(wp, ws, rp, rs, True)
         b, a = ellip(N, rp, rs, Wn, 'bs', True)
         w, h = freqs(b, a)
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
-        assert_equal(N, 8)
+        assert N == 8
         xp_assert_close(Wn, [1666.6666, 6000])
 
-        assert_equal(ellipord(1, 1.2, 1, 80, analog=True)[0], 9)
+        assert ellipord(1, 1.2, 1, 80, analog=True)[0] == 9
 
     def test_fs_param(self):
         wp = [400, 2400]
@@ -2027,12 +2012,10 @@ class TestEllipord:
         N, Wn = ellipord(wp, ws, rp, rs, False, fs=fs)
         b, a = ellip(N, rp, rs, Wn, 'bs', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert_array_less(-rp - 0.1,
-                          dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert_array_less(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]),
-                          -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
-        assert_equal(N, 7)
+        assert N == 7
         xp_assert_close(Wn, [590.3293117737195, 2400], rtol=1e-5)
 
     def test_invalid_input(self):
@@ -2071,8 +2054,8 @@ class TestBessel:
         for norm in ('delay', 'phase', 'mag'):
             # 0-order filter is just a passthrough
             b, a = bessel(0, 1, analog=True, norm=norm)
-            assert_array_equal(b, [1])
-            assert_array_equal(a, [1])
+            xp_assert_equal(b, np.asarray([1.0]))
+            xp_assert_equal(a, np.asarray([1.0]))
 
             # 1-order filter is same for all types
             b, a = bessel(1, 1, analog=True, norm=norm)
@@ -2080,7 +2063,7 @@ class TestBessel:
             xp_assert_close(a, np.asarray([1.0, 1]), rtol=1e-15)
 
             z, p, k = bessel(1, 0.3, analog=True, output='zpk', norm=norm)
-            assert_array_equal(z, np.asarray([]))
+            xp_assert_equal(z, np.asarray([]))
             xp_assert_close(p, np.asarray([-0.3+0j]), rtol=1e-14)
             xp_assert_close(k, 0.3, rtol=1e-14)
 
@@ -2103,7 +2086,7 @@ class TestBessel:
              -2.433481337524861e+01 + 1.207298683731973e+02j,
              ]
         k2 = 9.999999999999989e+47
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
         xp_assert_close(k, k2, rtol=1e-14)
@@ -2125,7 +2108,7 @@ class TestBessel:
              -6.225903228776276e+02 + 8.301558302815096e+02j,
              -9.066732476324988e+02]
         k2 = 9.999999999999983e+68
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
         xp_assert_close(k, k2, rtol=1e-14)
@@ -2266,17 +2249,17 @@ class TestBessel:
         assert_array_almost_equal(a[::-1], a2/b2, decimal=1)
 
         # Table of -3 dB factors:
-        N, scale = 2, 1.272
+        N, scale = 2, np.asarray([1.272, 1.272], dtype=np.complex128)
         scale2 = besselap(N, 'mag')[1] / besselap(N, 'phase')[1]
-        assert_array_almost_equal(scale, scale2, decimal=3)
+        assert_array_almost_equal(scale2, scale, decimal=3)
 
         # TODO: Why so inaccurate?  Is reference flawed?
-        N, scale = 3, 1.413
+        N, scale = 3, np.asarray([1.413, 1.413, 1.413], dtype=np.complex128)
         scale2 = besselap(N, 'mag')[1] / besselap(N, 'phase')[1]
-        assert_array_almost_equal(scale, scale2, decimal=2)
+        assert_array_almost_equal(scale2, scale, decimal=2)
 
         # TODO: Why so inaccurate?  Is reference flawed?
-        N, scale = 4, 1.533
+        N, scale = 4, np.asarray([1.533]*4, dtype=np.complex128)
         scale2 = besselap(N, 'mag')[1] / besselap(N, 'phase')[1]
         assert_array_almost_equal(scale, scale2, decimal=1)
 
@@ -2515,11 +2498,11 @@ class TestBessel:
             xp_assert_close(mpmath_values[N], _norm_factor(p, k), rtol=1e-13)
 
     def test_bessel_poly(self):
-        assert_array_equal(_bessel_poly(5), [945, 945, 420, 105, 15, 1])
-        assert_array_equal(_bessel_poly(4, True), [1, 10, 45, 105, 105])
+        xp_assert_equal(_bessel_poly(5), [945, 945, 420, 105, 15, 1])
+        xp_assert_equal(_bessel_poly(4, True), [1, 10, 45, 105, 105])
 
     def test_bessel_zeros(self):
-        assert_array_equal(_bessel_zeros(0), [])
+        xp_assert_equal(_bessel_zeros(0), [])
 
     def test_invalid(self):
         assert_raises(ValueError, besselap, 5, 'nonsense')
@@ -2554,8 +2537,8 @@ class TestButter:
     def test_degenerate(self):
         # 0-order filter is just a passthrough
         b, a = butter(0, 1, analog=True)
-        assert_array_equal(b, [1])
-        assert_array_equal(a, [1])
+        xp_assert_equal(b, np.asarray([1.0]))
+        xp_assert_equal(a, np.asarray([1.0]))
 
         # 1-order filter is same for all types
         b, a = butter(1, 1, analog=True)
@@ -2563,7 +2546,7 @@ class TestButter:
         assert_array_almost_equal(a, [1, 1])
 
         z, p, k = butter(1, 0.3, output='zpk')
-        assert_array_equal(z, [-1])
+        xp_assert_equal(z, np.asarray([-1.0]))
         xp_assert_close(p, [3.249196962329063e-01 + 0j], rtol=1e-14)
         xp_assert_close(k, 3.375401518835469e-01, rtol=1e-14)
 
@@ -2573,18 +2556,18 @@ class TestButter:
             wn = 0.01
             z, p, k = butter(N, wn, 'low', analog=True, output='zpk')
             assert_array_almost_equal([], z)
-            assert_(len(p) == N)
+            assert len(p) == N
             # All poles should be at distance wn from origin
-            assert_array_almost_equal(wn, abs(p))
-            assert_(all(np.real(p) <= 0))  # No poles in right half of S-plane
+            assert_array_almost_equal(abs(p), np.asarray(wn))
+            assert all(np.real(p) <= 0)  # No poles in right half of S-plane
             assert_array_almost_equal(wn**N, k)
 
         # digital z-plane
         for N in range(25):
             wn = 0.01
             z, p, k = butter(N, wn, 'high', analog=False, output='zpk')
-            assert_array_equal(np.ones(N), z)  # All zeros exactly at DC
-            assert_(all(np.abs(p) <= 1))  # No poles outside unit circle
+            xp_assert_equal(np.ones(N), z)  # All zeros exactly at DC
+            assert all(np.abs(p) <= 1)  # No poles outside unit circle
 
         b1, a1 = butter(2, 1, analog=True)
         assert_array_almost_equal(b1, [1])
@@ -2650,7 +2633,7 @@ class TestButter:
             1.176516491045901e-01 - 2.546021573417188e-01j,
             ]
         k2 = 1.446671081817286e-06
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-7)
         xp_assert_close(k, k2, rtol=1e-10)
@@ -2688,7 +2671,7 @@ class TestButter:
             -9.452783117928215e-02
             ]
         k2 = 9.585686688851069e-09
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-8)
         xp_assert_close(k, k2)
@@ -2716,14 +2699,15 @@ class TestButter:
             6.521767004237027e-01 - 6.744414640183752e-01j,
             ]
         k2 = 3.398854055800844e-08
-        assert_array_equal(z, z2)
+        z2 = np.asarray(z2, dtype=z.dtype)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-13)
 
         # bandpass analog
         z, p, k = butter(4, [90.5, 110.5], 'bp', analog=True, output='zpk')
-        z2 = np.zeros(4)
+        z2 = np.zeros(4, dtype=z.dtype)
         p2 = [
             -4.179137760733086e+00 + 1.095935899082837e+02j,
             -4.179137760733086e+00 - 1.095935899082837e+02j,
@@ -2735,7 +2719,7 @@ class TestButter:
             -3.474530886568715e+00 - 9.111599925805801e+01j,
             ]
         k2 = 1.600000000000001e+05
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)))
         xp_assert_close(k, k2, rtol=1e-15)
@@ -2814,7 +2798,7 @@ class TestCheby1:
         # Even-order filters have DC gain of -rp dB
         b, a = cheby1(0, 10*np.log10(2), 1, analog=True)
         assert_array_almost_equal(b, [1/np.sqrt(2)])
-        assert_array_equal(a, [1])
+        xp_assert_equal(a, np.asarray([1.0]))
 
         # 1-order filter is same for all types
         b, a = cheby1(1, 10*np.log10(2), 1, analog=True)
@@ -2822,7 +2806,7 @@ class TestCheby1:
         assert_array_almost_equal(a, [1, 1])
 
         z, p, k = cheby1(1, 0.1, 0.3, output='zpk')
-        assert_array_equal(z, [-1])
+        xp_assert_equal(z, np.asarray([-1.0]))
         xp_assert_close(p, [-5.390126972799615e-01 + 0j], rtol=1e-14)
         xp_assert_close(k, 7.695063486399808e-01, rtol=1e-14)
 
@@ -2831,14 +2815,14 @@ class TestCheby1:
             wn = 0.01
             z, p, k = cheby1(N, 1, wn, 'low', analog=True, output='zpk')
             assert_array_almost_equal([], z)
-            assert_(len(p) == N)
-            assert_(all(np.real(p) <= 0))  # No poles in right half of S-plane
+            assert len(p) == N
+            assert all(np.real(p) <= 0)  # No poles in right half of S-plane
 
         for N in range(25):
             wn = 0.01
             z, p, k = cheby1(N, 1, wn, 'high', analog=False, output='zpk')
-            assert_array_equal(np.ones(N), z)  # All zeros exactly at DC
-            assert_(all(np.abs(p) <= 1))  # No poles outside unit circle
+            xp_assert_equal(np.ones(N), z)  # All zeros exactly at DC
+            assert all(np.abs(p) <= 1)  # No poles outside unit circle
 
         # Same test as TestNormalize
         b, a = cheby1(8, 0.5, 0.048)
@@ -2920,7 +2904,7 @@ class TestCheby1:
               8.069756417293870e-01 + 5.862214589217275e-01j,
               8.069756417293870e-01 - 5.862214589217275e-01j]
         k2 = 6.190427617192018e-04
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
         xp_assert_close(k, k2, rtol=1e-10)
@@ -2952,7 +2936,7 @@ class TestCheby1:
               5.688812849391721e-01 + 8.086497795114683e-01j,
               5.688812849391721e-01 - 8.086497795114683e-01j]
         k2 = 1.941697029206324e-05
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
         xp_assert_close(k, k2, rtol=1e-10)
@@ -2970,7 +2954,7 @@ class TestCheby1:
               -2.250315039031946e+01 + 1.001723931471477e+03j,
               -2.250315039031946e+01 - 1.001723931471477e+03j]
         k2 = 8.912509381337453e-01
-        assert_array_equal(z, z2)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-15)
@@ -2995,7 +2979,8 @@ class TestCheby1:
               5.615189063336070e-01 + 8.100667803850766e-01j,
               5.615189063336070e-01 - 8.100667803850766e-01j]
         k2 = 5.007028718074307e-09
-        assert_array_equal(z, z2)
+        z2 = np.asarray(z2, dtype=z.dtype)
+        xp_assert_equal(z, z2)
         xp_assert_close(np.asarray(sorted(p, key=np.imag)),
                         np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-13)
@@ -3081,8 +3066,8 @@ class TestCheby2:
         # 0-order filter is just a passthrough
         # Stopband ripple factor doesn't matter
         b, a = cheby2(0, 123.456, 1, analog=True)
-        assert_array_equal(b, [1])
-        assert_array_equal(a, [1])
+        xp_assert_equal(b, np.asarray([1.0]))
+        xp_assert_equal(a, np.asarray([1.0]))
 
         # 1-order filter is same for all types
         b, a = cheby2(1, 10*np.log10(2), 1, analog=True)
@@ -3090,7 +3075,7 @@ class TestCheby2:
         assert_array_almost_equal(a, [1, 1])
 
         z, p, k = cheby2(1, 50, 0.3, output='zpk')
-        assert_array_equal(z, [-1])
+        xp_assert_equal(z, np.asarray([-1], dtype=np.complex128))
         xp_assert_close(p, [9.967826460175649e-01 + 0j], rtol=1e-14)
         xp_assert_close(k, 1.608676991217512e-03, rtol=1e-14)
 
@@ -3098,13 +3083,13 @@ class TestCheby2:
         for N in range(25):
             wn = 0.01
             z, p, k = cheby2(N, 40, wn, 'low', analog=True, output='zpk')
-            assert_(len(p) == N)
-            assert_(all(np.real(p) <= 0))  # No poles in right half of S-plane
+            assert len(p) == N
+            assert all(np.real(p) <= 0)  # No poles in right half of S-plane
 
         for N in range(25):
             wn = 0.01
             z, p, k = cheby2(N, 40, wn, 'high', analog=False, output='zpk')
-            assert_(all(np.abs(p) <= 1))  # No poles outside unit circle
+            assert all(np.abs(p) <= 1)  # No poles outside unit circle
 
         B, A = cheby2(18, 100, 0.5)
         assert_array_almost_equal(B, [
@@ -3367,7 +3352,7 @@ class TestEllip:
         # Stopband ripple factor doesn't matter
         b, a = ellip(0, 10*np.log10(2), 123.456, 1, analog=True)
         assert_array_almost_equal(b, [1/np.sqrt(2)])
-        assert_array_equal(a, [1])
+        xp_assert_equal(a, np.asarray([1.0]))
 
         # 1-order filter is same for all types
         b, a = ellip(1, 10*np.log10(2), 1, 1, analog=True)
@@ -3383,13 +3368,13 @@ class TestEllip:
         for N in range(25):
             wn = 0.01
             z, p, k = ellip(N, 1, 40, wn, 'low', analog=True, output='zpk')
-            assert_(len(p) == N)
-            assert_(all(np.real(p) <= 0))  # No poles in right half of S-plane
+            assert len(p) == N
+            assert all(np.real(p) <= 0)  # No poles in right half of S-plane
 
         for N in range(25):
             wn = 0.01
             z, p, k = ellip(N, 1, 40, wn, 'high', analog=False, output='zpk')
-            assert_(all(np.abs(p) <= 1))  # No poles outside unit circle
+            assert all(np.abs(p) <= 1)  # No poles outside unit circle
 
         b3, a3 = ellip(5, 3, 26, 1, analog=True)
         assert_array_almost_equal(b3, [0.1420, 0, 0.3764, 0,
@@ -3955,9 +3940,9 @@ class TestIIRComb:
     def test_iir_symmetry(self):
         b, a = iircomb(400, 30, fs=24000)
         z, p, k = tf2zpk(b, a)
-        assert_array_equal(np.asarray(sorted(z)), np.asarray(sorted(z.conj())))
-        assert_array_equal(np.asarray(sorted(p)), np.asarray(sorted(p.conj())))
-        assert_equal(k, np.real(k))
+        xp_assert_equal(np.asarray(sorted(z)), np.asarray(sorted(z.conj())))
+        xp_assert_equal(np.asarray(sorted(p)), np.asarray(sorted(p.conj())))
+        xp_assert_equal(k, np.real(k))
 
         assert issubclass(b.dtype.type, np.floating)
         assert issubclass(a.dtype.type, np.floating)
@@ -4132,16 +4117,16 @@ class TestIIRFilter:
             for ftype in ('butter', 'bessel', 'cheby1', 'cheby2', 'ellip'):
                 z, p, k = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='zpk')
-                assert_array_equal(np.asarray(sorted(z)),
+                xp_assert_equal(np.asarray(sorted(z)),
                                    np.asarray(sorted(z.conj())))
-                assert_array_equal(np.asarray(sorted(p)),
+                xp_assert_equal(np.asarray(sorted(p)),
                                    np.asarray(sorted(p.conj())))
-                assert_equal(k, np.real(k))
+                xp_assert_equal(k, np.real(k))
 
                 b, a = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                  ftype=ftype, output='ba')
-                assert_(issubclass(b.dtype.type, np.floating))
-                assert_(issubclass(a.dtype.type, np.floating))
+                assert issubclass(b.dtype.type, np.floating)
+                assert issubclass(a.dtype.type, np.floating)
 
     def test_int_inputs(self):
         # Using integer frequency arguments and large N should not produce
@@ -4375,12 +4360,12 @@ class TestGammatone:
     def test_iir_symmetry(self):
         b, a = gammatone(440, 'iir', fs=24000)
         z, p, k = tf2zpk(b, a)
-        assert_array_equal(sorted(z), sorted(z.conj()))
-        assert_array_equal(sorted(p), sorted(p.conj()))
-        assert_equal(k, np.real(k))
+        xp_assert_equal(sorted(z), sorted(z.conj()))
+        xp_assert_equal(sorted(p), sorted(p.conj()))
+        xp_assert_equal(k, np.real(k))
 
-        assert_(issubclass(b.dtype.type, np.floating))
-        assert_(issubclass(a.dtype.type, np.floating))
+        assert issubclass(b.dtype.type, np.floating)
+        assert issubclass(a.dtype.type, np.floating)
 
     # Verify FIR filter coefficients with the paper's
     # Mathematica implementation

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -8,7 +8,7 @@ from numpy.testing import (
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (
-    xp_assert_close, xp_assert_equal, xp_assert_less,
+    xp_assert_close, xp_assert_equal,
     assert_array_almost_equal,
 )
 
@@ -113,7 +113,7 @@ class TestCplxPair:
 class TestCplxReal:
 
     def test_trivial_input(self):
-        assert all(x.size ==0 for x in _cplxreal([]))
+        assert all(x.size == 0 for x in _cplxreal([]))
 
         x = _cplxreal(1)
         assert x[0].size == 0
@@ -859,7 +859,7 @@ class TestFreqz:
             w1, h1 = freqz(b, a, w, fs=fs)
             w2, h2 = freqz(b, a, 2*pi*np.array(w)/fs)
             xp_assert_close(h1, h2)
-            xp_assert_close(np.asarray(w), w1, check_dtype=False)
+            xp_assert_close(w, w1, check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 7 (polyval) or 8 (fft) equally-spaced points
@@ -984,8 +984,8 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
-        xp_assert_close(dB[w <= 0.1], 0.0, atol=3.01, check_0d=False, check_shape=False)
-        xp_assert_close(dB[w >= 0.6], 0.0, atol=3.01, check_0d=False, check_shape=False)
+        xp_assert_close(dB[w <= 0.1], np.asarray(0.0), atol=3.01, check_shape=False)
+        xp_assert_close(dB[w >= 0.6], np.asarray(0.0), atol=3.01, check_shape=False)
         assert np.all(dB[(w >= 0.2) & (w <= 0.5)] < -149.9)
 
         # from cheb1ord
@@ -994,18 +994,18 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        xp_assert_close(20 * np.log10(h[w <= 0.2]), 0.0, atol=3.01,
-                        check_0d=False, check_shape=False)
-        xp_assert_close(h[w >= 0.3], 0., atol=1e-2,
-                        check_0d=False, check_shape=False)  # <= -40 dB
+        xp_assert_close(20 * np.log10(h[w <= 0.2]), np.asarray(0.0), atol=3.01,
+                        check_shape=False)
+        xp_assert_close(h[w >= 0.3], np.asarray(0.0), atol=1e-2,
+                        check_shape=False)  # <= -40 dB
 
         N, Wn = cheb1ord(0.2, 0.3, 1, 150)
         sos = cheby1(N, 1, Wn, 'low', output='sos')
         w, h = freqz_sos(sos)
         dB = 20*np.log10(np.abs(h))
         w /= np.pi
-        xp_assert_close(dB[w <= 0.2], 0.0, atol=1.01,
-                        check_0d=False, check_shape=False)
+        xp_assert_close(dB[w <= 0.2], np.asarray(0.0), atol=1.01,
+                        check_shape=False)
         assert np.all(dB[w >= 0.3] < -149.9)
 
         # adapted from ellipord
@@ -1014,10 +1014,10 @@ class Testfreqz_sos:
         w, h = freqz_sos(sos)
         h = np.abs(h)
         w /= np.pi
-        xp_assert_close(20 * np.log10(h[w >= 0.3]), 0.0, atol=3.01,
-                        check_0d=False, check_shape=False)
-        xp_assert_close(h[w <= 0.1], 0., atol=1.5e-3,
-                        check_0d=False, check_shape=False)  # <= -60 dB (approx)
+        xp_assert_close(20 * np.log10(h[w >= 0.3]), np.asarray(0.0), atol=3.01,
+                        check_shape=False)
+        xp_assert_close(h[w <= 0.1], np.asarray(0.0), atol=1.5e-3,
+                        check_shape=False)  # <= -60 dB (approx)
 
         # adapted from buttord
         N, Wn = buttord([0.2, 0.5], [0.14, 0.6], 3, 40)
@@ -1124,7 +1124,7 @@ class Testfreqz_sos:
             w1, h1 = freqz_sos(sos, w, fs=fs)
             w2, h2 = freqz_sos(sos, 2*pi*np.array(w)/fs)
             xp_assert_close(h1, h2)
-            xp_assert_close(np.asarray(w), np.asarray(w1), check_dtype=False)
+            xp_assert_close(w, w1, check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 7 (polyval) or 8 (fft) equally-spaced points
@@ -1228,7 +1228,7 @@ class TestFreqz_zpk:
             w1, h1 = freqz_zpk(z, p, k, w, fs=fs)
             w2, h2 = freqz_zpk(z, p, k, 2*pi*np.array(w)/fs)
             xp_assert_close(h1, h2)
-            xp_assert_close(np.asarray(w), w1, check_dtype=False)
+            xp_assert_close(w, w1, check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 8 equally-spaced points
@@ -1404,7 +1404,7 @@ class TestLp2lp_zpk:
         z_lp, p_lp, k_lp = lp2lp_zpk(z, p, k, 20)
         xp_assert_close(sort(z_lp), sort([-40j, +40j]))
         xp_assert_close(sort(p_lp), sort([-15, -10-10j, -10+10j]))
-        xp_assert_close(float(k_lp), 60.)
+        xp_assert_close(k_lp, 60.)
 
     def test_fs_validation(self):
         z = [-2j, +2j]
@@ -1428,7 +1428,7 @@ class TestLp2hp_zpk:
         z_hp, p_hp, k_hp = lp2hp_zpk(z, p, k, 5)
         xp_assert_equal(z_hp, np.asarray([0.0, 0.0]))
         xp_assert_close(sort(p_hp), sort(p)*5)
-        xp_assert_close(np.asarray(k_hp), np.asarray(1.0))
+        xp_assert_close(k_hp, 1.0)
 
         z = [-2j, +2j]
         p = [-0.75, -0.5-0.5j, -0.5+0.5j]
@@ -1595,7 +1595,6 @@ class TestButtord:
         N, Wn = buttord(wp, ws, rp, rs, True)
         b, a = butter(N, Wn, 'lowpass', True)
         w, h = freqs(b, a)
-        dbb = dB(h[w <= wp])
         assert np.all(-rp < dB(h[w <= wp]))
         assert np.all(dB(h[ws <= w]) < -rs)
 
@@ -2087,8 +2086,8 @@ class TestBessel:
              ]
         k2 = 9.999999999999989e+47
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
         xp_assert_close(k, k2, rtol=1e-14)
 
         # high odd order, 'phase'
@@ -2109,8 +2108,8 @@ class TestBessel:
              -9.066732476324988e+02]
         k2 = 9.999999999999983e+68
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
         xp_assert_close(k, k2, rtol=1e-14)
 
         # high even order, 'delay' (Orchard 1965 "The Roots of the
@@ -2133,8 +2132,8 @@ class TestBessel:
               - 8.005600 + 25.875019j,
               - 4.792045 + 28.406037j,
               ]
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
 
         # high odd order, 'delay'
         z, p, k = bessel(30, 1, analog=True, output='zpk', norm='delay')
@@ -2154,8 +2153,8 @@ class TestBessel:
               - 7.901170 + 24.924391j,
               - 4.734679 + 27.435615j,
               ]
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(np.union1d(p2, np.conj(p2)), key=np.imag)))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(np.union1d(p2, np.conj(p2)), key=np.imag))
 
     def test_refs(self):
         # Compare to http://www.crbond.com/papers/bsf2.pdf
@@ -2163,8 +2162,8 @@ class TestBessel:
         bond_b = np.asarray([10395.0])
         bond_a = np.asarray([1.0, 21, 210, 1260, 4725, 10395, 10395])
         b, a = bessel(6, 1, norm='delay', analog=True)
-        xp_assert_close(bond_b, b)
-        xp_assert_close(bond_a, a)
+        xp_assert_close(b, bond_b)
+        xp_assert_close(a, bond_a)
 
         # "Delay Normalized Bessel Pole Locations"
         bond_poles = {
@@ -2441,8 +2440,8 @@ class TestBessel:
             p1 = sorted(np.union1d(originals[N],
                                    np.conj(originals[N])), key=np.imag)
             p2 = sorted(besselap(N)[1], key=np.imag)
-            xp_assert_close(np.asarray(p1),
-                            np.asarray(p2), rtol=1e-14, check_dtype=False)
+            xp_assert_close(p1,
+                            p2, rtol=1e-14, check_dtype=False)
 
     def test_norm_phase(self):
         # Test some orders and frequencies and see that they have the right
@@ -2634,8 +2633,8 @@ class TestButter:
             ]
         k2 = 1.446671081817286e-06
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-7)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-7)
         xp_assert_close(k, k2, rtol=1e-10)
 
         # highpass, high odd order
@@ -2672,8 +2671,8 @@ class TestButter:
             ]
         k2 = 9.585686688851069e-09
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-8)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-8)
         xp_assert_close(k, k2)
 
     def test_bandpass(self):
@@ -2699,10 +2698,9 @@ class TestButter:
             6.521767004237027e-01 - 6.744414640183752e-01j,
             ]
         k2 = 3.398854055800844e-08
-        z2 = np.asarray(z2, dtype=z.dtype)
-        xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_equal(z, z2, check_dtype=False)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-13)
 
         # bandpass analog
@@ -2720,8 +2718,8 @@ class TestButter:
             ]
         k2 = 1.600000000000001e+05
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag))
         xp_assert_close(k, k2, rtol=1e-15)
 
     def test_bandstop(self):
@@ -2755,10 +2753,10 @@ class TestButter:
               -1.357545000491310e-02 + 8.382287744986582e-01j,
               -1.357545000491310e-02 - 8.382287744986582e-01j]
         k2 = 4.577122512960063e-01
-        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
-                        np.asarray(sorted(z2, key=np.imag)))
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)))
+        xp_assert_close(sorted(z, key=np.imag),
+                        sorted(z2, key=np.imag))
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag))
         xp_assert_close(k, k2, rtol=1e-14)
 
     def test_ba_output(self):
@@ -2905,8 +2903,8 @@ class TestCheby1:
               8.069756417293870e-01 - 5.862214589217275e-01j]
         k2 = 6.190427617192018e-04
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-10)
         xp_assert_close(k, k2, rtol=1e-10)
 
         # high odd order
@@ -2937,8 +2935,8 @@ class TestCheby1:
               5.688812849391721e-01 - 8.086497795114683e-01j]
         k2 = 1.941697029206324e-05
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-10)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-10)
         xp_assert_close(k, k2, rtol=1e-10)
 
         z, p, k = cheby1(10, 1, 1000, 'high', analog=True, output='zpk')
@@ -2955,8 +2953,8 @@ class TestCheby1:
               -2.250315039031946e+01 - 1.001723931471477e+03j]
         k2 = 8.912509381337453e-01
         xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-15)
 
     def test_bandpass(self):
@@ -2979,10 +2977,9 @@ class TestCheby1:
               5.615189063336070e-01 + 8.100667803850766e-01j,
               5.615189063336070e-01 - 8.100667803850766e-01j]
         k2 = 5.007028718074307e-09
-        z2 = np.asarray(z2, dtype=z.dtype)
-        xp_assert_equal(z, z2)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_equal(z, z2, check_dtype=False)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-13)
 
     def test_bandstop(self):
@@ -3016,10 +3013,10 @@ class TestCheby1:
               -3.072658345097743e-01 + 9.443589759799366e-01j,
               -3.072658345097743e-01 - 9.443589759799366e-01j]
         k2 = 3.619438310405028e-01
-        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
-                        np.asarray(sorted(z2, key=np.imag)), rtol=1e-13)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-13)
+        xp_assert_close(sorted(z, key=np.imag),
+                        sorted(z2, key=np.imag), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-13)
         xp_assert_close(k, k2, rtol=0, atol=5e-16)
 
     def test_ba_output(self):
@@ -3165,10 +3162,10 @@ class TestCheby2:
               5.747812938519067e-01 + 6.643001536914696e-01j,
               5.747812938519067e-01 - 6.643001536914696e-01j]
         k2 = 9.932997786497189e-02
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-12)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-12)
         xp_assert_close(k, k2, rtol=1e-11)
 
         # high odd order
@@ -3224,10 +3221,10 @@ class TestCheby2:
               6.857277464483946e-03 + 8.383275456264492e-01j,
               6.857277464483946e-03 - 8.383275456264492e-01j]
         k2 = 6.507068761705037e-03
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-12)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-12)
         xp_assert_close(k, k2, rtol=1e-11)
 
     def test_bandpass(self):
@@ -3269,10 +3266,10 @@ class TestCheby2:
               9.438104703725529e-01 + 2.193509900269860e-01j,
               9.438104703725529e-01 - 2.193509900269860e-01j]
         k2 = 9.345352824659604e-03
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-11)
 
     def test_bandstop(self):
@@ -3302,10 +3299,10 @@ class TestCheby2:
                8.715844103386721e-01 + 1.370665039509331e-01j,
                8.715844103386721e-01 - 1.370665039509331e-01j]
         k2 = 2.917823332763358e-03
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-13)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-13)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-13)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-13)
         xp_assert_close(k, k2, rtol=1e-11)
 
     def test_ba_output(self):
@@ -3440,10 +3437,10 @@ class TestEllip:
                5.877753105317594e-01 + 8.090050577978136e-01j,
                5.877753105317594e-01 - 8.090050577978136e-01j]
         k2 = 4.918081266957108e-02
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-4)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-4)
         xp_assert_close(k, k2, rtol=1e-3)
 
         # high odd order
@@ -3495,10 +3492,10 @@ class TestEllip:
               -6.948417068525226e-07 + 9.999882737700173e-01j,
               -6.948417068525226e-07 - 9.999882737700173e-01j]
         k2 = 1.220910020289434e-02
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-4)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-4)
         xp_assert_close(k, k2, rtol=1e-3)
 
     def test_bandpass(self):
@@ -3532,10 +3529,10 @@ class TestEllip:
               9.747235066273385e-01 + 2.178937926146544e-01j,
               9.747235066273385e-01 - 2.178937926146544e-01j]
         k2 = 8.354782670263239e-03
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-4)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-4)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-4)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-4)
         xp_assert_close(k, k2, rtol=1e-3)
 
         z, p, k = ellip(5, 1, 75, [90.5, 110.5], 'pass', True, 'zpk')
@@ -3559,10 +3556,10 @@ class TestEllip:
               -7.230484977485752e-01 + 9.056598800801140e+01j,
               -7.230484977485752e-01 - 9.056598800801140e+01j]
         k2 = 3.774571622827070e-02
-        xp_assert_close(np.asarray(sorted(z, key=np.imag)),
-                        np.asarray(sorted(z2, key=np.imag)), rtol=1e-4)
-        xp_assert_close(np.asarray(sorted(p, key=np.imag)),
-                        np.asarray(sorted(p2, key=np.imag)), rtol=1e-6)
+        xp_assert_close(sorted(z, key=np.imag),
+                        sorted(z2, key=np.imag), rtol=1e-4)
+        xp_assert_close(sorted(p, key=np.imag),
+                        sorted(p2, key=np.imag), rtol=1e-6)
         xp_assert_close(k, k2, rtol=1e-3)
 
     def test_bandstop(self):
@@ -3601,10 +3598,10 @@ class TestEllip:
                8.062787978834571e-01 + 5.855780880424964e-01j,
                8.062787978834571e-01 - 5.855780880424964e-01j]
         k2 = 2.068622545291259e-01
-        xp_assert_close(np.asarray(sorted(z, key=np.angle)),
-                        np.asarray(sorted(z2, key=np.angle)), rtol=1e-6)
-        xp_assert_close(np.asarray(sorted(p, key=np.angle)),
-                        np.asarray(sorted(p2, key=np.angle)), rtol=1e-5)
+        xp_assert_close(sorted(z, key=np.angle),
+                        sorted(z2, key=np.angle), rtol=1e-6)
+        xp_assert_close(sorted(p, key=np.angle),
+                        sorted(p2, key=np.angle), rtol=1e-5)
         xp_assert_close(k, k2, rtol=1e-5)
 
     def test_ba_output(self):
@@ -3717,8 +3714,8 @@ class TestIIRNotch:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 0.3 and should be close to 1
-        xp_assert_close(abs(hp[0]), 1., rtol=1e-2, check_0d=False)
-        xp_assert_close(abs(hp[4]), 1., rtol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[0]), np.asarray(1.), rtol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[4]), np.asarray(1.), rtol=1e-2, check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to -3dB
@@ -3727,7 +3724,7 @@ class TestIIRNotch:
 
         # hp[2] correspond to the frequency that should be removed
         # the frequency response should be very close to 0
-        xp_assert_close(abs(hp[2]), 0.0, atol=1e-10, check_0d=False)
+        xp_assert_close(abs(hp[2]), np.asarray(0.0), atol=1e-10, check_0d=False)
 
     def test_errors(self):
         # Exception should be raised if w0 > 1 or w0 <0
@@ -3759,8 +3756,10 @@ class TestIIRNotch:
         # Check if the frequency response fulfill the specifications:
         # hp[0] and hp[4]  correspond to frequencies distant from
         # w0 = 1500 and should be close to 1
-        xp_assert_close(abs(hp[0]), np.ones_like(abs(hp[0])), rtol=1e-2, check_0d=False)
-        xp_assert_close(abs(hp[4]), np.ones_like(abs(hp[4])), rtol=1e-2, check_0d=False)
+        xp_assert_close(abs(hp[0]), np.ones_like(abs(hp[0])), rtol=1e-2,
+                        check_0d=False)
+        xp_assert_close(abs(hp[4]), np.ones_like(abs(hp[4])), rtol=1e-2,
+                        check_0d=False)
 
         # hp[1] and hp[3] correspond to frequencies approximately
         # on the edges of the passband and should be close to -3dB
@@ -3769,7 +3768,7 @@ class TestIIRNotch:
 
         # hp[2] correspond to the frequency that should be removed
         # the frequency response should be very close to 0
-        xp_assert_close(abs(hp[2]), 0., atol=1e-10, check_0d=False)
+        xp_assert_close(abs(hp[2]), np.asarray(0.0), atol=1e-10, check_0d=False)
 
 
 class TestIIRPeak:
@@ -3821,7 +3820,7 @@ class TestIIRPeak:
 
         # hp[2] correspond to the frequency that should be retained and
         # the frequency response should be very close to 1
-        xp_assert_close(abs(hp[2]), 1.0, rtol=1e-10, check_0d=False)
+        xp_assert_close(abs(hp[2]), np.asarray(1.0), rtol=1e-10, check_0d=False)
 
     def test_errors(self):
         # Exception should be raised if w0 > 1 or w0 <0
@@ -3940,8 +3939,8 @@ class TestIIRComb:
     def test_iir_symmetry(self):
         b, a = iircomb(400, 30, fs=24000)
         z, p, k = tf2zpk(b, a)
-        xp_assert_equal(np.asarray(sorted(z)), np.asarray(sorted(z.conj())))
-        xp_assert_equal(np.asarray(sorted(p)), np.asarray(sorted(p.conj())))
+        xp_assert_equal(sorted(z), sorted(z.conj()))
+        xp_assert_equal(sorted(p), sorted(p.conj()))
         xp_assert_equal(k, np.real(k))
 
         assert issubclass(b.dtype.type, np.floating)
@@ -4117,10 +4116,10 @@ class TestIIRFilter:
             for ftype in ('butter', 'bessel', 'cheby1', 'cheby2', 'ellip'):
                 z, p, k = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='zpk')
-                xp_assert_equal(np.asarray(sorted(z)),
-                                   np.asarray(sorted(z.conj())))
-                xp_assert_equal(np.asarray(sorted(p)),
-                                   np.asarray(sorted(p.conj())))
+                xp_assert_equal(sorted(z),
+                                sorted(z.conj()))
+                xp_assert_equal(sorted(p),
+                                sorted(p.conj()))
                 xp_assert_equal(k, np.real(k))
 
                 b, a = iirfilter(N, 1.1, 1, 20, 'low', analog=True,

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -9,15 +9,16 @@ import pytest
 
 from scipy.fft import fft
 from scipy.special import sinc
-from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
+from scipy.signal import (kaiser_beta, kaiser_atten, kaiserord,
     firwin, firwin2, freqz, remez, firls, minimum_phase
+)
 
 
 def test_kaiser_beta():
     b = kaiser_beta(58.7)
-    assert_almost_equal(np.asarray(b), np.asarray(0.1102 * 50.0))
+    assert_almost_equal(b, 0.1102 * 50.0)
     b = kaiser_beta(22.0)
-    assert_almost_equal(np.asarray(b), np.asarray(0.5842 + 0.07886))
+    assert_almost_equal(b, 0.5842 + 0.07886)
     b = kaiser_beta(21.0)
     assert b == 0.0
     b = kaiser_beta(10.0)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -1,7 +1,9 @@
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_equal, assert_,
-                           assert_allclose, assert_warns)
+from numpy.testing import assert_warns
+from scipy._lib._array_api import (
+    xp_assert_close, xp_assert_equal,
+    assert_almost_equal, assert_array_almost_equal,
+)
 from pytest import raises as assert_raises
 import pytest
 
@@ -13,26 +15,26 @@ from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
 
 def test_kaiser_beta():
     b = kaiser_beta(58.7)
-    assert_almost_equal(b, 0.1102 * 50.0)
+    assert_almost_equal(np.asarray(b), np.asarray(0.1102 * 50.0))
     b = kaiser_beta(22.0)
-    assert_almost_equal(b, 0.5842 + 0.07886)
+    assert_almost_equal(np.asarray(b), np.asarray(0.5842 + 0.07886))
     b = kaiser_beta(21.0)
-    assert_equal(b, 0.0)
+    assert b == 0.0
     b = kaiser_beta(10.0)
-    assert_equal(b, 0.0)
+    assert b == 0.0
 
 
 def test_kaiser_atten():
     a = kaiser_atten(1, 1.0)
-    assert_equal(a, 7.95)
+    assert a == 7.95
     a = kaiser_atten(2, 1/np.pi)
-    assert_equal(a, 2.285 + 7.95)
+    assert a == 2.285 + 7.95
 
 
 def test_kaiserord():
     assert_raises(ValueError, kaiserord, 1.0, 1.0)
     numtaps, beta = kaiserord(2.285 + 7.95 - 0.001, 1/np.pi)
-    assert_equal((numtaps, beta), (2, 0.0))
+    assert (numtaps, beta) == (2, 0.0)
 
 
 class TestFirwin:
@@ -44,7 +46,7 @@ class TestFirwin:
         for freq, expected in expected_response:
             actual = abs(np.sum(h*np.exp(-1.j*np.pi*m*freq)))
             mse = abs(actual-expected)**2
-            assert_(mse < tol, f'response not as expected, mse={mse:g} > {tol:g}')
+            assert mse < tol, f'response not as expected, mse={mse:g} > {tol:g}'
 
     def test_response(self):
         N = 51
@@ -118,8 +120,8 @@ class TestFirwin:
                     cutoff = [0] + cutoff
                 else:
                     cutoff = cutoff + [1]
-            assert_(self.mse(h, [cutoff]) < self.mse(hs, [cutoff]),
-                'least squares violation')
+            msg = 'least squares violation'
+            assert self.mse(h, [cutoff]) < self.mse(hs, [cutoff]), msg
             self.check_response(hs, [expected_response], 1e-12)
 
     def test_fs_validation(self):
@@ -147,7 +149,7 @@ class TestFirWinMore:
                                     [1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='lowpass', **kwargs)
-        assert_allclose(taps, taps_str)
+        xp_assert_close(taps, taps_str)
 
     def test_highpass(self):
         width = 0.04
@@ -170,7 +172,7 @@ class TestFirWinMore:
                                     [0.0, 0.0, 0.0, 1.0, 1.0, 1.0], decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='highpass', **kwargs)
-        assert_allclose(taps, taps_str)
+        xp_assert_close(taps, taps_str)
 
     def test_bandpass(self):
         width = 0.04
@@ -190,7 +192,7 @@ class TestFirWinMore:
                 [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='bandpass', **kwargs)
-        assert_allclose(taps, taps_str)
+        xp_assert_close(taps, taps_str)
 
     def test_bandstop_multi(self):
         width = 0.04
@@ -213,7 +215,7 @@ class TestFirWinMore:
                 decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='bandstop', **kwargs)
-        assert_allclose(taps, taps_str)
+        xp_assert_close(taps, taps_str)
 
     def test_fs_nyq(self):
         """Test the fs and nyq keywords."""
@@ -401,7 +403,7 @@ class TestFirwin2:
         freq = [0.0, 0.5, 0.55, 1.0]
         gain = [0.0, 0.5, 0.0, 0.0]
         taps = firwin2(ntaps, freq, gain, window=None, antisymmetric=True)
-        assert_equal(taps[ntaps // 2], 0.0)
+        assert taps[ntaps // 2] == 0.0
         assert_array_almost_equal(taps[: ntaps // 2], -taps[ntaps // 2 + 1:][::-1])
 
         freqs, response1 = freqz(taps, worN=2048)
@@ -422,7 +424,7 @@ class TestFirwin2:
         freq1 = np.array([0.0, 0.5, 0.5, 1.0])
         freq2 = np.array(freq1)
         firwin2(80, freq1, [1.0, 1.0, 0.0, 0.0])
-        assert_equal(freq1, freq2)
+        xp_assert_equal(freq1, freq2)
 
 
 class TestRemez:
@@ -438,14 +440,14 @@ class TestRemez:
         h = remez(11, [a, 0.5-a], [1], type='hilbert')
 
         # make sure the filter has correct # of taps
-        assert_(len(h) == N, "Number of Taps")
+        assert len(h) == N, "Number of Taps"
 
         # make sure it is type III (anti-symmetric tap coefficients)
         assert_array_almost_equal(h[:(N-1)//2], -h[:-(N-1)//2-1:-1])
 
         # Since the requested response is symmetric, all even coefficients
         # should be zero (or in this case really small)
-        assert_((abs(h[1::2]) < 1e-15).all(), "Even Coefficients Equal Zero")
+        assert (abs(h[1::2]) < 1e-15).all(), "Even Coefficients Equal Zero"
 
         # now check the frequency response
         w, H = freqz(h, 1)
@@ -453,11 +455,11 @@ class TestRemez:
         Hmag = abs(H)
 
         # should have a zero at 0 and pi (in this case close to zero)
-        assert_((Hmag[[0, -1]] < 0.02).all(), "Zero at zero and pi")
+        assert (Hmag[[0, -1]] < 0.02).all(), "Zero at zero and pi"
 
         # check that the pass band is close to unity
         idx = np.logical_and(f > a, f < 0.5-a)
-        assert_((abs(Hmag[idx] - 1) < 0.015).all(), "Pass Band Close To Unity")
+        assert (abs(Hmag[idx] - 1) < 0.015).all(), "Pass Band Close To Unity"
 
     def test_compare(self):
         # test comparison to MATLAB
@@ -466,7 +468,7 @@ class TestRemez:
              0.373400753484939, 0.193140296954975, -0.003530911231040,
              -0.075943803756711, -0.041314581814658, 0.024590270518440]
         h = remez(12, [0, 0.3, 0.5, 1], [1, 0], fs=2.)
-        assert_allclose(h, k)
+        xp_assert_close(h, k)
 
         h = [-0.038976016082299, 0.018704846485491, -0.014644062687875,
              0.002879152556419, 0.016849978528150, -0.043276706138248,
@@ -475,7 +477,7 @@ class TestRemez:
              0.129770906801075, -0.103908158578635, 0.073641298245579,
              -0.043276706138248, 0.016849978528150, 0.002879152556419,
              -0.014644062687875, 0.018704846485491, -0.038976016082299]
-        assert_allclose(remez(21, [0, 0.8, 0.9, 1], [0, 1], fs=2.), h)
+        xp_assert_close(remez(21, [0, 0.8, 0.9, 1], [0, 1], fs=2.), h)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
@@ -510,7 +512,7 @@ class TestFirls:
         h = firls(11, [0, a, 0.5-a, 0.5], [1, 1, 0, 0], fs=1.0)
 
         # make sure the filter has correct # of taps
-        assert_equal(len(h), N)
+        assert h.shape[0] == N
 
         # make sure it is symmetric
         midx = (N-1) // 2
@@ -522,7 +524,7 @@ class TestFirls:
         # For halfband symmetric, odd coefficients (except the center)
         # should be zero (really small)
         hodd = np.hstack((h[1:midx:2], h[-midx+1::2]))
-        assert_array_almost_equal(hodd, 0)
+        assert_array_almost_equal(hodd, np.zeros_like(hodd))
 
         # now check the frequency response
         w, H = freqz(h, 1)
@@ -531,11 +533,11 @@ class TestFirls:
 
         # check that the pass band is close to unity
         idx = np.logical_and(f > 0, f < a)
-        assert_array_almost_equal(Hmag[idx], 1, decimal=3)
+        assert_array_almost_equal(Hmag[idx], np.ones_like(Hmag[idx]), decimal=3)
 
         # check that the stop band is close to zero
         idx = np.logical_and(f > 0.5-a, f < 0.5)
-        assert_array_almost_equal(Hmag[idx], 0, decimal=3)
+        assert_array_almost_equal(Hmag[idx], np.zeros_like(Hmag[idx]), decimal=3)
 
     def test_compare(self):
         # compare to OCTAVE output
@@ -546,7 +548,7 @@ class TestFirls:
                       5.11409425599933e-01, 3.17271686090449e-01,
                       -9.81576747564301e-03, -1.03354450635036e-01,
                       -6.26930101730182e-04]
-        assert_allclose(taps, known_taps)
+        xp_assert_close(taps, known_taps)
 
         # compare to MATLAB output
         taps = firls(11, [0, 0.5, 0.5, 1], [1, 1, 0, 0], weight=[1, 2])
@@ -556,7 +558,7 @@ class TestFirls:
             0.012403323025279, 0.317930861136062, 0.488047220029700,
             0.317930861136062, 0.012403323025279, -0.104688258464392,
             -0.014233383714318, 0.058545300496815]
-        assert_allclose(taps, known_taps)
+        xp_assert_close(taps, known_taps)
 
         # With linear changes:
         taps = firls(7, (0, 1, 2, 3, 4, 5), [1, 0, 0, 1, 1, 0], fs=20)
@@ -565,14 +567,16 @@ class TestFirls:
             1.156090832768218, -4.1385894727395849, 7.5288619164321826,
             -8.5530572592947856, 7.5288619164321826, -4.1385894727395849,
             1.156090832768218]
-        assert_allclose(taps, known_taps)
+        xp_assert_close(taps, known_taps)
 
     def test_rank_deficient(self):
         # solve() runs but warns (only sometimes, so here we don't use match)
         x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
         w, h = freqz(x, fs=2.)
-        assert_allclose(np.abs(h[:2]), 1., atol=1e-5)
-        assert_allclose(np.abs(h[-2:]), 0., atol=1e-6)
+        absh2 = np.abs(h[:2])
+        xp_assert_close(absh2, np.ones_like(absh2), atol=1e-5)
+        absh2 = np.abs(h[-2:])
+        xp_assert_close(absh2, np.zeros_like(absh2), atol=1e-6, rtol=1e-7)
         # switch to pinvh (tolerances could be higher with longer
         # filters, but using shorter ones is faster computationally and
         # the idea is the same)
@@ -580,10 +584,12 @@ class TestFirls:
         w, h = freqz(x, fs=2.)
         mask = w < 0.01
         assert mask.sum() > 3
-        assert_allclose(np.abs(h[mask]), 1., atol=1e-4)
+        habs = np.abs(h[mask])
+        xp_assert_close(habs, np.ones_like(habs), atol=1e-4)
         mask = w > 0.99
         assert mask.sum() > 3
-        assert_allclose(np.abs(h[mask]), 0., atol=1e-4)
+        habs = np.abs(h[mask])
+        xp_assert_close(habs, np.zeros_like(habs), atol=1e-4)
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
@@ -610,7 +616,7 @@ class TestMinimumPhase:
         # for some cases we can get the actual filter back
         h = [1, -1]
         h_new = minimum_phase(np.convolve(h, h[::-1]))
-        assert_allclose(h_new, h, rtol=0.05)
+        xp_assert_close(h_new, np.asarray(h, dtype=np.float64), rtol=0.05)
 
         # but in general we only guarantee we get the magnitude back
         rng = np.random.RandomState(0)
@@ -618,10 +624,10 @@ class TestMinimumPhase:
             h = rng.randn(n)
             h_linear = np.convolve(h, h[::-1])
             h_new = minimum_phase(h_linear)
-            assert_allclose(np.abs(fft(h_new)), np.abs(fft(h)), rtol=1e-4)
+            xp_assert_close(np.abs(fft(h_new)), np.abs(fft(h)), rtol=1e-4)
             h_new = minimum_phase(h_linear, half=False)
             assert len(h_linear) == len(h_new)
-            assert_allclose(np.abs(fft(h_new)), np.abs(fft(h_linear)), rtol=1e-4)
+            xp_assert_close(np.abs(fft(h_new)), np.abs(fft(h_linear)), rtol=1e-4)
 
     def test_hilbert(self):
         # compare to MATLAB output of reference implementation
@@ -633,7 +639,7 @@ class TestMinimumPhase:
         k = [0.349585548646686, 0.373552164395447, 0.326082685363438,
              0.077152207480935, -0.129943946349364, -0.059355880509749]
         m = minimum_phase(h, 'hilbert')
-        assert_allclose(m, k, rtol=5e-3)
+        xp_assert_close(m, k, rtol=5e-3)
 
         # f=[0 0.8 0.9 1];
         # a=[0 0 1 1];
@@ -644,4 +650,4 @@ class TestMinimumPhase:
              0.100787844523204, -0.065832656741252, 0.035361328741024,
              -0.014977068692269, -0.158416139047557]
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
-        assert_allclose(m, k, rtol=2e-3)
+        xp_assert_close(m, k, rtol=2e-3)

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1,9 +1,11 @@
 import warnings
 
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_, suppress_warnings)
+from numpy.testing import suppress_warnings
 from pytest import raises as assert_raises
+from scipy._lib._array_api import(
+    assert_almost_equal, xp_assert_equal, xp_assert_close
+)
 
 from scipy.signal import (ss2tf, tf2ss, lti,
                           dlti, bode, freqresp, lsim, impulse, step,
@@ -165,15 +167,15 @@ class TestPlacePoles:
         fsf = self._check(A, B, P)
         # rtol and nb_iter should be set to np.nan as the identity can be
         # used as transfer matrix
-        assert_equal(fsf.rtol, np.nan)
-        assert_equal(fsf.nb_iter, np.nan)
+        assert np.isnan(fsf.rtol)
+        assert np.isnan(fsf.nb_iter)
 
         # check with complex poles too as they trigger a specific case in
         # the specific case :-)
         P = np.array((-2+1j,-2-1j,-3,-2))
         fsf = self._check(A, B, P)
-        assert_equal(fsf.rtol, np.nan)
-        assert_equal(fsf.nb_iter, np.nan)
+        assert np.isnan(fsf.rtol)
+        assert np.isnan(fsf.nb_iter)
 
         #now test with a B matrix with only one column (no optimisation)
         B = B[:,0].reshape(4,1)
@@ -181,8 +183,8 @@ class TestPlacePoles:
         fsf = self._check(A, B, P)
 
         #  we can't optimize anything, check they are set to 0 as expected
-        assert_equal(fsf.rtol, 0)
-        assert_equal(fsf.nb_iter, 0)
+        assert fsf.rtol == 0
+        assert fsf.nb_iter == 0
 
     def test_errors(self):
         # Test input mistakes from user
@@ -231,11 +233,11 @@ class TestPlacePoles:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             fsf = place_poles(A, B, (-1,-2,-3,-4), rtol=1e-16, maxiter=42)
-            assert_(len(w) == 1)
-            assert_(issubclass(w[-1].category, UserWarning))
-            assert_("Convergence was not reached after maxiter iterations"
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert ("Convergence was not reached after maxiter iterations"
                     in str(w[-1].message))
-            assert_equal(fsf.nb_iter, 42)
+            assert fsf.nb_iter == 42
 
         # should fail as a complex misses its conjugate
         assert_raises(ValueError, place_poles, A, B, (-2+1j,-2-1j,-2+3j,-2))
@@ -271,95 +273,95 @@ class TestSS2TF:
         a = np.array([1.0, 2.0, 3.0])
 
         A, B, C, D = tf2ss(b, a)
-        assert_allclose(A, [[-2, -3], [1, 0]], rtol=1e-13)
-        assert_allclose(B, [[1], [0]], rtol=1e-13)
-        assert_allclose(C, [[1, 2]], rtol=1e-13)
-        assert_allclose(D, [[1]], rtol=1e-14)
+        xp_assert_close(A, [[-2., -3], [1, 0]], rtol=1e-13)
+        xp_assert_close(B, [[1.], [0]], rtol=1e-13)
+        xp_assert_close(C, [[1., 2]], rtol=1e-13)
+        xp_assert_close(D, [[1.]], rtol=1e-14)
 
         bb, aa = ss2tf(A, B, C, D)
-        assert_allclose(bb[0], b, rtol=1e-13)
-        assert_allclose(aa, a, rtol=1e-13)
+        xp_assert_close(bb[0], b, rtol=1e-13)
+        xp_assert_close(aa, a, rtol=1e-13)
 
     def test_zero_order_round_trip(self):
         # See gh-5760
         tf = (2, 1)
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[0]], rtol=1e-13)
-        assert_allclose(B, [[0]], rtol=1e-13)
-        assert_allclose(C, [[0]], rtol=1e-13)
-        assert_allclose(D, [[2]], rtol=1e-13)
+        xp_assert_close(A, [[0.]], rtol=1e-13)
+        xp_assert_close(B, [[0.]], rtol=1e-13)
+        xp_assert_close(C, [[0.]], rtol=1e-13)
+        xp_assert_close(D, [[2.]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[2, 0]], rtol=1e-13)
-        assert_allclose(den, [1, 0], rtol=1e-13)
+        xp_assert_close(num, [[2., 0]], rtol=1e-13)
+        xp_assert_close(den, [1., 0], rtol=1e-13)
 
         tf = ([[5], [2]], 1)
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[0]], rtol=1e-13)
-        assert_allclose(B, [[0]], rtol=1e-13)
-        assert_allclose(C, [[0], [0]], rtol=1e-13)
-        assert_allclose(D, [[5], [2]], rtol=1e-13)
+        xp_assert_close(A, [[0.]], rtol=1e-13)
+        xp_assert_close(B, [[0.]], rtol=1e-13)
+        xp_assert_close(C, [[0.], [0]], rtol=1e-13)
+        xp_assert_close(D, [[5.], [2]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[5, 0], [2, 0]], rtol=1e-13)
-        assert_allclose(den, [1, 0], rtol=1e-13)
+        xp_assert_close(num, [[5., 0], [2, 0]], rtol=1e-13)
+        xp_assert_close(den, [1., 0], rtol=1e-13)
 
     def test_simo_round_trip(self):
         # See gh-5753
         tf = ([[1, 2], [1, 1]], [1, 2])
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[-2]], rtol=1e-13)
-        assert_allclose(B, [[1]], rtol=1e-13)
-        assert_allclose(C, [[0], [-1]], rtol=1e-13)
-        assert_allclose(D, [[1], [1]], rtol=1e-13)
+        xp_assert_close(A, [[-2.]], rtol=1e-13)
+        xp_assert_close(B, [[1.]], rtol=1e-13)
+        xp_assert_close(C, [[0.], [-1.]], rtol=1e-13)
+        xp_assert_close(D, [[1.], [1.]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[1, 2], [1, 1]], rtol=1e-13)
-        assert_allclose(den, [1, 2], rtol=1e-13)
+        xp_assert_close(num, [[1., 2.], [1., 1.]], rtol=1e-13)
+        xp_assert_close(den, [1., 2.], rtol=1e-13)
 
         tf = ([[1, 0, 1], [1, 1, 1]], [1, 1, 1])
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[-1, -1], [1, 0]], rtol=1e-13)
-        assert_allclose(B, [[1], [0]], rtol=1e-13)
-        assert_allclose(C, [[-1, 0], [0, 0]], rtol=1e-13)
-        assert_allclose(D, [[1], [1]], rtol=1e-13)
+        xp_assert_close(A, [[-1., -1.], [1., 0.]], rtol=1e-13)
+        xp_assert_close(B, [[1.], [0.]], rtol=1e-13)
+        xp_assert_close(C, [[-1., 0.], [0., 0.]], rtol=1e-13)
+        xp_assert_close(D, [[1.], [1.]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[1, 0, 1], [1, 1, 1]], rtol=1e-13)
-        assert_allclose(den, [1, 1, 1], rtol=1e-13)
+        xp_assert_close(num, [[1., 0., 1.], [1., 1., 1.]], rtol=1e-13)
+        xp_assert_close(den, [1., 1., 1.], rtol=1e-13)
 
         tf = ([[1, 2, 3], [1, 2, 3]], [1, 2, 3, 4])
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[-2, -3, -4], [1, 0, 0], [0, 1, 0]], rtol=1e-13)
-        assert_allclose(B, [[1], [0], [0]], rtol=1e-13)
-        assert_allclose(C, [[1, 2, 3], [1, 2, 3]], rtol=1e-13)
-        assert_allclose(D, [[0], [0]], rtol=1e-13)
+        xp_assert_close(A, [[-2., -3, -4], [1, 0, 0], [0, 1, 0]], rtol=1e-13)
+        xp_assert_close(B, [[1.], [0], [0]], rtol=1e-13)
+        xp_assert_close(C, [[1., 2, 3], [1, 2, 3]], rtol=1e-13)
+        xp_assert_close(D, [[0.], [0]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[0, 1, 2, 3], [0, 1, 2, 3]], rtol=1e-13)
-        assert_allclose(den, [1, 2, 3, 4], rtol=1e-13)
+        xp_assert_close(num, [[0., 1, 2, 3], [0, 1, 2, 3]], rtol=1e-13)
+        xp_assert_close(den, [1., 2, 3, 4], rtol=1e-13)
 
         tf = (np.array([1, [2, 3]], dtype=object), [1, 6])
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[-6]], rtol=1e-31)
-        assert_allclose(B, [[1]], rtol=1e-31)
-        assert_allclose(C, [[1], [-9]], rtol=1e-31)
-        assert_allclose(D, [[0], [2]], rtol=1e-31)
+        xp_assert_close(A, [[-6.]], rtol=1e-31)
+        xp_assert_close(B, [[1.]], rtol=1e-31)
+        xp_assert_close(C, [[1.], [-9]], rtol=1e-31)
+        xp_assert_close(D, [[0.], [2]], rtol=1e-31)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[0, 1], [2, 3]], rtol=1e-13)
-        assert_allclose(den, [1, 6], rtol=1e-13)
+        xp_assert_close(num, [[0., 1], [2, 3]], rtol=1e-13)
+        xp_assert_close(den, [1., 6], rtol=1e-13)
 
         tf = (np.array([[1, -3], [1, 2, 3]], dtype=object), [1, 6, 5])
         A, B, C, D = tf2ss(*tf)
-        assert_allclose(A, [[-6, -5], [1, 0]], rtol=1e-13)
-        assert_allclose(B, [[1], [0]], rtol=1e-13)
-        assert_allclose(C, [[1, -3], [-4, -2]], rtol=1e-13)
-        assert_allclose(D, [[0], [1]], rtol=1e-13)
+        xp_assert_close(A, [[-6., -5], [1, 0]], rtol=1e-13)
+        xp_assert_close(B, [[1.], [0]], rtol=1e-13)
+        xp_assert_close(C, [[1., -3], [-4, -2]], rtol=1e-13)
+        xp_assert_close(D, [[0.], [1]], rtol=1e-13)
 
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[0, 1, -3], [1, 2, 3]], rtol=1e-13)
-        assert_allclose(den, [1, 6, 5], rtol=1e-13)
+        xp_assert_close(num, [[0., 1, -3], [1, 2, 3]], rtol=1e-13)
+        xp_assert_close(den, [1., 6, 5], rtol=1e-13)
 
     def test_all_int_arrays(self):
         A = [[0, 1, 0], [0, 0, 1], [-3, -4, -2]]
@@ -367,8 +369,8 @@ class TestSS2TF:
         C = [[5, 1, 0]]
         D = [[0]]
         num, den = ss2tf(A, B, C, D)
-        assert_allclose(num, [[0.0, 0.0, 1.0, 5.0]], rtol=1e-13, atol=1e-14)
-        assert_allclose(den, [1.0, 2.0, 4.0, 3.0], rtol=1e-13)
+        xp_assert_close(num, [[0.0, 0.0, 1.0, 5.0]], rtol=1e-13, atol=1e-14)
+        xp_assert_close(den, [1.0, 2.0, 4.0, 3.0], rtol=1e-13)
 
     def test_multioutput(self):
         # Regression test for gh-2669.
@@ -403,10 +405,10 @@ class TestSS2TF:
         b2, a2 = ss2tf(A, B, C[2], D[2])
 
         # Check that we got the same results.
-        assert_allclose(a0, a, rtol=1e-13)
-        assert_allclose(a1, a, rtol=1e-13)
-        assert_allclose(a2, a, rtol=1e-13)
-        assert_allclose(b_all, np.vstack((b0, b1, b2)), rtol=1e-13, atol=1e-14)
+        xp_assert_close(a0, a, rtol=1e-13)
+        xp_assert_close(a1, a, rtol=1e-13)
+        xp_assert_close(a2, a, rtol=1e-13)
+        xp_assert_close(b_all, np.vstack((b0, b1, b2)), rtol=1e-13, atol=1e-14)
 
 
 class TestLsim:
@@ -553,7 +555,7 @@ class TestImpulse:
         n = 21
         t = np.linspace(0, 2.0, n)
         tout, y = impulse(system, T=t)
-        assert_equal(tout.shape, (n,))
+        assert tout.shape == (n,)
         assert_almost_equal(tout, t)
         expected_y = np.exp(-t)
         assert_almost_equal(y, expected_y)
@@ -624,7 +626,7 @@ class TestStep:
         n = 21
         t = np.linspace(0, 2.0, n)
         tout, y = step(system, T=t)
-        assert_equal(tout.shape, (n,))
+        assert tout.shape == (n,)
         assert_almost_equal(tout, t)
         expected_y = 1 - np.exp(-t)
         assert_almost_equal(y, expected_y)
@@ -686,25 +688,25 @@ class TestLti:
 
         # TransferFunction
         s = lti([1], [-1])
-        assert_(isinstance(s, TransferFunction))
-        assert_(isinstance(s, lti))
-        assert_(not isinstance(s, dlti))
-        assert_(s.dt is None)
+        assert isinstance(s, TransferFunction)
+        assert isinstance(s, lti)
+        assert not isinstance(s, dlti)
+        assert s.dt is None
 
         # ZerosPolesGain
         s = lti(np.array([]), np.array([-1]), 1)
-        assert_(isinstance(s, ZerosPolesGain))
-        assert_(isinstance(s, lti))
-        assert_(not isinstance(s, dlti))
-        assert_(s.dt is None)
+        assert isinstance(s, ZerosPolesGain)
+        assert isinstance(s, lti)
+        assert not isinstance(s, dlti)
+        assert s.dt is None
 
         # StateSpace
         s = lti([], [-1], 1)
         s = lti([1], [-1], 1, 3)
-        assert_(isinstance(s, StateSpace))
-        assert_(isinstance(s, lti))
-        assert_(not isinstance(s, dlti))
-        assert_(s.dt is None)
+        assert isinstance(s, StateSpace)
+        assert isinstance(s, lti)
+        assert not isinstance(s, dlti)
+        assert s.dt is None
 
 
 class TestStateSpace:
@@ -718,13 +720,13 @@ class TestStateSpace:
     def test_conversion(self):
         # Check the conversion functions
         s = StateSpace(1, 2, 3, 4)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(StateSpace(s) is not s)
-        assert_(s.to_ss() is not s)
+        assert StateSpace(s) is not s
+        assert s.to_ss() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
@@ -732,9 +734,9 @@ class TestStateSpace:
 
         # Getters
         s = StateSpace(1, 1, 1, 1)
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
-        assert_(s.dt is None)
+        xp_assert_equal(s.poles, [1.])
+        xp_assert_equal(s.zeros, [0.])
+        assert s.dt is None
 
     def test_operators(self):
         # Test +/-/* operators on systems
@@ -765,22 +767,22 @@ class TestStateSpace:
 
         # Test multiplication
         for typ in (int, float, complex, np.float32, np.complex128, np.array):
-            assert_allclose(lsim(typ(2) * s1, U=u, T=t)[1],
+            xp_assert_close(lsim(typ(2) * s1, U=u, T=t)[1],
                             typ(2) * lsim(s1, U=u, T=t)[1])
 
-            assert_allclose(lsim(s1 * typ(2), U=u, T=t)[1],
+            xp_assert_close(lsim(s1 * typ(2), U=u, T=t)[1],
                             lsim(s1, U=u, T=t)[1] * typ(2))
 
-            assert_allclose(lsim(s1 / typ(2), U=u, T=t)[1],
+            xp_assert_close(lsim(s1 / typ(2), U=u, T=t)[1],
                             lsim(s1, U=u, T=t)[1] / typ(2))
 
             with assert_raises(TypeError):
                 typ(2) / s1
 
-        assert_allclose(lsim(s1 * 2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 * 2, U=u, T=t)[1],
                         lsim(s1, U=2 * u, T=t)[1])
 
-        assert_allclose(lsim(s1 * s2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 * s2, U=u, T=t)[1],
                         lsim(s1, U=lsim(s2, U=u, T=t)[1], T=t)[1],
                         atol=1e-5)
 
@@ -807,7 +809,7 @@ class TestStateSpace:
             BadType() / s1
 
         # Test addition
-        assert_allclose(lsim(s1 + 2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 + 2, U=u, T=t)[1],
                         2 * u + lsim(s1, U=u, T=t)[1])
 
         # Check for dimension mismatch
@@ -833,17 +835,17 @@ class TestStateSpace:
         with assert_raises(TypeError):
             BadType() + s1
 
-        assert_allclose(lsim(s1 + s2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 + s2, U=u, T=t)[1],
                         lsim(s1, U=u, T=t)[1] + lsim(s2, U=u, T=t)[1])
 
         # Test subtraction
-        assert_allclose(lsim(s1 - 2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 - 2, U=u, T=t)[1],
                         -2 * u + lsim(s1, U=u, T=t)[1])
 
-        assert_allclose(lsim(2 - s1, U=u, T=t)[1],
+        xp_assert_close(lsim(2 - s1, U=u, T=t)[1],
                         2 * u + lsim(-s1, U=u, T=t)[1])
 
-        assert_allclose(lsim(s1 - s2, U=u, T=t)[1],
+        xp_assert_close(lsim(s1 - s2, U=u, T=t)[1],
                         lsim(s1, U=u, T=t)[1] - lsim(s2, U=u, T=t)[1])
 
         with assert_raises(TypeError):
@@ -853,16 +855,16 @@ class TestStateSpace:
             BadType() - s1
 
         s = s_discrete + s3_discrete
-        assert_(s.dt == 0.1)
+        assert s.dt == 0.1
 
         s = s_discrete * s3_discrete
-        assert_(s.dt == 0.1)
+        assert s.dt == 0.1
 
         s = 3 * s_discrete
-        assert_(s.dt == 0.1)
+        assert s.dt == 0.1
 
         s = -s_discrete
-        assert_(s.dt == 0.1)
+        assert s.dt == 0.1
 
 class TestTransferFunction:
     def test_initialization(self):
@@ -874,13 +876,13 @@ class TestTransferFunction:
     def test_conversion(self):
         # Check the conversion functions
         s = TransferFunction([1, 0], [1, -1])
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(TransferFunction(s) is not s)
-        assert_(s.to_tf() is not s)
+        assert TransferFunction(s) is not s
+        assert s.to_tf() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
@@ -888,8 +890,8 @@ class TestTransferFunction:
 
         # Getters
         s = TransferFunction([1, 0], [1, -1])
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
+        xp_assert_equal(s.poles, [1.])
+        xp_assert_equal(s.zeros, [0.])
 
 
 class TestZerosPolesGain:
@@ -902,13 +904,13 @@ class TestZerosPolesGain:
     def test_conversion(self):
         #Check the conversion functions
         s = ZerosPolesGain(1, 2, 3)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        assert isinstance(s.to_ss(), StateSpace)
+        assert isinstance(s.to_tf(), TransferFunction)
+        assert isinstance(s.to_zpk(), ZerosPolesGain)
 
         # Make sure copies work
-        assert_(ZerosPolesGain(s) is not s)
-        assert_(s.to_zpk() is not s)
+        assert ZerosPolesGain(s) is not s
+        assert s.to_zpk() is not s
 
 
 class Test_abcd_normalize:
@@ -943,97 +945,97 @@ class Test_abcd_normalize:
 
     def test_normalized_matrices_unchanged(self):
         A, B, C, D = abcd_normalize(self.A, self.B, self.C, self.D)
-        assert_equal(A, self.A)
-        assert_equal(B, self.B)
-        assert_equal(C, self.C)
-        assert_equal(D, self.D)
+        xp_assert_equal(A, self.A)
+        xp_assert_equal(B, self.B)
+        xp_assert_equal(C, self.C)
+        xp_assert_equal(D, self.D)
 
     def test_shapes(self):
         A, B, C, D = abcd_normalize(self.A, self.B, [1, 0], 0)
-        assert_equal(A.shape[0], A.shape[1])
-        assert_equal(A.shape[0], B.shape[0])
-        assert_equal(A.shape[0], C.shape[1])
-        assert_equal(C.shape[0], D.shape[0])
-        assert_equal(B.shape[1], D.shape[1])
+        xp_assert_equal(A.shape[0], A.shape[1])
+        xp_assert_equal(A.shape[0], B.shape[0])
+        xp_assert_equal(A.shape[0], C.shape[1])
+        xp_assert_equal(C.shape[0], D.shape[0])
+        xp_assert_equal(B.shape[1], D.shape[1])
 
     def test_zero_dimension_is_not_none1(self):
         B_ = np.zeros((2, 0))
         D_ = np.zeros((0, 0))
         A, B, C, D = abcd_normalize(A=self.A, B=B_, D=D_)
-        assert_equal(A, self.A)
-        assert_equal(B, B_)
-        assert_equal(D, D_)
-        assert_equal(C.shape[0], D_.shape[0])
-        assert_equal(C.shape[1], self.A.shape[0])
+        xp_assert_equal(A, self.A)
+        xp_assert_equal(B, B_)
+        xp_assert_equal(D, D_)
+        assert C.shape[0] == D_.shape[0]
+        assert C.shape[1] == self.A.shape[0]
 
     def test_zero_dimension_is_not_none2(self):
         B_ = np.zeros((2, 0))
         C_ = np.zeros((0, 2))
         A, B, C, D = abcd_normalize(A=self.A, B=B_, C=C_)
-        assert_equal(A, self.A)
-        assert_equal(B, B_)
-        assert_equal(C, C_)
-        assert_equal(D.shape[0], C_.shape[0])
-        assert_equal(D.shape[1], B_.shape[1])
+        xp_assert_equal(A, self.A)
+        xp_assert_equal(B, B_)
+        xp_assert_equal(C, C_)
+        assert D.shape[0] == C_.shape[0]
+        assert D.shape[1] == B_.shape[1]
 
     def test_missing_A(self):
         A, B, C, D = abcd_normalize(B=self.B, C=self.C, D=self.D)
-        assert_equal(A.shape[0], A.shape[1])
-        assert_equal(A.shape[0], B.shape[0])
-        assert_equal(A.shape, (self.B.shape[0], self.B.shape[0]))
+        assert A.shape[0] == A.shape[1]
+        assert A.shape[0] == B.shape[0]
+        assert A.shape == (self.B.shape[0], self.B.shape[0])
 
     def test_missing_B(self):
         A, B, C, D = abcd_normalize(A=self.A, C=self.C, D=self.D)
-        assert_equal(B.shape[0], A.shape[0])
-        assert_equal(B.shape[1], D.shape[1])
-        assert_equal(B.shape, (self.A.shape[0], self.D.shape[1]))
+        assert B.shape[0] == A.shape[0]
+        assert B.shape[1] == D.shape[1]
+        assert B.shape == (self.A.shape[0], self.D.shape[1])
 
     def test_missing_C(self):
         A, B, C, D = abcd_normalize(A=self.A, B=self.B, D=self.D)
-        assert_equal(C.shape[0], D.shape[0])
-        assert_equal(C.shape[1], A.shape[0])
-        assert_equal(C.shape, (self.D.shape[0], self.A.shape[0]))
+        assert C.shape[0] == D.shape[0]
+        assert C.shape[1] == A.shape[0]
+        assert C.shape == (self.D.shape[0], self.A.shape[0])
 
     def test_missing_D(self):
         A, B, C, D = abcd_normalize(A=self.A, B=self.B, C=self.C)
-        assert_equal(D.shape[0], C.shape[0])
-        assert_equal(D.shape[1], B.shape[1])
-        assert_equal(D.shape, (self.C.shape[0], self.B.shape[1]))
+        assert D.shape[0] == C.shape[0]
+        assert D.shape[1] == B.shape[1]
+        assert D.shape == (self.C.shape[0], self.B.shape[1])
 
     def test_missing_AB(self):
         A, B, C, D = abcd_normalize(C=self.C, D=self.D)
-        assert_equal(A.shape[0], A.shape[1])
-        assert_equal(A.shape[0], B.shape[0])
-        assert_equal(B.shape[1], D.shape[1])
-        assert_equal(A.shape, (self.C.shape[1], self.C.shape[1]))
-        assert_equal(B.shape, (self.C.shape[1], self.D.shape[1]))
+        assert A.shape[0] == A.shape[1]
+        assert A.shape[0] == B.shape[0]
+        assert B.shape[1] == D.shape[1]
+        assert A.shape == (self.C.shape[1], self.C.shape[1])
+        assert B.shape == (self.C.shape[1], self.D.shape[1])
 
     def test_missing_AC(self):
         A, B, C, D = abcd_normalize(B=self.B, D=self.D)
-        assert_equal(A.shape[0], A.shape[1])
-        assert_equal(A.shape[0], B.shape[0])
-        assert_equal(C.shape[0], D.shape[0])
-        assert_equal(C.shape[1], A.shape[0])
-        assert_equal(A.shape, (self.B.shape[0], self.B.shape[0]))
-        assert_equal(C.shape, (self.D.shape[0], self.B.shape[0]))
+        assert A.shape[0] == A.shape[1]
+        assert A.shape[0] == B.shape[0]
+        assert C.shape[0] == D.shape[0]
+        assert C.shape[1] == A.shape[0]
+        assert A.shape == (self.B.shape[0], self.B.shape[0])
+        assert C.shape == (self.D.shape[0], self.B.shape[0])
 
     def test_missing_AD(self):
         A, B, C, D = abcd_normalize(B=self.B, C=self.C)
-        assert_equal(A.shape[0], A.shape[1])
-        assert_equal(A.shape[0], B.shape[0])
-        assert_equal(D.shape[0], C.shape[0])
-        assert_equal(D.shape[1], B.shape[1])
-        assert_equal(A.shape, (self.B.shape[0], self.B.shape[0]))
-        assert_equal(D.shape, (self.C.shape[0], self.B.shape[1]))
+        assert A.shape[0] == A.shape[1]
+        assert A.shape[0] == B.shape[0]
+        assert D.shape[0] == C.shape[0]
+        assert D.shape[1] == B.shape[1]
+        assert A.shape == (self.B.shape[0], self.B.shape[0])
+        assert D.shape == (self.C.shape[0], self.B.shape[1])
 
     def test_missing_BC(self):
         A, B, C, D = abcd_normalize(A=self.A, D=self.D)
-        assert_equal(B.shape[0], A.shape[0])
-        assert_equal(B.shape[1], D.shape[1])
-        assert_equal(C.shape[0], D.shape[0])
-        assert_equal(C.shape[1], A.shape[0])
-        assert_equal(B.shape, (self.A.shape[0], self.D.shape[1]))
-        assert_equal(C.shape, (self.D.shape[0], self.A.shape[0]))
+        assert B.shape[0] == A.shape[0]
+        assert B.shape[1] == D.shape[1]
+        assert C.shape[0] == D.shape[0]
+        assert C.shape[1], A.shape[0]
+        assert B.shape == (self.A.shape[0], self.D.shape[1])
+        assert C.shape == (self.D.shape[0], self.A.shape[0])
 
     def test_missing_ABC_fails(self):
         assert_raises(ValueError, abcd_normalize, D=self.D)
@@ -1110,7 +1112,7 @@ class Test_bode:
         # integrator, pole at zero: H(s) = 1 / s
         system = lti([1], [1, 0])
         w, mag, phase = bode(system, n=2)
-        assert_equal(w[0], 0.01)  # a fail would give not-a-number
+        assert w[0] == 0.01   # a fail would give not-a-number
 
     def test_07(self):
         # bode() should not fail on a system with pure imaginary poles.
@@ -1187,7 +1189,7 @@ class Test_freqresp:
         # integrator, pole at zero: H(s) = 1 / s
         system = lti([1], [1, 0])
         w, H = freqresp(system, n=2)
-        assert_equal(w[0], 0.01)  # a fail would give not-a-number
+        assert w[0] == 0.01  # a fail would give not-a-number
 
     def test_from_state_space(self):
         # Ensure that freqresp works with a system that was created from the

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -1,6 +1,6 @@
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest import raises as assert_raises
+from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 
 from numpy.fft import fft, ifft
 
@@ -18,7 +18,9 @@ class TestMLS:
                       state=np.ones(3))
         # wrong length
         assert_raises(ValueError, max_len_seq, 10, length=-1)
-        assert_array_equal(max_len_seq(10, length=0)[0], [])
+        xp_assert_equal(max_len_seq(10, length=0)[0],
+                        np.asarray([], dtype=np.int8)
+        )
         # unknown taps
         assert_raises(ValueError, max_len_seq, 64)
         # bad taps
@@ -39,7 +41,7 @@ class TestMLS:
                     m = 2. * orig_m - 1.  # convert to +/- 1 representation
                     # First, make sure we got all 1's or -1
                     err_msg = "mls had non binary terms"
-                    assert_array_equal(np.abs(m), np.ones_like(m),
+                    xp_assert_equal(np.abs(m), np.ones_like(m),
                                        err_msg=err_msg)
                     # Test via circular cross-correlation, which is just mult.
                     # in the frequency domain with one signal conjugated
@@ -47,10 +49,15 @@ class TestMLS:
                     out_len = 2**nbits - 1
                     # impulse amplitude == test_len
                     err_msg = "mls impulse has incorrect value"
-                    assert_allclose(tester[0], out_len, err_msg=err_msg)
+                    xp_assert_close(tester[0],
+                                    np.asarray(out_len, dtype=np.float64),
+                                    check_0d=False,
+                                    err_msg=err_msg
+                    )
                     # steady-state is -1
                     err_msg = "mls steady-state has incorrect value"
-                    assert_allclose(tester[1:], np.full(out_len - 1, -1),
+                    xp_assert_close(tester[1:],
+                                    np.full(out_len - 1, -1, dtype=tester.dtype),
                                     err_msg=err_msg)
                     # let's do the split thing using a couple options
                     for n in (1, 2**(nbits - 1)):
@@ -61,5 +68,5 @@ class TestMLS:
                         m3, s3 = max_len_seq(nbits, state=s2, taps=taps,
                                              length=out_len - n - 1)
                         new_m = np.concatenate((m1, m2, m3))
-                        assert_array_equal(orig_m, new_m)
+                        xp_assert_equal(orig_m, new_m)
 

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -50,8 +50,7 @@ class TestMLS:
                     # impulse amplitude == test_len
                     err_msg = "mls impulse has incorrect value"
                     xp_assert_close(tester[0],
-                                    np.asarray(out_len, dtype=np.float64),
-                                    check_0d=False,
+                                    float(out_len),
                                     err_msg=err_msg
                     )
                     # steady-state is -1

--- a/scipy/signal/tests/test_result_type.py
+++ b/scipy/signal/tests/test_result_type.py
@@ -1,7 +1,6 @@
 # Regressions tests on result types of some signal functions
 
 import numpy as np
-from numpy.testing import assert_
 
 from scipy.signal import (decimate,
                           lfilter_zi,
@@ -12,16 +11,16 @@ from scipy.signal import (decimate,
 
 def test_decimate():
     ones_f32 = np.ones(32, dtype=np.float32)
-    assert_(decimate(ones_f32, 2).dtype == np.float32)
+    assert decimate(ones_f32, 2).dtype == np.float32
 
     ones_i64 = np.ones(32, dtype=np.int64)
-    assert_(decimate(ones_i64, 2).dtype == np.float64)
+    assert decimate(ones_i64, 2).dtype == np.float64
     
 
 def test_lfilter_zi():
     b_f32 = np.array([1, 2, 3], dtype=np.float32)
     a_f32 = np.array([4, 5, 6], dtype=np.float32)
-    assert_(lfilter_zi(b_f32, a_f32).dtype == np.float32)
+    assert lfilter_zi(b_f32, a_f32).dtype == np.float32
 
 
 def test_lfiltic():
@@ -34,19 +33,19 @@ def test_lfiltic():
     a_f64 = a_f32.astype(np.float64)
     x_f64 = x_f32.astype(np.float64)
 
-    assert_(lfiltic(b_f64, a_f32, x_f32).dtype == np.float64)
-    assert_(lfiltic(b_f32, a_f64, x_f32).dtype == np.float64)
-    assert_(lfiltic(b_f32, a_f32, x_f64).dtype == np.float64)
-    assert_(lfiltic(b_f32, a_f32, x_f32, x_f64).dtype == np.float64)
+    assert lfiltic(b_f64, a_f32, x_f32).dtype == np.float64
+    assert lfiltic(b_f32, a_f64, x_f32).dtype == np.float64
+    assert lfiltic(b_f32, a_f32, x_f64).dtype == np.float64
+    assert lfiltic(b_f32, a_f32, x_f32, x_f64).dtype == np.float64
 
 
 def test_sos2tf():
     sos_f32 = np.array([[4, 5, 6, 1, 2, 3]], dtype=np.float32)
     b, a = sos2tf(sos_f32)
-    assert_(b.dtype == np.float32)
-    assert_(a.dtype == np.float32)
+    assert b.dtype == np.float32
+    assert a.dtype == np.float32
 
 
 def test_sosfilt_zi():
     sos_f32 = np.array([[4, 5, 6, 1, 2, 3]], dtype=np.float32)
-    assert_(sosfilt_zi(sos_f32).dtype == np.float32)
+    assert sosfilt_zi(sos_f32).dtype == np.float32

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -1,8 +1,7 @@
 # pylint: disable=missing-docstring
 import numpy as np
-from numpy import array
-from numpy.testing import assert_allclose, assert_raises
 import pytest
+from scipy._lib._array_api import xp_assert_close
 
 from scipy.signal._spline import (
     symiirorder1_ic, symiirorder2_ic_fwd, symiirorder2_ic_bwd)
@@ -52,20 +51,20 @@ class TestSymIIR:
 
         # Create a step signal of size n + 1
         x = np.ones(n_exp + 1, dtype=dtype)
-        assert_allclose(symiirorder1_ic(x, b, precision), expected,
+        xp_assert_close(symiirorder1_ic(x, b, precision), expected,
                         atol=2e-6, rtol=2e-7)
 
         # Check the conditions for a exponential decreasing signal with base 2.
         # Same conditions hold, as the product of 0.5^n * 0.85^n is
         # still a geometric series
-        b_d = array(b, dtype=dtype)
+        b_d = np.asarray(b, dtype=dtype)
         expected = np.asarray(
             [[(1 - (0.5 * b_d) ** n_exp) / (1 - (0.5 * b_d))]], dtype=dtype)
         expected = 1 + b_d * expected
 
         # Create an exponential decreasing signal of size n + 1
         x = 2 ** -np.arange(n_exp + 1, dtype=dtype)
-        assert_allclose(symiirorder1_ic(x, b, precision), expected,
+        xp_assert_close(symiirorder1_ic(x, b, precision), expected,
                         atol=2e-6, rtol=2e-7)
 
     def test_symiir1_ic_fails(self):
@@ -76,11 +75,11 @@ class TestSymIIR:
 
         # Compute the closed form for the geometrical series
         precision = 1 / (1 - b)
-        assert_raises(ValueError, symiirorder1_ic, x, b, precision)
+        pytest.raises(ValueError, symiirorder1_ic, x, b, precision)
 
         # Test that symiirorder1_ic fails when |z1| >= 1
-        assert_raises(ValueError, symiirorder1_ic, x, 1.0, -1)
-        assert_raises(ValueError, symiirorder1_ic, x, 2.0, -1)
+        pytest.raises(ValueError, symiirorder1_ic, x, 1.0, -1)
+        pytest.raises(ValueError, symiirorder1_ic, x, 2.0, -1)
 
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64, np.complex64, np.complex128])
@@ -149,11 +148,12 @@ class TestSymIIR:
         exp_out = exp_out[::-1]
 
         out = symiirorder1(signal, c0, z1, precision)
-        assert_allclose(out, exp_out, atol=4e-6, rtol=6e-7)
+        xp_assert_close(out, exp_out, atol=4e-6, rtol=6e-7)
 
-    @pytest.mark.parametrize('dtyp', [np.float32, np.float64])
+    @pytest.mark.parametrize('dtyp', ['float32', 'float64'])
     def test_symiir1_values(self, dtyp):
         rng = np.random.RandomState(1234)
+        dtyp = getattr(np, dtyp)
         s = rng.uniform(size=16).astype(dtyp)
         res = symiirorder1(s, 0.5, 0.1)
 
@@ -161,20 +161,21 @@ class TestSymIIR:
         exp_res = np.array([0.14387447, 0.35166047, 0.29735238, 0.46295986, 0.45174927,
                             0.19982875, 0.20355805, 0.47378628, 0.57232247, 0.51597393,
                            0.25935107, 0.31438554, 0.41096728, 0.4190693 , 0.25812255,
-                           0.33671467])
+                           0.33671467], dtype=res.dtype)
         assert res.dtype == dtyp
         atol = {np.float64: 1e-15, np.float32: 1e-7}[dtyp]
-        assert_allclose(res, exp_res, atol=atol)
+        xp_assert_close(res, exp_res, atol=atol)
 
         s = s + 1j*s
         res = symiirorder1(s, 0.5, 0.1)
         assert res.dtype == np.complex64 if dtyp == np.float32 else np.complex128
-        assert_allclose(res, exp_res + 1j*exp_res, atol=atol)
+        xp_assert_close(res, exp_res + 1j*exp_res, atol=atol)
 
     @pytest.mark.parametrize(
-        'dtype', [np.float32, np.float64])
+        'dtype', ['float32', 'float64'])
     @pytest.mark.parametrize('precision', [-1.0, 0.7, 0.5, 0.25, 0.0075])
     def test_symiir2_initial_fwd(self, dtype, precision):
+        dtype = getattr(np, dtype)
         c_precision = precision
         if precision <= 0.0 or precision > 1.0:
             if dtype in {np.float32, np.complex64}:
@@ -229,12 +230,13 @@ class TestSymIIR:
              r**(n_exp + 4) * np.sin(omega * (n_exp + 3))) / np.sin(omega))
 
         expected = np.r_[fwd_initial_1, fwd_initial_2][None, :]
+        expected = expected.astype(dtype)
 
         n = 100
         signal = np.ones(n, dtype=dtype)
 
         out = symiirorder2_ic_fwd(signal, r, omega, precision)
-        assert_allclose(out, expected, atol=4e-6, rtol=6e-7)
+        xp_assert_close(out, expected, atol=4e-6, rtol=6e-7)
 
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64])
@@ -282,7 +284,7 @@ class TestSymIIR:
         ic2[1] = ic2_1_all[pos[0]]
 
         out_ic = symiirorder2_ic_bwd(out, r, omega, precision)[0]
-        assert_allclose(out_ic, ic2, atol=4e-6, rtol=6e-7)
+        xp_assert_close(out_ic, ic2, atol=4e-6, rtol=6e-7)
 
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64])
@@ -317,10 +319,11 @@ class TestSymIIR:
             exp[i] = cs * out1[i] + a2 * exp[i + 1] + a3 * exp[i + 2]
 
         out = symiirorder2(signal, r, omega, precision)
-        assert_allclose(out, exp, atol=4e-6, rtol=6e-7)
+        xp_assert_close(out, exp, atol=4e-6, rtol=6e-7)
 
-    @pytest.mark.parametrize('dtyp', [np.float32, np.float64])
+    @pytest.mark.parametrize('dtyp', ['float32', 'float64'])
     def test_symiir2_values(self, dtyp):
+        dtyp = getattr(np, dtyp)
         rng = np.random.RandomState(1234)
         s = rng.uniform(size=16).astype(dtyp)
         res = symiirorder2(s, 0.1, 0.1, precision=1e-10)
@@ -329,7 +332,7 @@ class TestSymIIR:
         exp_res = np.array([0.26572609, 0.53408018, 0.51032696, 0.72115829, 0.69486885,
            0.3649055 , 0.37349478, 0.74165032, 0.89718521, 0.80582483,
            0.46758053, 0.51898709, 0.65025605, 0.65394321, 0.45273595,
-           0.53539183])
+           0.53539183], dtype=dtyp)
 
         assert res.dtype == dtyp
         # The values in SciPy 1.14 agree with those in SciPy 1.9.1 to this
@@ -340,20 +343,20 @@ class TestSymIIR:
         # test_symiir2_initial_{fwd,bwd} above, so the difference is likely
         # due to a different way roundoff errors accumulate in the filter.
         # In that respect, sosfilt is likely doing a better job.
-        assert_allclose(res, exp_res, atol=2e-6)
+        xp_assert_close(res, exp_res, atol=2e-6)
 
         s = s + 1j*s
-        with assert_raises(TypeError):
+        with pytest.raises(TypeError):
             res = symiirorder2(s, 0.5, 0.1)
 
     def test_symiir1_integer_input(self):
         s = np.where(np.arange(100) % 2, -1, 1)
         expected = symiirorder1(s.astype(float), 0.5, 0.5)
         out = symiirorder1(s, 0.5, 0.5)
-        assert_allclose(out, expected)
+        xp_assert_close(out, expected)
 
     def test_symiir2_integer_input(self):
         s = np.where(np.arange(100) % 2, -1, 1)
         expected = symiirorder2(s.astype(float), 0.5, np.pi / 3.0)
         out = symiirorder2(s, 0.5, np.pi / 3.0)
-        assert_allclose(out, expected)
+        xp_assert_close(out, expected)

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -150,11 +150,11 @@ class TestSymIIR:
         out = symiirorder1(signal, c0, z1, precision)
         xp_assert_close(out, exp_out, atol=4e-6, rtol=6e-7)
 
-    @pytest.mark.parametrize('dtyp', ['float32', 'float64'])
-    def test_symiir1_values(self, dtyp):
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    def test_symiir1_values(self, dtype):
         rng = np.random.RandomState(1234)
-        dtyp = getattr(np, dtyp)
-        s = rng.uniform(size=16).astype(dtyp)
+        dtype = getattr(np, dtype)
+        s = rng.uniform(size=16).astype(dtype)
         res = symiirorder1(s, 0.5, 0.1)
 
         # values from scipy 1.9.1
@@ -162,13 +162,13 @@ class TestSymIIR:
                             0.19982875, 0.20355805, 0.47378628, 0.57232247, 0.51597393,
                            0.25935107, 0.31438554, 0.41096728, 0.4190693 , 0.25812255,
                            0.33671467], dtype=res.dtype)
-        assert res.dtype == dtyp
-        atol = {np.float64: 1e-15, np.float32: 1e-7}[dtyp]
+        assert res.dtype == dtype
+        atol = {np.float64: 1e-15, np.float32: 1e-7}[dtype]
         xp_assert_close(res, exp_res, atol=atol)
 
         s = s + 1j*s
         res = symiirorder1(s, 0.5, 0.1)
-        assert res.dtype == np.complex64 if dtyp == np.float32 else np.complex128
+        assert res.dtype == np.complex64 if dtype == np.float32 else np.complex128
         xp_assert_close(res, exp_res + 1j*exp_res, atol=atol)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Manually convert tests in preparation for the array api convertion. Am working test file by test file, aming to limit the diff size to < 1kLOC per PR to keep it manageable.

- [x] test_array_tools.py
- [x] test_bsplines.py
- [x] test_splines.py
- [x]  test_czt.py
- [x] test_result_type.py
- [x]  test_dltisys.py
- [x] test_ltisys.py
- [x] test_max_len_seq.py
- [x] test_fir_filter_design.py
- [x] test_filter_design.py