### PR TITLE
MAINT: `stats.dirichlet_multinomial` relax `n` to `>= 0`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -5965,7 +5965,7 @@ alpha : array_like
     determines the dimensionality of the distribution. Each entry must be
     strictly positive.
 n : int or array_like
-    The number of trials. Each element must be a strictly positive integer.
+    The number of trials. Each element must be a non-negative integer.
 """
 
 _dirichlet_mn_doc_frozen_callparams = ""
@@ -6007,8 +6007,8 @@ def _dirichlet_multinomial_check_parameters(alpha, n, x=None):
         raise ValueError("`alpha` must contain only positive values.")
 
     n_int = np.floor(n)
-    if np.any(n <= 0) or np.any(n != n_int):
-        raise ValueError("`n` must be a positive integer.")
+    if np.any(n < 0) or np.any(n != n_int):
+        raise ValueError("`n` must be a non-negative integer.")
     n = n_int
 
     sum_alpha = np.sum(alpha, axis=-1)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3751,6 +3751,21 @@ class TestDirichletMultinomial:
         assert_equal(dist.var(), 0)
         assert_equal(dist.cov(), 0)
 
+    def test_n_is_zero(self):
+        # similarly, only one possible outcome if n is zero
+        n = 0
+        alpha = np.asarray([1., 1.])
+        x = np.asarray([0, 0])
+        dist = dirichlet_multinomial(alpha, n)
+
+        assert_equal(dist.pmf(x), 1)
+        assert_equal(dist.pmf(x+1), 0)
+        assert_equal(dist.logpmf(x), 0)
+        assert_equal(dist.logpmf(x+1), -np.inf)
+        assert_equal(dist.mean(), [0, 0])
+        assert_equal(dist.var(), [0, 0])
+        assert_equal(dist.cov(), [[0, 0], [0, 0]])
+
     @pytest.mark.parametrize('method_name', ['pmf', 'logpmf'])
     def test_against_betabinom_pmf(self, method_name):
         rng, m, alpha, n, x = self.get_params(100)
@@ -3813,11 +3828,11 @@ class TestDirichletMultinomial:
         with assert_raises(ValueError, match=text):
             dirichlet_multinomial.logpmf(x0, [3, -1, 4], n0)
 
-        text = "`n` must be a positive integer."
+        text = "`n` must be a non-negative integer."
         with assert_raises(ValueError, match=text):
             dirichlet_multinomial.logpmf(x0, alpha0, 49.1)
         with assert_raises(ValueError, match=text):
-            dirichlet_multinomial.logpmf(x0, alpha0, 0)
+            dirichlet_multinomial.logpmf(x0, alpha0, -1)
 
         x = np.array([1, 2, 3, 4])
         alpha = np.array([3, 4, 5])


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/21531, see that issue for the motivation of this change.

Reference: https://en.wikipedia.org/wiki/Dirichlet-multinomial_distribution. Note that the article previously had n > 0, and I edited it on September 17th 2024. The fact that this change has stood for a few weeks in my opinion implies that it is not controversial.

Apart from relaxing the constraint, I
 - Carefully read through the methods in `dirichlet_multinomial` (`pmf`, `logpmf`, `mean`, `var` and `cov`). It was clear that relaxing the constraint would not break anything.
 - Added a new test to check everything behaves correctly when `n == 0`
 - Updated the existing tests where necessary
 - Updated the docstring of the `n` parameter.