### PR TITLE
ENH: sparse.linalg: convert sparse.linalg to use sparray internally

### DIFF
--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -103,7 +103,7 @@ Their signatures are::
    def block_array(blocks, format=None, dtype=None):
    def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None):
    def eye_array(m, n=None, *, k=0, dtype=float, format=None):
-   def random_array(shape, density=0.01, format='coo', dtype=None, random_state=None, data_random_state=None):
+   def random_array(m, n, density=0.01, format='coo', dtype=None, random_state=None, data_random_state=None):
 
 Existing functions that need careful migration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -103,7 +103,7 @@ Their signatures are::
    def block_array(blocks, format=None, dtype=None):
    def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None):
    def eye_array(m, n=None, *, k=0, dtype=float, format=None):
-   def random_array(m, n, density=0.01, format='coo', dtype=None, random_state=None, data_random_state=None):
+   def random_array(shape, density=0.01, format='coo', dtype=None, random_state=None, data_random_state=None):
 
 Existing functions that need careful migration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/tutorial/examples/newton_krylov_preconditioning.py
+++ b/doc/source/tutorial/examples/newton_krylov_preconditioning.py
@@ -1,5 +1,5 @@
 from scipy.optimize import root
-from scipy.sparse import spdiags, kron
+from scipy.sparse import dia_array, kron
 from scipy.sparse.linalg import spilu, LinearOperator
 from numpy import cosh, zeros_like, mgrid, zeros, eye
 
@@ -16,13 +16,13 @@ def get_preconditioner():
     diags_x[0,:] = 1/hx/hx
     diags_x[1,:] = -2/hx/hx
     diags_x[2,:] = 1/hx/hx
-    Lx = spdiags(diags_x, [-1,0,1], nx, nx)
+    Lx = dia_array((diags_x, [-1,0,1]), shape=(nx, nx))
 
     diags_y = zeros((3, ny))
     diags_y[0,:] = 1/hy/hy
     diags_y[1,:] = -2/hy/hy
     diags_y[2,:] = 1/hy/hy
-    Ly = spdiags(diags_y, [-1,0,1], ny, ny)
+    Ly = dia_array((diags_y, [-1,0,1]), shape=(ny, ny))
 
     J1 = kron(Lx, eye(ny)) + kron(eye(nx), Ly)
 

--- a/scipy/sparse/linalg/_dsolve/__init__.py
+++ b/scipy/sparse/linalg/_dsolve/__init__.py
@@ -15,12 +15,12 @@ to solve in the single precision. See also use_solver documentation.
 
 Example session::
 
-    >>> from scipy.sparse import csc_matrix, spdiags
+    >>> from scipy.sparse import csc_array, dia_array
     >>> from numpy import array
     >>>
     >>> print("Inverting a sparse linear system:")
     >>> print("The sparse matrix (constructed from diagonals):")
-    >>> a = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5)
+    >>> a = dia_array(([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1]), shape=(5, 5))
     >>> b = array([1, 2, 3, 4, 5])
     >>> print("Solve: single precision complex:")
     >>> use_solver( useUmfpack = False )

--- a/scipy/sparse/linalg/_dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/_dsolve/_add_newdocs.py
@@ -34,9 +34,9 @@ add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU',
     The LU decomposition can be used to solve matrix equations. Consider:
 
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import splu
-    >>> A = csc_matrix([[1,2,0,4], [1,0,0,1], [1,0,2,1], [2,2,1,0.]])
+    >>> A = csc_array([[1,2,0,4], [1,0,0,1], [1,0,2,1], [2,2,1,0.]])
 
     This can be solved for a given right-hand side:
 
@@ -70,8 +70,8 @@ add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU',
 
     The permutation matrices can be constructed:
 
-    >>> Pr = csc_matrix((np.ones(4), (lu.perm_r, np.arange(4))))
-    >>> Pc = csc_matrix((np.ones(4), (np.arange(4), lu.perm_c)))
+    >>> Pr = csc_array((np.ones(4), (lu.perm_r, np.arange(4))))
+    >>> Pc = csc_array((np.ones(4), (np.arange(4), lu.perm_c)))
 
     We can reassemble the original matrix:
 
@@ -110,14 +110,14 @@ add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU', ('solve',
 add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU', ('L',
     """
     Lower triangular factor with unit diagonal as a
-    `scipy.sparse.csc_matrix`.
+    `scipy.sparse.csc_array`.
 
     .. versionadded:: 0.14.0
     """))
 
 add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU', ('U',
     """
-    Upper triangular factor as a `scipy.sparse.csc_matrix`.
+    Upper triangular factor as a `scipy.sparse.csc_array`.
 
     .. versionadded:: 0.14.0
     """))

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -146,9 +146,9 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
     Parameters
     ----------
-    A : ndarray or sparse matrix
+    A : ndarray or sparse array or matrix
         The square matrix A will be converted into CSC or CSR form
-    b : ndarray or sparse matrix
+    b : ndarray or sparse array or matrix
         The matrix or vector representing the right hand side of the equation.
         If a vector, b.shape must be (n,) or (n, 1).
     permc_spec : str, optional
@@ -167,7 +167,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
     Returns
     -------
-    x : ndarray or sparse matrix
+    x : ndarray or sparse array or matrix
         the solution of the sparse linear equation.
         If b is a vector, then x is a vector of size A.shape[1]
         If b is a matrix, then x is a matrix of size (A.shape[1], b.shape[1])
@@ -339,8 +339,8 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     Parameters
     ----------
-    A : sparse matrix
-        Sparse matrix to factorize. Most efficient when provided in CSC
+    A : sparse array or matrix
+        Sparse array to factorize. Most efficient when provided in CSC
         format. Other formats will be converted to CSC before factorization.
     permc_spec : str, optional
         How to permute the columns of the matrix for sparsity preservation.
@@ -447,7 +447,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     Parameters
     ----------
     A : (N, N) array_like
-        Sparse matrix to factorize. Most efficient when provided in CSC format.
+        Sparse array to factorize. Most efficient when provided in CSC format.
         Other formats will be converted to CSC before factorization.
     drop_tol : float, optional
         Drop tolerance (0 <= tol <= 1) for an incomplete LU decomposition.
@@ -608,7 +608,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
 
     Parameters
     ----------
-    A : (M, M) sparse matrix
+    A : (M, M) sparse array or matrix
         A sparse square triangular matrix. Should be in CSR or CSC format.
     b : (M,) or (M, N) array_like
         Right-hand side matrix in ``A x = b``

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -3,7 +3,7 @@ from warnings import warn, catch_warnings, simplefilter
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse,
-                          SparseEfficiencyWarning, csc_matrix, eye, diags)
+                          SparseEfficiencyWarning, csc_array, eye_array, diags_array)
 from scipy.sparse._sputils import is_pydata_spmatrix, convert_pydata_sparse_to_scipy
 from scipy.linalg import LinAlgError
 import copy
@@ -77,9 +77,9 @@ def use_solver(**kwargs):
     --------
     >>> import numpy as np
     >>> from scipy.sparse.linalg import use_solver, spsolve
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> R = np.random.randn(5, 5)
-    >>> A = csc_matrix(R)
+    >>> A = csc_array(R)
     >>> b = np.random.randn(5)
     >>> use_solver(useUmfpack=False) # enforce superLU over UMFPACK
     >>> x = spsolve(A, b)
@@ -215,10 +215,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import spsolve
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
-    >>> B = csc_matrix([[2, 0], [-1, 0], [2, 0]], dtype=float)
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> B = csc_array([[2, 0], [-1, 0], [2, 0]], dtype=float)
     >>> x = spsolve(A, B)
     >>> np.allclose(A.dot(x).toarray(), B.toarray())
     True
@@ -229,7 +229,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     b = convert_pydata_sparse_to_scipy(b)
 
     if not (issparse(A) and A.format in ("csc", "csr")):
-        A = csc_matrix(A)
+        A = csc_array(A)
         warn('spsolve requires A be CSC or CSR matrix format',
              SparseEfficiencyWarning, stacklevel=2)
 
@@ -305,7 +305,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                 warn('spsolve is more efficient when sparse b '
                      'is in the CSC matrix format',
                      SparseEfficiencyWarning, stacklevel=2)
-                b = csc_matrix(b)
+                b = csc_array(b)
 
             # Create a sparse output matrix by repeatedly applying
             # the sparse factorization to solve columns of b.
@@ -387,9 +387,9 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import splu
-    >>> A = csc_matrix([[1., 0., 0.], [5., 0., 2.], [0., -1., 0.]], dtype=float)
+    >>> A = csc_array([[1., 0., 0.], [5., 0., 2.], [0., -1., 0.]], dtype=float)
     >>> B = splu(A)
     >>> x = np.array([1., 2., 3.], dtype=float)
     >>> B.solve(x)
@@ -403,13 +403,13 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if is_pydata_spmatrix(A):
         A_cls = type(A)
         def csc_construct_func(*a, cls=A_cls):
-            return cls.from_scipy_sparse(csc_matrix(*a))
+            return cls.from_scipy_sparse(csc_array(*a))
         A = A.to_scipy_sparse().tocsc()
     else:
-        csc_construct_func = csc_matrix
+        csc_construct_func = csc_array
 
     if not (issparse(A) and A.format == "csc"):
-        A = csc_matrix(A)
+        A = csc_array(A)
         warn('splu converted its input to CSC format',
              SparseEfficiencyWarning, stacklevel=2)
 
@@ -483,9 +483,9 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import spilu
-    >>> A = csc_matrix([[1., 0., 0.], [5., 0., 2.], [0., -1., 0.]], dtype=float)
+    >>> A = csc_array([[1., 0., 0.], [5., 0., 2.], [0., -1., 0.]], dtype=float)
     >>> B = spilu(A)
     >>> x = np.array([1., 2., 3.], dtype=float)
     >>> B.solve(x)
@@ -499,13 +499,13 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if is_pydata_spmatrix(A):
         A_cls = type(A)
         def csc_construct_func(*a, cls=A_cls):
-            return cls.from_scipy_sparse(csc_matrix(*a))
+            return cls.from_scipy_sparse(csc_array(*a))
         A = A.to_scipy_sparse().tocsc()
     else:
-        csc_construct_func = csc_matrix
+        csc_construct_func = csc_array
 
     if not (issparse(A) and A.format == "csc"):
-        A = csc_matrix(A)
+        A = csc_array(A)
         warn('spilu converted its input to CSC format',
              SparseEfficiencyWarning, stacklevel=2)
 
@@ -555,11 +555,11 @@ def factorized(A):
     --------
     >>> import numpy as np
     >>> from scipy.sparse.linalg import factorized
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> A = np.array([[ 3. ,  2. , -1. ],
     ...               [ 2. , -2. ,  4. ],
     ...               [-1. ,  0.5, -1. ]])
-    >>> solve = factorized(csc_matrix(A)) # Makes LU decomposition.
+    >>> solve = factorized(csc_array(A)) # Makes LU decomposition.
     >>> rhs1 = np.array([1, -2, 0])
     >>> solve(rhs1) # Uses the LU factors.
     array([ 1., -2., -2.])
@@ -573,7 +573,7 @@ def factorized(A):
             raise RuntimeError('Scikits.umfpack not installed.')
 
         if not (issparse(A) and A.format == "csc"):
-            A = csc_matrix(A)
+            A = csc_array(A)
             warn('splu converted its input to CSC format',
                  SparseEfficiencyWarning, stacklevel=2)
 
@@ -659,17 +659,17 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
 
     if is_pydata_spmatrix(A):
         A = A.to_scipy_sparse().tocsc()
-    
+
     trans = "N"
     if issparse(A) and A.format == "csr":
         A = A.T
         trans = "T"
         lower = not lower
 
-    if not (issparse(A) and A.format == "csc"): 
+    if not (issparse(A) and A.format == "csc"):
         warn('CSC or CSR matrix format is required. Converting to CSC matrix.',
              SparseEfficiencyWarning, stacklevel=2)
-        A = csc_matrix(A)
+        A = csc_array(A)
     elif not overwrite_A:
         A = A.copy()
 
@@ -690,9 +690,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
                 'A is singular: zero entry on diagonal.')
         invdiag = 1/diag
         if trans == "N":
-            A = A @ diags(invdiag)
+            A = A @ diags_array(invdiag)
         else:
-            A = (A.T @ diags(invdiag)).T
+            A = (A.T @ diags_array(invdiag)).T
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -719,9 +719,9 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
 
     if lower:
         L = A
-        U = csc_matrix((N, N), dtype=result_dtype)
+        U = csc_array((N, N), dtype=result_dtype)
     else:
-        L = eye(N, dtype=result_dtype, format='csc')
+        L = eye_array(N, dtype=result_dtype, format='csc')
         U = A
         U.setdiag(0)
 

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -13,8 +13,8 @@ from pytest import raises as assert_raises
 
 import scipy.linalg
 from scipy.linalg import norm, inv
-from scipy.sparse import (spdiags, SparseEfficiencyWarning, csc_matrix,
-        csr_matrix, identity, issparse, dok_matrix, lil_matrix, bsr_matrix)
+from scipy.sparse import (dia_array, SparseEfficiencyWarning, csc_array,
+        csr_array, eye_array, issparse, dok_array, lil_array, bsr_array, kron)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, use_solver, splu, spilu,
         MatrixRankWarning, _superlu, spsolve_triangular, factorized)
@@ -45,12 +45,11 @@ def toarray(a):
 def setup_bug_8278():
     N = 2 ** 6
     h = 1/N
-    Ah1D = scipy.sparse.diags([-1, 2, -1], [-1, 0, 1],
-                              shape=(N-1, N-1))/(h**2)
-    eyeN = scipy.sparse.eye(N - 1)
-    A = (scipy.sparse.kron(eyeN, scipy.sparse.kron(eyeN, Ah1D))
-         + scipy.sparse.kron(eyeN, scipy.sparse.kron(Ah1D, eyeN))
-         + scipy.sparse.kron(Ah1D, scipy.sparse.kron(eyeN, eyeN)))
+    Ah1D = dia_array(([-1, 2, -1], [-1, 0, 1]), shape=(N-1, N-1))/(h**2)
+    eyeN = eye_array(N - 1)
+    A = (kron(eyeN, kron(eyeN, Ah1D))
+         + kron(eyeN, kron(Ah1D, eyeN))
+         + kron(Ah1D, kron(eyeN, eyeN)))
     b = np.random.rand((N-1)**3)
     return A, b
 
@@ -60,18 +59,18 @@ class TestFactorized:
         n = 5
         d = arange(n) + 1
         self.n = n
-        self.A = spdiags((d, 2*d, d[::-1]), (-3, 0, 5), n, n).tocsc()
+        self.A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(n,n)).tocsc()
         random.seed(1234)
 
     def _check_singular(self):
-        A = csc_matrix((5,5), dtype='d')
+        A = csc_array((5,5), dtype='d')
         b = ones(5)
         assert_array_almost_equal(0. * b, factorized(A)(b))
 
     def _check_non_singular(self):
         # Make a diagonal dominant, to make sure it is not singular
         n = 5
-        a = csc_matrix(random.rand(n, n))
+        a = csc_array(random.rand(n, n))
         b = ones(n)
 
         expected = splu(a).solve(b)
@@ -163,7 +162,7 @@ class TestFactorized:
         unsorted_inds = np.array([2, 0, 1, 0])
         data = np.array([10, 16, 5, 0.4])
         indptr = np.array([0, 1, 2, 4])
-        A = csc_matrix((data, unsorted_inds, indptr), (3, 3))
+        A = csc_array((data, unsorted_inds, indptr), (3, 3))
         b = ones(3)
 
         # should raise when incorrectly assuming indices are sorted
@@ -196,7 +195,7 @@ class TestLinsolve:
         use_solver(useUmfpack=False)
 
     def test_singular(self):
-        A = csc_matrix((5,5), dtype='d')
+        A = csc_array((5,5), dtype='d')
         b = array([1, 2, 3, 4, 5],dtype='d')
         with suppress_warnings() as sup:
             sup.filter(MatrixRankWarning, "Matrix is exactly singular")
@@ -208,7 +207,7 @@ class TestLinsolve:
         # arguments. Check that it fails moderately gracefully.
         ij = np.array([(17, 0), (17, 6), (17, 12), (10, 13)], dtype=np.int32)
         v = np.array([0.284213, 0.94933781, 0.15767017, 0.38797296])
-        A = csc_matrix((v, ij.T), shape=(20, 20))
+        A = csc_array((v, ij.T), shape=(20, 20))
         b = np.arange(20)
 
         try:
@@ -224,8 +223,8 @@ class TestLinsolve:
     @pytest.mark.parametrize('format', ['csc', 'csr'])
     @pytest.mark.parametrize('idx_dtype', [np.int32, np.int64])
     def test_twodiags(self, format: str, idx_dtype: np.dtype):
-        A = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5,
-                    format=format)
+        A = dia_array(([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1]),
+                        shape=(5, 5)).tocsr()
         b = array([1, 2, 3, 4, 5])
 
         # condition number of A
@@ -245,7 +244,7 @@ class TestLinsolve:
         Adense = array([[0., 1., 1.],
                         [1., 0., 1.],
                         [0., 0., 1.]])
-        As = csc_matrix(Adense)
+        As = csc_array(Adense)
         random.seed(1234)
         x = random.randn(3)
         b = As@x
@@ -257,11 +256,11 @@ class TestLinsolve:
         Adense = array([[0., 1., 1.],
                         [1., 0., 1.],
                         [0., 0., 1.]])
-        As = csc_matrix(Adense)
+        As = csc_array(Adense)
         random.seed(1234)
         x = random.randn(3, 4)
         Bdense = As.dot(x)
-        Bs = csc_matrix(Bdense)
+        Bs = csc_array(Bdense)
         x2 = spsolve(As, Bs)
         assert_array_almost_equal(x, x2.toarray())
 
@@ -272,7 +271,7 @@ class TestLinsolve:
         b = ones((4, 1))
         assert_raises(ValueError, spsolve, A, b)
         # A2 and b2 have incompatible shapes.
-        A2 = csc_matrix(eye(3))
+        A2 = csc_array(eye(3))
         b2 = array([1.0, 2.0])
         assert_raises(ValueError, spsolve, A2, b2)
 
@@ -281,13 +280,13 @@ class TestLinsolve:
         row = array([0,0,1,2,2,2])
         col = array([0,2,2,0,1,2])
         data = array([1,2,3,-4,5,6])
-        sM = csr_matrix((data,(row,col)), shape=(3,3), dtype=float)
+        sM = csr_array((data,(row,col)), shape=(3,3), dtype=float)
         M = sM.toarray()
 
         row = array([0,0,1,1,0,0])
         col = array([0,2,1,1,0,0])
         data = array([1,1,1,1,1,1])
-        sN = csr_matrix((data, (row,col)), shape=(3,3), dtype=float)
+        sN = csr_array((data, (row,col)), shape=(3,3), dtype=float)
         N = sN.toarray()
 
         sX = spsolve(sM, sN)
@@ -299,26 +298,26 @@ class TestLinsolve:
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_shape_compatibility(self):
         use_solver(useUmfpack=True)
-        A = csc_matrix([[1., 0], [0, 2]])
+        A = csc_array([[1., 0], [0, 2]])
         bs = [
             [1, 6],
             array([1, 6]),
             [[1], [6]],
             array([[1], [6]]),
-            csc_matrix([[1], [6]]),
-            csr_matrix([[1], [6]]),
-            dok_matrix([[1], [6]]),
-            bsr_matrix([[1], [6]]),
+            csc_array([[1], [6]]),
+            csr_array([[1], [6]]),
+            dok_array([[1], [6]]),
+            bsr_array([[1], [6]]),
             array([[1., 2., 3.], [6., 8., 10.]]),
-            csc_matrix([[1., 2., 3.], [6., 8., 10.]]),
-            csr_matrix([[1., 2., 3.], [6., 8., 10.]]),
-            dok_matrix([[1., 2., 3.], [6., 8., 10.]]),
-            bsr_matrix([[1., 2., 3.], [6., 8., 10.]]),
+            csc_array([[1., 2., 3.], [6., 8., 10.]]),
+            csr_array([[1., 2., 3.], [6., 8., 10.]]),
+            dok_array([[1., 2., 3.], [6., 8., 10.]]),
+            bsr_array([[1., 2., 3.], [6., 8., 10.]]),
             ]
 
         for b in bs:
             x = np.linalg.solve(A.toarray(), toarray(b))
-            for spmattype in [csc_matrix, csr_matrix, dok_matrix, lil_matrix]:
+            for spmattype in [csc_array, csr_array, dok_array, lil_array]:
                 x1 = spsolve(spmattype(A), b, use_umfpack=True)
                 x2 = spsolve(spmattype(A), b, use_umfpack=False)
 
@@ -350,8 +349,8 @@ class TestLinsolve:
                     assert_equal(x1.shape, x.shape)
                     assert_equal(x2.shape, x.shape)
 
-        A = csc_matrix((3, 3))
-        b = csc_matrix((1, 3))
+        A = csc_array((3, 3))
+        b = csc_array((1, 3))
         assert_raises(ValueError, spsolve, A, b)
 
     @sup_sparse_efficiency
@@ -365,9 +364,9 @@ class TestLinsolve:
     def test_gssv_badinput(self):
         N = 10
         d = arange(N) + 1.0
-        A = spdiags((d, 2*d, d[::-1]), (-3, 0, 5), N, N)
+        A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(N, N))
 
-        for spmatrix in (csc_matrix, csr_matrix):
+        for spmatrix in (csc_array, csr_array):
             A = spmatrix(A)
             b = np.arange(N)
 
@@ -390,20 +389,20 @@ class TestLinsolve:
                 # Not C-contiguous
                 assert_raises((ValueError, TypeError), _superlu.gssv,
                               N, A.nnz, badop(A.data), A.indices, A.indptr,
-                              b, int(spmatrix == csc_matrix), err_msg=msg)
+                              b, int(spmatrix == csc_array), err_msg=msg)
                 assert_raises((ValueError, TypeError), _superlu.gssv,
                               N, A.nnz, A.data, badop(A.indices), A.indptr,
-                              b, int(spmatrix == csc_matrix), err_msg=msg)
+                              b, int(spmatrix == csc_array), err_msg=msg)
                 assert_raises((ValueError, TypeError), _superlu.gssv,
                               N, A.nnz, A.data, A.indices, badop(A.indptr),
-                              b, int(spmatrix == csc_matrix), err_msg=msg)
+                              b, int(spmatrix == csc_array), err_msg=msg)
 
     def test_sparsity_preservation(self):
-        ident = csc_matrix([
+        ident = csc_array([
             [1, 0, 0],
             [0, 1, 0],
             [0, 0, 1]])
-        b = csc_matrix([
+        b = csc_array([
             [0, 1],
             [1, 0],
             [0, 0]])
@@ -414,10 +413,10 @@ class TestLinsolve:
         assert_allclose(x.toarray(), b.toarray(), atol=1e-12, rtol=1e-12)
 
     def test_dtype_cast(self):
-        A_real = scipy.sparse.csr_matrix([[1, 2, 0],
+        A_real = scipy.sparse.csr_array([[1, 2, 0],
                                           [0, 0, 3],
                                           [4, 0, 5]])
-        A_complex = scipy.sparse.csr_matrix([[1, 2, 0],
+        A_complex = scipy.sparse.csr_array([[1, 2, 0],
                                              [0, 0, 3],
                                              [4, 0, 5 + 1j]])
         b_real = np.array([1,1,1])
@@ -447,7 +446,7 @@ class TestSplu:
         n = 40
         d = arange(n) + 1
         self.n = n
-        self.A = spdiags((d, 2*d, d[::-1]), (-3, 0, 5), n, n, format='csc')
+        self.A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(n, n)).tocsc()
         random.seed(1234)
 
     def _smoketest(self, spxlu, check, dtype, idx_dtype):
@@ -523,7 +522,7 @@ class TestSplu:
     @sup_sparse_efficiency
     def test_spilu_drop_rule(self):
         # Test passing in the drop_rule argument to spilu.
-        A = identity(2)
+        A = eye_array(2)
 
         rules = [
             b'basic,area'.decode('ascii'),  # unicode
@@ -535,11 +534,11 @@ class TestSplu:
             assert_(isinstance(spilu(A, drop_rule=rule), SuperLU))
 
     def test_splu_nnz0(self):
-        A = csc_matrix((5,5), dtype='d')
+        A = csc_array((5,5), dtype='d')
         assert_raises(RuntimeError, splu, A)
 
     def test_spilu_nnz0(self):
-        A = csc_matrix((5,5), dtype='d')
+        A = csc_array((5,5), dtype='d')
         assert_raises(RuntimeError, spilu, A)
 
     def test_splu_basic(self):
@@ -550,13 +549,13 @@ class TestSplu:
         a[a < 0.95] = 0
         # First test with a singular matrix
         a[:, 0] = 0
-        a_ = csc_matrix(a)
+        a_ = csc_array(a)
         # Matrix is exactly singular
         assert_raises(RuntimeError, splu, a_)
 
         # Make a diagonal dominant, to make sure it is not singular
         a += 4*eye(n)
-        a_ = csc_matrix(a)
+        a_ = csc_array(a)
         lu = splu(a_)
         b = ones(n)
         x = lu.solve(b)
@@ -569,7 +568,7 @@ class TestSplu:
         a[a < 0.95] = 0
         # Make a diagonal dominant, to make sure it is not singular
         a += 4*eye(n)
-        a_ = csc_matrix(a)
+        a_ = csc_array(a)
         lu = splu(a_)
         # Check that the permutation indices do belong to [0, n-1].
         for perm in (lu.perm_r, lu.perm_c):
@@ -581,7 +580,7 @@ class TestSplu:
         # the same
         # Note: a += a.T relies on undefined behavior.
         a = a + a.T
-        a_ = csc_matrix(a)
+        a_ = csc_array(a)
         lu = splu(a_)
         assert_array_equal(lu.perm_r, lu.perm_c)
 
@@ -594,15 +593,15 @@ class TestSplu:
         A = scipy.sparse.random(n, n, p)
         x = np.random.rand(n)
         # Make A diagonal dominant to make sure it is not singular
-        A += (n+1)*scipy.sparse.identity(n)
-        A_ = csc_matrix(A)
+        A += (n+1)*scipy.sparse.eye_array(n)
+        A_ = csc_array(A)
         b = A_ @ x
 
-        # without permc_spec, permutation is not identity
+        # without permc_spec, permutation is not eye_array
         lu = splu_fun(A_)
         assert_(np.any(lu.perm_c != np.arange(n)))
 
-        # with permc_spec="NATURAL", permutation is identity
+        # with permc_spec="NATURAL", permutation is eye_array
         lu = splu_fun(A_, permc_spec="NATURAL")
         assert_array_equal(lu.perm_c, np.arange(n))
 
@@ -618,7 +617,7 @@ class TestSplu:
         a[a < 0.95] = 0
         # Make a diagonal dominant, to make sure it is not singular
         a += 4*eye(n)
-        a_ = csc_matrix(a)
+        a_ = csc_array(a)
         lu = splu(a_)
 
         # And now test that we don't have a refcount bug
@@ -657,7 +656,7 @@ class TestSplu:
         # Here's a test case that triggered the issue.
         n = 8
         d = np.arange(n) + 1
-        A = spdiags((d, 2*d, d[::-1]), (-3, 0, 5), n, n)
+        A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(n, n))
         A = A.astype(np.float32)
         spilu(A)
         A = A + 1j*A
@@ -725,7 +724,7 @@ class TestSplu:
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is
         # passed. See gh-20993.
-        A = identity(10, format='csr').tocsr()
+        A = eye_array(10, format='csr').tocsr()
         A[-1, -1] = 0
         b = np.zeros(10)
         with pytest.warns(MatrixRankWarning):
@@ -757,7 +756,7 @@ class TestGstrsErrors:
         U = scipy.sparse.triu(self.A, k=1, format='csc')
         with assert_raises(ValueError, match="right hand side array has invalid shape"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
-                                U.shape[0], U.nnz, U.data, U.indices, U.indptr, 
+                                U.shape[0], U.nnz, U.data, U.indices, U.indptr,
                                 self.b[0:2])
 
     def test_types_differ(self):
@@ -772,7 +771,7 @@ class TestGstrsErrors:
         U = scipy.sparse.triu(self.A.astype(np.uint8), k=1, format='csc')
         with assert_raises(TypeError, match="nzvals is not of a type supported"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
-                                U.shape[0], U.nnz, U.data, U.indices, U.indptr, 
+                                U.shape[0], U.nnz, U.data, U.indices, U.indptr,
                                 self.b.astype(np.uint8))
 
 class TestSpsolveTriangular:
@@ -803,9 +802,9 @@ class TestSpsolveTriangular:
     def test_singular(self,fmt):
         n = 5
         if fmt == "csr":
-            A = csr_matrix((n, n))
+            A = csr_array((n, n))
         else:
-            A = csc_matrix((n, n))
+            A = csc_array((n, n))
         b = np.arange(n)
         for lower in (True, False):
             assert_raises(scipy.linalg.LinAlgError,
@@ -818,7 +817,7 @@ class TestSpsolveTriangular:
         b = ones((4, 1))
         assert_raises(ValueError, spsolve_triangular, A, b)
         # A2 and b2 have incompatible shapes.
-        A2 = csr_matrix(eye(3))
+        A2 = csr_array(eye(3))
         b2 = array([1.0, 2.0])
         assert_raises(ValueError, spsolve_triangular, A2, b2)
 
@@ -826,7 +825,7 @@ class TestSpsolveTriangular:
     def test_input_types(self):
         A = array([[1., 0.], [1., 2.]])
         b = array([[2., 0.], [2., 2.]])
-        for matrix_type in (array, csc_matrix, csr_matrix):
+        for matrix_type in (array, csc_array, csr_array):
             x = spsolve_triangular(matrix_type(A), b, lower=True)
             assert_array_almost_equal(A.dot(x), b)
 

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -294,7 +294,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     >>> rng = np.random.RandomState(0)
     >>> X_dense = rng.random(size=(100, 100))
     >>> X_dense[:, 2 * np.arange(50)] = 0
-    >>> X = sparse.csr_matrix(X_dense)
+    >>> X = sparse.csr_array(X_dense)
     >>> _, singular_values, _ = svds(X, k=5, random_state=rng)
     >>> print(singular_values)
     [ 4.3293...  4.4491...  4.5420...  4.5987... 35.2410...]
@@ -303,7 +303,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     ever explicitly constructed.
 
     >>> rng = np.random.default_rng(102524723947864966825913730119128190974)
-    >>> G = sparse.rand(8, 9, density=0.5, random_state=rng)
+    >>> G = sparse.random_array(8, 9, density=0.5, random_state=rng)
     >>> Glo = aslinearoperator(G)
     >>> _, singular_values_svds, _ = svds(Glo, k=5, random_state=rng)
     >>> _, singular_values_svd, _ = linalg.svd(G.toarray())

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -303,7 +303,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     ever explicitly constructed.
 
     >>> rng = np.random.default_rng(102524723947864966825913730119128190974)
-    >>> G = sparse.random_array(8, 9, density=0.5, random_state=rng)
+    >>> G = sparse.random_array((8, 9), density=0.5, random_state=rng)
     >>> Glo = aslinearoperator(G)
     >>> _, singular_values_svds, _ = svds(Glo, k=5, random_state=rng)
     >>> _, singular_values_svd, _ = linalg.svd(G.toarray())

--- a/scipy/sparse/linalg/_eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/_eigen/_svds_doc.py
@@ -90,14 +90,14 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     >>> import numpy as np
     >>> from scipy.stats import ortho_group
-    >>> from scipy.sparse import csc_matrix, diags
+    >>> from scipy.sparse import csc_array, diags_array
     >>> from scipy.sparse.linalg import svds
     >>> rng = np.random.default_rng()
-    >>> orthogonal = csc_matrix(ortho_group.rvs(10, random_state=rng))
+    >>> orthogonal = csc_array(ortho_group.rvs(10, random_state=rng))
     >>> s = [0.0001, 0.001, 3, 4, 5]  # singular values
     >>> u = orthogonal[:, :5]         # left singular vectors
     >>> vT = orthogonal[:, 5:].T      # right singular vectors
-    >>> A = u @ diags(s) @ vT
+    >>> A = u @ diags_array(s) @ vT
 
     With only three singular values/vectors, the SVD approximates the original
     matrix.

--- a/scipy/sparse/linalg/_eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/_eigen/_svds_doc.py
@@ -220,14 +220,14 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     >>> import numpy as np
     >>> from scipy.stats import ortho_group
-    >>> from scipy.sparse import csc_matrix, diags
+    >>> from scipy.sparse import csc_array, diags_array
     >>> from scipy.sparse.linalg import svds
     >>> rng = np.random.default_rng()
-    >>> orthogonal = csc_matrix(ortho_group.rvs(10, random_state=rng))
+    >>> orthogonal = csc_array(ortho_group.rvs(10, random_state=rng))
     >>> s = [0.0001, 0.001, 3, 4, 5]  # singular values
     >>> u = orthogonal[:, :5]         # left singular vectors
     >>> vT = orthogonal[:, 5:].T      # right singular vectors
-    >>> A = u @ diags(s) @ vT
+    >>> A = u @ diags_array(s) @ vT
 
     With only three singular values/vectors, the SVD approximates the original
     matrix.
@@ -357,14 +357,14 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     >>> import numpy as np
     >>> from scipy.stats import ortho_group
-    >>> from scipy.sparse import csc_matrix, diags
+    >>> from scipy.sparse import csc_array, diags_array
     >>> from scipy.sparse.linalg import svds
     >>> rng = np.random.default_rng()
-    >>> orthogonal = csc_matrix(ortho_group.rvs(10, random_state=rng))
+    >>> orthogonal = csc_array(ortho_group.rvs(10, random_state=rng))
     >>> s = [0.0001, 0.001, 3, 4, 5]  # singular values
     >>> u = orthogonal[:, :5]         # left singular vectors
     >>> vT = orthogonal[:, 5:].T      # right singular vectors
-    >>> A = u @ diags(s) @ vT
+    >>> A = u @ diags_array(s) @ vT
 
     With only three singular values/vectors, the SVD approximates the original
     matrix.

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -676,10 +676,10 @@ def test_eigsh_for_k_greater():
 
 
 def test_real_eigs_real_k_subset():
-    np.random.seed(2)
+    rng = np.random.default_rng(2)
 
     n = 10
-    A = random_array(shape=(n, n), density=0.5)
+    A = random_array(shape=(n, n), density=0.5, random_state=rng)
     A.data *= 2
     A.data -= 1
     A += A.T  # make symmetric to test real eigenvalues

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -15,7 +15,7 @@ import pytest
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh
-from scipy.sparse import csc_matrix, csr_matrix, diags, rand
+from scipy.sparse import csc_array, csr_array, diags_array, random_array, rand
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.arpack import (eigs, eigsh, arpack,
                                               ArpackNoConvergence)
@@ -36,7 +36,7 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
     ----------
     type_char : {'f', 'd', 'F', 'D'}
         Data type in ARPACK eigenvalue problem
-    mattype : {csr_matrix, aslinearoperator, asarray}, optional
+    mattype : {csr_array, aslinearoperator, asarray}, optional
         Linear operator type
 
     Returns
@@ -63,7 +63,7 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if mattype is csr_matrix and type_char in ('f', 'F'):
+    if mattype is csr_array and type_char in ('f', 'F'):
         # sparse in single precision: worse errors
         rtol *= 5
 
@@ -122,11 +122,11 @@ def generate_matrix_symmetric(N, pos_definite=False, sparse=False):
     if pos_definite:
         Id = N * np.eye(N)
         if sparse:
-            M = csr_matrix(M)
+            M = csr_array(M)
         M += Id
     else:
         if sparse:
-            M = csr_matrix(M)
+            M = csr_array(M)
 
     return M
 
@@ -287,7 +287,7 @@ class SymmetricParams:
     def __init__(self):
         self.eigs = eigsh
         self.which = ['LM', 'SM', 'LA', 'SA', 'BE']
-        self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
+        self.mattypes = [csr_array, aslinearoperator, np.asarray]
         self.sigmas_modes = {None: ['normal'],
                              0.5: ['normal', 'buckling', 'cayley']}
 
@@ -347,7 +347,7 @@ class NonSymmetricParams:
     def __init__(self):
         self.eigs = eigs
         self.which = ['LM', 'LR', 'LI']  # , 'SM', 'LR', 'SR', 'LI', 'SI']
-        self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
+        self.mattypes = [csr_array, aslinearoperator, np.asarray]
         self.sigmas_OPparts = {None: [None],
                                0.1: ['r'],
                                0.1 + 0.1j: ['r', 'i']}
@@ -518,13 +518,13 @@ def test_standard_nonsymmetric_no_convergence():
 
 def test_eigen_bad_shapes():
     # A is not square.
-    A = csc_matrix(np.zeros((2, 3)))
+    A = csc_array(np.zeros((2, 3)))
     assert_raises(ValueError, eigs, A)
 
 
 def test_eigen_bad_kwargs():
     # Test eigen on wrong keyword argument
-    A = csc_matrix(np.zeros((8, 8)))
+    A = csc_array(np.zeros((8, 8)))
     assert_raises(ValueError, eigs, A, which='XX')
 
 
@@ -555,7 +555,7 @@ def test_linearoperator_deallocation():
     # running out of memory if eigs/eigsh are called in a tight loop.
 
     M_d = np.eye(10)
-    M_s = csc_matrix(M_d)
+    M_s = csc_array(M_d)
     M_o = aslinearoperator(M_d)
 
     with assert_deallocated(lambda: arpack.SpLuInv(M_s)):
@@ -574,7 +574,7 @@ def test_parallel_threads():
     v0 = np.random.rand(50)
 
     def worker():
-        x = diags([1, -2, 1], [-1, 0, 1], shape=(50, 50))
+        x = diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(50, 50))
         w, v = eigs(x, k=3, v0=v0)
         results.append(w)
 
@@ -596,7 +596,7 @@ def test_parallel_threads():
 def test_reentering():
     # Just some linear operator that calls eigs recursively
     def A_matvec(x):
-        x = diags([1, -2, 1], [-1, 0, 1], shape=(50, 50))
+        x = diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(50, 50))
         w, v = eigs(x, k=1)
         return v / w[0]
     A = LinearOperator(matvec=A_matvec, dtype=float, shape=(50, 50))
@@ -615,7 +615,7 @@ def test_regression_arpackng_1315():
         np.random.seed(1234)
 
         w0 = np.arange(1, 1000+1).astype(dtype)
-        A = diags([w0], [0], shape=(1000, 1000))
+        A = diags_array([w0], offsets=[0], shape=(1000, 1000))
 
         v0 = np.random.rand(1000).astype(dtype)
         w, v = eigs(A, k=9, ncv=2*9+1, which="LM", v0=v0)
@@ -626,7 +626,7 @@ def test_regression_arpackng_1315():
 
 def test_eigs_for_k_greater():
     # Test eigs() for k beyond limits.
-    A_sparse = diags([1, -2, 1], [-1, 0, 1], shape=(4, 4))  # sparse
+    A_sparse = diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(4, 4))  # sparse
     A = generate_matrix(4, sparse=False)
     M_dense = np.random.random((4, 4))
     M_sparse = generate_matrix(4, sparse=True)
@@ -652,7 +652,7 @@ def test_eigs_for_k_greater():
 
 def test_eigsh_for_k_greater():
     # Test eigsh() for k beyond limits.
-    A_sparse = diags([1, -2, 1], [-1, 0, 1], shape=(4, 4))  # sparse
+    A_sparse = diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(4, 4))  # sparse
     A = generate_matrix(4, sparse=False)
     M_dense = generate_matrix_symmetric(4, pos_definite=True)
     M_sparse = generate_matrix_symmetric(4, pos_definite=True, sparse=True)
@@ -679,7 +679,7 @@ def test_real_eigs_real_k_subset():
     np.random.seed(2)
 
     n = 10
-    A = rand(n, n, density=0.5)
+    A = random_array(shape=(n, n), density=0.5)
     A.data *= 2
     A.data -= 1
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -682,6 +682,7 @@ def test_real_eigs_real_k_subset():
     A = random_array(shape=(n, n), density=0.5)
     A.data *= 2
     A.data -= 1
+    A += A.T  # make symmetric to test real eigenvalues
 
     v0 = np.ones(n)
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -63,7 +63,7 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if mattype is csr_array and type_char in ('f', 'F'):
+    if issubclass(mattype, csr_array) and type_char in ('f', 'F'):
         # sparse in single precision: worse errors
         rtol *= 5
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -63,7 +63,10 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if issubclass(mattype, csr_array) and type_char in ('f', 'F'):
+    if (
+        isinstance(mattype, type) and issubclass(mattype, csr_array)
+        and type_char in ('f', 'F')
+    ):
         # sparse in single precision: worse errors
         rtol *= 5
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -15,7 +15,7 @@ import pytest
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh
-from scipy.sparse import csc_array, csr_array, diags_array, random_array, rand
+from scipy.sparse import csc_array, csr_array, diags_array, random_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.arpack import (eigs, eigsh, arpack,
                                               ArpackNoConvergence)

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -13,7 +13,7 @@ from numpy.testing import (assert_almost_equal, assert_equal,
 from scipy import sparse
 from scipy.linalg import (eigh, toeplitz,
                           cholesky_banded, cho_solve_banded)
-from scipy.sparse import spdiags, diags, eye, csr_matrix
+from scipy.sparse import dia_array, eye_array, csr_array
 from scipy.sparse.linalg import eigsh, LinearOperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg
 from scipy.sparse.linalg._eigen.lobpcg.lobpcg import _b_orthonormalize
@@ -89,7 +89,7 @@ def test_b_orthonormalize(n, m, Vdtype, Bdtype, BVdtype):
     X = rnd.standard_normal((n, m)).astype(Vdtype)
     Xcopy = np.copy(X)
     vals = np.arange(1, n+1, dtype=float)
-    B = diags([vals], [0], (n, n)).astype(Bdtype)
+    B = dia_array(([vals], [0]), shape=(n, n)).astype(Bdtype)
     BX = B @ X
     BX = BX.astype(BVdtype)
     is_all_complex = (np.issubdtype(Vdtype, np.complexfloating) and
@@ -194,7 +194,7 @@ def test_diagonal(n, m, m_excluded):
     # A is the diagonal matrix whose entries are 1,...n,
     # B is the identity matrix.
     vals = np.arange(1, n+1, dtype=float)
-    A_s = diags([vals], [0], (n, n))
+    A_s = dia_array(([vals], [0]), shape=(n, n))
     A_a = A_s.toarray()
 
     def A_f(x):
@@ -204,8 +204,8 @@ def test_diagonal(n, m, m_excluded):
                           matmat=A_f,
                           shape=(n, n), dtype=float)
 
-    B_a = eye(n)
-    B_s = csr_matrix(B_a)
+    B_a = eye_array(n)
+    B_s = csr_array(B_a)
 
     def B_f(x):
         return B_a @ x
@@ -215,7 +215,7 @@ def test_diagonal(n, m, m_excluded):
                           shape=(n, n), dtype=float)
 
     # Let the preconditioner M be the inverse of A.
-    M_s = diags([1./vals], [0], (n, n))
+    M_s = dia_array(([1./vals], [0]), shape=(n, n))
     M_a = M_s.toarray()
 
     def M_f(x):
@@ -399,7 +399,7 @@ def test_eigsh_consistency(n, atol):
     """Check eigsh vs. lobpcg consistency.
     """
     vals = np.arange(1, n+1, dtype=np.float64)
-    A = spdiags(vals, 0, n, n)
+    A = dia_array((vals, 0), shape=(n, n))
     rnd = np.random.RandomState(0)
     X = rnd.standard_normal((n, 2))
     lvals, lvecs = lobpcg(A, X, largest=True, maxiter=100)
@@ -433,7 +433,7 @@ def test_tolerance_float32():
     n = 50
     m = 3
     vals = -np.arange(1, n + 1)
-    A = diags([vals], [0], (n, n))
+    A = dia_array(([vals], [0]), shape=(n, n))
     A = A.astype(np.float32)
     X = rnd.standard_normal((n, m))
     X = X.astype(np.float32)
@@ -444,8 +444,8 @@ def test_tolerance_float32():
 @pytest.mark.parametrize("vdtype", INEXECTDTYPES)
 @pytest.mark.parametrize("mdtype", ALLDTYPES)
 @pytest.mark.parametrize("arr_type", [np.array,
-                                      sparse.csr_matrix,
-                                      sparse.coo_matrix])
+                                      sparse.csr_array,
+                                      sparse.coo_array])
 def test_dtypes(vdtype, mdtype, arr_type):
     """Test lobpcg in various dtypes.
     """
@@ -471,7 +471,7 @@ def test_inplace_warning():
     n = 6
     m = 1
     vals = -np.arange(1, n + 1)
-    A = diags([vals], [0], (n, n))
+    A = dia_array(([vals], [0]), shape=(n, n))
     A = A.astype(np.cdouble)
     X = rnd.standard_normal((n, m))
     with pytest.warns(UserWarning, match="Inplace update"):
@@ -489,7 +489,7 @@ def test_maxit():
     n = 50
     m = 4
     vals = -np.arange(1, n + 1)
-    A = diags([vals], [0], (n, n))
+    A = dia_array(([vals], [0]), shape=(n, n))
     A = A.astype(np.float32)
     X = rnd.standard_normal((n, m))
     X = X.astype(np.float64)
@@ -629,7 +629,7 @@ def test_diagonal_data_types(n, m):
     list_sparse_format = ['bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil']
     for s_f_i, s_f in enumerate(list_sparse_format):
 
-        As64 = diags([vals * vals], [0], (n, n), format=s_f)
+        As64 = dia_array(([vals * vals], [0]), shape=(n, n), format=s_f)
         As32 = As64.astype(np.float32)
         Af64 = As64.toarray()
         Af32 = Af64.astype(np.float32)
@@ -643,7 +643,7 @@ def test_diagonal_data_types(n, m):
 
         listA = [Af64, As64, Af32, As32, As32f, As32LO, lambda v: As32 @ v]
 
-        Bs64 = diags([vals], [0], (n, n), format=s_f)
+        Bs64 = dia_array(([vals], [0]), shape=(n, n), format=s_f)
         Bf64 = Bs64.toarray()
         Bs32 = Bs64.astype(np.float32)
 
@@ -656,7 +656,7 @@ def test_diagonal_data_types(n, m):
         listB = [Bf64, Bs64, Bs32, Bs32f, Bs32LO, lambda v: Bs32 @ v]
 
         # Define the preconditioner function as LinearOperator.
-        Ms64 = diags([1./vals], [0], (n, n), format=s_f)
+        Ms64 = dia_array(([1./vals], [0]), shape=(n, n), format=s_f)
 
         def Ms64precond(x):
             return Ms64 @ x

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -629,7 +629,7 @@ def test_diagonal_data_types(n, m):
     list_sparse_format = ['bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil']
     for s_f_i, s_f in enumerate(list_sparse_format):
 
-        As64 = dia_array(([vals * vals], [0]), shape=(n, n), format=s_f)
+        As64 = dia_array(([vals * vals], [0]), shape=(n, n)).asformat(s_f)
         As32 = As64.astype(np.float32)
         Af64 = As64.toarray()
         Af32 = Af64.astype(np.float32)
@@ -643,7 +643,7 @@ def test_diagonal_data_types(n, m):
 
         listA = [Af64, As64, Af32, As32, As32f, As32LO, lambda v: As32 @ v]
 
-        Bs64 = dia_array(([vals], [0]), shape=(n, n), format=s_f)
+        Bs64 = dia_array(([vals], [0]), shape=(n, n)).asformat(s_f)
         Bf64 = Bs64.toarray()
         Bs32 = Bs64.astype(np.float32)
 
@@ -656,7 +656,7 @@ def test_diagonal_data_types(n, m):
         listB = [Bf64, Bs64, Bs32, Bs32f, Bs32LO, lambda v: Bs32 @ v]
 
         # Define the preconditioner function as LinearOperator.
-        Ms64 = dia_array(([1./vals], [0]), shape=(n, n), format=s_f)
+        Ms64 = dia_array(([1./vals], [0]), shape=(n, n)).asformat(s_f)
 
         def Ms64precond(x):
             return Ms64 @ x

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -818,7 +818,7 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         k = 3
         if ncv in {4, 5}:
             u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver, random_state=0)
-        # partial decomposition, so don't check that u@dia_array(s)@vh=A;
+        # partial decomposition, so don't check that u@diag(s)@vh=A;
         # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
             _check_svds(A, k, u, s, vh)
         else:

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 import pytest
 
 from scipy.linalg import svd, null_space
-from scipy.sparse import csc_matrix, issparse, spdiags, random
+from scipy.sparse import csc_array, issparse, dia_array, random_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg import svds
 from scipy.sparse.linalg._eigen.arpack import ArpackNoConvergence
@@ -288,7 +288,7 @@ class SVDSCommonTests:
         _, s, _ = svd(A)  # calculate ground truth
 
         # calculate the error as a function of `tol`
-        A = csc_matrix(A)
+        A = csc_array(A)
 
         def err(tol):
             _, s2, _ = svds(A, k=k, v0=np.ones(n), maxiter=1000,
@@ -526,7 +526,7 @@ class SVDSCommonTests:
     @pytest.mark.parametrize('real', (True, False))
     @pytest.mark.parametrize('transpose', (False, True))
     # In gh-14299, it was suggested the `svds` should _not_ work with lists
-    @pytest.mark.parametrize('lo_type', (np.asarray, csc_matrix,
+    @pytest.mark.parametrize('lo_type', (np.asarray, csc_array,
                                          aslinearoperator))
     def test_svd_simple(self, A, k, real, transpose, lo_type):
 
@@ -664,12 +664,12 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         k = 5
         (m, n) = shape
-        S = random(m, n, density=0.1, random_state=rng)
+        S = random_array(shape=(m, n), density=0.1, random_state=rng)
         if dtype is complex:
-            S = + 1j * random(m, n, density=0.1, random_state=rng)
+            S = + 1j * random_array(shape=(m, n), density=0.1, random_state=rng)
         e = np.ones(m)
         e[0:5] *= 1e1 ** np.arange(-5, 0, 1)
-        S = spdiags(e, 0, m, m) @ S
+        S = dia_array((e, 0), shape=(m, m)) @ S
         S = S.astype(dtype)
         u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000,
                         random_state=0)
@@ -784,7 +784,7 @@ class SVDSCommonTests:
         assert_allclose(mat @ vh[-dim:, :].T, 0, atol=1e-6, rtol=1e0)
 
         # Smallest singular values should be 0
-        sp_mat = csc_matrix(mat)
+        sp_mat = csc_array(mat)
         su, ss, svh = svds(sp_mat, k=dim, which='SM', solver=self.solver,
                            random_state=0)
         # Smallest dim singular values are 0:
@@ -818,7 +818,7 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         k = 3
         if ncv in {4, 5}:
             u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver, random_state=0)
-        # partial decomposition, so don't check that u@diag(s)@vh=A;
+        # partial decomposition, so don't check that u@dia_array(s)@vh=A;
         # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
             _check_svds(A, k, u, s, vh)
         else:

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -99,7 +99,7 @@ def _ident_like(A):
         return scipy.sparse.dia_array(out).asformat(A.format)
     elif is_pydata_spmatrix(A):
         import sparse
-        return sparse.eye_array(A.shape[0], A.shape[1], dtype=A.dtype)
+        return sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)
     elif isinstance(A, scipy.sparse.linalg.LinearOperator):
         return IdentityOperator(A.shape, dtype=A.dtype)
     else:

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -94,12 +94,12 @@ def _ident_like(A):
     if scipy.sparse.issparse(A):
         # Creates a sparse matrix in dia format
         out = scipy.sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)
-        if isinstance(A, scipy.sparse.spmatrix):
+        if scipy.sparse.issparse(A):
             return out.asformat(A.format)
         return scipy.sparse.dia_array(out).asformat(A.format)
     elif is_pydata_spmatrix(A):
         import sparse
-        return sparse.eye(A.shape[0], A.shape[1], dtype=A.dtype)
+        return sparse.eye_array(A.shape[0], A.shape[1], dtype=A.dtype)
     elif isinstance(A, scipy.sparse.linalg.LinearOperator):
         return IdentityOperator(A.shape, dtype=A.dtype)
     else:
@@ -183,9 +183,9 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import expm, expm_multiply
-    >>> A = csc_matrix([[1, 0], [0, 1]])
+    >>> A = csc_array([[1, 0], [0, 1]])
     >>> A.toarray()
     array([[1, 0],
            [0, 1]], dtype=int64)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -26,8 +26,8 @@ how this linear operator multiplies with (operates on) a vector. We can now
 add this operator to a sparse matrix that stores only offsets from one::
 
     >>> from scipy.sparse.linalg._interface import aslinearoperator
-    >>> from scipy.sparse import csr_matrix
-    >>> offsets = csr_matrix([[1, 0, 2], [0, -1, 0], [0, 0, 3]])
+    >>> from scipy.sparse import csr_array
+    >>> offsets = csr_array([[1, 0, 2], [0, -1, 0], [0, 0, 3]])
     >>> A = aslinearoperator(offsets) + Ones(offsets.shape)
     >>> A.dot([1, 2, 3])
     array([13,  4, 15])
@@ -844,7 +844,7 @@ def aslinearoperator(A):
     'A' may be any of the following types:
      - ndarray
      - matrix
-     - sparse matrix (e.g. csr_matrix, lil_matrix, etc.)
+     - sparse array (e.g. csr_array, lil_array, etc.)
      - LinearOperator
      - An object with .shape and .matvec attributes
 

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -188,7 +188,7 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -205,7 +205,7 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved. The
         default is ``1000``.
-    M : {sparse matrix, ndarray, LinearOperator}, optional
+    M : {sparse array, ndarray, LinearOperator}, optional
         Preconditioner for `A`.  The preconditioner should approximate the
         inverse of `A`. gcrotmk is a 'flexible' algorithm and the preconditioner
         can vary from iteration to iteration. Effective preconditioning
@@ -261,10 +261,10 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import gcrotmk
     >>> R = np.random.randn(5, 5)
-    >>> A = csc_matrix(R)
+    >>> A = csc_array(R)
     >>> b = np.random.randn(5)
     >>> x, exit_code = gcrotmk(A, b, atol=1e-5)
     >>> print(exit_code)

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -26,7 +26,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` and ``A^T x`` using, e.g.,
@@ -42,7 +42,7 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Preconditioner for `A`. It should approximate the
         inverse of `A` (see Notes). Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
@@ -76,9 +76,9 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import bicg
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1.]])
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1.]])
     >>> b = np.array([2., 4., -1.])
     >>> x, exitCode = bicg(A, b, atol=1e-5)
     >>> print(exitCode)  # 0 indicates successful convergence
@@ -160,7 +160,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` and ``A^T x`` using, e.g.,
@@ -176,7 +176,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Preconditioner for `A`. It should approximate the
         inverse of `A` (see Notes). Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
@@ -210,13 +210,13 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import bicgstab
     >>> R = np.array([[4, 2, 0, 1],
     ...               [3, 0, 0, 2],
     ...               [0, 1, 1, 1],
     ...               [0, 2, 1, 0]])
-    >>> A = csc_matrix(R)
+    >>> A = csc_array(R)
     >>> b = np.array([-1, -0.5, -1, 2])
     >>> x, exit_code = bicgstab(A, b, atol=1e-5)
     >>> print(exit_code)  # 0 indicates successful convergence
@@ -307,7 +307,7 @@ def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         `A` must represent a hermitian, positive definite matrix.
         Alternatively, `A` can be a linear operator which can
@@ -324,7 +324,7 @@ def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Preconditioner for `A`. `M` must represent a hermitian, positive definite
         matrix. It should approximate the inverse of `A` (see Notes).
         Effective preconditioning dramatically improves the
@@ -358,13 +358,13 @@ def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import cg
     >>> P = np.array([[4, 0, 1, 0],
     ...               [0, 5, 0, 0],
     ...               [1, 0, 3, 2],
     ...               [0, 0, 2, 4]])
-    >>> A = csc_matrix(P)
+    >>> A = csc_array(P)
     >>> b = np.array([-1, -0.5, -1, 2])
     >>> x, exit_code = cg(A, b, atol=1e-5)
     >>> print(exit_code)    # 0 indicates successful convergence
@@ -427,7 +427,7 @@ def cgs(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=Non
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real-valued N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -443,7 +443,7 @@ def cgs(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=Non
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Preconditioner for ``A``. It should approximate the
         inverse of `A` (see Notes). Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
@@ -477,13 +477,13 @@ def cgs(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=Non
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import cgs
     >>> R = np.array([[4, 2, 0, 1],
     ...               [3, 0, 0, 2],
     ...               [0, 1, 1, 1],
     ...               [0, 2, 1, 0]])
-    >>> A = csc_matrix(R)
+    >>> A = csc_array(R)
     >>> b = np.array([-1, -0.5, -1, 2])
     >>> x, exit_code = cgs(A, b)
     >>> print(exit_code)  # 0 indicates successful convergence
@@ -586,7 +586,7 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=No
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -607,7 +607,7 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=No
         Maximum number of iterations (restart cycles).  Iteration will stop
         after maxiter steps even if the specified tolerance has not been
         achieved. See `callback_type`.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Inverse of the preconditioner of `A`.  `M` should approximate the
         inverse of `A` and be easy to solve for (see Notes).  Effective
         preconditioning dramatically improves the rate of convergence,
@@ -658,9 +658,9 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=No
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import gmres
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
     >>> b = np.array([2, 4, -1], dtype=float)
     >>> x, exitCode = gmres(A, b, atol=1e-5)
     >>> print(exitCode)            # 0 indicates successful convergence
@@ -847,7 +847,7 @@ def qmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M1=None, M2=None,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real-valued N-by-N matrix of the linear system.
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` and ``A^T x`` using, e.g.,
@@ -863,9 +863,9 @@ def qmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M1=None, M2=None,
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M1 : {sparse matrix, ndarray, LinearOperator}
+    M1 : {sparse array, ndarray, LinearOperator}
         Left preconditioner for A.
-    M2 : {sparse matrix, ndarray, LinearOperator}
+    M2 : {sparse array, ndarray, LinearOperator}
         Right preconditioner for A. Used together with the left
         preconditioner M1.  The matrix M1@A@M2 should have better
         conditioned than A alone.
@@ -890,9 +890,9 @@ def qmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M1=None, M2=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import qmr
-    >>> A = csc_matrix([[3., 2., 0.], [1., -1., 0.], [0., 5., 1.]])
+    >>> A = csc_array([[3., 2., 0.], [1., -1., 0.], [0., 5., 1.]])
     >>> b = np.array([2., 4., -1.])
     >>> x, exitCode = qmr(A, b, atol=1e-5)
     >>> print(exitCode)            # 0 indicates successful convergence

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -24,7 +24,7 @@ def lgmres(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -40,7 +40,7 @@ def lgmres(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}, optional
+    M : {sparse array, ndarray, LinearOperator}, optional
         Preconditioner for A.  The preconditioner should approximate the
         inverse of A.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
@@ -109,9 +109,9 @@ def lgmres(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import lgmres
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
     >>> b = np.array([2, 4, -1], dtype=float)
     >>> x, exitCode = lgmres(A, b, atol=1e-5)
     >>> print(exitCode)            # 0 indicates successful convergence

--- a/scipy/sparse/linalg/_isolve/lsmr.py
+++ b/scipy/sparse/linalg/_isolve/lsmr.py
@@ -38,7 +38,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         Matrix A in the linear system.
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` and ``A^H x`` using, e.g.,
@@ -142,9 +142,9 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import lsmr
-    >>> A = csc_matrix([[1., 0.], [1., 1.], [0., 1.]], dtype=float)
+    >>> A = csc_array([[1., 0.], [1., 1.], [0., 1.]], dtype=float)
 
     The first example has the trivial solution ``[0, 0]``
 

--- a/scipy/sparse/linalg/_isolve/lsqr.py
+++ b/scipy/sparse/linalg/_isolve/lsqr.py
@@ -118,7 +118,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         Representation of an m-by-n matrix.
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` and ``A^T x`` using, e.g.,
@@ -269,9 +269,9 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import lsqr
-    >>> A = csc_matrix([[1., 0.], [1., 1.], [0., 1.]], dtype=float)
+    >>> A = csc_array([[1., 0.], [1., 1.], [0., 1.]], dtype=float)
 
     The first example has the trivial solution ``[0, 0]``
 

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -19,7 +19,7 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real symmetric N-by-N matrix of the linear system
         Alternatively, ``A`` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -49,7 +49,7 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Preconditioner for A.  The preconditioner should approximate the
         inverse of A.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
@@ -67,9 +67,9 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import minres
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
     >>> A = A + A.T
     >>> b = np.array([2, 4, -1], dtype=float)
     >>> x, exitCode = minres(A, b)

--- a/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
@@ -72,8 +72,8 @@ class TestGCROTMK:
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x0, flag0 = gcrotmk(A, b, x0=zeros(A.shape[0]), m=15, k=0, maxiter=1)
-            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=15, maxiter=1)
+            x0, flag0 = gcrotmk(A, b, x0=zeros(A.shape[0]), m=10, k=0, maxiter=1)
+            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=10, maxiter=1)
 
         assert_equal(flag0, 1)
         assert_equal(flag1, 1)

--- a/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
@@ -8,14 +8,14 @@ from numpy.testing import (assert_, assert_allclose, assert_equal,
 import numpy as np
 from numpy import zeros, array, allclose
 from scipy.linalg import norm
-from scipy.sparse import csr_matrix, eye, rand
+from scipy.sparse import csr_array, eye_array, random_array
 
 from scipy.sparse.linalg._interface import LinearOperator
 from scipy.sparse.linalg import splu
 from scipy.sparse.linalg._isolve import gcrotmk, gmres
 
 
-Am = csr_matrix(array([[-2,1,0,0,0,9],
+Am = csr_array(array([[-2,1,0,0,0,9],
                        [1,-2,1,0,5,0],
                        [0,1,-2,1,0,0],
                        [0,0,1,-2,1,0],
@@ -66,7 +66,7 @@ class TestGCROTMK:
     def test_arnoldi(self):
         np.random.seed(1)
 
-        A = eye(2000) + rand(2000, 2000, density=5e-4)
+        A = eye_array(2000) + random_array((2000, 2000), density=5e-4)
         b = np.random.rand(2000)
 
         # The inner arnoldi should be equivalent to gmres
@@ -77,7 +77,7 @@ class TestGCROTMK:
 
         assert_equal(flag0, 1)
         assert_equal(flag1, 1)
-        assert np.linalg.norm(A.dot(x0) - b) > 1e-3
+        assert np.linalg.norm(A.dot(x0) - b) > 1e-4
 
         assert_allclose(x0, x1)
 
@@ -89,7 +89,7 @@ class TestGCROTMK:
         # exceptions are raised
 
         for n in [3, 5, 10, 100]:
-            A = 2*eye(n)
+            A = 2*eye_array(n)
 
             with suppress_warnings() as sup:
                 sup.filter(DeprecationWarning, ".*called without specifying.*")
@@ -112,7 +112,7 @@ class TestGCROTMK:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
     def test_nans(self):
-        A = eye(3, format='lil')
+        A = eye_array(3, format='lil')
         A[1,1] = np.nan
         b = np.ones(3)
 

--- a/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
@@ -64,10 +64,10 @@ class TestGCROTMK:
         assert niter[0] < 3
 
     def test_arnoldi(self):
-        np.random.seed(1)
+        rng = np.random.default_rng(1)
 
-        A = eye_array(2000) + random_array((2000, 2000), density=5e-4)
-        b = np.random.rand(2000)
+        A = eye_array(2000) + random_array((2000, 2000), density=5e-4, random_state=rng)
+        b = rng.random(2000)
 
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -232,7 +232,10 @@ def test_maxiter(case):
     residuals = []
 
     def callback(x):
-        residuals.append(norm(b - case.A * x))
+        if x.ndim == 0:
+            residuals.append(norm(b - case.A * x))
+        else:
+            residuals.append(norm(b - case.A @ x))
 
     if case.solver == gmres:
         with pytest.warns(DeprecationWarning, match=CB_TYPE_FILTER):

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 from numpy import zeros, arange, array, ones, eye, iscomplexobj
 from numpy.linalg import norm
 
-from scipy.sparse import spdiags, csr_matrix, kronsum
+from scipy.sparse import dia_array, csr_array, kronsum
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._isolve import (bicg, bicgstab, cg, cgs,
@@ -82,7 +82,7 @@ class IterativeParams:
         data[0, :] = 2
         data[1, :] = -1
         data[2, :] = -1
-        Poisson1D = spdiags(data, [0, -1, 1], N, N, format='csr')
+        Poisson1D = dia_array((data, [0, -1, 1]), shape=(N, N)).tocsr()
         self.cases.append(Case("poisson1d", Poisson1D))
         # note: minres fails for single precision
         self.cases.append(Case("poisson1d-F", Poisson1D.astype('f'),
@@ -106,7 +106,7 @@ class IterativeParams:
 
         # Symmetric and Indefinite
         data = array([[6, -5, 2, 7, -1, 10, 4, -3, -8, 9]], dtype='d')
-        RandDiag = spdiags(data, [0], 10, 10, format='csr')
+        RandDiag = dia_array((data, [0]), shape=(10, 10)).tocsr()
         self.cases.append(Case("rand-diag", RandDiag, skip=posdef_solvers))
         self.cases.append(Case("rand-diag-F", RandDiag.astype('f'),
                                skip=posdef_solvers))
@@ -168,7 +168,7 @@ class IterativeParams:
         data = ones((2, 10))
         data[0, :] = 2
         data[1, :] = -1
-        A = spdiags(data, [0, -1], 10, 10, format='csr')
+        A = dia_array((data, [0, -1]), shape=(10, 10)).tocsr()
         self.cases.append(Case("nonsymposdef", A,
                                skip=sym_solvers + [cgs, qmr, bicg, tfqmr]))
         self.cases.append(Case("nonsymposdef-F", A.astype('F'),
@@ -283,7 +283,7 @@ def test_precond_dummy(case):
     # 1.0/A.diagonal()
     diagOfA = A.diagonal()
     if np.count_nonzero(diagOfA) == len(diagOfA):
-        spdiags([1.0 / diagOfA], [0], M, N)
+        dia_array(([1.0 / diagOfA], [0]), shape=(M, N))
 
     b = case.b
     x0 = 0 * b
@@ -594,11 +594,11 @@ class TestQMR:
         n = 100
 
         dat = ones(n)
-        A = spdiags([-2 * dat, 4 * dat, -dat], [-1, 0, 1], n, n)
+        A = dia_array(([-2 * dat, 4 * dat, -dat], [-1, 0, 1]), shape=(n, n))
         b = arange(n, dtype='d')
 
-        L = spdiags([-dat / 2, dat], [-1, 0], n, n)
-        U = spdiags([4 * dat, -dat], [0, 1], n, n)
+        L = dia_array(([-dat / 2, dat], [-1, 0]), shape=(n, n))
+        U = dia_array(([4 * dat, -dat], [0, 1]), shape=(n, n))
         L_solver = splu(L)
         U_solver = splu(U)
 
@@ -641,12 +641,12 @@ class TestGMRES:
             rvec[rvec.nonzero()[0].max() + 1] = r
 
         # Define, A,b
-        A = csr_matrix(array([[-2, 1, 0, 0, 0, 0],
-                              [1, -2, 1, 0, 0, 0],
-                              [0, 1, -2, 1, 0, 0],
-                              [0, 0, 1, -2, 1, 0],
-                              [0, 0, 0, 1, -2, 1],
-                              [0, 0, 0, 0, 1, -2]]))
+        A = csr_array(array([[-2, 1, 0, 0, 0, 0],
+                             [1, -2, 1, 0, 0, 0],
+                             [0, 1, -2, 1, 0, 0],
+                             [0, 0, 1, -2, 1, 0],
+                             [0, 0, 0, 1, -2, 1],
+                             [0, 0, 0, 0, 1, -2]]))
         b = ones((A.shape[0],))
         maxiter = 1
         rvec = zeros(maxiter + 1)

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -10,7 +10,7 @@ from platform import python_implementation
 import numpy as np
 from numpy import zeros, array, allclose
 from scipy.linalg import norm
-from scipy.sparse import csr_array, eye_array, random,random_array
+from scipy.sparse import csr_array, eye_array, random_array
 
 from scipy.sparse.linalg._interface import LinearOperator
 from scipy.sparse.linalg import splu

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -10,19 +10,19 @@ from platform import python_implementation
 import numpy as np
 from numpy import zeros, array, allclose
 from scipy.linalg import norm
-from scipy.sparse import csr_matrix, eye, rand
+from scipy.sparse import csr_array, eye_array, random,random_array
 
 from scipy.sparse.linalg._interface import LinearOperator
 from scipy.sparse.linalg import splu
 from scipy.sparse.linalg._isolve import lgmres, gmres
 
 
-Am = csr_matrix(array([[-2, 1, 0, 0, 0, 9],
-                       [1, -2, 1, 0, 5, 0],
-                       [0, 1, -2, 1, 0, 0],
-                       [0, 0, 1, -2, 1, 0],
-                       [0, 3, 0, 1, -2, 1],
-                       [1, 0, 0, 0, 1, -2]]))
+Am = csr_array(array([[-2, 1, 0, 0, 0, 9],
+                      [1, -2, 1, 0, 5, 0],
+                      [0, 1, -2, 1, 0, 0],
+                      [0, 0, 1, -2, 1, 0],
+                      [0, 3, 0, 1, -2, 1],
+                      [1, 0, 0, 0, 1, -2]]))
 b = array([1, 2, 3, 4, 5, 6])
 count = [0]
 niter = [0]
@@ -100,16 +100,15 @@ class TestLGMRES:
     def test_arnoldi(self):
         np.random.seed(1234)
 
-        A = eye(2000) + rand(2000, 2000, density=5e-4)
+        A = eye_array(2000) + random_array((2000, 2000), density=5e-4)
+
         b = np.random.rand(2000)
 
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x0, flag0 = lgmres(A, b, x0=zeros(A.shape[0]),
-                               inner_m=15, maxiter=1)
-            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]),
-                              restart=15, maxiter=1)
+            x0, flag0 = lgmres(A, b, x0=zeros(A.shape[0]), inner_m=15, maxiter=1)
+            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=15, maxiter=1)
 
         assert_equal(flag0, 1)
         assert_equal(flag1, 1)
@@ -125,7 +124,7 @@ class TestLGMRES:
         # exceptions are raised
 
         for n in [3, 5, 10, 100]:
-            A = 2*eye(n)
+            A = 2*eye_array(n)
 
             with suppress_warnings() as sup:
                 sup.filter(DeprecationWarning, ".*called without specifying.*")
@@ -149,7 +148,7 @@ class TestLGMRES:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
     def test_nans(self):
-        A = eye(3, format='lil')
+        A = eye_array(3, format='lil')
         A[1, 1] = np.nan
         b = np.ones(3)
 

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -111,7 +111,7 @@ class TestLGMRES:
             x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=10, maxiter=1)
 
         assert_equal(flag0, 1)
-        assert_equal(flag1, 1, f'{i=} {np.allclose(x0, x1)=}')
+        assert_equal(flag1, 1)
         norm = np.linalg.norm(A.dot(x0) - b)
         assert_(norm > 1e-4)
         assert_allclose(x0, x1)

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -98,11 +98,10 @@ class TestLGMRES:
     @pytest.mark.skipif(python_implementation() == 'PyPy',
                         reason="Fails on PyPy CI runs. See #9507")
     def test_arnoldi(self):
-        np.random.seed(1234)
+        rng = np.random.default_rng(123)
 
-        A = eye_array(2000) + random_array((2000, 2000), density=5e-4)
-
-        b = np.random.rand(2000)
+        A = eye_array(2000) + random_array((2000, 2000), density=5e-4, random_state=rng)
+        b = rng.random(2000)
 
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -107,11 +107,11 @@ class TestLGMRES:
         # The inner arnoldi should be equivalent to gmres
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x0, flag0 = lgmres(A, b, x0=zeros(A.shape[0]), inner_m=15, maxiter=1)
-            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=15, maxiter=1)
+            x0, flag0 = lgmres(A, b, x0=zeros(A.shape[0]), inner_m=10, maxiter=1)
+            x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=10, maxiter=1)
 
         assert_equal(flag0, 1)
-        assert_equal(flag1, 1)
+        assert_equal(flag1, 1, f'{i=} {np.allclose(x0, x1)=}')
         norm = np.linalg.norm(A.dot(x0) - b)
         assert_(norm > 1e-4)
         assert_allclose(x0, x1)

--- a/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
@@ -20,7 +20,7 @@ from numpy import array, arange, eye, zeros, ones, transpose, hstack
 from numpy.linalg import norm
 from numpy.testing import assert_allclose
 import pytest
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 from scipy.sparse.linalg._interface import aslinearoperator
 from scipy.sparse.linalg import lsmr
 from .test_lsqr import G, b
@@ -174,7 +174,7 @@ def lowerBidiagonalMatrix(m, n):
                       arange(m-1, dtype=int)))
         data = hstack((arange(1, m+1, dtype=float),
                        arange(1,m, dtype=float)))
-        return coo_matrix((data, (row, col)), shape=(m,n))
+        return coo_array((data, (row, col)), shape=(m,n))
     else:
         row = hstack((arange(n, dtype=int),
                       arange(1, n+1, dtype=int)))
@@ -182,4 +182,4 @@ def lowerBidiagonalMatrix(m, n):
                       arange(n, dtype=int)))
         data = hstack((arange(1, n+1, dtype=float),
                        arange(1,n+1, dtype=float)))
-        return coo_matrix((data,(row, col)), shape=(m,n))
+        return coo_array((data,(row, col)), shape=(m,n))

--- a/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
@@ -55,7 +55,7 @@ def test_gh_2466():
     row = np.array([0, 0])
     col = np.array([0, 1])
     val = np.array([1, -1])
-    A = scipy.sparse.coo_matrix((val, (row, col)), shape=(1, 2))
+    A = scipy.sparse.coo_array((val, (row, col)), shape=(1, 2))
     b = np.asarray([4])
     lsqr(A, b)
 
@@ -66,7 +66,7 @@ def test_well_conditioned_problems():
     # This is a non-regression test for a potential ZeroDivisionError
     # raised when computing the `test2` & `test3` convergence conditions.
     n = 10
-    A_sparse = scipy.sparse.eye(n, n)
+    A_sparse = scipy.sparse.eye_array(n, n)
     A_dense = A_sparse.toarray()
 
     with np.errstate(invalid='raise'):

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -13,7 +13,7 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperator}
+    A : {sparse array, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -30,7 +30,7 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
         Default is ``min(10000, ndofs * 10)``, where ``ndofs = A.shape[0]``.
-    M : {sparse matrix, ndarray, LinearOperator}
+    M : {sparse array, ndarray, LinearOperator}
         Inverse of the preconditioner of A.  M should approximate the
         inverse of A and be easy to solve for (see Notes).  Effective
         preconditioning dramatically improves the rate of convergence,
@@ -78,9 +78,9 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import tfqmr
-    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> A = csc_array([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
     >>> b = np.array([2, 4, -1], dtype=float)
     >>> x, exitCode = tfqmr(A, b, atol=0.0)
     >>> print(exitCode)            # 0 indicates successful convergence

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -20,7 +20,7 @@ from scipy.sparse._sputils import is_pydata_spmatrix, isintlike
 import scipy.sparse
 import scipy.sparse.linalg
 from scipy.sparse.linalg._interface import LinearOperator
-from scipy.sparse._construct import eye
+from scipy.sparse._construct import eye_array
 
 from ._expm_multiply import _ident_like, _exact_1_norm as _onenorm
 
@@ -30,16 +30,16 @@ UPPER_TRIANGULAR = 'upper_triangular'
 
 def inv(A):
     """
-    Compute the inverse of a sparse matrix
+    Compute the inverse of a sparse arrays
 
     Parameters
     ----------
-    A : (M, M) sparse matrix
+    A : (M, M) sparse arrays
         square matrix to be inverted
 
     Returns
     -------
-    Ainv : (M, M) sparse matrix
+    Ainv : (M, M) sparse arrays
         inverse of `A`
 
     Notes
@@ -50,15 +50,15 @@ def inv(A):
 
     Examples
     --------
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import inv
-    >>> A = csc_matrix([[1., 0.], [1., 2.]])
+    >>> A = csc_array([[1., 0.], [1., 2.]])
     >>> Ainv = inv(A)
     >>> Ainv
-    <Compressed Sparse Column sparse matrix of dtype 'float64'
+    <Compressed Sparse Column sparse arrays of dtype 'float64'
         with 3 stored elements and shape (2, 2)>
     >>> A.dot(Ainv)
-    <Compressed Sparse Column sparse matrix of dtype 'float64'
+    <Compressed Sparse Column sparse arrays of dtype 'float64'
         with 2 stored elements and shape (2, 2)>
     >>> A.dot(Ainv).toarray()
     array([[ 1.,  0.],
@@ -68,8 +68,8 @@ def inv(A):
 
     """
     # Check input
-    if not (scipy.sparse.issparse(A) or is_pydata_spmatrix(A)):
-        raise TypeError('Input must be a sparse matrix')
+    if not (issparse(A) or is_pydata_spmatrix(A)):
+        raise TypeError('Input must be a sparse arrays')
 
     # Use sparse direct solver to solve "AX = I" accurately
     I = _ident_like(A)
@@ -83,7 +83,7 @@ def _onenorm_matrix_power_nnm(A, p):
 
     Parameters
     ----------
-    A : a square ndarray or matrix or sparse matrix
+    A : a square ndarray or matrix or sparse arrays
         Input matrix with non-negative entries.
     p : non-negative integer
         The power to which the matrix is to be raised.
@@ -102,7 +102,7 @@ def _onenorm_matrix_power_nnm(A, p):
         raise ValueError('expected A to be like a square matrix')
 
     # Explicitly make a column vector so that this works when A is a
-    # numpy matrix (in addition to ndarray and sparse matrix).
+    # numpy matrix (in addition to ndarray and sparse arrays).
     v = np.ones((A.shape[0], 1), dtype=float)
     M = A.T
     for i in range(p):
@@ -277,7 +277,7 @@ def _onenormest_matrix_power(A, p,
     Returns
     -------
     est : float
-        An underestimate of the 1-norm of the sparse matrix.
+        An underestimate of the 1-norm of the sparse arrays.
     v : ndarray, optional
         The vector such that ||Av||_1 == est*||v||_1.
         It can be thought of as an input to the linear operator
@@ -319,7 +319,7 @@ def _onenormest_product(operator_seq,
     Returns
     -------
     est : float
-        An underestimate of the 1-norm of the sparse matrix.
+        An underestimate of the 1-norm of the sparse arrays.
     v : ndarray, optional
         The vector such that ||Av||_1 == est*||v||_1.
         It can be thought of as an input to the linear operator
@@ -549,7 +549,7 @@ def expm(A):
 
     Parameters
     ----------
-    A : (M,M) array_like or sparse matrix
+    A : (M,M) array_like or sparse array
         2D Array or Matrix (sparse or dense) to be exponentiated
 
     Returns
@@ -572,16 +572,16 @@ def expm(A):
 
     Examples
     --------
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import expm
-    >>> A = csc_matrix([[1, 0, 0], [0, 2, 0], [0, 0, 3]])
+    >>> A = csc_array([[1, 0, 0], [0, 2, 0], [0, 0, 3]])
     >>> A.toarray()
     array([[1, 0, 0],
            [0, 2, 0],
            [0, 0, 3]], dtype=int64)
     >>> Aexp = expm(A)
     >>> Aexp
-    <Compressed Sparse Column sparse matrix of dtype 'float64'
+    <Compressed Sparse Column sparse array of dtype 'float64'
         with 3 stored elements and shape (3, 3)>
     >>> Aexp.toarray()
     array([[  2.71828183,   0.        ,   0.        ],
@@ -777,7 +777,7 @@ def _fragment_2_1(X, T, s):
     The argument X is modified in-place, but this modification is not the same
     as the returned value of the function.
     This function also takes pains to do things in ways that are compatible
-    with sparse matrices, for example by avoiding fancy indexing
+    with sparse arrays, for example by avoiding fancy indexing
     and by using methods of the matrices whenever possible instead of
     using functions of the numpy or scipy libraries themselves.
 
@@ -926,7 +926,7 @@ def matrix_power(A, power):
             raise ValueError('exponent must be >= 0')
 
         if power == 0:
-            return eye(M, dtype=A.dtype)
+            return eye_array(M, dtype=A.dtype)
 
         if power == 1:
             return A.copy()

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -55,10 +55,10 @@ def inv(A):
     >>> A = csc_array([[1., 0.], [1., 2.]])
     >>> Ainv = inv(A)
     >>> Ainv
-    <Compressed Sparse Column sparse arrays of dtype 'float64'
+    <Compressed Sparse Column sparse array of dtype 'float64'
         with 3 stored elements and shape (2, 2)>
     >>> A.dot(Ainv)
-    <Compressed Sparse Column sparse arrays of dtype 'float64'
+    <Compressed Sparse Column sparse array of dtype 'float64'
         with 2 stored elements and shape (2, 2)>
     >>> A.dot(Ainv).toarray()
     array([[ 1.,  0.],

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -26,8 +26,8 @@ def norm(x, ord=None, axis=None):
 
     Parameters
     ----------
-    x : a sparse matrix
-        Input sparse matrix.
+    x : a sparse array
+        Input sparse array.
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.
@@ -45,7 +45,7 @@ def norm(x, ord=None, axis=None):
     Notes
     -----
     Some of the ord are not implemented because some associated functions like,
-    _multi_svd_norm, are not yet available for sparse matrix.
+    _multi_svd_norm, are not yet available for sparse array.
 
     This docstring is modified based on numpy.linalg.norm.
     https://github.com/numpy/numpy/blob/main/numpy/linalg/linalg.py
@@ -53,7 +53,7 @@ def norm(x, ord=None, axis=None):
     The following norms can be calculated:
 
     =====  ============================
-    ord    norm for sparse matrices
+    ord    norm for sparse arrays
     =====  ============================
     None   Frobenius norm
     'fro'  Frobenius norm
@@ -78,7 +78,7 @@ def norm(x, ord=None, axis=None):
 
     Examples
     --------
-    >>> from scipy.sparse import *
+    >>> from scipy.sparse import csr_array, diags_array
     >>> import numpy as np
     >>> from scipy.sparse.linalg import norm
     >>> a = np.arange(9) - 4
@@ -90,7 +90,7 @@ def norm(x, ord=None, axis=None):
            [-1, 0, 1],
            [ 2, 3, 4]])
 
-    >>> b = csr_matrix(b)
+    >>> b = csr_array(b)
     >>> norm(b)
     7.745966692414834
     >>> norm(b, 'fro')
@@ -107,7 +107,7 @@ def norm(x, ord=None, axis=None):
     The matrix 2-norm or the spectral norm is the largest singular
     value, computed approximately and with limitations.
 
-    >>> b = diags([-1, 1], [0, 1], shape=(9, 10))
+    >>> b = diags_array([-1, 1], [0, 1], shape=(9, 10))
     >>> norm(b, 2)
     1.9753...
     """

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -10,7 +10,7 @@ __all__ = ['onenormest']
 
 def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
     """
-    Compute a lower bound of the 1-norm of a sparse matrix.
+    Compute a lower bound of the 1-norm of a sparse array.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
     Returns
     -------
     est : float
-        An underestimate of the 1-norm of the sparse matrix.
+        An underestimate of the 1-norm of the sparse array.
     v : ndarray, optional
         The vector such that ||Av||_1 == est*||v||_1.
         It can be thought of as an input to the linear operator
@@ -68,9 +68,9 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import onenormest
-    >>> A = csc_matrix([[1., 0., 0.], [5., 8., 2.], [0., -1., 0.]], dtype=float)
+    >>> A = csc_array([[1., 0., 0.], [5., 8., 2.], [0., -1., 0.]], dtype=float)
     >>> A.toarray()
     array([[ 1.,  0.,  0.],
            [ 5.,  8.,  2.],
@@ -323,7 +323,7 @@ def _algorithm_2_2(A, AT, t):
 
 def _onenormest_core(A, AT, t, itmax):
     """
-    Compute a lower bound of the 1-norm of a sparse matrix.
+    Compute a lower bound of the 1-norm of a sparse array.
 
     Parameters
     ----------
@@ -340,7 +340,7 @@ def _onenormest_core(A, AT, t, itmax):
     Returns
     -------
     est : float
-        An underestimate of the 1-norm of the sparse matrix.
+        An underestimate of the 1-norm of the sparse array.
     v : ndarray, optional
         The vector such that ||Av||_1 == est*||v||_1.
         It can be thought of as an input to the linear operator

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -143,13 +143,13 @@ class TestExpmActionSimple:
         assert_allclose(observed, expected)
 
     def test_sparse_expm_multiply(self):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         n = 40
         k = 3
         nsamples = 10
         for i in range(nsamples):
-            A = scipy.sparse.random_array((n, n), density=0.05)
-            B = np.random.randn(n, k)
+            A = scipy.sparse.random_array((n, n), density=0.05, random_state=rng)
+            B = rng.standard_normal((n, k))
             observed = expm_multiply(A, B)
             with suppress_warnings() as sup:
                 sup.filter(SparseEfficiencyWarning,
@@ -180,16 +180,16 @@ class TestExpmActionInterval:
 
     @pytest.mark.fail_slow(20)
     def test_sparse_expm_multiply_interval(self):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         start = 0.1
         stop = 3.2
         n = 40
         k = 3
         endpoint = True
         for num in (14, 13, 2):
-            A = scipy.sparse.random_array((n, n), density=0.05)
-            B = np.random.randn(n, k)
-            v = np.random.randn(n)
+            A = scipy.sparse.random_array((n, n), density=0.05, random_state=rng)
+            B = rng.standard_normal((n, k))
+            v = rng.standard_normal((n,))
             for target in (B, v):
                 X = expm_multiply(A, target, start=start, stop=stop,
                                   num=num, endpoint=endpoint)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -148,7 +148,7 @@ class TestExpmActionSimple:
         k = 3
         nsamples = 10
         for i in range(nsamples):
-            A = scipy.sparse.rand(n, n, density=0.05)
+            A = scipy.sparse.random_array((n, n), density=0.05)
             B = np.random.randn(n, k)
             observed = expm_multiply(A, B)
             with suppress_warnings() as sup:
@@ -187,7 +187,7 @@ class TestExpmActionInterval:
         k = 3
         endpoint = True
         for num in (14, 13, 2):
-            A = scipy.sparse.rand(n, n, density=0.05)
+            A = scipy.sparse.random_array((n, n), density=0.05)
             B = np.random.randn(n, k)
             v = np.random.randn(n)
             for target in (B, v):
@@ -249,21 +249,21 @@ class TestExpmActionInterval:
 
     def test_sparse_expm_multiply_interval_dtypes(self):
         # Test A & B int
-        A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
+        A = scipy.sparse.diags_array(np.arange(5),format='csr', dtype=int)
         B = np.ones(5, dtype=int)
-        Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
+        Aexpm = scipy.sparse.diags_array(np.exp(np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
 
         # Test A complex, B int
-        A = scipy.sparse.diags(-1j*np.arange(5),format='csr', dtype=complex)
+        A = scipy.sparse.diags_array(-1j*np.arange(5),format='csr', dtype=complex)
         B = np.ones(5, dtype=int)
-        Aexpm = scipy.sparse.diags(np.exp(-1j*np.arange(5)),format='csr')
+        Aexpm = scipy.sparse.diags_array(np.exp(-1j*np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
 
         # Test A int, B complex
-        A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
+        A = scipy.sparse.diags_array(np.arange(5),format='csr', dtype=int)
         B = np.full(5, 1j, dtype=complex)
-        Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
+        Aexpm = scipy.sparse.diags_array(np.exp(np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
 
     def test_expm_multiply_interval_status_0(self):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -221,7 +221,7 @@ class TestAsLinearOperator:
 
             cases.append((matrix(original, dtype=dtype), original))
             cases.append((np.array(original, dtype=dtype), original))
-            cases.append((sparse.csr_matrix(original, dtype=dtype), original))
+            cases.append((sparse.csr_array(original, dtype=dtype), original))
 
             # Test default implementations of _adjoint and _rmatvec, which
             # refer to each other.
@@ -485,7 +485,7 @@ def test_transpose_noconjugate():
 
 def test_sparse_matmat_exception():
     A = interface.LinearOperator((2, 2), matvec=lambda x: x)
-    B = sparse.identity(2)
+    B = sparse.eye_array(2)
     msg = "Unable to multiply a LinearOperator with a sparse matrix."
     with assert_raises(TypeError, match=msg):
         A @ B

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -12,8 +12,8 @@ from numpy.testing import (
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
         assert_array_almost_equal_nulp, suppress_warnings)
 
-from scipy.sparse import csc_matrix, csc_array, SparseEfficiencyWarning
-from scipy.sparse._construct import eye as speye
+from scipy.sparse import csc_array, SparseEfficiencyWarning
+from scipy.sparse._construct import eye_array
 from scipy.sparse.linalg._matfuncs import (expm, _expm,
         ProductOperator, MatrixPowerOperator,
         _onenorm_matrix_power_nnm, matrix_power)
@@ -70,12 +70,12 @@ def test_matrix_power():
     np.random.seed(1234)
     row, col = np.random.randint(0, 4, size=(2, 6))
     data = np.random.random(size=(6,))
-    Amat = csc_matrix((data, (row, col)), shape=(4, 4))
+    Amat = csc_array((data, (row, col)), shape=(4, 4))
     A = csc_array((data, (row, col)), shape=(4, 4))
     Adense = A.toarray()
     for power in (2, 5, 6):
         Apow = matrix_power(A, power).toarray()
-        Amat_pow = (Amat**power).toarray()
+        Amat_pow = matrix_power(Amat, power).toarray()
         Adense_pow = np.linalg.matrix_power(Adense, power)
         assert_allclose(Apow, Adense_pow)
         assert_allclose(Apow, Amat_pow)
@@ -87,7 +87,7 @@ class TestExpM:
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_zero_sparse(self):
-        a = csc_matrix([[0.,0],[0,0]])
+        a = csc_array([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
 
     def test_zero_matrix(self):
@@ -100,15 +100,15 @@ class TestExpM:
         assert_allclose(expm([[1]]), A)
         assert_allclose(expm(matrix([[1]])), A)
         assert_allclose(expm(np.array([[1]])), A)
-        assert_allclose(expm(csc_matrix([[1]])).toarray(), A)
+        assert_allclose(expm(csc_array([[1]])).toarray(), A)
         B = expm(np.array([[1j]]))
         assert_allclose(expm(((1j,),)), B)
         assert_allclose(expm([[1j]]), B)
         assert_allclose(expm(matrix([[1j]])), B)
-        assert_allclose(expm(csc_matrix([[1j]])).toarray(), B)
+        assert_allclose(expm(csc_array([[1j]])).toarray(), B)
 
     def test_bidiagonal_sparse(self):
-        A = csc_matrix([
+        A = csc_array([
             [1, 3, 0],
             [0, 1, 5],
             [0, 0, 2]], dtype=float)
@@ -141,7 +141,7 @@ class TestExpM:
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.float64
         for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            a = scale * eye_array(3, 3, dtype=dtype, format='csc')
             e = exp(scale, dtype=dtype) * eye(3, dtype=dtype)
             with suppress_warnings() as sup:
                 sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
@@ -154,7 +154,7 @@ class TestExpM:
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.complex128
         for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            a = scale * eye_array(3, 3, dtype=dtype, format='csc')
             e = exp(scale) * eye(3, dtype=dtype)
             with suppress_warnings() as sup:
                 sup.filter(SparseEfficiencyWarning, "Changing the sparsity structure")
@@ -187,7 +187,7 @@ class TestExpM:
                       [0, 0, 0, 0]], dtype=np.int16)
         assert_allclose(expm(Q), expm(1.0 * Q))
 
-        Q = csc_matrix(Q)
+        Q = csc_array(Q)
         assert_allclose(expm(Q).toarray(), expm(1.0 * Q).toarray())
 
     def test_triangularity_perturbation(self):

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -38,7 +38,7 @@ class TestNorm:
     def setup_method(self):
         a = np.arange(9) - 4
         b = a.reshape((3, 3))
-        self.b = scipy.sparse.csr_matrix(b)
+        self.b = scipy.sparse.csr_array(b)
 
     def test_matrix_norm(self):
 
@@ -55,7 +55,7 @@ class TestNorm:
             assert_allclose(spnorm(self.b.astype(np.float64), 2),
                             7.348469228349534)
 
-        # _multi_svd_norm is not implemented for sparse matrix
+        # _multi_svd_norm is not implemented for sparse array
         assert_raises(NotImplementedError, spnorm, self.b, -2)
 
     def test_matrix_norm_axis(self):
@@ -94,13 +94,13 @@ class TestNorm:
 
 class TestVsNumpyNorm:
     _sparse_types = (
-            scipy.sparse.bsr_matrix,
-            scipy.sparse.coo_matrix,
-            scipy.sparse.csc_matrix,
-            scipy.sparse.csr_matrix,
-            scipy.sparse.dia_matrix,
-            scipy.sparse.dok_matrix,
-            scipy.sparse.lil_matrix,
+            scipy.sparse.bsr_array,
+            scipy.sparse.coo_array,
+            scipy.sparse.csc_array,
+            scipy.sparse.csr_array,
+            scipy.sparse.dia_array,
+            scipy.sparse.dok_array,
+            scipy.sparse.lil_array,
             )
     _test_matrices = (
             (np.arange(9) - 4).reshape((3, 3)),

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from pytest import raises as assert_raises
 from scipy.sparse.linalg._svdp import _svdp
-from scipy.sparse import csr_matrix, csc_matrix
+from scipy.sparse import csr_array, csc_array
 
 
 # dtype_flavour to tolerance
@@ -33,7 +33,7 @@ _dtypes = tuple(_dtypes)  # type: ignore[assignment]
 
 def generate_matrix(constructor, n, m, f,
                     dtype=float, rseed=0, **kwargs):
-    """Generate a random sparse matrix"""
+    """Generate a random sparse array"""
     rng = np.random.RandomState(rseed)
     if is_complex_type(dtype):
         M = (- 5 + 10 * rng.rand(n, m)
@@ -74,7 +74,7 @@ def check_svdp(n, m, constructor, dtype, k, irl_mode, which, f=0.8):
     assert_orthogonal(vt1.T, vt2.T, rtol=tol, atol=tol)
 
 
-@pytest.mark.parametrize('ctor', (np.array, csr_matrix, csc_matrix))
+@pytest.mark.parametrize('ctor', (np.array, csr_array, csc_array))
 @pytest.mark.parametrize('dtype', _dtypes)
 @pytest.mark.parametrize('irl', (True, False))
 @pytest.mark.parametrize('which', ('LM', 'SM'))

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -22,12 +22,12 @@ sparse_params = (pytest.param("COO"),
                  pytest.param("DOK", marks=[pytest.mark.xfail(reason=msg)]))
 
 scipy_sparse_classes = [
-    sp.bsr_matrix,
-    sp.csr_matrix,
-    sp.coo_matrix,
-    sp.csc_matrix,
-    sp.dia_matrix,
-    sp.dok_matrix
+    sp.bsr_array,
+    sp.csr_array,
+    sp.coo_array,
+    sp.csc_array,
+    sp.dia_array,
+    sp.dok_array
 ]
 
 
@@ -140,23 +140,23 @@ def test_spsolve(matrices):
     A_dense, A_sparse, b = matrices
     b2 = np.random.rand(len(b), 3)
 
-    x0 = splin.spsolve(sp.csc_matrix(A_dense), b)
+    x0 = splin.spsolve(sp.csc_array(A_dense), b)
     x = splin.spsolve(A_sparse, b)
     assert isinstance(x, np.ndarray)
     assert_allclose(x, x0)
 
-    x0 = splin.spsolve(sp.csc_matrix(A_dense), b)
+    x0 = splin.spsolve(sp.csc_array(A_dense), b)
     x = splin.spsolve(A_sparse, b, use_umfpack=True)
     assert isinstance(x, np.ndarray)
     assert_allclose(x, x0)
 
-    x0 = splin.spsolve(sp.csc_matrix(A_dense), b2)
+    x0 = splin.spsolve(sp.csc_array(A_dense), b2)
     x = splin.spsolve(A_sparse, b2)
     assert isinstance(x, np.ndarray)
     assert_allclose(x, x0)
 
-    x0 = splin.spsolve(sp.csc_matrix(A_dense),
-                       sp.csc_matrix(A_dense))
+    x0 = splin.spsolve(sp.csc_array(A_dense),
+                       sp.csc_array(A_dense))
     x = splin.spsolve(A_sparse, A_sparse)
     assert isinstance(x, type(A_sparse))
     assert_allclose(x.todense(), x0.todense())
@@ -172,8 +172,8 @@ def test_splu(matrices):
     assert isinstance(lu.L, sparse_cls)
     assert isinstance(lu.U, sparse_cls)
 
-    _Pr_scipy = sp.csc_matrix((np.ones(n), (lu.perm_r, np.arange(n))))
-    _Pc_scipy = sp.csc_matrix((np.ones(n), (np.arange(n), lu.perm_c)))
+    _Pr_scipy = sp.csc_array((np.ones(n), (lu.perm_r, np.arange(n))))
+    _Pc_scipy = sp.csc_array((np.ones(n), (np.arange(n), lu.perm_c)))
     Pr = sparse_cls.from_scipy_sparse(_Pr_scipy)
     Pc = sparse_cls.from_scipy_sparse(_Pc_scipy)
     A2 = Pr.T @ lu.L @ lu.U @ Pc.T
@@ -214,21 +214,21 @@ def test_onenormest(matrices):
 
 def test_norm(matrices):
     A_dense, A_sparse, b = matrices
-    norm0 = splin.norm(sp.csr_matrix(A_dense))
+    norm0 = splin.norm(sp.csr_array(A_dense))
     norm = splin.norm(A_sparse)
     assert_allclose(norm, norm0)
 
 
 def test_inv(matrices):
     A_dense, A_sparse, b = matrices
-    x0 = splin.inv(sp.csc_matrix(A_dense))
+    x0 = splin.inv(sp.csc_array(A_dense))
     x = splin.inv(A_sparse)
     assert_allclose(x.todense(), x0.todense())
 
 
 def test_expm(matrices):
     A_dense, A_sparse, b = matrices
-    x0 = splin.expm(sp.csc_matrix(A_dense))
+    x0 = splin.expm(sp.csc_array(A_dense))
     x = splin.expm(A_sparse)
     assert_allclose(x.todense(), x0.todense())
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -242,9 +242,13 @@ def test_expm_multiply(matrices):
 
 def test_eq(same_matrix):
     sp_sparse, pd_sparse = same_matrix
+    # temporary splint until pydata sparse support sparray equality
+    sp_sparse = sp.coo_matrix(sp_sparse).asformat(sp_sparse.format)
     assert (sp_sparse == pd_sparse).all()
 
 
 def test_ne(same_matrix):
     sp_sparse, pd_sparse = same_matrix
+    # temporary splint until pydata sparse support sparray equality
+    sp_sparse = sp.coo_matrix(sp_sparse).asformat(sp_sparse.format)
     assert not (sp_sparse != pd_sparse).any()


### PR DESCRIPTION
This PR converts `sparse.linalg` to use `sparray` internally instead of `spmatrix`.

With full functionality for sparray, we can start to move SciPy's internal usage of sparse matrix to sparse array. This PR converts the sparse.linalg subpackage.

The linalg functions all still take spmatrix as input and return spmatrix where appropriate when the input is spmatrix. But they no longer construct any spmatrix objects or use any sparse spmatrix functionality internally. Thus `sparse.linalg` is now independent of spmatrix and should not need to be changed as that functionality is slowly removed from use. 
