### PR TITLE
STY: ignore rule UP038

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -441,7 +441,7 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     2.80668351922014
 
     """
-    if not isinstance(p, (int | float)):
+    if not isinstance(p, (int, float)):
         raise ValueError("Power mean only defined for exponent of type int or "
                          "float.")
     if p == 0:

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -20,7 +20,7 @@ target-version = "py310"
 # `ICN001` added in gh-20382 to enforce common conventions for import.
 # `W292` added in gh-21023 to enforce newlines at end of files.
 select = ["E", "F", "PGH004", "UP", "B006", "B008", "B028", "ICN001", "W292"]
-ignore = ["E741"]
+ignore = ["E741", "UP038"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
#### Reference issue
gh-21467, gh-21544, gh-21339

#### What does this implement/fix?
Lint rule UP038 recommends using `isinstance(a | b)` instead of `isinstance((a, b))`. This has caused unexpected lint failures in many CI jobs when files with the older style are modified, whether or not the offending lines are added or edited. I expect this will continue for some time unless either the rule is ignored or all offending files are fixed at once. This PR proposes ignoring the rule rather than changing the codebase, the rationale being that the new style is not necessarily clearer or otherwise better.

#### Additional information
The alternative, of course, is to "fix" throughout. Feel free to close this and do that. 