### PR TITLE
DOC: Reduce duplication in user guide

### DIFF
--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -2,7 +2,7 @@
 <nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
   <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
   <div class="bd-toc-item navbar-nav">
-    {% if pagename.startswith("reference") %}
+    {% if pagename.startswith(("reference", "tutorial")) %}
       {{- generate_toctree_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) -}}
     {% else %}
       {{- generate_toctree_html("sidebar", maxdepth=2, collapse=True, includehidden=False, titles_only=True) -}}

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -14,37 +14,42 @@ high-level commands and classes for manipulating and visualizing data.
 
 .. _NumPy: https://numpy.org
 
-Subpackages
------------
+Subpackages and User Guides
+---------------------------
 
 SciPy is organized into subpackages covering different scientific
-computing domains. These are summarized in the following table:
+computing domains. These are summarized in the following table, with
+their API reference linked in the Subpackage column and user guide (if available)
+linked in the Description column:
 
-==================  ======================================================
-Subpackage          Description
-==================  ======================================================
+==================  ========================================
+Subpackage          Description and User Guide
+==================  ========================================
 `cluster`           Clustering algorithms
 `constants`         Physical and mathematical constants
 `differentiate`     Finite difference differentiation tools
-`fft`               Discrete Fourier transforms
+`fft`               :doc:`./fft`
 `fftpack`           Fast Fourier Transform routines (legacy)
-`integrate`         Integration and ordinary differential equation solvers
-`interpolate`       Interpolation and smoothing splines
-`io`                Input and Output
-`linalg`            Linear algebra
-`ndimage`           N-dimensional image processing
+`integrate`         :doc:`./integrate`
+`interpolate`       :doc:`./interpolate`
+`io`                :doc:`./io`
+`linalg`            :doc:`./linalg`
+`ndimage`           :doc:`./ndimage`
 `odr`               Orthogonal distance regression
-`optimize`          Optimization and root-finding routines
-`signal`            Signal processing
-`sparse`            Sparse matrices and associated routines
-`spatial`           Spatial data structures and algorithms
-`special`           Special functions
-`stats`             Statistical distributions and functions
-==================  ======================================================
+`optimize`          :doc:`./optimize`
+`signal`            :doc:`./signal`
+`sparse`            :doc:`./sparse`
+`spatial`           :doc:`./spatial`
+`special`           :doc:`./special`
+`stats`             :doc:`./stats`
+==================  ========================================
+
+There are also additional user guides for these topics:
+
+- :doc:`./arpack` - Eigenvalue problem solver using iterative methods
+- :doc:`./csgraph` - Compressed Sparse Graph Routines
 
 For guidance on organizing and importing functions from SciPy subpackages, refer to the `Guidelines for Importing Functions from SciPy <https://scipy.github.io/devdocs/reference/index.html#guidelines-for-importing-functions-from-scipy>`_.
-
-Below, you can find the complete user guide organized by subpackages.
 
 .. raw:: latex
 
@@ -53,21 +58,22 @@ Below, you can find the complete user guide organized by subpackages.
 .. toctree::
    :caption: User guide
    :maxdepth: 1
+   :hidden:
 
-   special
-   integrate
-   optimize
-   interpolate
    fft
-   signal
+   integrate
+   interpolate
+   io
    linalg
+   ndimage
+   optimize
+   signal
    sparse
+   spatial
+   special
+   stats
    arpack
    csgraph
-   spatial
-   stats
-   ndimage
-   io
 
 .. raw:: latex
 

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -19,7 +19,7 @@ Subpackages and User Guides
 
 SciPy is organized into subpackages covering different scientific
 computing domains. These are summarized in the following table, with
-their API reference linked in the Subpackage column and user guide (if available)
+their API reference linked in the Subpackage column, and user guide (if available)
 linked in the Description column:
 
 ==================  ========================================

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1,5 +1,5 @@
-Multidimensional image processing (`scipy.ndimage`)
-====================================================
+Multidimensional Image Processing (`scipy.ndimage`)
+===================================================
 
 .. moduleauthor:: Peter Verveer <verveer@users.sourceforge.net>
 
@@ -215,7 +215,7 @@ Smoothing filters
   corresponds to convolution with a Gaussian kernel. An order of 1, 2,
   or 3 corresponds to convolution with the first, second, or third
   derivatives of a Gaussian. Higher-order derivatives are not
-  implemented. 
+  implemented.
 
 
 
@@ -232,7 +232,7 @@ Smoothing filters
   number, to specify the same order for all axes, or a sequence of
   numbers to specify a different order for each axis. The example below
   shows the filter applied on test data with different values of *sigma*.
-  The *order* parameter is kept at 0. 
+  The *order* parameter is kept at 0.
 
   .. plot:: tutorial/examples/gaussian_filter_plot1.py
       :align: center

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -1,6 +1,6 @@
 .. _qhulltutorial:
 
-Spatial data structures and algorithms (`scipy.spatial`)
+Spatial Data Structures and Algorithms (`scipy.spatial`)
 ========================================================
 
 .. currentmodule:: scipy.spatial

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -1,4 +1,4 @@
-Special functions (:mod:`scipy.special`)
+Special Functions (:mod:`scipy.special`)
 ========================================
 
 .. currentmodule:: scipy.special


### PR DESCRIPTION
1. I was a bit bothered by the triplet of near-redundancy on the User Guide page between the left sidebar, main panel top table, and main panel bottom toctree list which all have to do with submodules and/or user guides:

   ![image](https://github.com/user-attachments/assets/ea6bf0c9-d486-4402-a668-8729d8251b8e)

   and by the fact that I had to scroll down to get to the actual guides in the main panel. (I didn't notice I could have gotten to them on the left, but they might as well be higher up in the main panel!)

   This is a suggestion-via-PR to reduce the redundancy from triple to double by moving the user guide entries from the bottom into the table at the top as clickable titles:

   ![image](https://github.com/user-attachments/assets/47d8fa64-c396-4227-b556-d35130da6d1e)

   It not only reduces redundancy but immediately makes it clear which submodules actually have tutorials associated with them and which don't.

2. DRY the titles by using whatever the title is in the `:doc:` itself. This is nice because it's DRY but maybe not so nice because it adds a redundant parethetical like `(scipy.signal)` to the end, so I was so-so on this one.

3. Reorders the sections to be alphabetical by submodule name followed by the two that are not directly tied to root-level submodules. If there was a rationale for the original order, happy to restore it and add a comment so the next person doesn't errantly assume (like I did!) that order wasn't intentional.

4. Increases consistency on Title Casing submodule docs.

These are all opinionated, debatable choices -- happy to revert some of them or close if this doesn't seem useful!