### PR TITLE
TST/DEV: allow CPU jax with GPU

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -150,7 +150,7 @@ if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
         xp_available_backends.update({'jax.numpy': jax.numpy})
         jax.config.update("jax_enable_x64", True)
         jax.config.update("jax_default_device", jax.devices(SCIPY_DEVICE)[0])
-    except ImportError:
+    except (ImportError, RuntimeError):
         pass
 
     # by default, use all available backends


### PR DESCRIPTION
* Fixes #21761

* Allows the full testsuite to pass when CPU-based `jax` install is present for a GPU-based array API test run; i.e., `SCIPY_DEVICE=cuda python dev.py test -j 32 -b all`

* Given that there's already a `try/except` block present, and the fact that the following warning shows up reliably after the final `pytest` output for clarity, it seems like this shouldn't cause much confusion:
`An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.`

* One thing I didn't check is if this actually runs the (CPU) `jax`-based tests that we do have, or whether it might be confusing if that would happen when `SCIPY_DEVICE` is no longer set to the CPU.

[skip cirrus] [skip circle]