### PR TITLE
BUG: handle pearsonr constant case with n=2 vectors

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4612,20 +4612,6 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
                    '`MonteCarloMethod`, or None.')
         raise ValueError(message)
 
-    if n == 2:
-        if xp.any(const_xy):
-            r = np.nan
-            pvalue = np.nan
-        else:
-            r = (xp.sign(x[..., 1] - x[..., 0])*xp.sign(y[..., 1] - y[..., 0]))
-            r = r[()] if r.ndim == 0 else r
-            pvalue = xp.ones_like(r)
-            pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
-
-        result = PearsonRResult(statistic=r, pvalue=pvalue, n=n,
-                                alternative=alternative, x=x, y=y, axis=axis)
-        return result
-
     xmean = xp.mean(x, axis=axis, keepdims=True)
     ymean = xp.mean(y, axis=axis, keepdims=True)
     xm = x - xmean
@@ -4653,20 +4639,27 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
                "correlation coefficient may be inaccurate.")
         warnings.warn(stats.NearConstantInputWarning(msg), stacklevel=2)
 
-    with np.errstate(invalid='ignore', divide='ignore'):
-        r = xp.sum(xm/normxm * ym/normym, axis=axis)
+    if n == 2:
+        r = xp.asarray(
+                xp.sign(x[..., 1] - x[..., 0])*xp.sign(y[..., 1] - y[..., 0]))
+        pvalue = xp.ones_like(r)
+        r[const_xy] = xp.nan
+    else:
+        with np.errstate(invalid='ignore', divide='ignore'):
+            r = xp.sum(xm/normxm * ym/normym, axis=axis)
+        # Presumably, if abs(r) > 1, then it is only some small artifact of
+        # floating point arithmetic.
+        one = xp.asarray(1, dtype=dtype)
+        r = xp.asarray(xp.clip(r, -one, one))
+        r[const_xy] = xp.nan
 
-    # Presumably, if abs(r) > 1, then it is only some small artifact of
-    # floating point arithmetic.
-    one = xp.asarray(1, dtype=dtype)
-    r = xp.asarray(xp.clip(r, -one, one))
-    r[const_xy] = xp.nan
+        # As explained in the docstring, the distribution of `r` under the null
+        # hypothesis is the beta distribution on (-1, 1) with a = b = n/2 - 1.
+        ab = xp.asarray(n/2 - 1)
+        dist = _SimpleBeta(ab, ab, loc=-1, scale=2)
+        pvalue = xp.asarray(_get_pvalue(r, dist, alternative, xp=xp))
 
-    # As explained in the docstring, the distribution of `r` under the null
-    # hypothesis is the beta distribution on (-1, 1) with a = b = n/2 - 1.
-    ab = xp.asarray(n/2 - 1)
-    dist = _SimpleBeta(ab, ab, loc=-1, scale=2)
-    pvalue = _get_pvalue(r, dist, alternative, xp=xp)
+    pvalue[const_xy] = xp.nan
 
     r = r[()] if r.ndim == 0 else r
     pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4652,8 +4652,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     # in the docs.
     if n == 2:
         r = xp.round(r)
-        pvalue = xp.ones_like(r)
-        pvalue[xp.asarray(xp.isnan(r))] = xp.nan
+        pvalue = np.where(xp.asarray(xp.isnan(r)), xp.nan, 1.0)
     else:
         # As explained in the docstring, the distribution of `r` under the null
         # hypothesis is the beta distribution on (-1, 1) with a = b = n/2 - 1.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4651,7 +4651,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     # Make sure we return exact 1.0 or -1.0 values for n == 2 case as promised
     # in the docs.
     if n == 2:
-        r = xp_sign(r)
+        r = xp.round(r)
         pvalue = xp.ones_like(r)
         pvalue[xp.asarray(xp.isnan(r))] = xp.nan
     else:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4648,7 +4648,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     r = xp.asarray(xp.clip(r, -one, one))
     r[const_xy] = xp.nan
 
-    # Make sure we return exact 1.0 or -1.0 values for n == 2 case as promissed
+    # Make sure we return exact 1.0 or -1.0 values for n == 2 case as promised
     # in the docs.
     if n == 2:
         r = xp_sign(r)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4652,7 +4652,8 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     # in the docs.
     if n == 2:
         r = xp.round(r)
-        pvalue = np.where(xp.asarray(xp.isnan(r)), xp.nan, 1.0)
+        one = xp.asarray(1, dtype=dtype)
+        pvalue = xp.where(xp.asarray(xp.isnan(r)), xp.nan*one, one)
     else:
         # As explained in the docstring, the distribution of `r` under the null
         # hypothesis is the beta distribution on (-1, 1) with a = b = n/2 - 1.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4613,10 +4613,15 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         raise ValueError(message)
 
     if n == 2:
-        r = (xp.sign(x[..., 1] - x[..., 0])*xp.sign(y[..., 1] - y[..., 0]))
-        r = r[()] if r.ndim == 0 else r
-        pvalue = xp.ones_like(r)
-        pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
+        if xp.any(const_xy):
+            r = np.nan
+            pvalue = np.nan
+        else:
+            r = (xp.sign(x[..., 1] - x[..., 0])*xp.sign(y[..., 1] - y[..., 0]))
+            r = r[()] if r.ndim == 0 else r
+            pvalue = xp.ones_like(r)
+            pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
+
         result = PearsonRResult(statistic=r, pvalue=pvalue, n=n,
                                 alternative=alternative, x=x, y=y, axis=axis)
         return result

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -528,6 +528,7 @@ class TestPearsonr:
         xp_assert_equal(low, -one)
         xp_assert_equal(high, one)
 
+    @skip_xp_backends('jax.numpy', reason="JAX doesn't allow item assignment.")
     def test_length_two_constant_input(self, xp):
         # Zero variance input
         # See https://github.com/scipy/scipy/issues/3728

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -500,6 +500,7 @@ class TestPearsonr:
         xp_assert_close(r, xp.asarray(0.351312332103289, dtype=xp.float64))
         xp_assert_close(p, xp.asarray(0.648687667896711, dtype=xp.float64))
 
+    @skip_xp_backends('jax.numpy', reason="JAX doesn't allow item assignment.")
     def test_length_two_pos1(self, xp):
         # Inputs with length 2.
         # See https://github.com/scipy/scipy/issues/7730
@@ -514,6 +515,7 @@ class TestPearsonr:
         xp_assert_equal(low, -one)
         xp_assert_equal(high, one)
 
+    @skip_xp_backends('jax.numpy', reason="JAX doesn't allow item assignment.")
     def test_length_two_neg1(self, xp):
         # Inputs with length 2.
         # See https://github.com/scipy/scipy/issues/7730

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -528,6 +528,18 @@ class TestPearsonr:
         xp_assert_equal(low, -one)
         xp_assert_equal(high, one)
 
+    def test_length_two_constant_input(self, xp):
+        # Zero variance input
+        # See https://github.com/scipy/scipy/issues/3728
+        # and https://github.com/scipy/scipy/issues/7730
+        msg = "An input array is constant"
+        with pytest.warns(stats.ConstantInputWarning, match=msg):
+            x = xp.asarray([0.667, 0.667])
+            y = xp.asarray([0.123, 0.456])
+            r, p = stats.pearsonr(x, y)
+            xp_assert_close(r, xp.asarray(xp.nan))
+            xp_assert_close(p, xp.asarray(xp.nan))
+
     # Expected values computed with R 3.6.2 cor.test, e.g.
     # options(digits=16)
     # x <- c(1, 2, 3, 4)


### PR DESCRIPTION
The documentation [states](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#:~:text=The%20correlation%20coefficient%20is%20not%20defined%20in%20this%20case%2C%20so%20np.nan%20is%20returned.) that in case of one or more constant inputs, `stats.pearsonr` returns `np.nan` as well as raising a warning.

While this works as described for most cases, for the special case of input arrays of length two this is not working:

```pycon
>>> from scipy import stats
>>> stats.pearsonr([1, 1], [2, 3])
<stdin>:1: ConstantInputWarning: An input array is constant; the correlation coefficient is not defined.
PearsonRResult(statistic=np.float64(0.0), pvalue=np.float64(1.0))
```

This now returns the expected outcome:

```pycon
>>> from scipy import stats
>>> stats.pearsonr([1, 1], [2, 3])
<stdin>:1: ConstantInputWarning: An input array is constant; the correlation coefficient is not defined.
PearsonRResult(statistic=nan, pvalue=nan)
```

This probably came about as a side effect of #9562.