### PR TITLE
DOC/MAINT: sparse: fix some typos

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -316,7 +316,7 @@ class _dok_base(_spbase, IndexMixin, dict):
         return new
 
     def __radd__(self, other):
-        return self + other  # addition is comutative
+        return self + other  # addition is commutative
 
     def __neg__(self):
         if self.dtype.kind == 'b':

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -187,7 +187,7 @@ cdef tuple _hopcroft_karp(const ITYPE_t[:] indices, const ITYPE_t[:] indptr,
 
     # Similarly, we use a stack for our depth-first search. As above, we only
     # represent vertices in the left partition, and since no augmenting path
-    # will visit more than i of thse before encountering an unmatched vertex
+    # will visit more than i of these before encountering an unmatched vertex
     # (as represented by i), the stack capacity can be limited to i + 1.
     # Elements will be pushed to stack_head and popped from stack_head - 1.
     cdef ITYPE_t[:] stack = np.empty(i + 1, dtype=ITYPE)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -268,7 +268,7 @@ def csgraph_to_dense(csgraph, null_value=0):
     The reason for this difference is to allow a compressed sparse graph to
     represent multiple edges between any two nodes.  As most sparse graph
     algorithms are concerned with the single lowest-cost edge between any
-    two nodes, the default scipy.sparse behavior of summming multiple weights
+    two nodes, the default scipy.sparse behavior of summing multiple weights
     does not make sense in this context.
 
     The other reason for using this routine is to allow for graphs with

--- a/scipy/sparse/linalg/_eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/_eigen/_svds_doc.py
@@ -21,7 +21,7 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     ncv : int, optional
         The number of Lanczos vectors generated.
         The default is ``min(n, max(2*k + 1, 20))``.
-        If specified, must satistify ``k + 1 < ncv < min(M, N)``; ``ncv > 2*k``
+        If specified, must satisfy ``k + 1 < ncv < min(M, N)``; ``ncv > 2*k``
         is recommended.
     tol : float, optional
         Tolerance for singular values. Zero (default) means machine precision.

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -521,7 +521,7 @@ class Sakurai(LinearOperator):
 
     Constructs the "Sakurai" matrix motivated by reference [1]_:
     square real symmetric positive definite and 5-diagonal
-    with the main digonal ``[5, 6, 6, ..., 6, 6, 5], the ``+1`` and ``-1``
+    with the main diagonal ``[5, 6, 6, ..., 6, 6, 5], the ``+1`` and ``-1``
     diagonals filled with ``-4``, and the ``+2`` and ``-2`` diagonals
     made of ``1``. Its eigenvalues are analytically known to be
     ``16. * np.power(np.cos(0.5 * k * np.pi / (n + 1)), 4)``.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1873,7 +1873,7 @@ class _TestCommon:
         assert_array_almost_equal(a @ bsp, a @ b)
         assert_array_almost_equal(a2 @ bsp, a @ b)
 
-        # Now try performing cross-type multplication:
+        # Now try performing cross-type multiplication:
         csp = bsp.tocsc()
         c = b
         want = a @ c


### PR DESCRIPTION
@lucascolley

dumped directory strings exposed a few typos