### PR TITLE
BUG: optimize.minimize.powell: stop squeezing everything

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -29,8 +29,7 @@ import math
 import warnings
 import sys
 import inspect
-from numpy import (atleast_1d, eye, argmin, zeros, shape, squeeze,
-                   asarray, sqrt)
+from numpy import atleast_1d, eye, argmin, zeros, shape, asarray, sqrt
 import numpy as np
 from scipy.linalg import cholesky, issymmetric, LinAlgError
 from scipy.sparse.linalg import LinearOperator

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -3184,7 +3184,7 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
                                           myfunc, None, tuple(), xtol=tol)
         alpha_min, fret = res.x, res.fun
         xi = alpha_min * xi
-        return squeeze(fret), p + xi, xi
+        return fret, p + xi, xi
     else:
         bound = _line_for_search(p, xi, lower_bound, upper_bound)
         if np.isneginf(bound[0]) and np.isposinf(bound[1]):
@@ -3194,7 +3194,7 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
             # we can use a bounded scalar minimization
             res = _minimize_scalar_bounded(myfunc, bound, xatol=tol / 100)
             xi = res.x * xi
-            return squeeze(res.fun), p + xi, xi
+            return res.fun, p + xi, xi
         else:
             # only bounded on one side. use the tangent function to convert
             # the infinity bound to a finite bound. The new bounded region
@@ -3205,7 +3205,7 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
                 bound,
                 xatol=tol / 100)
             xi = np.tan(res.x) * xi
-            return squeeze(res.fun), p + xi, xi
+            return res.fun, p + xi, xi
 
 
 def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
@@ -3493,7 +3493,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, stacklevel=3)
 
-    fval = squeeze(func(x))
+    fval = func(x)
     x1 = x.copy()
     iter = 0
     while True:
@@ -3538,7 +3538,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             else:
                 _, lmax = _line_for_search(x, direc1, lower_bound, upper_bound)
             x2 = x + min(lmax, 1) * direc1
-            fx2 = squeeze(func(x2))
+            fx2 = func(x2)
 
             if (fx > fx2):
                 t = 2.0*(fx + fx2 - 2.0*fval)
@@ -3584,7 +3584,6 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         print(f"         Current function value: {fval:f}")
         print("         Iterations: %d" % iter)
         print("         Function evaluations: %d" % fcalls[0])
-
     result = OptimizeResult(fun=fval, direc=direc, nit=iter, nfev=fcalls[0],
                             status=warnflag, success=(warnflag == 0),
                             message=msg, x=x)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2424,6 +2424,13 @@ def test_powell_limits():
     optimize.minimize(fun=func, x0=[0.5], method='powell', bounds=bounds)
 
 
+def test_powell_output():
+    funs = [rosen, lambda x: np.array(rosen(x)), lambda x: np.array([rosen(x)])]
+    for fun in funs:
+        res = optimize.minimize(fun, x0=[0.6, 20], method='Powell')
+        assert np.isscalar(res.fun)
+
+
 class TestRosen:
 
     def test_hess(self):


### PR DESCRIPTION
I think this closes https://github.com/scipy/scipy/issues/21519.

Squeezing everything is generally a bad idea:

```python
>>> np.squeeze(1.0)
array(1.)
```

It turns things into zero-length arrays.