### PR TITLE
TST: differentiate: small tolerance bump on failing test

### DIFF
--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -589,7 +589,7 @@ class TestJacobian(JacobianHessianTest):
         for attr in ['success', 'status', 'df', 'nit', 'nfev']:
             ref[attr] = np.squeeze([[getattr(res00, attr), getattr(res01, attr)],
                                     [getattr(res10, attr), getattr(res11, attr)]])
-            np.testing.assert_allclose(res[attr], ref[attr], rtol=1e-14)
+            np.testing.assert_allclose(res[attr], ref[attr], rtol=1.5e-14)
 
     def test_step_direction_size(self):
         # Check that `step_direction` and `initial_step` can be used to ensure that


### PR DESCRIPTION
Failure looked like this in conda environment on Linux x86-64:
```
____________________________________ TestJacobian.test_attrs _____________________________________
scipy/differentiate/tests/test_differentiate.py:592: in test_attrs
    np.testing.assert_allclose(res[attr], ref[attr], rtol=1e-14)
        attr       = 'df'
        df1        = <function TestJacobian.test_attrs.<locals>.df1 at 0x71068a5d8f40>
        df1_0xy    = <function TestJacobian.test_attrs.<locals>.df1_0xy at 0x71068a5d82c0>
        df1_1xy    = <function TestJacobian.test_attrs.<locals>.df1_1xy at 0x71068a5d9080>
        ref        =  success: [[ True  True]
           [ True  True]]
  status: [[0 0]
           [0 0]]
      df: [[-1.199e-01 -2.397e-01]
           [ 6.754e-02  4.207e-01]]
        res        =      success: [[ True  True]
               [ True  True]]
      status: [[0 0]
               [0 0]]
          df: [[...     [ 2.647e-10  1.665e-16]]
         nit: [[4 5]
               [6 2]]
        nfev: [[15 17]
               [19 11]]
        res00      =      success: [[ True]]
      status: [[0]]
          df: [[-1.199e-01]]
       error: [[ 4.698e-10]]
         nit: [[4]]
        nfev: [[15]]
        res01      =      success: [[ True]]
      status: [[0]]
          df: [[-2.397e-01]]
       error: [[ 9.396e-10]]
         nit: [[5]]
        nfev: [[17]]
        res10      =      success: [[ True]]
      status: [[0]]
          df: [[ 6.754e-02]]
       error: [[ 2.647e-10]]
         nit: [[6]]
        nfev: [[19]]
        res11      =      success: [[ True]]
      status: [[0]]
          df: [[ 4.207e-01]]
       error: [[ 0.000e+00]]
         nit: [[2]]
        nfev: [[11]]
        self       = <scipy.differentiate.tests.test_differentiate.TestJacobian object at 0x71069291ee70>
        z          = array([0.5 , 0.25])
../../../../../.pixi/envs/default/lib/python3.12/contextlib.py:81: in inner
    return func(*args, **kwds)
E   AssertionError:
E   Not equal to tolerance rtol=1e-14, atol=0
E
E   Mismatched elements: 2 / 4 (50%)
E   Max absolute difference among violations: 2.83106871e-15
E   Max relative difference among violations: 1.18102541e-14
E    ACTUAL: array([[-0.119856, -0.239713],
E          [ 0.067538,  0.420735]])
E    DESIRED: array([[-0.119856, -0.239713],
E          [ 0.067538,  0.420735]])
        args       = (<function assert_allclose.<locals>.compare at 0x71068a5d8540>, array([[-0.11985638, -0.23971277],
       [ 0.06753779,  0.42073549]]), array([[-0.11985638, -0.23971277],
       [ 0.06753779,  0.42073549]]))
        func       = <function assert_array_compare at 0x7106a575b380>
        kwds       = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-14, atol=0', 'strict': False, ...}
        self       = <contextlib._GeneratorContextManager object at 0x7106a5781d00>
```

[ci skip]