### PR TITLE
DOC: `stats.bootstrap`: improve description of `paired` argument

### DIFF
--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -367,7 +367,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         Whether the statistic treats corresponding elements of the samples
         in `data` as paired. If True, `bootstrap` resamples an array of
         *indices* and uses the same indices for all arrays in `data`; otherwise,
-        `bootstrap` independently resamples the *observations* in each array.
+        `bootstrap` independently resamples the elements of each array.
     axis : int, default: ``0``
         The axis of the samples in `data` along which the `statistic` is
         calculated.

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -365,7 +365,9 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         a vectorized statistic typically reduces computation time.
     paired : bool, default: ``False``
         Whether the statistic treats corresponding elements of the samples
-        in `data` as paired.
+        in `data` as paired. If True, `bootstrap` resamples an array of
+        *indices* and uses the same indices for all arrays in `data`; otherwise,
+        `bootstrap` independently resamples the *observations* in each array.
     axis : int, default: ``0``
         The axis of the samples in `data` along which the `statistic` is
         calculated.


### PR DESCRIPTION
#### Reference issue
Closes gh-21704

#### What does this implement/fix?
gh-21704 noted confusion about the meaning of the `paired` argument of `scipy.stats.bootstrap`This clarifies it. 

@TopCoder2K how does this look?