### PR TITLE
DOC/TST: `integrate.cubature`: Clean up docstring and add additional tests

### DIFF
--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -180,7 +180,8 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
     .. [2] A.C. Genz, A.A. Malik, Remarks on algorithm 006: An adaptive algorithm for
         numerical integration over an N-dimensional rectangular region, Journal of
         Computational and Applied Mathematics, Volume 6, Issue 4, 1980, Pages 295-302,
-        ISSN 0377-0427, https://doi.org/10.1016/0771-050X(80)90039-X.
+        ISSN 0377-0427
+        :doi:`10.1016/0771-050X(80)90039-X`
 
     Examples
     --------

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -90,23 +90,21 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
         Rule used to estimate the integral. If passing a string, the options are
         "gauss-kronrod" (21 node), or "genz-malik" (degree 7). If a rule like
         "gauss-kronrod" is specified for an ``n``-dim integrand, the corresponding
-        Cartesian product rule is used. See Notes.
-
-        "gk21", "gk15" are also supported for compatibility with `quad_vec`.
+        Cartesian product rule is used. "gk21", "gk15" are also supported for
+        compatibility with `quad_vec`. See Notes.
     rtol, atol : float, optional
         Relative and absolute tolerances. Iterations are performed until the error is
         estimated to be less than ``atol + rtol * abs(est)``. Here `rtol` controls
         relative accuracy (number of correct digits), while `atol` controls absolute
         accuracy (number of correct decimal places). To achieve the desired `rtol`, set
         `atol` to be smaller than the smallest value that can be expected from
-        ``rtol * abs(y)`` so that rtol dominates the allowable error. If `atol` is
+        ``rtol * abs(y)`` so that `rtol` dominates the allowable error. If `atol` is
         larger than ``rtol * abs(y)`` the number of correct digits is not guaranteed.
-        Conversely, to achieve the desired `atol` set `rtol` such that ``rtol * abs(y)``
-        is always smaller than `atol`. Default values are 1e-8 for `rtol` and 0 for
-        `atol`.
+        Conversely, to achieve the desired `atol`, set `rtol` such that
+        ``rtol * abs(y)`` is always smaller than `atol`. Default values are 1e-8 for
+        `rtol` and 0 for `atol`.
     max_subdivisions : int, optional
-        Upper bound on the number of subdivisions to perform to improve the estimate
-        over a subregion. Default is 10,000.
+        Upper bound on the number of subdivisions to perform. Default is 10,000.
     args : tuple, optional
         Additional positional args passed to `f`, if any.
     workers : int or map-like callable, optional
@@ -119,87 +117,36 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
 
     Returns
     -------
-    res : CubatureResult
-        Result of estimation. The estimate of the integral is `res.estimate`, and the
-        estimated error is `res.error`. If the integral converges within
-        `max_subdivions`, then `res.status` will be ``"converged"``, otherwise it will
-        be ``"not_converged"``. See `CubatureResult`.
+    res : object
+        Object containing the results of the estimation. It has the following
+        attributes:
 
-    Examples
-    --------
-    A simple 1D integral with vector output. Here ``f(x) = x^n`` is integrated over the
-    interval ``[0, 1]``. Since no rule is specified, the default "gk21" is used, which
-    corresponds to `GaussKronrod` rule with 21 nodes.
+        estimate : ndarray
+            Estimate of the value of the integral over the overall region specified.
+        error : ndarray
+            Estimate of the error of the approximation over the overall region
+            specified.
+        status : str
+            Whether the estimation was successful. Can be either: "converged",
+            "not_converged".
+        subdivisions : int
+            Number of subdivisions performed.
+        atol, rtol : float
+            Requested tolerances for the approximation.
+        regions: list of object
+            List of objects containing the estimates of the integral over smaller
+            regions of the domain.
 
-    >>> import numpy as np
-    >>> from scipy.integrate import cubature
-    >>> def f(x, n):
-    ...    return x.reshape(-1, 1)**n  # Make sure x and n are broadcastable
-    >>> res = cubature(
-    ...     f,
-    ...     a=[0],
-    ...     b=[1],
-    ...     args=(
-    ...         # Since f accepts arrays of shape (npoints, ndim) we need to
-    ...         # make sure n is the right shape
-    ...         np.arange(10).reshape(1, -1),
-    ...     )
-    ... )
-    >>> res.estimate
-     array([1.        , 0.5       , 0.33333333, 0.25      , 0.2       ,
-            0.16666667, 0.14285714, 0.125     , 0.11111111, 0.1       ])
+        Each object in ``regions`` has the following attributes:
 
-    A 7D integral with arbitrary-shaped array output. Here::
-
-        f(x) = cos(2*pi*r + alphas @ x)
-
-    for some ``r`` and ``alphas``, and the integral is performed over the unit
-    hybercube, :math:`[0, 1]^7`. Since the integral is in a moderate number of
-    dimensions, "genz-malik" is used rather than the default "gauss-kronrod" to avoid
-    constructing a product rule with :math:`21^7 \approx 2 \times 10^9` nodes.
-
-    >>> import numpy as np
-    >>> from scipy.integrate import cubature
-    >>> def f(x, r, alphas):
-    ...     # f(x) = cos(2*pi*r + alpha @ x)
-    ...     # Need to allow r and alphas to be arbitrary shape
-    ...     npoints, ndim = x.shape[0], x.shape[-1]
-    ...     alphas_reshaped = alphas[np.newaxis, :]
-    ...     x_reshaped = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
-    ...     return np.cos(2*np.pi*r + np.sum(alphas_reshaped * x_reshaped, axis=-1))
-    >>> rng = np.random.default_rng()
-    >>> r, alphas = rng.random((2, 3)), rng.random((2, 3, 7))
-    >>> res = cubature(
-    ...     f=f,
-    ...     a=np.array([0, 0, 0, 0, 0, 0, 0]),
-    ...     b=np.array([1, 1, 1, 1, 1, 1, 1]),
-    ...     rtol=1e-5,
-    ...     rule="genz-malik",
-    ...     args=(r, alphas),
-    ... )
-    >>> res.estimate
-     array([[-0.79812452,  0.35246913, -0.52273628],
-            [ 0.88392779,  0.59139899,  0.41895111]])
-
-    To compute in parallel, it is possible to use the argument `workers`, for example:
-
-    >>> from concurrent.futures import ThreadPoolExecutor
-    >>> with ThreadPoolExecutor() as executor:
-    ...     res = cubature(
-    ...         f=f,
-    ...         a=np.array([0, 0, 0, 0, 0, 0, 0]),
-    ...         b=np.array([1, 1, 1, 1, 1, 1, 1]),
-    ...         rtol=1e-5,
-    ...         rule="genz-malik",
-    ...         args=(r, alphas),
-    ...         workers=executor.map,
-    ...      )
-    >>> res.estimate
-     array([[-0.79812452,  0.35246913, -0.52273628],
-            [ 0.88392779,  0.59139899,  0.41895111]])
-
-    When this is done with process-based parallelization (as would be the case passing
-    `workers` as an integer) you should ensure the main module is import-safe.
+        a, b : ndarray
+            Points describing the corners of the region. If the original integral
+            contained infinite limits or was over a region described by `region`,
+            then `a` and `b` are in the transformed coordinates.
+        estimate : ndarray
+            Estimate of the value of the integral over this region.
+        error : ndarray
+            Estimate of the error of the approximation over this region.
 
     Notes
     -----
@@ -234,6 +181,82 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
         numerical integration over an N-dimensional rectangular region, Journal of
         Computational and Applied Mathematics, Volume 6, Issue 4, 1980, Pages 295-302,
         ISSN 0377-0427, https://doi.org/10.1016/0771-050X(80)90039-X.
+
+    Examples
+    --------
+    **1D integral with vector output**:
+
+    .. math::
+
+        \int^1_0 \mathbf f(x) \text dx
+
+    Where ``f(x) = x^n`` and ``n = np.arange(10)`` is a vector. Since no rule is
+    specified, the default "gk21" is used, which corresponds to Gauss-Kronrod
+    integration with 21 nodes.
+
+    >>> import numpy as np
+    >>> from scipy.integrate import cubature
+    >>> def f(x, n):
+    ...    # Make sure x and n are broadcastable
+    ...    return x[:, np.newaxis]**n[np.newaxis, :]
+    >>> res = cubature(
+    ...     f,
+    ...     a=[0],
+    ...     b=[1],
+    ...     args=(np.arange(10),),
+    ... )
+    >>> res.estimate
+     array([1.        , 0.5       , 0.33333333, 0.25      , 0.2       ,
+            0.16666667, 0.14285714, 0.125     , 0.11111111, 0.1       ])
+
+    **7D integral with arbitrary-shaped array output**::
+
+        f(x) = cos(2*pi*r + alphas @ x)
+
+    for some ``r`` and ``alphas``, and the integral is performed over the unit
+    hybercube, :math:`[0, 1]^7`. Since the integral is in a moderate number of
+    dimensions, "genz-malik" is used rather than the default "gauss-kronrod" to
+    avoid constructing a product rule with :math:`21^7 \approx 2 \times 10^9` nodes.
+
+    >>> import numpy as np
+    >>> from scipy.integrate import cubature
+    >>> def f(x, r, alphas):
+    ...     # f(x) = cos(2*pi*r + alphas @ x)
+    ...     # Need to allow r and alphas to be arbitrary shape
+    ...     npoints, ndim = x.shape[0], x.shape[-1]
+    ...     alphas = alphas[np.newaxis, ...]
+    ...     x = x.reshape(npoints, *([1]*(len(alphas.shape) - 1)), ndim)
+    ...     return np.cos(2*np.pi*r + np.sum(alphas * x, axis=-1))
+    >>> rng = np.random.default_rng()
+    >>> r, alphas = rng.random((2, 3)), rng.random((2, 3, 7))
+    >>> res = cubature(
+    ...     f=f,
+    ...     a=np.array([0, 0, 0, 0, 0, 0, 0]),
+    ...     b=np.array([1, 1, 1, 1, 1, 1, 1]),
+    ...     rtol=1e-5,
+    ...     rule="genz-malik",
+    ...     args=(r, alphas),
+    ... )
+    >>> res.estimate
+     array([[-0.79812452,  0.35246913, -0.52273628],
+            [ 0.88392779,  0.59139899,  0.41895111]])
+
+    **Parallel computation with** `workers`:
+
+    >>> from concurrent.futures import ThreadPoolExecutor
+    >>> with ThreadPoolExecutor() as executor:
+    ...     res = cubature(
+    ...         f=f,
+    ...         a=np.array([0, 0, 0, 0, 0, 0, 0]),
+    ...         b=np.array([1, 1, 1, 1, 1, 1, 1]),
+    ...         rtol=1e-5,
+    ...         rule="genz-malik",
+    ...         args=(r, alphas),
+    ...         workers=executor.map,
+    ...      )
+    >>> res.estimate
+     array([[-0.79812452,  0.35246913, -0.52273628],
+            [ 0.88392779,  0.59139899,  0.41895111]])
     """
 
     # It is also possible to use a custom rule, but this is not yet part of the public

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -269,6 +269,9 @@ def cubature(f, a, b, rule="gk21", rtol=1e-8, atol=0, max_subdivisions=10000,
     a = xp.asarray(a, dtype=xp.float64)
     b = xp.asarray(b, dtype=xp.float64)
 
+    if xp_size(a) == 0 or xp_size(b) == 0:
+        raise ValueError("`a` and `b` must be nonempty")
+
     if a.ndim != 1 or b.ndim != 1:
         raise ValueError("`a` and `b` must be 1D arrays")
 

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -1,7 +1,7 @@
 import heapq
 import itertools
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any, TYPE_CHECKING
 
@@ -29,7 +29,7 @@ class CubatureRegion:
     error: Array
     a: Array
     b: Array
-    _xp: ModuleType
+    _xp: ModuleType = field(repr=False)
 
     def __lt__(self, other):
         # Consider regions with higher error estimates as being "less than" regions with

--- a/scipy/integrate/_rules/_base.py
+++ b/scipy/integrate/_rules/_base.py
@@ -1,7 +1,5 @@
 from scipy._lib._array_api import array_namespace, xp_size
 
-import math
-
 from functools import cached_property
 
 
@@ -498,7 +496,7 @@ def _apply_fixed_rule(f, a, b, orig_nodes, orig_weights, args=()):
 
     # Also need to multiply the weights by a scale factor equal to the determinant
     # of the Jacobian for this coordinate change.
-    weight_scale_factor = math.prod(lengths) / 2**rule_ndim
+    weight_scale_factor = xp.prod(lengths) / 2**rule_ndim
     weights = orig_weights * weight_scale_factor
 
     f_nodes = f(nodes, *args)

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -447,7 +447,7 @@ class TestCubatureProblems:
             genz_malik_1980_f_1,
             genz_malik_1980_f_1_exact,
             [0, 0, 0],
-            [10, 10, 10],
+            [5, 5, 5],
             (
                 1/2,
                 [1, 1, 1],
@@ -469,7 +469,7 @@ class TestCubatureProblems:
             genz_malik_1980_f_2,
             genz_malik_1980_f_2_exact,
 
-            [10, 50],
+            [0, 0],
             [10, 50],
             (
                 [-3, 3],

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -359,6 +359,13 @@ class TestCubature:
         with pytest.raises(Exception, match="`a` and `b` must be 1D arrays"):
             cubature(basic_1d_integrand, a, b, args=(xp,))
 
+    def test_a_and_b_must_be_nonempty(self, xp):
+        a = xp.asarray([])
+        b = xp.asarray([])
+
+        with pytest.raises(Exception, match="`a` and `b` must be nonempty"):
+            cubature(basic_1d_integrand, a, b, args=(xp,))
+
 
 @pytest.mark.parametrize("rtol", [1e-4])
 @pytest.mark.parametrize("atol", [1e-5])

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -366,6 +366,26 @@ class TestCubature:
         with pytest.raises(Exception, match="`a` and `b` must be nonempty"):
             cubature(basic_1d_integrand, a, b, args=(xp,))
 
+    def test_zero_width_limits(self, xp):
+        n = xp.arange(5, dtype=xp.float64)
+
+        a = xp.asarray([0], dtype=xp.float64)
+        b = xp.asarray([0], dtype=xp.float64)
+
+        res = cubature(
+            basic_1d_integrand,
+            a,
+            b,
+            args=(n, xp),
+        )
+
+        xp_assert_close(
+            res.estimate,
+            xp.asarray([[0], [0], [0], [0], [0]], dtype=xp.float64),
+            rtol=1e-1,
+            atol=0,
+        )
+
 
 @pytest.mark.parametrize("rtol", [1e-4])
 @pytest.mark.parametrize("atol", [1e-5])

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -402,7 +402,7 @@ class TestCubatureProblems:
     Tests that `cubature` gives the correct answer.
     """
 
-    problems_scalar_output = [
+    @pytest.mark.parametrize("problem", [
         # -- f1 --
         (
             # Function to integrate, like `f(x, *args)`
@@ -612,42 +612,7 @@ class TestCubatureProblems:
                 [1, 1, 1],
             ),
         ),
-    ]
-
-    problem_array_output = [
-        (
-            # Function to integrate, like `f(x, *args)`
-            genz_malik_1980_f_1,
-
-            # Exact solution, like `exact(a, b, *args)`
-            genz_malik_1980_f_1_exact,
-
-            # Function that generates random args of a certain shape.
-            genz_malik_1980_f_1_random_args,
-        ),
-        (
-            genz_malik_1980_f_2,
-            genz_malik_1980_f_2_exact,
-            genz_malik_1980_f_2_random_args,
-        ),
-        (
-            genz_malik_1980_f_3,
-            genz_malik_1980_f_3_exact,
-            genz_malik_1980_f_3_random_args
-        ),
-        (
-            genz_malik_1980_f_4,
-            genz_malik_1980_f_4_exact,
-            genz_malik_1980_f_4_random_args
-        ),
-        (
-            genz_malik_1980_f_5,
-            genz_malik_1980_f_5_exact,
-            genz_malik_1980_f_5_random_args,
-        ),
-    ]
-
-    @pytest.mark.parametrize("problem", problems_scalar_output)
+    ])
     def test_scalar_output(self, problem, rule, rtol, atol, xp):
         f, exact, a, b, args = problem
 
@@ -683,7 +648,38 @@ class TestCubatureProblems:
             err_msg=f"estimate_error={res.error}, subdivisions={res.subdivisions}",
         )
 
-    @pytest.mark.parametrize("problem", problem_array_output)
+    @pytest.mark.parametrize("problem", [
+        (
+            # Function to integrate, like `f(x, *args)`
+            genz_malik_1980_f_1,
+
+            # Exact solution, like `exact(a, b, *args)`
+            genz_malik_1980_f_1_exact,
+
+            # Function that generates random args of a certain shape.
+            genz_malik_1980_f_1_random_args,
+        ),
+        (
+            genz_malik_1980_f_2,
+            genz_malik_1980_f_2_exact,
+            genz_malik_1980_f_2_random_args,
+        ),
+        (
+            genz_malik_1980_f_3,
+            genz_malik_1980_f_3_exact,
+            genz_malik_1980_f_3_random_args
+        ),
+        (
+            genz_malik_1980_f_4,
+            genz_malik_1980_f_4_exact,
+            genz_malik_1980_f_4_random_args
+        ),
+        (
+            genz_malik_1980_f_5,
+            genz_malik_1980_f_5_exact,
+            genz_malik_1980_f_5_random_args,
+        ),
+    ])
     @pytest.mark.parametrize("shape", [
         (2,),
         (3,),

--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -34,6 +34,7 @@ def basic_1d_integrand(x, n, xp):
 
 
 def basic_1d_integrand_exact(n, xp):
+    # Exact only for integration over interval [0, 2].
     return xp.reshape(2**(n+1)/(n+1), (-1, 1))
 
 
@@ -42,6 +43,7 @@ def basic_nd_integrand(x, n, xp):
 
 
 def basic_nd_integrand_exact(n, xp):
+    # Exact only for integration over interval [0, 2].
     return (-2**(3+n) + 4**(2+n))/((1+n)*(2+n))
 
 


### PR DESCRIPTION
### Reference issues
- #20252
- Builds on:
	- #21330
	- #21473
- Originally part of #21632, which is now being split into multiple PRs so it is easier to review.

#### What does this implement/fix?
This makes some improvements to the documentation for `integrate.cubature` and adds some new tests for the existing functionality. It also prevents `_xp` being printed in the `CubatureResult` dataclass.

To be specific, this makes the following changes:

- Don't display the value of `_xp` when printing `CubatureResult`
- Switch the order of the Notes and Examples section to match how it is is rendered in the docs
- Remove linebreak in description of `rule` parameter
- Use correct formatting for `rtol` and `atol` in parameters section
- Don't use ambiguous phrase for `max_subdivisions` in parameters section
- Include documentation for `CubatureResult` in Returns section as `CubatureResult` is private (as mentioned in #20252)
- Update examples to use consistent reshaping syntax
- Give each example a title
- Use `alphas` rather than `alpha` in the 7D integral example
- Require `a` and `b` to be nonempty
- Add a test for when `a` and `b` are empty
- Add a test that checks the result should be zero when `a` and `b` describe a region that has zero width in one of its dimensions
- Use `xp.prod` rather than `math.prod` in `_apply_fixed_rule`
- Add a comment to `basic_1d_integrand_exact` and `basic_nd_integrand_exact` explaining that they are only exact for a specific interval
- Removes the definitions of `problems_scalar_output` and `problems_array_output` and instead parameterises the tests with these lists directly
- Reduce the size of the region being integrated over in one case of `test_scalar_output` so that it would run faster, occasionally this would take more than 1 second
- Fix a typo for another case in `test_scalar_output` where integration was being done over `[10, 50] x [10, 50]` rather than `[0, 0] x [10, 50]`.
