### PR TITLE
MAINT: differentiate: manually promote dtype before element assignment

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -397,7 +397,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     h0 = xp.broadcast_to(h0, shape)
     h0 = xp.reshape(h0, (-1,))
     h0 = xp.astype(h0, dtype)
-    h0[h0 <= 0] = xp.asarray(xp.nan)
+    h0[h0 <= 0] = xp.asarray(xp.nan, dtype=dtype)
 
     status = xp.full_like(x, eim._EINPROGRESS, dtype=xp.int32)  # in progress
     nit, nfev = 0, 1  # one function evaluations performed above


### PR DESCRIPTION
#### Reference issue
Closes gh-21513

#### What does this implement/fix?
On some platforms, it looks like PyTorch doesn't automatically promote when assigning to elements of an array. Fix by manually specifying the dtype.

#### Additional information
(I'm pretty sure there was also a reason for making the RHS an array rather than leaving it a Python scalar.)
