### PR TITLE
MAINT: Allow greek Unicode symbols in linter.

### DIFF
--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -24,6 +24,11 @@ rule.
 
 Coding Style and Guidelines
 ---------------------------
+Note that docstrings should be generally made up of ASCII characters
+in spite of being Unicode. Additionally, lower case greek letters
+"αβγδεζηθικλμνξoπρστυϕχψω" as well the following upper case greek letters
+"ΓΔΘΛΞΠΣϒΦΨΩ" are allowed. Also the following symbols may be used:
+"®ő∫≠≥≤±∞²³".
 
 Required keyword names
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -25,10 +25,15 @@ rule.
 Coding Style and Guidelines
 ---------------------------
 Note that docstrings should be generally made up of ASCII characters
-in spite of being Unicode. Additionally, lower case greek letters
-"αβγδεζηθικλμνξoπρστυϕχψω" as well the following upper case greek letters
-"ΓΔΘΛΞΠΣϒΦΨΩ" are allowed. Also the following symbols may be used:
-"®ő∫≠≥≤±∞²³".
+in spite of being Unicode. The following code block from the file
+``tools/unicode-check.py`` tells the linter which additional characters
+are allowed:
+
+.. literalinclude:: ../../../tools/unicode-check.py
+    :start-after: # BEGIN_INCLUDE_RST
+    :end-before: # END_INCLUDE_RST
+    :lineno-match:
+
 
 Required keyword names
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -7,15 +7,18 @@ import sys
 import argparse
 
 
-# The set of Unicode code points greater than 127 that we
-# allow in the source code (when changing the `allowed` symbols,
-# do not forget to update them in the documentation file
-# `doc/source/dev/missing-bits.rst`):
+# The set of Unicode code points greater than 127 that we allow in the source code:
+# Note that the lines enclosed by the marker lines BEGIN_INCLUDE_RST/END_INCLUDE_RST
+# are included in the file `doc/source/dev/missing-bits.rst` to be rendered in the user
+# documentation.
+#
+# BEGIN_INCLUDE_RST (do not change this line!)
 latin1_letters = set(chr(cp) for cp in range(192, 256))
 greek_letters = set('αβγδεζηθικλμνξoπρστυϕχψω' + 'ΓΔΘΛΞΠΣϒΦΨΩ')
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
 extra_symbols = set('®ő∫≠≥≤±∞²³')
 allowed = latin1_letters | greek_letters | box_drawing_chars | extra_symbols
+# END_INCLUDE_RST (do not change this line!)
 
 
 def unicode_check(showall=False):

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -8,12 +8,14 @@ import argparse
 
 
 # The set of Unicode code points greater than 127 that we
-# allow in the source code.
+# allow in the source code (when changing the `allowed` symbols,
+# do not forget to update them in the documentation file
+# `doc/source/dev/missing-bits.rst`):
 latin1_letters = set(chr(cp) for cp in range(192, 256))
+greek_letters = set('αβγδεζηθικλμνξoπρστυϕχψω' + 'ΓΔΘΛΞΠΣϒΦΨΩ')
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
-extra_symbols = set(['®', 'ő', 'λ', 'π', 'ω', '∫', '≠', '≥', '≤', 'μ',
-                     '±', '∞'])
-allowed = latin1_letters | box_drawing_chars | extra_symbols
+extra_symbols = set('®ő∫≠≥≤±∞²³')
+allowed = latin1_letters | greek_letters | box_drawing_chars | extra_symbols
 
 
 def unicode_check(showall=False):


### PR DESCRIPTION
I noticed that some Greek letters like 'λ', 'π', 'ω', 'μ' are allowed by the linter while the others are not.

This PR adds all lower case greek letters and the distinguishable upper case letters to the allowed symbol list. 
Furthermore the symbols '²' and '³' are added. This should make writing inline formulas like Δx = cos(ω t + ϕ) easier to read. A short note about the allowed characters was also added to the documentation.
