### PR TITLE
BUG: sparse: fix indexing after ellipsis and 2D array indexing

### DIFF
--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -132,7 +132,10 @@ class _csc_base(_cs_matrix):
         return self._major_index_fancy(col)._minor_slice(row)
 
     def _get_arrayXint(self, row, col):
-        return self._get_submatrix(major=col)._minor_index_fancy(row)
+        res = self._get_submatrix(major=col)._minor_index_fancy(row)
+        if row.ndim > 1:
+            return res.reshape(row.shape)
+        return res
 
     def _get_arrayXslice(self, row, col):
         return self._major_slice(col)._minor_index_fancy(row)

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -265,7 +265,10 @@ class _csr_base(_cs_matrix):
         return self._major_slice(row)._minor_index_fancy(col)
 
     def _get_arrayXint(self, row, col):
-        return self._major_index_fancy(row)._get_submatrix(minor=col)
+        res = self._major_index_fancy(row)._get_submatrix(minor=col)
+        if row.ndim > 1:
+            return res.reshape(row.shape)
+        return res
 
     def _get_arrayXslice(self, row, col):
         if col.step not in (1, None):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -206,12 +206,10 @@ class _dok_base(_spbase, IndexMixin, dict):
         return newdok
 
     def _get_intXarray(self, row, col):
-        col = col.squeeze()
-        return self._get_columnXarray([row], col)
+        return self._get_columnXarray([row], col.ravel())
 
     def _get_arrayXint(self, row, col):
-        row = row.squeeze()
-        return self._get_columnXarray(row, [col])
+        return self._get_columnXarray(row.ravel(), [col])
 
     def _get_sliceXarray(self, row, col):
         row = list(range(*row.indices(self.shape[0])))

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -209,7 +209,10 @@ class _dok_base(_spbase, IndexMixin, dict):
         return self._get_columnXarray([row], col.ravel())
 
     def _get_arrayXint(self, row, col):
-        return self._get_columnXarray(row.ravel(), [col])
+        res = self._get_columnXarray(row.ravel(), [col])
+        if row.ndim > 1:
+            return res.reshape(row.shape)
+        return res
 
     def _get_sliceXarray(self, row, col):
         row = list(range(*row.indices(self.shape[0])))

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -224,7 +224,7 @@ class IndexMixin:
                 idx_shape.append(len_slice)
                 index_ndim += 1
             elif isintlike(idx):
-                N = self._shape[index_ndim]
+                N = self._shape[index_ndim] if ellps_pos is None else self._shape[-1]
                 if not (-N <= idx < N):
                     raise IndexError(f'index ({idx}) out of range')
                 idx = int(idx + N if idx < 0 else idx)

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -83,8 +83,6 @@ class IndexMixin:
         else:
             if isinstance(col, INT_TYPES):
                 res = self._get_arrayXint(row, col)
-                if row.ndim > 1:
-                    res = res.reshape(row.shape)
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -83,6 +83,8 @@ class IndexMixin:
         else:
             if isinstance(col, INT_TYPES):
                 res = self._get_arrayXint(row, col)
+                if row.ndim > 1:
+                    res = res.reshape(row.shape)
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -181,7 +181,10 @@ class _lil_base(_spbase, IndexMixin):
         return self._get_row_ranges(row, slice(col, col+1))
 
     def _get_arrayXint(self, row, col):
-        return self._get_row_ranges(row.ravel(), slice(col, col+1))
+        res = self._get_row_ranges(row.ravel(), slice(col, col+1))
+        if row.ndim > 1:
+            return res.reshape(row.shape)
+        return res
 
     def _get_intXslice(self, row, col):
         return self._get_row_ranges((row,), col)

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -181,8 +181,7 @@ class _lil_base(_spbase, IndexMixin):
         return self._get_row_ranges(row, slice(col, col+1))
 
     def _get_arrayXint(self, row, col):
-        row = row.squeeze()
-        return self._get_row_ranges(row, slice(col, col+1))
+        return self._get_row_ranges(row.ravel(), slice(col, col+1))
 
     def _get_intXslice(self, row, col):
         return self._get_row_ranges((row,), col)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2773,9 +2773,11 @@ class _TestSlicing:
         assert_array_equal(a[..., 4].toarray(), b[..., 4])
         assert_array_equal(a[..., 5].toarray(), b[..., 5])
         with pytest.raises(IndexError, match='index .5. out of range'):
-            assert_array_equal(a[5, ...].toarray(), b[5, ...])
+            a[5, ...]
         with pytest.raises(IndexError, match='index .10. out of range'):
-            assert_array_equal(a[..., 10].toarray(), b[..., 10])
+            a[..., 10]
+        with pytest.raises(IndexError, match='index .5. out of range'):
+            a.T[..., 5]
 
         assert_array_equal(a[1:, ...].toarray(), b[1:, ...])
         assert_array_equal(a[..., 1:].toarray(), b[..., 1:])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2769,16 +2769,54 @@ class _TestSlicing:
         assert_array_equal(a[...].toarray(), b[...])
         assert_array_equal(a[...,].toarray(), b[...,])
 
-        assert_array_equal(a[1, ...].toarray(), b[1, ...])
-        assert_array_equal(a[..., 1].toarray(), b[..., 1])
+        assert_array_equal(a[4, ...].toarray(), b[4, ...])
+        assert_array_equal(a[..., 4].toarray(), b[..., 4])
+        assert_array_equal(a[..., 5].toarray(), b[..., 5])
+        with pytest.raises(IndexError, match='index .5. out of range'):
+            assert_array_equal(a[5, ...].toarray(), b[5, ...])
+        with pytest.raises(IndexError, match='index .10. out of range'):
+            assert_array_equal(a[..., 10].toarray(), b[..., 10])
+
         assert_array_equal(a[1:, ...].toarray(), b[1:, ...])
         assert_array_equal(a[..., 1:].toarray(), b[..., 1:])
+        assert_array_equal(a[:2, ...].toarray(), b[:2, ...])
+        assert_array_equal(a[..., :2].toarray(), b[..., :2])
 
+        # check slice limit outside range
+        assert_array_equal(a[:5, ...].toarray(), b[:5, ...])
+        assert_array_equal(a[..., :5].toarray(), b[..., :5])
+        assert_array_equal(a[5:, ...].toarray(), b[5:, ...])
+        assert_array_equal(a[..., 5:].toarray(), b[..., 5:])
+        assert_array_equal(a[10:, ...].toarray(), b[10:, ...])
+        assert_array_equal(a[..., 10:].toarray(), b[..., 10:])
+
+        # ellipsis should be ignored
         assert_array_equal(a[1:, 1, ...].toarray(), b[1:, 1, ...])
         assert_array_equal(a[1, ..., 1:].toarray(), b[1, ..., 1:])
+        assert_array_equal(a[..., 1, 1:].toarray(), b[1, ..., 1:])
+        assert_array_equal(a[:2, 1, ...].toarray(), b[:2, 1, ...])
+        assert_array_equal(a[1, ..., :2].toarray(), b[1, ..., :2])
+        assert_array_equal(a[..., 1, :2].toarray(), b[1, ..., :2])
         # These return ints
         assert_equal(a[1, 1, ...], b[1, 1, ...])
         assert_equal(a[1, ..., 1], b[1, ..., 1])
+
+    def test_ellipsis_fancy_slicing(self):
+        b = arange(50).reshape(5,10)
+        a = self.spcreator(b)
+
+        assert_array_equal(a[[4], ...].toarray(), b[[4], ...])
+        assert_array_equal(a[[2, 4], ...].toarray(), b[[2, 4], ...])
+        assert_array_equal(a[..., [4]].toarray(), b[..., [4]])
+        assert_array_equal(a[..., [2, 4]].toarray(), b[..., [2, 4]])
+
+        assert_array_equal(a[[4], 1, ...].toarray(), b[[4], 1, ...])
+        assert_array_equal(a[[2, 4], 1, ...].toarray(), b[[2, 4], 1, ...])
+        assert_array_equal(a[[4], ..., 1].toarray(), b[[4], ..., 1])
+        assert_array_equal(a[..., [4], 1].toarray(), b[..., [4], 1])
+        # fancy index gives dense
+        assert_array_equal(a[[2, 4], ..., [2, 4]], b[[2, 4], ..., [2, 4]])
+        assert_array_equal(a[..., [2, 4], [2, 4]], b[..., [2, 4], [2, 4]])
 
     def test_multiple_ellipsis_slicing(self):
         a = self.spcreator(arange(6).reshape(3, 2))


### PR DESCRIPTION
#### Reference issue

Closes #21615.

#### What does this implement/fix?

When checking indices, `scipy.sparse._index.IndexMixin._validate_indices` skip ellipsis. This PR fixes it.

I apologize for not writing a test - I have problems building scipy on my machine.