### PR TITLE
DOC: sparse: update spdiags handling in `doc_string` and migration guide for sparray

### DIFF
--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -70,7 +70,7 @@ Recommended steps for migration
       Moreover ``isspmatrix_csr(G) or isspmatrix_csc(G)`` becomes
       ``issparse(G) and G.format in ['csr', 'csc']``.
    -  Convert all ``spdiags`` calls to ``dia_matrix``.
-      See docs in :func:`spdiags<scipy.sparse.spdiags>`_
+      See docs in :func:`spdiags<scipy.sparse.spdiags>`.
    -  Run all your tests on the resulting code. You are still using
       spmatrix, not sparray. But your code and tests are prepared for
       the change.

--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -69,6 +69,8 @@ Recommended steps for migration
       and ``isspmatrix_csr(G)`` with ``issparse(G) and G.format == "csr"``.
       Moreover ``isspmatrix_csr(G) or isspmatrix_csc(G)`` becomes
       ``issparse(G) and G.format in ['csr', 'csc']``.
+   -  Convert all ``spdiags`` calls to ``dia_matrix``.
+      See docs in :func:`spdiags<scipy.sparse.spdiags>`_
    -  Run all your tests on the resulting code. You are still using
       spmatrix, not sparray. But your code and tests are prepared for
       the change.
@@ -135,7 +137,7 @@ Functions that changed names for the migration
    eye         eye_array
    identity    eye_array
    diags       diags_array
-   spdiags     diags_array
+   spdiags     dia_array
    bmat        block
    rand        random_array
    random      random_array

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -95,11 +95,10 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
         Sequence of arrays containing the array diagonals,
         corresponding to `offsets`.
     offsets : sequence of int or an int, optional
-        Diagonals to set:
+        Diagonals to set (repeated offsets are not allowed):
           - k = 0  the main diagonal (default)
           - k > 0  the kth upper diagonal
           - k < 0  the kth lower diagonal
-        Repeated diagonal offsets are disallowed.
     shape : tuple of int, optional
         Shape of the result. If omitted, a square array large enough
         to contain the diagonals is returned.
@@ -228,11 +227,10 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         Sequence of arrays containing the matrix diagonals,
         corresponding to `offsets`.
     offsets : sequence of int or an int, optional
-        Diagonals to set:
+        Diagonals to set (repeated offsets are not allowed):
           - k = 0  the main diagonal (default)
           - k > 0  the kth upper diagonal
           - k < 0  the kth lower diagonal
-        Repeated diagonal offsets are disallowed.
     shape : tuple of int, optional
         Shape of the result. If omitted, a square matrix large enough
         to contain the diagonals is returned.

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -55,7 +55,9 @@ def spdiags(data, diags, m=None, n=None, format=None):
     Notes
     -----
     This function can be replaced by an equivalent call to ``dia_matrix``
-    as ``dia_matrix((data, diags), shape=(m, n)).asformat(format)``.
+    as::
+
+        dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
     See Also
     --------
@@ -119,8 +121,10 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
         + np.diag(diagonals[k], offsets[k])
 
     ``diags_array`` differs from `dia_array` in the way it handles off-diagonals.
-    Specifically, ``diags_array`` does not pad the diagonal data with
-    ignored values at the start/end for positive/negative offset.
+    Specifically, `dia_array` assumes the data input includes padding
+    (ignored values) at the start/end of the rows for positive/negative
+    offset, while ``diags_array` assumes the input data has no padding.
+    Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 1.11
 
@@ -152,6 +156,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
            [ 0.,  0.,  2.,  0.],
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
+
     """
     # if offsets is not a sequence, assume that there's only one diagonal
     if isscalarlike(offsets):
@@ -254,8 +259,10 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         + np.diag(diagonals[k], offsets[k])
 
     ``diags`` differs from ``dia_matrix`` in the way it handles off-diagonals.
-    Specifically, ``diags`` does not pad the diagonal data with
-    ignored values at the start/end for positive/negative offset.
+    Specifically, `dia_matrix` assumes the data input includes padding
+    (ignored values) at the start/end of the rows for positive/negative
+    offset, while ``diags` assumes the input data has no padding.
+    Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 0.11
 
@@ -287,6 +294,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
            [ 0.,  0.,  2.,  0.],
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
+
     """
     A = diags_array(diagonals, offsets=offsets, shape=shape, dtype=dtype)
     return dia_matrix(A).asformat(format)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -49,8 +49,13 @@ def spdiags(data, diags, m=None, n=None, format=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``diags_array`` to take advantage
+        You are encouraged to use ``dia_array`` to take advantage
         of the sparse array functionality.
+
+    Notes
+    -----
+    This function can be replaced by an equivalent call to ``dia_matrix``
+    as ``dia_matrix((data, diags), shape=(m, n)).asformat(format)``.
 
     See Also
     --------
@@ -92,6 +97,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
           - k = 0  the main diagonal (default)
           - k > 0  the kth upper diagonal
           - k < 0  the kth lower diagonal
+        Repeated diagonal offsets are disallowed.
     shape : tuple of int, optional
         Shape of the result. If omitted, a square array large enough
         to contain the diagonals is returned.
@@ -104,13 +110,17 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
 
     Notes
     -----
+    Repeated diagonal offsets are disallowed.
+
     The result from `diags_array` is the sparse equivalent of::
 
         np.diag(diagonals[0], offsets[0])
         + ...
         + np.diag(diagonals[k], offsets[k])
 
-    Repeated diagonal offsets are disallowed.
+    ``diags_array`` differs from `dia_array` in the way it handles off-diagonals.
+    Specifically, ``diags_array`` does not pad the diagonal data with
+    ignored values at the start/end for positive/negative offset.
 
     .. versionadded:: 1.11
 
@@ -217,6 +227,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
           - k = 0  the main diagonal (default)
           - k > 0  the kth upper diagonal
           - k < 0  the kth lower diagonal
+        Repeated diagonal offsets are disallowed.
     shape : tuple of int, optional
         Shape of the result. If omitted, a square matrix large enough
         to contain the diagonals is returned.
@@ -234,8 +245,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
 
     Notes
     -----
-    This function differs from `spdiags` in the way it handles
-    off-diagonals.
+    Repeated diagonal offsets are disallowed.
 
     The result from `diags` is the sparse equivalent of::
 
@@ -243,7 +253,9 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         + ...
         + np.diag(diagonals[k], offsets[k])
 
-    Repeated diagonal offsets are disallowed.
+    ``diags`` differs from ``dia_matrix`` in the way it handles off-diagonals.
+    Specifically, ``diags`` does not pad the diagonal data with
+    ignored values at the start/end for positive/negative offset.
 
     .. versionadded:: 0.11
 


### PR DESCRIPTION
Update migration guide for sparray to direct folks to replace `spdiags` with `dia_array` instead of `diags_array`.

This is an easier migration path  because it is a direct replacement with no change to input data, only to function signature. Replacing with diags_array requires removing padding of diagonal data.