### PR TITLE
MAINT: `differentiate.differentiate`: rename function to `derivative`

### DIFF
--- a/scipy/differentiate/__init__.py
+++ b/scipy/differentiate/__init__.py
@@ -11,7 +11,7 @@ numerical differentiation of black-box functions.
 .. autosummary::
    :toctree: generated/
 
-   differentiate
+   derivative
    jacobian
    hessian
 
@@ -20,7 +20,7 @@ numerical differentiation of black-box functions.
 
 from ._differentiate import *
 
-__all__ = ['differentiate', 'jacobian', 'hessian']
+__all__ = ['derivative', 'jacobian', 'hessian']
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -5,11 +5,11 @@ import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
 from scipy._lib._array_api import array_namespace, xp_sign
 
-_EERRORINCREASE = -1  # used in differentiate
+_EERRORINCREASE = -1  # used in derivative
 
-def _differentiate_iv(f, x, args, tolerances, maxiter, order, initial_step,
-                      step_factor, step_direction, preserve_shape, callback):
-    # Input validation for `differentiate`
+def _derivative_iv(f, x, args, tolerances, maxiter, order, initial_step,
+                   step_factor, step_direction, preserve_shape, callback):
+    # Input validation for `derivative`
     xp = array_namespace(x)
 
     if not callable(f):
@@ -56,12 +56,12 @@ def _differentiate_iv(f, x, args, tolerances, maxiter, order, initial_step,
             step_factor, step_direction, preserve_shape, callback)
 
 
-def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
-                  order=8, initial_step=0.5, step_factor=2.0,
-                  step_direction=0, preserve_shape=False, callback=None):
+def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
+               order=8, initial_step=0.5, step_factor=2.0,
+               step_direction=0, preserve_shape=False, callback=None):
     """Evaluate the derivative of a elementwise, real scalar function numerically.
 
-    For each element of the output of `f`, `differentiate` approximates the first
+    For each element of the output of `f`, `derivative` approximates the first
     derivative of `f` at the corresponding element of `x` using finite difference
     differentiation.
 
@@ -144,10 +144,10 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
         An optional user-supplied function to be called before the first
         iteration and after each iteration.
         Called as ``callback(res)``, where ``res`` is a ``_RichResult``
-        similar to that returned by `differentiate` (but containing the current
+        similar to that returned by `derivative` (but containing the current
         iterate's values of all variables). If `callback` raises a
         ``StopIteration``, the algorithm will terminate immediately and
-        `differentiate` will return a result. `callback` must not mutate
+        `derivative` will return a result. `callback` must not mutate
         `res` or its attributes.
 
     Returns
@@ -236,11 +236,11 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     Evaluate the derivative of ``np.exp`` at several points ``x``.
 
     >>> import numpy as np
-    >>> from scipy.differentiate import differentiate
+    >>> from scipy.differentiate import derivative
     >>> f = np.exp
     >>> df = np.exp  # true derivative
     >>> x = np.linspace(1, 2, 5)
-    >>> res = differentiate(f, x)
+    >>> res = derivative(f, x)
     >>> res.df  # approximation of the derivative
     array([2.71828183, 3.49034296, 4.48168907, 5.75460268, 7.3890561 ])
     >>> res.error  # estimate of the error
@@ -265,10 +265,10 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     >>> ref = df(x)
     >>> errors = []  # true error
     >>> for i in iter:
-    ...     res = differentiate(f, x, maxiter=i, step_factor=hfac,
-    ...                         step_direction=hdir, order=order,
-    ...                         # prevent early termination
-    ...                         tolerances=dict(atol=0, rtol=0))
+    ...     res = derivative(f, x, maxiter=i, step_factor=hfac,
+    ...                      step_direction=hdir, order=order,
+    ...                      # prevent early termination
+    ...                      tolerances=dict(atol=0, rtol=0))
     ...     errors.append(abs(res.df - ref))
     >>> errors = np.array(errors)
     >>> plt.semilogy(iter, errors[:, 0], label='left differences')
@@ -294,7 +294,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     >>> x = np.arange(1, 5)
     >>> p = np.arange(1, 6).reshape((-1, 1))
     >>> hdir = np.arange(-1, 2).reshape((-1, 1, 1))
-    >>> res = differentiate(f, x, args=(p,), step_direction=hdir, maxiter=1)
+    >>> res = derivative(f, x, args=(p,), step_direction=hdir, maxiter=1)
     >>> np.allclose(res.df, df(x, p))
     True
     >>> res.df.shape
@@ -313,12 +313,12 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     ...    return np.sin(c*x)
     >>>
     >>> c = [1, 5, 10, 20]
-    >>> res = differentiate(f, 0, args=(c,))
+    >>> res = derivative(f, 0, args=(c,))
     >>> shapes
     [(4,), (4, 8), (4, 2), (3, 2), (2, 2), (1, 2)]
 
     To understand where these shapes are coming from - and to better
-    understand how `differentiate` computes accurate results - note that
+    understand how `derivative` computes accurate results - note that
     higher values of ``c`` correspond with higher frequency sinusoids.
     The higher frequency sinusoids make the function's derivative change
     faster, so more function evaluations are required to achieve the target
@@ -346,7 +346,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     >>> def f(x):
     ...    return [x, np.sin(3*x), x+np.sin(10*x), np.sin(20*x)*(x-1)**2]
 
-    This integrand is not compatible with `differentiate` as written; for instance,
+    This integrand is not compatible with `derivative` as written; for instance,
     the shape of the output will not be the same as the shape of ``x``. Such a
     function *could* be converted to a compatible form with the introduction of
     additional parameters, but this would be inconvenient. In such cases,
@@ -359,7 +359,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     ...     return [x0, np.sin(3*x1), x2+np.sin(10*x2), np.sin(20*x3)*(x3-1)**2]
     >>>
     >>> x = np.zeros(4)
-    >>> res = differentiate(f, x, preserve_shape=True)
+    >>> res = derivative(f, x, preserve_shape=True)
     >>> shapes
     [(4,), (4, 8), (4, 2), (4, 2), (4, 2), (4, 2)]
 
@@ -374,7 +374,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     #  - relative steps?
     #  - show example of `np.vectorize`
 
-    res = _differentiate_iv(f, x, args, tolerances, maxiter, order, initial_step,
+    res = _derivative_iv(f, x, args, tolerances, maxiter, order, initial_step,
                             step_factor, step_direction, preserve_shape, callback)
     (func, x, args, atol, rtol, maxiter, order,
      h0, fac, hdir, preserve_shape, callback) = res
@@ -396,7 +396,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
 
     # Ideally we'd broadcast the shape of `hdir` in `_elementwise_algo_init`, but
     # it's simpler to do it here than to generalize `_elementwise_algo_init` further.
-    # `hdir` and `x` are already broadcasted in `_differentiate_iv`, so we know
+    # `hdir` and `x` are already broadcasted in `_derivative_iv`, so we know
     # that `hdir` can be broadcasted to the final shape. Same with `h0`.
     hdir = xp.broadcast_to(hdir, shape)
     hdir = xp.reshape(hdir, (-1,))
@@ -418,7 +418,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     # - `fs` holds all the function values of all active `x`. The zeroth
     #   axis corresponds with active points `x`, the first axis corresponds
     #   with the different steps (in the order described in
-    #   `_differentiate_weights`).
+    #   `_derivative_weights`).
     # - `terms` (which could probably use a better name) is half the `order`,
     #   which is always even.
     work = _RichResult(x=x, df=df, fs=f[:, xp.newaxis], error=xp.nan, h=h0,
@@ -435,7 +435,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
     def pre_func_eval(work):
         """Determine the abscissae at which the function needs to be evaluated.
 
-        See `_differentiate_weights` for a description of the stencil (pattern
+        See `_derivative_weights` for a description of the stencil (pattern
         of the abscissae).
 
         In the first iteration, there is only one stored function value in
@@ -485,7 +485,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
         function value in `work.fs`, `f(x)`, so we need to add the `order` new
         points. In subsequent iterations, we add two new points. The tricky
         part is getting the order to match that of the weights, which is
-        described in `_differentiate_weights`.
+        described in `_derivative_weights`.
 
         For improvement:
         - Change the order of the weights (and steps in `pre_func_eval`) to
@@ -528,7 +528,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
         work.fs[ic] = work_fc
         work.fs[io] = work_fo
 
-        wc, wo = _differentiate_weights(work, n, xp)
+        wc, wo = _derivative_weights(work, n, xp)
         work.df_last = xp.asarray(work.df, copy=True)
         work.df[ic] = fc @ wc / work.h[ic]
         work.df[io] = fo @ wo / work.h[io]
@@ -583,7 +583,7 @@ def differentiate(f, x, *, args=(), tolerances=None, maxiter=10,
                      xp, preserve_shape)
 
 
-def _differentiate_weights(work, n, xp):
+def _derivative_weights(work, n, xp):
     # This produces the weights of the finite difference formula for a given
     # stencil. In experiments, use of a second-order central difference formula
     # with Richardson extrapolation was more accurate numerically, but it was
@@ -651,15 +651,15 @@ def _differentiate_weights(work, n, xp):
 
     # Note that if the user switches back to floating point precision with
     # `x` and `args`, then `fac` will not necessarily equal the (lower
-    # precision) cached `_differentiate_weights.fac`, and the weights will
+    # precision) cached `_derivative_weights.fac`, and the weights will
     # need to be recalculated. This could be fixed, but it's late, and of
     # low consequence.
-    if fac != _differentiate_weights.fac:
-        _differentiate_weights.central = []
-        _differentiate_weights.right = []
-        _differentiate_weights.fac = fac
+    if fac != _derivative_weights.fac:
+        _derivative_weights.central = []
+        _derivative_weights.right = []
+        _derivative_weights.fac = fac
 
-    if len(_differentiate_weights.central) != 2*n + 1:
+    if len(_derivative_weights.central) != 2*n + 1:
         # Central difference weights. Consider refactoring this; it could
         # probably be more compact.
         # Note: Using NumPy here is OK; we convert to xp-type at the end
@@ -680,7 +680,7 @@ def _differentiate_weights(work, n, xp):
 
         # Cache the weights. We only need to calculate them once unless
         # the step factor changes.
-        _differentiate_weights.central = weights
+        _derivative_weights.central = weights
 
         # One-sided difference weights. The left one-sided weights (with
         # negative steps) are simply the negative of the right one-sided
@@ -695,13 +695,13 @@ def _differentiate_weights(work, n, xp):
         b[1] = 1
         weights = np.linalg.solve(A, b)
 
-        _differentiate_weights.right = weights
+        _derivative_weights.right = weights
 
-    return (xp.asarray(_differentiate_weights.central, dtype=work.dtype),
-            xp.asarray(_differentiate_weights.right, dtype=work.dtype))
-_differentiate_weights.central = []
-_differentiate_weights.right = []
-_differentiate_weights.fac = None
+    return (xp.asarray(_derivative_weights.central, dtype=work.dtype),
+            xp.asarray(_derivative_weights.right, dtype=work.dtype))
+_derivative_weights.central = []
+_derivative_weights.right = []
+_derivative_weights.fac = None
 
 
 def jacobian(f, x, *, tolerances=None, maxiter=10,
@@ -787,7 +787,7 @@ def jacobian(f, x, *, tolerances=None, maxiter=10,
 
     See Also
     --------
-    differentiate, hessian
+    derivative, hessian
 
     Notes
     -----
@@ -895,9 +895,9 @@ def jacobian(f, x, *, tolerances=None, maxiter=10,
         xph[i, i] = x
         return f(xph)
 
-    res = differentiate(wrapped, x, tolerances=tolerances,
-                        maxiter=maxiter, order=order, initial_step=initial_step,
-                        step_factor=step_factor, preserve_shape=True)
+    res = derivative(wrapped, x, tolerances=tolerances,
+                     maxiter=maxiter, order=order, initial_step=initial_step,
+                     step_factor=step_factor, preserve_shape=True)
     del res.x  # the user knows `x`, and the way it gets broadcasted is meaningless here
     return res
 
@@ -983,7 +983,7 @@ def hessian(f, x, *, tolerances=None, maxiter=10,
 
     See Also
     --------
-    differentiate, jacobian
+    derivative, jacobian
 
     Notes
     -----
@@ -1064,7 +1064,7 @@ def hessian(f, x, *, tolerances=None, maxiter=10,
     x = np.asarray(x)
     dtype = x.dtype if np.issubdtype(x.dtype, np.inexact) else np.float64
     finfo = np.finfo(dtype)
-    rtol = finfo.eps**0.5 if rtol is None else rtol  # keep same as `differentiate`
+    rtol = finfo.eps**0.5 if rtol is None else rtol  # keep same as `derivative`
 
     # tighten the inner tolerance to make the inner error negligible
     rtol_min = finfo.eps * 100

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -434,7 +434,7 @@ class TestDerivative:
         (lambda x: np.where(x > 1, (x - 1) ** 5, (x - 1) ** 3), 1)
     ))
     def test_saddle_gh18811(self, case):
-        # With default settings, differentiate will not always converge when
+        # With default settings, `derivative` will not always converge when
         # the true derivative is exactly zero. This tests that specifying a
         # (tight) `atol` alleviates the problem. See discussion in gh-18811.
         atol = 1e-16

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -9,7 +9,7 @@ from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_ass
 from scipy._lib._array_api import is_numpy, is_torch, array_namespace
 
 from scipy import stats, optimize, special
-from scipy.differentiate import differentiate, jacobian, hessian
+from scipy.differentiate import derivative, jacobian, hessian
 from scipy.differentiate._differentiate import _EERRORINCREASE
 
 
@@ -21,7 +21,7 @@ from scipy.differentiate._differentiate import _EERRORINCREASE
                               reason='JAX arrays do not support item assignment.')
 @pytest.mark.skip_xp_backends('cupy',
                               reason='cupy/cupy#8391')
-class TestDifferentiate:
+class TestDerivative:
 
     def f(self, x):
         return special.ndtr(x)
@@ -30,7 +30,7 @@ class TestDifferentiate:
     def test_basic(self, x, xp):
         # Invert distribution CDF and compare against distribution `ppf`
         default_dtype = xp.asarray(1.).dtype
-        res = differentiate(self.f, xp.asarray(x, dtype=default_dtype))
+        res = derivative(self.f, xp.asarray(x, dtype=default_dtype))
         ref = xp.asarray(stats.norm().pdf(x), dtype=default_dtype)
         xp_assert_close(res.df, ref)
         # This would be nice, but doesn't always work out. `error` is an
@@ -44,7 +44,7 @@ class TestDifferentiate:
         distname, params = case
         dist = getattr(stats, distname)(*params)
         x = dist.median() + 0.1
-        res = differentiate(dist.cdf, x)
+        res = derivative(dist.cdf, x)
         ref = dist.pdf(x)
         assert_allclose(res.df, ref, atol=1e-10)
 
@@ -57,8 +57,8 @@ class TestDifferentiate:
         n = np.size(x)
 
         @np.vectorize
-        def _differentiate_single(x):
-            return differentiate(self.f, x, order=order)
+        def _derivative_single(x):
+            return derivative(self.f, x, order=order)
 
         def f(x, *args, **kwargs):
             f.nit += 1
@@ -67,8 +67,8 @@ class TestDifferentiate:
         f.nit = -1
         f.feval = 0
 
-        res = differentiate(f, xp.asarray(x, dtype=xp.float64), order=order)
-        refs = _differentiate_single(x).ravel()
+        res = derivative(f, xp.asarray(x, dtype=xp.float64), order=order)
+        refs = _derivative_single(x).ravel()
 
         ref_x = [ref.x for ref in refs]
         xp_assert_close(xp.reshape(res.x, (-1,)), xp.asarray(ref_x))
@@ -111,9 +111,9 @@ class TestDifferentiate:
         f.nit = 0
 
         args = (xp.arange(4, dtype=xp.int64),)
-        res = differentiate(f, xp.ones(4, dtype=xp.float64),
-                            tolerances=dict(rtol=1e-14),
-                            order=2, args=args)
+        res = derivative(f, xp.ones(4, dtype=xp.float64),
+                         tolerances=dict(rtol=1e-14),
+                         order=2, args=args)
 
         ref_flags = xp.asarray([eim._ECONVERGED,
                                 _EERRORINCREASE,
@@ -131,9 +131,9 @@ class TestDifferentiate:
                    xp.full_like(x, xp.nan)]  # stops due to NaN
             return xp.stack(out)
 
-        res = differentiate(f, xp.asarray(1, dtype=xp.float64),
-                            tolerances=dict(rtol=1e-14),
-                            order=2, preserve_shape=True)
+        res = derivative(f, xp.asarray(1, dtype=xp.float64),
+                         tolerances=dict(rtol=1e-14),
+                         order=2, preserve_shape=True)
 
         ref_flags = xp.asarray([eim._ECONVERGED,
                                 _EERRORINCREASE,
@@ -150,7 +150,7 @@ class TestDifferentiate:
         x = xp.asarray(0.)
         ref = xp.asarray([xp.asarray(1), 3*xp.cos(3*x), 1+10*xp.cos(10*x),
                           20*xp.cos(20*x)*(x-1)**2 + 2*xp.sin(20*x)*(x-1)])
-        res = differentiate(f, x, preserve_shape=True)
+        res = derivative(f, x, preserve_shape=True)
         xp_assert_close(res.df, ref)
 
     def test_convergence(self, xp):
@@ -162,19 +162,19 @@ class TestDifferentiate:
 
         tolerances = tolerances0.copy()
         tolerances['atol'] = 1e-3
-        res1 = differentiate(f, x, tolerances=tolerances, order=4)
+        res1 = derivative(f, x, tolerances=tolerances, order=4)
         assert abs(res1.df - ref) < 1e-3
         tolerances['atol'] = 1e-6
-        res2 = differentiate(f, x, tolerances=tolerances, order=4)
+        res2 = derivative(f, x, tolerances=tolerances, order=4)
         assert abs(res2.df - ref) < 1e-6
         assert abs(res2.df - ref) < abs(res1.df - ref)
 
         tolerances = tolerances0.copy()
         tolerances['rtol'] = 1e-3
-        res1 = differentiate(f, x, tolerances=tolerances, order=4)
+        res1 = derivative(f, x, tolerances=tolerances, order=4)
         assert abs(res1.df - ref) < 1e-3 * ref
         tolerances['rtol'] = 1e-6
-        res2 = differentiate(f, x, tolerances=tolerances, order=4)
+        res2 = derivative(f, x, tolerances=tolerances, order=4)
         assert abs(res2.df - ref) < 1e-6 * ref
         assert abs(res2.df - ref) < abs(res1.df - ref)
 
@@ -184,31 +184,29 @@ class TestDifferentiate:
         f = special.ndtr
         ref = float(stats.norm.pdf(1.))
 
-        res1 = differentiate(f, x, initial_step=0.5, maxiter=1)
-        res2 = differentiate(f, x, initial_step=0.05, maxiter=1)
+        res1 = derivative(f, x, initial_step=0.5, maxiter=1)
+        res2 = derivative(f, x, initial_step=0.05, maxiter=1)
         assert abs(res2.df - ref) < abs(res1.df - ref)
 
-        res1 = differentiate(f, x, step_factor=2, maxiter=1)
-        res2 = differentiate(f, x, step_factor=20, maxiter=1)
+        res1 = derivative(f, x, step_factor=2, maxiter=1)
+        res2 = derivative(f, x, step_factor=20, maxiter=1)
         assert abs(res2.df - ref) < abs(res1.df - ref)
 
         # `step_factor` can be less than 1: `initial_step` is the minimum step
         kwargs = dict(order=4, maxiter=1, step_direction=0)
-        res = differentiate(f, x, initial_step=0.5, step_factor=0.5, **kwargs)
-        ref = differentiate(f, x, initial_step=1, step_factor=2, **kwargs)
+        res = derivative(f, x, initial_step=0.5, step_factor=0.5, **kwargs)
+        ref = derivative(f, x, initial_step=1, step_factor=2, **kwargs)
         xp_assert_close(res.df, ref.df, rtol=5e-15)
 
         # This is a similar test for one-sided difference
         kwargs = dict(order=2, maxiter=1, step_direction=1)
-        res = differentiate(f, x, initial_step=1, step_factor=2, **kwargs)
-        ref = differentiate(f, x, initial_step=1/np.sqrt(2), step_factor=0.5,
-                                   **kwargs)
+        res = derivative(f, x, initial_step=1, step_factor=2, **kwargs)
+        ref = derivative(f, x, initial_step=1/np.sqrt(2), step_factor=0.5, **kwargs)
         xp_assert_close(res.df, ref.df, rtol=5e-15)
 
         kwargs['step_direction'] = -1
-        res = differentiate(f, x, initial_step=1, step_factor=2, **kwargs)
-        ref = differentiate(f, x, initial_step=1/np.sqrt(2), step_factor=0.5,
-                                   **kwargs)
+        res = derivative(f, x, initial_step=1, step_factor=2, **kwargs)
+        ref = derivative(f, x, initial_step=1/np.sqrt(2), step_factor=0.5, **kwargs)
         xp_assert_close(res.df, ref.df, rtol=5e-15)
 
     def test_step_direction(self, xp):
@@ -221,7 +219,7 @@ class TestDifferentiate:
         x = xp.linspace(0, 2, 10)
         step_direction = xp.zeros_like(x)
         step_direction[x < 0.6], step_direction[x > 1.4] = 1, -1
-        res = differentiate(f, x, step_direction=step_direction)
+        res = derivative(f, x, step_direction=step_direction)
         xp_assert_close(res.df, xp.exp(x))
         assert xp.all(res.success)
 
@@ -236,7 +234,7 @@ class TestDifferentiate:
         x = xp.reshape(xp.asarray([1, 2, 3, 4]), (-1, 1, 1))
         hdir = xp.reshape(xp.asarray([-1, 0, 1]), (1, -1, 1))
         p = xp.reshape(xp.asarray([2, 3]), (1, 1, -1))
-        res = differentiate(f, x, step_direction=hdir, args=(p,))
+        res = derivative(f, x, step_direction=hdir, args=(p,))
         ref = xp.broadcast_to(df(x, p), res.df.shape)
         ref = xp.asarray(ref, dtype=xp.asarray(1.).dtype)
         xp_assert_close(res.df, ref)
@@ -249,8 +247,8 @@ class TestDifferentiate:
         x = xp.asarray(0., dtype=xp.float64)
         step_direction = xp.asarray([-1, 0, 1])
         h0 = xp.reshape(xp.logspace(-3, 0, 10), (-1, 1))
-        res = differentiate(f, x, initial_step=h0, order=2, maxiter=1,
-                            step_direction=step_direction)
+        res = derivative(f, x, initial_step=h0, order=2, maxiter=1,
+                         step_direction=step_direction)
         err = xp.abs(res.df - f(x))
 
         # error should be smaller for smaller step sizes
@@ -259,8 +257,8 @@ class TestDifferentiate:
         # results of vectorized call should match results with
         # initial_step taken one at a time
         for i in range(h0.shape[0]):
-            ref = differentiate(f, x, initial_step=h0[i, 0], order=2, maxiter=1,
-                                step_direction=step_direction)
+            ref = derivative(f, x, initial_step=h0[i, 0], order=2, maxiter=1,
+                             step_direction=step_direction)
             xp_assert_close(res.df[i, :], ref.df, rtol=1e-14)
 
     def test_maxiter_callback(self, xp):
@@ -273,7 +271,7 @@ class TestDifferentiate:
             return res
 
         default_order = 8
-        res = differentiate(f, x, maxiter=maxiter, tolerances=dict(rtol=1e-15))
+        res = derivative(f, x, maxiter=maxiter, tolerances=dict(rtol=1e-15))
         assert not xp.any(res.success)
         assert xp.all(res.nfev == default_order + 1 + (maxiter - 1)*2)
         assert xp.all(res.nit == maxiter)
@@ -291,7 +289,7 @@ class TestDifferentiate:
         callback.res = None
         callback.dfs = set()
 
-        res2 = differentiate(f, x, callback=callback, tolerances=dict(rtol=1e-15))
+        res2 = derivative(f, x, callback=callback, tolerances=dict(rtol=1e-15))
         # terminating with callback is identical to terminating due to maxiter
         # (except for `status`)
         for key in res.keys():
@@ -321,8 +319,7 @@ class TestDifferentiate:
             assert res.df.dtype == dtype
             assert res.error.dtype == dtype
 
-        res = differentiate(f, x, order=4, step_direction=hdir,
-                                   callback=callback)
+        res = derivative(f, x, order=4, step_direction=hdir, callback=callback)
         assert res.x.dtype == dtype
         assert res.df.dtype == dtype
         assert res.error.dtype == dtype
@@ -337,43 +334,43 @@ class TestDifferentiate:
 
         message = '`f` must be callable.'
         with pytest.raises(ValueError, match=message):
-            differentiate(None, one)
+            derivative(None, one)
 
         message = 'Abscissae and function output must be real numbers.'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, xp.asarray(-4+1j))
+            derivative(lambda x: x, xp.asarray(-4+1j))
 
         message = "When `preserve_shape=False`, the shape of the array..."
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: [1, 2, 3], xp.asarray([-2, -3]))
+            derivative(lambda x: [1, 2, 3], xp.asarray([-2, -3]))
 
         message = 'Tolerances and step parameters must be non-negative...'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, tolerances=dict(atol=-1))
+            derivative(lambda x: x, one, tolerances=dict(atol=-1))
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, tolerances=dict(rtol='ekki'))
+            derivative(lambda x: x, one, tolerances=dict(rtol='ekki'))
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, step_factor=object())
+            derivative(lambda x: x, one, step_factor=object())
 
         message = '`maxiter` must be a positive integer.'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, maxiter=1.5)
+            derivative(lambda x: x, one, maxiter=1.5)
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, maxiter=0)
+            derivative(lambda x: x, one, maxiter=0)
 
         message = '`order` must be a positive integer'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, order=1.5)
+            derivative(lambda x: x, one, order=1.5)
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, order=0)
+            derivative(lambda x: x, one, order=0)
 
         message = '`preserve_shape` must be True or False.'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, preserve_shape='herring')
+            derivative(lambda x: x, one, preserve_shape='herring')
 
         message = '`callback` must be callable.'
         with pytest.raises(ValueError, match=message):
-            differentiate(lambda x: x, one, callback='shrubbery')
+            derivative(lambda x: x, one, callback='shrubbery')
 
     def test_special_cases(self, xp):
         # Test edge cases and other special cases
@@ -386,16 +383,16 @@ class TestDifferentiate:
             return x ** 99 - 1
 
         if not is_torch(xp):  # torch defaults to float32
-            res = differentiate(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
+            res = derivative(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
             assert res.success
             xp_assert_close(res.df, xp.asarray(99*7.**98))
 
         # Test invalid step size and direction
-        res = differentiate(xp.exp, xp.asarray(1), step_direction=xp.nan)
+        res = derivative(xp.exp, xp.asarray(1), step_direction=xp.nan)
         xp_assert_equal(res.df, xp.asarray(xp.nan))
         xp_assert_equal(res.status, xp.asarray(-3, dtype=xp.int32))
 
-        res = differentiate(xp.exp, xp.asarray(1), initial_step=0)
+        res = derivative(xp.exp, xp.asarray(1), initial_step=0)
         xp_assert_equal(res.df, xp.asarray(xp.nan))
         xp_assert_equal(res.status, xp.asarray(-3, dtype=xp.int32))
 
@@ -403,7 +400,7 @@ class TestDifferentiate:
         # of iterations if function is a polynomial. Ideally, all polynomials
         # of order 0-2 would get exact result with 0 refinement iterations,
         # all polynomials of order 3-4 would be differentiated exactly after
-        # 1 iteration, etc. However, it seems that differentiate needs an
+        # 1 iteration, etc. However, it seems that `derivative` needs an
         # extra iteration to detect convergence based on the error estimate.
 
         for n in range(6):
@@ -413,11 +410,11 @@ class TestDifferentiate:
 
             ref = 2*n*x**(n-1)
 
-            res = differentiate(f, x, maxiter=1, order=max(1, n))
+            res = derivative(f, x, maxiter=1, order=max(1, n))
             xp_assert_close(res.df, ref, rtol=1e-15)
             xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64))
 
-            res = differentiate(f, x, order=max(1, n))
+            res = derivative(f, x, order=max(1, n))
             assert res.success
             assert res.nit == 2
             xp_assert_close(res.df, ref, rtol=1e-15)
@@ -426,7 +423,7 @@ class TestDifferentiate:
         def f(x, c):
             return c*x - 1
 
-        res = differentiate(f, xp.asarray(2), args=xp.asarray(3))
+        res = derivative(f, xp.asarray(2), args=xp.asarray(3))
         xp_assert_close(res.df, xp.asarray(3.))
 
     # no need to run a test on multiple backends if it's xfailed
@@ -441,7 +438,7 @@ class TestDifferentiate:
         # the true derivative is exactly zero. This tests that specifying a
         # (tight) `atol` alleviates the problem. See discussion in gh-18811.
         atol = 1e-16
-        res = differentiate(*case, step_direction=[-1, 0, 1], atol=atol)
+        res = derivative(*case, step_direction=[-1, 0, 1], atol=atol)
         assert np.all(res.success)
         assert_allclose(res.df, 0, atol=atol)
 
@@ -455,7 +452,7 @@ class JacobianHessianTest:
         with pytest.raises(ValueError, match=message):
             jh_func(np.sin, 1, tolerances=dict(atol=-1))
 
-        # Confirm that other parameters are being passed to `differentiate`,
+        # Confirm that other parameters are being passed to `derivative`,
         # which raises an appropriate error message.
         x = np.ones(3)
         func = optimize.rosen


### PR DESCRIPTION
#### Reference issue
gh-20708

#### What does this implement/fix?
This proposes renaming the `scipy.differentiate.differentiate` function to `scipy.differentiate.derivative` before its release in SciPy 1.15 because:

- The noun `derivative` fits better next to the nouns `jacobian` and `hessian`.
- `derivative` may be less likely ($n=2$) to be confused with other (e.g. multivariate) differentiation operations
- `derivative` is shorter
- `differentiate.differentiate` sounds repetitive.

Of course, there are arguments against it, such as the usual arguments for naming functions with a verb. However, I doubt there would be support for renaming the other functions to verbs like `jacobianate` or `hessianize`, so this may be the better way of making the forms at least consistent.