### PR TITLE
DEP: signal: deprecate object arrays in sosfilt

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4374,6 +4374,11 @@ def sosfilt(sos, x, axis=-1, zi=None):
     >>> plt.show()
 
     """
+    _reject_objects(sos, 'sosfilt')
+    _reject_objects(x, 'sosfilt')
+    if zi is not None:
+        _reject_objects(zi, 'sosfilt')
+
     x = _validate_x(x)
     sos, n_sections = _validate_sos(sos)
     x_zi_shape = list(x.shape)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3565,6 +3565,13 @@ class TestSOSFilt:
         _, zf = sosfilt(sos, np.ones(40, dt), zi=zi.tolist())
         assert_allclose_cast(zf, zi, rtol=1e-13)
 
+    def test_dtype_deprecation(self, dt):
+        # gh-21211
+        sos = np.asarray([1, 2, 3, 1, 5, 3], dtype=object).reshape(1, 6)
+        x = np.asarray([2, 3, 4, 5, 3, 4, 2, 2, 1], dtype=object)
+        with pytest.deprecated_call(match="dtype=object is not supported"):
+            sosfilt(sos, x)
+
 
 class TestDeconvolve:
 


### PR DESCRIPTION
This is a follow-up to gh-21211: we deprecated object arrays as inputs to `lfilter`, but forgot or did not know about `sosfilt`. These two should probably be in sync, hence follow the lfilter deprecation in sosfilt.
