### PR TITLE
BUG: fix `nan` output of `special.betaincinv`

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -18,6 +18,7 @@
 typedef boost::math::policies::policy<
     boost::math::policies::promote_float<false >,
     boost::math::policies::promote_double<false >,
+    boost::math::policies::evaluation_error<boost::math::policies::user_error >,
     boost::math::policies::max_root_iterations<400 > > SpecialPolicy;
 
 // Round up to achieve correct ppf(cdf) round-trips for discrete distributions

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -18,7 +18,6 @@
 typedef boost::math::policies::policy<
     boost::math::policies::promote_float<false >,
     boost::math::policies::promote_double<false >,
-    boost::math::policies::evaluation_error<boost::math::policies::user_error >,
     boost::math::policies::max_root_iterations<400 > > SpecialPolicy;
 
 // Round up to achieve correct ppf(cdf) round-trips for discrete distributions

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1445,10 +1445,11 @@ class TestBetaInc:
             with pytest.raises(special.SpecialFunctionError, match='domain'):
                 special.betainc(*args)
 
-    def test_gh21426(self):
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_gh21426(self, dtype):
         # Test for gh-21426: betaincinv must not return NaN
-        a = 5.
-        x = 0.5
+        a = np.array([5.], dtype=dtype)
+        x = np.array([0.5], dtype=dtype)
         assert_allclose(special.betaincinv(a, a, x), x, rtol=1e-15)
 
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1450,7 +1450,8 @@ class TestBetaInc:
         # Test for gh-21426: betaincinv must not return NaN
         a = np.array([5.], dtype=dtype)
         x = np.array([0.5], dtype=dtype)
-        assert_allclose(special.betaincinv(a, a, x), x, rtol=1e-15)
+        result = special.betaincinv(a, a, x)
+        assert_allclose(result, x, rtol=1e-15)
 
 
 class TestCombinatorics:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1451,7 +1451,14 @@ class TestBetaInc:
         a = np.array([5.], dtype=dtype)
         x = np.array([0.5], dtype=dtype)
         result = special.betaincinv(a, a, x)
-        assert_allclose(result, x, rtol=1e-15)
+        if sys.maxsize <= 2**32 and dtype == np.float32:
+            # result is not very precise for 32bit architecture and single
+            # precision
+            rtol = 1e-6
+        else:
+
+            rtol = 1e-15
+        assert_allclose(result, x, rtol=rtol)
 
 
 class TestCombinatorics:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1456,7 +1456,6 @@ class TestBetaInc:
             # precision
             rtol = 1e-6
         else:
-
             rtol = 1e-15
         assert_allclose(result, x, rtol=rtol)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1445,6 +1445,12 @@ class TestBetaInc:
             with pytest.raises(special.SpecialFunctionError, match='domain'):
                 special.betainc(*args)
 
+    def test_gh21426(self):
+        # Test for gh-21426: betaincinv must not return NaN
+        a = 5.
+        x = 0.5
+        assert_allclose(special.betaincinv(a, a, x), x, rtol=1e-15)
+
 
 class TestCombinatorics:
     def test_comb(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1451,13 +1451,7 @@ class TestBetaInc:
         a = np.array([5.], dtype=dtype)
         x = np.array([0.5], dtype=dtype)
         result = special.betaincinv(a, a, x)
-        if sys.maxsize <= 2**32 and dtype == np.float32:
-            # result is not very precise for 32bit architecture and single
-            # precision
-            rtol = 1e-6
-        else:
-            rtol = 1e-15
-        assert_allclose(result, x, rtol=rtol)
+        assert_allclose(result, x, rtol=10 * np.finfo(dtype).eps)
 
 
 class TestCombinatorics:


### PR DESCRIPTION

#### Reference issue
Closes gh-21426

#### What does this implement/fix?
The underlying issue was fixed in Boost, so I simply updated it.

#### Additional information
@steppi: I do not want to open the can of worms to unify the `stats` and `special` wrappers of boost functions here. This PR is a simple bugfix that can be backported.