### PR TITLE
MAINT: `_lib`: vendor and use array-api-extra

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "scipy/_lib/cobyqa"]
 	path = scipy/_lib/cobyqa
 	url = https://github.com/cobyqa/cobyqa.git
+[submodule "scipy/_lib/array_api_extra"]
+	path = scipy/_lib/array_api_extra
+	url = https://github.com/lucascolley/array-api-extra.git

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -9,7 +9,6 @@ https://data-apis.org/array-api/latest/use_cases.html#use-case-scipy
 from __future__ import annotations
 
 import os
-import warnings
 
 from types import ModuleType
 from typing import Any, Literal, TYPE_CHECKING
@@ -31,7 +30,7 @@ __all__ = [
     'is_array_api_strict', 'is_complex', 'is_cupy', 'is_jax', 'is_numpy', 'is_torch', 
     'SCIPY_ARRAY_API', 'SCIPY_DEVICE', 'scipy_namespace_for',
     'xp_assert_close', 'xp_assert_equal', 'xp_assert_less',
-    'xp_atleast_nd', 'xp_copy', 'xp_copysign', 'xp_device',
+    'xp_copy', 'xp_copysign', 'xp_device',
     'xp_moveaxis_to_end', 'xp_ravel', 'xp_real', 'xp_sign', 'xp_size',
     'xp_take_along_axis', 'xp_unsupported_param_msg', 'xp_vector_norm',
     'xp_create_diagonal'
@@ -193,17 +192,6 @@ def _asarray(
         _check_finite(array, xp)
 
     return array
-
-
-def xp_atleast_nd(x: Array, *, ndim: int, xp: ModuleType | None = None) -> Array:
-    """Recursively expand the dimension to have at least `ndim`."""
-    if xp is None:
-        xp = array_namespace(x)
-    x = xp.asarray(x)
-    if x.ndim < ndim:
-        x = xp.expand_dims(x, axis=0)
-        x = xp_atleast_nd(x, ndim=ndim, xp=xp)
-    return x
 
 
 def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array:
@@ -395,34 +383,6 @@ def assert_almost_equal(actual, desired, decimal=7, *args, **kwds):
     return xp_assert_close(actual, desired,
                            atol=atol, rtol=rtol, check_dtype=False, check_shape=False,
                            *args, **kwds)
-
-
-def xp_cov(x: Array, *, xp: ModuleType | None = None) -> Array:
-    if xp is None:
-        xp = array_namespace(x)
-
-    X = xp_copy(x, xp=xp)
-    dtype = xp.result_type(X, xp.float64)
-
-    X = xp_atleast_nd(X, ndim=2, xp=xp)
-    X = xp.asarray(X, dtype=dtype)
-
-    avg = xp.mean(X, axis=1)
-    fact = X.shape[1] - 1
-
-    if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice",
-                      RuntimeWarning, stacklevel=2)
-        fact = 0.0
-
-    X -= avg[:, None]
-    X_T = X.T
-    if xp.isdtype(X_T.dtype, 'complex floating'):
-        X_T = xp.conj(X_T)
-    c = X @ X_T
-    c /= fact
-    axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
-    return xp.squeeze(c, axis=axes)
 
 
 def xp_unsupported_param_msg(param: Any) -> str:

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -11,6 +11,9 @@ endif
 if not fs.exists('array_api_compat/README.md')
   error('Missing the `array_api_compat` submodule! Run `git submodule update --init` to fix this.')
 endif
+if not fs.exists('array_api_extra/README.md')
+  error('Missing the `array_api_extra` submodule! Run `git submodule update --init` to fix this.')
+endif
 if not fs.exists('pocketfft/README.md')
   error('Missing the `pocketfft` submodule! Run `git submodule update --init` to fix this.')
 endif
@@ -209,6 +212,18 @@ py3.install_sources(
     'array_api_compat/array_api_compat/torch/linalg.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/torch',
+)
+
+# `array_api_extra` install to simplify import path;
+# should be updated whenever new files are added to `array_api_extra`
+
+py3.install_sources(
+  [
+    'array_api_extra/src/array_api_extra/__init__.py',
+    'array_api_extra/src/array_api_extra/_funcs.py',
+    'array_api_extra/src/array_api_extra/_typing.py',
+  ],
+  subdir: 'scipy/_lib/array_api_extra',
 )
 
 py3.install_sources(

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -15,8 +15,9 @@ from scipy.cluster import _vq
 from scipy.conftest import array_api_compatible
 from scipy.sparse._sputils import matrix
 
+from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api import (
-    SCIPY_ARRAY_API, xp_copy, xp_cov, xp_assert_close, xp_assert_equal
+    SCIPY_ARRAY_API, array_namespace, xp_copy, xp_assert_close, xp_assert_equal
 )
 
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
@@ -352,11 +353,12 @@ class TestKMean:
         datas = [xp.reshape(data, (200, 2)),
                  xp.reshape(data, (20, 20))[:10, :]]
         k = int(1e6)
+        xp_test = array_namespace(data)
         for data in datas:
             rng = np.random.default_rng(1234)
-            init = _krandinit(data, k, rng, xp)
-            orig_cov = xp_cov(data.T)
-            init_cov = xp_cov(init.T)
+            init = _krandinit(data, k, rng, xp_test)
+            orig_cov = xpx.cov(data.T, xp=xp_test)
+            init_cov = xpx.cov(init.T, xp=xp_test)
             xp_assert_close(orig_cov, init_cov, atol=1.1e-2)
 
     def test_kmeans2_empty(self, xp):

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -68,10 +68,11 @@ import warnings
 import numpy as np
 from collections import deque
 from scipy._lib._array_api import (
-    _asarray, array_namespace, xp_size, xp_atleast_nd, xp_copy, xp_cov
+    _asarray, array_namespace, xp_size, xp_copy
 )
 from scipy._lib._util import (check_random_state, rng_integers,
                               _transition_to_rng)
+from scipy._lib import array_api_extra as xpx
 from scipy.spatial.distance import cdist
 
 from . import _vq
@@ -548,7 +549,7 @@ def _krandinit(data, k, rng, xp):
     k = np.asarray(k)
 
     if data.ndim == 1:
-        _cov = xp_cov(data)
+        _cov = xpx.cov(data, xp=xp)
         x = rng.standard_normal(size=k)
         x = xp.asarray(x)
         x *= xp.sqrt(_cov)
@@ -560,7 +561,7 @@ def _krandinit(data, k, rng, xp):
         sVh = s[:, None] * vh / xp.sqrt(data.shape[0] - xp.asarray(1.))
         x = x @ sVh
     else:
-        _cov = xp_atleast_nd(xp_cov(data.T), ndim=2)
+        _cov = xpx.atleast_nd(xpx.cov(data.T, xp=xp), ndim=2, xp=xp)
 
         # k rows, d cols (one row = one obs)
         # Generate k sample of a random variable ~ Gaussian(mu, cov)

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -3,7 +3,8 @@ import scipy.sparse as sps
 from ._numdiff import approx_derivative, group_columns
 from ._hessian_update_strategy import HessianUpdateStrategy
 from scipy.sparse.linalg import LinearOperator
-from scipy._lib._array_api import xp_atleast_nd, array_namespace
+from scipy._lib._array_api import array_namespace
+from scipy._lib import array_api_extra as xpx
 
 
 FD_METHODS = ('2-point', '3-point', 'cs')
@@ -183,7 +184,7 @@ class ScalarFunction:
                              "quasi-Newton strategies.")
 
         self.xp = xp = array_namespace(x0)
-        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
+        _x = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -274,7 +275,7 @@ class ScalarFunction:
             # ensure that self.x is a copy of x. Don't store a reference
             # otherwise the memoization doesn't work properly.
 
-            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xpx.atleast_nd(self.xp.asarray(x), ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
             self.g_updated = False
@@ -283,7 +284,7 @@ class ScalarFunction:
         else:
             # ensure that self.x is a copy of x. Don't store a reference
             # otherwise the memoization doesn't work properly.
-            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xpx.atleast_nd(self.xp.asarray(x), ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
             self.g_updated = False
@@ -380,7 +381,7 @@ class VectorFunction:
                              "strategies.")
 
         self.xp = xp = array_namespace(x0)
-        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
+        _x = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -557,7 +558,7 @@ class VectorFunction:
                 self._update_jac()
                 self.x_prev = self.x
                 self.J_prev = self.J
-                _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
+                _x = xpx.atleast_nd(self.xp.asarray(x), ndim=1, xp=self.xp)
                 self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
@@ -565,7 +566,7 @@ class VectorFunction:
                 self._update_hess()
         else:
             def update_x(x):
-                _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
+                _x = xpx.atleast_nd(self.xp.asarray(x), ndim=1, xp=self.xp)
                 self.x = self.xp.astype(_x, self.x_dtype)
                 self.f_updated = False
                 self.J_updated = False
@@ -637,7 +638,7 @@ class LinearVectorFunction:
         self.m, self.n = self.J.shape
 
         self.xp = xp = array_namespace(x0)
-        _x = xp_atleast_nd(x0, ndim=1, xp=xp)
+        _x = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
         _dtype = xp.float64
         if xp.isdtype(_x.dtype, "real floating"):
             _dtype = _x.dtype
@@ -654,7 +655,7 @@ class LinearVectorFunction:
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
-            _x = xp_atleast_nd(x, ndim=1, xp=self.xp)
+            _x = xpx.atleast_nd(self.xp.asarray(x), ndim=1, xp=self.xp)
             self.x = self.xp.astype(_x, self.x_dtype)
             self.f_updated = False
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -6,7 +6,8 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, csc_matrix, csr_matrix, coo_matrix, find
 from ._group_columns import group_dense, group_sparse
-from scipy._lib._array_api import xp_atleast_nd, array_namespace
+from scipy._lib._array_api import array_namespace
+from scipy._lib import array_api_extra as xpx
 
 
 def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
@@ -440,7 +441,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         raise ValueError(f"Unknown method '{method}'. ")
 
     xp = array_namespace(x0)
-    _x = xp_atleast_nd(x0, ndim=1, xp=xp)
+    _x = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
     _dtype = xp.float64
     if xp.isdtype(_x.dtype, "real floating"):
         _dtype = _x.dtype

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -41,8 +41,8 @@ from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._util import (MapWrapper, check_random_state, _RichResult,
                               _call_callback_maybe_halt, _transition_to_rng)
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy._lib._array_api import (array_namespace, xp_atleast_nd,
-                                   xp_create_diagonal)
+from scipy._lib._array_api import array_namespace, xp_create_diagonal
+from scipy._lib import array_api_extra as xpx
 
 
 # standard status messages of optimizers
@@ -442,7 +442,7 @@ def rosen_hess(x):
 
     """
     xp = array_namespace(x)
-    x = xp_atleast_nd(x, ndim=1, xp=xp)
+    x = xpx.atleast_nd(x, ndim=1, xp=xp)
     if xp.isdtype(x.dtype, 'integral'):
         x = xp.astype(x, xp.asarray(1.).dtype)
     H = (xp_create_diagonal(-400 * x[:-1], offset=1, xp=xp) 
@@ -486,7 +486,7 @@ def rosen_hess_prod(x, p):
 
     """
     xp = array_namespace(x, p)
-    x = xp_atleast_nd(x, ndim=1, xp=xp)
+    x = xpx.atleast_nd(x, ndim=1, xp=xp)
     if xp.isdtype(x.dtype, 'integral'):
         x = xp.astype(x, xp.asarray(1.).dtype)
     p = xp.asarray(p, dtype=x.dtype)

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -24,7 +24,8 @@ from ._optimize import (OptimizeResult, _check_unknown_options,
                         _check_clip_x)
 from ._numdiff import approx_derivative
 from ._constraints import old_bound_to_new, _arr_to_scalar
-from scipy._lib._array_api import xp_atleast_nd, array_namespace
+from scipy._lib._array_api import array_namespace
+from scipy._lib import array_api_extra as xpx
 
 
 __docformat__ = "restructuredtext en"
@@ -250,7 +251,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
     # Transform x0 into an array.
     xp = array_namespace(x0)
-    x0 = xp_atleast_nd(x0, ndim=1, xp=xp)
+    x0 = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
     dtype = xp.float64
     if xp.isdtype(x0.dtype, "real floating"):
         dtype = x0.dtype

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -36,7 +36,8 @@ from scipy.optimize import _moduleTNC as moduleTNC
 from ._optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._constraints import old_bound_to_new
-from scipy._lib._array_api import xp_atleast_nd, array_namespace
+from scipy._lib._array_api import array_namespace
+from scipy._lib import array_api_extra as xpx
 
 from numpy import inf, array, zeros
 
@@ -356,7 +357,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     pgtol = gtol
 
     xp = array_namespace(x0)
-    x0 = xp_atleast_nd(x0, ndim=1, xp=xp)
+    x0 = xpx.atleast_nd(xp.asarray(x0), ndim=1, xp=xp)
     dtype = xp.float64
     if xp.isdtype(x0.dtype, "real floating"):
         dtype = x0.dtype

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -5,11 +5,11 @@ from scipy._lib._array_api import (
     array_namespace,
     xp_size,
     xp_broadcast_promote,
-    xp_atleast_nd,
     xp_real,
     xp_copy,
     xp_float_to_complex,
 )
+from scipy._lib import array_api_extra as xpx
 
 __all__ = ["logsumexp", "softmax", "log_softmax"]
 
@@ -109,8 +109,8 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     """
     xp = array_namespace(a, b)
     a, b = xp_broadcast_promote(a, b, ensure_writeable=True, force_floating=True, xp=xp)
-    a = xp_atleast_nd(a, ndim=1)
-    b = xp_atleast_nd(b, ndim=1) if b is not None else b
+    a = xpx.atleast_nd(a, ndim=1, xp=xp)
+    b = xpx.atleast_nd(b, ndim=1, xp=xp) if b is not None else b
     axis = tuple(range(a.ndim)) if axis is None else axis
 
     if xp_size(a) != 0:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -72,13 +72,13 @@ from scipy._lib._util import normalize_axis_index
 from scipy._lib._array_api import (
     _asarray,
     array_namespace,
-    xp_atleast_nd,
     is_numpy,
     xp_size,
     xp_moveaxis_to_end,
     xp_sign,
     xp_vector_norm,
 )
+from scipy._lib import array_api_extra as xpx
 from scipy._lib.deprecation import _deprecated
 
 
@@ -2613,7 +2613,7 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     if axis is None:
         a = xp.reshape(a, (-1,))
         axis = 0
-    a = xp_atleast_nd(a, ndim=1, xp=xp)
+    a = xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp)
     n = a.shape[axis]
     s = xp.std(a, axis=axis, correction=ddof) / n**0.5
     return s


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
Proof of concept for the new library https://github.com/data-apis/array-api-extra. Here I show that it is vendor-able, and use it to replace `xp_atleast_nd` with `xpx.atleast_nd`, and `xp_cov` with `xpx.cov`.

#### Additional information
With a view to upstreaming all of our private array-agnostic functions like this which may be useful for other libraries.