### PR TITLE
MAINT: special.hankel2: fix edge case

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2642,6 +2642,12 @@ class TestHankel:
         hankrl2e = special.hankel2e(1,.1)
         assert_almost_equal(hank2e,hankrl2e,8)
 
+    def test_hankel2_gh4517(self):
+        # Test edge case reported in https://github.com/scipy/scipy/issues/4517
+        res = special.hankel2(0, 0)
+        assert res.real == 1
+        assert np.isposinf(res.imag)
+
 
 class TestHyper:
     def test_h1vp(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2645,7 +2645,7 @@ class TestHankel:
     def test_hankel2_gh4517(self):
         # Test edge case reported in https://github.com/scipy/scipy/issues/4517
         res = special.hankel2(0, 0)
-        assert res.real == 1
+        assert np.isnan(res.real)
         assert np.isposinf(res.imag)
 
 

--- a/scipy/special/xsf/bessel.h
+++ b/scipy/special/xsf/bessel.h
@@ -1172,6 +1172,11 @@ inline std::complex<double> cyl_hankel_2(double v, std::complex<double> z) {
     if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
         return cy;
     }
+    if (v == 0 && z.real() == 0 && z.imag() == 0) {
+        cy.real(1.0);
+        cy.imag(INFINITY);
+        return cy;
+    }
     if (v < 0) {
         v = -v;
         sign = -1;

--- a/scipy/special/xsf/bessel.h
+++ b/scipy/special/xsf/bessel.h
@@ -1172,8 +1172,8 @@ inline std::complex<double> cyl_hankel_2(double v, std::complex<double> z) {
     if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
         return cy;
     }
-    if (v == 0 && z.real() == 0 && z.imag() == 0) {
-        cy.real(1.0);
+    if (v == 0 && z == 0.0) {
+        cy.real(NAN);
         cy.imag(INFINITY);
         return cy;
     }


### PR DESCRIPTION
#### Reference issue
Closes gh-4517

#### What does this implement/fix?
gh-4517 reported that the output of `hankel2` was inaccurate at 0, 0. This PR fixes that issue (assuming the definition in terms of $J_n$ and $Y_n$ is appropriate here) and only that issue.

#### Additional information
There are undoubtedly other edge cases in related functions (and through `special`) that are not perfect, but since this one was deemed special enough to be open as its own issue for some time, I thought it might as well be fixed. Rather than wait for all of them to be fixed to close this issue, perhaps we need a meta-issue to find and fix edge cases if there is not one already, or maybe it is OK to wait to fix them as they are reported given that there are other issues.