### PR TITLE
DOC: `spatial.voronoi_plot_2d`: notes on degeneracy

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -185,7 +185,11 @@ def voronoi_plot_2d(vor, ax=None, **kw):
 
     Notes
     -----
-    Requires Matplotlib.
+    Requires Matplotlib. For degenerate input, including collinearity and
+    other violations of general position, it may be preferable to
+    calculate the Voronoi diagram with Qhull options ``QJ`` for random
+    joggling, or ``Qt`` to enforce triangulated output. Otherwise, some
+    Voronoi regions may not be visible.
 
     Examples
     --------


### PR DESCRIPTION
* Fixes gh-21379 (my argument is this is a docs issue)

* Expand the `Notes` section of `voronoi_plot_2d` to provide some suggestions for generators that violate general position. There may be a way for us to warn the user in such situations, but I think I'd prefer to try documenting first since there are probably many ways to violate general position and the calculations (every point is the same point, all points are collinear, etc.) may be expensive.

[docs only]