### PR TITLE
ENH: estimate condition number for sparse matrices

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -32,6 +32,7 @@ Matrix norms
 
    norm -- Norm of a sparse matrix
    onenormest -- Estimate the 1-norm of a sparse matrix
+   rinvnormest -- Estimate the 1- or inf-norm of the inverse of a sparse matrix
 
 Solving linear problems
 -----------------------
@@ -132,6 +133,7 @@ from ._interface import *
 from ._eigen import *
 from ._matfuncs import *
 from ._onenormest import *
+from ._rinvnormest import *
 from ._norm import *
 from ._expm_multiply import *
 from ._special_sparse_arrays import *

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -123,8 +123,7 @@ static PyObject *SuperLU_rinvnormest(SuperLUObject * self, PyObject * args,
         return NULL;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s", kwlist,
-                                     &PyArray_Type, &norm))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s", kwlist, &norm))
         return NULL;
 
     // norm should be a single-character string

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -151,9 +151,34 @@ static PyObject *SuperLU_rinvnormest(SuperLUObject * self, PyObject * args,
         SLU_END_THREADS;
         goto fail;
     }
-    gscon(self->type,
-          (char *)&norm_c, &self->L, &self->U, 1.0,
-          (double *)&rcond, (SuperLUStat_t *)&stat, (int *)&info);
+    float rcond_float;
+    switch(self->type) {
+        case NPY_FLOAT:
+            sgscon(
+                (char *)&norm_c, &self->L, &self->U, 1.0f,
+                (float *)&rcond_float, (SuperLUStat_t *)&stat, (int *)&info);
+                rcond = rcond_float;
+            break;
+        case NPY_DOUBLE:
+            dgscon(
+                (char *)&norm_c, &self->L, &self->U, 1.0,
+                (double *)&rcond, (SuperLUStat_t *)&stat, (int *)&info);
+            break;
+        case NPY_CFLOAT:
+            cgscon(
+                (char *)&norm_c, &self->L, &self->U, 1.0f,
+                (float *)&rcond_float, (SuperLUStat_t *)&stat, (int *)&info);
+                rcond = rcond_float;
+            break;
+        case NPY_CDOUBLE:
+            zgscon(
+                (char *)&norm_c, &self->L, &self->U, 1.0,
+                (double *)&rcond, (SuperLUStat_t *)&stat, (int *)&info);
+            break;
+        default: 
+            PyErr_SetString(PyExc_ValueError, "unsupported data type");
+            return NULL;
+    }
     SLU_END_THREADS;
 
     if (info) {

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -105,10 +105,77 @@ static PyObject *SuperLU_solve(SuperLUObject * self, PyObject * args,
     return NULL;
 }
 
+
+static PyObject *SuperLU_rinvnormest(SuperLUObject * self, PyObject * args,
+                               PyObject * kwds)
+{
+    volatile int info;
+    volatile double rcond;
+    const char* volatile norm = "1";
+    char norm_c;
+    volatile SuperLUStat_t stat = { 0 };
+    static char *kwlist[] = { "norm", NULL };
+    volatile jmp_buf *jmpbuf_ptr;
+    SLU_BEGIN_THREADS_DEF;
+
+    if (!CHECK_SLU_TYPE(self->type)) {
+        PyErr_SetString(PyExc_ValueError, "unsupported data type");
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s", kwlist,
+                                     &PyArray_Type, &norm))
+        return NULL;
+
+    // norm should be a single-character string
+    int singlechar = (norm[0] != 0 || norm[1] == 0);
+    if (singlechar && (norm[0] == '0' || norm[0] == '1')){
+        norm_c = '1';
+    } else if (singlechar && norm[0] == 'I'){
+        norm_c = 'I';
+    } else {
+        PyErr_SetString(PyExc_ValueError, "norm must be \"0\", \"1\", or \"I\"");
+        return NULL;
+    }
+
+    jmpbuf_ptr = (volatile jmp_buf *)superlu_python_jmpbuf();
+    if (setjmp(*(jmp_buf*)jmpbuf_ptr)) {
+        goto fail;
+    }
+
+    StatInit((SuperLUStat_t *)&stat);
+
+
+    jmpbuf_ptr = (volatile jmp_buf *)superlu_python_jmpbuf();
+    SLU_BEGIN_THREADS;
+    if (setjmp(*(jmp_buf*)jmpbuf_ptr)) {
+        SLU_END_THREADS;
+        goto fail;
+    }
+    gscon(self->type,
+          (char *)&norm_c, &self->L, &self->U, 1.0,
+          (double *)&rcond, (SuperLUStat_t *)&stat, (int *)&info);
+    SLU_END_THREADS;
+
+    if (info) {
+        PyErr_SetString(PyExc_SystemError,
+                        "gscon was called with invalid arguments");
+        goto fail;
+    }
+
+    StatFree((SuperLUStat_t *)&stat);
+    return PyFloat_FromDouble(rcond);
+
+  fail:
+    XStatFree((SuperLUStat_t *)&stat);
+    return NULL;
+}
+
 /** table of object methods
  */
 PyMethodDef SuperLU_methods[] = {
     {"solve", (PyCFunction) SuperLU_solve, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"rinvnormest", (PyCFunction) SuperLU_rinvnormest, METH_VARARGS | METH_KEYWORDS, NULL},
     {NULL, NULL}                /* sentinel */
 };
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.h
@@ -145,10 +145,10 @@ jmp_buf *superlu_python_jmpbuf(void);
     SuperLUStat_t *h, int *i
 #define gssv_ARGS_REF a,b,c,d,e,f,g,h,i
 
-#define gscon_ARGS                                               \
-    char *a, SuperMatrix *b, SuperMatrix *c,                 \
-    double d, double *e, SuperLUStat_t *f, int *g 
-#define gscon_ARGS_REF a,b,c,d,e,f,g
+void sgscon(char*, SuperMatrix*, SuperMatrix*, float, float*, SuperLUStat_t*, int*);
+void dgscon(char*, SuperMatrix*, SuperMatrix*, double, double*, SuperLUStat_t*, int*);
+void cgscon(char*, SuperMatrix*, SuperMatrix*, float, float*, SuperLUStat_t*, int*);
+void zgscon(char*, SuperMatrix*, SuperMatrix*, double, double*, SuperLUStat_t*, int*);
 
 #define Create_Dense_Matrix_ARGS                               \
     SuperMatrix *a, int b, int c, void *d, int e,              \
@@ -175,7 +175,6 @@ TYPE_GENERIC_FUNC(gstrf, void);
 TYPE_GENERIC_FUNC(gsitrf, void);
 TYPE_GENERIC_FUNC(gstrs, void);
 TYPE_GENERIC_FUNC(gssv, void);
-TYPE_GENERIC_FUNC(gscon, void);
 TYPE_GENERIC_FUNC(Create_Dense_Matrix, void);
 TYPE_GENERIC_FUNC(Create_CompRow_Matrix, void);
 TYPE_GENERIC_FUNC(Create_CompCol_Matrix, void);

--- a/scipy/sparse/linalg/_dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.h
@@ -145,6 +145,11 @@ jmp_buf *superlu_python_jmpbuf(void);
     SuperLUStat_t *h, int *i
 #define gssv_ARGS_REF a,b,c,d,e,f,g,h,i
 
+#define gscon_ARGS                                               \
+    char *a, SuperMatrix *b, SuperMatrix *c,                 \
+    double d, double *e, SuperLUStat_t *f, int *g 
+#define gscon_ARGS_REF a,b,c,d,e,f,g
+
 #define Create_Dense_Matrix_ARGS                               \
     SuperMatrix *a, int b, int c, void *d, int e,              \
     Stype_t f, Dtype_t g, Mtype_t h
@@ -170,6 +175,7 @@ TYPE_GENERIC_FUNC(gstrf, void);
 TYPE_GENERIC_FUNC(gsitrf, void);
 TYPE_GENERIC_FUNC(gstrs, void);
 TYPE_GENERIC_FUNC(gssv, void);
+TYPE_GENERIC_FUNC(gscon, void);
 TYPE_GENERIC_FUNC(Create_Dense_Matrix, void);
 TYPE_GENERIC_FUNC(Create_CompRow_Matrix, void);
 TYPE_GENERIC_FUNC(Create_CompCol_Matrix, void);

--- a/scipy/sparse/linalg/_rinvnormest.py
+++ b/scipy/sparse/linalg/_rinvnormest.py
@@ -1,0 +1,45 @@
+from scipy.sparse.linalg import splu
+
+__all__ = ['rinvnormest']
+
+
+def rinvnormest(A, norm="1"):
+    """
+    Compute an estimate for the reciprocal of the norm of the inverse 
+    of a sparse matrix.
+
+    Parameters
+    ----------
+    A : ndarray or other linear operator
+        A sparse matrix for which an LU matrix can be computed.
+    norm : string, optional
+        "1"/"0" [default] computes the 1-norm, "I" computes the inf-norm.
+
+    Returns
+    -------
+    est : float
+        An estimate of the norm of the inverse matrix.
+
+    Notes
+    -----
+    Computes an LU decomposition and runs the gscon procedure from SuperLU.
+    Use scipy.sparse.linalg.SuperLU.rinvnormest if you already have an LU 
+    decomposition.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse.linalg import rinvnormest
+    >>> A = csc_matrix([[1., 0., 0.], [5., 8., 2.], [0., -1., 0.]], dtype=float)
+    >>> A.toarray()
+    array([[ 1.,  0.,  0.],
+           [ 5.,  8.,  2.],
+           [ 0., -1.,  0.]])
+    >>> rinvnormest(A,norm="1")
+    0.2
+    >>> 1/np.linalg.norm(np.linalg.inv(A.toarray()), ord=1)
+    0.2
+    """
+    lu_decomposition = splu(A)
+    return lu_decomposition.rinvnormest(norm=norm)

--- a/scipy/sparse/linalg/_rinvnormest.py
+++ b/scipy/sparse/linalg/_rinvnormest.py
@@ -78,9 +78,9 @@ def cond1est(A):
     array([[ 1.,  0.,  0.],
            [ 5.,  8.,  2.],
            [ 0., -1.,  0.]])
-    >>> cond1est(A,norm="1")
-    0.022222222222222223
-    >>> 1./np.linalg.cond(A.toarray(), p=1)
-    0.022222222222222223
+    >>> cond1est(A)
+    45.0
+    >>> np.linalg.cond(A.toarray(), p=1)
+    45.0
     """
-    return rinvnormest(A)/onenormest(A)
+    return onenormest(A)/rinvnormest(A)

--- a/scipy/sparse/linalg/_rinvnormest.py
+++ b/scipy/sparse/linalg/_rinvnormest.py
@@ -12,7 +12,8 @@ def rinvnormest(A, norm="1"):
     Parameters
     ----------
     A : ndarray or other linear operator
-        A sparse matrix for which an LU matrix can be computed.
+        A sparse matrix for which an LU matrix can be computed. CSC would
+        be most efficient.
     norm : string, optional
         "1"/"0" [default] computes the 1-norm, "I" computes the inf-norm.
 
@@ -53,12 +54,19 @@ def cond1est(A):
     Parameters
     ----------
     A : ndarray or other linear operator
-        A sparse matrix for which an LU matrix can be computed.
+        A sparse matrix for which an LU matrix can be computed. CSC would
+        be most efficient.
 
     Returns
     -------
     cond : float
         An estimate of the 1-norm condition number of A.
+
+    Notes
+    -----
+    Computes an LU decomposition and runs the gscon procedure from SuperLU.
+    Use scipy.sparse.linalg.SuperLU.rinvnormest if you already have an LU 
+    decomposition.
 
     Examples
     --------

--- a/scipy/sparse/linalg/_rinvnormest.py
+++ b/scipy/sparse/linalg/_rinvnormest.py
@@ -1,6 +1,7 @@
 from scipy.sparse.linalg import splu
+from scipy.sparse.linalg._onenormest import *
 
-__all__ = ['rinvnormest']
+__all__ = ['rinvnormest', 'cond1est']
 
 
 def rinvnormest(A, norm="1"):
@@ -43,3 +44,35 @@ def rinvnormest(A, norm="1"):
     """
     lu_decomposition = splu(A)
     return lu_decomposition.rinvnormest(norm=norm)
+
+def cond1est(A):
+    """
+    Compute an estimate for the reciprocal of the condition number 
+    of a sparse matrix, using 1-norms.
+
+    Parameters
+    ----------
+    A : ndarray or other linear operator
+        A sparse matrix for which an LU matrix can be computed.
+
+    Returns
+    -------
+    cond : float
+        An estimate of the 1-norm condition number of A.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse.linalg import cond1est
+    >>> A = csc_matrix([[1., 0., 0.], [5., 8., 2.], [0., -1., 0.]], dtype=float)
+    >>> A.toarray()
+    array([[ 1.,  0.,  0.],
+           [ 5.,  8.,  2.],
+           [ 0., -1.,  0.]])
+    >>> cond1est(A,norm="1")
+    0.022222222222222223
+    >>> 1./np.linalg.cond(A.toarray(), p=1)
+    0.022222222222222223
+    """
+    return rinvnormest(A)/onenormest(A)

--- a/scipy/sparse/linalg/meson.build
+++ b/scipy/sparse/linalg/meson.build
@@ -5,6 +5,7 @@ py3.install_sources([
     '_matfuncs.py',
     '_norm.py',
     '_onenormest.py',
+    '_rinvnormest.py',
     '_svdp.py',
     '_special_sparse_arrays.py',
     'dsolve.py',

--- a/scipy/sparse/linalg/tests/meson.build
+++ b/scipy/sparse/linalg/tests/meson.build
@@ -8,6 +8,7 @@ py3.install_sources([
     'test_onenormest.py',
     'test_propack.py',
     'test_pydata_sparse.py',
+    'test_rinvnormest.py',
     'test_special_sparse_arrays.py'
   ],
   subdir: 'scipy/sparse/linalg/tests',

--- a/scipy/sparse/linalg/tests/test_rinvnormest.py
+++ b/scipy/sparse/linalg/tests/test_rinvnormest.py
@@ -2,37 +2,40 @@
 """
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal, assert_
+from numpy.testing import assert_allclose, assert_raises
 import pytest
 import scipy.linalg
 import scipy.sparse.linalg
 
 class TestRinvnormest:
-    @pytest.mark.parametrize("norm", [1, np.inf])
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
-    def test_rinvnormest(self, norm, dtype):
-        n = 5
+    def generate_matrix(self, n, dtype):
         rng = np.random.default_rng(789002319)
         rvs = rng.random
         A = scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
             random_state=rng, data_rvs=rvs)
-        A = A + scipy.sparse.eye(n, format="lil") # make it likely invertible
+        A = A + scipy.sparse.eye(n, format="lil", dtype=dtype) # make it likely invertible
         A = A.tocsc()
+        return A
+
+    @pytest.mark.parametrize("norm", [1, np.inf])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+    def test_rinvnormest(self, norm, dtype):
+        A = self.generate_matrix(5, dtype)
         true_rinvnorm = 1/np.linalg.norm(np.linalg.inv(A.toarray()), ord=norm)
         est_rinvnorm = scipy.sparse.linalg.rinvnormest(A, norm="1" if norm==1 else "I")
         assert_allclose(est_rinvnorm, true_rinvnorm)
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
     def test_cond1normest(self, dtype):
-        n = 5
-        rng = np.random.default_rng(789002319)
-        rvs = rng.random
-        A = scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
-            random_state=rng, data_rvs=rvs)
-        A = A + scipy.sparse.eye(n, format="lil") # make it likely invertible
-        A = A.tocsc()
+        A = self.generate_matrix(5, dtype)
         true_cond1norm = np.linalg.cond(A.toarray(), p=1)
         est_cond1norm = scipy.sparse.linalg.cond1est(A)
         assert_allclose(est_cond1norm, true_cond1norm)
+
+    def test_error_unsupported_norm(self):
+        A = self.generate_matrix(5, np.float64)
+        with assert_raises(ValueError):
+            scipy.sparse.linalg.splu(A).rinvnormest(norm="2")
+        
 
 

--- a/scipy/sparse/linalg/tests/test_rinvnormest.py
+++ b/scipy/sparse/linalg/tests/test_rinvnormest.py
@@ -13,6 +13,9 @@ class TestRinvnormest:
         rvs = rng.random
         A = scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
             random_state=rng, data_rvs=rvs)
+        if dtype==np.complex64 or dtype==np.complex128:
+          A += 1j * scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
+              random_state=rng, data_rvs=rvs)
         A = A + scipy.sparse.eye(n, format="lil", dtype=dtype) # make it likely invertible
         A = A.tocsc()
         return A
@@ -30,7 +33,7 @@ class TestRinvnormest:
         A = self.generate_matrix(5, dtype)
         true_cond1norm = np.linalg.cond(A.toarray(), p=1)
         est_cond1norm = scipy.sparse.linalg.cond1est(A)
-        assert_allclose(est_cond1norm, true_cond1norm)
+        assert_allclose(est_cond1norm, true_cond1norm, rtol=1e-4)
 
     def test_error_unsupported_norm(self):
         A = self.generate_matrix(5, np.float64)

--- a/scipy/sparse/linalg/tests/test_rinvnormest.py
+++ b/scipy/sparse/linalg/tests/test_rinvnormest.py
@@ -1,0 +1,26 @@
+"""Test functions for the sparse.linalg._rinvnormest module
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal, assert_
+import pytest
+import scipy.linalg
+import scipy.sparse.linalg
+
+class TestRinvnormest:
+    @pytest.mark.parametrize("norm", [1, np.inf])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+    def test_rinvnormest(self, norm, dtype):
+        n = 5
+        rng = np.random.default_rng(789002319)
+        rvs = rng.random
+        A = scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
+            random_state=rng, data_rvs=rvs)
+        A = A + scipy.sparse.eye(n, format="lil") # make it likely invertible
+        A = A.tocsc()
+        true_rinvnorm = 1/np.linalg.norm(np.linalg.inv(A.toarray()), ord=norm)
+        est_rinvnorm = scipy.sparse.linalg.rinvnormest(A, norm="1" if norm==1 else "I")
+        assert_allclose(est_rinvnorm, true_rinvnorm)
+
+
+

--- a/scipy/sparse/linalg/tests/test_rinvnormest.py
+++ b/scipy/sparse/linalg/tests/test_rinvnormest.py
@@ -22,5 +22,17 @@ class TestRinvnormest:
         est_rinvnorm = scipy.sparse.linalg.rinvnormest(A, norm="1" if norm==1 else "I")
         assert_allclose(est_rinvnorm, true_rinvnorm)
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+    def test_cond1normest(self, dtype):
+        n = 5
+        rng = np.random.default_rng(789002319)
+        rvs = rng.random
+        A = scipy.sparse.random(n, n, density=0.3, format="lil", dtype=dtype,
+            random_state=rng, data_rvs=rvs)
+        A = A + scipy.sparse.eye(n, format="lil") # make it likely invertible
+        A = A.tocsc()
+        true_cond1norm = np.linalg.cond(A.toarray(), p=1)
+        est_cond1norm = scipy.sparse.linalg.cond1est(A)
+        assert_allclose(est_cond1norm, true_cond1norm)
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-18969

#### What does this implement/fix?
Add
- `scipy.sparse.linalg.SuperLU.rinvnormest` to compute reciprocal norm of inverse matrix given an LU decomposition,
- `scipy.sparse.linalg.rinvnormest` to compute LU decomposition and call the function mentioned previously,
- `scipy.sparse.linalg.cond1est` to compute the 1-norm condition number, calling the function mentioned previously  and `scipy.sparse.linalg.onenormest`


