### PR TITLE
BUG: `special.log_wright_bessel`: fix non-log for `1<x<=2`

### DIFF
--- a/scipy/special/tests/test_wright_bessel.py
+++ b/scipy/special/tests/test_wright_bessel.py
@@ -121,7 +121,7 @@ def test_wright_data_grid_less_accurate(a, b, x, phi, accuracy):
 @pytest.mark.parametrize(
     'a, b, x',
     list(
-        product([0, 0.1, 0.5, 1.5, 5, 10], [1, 2], [1e-3, 1, 5, 10])
+        product([0, 0.1, 0.5, 1.5, 5, 10], [1, 2], [1e-3, 1, 1.5, 5, 10])
     )
 )
 def test_log_wright_bessel_same_as_wright_bessel(a, b, x):

--- a/scipy/special/xsf/wright_bessel.h
+++ b/scipy/special/xsf/wright_bessel.h
@@ -780,7 +780,9 @@ XSF_HOST_DEVICE inline double wright_bessel_t(double a, double b, double x) {
     }
     if (x <= 2) {
         // 20 term Taylor Series => error mostly smaller 1e-12 to 1e-13
-        return detail::wb_series(a, b, x, 0, 20);
+        double res = detail::wb_series(a, b, x, 0, 20);
+        if (log_wb) res = std::log(res);
+        return res;
     }
     if (a >= 5) {
         /* Taylor series around the approximate maximum term.


### PR DESCRIPTION
#### Reference issue
Closes gh-21651 @dskoch

#### What does this implement/fix?
Add a missing log check in the `{log_}wright_bessel` implementation in `xsf`.

#### Additional information
cc @lorentzenchr @steppi @WarrenWeckesser 
