### PR TITLE
DOC/MAINT: signal: fix some typos

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2299,7 +2299,7 @@ class Bunch:
 
 def _valid_inputs(A, B, poles, method, rtol, maxiter):
     """
-    Check the poles come in complex conjugage pairs
+    Check the poles come in complex conjugate pairs
     Check shapes of A, B and poles are compatible.
     Check the method chosen is compatible with provided poles
     Return update method to use and ordered poles
@@ -2380,7 +2380,7 @@ def _KNV0(B, ker_pole, transfer_matrix, j, poles):
     # Remove xj form the base
     transfer_matrix_not_j = np.delete(transfer_matrix, j, axis=1)
     # If we QR this matrix in full mode Q=Q0|Q1
-    # then Q1 will be a single column orthogonnal to
+    # then Q1 will be a single column orthogonal to
     # Q0, that's what we are looking for !
 
     # After merge of gh-4249 great speed improvements could be achieved
@@ -2722,7 +2722,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
                 are as close as possible to the requested poles.
             computed_poles : 1-D ndarray
                 The poles corresponding to ``A-BK`` sorted as first the real
-                poles in increasing order, then the complex congugates in
+                poles in increasing order, then the complex conjugates in
                 lexicographic order.
             requested_poles : 1-D ndarray
                 The poles the algorithm was asked to place sorted as above,
@@ -2931,7 +2931,7 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
 
             # after QR Q=Q0|Q1
             # only Q0 is used to reconstruct  the qr'ed (dot Q, R) matrix.
-            # Q1 is orthogonnal to Q0 and will be multiplied by the zeros in
+            # Q1 is orthogonal to Q0 and will be multiplied by the zeros in
             # R when using mode "complete". In default mode Q1 and the zeros
             # in R are not computed
 

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -886,7 +886,7 @@ class ShortTimeFFT:
         >>> f_i = 5e-3*(t_x - t_x[N // 3])**2 + 1  # varying frequency
         >>> x = square(2*np.pi*np.cumsum(f_i)*T_x)  # the signal
 
-        The utitlized Gaussian window is 50 samples or 2.5 s long. The
+        The utilized Gaussian window is 50 samples or 2.5 s long. The
         parameter ``mfft=800`` (oversampling factor 16) and the `hop` interval
         of 2 in `ShortTimeFFT` was chosen to produce a sufficient number of
         points:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -696,7 +696,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
 
 def _calc_oa_lens(s1, s2):
-    """Calculate the optimal FFT lengths for overlapp-add convolution.
+    """Calculate the optimal FFT lengths for overlap-add convolution.
 
     The calculation is done for a single dimension.
 
@@ -3575,7 +3575,7 @@ def detrend(data: np.ndarray, axis: int = -1,
 
     Notes
     -----
-    Detrending can be interpreted as subtracting a least squares fit polyonimial:
+    Detrending can be interpreted as subtracting a least squares fit polynomial:
     Setting the parameter `type` to 'constant' corresponds to fitting a zeroth degree
     polynomial, 'linear' to a first degree polynomial. Consult the example below.
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -775,7 +775,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
     window, nperseg = _triage_segments(window, nperseg,
                                        input_length=x.shape[axis])
 
-    # Less overlap than welch, so samples are more statisically independent
+    # Less overlap than welch, so samples are more statistically independent
     if noverlap is None:
         noverlap = nperseg // 8
 
@@ -1171,7 +1171,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     .. math:: x[n]=\frac{\sum_{t}x_{t}[n]w[n-tH]}{\sum_{t}w^{2}[n-tH]}
 
     The NOLA constraint ensures that every normalization term that appears
-    in the denomimator of the OLA reconstruction equation is nonzero. Whether a
+    in the denominator of the OLA reconstruction equation is nonzero. Whether a
     choice of `window`, `nperseg`, and `noverlap` satisfy this constraint can
     be tested with `check_NOLA`.
 

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -30,7 +30,7 @@ def spline_filter(Iin, lmbda=5.0):
     Iin : array_like
         input data set
     lmbda : float, optional
-        spline smooghing fall-off value, default is `5.0`.
+        spline smoothing fall-off value, default is `5.0`.
 
     Returns
     -------

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -224,7 +224,7 @@ class TestPlacePoles:
         # should fail as ndim(B) is two
         assert_raises(ValueError, place_poles, A, B, (-2,-2,-2,-2))
 
-        #unctrollable system
+        # uncontrollable system
         assert_raises(ValueError, place_poles, np.ones((4,4)),
                       np.ones((4,2)), (1,2,3,4))
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -512,7 +512,7 @@ class TestPeakWidths:
             # empty x with peaks supplied
             peak_widths([], [1, 2])
         with raises(TypeError, match='cannot safely cast'):
-            # peak cannot be safely casted to intp
+            # peak cannot be safely cast to intp
             peak_widths(np.arange(10), [1.1, 2.3])
         with raises(ValueError, match='rel_height'):
             # rel_height is < 0

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1151,8 +1151,8 @@ def kaiser(M, beta, sym=True):
 
     The Kaiser was named for Jim Kaiser, who discovered a simple approximation
     to the DPSS window based on Bessel functions.
-    The Kaiser window is a very good approximation to the Digital Prolate
-    Spheroidal Sequence, or Slepian window, which is the transform which
+    The Kaiser window is a very good approximation to the discrete prolate
+    spheroidal sequence, or Slepian window, which is the transform which
     maximizes the energy in the main lobe of the window relative to total
     energy.
 


### PR DESCRIPTION
@lucascolley

dumped directory strings exposed a few typos

scipy/signal/windows/_windows.py

fixed typo in the following and changed to lowercase

```diff
-     The Kaiser window is a very good approximation to the Digital Prolate
-     Spheroidal Sequence, or Slepian window, which is the transform which
+     The Kaiser window is a very good approximation to the discrete prolate
+     spheroidal sequence, or Slepian window, which is the transform which
```

Is this comment correct, i.e collection not a sequence but sequences?

```
$ sed -n '2035,2044p' scipy/scipy/signal/windows/_windows.py
    # Here we want to set up an optimization problem to find a sequence
    # whose energy is maximally concentrated within band [-W,W].
    # Thus, the measure lambda(T,W) is the ratio between the energy within
    # that band, and the total energy. This leads to the eigen-system
    # (A - (l1)I)v = 0, where the eigenvector corresponding to the largest
    # eigenvalue is the sequence with maximally concentrated energy. The
    # collection of eigenvectors of this system are called Slepian
    # sequences, or discrete prolate spheroidal sequences (DPSS). Only the
    # first K, K = 2NW/dt orders of DPSS will exhibit good spectral
    # concentration
$
```