### PR TITLE
ENH: `special.logsumexp`: improve precision when one element is much bigger than the rest

### DIFF
--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -844,7 +844,7 @@ class TestNSum:
             logres = nsum(lambda *args: np.log(f(*args)),
                            f.a, f.b, log=True, args=f.args)
         assert_allclose(np.exp(logres.sum), res.sum)
-        assert_allclose(np.exp(logres.error), res.error)
+        assert_allclose(np.exp(logres.error), res.error, atol=1e-15)
         assert_equal(logres.status, 0)
         assert_equal(logres.success, True)
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -211,7 +211,6 @@ def _logsumexp(a, b, axis, return_sign, xp):
     # Take log and undo shift
     out = xp.log1p(s) + xp.log(m) + a_max
 
-    # Sigh... imagine a world in which we could just take the real part of a real array
     out = xp_real(out) if return_sign else out
 
     return out, sgn

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -105,13 +105,13 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     a, b = xp_broadcast_promote(a, b, ensure_writeable=True, force_floating=True, xp=xp)
     a = xp_atleast_nd(a, ndim=1)
     b = xp_atleast_nd(b, ndim=1) if b is not None else b
+    axis = tuple(range(a.ndim)) if axis is None else axis
 
     if xp_size(a) != 0:
         with np.errstate(divide='ignore', invalid='ignore'):  # log of zero is OK
             out, sgn = _logsumexp(a, b, axis=axis, return_sign=return_sign, xp=xp)
     else:
         shape = np.asarray(a.shape)  # NumPy is convenient for shape manipulation
-        axis = tuple(range(a.ndim)) if axis is None else axis
         shape[axis] = 1
         out = xp.full(tuple(shape), -xp.inf, dtype=a.dtype)
         sgn = xp.sign(out)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -195,6 +195,12 @@ class TestLogSumExp:
         desired = xp.asarray(math.log(math.exp(2) - math.exp(1)), dtype=desired_dtype)
         xp_assert_close(logsumexp(a, b=b), desired)
 
+    def test_gh18295(self, xp):
+        a = xp.asarray([0.0, -40.0])
+        res = logsumexp(a)
+        ref = xp.logaddexp(a[0], a[1])
+        xp_assert_close(res, ref)
+
 
 class TestSoftmax:
     def test_softmax_fixtures(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-18295
Supersedes gh-18424
~~May be used to address gh-19521/gh-19549 and make `log_softmax` array API compatible.~~ (The idea of using `log1p` is essentially the same, but I think `softmax` needs its own implementation.)

#### What does this implement/fix?
gh-18295 reported that `logsumexp` can lose precision when one element is much bigger than the rest, especially when the exponential of it is close to 1. This improves the precision as described in the issue and [linked paper](https://academic.oup.com/imajna/article/41/4/2311/5893596?login=true).

#### Additional information
gh-18424 was out of date after converting `logsumexp` to the array API. For instance, `xp.max` does not work on the real component of complex arrays, so conversion of some parts would not be trivial. Also, there were some unresolved comments about the complexity, so I chose to start from scratch.

Also, `logsumexp` was getting quite complicated as it was. I found it challenging to work within the existing structure, so I refactored to simplify (26bb631f4c015a1ddea1c77f1c4f5a9ad2ebc28d) before getting started with the upgrade. 

I'll add a review that documents the math inline with the code.