### PR TITLE
MAINT: `special.gegenbauer`: fix behavior for `n=0`; add input validation of `alpha`

### DIFF
--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1616,6 +1616,8 @@ def gegenbauer(n, alpha, monic=False):
     >>> plt.show()
 
     """
+    if not np.isfinite(alpha) or alpha <= -0.5 :
+        raise ValueError("`alpha` must be a finite number greater than -1/2")
     base = jacobi(n, alpha - 0.5, alpha - 0.5, monic=monic)
     if monic or n == 0:
         return base

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1617,7 +1617,7 @@ def gegenbauer(n, alpha, monic=False):
 
     """
     base = jacobi(n, alpha - 0.5, alpha - 0.5, monic=monic)
-    if monic:
+    if monic or n == 0:
         return base
     #  Abrahmowitz and Stegan 22.5.20
     factor = (_gam(2*alpha + n) * _gam(alpha + 0.5) /

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -95,10 +95,11 @@ class TestGegenbauer:
         assert_array_almost_equal(Ca5.c,array([4*sc.poch(a,5),0,-20*sc.poch(a,4),
                                                0,15*sc.poch(a,3),0])/15.0,11)
 
-    def test_n_zero_gh8888(self):
+    @pytest.mark.parametrize('a', [0, 1])
+    def test_n_zero_gh8888(self, a):
         # gh-8888 reported that gegenbauer(0, 0) returns NaN polynomial
-        Ca0 = orth.gegenbauer(0, 0)
-        assert_equal(Ca0.c, np.asarray([1.]))
+        Cn0 = orth.gegenbauer(0, a)
+        assert_equal(Cn0.c, np.asarray([1.]))
 
     def test_valid_alpha(self):
         # Check input validation of `alpha`

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -1,8 +1,10 @@
+import pytest
+from pytest import raises as assert_raises
+
 import numpy as np
 from numpy import array, sqrt
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_almost_equal, assert_allclose)
-from pytest import raises as assert_raises
 
 from scipy import integrate
 import scipy.special as sc
@@ -97,6 +99,16 @@ class TestGegenbauer:
         # gh-8888 reported that gegenbauer(0, 0) returns NaN polynomial
         Ca0 = orth.gegenbauer(0, 0)
         assert_equal(Ca0.c, np.asarray([1.]))
+
+    def test_valid_alpha(self):
+        # Check input validation of `alpha`
+        message = '`alpha` must be a finite number greater...'
+        with pytest.raises(ValueError, match=message):
+            orth.gegenbauer(0, np.nan)
+        with pytest.raises(ValueError, match=message):
+            orth.gegenbauer(1, -0.5)
+        with pytest.raises(ValueError, match=message):
+            orth.gegenbauer(2, -np.inf)
 
 
 class TestHermite:

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -93,6 +93,11 @@ class TestGegenbauer:
         assert_array_almost_equal(Ca5.c,array([4*sc.poch(a,5),0,-20*sc.poch(a,4),
                                                0,15*sc.poch(a,3),0])/15.0,11)
 
+    def test_n_zero_gh8888(self):
+        # gh-8888 reported that gegenbauer(0, 0) returns NaN polynomial
+        Ca0 = orth.gegenbauer(0, 0)
+        assert_equal(Ca0.c, np.asarray([1.]))
+
 
 class TestHermite:
     def test_hermite(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-8888

#### What does this implement/fix?
gh-8888 noted that `special.gegenbauer(0, 0)` produced a NaN polynomial instead of the polynomial $1$. This fixes the bug and adds input validation for the `alpha` parameter.

#### Additional information
It would not be hard to find adjacent rough edges. Let's not go down that rabbit hole here.