### PR TITLE
TST: interpolate: fix a spurious failure with -b all

### DIFF
--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_warns
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_array_almost_equal
 )
+from scipy.conftest import skip_xp_invalid_arg
 
 from pytest import raises as assert_raises
 
@@ -1001,8 +1002,10 @@ class TestInterpN:
         v2 = interpn((x, y), values._v, [0.4, 0.7], method=method)
         xp_assert_close(v1, v2, check_dtype=False)
 
+    @skip_xp_invalid_arg
     @parametrize_rgi_interp_methods
     def test_matrix_input(self, method):
+        """np.matrix inputs are allowed for backwards compatibility"""
         x = np.linspace(0, 2, 6)
         y = np.linspace(0, 1, 7)
 


### PR DESCRIPTION
The failing test is testing np.matrix inputs to RGI. This is allowed for backwards compatibility but does not work with thexp_assert_* infrastructure. Thus, convert to arrays for assertions.

An alternative is to skip the test when running with SCIPY_ARRAY_API env variable (since then we're not bound by backwards compat). Converting to ndarray seems simpler though.

closes gh-21534