### PR TITLE
BUG: cluster: correct type of default value of `dist` in `ClusterNode`

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1080,7 +1080,7 @@ class ClusterNode:
 
     """
 
-    def __init__(self, id, left=None, right=None, dist=0, count=1):
+    def __init__(self, id, left=None, right=None, dist=0.0, count=1):
         if id < 0:
             raise ValueError('The id must be non-negative.')
         if dist < 0:


### PR DESCRIPTION
#### Reference issue
Closes [gh-21733](https://github.com/scipy/scipy/issues/21733)

#### What does this implement/fix?
Set the default value for field `dist` of `cluster.hierarchy.ClusterNode` to `0.0` so it conforms to the documented type `float`.