### PR TITLE
TST: stats.sampling: add fail slow exception

### DIFF
--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1109,6 +1109,7 @@ class TestNumericalInverseHermite:
         #     pytest.skip("Tested separately")
         self.basic_test_all_scipy_dists(distname, shapes)
 
+    @pytest.mark.fail_slow(5)
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     def test_basic_truncnorm_gh17155(self):
         self.basic_test_all_scipy_dists("truncnorm", (0.1, 2))


### PR DESCRIPTION
#### Reference issue
gh-18605
gh-20806

#### What does this implement/fix?
`scipy.stats.tests.test_sampling.test_basic_truncnorm_gh17155` has been failing in some CI runs due to slow execution. This PR gives it a more time to execute without causing a failure.>
