### PR TITLE
API: signal: rename `sosfilt` `sosfilt_zi` and `sosfiltfilt`

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -56,11 +56,11 @@ Filtering
 
    deconvolve    -- 1-D deconvolution using lfilter.
 
-   sosfilt       -- 1-D IIR digital linear filtering using
+   filt_sos      -- 1-D IIR digital linear filtering using
                  -- a second-order sections filter representation.
-   sosfilt_zi    -- Compute an initial state zi for the sosfilt function that
+   filt_zi_sos   -- Compute an initial state zi for the filt_sos function that
                  -- corresponds to the steady state of the step response.
-   sosfiltfilt   -- A forward-backward filter for second-order sections.
+   filtfilt_sos  -- A forward-backward filter for second-order sections.
    hilbert       -- Compute 1-D analytic signal, using the Hilbert transform.
    hilbert2      -- Compute 2-D analytic signal, using the Hilbert transform.
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -787,7 +787,7 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
 
     See Also
     --------
-    freqz, sosfilt
+    freqz, filt_sos
 
     Notes
     -----
@@ -1229,12 +1229,12 @@ def tf2sos(b, a, pairing=None, *, analog=False):
     -------
     sos : ndarray
         Array of second-order filter coefficients, with shape
-        ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
+        ``(n_sections, 6)``. See `filt_sos` for the SOS filter format
         specification.
 
     See Also
     --------
-    zpk2sos, sosfilt
+    zpk2sos, filt_sos
 
     Notes
     -----
@@ -1271,7 +1271,7 @@ def sos2tf(sos):
     ----------
     sos : array_like
         Array of second-order filter coefficients, must have shape
-        ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
+        ``(n_sections, 6)``. See `filt_sos` for the SOS filter format
         specification.
 
     Returns
@@ -1319,7 +1319,7 @@ def sos2zpk(sos):
     ----------
     sos : array_like
         Array of second-order filter coefficients, must have shape
-        ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
+        ``(n_sections, 6)``. See `filt_sos` for the SOS filter format
         specification.
 
     Returns
@@ -1398,12 +1398,12 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
     -------
     sos : ndarray
         Array of second-order filter coefficients, with shape
-        ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
+        ``(n_sections, 6)``. See `filt_sos` for the SOS filter format
         specification.
 
     See Also
     --------
-    sosfilt
+    filt_sos
 
     Notes
     -----
@@ -1414,8 +1414,8 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
     with the poles closest to the unit circle for discrete-time systems, and
     poles closest to the imaginary axis for continuous-time systems.
 
-    ``pairing='minimal'`` outputs may not be suitable for `sosfilt`,
-    and ``analog=True`` outputs will never be suitable for `sosfilt`.
+    ``pairing='minimal'`` outputs may not be suitable for `filt_sos`,
+    and ``analog=True`` outputs will never be suitable for `filt_sos`.
 
     *Algorithms*
 
@@ -1555,9 +1555,9 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
     """
     # TODO in the near future:
     # 1. Add SOS capability to `filtfilt`, `freqz`, etc. somehow (#3259).
-    # 2. Make `decimate` use `sosfilt` instead of `lfilter`.
-    # 3. Make sosfilt automatically simplify sections to first order
-    #    when possible. Note this might make `sosfiltfilt` a bit harder (ICs).
+    # 2. Make `decimate` use `filt_sos` instead of `lfilter`.
+    # 3. Make filt_sos automatically simplify sections to first order
+    #    when possible. Note this might make `filtfilt_sos` a bit harder (ICs).
     # 4. Further optimizations of the section ordering / pole-zero pairing.
     # See the wiki for other potential issues.
 
@@ -3232,7 +3232,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     (``ba``) format):
 
     >>> sos = signal.butter(10, 15, 'hp', fs=1000, output='sos')
-    >>> filtered = signal.sosfilt(sos, sig)
+    >>> filtered = signal.filt_sos(sos, sig)
     >>> ax2.plot(t, filtered)
     >>> ax2.set_title('After 15 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
@@ -3350,7 +3350,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
     (``ba``) format):
 
     >>> sos = signal.cheby1(10, 1, 15, 'hp', fs=1000, output='sos')
-    >>> filtered = signal.sosfilt(sos, sig)
+    >>> filtered = signal.filt_sos(sos, sig)
     >>> ax2.plot(t, filtered)
     >>> ax2.set_title('After 15 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
@@ -3463,7 +3463,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     (``ba``) format):
 
     >>> sos = signal.cheby2(12, 20, 17, 'hp', fs=1000, output='sos')
-    >>> filtered = signal.sosfilt(sos, sig)
+    >>> filtered = signal.filt_sos(sos, sig)
     >>> ax2.plot(t, filtered)
     >>> ax2.set_title('After 17 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])
@@ -3587,7 +3587,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     (``ba``) format):
 
     >>> sos = signal.ellip(8, 1, 100, 17, 'hp', fs=1000, output='sos')
-    >>> filtered = signal.sosfilt(sos, sig)
+    >>> filtered = signal.filt_sos(sos, sig)
     >>> ax2.plot(t, filtered)
     >>> ax2.set_title('After 17 Hz high-pass filter')
     >>> ax2.axis([0, 1, -2, 2])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -13,7 +13,8 @@ __all__ = [  # noqa: F822
     'residuez', 'resample', 'resample_poly', 'detrend',
     'lfilter_zi', 'sosfilt_zi', 'sosfiltfilt', 'choose_conv_method',
     'filtfilt', 'decimate', 'vectorstrength',
-    'dlti', 'upfirdn', 'get_window', 'cheby1', 'firwin'
+    'dlti', 'upfirdn', 'get_window', 'cheby1', 'firwin' 'sosfilt',
+    'sosfilt_zi', 'sosfiltfilt'
 ]
 
 

--- a/scipy/signal/tests/test_result_type.py
+++ b/scipy/signal/tests/test_result_type.py
@@ -6,7 +6,7 @@ from scipy.signal import (decimate,
                           lfilter_zi,
                           lfiltic,
                           sos2tf,
-                          sosfilt_zi)
+                          filt_zi_sos)
 
 
 def test_decimate():
@@ -46,6 +46,6 @@ def test_sos2tf():
     assert a.dtype == np.float32
 
 
-def test_sosfilt_zi():
+def test_filt_zi_sos():
     sos_f32 = np.array([[4, 5, 6, 1, 2, 3]], dtype=np.float32)
-    assert sosfilt_zi(sos_f32).dtype == np.float32
+    assert filt_zi_sos(sos_f32).dtype == np.float32

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -338,11 +338,11 @@ class TestSymIIR:
         # The values in SciPy 1.14 agree with those in SciPy 1.9.1 to this
         # accuracy only. Implementation differences are twofold:
         # 1. boundary conditions are computed differently
-        # 2. the filter itself uses sosfilt instead of a hardcoded iteration
+        # 2. the filter itself uses filt_sos instead of a hardcoded iteration
         # The boundary conditions seem are tested separately (see
         # test_symiir2_initial_{fwd,bwd} above, so the difference is likely
         # due to a different way roundoff errors accumulate in the filter.
-        # In that respect, sosfilt is likely doing a better job.
+        # In that respect, filt_sos is likely doing a better job.
         xp_assert_close(res, exp_res, atol=2e-6)
 
         s = s + 1j*s


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Continues https://github.com/scipy/scipy/pull/8213 and https://github.com/scipy/scipy/pull/21025

#### What does this implement/fix?
<!--Please explain your changes.-->
Renames: 
 * `sosfilt` to `filt_sos`
 * `sosfilt_zi` to `filt_zi_sos`
 * `sosfiltfilt` to `filtfilt_sos`

Adds one backwards compatibility test for each function.

The one difference to what's been done with `sosfreqz` (https://github.com/scipy/scipy/pull/21025) is that this PR haven't touched the release notes. Other that that they are very similar.

#### Additional information
<!--Any additional information you think is important.-->
The motivation for this change is that this naming does not follows other function naming standards

> https://github.com/scipy/scipy/pull/8213#issue-281608289
> The name `sosfreqz` is inconsistent with `freqz_zpk`, `lp2lp_zpk`, etc.
> 
> The function's purpose (`freqz`) should be the first part of the name, so that all variants come up during tab completion.
> 
> `sosfreqz` is left as an explanatory alias function for backwards compatibility.
> 
> `sosfilt` `sosfilt_zi` `sosfiltfilt` should also be renamed by the same logic?
