### PR TITLE
ENH: `optimize.differential_evolution`: respect workers when polishing

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1220,7 +1220,8 @@ class DifferentialEvolutionSolver:
                                   UserWarning, stacklevel=2)
             if self.disp:
                 print(f"Polishing solution with '{polish_method}'")
-            result = minimize(self.func,
+            result = minimize(lambda x:
+                                list(self._mapwrapper(self.func, np.atleast_2d(x)))[0],
                               np.copy(DE_result.x),
                               method=polish_method,
                               bounds=self.limits.T,

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -167,6 +167,13 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         being studied then the `trust-constr` method is used instead. For large
         problems with many constraints, polishing can take a long time due to
         the Jacobian computations.
+
+        .. versionchanged:: 1.15.0
+            If `workers` is specified then the map-like callable that wraps
+            `func` is supplied to `minimize` instead of it using `func`
+            directly. This allows the caller to control how and where the
+            invocations actually run.
+
     init : str or array-like, optional
         Specify which type of population initialization is performed. Should be
         one of:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -720,7 +720,7 @@ class TestDifferentialEvolutionSolver:
             # is being overridden by the workers keyword
             with warns(UserWarning):
                 with DifferentialEvolutionSolver(rosen, bounds, workers=p.map) as s:
-                    pass
+                    solver.solve()
             assert s._updating == 'deferred'
 
     @pytest.mark.fail_slow(10)
@@ -1697,27 +1697,3 @@ class TestDifferentialEvolutionSolver:
                 bounds,
                 strategy=custom_strategy_fn
             )
-
-    @pytest.mark.fail_slow(10)
-    def test_asyncio(self):
-        def quadratic(x):
-            return np.sum(x**2)
-
-        async def asyncio_quadratic(x):
-            await asyncio.sleep(0.01)
-            return quadratic(x)
-
-        async def gather(func, args):
-            return await asyncio.gather(*(func(arg) for arg in args))
-
-        def asyncio_map(func, args):
-            return asyncio.run(gather(func, args))
-
-        res1 = differential_evolution(quadratic, self.bounds,
-                                      updating='deferred')
-        res2 = differential_evolution(asyncio_quadratic, self.bounds,
-                                      workers=asyncio_map, updating='deferred')
-
-        assert res1.success
-        assert res2.success
-        assert_allclose(res1.x, res2.x)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1,7 +1,6 @@
 """
 Unit tests for the differential global minimization algorithm.
 """
-import asyncio
 import multiprocessing
 from multiprocessing.dummy import Pool as ThreadPool
 import platform


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
The polishing stage (when `polish=True`, which is the default) in `scipy.optimize.differential_evolution` calls `func` directly and thus sidesteps any map-like callable passed as the `workers` argument that is supposed to control how/where `func` actually runs.

This PR makes it so that polishing evaluations also go through the same mechanism as DE evaluations, which IMO is less surprising and allows the caller to control via `workers` how and where these invocations actually run.

The change is intended to support the more general uses of `workers`, such as passing a map-like callable that does the actual evaluations on a different machine.

#### Additional information
<!--Any additional information you think is important.-->
