### PR TITLE
BUG: ndimage: fix 0d arrays in `_normalize_sequence`

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -61,7 +61,7 @@ def _normalize_sequence(input, rank):
     check if its length is equal to the length of array.
     """
     is_str = isinstance(input, str)
-    if not is_str and isinstance(input, Iterable):
+    if not is_str and np.iterable(input):
         normalized = list(input)
         if len(normalized) != rank:
             err = "sequence argument must have length equal to input rank"

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1319,6 +1319,14 @@ class TestZoom:
         x = xp.reshape(xp.arange(12), (3, 4))
         ndimage.zoom(x, 2, output=xp.zeros((6, 8)))
 
+    def test_zoom_0d_array(self, xp):
+        # Ticket #21670 regression test
+        a = xp.arange(10.)
+        factor = 2
+        actual = ndimage.zoom(a, np.array(factor))
+        expected = ndimage.zoom(a, factor)
+        xp_assert_close(actual, expected)
+
 
 class TestRotate:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.--> 
Closes #21670

#### What does this implement/fix?
<!--Please explain your changes.-->
Change check on `input` of ndimage's `_normalize_sequence` function to use `np.iterable` instead of `collections.abc.Iterable`. The latter classifies a 0d array as a sequence and calls `list` on it, leading to an error. 

#### Additional information
<!--Any additional information you think is important.-->
