### PR TITLE
BUG: sparse.linalg: remove faulty test of eigval order from ARPACK

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -676,7 +676,7 @@ def test_eigsh_for_k_greater():
 
 
 def test_real_eigs_real_k_subset():
-    np.random.seed(1)
+    np.random.seed(2)
 
     n = 10
     A = rand(n, n, density=0.5)
@@ -701,14 +701,3 @@ def test_real_eigs_real_k_subset():
             assert_allclose(dist, 0, atol=np.sqrt(eps))
 
             prev_w = w
-
-            # Check sort order
-            if sigma is None:
-                d = w
-            else:
-                d = 1 / (w - sigma)
-
-            if which == 'LM':
-                # ARPACK is systematic for 'LM', but sort order
-                # appears not well defined for other modes
-                assert np.all(np.diff(abs(d)) <= 1e-6)


### PR DESCRIPTION
While working to convert scipy.sparse.linalg to sparse arrays, I discovered a test of the eigenvalue order returned by ARPACK that only passes for the specific random seed used in the test. A comment in the code says that the order of the eigenvalues is not systematic for all modes except `LM`. But changing the seed for the random matrix generation makes it clear that the order is not systematic for 'LM' mode either. The test passed for 'LM' mode by luck, not design.

The test method starts with `np.random.seed(1)`. I changed the seed value to 2, 3, 4, 5, 6, 7, and 8. The test failed for each of these.  

I think we should simply remove the test of the order. The comment implies to me that the order is not systematic for any of the other ARPACK methods, and this evidence convinces me that the order is not systematic for 'LM' mode either. Let stop testing for the order.

[motivation:] I discovered this because changing from `scipy.sparse.rand` to `scipy.sparse.random_array` made the test fail. There shouldn't be any difference between the two functions that affect eigenvalues. So I eventually changed the `seed` value and discovered this trait.