### PR TITLE
DOC: `special.riccati_yn`: highlight sign convention

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1337,9 +1337,10 @@ def riccati_jn(n, x):
 def riccati_yn(n, x):
     """Compute Ricatti-Bessel function of the second kind and its derivative.
 
-    The Ricatti-Bessel function of the second kind is defined as :math:`x
+    The Ricatti-Bessel function of the second kind is defined here as :math:`+x
     y_n(x)`, where :math:`y_n` is the spherical Bessel function of the second
-    kind of order :math:`n`.
+    kind of order :math:`n`. _Note that this is in contrast to a common convention
+    that includes a minus sign in the definition._
 
     This function computes the value and first derivative of the function for
     all orders up to and including `n`.

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1339,8 +1339,8 @@ def riccati_yn(n, x):
 
     The Ricatti-Bessel function of the second kind is defined here as :math:`+x
     y_n(x)`, where :math:`y_n` is the spherical Bessel function of the second
-    kind of order :math:`n`. _Note that this is in contrast to a common convention
-    that includes a minus sign in the definition._
+    kind of order :math:`n`. *Note that this is in contrast to a common convention
+    that includes a minus sign in the definition.*
 
     This function computes the value and first derivative of the function for
     all orders up to and including `n`.


### PR DESCRIPTION
#### Reference issue
Closes gh-12895
Closes gh-17920

#### What does this implement/fix?
gh-12895 requests that the sign convention for `special.riccati_yn` be changed from $xy_n(x)$ to $-xy_n(x)$. Both conventions are valid, and SciPy's convention can be found in reputable references including Abramowitz and Stegun and DLMF (https://github.com/scipy/scipy/issues/12895#issuecomment-2365361502), so I don't think we would change it now to please some and disrupt others. This PR modifies the documentation to highlight the convention used by SciPy.