### PR TITLE
Change phrasing in comments for boxcox_normax ymax default

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1225,9 +1225,10 @@ def boxcox_normmax(
         The unconstrained optimal transform parameter may cause Box-Cox
         transformed data to have extreme magnitude or even overflow.
         This parameter constrains MLE optimization such that the magnitude
-        of the transformed `x` does not exceed `ymax`. The default is
-        the maximum value of the input dtype. If set to infinity,
-        `boxcox_normmax` returns the unconstrained optimal lambda.
+        of the transformed `x` does not exceed `ymax`. The default value is 
+        calculated based on the input array's data type, or dtype. It is 
+        determined by dividing the dtype's maximum value by 10,000. If set 
+        to infinity, `boxcox_normmax` returns the unconstrained optimal lambda.
         Ignored when ``method='pearsonr'``.
 
     Returns


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes DOC: stats: boxcox_normmax docstring is incorrect about ymax default #21229

#### What does this implement/fix?
It edits one of the comments in the _morestats.py file, giving proper documentation for what is going on

#### Additional information
<!--Any additional information you think is important.-->
