### PR TITLE
BUG: array API conformance in cubature

### DIFF
--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -633,7 +633,7 @@ class _InfiniteLimitsTransform(_VariableTransform):
 
         self._num_inf = self._xp.sum(
             self._xp.astype(self._double_inf_pos | self._semi_inf_pos, self._xp.int64),
-        )
+        ).__int__()
 
     @property
     def transformed_limits(self):


### PR DESCRIPTION
* Fixes #21745

* The `self._num_inf` object in `_InfiniteLimitsTransform` results from an array API-based `sum` reduction operation, which correctly results in a 0d array. `self._num_inf` is later used in a `reshape` tuple and CuPy is likely justified in complaining about this because the array API standard species the `shape` provided to `reshape` as `Tuple[int, ...]`.

* This fixes the testing issue locally by converting the 0d array to a Python object using the array API conformant `__int__()`. Note, however, that this will/should raise an error for lazy backends. That said, it seems that local testing with `jax` is "ok," probably because of skips already present for other reasons.

[skip cirrus] [skip circle]
