### PR TITLE
TST: ndimage: skip fourier tests for JAX

### DIFF
--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -18,6 +18,7 @@ pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
               skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 
+@skip_xp_backends('jax.numpy', reason="jax-ml/jax#23827")
 class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])


### PR DESCRIPTION
https://github.com/scipy/scipy/pull/21579#issuecomment-2366842932, will need a rebase after that PR merges.