### PR TITLE
BUG: special.logsumexp: fix type promotion

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -580,12 +580,23 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
     args_not_none = [arg for arg in args if arg is not None]
 
     # determine minimum dtype
+    default_float = xp.asarray(1.).dtype
     dtypes = [arg.dtype for arg in args_not_none]
-    dtype = xp.result_type(*dtypes)
-    if force_floating and xp.isdtype(dtype, 'integral'):
-        # If we were to add `xp.float32` before checking whether the result
-        # type is otherwise integral, we risk promotion from lower float.
-        dtype = xp.result_type(dtype, xp.float32)
+    try:  # follow library's prefered mixed promotion rules
+        dtype = xp.result_type(*dtypes)
+        if force_floating and xp.isdtype(dtype, 'integral'):
+            # If we were to add `default_float` before checking whether the result
+            # type is otherwise integral, we risk promotion from lower float.
+            dtype = xp.result_type(dtype, default_float)
+    except TypeError:  # mixed type promotion isn't defined
+        float_dtypes = [arg.dtype for arg in args_not_none
+                        if not xp.isdtype(dtype, 'integral')]
+        if float_dtypes:
+            dtype = xp.result_type(*float_dtypes)
+        elif force_floating:
+            dtype = default_float
+        else:
+            dtype = xp.result_type(*dtypes)
 
     # determine result shape
     shapes = {arg.shape for arg in args_not_none}

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -580,11 +580,19 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
     args_not_none = [arg for arg in args if arg is not None]
 
     # determine minimum dtype
-    dtypes = [arg.dtype for arg in args_not_none
-              if not xp.isdtype(arg.dtype, 'integral')]
-    if force_floating:
-        dtypes.append(xp.asarray(1.).dtype)
-    dtype = xp.result_type(*dtypes)
+    floating_dtypes = [
+        arg.dtype for arg in args_not_none
+        if not xp.isdtype(arg.dtype, 'integral')
+    ]
+
+    if not floating_dtypes:
+        if force_floating:
+            dtype = xp.asarray(1.).dtype
+        else:
+            dtypes = [arg.dtype for arg in args_not_none]
+            dtype = xp.result_type(*dtypes)
+    else:
+        dtype = xp.result_type(*floating_dtypes)
 
     # determine result shape
     shapes = {arg.shape for arg in args_not_none}

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -583,6 +583,8 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
     dtypes = [arg.dtype for arg in args_not_none]
     dtype = xp.result_type(*dtypes)
     if force_floating and xp.isdtype(dtype, 'integral'):
+        # If we were to add `xp.float32` before checking whether the result
+        # type is otherwise integral, we risk promotion from lower float.
         dtype = xp.result_type(dtype, xp.float32)
 
     # determine result shape

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -589,10 +589,10 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
             # type is otherwise integral, we risk promotion from lower float.
             dtype = xp.result_type(dtype, default_float)
     except TypeError:  # mixed type promotion isn't defined
-        float_dtypes = [arg.dtype for arg in args_not_none
+        float_dtypes = [dtype for dtype in dtypes
                         if not xp.isdtype(dtype, 'integral')]
         if float_dtypes:
-            dtype = xp.result_type(*float_dtypes)
+            dtype = xp.result_type(*float_dtypes, default_float)
         elif force_floating:
             dtype = default_float
         else:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -580,19 +580,10 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
     args_not_none = [arg for arg in args if arg is not None]
 
     # determine minimum dtype
-    floating_dtypes = [
-        arg.dtype for arg in args_not_none
-        if not xp.isdtype(arg.dtype, 'integral')
-    ]
-
-    if not floating_dtypes:
-        if force_floating:
-            dtype = xp.asarray(1.).dtype
-        else:
-            dtypes = [arg.dtype for arg in args_not_none]
-            dtype = xp.result_type(*dtypes)
-    else:
-        dtype = xp.result_type(*floating_dtypes)
+    dtypes = [arg.dtype for arg in args_not_none]
+    dtype = xp.result_type(*dtypes)
+    if force_floating and xp.isdtype(dtype, 'integral'):
+        dtype = xp.result_type(dtype, xp.float32)
 
     # determine result shape
     shapes = {arg.shape for arg in args_not_none}

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -129,7 +129,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     # suppress warnings about log of zero
     with np.errstate(divide='ignore'):
-        s = xp.sum(tmp, axis=axis, keepdims=keepdims)
+        s = xp.sum(tmp, axis=axis, keepdims=keepdims, dtype=tmp.dtype)
         if return_sign:
             # For complex, use the numpy>=2.0 convention for sign.
             if xp.isdtype(s.dtype, "complex floating"):

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -155,6 +155,16 @@ class TestLogSumExp:
     def test_xp_invalid_input(self, arg, xp):
         assert logsumexp(arg) == logsumexp(np.asarray(np.atleast_1d(arg)))
 
+    @pytest.mark.parametrize(
+        'dtype', ['float32', 'float64', 'int32', 'int64', 'complex64', 'complex128']
+    )
+    def test_dtypes(self, dtype, xp):
+        dtype = getattr(xp, dtype)
+        desired_dtype = xp.asarray(1.).dtype if dtype in {xp.int32, xp.int64} else dtype
+        a = xp.asarray([1000., 1000.], dtype=dtype)
+        desired = xp.asarray(1000.0 + math.log(2.0), dtype=desired_dtype)
+        xp_assert_close(logsumexp(a), desired)
+
 
 class TestSoftmax:
     def test_softmax_fixtures(self):

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from scipy.conftest import array_api_compatible
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, is_array_api_strict
 from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 
 from scipy.special import logsumexp, softmax
@@ -183,7 +183,7 @@ class TestLogSumExp:
         a = xp.asarray([2, 1], dtype=xp_dtype_a)
         b = xp.asarray([1, -1], dtype=xp_dtype_b)
         xp_test = array_namespace(a, b)  # torch needs compatible result_type
-        if xp.__name__ == 'array_api_strict':
+        if is_array_api_strict(xp):
             xp_float_dtypes = [dtype for dtype in [xp_dtype_a, xp_dtype_b]
                                if not xp_test.isdtype(dtype, 'integral')]
             if len(xp_float_dtypes) < 2:  # at least one is integral
@@ -194,6 +194,7 @@ class TestLogSumExp:
             desired_dtype = xp_test.result_type(xp_dtype_a, xp_dtype_b, xp.float32)
         desired = xp.asarray(math.log(math.exp(2) - math.exp(1)), dtype=desired_dtype)
         xp_assert_close(logsumexp(a, b=b), desired)
+
 
 class TestSoftmax:
     def test_softmax_fixtures(self):

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -36,7 +36,7 @@ class TestLogSumExp:
         xp_assert_close(logsumexp(b), desired)
 
         n = 1000
-        b = xp.full((n,), 10000.)
+        b = xp.full((n,), 10000)
         desired = xp.asarray(10000.0 + math.log(n))
         xp_assert_close(logsumexp(b), desired)
 
@@ -76,7 +76,7 @@ class TestLogSumExp:
         desired = xp.log(xp.sum(b*xp.exp(a)))
         xp_assert_close(logsumexp(a, b=b), desired)
 
-        a = xp.asarray([1000., 1000.])
+        a = xp.asarray([1000, 1000])
         b = xp.asarray([1.2, 1.2])
         desired = xp.asarray(1000 + math.log(2 * 1.2))
         xp_assert_close(logsumexp(a, b=b), desired)
@@ -92,16 +92,16 @@ class TestLogSumExp:
         xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=1)), xp.sum(B * X, axis=1))
 
     def test_logsumexp_sign(self, xp):
-        a = xp.asarray([1., 1., 1.])
-        b = xp.asarray([1., -1., -1.])
+        a = xp.asarray([1, 1, 1])
+        b = xp.asarray([1, -1, -1])
 
         r, s = logsumexp(a, b=b, return_sign=True)
         xp_assert_close(r, xp.asarray(1.))
         xp_assert_equal(s, xp.asarray(-1.))
 
     def test_logsumexp_sign_zero(self, xp):
-        a = xp.asarray([1., 1.])
-        b = xp.asarray([1., -1.])
+        a = xp.asarray([1, 1])
+        b = xp.asarray([1, -1])
 
         r, s = logsumexp(a, b=b, return_sign=True)
         assert not xp.isfinite(r)
@@ -142,8 +142,8 @@ class TestLogSumExp:
         assert r.shape == (1, 3)
 
     def test_logsumexp_b_zero(self, xp):
-        a = xp.asarray([1., 10000.])
-        b = xp.asarray([1., 0.])
+        a = xp.asarray([1, 10000])
+        b = xp.asarray([1, 0])
 
         xp_assert_close(logsumexp(a, b=b), xp.asarray(1.))
 
@@ -167,28 +167,32 @@ class TestLogSumExp:
 
     @pytest.mark.parametrize('dtype', dtypes)
     def test_dtypes_a(self, dtype, xp):
-        if xp.__name__ == 'array_api_strict' and dtype in integral_dtypes:
-            pytest.skip('`array_api_strict` does not promote ints to floats')
         dtype = getattr(xp, dtype)
         a = xp.asarray([1000., 1000.], dtype=dtype)
-        xp_test = array_namespace(a)  # torch needs compatible result_type
-        desired_dtype = xp_test.result_type(dtype, xp.float32)
+        xp_test = array_namespace(a)  # torch needs compatible `isdtype`
+        desired_dtype = (xp.asarray(1.).dtype if xp_test.isdtype(dtype, 'integral')
+                         else dtype)  # true for all libraries tested
         desired = xp.asarray(1000.0 + math.log(2.0), dtype=desired_dtype)
         xp_assert_close(logsumexp(a), desired)
 
     @pytest.mark.parametrize('dtype_a', dtypes)
     @pytest.mark.parametrize('dtype_b', dtypes)
     def test_dtypes_ab(self, dtype_a, dtype_b, xp):
-        dtype_is_integral = dtype_a in integral_dtypes or dtype_b in integral_dtypes
-        if xp.__name__ == 'array_api_strict' and dtype_is_integral:
-            pytest.skip('`array_api_strict` does not promote ints to floats')
         xp_dtype_a = getattr(xp, dtype_a)
         xp_dtype_b = getattr(xp, dtype_b)
         a = xp.asarray([2, 1], dtype=xp_dtype_a)
         b = xp.asarray([1, -1], dtype=xp_dtype_b)
         xp_test = array_namespace(a, b)  # torch needs compatible result_type
-        result_dtype = xp_test.result_type(xp_dtype_a, xp_dtype_b, xp.float32)
-        desired = xp.asarray(math.log(math.exp(2) - math.exp(1)), dtype=result_dtype)
+        if xp.__name__ == 'array_api_strict':
+            xp_float_dtypes = [dtype for dtype in [xp_dtype_a, xp_dtype_b]
+                               if not xp_test.isdtype(dtype, 'integral')]
+            if len(xp_float_dtypes) < 2:  # at least one is integral
+                xp_float_dtypes.append(xp.asarray(1.).dtype)
+            desired_dtype = xp_test.result_type(*xp_float_dtypes)
+        else:
+            # True for all libraries tested
+            desired_dtype = xp_test.result_type(xp_dtype_a, xp_dtype_b, xp.float32)
+        desired = xp.asarray(math.log(math.exp(2) - math.exp(1)), dtype=desired_dtype)
         xp_assert_close(logsumexp(a, b=b), desired)
 
 class TestSoftmax:

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -36,7 +36,7 @@ class TestLogSumExp:
         xp_assert_close(logsumexp(b), desired)
 
         n = 1000
-        b = xp.full((n,), 10000)
+        b = xp.full((n,), 10000.)
         desired = xp.asarray(10000.0 + math.log(n))
         xp_assert_close(logsumexp(b), desired)
 
@@ -76,7 +76,7 @@ class TestLogSumExp:
         desired = xp.log(xp.sum(b*xp.exp(a)))
         xp_assert_close(logsumexp(a, b=b), desired)
 
-        a = xp.asarray([1000, 1000])
+        a = xp.asarray([1000., 1000.])
         b = xp.asarray([1.2, 1.2])
         desired = xp.asarray(1000 + math.log(2 * 1.2))
         xp_assert_close(logsumexp(a, b=b), desired)
@@ -92,16 +92,16 @@ class TestLogSumExp:
         xp_assert_close(xp.exp(logsumexp(logX, b=B, axis=1)), xp.sum(B * X, axis=1))
 
     def test_logsumexp_sign(self, xp):
-        a = xp.asarray([1, 1, 1])
-        b = xp.asarray([1, -1, -1])
+        a = xp.asarray([1., 1., 1.])
+        b = xp.asarray([1., -1., -1.])
 
         r, s = logsumexp(a, b=b, return_sign=True)
         xp_assert_close(r, xp.asarray(1.))
         xp_assert_equal(s, xp.asarray(-1.))
 
     def test_logsumexp_sign_zero(self, xp):
-        a = xp.asarray([1, 1])
-        b = xp.asarray([1, -1])
+        a = xp.asarray([1., 1.])
+        b = xp.asarray([1., -1.])
 
         r, s = logsumexp(a, b=b, return_sign=True)
         assert not xp.isfinite(r)
@@ -142,8 +142,8 @@ class TestLogSumExp:
         assert r.shape == (1, 3)
 
     def test_logsumexp_b_zero(self, xp):
-        a = xp.asarray([1, 10000])
-        b = xp.asarray([1, 0])
+        a = xp.asarray([1., 10000.])
+        b = xp.asarray([1., 0.])
 
         xp_assert_close(logsumexp(a, b=b), xp.asarray(1.))
 
@@ -170,8 +170,9 @@ class TestLogSumExp:
         if xp.__name__ == 'array_api_strict' and dtype in integral_dtypes:
             pytest.skip('`array_api_strict` does not promote ints to floats')
         dtype = getattr(xp, dtype)
-        desired_dtype = xp.result_type(dtype, xp.float32)
         a = xp.asarray([1000., 1000.], dtype=dtype)
+        xp_test = array_namespace(a)  # torch needs compatible result_type
+        desired_dtype = xp_test.result_type(dtype, xp.float32)
         desired = xp.asarray(1000.0 + math.log(2.0), dtype=desired_dtype)
         xp_assert_close(logsumexp(a), desired)
 
@@ -185,7 +186,8 @@ class TestLogSumExp:
         xp_dtype_b = getattr(xp, dtype_b)
         a = xp.asarray([2, 1], dtype=xp_dtype_a)
         b = xp.asarray([1, -1], dtype=xp_dtype_b)
-        result_dtype = xp.result_type(xp_dtype_a, xp_dtype_b, xp.float32)
+        xp_test = array_namespace(a, b)  # torch needs compatible result_type
+        result_dtype = xp_test.result_type(xp_dtype_a, xp_dtype_b, xp.float32)
         desired = xp.asarray(math.log(math.exp(2) - math.exp(1)), dtype=result_dtype)
         xp_assert_close(logsumexp(a, b=b), desired)
 


### PR DESCRIPTION
#### Reference issue
https://github.com/google/jax/issues/23496

#### What does this implement/fix?
gh-21149 included an unintended change in return dtypes. This PR reverts to the original behaviour to avoid a breaking change. 

#### Additional information
cc @dfm
