### PR TITLE
BUG: sparse.linalg: Set `t=2` in `test_onenormest_table_6_t_1`  in `scipy/sparse/linalg/test_onenormest.py` 

### DIFF
--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -249,4 +249,3 @@ class TestAlgorithm_2_2:
 
             # Compute the 1-norm bounds.
             g, ind = _algorithm_2_2(A, A.T, t)
-

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -141,14 +141,14 @@ class TestOnenormest:
         assert_allclose(est, est_plain)
 
     @pytest.mark.xslow
-    def test_onenormest_table_6_t_1(self):
+    def test_onenormest_table_6_t_2(self):
         #TODO this test seems to give estimates that match the table,
         #TODO even though no attempt has been made to deal with
         #TODO complex numbers in the one-norm estimation.
         # This will take multiple seconds if your computer is slow like mine.
         # It is stochastic, so the tolerance could be too strict.
         np.random.seed(1234)
-        t = 1
+        t = 2
         n = 100
         itmax = 5
         nsamples = 5000


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/17385 (also referenced in https://github.com/scipy/scipy/issues/15384)

#### What does this implement/fix?
<!--Please explain your changes.-->

With this change, `SCIPY_XSLOW=1` passes the tests. I think the new definition of `sign_round_up` wasn't tested in CI so got ignored. I found the previous definition from https://github.com/scipy/scipy/blob/0c222a6214207b7f6304b236d1a677706b76a59e/scipy/sparse/linalg/_onenormest.py#L110-L112 works well with the tests in `main`.

```zsh
scipy/sparse/linalg/tests/test_onenormest.py ......                                                                      [ 31%]
(scipy-dev) 16:49:04:~/Quansight/scipy % printenv SCIPY_XSLOW
1
```

#### Additional information
<!--Any additional information you think is important.-->
