### PR TITLE
DOC: `special.mathieu_c/sem`: add information to docstring

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -4764,14 +4764,14 @@ const char *mathieu_cem_doc = R"(
 
     Notes
     -----
-    Even Mathieu functions are the solutions to Mathieu's differential equation
+    The even Mathieu functions are the solutions to Mathieu's differential equation
 
     .. math::
 
         \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
 
     for which the characteristic number :math:`a_m` results in an even, periodic
-    solution :math:`y(x)`` with period 180 degrees (for even :math:`m`) or
+    solution :math:`y(x)` with period 180 degrees (for even :math:`m`) or
     360 degrees (for odd :math:`m`).
 
     References
@@ -4781,7 +4781,7 @@ const char *mathieu_cem_doc = R"(
 
     Examples
     --------
-    Plot Mathieu functions of orders ``2`` and ``4``.
+    Plot even Mathieu functions of orders ``2`` and ``4``.
 
     >>> import numpy as np
     >>> from scipy import special
@@ -4795,7 +4795,7 @@ const char *mathieu_cem_doc = R"(
     >>> plt.ylabel('y')
     >>> plt.legend(('m = 2', 'm = 4'))
 
-    Note that the functions are even. Also, because the orders ``2`` and
+    Because the orders ``2`` and
     ``4`` are even, the period of each function is 180 degrees.
 
     )";
@@ -4972,7 +4972,7 @@ const char *mathieu_sem_doc = R"(
         \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
 
     for which the characteristic number :math:`a_m` results in an odd, periodic
-    solution :math:`y(x)`` with period 180 degrees (for even :math:`m`) or
+    solution :math:`y(x)` with period 180 degrees (for even :math:`m`) or
     360 degrees (for odd :math:`m`).
 
     References
@@ -4982,7 +4982,7 @@ const char *mathieu_sem_doc = R"(
 
     Examples
     --------
-    Plot Mathieu functions of orders ``2`` and ``4``.
+    Plot odd Mathieu functions of orders ``2`` and ``4``.
 
     >>> import numpy as np
     >>> from scipy import special
@@ -4996,7 +4996,7 @@ const char *mathieu_sem_doc = R"(
     >>> plt.ylabel('y')
     >>> plt.legend(('m = 2', 'm = 4'))
 
-    Note that the functions are even. Also, because the orders ``2`` and
+    Because the orders ``2`` and
     ``4`` are even, the period of each function is 180 degrees.
 
     )";

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -4762,6 +4762,42 @@ const char *mathieu_cem_doc = R"(
     --------
     mathieu_a, mathieu_b, mathieu_sem
 
+    Notes
+    -----
+    Even Mathieu functions are the solutions to Mathieu's differential equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
+
+    for which the characteristic number :math:`a_m` results in an even, periodic
+    solution :math:`y(x)`` with period 180 degrees (for even :math:`m`) or
+    360 degrees (for odd :math:`m`).
+
+    References
+    ----------
+    'Mathieu function'. *Wikipedia*.
+    https://en.wikipedia.org/wiki/Mathieu_function
+
+    Examples
+    --------
+    Plot Mathieu functions of orders ``2`` and ``4``.
+
+    >>> import numpy as np
+    >>> from scipy import special
+    >>> import matplotlib.pyplot as plt
+    >>> m = np.asarray([2, 4])
+    >>> q = 50
+    >>> x = np.linspace(-180, 180, 300)[:, np.newaxis]
+    >>> y, _ = special.mathieu_cem(m, q, x)
+    >>> plt.plot(x, y)
+    >>> plt.xlabel('x (degrees)')
+    >>> plt.ylabel('y')
+    >>> plt.legend(('m = 2', 'm = 4'))
+
+    Note that the functions are even. Also, because the orders ``2`` and
+    ``4`` are even, the period of each function is 180 degrees.
+
     )";
 
 const char *mathieu_modcem1_doc = R"(
@@ -4926,6 +4962,42 @@ const char *mathieu_sem_doc = R"(
     See Also
     --------
     mathieu_a, mathieu_b, mathieu_cem
+
+    Notes
+    -----
+    Odd Mathieu functions are the solutions to Mathieu's differential equation
+
+    .. math::
+
+        \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
+
+    for which the characteristic number :math:`a_m` results in an odd, periodic
+    solution :math:`y(x)`` with period 180 degrees (for even :math:`m`) or
+    360 degrees (for odd :math:`m`).
+
+    References
+    ----------
+    'Mathieu function'. *Wikipedia*.
+    https://en.wikipedia.org/wiki/Mathieu_function
+
+    Examples
+    --------
+    Plot Mathieu functions of orders ``2`` and ``4``.
+
+    >>> import numpy as np
+    >>> from scipy import special
+    >>> import matplotlib.pyplot as plt
+    >>> m = np.asarray([2, 4])
+    >>> q = 50
+    >>> x = np.linspace(-180, 180, 300)[:, np.newaxis]
+    >>> y, _ = special.mathieu_sem(m, q, x)
+    >>> plt.plot(x, y)
+    >>> plt.xlabel('x (degrees)')
+    >>> plt.ylabel('y')
+    >>> plt.legend(('m = 2', 'm = 4'))
+
+    Note that the functions are even. Also, because the orders ``2`` and
+    ``4`` are even, the period of each function is 180 degrees.
 
     )";
 

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -4776,8 +4776,8 @@ const char *mathieu_cem_doc = R"(
 
     References
     ----------
-    'Mathieu function'. *Wikipedia*.
-    https://en.wikipedia.org/wiki/Mathieu_function
+    .. [1] 'Mathieu function'. *Wikipedia*.
+           https://en.wikipedia.org/wiki/Mathieu_function
 
     Examples
     --------
@@ -4977,8 +4977,8 @@ const char *mathieu_sem_doc = R"(
 
     References
     ----------
-    'Mathieu function'. *Wikipedia*.
-    https://en.wikipedia.org/wiki/Mathieu_function
+    .. [1] 'Mathieu function'. *Wikipedia*.
+           https://en.wikipedia.org/wiki/Mathieu_function
 
     Examples
     --------

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -4770,9 +4770,9 @@ const char *mathieu_cem_doc = R"(
 
         \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
 
-    for which the characteristic number :math:`a_m` results in an even, periodic
-    solution :math:`y(x)` with period 180 degrees (for even :math:`m`) or
-    360 degrees (for odd :math:`m`).
+    for which the characteristic number :math:`a_m` (calculated with `mathieu_a`)
+    results in an odd, periodic solution :math:`y(x)` with period 180 degrees
+    (for even :math:`m`) or 360 degrees (for odd :math:`m`).
 
     References
     ----------
@@ -4969,11 +4969,11 @@ const char *mathieu_sem_doc = R"(
 
     .. math::
 
-        \frac{d^2y}{dx^2} + (a_m - 2q \cos(2x))y = 0
+        \frac{d^2y}{dx^2} + (b_m - 2q \cos(2x))y = 0
 
-    for which the characteristic number :math:`a_m` results in an odd, periodic
-    solution :math:`y(x)` with period 180 degrees (for even :math:`m`) or
-    360 degrees (for odd :math:`m`).
+    for which the characteristic number :math:`b_m` (calculated with `mathieu_b`)
+    results in an odd, periodic solution :math:`y(x)` with period 180 degrees
+    (for even :math:`m`) or 360 degrees (for odd :math:`m`).
 
     References
     ----------


### PR DESCRIPTION
#### Reference issue
Closes gh-4096

#### What does this implement/fix?
Adds requested information and examples to the documentation of `mathieu_cem` and `mathieu_sem`.

*First push with `[docs only]` in the commit message did not build the docs, so force-pushing without that...*