### PR TITLE
TST: remove redundant torch skips

### DIFF
--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1576,7 +1576,7 @@ class TestWatershedIft:
         assert_array_almost_equal(out, xp.asarray(expected))
 
     @skip_xp_backends(
-        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"],
+        "cupy", reasons=["no watershed_ift on CuPy"],
         cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_watershed_ift08(self, xp):
@@ -1591,7 +1591,7 @@ class TestWatershedIft:
         assert_array_almost_equal(out, xp.asarray(expected))
 
     @skip_xp_backends(
-        "cupy", "pytorch", reasons=["no watershed_ift on CuPy", "torch.uint16"],
+        "cupy", reasons=["no watershed_ift on CuPy"],
         cpu_only=True, exceptions=['cupy', 'jax.numpy'],
     )
     def test_watershed_ift09(self, xp):


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
These skips were never actioned since the decorator expects the string 'torch' rather than 'pytorch'.

#### Additional information
@ev-br were you prompted to add these skips by test failures originally?
