### PR TITLE
TST: linalg: add test for lstsq non-determinism

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,13 +65,13 @@ jobs:
     - name: Install Python packages
       if: matrix.python-version == '3.10'
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis scikit-learn
 
     - name: Install Python packages from repositories
       if: matrix.python-version == '3.13-dev' # this run will use python dev versions when available
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
-        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
+        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis  scikit-learn "setuptools<67.3"
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install git+https://github.com/mesonbuild/meson.git
 
@@ -226,7 +226,7 @@ jobs:
       - name: Testing SciPy
         run: |
           cd doc
-          python3-dbg -m pip install pytest pytest-xdist pytest-timeout mpmath gmpy2 threadpoolctl pooch hypothesis
+          python3-dbg -m pip install pytest pytest-xdist pytest-timeout mpmath gmpy2 threadpoolctl pooch hypothesis scikit-learn
           python3-dbg -m pytest --pyargs scipy -n2 --durations=10 -m "not slow"
 
   #################################################################################
@@ -271,7 +271,7 @@ jobs:
       - name: Install test dependencies
         run: |
           # Downgrade numpy to oldest supported version
-          pip install gmpy2 threadpoolctl mpmath pooch pytest pytest-xdist==2.5.0 pytest-timeout hypothesis sparse "numpy==1.23.5"
+          pip install gmpy2 threadpoolctl mpmath pooch pytest pytest-xdist==2.5.0 pytest-timeout hypothesis sparse "numpy==1.23.5" scikit-learn
 
       - name: Run tests
         run: |
@@ -321,7 +321,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis matplotlib
+        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis matplotlib scikit-learn
         python -m pip install -r requirements/openblas.txt
         # Install numpy last, to ensure we get nightly (avoid possible <2.0 constraints).
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
@@ -398,7 +398,7 @@ jobs:
         runtime_library_dirs = \$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_lib_dir())')
         symbol_prefix = scipy_
         EOL
-        python -m pip install numpy==1.23.5 cython pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis && \
+        python -m pip install numpy==1.23.5 cython pybind11 pytest pytest-timeout pytest-xdist pytest-env 'Pillow<10.0.0' mpmath pythran pooch meson hypothesis scikit-learn && \
         python -c 'import numpy as np; np.show_config()' && \
         python dev.py build --with-scipy-openblas && \
         python dev.py --no-build test"
@@ -479,7 +479,7 @@ jobs:
       run: |
         pip install git+https://github.com/serge-sans-paille/pythran
         pip install ninja meson-python pybind11 click rich_click pydevtool
-        pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
+        pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis scikit-learn
         pip install -r requirements/openblas.txt
     - name: Build and run tests
       env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -178,7 +178,7 @@ jobs:
         pip install -r requirements/openblas.txt
         python dev.py build --with-scipy-openblas
 
-        pip install pooch pytest hypothesis
+        pip install pooch pytest hypothesis scikit-learn
         python dev.py -n test 
 
 
@@ -222,5 +222,5 @@ jobs:
         pip install click doit pydevtool rich_click meson cython pythran pybind11 ninja numpy
         python dev.py build --with-accelerate
 
-        pip install pooch pytest hypothesis
+        pip install pooch pytest hypothesis scikit-learn
         python dev.py -n test

--- a/.github/workflows/musllinux.yml
+++ b/.github/workflows/musllinux.yml
@@ -70,7 +70,7 @@ jobs:
 
         python -m pip install cython numpy
         # python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-        python -m pip install meson ninja pybind11 pythran pytest hypothesis
+        python -m pip install meson ninja pybind11 pythran pytest hypothesis scikit-learn
         python -m pip install click rich_click doit pydevtool pooch
         python -m pip install -r requirements/openblas.txt
         

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          pip install numpy cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis
+          pip install numpy cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis scikit-learn
           python -m pip install -r requirements/openblas.txt
 
       - name: Build
@@ -92,7 +92,7 @@ jobs:
         run: |
           # 1.23.5 is currently the oldest numpy usable on cp3.10 according
           # to pyproject.toml
-          python -m pip install numpy==1.23.5 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis
+          python -m pip install numpy==1.23.5 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis scikit-learn
           python -m pip install -r requirements/openblas.txt
 
       - name: Build
@@ -143,7 +143,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          python -m pip install build delvewheel cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis
+          python -m pip install build delvewheel cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis scikit-learn
           python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Build

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install packages from conda
         run: |
-          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich-click click doit pydevtool hypothesis
+          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich-click click doit pydevtool hypothesis scikit-learn
 
       - name: cache install
         id: cache-install

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2045,3 +2045,22 @@ class TestMatrix_Balance:
         assert scale.dtype == scale_n.dtype
         assert perm.dtype == perm_n.dtype
 
+@pytest.mark.fail_slow(90)
+def test_gh8208():
+    import numpy as np
+    from scipy.linalg import lstsq
+    # requires scikit-learn >= 0.19
+    from sklearn.tests.test_multioutput import generate_multilabel_dataset_with_correlations  # noqa: E501
+
+    def test_investigate_linear_regression_indeterminacy():
+        # Is scipy.linalg.lstsq deterministic?
+        X, Y = generate_multilabel_dataset_with_correlations()
+        y = Y[:, 1].astype(np.float64)
+        X -= X.mean(axis=0)
+        y -= y.mean()
+        ref = lstsq(X, y)[0]
+        for i in range(1000):
+            coef = lstsq(X, y)[0]
+            np.testing.assert_array_equal(ref, coef)
+
+    test_investigate_linear_regression_indeterminacy()


### PR DESCRIPTION
Not for merge; testing with CI only

#### Reference issue
gh-8208

#### What does this implement/fix?
gh-8208 reported that `lstsq` was non-deterministic. This is just to test whether the example (reported in 2017) is reproducible. If not, let's close gh-8208. If so, maybe we can find a reproducer that doesn't require scikit-learn.