### PR TITLE
TST: signal: convert to `xp_assert_*` infrastructure, pt 2

### DIFF
--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy._lib._array_api import (
-    assert_array_almost_equal, assert_almost_equal,
-    xp_assert_equal, xp_assert_close
+    assert_array_almost_equal, assert_almost_equal, xp_assert_close
 )
 
 import pytest

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -1,7 +1,8 @@
 import numpy as np
-from numpy.testing import \
-                          assert_array_almost_equal, assert_almost_equal, \
-                          assert_allclose, assert_equal
+from scipy._lib._array_api import (
+    assert_array_almost_equal, assert_almost_equal,
+    xp_assert_equal, xp_assert_close
+)
 
 import pytest
 from scipy.signal import cont2discrete as c2d
@@ -260,8 +261,8 @@ class TestC2D:
         # Compute the discrete tf using cont2discrete.
         c2dnum, c2dden, dt = c2d((cnum, cden), h, method='gbt', alpha=alpha)
 
-        assert_allclose(dnum, c2dnum)
-        assert_allclose(dden, c2dden)
+        xp_assert_close(dnum, c2dnum)
+        xp_assert_close(dden, c2dden)
 
         # Convert explicit solution to zpk.
         dz, dp, dk = ss2zpk(Ad, Bd, Cd, Dd)
@@ -269,9 +270,9 @@ class TestC2D:
         # Compute the discrete zpk using cont2discrete.
         c2dz, c2dp, c2dk, dt = c2d((cz, cp, ck), h, method='gbt', alpha=alpha)
 
-        assert_allclose(dz, c2dz)
-        assert_allclose(dp, c2dp)
-        assert_allclose(dk, c2dk)
+        xp_assert_close(dz, c2dz)
+        xp_assert_close(dp, c2dp)
+        xp_assert_close(dk, c2dk)
 
     def test_discrete_approx(self):
         """
@@ -311,16 +312,16 @@ class TestC2D:
         # actually approximates.
         ymid = 0.5 * (yout[:-1] + yout[1:])
 
-        assert_allclose(yd2.ravel(), ymid, rtol=1e-4)
+        xp_assert_close(yd2.ravel(), ymid, rtol=1e-4)
 
     def test_simo_tf(self):
         # See gh-5753
         tf = ([[1, 0], [1, 1]], [1, 1])
         num, den, dt = c2d(tf, 0.01)
 
-        assert_equal(dt, 0.01)  # sanity check
-        assert_allclose(den, [1, -0.990404983], rtol=1e-3)
-        assert_allclose(num, [[1, -1], [1, -0.99004983]], rtol=1e-3)
+        assert dt == 0.01  # sanity check
+        xp_assert_close(den, [1, -0.990404983], rtol=1e-3)
+        xp_assert_close(num, [[1, -1], [1, -0.99004983]], rtol=1e-3)
 
     def test_multioutput(self):
         ts = 0.01  # time step
@@ -335,16 +336,16 @@ class TestC2D:
         num2, den2, dt2 = c2d(tf2, ts)
 
         # Sanity checks
-        assert_equal(dt, dt1)
-        assert_equal(dt, dt2)
+        assert dt == dt1
+        assert dt == dt2
 
         # Check that we get the same results
-        assert_allclose(num, np.vstack((num1, num2)), rtol=1e-13)
+        xp_assert_close(num, np.vstack((num1, num2)), rtol=1e-13)
 
         # Single input, so the denominator should
         # not be multidimensional like the numerator
-        assert_allclose(den, den1, rtol=1e-13)
-        assert_allclose(den, den2, rtol=1e-13)
+        xp_assert_close(den, den1, rtol=1e-13)
+        xp_assert_close(den, den2, rtol=1e-13)
 
 class TestC2dLti:
     def test_c2d_ss(self):
@@ -361,10 +362,10 @@ class TestC2dLti:
         sys_ssc = lti(A, B, C, D)
         sys_ssd = sys_ssc.to_discrete(0.05)
 
-        assert_allclose(sys_ssd.A, A_res)
-        assert_allclose(sys_ssd.B, B_res)
-        assert_allclose(sys_ssd.C, C)
-        assert_allclose(sys_ssd.D, D)
+        xp_assert_close(sys_ssd.A, A_res)
+        xp_assert_close(sys_ssd.B, B_res)
+        xp_assert_close(sys_ssd.C, C)
+        xp_assert_close(sys_ssd.D, np.zeros_like(sys_ssd.D))
 
     def test_c2d_tf(self):
 
@@ -376,8 +377,8 @@ class TestC2dLti:
         den_res = np.array([1.0, -0.980198673306755])
 
         # Somehow a lot of numerical errors
-        assert_allclose(sys.den, den_res, atol=0.02)
-        assert_allclose(sys.num, num_res, atol=0.02)
+        xp_assert_close(sys.den, den_res, atol=0.02)
+        xp_assert_close(sys.num, num_res, atol=0.02)
 
 
 class TestC2dInvariants:
@@ -397,7 +398,7 @@ class TestC2dInvariants:
         _, yout_cont = impulse(sys, T=time)
         _, yout_disc = dimpulse(c2d(sys, sample_time, method='impulse'),
                                 n=len(time))
-        assert_allclose(sample_time * yout_cont.ravel(), yout_disc[0].ravel())
+        xp_assert_close(sample_time * yout_cont.ravel(), yout_disc[0].ravel())
 
     # Step invariant should hold for ZOH discretized systems
     @pytest.mark.parametrize("sys,sample_time,samples_number", cases)
@@ -405,7 +406,7 @@ class TestC2dInvariants:
         time = np.arange(samples_number) * sample_time
         _, yout_cont = step(sys, T=time)
         _, yout_disc = dstep(c2d(sys, sample_time, method='zoh'), n=len(time))
-        assert_allclose(yout_cont.ravel(), yout_disc[0].ravel())
+        xp_assert_close(yout_cont.ravel(), yout_disc[0].ravel())
 
     # Linear invariant should hold for FOH discretized systems
     @pytest.mark.parametrize("sys,sample_time,samples_number", cases)
@@ -413,4 +414,4 @@ class TestC2dInvariants:
         time = np.arange(samples_number) * sample_time
         _, yout_cont, _ = lsim(sys, T=time, U=time)
         _, yout_disc, _ = dlsim(c2d(sys, sample_time, method='foh'), u=time)
-        assert_allclose(yout_cont.ravel(), yout_disc.ravel())
+        xp_assert_close(yout_cont.ravel(), yout_disc.ravel())

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -85,25 +85,25 @@ class TestLocalMaxima1d:
         """Test with empty signal."""
         x = np.array([], dtype=np.float64)
         for array in _local_maxima_1d(x):
-            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            xp_assert_equal(array, np.array([]), check_dtype=False)
             assert array.base is None
 
     def test_linear(self):
         """Test with linear signal."""
         x = np.linspace(0, 100)
         for array in _local_maxima_1d(x):
-            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            xp_assert_equal(array, np.array([], dtype=np.intp))
             assert array.base is None
 
     def test_simple(self):
         """Test with simple signal."""
         x = np.linspace(-10, 10, 50)
         x[2::3] += 1
-        expected = np.arange(2, 50, 3)
+        expected = np.arange(2, 50, 3, dtype=np.intp)
         for array in _local_maxima_1d(x):
             # For plateaus of size 1, the edges are identical with the
             # midpoints
-            xp_assert_equal(array, expected)
+            xp_assert_equal(array, expected, check_dtype=False)
             assert array.base is None
 
     def test_flat_maxima(self):
@@ -111,9 +111,9 @@ class TestLocalMaxima1d:
         x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 2.99, 4, 4, 4, 4, -10,
                       -5, -5, -5, -5, -5, -10])
         midpoints, left_edges, right_edges = _local_maxima_1d(x)
-        xp_assert_equal(midpoints, np.array([2, 4, 8, 12, 18]))
-        xp_assert_equal(left_edges, np.array([2, 4, 7, 11, 16]))
-        xp_assert_equal(right_edges, np.array([2, 5, 9, 14, 20]))
+        xp_assert_equal(midpoints, np.array([2, 4, 8, 12, 18]), check_dtype=False)
+        xp_assert_equal(left_edges, np.array([2, 4, 7, 11, 16]), check_dtype=False)
+        xp_assert_equal(right_edges, np.array([2, 5, 9, 14, 20]), check_dtype=False)
 
     @pytest.mark.parametrize('x', [
         np.array([1., 0, 2]),
@@ -123,7 +123,7 @@ class TestLocalMaxima1d:
     def test_signal_edges(self, x):
         """Test if behavior on signal edges is correct."""
         for array in _local_maxima_1d(x):
-            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            xp_assert_equal(array, np.array([], dtype=np.intp))
             assert array.base is None
 
     def test_exceptions(self):
@@ -169,7 +169,7 @@ class TestRidgeLines:
                                                  max(gaps) + 1)
         assert len(identified_lines) == 1
         for iline_, line_ in zip(identified_lines[0], line):
-            xp_assert_equal(iline_, line_)
+            xp_assert_equal(iline_, line_, check_dtype=False)
 
     def test_single_bigdist(self):
         distances = [0, 1, 2, 5]
@@ -250,17 +250,17 @@ class TestArgrel:
 
         i = argrelmin(z1)
         xp_assert_equal(len(i), 1)
-        xp_assert_equal(i[0], empty_array)
+        xp_assert_equal(i[0], empty_array, check_dtype=False)
 
-        z2 = np.zeros((3,5))
+        z2 = np.zeros((3, 5))
 
         row, col = argrelmin(z2, axis=0)
-        xp_assert_equal(row, empty_array)
-        xp_assert_equal(col, empty_array)
+        xp_assert_equal(row, empty_array, check_dtype=False)
+        xp_assert_equal(col, empty_array, check_dtype=False)
 
         row, col = argrelmin(z2, axis=1)
-        xp_assert_equal(row, empty_array)
-        xp_assert_equal(col, empty_array)
+        xp_assert_equal(row, empty_array, check_dtype=False)
+        xp_assert_equal(col, empty_array, check_dtype=False)
 
     def test_basic(self):
         # Note: the docstrings for the argrel{min,max,extrema} functions
@@ -275,23 +275,23 @@ class TestArgrel:
 
         row, col = argrelmax(x, axis=0)
         order = np.argsort(row)
-        xp_assert_equal(row[order], [1, 2, 3])
-        xp_assert_equal(col[order], [4, 0, 1])
+        xp_assert_equal(row[order], [1, 2, 3], check_dtype=False)
+        xp_assert_equal(col[order], [4, 0, 1], check_dtype=False)
 
         row, col = argrelmax(x, axis=1)
         order = np.argsort(row)
-        xp_assert_equal(row[order], [0, 3, 4])
-        xp_assert_equal(col[order], [3, 1, 2])
+        xp_assert_equal(row[order], [0, 3, 4], check_dtype=False)
+        xp_assert_equal(col[order], [3, 1, 2], check_dtype=False)
 
         row, col = argrelmin(x, axis=0)
         order = np.argsort(row)
-        xp_assert_equal(row[order], [1, 2, 3])
-        xp_assert_equal(col[order], [1, 2, 3])
+        xp_assert_equal(row[order], [1, 2, 3], check_dtype=False)
+        xp_assert_equal(col[order], [1, 2, 3], check_dtype=False)
 
         row, col = argrelmin(x, axis=1)
         order = np.argsort(row)
-        xp_assert_equal(row[order], [1, 2, 3])
-        xp_assert_equal(col[order], [1, 2, 3])
+        xp_assert_equal(row[order], [1, 2, 3], check_dtype=False)
+        xp_assert_equal(col[order], [1, 2, 3], check_dtype=False)
 
     def test_highorder(self):
         order = 2
@@ -348,9 +348,9 @@ class TestPeakProminences:
         proms = x[peaks] - np.max([x[lbases], x[rbases]], axis=0)
         # Test if calculation matches handcrafted result
         out = peak_prominences(x, peaks)
-        xp_assert_equal(out[0], proms)
-        xp_assert_equal(out[1], lbases)
-        xp_assert_equal(out[2], rbases)
+        xp_assert_equal(out[0], proms, check_dtype=False)
+        xp_assert_equal(out[1], lbases, check_dtype=False)
+        xp_assert_equal(out[2], rbases, check_dtype=False)
 
     def test_edge_cases(self):
         """
@@ -360,17 +360,17 @@ class TestPeakProminences:
         x = [0, 2, 1, 2, 1, 2, 0]
         peaks = [1, 3, 5]
         proms, lbases, rbases = peak_prominences(x, peaks)
-        xp_assert_equal(proms, np.asarray([2.0, 2, 2]))
-        xp_assert_equal(lbases, [0, 0, 0])
-        xp_assert_equal(rbases, [6, 6, 6])
+        xp_assert_equal(proms, np.asarray([2.0, 2, 2]), check_dtype=False)
+        xp_assert_equal(lbases, [0, 0, 0], check_dtype=False)
+        xp_assert_equal(rbases, [6, 6, 6], check_dtype=False)
 
         # Peaks have same height & prominence but different bases
         x = [0, 1, 0, 1, 0, 1, 0]
         peaks = np.array([1, 3, 5])
         proms, lbases, rbases = peak_prominences(x, peaks)
         xp_assert_equal(proms, np.asarray([1.0, 1, 1]))
-        xp_assert_equal(lbases, peaks - 1)
-        xp_assert_equal(rbases, peaks + 1)
+        xp_assert_equal(lbases, peaks - 1, check_dtype=False)
+        xp_assert_equal(rbases, peaks + 1, check_dtype=False)
 
     def test_non_contiguous(self):
         """
@@ -380,8 +380,8 @@ class TestPeakProminences:
         peaks = np.repeat([1, 2, 4], 2)
         proms, lbases, rbases = peak_prominences(x[::2], peaks[::2])
         xp_assert_equal(proms, np.asarray([9.0, 9, 2]))
-        xp_assert_equal(lbases, [0, 0, 3])
-        xp_assert_equal(rbases, [3, 3, 5])
+        xp_assert_equal(lbases, [0, 0, 3], check_dtype=False)
+        xp_assert_equal(rbases, [3, 3, 5], check_dtype=False)
 
     def test_wlen(self):
         """
@@ -641,15 +641,20 @@ class TestFindPeaks:
 
         # Test full output
         peaks, props = find_peaks(x, plateau_size=(None, None))
-        xp_assert_equal(peaks, [1, 3, 7, 11, 18, 33, 100])
-        xp_assert_equal(props["plateau_sizes"], plateau_sizes)
-        xp_assert_equal(props["left_edges"], peaks - (plateau_sizes - 1) // 2)
-        xp_assert_equal(props["right_edges"], peaks + plateau_sizes // 2)
+        xp_assert_equal(peaks, [1, 3, 7, 11, 18, 33, 100], check_dtype=False)
+        xp_assert_equal(props["plateau_sizes"], plateau_sizes, check_dtype=False)
+        xp_assert_equal(props["left_edges"], peaks - (plateau_sizes - 1) // 2,
+                        check_dtype=False)
+        xp_assert_equal(props["right_edges"], peaks + plateau_sizes // 2,
+                        check_dtype=False)
 
         # Test conditions
-        xp_assert_equal(find_peaks(x, plateau_size=4)[0], [11, 18, 33, 100])
-        xp_assert_equal(find_peaks(x, plateau_size=(None, 3.5))[0], [1, 3, 7])
-        xp_assert_equal(find_peaks(x, plateau_size=(5, 50))[0], [18, 33])
+        xp_assert_equal(find_peaks(x, plateau_size=4)[0], [11, 18, 33, 100],
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, plateau_size=(None, 3.5))[0], [1, 3, 7],
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, plateau_size=(5, 50))[0], [18, 33],
+                        check_dtype=False)
 
     def test_height_condition(self):
         """
@@ -657,11 +662,15 @@ class TestFindPeaks:
         """
         x = (0., 1/3, 0., 2.5, 0, 4., 0)
         peaks, props = find_peaks(x, height=(None, None))
-        xp_assert_equal(peaks, np.array([1, 3, 5]))
-        xp_assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]))
-        xp_assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]))
-        xp_assert_equal(find_peaks(x, height=(None, 3))[0], np.array([1, 3]))
-        xp_assert_equal(find_peaks(x, height=(2, 3))[0], np.array([3]))
+        xp_assert_equal(peaks, np.array([1, 3, 5]), check_dtype=False)
+        xp_assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, height=(None, 3))[0], np.array([1, 3]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, height=(2, 3))[0], np.array([3]),
+                        check_dtype=False)
 
     def test_threshold_condition(self):
         """
@@ -669,14 +678,19 @@ class TestFindPeaks:
         """
         x = (0, 2, 1, 4, -1)
         peaks, props = find_peaks(x, threshold=(None, None))
-        xp_assert_equal(peaks, np.array([1, 3]))
+        xp_assert_equal(peaks, np.array([1, 3]), check_dtype=False)
         xp_assert_equal(props['left_thresholds'], np.array([2.0, 3.0]))
         xp_assert_equal(props['right_thresholds'], np.array([1.0, 5.0]))
-        xp_assert_equal(find_peaks(x, threshold=2)[0], np.array([3]))
-        xp_assert_equal(find_peaks(x, threshold=3.5)[0], np.array([], dtype=int))
-        xp_assert_equal(find_peaks(x, threshold=(None, 5))[0], np.array([1, 3]))
-        xp_assert_equal(find_peaks(x, threshold=(None, 4))[0], np.array([1]))
-        xp_assert_equal(find_peaks(x, threshold=(2, 4))[0], np.array([], dtype=int))
+        xp_assert_equal(find_peaks(x, threshold=2)[0], np.array([3]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, threshold=3.5)[0], np.array([], dtype=int),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, threshold=(None, 5))[0], np.array([1, 3]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, threshold=(None, 4))[0], np.array([1]),
+                        check_dtype=False)
+        xp_assert_equal(find_peaks(x, threshold=(2, 4))[0], np.array([], dtype=int),
+                        check_dtype=False)
 
     def test_distance_condition(self):
         """
@@ -688,7 +702,7 @@ class TestFindPeaks:
         x[peaks_all] += np.linspace(1, 2, peaks_all.size)
 
         # Test if peaks with "minimal" distance are still selected (distance = 3)
-        xp_assert_equal(find_peaks(x, distance=3)[0], peaks_all)
+        xp_assert_equal(find_peaks(x, distance=3)[0], peaks_all, check_dtype=False)
 
         # Select every second peak (distance > 3)
         peaks_subset = find_peaks(x, distance=3.0001)[0]
@@ -718,11 +732,12 @@ class TestFindPeaks:
             (interval[0] <= prominences) & (prominences <= interval[1]))
 
         peaks_calc, properties = find_peaks(x, prominence=interval)
-        xp_assert_equal(peaks_calc, peaks_true[keep])
-        xp_assert_equal(properties['prominences'], prominences[keep])
+        xp_assert_equal(peaks_calc, peaks_true[keep], check_dtype=False)
+        xp_assert_equal(properties['prominences'], prominences[keep], check_dtype=False)
         xp_assert_equal(properties['left_bases'],
                         np.zeros_like(properties['left_bases']))
-        xp_assert_equal(properties['right_bases'], peaks_true[keep] + 1)
+        xp_assert_equal(properties['right_bases'], peaks_true[keep] + 1,
+                        check_dtype=False)
 
     def test_width_condition(self):
         """
@@ -813,6 +828,7 @@ class TestFindPeaksCwt:
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=0,
                                          min_length=None)
         xp_assert_equal(found_locs, act_locs,
+                        check_dtype=False,
                         err_msg="Found maximum locations did not equal those expected"
         )
 
@@ -856,7 +872,7 @@ class TestFindPeaksCwt:
         widths = np.array([1, 2, 3, 4])
         a = find_peaks_cwt(x, widths, wavelet=gaussian)
 
-        xp_assert_equal(a, np.asarray([100]))
+        xp_assert_equal(a, np.asarray([100]), check_dtype=False)
 
     def test_find_peaks_window_size(self):
         """

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -720,7 +720,8 @@ class TestFindPeaks:
         peaks_calc, properties = find_peaks(x, prominence=interval)
         xp_assert_equal(peaks_calc, peaks_true[keep])
         xp_assert_equal(properties['prominences'], prominences[keep])
-        xp_assert_equal(properties['left_bases'], np.zeros_like(properties['left_bases']))
+        xp_assert_equal(properties['left_bases'],
+                        np.zeros_like(properties['left_bases']))
         xp_assert_equal(properties['right_bases'], peaks_true[keep] + 1)
 
     def test_width_condition(self):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -1,14 +1,9 @@
 import copy
 
 import numpy as np
-from numpy.testing import (
-    assert_,
-    assert_equal,
-    assert_allclose,
-    assert_array_equal
-)
 import pytest
 from pytest import raises, warns
+from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 
 from scipy.signal._peak_finding import (
     argrelmax,
@@ -90,15 +85,15 @@ class TestLocalMaxima1d:
         """Test with empty signal."""
         x = np.array([], dtype=np.float64)
         for array in _local_maxima_1d(x):
-            assert_equal(array, np.array([]))
-            assert_(array.base is None)
+            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            assert array.base is None
 
     def test_linear(self):
         """Test with linear signal."""
         x = np.linspace(0, 100)
         for array in _local_maxima_1d(x):
-            assert_equal(array, np.array([]))
-            assert_(array.base is None)
+            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            assert array.base is None
 
     def test_simple(self):
         """Test with simple signal."""
@@ -108,17 +103,17 @@ class TestLocalMaxima1d:
         for array in _local_maxima_1d(x):
             # For plateaus of size 1, the edges are identical with the
             # midpoints
-            assert_equal(array, expected)
-            assert_(array.base is None)
+            xp_assert_equal(array, expected)
+            assert array.base is None
 
     def test_flat_maxima(self):
         """Test if flat maxima are detected correctly."""
         x = np.array([-1.3, 0, 1, 0, 2, 2, 0, 3, 3, 3, 2.99, 4, 4, 4, 4, -10,
                       -5, -5, -5, -5, -5, -10])
         midpoints, left_edges, right_edges = _local_maxima_1d(x)
-        assert_equal(midpoints, np.array([2, 4, 8, 12, 18]))
-        assert_equal(left_edges, np.array([2, 4, 7, 11, 16]))
-        assert_equal(right_edges, np.array([2, 5, 9, 14, 20]))
+        xp_assert_equal(midpoints, np.array([2, 4, 8, 12, 18]))
+        xp_assert_equal(left_edges, np.array([2, 4, 7, 11, 16]))
+        xp_assert_equal(right_edges, np.array([2, 5, 9, 14, 20]))
 
     @pytest.mark.parametrize('x', [
         np.array([1., 0, 2]),
@@ -128,8 +123,8 @@ class TestLocalMaxima1d:
     def test_signal_edges(self, x):
         """Test if behavior on signal edges is correct."""
         for array in _local_maxima_1d(x):
-            assert_equal(array, np.array([]))
-            assert_(array.base is None)
+            xp_assert_equal(array, np.array([], dtype=array.dtype))
+            assert array.base is None
 
     def test_exceptions(self):
         """Test input validation and raised exceptions."""
@@ -148,18 +143,18 @@ class TestRidgeLines:
     def test_empty(self):
         test_matr = np.zeros([20, 100])
         lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
-        assert_(len(lines) == 0)
+        assert len(lines) == 0
 
     def test_minimal(self):
         test_matr = np.zeros([20, 100])
         test_matr[0, 10] = 1
         lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
-        assert_(len(lines) == 1)
+        assert len(lines) == 1
 
         test_matr = np.zeros([20, 100])
         test_matr[0:2, 10] = 1
         lines = _identify_ridge_lines(test_matr, np.full(20, 2), 1)
-        assert_(len(lines) == 1)
+        assert len(lines) == 1
 
     def test_single_pass(self):
         distances = [0, 1, 2, 5]
@@ -172,7 +167,9 @@ class TestRidgeLines:
         identified_lines = _identify_ridge_lines(test_matr,
                                                  max_distances,
                                                  max(gaps) + 1)
-        assert_array_equal(identified_lines, [line])
+        assert len(identified_lines) == 1
+        for iline_, line_ in zip(identified_lines[0], line):
+            xp_assert_equal(iline_, line_)
 
     def test_single_bigdist(self):
         distances = [0, 1, 2, 5]
@@ -187,7 +184,7 @@ class TestRidgeLines:
         identified_lines = _identify_ridge_lines(test_matr,
                                                  max_distances,
                                                  max(gaps) + 1)
-        assert_(len(identified_lines) == 2)
+        assert len(identified_lines) == 2
 
         for iline in identified_lines:
             adists = np.diff(iline[1])
@@ -208,7 +205,7 @@ class TestRidgeLines:
         max_distances = np.full(20, max_dist)
         #This should get 2 lines, since the gap is too large
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max_gap)
-        assert_(len(identified_lines) == 2)
+        assert len(identified_lines) == 2
 
         for iline in identified_lines:
             adists = np.diff(iline[1])
@@ -229,7 +226,7 @@ class TestRidgeLines:
         max_distances = np.full(50, max_dist)
         #This should get 3 lines, since the gaps are too large
         identified_lines = _identify_ridge_lines(test_matr, max_distances, max_gap)
-        assert_(len(identified_lines) == 3)
+        assert len(identified_lines) == 3
 
         for iline in identified_lines:
             adists = np.diff(iline[1])
@@ -252,18 +249,18 @@ class TestArgrel:
         z1 = np.zeros(5)
 
         i = argrelmin(z1)
-        assert_equal(len(i), 1)
-        assert_array_equal(i[0], empty_array)
+        xp_assert_equal(len(i), 1)
+        xp_assert_equal(i[0], empty_array)
 
         z2 = np.zeros((3,5))
 
         row, col = argrelmin(z2, axis=0)
-        assert_array_equal(row, empty_array)
-        assert_array_equal(col, empty_array)
+        xp_assert_equal(row, empty_array)
+        xp_assert_equal(col, empty_array)
 
         row, col = argrelmin(z2, axis=1)
-        assert_array_equal(row, empty_array)
-        assert_array_equal(col, empty_array)
+        xp_assert_equal(row, empty_array)
+        xp_assert_equal(col, empty_array)
 
     def test_basic(self):
         # Note: the docstrings for the argrel{min,max,extrema} functions
@@ -278,23 +275,23 @@ class TestArgrel:
 
         row, col = argrelmax(x, axis=0)
         order = np.argsort(row)
-        assert_equal(row[order], [1, 2, 3])
-        assert_equal(col[order], [4, 0, 1])
+        xp_assert_equal(row[order], [1, 2, 3])
+        xp_assert_equal(col[order], [4, 0, 1])
 
         row, col = argrelmax(x, axis=1)
         order = np.argsort(row)
-        assert_equal(row[order], [0, 3, 4])
-        assert_equal(col[order], [3, 1, 2])
+        xp_assert_equal(row[order], [0, 3, 4])
+        xp_assert_equal(col[order], [3, 1, 2])
 
         row, col = argrelmin(x, axis=0)
         order = np.argsort(row)
-        assert_equal(row[order], [1, 2, 3])
-        assert_equal(col[order], [1, 2, 3])
+        xp_assert_equal(row[order], [1, 2, 3])
+        xp_assert_equal(col[order], [1, 2, 3])
 
         row, col = argrelmin(x, axis=1)
         order = np.argsort(row)
-        assert_equal(row[order], [1, 2, 3])
-        assert_equal(col[order], [1, 2, 3])
+        xp_assert_equal(row[order], [1, 2, 3])
+        xp_assert_equal(col[order], [1, 2, 3])
 
     def test_highorder(self):
         order = 2
@@ -304,8 +301,8 @@ class TestArgrel:
         test_data[act_locs - order] = test_data[act_locs]*0.99999
         rel_max_locs = argrelmax(test_data, order=order, mode='clip')[0]
 
-        assert_(len(rel_max_locs) == len(act_locs))
-        assert_((rel_max_locs == act_locs).all())
+        assert len(rel_max_locs) == len(act_locs)
+        assert (rel_max_locs == act_locs).all()
 
     def test_2d_gaussians(self):
         sigmas = [1.0, 2.0, 10.0]
@@ -318,8 +315,8 @@ class TestArgrel:
         for rw in range(0, test_data_2.shape[0]):
             inds = (rel_max_rows == rw)
 
-            assert_(len(rel_max_cols[inds]) == len(act_locs))
-            assert_((act_locs == (rel_max_cols[inds] - rot_factor*rw)).all())
+            assert len(rel_max_cols[inds]) == len(act_locs)
+            assert (act_locs == (rel_max_cols[inds] - rot_factor*rw)).all()
 
 
 class TestPeakProminences:
@@ -330,13 +327,13 @@ class TestPeakProminences:
         """
         out = peak_prominences([1, 2, 3], [])
         for arr, dtype in zip(out, [np.float64, np.intp, np.intp]):
-            assert_(arr.size == 0)
-            assert_(arr.dtype == dtype)
+            assert arr.size == 0
+            assert arr.dtype == dtype
 
         out = peak_prominences([], [])
         for arr, dtype in zip(out, [np.float64, np.intp, np.intp]):
-            assert_(arr.size == 0)
-            assert_(arr.dtype == dtype)
+            assert arr.size == 0
+            assert arr.dtype == dtype
 
     def test_basic(self):
         """
@@ -351,9 +348,9 @@ class TestPeakProminences:
         proms = x[peaks] - np.max([x[lbases], x[rbases]], axis=0)
         # Test if calculation matches handcrafted result
         out = peak_prominences(x, peaks)
-        assert_equal(out[0], proms)
-        assert_equal(out[1], lbases)
-        assert_equal(out[2], rbases)
+        xp_assert_equal(out[0], proms)
+        xp_assert_equal(out[1], lbases)
+        xp_assert_equal(out[2], rbases)
 
     def test_edge_cases(self):
         """
@@ -363,17 +360,17 @@ class TestPeakProminences:
         x = [0, 2, 1, 2, 1, 2, 0]
         peaks = [1, 3, 5]
         proms, lbases, rbases = peak_prominences(x, peaks)
-        assert_equal(proms, [2, 2, 2])
-        assert_equal(lbases, [0, 0, 0])
-        assert_equal(rbases, [6, 6, 6])
+        xp_assert_equal(proms, np.asarray([2.0, 2, 2]))
+        xp_assert_equal(lbases, [0, 0, 0])
+        xp_assert_equal(rbases, [6, 6, 6])
 
         # Peaks have same height & prominence but different bases
         x = [0, 1, 0, 1, 0, 1, 0]
         peaks = np.array([1, 3, 5])
         proms, lbases, rbases = peak_prominences(x, peaks)
-        assert_equal(proms, [1, 1, 1])
-        assert_equal(lbases, peaks - 1)
-        assert_equal(rbases, peaks + 1)
+        xp_assert_equal(proms, np.asarray([1.0, 1, 1]))
+        xp_assert_equal(lbases, peaks - 1)
+        xp_assert_equal(rbases, peaks + 1)
 
     def test_non_contiguous(self):
         """
@@ -382,9 +379,9 @@ class TestPeakProminences:
         x = np.repeat([-9, 9, 9, 0, 3, 1], 2)
         peaks = np.repeat([1, 2, 4], 2)
         proms, lbases, rbases = peak_prominences(x[::2], peaks[::2])
-        assert_equal(proms, [9, 9, 2])
-        assert_equal(lbases, [0, 0, 3])
-        assert_equal(rbases, [3, 3, 5])
+        xp_assert_equal(proms, np.asarray([9.0, 9, 2]))
+        xp_assert_equal(lbases, [0, 0, 3])
+        xp_assert_equal(rbases, [3, 3, 5])
 
     def test_wlen(self):
         """
@@ -393,9 +390,14 @@ class TestPeakProminences:
         x = [0, 1, 2, 3, 1, 0, -1]
         peak = [3]
         # Test rounding behavior of wlen
-        assert_equal(peak_prominences(x, peak), [3., 0, 6])
+        proms = peak_prominences(x, peak)
+        for prom, val in zip(proms, [3.0, 0, 6]):
+            assert prom == val
+
         for wlen, i in [(8, 0), (7, 0), (6, 0), (5, 1), (3.2, 1), (3, 2), (1.1, 2)]:
-            assert_equal(peak_prominences(x, peak, wlen), [3. - i, 0 + i, 6 - i])
+            proms = peak_prominences(x, peak, wlen)
+            for prom, val in zip(proms, [3. - i, 0 + i, 6 - i]):
+                assert prom == val
 
     def test_exceptions(self):
         """
@@ -446,15 +448,15 @@ class TestPeakWidths:
         Test if an empty array is returned if no peaks are provided.
         """
         widths = peak_widths([], [])[0]
-        assert_(isinstance(widths, np.ndarray))
-        assert_equal(widths.size, 0)
+        assert isinstance(widths, np.ndarray)
+        assert widths.size == 0
         widths = peak_widths([1, 2, 3], [])[0]
-        assert_(isinstance(widths, np.ndarray))
-        assert_equal(widths.size, 0)
+        assert isinstance(widths, np.ndarray)
+        assert widths.size == 0
         out = peak_widths([], [])
         for arr in out:
-            assert_(isinstance(arr, np.ndarray))
-            assert_equal(arr.size, 0)
+            assert isinstance(arr, np.ndarray)
+            assert arr.size == 0
 
     @pytest.mark.filterwarnings("ignore:some peaks have a width of 0")
     def test_basic(self):
@@ -475,10 +477,10 @@ class TestPeakWidths:
         ]:
             width_calc, height, lip_calc, rip_calc = peak_widths(
                 x, [3], rel_height)
-            assert_allclose(width_calc, width_true)
-            assert_allclose(height, 2 - rel_height * prominence)
-            assert_allclose(lip_calc, lip_true)
-            assert_allclose(rip_calc, rip_true)
+            xp_assert_close(width_calc, np.asarray([width_true]))
+            xp_assert_close(height, np.asarray([2 - rel_height * prominence]))
+            xp_assert_close(lip_calc, np.asarray([lip_true]))
+            xp_assert_close(rip_calc, np.asarray([rip_true]))
 
     def test_non_contiguous(self):
         """
@@ -487,7 +489,9 @@ class TestPeakWidths:
         x = np.repeat([0, 100, 50], 4)
         peaks = np.repeat([1], 3)
         result = peak_widths(x[::4], peaks[::3])
-        assert_equal(result, [0.75, 75, 0.75, 1.5])
+        xp_assert_equal(result,
+                        np.asarray([[0.75], [75], [0.75], [1.5]])
+        )
 
     def test_exceptions(self):
         """
@@ -569,10 +573,10 @@ class TestPeakWidths:
         # Flatt peak with two possible intersection points if evaluated at 1
         x = [0, 1, 2, 1, 3, 3, 3, 1, 2, 1, 0]
         # relative height is 0 -> width is 0 as well, raises warning
-        assert_allclose(peak_widths(x, peaks=[5], rel_height=0),
+        xp_assert_close(peak_widths(x, peaks=[5], rel_height=0),
                         [(0.,), (3.,), (5.,), (5.,)])
         # width_height == x counts as intersection -> nearest 1 is chosen
-        assert_allclose(peak_widths(x, peaks=[5], rel_height=2/3),
+        xp_assert_close(peak_widths(x, peaks=[5], rel_height=2/3),
                         [(4.,), (1.,), (3.,), (7.,)])
 
 
@@ -586,16 +590,16 @@ def test_unpack_condition_args():
     peaks = amin_true[1::2]
 
     # Test unpacking with None or interval
-    assert_((None, None) == _unpack_condition_args((None, None), x, peaks))
-    assert_((1, None) == _unpack_condition_args(1, x, peaks))
-    assert_((1, None) == _unpack_condition_args((1, None), x, peaks))
-    assert_((None, 2) == _unpack_condition_args((None, 2), x, peaks))
-    assert_((3., 4.5) == _unpack_condition_args((3., 4.5), x, peaks))
+    assert (None, None) == _unpack_condition_args((None, None), x, peaks)
+    assert (1, None) == _unpack_condition_args(1, x, peaks)
+    assert (1, None) == _unpack_condition_args((1, None), x, peaks)
+    assert (None, 2) == _unpack_condition_args((None, 2), x, peaks)
+    assert (3., 4.5) == _unpack_condition_args((3., 4.5), x, peaks)
 
     # Test if borders are correctly reduced with `peaks`
     amin_calc, amax_calc = _unpack_condition_args((amin_true, amax_true), x, peaks)
-    assert_equal(amin_calc, amin_true[peaks])
-    assert_equal(amax_calc, amax_true[peaks])
+    xp_assert_equal(amin_calc, amin_true[peaks])
+    xp_assert_equal(amax_calc, amax_true[peaks])
 
     # Test raises if array borders don't match x
     with raises(ValueError, match="array size of lower"):
@@ -619,9 +623,9 @@ class TestFindPeaks:
         peaks, props = find_peaks(np.ones(10),
                                   height=open_interval, threshold=open_interval,
                                   prominence=open_interval, width=open_interval)
-        assert_(peaks.size == 0)
+        assert peaks.size == 0
         for key in self.property_keys:
-            assert_(props[key].size == 0)
+            assert props[key].size == 0
 
     def test_plateau_size(self):
         """
@@ -637,15 +641,15 @@ class TestFindPeaks:
 
         # Test full output
         peaks, props = find_peaks(x, plateau_size=(None, None))
-        assert_equal(peaks, [1, 3, 7, 11, 18, 33, 100])
-        assert_equal(props["plateau_sizes"], plateau_sizes)
-        assert_equal(props["left_edges"], peaks - (plateau_sizes - 1) // 2)
-        assert_equal(props["right_edges"], peaks + plateau_sizes // 2)
+        xp_assert_equal(peaks, [1, 3, 7, 11, 18, 33, 100])
+        xp_assert_equal(props["plateau_sizes"], plateau_sizes)
+        xp_assert_equal(props["left_edges"], peaks - (plateau_sizes - 1) // 2)
+        xp_assert_equal(props["right_edges"], peaks + plateau_sizes // 2)
 
         # Test conditions
-        assert_equal(find_peaks(x, plateau_size=4)[0], [11, 18, 33, 100])
-        assert_equal(find_peaks(x, plateau_size=(None, 3.5))[0], [1, 3, 7])
-        assert_equal(find_peaks(x, plateau_size=(5, 50))[0], [18, 33])
+        xp_assert_equal(find_peaks(x, plateau_size=4)[0], [11, 18, 33, 100])
+        xp_assert_equal(find_peaks(x, plateau_size=(None, 3.5))[0], [1, 3, 7])
+        xp_assert_equal(find_peaks(x, plateau_size=(5, 50))[0], [18, 33])
 
     def test_height_condition(self):
         """
@@ -653,11 +657,11 @@ class TestFindPeaks:
         """
         x = (0., 1/3, 0., 2.5, 0, 4., 0)
         peaks, props = find_peaks(x, height=(None, None))
-        assert_equal(peaks, np.array([1, 3, 5]))
-        assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]))
-        assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]))
-        assert_equal(find_peaks(x, height=(None, 3))[0], np.array([1, 3]))
-        assert_equal(find_peaks(x, height=(2, 3))[0], np.array([3]))
+        xp_assert_equal(peaks, np.array([1, 3, 5]))
+        xp_assert_equal(props['peak_heights'], np.array([1/3, 2.5, 4.]))
+        xp_assert_equal(find_peaks(x, height=0.5)[0], np.array([3, 5]))
+        xp_assert_equal(find_peaks(x, height=(None, 3))[0], np.array([1, 3]))
+        xp_assert_equal(find_peaks(x, height=(2, 3))[0], np.array([3]))
 
     def test_threshold_condition(self):
         """
@@ -665,14 +669,14 @@ class TestFindPeaks:
         """
         x = (0, 2, 1, 4, -1)
         peaks, props = find_peaks(x, threshold=(None, None))
-        assert_equal(peaks, np.array([1, 3]))
-        assert_equal(props['left_thresholds'], np.array([2, 3]))
-        assert_equal(props['right_thresholds'], np.array([1, 5]))
-        assert_equal(find_peaks(x, threshold=2)[0], np.array([3]))
-        assert_equal(find_peaks(x, threshold=3.5)[0], np.array([]))
-        assert_equal(find_peaks(x, threshold=(None, 5))[0], np.array([1, 3]))
-        assert_equal(find_peaks(x, threshold=(None, 4))[0], np.array([1]))
-        assert_equal(find_peaks(x, threshold=(2, 4))[0], np.array([]))
+        xp_assert_equal(peaks, np.array([1, 3]))
+        xp_assert_equal(props['left_thresholds'], np.array([2.0, 3.0]))
+        xp_assert_equal(props['right_thresholds'], np.array([1.0, 5.0]))
+        xp_assert_equal(find_peaks(x, threshold=2)[0], np.array([3]))
+        xp_assert_equal(find_peaks(x, threshold=3.5)[0], np.array([], dtype=int))
+        xp_assert_equal(find_peaks(x, threshold=(None, 5))[0], np.array([1, 3]))
+        xp_assert_equal(find_peaks(x, threshold=(None, 4))[0], np.array([1]))
+        xp_assert_equal(find_peaks(x, threshold=(2, 4))[0], np.array([], dtype=int))
 
     def test_distance_condition(self):
         """
@@ -684,21 +688,21 @@ class TestFindPeaks:
         x[peaks_all] += np.linspace(1, 2, peaks_all.size)
 
         # Test if peaks with "minimal" distance are still selected (distance = 3)
-        assert_equal(find_peaks(x, distance=3)[0], peaks_all)
+        xp_assert_equal(find_peaks(x, distance=3)[0], peaks_all)
 
         # Select every second peak (distance > 3)
         peaks_subset = find_peaks(x, distance=3.0001)[0]
         # Test if peaks_subset is subset of peaks_all
-        assert_(
-            np.setdiff1d(peaks_subset, peaks_all, assume_unique=True).size == 0
-        )
+        assert np.setdiff1d(peaks_subset, peaks_all, assume_unique=True).size == 0
+
         # Test if every second peak was removed
-        assert_equal(np.diff(peaks_subset), 6)
+        dfs = np.diff(peaks_subset)
+        xp_assert_equal(dfs, 6*np.ones_like(dfs))
 
         # Test priority of peak removal
         x = [-2, 1, -1, 0, -3]
         peaks_subset = find_peaks(x, distance=10)[0]  # use distance > x size
-        assert_(peaks_subset.size == 1 and peaks_subset[0] == 1)
+        assert peaks_subset.size == 1 and peaks_subset[0] == 1
 
     def test_prominence_condition(self):
         """
@@ -714,10 +718,10 @@ class TestFindPeaks:
             (interval[0] <= prominences) & (prominences <= interval[1]))
 
         peaks_calc, properties = find_peaks(x, prominence=interval)
-        assert_equal(peaks_calc, peaks_true[keep])
-        assert_equal(properties['prominences'], prominences[keep])
-        assert_equal(properties['left_bases'], 0)
-        assert_equal(properties['right_bases'], peaks_true[keep] + 1)
+        xp_assert_equal(peaks_calc, peaks_true[keep])
+        xp_assert_equal(properties['prominences'], prominences[keep])
+        xp_assert_equal(properties['left_bases'], np.zeros_like(properties['left_bases']))
+        xp_assert_equal(properties['right_bases'], peaks_true[keep] + 1)
 
     def test_width_condition(self):
         """
@@ -725,12 +729,12 @@ class TestFindPeaks:
         """
         x = np.array([1, 0, 1, 2, 1, 0, -1, 4, 0])
         peaks, props = find_peaks(x, width=(None, 2), rel_height=0.75)
-        assert_equal(peaks.size, 1)
-        assert_equal(peaks, 7)
-        assert_allclose(props['widths'], 1.35)
-        assert_allclose(props['width_heights'], 1.)
-        assert_allclose(props['left_ips'], 6.4)
-        assert_allclose(props['right_ips'], 7.75)
+        assert peaks.size == 1
+        xp_assert_equal(peaks, 7*np.ones_like(peaks))
+        xp_assert_close(props['widths'], np.asarray([1.35]))
+        xp_assert_close(props['width_heights'], np.asarray([1.]))
+        xp_assert_close(props['left_ips'], np.asarray([6.4]))
+        xp_assert_close(props['right_ips'], np.asarray([7.75]))
 
     def test_properties(self):
         """
@@ -741,9 +745,9 @@ class TestFindPeaks:
         peaks, props = find_peaks(x,
                                   height=open_interval, threshold=open_interval,
                                   prominence=open_interval, width=open_interval)
-        assert_(len(props) == len(self.property_keys))
+        assert len(props) == len(self.property_keys)
         for key in self.property_keys:
-            assert_(peaks.size == props[key].size)
+            assert peaks.size == props[key].size
 
     def test_raises(self):
         """
@@ -767,12 +771,12 @@ class TestFindPeaks:
         """
         peaks, props = find_peaks([0, 1, 1, 1, 0], prominence=(None, None),
                                   width=(None, None), wlen=2)
-        assert_equal(peaks, 2)
-        assert_equal(props["prominences"], 0)
-        assert_equal(props["widths"], 0)
-        assert_equal(props["width_heights"], 1)
+        xp_assert_equal(peaks, 2 * np.ones_like(peaks))
+        xp_assert_equal(props["prominences"], np.zeros_like(props["prominences"]))
+        xp_assert_equal(props["widths"], np.zeros_like(props["widths"]))
+        xp_assert_equal(props["width_heights"], np.ones_like(props["width_heights"]))
         for key in ("left_bases", "right_bases", "left_ips", "right_ips"):
-            assert_equal(props[key], peaks)
+            xp_assert_equal(props[key], peaks, check_dtype=False)
 
     @pytest.mark.parametrize("kwargs", [
         {},
@@ -792,7 +796,7 @@ class TestFindPeaks:
         peaks, _ = find_peaks(x)
         peaks_readonly, _ = find_peaks(x_readonly, **kwargs)
 
-        assert_allclose(peaks, peaks_readonly)
+        xp_assert_close(peaks, peaks_readonly)
 
 
 class TestFindPeaksCwt:
@@ -807,8 +811,9 @@ class TestFindPeaksCwt:
         widths = np.arange(0.1, max(sigmas))
         found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=0,
                                          min_length=None)
-        np.testing.assert_array_equal(found_locs, act_locs,
-                        "Found maximum locations did not equal those expected")
+        xp_assert_equal(found_locs, act_locs,
+                        err_msg="Found maximum locations did not equal those expected"
+        )
 
     def test_find_peaks_withnoise(self):
         """
@@ -825,8 +830,8 @@ class TestFindPeaksCwt:
         found_locs = find_peaks_cwt(test_data, widths, min_length=15,
                                          gap_thresh=1, min_snr=noise_amp / 5)
 
-        np.testing.assert_equal(len(found_locs), len(act_locs), 'Different number' +
-                                'of peaks found than expected')
+        err_msg ='Different number of peaks found than expected'
+        assert len(found_locs) == len(act_locs), err_msg
         diffs = np.abs(found_locs - act_locs)
         max_diffs = np.array(sigmas) / 5
         np.testing.assert_array_less(diffs, max_diffs, 'Maximum location differed' +
@@ -843,14 +848,14 @@ class TestFindPeaksCwt:
         test_data = (np.random.rand(num_points) - 0.5)*(2*noise_amp)
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
-        np.testing.assert_equal(len(found_locs), 0)
+        assert len(found_locs) == 0
 
     def test_find_peaks_with_non_default_wavelets(self):
         x = gaussian(200, 2)
         widths = np.array([1, 2, 3, 4])
         a = find_peaks_cwt(x, widths, wavelet=gaussian)
 
-        np.testing.assert_equal(np.array([100]), a)
+        xp_assert_equal(a, np.asarray([100]))
 
     def test_find_peaks_window_size(self):
         """

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -5,7 +5,7 @@ from numpy.testing import (assert_equal,
 )
 
 from scipy._lib._array_api import (
-    assert_almost_equal, assert_array_almost_equal, xp_assert_close, xp_assert_equal
+    assert_almost_equal, assert_array_almost_equal, xp_assert_close
 )
 
 from scipy.ndimage import convolve1d   # type: ignore[attr-defined]

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -1,8 +1,12 @@
 import pytest
 import numpy as np
-from numpy.testing import (assert_allclose, assert_equal,
-                           assert_almost_equal, assert_array_equal,
-                           assert_array_almost_equal)
+from numpy.testing import (assert_equal, 
+                           assert_array_equal,
+)
+
+from scipy._lib._array_api import (
+    assert_almost_equal, assert_array_almost_equal, xp_assert_close, xp_assert_equal
+)
 
 from scipy.ndimage import convolve1d   # type: ignore[attr-defined]
 
@@ -57,19 +61,19 @@ def alt_sg_coeffs(window_length, polyorder, pos):
 def test_sg_coeffs_trivial():
     # Test a trivial case of savgol_coeffs: polyorder = window_length - 1
     h = savgol_coeffs(1, 0)
-    assert_allclose(h, [1])
+    xp_assert_close(h, [1.0])
 
     h = savgol_coeffs(3, 2)
-    assert_allclose(h, [0, 1, 0], atol=1e-10)
+    xp_assert_close(h, [0.0, 1, 0], atol=1e-10)
 
     h = savgol_coeffs(5, 4)
-    assert_allclose(h, [0, 0, 1, 0, 0], atol=1e-10)
+    xp_assert_close(h, [0.0, 0, 1, 0, 0], atol=1e-10)
 
     h = savgol_coeffs(5, 4, pos=1)
-    assert_allclose(h, [0, 0, 0, 1, 0], atol=1e-10)
+    xp_assert_close(h, [0.0, 0, 0, 1, 0], atol=1e-10)
 
     h = savgol_coeffs(5, 4, pos=1, use='dot')
-    assert_allclose(h, [0, 1, 0, 0, 0], atol=1e-10)
+    xp_assert_close(h, [0.0, 1, 0, 0, 0], atol=1e-10)
 
 
 def compare_coeffs_to_alt(window_length, order):
@@ -79,7 +83,7 @@ def compare_coeffs_to_alt(window_length, order):
     for pos in [None] + list(range(window_length)):
         h1 = savgol_coeffs(window_length, order, pos=pos, use='dot')
         h2 = alt_sg_coeffs(window_length, order, pos=pos)
-        assert_allclose(h1, h2, atol=1e-10,
+        xp_assert_close(h1, h2, atol=1e-10,
                         err_msg=("window_length = %d, order = %d, pos = %s" %
                                  (window_length, order, pos)))
 
@@ -105,19 +109,19 @@ def test_sg_coeffs_exact():
     y = 0.5 * x ** 3 - x
     h = savgol_coeffs(window_length, polyorder)
     y0 = convolve1d(y, h)
-    assert_allclose(y0[halflen:-halflen], y[halflen:-halflen])
+    xp_assert_close(y0[halflen:-halflen], y[halflen:-halflen])
 
     # Check the same input, but use deriv=1.  dy is the exact result.
     dy = 1.5 * x ** 2 - 1
     h = savgol_coeffs(window_length, polyorder, deriv=1, delta=delta)
     y1 = convolve1d(y, h)
-    assert_allclose(y1[halflen:-halflen], dy[halflen:-halflen])
+    xp_assert_close(y1[halflen:-halflen], dy[halflen:-halflen])
 
     # Check the same input, but use deriv=2. d2y is the exact result.
     d2y = 3.0 * x
     h = savgol_coeffs(window_length, polyorder, deriv=2, delta=delta)
     y2 = convolve1d(y, h)
-    assert_allclose(y2[halflen:-halflen], d2y[halflen:-halflen])
+    xp_assert_close(y2[halflen:-halflen], d2y[halflen:-halflen])
 
 
 def test_sg_coeffs_deriv():
@@ -129,11 +133,11 @@ def test_sg_coeffs_deriv():
     d2x = np.full_like(i, 0.5)
     for pos in range(x.size):
         coeffs0 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot')
-        assert_allclose(coeffs0.dot(x), x[pos], atol=1e-10)
+        xp_assert_close(coeffs0.dot(x), x[pos], atol=1e-10)
         coeffs1 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=1)
-        assert_allclose(coeffs1.dot(x), dx[pos], atol=1e-10)
+        xp_assert_close(coeffs1.dot(x), dx[pos], atol=1e-10)
         coeffs2 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=2)
-        assert_allclose(coeffs2.dot(x), d2x[pos], atol=1e-10)
+        xp_assert_close(coeffs2.dot(x), d2x[pos], atol=1e-10)
 
 
 def test_sg_coeffs_deriv_gt_polyorder():
@@ -168,7 +172,7 @@ def test_sg_coeffs_even_window_length():
     window_lengths = [4, 6, 8, 10, 12, 14, 16]
     for length in window_lengths:
         h_p_d = savgol_coeffs(length, 0, 0)
-        assert_allclose(h_p_d, 1/length)
+        xp_assert_close(h_p_d, np.ones_like(h_p_d) / length)
 
     # Verify with closed forms
     # deriv=1, polyorder=1, 2
@@ -186,16 +190,16 @@ def test_sg_coeffs_even_window_length():
         expected_output = [h_p_d_closed_form_1(k, m)
                            for k in range(-m + 1, m + 1)][::-1]
         actual_output = savgol_coeffs(length, 1, 1)
-        assert_allclose(expected_output, actual_output)
+        xp_assert_close(expected_output, actual_output)
         actual_output = savgol_coeffs(length, 2, 1)
-        assert_allclose(expected_output, actual_output)
+        xp_assert_close(expected_output, actual_output)
 
         expected_output = [h_p_d_closed_form_2(k, m)
                            for k in range(-m + 1, m + 1)][::-1]
         actual_output = savgol_coeffs(length, 2, 2)
-        assert_allclose(expected_output, actual_output)
+        xp_assert_close(expected_output, actual_output)
         actual_output = savgol_coeffs(length, 3, 2)
-        assert_allclose(expected_output, actual_output)
+        xp_assert_close(expected_output, actual_output)
 
 #--------------------------------------------------------------------
 # savgol_filter tests
@@ -228,13 +232,13 @@ def test_sg_filter_basic():
     # Some basic test cases for savgol_filter().
     x = np.array([1.0, 2.0, 1.0])
     y = savgol_filter(x, 3, 1, mode='constant')
-    assert_allclose(y, [1.0, 4.0 / 3, 1.0])
+    xp_assert_close(y, [1.0, 4.0 / 3, 1.0])
 
     y = savgol_filter(x, 3, 1, mode='mirror')
-    assert_allclose(y, [5.0 / 3, 4.0 / 3, 5.0 / 3])
+    xp_assert_close(y, [5.0 / 3, 4.0 / 3, 5.0 / 3])
 
     y = savgol_filter(x, 3, 1, mode='wrap')
-    assert_allclose(y, [4.0 / 3, 4.0 / 3, 4.0 / 3])
+    xp_assert_close(y, [4.0 / 3, 4.0 / 3, 4.0 / 3])
 
 
 def test_sg_filter_2d():
@@ -243,10 +247,10 @@ def test_sg_filter_2d():
     expected = np.array([[1.0, 4.0 / 3, 1.0],
                          [2.0, 8.0 / 3, 2.0]])
     y = savgol_filter(x, 3, 1, mode='constant')
-    assert_allclose(y, expected)
+    xp_assert_close(y, expected)
 
     y = savgol_filter(x.T, 3, 1, mode='constant', axis=0)
-    assert_allclose(y, expected.T)
+    xp_assert_close(y, expected.T)
 
 
 def test_sg_filter_interp_edges():
@@ -270,15 +274,15 @@ def test_sg_filter_interp_edges():
     window_length = 7
 
     y = savgol_filter(x, window_length, 3, axis=-1, mode='interp')
-    assert_allclose(y, x, atol=1e-12)
+    xp_assert_close(y, x, atol=1e-12)
 
     y1 = savgol_filter(x, window_length, 3, axis=-1, mode='interp',
                        deriv=1, delta=delta)
-    assert_allclose(y1, dx, atol=1e-12)
+    xp_assert_close(y1, dx, atol=1e-12)
 
     y2 = savgol_filter(x, window_length, 3, axis=-1, mode='interp',
                        deriv=2, delta=delta)
-    assert_allclose(y2, d2x, atol=1e-12)
+    xp_assert_close(y2, d2x, atol=1e-12)
 
     # Transpose everything, and test again with axis=0.
 
@@ -287,15 +291,15 @@ def test_sg_filter_interp_edges():
     d2x = d2x.T
 
     y = savgol_filter(x, window_length, 3, axis=0, mode='interp')
-    assert_allclose(y, x, atol=1e-12)
+    xp_assert_close(y, x, atol=1e-12)
 
     y1 = savgol_filter(x, window_length, 3, axis=0, mode='interp',
                        deriv=1, delta=delta)
-    assert_allclose(y1, dx, atol=1e-12)
+    xp_assert_close(y1, dx, atol=1e-12)
 
     y2 = savgol_filter(x, window_length, 3, axis=0, mode='interp',
                        deriv=2, delta=delta)
-    assert_allclose(y2, d2x, atol=1e-12)
+    xp_assert_close(y2, d2x, atol=1e-12)
 
 
 def test_sg_filter_interp_edges_3d():
@@ -314,30 +318,30 @@ def test_sg_filter_interp_edges_3d():
     dz = np.array([dx1, dx2, dx3])
 
     y = savgol_filter(z, 7, 3, axis=-1, mode='interp', delta=delta)
-    assert_allclose(y, z, atol=1e-10)
+    xp_assert_close(y, z, atol=1e-10)
 
     dy = savgol_filter(z, 7, 3, axis=-1, mode='interp', deriv=1, delta=delta)
-    assert_allclose(dy, dz, atol=1e-10)
+    xp_assert_close(dy, dz, atol=1e-10)
 
     # z has shape (3, 21, 2)
     z = np.array([x1.T, x2.T, x3.T])
     dz = np.array([dx1.T, dx2.T, dx3.T])
 
     y = savgol_filter(z, 7, 3, axis=1, mode='interp', delta=delta)
-    assert_allclose(y, z, atol=1e-10)
+    xp_assert_close(y, z, atol=1e-10)
 
     dy = savgol_filter(z, 7, 3, axis=1, mode='interp', deriv=1, delta=delta)
-    assert_allclose(dy, dz, atol=1e-10)
+    xp_assert_close(dy, dz, atol=1e-10)
 
     # z has shape (21, 3, 2)
     z = z.swapaxes(0, 1).copy()
     dz = dz.swapaxes(0, 1).copy()
 
     y = savgol_filter(z, 7, 3, axis=0, mode='interp', delta=delta)
-    assert_allclose(y, z, atol=1e-10)
+    xp_assert_close(y, z, atol=1e-10)
 
     dy = savgol_filter(z, 7, 3, axis=0, mode='interp', deriv=1, delta=delta)
-    assert_allclose(dy, dz, atol=1e-10)
+    xp_assert_close(dy, dz, atol=1e-10)
 
 
 def test_sg_filter_valid_window_length_3d():

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -23,7 +23,7 @@ from typing import cast, get_args, Literal
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_equal
+from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 from scipy.fft import fftshift
 from scipy.stats import norm as normal_distribution  # type: ignore
 from scipy.signal import get_window, welch, stft, istft, spectrogram
@@ -44,7 +44,7 @@ def test__calc_dual_canonical_window_roundtrip():
     win = gaussian(51, std=10, sym=True)
     d_win = _calc_dual_canonical_window(win, 10)
     win2 = _calc_dual_canonical_window(d_win, 10)
-    assert_allclose(win2, win)
+    xp_assert_close(win2, win)
 
 
 def test__calc_dual_canonical_window_exceptions():
@@ -214,8 +214,8 @@ def test_from_window(win_params, Nx: int):
                                     symmetric_win=False, fft_mode='twosided',
                                     scale_to='psd', phase_shift=1)
     # Be informative when comparing instances:
-    assert_equal(SFT1.win, SFT0.win)
-    assert_allclose(SFT2.win, w_per / np.sqrt(sum(w_per**2) * fs))
+    xp_assert_equal(SFT1.win, SFT0.win)
+    xp_assert_close(SFT2.win, w_per / np.sqrt(sum(w_per**2) * fs))
     for n_ in ('hop', 'T', 'fft_mode', 'mfft', 'scaling', 'phase_shift'):
         v0, v1, v2 = (getattr(SFT_, n_) for SFT_ in (SFT0, SFT1, SFT2))
         assert v1 == v0, f"SFT1.{n_}={v1} does not equal SFT0.{n_}={v0}"
@@ -234,7 +234,7 @@ def test_dual_win_roundtrip():
               phase_shift=2)
     SFT0 = ShortTimeFFT(np.ones(4), **kw)
     SFT1 = ShortTimeFFT.from_dual(SFT0.dual_win, **kw)
-    assert_allclose(SFT1.dual_win, SFT0.win)
+    xp_assert_close(SFT1.dual_win, SFT0.win)
 
 
 @pytest.mark.parametrize('scale_to, fac_psd, fac_mag',
@@ -260,11 +260,11 @@ def test_scaling(scale_to: Literal['magnitude', 'psd'], fac_psd, fac_mag):
 
     SFT.scale_to('magnitude')
     x_mag = SFT.istft(Sx_mag, k1=len(x))
-    assert_allclose(x_mag, x)
+    xp_assert_close(x_mag, x)
 
     SFT.scale_to('psd')
     x_psd = SFT.istft(Sx_psd, k1=len(x))
-    assert_allclose(x_psd, x)
+    xp_assert_close(x_psd, x)
 
 
 def test_scale_to():
@@ -288,7 +288,7 @@ def test_scale_to():
         dual_win = SFT.dual_win.copy()
 
         SFT.scale_to(cast(Literal['magnitude', 'psd'], scale))
-        assert_allclose(SFT.dual_win, dual_win * s_fac)
+        xp_assert_close(SFT.dual_win, dual_win * s_fac)
 
 
 def test_x_slices_padding():
@@ -310,7 +310,8 @@ def test_x_slices_padding():
     for p_, xx in d.items():
         gen = SFT._x_slices(np.array(x), 0, 0, 2, padding=cast(PAD_TYPE, p_))
         yy = np.array([y_.copy() for y_ in gen])  # due to inplace copying
-        assert_equal(yy, xx, err_msg=f"Failed '{p_}' padding.")
+        xx = np.asarray(xx, dtype=np.float64)
+        xp_assert_equal(yy, xx, err_msg=f"Failed '{p_}' padding.")
 
 
 def test_invertible():
@@ -357,8 +358,8 @@ def test_t():
     assert SFT.fs == 2.
     assert SFT.delta_t == 4 * 1/2
     t_stft = np.arange(0, SFT.p_max(10)) * SFT.delta_t
-    assert_equal(SFT.t(10), t_stft)
-    assert_equal(SFT.t(10, 1, 3), t_stft[1:3])
+    xp_assert_equal(SFT.t(10), t_stft)
+    xp_assert_equal(SFT.t(10, 1, 3), t_stft[1:3])
     SFT.T = 1/4
     assert SFT.T == 1/4
     assert SFT.fs == 4
@@ -376,7 +377,7 @@ def test_f(fft_mode: FFT_MODE_TYPE, f):
     """Verify the frequency values property `f`."""
     SFT = ShortTimeFFT(np.ones(5), hop=4, fs=5, fft_mode=fft_mode,
                        scale_to='psd')
-    assert_equal(SFT.f, f)
+    xp_assert_equal(SFT.f, f)
 
 
 def test_extent():
@@ -396,8 +397,8 @@ def test_spectrogram():
     SFT = ShortTimeFFT(np.ones(8), hop=4, fs=1)
     x, y = np.ones(10), np.arange(10)
     X, Y = SFT.stft(x), SFT.stft(y)
-    assert_allclose(SFT.spectrogram(x), X.real**2+X.imag**2)
-    assert_allclose(SFT.spectrogram(x, y), X * Y.conj())
+    xp_assert_close(SFT.spectrogram(x), X.real**2+X.imag**2)
+    xp_assert_close(SFT.spectrogram(x, y), X * Y.conj())
 
 
 @pytest.mark.parametrize('n', [8, 9])
@@ -420,7 +421,8 @@ def test_fft_func_roundtrip(n: int):
                            scale_to=scaling, phase_shift=phase_shift)
         X0 = SFT._fft_func(x0)
         x1 = SFT._ifft_func(X0)
-        assert_allclose(x0, x1, err_msg="_fft_func() roundtrip failed for " +
+        xp_assert_close(x0.astype(x1.dtype), x1,
+                        err_msg="_fft_func() roundtrip failed for " +
                         f"{f_typ=}, {mfft=}, {scaling=}, {phase_shift=}")
 
     SFT = ShortTimeFFT(w, h_n, fs=1)
@@ -447,21 +449,21 @@ def test_impulse_roundtrip(i):
     Sx1 = SFT.stft(x[n_q:], padding='zeros')
     q0_ub = SFT.upper_border_begin(n_q)[1] - SFT.p_min
     q1_le = SFT.lower_border_end[1] - SFT.p_min
-    assert_allclose(Sx0[:, :q0_ub], Sx[:, :q0_ub], err_msg=f"{i=}")
-    assert_allclose(Sx1[:, q1_le:], Sx[:, q1_le-Sx1.shape[1]:],
+    xp_assert_close(Sx0[:, :q0_ub], Sx[:, :q0_ub], err_msg=f"{i=}")
+    xp_assert_close(Sx1[:, q1_le:], Sx[:, q1_le-Sx1.shape[1]:],
                     err_msg=f"{i=}")
 
     Sx01 = np.hstack((Sx0[:, :q0_ub],
                       Sx0[:, q0_ub:] + Sx1[:, :q1_le],
                       Sx1[:, q1_le:]))
-    assert_allclose(Sx, Sx01, atol=1e-8, err_msg=f"{i=}")
+    xp_assert_close(Sx, Sx01, atol=1e-8, err_msg=f"{i=}")
 
     y = SFT.istft(Sx, 0, n)
-    assert_allclose(y, x, atol=1e-8, err_msg=f"{i=}")
+    xp_assert_close(y, x, atol=1e-8, err_msg=f"{i=}")
     y0 = SFT.istft(Sx, 0, n//2)
-    assert_allclose(x[:n//2], y0, atol=1e-8, err_msg=f"{i=}")
+    xp_assert_close(x[:n//2], y0, atol=1e-8, err_msg=f"{i=}")
     y1 = SFT.istft(Sx, n // 2, n)
-    assert_allclose(x[n // 2:], y1, atol=1e-8, err_msg=f"{i=}")
+    xp_assert_close(x[n // 2:], y1, atol=1e-8, err_msg=f"{i=}")
 
 
 @pytest.mark.parametrize('hop', [1, 7, 8])
@@ -476,7 +478,7 @@ def test_asymmetric_window_roundtrip(hop: int):
     x = 10 * np.random.randn(64)
     Sx = SFT.stft(x)
     x1 = SFT.istft(Sx, k1=len(x))
-    assert_allclose(x1, x1, err_msg="Roundtrip for asymmetric window with " +
+    xp_assert_close(x1, x1, err_msg="Roundtrip for asymmetric window with " +
                                     f" {hop=} failed!")
 
 
@@ -488,7 +490,7 @@ def test_minimal_length_signal(m_num):
     x = np.ones(n)
     Sx = SFT.stft(x)
     x1 = SFT.istft(Sx, k1=n)
-    assert_allclose(x1, x, err_msg=f"Roundtrip minimal length signal ({n=})" +
+    xp_assert_close(x1, x, err_msg=f"Roundtrip minimal length signal ({n=})" +
                                    f" for {m_num} sample window failed!")
     with pytest.raises(ValueError, match=rf"len\(x\)={n-1} must be >= ceil.*"):
         SFT.stft(x[:-1])
@@ -548,20 +550,20 @@ def test_tutorial_stft_legacy_stft():
                                    scale_to='magnitude', phase_shift=None)
     Sz1 = SFT.stft(z)
 
-    assert_allclose(Sz0, Sz1[:, 2:-1])
+    xp_assert_close(Sz0, Sz1[:, 2:-1])
 
-    assert_allclose((abs(Sz1[:, 1]).min(), abs(Sz1[:, 1]).max()),
+    xp_assert_close((abs(Sz1[:, 1]).min(), abs(Sz1[:, 1]).max()),
                     (6.925060911593139e-07, 8.00271269218721e-07))
 
     t0_r, z0_r = istft(Sz0_u, fs, win, nperseg, noverlap, input_onesided=False,
                        scaling='spectrum')
     z1_r = SFT.istft(Sz1, k1=N)
     assert len(z0_r) == N + 9
-    assert_allclose(z0_r[:N], z)
-    assert_allclose(z1_r, z)
+    xp_assert_close(z0_r[:N], z)
+    xp_assert_close(z1_r, z)
 
     #  Spectrogram is just the absolute square of th STFT:
-    assert_allclose(SFT.spectrogram(z), abs(Sz1) ** 2)
+    xp_assert_close(SFT.spectrogram(z), abs(Sz1) ** 2)
 
 
 def test_tutorial_stft_legacy_spectrogram():
@@ -592,9 +594,9 @@ def test_tutorial_stft_legacy_spectrogram():
     Sz3 = SFT.stft(z, p0=0, p1=(N-noverlap) // SFT.hop, k_offset=nperseg // 2)
     t3 = SFT.t(N, p0=0, p1=(N-noverlap) // SFT.hop, k_offset=nperseg // 2)
 
-    assert_allclose(t2, t3)
-    assert_allclose(f2, SFT.f)
-    assert_allclose(Sz2, Sz3)
+    xp_assert_close(t2, t3)
+    xp_assert_close(f2, SFT.f)
+    xp_assert_close(Sz2, Sz3)
 
 
 def test_permute_axes():
@@ -602,7 +604,7 @@ def test_permute_axes():
     shape. """
     n = 25
     SFT = ShortTimeFFT(np.ones(8)/8, hop=3, fs=n)
-    x0 = np.arange(n)
+    x0 = np.arange(n, dtype=np.float64)
     Sx0 = SFT.stft(x0)
     Sx0 = Sx0.reshape((Sx0.shape[0], 1, 1, 1, Sx0.shape[-1]))
     SxT = np.moveaxis(Sx0, (0, -1), (-1, 0))
@@ -611,19 +613,19 @@ def test_permute_axes():
     for i in range(4):
         y = np.reshape(x0, np.roll((n, 1, 1, 1), i))
         Sy = SFT.stft(y, axis=i)
-        assert_allclose(Sy, np.moveaxis(Sx0, 0, i))
+        xp_assert_close(Sy, np.moveaxis(Sx0, 0, i))
 
         yb0 = SFT.istft(Sy, k1=n, f_axis=i)
-        assert_allclose(yb0, y, atol=atol)
+        xp_assert_close(yb0, y, atol=atol)
         # explicit t-axis parameter (for coverage):
         yb1 = SFT.istft(Sy, k1=n, f_axis=i, t_axis=Sy.ndim-1)
-        assert_allclose(yb1, y, atol=atol)
+        xp_assert_close(yb1, y, atol=atol)
 
         SyT = np.moveaxis(Sy, (i, -1), (-1, i))
-        assert_allclose(SyT, np.moveaxis(SxT, 0, i))
+        xp_assert_close(SyT, np.moveaxis(SxT, 0, i))
 
         ybT = SFT.istft(SyT, k1=n, t_axis=i, f_axis=-1)
-        assert_allclose(ybT, y, atol=atol)
+        xp_assert_close(ybT, y, atol=atol)
 
 
 @pytest.mark.parametrize("fft_mode",
@@ -634,16 +636,17 @@ def test_roundtrip_multidimensional(fft_mode: FFT_MODE_TYPE):
     This test can uncover potential problems with `fftshift()`.
     """
     n = 9
-    x = np.arange(4*n*2).reshape(4, n, 2)
+    x = np.arange(4*n*2, dtype=np.float64).reshape(4, n, 2)
     SFT = ShortTimeFFT(get_window('hann', 4), hop=2, fs=1,
                        scale_to='magnitude', fft_mode=fft_mode)
     Sx = SFT.stft(x, axis=1)
     y = SFT.istft(Sx, k1=n, f_axis=1, t_axis=-1)
-    assert_allclose(y, x, err_msg='Multidim. roundtrip failed!')
+    xp_assert_close(y, x.astype(y.dtype), err_msg='Multidim. roundtrip failed!')
 
     for i, j in product(range(x.shape[0]), range(x.shape[2])):
         y_ = SFT.istft(Sx[i, :, j, :], k1=n)
-        assert_allclose(y_, x[i, :, j], err_msg="Multidim. roundtrip for component " +
+        xp_assert_close(y_, x[i, :, j].astype(y_.dtype),
+                        err_msg="Multidim. roundtrip for component " +
                         f"x[{i}, :, {j}] and {fft_mode=} failed!")
 
 
@@ -676,17 +679,20 @@ def test_roundtrip_windows(window, n: int, nperseg: int, noverlap: int):
     z = 10 * np.random.randn(n) + 10j * np.random.randn(n)
     Sz = SFT.stft(z)
     z1 = SFT.istft(Sz, k1=len(z))
-    assert_allclose(z, z1, err_msg="Roundtrip for complex values failed")
+    xp_assert_close(z, z1, err_msg="Roundtrip for complex values failed")
 
     x = 10 * np.random.randn(n)
     Sx = SFT.stft(x)
     x1 = SFT.istft(Sx, k1=len(z))
-    assert_allclose(x, x1, err_msg="Roundtrip for float values failed")
+    xp_assert_close(x.astype(np.complex128), x1, err_msg="Roundtrip for float values failed")
 
     x32 = x.astype(np.float32)
     Sx32 = SFT.stft(x32)
     x32_1 = SFT.istft(Sx32, k1=len(x32))
-    assert_allclose(x32, x32_1,
+    x32_1_r = x32_1.real
+    xp_assert_close(x32, x32_1_r.astype(np.float32),
+                    err_msg="Roundtrip for 32 Bit float values failed")
+    xp_assert_close(x32.imag, np.zeros_like(x32.imag),
                     err_msg="Roundtrip for 32 Bit float values failed")
 
 
@@ -706,7 +712,7 @@ def test_roundtrip_complex_window(signal_type):
         z = z + 2j * z
     Sz = SFT.stft(z)
     z1 = SFT.istft(Sz, k1=len(z))
-    assert_allclose(z, z1,
+    xp_assert_close(z.astype(np.complex128), z1,
                     err_msg="Roundtrip for complex-valued window failed")
 
 
@@ -729,8 +735,8 @@ def test_average_all_segments():
     P = SFT.spectrogram(x, detr='constant', p0=0,
                         p1=(len(x)-noverlap)//SFT.hop, k_offset=nperseg//2)
 
-    assert_allclose(SFT.f, fw)
-    assert_allclose(np.mean(P, axis=-1), Pw)
+    xp_assert_close(SFT.f, fw)
+    xp_assert_close(np.mean(P, axis=-1), Pw)
 
 
 @pytest.mark.parametrize('window, N, nperseg, noverlap, mfft',
@@ -763,12 +769,12 @@ def test_stft_padding_roundtrip(window, N: int, nperseg: int, noverlap: int,
                                    fft_mode='twosided', mfft=mfft)
     Sx = SFT.stft(x, padding=padding)
     x1 = SFT.istft(Sx, k1=N)
-    assert_allclose(x1, x,
+    xp_assert_close(x1, x.astype(np.complex128),
                     err_msg=f"Failed real roundtrip with '{padding}' padding")
 
     Sz = SFT.stft(z, padding=padding)
     z1 = SFT.istft(Sz, k1=N)
-    assert_allclose(z1, z, err_msg="Failed complex roundtrip with " +
+    xp_assert_close(z1, z, err_msg="Failed complex roundtrip with " +
                     f" '{padding}' padding")
 
 
@@ -808,13 +814,13 @@ def test_energy_conservation(N_x: int, w_size: int, t_step: int, f_c: float):
     assert X.shape[1] == SFT.f_pts
     assert np.all(SFT.f >= 0.)
     assert np.abs(max_freq - f_c) < 1.
-    assert_allclose(x, xp, atol=atol)
+    xp_assert_close(x, xp, atol=atol)
 
     # check L2-norm squared (i.e., energy) conservation:
     E_x = np.sum(x**2, axis=-1) * SFT.T  # numerical integration
     aX2 = X.real**2 + X.imag.real**2
     E_X = np.sum(np.sum(aX2, axis=-1) * SFT.delta_t, axis=-1) * SFT.delta_f
-    assert_allclose(E_X, E_x, atol=atol)
+    xp_assert_close(E_X, E_x, atol=atol)
 
     # Test with random signal
     np.random.seed(2392795)
@@ -825,13 +831,13 @@ def test_energy_conservation(N_x: int, w_size: int, t_step: int, f_c: float):
     assert X.shape[1] == SFT.f_pts
     assert np.all(SFT.f >= 0.)
     assert np.abs(max_freq - f_c) < 1.
-    assert_allclose(x, xp, atol=atol)
+    xp_assert_close(x, xp, atol=atol)
 
     # check L2-norm squared (i.e., energy) conservation:
     E_x = np.sum(x**2, axis=-1) * SFT.T  # numeric integration
     aX2 = X.real ** 2 + X.imag.real ** 2
     E_X = np.sum(np.sum(aX2, axis=-1) * SFT.delta_t, axis=-1) * SFT.delta_f
-    assert_allclose(E_X, E_x, atol=atol)
+    xp_assert_close(E_X, E_x, atol=atol)
 
     # Try with empty array
     x = np.zeros((0, N_x))

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -684,7 +684,8 @@ def test_roundtrip_windows(window, n: int, nperseg: int, noverlap: int):
     x = 10 * np.random.randn(n)
     Sx = SFT.stft(x)
     x1 = SFT.istft(Sx, k1=len(z))
-    xp_assert_close(x.astype(np.complex128), x1, err_msg="Roundtrip for float values failed")
+    xp_assert_close(x.astype(np.complex128), x1,
+                    err_msg="Roundtrip for float values failed")
 
     x32 = x.astype(np.float32)
     Sx32 = SFT.stft(x32)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -35,7 +35,7 @@
 import numpy as np
 from itertools import product
 
-from numpy.testing import assert_equal, assert_allclose
+from scipy._lib._array_api import xp_assert_close
 from pytest import raises as assert_raises
 import pytest
 
@@ -98,16 +98,16 @@ class UpFIRDnCase:
         assert y.shape == yr.shape
         dtypes = (self.h.dtype, x.dtype)
         if all(d == np.complex64 for d in dtypes):
-            assert_equal(y.dtype, np.complex64)
+            assert y.dtype == np.complex64
         elif np.complex64 in dtypes and np.float32 in dtypes:
-            assert_equal(y.dtype, np.complex64)
+            assert y.dtype == np.complex64
         elif all(d == np.float32 for d in dtypes):
-            assert_equal(y.dtype, np.float32)
+            assert y.dtype == np.float32
         elif np.complex128 in dtypes or np.complex64 in dtypes:
-            assert_equal(y.dtype, np.complex128)
+            assert y.dtype == np.complex128
         else:
-            assert_equal(y.dtype, np.float64)
-        assert_allclose(yr, y)
+            assert y.dtype == np.float64
+        xp_assert_close(yr.astype(y.dtype), y)
 
 
 _UPFIRDN_TYPES = (int, np.float32, np.complex64, float, complex)
@@ -129,14 +129,14 @@ class TestUpfirdn:
         x = np.ones(len_x)
         y = upfirdn(h, x, 1, 1)
         want = np.pad(x, (len_h // 2, (len_h - 1) // 2), 'constant')
-        assert_allclose(y, want)
+        xp_assert_close(y, want)
 
     def test_shift_x(self):
         # gh-9844: shifted x can change values?
         y = upfirdn([1, 1], [1.], 1, 1)
-        assert_allclose(y, [1, 1])  # was [0, 1] in the issue
+        xp_assert_close(y, np.asarray([1.0, 1.0]))  # was [0, 1] in the issue
         y = upfirdn([1, 1], [0., 1.], 1, 1)
-        assert_allclose(y, [0, 1, 1])
+        xp_assert_close(y, np.asarray([0.0, 1.0, 1.0]))
 
     # A bunch of lengths/factors chosen because they exposed differences
     # between the "old way" and new way of computing length, and then
@@ -154,7 +154,8 @@ class TestUpfirdn:
         h[0] = 1.
         x = np.ones(len_x)
         y = upfirdn(h, x, up, down)
-        assert_allclose(y, expected)
+        expected = np.asarray(expected, dtype=np.float64)
+        xp_assert_close(y, expected)
 
     @pytest.mark.parametrize('down, want_len', [  # lengths from MATLAB
         (2, 5015),
@@ -177,7 +178,7 @@ class TestUpfirdn:
             y = upfirdn(h, x, up=1, down=down)
             assert y.shape == (want_len,)
             assert yl.shape[0] == y.shape[0]
-            assert_allclose(yl, y, atol=1e-7, rtol=1e-7)
+            xp_assert_close(yl, y, atol=1e-7, rtol=1e-7)
 
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h', (1., 1j))
@@ -226,13 +227,13 @@ class TestUpfirdn:
         y = _pad_test(x, npre=npre, npost=npost, mode=mode)
         if mode == 'antisymmetric':
             y_expected = np.asarray(
-                [3, 1, -1, -3, -2, -1, 1, 2, 3, 1, -1, -3, -2, -1, 1, 2])
+                [3.0, 1, -1, -3, -2, -1, 1, 2, 3, 1, -1, -3, -2, -1, 1, 2])
         elif mode == 'antireflect':
             y_expected = np.asarray(
-                [1, 2, 3, 1, -1, 0, 1, 2, 3, 1, -1, 0, 1, 2, 3, 1])
+                [1.0, 2, 3, 1, -1, 0, 1, 2, 3, 1, -1, 0, 1, 2, 3, 1])
         elif mode == 'smooth':
             y_expected = np.asarray(
-                [-5, -4, -3, -2, -1, 0, 1, 2, 3, 1, -1, -3, -5, -7, -9, -11])
+                [-5.0, -4, -3, -2, -1, 0, 1, 2, 3, 1, -1, -3, -5, -7, -9, -11])
         elif mode == "line":
             lin_slope = (x[-1] - x[0]) / (len(x) - 1)
             left = x[0] + np.arange(-npre, 0, 1) * lin_slope
@@ -240,7 +241,7 @@ class TestUpfirdn:
             y_expected = np.concatenate((left, x, right))
         else:
             y_expected = np.pad(x, (npre, npost), mode=mode)
-        assert_allclose(y, y_expected)
+        xp_assert_close(y, y_expected)
 
     @pytest.mark.parametrize(
         'size, h_len, mode, dtype',
@@ -270,7 +271,7 @@ class TestUpfirdn:
         y_expected = ypad[npad:-npad]
 
         atol = rtol = np.finfo(dtype).eps * 1e2
-        assert_allclose(y, y_expected, atol=atol, rtol=rtol)
+        xp_assert_close(y, y_expected, atol=atol, rtol=rtol)
 
 
 def test_output_len_long_input():

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -1,7 +1,8 @@
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_equal,
-                           assert_, assert_allclose, assert_array_equal)
 from pytest import raises as assert_raises
+from scipy._lib._array_api import (
+    assert_almost_equal, xp_assert_equal, xp_assert_close
+)
 
 import scipy.signal._waveforms as waveforms
 
@@ -59,7 +60,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_linear(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_linear_freq_02(self):
         method = 'linear'
@@ -70,7 +71,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_linear(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_quadratic_at_zero(self):
         w = waveforms.chirp(t=0, f0=1.0, f1=2.0, t1=1.0, method='quadratic')
@@ -90,7 +91,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_quadratic(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_quadratic_freq_02(self):
         method = 'quadratic'
@@ -101,7 +102,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_quadratic(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_logarithmic_at_zero(self):
         w = waveforms.chirp(t=0, f0=1.0, f1=2.0, t1=1.0, method='logarithmic')
@@ -116,7 +117,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_geometric(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_logarithmic_freq_02(self):
         method = 'logarithmic'
@@ -127,7 +128,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_geometric(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_logarithmic_freq_03(self):
         method = 'logarithmic'
@@ -138,7 +139,7 @@ class TestChirp:
         phase = waveforms._chirp_phase(t, f0, t1, f1, method)
         tf, f = compute_frequency(t, phase)
         abserr = np.max(np.abs(f - chirp_geometric(tf, f0, f1, t1)))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_hyperbolic_at_zero(self):
         w = waveforms.chirp(t=0, f0=10.0, f1=1.0, t1=1.0, method='hyperbolic')
@@ -157,7 +158,7 @@ class TestChirp:
             phase = waveforms._chirp_phase(t, f0, t1, f1, method)
             tf, f = compute_frequency(t, phase)
             expected = chirp_hyperbolic(tf, f0, f1, t1)
-            assert_allclose(f, expected)
+            xp_assert_close(f, expected, atol=1e-7)
 
     def test_hyperbolic_zero_freq(self):
         # f0=0 or f1=0 must raise a ValueError.
@@ -184,7 +185,7 @@ class TestChirp:
         t1 = 3
         int_result = waveforms.chirp(t, f0, t1, f1)
         err_msg = "Integer input 't1=3' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_f0(self):
         f1 = 20.0
@@ -195,7 +196,7 @@ class TestChirp:
         f0 = 10
         int_result = waveforms.chirp(t, f0, t1, f1)
         err_msg = "Integer input 'f0=10' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_f1(self):
         f0 = 10.0
@@ -206,7 +207,7 @@ class TestChirp:
         f1 = 20
         int_result = waveforms.chirp(t, f0, t1, f1)
         err_msg = "Integer input 'f1=20' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_all(self):
         f0 = 10
@@ -216,7 +217,7 @@ class TestChirp:
         float_result = waveforms.chirp(t, float(f0), float(t1), float(f1))
         int_result = waveforms.chirp(t, f0, t1, f1)
         err_msg = "Integer input 'f0=10, t1=3, f1=20' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
 
 class TestSweepPoly:
@@ -228,7 +229,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = p(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_const(self):
         p = np.poly1d(2.0)
@@ -237,7 +238,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = p(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_linear(self):
         p = np.poly1d([-1.0, 10.0])
@@ -246,7 +247,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = p(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_quad2(self):
         p = np.poly1d([1.0, 0.0, -2.0])
@@ -255,7 +256,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = p(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_cubic(self):
         p = np.poly1d([2.0, 1.0, 0.0, -2.0])
@@ -264,7 +265,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = p(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_cubic2(self):
         """Use an array of coefficients instead of a poly1d."""
@@ -274,7 +275,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = np.poly1d(p)(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
     def test_sweep_poly_cubic3(self):
         """Use a list of coefficients instead of a poly1d."""
@@ -284,7 +285,7 @@ class TestSweepPoly:
         tf, f = compute_frequency(t, phase)
         expected = np.poly1d(p)(tf)
         abserr = np.max(np.abs(f - expected))
-        assert_(abserr < 1e-6)
+        assert abserr < 1e-6
 
 
 class TestGaussPulse:
@@ -293,59 +294,60 @@ class TestGaussPulse:
         float_result = waveforms.gausspulse('cutoff', fc=1000.0)
         int_result = waveforms.gausspulse('cutoff', fc=1000)
         err_msg = "Integer input 'fc=1000' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_bw(self):
         float_result = waveforms.gausspulse('cutoff', bw=1.0)
         int_result = waveforms.gausspulse('cutoff', bw=1)
         err_msg = "Integer input 'bw=1' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_bwr(self):
         float_result = waveforms.gausspulse('cutoff', bwr=-6.0)
         int_result = waveforms.gausspulse('cutoff', bwr=-6)
         err_msg = "Integer input 'bwr=-6' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
     def test_integer_tpr(self):
         float_result = waveforms.gausspulse('cutoff', tpr=-60.0)
         int_result = waveforms.gausspulse('cutoff', tpr=-60)
         err_msg = "Integer input 'tpr=-60' gives wrong result"
-        assert_equal(int_result, float_result, err_msg=err_msg)
+        xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
 
 class TestUnitImpulse:
 
     def test_no_index(self):
-        assert_array_equal(waveforms.unit_impulse(7), [1, 0, 0, 0, 0, 0, 0])
-        assert_array_equal(waveforms.unit_impulse((3, 3)),
-                           [[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+        xp_assert_equal(waveforms.unit_impulse(7),
+                        np.asarray([1.0, 0, 0, 0, 0, 0, 0]))
+        xp_assert_equal(waveforms.unit_impulse((3, 3)),
+                        np.asarray([[1.0, 0, 0], [0, 0, 0], [0, 0, 0]]))
 
     def test_index(self):
-        assert_array_equal(waveforms.unit_impulse(10, 3),
-                           [0, 0, 0, 1, 0, 0, 0, 0, 0, 0])
-        assert_array_equal(waveforms.unit_impulse((3, 3), (1, 1)),
-                           [[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+        xp_assert_equal(waveforms.unit_impulse(10, 3),
+                        np.asarray([0.0, 0, 0, 1, 0, 0, 0, 0, 0, 0]))
+        xp_assert_equal(waveforms.unit_impulse((3, 3), (1, 1)),
+                        np.asarray([[0.0, 0, 0], [0, 1, 0], [0, 0, 0]]))
 
         # Broadcasting
         imp = waveforms.unit_impulse((4, 4), 2)
-        assert_array_equal(imp, np.array([[0, 0, 0, 0],
-                                          [0, 0, 0, 0],
-                                          [0, 0, 1, 0],
-                                          [0, 0, 0, 0]]))
+        xp_assert_equal(imp, np.asarray([[0.0, 0, 0, 0],
+                                         [0.0, 0, 0, 0],
+                                         [0.0, 0, 1, 0],
+                                         [0.0, 0, 0, 0]]))
 
     def test_mid(self):
-        assert_array_equal(waveforms.unit_impulse((3, 3), 'mid'),
-                           [[0, 0, 0], [0, 1, 0], [0, 0, 0]])
-        assert_array_equal(waveforms.unit_impulse(9, 'mid'),
-                           [0, 0, 0, 0, 1, 0, 0, 0, 0])
+        xp_assert_equal(waveforms.unit_impulse((3, 3), 'mid'),
+                        np.asarray([[0.0, 0, 0], [0, 1, 0], [0, 0, 0]]))
+        xp_assert_equal(waveforms.unit_impulse(9, 'mid'),
+                        np.asarray([0.0, 0, 0, 0, 1, 0, 0, 0, 0]))
 
     def test_dtype(self):
         imp = waveforms.unit_impulse(7)
-        assert_(np.issubdtype(imp.dtype, np.floating))
+        assert np.issubdtype(imp.dtype, np.floating)
 
         imp = waveforms.unit_impulse(5, 3, dtype=int)
-        assert_(np.issubdtype(imp.dtype, np.integer))
+        assert np.issubdtype(imp.dtype, np.integer)
 
         imp = waveforms.unit_impulse((5, 2), (3, 1), dtype=complex)
-        assert_(np.issubdtype(imp.dtype, np.complexfloating))
+        assert np.issubdtype(imp.dtype, np.complexfloating)


### PR DESCRIPTION
A follow-up to https://github.com/scipy/scipy/pull/21512

- [x] test_upfirdn.py
- [x] test_cont2discrete.py
- [x] test_peak_finding.py
- [x] test_savitzky_golay.py
- [x] test_short_time_fft.py
- [x]  test_waveforms.py
