### PR TITLE
MAINT: special: performance optimization for simple autodifferentiation

### DIFF
--- a/scipy/special/xsf/config.h
+++ b/scipy/special/xsf/config.h
@@ -247,8 +247,6 @@ using cuda::std::uint64_t;
 #define XSF_ASSERT(a)
 #endif
 
-#endif
-
 namespace xsf {
 
 // basic
@@ -302,3 +300,5 @@ template <typename T>
 using complex = complex_type_t<T>;
 
 } // namespace xsf
+
+#endif

--- a/scipy/special/xsf/dual.h
+++ b/scipy/special/xsf/dual.h
@@ -462,24 +462,6 @@ bool operator>=(const dual<T, Orders...> &lhs, const dual<T, Orders...> &rhs) {
     return lhs.value() >= rhs.value();
 }
 
-template <typename T>
-struct dual_value_type {
-    using type = T;
-};
-
-template <typename T, size_t... Orders>
-struct dual_value_type<dual<T, Orders...>> {
-    using type = T;
-};
-
-template <typename T, size_t Order0, size_t Order1, size_t... Orders>
-struct dual_value_type<dual<T, Order0, Order1, Orders...>> {
-    using type = T;
-};
-
-template <typename T>
-using dual_value_type_t = typename dual_value_type<T>::type;
-
 template <size_t Order, typename T>
 dual<T, Order> dual_var(T value, size_t dim = 0) {
     // dim must be zero

--- a/scipy/special/xsf/dual.h
+++ b/scipy/special/xsf/dual.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binom.h"
 #include "config.h"
 #include "numbers.h"
 
@@ -13,13 +14,13 @@ namespace detail {
 
     /* Since we only compute derivatives up to order 2, we only need
      * Binomial coefficients with n <= 2 for use in the General
-     * Leibniz rule. This is an optimized way to get them. */
+     * Leibniz rule. Get these from a lookup table. */
     template <typename T>
-    T dumb_binom(size_t n, size_t k) {
+    T fast_binom(size_t n, size_t k) {
         if ((n <= 2) && (k <= 2)) {
             return small_binom_coefs<T>[n][k];
         }
-        return T(0);
+        return T(xsf::binom(static_cast<double>(n), static_cast<double>(k)));
     }
 } // namespace detail
 
@@ -102,7 +103,7 @@ class dual<T, Order> {
             data[i] *= other.data[0];
             // General Leibniz Rule
             for (size_t j = 0; j < i; ++j) {
-                data[i] += detail::dumb_binom<T>(i, j) * data[j] * other.data[i - j];
+                data[i] += detail::fast_binom<T>(i, j) * data[j] * other.data[i - j];
             }
         }
 
@@ -121,7 +122,7 @@ class dual<T, Order> {
         for (size_t i = 0; i <= Order; ++i) {
             // General Leibniz Rule
             for (size_t j = 1; j <= i; ++j) {
-                data[i] -= detail::dumb_binom<T>(i, j) * other.data[j] * data[i - j];
+                data[i] -= detail::fast_binom<T>(i, j) * other.data[j] * data[i - j];
             }
 
             data[i] /= other.data[0];
@@ -232,7 +233,7 @@ class dual<T, Order0, Order1, Orders...> {
             data[i] *= other.data[0];
             // General Leibniz Rule
             for (size_t j = 0; j < i; ++j) {
-                data[i] += detail::dumb_binom<T>(i, j) * data[j] * other.data[i - j];
+                data[i] += detail::fast_binom<T>(i, j) * data[j] * other.data[i - j];
             }
         }
 
@@ -251,7 +252,7 @@ class dual<T, Order0, Order1, Orders...> {
         for (size_t i = 0; i <= Order0; ++i) {
             // General Leibniz Rule
             for (size_t j = 1; j <= i; ++j) {
-                data[i] -= detail::dumb_binom<T>(i, j) * other.data[j] * data[i - j];
+                data[i] -= detail::fast_binom<T>(i, j) * other.data[j] * data[i - j];
             }
 
             data[i] /= other.data[0];

--- a/scipy/special/xsf/dual.h
+++ b/scipy/special/xsf/dual.h
@@ -236,10 +236,9 @@ class dual<T, Order0, Order1, Orders...> {
 
     dual &operator/=(const dual &other) {
         for (size_t i = 0; i <= Order0; ++i) {
-            T coef = 1; // binomial coefficient
+	    // General Leibniz Rule
             for (size_t j = 1; j <= i; ++j) {
-                data[i] -= coef * other.data[j] * data[i - j];
-                coef *= T(i - j) / T(j + 1);
+                data[i] -= detail::dumb_binom<T>(i, j) * other.data[j] * data[i - j];
             }
 
             data[i] /= other.data[0];

--- a/scipy/special/xsf/legendre.h
+++ b/scipy/special/xsf/legendre.h
@@ -21,7 +21,7 @@ struct legendre_p_recurrence_n {
     T z;
 
     void operator()(int n, T (&res)[2]) const {
-        using value_type = dual_value_type_t<T>;
+        using value_type = remove_dual_t<T>;
         value_type fac0 = -value_type(n - 1) / value_type(n);
         value_type fac1 = value_type(2 * n - 1) / value_type(n);
 
@@ -271,7 +271,7 @@ struct assoc_legendre_p_recurrence_n<T, assoc_legendre_unnorm_policy> {
     int type;
 
     void operator()(int n, T (&res)[2]) const {
-        using value_type = dual_value_type_t<T>;
+        using value_type = remove_dual_t<T>;
         value_type fac0 = -value_type(n + m - 1) / value_type(n - m);
         value_type fac1 = value_type(2 * n - 1) / value_type(n - m);
 
@@ -287,7 +287,7 @@ struct assoc_legendre_p_recurrence_n<T, assoc_legendre_norm_policy> {
     int type;
 
     void operator()(int n, T (&res)[2]) const {
-        using value_type = dual_value_type_t<T>;
+        using value_type = remove_dual_t<T>;
         value_type fac0 =
             -sqrt(value_type((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / value_type((2 * n - 3) * (n * n - m * m)));
         value_type fac1 =
@@ -571,7 +571,7 @@ struct sph_legendre_p_recurrence_n {
     sph_legendre_p_recurrence_n(int m, T theta) : m(m), theta(theta), theta_cos(cos(theta)) {}
 
     void operator()(int n, T (&res)[2]) const {
-        using value_type = dual_value_type_t<T>;
+        using value_type = remove_dual_t<T>;
         value_type fac0 =
             -sqrt(value_type((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / value_type((2 * n - 3) * (n * n - m * m)));
         value_type fac1 =

--- a/scipy/special/xsf/legendre.h
+++ b/scipy/special/xsf/legendre.h
@@ -21,8 +21,9 @@ struct legendre_p_recurrence_n {
     T z;
 
     void operator()(int n, T (&res)[2]) const {
-        T fac0 = -T(n - 1) / T(n);
-        T fac1 = T(2 * n - 1) / T(n);
+        using value_type = dual_value_type_t<T>;
+        value_type fac0 = -value_type(n - 1) / value_type(n);
+        value_type fac1 = value_type(2 * n - 1) / value_type(n);
 
         res[0] = fac0;
         res[1] = fac1 * z;
@@ -270,8 +271,9 @@ struct assoc_legendre_p_recurrence_n<T, assoc_legendre_unnorm_policy> {
     int type;
 
     void operator()(int n, T (&res)[2]) const {
-        T fac0 = -T(n + m - 1) / T(n - m);
-        T fac1 = T(2 * n - 1) / T(n - m);
+        using value_type = dual_value_type_t<T>;
+        value_type fac0 = -value_type(n + m - 1) / value_type(n - m);
+        value_type fac1 = value_type(2 * n - 1) / value_type(n - m);
 
         res[0] = fac0;
         res[1] = fac1 * z;
@@ -285,8 +287,11 @@ struct assoc_legendre_p_recurrence_n<T, assoc_legendre_norm_policy> {
     int type;
 
     void operator()(int n, T (&res)[2]) const {
-        T fac0 = -sqrt(T((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / T((2 * n - 3) * (n * n - m * m)));
-        T fac1 = sqrt(T((2 * n + 1) * (4 * (n - 1) * (n - 1) - 1)) / T((2 * n - 3) * (n * n - m * m)));
+        using value_type = dual_value_type_t<T>;
+        value_type fac0 =
+            -sqrt(value_type((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / value_type((2 * n - 3) * (n * n - m * m)));
+        value_type fac1 =
+            sqrt(value_type((2 * n + 1) * (4 * (n - 1) * (n - 1) - 1)) / value_type((2 * n - 3) * (n * n - m * m)));
 
         res[0] = fac0;
         res[1] = fac1 * z;
@@ -566,8 +571,11 @@ struct sph_legendre_p_recurrence_n {
     sph_legendre_p_recurrence_n(int m, T theta) : m(m), theta(theta), theta_cos(cos(theta)) {}
 
     void operator()(int n, T (&res)[2]) const {
-        T fac0 = -sqrt(T((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / T((2 * n - 3) * (n * n - m * m)));
-        T fac1 = sqrt(T((2 * n + 1) * (4 * (n - 1) * (n - 1) - 1)) / T((2 * n - 3) * (n * n - m * m)));
+        using value_type = dual_value_type_t<T>;
+        value_type fac0 =
+            -sqrt(value_type((2 * n + 1) * ((n - 1) * (n - 1) - m * m)) / value_type((2 * n - 3) * (n * n - m * m)));
+        value_type fac1 =
+            sqrt(value_type((2 * n + 1) * (4 * (n - 1) * (n - 1) - 1)) / value_type((2 * n - 3) * (n * n - m * m)));
 
         res[0] = fac0;
         res[1] = fac1 * theta_cos;


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR is a follow up to @izaid's PR #21483, which implemented a simple forward auto-differentiation scheme using dual numbers for use in getting derivatives of special functions in a cleaner way. I reviewed his PR carefully, and found that while using auto-differentiation produces correct results, and does not increase binary size or compile times, his implementation did result up to a 5x slowdown in runtime speed. @izaid and I identified some simple optimizations we could do to improve performance. @izaid did not have the bandwidth to make these optimizations on #21483 this week,  so I've agreed to merge #21483 and then follow up with a PR to make the optimizations.

The optimizations are:

1. Getting binomial coefficients for use in the General Leibniz rule  from a lookup table rather than computing them from scratch every-time two dual numbers are multipled or divided.
2. Adding a `dual_value_type` template function and `dual_value_type_t` helper to get the underlying value type for a dual number, to avoid casting scalars to dual numbers and performing wasteful operations on dual numbers, when scalar operations would have sufficed.

#### Additional information
<!--Any additional information you think is important.-->

The following table shows runtimes in seconds (averaged over 5 runs) for evaluating the below multiufuncs  with a randomly sampled input array `z` with 1,000,000 elements and `m = 5`, `n = 10` (`legendre_p_all` only uses `n`), for differing values of `diff_n` and for real and complex inputs. It was generated by aggregating the dataframes generated by the script in the details section below after building from 1. the commit before #21483 went in, 2. main, 3. This PR branch.

<details>

```python

import itertools as it
import numpy as np
import pandas as pd
import timeit

from scipy.special import (
    legendre_p_all, assoc_legendre_p_all, sph_legendre_p_all
)


# seed generated with np.random.SeedSequence().entropy
rng = np.random.default_rng(279694067345215356537280863015401985309)

z = rng.uniform(-1, 1, size=10**6) + rng.uniform(-1, 1, size=10**6) * 1j

rows = []
for diff_n, complex_, (func, name, params) in it.product(
        (0, 1, 2),
        (False, True),
        (
            (legendre_p_all, "legendre_p_all", (10, )),
            (assoc_legendre_p_all, "assoc_legendre_p_all", (10, 5)),
            (sph_legendre_p_all, "sph_legendre_p_all", (10, 5)),
        )
):
    if complex_ and func == sph_legendre_p_all:
        continue
    x = z if complex_ else z.real

    def timing_func():
        func(*params, x, diff_n=diff_n)

    timing = timeit.timeit("timing_func()", globals=globals(), number=5)
    rows.append(
        [
            name,
            "complex" if complex_ else "real",
            diff_n,
            timing / 5,
        ]
    )

df = pd.DataFrame(rows, columns=["function", "type", "diff_n", "timing"])
df = df.sort_values(["type", "function", "diff_n"])

```

</details>


|    | function             | type    |   diff_n | pre-autograd   | autograd       | optimized     |
|----|----------------------|---------|----------|----------------|----------------|---------------|
|  0 | assoc_legendre_p_all | complex |        0 | 1.275 seconds  | 1.142 seconds  | 1.120 seconds |
|  1 | assoc_legendre_p_all | complex |        1 | 2.464 seconds  | 3.531 seconds  | 2.248 seconds |
|  2 | assoc_legendre_p_all | complex |        2 | 3.901 seconds  | 14.282 seconds | 4.647 seconds |
|  3 | legendre_p_all       | complex |        0 | 0.103 seconds  | 0.105 seconds  | 0.103 seconds |
|  4 | legendre_p_all       | complex |        1 | 0.178 seconds  | 0.280 seconds  | 0.192 seconds |
|  5 | legendre_p_all       | complex |        2 | 0.277 seconds  | 1.322 seconds  | 0.338 seconds |
|  6 | assoc_legendre_p_all | real    |        0 | 0.525 seconds  | 0.323 seconds  | 0.291 seconds |
|  7 | assoc_legendre_p_all | real    |        1 | 1.209 seconds  | 0.979 seconds  | 0.944 seconds |
|  8 | assoc_legendre_p_all | real    |        2 | 2.131 seconds  | 2.843 seconds  | 2.254 seconds |
|  9 | legendre_p_all       | real    |        0 | 0.040 seconds  | 0.024 seconds  | 0.023 seconds |
| 10 | legendre_p_all       | real    |        1 | 0.074 seconds  | 0.079 seconds  | 0.082 seconds |
| 11 | legendre_p_all       | real    |        2 | 0.114 seconds  | 0.243 seconds  | 0.183 seconds |
| 12 | sph_legendre_p_all   | real    |        0 | 0.641 seconds  | 0.472 seconds  | 0.472 seconds |
| 13 | sph_legendre_p_all   | real    |        1 | 1.361 seconds  | 1.291 seconds  | 1.030 seconds |
| 14 | sph_legendre_p_all   | real    |        2 | 2.426 seconds  | 7.474 seconds  | 3.051 seconds |
