### PR TITLE
ENH: private support for enabling array API programmatically

### DIFF
--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
-    _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy
+    GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy
 )
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
 import scipy._lib.array_api_compat.numpy as np_compat
@@ -11,7 +11,7 @@ import scipy._lib.array_api_compat.numpy as np_compat
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
-@pytest.mark.skipif(not _GLOBAL_CONFIG["SCIPY_ARRAY_API"],
+@pytest.mark.skipif(not GLOBAL_CONFIG.SCIPY_ARRAY_API,
         reason="Array API test; set environment variable SCIPY_ARRAY_API=1 to run it")
 class TestArrayAPI:
 
@@ -20,10 +20,10 @@ class TestArrayAPI:
         xp = array_namespace(x, y)
         assert 'array_api_compat.numpy' in xp.__name__
 
-        _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = False
+        GLOBAL_CONFIG.SCIPY_ARRAY_API = False
         xp = array_namespace(x, y)
         assert 'array_api_compat.numpy' in xp.__name__
-        _GLOBAL_CONFIG["SCIPY_ARRAY_API"] = True
+        GLOBAL_CONFIG.SCIPY_ARRAY_API = True
 
     @array_api_compatible
     def test_asarray(self, xp):

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -12,7 +12,7 @@ from pytest import raises as assert_raises
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, vq, whiten,
                               ClusterError, _krandinit)
 from scipy.cluster import _vq
-from scipy.conftest import array_api_compatible
+from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
 from scipy.sparse._sputils import matrix
 
 from scipy._lib._array_api import (
@@ -121,8 +121,7 @@ class TestWhiten:
                               [0.45067590, 0.45464607]])
             assert_raises(ValueError, whiten, obs)
 
-    @pytest.mark.skipif(SCIPY_ARRAY_API,
-                        reason='`np.matrix` unsupported in array API mode')
+    @skip_xp_invalid_arg
     def test_whiten_not_finite_matrix(self, xp):
         for bad_value in np.nan, np.inf, -np.inf:
             obs = matrix([[0.98744510, bad_value],
@@ -143,8 +142,7 @@ class TestVq:
         xp_assert_equal(label1, xp.asarray(LABEL1, dtype=xp.int64),
                         check_dtype=False)
 
-    @pytest.mark.skipif(SCIPY_ARRAY_API,
-                        reason='`np.matrix` unsupported in array API mode')
+    @skip_xp_invalid_arg
     def test_py_vq_matrix(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         # label1.dtype varies between int32 and int64 over platforms
@@ -158,8 +156,7 @@ class TestVq:
         assert_array_equal(label1, LABEL1)
         _, _ = vq(xp.asarray(X), xp.asarray(initc))
 
-    @pytest.mark.skipif(SCIPY_ARRAY_API,
-                        reason='`np.matrix` unsupported in array API mode')
+    @skip_xp_invalid_arg
     def test_vq_matrix(self, xp):
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         label1, _ = _vq.vq(matrix(X), matrix(initc))
@@ -256,8 +253,7 @@ class TestKMean:
         code1 = kmeans(xp.asarray(X), xp.asarray(initc), iter=1)[0]
         xp_assert_close(code1, xp.asarray(CODET2))
 
-    @pytest.mark.skipif(SCIPY_ARRAY_API,
-                        reason='`np.matrix` unsupported in array API mode')
+    @skip_xp_invalid_arg
     def test_kmeans_simple_matrix(self, xp):
         np.random.seed(54321)
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
@@ -291,8 +287,7 @@ class TestKMean:
             xp_assert_close(code1, xp.asarray(CODET1))
             xp_assert_close(code2, xp.asarray(CODET2))
 
-    @pytest.mark.skipif(SCIPY_ARRAY_API,
-                        reason='`np.matrix` unsupported in array API mode')
+    @skip_xp_invalid_arg
     def test_kmeans2_simple_matrix(self, xp):
         np.random.seed(12345678)
         initc = xp.asarray(np.concatenate([[X[0]], [X[1]], [X[2]]]))

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -118,7 +118,7 @@ def check_fpu_mode(request):
 # Array API backend handling
 xp_available_backends = {'numpy': np}
 
-if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
+if SCIPY_ARRAY_API:
     # fill the dict of backends with available libraries
     try:
         import array_api_strict

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -1,6 +1,6 @@
 import functools
 from scipy._lib._array_api import (
-    is_cupy, is_jax, scipy_namespace_for, SCIPY_ARRAY_API
+    is_cupy, is_jax, scipy_namespace_for, GLOBAL_CONFIG
 )
 
 import numpy as np
@@ -36,7 +36,7 @@ def delegate_xp(delegator, module_name):
                 # XXX: output arrays
                 result = func(*args, **kwds)
 
-                if isinstance(result, (np.ndarray, np.generic)):
+                if isinstance(result, np.ndarray | np.generic):
                     # XXX: np.int32->np.array_0D
                     return xp.asarray(result)
                 elif isinstance(result, int):
@@ -65,7 +65,7 @@ for func_name in _ndimage_api.__all__:
     delegator = getattr(_delegators, func_name + "_signature")
 
     f = (delegate_xp(delegator, MODULE_NAME)(bare_func)
-         if SCIPY_ARRAY_API
+         if GLOBAL_CONFIG.SCIPY_ARRAY_API
          else bare_func)
 
     # add the decorated function to the namespace, to be imported in __init__.py

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -1,10 +1,9 @@
-import os
 import sys
 import functools
 
 import numpy as np
 from scipy._lib._array_api import (
-    array_namespace, scipy_namespace_for, is_numpy
+    array_namespace, GLOBAL_CONFIG, scipy_namespace_for, is_numpy
 )
 from . import _ufuncs
 # These don't really need to be imported, but otherwise IDEs might not realize
@@ -15,7 +14,6 @@ from ._ufuncs import (
     chdtr, chdtrc, betainc, betaincc, stdtr  # noqa: F401
 )
 
-_SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API", False)
 array_api_compat_prefix = "scipy._lib.array_api_compat"
 
 
@@ -195,7 +193,8 @@ array_special_func_map = {
 }
 
 for f_name, n_array_args in array_special_func_map.items():
-    f = (support_alternative_backends(f_name, n_array_args) if _SCIPY_ARRAY_API
+    f = (support_alternative_backends(f_name, n_array_args)
+         if GLOBAL_CONFIG.SCIPY_ARRAY_API
          else getattr(_ufuncs, f_name))
     sys.modules[__name__].__dict__[f_name] = f
 


### PR DESCRIPTION
#### Reference issue
Towards gh-21529

#### What does this implement/fix?
Replaces the existing (unused) `_GLOBAL_CONFIG` dict with a `GLOBAL_CONFIG` dataclass, and adds a setter `set_scipy_array_api` for programmatically changing `GLOBAL_CONFIG.SCIPY_ARRAY_API`.

Within our tests we can continue to just use `SCIPY_ARRAY_API` and `SCIPY_DEVICE`, which will store the value of the env vars when starting the tests (or whatever is passed via CLI), but for production code we should instead use the dynamic `GLOBAL_CONFIG.SCIPY_ARRAY_API`.

This is all private for now and can be used downstream with no BC guarantees. If this works well then perhaps we can commit to supporting it officially.

#### Additional information
- The name `GLOBAL_CONFIG` feels a bit too general to me.
- This should be documented on https://scipy.github.io/devdocs/dev/api-dev/array_api.html.
- I've also cleaned up a few lines by utilising `skip_xp_invalid_arg`.

cc @ogrisel 