### PR TITLE
MAINT, BLD: 3.13 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
* Update `pyproject.toml` to include Python `3.13` in the `classifiers` metadata. Considering we already ship `3.13` wheels on PyPI built from `pyproject.toml`, I can't imagine there's a good reason to delay adding it now.

[ci skip]
