### PR TITLE
MAINT/DEV: fix `python dev.py ipython` under Debian 12 / Python 3.11

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -106,7 +106,7 @@ import importlib
 import importlib.util
 import errno
 import contextlib
-from sysconfig import get_path
+import sysconfig
 import math
 import traceback
 from concurrent.futures.process import _MAX_WINDOWS_WORKERS
@@ -326,22 +326,14 @@ class Dirs:
         return dist_packages path or site_packages path.
         """
         if sys.version_info >= (3, 12):
-            plat_path = Path(get_path('platlib'))
+            plat_path = Path(sysconfig.get_path('platlib'))
         else:
-            # distutils is required to infer meson install path
-            # for python < 3.12 in debian patched python
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                from distutils import dist
-                from distutils.command.install import INSTALL_SCHEMES
-            if 'deb_system' in INSTALL_SCHEMES:
-                # debian patched python in use
-                install_cmd = dist.Distribution().get_command_obj('install')
-                install_cmd.select_scheme('deb_system')
-                install_cmd.finalize_options()
-                plat_path = Path(install_cmd.install_platlib)
+            # infer meson install path for python < 3.12 in
+            # debian patched python
+            if 'deb_system' in sysconfig.get_scheme_names():
+                plat_path = Path(sysconfig.get_path('platlib', 'deb_system'))
             else:
-                plat_path = Path(get_path('platlib'))
+                plat_path = Path(sysconfig.get_path('platlib'))
         return self.installed / plat_path.relative_to(sys.exec_prefix)
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-21080.

#### What does this implement/fix?
Fixes an installation path detection issue that causes `python dev.py ipython` and similar commands to fail under Debian 12 / Python 3.11.

#### Implementation details

As described in the [doc](https://docs.scipy.org/doc/scipy/building/index.html#building-from-source-for-scipy-development), `python dev.py ipython` and related commands is a way to work with scipy built from source in the source tree without doing an (editable) install.

gh-21080 reports that these commands raise an exception under Debian + Python 3.11, even though `python dev.py build` succeeds. The cause is that the `dev.py` script fails to correctly detect the installation path where meson puts the built files. Specifically, the script detects Debian path scheme by checking the existence of the key `'deb_system'` in `distutils.command.install.INSTALL_SCHEMES`; however, that key is not present under Debian + Python 3.11.

This PR fixes this issue by checking the existence of the key in `sysconfig.get_scheme_names()` instead.

When Debian is detected, the current code of `dev.py` retrieves the installation path by calling a method fron the `distutils` module. Since this module is deprecated, this leads to a number of “setup.py is deprecated” warnings being displayed every time `python dev.py ipython` or a similar command is invoked.

This PR gets rid of these warnings by removing the use of `distutils` and instead retrieving the installation path via `sysconfig.get_path(..., 'deb_system')`. 

#### Additional information

I tested the PR under Debian 12 + Python 3.11 and Ubuntu 22 + Python 3.10; both work. Since Python 3.9 and below is no longer supported by scipy and Python 3.12 and above triggers a code path not touched by this PR, I think the test coverage is reasonable.

At least on Debian 12 + Python 3.11, It seems impossible to detect the installation path correctly solely using documented functions and parameter values of the `sysconfig` module. Special-casing for `'deb_system'` seems unavoidable.

For more information on the special installation path scheme of Debian, see https://github.com/mesonbuild/meson/issues/8739 and https://salsa.debian.org/cpython-team/python3-stdlib/-/tree/master/debian/patches.