### PR TITLE
BUG:signal: Fix passing lti as system to cont2discrete

### DIFF
--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -431,8 +431,9 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
     >>> plt.show()
 
     """
-    if len(system) == 1:
-        return system.to_discrete()
+    if hasattr(system, 'to_discrete') and callable(system.to_discrete):
+        return system.to_discrete(dt=dt, method=method, alpha=alpha)
+
     if len(system) == 2:
         sysd = cont2discrete(tf2ss(system[0], system[1]), dt, method=method,
                              alpha=alpha)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -353,18 +353,26 @@ class TestC2dLti:
         B = np.array([[0], [1]])
         C = np.array([[1, 0]])
         D = 0
+        dt = 0.05
 
         A_res = np.array([[0.985136404135682, 0.004876671474795],
                           [0.009753342949590, 0.965629718236502]])
         B_res = np.array([[0.000122937599964], [0.049135527547844]])
 
         sys_ssc = lti(A, B, C, D)
-        sys_ssd = sys_ssc.to_discrete(0.05)
+        sys_ssd = sys_ssc.to_discrete(dt=dt)
 
         xp_assert_close(sys_ssd.A, A_res)
         xp_assert_close(sys_ssd.B, B_res)
         xp_assert_close(sys_ssd.C, C)
         xp_assert_close(sys_ssd.D, np.zeros_like(sys_ssd.D))
+
+        sys_ssd2 = c2d(sys_ssc, dt=dt)
+
+        xp_assert_close(sys_ssd2.A, A_res)
+        xp_assert_close(sys_ssd2.B, B_res)
+        xp_assert_close(sys_ssd2.C, C)
+        xp_assert_close(sys_ssd2.D, np.zeros_like(sys_ssd2.D))
 
     def test_c2d_tf(self):
 


### PR DESCRIPTION
#### Reference issue
Fixes #11312

#### What does this implement/fix?
This should fix passing `StateSpaceContinuous` inherited classes to `cont2discrete` as system argument.

#### Additional information
Because #13521 looks inactive anymore, i am making my own PR.

Best way to fix this IMO would be to just check if system is instance of `StateSpaceContinuous`, however we can't do `import _ltisys` in `_lti_conversion.py` because it makes circular dependency error.

However as i found there unique `to_discrete` method only for classes which inherit `StateSpaceContinuous`. By `grep -r "to_discrete" scipy.git/scipy` this function is only used in scipy/signal.
So my fix is to check if system has `to_discrete` method and use it for cont2discrete. This also removes `len(system) == 1` check because it probably will never be called and also i can't find any implementation of `to_discrete` method in the code that takes no arguments.

I also added simple test for this and tested with `python -m pytest --pyargs scipy/signal` to pass.
