### PR TITLE
MAINT: sparse.linalg: use @ for matmul in docs/tests for Linear Operator interface

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -56,9 +56,9 @@ class LinearOperator:
     """Common interface for performing matrix vector products
 
     Many iterative methods (e.g. cg, gmres) do not need to know the
-    individual entries of a matrix to solve a linear system A*x=b.
+    individual entries of a matrix to solve a linear system A@x=b.
     Such solvers only require the computation of matrix vector
-    products, A*v where v is a dense vector.  This class serves as
+    products, A@v where v is a dense vector.  This class serves as
     an abstract interface between iterative solvers and matrix-like
     objects.
 
@@ -84,15 +84,15 @@ class LinearOperator:
     shape : tuple
         Matrix dimensions (M, N).
     matvec : callable f(v)
-        Returns returns A * v.
+        Returns returns A @ v.
     rmatvec : callable f(v)
-        Returns A^H * v, where A^H is the conjugate transpose of A.
+        Returns A^H @ v, where A^H is the conjugate transpose of A.
     matmat : callable f(V)
-        Returns A * V, where V is a dense matrix with dimensions (N, K).
+        Returns A @ V, where V is a dense matrix with dimensions (N, K).
     dtype : dtype
         Data type of the matrix.
     rmatmat : callable f(V)
-        Returns A^H * V, where V is a dense matrix with dimensions (M, K).
+        Returns A^H @ V, where V is a dense matrix with dimensions (M, K).
 
     Attributes
     ----------
@@ -134,7 +134,7 @@ class LinearOperator:
     <2x2 _CustomLinearOperator with dtype=float64>
     >>> A.matvec(np.ones(2))
     array([ 2.,  3.])
-    >>> A * np.ones(2)
+    >>> A @ np.ones(2)
     array([ 2.,  3.])
 
     """
@@ -205,7 +205,7 @@ class LinearOperator:
     def matvec(self, x):
         """Matrix-vector multiplication.
 
-        Performs the operation y=A*x where A is an MxN linear
+        Performs the operation y=A@x where A is an MxN linear
         operator and x is a column vector or 1-d array.
 
         Parameters
@@ -252,7 +252,7 @@ class LinearOperator:
     def rmatvec(self, x):
         """Adjoint matrix-vector multiplication.
 
-        Performs the operation y = A^H * x where A is an MxN linear
+        Performs the operation y = A^H @ x where A is an MxN linear
         operator and x is a column vector or 1-d array.
 
         Parameters
@@ -307,7 +307,7 @@ class LinearOperator:
     def matmat(self, X):
         """Matrix-matrix multiplication.
 
-        Performs the operation y=A*X where A is an MxN linear
+        Performs the operation y=A@X where A is an MxN linear
         operator and X dense N*K matrix or ndarray.
 
         Parameters
@@ -354,7 +354,7 @@ class LinearOperator:
     def rmatmat(self, X):
         """Adjoint matrix-matrix multiplication.
 
-        Performs the operation y = A^H * x where A is an MxN linear
+        Performs the operation y = A^H @ x where A is an MxN linear
         operator and x is a column vector or 1-d array, or 2-d array.
         The default implementation defers to the adjoint.
 
@@ -405,7 +405,7 @@ class LinearOperator:
             return self.H.matmat(X)
 
     def __call__(self, x):
-        return self*x
+        return self@x
 
     def __mul__(self, x):
         return self.dot(x)
@@ -716,7 +716,7 @@ class _ProductLinearOperator(LinearOperator):
 
     def _adjoint(self):
         A, B = self.args
-        return B.H * A.H
+        return B.H @ A.H
 
 
 class _ScaledLinearOperator(LinearOperator):
@@ -734,6 +734,7 @@ class _ScaledLinearOperator(LinearOperator):
         dtype = _get_dtype([A], [type(alpha)])
         super().__init__(dtype, A.shape)
         self.args = (A, alpha)
+        # Note: args[1] is alpha (a scalar), so use `*` below, not `@`
 
     def _matvec(self, x):
         return self.args[1] * self.args[0].matvec(x)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -47,32 +47,34 @@ class TestLinearOperator:
 
             assert_equal(A.matvec(np.array([1,2,3])), [14,32])
             assert_equal(A.matvec(np.array([[1],[2],[3]])), [[14],[32]])
-            assert_equal(A * np.array([1,2,3]), [14,32])
-            assert_equal(A * np.array([[1],[2],[3]]), [[14],[32]])
+            assert_equal(A @ np.array([1,2,3]), [14,32])
+            assert_equal(A @ np.array([[1],[2],[3]]), [[14],[32]])
             assert_equal(A.dot(np.array([1,2,3])), [14,32])
             assert_equal(A.dot(np.array([[1],[2],[3]])), [[14],[32]])
 
             assert_equal(A.matvec(matrix([[1],[2],[3]])), [[14],[32]])
-            assert_equal(A * matrix([[1],[2],[3]]), [[14],[32]])
+            assert_equal(A @ matrix([[1],[2],[3]]), [[14],[32]])
             assert_equal(A.dot(matrix([[1],[2],[3]])), [[14],[32]])
 
-            assert_equal((2*A)*[1,1,1], [12,30])
+            assert_equal((2*A)@[1,1,1], [12,30])
             assert_equal((2 * A).rmatvec([1, 1]), [10, 14, 18])
             assert_equal((2*A).H.matvec([1,1]), [10, 14, 18])
-            assert_equal((2*A)*[[1],[1],[1]], [[12],[30]])
+            assert_equal((2*A).adjoint().matvec([1,1]), [10, 14, 18])
+            assert_equal((2*A)@[[1],[1],[1]], [[12],[30]])
             assert_equal((2 * A).matmat([[1], [1], [1]]), [[12], [30]])
-            assert_equal((A*2)*[1,1,1], [12,30])
-            assert_equal((A*2)*[[1],[1],[1]], [[12],[30]])
-            assert_equal((2j*A)*[1,1,1], [12j,30j])
-            assert_equal((A+A)*[1,1,1], [12, 30])
+            assert_equal((A*2)@[1,1,1], [12,30])
+            assert_equal((A*2)@[[1],[1],[1]], [[12],[30]])
+            assert_equal((2j*A)@[1,1,1], [12j,30j])
+            assert_equal((A+A)@[1,1,1], [12, 30])
             assert_equal((A + A).rmatvec([1, 1]), [10, 14, 18])
             assert_equal((A+A).H.matvec([1,1]), [10, 14, 18])
-            assert_equal((A+A)*[[1],[1],[1]], [[12], [30]])
+            assert_equal((A+A).adjoint().matvec([1,1]), [10, 14, 18])
+            assert_equal((A+A)@[[1],[1],[1]], [[12], [30]])
             assert_equal((A+A).matmat([[1],[1],[1]]), [[12], [30]])
-            assert_equal((-A)*[1,1,1], [-6,-15])
-            assert_equal((-A)*[[1],[1],[1]], [[-6],[-15]])
-            assert_equal((A-A)*[1,1,1], [0,0])
-            assert_equal((A - A) * [[1], [1], [1]], [[0], [0]])
+            assert_equal((-A)@[1,1,1], [-6,-15])
+            assert_equal((-A)@[[1],[1],[1]], [[-6],[-15]])
+            assert_equal((A-A)@[1,1,1], [0,0])
+            assert_equal((A - A) @ [[1], [1], [1]], [[0], [0]])
 
             X = np.array([[1, 2], [3, 4]])
             # A_asarray = np.array([[1, 2, 3], [4, 5, 6]])
@@ -99,13 +101,13 @@ class TestLinearOperator:
 
             assert_(isinstance(A.matvec([1, 2, 3]), np.ndarray))
             assert_(isinstance(A.matvec(np.array([[1],[2],[3]])), np.ndarray))
-            assert_(isinstance(A * np.array([1,2,3]), np.ndarray))
-            assert_(isinstance(A * np.array([[1],[2],[3]]), np.ndarray))
+            assert_(isinstance(A @ np.array([1,2,3]), np.ndarray))
+            assert_(isinstance(A @ np.array([[1],[2],[3]]), np.ndarray))
             assert_(isinstance(A.dot(np.array([1,2,3])), np.ndarray))
             assert_(isinstance(A.dot(np.array([[1],[2],[3]])), np.ndarray))
 
             assert_(isinstance(A.matvec(matrix([[1],[2],[3]])), np.ndarray))
-            assert_(isinstance(A * matrix([[1],[2],[3]]), np.ndarray))
+            assert_(isinstance(A @ matrix([[1],[2],[3]]), np.ndarray))
             assert_(isinstance(A.dot(matrix([[1],[2],[3]])), np.ndarray))
 
             assert_(isinstance(2*A, interface._ScaledLinearOperator))
@@ -136,7 +138,7 @@ class TestLinearOperator:
             assert_raises(ValueError, A.matvec, np.array([[1],[2]]))
             assert_raises(ValueError, A.matvec, np.array([[1],[2],[3],[4]]))
 
-            assert_raises(ValueError, lambda: A*A)
+            assert_raises(ValueError, lambda: A@A)
             assert_raises(ValueError, lambda: A**2)
 
         for matvecsA, matvecsB in product(get_matvecs(self.A),
@@ -147,23 +149,24 @@ class TestLinearOperator:
             AtimesB = self.A.dot(self.B)
             X = np.array([[1, 2], [3, 4]])
 
-            assert_equal((A * B).rmatmat(X), np.dot((AtimesB).T, X))
-            assert_equal((2j * A * B).rmatmat(X),
+            assert_equal((A @ B).rmatmat(X), np.dot((AtimesB).T, X))
+            assert_equal((2j * A @ B).rmatmat(X),
                          np.dot((2j * AtimesB).T.conj(), X))
 
-            assert_equal((A*B)*[1,1], [50,113])
-            assert_equal((A*B)*[[1],[1]], [[50],[113]])
-            assert_equal((A*B).matmat([[1],[1]]), [[50],[113]])
+            assert_equal((A@B)@[1,1], [50,113])
+            assert_equal((A@B)@[[1],[1]], [[50],[113]])
+            assert_equal((A@B).matmat([[1],[1]]), [[50],[113]])
 
-            assert_equal((A * B).rmatvec([1, 1]), [71, 92])
-            assert_equal((A * B).H.matvec([1, 1]), [71, 92])
+            assert_equal((A @ B).rmatvec([1, 1]), [71, 92])
+            assert_equal((A @ B).H.matvec([1, 1]), [71, 92])
+            assert_equal((A @ B).adjoint().matvec([1, 1]), [71, 92])
 
-            assert_(isinstance(A*B, interface._ProductLinearOperator))
+            assert_(isinstance(A@B, interface._ProductLinearOperator))
 
             assert_raises(ValueError, lambda: A+B)
             assert_raises(ValueError, lambda: A**2)
 
-            z = A*B
+            z = A@B
             assert_(len(z.args) == 2 and z.args[0] is A and z.args[1] is B)
 
         for matvecsC in get_matvecs(self.C):
@@ -174,9 +177,10 @@ class TestLinearOperator:
             assert_equal((C**2).rmatmat(X),
                          np.dot((np.dot(self.C, self.C)).T, X))
 
-            assert_equal((C**2)*[1,1], [17,37])
+            assert_equal((C**2)@[1,1], [17,37])
             assert_equal((C**2).rmatvec([1, 1]), [22, 32])
             assert_equal((C**2).H.matvec([1, 1]), [22, 32])
+            assert_equal((C**2).adjoint().matvec([1, 1]), [22, 32])
             assert_equal((C**2).matmat([[1],[1]]), [[17],[37]])
 
             assert_(isinstance(C**2, interface._PowerLinearOperator))
@@ -196,10 +200,14 @@ class TestLinearOperator:
 
         assert_equal(operator.matmul(A, b), A * b)
         assert_equal(operator.matmul(A, b.reshape(-1, 1)), A * b.reshape(-1, 1))
-        assert_equal(operator.matmul(A, B), A * B)
+        assert_equal(operator.matmul(A, B), A @ B)
         assert_equal(operator.matmul(b, A.H), b * A.H)
+        assert_equal(operator.matmul(b, A.adjoint()), b * A.adjoint())
         assert_equal(operator.matmul(b.reshape(1, -1), A.H), b.reshape(1, -1) * A.H)
-        assert_equal(operator.matmul(B, A.H), B * A.H)
+        assert_equal(operator.matmul(b.reshape(1, -1), A.adjoint()),
+                     b.reshape(1, -1) * A.adjoint())
+        assert_equal(operator.matmul(B, A.H), B @ A.H)
+        assert_equal(operator.matmul(B, A.adjoint()), B @ A.adjoint())
         assert_raises(ValueError, operator.matmul, A, 2)
         assert_raises(ValueError, operator.matmul, 2, A)
 
@@ -274,12 +282,16 @@ class TestAsLinearOperator:
                        for M, A in make_cases(original.T, np.float64)]
         self.cases += [(interface.aslinearoperator(M).H, A.T.conj())
                        for M, A in make_cases(original.T, np.float64)]
+        self.cases += [(interface.aslinearoperator(M).adjoint(), A.T.conj())
+                       for M, A in make_cases(original.T, np.float64)]
 
         original = np.array([[1, 2j, 3j], [4j, 5j, 6]])
         self.cases += make_cases(original, np.complex128)
         self.cases += [(interface.aslinearoperator(M).T, A.T)
                        for M, A in make_cases(original.T, np.complex128)]
         self.cases += [(interface.aslinearoperator(M).H, A.T.conj())
+                       for M, A in make_cases(original.T, np.complex128)]
+        self.cases += [(interface.aslinearoperator(M).adjoint(), A.T.conj())
                        for M, A in make_cases(original.T, np.complex128)]
 
     def test_basic(self):
@@ -301,15 +313,16 @@ class TestAsLinearOperator:
 
             for x in xs:
                 assert_equal(A.matvec(x), A_array.dot(x))
-                assert_equal(A * x, A_array.dot(x))
+                assert_equal(A @ x, A_array.dot(x))
 
             assert_equal(A.matmat(x2), A_array.dot(x2))
-            assert_equal(A * x2, A_array.dot(x2))
+            assert_equal(A @ x2, A_array.dot(x2))
 
             for y in ys:
                 assert_equal(A.rmatvec(y), A_array.T.conj().dot(y))
                 assert_equal(A.T.matvec(y), A_array.T.dot(y))
                 assert_equal(A.H.matvec(y), A_array.T.conj().dot(y))
+                assert_equal(A.adjoint().matvec(y), A_array.T.conj().dot(y))
 
             for y in ys:
                 if y.ndim < 2:
@@ -317,6 +330,7 @@ class TestAsLinearOperator:
                 assert_equal(A.rmatmat(y), A_array.T.conj().dot(y))
                 assert_equal(A.T.matmat(y), A_array.T.dot(y))
                 assert_equal(A.H.matmat(y), A_array.T.conj().dot(y))
+                assert_equal(A.adjoint().matmat(y), A_array.T.conj().dot(y))
 
             if hasattr(M,'dtype'):
                 assert_equal(A.dtype, M.dtype)
@@ -346,7 +360,7 @@ def test_repr():
 
 def test_identity():
     ident = interface.IdentityOperator((3, 3))
-    assert_equal(ident * [1, 2, 3], [1, 2, 3])
+    assert_equal(ident @ [1, 2, 3], [1, 2, 3])
     assert_equal(ident.dot(np.arange(9).reshape(3, 3)).ravel(), np.arange(9))
 
     assert_raises(ValueError, ident.matvec, [1, 2, 3, 4])
@@ -362,7 +376,8 @@ def test_attributes():
 
     B = interface.LinearOperator(shape=(4, 3), matvec=always_four_ones)
 
-    for op in [A, B, A * B, A.H, A + A, B + B, A**4]:
+    ops = [A, B, A * B, A @ B, A.H, A.adjoint(), A + A, B + B, A**4]
+    for op in ops:
         assert_(hasattr(op, "dtype"))
         assert_(hasattr(op, "shape"))
         assert_(hasattr(op, "_matvec"))
@@ -449,6 +464,7 @@ def test_adjoint_conjugate():
 
     assert_equal(B.dot(v), Y.dot(v))
     assert_equal(B.H.dot(v), Y.T.conj().dot(v))
+    assert_equal(B.adjoint().dot(v), Y.T.conj().dot(v))
 
 def test_ndim():
     X = np.array([[1]])


### PR DESCRIPTION
The Linear Operator interface uses ideas from matrix multiplication, and it supports `@`. But the docs and tests haven't been updated to use the "new" 10-year-old operator @. They use `*` for both matmul and scalar multiplication, which is allowed, but not preferred and less descriptive about whether the operation is scalar mult or matmul. 

This PR updates the doc_string examples, the docs and the tests to use `@` for applying the operator. This is the preferred notation, and has the benefit of making clear which multiplications are scalar multiplication and which involve applying the linear operator. `*` is used for scalar multiplication while `@` is used for applying the operator. (Users can still use `*` for both -- only docs and tests change.)  The PR also switches `.H` to use `adjoint()`. And it adds tests for these two "new" operators to the tests of all operators. (alongside tests for `*` applying Operators and `.H` for computing the adjoint). Those are the only new tests content-wise. The rest just change notation.

This PR runs parallel to #21710 which converts `linalg` from using `spmatrix` to `sparray` internally. This PR is separate because it deals with the Linear Operator `interface.py` which isn't strictly speaking using `spmatrix` or `sparray`. So the decisions are different and better to keep separate.

I believe no content is changed (only notation) except to add tests of `.adjoint()` and `@`.