### PR TITLE
MAINT: special.logsumexp: preserve tiny imaginary components

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -125,11 +125,11 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     if xp.isdtype(out.dtype, 'complex floating'):
         if return_sign:
             real = xp.real(sgn)
-            imag = xp_float_to_complex(_wrap_radians(xp.imag(sgn)))
+            imag = xp_float_to_complex(_wrap_radians(xp.imag(sgn), xp))
             sgn = real + imag*1j
         else:
             real = xp.real(out)
-            imag = xp_float_to_complex(_wrap_radians(xp.imag(out)))
+            imag = xp_float_to_complex(_wrap_radians(xp.imag(out), xp))
             out = real + imag*1j
 
     # Deal with shape details - reducing dimensions and convert 0-D to scalar for NumPy
@@ -141,9 +141,13 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     return (out, sgn) if return_sign else out
 
 
-def _wrap_radians(x):
+def _wrap_radians(x, xp):
     # Wrap radians to -pi, pi interval
-    return (x + math.pi) % (2 * math.pi) - math.pi
+    out = (x + math.pi) % (2 * math.pi) - math.pi
+    # preserve relative precision
+    no_wrap = xp.abs(x) < xp.pi
+    out[no_wrap] = x[no_wrap]
+    return out
 
 
 def _elements_and_indices_with_max_real(a, axis=-1, xp=None):

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -141,9 +141,10 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     return (out, sgn) if return_sign else out
 
 
-def _wrap_radians(x, xp):
-    # Wrap radians to -pi, pi interval
-    out = (x + math.pi) % (2 * math.pi) - math.pi
+def _wrap_radians(x, xp=None):
+    xp = array_namespace(x) if xp is None else xp
+    # Wrap radians to (-pi, pi] interval
+    out = -((-x + math.pi) % (2 * math.pi) - math.pi)
     # preserve relative precision
     no_wrap = xp.abs(x) < xp.pi
     out[no_wrap] = x[no_wrap]

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -10,10 +10,25 @@ from scipy._lib._array_api_no_0d import (xp_assert_equal, xp_assert_close,
                                          xp_assert_less)
 
 from scipy.special import logsumexp, softmax
+from scipy.special._logsumexp import _wrap_radians
 
 
 dtypes = ['float32', 'float64', 'int32', 'int64', 'complex64', 'complex128']
 integral_dtypes = ['int32', 'int64']
+
+
+@array_api_compatible
+@pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('jax.numpy',
+                              reason="JAX arrays do not support item assignment")
+def test_wrap_radians(xp):
+    x = xp.asarray([-math.pi-1, -math.pi, -1, -1e-300,
+                    0, 1e-300, 1, math.pi, math.pi+1])
+    ref = xp.asarray([math.pi-1, math.pi, -1, -1e-300,
+                    0, 1e-300, 1, math.pi, -math.pi+1])
+    res = _wrap_radians(x, xp)
+    xp_assert_close(res, ref, atol=0)
+
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -229,6 +229,19 @@ class TestLogSumExp:
         xp_assert_close(out, xp.real(xp.log(ref)))
         xp_assert_close(sgn, ref/xp.abs(ref))
 
+    def test_gh21709_small_imaginary(self, xp):
+        # Test that `logsumexp` does not lose relative precision of
+        # small imaginary components
+        x = xp.asarray([0, 0.+2.2204460492503132e-17j])
+        res = logsumexp(x)
+        # from mpmath import mp
+        # mp.dps = 100
+        # x, y = mp.mpc(0), mp.mpc('0', '2.2204460492503132e-17')
+        # ref = complex(mp.log(mp.exp(x) + mp.exp(y)))
+        ref = xp.asarray(0.6931471805599453+1.1102230246251566e-17j)
+        xp_assert_close(xp.real(res), xp.real(ref))
+        xp_assert_close(xp.imag(res), xp.imag(ref), atol=0, rtol=1e-15)
+
 
 class TestSoftmax:
     def test_softmax_fixtures(self):


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/pull/21622#discussion_r1781742660
Closes gh-21709

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/21622#discussion_r1781742660 noted that `logsumexp` woule lose precision for tiny imaginary components; gh-21709 reported it as a bug. This fixes that.