### PR TITLE
DOC: optimize: Document that `OptimizeResult.fun` is scalar

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -123,9 +123,11 @@ class OptimizeResult(_RichResult):
         underlying solver. Refer to `message` for details.
     message : str
         Description of the cause of the termination.
-    fun, jac, hess: ndarray
-        Values of objective function, its Jacobian and its Hessian (if
-        available). The Hessians may be approximations, see the documentation
+    fun : float
+        Value of objective function at `x`.
+    jac, hess : ndarray
+        Values of objective function's Jacobian and its Hessian at `x` (if
+        available). The Hessian may be an approximation, see the documentation
         of the function in question.
     hess_inv : object
         Inverse of the objective function's Hessian; may be an approximation.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

See discussion in #21519

#### What does this implement/fix?

Since OptimizeResult is used to represent the result of optimizing a scalar-valued function, `OptimizeResult.fun` is intended to be a scalar. In most cases, it is. Change the documentation to reflect this.

#### Additional information

OptimizeResult.fun is not always scalar - see #21519. However, this is not intended behavior.
<!--Any additional information you think is important.-->

Also, OptimizeResult.fun could be an np.float64 or a float, depending on what the objective function returns and the specific optimization method. However, `np.float64` is a subclass of float, so this is still technically correct.