### PR TITLE
MAINT: interpolate: remove undocumented nu arg of BSpline.design_matrix

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -386,8 +386,7 @@ def _make_design_matrix(const double[::1] x,
                         const double[::1] t,
                         int k,
                         bint extrapolate,
-                        int32_or_int64[::1] indices,
-                        int nu=0):
+                        int32_or_int64[::1] indices):
     """
     Returns a design matrix in CSR format.
 
@@ -431,7 +430,7 @@ def _make_design_matrix(const double[::1] x,
         # extrapolate=False and out of bound values are already dealt with in
         # design_matrix
         ind = find_interval(t, k, xval, ind, extrapolate)
-        _deBoor_D(&t[0], xval, k, ind, nu, &work[0])
+        _deBoor_D(&t[0], xval, k, ind, 0, &work[0])
 
         # data[(k + 1) * i : (k + 1) * (i + 1)] = work[:k + 1]
         # indices[(k + 1) * i : (k + 1) * (i + 1)] = np.arange(ind - k, ind + 1)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -337,7 +337,7 @@ class BSpline:
         return cls.construct_fast(t, c, k, extrapolate)
 
     @classmethod
-    def design_matrix(cls, x, t, k, extrapolate=False, nu=0):
+    def design_matrix(cls, x, t, k, extrapolate=False):
         """
         Returns a design matrix as a CSR format sparse array.
 
@@ -456,7 +456,7 @@ class BSpline:
 
         # indptr is not passed to Cython as it is already fully computed
         data, indices = _bspl._make_design_matrix(
-            x, t, k, extrapolate, indices, nu
+            x, t, k, extrapolate, indices
         )
         return csr_array(
             (data, indices, indptr),

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3261,7 +3261,7 @@ def disc_naive(t, k):
     tii = np.repeat(ti, 2)
     tii[::2] += 1e-10
     tii[1::2] -= 1e-10
-    m = BSpline.design_matrix(tii, t, k, nu=k).todense()
+    m = BSpline(t, np.eye(n - k - 1), k)(tii, nu=k)
 
     matr = np.empty((nrint-1, m.shape[1]), dtype=float)
     for i in range(0, m.shape[0], 2):
@@ -3284,18 +3284,16 @@ class F_dense:
         assert self.w.ndim == 1
 
         # lhs
-        a_csr = BSpline.design_matrix(x, t, k)
-        self.a_w = (a_csr * self.w[:, None]).tocsr()
-        from scipy.interpolate import _fitpack_repro as _fr
-        self.b = PackedMatrix(*_fr.disc(t, k))
+        a_dense = BSpline(t, np.eye(t.shape[0] - k - 1), k)(x)
+        self.a_dense = a_dense * self.w[:, None]
 
-        self.a_dense = (a_csr * self.w[:, None]).todense()
+        from scipy.interpolate import _fitpack_repro as _fr
         self.b_dense = PackedMatrix(*_fr.disc(t, k)).todense()
 
         # rhs
         assert y.ndim == 1
         yy = y * self.w
-        self.yy = np.r_[yy, np.zeros(self.b.shape[0])]
+        self.yy = np.r_[yy, np.zeros(self.b_dense.shape[0])]
 
         self.s = s
 


### PR DESCRIPTION
It was added as a technical implement for testing `disc`, the discontinuity matrix FITPACK clone. This PR replaces (the only) call site with an equivalent call.

The argument was added in SciPy 1.15dev cycle in https://github.com/scipy/scipy/pull/19970, so there are no backwards compat effects _as long as this commit lands in the 1.15 release cycle_. 
