### PR TITLE
ENH: integrate.cubature: support non-rectangular regions of integration

### DIFF
--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -243,7 +243,7 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     xp = array_namespace(a, b)
     max_subdivisions = float("inf") if max_subdivisions is None else max_subdivisions
-    points = [] if points is None else points
+    points = [] if points is None else [xp.asarray(p, dtype=xp.float64) for p in points]
 
     # Convert a and b to arrays
     a = xp.asarray(a, dtype=xp.float64)
@@ -260,9 +260,9 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     # If any of limits are the wrong way around (a > b), flip them and keep track of
     # the sign.
-    sign = (-1) ** np.sum(a > b)
-    a_flipped = np.min(np.array([a, b]), axis=0)
-    b_flipped = np.max(np.array([a, b]), axis=0)
+    sign = (-1.0) ** xp.sum(xp.astype(a > b, xp.float64))
+    a_flipped = xp.min(xp.asarray([a, b]), axis=0)
+    b_flipped = xp.max(xp.asarray([a, b]), axis=0)
 
     a, b = a_flipped, b_flipped
 
@@ -397,10 +397,12 @@ def _process_subregion(data):
 
 
 def _is_strictly_in_region(point, a, b):
-    if (point == a).all() or (point == b).all():
+    xp = array_namespace(point, a, b)
+
+    if xp.all(point == a) or xp.all(point == b):
         return False
 
-    return (a <= point).all() and (point <= b).all()
+    return xp.all(a <= point) and xp.all(point <= b)
 
 
 def _split_at_points(a, b, points):
@@ -411,7 +413,6 @@ def _split_at_points(a, b, points):
     any of the subregions.
     """
 
-    points = np.sort(points)
     regions = [(a, b)]
 
     for point in points:

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -830,7 +830,7 @@ class _InfiniteLimitsTransform(_VariableTransform):
             B_{i}(x_1, \ldots, x_n, y_1, \ldots, y_{i-1})
             - A_i(x_1, \ldots, x_n, y_1, \ldots, y_{i-1})
         }{2}
-    """
+    """  # noqa: E501
 
     def __init__(self, f, a, b):
         self._xp = array_namespace(a, b)

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -176,32 +176,34 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
         Object containing the results of the estimation. It has the following
         attributes:
 
-            estimate : ndarray
-                Estimate of the value of the integral over the overall region specified.
-            error : ndarray
-                Estimate of the error of the approximation over the overall region
-                specified.
-            status : str
-                Whether the estimation was successful. Can be either: "converged",
-                "not_converged".
-            subdivisions : int
-                Number of subdivisions performed.
-            atol, rtol : float
-                Requested tolerances for the approximation.
-            patches: list of object
-                List of objects containing the estimates of the integral over smaller
-                patches of the domain.
+        estimate : ndarray
+            Estimate of the value of the integral over the overall region specified.
+        error : ndarray
+            Estimate of the error of the approximation over the overall region
+            specified.
+        status : str
+            Whether the estimation was successful. Can be either: "converged",
+            "not_converged".
+        subdivisions : int
+            Number of subdivisions performed.
+        atol, rtol : float
+            Requested tolerances for the approximation.
+        patches: list of object
+            List of objects containing the estimates of the integral over smaller
+            patches of the domain.
+
 
         Each object in ``patches`` has the following attributes:
 
-            a, b : ndarray
-                Points describing the corners of the patch. If the original integral
-                contained infinite limits or was over a region described by `region`,
-                then `a` and `b` are in the transformed coordinates.
-            estimate : ndarray
-                Estimate of the value of the integral over this patch.
-            error : ndarray
-                Estimate of the error of the approximation over this patch.
+        a, b : ndarray
+            Points describing the corners of the patch. If the original integral
+            contained infinite limits or was over a region described by `region`,
+            then `a` and `b` are in the transformed coordinates.
+        estimate : ndarray
+            Estimate of the value of the integral over this patch.
+        error : ndarray
+            Estimate of the error of the approximation over this patch.
+
 
     Notes
     -----
@@ -302,7 +304,7 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     To specify this type of integral programatically, the limits should be specified as
     two arrays, ``a`` and ``b`` for the constant limits, and a list of callables
-    ``region`` describing the function limits.
+    ``region`` describing the function limits::
 
         a = [a_1, ..., a_n]
         b = [b_1, ..., b_n]
@@ -1037,7 +1039,7 @@ class _FuncLimitsTransform(_VariableTransform):
 
     To specify this type of integral programatically, the limits should be specified as
     two arrays, ``a`` and ``b`` for the constant limits, and a list of callables
-    ``region`` describing the function limits.
+    ``region`` describing the function limits::
 
         a = [a_1, ..., a_n]
         b = [b_1, ..., b_n]

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -811,7 +811,7 @@ class _VariableTransform:
     """
 
     @property
-    def transformed_limits(self, a, b):
+    def transformed_limits(self):
         """
         New limits of integration after applying the transformation.
         """

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -147,7 +147,7 @@ class Rule:
         est = self.estimate(f, a, b, args)
         refined_est = 0
 
-        for a_k, b_k in _subregion_coordinates(a, b):
+        for a_k, b_k in _split_patch(a, b):
             refined_est += self.estimate(f, a_k, b_k, args)
 
         return self.xp.abs(est - refined_est)
@@ -444,10 +444,10 @@ def _cartesian_product(arrays):
     return result
 
 
-def _subregion_coordinates(a, b, split_at=None):
+def _split_patch(a, b, split_at=None):
     """
-    Given the coordinates of a region like a=[0, 0] and b=[1, 1], yield the coordinates
-    of all subregions split at a specific point (by default the midpoint). For a=[0, 0]
+    Given the coordinates of a patch like a=[0, 0] and b=[1, 1], yield the coordinates
+    of all subpatch split at a specific point (by default the midpoint). For a=[0, 0]
     and b=[1, 1], this would be::
 
         ([0, 0], [1/2, 1/2]),

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -1,7 +1,5 @@
 from scipy._lib._array_api import array_namespace, xp_size
 
-import math
-
 from functools import cached_property
 
 
@@ -500,7 +498,7 @@ def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
 
     # Also need to multiply the weights by a scale factor equal to the determinant
     # of the Jacobian for this coordinate change.
-    weight_scale_factor = math.prod(lengths) / 2**rule_ndim
+    weight_scale_factor = xp.prod(lengths) / 2**rule_ndim
     weights = orig_weights * weight_scale_factor
 
     f_nodes = f(nodes, *args)

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -444,22 +444,24 @@ def _cartesian_product(arrays):
     return result
 
 
-def _subregion_coordinates(a, b):
+def _subregion_coordinates(a, b, split_at=None):
     """
     Given the coordinates of a region like a=[0, 0] and b=[1, 1], yield the coordinates
-    of all subregions, which in this case would be::
+    of all subregions split at a specific point (by default the midpoint). For a=[0, 0]
+    and b=[1, 1], this would be::
 
         ([0, 0], [1/2, 1/2]),
         ([0, 1/2], [1/2, 1]),
         ([1/2, 0], [1, 1/2]),
         ([1/2, 1/2], [1, 1])
     """
-
     xp = array_namespace(a, b)
-    m = (a + b) * 0.5
 
-    left = [xp.asarray([a[i], m[i]]) for i in range(a.shape[0])]
-    right = [xp.asarray([m[i], b[i]]) for i in range(b.shape[0])]
+    if split_at is None:
+        split_at = (a + b) / 2
+
+    left = [xp.asarray([a[i], split_at[i]]) for i in range(a.shape[0])]
+    right = [xp.asarray([split_at[i], b[i]]) for i in range(b.shape[0])]
 
     a_sub = _cartesian_product(left)
     b_sub = _cartesian_product(right)

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1529,8 +1529,8 @@ class TestRulesCubature:
 
 @array_api_compatible
 @skip_xp_backends(
-    'jax',
-    reasons=['transforms make use of boolean indexing assignment'],
+    "jax.numpy",
+    reasons=["transforms make use of indexing assignment"],
 )
 class TestTransformations:
     @pytest.mark.parametrize(("a", "b", "points"), [

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -981,113 +981,250 @@ class TestCubatureProblems:
             err_msg=f"error_estimate={res.error}, subdivisions={res.subdivisions}"
         )
 
-    @pytest.mark.parametrize("problem", [
-        (
-            # Integrate
-            #   f(x_1, x_2, x_3) = x_1
-            # with limits
-            #   a = [0, 0, 0]
-            #   b = [1, 1, 1]
-
-            # f
-            lambda x: x[:, 0],
-
-            # exact solution
-            0.5,
-
-            # args
-            (),
-
-            # a & b
-            np.array([0, 0]),
-            np.array([1, 1]),
-
-            # region, here just constants
-            # [
-            lambda x: (
-                np.array([np.zeros(x.shape[0])]),
-                np.array([np.ones(x.shape[0])]),
+    @pytest.mark.parametrize(
+        "problem",
+        [
+            (
+                # Integrate
+                #   f(x_1, x_2, x_3) = x_1
+                # with limits
+                #   a = [0, 0, 0]
+                #   b = [1, 1, 1]
+                # f
+                lambda x: x[:, 0],
+                # exact solution
+                0.5,
+                # args
+                (),
+                # a & b
+                np.array([0, 0]),
+                np.array([1, 1]),
+                # region, here just constants
+                [
+                    lambda x: (
+                        np.zeros(x.shape[0]).reshape(-1, 1),
+                        np.ones(x.shape[0]).reshape(-1, 1),
+                    ),
+                ],
             ),
-            # ],
-        ),
-        (
-            # Integrate
-            #   f(x_1, x_2, x_3) = 1
-            # with limits
-            #   a = [0, 0, 0]
-            #   b = [1, 1, x_1 * x_2]
-
-            lambda x: np.ones(x.shape[0]),
-            0.25,
-            (),
-            np.array([0, 0]),
-            np.array([1, 1]),
-            # [
-            lambda x: (
-                np.array([np.zeros(x.shape[0])]),
-                np.array([x[:, 0] * x[:, 1]]),
+            (
+                # Integrate
+                #   f(x_1, x_2, x_3) = 1
+                # with limits
+                #   a = [0, 0, 0]
+                #   b = [1, 1, x_1 * x_2]
+                lambda x: np.ones(x.shape[0]),
+                0.25,
+                (),
+                np.array([0, 0]),
+                np.array([1, 1]),
+                [
+                    lambda x: (
+                        np.zeros(x.shape[0]).reshape(-1, 1),
+                        (x[:, 0] * x[:, 1]).reshape(-1, 1),
+                    ),
+                ],
             ),
-            # ],
-        ),
-        (
-            # Integrate
-            #   f(x_1, ..., x_n) = 1
-            # with limits
-            #   a = [-1, -sqrt(1 - x_1**2)]
-            #   b = [1, sqrt(1 - x_1**2)]
-
-            lambda x: np.ones(x.shape[0]),
-            np.pi,
-            (),
-            np.array([-1]),
-            np.array([1]),
-            # [
-            lambda x: (
-                np.array([-np.sqrt(1 - x[:, 0]**2)]),
-                np.array([np.sqrt(1 - x[:, 0]**2)]),
+            (
+                # Integrate
+                #   f(x_1, ..., x_n) = 1
+                # with limits
+                #   a = [-1, -sqrt(1 - x_1**2)]
+                #   b = [1, sqrt(1 - x_1**2)]
+                lambda x: np.ones(x.shape[0]),
+                np.pi,
+                (),
+                np.array([-1]),
+                np.array([1]),
+                [
+                    lambda x: (
+                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                    ),
+                ],
             ),
-            # ],
-        ),
-        (
-            # Integrate
-            #   f(x_1, x_2) = 1
-            # with limits
-            #   a = [-inf, -exp(-x_1**2)]
-            #   b = [inf, exp(x_1**2)]
-
-            lambda x: np.ones(x.shape[0]),
-            2*math.sqrt(np.pi),
-            (),
-            np.array([-np.inf]),
-            np.array([np.inf]),
-            # [
-            lambda x: (
-                np.array([-np.exp(-x[:, 0]**2)]),
-                np.array([np.exp(-x[:, 0]**2)]),
+            (
+                # Integrate
+                #   f(x_1, x_2) = 1
+                # with limits
+                #   a = [-inf, -exp(-x_1**2)]
+                #   b = [inf, exp(x_1**2)]
+                lambda x: np.ones(x.shape[0]),
+                2 * math.sqrt(np.pi),
+                (),
+                np.array([-np.inf]),
+                np.array([np.inf]),
+                [
+                    lambda x: (
+                        -np.exp(-x[:, 0] ** 2).reshape(-1, 1),
+                        np.exp(-x[:, 0] ** 2).reshape(-1, 1),
+                    ),
+                ],
             ),
-            # ],
-        ),
-        (
-            # Integrate
-            #   f(x_1, x_2) = n
-            # with limits
-            #   a = [-inf, -exp(-x_1**2)]
-            #   b = [inf, exp(x_1**2)]
-            # for n = range(5)
-
-            lambda x, n: np.tile(n, (x.shape[0], 1)),
-            np.arange(5) * 2*math.sqrt(np.pi),
-            (np.arange(5),),
-            np.array([-np.inf]),
-            np.array([np.inf]),
-            # [
-            lambda x: (
-                np.array([-np.exp(-x[:, 0]**2)]),
-                np.array([np.exp(-x[:, 0]**2)]),
+            (
+                # Integrate
+                #   f(x_1, x_2) = n
+                # with limits
+                #   a = [-inf, -exp(-x_1**2)]
+                #   b = [inf, exp(x_1**2)]
+                # for n = range(5)
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                np.arange(5) * 2 * math.sqrt(np.pi),
+                (np.arange(5),),
+                np.array([-np.inf]),
+                np.array([np.inf]),
+                [
+                    lambda x: (
+                        -np.exp(-x[:, 0] ** 2).reshape(-1, 1),
+                        np.exp(-x[:, 0] ** 2).reshape(-1, 1),
+                    ),
+                ],
             ),
-            # ],
-        )
-    ])
+            (
+                # Integrate
+                #   f(x, y, z) = n
+                # with limits
+                #   a = [-1, -sqrt(1-x^2), -sqrt(1-x^2-y^2)],
+                #   b = [1, sqrt(1-x^2), sqrt(1-x^2-y^2)]
+                # for n = range(5)
+                # i.e. integrate a unit ball with densities 0, 1, 2, 3, 4
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                4 / 3 * math.pi * np.arange(5),
+                (np.arange(5),),
+                np.array([-1]),
+                np.array([1]),
+                [
+                    lambda x: (
+                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                    ),
+                    lambda x: (
+                        -np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                        np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                    ),
+                ],
+            ),
+            (
+                # Integrate
+                #   f(x, y, z, w) = n
+                # with limits
+                #   a = [-1, -1, -sqrt(1-x^2), -sqrt(1-x^2)],
+                #   b = [1, 1, sqrt(1-x^2), sqrt(1-x^2)]
+                # for n = range(5)
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                32 / 3 * np.arange(5),
+                (np.arange(5),),
+                np.array([-1, -1]),
+                np.array([1, 1]),
+                [
+                    lambda x: (
+                        -np.repeat(np.sqrt(1 - x[:, 0] ** 2), 2).reshape(-1, 2),
+                        np.repeat(np.sqrt(1 - x[:, 0] ** 2), 2).reshape(-1, 2),
+                    ),
+                ],
+            ),
+            (
+                # Integrate
+                #   f(x, y, z, w) = n
+                # with limits
+                #   a = [0, 0, 0, 0],
+                #   b = [1, x, x, x]
+                # for n = range(5)
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                1 / 4 * np.arange(5),
+                (np.arange(5),),
+                np.array([0]),
+                np.array([1]),
+                [
+                    lambda x: (
+                        np.zeros((x.shape[0], 3)),
+                        np.repeat(x[:, 0], 3).reshape(-1, 3),
+                    ),
+                ],
+            ),
+            (
+                # Integrate
+                #   f(x, y, z, w, p) = n
+                # with limits
+                #   a = [0, 0, 0, 0, 0],
+                #   b = [1, x, x, xy, xy]
+                # for n = range(5)
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                1 / 21 * np.arange(5),
+                (np.arange(5),),
+                np.array([0]),
+                np.array([1]),
+                [
+                    lambda x: (
+                        np.zeros((x.shape[0], 2)),
+                        np.repeat(x[:, 0], 2).reshape(-1, 2),
+                    ),
+                    lambda x: (
+                        np.zeros((x.shape[0], 2)),
+                        np.repeat(x[:, 0] * x[:, 1], 2).reshape(-1, 2),
+                    ),
+                ],
+            ),
+            (
+                # Integrate
+                #   f(x, y) = n
+                # with limits
+                #   a = [0, -sqrt(1-x^2)],
+                #   b = [1, sqrt(1-x^2)]
+                # for n = range(5)
+                lambda x, n: np.tile(n, (x.shape[0], 1)),
+                math.pi * np.arange(5),
+                (np.arange(5),),
+                np.array([]),  # Here the initial limits are empty
+                np.array([]),
+                [
+                    lambda x: (
+                        -np.ones((x.shape[0], 1)),
+                        np.ones((x.shape[0], 1)),
+                    ),
+                    lambda x: (
+                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                    ),
+                ],
+            ),
+            pytest.param(
+                (
+                    # Integrate
+                    #   f(x, y, z, w) = n
+                    # with limits
+                    #   a = [-1, -sqrt(1-x^2), -sqrt(1-x^2-y^2), -sqrt(1-x^2-y^2-z^2)],
+                    #   b = [1, sqrt(1-x^2), sqrt(1-x^2-y^2), sqrt(1-x^2-y^2-z^2)]
+                    # for n = range(5)
+                    # i.e. integration over a hypersphere
+                    lambda x, n: np.tile(n, (x.shape[0], 1)),
+                    math.pi**2 / 2 * np.arange(5),
+                    (np.arange(5),),
+                    np.array([-1]),
+                    np.array([1]),
+                    [
+                        lambda x: (
+                            -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                            np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                        ),
+                        lambda x: (
+                            -np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                            np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                        ),
+                        lambda x: (
+                            -np.sqrt(
+                                1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
+                            ).reshape(-1, 1),
+                            np.sqrt(
+                                1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
+                            ).reshape(-1, 1),
+                        ),
+                    ],
+                ),
+                marks=pytest.mark.slow,
+            ),
+        ],
+    )
     def test_cub_func_limits(self, problem, rule, rtol, atol):
         f, exact, args, a_outer, b_outer, region = problem
 

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1047,7 +1047,7 @@ class TestCubatureProblems:
                 [1, math.inf, math.inf, math.inf]
             ),
 
-            marks=pytest.mark.slow,
+            marks=pytest.mark.xslow,
         ),
     ])
     def test_infinite_limits(self, problem, rule, rtol, atol, xp):
@@ -1343,7 +1343,7 @@ class TestCubatureProblems:
                         ),
                     ],
                 ),
-                marks=pytest.mark.slow,
+                marks=pytest.mark.xslow,
             ),
         ],
     )

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1063,7 +1063,7 @@ class TestCubatureProblems:
             pytest.mark.slow("Genz-Malik is slow in >= 5 dim")
 
         if rule == "genz-malik" and ndim >= 4 and is_array_api_strict(xp):
-            pytest.skip("Genz-Malik is very slow for array_api_strict in >= 4 dim")
+            pytest.mark.xslow("Genz-Malik very slow for array_api_strict in >= 4 dim")
 
         res = cubature(
             f,

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -940,6 +940,10 @@ class TestCubatureProblems:
                    f"true_error={xp.abs(res.estimate - exact)}")
         assert res.status == "converged", err_msg
 
+    @skip_xp_backends(
+        "jax.numpy",
+        reasons=["transforms make use of indexing assignment"],
+    )
     @pytest.mark.parametrize("problem", [
         (
             # Function to integrate
@@ -1086,6 +1090,10 @@ class TestCubatureProblems:
             check_0d=False,
         )
 
+    @skip_xp_backends(
+        "jax.numpy",
+        reasons=["transforms make use of indexing assignment"],
+    )
     @pytest.mark.parametrize(
         "problem",
         [
@@ -1352,6 +1360,8 @@ class TestCubatureProblems:
         args = tuple(xp.asarray(arg, dtype=xp.float64) for arg in args)
         exact = xp.asarray(exact, dtype=xp.float64)
 
+        xp_compat = array_namespace(xp.empty(0))
+
         res = cubature(
             f,
             a_outer,
@@ -1359,8 +1369,8 @@ class TestCubatureProblems:
             rule,
             rtol,
             atol,
-            args=(*args, xp),
-            region=region(xp),
+            args=(*args, xp_compat),
+            region=region(xp_compat),
         )
 
         assert res.status == "converged"

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1539,7 +1539,7 @@ class TestTransformations:
         )
 
         for point in points:
-            transformed_point = f_transformed.x_to_t(xp.reshape(point, (1, -1)))
+            transformed_point = f_transformed.inv(xp.reshape(point, (1, -1)))
 
             with pytest.raises(Exception, match="called with a problematic point"):
                 f_transformed(transformed_point)
@@ -1622,7 +1622,7 @@ class TestTransformations:
         )
 
         for point in points:
-            transformed_point = f_transformed.x_to_t(xp.reshape(point, (1, -1)))
+            transformed_point = f_transformed.inv(xp.reshape(point, (1, -1)))
 
             with pytest.raises(Exception, match="called with a problematic point"):
                 f_transformed(transformed_point)

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -4,8 +4,6 @@ import itertools
 
 import pytest
 
-import numpy as np  # TODO: remove
-
 from scipy._lib._array_api import array_namespace, xp_assert_close, xp_size, np_compat
 from scipy.conftest import array_api_compatible
 
@@ -911,7 +909,7 @@ class TestCubatureProblems:
 
         err_msg = (f"estimate_error={res.error}, "
                    f"subdivisions= {res.subdivisions}, "
-                   f"true_error={np.abs(res.estimate - exact)}")
+                   f"true_error={xp.abs(res.estimate - exact)}")
         assert res.status == "converged", err_msg
 
     @pytest.mark.parametrize("problem", [
@@ -1052,20 +1050,27 @@ class TestCubatureProblems:
                 # with limits
                 #   a = [0, 0, 0]
                 #   b = [1, 1, 1]
+
                 # f
-                lambda x: x[:, 0],
+                lambda x, xp: x[:, 0],
+
                 # exact solution
                 0.5,
+
                 # args
                 (),
+
                 # a & b
-                np.array([0, 0]),
-                np.array([1, 1]),
-                # region, here just constants
-                [
+                [0, 0],
+                [1, 1],
+
+                # region
+                # Wrapped in a function so that each region_func has access
+                # to the array namespace
+                lambda xp: [
                     lambda x: (
-                        np.zeros(x.shape[0]).reshape(-1, 1),
-                        np.ones(x.shape[0]).reshape(-1, 1),
+                        xp.reshape(xp.zeros(x.shape[0]), (-1, 1)),
+                        xp.reshape(xp.ones(x.shape[0]), (-1, 1)),
                     ),
                 ],
             ),
@@ -1075,15 +1080,15 @@ class TestCubatureProblems:
                 # with limits
                 #   a = [0, 0, 0]
                 #   b = [1, 1, x_1 * x_2]
-                lambda x: np.ones(x.shape[0]),
+                lambda x, xp: xp.ones(x.shape[0]),
                 0.25,
                 (),
-                np.array([0, 0]),
-                np.array([1, 1]),
-                [
+                [0, 0],
+                [1, 1],
+                lambda xp: [
                     lambda x: (
-                        np.zeros(x.shape[0]).reshape(-1, 1),
-                        (x[:, 0] * x[:, 1]).reshape(-1, 1),
+                        xp.reshape(xp.zeros(x.shape[0]), (-1, 1)),
+                        xp.reshape((x[:, 0] * x[:, 1]), (-1, 1)),
                     ),
                 ],
             ),
@@ -1093,15 +1098,15 @@ class TestCubatureProblems:
                 # with limits
                 #   a = [-1, -sqrt(1 - x_1**2)]
                 #   b = [1, sqrt(1 - x_1**2)]
-                lambda x: np.ones(x.shape[0]),
-                np.pi,
+                lambda x, xp: xp.ones(x.shape[0]),
+                math.pi,
                 (),
-                np.array([-1]),
-                np.array([1]),
-                [
+                [-1],
+                [1],
+                lambda xp: [
                     lambda x: (
-                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                        xp.reshape(-xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
+                        xp.reshape(xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
                     ),
                 ],
             ),
@@ -1111,15 +1116,15 @@ class TestCubatureProblems:
                 # with limits
                 #   a = [-inf, -exp(-x_1**2)]
                 #   b = [inf, exp(x_1**2)]
-                lambda x: np.ones(x.shape[0]),
-                2 * math.sqrt(np.pi),
+                lambda x, xp: xp.ones(x.shape[0]),
+                2 * math.sqrt(math.pi),
                 (),
-                np.array([-np.inf]),
-                np.array([np.inf]),
-                [
+                [-math.inf],
+                [math.inf],
+                lambda xp: [
                     lambda x: (
-                        -np.exp(-x[:, 0] ** 2).reshape(-1, 1),
-                        np.exp(-x[:, 0] ** 2).reshape(-1, 1),
+                        xp.reshape(-xp.exp(-x[:, 0] ** 2), (-1, 1)),
+                        xp.reshape(xp.exp(-x[:, 0] ** 2), (-1, 1)),
                     ),
                 ],
             ),
@@ -1130,39 +1135,15 @@ class TestCubatureProblems:
                 #   a = [-inf, -exp(-x_1**2)]
                 #   b = [inf, exp(x_1**2)]
                 # for n = range(5)
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                np.arange(5) * 2 * math.sqrt(np.pi),
-                (np.arange(5),),
-                np.array([-np.inf]),
-                np.array([np.inf]),
-                [
+                lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                [2 * math.sqrt(math.pi) * i for i in range(5)],
+                ([0, 1, 2, 3, 4],),
+                [-math.inf],
+                [math.inf],
+                lambda xp: [
                     lambda x: (
-                        -np.exp(-x[:, 0] ** 2).reshape(-1, 1),
-                        np.exp(-x[:, 0] ** 2).reshape(-1, 1),
-                    ),
-                ],
-            ),
-            (
-                # Integrate
-                #   f(x, y, z) = n
-                # with limits
-                #   a = [-1, -sqrt(1-x^2), -sqrt(1-x^2-y^2)],
-                #   b = [1, sqrt(1-x^2), sqrt(1-x^2-y^2)]
-                # for n = range(5)
-                # i.e. integrate a unit ball with densities 0, 1, 2, 3, 4
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                4 / 3 * math.pi * np.arange(5),
-                (np.arange(5),),
-                np.array([-1]),
-                np.array([1]),
-                [
-                    lambda x: (
-                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                    ),
-                    lambda x: (
-                        -np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
-                        np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                        xp.reshape(-xp.exp(-x[:, 0] ** 2), (-1, 1)),
+                        xp.reshape(xp.exp(-x[:, 0] ** 2), (-1, 1)),
                     ),
                 ],
             ),
@@ -1173,15 +1154,15 @@ class TestCubatureProblems:
                 #   a = [-1, -1, -sqrt(1-x^2), -sqrt(1-x^2)],
                 #   b = [1, 1, sqrt(1-x^2), sqrt(1-x^2)]
                 # for n = range(5)
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                32 / 3 * np.arange(5),
-                (np.arange(5),),
-                np.array([-1, -1]),
-                np.array([1, 1]),
-                [
+                lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                [32 / 3 * i for i in range(5)],
+                ([0, 1, 2, 3, 4],),
+                [-1, -1],
+                [1, 1],
+                lambda xp: [
                     lambda x: (
-                        -np.repeat(np.sqrt(1 - x[:, 0] ** 2), 2).reshape(-1, 2),
-                        np.repeat(np.sqrt(1 - x[:, 0] ** 2), 2).reshape(-1, 2),
+                        xp.reshape(-xp.repeat(xp.sqrt(1 - x[:, 0] ** 2), 2), (-1, 2)),
+                        xp.reshape(xp.repeat(xp.sqrt(1 - x[:, 0] ** 2), 2), (-1, 2)),
                     ),
                 ],
             ),
@@ -1192,63 +1173,77 @@ class TestCubatureProblems:
                 #   a = [0, 0, 0, 0],
                 #   b = [1, x, x, x]
                 # for n = range(5)
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                1 / 4 * np.arange(5),
-                (np.arange(5),),
-                np.array([0]),
-                np.array([1]),
-                [
+                lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                [i / 4 for i in range(5)],
+                ([0, 1, 2, 3, 4],),
+                [0],
+                [1],
+                lambda xp: [
                     lambda x: (
-                        np.zeros((x.shape[0], 3)),
-                        np.repeat(x[:, 0], 3).reshape(-1, 3),
+                        xp.zeros((x.shape[0], 3)),
+                        xp.reshape(xp.repeat(x[:, 0], 3), (-1, 3)),
                     ),
                 ],
             ),
-            (
-                # Integrate
-                #   f(x, y, z, w, p) = n
-                # with limits
-                #   a = [0, 0, 0, 0, 0],
-                #   b = [1, x, x, xy, xy]
-                # for n = range(5)
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                1 / 21 * np.arange(5),
-                (np.arange(5),),
-                np.array([0]),
-                np.array([1]),
-                [
-                    lambda x: (
-                        np.zeros((x.shape[0], 2)),
-                        np.repeat(x[:, 0], 2).reshape(-1, 2),
-                    ),
-                    lambda x: (
-                        np.zeros((x.shape[0], 2)),
-                        np.repeat(x[:, 0] * x[:, 1], 2).reshape(-1, 2),
-                    ),
-                ],
+
+            pytest.param(
+                (
+                    # Integrate
+                    #   f(x, y, z, w, p) = n
+                    # with limits
+                    #   a = [0, 0, 0, 0, 0],
+                    #   b = [1, x, x, xy, xy]
+                    # for n = range(5)
+                    lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                    [i / 21 for i in range(5)],
+                    ([0, 1, 2, 3, 4],),
+                    [0],
+                    [1],
+                    lambda xp: [
+                        lambda x: (
+                            xp.zeros((x.shape[0], 2)),
+                            xp.reshape(xp.repeat(x[:, 0], 2), (-1, 2)),
+                        ),
+                        lambda x: (
+                            xp.zeros((x.shape[0], 2)),
+                            xp.reshape(xp.repeat(x[:, 0] * x[:, 1], 2), (-1, 2)),
+                        ),
+                    ],
+                ),
+                marks=pytest.mark.slow,
             ),
-            (
-                # Integrate
-                #   f(x, y) = n
-                # with limits
-                #   a = [0, -sqrt(1-x^2)],
-                #   b = [1, sqrt(1-x^2)]
-                # for n = range(5)
-                lambda x, n: np.tile(n, (x.shape[0], 1)),
-                math.pi * np.arange(5),
-                (np.arange(5),),
-                np.array([]),  # Here the initial limits are empty
-                np.array([]),
-                [
-                    lambda x: (
-                        -np.ones((x.shape[0], 1)),
-                        np.ones((x.shape[0], 1)),
-                    ),
-                    lambda x: (
-                        -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                        np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                    ),
-                ],
+            pytest.param(
+                (
+                    # Integrate
+                    #   f(x, y, z) = n
+                    # with limits
+                    #   a = [-1, -sqrt(1-x^2), -sqrt(1-x^2-y^2)],
+                    #   b = [1, sqrt(1-x^2), sqrt(1-x^2-y^2)]
+                    # for n = range(5)
+                    # i.e. integrate a unit ball with densities 0, 1, 2, 3, 4
+                    lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                    [4 / 3 * math.pi * i for i in range(5)],
+                    ([0, 1, 2, 3, 4],),
+                    [-1],
+                    [1],
+                    lambda xp: [
+                        lambda x: (
+                            xp.reshape(-xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
+                            xp.reshape(xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
+                        ),
+                        lambda x: (
+                            xp.reshape(
+                                -xp.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2),
+                                (-1, 1),
+                            ),
+                            xp.reshape(
+                                xp.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2),
+                                (-1, 1),
+                            ),
+                        ),
+                    ],
+                ),
+                marks=pytest.mark.slow,
             ),
             pytest.param(
                 (
@@ -1259,27 +1254,39 @@ class TestCubatureProblems:
                     #   b = [1, sqrt(1-x^2), sqrt(1-x^2-y^2), sqrt(1-x^2-y^2-z^2)]
                     # for n = range(5)
                     # i.e. integration over a hypersphere
-                    lambda x, n: np.tile(n, (x.shape[0], 1)),
-                    math.pi**2 / 2 * np.arange(5),
-                    (np.arange(5),),
-                    np.array([-1]),
-                    np.array([1]),
-                    [
+                    lambda x, n, xp: xp.tile(n, (x.shape[0], 1)),
+                    [math.pi**2 / 2 * i for i in range(5)],
+                    ([0, 1, 2, 3, 4],),
+                    [-1],
+                    [1],
+                    lambda xp: [
                         lambda x: (
-                            -np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
-                            np.sqrt(1 - x[:, 0] ** 2).reshape(-1, 1),
+                            xp.reshape(-xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
+                            xp.reshape(xp.sqrt(1 - x[:, 0] ** 2), (-1, 1)),
                         ),
                         lambda x: (
-                            -np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
-                            np.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2).reshape(-1, 1),
+                            xp.reshape(
+                                -xp.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2),
+                                (-1, 1),
+                            ),
+                            xp.reshape(
+                                xp.sqrt(1 - x[:, 0] ** 2 - x[:, 1] ** 2),
+                                (-1, 1),
+                            ),
                         ),
                         lambda x: (
-                            -np.sqrt(
-                                1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
-                            ).reshape(-1, 1),
-                            np.sqrt(
-                                1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
-                            ).reshape(-1, 1),
+                            xp.reshape(
+                                -xp.sqrt(
+                                    1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
+                                ),
+                                (-1, 1),
+                            ),
+                            xp.reshape(
+                                xp.sqrt(
+                                    1 - x[:, 0] ** 2 - x[:, 1] ** 2 - x[:, 2] ** 2
+                                ),
+                                (-1, 1),
+                            )
                         ),
                     ],
                 ),
@@ -1287,8 +1294,13 @@ class TestCubatureProblems:
             ),
         ],
     )
-    def test_func_limits(self, problem, rule, rtol, atol):
+    def test_func_limits(self, problem, rule, rtol, atol, xp):
         f, exact, args, a_outer, b_outer, region = problem
+
+        a_outer = xp.asarray(a_outer, dtype=xp.float64)
+        b_outer = xp.asarray(b_outer, dtype=xp.float64)
+        args = tuple(xp.asarray(arg, dtype=xp.float64) for arg in args)
+        exact = xp.asarray(exact, dtype=xp.float64)
 
         res = cubature(
             f,
@@ -1297,18 +1309,19 @@ class TestCubatureProblems:
             rule,
             rtol,
             atol,
-            args=args,
-            region=region,
+            args=(*args, xp),
+            region=region(xp),
         )
 
         assert res.status == "converged"
 
-        np.testing.assert_allclose(
+        xp_assert_close(
             res.estimate,
             exact,
             rtol=rtol,
             atol=atol,
-            err_msg=f"error_estimate={res.error}, subdivisions={res.subdivisions}"
+            err_msg=f"error_estimate={res.error}, subdivisions={res.subdivisions}",
+            check_0d=False,
         )
 
 

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -18,6 +18,11 @@ from scipy.integrate._rules import (
     GenzMalikCubature,
 )
 
+from scipy.integrate._cubature import (
+    _InfiniteLimitsTransform,
+    _FuncLimitsTransform,
+)
+
 pytestmark = [pytest.mark.usefixtures("skip_xp_backends"),]
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -1490,6 +1495,30 @@ class TestRulesCubature:
     def test_genz_malik_1d_raises_error(self, xp):
         with pytest.raises(Exception, match="only defined for ndim >= 2"):
             GenzMalikCubature(1, xp=xp)
+
+
+@array_api_compatible
+class TestTransformations:
+    def test_infinite_limits_x_to_t(self, xp):
+        f_transformed = _InfiniteLimitsTransform(
+            lambda x: None,  # Not called
+            xp.asarray([0, 1, -math.inf], dtype=xp.float64),
+            xp.asarray([1, math.inf, math.inf], dtype=xp.float64),
+        )
+
+        point = xp.asarray([[1, 1, 1]], dtype=xp.float64)
+        actual = f_transformed.x_to_t(point)
+
+        expecting = xp.asarray([[1, 1, 0.5]], dtype=xp.float64)
+
+        xp_assert_close(
+            actual,
+            expecting,
+        )
+
+    def test_func_limits_x_to_t(self, xp):
+        # TODO
+        assert False
 
 
 class BadErrorRule(Rule):


### PR DESCRIPTION
### Reference issues
- #20252
- Builds on:
	- #21330
	- #21473

### What does this implement/fix?
This adds support to `integrate.cubature` for integrals with infinite limits and for integrals with limits that are functions of the preceding variables:

*Infinite limits*:

$$
\int^\infty_{-\infty} \int^\infty_{-\infty} e^{-x^2-y^2} \text dx \text dy
$$

```python
cubature(gaussian, [-np.inf, -np.inf], [np.inf, np.inf])
```

*Limits are functions*:

$$
\int _ {-1}^1 \int^{\sqrt{1-x^2}} _ {-\sqrt{1-x^2}} \int^{\sqrt{1-x^2-y^2}} _ {-\sqrt{1-x^2-y^2}} \mathbf f (x, y, z) \text dz \text dy \text dx
$$

```python
cubature(f, [-1], [1], region=sphere)
```

*A combination of both*:

$$
\int^\infty _ {0} \int^{x} _ {0} e^{-x^2-y^2} \text dx \text d y
$$

```python
cubature(f, [0], [np.inf], region=ray)
```

(The definitions for `region=sphere` and `region=ray` can be found in the [examples](#examples) section).

The implementation still does "true cubature" by performing subdivisions in $\mathbb R^n$, unlike `nquad` which will treat the integral as a nested series of 1D integrals. To achieve this, if any limits are infinite or are functions of the preceding variables, it will apply an appropriate variable transformation to convert the integral into one over a rectangle, and perform subdivisions like normal. In the case of infinite limits, the transformations used are the same as those used by `quad_vec`.

This PR:

- Allows infinite limits to be specified by including $\pm \infty$ in `a` or `b`,
- Allows regions described by function limits through a new `region` argument, details of which are included in the [additional information section](#additional-information).
- Add a `points` argument to `cubature` which can be used like it is [in `quad_vec`](https://github.com/scipy/scipy/blob/main/scipy/integrate/_quad_vec.py#L141) to avoid evaluating the integrand at singularities or other problematic points.
- Maintains Array API support (although tests are not passing with `jax.numpy` when using infinite or function limits because of index assignment errors).
- Improves documentation by tidying up the "Examples" section of the `cubature` docstring and also addressing a problem raised in #20252 where the docs in the "Return" section referred to a private object. Now the attributes of this object are included in the public docstring. A few style and formatting issues in the docstring have also been addressed.
- Renames `CubatureRegion` to `CubaturePatch` in the source of `cubature` to avoid a naming clash with the new `region=` argument.
- Adds more tests for infinite limits and limits that are functions, and a few of the existing tests have been modified so they are faster. Tests have also been added for cases when `a` and `b` are empty, `a` and `b` are the same, or `a > b`.

### Additional information


#### Examples
##### 2D integral with infinite limits

$$
\int^{ \infty } _ { -\infty } \int^{ \infty } _ { -\infty } e^{-x^2-y^2} \text dy \text dx
$$

```python
>>> def gaussian(x):
...     return np.exp(-np.sum(x**2, axis=-1))
>>> res = cubature(gaussian, [-np.inf, -np.inf], [np.inf, np.inf])
>>> res.estimate
 3.1415926
```

##### 1D integral with singularities avoided using `points`
$$
\int^{ 1 } _ { -1 } \frac{\sin(x)}{x} \text dx
$$

```python
>>> def sinc(x):
...     return np.sin(x)/x
>>> res = cubature(sinc, [-1], [1], points=[[0]])
>>> res.estimate
 1.8921661
```

##### 2D integral over a circle using `region`

$$
\int^{ 1 } _ { -1 } \int^{ \sqrt{1-x^2} } _ { -\sqrt{1-x^2} } \mathbf \rho(x _ 1, x _ 2 ) \text dx _ 2 \text dx _ 1
$$

```python
>>> def density(x_arr):
...     x_0, x_1 = x_arr[:, 0], x_arr[:, 1]
...     # For example, 4 different densities:
...     return (x_0**2 + x_1**2)[:, np.newaxis] / np.arange(1, 5)[np.newaxis, :]
>>> # density takes arrays of shape (npoints, 2) and returns arrays of shape
>>> # (npoints, 4)
>>> density(np.array([[-0.5, 0.5], [1, 1]]))
 array([[0.5       , 0.25      , 0.16666667, 0.125     ],
		[2.        , 1.        , 0.66666667, 0.5       ]])
>>> res = cubature(
...     density,
...     # Outer limits:
...     a=[-1],
...     b=[1],
...     # Inner limits. In the problem there is only one pair of function limits, so
...     # region is a list of length 1.
...     region=[
...           # This function takes the value of the outer variables, which in this
...           # case is the value of x_0. It then returns the new limits for the
...           # inner variables, which in this case is just x_1.
...           #
...           # In general, there might be more outer variables and more inner
...           # variables, and new limits might need to be calculated for several
...           # different values of outer variables at once. This means x_arr is of
...           # shape (npoints, num_outer) and it needs to return a tuple of arrays
...           # of shape (npoints, num_inner).
...           lambda x_arr: (
...               -np.sqrt(1-x_arr[:, 0]**2)[:, np.newaxis],
...                np.sqrt(1-x_arr[:, 0]**2)[:, np.newaxis],
...           ),
...     ],
... )
>>> res.estimate
 array([1.57079633, 0.78539816, 0.52359878, 0.39269908])
```

##### 3D integral over a sphere with `region`

$$
\int^{ 1 } _ { -1 } \int^{ \sqrt{1-x _ 0^2} }_{ -\sqrt{1-x _ 0^2} } \int^{ \sqrt{1-x _ 0^2-x _ 1^2} } _ { -\sqrt{1-x _ 0^2-x _ 1^2} } 1 \text dx _ 2 \text dx _ 1 \text dx _ 0
$$

```python
>>> res = cubature(
...     lambda x_arr: np.ones(x_arr.shape[0]),
...     a=[-1],
...     b=[1],
...     rtol=1e-5,  # Reduce tolerance, can be slow otherwise
...     region=[
...         lambda x_arr: (
...             -np.sqrt(1-x_arr[:, 0]**2)[:, np.newaxis],
...              np.sqrt(1-x_arr[:, 0]**2)[:, np.newaxis],
...         ),
...         lambda x_arr: (
...             -np.sqrt(1-x_arr[:, 0]**2-x_arr[:, 1]**2)[:, np.newaxis],
...              np.sqrt(1-x_arr[:, 0]**2-x_arr[:, 1]**2)[:, np.newaxis],
...         ),
...     ],
... )
>>> res.estimate  # True value 4*pi/3
 4.188792
```

##### Returning multiple limits at once using `region`
In the above uses of `region`, each function in the list has returned an array of shape ``(npoints, 1)``. In the previous example, it is **not** possible to combine these two functions into one:

```python
>>> # Won't work:
>>> res = cubature(
...     lambda x_arr: np.ones(x_arr.shape[0]),
...     a=[-1],
...     b=[1],
...     rtol=1e-5,
...     region=[
...         lambda x_arr: (
...             [
...                 -np.sqrt(1-x_arr[:, 0]**2),
...                 -np.sqrt(1-x_arr[:, 0]**2-x_arr[:, 1]**2),
...                 #                         ^^^^^^^^^^^
...                 # This will cause an error since x_arr[:, 1] depends on the
...                 # value of the previous limit, which has not yet been returned.
...             ],
...             [
...                 np.sqrt(1-x_arr[:, 0]**2),
...                 np.sqrt(1-x_arr[:, 0]**2-x_arr[:, 1]**2),
...                 # Also a problem here:   ^^^^^^^^^^^
...             ],
...         ),
...     ],
... )
Traceback (most recent call last):
 ...
IndexError: index 1 is out of bounds for axis 1 with size 1
```

This is because the expression ``np.sqrt(1-x_arr[:, 0]**2-x_arr[:, 1]**2)`` depends
on the value of ``x[:, 1]`` which will not be known when this function is called. This is because the limits for ``x[:, 1]`` cannot be determined without calling this function.

If you have an integral where a group of limits do not depend on one another, you can return them together. For example:

$$
\int^{ 1 } _ { 0 } \int^{ x _ 0 } _ { 0 } \int^{ x _ 0 } _ { 0 } 1 \text dx _ 2 \text dx _ 1 \text dx _ 0
$$

Here the limits for $x_1$ and $x_2$ depend only on $x_0$. This means it is possible to specify `region` like so:

```python
>>> res = cubature(
...     lambda x_arr: np.ones(x_arr.shape[0]),
...     a=[-1],
...     b=[1],
...     region=[
...         lambda x_arr: (
...             np.zeros((x_arr.shape[0], 2)),            # [0, 0]
...             np.repeat(x_arr[:, 0], 2).reshape(-1, 2), # [x_0, x_0]
...         ),
...     ],
... )
>>> res.estimate
 0.666666
```

#### `region` implementation and interface details
If the integral being computed has the form

$$
\int^{b _ 1} _ {a _ 1} \cdots \int^{b _ n} _ {a _ n} \int^{B _ {n+1}(x _ 1, \ldots, x _ n)} _ {A _ {n+1}(x _ 1, \ldots, x _ n)}
\cdots \int^{B _ {n+m}(x _ 1, \ldots, x _ {n+m-1})} _ {A _ {n+m}(x _ 1, \ldots, x _ {n+m-1})} \mathbf f(x _ 1, \ldots, x _ {n+m}) \text dx _ {n+m} \cdots \text dx _ 1
$$

$x_1, \ldots, x_n$ are referred to as the "outer variables" and their limits are specified by the constant intervals $(a_i, b_i)$ for $1 \le i \le n$.

$x_{n+1}, \ldots, x_{n+m}$ are referred to as the "inner variables" and their limits given the values of the preceding variables range over the interval $(A_i(x_1, \ldots, x_{i-1}), B_i(x_1, \ldots, x_{i-1}))$.

Integrals of this form will be transformed into an integral over constant limits using the technique described in Philip J. Davis, Philip Rabinowitz, Methods of Numerical Integration, Section 5.4:

$$
\int^{b _ 1} _ {a _ 1} \cdots \int^{b _ n} _ {a _ n} \int^{1} _ {-1} \cdots \int^{1} _ {-1} g(t _ 1, \ldots, t _ {n+m}) \text dt _ {n+m} \cdots \text dt _ 1
$$

The outer variables are unchanged, $x_i = t_i$ for $1 \le x_i \le t_i$.

For $i > n$, the inner variables are mapped via the transformation:

$$
x _ i = \frac{ B _ {i}(x _ 1, \ldots, x _ {i-1}) + A _ {i}(x _ 1, \ldots, x _ {i-1}) }{2} + t _ i \frac{ B _ {i}(x _ 1, \ldots, x _ {i-1}) - A _ {i}(x _ 1, \ldots, x _ {i-1}) }{2}
$$

To specify this type of integral programatically, the outer limits should be included in ``a`` and ``b`` and a list of callables ``region`` should describe the function limits.

```
a = [a_1, ..., a_n]
b = [b_1, ..., b_n]

region = [
	region_func_1,
	...,
	region_func_k,
]
```

Each ``region_func_i`` should accepts arrays of shape ``(npoints, num_preceding_variables)`` and return a tuple of two arrays, one for the next set of lower limits given the values of the preceding variables, and one for the next set of upper limits given the values of the preceding variables. Both of the returned arrays should have shape ``(npoints, num_new_variables)``.

Then `cubature` would be called like so:

```python
cubature(f, a, b, region=region)
```

##### Why this interface?
Some of the other interfaces considered for limits with functions included:


```python
# Mixing numbers and callables together in `a` and `b`
cubature(
    f,
    [-1, lambda x: -np.sqrt(1 - x**2), lambda x, y: -np.sqrt(1 - x**2 - y**2)],
    [ 1, lambda x:  np.sqrt(1 - x**2), lambda x, y:  np.sqrt(1 - x**2 - y**2)],
)

# Having `a_func` and `b_func` arguments
cubature(
    f,
    [-1],
    [ 1],
    a_func=[lambda x: -np.sqrt(1 - x**2), lambda x, y: -np.sqrt(1 - x**2 - y**2)],
    b_func=[lambda x:  np.sqrt(1 - x**2), lambda x, y:  np.sqrt(1 - x**2 - y**2)]
)

# Mixing numbers and callables together in `a` and `b`, but the callables are vectorized
cubature(
    f,
    [-1, lambda x: -np.sqrt(1 - x[:, 0]**2), lambda x: -np.sqrt(1 - x[:, 0]**2 - x[:, 1]**2)],
    [ 1, lambda x:  np.sqrt(1 - x[:, 0]**2), lambda x:  np.sqrt(1 - x[:, 0]**2 - x[:, 1]**2)],
)
```

All of these have their own pros/cons. For example, mixing numbers and callables together might look the most natural but this means that a lot of work might be unnecessarily repeated if the limits are symmetric and it's not easy to return the values of multiple limits for multiple variables at the same time. In all the interfaces above, if the limits get more complicated, it will be difficult to refactor.

Definitely open to suggestions!

### Acknowledgements
Many thanks to @izaid and @ev-br, who have provided lots of help in making this PR, and thanks to @lucascolley for help with the array API support.