### PR TITLE
MAINT: stats.wilcoxon: small improvements/fixes

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3681,6 +3681,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     """
     # replace approx by asymptotic to ensure backwards compatability
     if method == "approx":
+        depr_msg = ("The method `approx` has been renamed to `aymptotic`. "
+                    "`approx` will be removed in SciPy 1.17.")
+        warnings.warn(depr_msg, DeprecationWarning, stacklevel=2)
         method = "asymptotic"
     return _wilcoxon._wilcoxon_nd(x, y, zero_method, correction, alternative,
                                   method, axis)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3576,9 +3576,11 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
 
     - The default, ``method='auto'``, selects between the two: when
       ``len(d) <= 50`` and there are no zeros and no ties, the exact method
-      is used; if ``len(d) <= 50`` and there are zeros or ties, the
+      is used; if the sample size is small and there are zeros or ties, the
       p-value is computed using `permutation_test`;
-      otherwise, the approximate method is used.
+      otherwise, the approximate method is used. The p-value computed by
+      the permutation test is deterministic since it is only used if the
+      sample size is small enough to iterate over all possible outcomes.
 
     The presence of "ties" (i.e. not all elements of ``d`` are unique) or
     "zeros" (i.e. elements of ``d`` are zero) changes the null distribution

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3575,7 +3575,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
       execution time).
 
     - The default, ``method='auto'``, selects between the two: when
-      ``len(d) <= 50`` and there are no zeros, the exact method is used;
+      ``len(d) <= 50`` and there are no zeros and no ties, the exact method
+      is used; if ``len(d) <= 50`` and there are zeros or ties, the
+      p-value is computed using `permutation_test`;
       otherwise, the approximate method is used.
 
     The presence of "ties" (i.e. not all elements of ``d`` are unique) or
@@ -3681,7 +3683,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     """
     # replace approx by asymptotic to ensure backwards compatability
     if method == "approx":
-        depr_msg = ("The method `approx` has been renamed to `aymptotic`. "
+        depr_msg = ("The method `approx` has been renamed to `asymptotic`. "
                     "`approx` will be removed in SciPy 1.17.")
         warnings.warn(depr_msg, DeprecationWarning, stacklevel=2)
         method = "asymptotic"

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3467,7 +3467,7 @@ def wilcoxon_outputs(kwds):
     n_samples=lambda kwds: 2 if kwds.get('y', None) is not None else 1,
     result_to_tuple=wilcoxon_result_unpacker, n_outputs=wilcoxon_outputs,
 )
-def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
+def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
              alternative="two-sided", method='auto', *, axis=0):
     """Calculate the Wilcoxon signed-rank test.
 
@@ -3512,7 +3512,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     correction : bool, optional
         If True, apply continuity correction by adjusting the Wilcoxon rank
         statistic by 0.5 towards the mean value when computing the
-        z-statistic if a normal approximation is used.  Default is False.
+        z-statistic if a normal approximation is used.  Default is True.
     alternative : {"two-sided", "greater", "less"}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
         In the following, let ``d`` represent the difference between the paired

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3592,6 +3592,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     `method` parameter also accepts instances `PermutationMethod`. In this
     case, the p-value is computed using `permutation_test` with the provided
     configuration options and other appropriate settings.
+    Please also note that in the edge case that all elements of ``d`` are zero,
+    the p-value relying on the normal approximaton cannot be computed (NaN)
+    if ``zero_method='wilcox'`` or ``zero_method='pratt'``.
 
     References
     ----------

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3456,7 +3456,7 @@ def wilcoxon_result_object(statistic, pvalue, zstatistic=None):
 
 def wilcoxon_outputs(kwds):
     method = kwds.get('method', 'auto')
-    if method == 'approx':
+    if method == 'asymptotic':
         return 3
     return 2
 
@@ -3526,7 +3526,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
         * 'greater': the distribution underlying ``d`` is stochastically
           greater than a distribution symmetric about zero.
 
-    method : {"auto", "exact", "approx"} or `PermutationMethod` instance, optional
+    method : {"auto", "exact", "asymptotic"} or `PermutationMethod` instance, optional
         Method to calculate the p-value, see Notes. Default is "auto".
 
     axis : int or None, default: 0
@@ -3546,14 +3546,14 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     pvalue : array_like
         The p-value for the test depending on `alternative` and `method`.
     zstatistic : array_like
-        When ``method = 'approx'``, this is the normalized z-statistic::
+        When ``method = 'asymptotic'``, this is the normalized z-statistic::
 
             z = (T - mn - d) / se
 
         where ``T`` is `statistic` as defined above, ``mn`` is the mean of the
         distribution under the null hypothesis, ``d`` is a continuity
         correction, and ``se`` is the standard error.
-        When ``method != 'approx'``, this attribute is not available.
+        When ``method != 'asymptotic'``, this attribute is not available.
 
     See Also
     --------
@@ -3568,7 +3568,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
 
     - When ``len(d)`` is sufficiently large, the null distribution of the
       normalized test statistic (`zstatistic` above) is approximately normal,
-      and ``method = 'approx'`` can be used to compute the p-value.
+      and ``method = 'asymptotic'`` can be used to compute the p-value.
 
     - When ``len(d)`` is small, the normal approximation may not be accurate,
       and ``method='exact'`` is preferred (at the cost of additional
@@ -3581,7 +3581,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     The presence of "ties" (i.e. not all elements of ``d`` are unique) or
     "zeros" (i.e. elements of ``d`` are zero) changes the null distribution
     of the test statistic, and ``method='exact'`` no longer calculates
-    the exact p-value. If ``method='approx'``, the z-statistic is adjusted
+    the exact p-value. If ``method='asymptotic'``, the z-statistic is adjusted
     for more accurate comparison against the standard normal, but still,
     for finite sample sizes, the standard normal is only an approximation of
     the true null distribution of the z-statistic. For such situations, the
@@ -3633,7 +3633,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     the median is greater than zero. The p-values above are exact. Using the
     normal approximation gives very similar values:
 
-    >>> res = wilcoxon(d, method='approx')
+    >>> res = wilcoxon(d, method='asymptotic')
     >>> res.statistic, res.pvalue
     (24.0, 0.04088813291185591)
 
@@ -3679,6 +3679,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     WilcoxonResult(statistic=6.0, pvalue=0.4375)
 
     """
+    # replace approx by asymptotic to ensure backwards compatability
+    if method == "approx":
+        method = "asymptotic"
     return _wilcoxon._wilcoxon_nd(x, y, zero_method, correction, alternative,
                                   method, axis)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3688,9 +3688,6 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     """
     # replace approx by asymptotic to ensure backwards compatability
     if method == "approx":
-        depr_msg = ("The method `approx` has been renamed to `asymptotic`. "
-                    "`approx` will be removed in SciPy 1.17.")
-        warnings.warn(depr_msg, DeprecationWarning, stacklevel=2)
         method = "asymptotic"
     return _wilcoxon._wilcoxon_nd(x, y, zero_method, correction, alternative,
                                   method, axis)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3467,7 +3467,7 @@ def wilcoxon_outputs(kwds):
     n_samples=lambda kwds: 2 if kwds.get('y', None) is not None else 1,
     result_to_tuple=wilcoxon_result_unpacker, n_outputs=wilcoxon_outputs,
 )
-def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
+def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
              alternative="two-sided", method='auto', *, axis=0):
     """Calculate the Wilcoxon signed-rank test.
 
@@ -3512,7 +3512,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=True,
     correction : bool, optional
         If True, apply continuity correction by adjusting the Wilcoxon rank
         statistic by 0.5 towards the mean value when computing the
-        z-statistic if a normal approximation is used.  Default is True.
+        z-statistic if a normal approximation is used.  Default is False.
     alternative : {"two-sided", "greater", "less"}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
         In the following, let ``d`` represent the difference between the paired

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3666,7 +3666,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     >>> d = [-0.025, 0.05, 0.05, -0.05]
     >>> ref = wilcoxon(d, alternative='greater')
     >>> ref
-    WilcoxonResult(statistic=6.0, pvalue=0.4375)
+    WilcoxonResult(statistic=6.0, pvalue=0.5)
 
     The substantial difference is due to roundoff error in the results of
     ``x-y``:
@@ -3683,7 +3683,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
 
     >>> d2 = np.around(x - y, decimals=3)
     >>> wilcoxon(d2, alternative='greater')
-    WilcoxonResult(statistic=6.0, pvalue=0.4375)
+    WilcoxonResult(statistic=6.0, pvalue=0.5)
 
     """
     # replace approx by asymptotic to ensure backwards compatability

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -185,7 +185,7 @@ def _wilcoxon_statistic(d, zero_method='wilcox'):
     #   the statistic is calculated
     # - for method != "asymptotic", avoid division by zero warning
     #   (z is not needed anyways)
-    if se == 0:
+    if np.any(se) == 0:
         z = np.nan
     else:
         z = (r_plus - mn) / se

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -72,7 +72,7 @@ axis_nan_policy_cases = [
      lambda res: (res.statistic, res.pvalue)),
     (stats.wilcoxon, tuple(), dict(), 1, 2, True,
      lambda res: (res.statistic, res.pvalue)),
-    (stats.wilcoxon, tuple(), {'mode': 'approx'}, 1, 3, True,
+    (stats.wilcoxon, tuple(), {'method': 'asymptotic'}, 1, 3, True,
      lambda res: (res.statistic, res.pvalue, res.zstatistic)),
     (stats.gmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.hmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1684,12 +1684,23 @@ class TestWilcoxon:
         pm = stats.PermutationMethod()
         d = np.arange(0, 13)
         w, p = stats.wilcoxon(d)
-        assert_equal(stats.wilcoxon(d, method=pm), (w, p))
+        # rerunning the test gives the same results since n_resamples
+        # is large enough to get deterministic results if n <= 13
+        # so we do not need to use a seed
+        assert_equal((w, p), stats.wilcoxon(d, method=pm))
+
+        # for larger vectors, also run permutation test but warn user
+        # that value is not deterministic
+        d = np.arange(0, 14)
+        with pytest.warns(UserWarning, match="not deterministic"):
+            w, p = stats.wilcoxon(d)
+        # we should reject null since d >=0 ...
+        assert_(p < 0.05)
 
         # n <= 50: if there are ties in d = x-y, use PermutationMethod
         d = np.array([1, 2, 2, 7, 5, -6, 9, -4])
         w, p = stats.wilcoxon(d)
-        assert_equal(stats.wilcoxon(d, method=pm), (w, p))
+        assert_equal((w, p), stats.wilcoxon(d, method=pm))
 
         # use approximation for samples > 50
         d = np.arange(1, 52)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1492,7 +1492,8 @@ class TestWilcoxon:
         y = [1, 2, 3, 5]
         with suppress_warnings() as sup:
             sup.filter(UserWarning, message="Sample size too small")
-            res = stats.wilcoxon(x, y, zero_method="pratt", mode="approx")
+            res = stats.wilcoxon(x, y, zero_method="pratt", mode="approx",
+                                 correction=False)
         assert_allclose(res, (0.0, 0.31731050786291415))
 
     def test_wilcoxon_arg_type(self):
@@ -1510,15 +1511,15 @@ class TestWilcoxon:
         x = np.concatenate([[u] * v for u, v in zip(nums, freq)])
         y = np.zeros(x.size)
 
-        T, p = stats.wilcoxon(x, y, "pratt", mode="approx")
+        T, p = stats.wilcoxon(x, y, "pratt", mode="approx", correction=False)
         assert_allclose(T, 423)
         assert_allclose(p, 0.0031724568006762576)
 
-        T, p = stats.wilcoxon(x, y, "zsplit", mode="approx")
+        T, p = stats.wilcoxon(x, y, "zsplit", mode="approx", correction=False)
         assert_allclose(T, 441)
         assert_allclose(p, 0.0032145343172473055)
 
-        T, p = stats.wilcoxon(x, y, "wilcox", mode="approx")
+        T, p = stats.wilcoxon(x, y, "wilcox", mode="approx", correction=False)
         assert_allclose(T, 327)
         assert_allclose(p, 0.00641346115861)
 
@@ -1563,7 +1564,7 @@ class TestWilcoxon:
         #   > result = wilcox.test(rep(0.1, 10), exact=FALSE, correct=TRUE)
         #   > result$p.value
         #   [1] 0.001904195
-        stat, p = stats.wilcoxon([0.1] * 10, mode="approx")
+        stat, p = stats.wilcoxon([0.1] * 10, mode="approx", correction=False)
         expected_p = 0.001565402
         assert_equal(stat, 0)
         assert_allclose(p, expected_p, rtol=1e-6)
@@ -1587,7 +1588,8 @@ class TestWilcoxon:
 
         with suppress_warnings() as sup:
             sup.filter(UserWarning, message="Sample size too small")
-            w, p = stats.wilcoxon(x, y, alternative="less", mode="approx")
+            w, p = stats.wilcoxon(x, y, alternative="less", mode="approx",
+                                  correction=False)
         assert_equal(w, 27)
         assert_almost_equal(p, 0.7031847, decimal=6)
 
@@ -1600,7 +1602,8 @@ class TestWilcoxon:
 
         with suppress_warnings() as sup:
             sup.filter(UserWarning, message="Sample size too small")
-            w, p = stats.wilcoxon(x, y, alternative="greater", mode="approx")
+            w, p = stats.wilcoxon(x, y, alternative="greater", mode="approx",
+                                  correction=False)
         assert_equal(w, 27)
         assert_almost_equal(p, 0.2968153, decimal=6)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1671,20 +1671,24 @@ class TestWilcoxon:
         assert_equal(p, 1)
 
     def test_auto(self):
-        # auto default to exact if there are no ties and n<= 25
-        x = np.arange(0, 25) + 0.5
-        y = np.arange(25, 0, -1)
+        # auto default to exact if there are no ties and n <= 50
+        x = np.arange(0, 50) + 0.5
+        y = np.arange(50, 0, -1)
         assert_equal(stats.wilcoxon(x, y),
                      stats.wilcoxon(x, y, mode="exact"))
 
-        # if there are ties (i.e. zeros in d = x-y), then switch to asymptotic
+        # n <= 50: if there are zeros in d = x-y, use PermutationMethod
+        pm = stats.PermutationMethod()
         d = np.arange(0, 13)
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning, message="Exact p-value calculation")
-            w, p = stats.wilcoxon(d)
-        assert_equal(stats.wilcoxon(d, mode="asymptotic"), (w, p))
+        w, p = stats.wilcoxon(d)
+        assert_equal(stats.wilcoxon(d, method=pm), (w, p))
 
-        # use approximation for samples > 25
+        # n <= 50: if there are ties in d = x-y, use PermutationMethod
+        d = np.array([1, 2, 2, 7, 5, -6, 9, -4])
+        w, p = stats.wilcoxon(d)
+        assert_equal(stats.wilcoxon(d, method=pm), (w, p))
+
+        # use approximation for samples > 50
         d = np.arange(1, 52)
         assert_equal(stats.wilcoxon(d), stats.wilcoxon(d, mode="asymptotic"))
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1527,7 +1527,10 @@ class TestWilcoxon:
         assert_allclose(p, 0.00641346115861)
 
         # removed keyword argument "approx" is still accepted
-        T, p = stats.wilcoxon(x, y, "wilcox", mode="approx", correction=False)
+        msg = "`approx` has been renamed"
+        with pytest.warns(DeprecationWarning, match=msg):
+            T, p = stats.wilcoxon(x, y, "wilcox", mode="approx",
+                                  correction=False)
         assert_allclose(T, 327)
         assert_allclose(p, 0.00641346115861)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1530,14 +1530,6 @@ class TestWilcoxon:
         assert_allclose(T, 327)
         assert_allclose(p, 0.00641346115861)
 
-        # removed keyword argument "approx" is still accepted
-        msg = "`approx` has been renamed"
-        with pytest.warns(DeprecationWarning, match=msg):
-            T, p = stats.wilcoxon(x, y, "wilcox", mode="approx",
-                                  correction=False)
-        assert_allclose(T, 327)
-        assert_allclose(p, 0.00641346115861)
-
         # Test the 'correction' option, using values computed in R with:
         # > wilcox.test(x, y, paired=TRUE, exact=FALSE, correct={FALSE,TRUE})
         x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
@@ -1548,6 +1540,14 @@ class TestWilcoxon:
         T, p = stats.wilcoxon(x, y, correction=True, mode="asymptotic")
         assert_equal(T, 34)
         assert_allclose(p, 0.7240817, rtol=1e-6)
+
+    def test_approx_method(self):
+        # removed keyword argument "approx" is still accepted
+        x = np.array([3, 5, 23, 7, 243, 58, 98, 2, 8, -3, 9, 11])
+        y = np.array([2, -2, 1, 23, 0, 5, 12, 18, 99, 12, 17, 27])
+        T1, p1 = stats.wilcoxon(x, y, "wilcox", mode="approx")
+        T2, p2 = stats.wilcoxon(x, y, "wilcox", mode="asymptotic")
+        assert_array_equal((T1, p1), (T2, p2))
 
     def test_wilcoxon_result_attributes(self):
         x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1477,14 +1477,12 @@ class TestWilcoxon:
     def test_zero_diff(self):
         x = np.arange(20)
         # pratt and wilcox do not work if x - y == 0 and method == "asymptotic"
-        # => warning is emitted and p-value is nan
-        msg = "invalid value encountered in scalar divide"
-        with pytest.warns(RuntimeWarning, match=msg):
+        # => warning may be emitted and p-value is nan
+        with np.errstate(invalid="ignore"):
             w, p = stats.wilcoxon(x, x, "wilcox", method="asymptotic")
-        assert_equal((w, p), (0.0, np.nan))
-        with pytest.warns(RuntimeWarning, match=msg):
+            assert_equal((w, p), (0.0, np.nan))
             w, p = stats.wilcoxon(x, x, "pratt", method="asymptotic")
-        assert_equal((w, p), (0.0, np.nan))
+            assert_equal((w, p), (0.0, np.nan))
         # ranksum is n*(n+1)/2, split in half if zero_method == "zsplit"
         assert_equal(stats.wilcoxon(x, x, "zsplit", method="asymptotic"),
                      (20*21/4, 1.0))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1692,14 +1692,15 @@ class TestWilcoxon:
 
         # n <= 50: if there are zeros in d = x-y, use PermutationMethod
         pm = stats.PermutationMethod()
-        d = np.arange(0, 13)
+        d = np.arange(0, 5)
         w, p = stats.wilcoxon(d)
         # rerunning the test gives the same results since n_resamples
         # is large enough to get deterministic results if n <= 13
-        # so we do not need to use a seed
+        # so we do not need to use a seed. to avoid longer runtimes of the
+        # test, use n=5 only. For n=13, see test_auto_permutation_edge_case
         assert_equal((w, p), stats.wilcoxon(d, method=pm))
 
-        # for larger vectors with ties/zeros, use asymptotic test
+        # for larger vectors (n > 13) with ties/zeros, use asymptotic test
         d = np.arange(0, 14)
         w, p = stats.wilcoxon(d)
         assert_equal((w, p), stats.wilcoxon(d, method="asymptotic"))
@@ -1708,6 +1709,14 @@ class TestWilcoxon:
         d = np.arange(1, 52)
         assert_equal(stats.wilcoxon(d), stats.wilcoxon(d, mode="asymptotic"))
 
+    @pytest.mark.xslow
+    def test_auto_permutation_edge_case(self):
+        # n <= 50: if there are zeros in d = x-y, use PermutationMethod
+        # this is a slower test to show that results are deterministic if n=13
+        pm = stats.PermutationMethod()
+        d = np.arange(0, 13)
+        w, p = stats.wilcoxon(d)
+        assert_equal((w, p), stats.wilcoxon(d, method=pm))
 
     @pytest.mark.parametrize('size', [3, 5, 10])
     def test_permutation_method(self, size):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
see points 1.-4. in https://github.com/scipy/scipy/pull/19770#issuecomment-1880158299

#### What does this implement/fix?
1. ~use continuity correction by default to improve accuracy if `method == "approx"` (now "asymptotic", see 4.)~
2. respect the method parameter if it is explicitly passed by the user. in particular, if exact calculation is requested, perform it and warn in case of ties/zeros, but do not change to approx
3. improve auto method by performing a permutation test if the sample size is small and there are ties/zeros
4. rename `method='approx'` to `method ='asymptotic'` for consistency with closely related tests ([mannwhitneyu](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mannwhitneyu.html), [kendalltau](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kendalltau.html), and [page_trend_test](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.page_trend_test.html)). ~Raise deprecation warning if `approx` is used~

#### Additional information

- The values in the documentation need to be adjusted once there is an agreement about the changes
- The parameters of the PermutationMethod still need to be determined if `method ==  "auto"` (e.g., sample size to achieve sufficient accuracy). One open question is if the results need to be reproducible (currently no seed it set)
