### PR TITLE
DOC: optimize: document recipe for `*args` and `**kwargs`

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -66,10 +66,12 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         is a tuple of the fixed parameters needed to completely
         specify the function.
 
-        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
-        and ``kwargs`` are required positional and keyword arguments. Rather than
-        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
-        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
+        Suppose the callable has signature ``f0(x, *my_args, **my_kwargs)``, where
+        ``my_args`` and ``my_kwargs`` are required positional and keyword arguments.
+        Rather than passing ``f0`` as the callable, wrap it to accept
+        only ``x``; e.g., pass ``fun=lambda x: f0(x, *my_args, **my_kwargs)`` as the
+        callable, where ``my_args`` (tuple) and ``my_kwargs`` (dict) have been
+        gathered before invoking this function.
     x0 : ndarray, shape (n,)
         Initial guess. Array of real elements of size (n,),
         where ``n`` is the number of independent variables.
@@ -790,10 +792,12 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         Objective function.
         Scalar function, must return a scalar.
 
-        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
-        and ``kwargs`` are required positional and keyword arguments. Rather than
-        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
-        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
+        Suppose the callable has signature ``f0(x, *my_args, **my_kwargs)``, where
+        ``my_args`` and ``my_kwargs`` are required positional and keyword arguments.
+        Rather than passing ``f0`` as the callable, wrap it to accept
+        only ``x``; e.g., pass ``fun=lambda x: f0(x, *my_args, **my_kwargs)`` as the
+        callable, where ``my_args`` (tuple) and ``my_kwargs`` (dict) have been
+        gathered before invoking this function.
 
     bracket : sequence, optional
         For methods 'brent' and 'golden', `bracket` defines the bracketing

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -65,6 +65,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         where ``x`` is a 1-D array with shape (n,) and ``args``
         is a tuple of the fixed parameters needed to completely
         specify the function.
+
+        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
+        and ``kwargs`` are required positional and keyword arguments. Rather than
+        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
+        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
     x0 : ndarray, shape (n,)
         Initial guess. Array of real elements of size (n,),
         where ``n`` is the number of independent variables.
@@ -784,6 +789,12 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     fun : callable
         Objective function.
         Scalar function, must return a scalar.
+
+        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
+        and ``kwargs`` are required positional and keyword arguments. Rather than
+        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
+        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
+
     bracket : sequence, optional
         For methods 'brent' and 'golden', `bracket` defines the bracketing
         interval and is required.

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -956,10 +956,12 @@ def approx_fprime(xk, f, epsilon=_epsilon, *args):
         function is an ndarray of shape (n,) (never a scalar even if n=1).
         It must return a 1-D array_like of shape (m,) or a scalar.
 
-        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
-        and ``kwargs`` are required positional and keyword arguments. Rather than
-        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
-        e.g., pass ``f=lambda x: f0(x, *args, **kwargs)`` as the callable.
+        Suppose the callable has signature ``f0(x, *my_args, **my_kwargs)``, where
+        ``my_args`` and ``my_kwargs`` are required positional and keyword arguments.
+        Rather than passing ``f0`` as the callable, wrap it to accept
+        only ``x``; e.g., pass ``fun=lambda x: f0(x, *my_args, **my_kwargs)`` as the
+        callable, where ``my_args`` (tuple) and ``my_kwargs`` (dict) have been
+        gathered before invoking this function.
 
         .. versionchanged:: 1.9.0
             `f` is now able to return a 1-D array-like, with the :math:`(m, n)`

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -956,6 +956,11 @@ def approx_fprime(xk, f, epsilon=_epsilon, *args):
         function is an ndarray of shape (n,) (never a scalar even if n=1).
         It must return a 1-D array_like of shape (m,) or a scalar.
 
+        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
+        and ``kwargs`` are required positional and keyword arguments. Rather than
+        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
+        e.g., pass ``f=lambda x: f0(x, *args, **kwargs)`` as the callable.
+
         .. versionchanged:: 1.9.0
             `f` is now able to return a 1-D array-like, with the :math:`(m, n)`
             Jacobian being estimated.

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -31,6 +31,11 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     ----------
     fun : callable
         A vector function to find a root of.
+
+        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
+        and ``kwargs`` are required positional and keyword arguments. Rather than
+        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
+        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
     x0 : ndarray
         Initial guess.
     args : tuple, optional

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -32,10 +32,12 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     fun : callable
         A vector function to find a root of.
 
-        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
-        and ``kwargs`` are required positional and keyword arguments. Rather than
-        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
-        e.g., pass ``fun=lambda x: f0(x, *args, **kwargs)`` as the callable.
+        Suppose the callable has signature ``f0(x, *my_args, **my_kwargs)``, where
+        ``my_args`` and ``my_kwargs`` are required positional and keyword arguments.
+        Rather than passing ``f0`` as the callable, wrap it to accept
+        only ``x``; e.g., pass ``fun=lambda x: f0(x, *my_args, **my_kwargs)`` as the
+        callable, where ``my_args`` (tuple) and ``my_kwargs`` (dict) have been
+        gathered before invoking this function.
     x0 : ndarray
         Initial guess.
     args : tuple, optional

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -72,10 +72,12 @@ def root_scalar(f, args=(), method=None, bracket=None,
     f : callable
         A function to find a root of.
 
-        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
-        and ``kwargs`` are required positional and keyword arguments. Rather than
-        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
-        e.g., pass ``f=lambda x: f0(x, *args, **kwargs)`` as the callable.
+        Suppose the callable has signature ``f0(x, *my_args, **my_kwargs)``, where
+        ``my_args`` and ``my_kwargs`` are required positional and keyword arguments.
+        Rather than passing ``f0`` as the callable, wrap it to accept
+        only ``x``; e.g., pass ``fun=lambda x: f0(x, *my_args, **my_kwargs)`` as the
+        callable, where ``my_args`` (tuple) and ``my_kwargs`` (dict) have been
+        gathered before invoking this function.
     args : tuple, optional
         Extra arguments passed to the objective function and its derivative(s).
     method : str, optional

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -71,6 +71,11 @@ def root_scalar(f, args=(), method=None, bracket=None,
     ----------
     f : callable
         A function to find a root of.
+
+        Suppose the callable has signature ``f0(x, *args, **kwargs)``, where ``args``
+        and ``kwargs`` are required positional and keyword arguments. Rather than
+        passing ``f0`` as the callable, consider wrapping it to accept only ``x``;
+        e.g., pass ``f=lambda x: f0(x, *args, **kwargs)`` as the callable.
     args : tuple, optional
         Extra arguments passed to the objective function and its derivative(s).
     method : str, optional


### PR DESCRIPTION
#### Reference issue
Closes gh-21504

#### What does this implement/fix?
gh-21504 (and many others) have proposed adding `kwargs` as an additional argument to `approx_fprime`. By extension, the proposal would be to ensure that `args` and `kwargs` are accepted by all SciPy functions that accept a callable. Rather than implementing, documenting, and testing new arguments for dozens of functions, the resolution was to document (in key places) the standard recipe for users to achieve the same goal. This is already documented near the top of the `optimize` tutorial, so this adds a standard note to the `f`/`fun` argument documentation of some fundamental `optimize` functions.

#### Additional information
Because most of these functions already accept `args`, I didn't think I could use the imperative; rather, I suggest "consider wrapping the callable...". This may be misunderstood as meaning that it is entirely optional, even when there are keyword arguments. There are a few options for addressing this if it is deemed essential, but I thought that leaving it as-is was the best option.