### PR TITLE
TST: `special._smirnovp`: remove test xfail after translation to C++

### DIFF
--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -303,8 +303,6 @@ class TestSmirnovp:
             _smirnovp, dataset0, (0, 1), 2, rtol=_rtol
         ).check(dtypes=[int, float, float])
 
-    @pytest.mark.xfail(sys.maxsize <= 2**32,
-                       reason="requires 64-bit platform")
     def test_oneovernclose(self):
         # Check derivative at x=1/n
         # (Discontinuous at x=1/n, test on either side: x=1/n +/- 2epsilon)

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -1,6 +1,4 @@
 import itertools
-import sys
-import pytest
 
 import numpy as np
 from numpy.testing import assert_


### PR DESCRIPTION
#### Reference issue
Closes gh-9509
Closes gh-16700

#### What does this implement/fix?
There were issues with `_smirnovp` (PDF of `scipy.stats.ksone`) on 32-bit platforms. After the translation to C++ (gh-20390), perhaps they are no longer relevant.