### PR TITLE
ENH: integrate.trapezoid: add array API standard support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -28,6 +28,7 @@ env:
     -t scipy.optimize.tests.test_chandrupatla
     -t scipy.stats
     -t scipy.ndimage
+    -t scipy.integrate.tests.test_quadrature
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Callable, Any, cast
+from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import numpy.typing as npt
 import math
 import warnings
 from collections import namedtuple
+from collections.abc import Callable
 
 from scipy.special import roots_legendre
 from scipy.special import gammaln, logsumexp
 from scipy._lib._util import _rng_spawn
+from scipy._lib._array_api import _asarray, array_namespace, xp_broadcast_promote
 
 
 __all__ = ['fixed_quad', 'romb',
@@ -41,7 +43,7 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     dx : scalar, optional
         The spacing between sample points when `x` is None. The default is 1.
     axis : int, optional
-        The axis along which to integrate.
+        The axis along which to integrate. The default is the last axis.
 
     Returns
     -------
@@ -119,31 +121,42 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     >>> integrate.trapezoid(a, axis=1)
     array([2.,  8.])
     """
-    y = np.asanyarray(y)
-    if x is None:
-        d = dx
-    else:
-        x = np.asanyarray(x)
-        if x.ndim == 1:
-            d = np.diff(x)
-            # reshape to correct shape
-            shape = [1]*y.ndim
-            shape[axis] = d.shape[0]
-            d = d.reshape(shape)
-        else:
-            d = np.diff(x, axis=axis)
+    xp = array_namespace(y)
+    y = _asarray(y, xp=xp, subok=True)
+    # Cannot just use the broadcasted arrays that are returned
+    # because trapezoid does not follow normal broadcasting rules
+    # cf. https://github.com/scipy/scipy/pull/21524#issuecomment-2354105942
+    result_dtype = xp_broadcast_promote(y, force_floating=True, xp=xp)[0].dtype
     nd = y.ndim
     slice1 = [slice(None)]*nd
     slice2 = [slice(None)]*nd
     slice1[axis] = slice(1, None)
     slice2[axis] = slice(None, -1)
+    if x is None:
+        d = dx
+    else:
+        x = _asarray(x, xp=xp, subok=True)
+        if x.ndim == 1:
+            d = x[1:] - x[:-1]
+            # reshape to correct shape
+            shape = [1]*y.ndim
+            shape[axis] = d.shape[0]
+            d = xp.reshape(d, shape)
+        else:
+            d = x[tuple(slice1)] - x[tuple(slice2)]
     try:
-        ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
+        ret = xp.sum(
+            d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0,
+            axis=axis, dtype=result_dtype
+        )
     except ValueError:
         # Operations didn't work, cast to ndarray
-        d = np.asarray(d)
-        y = np.asarray(y)
-        ret = np.add.reduce(d * (y[tuple(slice1)]+y[tuple(slice2)])/2.0, axis)
+        d = xp.asarray(d)
+        y = xp.asarray(y)
+        ret = xp.sum(
+            d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0,
+            axis=axis, dtype=result_dtype
+        )
     return ret
 
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -136,14 +136,11 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
         d = dx
     else:
         x = _asarray(x, xp=xp, subok=True)
-        if x.ndim == 1:
-            d = x[1:] - x[:-1]
-            # reshape to correct shape
-            shape = [1]*y.ndim
-            shape[axis] = d.shape[0]
-            d = xp.reshape(d, shape)
-        else:
-            d = x[tuple(slice1)] - x[tuple(slice2)]
+        # reshape to correct shape
+        shape = [1] * y.ndim
+        shape[axis] = y.shape[axis]
+        x = xp.reshape(x, shape)
+        d = x[tuple(slice1)] - x[tuple(slice2)]
     try:
         ret = xp.sum(
             d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0,

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -12,6 +12,8 @@ from scipy.integrate import (romb, newton_cotes,
                              qmc_quad, cumulative_simpson)
 from scipy.integrate._quadrature import _cumulative_simpson_unequal_intervals
 from scipy import stats, special
+from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
+from scipy._lib._array_api import xp_assert_close
 
 
 class TestFixedQuad:
@@ -264,51 +266,53 @@ class TestCumulative_trapezoid:
             cumulative_trapezoid(y=[])
 
 
+@array_api_compatible
 class TestTrapezoid:
-    def test_simple(self):
-        x = np.arange(-10, 10, .1)
-        r = trapezoid(np.exp(-.5 * x ** 2) / np.sqrt(2 * np.pi), dx=0.1)
+    def test_simple(self, xp):
+        x = xp.arange(-10, 10, .1)
+        r = trapezoid(xp.exp(-.5 * x ** 2) / xp.sqrt(2 * xp.asarray(xp.pi)), dx=0.1)
         # check integral of normal equals 1
-        assert_allclose(r, 1)
+        xp_assert_close(xp.asarray(r), xp.asarray(1.0))
 
-    def test_ndim(self):
-        x = np.linspace(0, 1, 3)
-        y = np.linspace(0, 2, 8)
-        z = np.linspace(0, 3, 13)
+    def test_ndim(self, xp):
+        x = xp.linspace(0, 1, 3)
+        y = xp.linspace(0, 2, 8)
+        z = xp.linspace(0, 3, 13)
 
-        wx = np.ones_like(x) * (x[1] - x[0])
+        wx = xp.ones_like(x) * (x[1] - x[0])
         wx[0] /= 2
         wx[-1] /= 2
-        wy = np.ones_like(y) * (y[1] - y[0])
+        wy = xp.ones_like(y) * (y[1] - y[0])
         wy[0] /= 2
         wy[-1] /= 2
-        wz = np.ones_like(z) * (z[1] - z[0])
+        wz = xp.ones_like(z) * (z[1] - z[0])
         wz[0] /= 2
         wz[-1] /= 2
 
         q = x[:, None, None] + y[None,:, None] + z[None, None,:]
 
-        qx = (q * wx[:, None, None]).sum(axis=0)
-        qy = (q * wy[None, :, None]).sum(axis=1)
-        qz = (q * wz[None, None, :]).sum(axis=2)
+        qx = xp.sum(q * wx[:, None, None], axis=0)
+        qy = xp.sum(q * wy[None, :, None], axis=1)
+        qz = xp.sum(q * wz[None, None, :], axis=2)
 
         # n-d `x`
         r = trapezoid(q, x=x[:, None, None], axis=0)
-        assert_allclose(r, qx)
+        xp_assert_close(r, qx)
         r = trapezoid(q, x=y[None,:, None], axis=1)
-        assert_allclose(r, qy)
+        xp_assert_close(r, qy)
         r = trapezoid(q, x=z[None, None,:], axis=2)
-        assert_allclose(r, qz)
+        xp_assert_close(r, qz)
 
         # 1-d `x`
         r = trapezoid(q, x=x, axis=0)
-        assert_allclose(r, qx)
+        xp_assert_close(r, qx)
         r = trapezoid(q, x=y, axis=1)
-        assert_allclose(r, qy)
+        xp_assert_close(r, qy)
         r = trapezoid(q, x=z, axis=2)
-        assert_allclose(r, qz)
+        xp_assert_close(r, qz)
 
-    def test_masked(self):
+    @skip_xp_invalid_arg
+    def test_masked(self, xp):
         # Testing that masked arrays behave as if the function is 0 where
         # masked
         x = np.arange(5)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -341,6 +341,18 @@ class TestTrapezoid:
         xm = np.ma.array(x, mask=mask)
         assert_allclose(trapezoid(y, xm), r)
 
+    @skip_xp_backends(np_only=True,
+                      reasons=['array-likes only supported for NumPy backend'])
+    @pytest.mark.usefixtures("skip_xp_backends")
+    def test_array_like(self, xp):
+        x = list(range(5))
+        y = [t * t for t in x]
+        xarr = xp.asarray(x, dtype=xp.float64)
+        yarr = xp.asarray(y, dtype=xp.float64)
+        res = trapezoid(y, x)
+        resarr = trapezoid(yarr, xarr)
+        xp_assert_close(res, resarr)
+
 
 class TestQMCQuad:
     def test_input_validation(self):

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -13,7 +13,9 @@ from scipy.integrate import (romb, newton_cotes,
 from scipy.integrate._quadrature import _cumulative_simpson_unequal_intervals
 from scipy import stats, special
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
-from scipy._lib._array_api import xp_assert_close
+from scipy._lib._array_api_no_0d import xp_assert_close
+
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 class TestFixedQuad:
@@ -272,8 +274,11 @@ class TestTrapezoid:
         x = xp.arange(-10, 10, .1)
         r = trapezoid(xp.exp(-.5 * x ** 2) / xp.sqrt(2 * xp.asarray(xp.pi)), dx=0.1)
         # check integral of normal equals 1
-        xp_assert_close(xp.asarray(r), xp.asarray(1.0))
+        xp_assert_close(r, xp.asarray(1.0))
 
+    @skip_xp_backends('jax.numpy',
+                      reasons=["JAX arrays do not support item assignment"])
+    @pytest.mark.usefixtures("skip_xp_backends")
     def test_ndim(self, xp):
         x = xp.linspace(0, 1, 3)
         y = xp.linspace(0, 2, 8)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -303,6 +303,14 @@ class TestTrapezoid:
         r = trapezoid(q, x=z[None, None,:], axis=2)
         xp_assert_close(r, qz)
 
+        # n-d `x` but not the same as `y`
+        r = trapezoid(q, x=xp.reshape(x[:, None, None], (3, 1)), axis=0)
+        xp_assert_close(r, qx)
+        r = trapezoid(q, x=xp.reshape(y[None,:, None], (8, 1)), axis=1)
+        xp_assert_close(r, qy)
+        r = trapezoid(q, x=xp.reshape(z[None, None,:], (13, 1)), axis=2)
+        xp_assert_close(r, qz)
+
         # 1-d `x`
         r = trapezoid(q, x=x, axis=0)
         xp_assert_close(r, qx)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-20930.-->

Towards [gh-20930](https://github.com/scipy/scipy/issues/20930).

#### What does this implement/fix?
<!--Please explain your changes.-->

Implement the Array API for `integrate.trapezoid`.

#### Additional information
<!--Any additional information you think is important.-->

Hello! I met @lucascolley at the NumFocus summit this week, and he advised me to start with `integrate.trapezoid` to help with the Array API implementation effort. I am submitting this as a draft PR because I don't understand yet everything that is going on here, and I am looking for feedback and advice.

I have several questions so far:
* There is a masked array test, which does not work with Array API. I understand that supporting masked arrays is out of scope of Array API. How should we then proceed with this test?
* I remember that Lucas told me that `np.diff` would probably need to be reimplemented, so I don't really understand why my initial strategy of blindly replacing `np` with `xp` seems to pass some tests.