### PR TITLE
ENH: linalg.solve: add `assume_a='banded'`

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -61,8 +61,6 @@ def _find_matrix_structure(a):
         kind = 'upper triangular'
     elif n_above <= 1 and n_below <= 1 and n > 3:
         kind = 'tridiagonal'
-    elif n_above <= n/10 and n_below <= n/10:
-        kind = 'banded'
     elif np.issubdtype(a.dtype, np.complexfloating) and ishermitian(a):
         kind = 'hermitian'
     elif issymmetric(a):

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -51,23 +51,26 @@ def _solve_check(n, info, lamch=None, rcond=None):
 
 def _find_matrix_structure(a):
     n = a.shape[0]
-    below, above = bandwidth(a)
+    n_below, n_above = bandwidth(a)
 
-    if below == above == 0:
-        return 'diagonal'
-    elif above == 0:
-        return 'lower triangular'
-    elif below == 0:
-        return 'upper triangular'
-    elif above <= 1 and below <= 1 and n > 3:
-        return 'tridiagonal'
-
-    if np.issubdtype(a.dtype, np.complexfloating) and ishermitian(a):
-        return 'hermitian'
+    if n_below == n_above == 0:
+        kind = 'diagonal'
+    elif n_above == 0:
+        kind = 'lower triangular'
+    elif n_below == 0:
+        kind = 'upper triangular'
+    elif n_above <= 1 and n_below <= 1 and n > 3:
+        kind = 'tridiagonal'
+    elif n_above <= n/10 and n_below <= n/10:
+        kind = 'banded'
+    elif np.issubdtype(a.dtype, np.complexfloating) and ishermitian(a):
+        kind = 'hermitian'
     elif issymmetric(a):
-        return 'symmetric'
+        kind = 'symmetric'
+    else:
+        kind = 'general'
 
-    return 'general'
+    return kind, n_below, n_above
 
 
 def solve(a, b, lower=False, overwrite_a=False,
@@ -84,6 +87,7 @@ def solve(a, b, lower=False, overwrite_a=False,
     ===================  ================================
      diagonal             'diagonal'
      tridiagonal          'tridiagonal'
+     banded               'banded'
      upper triangular     'upper triangular'
      lower triangular     'lower triangular'
      symmetric            'symmetric' (or 'sym')
@@ -201,7 +205,7 @@ def solve(a, b, lower=False, overwrite_a=False,
             b1 = b1[:, None]
         b_is_1D = True
 
-    if assume_a not in {None, 'diagonal', 'tridiagonal', 'lower triangular',
+    if assume_a not in {None, 'diagonal', 'tridiagonal', 'banded', 'lower triangular',
                         'upper triangular', 'symmetric', 'hermitian',
                         'positive definite', 'general', 'sym', 'her', 'pos', 'gen'}:
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
@@ -211,8 +215,9 @@ def solve(a, b, lower=False, overwrite_a=False,
     if assume_a in {'hermitian', 'her'} and not np.iscomplexobj(a1):
         assume_a = 'symmetric'
 
+    n_below, n_above = None, None
     if assume_a is None:
-        assume_a = _find_matrix_structure(a1)
+        assume_a, n_below, n_above = _find_matrix_structure(a1)
 
     # Get the correct lamch function.
     # The LAMCH functions only exists for S and D
@@ -301,6 +306,20 @@ def solve(a, b, lower=False, overwrite_a=False,
         x, info = _gttrs(dl, d, du, du2, ipiv, b1, overwrite_b=overwrite_b)
         _solve_check(n, info)
         rcond, info = _gtcon(dl, d, du, du2, ipiv, anorm)
+    # Banded case
+    elif assume_a == 'banded':
+        a1, n_below, n_above = ((a1.T, n_above, n_below) if transposed
+                                else (a1, n_below, n_above))
+        n_below, n_above = bandwidth(a1) if n_below is None else (n_below, n_above)
+        ab = _to_banded(n_below, n_above, a1)
+        gbsv, = get_lapack_funcs(('gbsv',), (a1, b1))
+        # Next two lines copied from `solve_banded`
+        a2 = np.zeros((2*n_below + n_above + 1, ab.shape[1]), dtype=gbsv.dtype)
+        a2[n_below:, :] = ab
+        _, _, x, info = gbsv(n_below, n_above, a2, b1,
+                             overwrite_ab=True, overwrite_b=overwrite_b)
+        _solve_check(n, info)
+        # TODO: wrap gbcon and use to get rcond
     # Triangular case
     elif assume_a in {'lower triangular', 'upper triangular'}:
         lower = assume_a == 'lower triangular'
@@ -361,6 +380,18 @@ def _matrix_norm_general(norm, a, check_finite):
     a = np.asarray_chkfinite(a) if check_finite else a
     lange = get_lapack_funcs('lange', (a,))
     return lange(norm, a)
+
+
+def _to_banded(n_below, n_above, a):
+    n = a.shape[0]
+    rows = n_above + n_below + 1
+    ab = np.zeros((rows, n), dtype=a.dtype)
+    ab[n_above] = np.diag(a)
+    for i in range(1, n_above + 1):
+        ab[n_above - i, i:] = np.diag(a, i)
+    for i in range(1, n_below + 1):
+        ab[n_above + i, :-i] = np.diag(a, -i)
+    return ab
 
 
 def _ensure_dtype_cdsz(*arrays):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -882,8 +882,9 @@ class TestSolve:
         assert_(x.shape == (2, 0), 'Returned empty array shape is wrong')
 
     @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-    @pytest.mark.parametrize('assume_a', ['diagonal', 'tridiagonal', 'lower triangular',
-                                          'upper triangular', 'symmetric', 'hermitian',
+    @pytest.mark.parametrize('assume_a', ['diagonal', 'tridiagonal', 'banded',
+                                          'lower triangular', 'upper triangular',
+                                          'symmetric', 'hermitian',
                                           'positive definite', 'general',
                                           'sym', 'her', 'pos', 'gen'])
     @pytest.mark.parametrize('nrhs', [(), (5,)])
@@ -893,7 +894,7 @@ class TestSolve:
     def test_structure_detection(self, dtype, assume_a, nrhs, transposed,
                                  overwrite, fortran):
         rng = np.random.default_rng(982345982439826)
-        n = 5
+        n = 5 if not assume_a == 'banded' else 20
         b = rng.random(size=(n,) + nrhs)
         A = rng.random(size=(n, n))
 
@@ -911,6 +912,8 @@ class TestSolve:
             A = (np.diag(np.diag(A))
                  + np.diag(np.diag(A, -1), -1)
                  + np.diag(np.diag(A, 1), 1))
+        elif assume_a == 'banded':
+            A = np.triu(np.tril(A, 2), -1)
         elif assume_a in {'symmetric', 'sym'}:
             A = A + A.T
         elif assume_a in {'hermitian', 'her'}:


### PR DESCRIPTION
#### Reference issue
gh-21363

#### What does this implement/fix?
This allows `linalg.solve` to detect if a matrix has a banded structure (with a "small" number of bands) and, if so, use a banded matrix solver.

Best case - four diagonals (otherwise tridiagonal solver could be used)
![image](https://github.com/user-attachments/assets/7980af33-b673-44e6-88f5-ebf19998d9f3)

Worst case - number of upper and lower bands is 10% of matrix size `n`. (Otherwise, we switch to general solver.)
![image](https://github.com/user-attachments/assets/c50a70d8-ce74-4d6d-a1bf-28fa70f1e354)

#### Additional information
- I did not optimize the criterion for what constitutes a "small" number of bands.  I just chose a simple criterion that didn't appear to make performance *worse* for slow cases. It might be worth adding a minimum matrix size threshold, since this is a bit slower for small matrices.
- I'm out of practice wrapping LAPACK routines, and I'd rather not mess with that again. We'll need to wrap `gbcon` , use it to estimate the reciprocal condition number, and add `'banded'` to the parametrization of `test_ill_condition_warning` as a follow-up. It would be nice to wrap `langb` and use it in a `_matrix_norm` function instead of `lange`.
- `_to_banded` can be compiled easily (by someone else) if desired.
- It might be good to add a way to specify the bandwidth in the `assume_a` argument, but that is make-better that can be added at any time.