### PR TITLE
BUG: signal: int handling for `resample_poly`

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3416,8 +3416,12 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         max_rate = max(up, down)
         f_c = 1. / max_rate  # cutoff of FIR filter (rel. to Nyquist)
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
-        h = firwin(2 * half_len + 1, f_c,
-                   window=window).astype(x.dtype)  # match dtype of x
+        if np.issubdtype(x.dtype, np.floating):
+            h = firwin(2 * half_len + 1, f_c,
+                       window=window).astype(x.dtype)  # match dtype of x
+        else:
+            h = firwin(2 * half_len + 1, f_c,
+                       window=window)
     h *= up
 
     # Zero-pad our filter to put the output samples at the center

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1414,6 +1414,15 @@ class TestResample:
                         x, up=1, down=down, window=weights)
                     assert_allclose(y_g[::down], y_s)
 
+    @pytest.mark.parametrize('dtype', [np.int32, np.float32])
+    def test_gh_15620(self, dtype):
+        data = np.array([0, 1, 2, 3, 2, 1, 0], dtype=dtype)
+        actual = signal.resample_poly(data,
+                                      up=2,
+                                      down=1,
+                                      padtype='smooth')
+        assert np.count_nonzero(actual) > 0
+
 
 class TestCSpline1DEval:
 


### PR DESCRIPTION
* Fixes gh-15620

* Allows `resample_poly` to accept integer array dtypes for `x` without producing the weird truncation-like all-zero result described in the ticket. One design note is that this would mean we enforce preservation of input `dtype` for floating inputs but not for integer inputs, which the testsuite seems fine with, but I haven't thought too deeply about it.

[skip cirrus] [skip circle]