### PR TITLE
MAINT: use dependabot to keep GH actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "MAINT"


### PR DESCRIPTION
numpy uses dependabot to keep github actions updated. This PR replicates that for scipy. When it runs it figures out which actions need bumping to more recent versions. This would be useful for scipy as we have so many CI files.