### PR TITLE
DOC: optimize.root: replace 'fprime' with 'jac' in `method=’hybr’`

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -212,10 +212,10 @@ def _root_hybr(func, x0, args=(), jac=None,
     band : tuple
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
-        Jacobi matrix is considered banded (only for ``fprime=None``).
+        Jacobi matrix is considered banded (only for ``jac=None``).
     eps : float
         A suitable step length for the forward-difference
-        approximation of the Jacobian (for ``fprime=None``). If
+        approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
         the machine precision.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-21627.

#### What does this implement/fix?
<!--Please explain your changes.-->
This pull request updates the documentation for optimize.root(method='hybr') by replacing outdated references to the parameter fprime with jac. The incorrect fprime references appear in the descriptions of the band and eps parameters. The change reflects the renaming of fprime to jac in SciPy 0.11.

#### Additional information
<!--Any additional information you think is important.-->
The issue arises from outdated documentation, as fprime has not been a valid parameter for this function since SciPy 0.11. This update ensures consistency and clarity in the documentation, preventing confusion for users referring to optimize.root(method='hybr').
