### PR TITLE
MAINT: special: clean up factorial corner cases, including complex nans

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3047,9 +3047,9 @@ def factorial(n, exact=False):
         if not _is_subdtype(type(n), ["i", "f", type(None)]):
             raise ValueError(msg_wrong_dtype.format(dtype=type(n)))
         elif n is None or np.isnan(n):
-            return np.nan
+            return np.float64("nan")
         elif n < 0:
-            return 0
+            return 0 if exact else np.float64(0)
         elif exact and _is_subdtype(type(n), "i"):
             return math.factorial(n)
         elif exact:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3044,10 +3044,10 @@ def factorial(n, exact=False):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if n is None or np.isnan(n):
-            return np.nan
-        elif not _is_subdtype(type(n), ["i", "f"]):
+        if not _is_subdtype(type(n), ["i", "f", type(None)]):
             raise ValueError(msg_wrong_dtype.format(dtype=type(n)))
+        elif n is None or np.isnan(n):
+            return np.nan
         elif n < 0:
             return 0
         elif exact and _is_subdtype(type(n), "i"):
@@ -3060,9 +3060,7 @@ def factorial(n, exact=False):
 
     # arrays & array-likes
     n = asarray(n)
-    if n.size == 0:
-        # return empty arrays unchanged
-        return n
+
     if not _is_subdtype(n.dtype, ["i", "f"]):
         raise ValueError(msg_wrong_dtype.format(dtype=n.dtype))
     if exact and not _is_subdtype(n.dtype, "i"):
@@ -3070,7 +3068,10 @@ def factorial(n, exact=False):
                "support non-integral arrays")
         raise ValueError(msg)
 
-    if exact:
+    if n.size == 0:
+        # return empty arrays unchanged
+        return n
+    elif exact:
         return _factorialx_array_exact(n, k=1)
     return _factorialx_array_approx(n, k=1)
 
@@ -3117,9 +3118,7 @@ def factorial2(n, exact=False):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if n is None or np.isnan(n):
-            return np.nan
-        elif not _is_subdtype(type(n), "i"):
+        if not _is_subdtype(type(n), "i"):
             raise ValueError(msg_wrong_dtype.format(dtype=type(n)))
         elif n < 0:
             return 0
@@ -3129,14 +3128,17 @@ def factorial2(n, exact=False):
         if exact:
             return _range_prod(1, n, k=2)
         return _factorialx_approx_core(n, k=2)
+
     # arrays & array-likes
     n = asarray(n)
+
+    if not _is_subdtype(n.dtype, "i"):
+        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype))
+
     if n.size == 0:
         # return empty arrays unchanged
         return n
-    if not _is_subdtype(n.dtype, "i"):
-        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype))
-    if exact:
+    elif exact:
         return _factorialx_array_exact(n, k=2)
     return _factorialx_array_approx(n, k=2)
 
@@ -3227,9 +3229,7 @@ def factorialk(n, k, exact=None):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if n is None or np.isnan(n):
-            return np.nan
-        elif not _is_subdtype(type(n), "i"):
+        if not _is_subdtype(type(n), "i"):
             raise ValueError(msg_wrong_dtype.format(dtype=type(n)) + helpmsg)
         elif n < 0:
             return 0
@@ -3239,14 +3239,17 @@ def factorialk(n, k, exact=None):
         if exact:
             return _range_prod(1, n, k=k)
         return _factorialx_approx_core(n, k=k)
+
     # arrays & array-likes
     n = asarray(n)
+
+    if not _is_subdtype(n.dtype, "i"):
+        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype) + helpmsg)
+
     if n.size == 0:
         # return empty arrays unchanged
         return n
-    if not _is_subdtype(n.dtype, "i"):
-        raise ValueError(msg_wrong_dtype.format(dtype=n.dtype) + helpmsg)
-    if exact:
+    elif exact:
         return _factorialx_array_exact(n, k=k)
     return _factorialx_array_approx(n, k=k)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2441,7 +2441,7 @@ class TestFactorialFunctions:
             # result is empty if and only if n is empty, and has the same dimension
             # as n; dtype stays the same, except when not empty and not exact:
             if n.size:
-                dtype = np.int64 if exact else np.float64
+                dtype = native_int if exact else np.float64
             expected = np.array(ref, ndmin=dim, dtype=dtype)
             assert_really_equal(result, expected, rtol=1e-15)
 
@@ -2527,7 +2527,7 @@ class TestFactorialFunctions:
             # result is empty if and only if n is empty, and has the same dimension
             # as n; dtype stays the same, except when not empty and not exact:
             if n.size:
-                dtype = np.int64 if exact else np.float64
+                dtype = native_int if exact else np.float64
             expected = np.array(ref, ndmin=dim, dtype=dtype)
             assert_really_equal(result, expected, rtol=1e-15)
 


### PR DESCRIPTION
This is part 2/N towards #18409, see #19989 for the predecessor and #19988 for an overview.

It contains minor behavioural changes around whether e.g. the dtype of an empty array is returned unchanged in all cases or whether we raise a type error on the dtype (more consistent with all other wrongly-typed inputs). It should be pretty minor stuff, and I'm happy to explain in more detail (beyond the code) what's happening, but for now I need to figure out how I can marry the complex-nan testing with the `xp_assert_*` infrastructure...

I reintroduced the `assert_really_equal` wrapper mainly for discussion purposes - it doesn't have to look like this, but IMO it'd be pretty benign, as all the core equality logic would continue to live in the `xp_assert_*` functions, and only the extra type- & nan-comparisons on top would live in that simple wrapper.

Or we could say we don't care about differences between float nans and complex nans (or whether a complex nan is `np.nan + 0j` or `np.nan + 1j*np.nan`). 🤷 

In short: the middle 3 commits are up for discussion and could be squashed/dropped/reshuffled. The first one is ready though - I can also break that out into a separate PR if desired.

CC @lucascolley @j-bowhay 