### PR TITLE
ENH: optimize.least_squares: Add `callback` that runs on each iteration

### DIFF
--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -147,7 +147,7 @@ def dogleg_step(x, newton_step, g, a, b, tr_bounds, lb, ub):
 
 
 def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
-           loss_function, tr_solver, tr_options, verbose):
+           loss_function, tr_solver, tr_options, verbose, outfun=None):
     f = f0
     f_true = f.copy()
     nfev = 1
@@ -320,6 +320,15 @@ def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
         else:
             step_norm = 0
             actual_reduction = 0
+
+        # Call output function and possibly stop optimization
+        if outfun is not None:
+            stop = outfun(x_new, f_new, cost_new, iteration)
+
+            if stop:
+                termination_status = -2
+                break
+
 
         iteration += 1
 

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -110,7 +110,7 @@ from .common import (
 
 
 def trf(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
-        loss_function, tr_solver, tr_options, verbose):
+        loss_function, tr_solver, tr_options, verbose, outfun=None):
     # For efficiency, it makes sense to run the simplified version of the
     # algorithm when no bounds are imposed. We decided to write the two
     # separate functions. It violates the DRY principle, but the individual
@@ -118,11 +118,11 @@ def trf(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
     if np.all(lb == -np.inf) and np.all(ub == np.inf):
         return trf_no_bounds(
             fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev, x_scale,
-            loss_function, tr_solver, tr_options, verbose)
+            loss_function, tr_solver, tr_options, verbose, outfun=outfun)
     else:
         return trf_bounds(
             fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
-            loss_function, tr_solver, tr_options, verbose)
+            loss_function, tr_solver, tr_options, verbose, outfun=outfun)
 
 
 def select_step(x, J_h, diag_h, g_h, p, p_h, d, Delta, lb, ub, theta):
@@ -203,7 +203,7 @@ def select_step(x, J_h, diag_h, g_h, p, p_h, d, Delta, lb, ub, theta):
 
 
 def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
-               x_scale, loss_function, tr_solver, tr_options, verbose):
+               x_scale, loss_function, tr_solver, tr_options, verbose, outfun=None):
     x = x0.copy()
 
     f = f0
@@ -385,6 +385,14 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
         else:
             step_norm = 0
             actual_reduction = 0
+            
+        # Call output function and possibly stop optimization
+        if outfun is not None:
+            stop = outfun(x_new, f_new, cost_new, iteration)
+
+            if stop:
+                termination_status = -2
+                break
 
         iteration += 1
 
@@ -399,7 +407,7 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
 
 
 def trf_no_bounds(fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev,
-                  x_scale, loss_function, tr_solver, tr_options, verbose):
+                  x_scale, loss_function, tr_solver, tr_options, verbose, outfun=None):
     x = x0.copy()
 
     f = f0
@@ -547,6 +555,14 @@ def trf_no_bounds(fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev,
         else:
             step_norm = 0
             actual_reduction = 0
+
+        # Call output function and possibly stop optimization
+        if outfun is not None:
+            stop = outfun(x_new, f_new, cost_new, iteration)
+
+            if stop:
+                termination_status = -2
+                break
 
         iteration += 1
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -787,6 +787,41 @@ def test_basic():
     assert_allclose(res.x, 0, atol=1e-10)
 
 
+
+
+def test_outfun():
+    # test that output function works as expected
+    
+    p = [0.0, 0.0, 0.0, 0.0]
+    
+    def my_outfun(x_new, f_new, cost_new, iteration):
+        p[0] = x_new
+        p[1] = f_new
+        p[2] = cost_new
+        p[3] = iteration
+        return False
+    
+    res = least_squares(fun_trivial, 5.0, method='trf', outfun=my_outfun)
+    assert_(p[0] != 0)
+    assert_(p[1] != 0)
+    assert_(p[2] != 0)
+    assert_(p[3] != 0)
+    
+    p = [0.0, 0.0, 0.0, 0.0]
+    res = least_squares(fun_trivial, 5.0, method='trf', bounds=(-8.0, 8.0), outfun=my_outfun)
+    assert_(p[0] != 0)
+    assert_(p[1] != 0)
+    assert_(p[2] != 0)
+    assert_(p[3] != 0)
+    
+    p = [0.0, 0.0, 0.0, 0.0]
+    res = least_squares(fun_trivial, 5.0, method='dogbox', outfun=my_outfun)
+    assert_(p[0] != 0)
+    assert_(p[1] != 0)
+    assert_(p[2] != 0)
+    assert_(p[3] != 0)
+
+
 def test_small_tolerances_for_lm():
     for ftol, xtol, gtol in [(None, 1e-13, 1e-13),
                              (1e-13, None, 1e-13),


### PR DESCRIPTION
Add an optional argument `outfun` to optimize.least_squares. If `outfun` is a Callable, it will get called by the optimization algorithm on each iteration. If the Callable returns True, this causes the algorithm to stop at the current iteration with status code -2. If it returns False, optimization proceeds as usual. This can be used to plot the intermediate optimization results or to implement a user-defined stop condition. By default `outfun` is None, which provides backward compatibility (if no `outfun` is passed, least_squares behavior remains unchanged)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Added new optional argument `outfun` to optimize.least_squares 

#### Additional information
Added test `test_outfun` in test_least_squares.py, all tests passing locally
