### PR TITLE
DOC/MAINT: stats: fix some typos

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1617,7 +1617,7 @@ class _ShapeInfo:
 def _get_fixed_fit_value(kwds, names):
     """
     Given names such as ``['f0', 'fa', 'fix_a']``, check that there is
-    at most one non-None value in `kwds` associaed with those names.
+    at most one non-None value in `kwds` associated with those names.
     Return that value, or None if none of the names occur in `kwds`.
     As a side effect, all occurrences of those names in `kwds` are
     removed.

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -433,7 +433,7 @@ def fit(dist, data, bounds=None, *, guess=None, method='mle',
         The object has the following method:
 
         nllf(params=None, data=None)
-            By default, the negative log-likehood function at the fitted
+            By default, the negative log-likelihood function at the fitted
             `params` for the given `data`. Accepts a tuple containing
             alternative shapes, location, and scale of the distribution and
             an array of alternative data.

--- a/scipy/stats/_levy_stable/c_src/levyst.c
+++ b/scipy/stats/_levy_stable/c_src/levyst.c
@@ -2,8 +2,8 @@
  * Implements special functions for stable distribution calculations.
  *
  * A function g appears in the integrand in Nolan's method for calculating
- * stable densitities and distribution functions. It takes a different form for
- * for alpha = 1 vs alpha ≠ 1. See [NO] for more info.
+ * stable densities and distribution functions. It takes a different form for
+ * alpha = 1 vs alpha ≠ 1. See [NO] for more info.
  *
  * References
  * [NO] John P. Nolan (1997) Numerical calculation of stable densities and

--- a/scipy/stats/_mgc.py
+++ b/scipy/stats/_mgc.py
@@ -407,7 +407,7 @@ def _mgc_stat(distx, disty):
 
     n, m = stat_mgc_map.shape
     if m == 1 or n == 1:
-        # the global scale at is the statistic calculated at maximial nearest
+        # the global scale at is the statistic calculated at maximal nearest
         # neighbors. There is not enough local scale to search over, so
         # default to global scale
         stat = stat_mgc_map[m - 1][n - 1]
@@ -453,7 +453,7 @@ def _threshold_mgc_map(stat_mgc_map, samp_size):
     threshold = samp_size * (samp_size - 3)/4 - 1/2  # Beta approximation
     threshold = distributions.beta.ppf(per_sig, threshold, threshold) * 2 - 1
 
-    # the global scale at is the statistic calculated at maximial nearest
+    # the global scale at is the statistic calculated at maximal nearest
     # neighbors. Threshold is the maximum on the global and local scales
     threshold = max(threshold, stat_mgc_map[m - 1][n - 1])
 
@@ -495,7 +495,7 @@ def _smooth_mgc_map(sig_connect, stat_mgc_map):
     """
     m, n = stat_mgc_map.shape
 
-    # the global scale at is the statistic calculated at maximial nearest
+    # the global scale at is the statistic calculated at maximal nearest
     # neighbors. By default, statistic and optimal scale are global.
     stat = stat_mgc_map[m - 1][n - 1]
     opt_scale = [m, n]

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1474,7 +1474,7 @@ def boxcox_normplot(x, la, lb, plot=None, N=80):
     lmbdas : ndarray
         The ``lmbda`` values for which a Box-Cox transform was done.
     ppcc : ndarray
-        Probability Plot Correlelation Coefficient, as obtained from `probplot`
+        Probability Plot Correlation Coefficient, as obtained from `probplot`
         when fitting the Box-Cox transformed input `x` against a normal
         distribution.
 
@@ -1849,7 +1849,7 @@ def yeojohnson_normplot(x, la, lb, plot=None, N=80):
     lmbdas : ndarray
         The ``lmbda`` values for which a Yeo-Johnson transform was done.
     ppcc : ndarray
-        Probability Plot Correlelation Coefficient, as obtained from `probplot`
+        Probability Plot Correlation Coefficient, as obtained from `probplot`
         when fitting the Box-Cox transformed input `x` against a normal
         distribution.
 
@@ -2147,7 +2147,7 @@ def anderson(x, dist='norm'):
 
     For `weibull_min`, maximum likelihood estimation is known to be
     challenging. If the test returns successfully, then the first order
-    conditions for a maximum likehood estimate have been verified and
+    conditions for a maximum likelihood estimate have been verified and
     the critical values correspond relatively well to the significance levels,
     provided that the sample is sufficiently large (>10 observations [7]).
     However, for some data - especially data with no left tail - `anderson`

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -1344,7 +1344,7 @@ def sen_seasonal_slopes(x):
             For each season, the Theil-Sen slope estimator: the median of
             within-season slopes.
         inter_slope : float
-            The seasonal Kendall slope estimateor: the median of within-season
+            The seasonal Kendall slope estimator: the median of within-season
             slopes *across all* seasons.
 
     See Also

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2092,7 +2092,7 @@ class wishart_gen(multi_rv_generic):
         log_det_scale : float
             Logarithm of the determinant of the scale matrix
         C : ndarray
-            Cholesky factorization of the scale matrix, lower triagular.
+            Cholesky factorization of the scale matrix, lower triangular.
 
         Notes
         -----
@@ -2697,7 +2697,7 @@ class invwishart_gen(wishart_gen):
         log_det_scale : float
             Logarithm of the determinant of the scale matrix
         C : ndarray
-            Cholesky factorization of the scale matrix, lower triagular.
+            Cholesky factorization of the scale matrix, lower triangular.
 
         Notes
         -----
@@ -2959,7 +2959,7 @@ class invwishart_gen(wishart_gen):
         df : int
             Degrees of freedom
         C : ndarray
-            Cholesky factorization of the scale matrix, lower triagular.
+            Cholesky factorization of the scale matrix, lower triangular.
         %(_doc_random_state)s
 
         Notes

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1117,7 +1117,7 @@ class Halton(QMCEngine):
     The Halton sequence has severe striping artifacts for even modestly
     large dimensions. These can be ameliorated by scrambling. Scrambling
     also supports replication-based error estimates and extends
-    applicabiltiy to unbounded integrands.
+    applicability to unbounded integrands.
 
     References
     ----------

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1502,7 +1502,7 @@ def _calculate_null_pairings(data, statistic, n_permutations, batch,
         exact_test = True
         n_permutations = n_max
         batch = batch or int(n_permutations)
-        # cartesian product of the sets of all permutations of indices
+        # Cartesian product of the sets of all permutations of indices
         perm_generator = product(*(permutations(range(n_obs_sample))
                                    for i in range(n_samples)))
         batched_perm_generator = _batch_generator(perm_generator, batch=batch)

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -407,7 +407,7 @@ def sobol_indices(
         consider at minima ``n >= 2**12``. The more complex the model is,
         the more samples will be needed.
 
-        Even for a purely addiditive model, the indices may not sum to 1 due
+        Even for a purely additive model, the indices may not sum to 1 due
         to numerical noise.
 
     References

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6230,7 +6230,7 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
           * 'omit': performs the calculations ignoring nan values
 
         The 'omit' option is not currently available for permutation tests or
-        one-sided asympyotic tests.
+        one-sided asymptotic tests.
 
     permutations : non-negative int, np.inf, or None (default), optional
         If 0 or None (default), use the t-distribution to calculate p-values.
@@ -7926,7 +7926,7 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto'):
                           stacklevel=3)
 
     if mode == 'asymp':
-        # The product n1*n2 is large.  Use Smirnov's asymptoptic formula.
+        # The product n1*n2 is large.  Use Smirnov's asymptotic formula.
         # Ensure float to avoid overflow in multiplication
         # sorted because the one-sided formula is not symmetric in n1, n2
         m, n = sorted([float(n1), float(n2)], reverse=True)
@@ -9320,7 +9320,7 @@ def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
     where :math:`\Gamma (u, v)` is the set of (probability) distributions on
     :math:`\mathbb{R}^n \times \mathbb{R}^n` whose marginals are :math:`u` and
     :math:`v` on the first and second factors respectively. For a given value
-    :math:`x`, :math:`u(x)` gives the probabilty of :math:`u` at position
+    :math:`x`, :math:`u(x)` gives the probability of :math:`u` at position
     :math:`x`, and the same for :math:`v(x)`.
 
     This is also called the optimal transport problem or the Monge problem.
@@ -9343,7 +9343,7 @@ def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
     The :math:`\text{vec}()` function denotes the Vectorization function
     that transforms a matrix into a column vector by vertically stacking
     the columns of the matrix.
-    The tranport plan :math:`\Gamma` is a matrix :math:`[\gamma_{ij}]` in
+    The transport plan :math:`\Gamma` is a matrix :math:`[\gamma_{ij}]` in
     which :math:`\gamma_{ij}` is a positive value representing the amount of
     probability mass transported from :math:`u(x_i)` to :math:`v(y_i)`.
     Summing over the rows of :math:`\Gamma` should give the source distribution
@@ -9524,7 +9524,7 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     where :math:`\Gamma (u, v)` is the set of (probability) distributions on
     :math:`\mathbb{R} \times \mathbb{R}` whose marginals are :math:`u` and
     :math:`v` on the first and second factors respectively. For a given value
-    :math:`x`, :math:`u(x)` gives the probabilty of :math:`u` at position
+    :math:`x`, :math:`u(x)` gives the probability of :math:`u` at position
     :math:`x`, and the same for :math:`v(x)`.
 
     If :math:`U` and :math:`V` are the respective CDFs of :math:`u` and

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4264,7 +4264,7 @@ class TestSkewNorm:
         # MoM fits variance and skewness
         a5, loc5, scale5 = stats.skewnorm.fit(rvs2, method='mm')
         assert np.isinf(a5)
-        # distribution infrastruction doesn't allow infinite shape parameters
+        # distribution infrastructure doesn't allow infinite shape parameters
         # into _stats; it just bypasses it and produces NaNs. Calculate
         # moments manually.
         m, v = np.mean(rvs2), np.var(rvs2)
@@ -6762,7 +6762,7 @@ class TestExpect:
         assert_almost_equal(res1, res2, decimal=14)
 
     def test_rice_overflow(self):
-        # rice.pdf(999, 0.74) was inf since special.i0 silentyly overflows
+        # rice.pdf(999, 0.74) was inf since special.i0 silently overflows
         # check that using i0e fixes it
         assert_(np.isfinite(stats.rice.pdf(999, 0.74)))
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -635,7 +635,7 @@ class TestMannWhitneyU:
         stats.mannwhitneyu(y, x, method='exact')
         assert shape == _mwu_state.configurations.shape  # same when sizes are reversed
 
-        # Also, we weren't exploiting the symmmetry of the null distribution
+        # Also, we weren't exploiting the symmetry of the null distribution
         # to its full potential. Ensure that the null distribution is not
         # evaluated explicitly for `k > m*n/2`.
         _mwu_state.reset()  # reset cache
@@ -1732,7 +1732,7 @@ class TestPoissonMeansTest:
         with assert_raises(ValueError, match=message):
             stats.poisson_means_test(count1, nobs1, count2, nobs2, diff=-1)
 
-        # test invalid alternatvie
+        # test invalid alternative
         message = 'Alternative must be one of ...'
         with assert_raises(ValueError, match=message):
             stats.poisson_means_test(1, 2, 1, 2, alternative='error')

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -477,7 +477,7 @@ def test_marginal_iv():
     with pytest.raises(ValueError, match=message):
         kde.marginal([1, 2.5])
 
-    # IV for uniquenes
+    # IV for uniqueness
     message = "All elements of `dimensions` must be unique."
     with pytest.raises(ValueError, match=message):
         kde.marginal([1, 2, 2])

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1034,7 +1034,7 @@ def test_siegelslopes():
     y[:4] = 1000
     assert_equal(mstats.siegelslopes(y, x), (5.0, -3.0))
 
-    # if there are no outliers, results should be comparble to linregress
+    # if there are no outliers, results should be comparable to linregress
     x = np.arange(10)
     y = -2.3 + 0.3*x + stats.norm.rvs(size=10, random_state=231)
     slope_ols, intercept_ols, _, _, _ = stats.linregress(x, y)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -288,7 +288,7 @@ def test_multisample_BCa_against_R():
 def test_BCa_acceleration_against_reference():
     # Compare the (deterministic) acceleration parameter for a multi-sample
     # problem against a reference value. The example is from [1], but Efron's
-    # value seems inaccurate. Straightorward code for computing the
+    # value seems inaccurate. Straightforward code for computing the
     # reference acceleration (0.011008228344026734) is available at:
     # https://github.com/scipy/scipy/pull/16455#issuecomment-1193400981
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -826,7 +826,7 @@ class TestFisherExact:
                                            verbose=True)
 
     def test_gh4130(self):
-        # Previously, a fudge factor used to distinguish between theoeretically
+        # Previously, a fudge factor used to distinguish between theoretically
         # and numerically different probability masses was 1e-4; it has been
         # tightened to fix gh4130. Accuracy checked against R fisher.test.
         # options(digits=16)
@@ -2176,7 +2176,7 @@ class TestRegression:
         result = stats.linregress(x, y)
 
         # This test used to use 'assert_array_almost_equal' but its
-        # formualtion got confusing since LinregressResult became
+        # formulation got confusing since LinregressResult became
         # _lib._bunch._make_tuple_bunch instead of namedtuple
         # (for backwards compatibility, see PR #12983)
         def assert_ae(x, y):
@@ -2198,7 +2198,7 @@ class TestRegression:
         result = stats.linregress(x, y)
 
         # Make sure propagated numerical errors
-        # did not bring rvalue below -1 (or were coersced)
+        # did not bring rvalue below -1 (or were coerced)
         assert_(result.rvalue >= -1)
         assert_almost_equal(result.rvalue, -1)
 


### PR DESCRIPTION
_cf_: https://github.com/scipy/scipy/pull/19295#issuecomment-1732672660

per request will revert changes to the C code

WONT' FIX

```
$ grep -nr awailable scipy
scipy/scipy/stats/biasedurn/stoc3.cpp:802:   For further documentation see nchyp.pdf, awailable from www.agner.org/random
$ grep -nr consequtive scipy/scipy/stats
scipy/scipy/stats/biasedurn/wnchyppr.cpp:832:   int converg = 0;              // number of consequtive terms below accuracy
scipy/scipy/stats/biasedurn/wnchyppr.cpp:1607:   int converg = 0;                    // number of consequtive terms below accuracy
$ grep -nr obtimized scipy/scipy/stats
scipy/scipy/stats/biasedurn/stoc3.cpp:329:   // and one for up search, because they are obtimized for consecutive x values.
$
```