### PR TITLE
DOC/MAINT: spatial: fix some typos

### DIFF
--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -2,7 +2,7 @@
 #define CKDTREE_CPP_DECL
 
 /*
- * Use numpy to provide some platform independency.
+ * Use numpy to provide some platform independence.
  * Define these functions for your platform
  * */
 #include <numpy/npy_common.h>

--- a/scipy/spatial/ckdtree/src/count_neighbors.cxx
+++ b/scipy/spatial/ckdtree/src/count_neighbors.cxx
@@ -23,7 +23,7 @@ struct WeightedTree {
 struct CNBParams
 {
     double *r;
-    void * results; /* will be casted inside */
+    void * results; /* will be cast inside */
     WeightedTree self, other;
     int cumulative;
 };

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1210,7 +1210,7 @@ cdef class Rotation:
         >>> r.as_rotvec().shape
         (2, 3)
 
-        It is also possible to have a stack of a single rotaton:
+        It is also possible to have a stack of a single rotation:
 
         >>> r = R.from_rotvec([[0, 0, np.pi/2]])
         >>> r.as_rotvec().shape
@@ -3488,7 +3488,7 @@ cdef class Rotation:
             tolerance = 1e-3  # tolerance for small angle approximation (rad)
             R_flip = cls.identity()
             if (np.pi - theta) < tolerance:
-                # Near pi radians, the Taylor series appoximation of x/sin(x)
+                # Near pi radians, the Taylor series approximation of x/sin(x)
                 # diverges, so for numerical stability we flip pi and then
                 # rotate back by the small angle pi - theta
                 if cross_norm == 0:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -705,7 +705,7 @@ def test_as_euler_asymmetric_axes(seq_tuple, intrinsic):
     seq = "".join(seq_tuple)
     if intrinsic:
         # Extrinsic rotation (wrt to global world) at lower case
-        # intrinsinc (WRT the object itself) lower case.
+        # intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles)
     angles_quat = rotation.as_euler(seq)
@@ -846,7 +846,7 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
     # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
-        # Extrinsinc rotation (wrt to global world) at lower case
+        # Extrinsic rotation (wrt to global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
 


### PR DESCRIPTION
dumped directory strings exposed a few typos

per request will revert changes to the C++ code

Qhull development: `https://github.com/qhull/qhull`