### PR TITLE
ENH: spatial: support distance computation kernels

### DIFF
--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -71,7 +71,7 @@ py3.extension_module('_ckdtree',
 
 py3.extension_module('_distance_wrap',
   'src/distance_wrap.c',
-  include_directories: '../_lib',
+  include_directories: ['../_lib', '../_lib/src'],
   dependencies: np_dep,
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
#### Reference issue
Toward gh-21645.

#### What does this implement/fix?
Through a simple “front-to-back” example, this PR illustrates how a distance computation kernel proposed in the referenced issue (gh-21645) may look like in SciPy.

Tasks of the backend:
1. Write a C function that does the actual computation (`cdist_cosine`, already exists)
2. If the above function doesn’t have the prescribed signature required by the front-end, write a C wrapper (`cosine_DistanceMatrix`)
3. Make the C function from step 2 available to Python. There are (at least) two ways:
  a. Export the function pointer via a Python capsule. This requires the backend to link the Python library. This PR uses this approach because it already links the Python library so is convenient.
  b. Build the backend as a dynamic library, and load the symbol from Python using `ctypes`.
4. Call `add_distance_kernel` to make the exported function available to the front end.

Tasks of the front end:
1. Implement `add_distance_kernel`. (implemented by this PR)
2. Delegate the user call to the appropriate kernel. This PR updates `cdist` to take an optional `backend` parameter. If `metric` starts with `new_`,  `new_cdist` is called with the `backend` argument. (This is of course just for demo.)

The Examples section of the doc string of `add_distance_kernel` contains a working example to execute a kernel provided by the backend.

#### Additional information
Pending points to be implemented for the front-end:
- Select the most appropriate kernel from multiple backends. (Currently a unique backend must be specified.)
- Make use of DistanceScalar, DistanceVector or DistanceMatrix, whichever is provided by the backend.
- Clarify type promotion rules.
- A bit of refactoring to support pdist with minimal code duplication.