### PR TITLE
MAINT: `stats.ContinuousDistribution`: protect attributes, correct right operators, improve `__repr__`

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1821,13 +1821,14 @@ class ContinuousDistribution:
         return self.__add__(other)
 
     def __rsub__(self, other):
-        return self.__add__(other)
+        return self.__neg__().__add__(other)
 
     def __rmul__(self, other):
-        return self.__add__(other)
+        return self.__mul__(other)
 
     def __rtruediv__(self, other):
-        return self.__add__(other)
+        message = "Division by a random variable is not yet implemented."
+        raise NotImplementedError(message)
 
     def __neg__(self):
         return self * -1
@@ -5193,19 +5194,3 @@ class ShiftedScaledDistribution(TransformedDistribution):
         return ShiftedScaledDistribution(self._dist,
                                          loc=self.loc / scale,
                                          scale=self.scale / scale)
-
-    def __radd__(self, other):
-        return self.__add__(other)
-
-    def __rsub__(self, other):
-        return self.__neg__().__add__(other)
-
-    def __rmul__(self, other):
-        return self.__mul__(other)
-
-    def __rtruediv__(self, other):
-        message = "Division by a random variable is not yet implemented."
-        raise NotImplementedError(message)
-
-    def __neg__(self):
-        return self * -1

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1571,6 +1571,12 @@ class ContinuousDistribution:
         self._parameters = parameters
         self._parameterization = parameterization
         self._original_parameters = original_parameters
+        for name in self._parameters.keys():
+            # Make parameters properties of the class; return values from the instance
+            if hasattr(self.__class__, name):
+                continue
+            setattr(self.__class__, name, property(lambda self_, name_=name:
+                                                   self_._parameters[name_].copy()[()]))
 
     def reset_cache(self):
         r""" Clear all cached values.
@@ -1771,22 +1777,6 @@ class ContinuousDistribution:
                        f"must be one of {iv_policies}, if specified.")
             raise ValueError(message)
         self._validation_policy = validation_policy
-
-    def __getattr__(self, item):
-        # This override allows distribution parameters to be accessed as
-        # attributes. See Question 1 at the top.
-
-        # This might be needed in __init__ to ensure that `_parameters` exists
-        # super().__setattr__('_parameters', dict())
-
-        # This is needed for deepcopy/pickling
-        if '_parameters' not in vars(self):
-            return super().__getattribute__(item)
-
-        if item in self._parameters:
-            return self._parameters[item][()]
-
-        return super().__getattribute__(item)
 
     ### Other magic methods
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5015,7 +5015,7 @@ class TransformedDistribution(ContinuousDistribution):
 
     def __repr__(self):
         s = super().__repr__()
-        return s.replace(self.__class__.__name__,
+        return s.replace("Distribution",
                          self._dist.__class__.__name__)
 
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -894,6 +894,25 @@ class TestAttributes:
         with pytest.raises(ValueError, match=message):
             X.validation_policy = "invalid"
 
+    def test_shapes(self):
+        X = stats.Normal(mu=1, sigma=2)
+        Y = stats.Normal(mu=[2], sigma=3)
+
+        # Check that attributes are available as expected
+        assert X.mu == 1
+        assert X.sigma == 2
+        assert Y.mu[0] == 2
+        assert Y.sigma[0] == 3
+
+        # Trying to set an attribute raises
+        message = "property of 'Normal' object has no setter"
+        with pytest.raises(AttributeError, match=message):
+            X.mu = 2
+
+        # Trying to mutate an attribute really mutates a copy
+        Y.mu[0] = 10
+        assert Y.mu[0] == 2
+
 
 class TestTransforms:
     @pytest.mark.fail_slow(10)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1102,6 +1102,8 @@ class TestFullCoverage:
         X = _Uniform(a=0, b=1)
         assert str(X) == "_Uniform(a=0.0, b=1.0)"
 
+        assert str(X*3 + 2) == "ShiftedScaled_Uniform(a=0.0, b=1.0, loc=2.0, scale=3.0)"
+
         X = _Uniform(a=np.zeros(4), b=1)
         assert str(X) == "_Uniform(a, b, shape=(4,))"
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -905,8 +905,8 @@ class TestAttributes:
         assert Y.sigma[0] == 3
 
         # Trying to set an attribute raises
-        message = "property of 'Normal' object has no setter"
-        with pytest.raises(AttributeError, match=message):
+        # message depends on Python version
+        with pytest.raises(AttributeError):
             X.mu = 2
 
         # Trying to mutate an attribute really mutates a copy

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1017,6 +1017,28 @@ class TestTransforms:
             #                 dist0.sample(x_result_shape, rng=rng0) * scale + loc)
             # Should also try to test fit, plot?
 
+    def test_arithmetic_operators(self):
+        rng = np.random.default_rng(2348923495832349834)
+
+        a, b, loc, scale = 0.294, 1.34, 0.57, 1.16
+
+        x = rng.uniform(-3, 3, 100)
+        Y = _LogUniform(a=a, b=b)
+
+        X = scale*Y + loc
+        assert_allclose(X.cdf(x), Y.cdf((x - loc) / scale))
+        X = loc + Y*scale
+        assert_allclose(X.cdf(x), Y.cdf((x - loc) / scale))
+
+        X = Y/scale - loc
+        assert_allclose(X.cdf(x), Y.cdf((x + loc) * scale))
+        X = loc -_LogUniform(a=a, b=b)/scale
+        assert_allclose(X.cdf(x), Y.ccdf((-x + loc)*scale))
+
+        message = "Division by a random variable is not yet implemented."
+        with pytest.raises(NotImplementedError, match=message):
+            1 / Y
+
 
 class TestFullCoverage:
     # Adds tests just to get to 100% test coverage; this way it's more obvious


### PR DESCRIPTION
#### Reference issue
gh-21700 

#### What does this implement/fix?
This improves/fixes a few things I've noticed recently:

- The behavior noted in https://github.com/scipy/scipy/pull/21700#discussion_r1818116775 is not ideal. Here, the shape parameter attributes return copies of the arrays (so they can't be mutated) and trying to write to the attribute raises an error.
- The right operators of `ContinuousDistribution` were incorrect due to copy-paste + distraction. I thought I fixed this earlier, but it looks like I fixed `TransformedDistribution` (which didn't need to defined these separately, anyway)
- The `__repr__` behavior was a little confusing before. Now, transformations applied to distributions are represented in the displayed name, e.g. (`1 + stats.Normal()` displays `ShiftedScaledStandardNormal(loc=1.0)`). This is something that can be improved further by someone who is interested; let's let this stand as an incremental improvement.
