### PR TITLE
DOC/MAINT: optimize: fix some typos

### DIFF
--- a/scipy/optimize/_bglu_dense.pyx
+++ b/scipy/optimize/_bglu_dense.pyx
@@ -81,7 +81,7 @@ cdef void hess_lu(self, double[:, ::1] H, int i, double[:,::1] ops) noexcept:
 cdef void perform_ops(self, double[::1] y, const double[:,::1] ops, bint rev = False) noexcept:
     """
     Replays operations needed to convert Hessenberg matrix into upper
-    triangular form on a vector y. Equivalent to matrix multlication by
+    triangular form on a vector y. Equivalent to matrix multiplication by
     inverse of matrix 5.12.
     """
     cdef int i, j, k, m

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -369,7 +369,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
         For mixed integrality constraints, supply an array of shape ``c.shape``.
         To infer a constraint on each decision variable from shorter inputs,
-        the argument will be broadcasted to ``c.shape`` using `numpy.broadcast_to`.
+        the argument will be broadcast to ``c.shape`` using `numpy.broadcast_to`.
 
         This argument is currently used only by the
         :ref:`'highs' <optimize.linprog-highs>` method and is ignored otherwise.

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -98,7 +98,7 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
         For mixed integrality constraints, supply an array of shape `c.shape`.
         To infer a constraint on each decision variable from shorter inputs,
-        the argument will be broadcasted to `c.shape` using `np.broadcast_to`.
+        the argument will be broadcast to `c.shape` using `np.broadcast_to`.
 
         This argument is currently used only by the ``'highs'`` method and
         ignored otherwise.
@@ -1017,7 +1017,7 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ``sym_pos=False`` skips to solver 3, and ``lstsq=True`` skips
     to solver 4 for both sparse and dense problems.
 
-    Potential improvements for combatting issues associated with dense
+    Potential improvements for combating issues associated with dense
     columns in otherwise sparse problems are outlined in [4]_ Section 5.3 and
     [10]_ Section 4.1-4.2; the latter also discusses the alleviation of
     accuracy issues associated with the substitution approach to free

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -1005,7 +1005,7 @@ def _linprog_ip(c, c0, A, b, callback, postsolve_args, maxiter=1000, tol=1e-8,
     ``sym_pos=False`` skips to solver 3, and ``lstsq=True`` skips
     to solver 4 for both sparse and dense problems.
 
-    Potential improvements for combatting issues associated with dense
+    Potential improvements for combating issues associated with dense
     columns in otherwise sparse problems are outlined in [4]_ Section 5.3 and
     [10]_ Section 4.1-4.2; the latter also discusses the alleviation of
     accuracy issues associated with the substitution approach to free

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -541,7 +541,7 @@ def _linprog_rs(c, c0, A, b, x0, callback, postsolve_args,
                 "problem terminated successfully with a residual of {0:.1e}, "
                 "greater than the tolerance {1} required for the solution to "
                 "be considered feasible. Consider increasing the tolerance to "
-                "be greater than {0:.1e}. If this tolerance is unnaceptably "
+                "be greater than {0:.1e}. If this tolerance is unacceptably "
                 "large, the problem is likely infeasible.",
                 "The problem is unbounded, as the simplex algorithm found "
                 "a basic feasible solution from which there is a direction "

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -69,7 +69,7 @@ _LPProblem.__doc__ = \
 
         For mixed integrality constraints, supply an array of shape `c.shape`.
         To infer a constraint on each decision variable from shorter inputs,
-        the argument will be broadcasted to `c.shape` using `np.broadcast_to`.
+        the argument will be broadcast to `c.shape` using `np.broadcast_to`.
 
         This argument is currently used only by the ``'highs'`` method and
         ignored otherwise.

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -474,7 +474,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     .. [16] Byrd, Richard H., Mary E. Hribar, and Jorge Nocedal. 1999.
         An interior point algorithm for large-scale nonlinear  programming.
         SIAM Journal on Optimization 9.4: 877-900.
-    .. [17] Lalee, Marucha, Jorge Nocedal, and Todd Plantega. 1998. On the
+    .. [17] Lalee, Marucha, Jorge Nocedal, and Todd Plantenga. 1998. On the
         implementation of an algorithm for large-scale equality constrained
         optimization. SIAM Journal on Optimization 8.3: 682-706.
     .. [18] Ragonneau, T. M. *Model-Based Derivative-Free Optimization Methods

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -677,7 +677,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
         .. versionadded:: 0.18
     full_output : boolean, optional
-        If True, this function returns additioal information: `infodict`,
+        If True, this function returns additional information: `infodict`,
         `mesg`, and `ier`.
 
         .. versionadded:: 1.9

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -2934,7 +2934,7 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
     The algorithm attempts to find three strictly ordered points (i.e.
     :math:`x_a < x_b < x_c` or :math:`x_c < x_b < x_a`) satisfying
     :math:`f(x_b) ≤ f(x_a)` and :math:`f(x_b) ≤ f(x_c)`, where one of the
-    inequalities must be satistfied strictly and all :math:`x_i` must be
+    inequalities must be satisfied strictly and all :math:`x_i` must be
     finite.
 
     Examples

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -421,7 +421,7 @@ class Complex:
                     if (self.bounds[symmetry[i]] is not
                             self.bounds[symmetry[j]]):
                         logging.warning(f"Variable {i} was specified as "
-                                        f"symmetetric to variable {j}, however"
+                                        f"symmetric to variable {j}, however"
                                         f", the bounds {i} ="
                                         f" {self.bounds[symmetry[i]]} and {j}"
                                         f" ="
@@ -1046,7 +1046,7 @@ class Complex:
                     try:
                         vn_pool.remove(vn)
                     except KeyError:
-                        pass  # NOTE: Not all neigbouds are in initial pool
+                        pass  # NOTE: Not all neighbours are in initial pool
         return vn_pool
 
     def vf_to_vv(self, vertices, simplices):
@@ -1219,7 +1219,7 @@ class Complex:
         #       dimensions higher than 2?
         # TODO: Literature seems to suggest using proj.T, but why is this
         #       needed?
-        if np.linalg.det(proj) == 0.0:  # TODO: Repalace with tolerance?
+        if np.linalg.det(proj) == 0.0:  # TODO: Replace with tolerance?
             return True  # Simplex is degenerate
         else:
             return False  # Simplex is not degenerate

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -331,7 +331,7 @@ def initial_constraints_as_canonical(n, prepared_constraints, sparse_jacobian):
     """Convert initial values of the constraints to the canonical format.
 
     The purpose to avoid one additional call to the constraints at the initial
-    point. It takes saved values in `PreparedConstraint`, modififies and
+    point. It takes saved values in `PreparedConstraint`, modifies and
     concatenates them to the canonical constraint format.
     """
     c_eq = []

--- a/scipy/optimize/_trustregion_constr/equality_constrained_sqp.py
+++ b/scipy/optimize/_trustregion_constr/equality_constrained_sqp.py
@@ -221,7 +221,7 @@ def equality_constrained_sqp(fun_and_constr, grad_and_jac, lagr_hess,
             H = lagr_hess(x, v)
             # Set Flag
             last_iteration_failed = False
-            # Otimality values
+            # Optimality values
             optimality = norm(c + A.T.dot(v), np.inf)
             constr_violation = norm(b, np.inf) if len(b) > 0 else 0
         else:

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -33,7 +33,7 @@ class TestEQPDirectFactorization(TestCase):
 class TestSphericalBoundariesIntersections(TestCase):
 
     def test_2d_sphere_constraints(self):
-        # Interior inicial point
+        # Interior initial point
         ta, tb, intersect = sphere_intersections([0, 0],
                                                  [1, 0], 0.5)
         assert_array_almost_equal([ta, tb], [0, 0.5])
@@ -184,7 +184,7 @@ class TestBoxBoundariesIntersections(TestCase):
         assert_array_almost_equal([ta, tb], [1, 3])
         assert_equal(intersect, True)
 
-        # Interior initial pointoint
+        # Interior initial point
         ta, tb, intersect = box_intersections([0, 0], [4, 4],
                                               [-2, -3], [3, 2],
                                               entire_line=True)

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -4,7 +4,7 @@ from scipy.optimize import minimize, Bounds
 
 def test_gh10880():
     # checks that verbose reporting works with trust-constr for
-    # bound-contrained problems
+    # bound-constrained problems
     bnds = Bounds(1, 2)
     opts = {'maxiter': 1000, 'verbose': 2}
     minimize(lambda x: x**2, x0=2., method='trust-constr',

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -300,7 +300,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
     # variables. Represents ``tau`` from [1]_ p.885, formula (3.18).
     BOUNDARY_PARAMETER = 0.995
     # BARRIER_DECAY_RATIO controls the decay of the barrier parameter
-    # and of the subproblem toloerance. Represents ``theta`` from [1]_ p.879.
+    # and of the subproblem tolerance. Represents ``theta`` from [1]_ p.879.
     BARRIER_DECAY_RATIO = 0.2
     # TRUST_ENLARGEMENT controls the enlargement on trust radius
     # after each iteration

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -55,7 +55,7 @@ def estimate_smallest_singular_value(U):
     s_min : float
         Estimated smallest singular value of the provided matrix.
     z_min : ndarray
-        Estimatied right singular vector.
+        Estimated right singular vector.
 
     Notes
     -----
@@ -172,7 +172,7 @@ def singular_leading_submatrix(A, U, k):
 
     n = len(A)
 
-    # Inicialize v
+    # Initialize v
     v = np.zeros(n)
     v[k-1] = 1
 
@@ -246,7 +246,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
         self.hess_fro = norm(self.hess, 'fro')
 
         # A constant such that for vectors smaller than that
-        # backward substituition is not reliable. It was stabilished
+        # backward substitution is not reliable. It was established
         # based on Golub, G. H., Van Loan, C. F. (2013).
         # "Matrix computations". Forth Edition. JHU press., p.165.
         self.CLOSE_TO_ZERO = self.dimension * self.EPS * self.hess_inf
@@ -350,7 +350,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
                         p += step_len * z_min
                         break
 
-                    # Update uncertanty bounds
+                    # Update uncertainty bounds
                     lambda_ub = lambda_current
                     lambda_lb = max(lambda_lb, lambda_current - s_min**2)
 
@@ -367,7 +367,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
                         lambda_current = lambda_new
                         already_factorized = True
                     else:  # Unsuccessful factorization
-                        # Update uncertanty bounds
+                        # Update uncertainty bounds
                         lambda_lb = max(lambda_lb, lambda_new)
 
                         # Update damping factor
@@ -382,7 +382,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
                     if relative_error <= self.k_easy:
                         break
 
-                    # Update uncertanty bounds
+                    # Update uncertainty bounds
                     lambda_lb = lambda_current
 
                     # Update damping factor
@@ -406,7 +406,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
                     p = step_len * z_min
                     break
 
-                # Update uncertanty bounds
+                # Update uncertainty bounds
                 lambda_ub = lambda_current
                 lambda_lb = max(lambda_lb, lambda_current - s_min**2)
 
@@ -422,7 +422,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
                 delta, v = singular_leading_submatrix(H, U, info)
                 v_norm = norm(v)
 
-                # Update uncertanty interval
+                # Update uncertainty interval
                 lambda_lb = max(lambda_lb, lambda_current + delta/v_norm**2)
 
                 # Update damping factor

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1333,7 +1333,7 @@ def toms748(f, a, b, args=(), k=1,
     iteration with the same asymptotic efficiency as it finds the root.
 
     For easy statement of efficiency indices, assume that `f` has 4
-    continuouous deriviatives.
+    continuous deriviatives.
     For ``k=1``, the convergence order is at least 2.7, and with about
     asymptotically 2 function evaluations per iteration, the efficiency
     index is approximately 1.65.

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -472,7 +472,7 @@ class TestShgoSimplicialTestFunctions:
 
     @pytest.mark.fail_slow(10)
     def test_f5_3_cons_symmetry(self):
-        """Assymmetrically constrained test function"""
+        """Asymmetrically constrained test function"""
         options = {'symmetry': [0, 0, 0, 3],
                    'disp': True}
 

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -15,7 +15,7 @@ from scipy import stats
 # `_bracket_root`/`_bracket_minimum` from `_bracket.py`, we import
 # `bracket_root`/`bracket_minimum` from `optimize.elementwise` and wrap those
 # functions to conform to the private interface. This may look a little strange,
-# since it effectly just inverts the interface transformation done within the
+# since it effectively just inverts the interface transformation done within the
 # `bracket_root`/`bracket_minimum` functions, but it allows us to run the original,
 # unmodified tests on the public interfaces, simplifying the PR that adds
 # the public interfaces. We'll refactor this when we want to @parametrize the
@@ -525,7 +525,7 @@ class TestBracketMinimum:
     @pytest.mark.parametrize("xm0", (0.05, 0.1, 0.15))
     @pytest.mark.parametrize("xr0", (0.2, 0.4, 0.6, None))
     # Minimum is ``a`` for each tuple ``(a, b)`` below. Tests cases where minimum
-    # is within, or at varying disances to the left or right of the initial
+    # is within, or at varying distances to the left or right of the initial
     # bracket.
     @pytest.mark.parametrize(
         "args",

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -40,7 +40,7 @@ def _vectorize(xp):
 # `_chandrupatla`/`_chandrupatla_minimize` from `_chandrupatla.py`, we import
 # `find_root`/`find_minimum` from `optimize.elementwise` and wrap those
 # functions to conform to the private interface. This may look a little strange,
-# since it effectly just inverts the interface transformation done within the
+# since it effectively just inverts the interface transformation done within the
 # `find_root`/`find_minimum` functions, but it allows us to run the original,
 # unmodified tests on the public interfaces, simplifying the PR that adds
 # the public interfaces. We'll refactor this when we want to @parametrize the
@@ -567,7 +567,7 @@ class TestChandrupatla(TestScalarRootFinders):
 
     @pytest.mark.parametrize('p', [0.6, np.linspace(-0.05, 1.05, 10)])
     def test_basic(self, p, xp):
-        # Invert distribution CDF and compare against distrtibution `ppf`
+        # Invert distribution CDF and compare against distribution `ppf`
         a, b = xp.asarray(-5.), xp.asarray(5.)
         res = _chandrupatla_root(self.f, a, b, args=(xp.asarray(p),))
         ref = xp.asarray(stats.norm().ppf(p), dtype=xp.asarray(p).dtype)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -404,7 +404,7 @@ class BoundsMixin:
     def test_inconsistent_shape(self):
         assert_raises(ValueError, least_squares, fun_trivial, 2.0,
                       bounds=(1.0, [2.0, 3.0]), method=self.method)
-        # 1-D array wont't be broadcasted
+        # 1-D array won't be broadcast
         assert_raises(ValueError, least_squares, fun_rosenbrock, [1.0, 2.0],
                       bounds=([0.0], [3.0, 4.0]), method=self.method)
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -1047,7 +1047,7 @@ class TestCurveFit:
 
     @pytest.mark.parametrize('method', ['trf', 'dogbox'])
     def test_gh20155_error_mentions_x0(self, method):
-        # `curve_fit` produced an error message that refered to an undocumented
+        # `curve_fit` produced an error message that referred to an undocumented
         # variable `x0`, which was really `p0`. Check that this is resolved.
         def func(x,a):
             return x**a

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -495,7 +495,7 @@ class TestNewton(TestScalarRootFinders):
     @pytest.mark.parametrize('method', ['secant', 'newton'])
     def test_int_x0_gh19280(self, method):
         # Originally, `newton` ensured that only floats were passed to the
-        # callable. This was indadvertently changed by gh-17669. Check that
+        # callable. This was inadvertently changed by gh-17669. Check that
         # it has been changed back.
         def f(x):
             # an integer raised to a negative integer power would fail

--- a/scipy/optimize/tnc/tnc.c
+++ b/scipy/optimize/tnc/tnc.c
@@ -508,7 +508,7 @@ static void setConstraints(int n, double x[], int pivot[], double xscale[],
  * the truncated-newton method is preconditioned by a limited-memory
  * quasi-newton method (this preconditioning strategy is developed
  * in this routine) with a further diagonal scaling
- * (see routine diagonalscaling).
+ * (see routine diagonalScaling).
  */
 static tnc_rc tnc_minimize(int n, double x[],
                            double *f, double gfull[],

--- a/scipy/optimize/tnc/tnc.h
+++ b/scipy/optimize/tnc/tnc.h
@@ -78,7 +78,7 @@ typedef enum
   TNC_LSFAIL       =  4, /* Linear search failed */
   TNC_CONSTANT     =  5, /* All lower bounds are equal to the upper bounds */
   TNC_NOPROGRESS   =  6, /* Unable to progress */
-  TNC_USERABORT    =  7  /* User requested end of minization */
+  TNC_USERABORT    =  7  /* User requested end of minimization */
 } tnc_rc;
 
 /*


### PR DESCRIPTION
@lucascolley

dumped directory strings exposed a few typos

the sole C language files modified are in the tnc subdirectory

check that the replacement string in this file is correct

```
$ grep -nr neigbouds scipy/scipy/optimize
scipy/scipy/optimize/_shgo_lib/_complex.py:1049:                        pass  # NOTE: Not all neigbouds are in initial pool
$ 
```