### PR TITLE
DEP: spatial.distance: deprecate `kulczynski1` and `sokalmichener` metrics

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1591,8 +1591,20 @@ def russellrao(u, v, w=None):
     return float(n - ntt) / n
 
 
+def _deprecate_sokalmichener(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        warnings.warn(
+            "The sokalmichener metric is deprecated since Scipy 1.15.0 and will "
+            "be removed in SciPy 1.17.0.", DeprecationWarning, stacklevel=2)
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@_deprecate_sokalmichener
 def sokalmichener(u, v, w=None):
     """
+    (Deprecated)
     Compute the Sokal-Michener dissimilarity between two boolean 1-D arrays.
 
     The Sokal-Michener dissimilarity between boolean 1-D arrays `u` and `v`,
@@ -1921,8 +1933,8 @@ _METRIC_INFOS = [
         aka={'sokalmichener'},
         types=['bool'],
         dist_func=sokalmichener,
-        cdist_func=_distance_pybind.cdist_sokalmichener,
-        pdist_func=_distance_pybind.pdist_sokalmichener,
+        cdist_func=_deprecate_sokalmichener(_distance_pybind.cdist_sokalmichener),
+        pdist_func=_deprecate_sokalmichener(_distance_pybind.pdist_sokalmichener),
     ),
     MetricInfo(
         canonical_name='sokalsneath',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -111,7 +111,7 @@ import numpy as np
 import dataclasses
 
 from collections.abc import Callable
-from functools import partial
+from functools import partial, wraps
 from scipy._lib._util import _asarray_validated
 
 from . import _distance_wrap
@@ -890,9 +890,23 @@ def jaccard(u, v, w=None):
     return (a / b) if b != 0 else np.float64(0)
 
 
+def _deprecate_kulczynski1(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        warnings.warn(
+            "The kulczynski1 metric is deprecated since Scipy 1.15.0 and will "
+            "be removed in SciPy 1.17.0.", DeprecationWarning, stacklevel=2)
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@_deprecate_kulczynski1
 def kulczynski1(u, v, *, w=None):
     """
-    Compute the Kulczynski 1 dissimilarity between two boolean 1-D arrays.
+    (Deprecated) Compute the Kulczynski 1 dissimilarity between two boolean 1-D arrays.
+
+    .. deprecated:: 1.15.0
+       This function is deprecated and will be removed in SciPy 1.17.0
 
     The Kulczynski 1 dissimilarity between two boolean 1-D arrays `u` and `v`
     of length ``n``, is defined as
@@ -949,6 +963,10 @@ def kulczynski1(u, v, *, w=None):
     -3.0
 
     """
+    warnings.warn(
+        "This function is deprecated and will be removed in SciPy 1.17.0.",
+        DeprecationWarning, stacklevel=2)
+
     u = _validate_vector(u)
     v = _validate_vector(v)
     if w is not None:
@@ -1855,8 +1873,8 @@ _METRIC_INFOS = [
         aka={'kulczynski1'},
         types=['bool'],
         dist_func=kulczynski1,
-        cdist_func=_distance_pybind.cdist_kulczynski1,
-        pdist_func=_distance_pybind.pdist_kulczynski1,
+        cdist_func=_deprecate_kulczynski1(_distance_pybind.cdist_kulczynski1),
+        pdist_func=_deprecate_kulczynski1(_distance_pybind.pdist_kulczynski1),
     ),
     MetricInfo(
         canonical_name='mahalanobis',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -111,7 +111,7 @@ import numpy as np
 import dataclasses
 
 from collections.abc import Callable
-from functools import partial, wraps
+from functools import partial
 from scipy._lib._util import _asarray_validated
 from scipy._lib.deprecation import _deprecated
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -893,7 +893,8 @@ def jaccard(u, v, w=None):
 
 _deprecated_kulczynski1 = _deprecated(
     "The kulczynski1 metric is deprecated since SciPy 1.15.0 and will be "
-    "removed in SciPy 1.17.0."
+    "removed in SciPy 1.17.0.  Replace usage of 'kulczynski1(u, v)' with "
+    "'1/jaccard(u, v) - 1'."
 )
 
 
@@ -904,6 +905,7 @@ def kulczynski1(u, v, *, w=None):
 
     .. deprecated:: 1.15.0
        This function is deprecated and will be removed in SciPy 1.17.0.
+       Replace usage of ``kulczynski1(u, v)`` with ``1/jaccard(u, v) - 1``.
 
     The Kulczynski 1 dissimilarity between two boolean 1-D arrays `u` and `v`
     of length ``n``, is defined as
@@ -1586,7 +1588,8 @@ def russellrao(u, v, w=None):
 
 _deprecated_sokalmichener = _deprecated(
     "The sokalmichener metric is deprecated since SciPy 1.15.0 and will be "
-    " removed in SciPy 1.17.0."
+    "removed in SciPy 1.17.0.  Replace usage of 'sokalmichener(u, v)' with "
+    "'rogerstanimoto(u, v)'."
 )
 
 
@@ -1597,6 +1600,7 @@ def sokalmichener(u, v, w=None):
 
     .. deprecated:: 1.15.0
        This function is deprecated and will be removed in SciPy 1.17.0.
+       Replace usage of ``sokalmichener(u, v)`` with ``rogerstanimoto(u, v)``.
 
     The Sokal-Michener dissimilarity between boolean 1-D arrays `u` and `v`,
     is defined as

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -113,6 +113,7 @@ import dataclasses
 from collections.abc import Callable
 from functools import partial, wraps
 from scipy._lib._util import _asarray_validated
+from scipy._lib.deprecation import _deprecated
 
 from . import _distance_wrap
 from . import _hausdorff
@@ -890,23 +891,19 @@ def jaccard(u, v, w=None):
     return (a / b) if b != 0 else np.float64(0)
 
 
-def _deprecate_kulczynski1(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        warnings.warn(
-            "The kulczynski1 metric is deprecated since Scipy 1.15.0 and will "
-            "be removed in SciPy 1.17.0.", DeprecationWarning, stacklevel=2)
-        return fn(*args, **kwargs)
-    return wrapper
+_deprecated_kulczynski1 = _deprecated(
+    "The kulczynski1 metric is deprecated since SciPy 1.15.0 and will be "
+    "removed in SciPy 1.17.0."
+)
 
 
-@_deprecate_kulczynski1
+@_deprecated_kulczynski1
 def kulczynski1(u, v, *, w=None):
     """
-    (Deprecated) Compute the Kulczynski 1 dissimilarity between two boolean 1-D arrays.
+    Compute the Kulczynski 1 dissimilarity between two boolean 1-D arrays.
 
     .. deprecated:: 1.15.0
-       This function is deprecated and will be removed in SciPy 1.17.0
+       This function is deprecated and will be removed in SciPy 1.17.0.
 
     The Kulczynski 1 dissimilarity between two boolean 1-D arrays `u` and `v`
     of length ``n``, is defined as
@@ -963,10 +960,6 @@ def kulczynski1(u, v, *, w=None):
     -3.0
 
     """
-    warnings.warn(
-        "This function is deprecated and will be removed in SciPy 1.17.0.",
-        DeprecationWarning, stacklevel=2)
-
     u = _validate_vector(u)
     v = _validate_vector(v)
     if w is not None:
@@ -1591,21 +1584,19 @@ def russellrao(u, v, w=None):
     return float(n - ntt) / n
 
 
-def _deprecate_sokalmichener(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        warnings.warn(
-            "The sokalmichener metric is deprecated since Scipy 1.15.0 and will "
-            "be removed in SciPy 1.17.0.", DeprecationWarning, stacklevel=2)
-        return fn(*args, **kwargs)
-    return wrapper
+_deprecated_sokalmichener = _deprecated(
+    "The sokalmichener metric is deprecated since SciPy 1.15.0 and will be "
+    " removed in SciPy 1.17.0."
+)
 
 
-@_deprecate_sokalmichener
+@_deprecated_sokalmichener
 def sokalmichener(u, v, w=None):
     """
-    (Deprecated)
     Compute the Sokal-Michener dissimilarity between two boolean 1-D arrays.
+
+    .. deprecated:: 1.15.0
+       This function is deprecated and will be removed in SciPy 1.17.0.
 
     The Sokal-Michener dissimilarity between boolean 1-D arrays `u` and `v`,
     is defined as
@@ -1885,8 +1876,8 @@ _METRIC_INFOS = [
         aka={'kulczynski1'},
         types=['bool'],
         dist_func=kulczynski1,
-        cdist_func=_deprecate_kulczynski1(_distance_pybind.cdist_kulczynski1),
-        pdist_func=_deprecate_kulczynski1(_distance_pybind.pdist_kulczynski1),
+        cdist_func=_deprecated_kulczynski1(_distance_pybind.cdist_kulczynski1),
+        pdist_func=_deprecated_kulczynski1(_distance_pybind.pdist_kulczynski1),
     ),
     MetricInfo(
         canonical_name='mahalanobis',
@@ -1933,8 +1924,8 @@ _METRIC_INFOS = [
         aka={'sokalmichener'},
         types=['bool'],
         dist_func=sokalmichener,
-        cdist_func=_deprecate_sokalmichener(_distance_pybind.cdist_sokalmichener),
-        pdist_func=_deprecate_sokalmichener(_distance_pybind.pdist_sokalmichener),
+        cdist_func=_deprecated_sokalmichener(_distance_pybind.cdist_sokalmichener),
+        pdist_func=_deprecated_sokalmichener(_distance_pybind.pdist_sokalmichener),
     ),
     MetricInfo(
         canonical_name='sokalsneath',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2177,6 +2177,11 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         Computes the kulczynski1 distance between each pair of
         boolean vectors. (see kulczynski1 function documentation)
 
+        .. deprecated:: 1.15.0
+           This metric is deprecated and will be removed in SciPy 1.17.0.
+           Replace usage of ``pdist(X, 'kulczynski1')`` with
+           ``1 / pdist(X, 'jaccard') - 1``.
+
     19. ``Y = pdist(X, 'rogerstanimoto')``
 
         Computes the Rogers-Tanimoto distance between each pair of
@@ -2191,6 +2196,11 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
 
         Computes the Sokal-Michener distance between each pair of
         boolean vectors. (see sokalmichener function documentation)
+
+        .. deprecated:: 1.15.0
+           This metric is deprecated and will be removed in SciPy 1.17.0.
+           Replace usage of ``pdist(X, 'sokalmichener')`` with
+           ``pdist(X, 'rogerstanimoto')``.
 
     22. ``Y = pdist(X, 'sokalsneath')``
 
@@ -2959,6 +2969,11 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         Computes the kulczynski distance between the boolean
         vectors. (see `kulczynski1` function documentation)
 
+        .. deprecated:: 1.15.0
+           This metric is deprecated and will be removed in SciPy 1.17.0.
+           Replace usage of ``cdist(XA, XB, 'kulczynski1')`` with
+           ``1 / cdist(XA, XB, 'jaccard') - 1``.
+
     19. ``Y = cdist(XA, XB, 'rogerstanimoto')``
 
         Computes the Rogers-Tanimoto distance between the boolean
@@ -2973,6 +2988,11 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
 
         Computes the Sokal-Michener distance between the boolean
         vectors. (see `sokalmichener` function documentation)
+
+        .. deprecated:: 1.15.0
+           This metric is deprecated and will be removed in SciPy 1.17.0.
+           Replace usage of ``cdist(XA, XB, 'sokalmichener')`` with
+           ``cdist(XA, XB, 'rogerstanimoto')``.
 
     22. ``Y = cdist(XA, XB, 'sokalsneath')``
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -385,7 +385,7 @@ class DummyContextManager:
 
 
 def maybe_deprecated(metric: str):
-    if metric == 'kulczynski1':
+    if metric in ('kulczynski1', 'sokalmichener'):
         return pytest.deprecated_call()
     else:
         return DummyContextManager()
@@ -2034,8 +2034,10 @@ def test_sokalmichener():
     q = [True, False, True]
     x = [int(b) for b in p]
     y = [int(b) for b in q]
-    dist1 = sokalmichener(p, q)
-    dist2 = sokalmichener(x, y)
+    with pytest.deprecated_call():
+        dist1 = sokalmichener(p, q)
+    with pytest.deprecated_call():
+        dist2 = sokalmichener(x, y)
     # These should be exactly the same.
     assert_equal(dist1, dist2)
 
@@ -2050,7 +2052,8 @@ def test_sokalmichener_with_weight():
     nff = 0 * 1 + 0 * 0.2
     expected = 2 * (nft + ntf) / (ntt + nff + 2 * (nft + ntf))
     assert_almost_equal(expected, 0.2857143)
-    actual = sokalmichener([1, 0], [1, 1], w=[1, 0.2])
+    with pytest.deprecated_call():
+        actual = sokalmichener([1, 0], [1, 1], w=[1, 0.2])
     assert_almost_equal(expected, actual)
 
     a1 = [False, False, True, True, True, False, False, True, True, True, True,
@@ -2059,7 +2062,8 @@ def test_sokalmichener_with_weight():
           True, True, True, True, False, False, False, True, True, True]
 
     for w in [0.05, 0.1, 1.0, 20.0]:
-        assert_almost_equal(sokalmichener(a2, a1, [w]), 0.6666666666666666)
+        with pytest.deprecated_call():
+            assert_almost_equal(sokalmichener(a2, a1, [w]), 0.6666666666666666)
 
 
 def test_modifies_input(metric):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -445,14 +445,11 @@ class TestCdist:
             with maybe_deprecated(metric):
                 cdist(X1, X2, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric=metric, *args)
+            cdist(X1, X2, metric=metric, *args)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric=eval(metric), *args)
+            cdist(X1, X2, metric=eval(metric), *args)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric="test_" + metric, *args)
+            cdist(X1, X2, metric="test_" + metric, *args)
 
     def test_cdist_extra_args_custom(self):
         # Tests that args and kwargs are correctly handled
@@ -753,14 +750,11 @@ class TestPdist:
             with maybe_deprecated(metric):
                 pdist(X1, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric=metric, *args)
+            pdist(X1, metric=metric, *args)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric=eval(metric), *args)
+            pdist(X1, metric=eval(metric), *args)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric="test_" + metric, *args)
+            pdist(X1, metric="test_" + metric, *args)
 
     def test_pdist_extra_args_custom(self):
         # Tests that args and kwargs are correctly handled
@@ -2090,12 +2084,10 @@ def test_Xdist_deprecated_args(metric):
                      [22.2, 23.3, 44.4]])
 
     with pytest.raises(TypeError):
-        with maybe_deprecated(metric):
-            cdist(X1, X1, metric, 2.)
+        cdist(X1, X1, metric, 2.)
 
     with pytest.raises(TypeError):
-        with maybe_deprecated(metric):
-            pdist(X1, metric, 2.)
+        pdist(X1, metric, 2.)
 
     for arg in ["p", "V", "VI"]:
         kwargs = {arg: "foo"}

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -377,6 +377,20 @@ def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg
     return wrapped
 
 
+class DummyContextManager:
+    def __enter__(self):
+        pass
+    def __exit__(self, *args):
+        pass
+
+
+def maybe_deprecated(metric: str):
+    if metric == 'kulczynski1':
+        return pytest.deprecated_call()
+    else:
+        return DummyContextManager()
+
+
 wcdist = _weight_checked(cdist, default_axis=1, squeeze=False)
 wcdist_no_const = _weight_checked(cdist, default_axis=1,
                                   squeeze=False, const_test=False)
@@ -422,17 +436,23 @@ class TestCdist:
         args = [3.14] * 200
 
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric=metric, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric=metric, **kwargs)
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric=eval(metric), **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric=eval(metric), **kwargs)
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric="test_" + metric, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric=metric, *args)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric=metric, *args)
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric=eval(metric), *args)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric=eval(metric), *args)
         with pytest.raises(TypeError):
-            cdist(X1, X2, metric="test_" + metric, *args)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric="test_" + metric, *args)
 
     def test_cdist_extra_args_custom(self):
         # Tests that args and kwargs are correctly handled
@@ -623,8 +643,10 @@ class TestCdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
         out1 = np.empty((out_r, out_c), dtype=np.float64)
-        Y1 = cdist(X1, X2, metric, **kwargs)
-        Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
+        with maybe_deprecated(metric):
+            Y1 = cdist(X1, X2, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
 
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
@@ -635,21 +657,25 @@ class TestCdist:
         # test for incorrect shape
         out2 = np.empty((out_r-1, out_c+1), dtype=np.float64)
         with pytest.raises(ValueError):
-            cdist(X1, X2, metric, out=out2, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric, out=out2, **kwargs)
 
         # test for C-contiguous order
         out3 = np.empty(
             (2 * out_r, 2 * out_c), dtype=np.float64)[::2, ::2]
         out4 = np.empty((out_r, out_c), dtype=np.float64, order='F')
         with pytest.raises(ValueError):
-            cdist(X1, X2, metric, out=out3, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric, out=out3, **kwargs)
         with pytest.raises(ValueError):
-            cdist(X1, X2, metric, out=out4, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric, out=out4, **kwargs)
 
         # test for incorrect dtype
         out5 = np.empty((out_r, out_c), dtype=np.int64)
         with pytest.raises(ValueError):
-            cdist(X1, X2, metric, out=out5, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X2, metric, out=out5, **kwargs)
 
     def test_striding(self, metric):
         # test that striding is handled correct with calls to
@@ -672,8 +698,10 @@ class TestCdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        Y1 = cdist(X1, X2, metric, **kwargs)
-        Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y1 = cdist(X1, X2, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
 
@@ -685,7 +713,8 @@ class TestCdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
 
-        out = cdist(x1, x2, metric=metric, **kwargs)
+        with maybe_deprecated(metric):
+            out = cdist(x1, x2, metric=metric, **kwargs)
 
         # Check reference counts aren't messed up. If we only hold weak
         # references, the arrays should be deallocated.
@@ -715,17 +744,23 @@ class TestPdist:
         args = [3.14] * 200
 
         with pytest.raises(TypeError):
-            pdist(X1, metric=metric, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X1, metric=metric, **kwargs)
         with pytest.raises(TypeError):
-            pdist(X1, metric=eval(metric), **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X1, metric=eval(metric), **kwargs)
         with pytest.raises(TypeError):
-            pdist(X1, metric="test_" + metric, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X1, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
-            pdist(X1, metric=metric, *args)
+            with maybe_deprecated(metric):
+                pdist(X1, metric=metric, *args)
         with pytest.raises(TypeError):
-            pdist(X1, metric=eval(metric), *args)
+            with maybe_deprecated(metric):
+                pdist(X1, metric=eval(metric), *args)
         with pytest.raises(TypeError):
-            pdist(X1, metric="test_" + metric, *args)
+            with maybe_deprecated(metric):
+                pdist(X1, metric="test_" + metric, *args)
 
     def test_pdist_extra_args_custom(self):
         # Tests that args and kwargs are correctly handled
@@ -1434,8 +1469,10 @@ class TestPdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
         out1 = np.empty(out_size, dtype=np.float64)
-        Y_right = pdist(X, metric, **kwargs)
-        Y_test1 = pdist(X, metric, out=out1, **kwargs)
+        with maybe_deprecated(metric):
+            Y_right = pdist(X, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y_test1 = pdist(X, metric, out=out1, **kwargs)
 
         # test that output is numerically equivalent
         assert_allclose(Y_test1, Y_right, rtol=eps)
@@ -1446,17 +1483,20 @@ class TestPdist:
         # test for incorrect shape
         out2 = np.empty(out_size + 3, dtype=np.float64)
         with pytest.raises(ValueError):
-            pdist(X, metric, out=out2, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X, metric, out=out2, **kwargs)
 
         # test for (C-)contiguous output
         out3 = np.empty(2 * out_size, dtype=np.float64)[::2]
         with pytest.raises(ValueError):
-            pdist(X, metric, out=out3, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X, metric, out=out3, **kwargs)
 
         # test for incorrect dtype
         out5 = np.empty(out_size, dtype=np.int64)
         with pytest.raises(ValueError):
-            pdist(X, metric, out=out5, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X, metric, out=out5, **kwargs)
 
     def test_striding(self, metric):
         # test that striding is handled correct with calls to
@@ -1472,8 +1512,10 @@ class TestPdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        Y1 = pdist(X, metric, **kwargs)
-        Y2 = pdist(X_copy, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y1 = pdist(X, metric, **kwargs)
+        with maybe_deprecated(metric):
+            Y2 = pdist(X_copy, metric, **kwargs)
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
 
@@ -2033,8 +2075,10 @@ def test_modifies_input(metric):
                      [2.2, 2.3, 4.4],
                      [22.2, 23.3, 44.4]])
     X1_copy = X1.copy()
-    cdist(X1, X1, metric)
-    pdist(X1, metric)
+    with maybe_deprecated(metric):
+        cdist(X1, X1, metric)
+    with maybe_deprecated(metric):
+        pdist(X1, metric)
     assert_array_equal(X1, X1_copy)
 
 
@@ -2046,10 +2090,12 @@ def test_Xdist_deprecated_args(metric):
                      [22.2, 23.3, 44.4]])
 
     with pytest.raises(TypeError):
-        cdist(X1, X1, metric, 2.)
+        with maybe_deprecated(metric):
+            cdist(X1, X1, metric, 2.)
 
     with pytest.raises(TypeError):
-        pdist(X1, metric, 2.)
+        with maybe_deprecated(metric):
+            pdist(X1, metric, 2.)
 
     for arg in ["p", "V", "VI"]:
         kwargs = {arg: "foo"}
@@ -2060,10 +2106,12 @@ def test_Xdist_deprecated_args(metric):
             continue
 
         with pytest.raises(TypeError):
-            cdist(X1, X1, metric, **kwargs)
+            with maybe_deprecated(metric):
+                cdist(X1, X1, metric, **kwargs)
 
         with pytest.raises(TypeError):
-            pdist(X1, metric, **kwargs)
+            with maybe_deprecated(metric):
+                pdist(X1, metric, **kwargs)
 
 
 def test_Xdist_non_negative_weights(metric):
@@ -2076,9 +2124,11 @@ def test_Xdist_non_negative_weights(metric):
 
     for m in [metric, eval(metric), "test_" + metric]:
         with pytest.raises(ValueError):
-            pdist(X, m, w=w)
+            with maybe_deprecated(metric):
+                pdist(X, m, w=w)
         with pytest.raises(ValueError):
-            cdist(X, X, m, w=w)
+            with maybe_deprecated(metric):
+                cdist(X, X, m, w=w)
 
 
 def test__validate_vector():
@@ -2165,7 +2215,8 @@ def test_immutable_input(metric):
         pytest.skip("not applicable")
     x = np.arange(10, dtype=np.float64)
     x.setflags(write=False)
-    getattr(scipy.spatial.distance, metric)(x, x, w=x)
+    with maybe_deprecated(metric):
+        getattr(scipy.spatial.distance, metric)(x, x, w=x)
 
 
 class TestJaccard:


### PR DESCRIPTION
#### Reference issue
Closes gh-21187, gh-2011.

#### What does this implement/fix?
This PR deprecates two metrics under `scipy.spatial.distance` in order to clean up the namespace.

*kulczynski1*. As explained in gh-21187, the `kulczynski1` metric is documented to be a *dissimilarity* measure, as is all the rest metrics, but its return value is in fact a *similarity* measure. The fact that no one has complained about this suggests that this metric might not actually be in use. Therefore this PR deprecates the `kulczynski1` metric and schedules it for removal later.

*sokalmichener*. As explained in gh-2011, `sokalmichener` returns the same as `rogerstanimoto`, making (the implementation of) one of them redundant. In addition, in the literature the Sokal-Michener dissimilarity almost always refers to the `matching` similarity, which does not agree with the current implementation of `sokalmichener`. Therefore this PR deprecates the `sokalmichener` metric and schedules for removal later.

#### Additional information
I considered three solutions to resolve the contradiction between the documentation and implementation of `kulcyznski1`:

1. Amend the doc to state that the metric returns a *similarity* index. Pro: backward compatible. Con: different from all the other distance metrics, and probably not what the function is intended for.
2. Modify the implementation to return a *dissimilarity* index. Pro: consistent with doc and other functions. Con: "flipping" the return value (even with deprecation warning or future warning) breaks backward compatibility in a subtle way that could lead to serious bugs.
3. Deprecate and later remove the `kulczynski1` metric altogether. Pro: cleaner code base, less future maintenance. Con: existing code that does rely on `kulczynski1` returning a similarity index has to be updated to use an equivalent formula, e.g. `0.5*(1/D-1)` where `D` is the [dice distance](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.dice.html#scipy.spatial.distance.dice).

This PR goes with option 3.

Similar rationale applies to the `sokalmichener` metric.