### PR TITLE
ENH: signal: add array API support / delegation to lfilter et al

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2422,8 +2422,8 @@ def deconvolve(signal, divisor):
     """
     xp = array_namespace(signal, divisor)
 
-    num = xpx.atleast_nd(signal, ndim=1, xp=xp)
-    den = xpx.atleast_nd(divisor, ndim=1, xp=xp)
+    num = xpx.atleast_nd(xp.asarray(signal), ndim=1, xp=xp)
+    den = xpx.atleast_nd(xp.asarray(divisor), ndim=1, xp=xp)
     if num.ndim > 1:
         raise ValueError("signal must be 1-D.")
     if den.ndim > 1:
@@ -2585,7 +2585,7 @@ def hilbert2(x, N=None):
 
     """
     xp = array_namespace(x)
-    x = xpx.atleast_nd(x, ndim=2, xp=xp)
+    x = xpx.atleast_nd(xp.asarray(x), ndim=2, xp=xp)
     if x.ndim > 2:
         raise ValueError("x must be 2-D.")
     if xp.isdtype(x.dtype, 'complex floating'):
@@ -4191,10 +4191,10 @@ def lfilter_zi(b, a):
     # We could use scipy.signal.normalize, but it uses warnings in
     # cases where a ValueError is more appropriate, and it allows
     # b to be 2D.
-    b = xpx.atleast_nd(b, ndim=1, xp=xp)
+    b = xpx.atleast_nd(xp.asarray(b), ndim=1, xp=xp)
     if b.ndim != 1:
         raise ValueError("Numerator b must be 1-D.")
-    a = xpx.atleast_nd(a, ndim=1, xp=xp)
+    a = xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp)
     if a.ndim != 1:
         raise ValueError("Denominator a must be 1-D.")
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -28,9 +28,11 @@ from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
     array_namespace, is_torch, is_numpy, xp_copy, xp_size
+
 )
 import scipy._lib.array_api_compat.numpy as np_compat
 import scipy._lib.array_api_extra as xpx
+
 
 __all__ = ['correlate', 'correlation_lags', 'correlate2d',
            'convolve', 'convolve2d', 'fftconvolve', 'oaconvolve',
@@ -2192,12 +2194,22 @@ def lfilter(b, a, x, axis=-1, zi=None):
     >>> plt.show()
 
     """
+    try:
+        xp = array_namespace(b, a, x, zi)
+    except TypeError:
+        # either in1 or in2 are object arrays
+        xp = np_compat
+
+    if is_numpy(xp):
+        _reject_objects(x, 'lfilter')
+        _reject_objects(a, 'lfilter')
+        _reject_objects(b, 'lfilter')
+
     b = np.atleast_1d(b)
     a = np.atleast_1d(a)
-
-    _reject_objects(x, 'lfilter')
-    _reject_objects(a, 'lfilter')
-    _reject_objects(b, 'lfilter')
+    x = np.asarray(x)
+    if zi is not None:
+       zi = np.asarray(zi)
 
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
@@ -2256,16 +2268,18 @@ def lfilter(b, a, x, axis=-1, zi=None):
         out = out_full[tuple(ind)]
 
         if zi is None:
-            return out
+            return xp.asarray(out)
         else:
             ind[axis] = slice(out_full.shape[axis] - len(b) + 1, None)
             zf = out_full[tuple(ind)]
-            return out, zf
+            return xp.asarray(out), xp.asarray(zf)
     else:
         if zi is None:
-            return _sigtools._linear_filter(b, a, x, axis)
+            result =_sigtools._linear_filter(b, a, x, axis)
+            return xp.asarray(result)
         else:
-            return _sigtools._linear_filter(b, a, x, axis, zi)
+            out, zf = _sigtools._linear_filter(b, a, x, axis, zi)
+            return xp.asarray(out), xp.asarray(zf)
 
 
 def lfiltic(b, a, y, x=None):
@@ -2308,40 +2322,59 @@ def lfiltic(b, a, y, x=None):
     lfilter, lfilter_zi
 
     """
-    N = np.size(a) - 1
-    M = np.size(b) - 1
+    try:
+        xp = array_namespace(a, b, y, x)
+    except TypeError:
+        xp = np_compat
+
+    if is_numpy(xp):
+        _reject_objects(a, 'lfiltic')
+        _reject_objects(b, 'lfiltic')
+        _reject_objects(y, 'lfiltic')
+        if x is not None:
+            _reject_objects(x, 'lfiltic')
+
+    a = xp.asarray(a)
+    b = xp.asarray(b)
+
+    N = xp_size(a) - 1
+    M = xp_size(b) - 1
     K = max(M, N)
-    y = np.asarray(y)
+    y = xp.asarray(y)
 
     if x is None:
-        result_type = np.result_type(np.asarray(b), np.asarray(a), y)
-        if result_type.kind in 'bui':
-            result_type = np.float64
-        x = np.zeros(M, dtype=result_type)
+        result_type = xp.result_type(b, a, y)
+        if xp.isdtype(result_type, ('bool', 'integral')):  #'bui':
+            result_type = xp.float64
+        x = xp.zeros(M, dtype=result_type)
     else:
-        x = np.asarray(x)
+        x = xp.asarray(x)
 
-        result_type = np.result_type(np.asarray(b), np.asarray(a), y, x)
-        if result_type.kind in 'bui':
-            result_type = np.float64
-        x = x.astype(result_type)
+        result_type = xp.result_type(b, a, y, x)
+        if xp.isdtype(result_type, ('bool', 'integral')):  #'bui':
+            result_type = xp.float64
+        x = xp.astype(x, result_type)
 
-        L = np.size(x)
+        concat = array_namespace(a).concat
+
+        L = xp_size(x)
         if L < M:
-            x = np.r_[x, np.zeros(M - L)]
+            x = concat((x, xp.zeros(M - L)))
 
-    y = y.astype(result_type)
-    zi = np.zeros(K, result_type)
+    y = xp.astype(y, result_type)
+    zi = xp.zeros(K, dtype=result_type)
 
-    L = np.size(y)
+    concat = array_namespace(xp.ones(3)).concat
+
+    L = xp_size(y)
     if L < N:
-        y = np.r_[y, np.zeros(N - L)]
+        y = concat((y, np.zeros(N - L)))
 
     for m in range(M):
-        zi[m] = np.sum(b[m + 1:] * x[:M - m], axis=0)
+        zi[m] = xp.sum(b[m + 1:] * x[:M - m], axis=0)
 
     for m in range(N):
-        zi[m] -= np.sum(a[m + 1:] * y[:N - m], axis=0)
+        zi[m] -= xp.sum(a[m + 1:] * y[:N - m], axis=0)
 
     return zi
 
@@ -2387,19 +2420,21 @@ def deconvolve(signal, divisor):
     array([ 0.,  1.,  0.,  0.,  1.,  1.,  0.,  0.])
 
     """
-    num = np.atleast_1d(signal)
-    den = np.atleast_1d(divisor)
+    xp = array_namespace(signal, divisor)
+
+    num = xpx.atleast_nd(signal, ndim=1, xp=xp)
+    den = xpx.atleast_nd(divisor, ndim=1, xp=xp)
     if num.ndim > 1:
         raise ValueError("signal must be 1-D.")
     if den.ndim > 1:
         raise ValueError("divisor must be 1-D.")
-    N = len(num)
-    D = len(den)
+    N = num.shape[0]
+    D = den.shape[0]
     if D > N:
         quot = []
         rem = num
     else:
-        input = np.zeros(N - D + 1, float)
+        input = xp.zeros(N - D + 1, dtype=xp.float64)
         input[0] = 1
         quot = lfilter(num, den, input)
         rem = num - convolve(den, quot, mode='full')
@@ -2550,7 +2585,6 @@ def hilbert2(x, N=None):
 
     """
     xp = array_namespace(x)
-
     x = xpx.atleast_nd(x, ndim=2, xp=xp)
     if x.ndim > 2:
         raise ValueError("x must be 2-D.")
@@ -4147,6 +4181,7 @@ def lfilter_zi(b, a):
     transient until the input drops from 0.5 to 0.0.
 
     """
+    xp = array_namespace(b, a)
 
     # FIXME: Can this function be replaced with an appropriate
     # use of lfiltic?  For example, when b,a = butter(N,Wn),
@@ -4156,16 +4191,16 @@ def lfilter_zi(b, a):
     # We could use scipy.signal.normalize, but it uses warnings in
     # cases where a ValueError is more appropriate, and it allows
     # b to be 2D.
-    b = np.atleast_1d(b)
+    b = xpx.atleast_nd(b, ndim=1, xp=xp)
     if b.ndim != 1:
         raise ValueError("Numerator b must be 1-D.")
-    a = np.atleast_1d(a)
+    a = xpx.atleast_nd(a, ndim=1, xp=xp)
     if a.ndim != 1:
         raise ValueError("Denominator a must be 1-D.")
 
-    while len(a) > 1 and a[0] == 0.0:
+    while a.shape[0] > 1 and a[0] == 0.0:
         a = a[1:]
-    if a.size < 1:
+    if xp_size(a) < 1:
         raise ValueError("There must be at least one nonzero `a` coefficient.")
 
     if a[0] != 1.0:
@@ -4173,18 +4208,20 @@ def lfilter_zi(b, a):
         b = b / a[0]
         a = a / a[0]
 
-    n = max(len(a), len(b))
+    n = max(a.shape[0], b.shape[0])
 
     # Pad a or b with zeros so they are the same length.
-    if len(a) < n:
-        a = np.r_[a, np.zeros(n - len(a), dtype=a.dtype)]
-    elif len(b) < n:
-        b = np.r_[b, np.zeros(n - len(b), dtype=b.dtype)]
+    if a.shape[0] < n:
+        a = xp.concat((a, xp.zeros(n - a.shape[0], dtype=a.dtype)))
+    elif b.shape[0] < n:
+        b = xp.concat((b, xp.zeros(n - b.shape[0], dtype=b.dtype)))
 
-    IminusA = np.eye(n - 1, dtype=np.result_type(a, b)) - linalg.companion(a).T
+    dt = xp.result_type(a, b)
+    IminusA = np.eye(n - 1) - linalg.companion(a).T
+    IminusA = xp.asarray(IminusA, dtype=dt)
     B = b[1:] - a[1:] * b[0]
     # Solve zi = A*zi + B
-    zi = np.linalg.solve(IminusA, B)
+    zi = xp.linalg.solve(IminusA, B)
 
     # For future reference: we could also use the following
     # explicit formulas to solve the linear system:
@@ -4255,24 +4292,26 @@ def sosfilt_zi(sos):
     >>> plt.show()
 
     """
-    sos = np.asarray(sos)
+    xp = array_namespace(sos)
+
+    sos = xp.asarray(sos)
     if sos.ndim != 2 or sos.shape[1] != 6:
         raise ValueError('sos must be shape (n_sections, 6)')
 
-    if sos.dtype.kind in 'bui':
-        sos = sos.astype(np.float64)
+    if xp.isdtype(sos.dtype, ("integral", "bool")):
+        sos = xp.astype(sos, xp.float64)
 
     n_sections = sos.shape[0]
-    zi = np.empty((n_sections, 2), dtype=sos.dtype)
+    zi = xp.empty((n_sections, 2), dtype=sos.dtype)
     scale = 1.0
     for section in range(n_sections):
         b = sos[section, :3]
         a = sos[section, 3:]
-        zi[section] = scale * lfilter_zi(b, a)
+        zi[section, ...] = scale * lfilter_zi(b, a)
         # If H(z) = B(z)/A(z) is this section's transfer function, then
         # b.sum()/a.sum() is H(1), the gain at omega=0.  That's the steady
         # state value of this section's step response.
-        scale *= b.sum() / a.sum()
+        scale *= xp.sum(b) / xp.sum(a)
 
     return zi
 
@@ -4614,6 +4653,8 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     2.875334415008979e-10
 
     """
+    xp = array_namespace(b, a, x)
+
     b = np.atleast_1d(b)
     a = np.atleast_1d(a)
     x = np.asarray(x)
@@ -4623,7 +4664,7 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 
     if method == "gust":
         y, z1, z2 = _filtfilt_gust(b, a, x, axis=axis, irlen=irlen)
-        return y
+        return xp.asarray(y)
 
     # method == "pad"
     edge, ext = _validate_pad(padtype, padlen, x, axis,
@@ -4655,7 +4696,7 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
         # Slice the actual signal from the extended signal.
         y = axis_slice(y, start=edge, stop=-edge, axis=axis)
 
-    return y
+    return xp.asarray(y)
 
 
 def _validate_pad(padtype, padlen, x, axis, ntaps):
@@ -4769,10 +4810,17 @@ def sosfilt(sos, x, axis=-1, zi=None):
     >>> plt.show()
 
     """
-    _reject_objects(sos, 'sosfilt')
-    _reject_objects(x, 'sosfilt')
-    if zi is not None:
-        _reject_objects(zi, 'sosfilt')
+    try:
+        xp = array_namespace(sos, x, zi)
+    except TypeError:
+        # either in1 or in2 are object arrays
+        xp = np_compat
+
+    if is_numpy(xp):
+        _reject_objects(sos, 'sosfilt')
+        _reject_objects(x, 'sosfilt')
+        if zi is not None:
+            _reject_objects(zi, 'sosfilt')
 
     x = _validate_x(x)
     sos, n_sections = _validate_sos(sos)
@@ -4786,7 +4834,12 @@ def sosfilt(sos, x, axis=-1, zi=None):
     if dtype.char not in 'fdgFDGO':
         raise NotImplementedError(f"input type '{dtype}' not supported")
     if zi is not None:
-        zi = np.array(zi, dtype)  # make a copy so that we can operate in place
+        zi = np.asarray(zi, dtype=dtype)
+
+        # make a copy so that we can operate in place
+        # NB: 1. use xp_copy to paper over numpy 1/2 copy= keyword
+        #     2. make sure the copied zi remains a numpy array
+        zi = xp_copy(zi, xp=array_namespace(zi))
         if zi.shape != x_zi_shape:
             raise ValueError('Invalid zi shape. With axis=%r, an input with '
                              'shape %r, and an sos array with %d sections, zi '
@@ -4798,7 +4851,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
         return_zi = False
     axis = axis % x.ndim  # make positive
     x = np.moveaxis(x, axis, -1)
-    zi = np.moveaxis(zi, [0, axis + 1], [-2, -1])
+    zi = np.moveaxis(zi, (0, axis + 1), (-2, -1))
     x_shape, zi_shape = x.shape, zi.shape
     x = np.reshape(x, (-1, x.shape[-1]))
     x = np.array(x, dtype, order='C')  # make a copy, can modify in place
@@ -4809,10 +4862,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     x = np.moveaxis(x, -1, axis)
     if return_zi:
         zi.shape = zi_shape
-        zi = np.moveaxis(zi, [-2, -1], [0, axis + 1])
-        out = (x, zi)
+        zi = np.moveaxis(zi, (-2, -1), (0, axis + 1))
+        out = (xp.asarray(x), xp.asarray(zi))
     else:
-        out = x
+        out = xp.asarray(x)
     return out
 
 
@@ -4905,6 +4958,8 @@ def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
     >>> plt.show()
 
     """
+    xp = array_namespace(sos, x)
+
     sos, n_sections = _validate_sos(sos)
     x = _validate_x(x)
 
@@ -4926,7 +4981,7 @@ def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
     y = axis_reverse(y, axis=axis)
     if edge > 0:
         y = axis_slice(y, start=edge, stop=-edge, axis=axis)
-    return y
+    return xp.asarray(y)
 
 
 def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3991,6 +3991,12 @@ def test_nonnumeric_dtypes(func, xp):
         func(*args, x=1.)
 
 
+# XXX: restore testing on CuPy, where possible. Multiple issues in this test:
+#  1. _zi functions deliberately incompatible in cupy
+#     (https://github.com/scipy/scipy/pull/21713#issuecomment-2417494443)
+#  2. a CuPy issue to be fixed in 14.0 only
+#      (https://github.com/cupy/cupy/pull/8677)
+#  3. an issue with CuPy's __array__ not numpy-2.0 compatible
 @skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize('dt', ['float32', 'float64', 'complex64', 'complex128'])
 class TestSOSFilt:
@@ -4006,16 +4012,16 @@ class TestSOSFilt:
         # Test simple IIR
         y_r = xp.asarray([0, 2, 4, 6, 8, 10.], dtype=dt)
         sos = tf2sos(b, a)
-        sos = xp.asarray(sos)   # XXX until tf2sos is numpy only
+        sos = xp.asarray(sos)   # XXX while tf2sos is numpy only
         assert_array_almost_equal(sosfilt(sos, x), y_r)
 
         # Test simple FIR
-        b = xp.asarray([1, 1],  dtype=dt)
+        b = xp.asarray([1, 1], dtype=dt)
         # NOTE: This was changed (rel. to TestLinear...) to add a pole @zero:
         a = xp.asarray([1, 0], dtype=dt)
         y_r = xp.asarray([0, 1, 3, 5, 7, 9.], dtype=dt)
         sos = tf2sos(b, a)
-        sos = xp.asarray(sos)   # XXX until tf2sos is numpy only
+        sos = xp.asarray(sos)   # XXX while tf2sos is numpy only
         assert_array_almost_equal(sosfilt(sos, x), y_r)
 
         b = xp.asarray([1.0, 1, 0])
@@ -4239,6 +4245,7 @@ class TestSOSFilt:
             sosfilt(sos, x)
 
 
+@skip_xp_backends(cpu_only=True, reason='lfilter is CPU-only compiled code')
 @skip_xp_backends('jax.numpy', reason='item assignment')
 class TestDeconvolve:
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2609,6 +2609,12 @@ class TestCorrelate2d:
 @skip_xp_backends('cupy', reason='lfilter_zi is incompatible')
 class TestLFilterZI:
 
+    @skip_xp_backends(np_only=True, reason='list inputs are numpy specific')
+    def test_array_like(self, xp):
+        zi_expected = xp.asarray([5.0, -1.0])
+        zi = lfilter_zi([1.0, 0.0, 2.0], [1.0, -1.0, 0.5])
+        assert_array_almost_equal(zi, zi_expected)
+
     def test_basic(self, xp):
         a = xp.asarray([1.0, -1.0, 0.5])
         b = xp.asarray([1.0, 0.0, 2.0])
@@ -3229,6 +3235,10 @@ class TestHilbert:
 @skip_xp_backends("jax.numpy",
    reason="jax arrays do not support item assignment")
 class TestHilbert2:
+
+    @skip_xp_backends(np_only=True, reason='list inputs are numpy-specific')
+    def test_array_like(self, xp):
+        hilbert2([[1, 2, 3], [4, 5, 6]])
 
     def test_bad_args(self, xp):
         # x must be real.
@@ -4230,6 +4240,15 @@ class TestSOSFilt:
 
 @skip_xp_backends('jax.numpy', reason='item assignment')
 class TestDeconvolve:
+
+    @skip_xp_backends(np_only=True, reason="list inputs are numpy-specific")
+    def test_array_like(self, xp):
+        # From docstring example: with lists
+        original = [0.0, 1, 0, 0, 1, 1, 0, 0]
+        impulse_response = [2, 1]
+        recorded = xp.asarray([0.0, 2, 1, 0, 2, 3, 1, 0, 0])
+        recovered, remainder = signal.deconvolve(recorded, impulse_response)
+        xp_assert_close(recovered, original)
 
     def test_basic(self, xp):
         # From docstring example

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1668,7 +1668,7 @@ class _TestLinearFilter:
         y_r = self.convert_dtype([0, 1, 3, 5, 7, 9.], xp)
         self.assert_array_almost_equal(lfilter(b, a, x), y_r)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug?)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_rank_1_IIR_init_cond(self, xp):
         x = self.generate((6,), xp)
         b = self.convert_dtype([1, 0, -1], xp)
@@ -1680,7 +1680,7 @@ class _TestLinearFilter:
         self.assert_array_almost_equal(y, y_r)
         self.assert_array_almost_equal(zf, zf_r)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug?)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_rank_1_FIR_init_cond(self, xp):
         x = self.generate((6,), xp)
         b = self.convert_dtype([1, 1, 1], xp)
@@ -1710,7 +1710,7 @@ class _TestLinearFilter:
         y = lfilter(b, a, x, axis=1)
         self.assert_array_almost_equal(y_r2_a1, y)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_rank_2_IIR_axis_0_init_cond(self, xp):
         x = self.generate((4, 3), xp)
         b = self.convert_dtype([1, -1], xp)
@@ -1724,7 +1724,7 @@ class _TestLinearFilter:
         self.assert_array_almost_equal(y_r2_a0_1, y)
         self.assert_array_almost_equal(zf, zf_r)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_rank_2_IIR_axis_1_init_cond(self, xp):
         x = self.generate((4, 3), xp)
         b = self.convert_dtype([1, -1], xp)
@@ -1738,7 +1738,7 @@ class _TestLinearFilter:
         self.assert_array_almost_equal(y_r2_a0_0, y)
         self.assert_array_almost_equal(zf, zf_r)
 
-    @skip_xp_backends('cupy', reason='np.apply_along_axis is np only')
+    @skip_xp_backends(np_only=True, reason='np.apply_along_axis is np only')
     def test_rank_3_IIR(self, xp):
         x = self.generate((4, 3, 2), xp)
         b = self.convert_dtype([1, -1], xp)
@@ -1750,7 +1750,7 @@ class _TestLinearFilter:
             y_r = np.apply_along_axis(lambda w: lfilter(b_np, a_np, w), axis, x_np)
             self.assert_array_almost_equal(y, xp.asarray(y_r))
 
-    @skip_xp_backends('cupy', reason='np.apply_along_axis is np only')
+    @skip_xp_backends(np_only=True, reason='np.apply_along_axis is np only')
     def test_rank_3_IIR_init_cond(self, xp):
         x = self.generate((4, 3, 2), xp)
         b = self.convert_dtype([1, -1], xp)
@@ -1771,7 +1771,7 @@ class _TestLinearFilter:
             self.assert_array_almost_equal(y, xp.asarray(y_r))
             self.assert_array_almost_equal(zf, xp.asarray(zf_r))
 
-    @skip_xp_backends('cupy', reason='np.apply_along_axis is np only')
+    @skip_xp_backends(np_only=True, reason='np.apply_along_axis is np only')
     def test_rank_3_FIR(self, xp):
         x = self.generate((4, 3, 2), xp)
         b = self.convert_dtype([1, 0, -1], xp)
@@ -1783,7 +1783,7 @@ class _TestLinearFilter:
             y_r = np.apply_along_axis(lambda w: lfilter(b_np, a_np, w), axis, x_np)
             self.assert_array_almost_equal(y, xp.asarray(y_r))
 
-    @skip_xp_backends('cupy', reason='np.apply_along_axis is np only')
+    @skip_xp_backends(np_only=True, reason='np.apply_along_axis is np only')
     def test_rank_3_FIR_init_cond(self, xp):
         x = self.generate((4, 3, 2), xp)
         b = self.convert_dtype([1, 0, -1], xp)
@@ -1805,7 +1805,7 @@ class _TestLinearFilter:
             self.assert_array_almost_equal(y, xp.asarray(y_r))
             self.assert_array_almost_equal(zf, xp.asarray(zf_r))
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_zi_pseudobroadcast(self, xp):
         x = self.generate((4, 5, 20), xp)
         b, a = signal.butter(8, 0.2, output='ba')
@@ -1827,7 +1827,7 @@ class _TestLinearFilter:
         # lfilter does not prepend ones
         assert_raises(ValueError, lfilter, b, a, x, -1, xp.ones(zi_size))
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_scalar_a(self, xp):
         # a can be a scalar.
         x = self.generate(6, xp)
@@ -1838,7 +1838,7 @@ class _TestLinearFilter:
         y = lfilter(b, a[0], x)
         self.assert_array_almost_equal(y, y_r)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_zi_some_singleton_dims(self, xp):
         # lfilter doesn't really broadcast (no prepending of 1's).  But does
         # do singleton expansion if x and zi have the same ndim.  This was
@@ -2011,7 +2011,7 @@ class _TestLinearFilter:
         check_dtype_arg = {} if self.dtype == object else {'check_dtype': False}
         self.assert_equal(zi, zi_2, **check_dtype_arg)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_short_x_FIR(self, xp):
         # regression test for #5116
         # x shorter than b, with non None zi fails
@@ -2025,7 +2025,7 @@ class _TestLinearFilter:
         self.assert_array_almost_equal(y, ye)
         self.assert_array_almost_equal(zf, zfe)
 
-    @skip_xp_backends('cupy', reason='results differ (a cupy bug)')
+    @skip_xp_backends('cupy', reason='XXX https://github.com/cupy/cupy/pull/8677')
     def test_short_x_IIR(self, xp):
         # regression test for #5116
         # x shorter than b, with non None zi fails
@@ -2147,6 +2147,7 @@ def test_lfilter_notimplemented_input(xp):
 
 
 class _TestCorrelateReal:
+
     def _get_assertion(self, dt):
         """Use np.testing while object arrays are a thing."""
         if dt == Decimal:


### PR DESCRIPTION
<s>Is on top of https://github.com/scipy/scipy/pull/20772</s>

Add array API / delegation support to more routines from `signaltools`: lfilter, sosfilt, filtfilt, sosfiltfilt. Also `lfiltic` and `lfilt_zi`. While at it, also add `deconvolve` since it's only a small thing on top of `lfilter` anyway.
