### PR TITLE
BUG: sparse: enable sparray for sparse.linalg.norm

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -123,7 +123,7 @@ def norm(x, ord=None, axis=None):
     x = x.tocsr()
 
     if axis is None:
-        axis = (0, 1)
+        axis = tuple(range(x.ndim))
     elif not isinstance(axis, tuple):
         msg = "'axis' must be None, an integer or a tuple of integers"
         try:
@@ -134,7 +134,7 @@ def norm(x, ord=None, axis=None):
             raise TypeError(msg)
         axis = (int_axis,)
 
-    nd = 2
+    nd = x.ndim
     if len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
@@ -150,13 +150,13 @@ def norm(x, ord=None, axis=None):
             raise NotImplementedError
             #return _multi_svd_norm(x, row_axis, col_axis, amin)
         elif ord == 1:
-            return abs(x).sum(axis=row_axis).max(axis=col_axis)[0,0]
+            return abs(x).sum(axis=row_axis).max().item()
         elif ord == np.inf:
-            return abs(x).sum(axis=col_axis).max(axis=row_axis)[0,0]
+            return abs(x).sum(axis=col_axis).max().item()
         elif ord == -1:
-            return abs(x).sum(axis=row_axis).min(axis=col_axis)[0,0]
+            return abs(x).sum(axis=row_axis).min().item()
         elif ord == -np.inf:
-            return abs(x).sum(axis=col_axis).min(axis=row_axis)[0,0]
+            return abs(x).sum(axis=col_axis).min().item()
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
             return _sparse_frobenius_norm(x)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -24,7 +24,7 @@ def test_sparray_norm():
             for A in (test_arr, test_mat):
                 expected = npnorm(A.toarray(), ord=ord, axis=ax)
                 assert_equal(spnorm(A, ord=ord, axis=ax), expected)
-    # test 1d
+    # test 1d array and 1d-like (column) matrix
     test_arr_1d = scipy.sparse.coo_array((data, (col,)), shape=(4,))
     test_mat_col = scipy.sparse.coo_matrix((data, (col, [0, 0, 0, 0])), shape=(4, 1))
     for ord in (1, np.inf, None):

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -12,16 +12,26 @@ from scipy.sparse.linalg import norm as spnorm
 
 
 # https://github.com/scipy/scipy/issues/16031
+# https://github.com/scipy/scipy/issues/21690
 def test_sparray_norm():
     row = np.array([0, 0, 1, 1])
     col = np.array([0, 1, 2, 3])
     data = np.array([4, 5, 7, 9])
     test_arr = scipy.sparse.coo_array((data, (row, col)), shape=(2, 4))
     test_mat = scipy.sparse.coo_matrix((data, (row, col)), shape=(2, 4))
-    assert_equal(spnorm(test_arr, ord=1, axis=0), np.array([4, 5, 7, 9]))
-    assert_equal(spnorm(test_mat, ord=1, axis=0), np.array([4, 5, 7, 9]))
-    assert_equal(spnorm(test_arr, ord=1, axis=1), np.array([9, 16]))
-    assert_equal(spnorm(test_mat, ord=1, axis=1), np.array([9, 16]))
+    for ord in (1, np.inf, None):
+        for ax in [0, 1, None, (0, 1), (1, 0)]:
+            for A in (test_arr, test_mat):
+                expected = npnorm(A.toarray(), ord=ord, axis=ax)
+                assert_equal(spnorm(A, ord=ord, axis=ax), expected)
+    # test 1d
+    test_arr_1d = scipy.sparse.coo_array((data, (col,)), shape=(4,))
+    test_mat_col = scipy.sparse.coo_matrix((data, (col, [0, 0, 0, 0])), shape=(4, 1))
+    for ord in (1, np.inf, None):
+        for ax in [0, None]:
+            for A in (test_arr_1d, test_mat_col):
+                expected = npnorm(A.toarray(), ord=ord, axis=ax)
+                assert_equal(spnorm(A, ord=ord, axis=ax), expected)
 
 
 class TestNorm:
@@ -33,7 +43,7 @@ class TestNorm:
     def test_matrix_norm(self):
 
         # Frobenius norm is the default
-        assert_allclose(spnorm(self.b), 7.745966692414834)        
+        assert_allclose(spnorm(self.b), 7.745966692414834)
         assert_allclose(spnorm(self.b, 'fro'), 7.745966692414834)
 
         assert_allclose(spnorm(self.b, np.inf), 9)
@@ -50,7 +60,7 @@ class TestNorm:
 
     def test_matrix_norm_axis(self):
         for m, axis in ((self.b, None), (self.b, (0, 1)), (self.b.T, (1, 0))):
-            assert_allclose(spnorm(m, axis=axis), 7.745966692414834)        
+            assert_allclose(spnorm(m, axis=axis), 7.745966692414834)
             assert_allclose(spnorm(m, 'fro', axis=axis), 7.745966692414834)
             assert_allclose(spnorm(m, np.inf, axis=axis), 9)
             assert_allclose(spnorm(m, -np.inf, axis=axis), 2)


### PR DESCRIPTION
Fixes #21690 

This allow spasre arrays (sparray) in `sparse.linalg.norm`. As reported in #21690 this wasn't working because the indexing of the 1D results from (max/sum) reductions didn't align with later reductions.

Note that tests already existed for the case when `axis` was specified as an integer. This bug only arises for `axis` as a 2-tuple or None.

Added tests to test this case.   

It is pretty clear that more testing of sparse.linalg and sparse.csgraph is needed for sparray. But that's a different PR.