### PR TITLE
TST, MAINT: skip some torch GPU tests

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -923,7 +923,9 @@ class TestNdimageFilters:
         xp_assert_close(output, expected)
 
     @skip_xp_backends("cupy",
-                      reasons=["these filters do not yet have axes support"])
+                      reasons=["these filters do not yet have axes support"],
+                      cpu_only=True,
+                      exceptions=['cupy', 'jax.numpy'])
     @pytest.mark.parametrize(('filter_func', 'kwargs'),
                              [(ndimage.laplace, {}),
                               (ndimage.gaussian_gradient_magnitude,
@@ -964,7 +966,9 @@ class TestNdimageFilters:
         xp_assert_close(output, expected)
 
     @skip_xp_backends("cupy",
-                      reasons=["generic_filter does not yet have axes support"])
+                      reasons=["generic_filter does not yet have axes support"],
+                      cpu_only=True,
+                      exceptions=['cupy', 'jax.numpy'])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
@@ -986,7 +990,9 @@ class TestNdimageFilters:
         xp_assert_close(output, expected)
 
     @skip_xp_backends("cupy",
-                      reasons=["https://github.com/cupy/cupy/pull/8339"])
+                      reasons=["https://github.com/cupy/cupy/pull/8339"],
+                      cpu_only=True,
+                      exceptions=['cupy', 'jax.numpy'])
     @pytest.mark.parametrize('func', [ndimage.correlate, ndimage.convolve])
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64, np.complex64, np.complex128]


### PR DESCRIPTION
* these three test skips fix up 265 test failures in `TestNdimageFilters` test class, when `cuda`
backend is used with `torch`.

[skip cirrus] [skip circle]

I'll place a representative failure below the fold.

<details>

```
______________________________________________________________ TestNdimageFilters.test_derivative_filter_axes[laplace-kwargs0-torch] ______________________________________________________________
scipy/ndimage/tests/test_filters.py:938: in test_derivative_filter_axes
    filter_func(array, axes=(1, 1), **kwargs)
        array      = tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  14...., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)
        filter_func = <function laplace at 0x7f4e29f63100>
        kwargs     = {}
        self       = <scipy.ndimage.tests.test_filters.TestNdimageFilters object at 0x7f4e25f10850>
        xp         = <module 'torch' from '/home/treddy/python_venvs/py_311_scipy_dev/lib/python3.11/site-packages/torch/__init__.py'>
scipy/ndimage/_support_alternative_backends.py:37: in wrapper
    result = func(*args, **kwds)
        args       = (tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  1... 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64),)
        delegator  = <function laplace_signature at 0x7f4e29f60cc0>
        func       = <function laplace at 0x7f4e29f03d80>
        kwds       = {'axes': (1, 1)}
        module_name = 'ndimage'
        xp         = <module 'scipy._lib.array_api_compat.torch' from '/home/treddy/github_projects/scipy/build-install/lib/python3.11/site-packages/scipy/_lib/array_api_compat/torch/__init__.py'>
scipy/ndimage/_filters.py:639: in laplace
    return generic_laplace(input, derivative2, output, mode, cval, axes=axes)
        axes       = (1, 1)
        cval       = 0.0
        derivative2 = <function laplace.<locals>.derivative2 at 0x7f4e116179c0>
        input      = tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  14...., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)
        mode       = 'reflect'
        output     = None
scipy/ndimage/_filters.py:588: in generic_laplace
    input = np.asarray(input)
        axes       = (1, 1)
        cval       = 0.0
        derivative2 = <function laplace.<locals>.derivative2 at 0x7f4e116179c0>
        extra_arguments = ()
        extra_keywords = {}
        input      = tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  14...., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)
        mode       = 'reflect'
        output     = None
/home/treddy/python_venvs/py_311_scipy_dev/lib/python3.11/site-packages/torch/_tensor.py:1081: in __array__
    return handle_torch_function(Tensor.__array__, (self,), self, dtype=dtype)
        dtype      = None
        self       = tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  14...., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)
/home/treddy/python_venvs/py_311_scipy_dev/lib/python3.11/site-packages/torch/overrides.py:1630: in handle_torch_function
    result = mode.__torch_function__(public_api, types, args, kwargs)
        args       = (tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  1... 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64),)
        kwargs     = {'dtype': None}
        mode       = <torch.utils._device.DeviceContext object at 0x7f4e364f3b50>
        overloaded_args = [tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  1..., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)]
        public_api = <function Tensor.__array__ at 0x7f4ee67a23e0>
        relevant_args = (tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  1... 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64),)
        types      = (<class 'torch.Tensor'>,)
/home/treddy/python_venvs/py_311_scipy_dev/lib/python3.11/site-packages/torch/utils/_device.py:79: in __torch_function__
    return func(*args, **kwargs)
        args       = (tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  1... 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64),)
        func       = <function Tensor.__array__ at 0x7f4ee67a23e0>
        kwargs     = {'dtype': None}
        self       = <torch.utils._device.DeviceContext object at 0x7f4e364f3b50>
        types      = (<class 'torch.Tensor'>,)
/home/treddy/python_venvs/py_311_scipy_dev/lib/python3.11/site-packages/torch/_tensor.py:1083: in __array__
    return self.numpy()
E   TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
        dtype      = None
        self       = tensor([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
           11.],
         [ 12.,  13.,  14...., 565., 566., 567., 568., 569., 570., 571., 572., 573., 574.,
          575.]]], device='cuda:0', dtype=torch.float64)
```

</details>