### PR TITLE
TST: special: fix XSLOW failure in `test_mpmath.TestSystematic.test_spherical_jn` 

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -2152,6 +2152,8 @@ class TestSystematic:
             exception_to_nan(mp_spherical_jn),
             [IntArg(0, 200), Arg(-1e8, 1e8)],
             dps=300,
+            # underflow of `spherical_jn` is a bit premature; see gh-21629
+            param_filter=(None, lambda z: np.abs(z) > 1e-20),
         )
 
     def test_spherical_jn_complex(self):


### PR DESCRIPTION
#### Reference issue
gh-21629

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/21629#issuecomment-2379763853 reported a test failure.
https://github.com/scipy/scipy/pull/21629#issuecomment-2380069215 identified the underlying issue, which was unrelated to recent changes.
This skips the problematic part of the test.