### PR TITLE
DEP: special: Remove `special.btdtr` and `special.btdtri`

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -231,10 +231,8 @@ Beta distribution
 .. autosummary::
    :toctree: generated/
 
-   btdtr        -- Cumulative distribution function of the beta distribution.
-   btdtri       -- The `p`-th quantile of the beta distribution.
-   btdtria      -- Inverse of `btdtr` with respect to `a`.
-   btdtrib      -- btdtria(a, p, x).
+   btdtria      -- Inverse of `betainc` with respect to `a`.
+   btdtrib      -- Inverse of `betainc` with respect to `b`.
 
 F distribution
 ^^^^^^^^^^^^^^
@@ -879,25 +877,6 @@ del PytestTester
 
 _depr_msg = ('\nThis function was deprecated in SciPy 1.12.0, and will be '
              'removed in SciPy 1.14.0.  Use scipy.special.{} instead.')
-
-
-def btdtr(*args, **kwargs):  # type: ignore [no-redef]
-    warnings.warn(_depr_msg.format('betainc'), category=DeprecationWarning,
-                  stacklevel=2)
-    return _ufuncs.btdtr(*args, **kwargs)
-
-
-btdtr.__doc__ = _ufuncs.btdtr.__doc__  # type: ignore [misc]
-
-
-def btdtri(*args, **kwargs):  # type: ignore [no-redef]
-    warnings.warn(_depr_msg.format('betaincinv'), category=DeprecationWarning,
-                  stacklevel=2)
-    return _ufuncs.btdtri(*args, **kwargs)
-
-
-btdtri.__doc__ = _ufuncs.btdtri.__doc__  # type: ignore [misc]
-
 
 def _get_include():
     """This function is for development purposes only.

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -875,8 +875,6 @@ from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
 del PytestTester
 
-_depr_msg = ('\nThis function was deprecated in SciPy 1.12.0, and will be '
-             'removed in SciPy 1.14.0.  Use scipy.special.{} instead.')
 
 def _get_include():
     """This function is for development purposes only.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -742,11 +742,11 @@ add_newdoc("btdtria",
     r"""
     btdtria(p, b, x, out=None)
 
-    Inverse of `btdtr` with respect to `a`.
+    Inverse of `betainc` with respect to `a`.
 
-    This is the inverse of the beta cumulative distribution function, `btdtr`,
+    This is the inverse of the beta cumulative distribution function, `betainc`,
     considered as a function of `a`, returning the value of `a` for which
-    `btdtr(a, b, x) = p`, or
+    `betainc(a, b, x) = p`, or
 
     .. math::
         p = \int_0^x \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} t^{a-1} (1-t)^{b-1}\,dt
@@ -765,13 +765,11 @@ add_newdoc("btdtria",
     Returns
     -------
     a : scalar or ndarray
-        The value of the shape parameter `a` such that `btdtr(a, b, x) = p`.
+        The value of the shape parameter `a` such that `betainc(a, b, x) = p`.
 
     See Also
     --------
-    btdtr : Cumulative distribution function of the beta distribution.
-    btdtri : Inverse with respect to `x`.
-    btdtrib : Inverse with respect to `b`.
+    btdtrib : Inverse of the beta cumulative distribution function, with respect to `b`.
 
     Notes
     -----
@@ -797,11 +795,11 @@ add_newdoc("btdtrib",
     r"""
     btdtria(a, p, x, out=None)
 
-    Inverse of `btdtr` with respect to `b`.
+    Inverse of `betainc` with respect to `b`.
 
-    This is the inverse of the beta cumulative distribution function, `btdtr`,
+    This is the inverse of the beta cumulative distribution function, `betainc`,
     considered as a function of `b`, returning the value of `b` for which
-    `btdtr(a, b, x) = p`, or
+    `betainc(a, b, x) = p`, or
 
     .. math::
         p = \int_0^x \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} t^{a-1} (1-t)^{b-1}\,dt
@@ -820,13 +818,11 @@ add_newdoc("btdtrib",
     Returns
     -------
     b : scalar or ndarray
-        The value of the shape parameter `b` such that `btdtr(a, b, x) = p`.
+        The value of the shape parameter `b` such that `betainc(a, b, x) = p`.
 
     See Also
     --------
-    btdtr : Cumulative distribution function of the beta distribution.
-    btdtri : Inverse with respect to `x`.
-    btdtria : Inverse with respect to `a`.
+    btdtria : Inverse of the beta cumulative distribution function, with respect to `a`.
 
     Notes
     -----
@@ -1311,110 +1307,6 @@ add_newdoc("inv_boxcox1p",
     >>> y = boxcox1p([1, 4, 10], 2.5)
     >>> inv_boxcox1p(y, 2.5)
     array([1., 4., 10.])
-    """)
-
-add_newdoc("btdtr",
-    r"""
-    btdtr(a, b, x, out=None)
-
-    Cumulative distribution function of the beta distribution.
-
-    Returns the integral from zero to `x` of the beta probability density
-    function,
-
-    .. math::
-        I = \int_0^x \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} t^{a-1} (1-t)^{b-1}\,dt
-
-    where :math:`\Gamma` is the gamma function.
-
-    .. deprecated:: 1.12.0
-        This function is deprecated and will be removed from SciPy 1.14.0.
-        Use `scipy.special.betainc` instead.
-
-    Parameters
-    ----------
-    a : array_like
-        Shape parameter (a > 0).
-    b : array_like
-        Shape parameter (b > 0).
-    x : array_like
-        Upper limit of integration, in [0, 1].
-    out : ndarray, optional
-        Optional output array for the function values
-
-    Returns
-    -------
-    I : scalar or ndarray
-        Cumulative distribution function of the beta distribution with
-        parameters `a` and `b` at `x`.
-
-    See Also
-    --------
-    betainc
-
-    Notes
-    -----
-    This function is identical to the incomplete beta integral function
-    `betainc`.
-
-    Wrapper for the Cephes [1]_ routine `btdtr`.
-
-    References
-    ----------
-    .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/
-
-    """)
-
-add_newdoc("btdtri",
-    r"""
-    btdtri(a, b, p, out=None)
-
-    The `p`-th quantile of the beta distribution.
-
-    This function is the inverse of the beta cumulative distribution function,
-    `btdtr`, returning the value of `x` for which `btdtr(a, b, x) = p`, or
-
-    .. math::
-        p = \int_0^x \frac{\Gamma(a + b)}{\Gamma(a)\Gamma(b)} t^{a-1} (1-t)^{b-1}\,dt
-
-    .. deprecated:: 1.12.0
-        This function is deprecated and will be removed from SciPy 1.14.0.
-        Use `scipy.special.betaincinv` instead.
-
-    Parameters
-    ----------
-    a : array_like
-        Shape parameter (`a` > 0).
-    b : array_like
-        Shape parameter (`b` > 0).
-    p : array_like
-        Cumulative probability, in [0, 1].
-    out : ndarray, optional
-        Optional output array for the function values
-
-    Returns
-    -------
-    x : scalar or ndarray
-        The quantile corresponding to `p`.
-
-    See Also
-    --------
-    betaincinv
-    btdtr
-
-    Notes
-    -----
-    The value of `x` is found by interval halving or Newton iterations.
-
-    Wrapper for the Cephes [1]_ routine `incbi`, which solves the equivalent
-    problem of finding the inverse of the incomplete beta integral.
-
-    References
-    ----------
-    .. [1] Cephes Mathematical Functions Library,
-           http://www.netlib.org/cephes/
-
     """)
 
 add_newdoc("chdtr",

--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -28,8 +28,6 @@ __all__ = [
     'binom',
     'boxcox',
     'boxcox1p',
-    'btdtr',
-    'btdtri',
     'btdtria',
     'btdtrib',
     'cbrt',
@@ -310,8 +308,6 @@ betaln: np.ufunc
 binom: np.ufunc
 boxcox1p: np.ufunc
 boxcox: np.ufunc
-btdtr: np.ufunc
-btdtri: np.ufunc
 btdtria: np.ufunc
 btdtrib: np.ufunc
 cbrt: np.ufunc

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -49,8 +49,6 @@ cpdef double betaln(double x0, double x1) noexcept nogil
 cpdef double binom(double x0, double x1) noexcept nogil
 cpdef double boxcox(double x0, double x1) noexcept nogil
 cpdef double boxcox1p(double x0, double x1) noexcept nogil
-cpdef double btdtr(double x0, double x1, double x2) noexcept nogil
-cpdef double btdtri(double x0, double x1, double x2) noexcept nogil
 cpdef double btdtria(double x0, double x1, double x2) noexcept nogil
 cpdef double btdtrib(double x0, double x1, double x2) noexcept nogil
 cpdef double cbrt(double x0) noexcept nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -129,14 +129,6 @@ Available functions
 
         double boxcox1p(double, double)
 
-- :py:func:`~scipy.special.btdtr`::
-
-        double btdtr(double, double, double)
-
-- :py:func:`~scipy.special.btdtri`::
-
-        double btdtri(double, double, double)
-
 - :py:func:`~scipy.special.btdtria`::
 
         double btdtria(double, double, double)
@@ -1334,8 +1326,6 @@ cdef extern from r"xsf_wrappers.h":
     double xsf_bdtr(double k, int n, double p) nogil
     double xsf_bdtri(double k, int n, double y) nogil
     double xsf_bdtrc(double k, int n, double p) nogil
-    double xsf_btdtri(double aa, double bb, double yy0) nogil
-    double xsf_btdtr(double a, double b, double x) nogil
     double xsf_chdtr(double df, double x) nogil
     double xsf_chdtrc(double df, double x) nogil
     double xsf_chdtri(double df, double y) nogil
@@ -2014,14 +2004,6 @@ cpdef double boxcox(double x0, double x1) noexcept nogil:
 cpdef double boxcox1p(double x0, double x1) noexcept nogil:
     """See the documentation for scipy.special.boxcox1p"""
     return _func_boxcox1p(x0, x1)
-
-cpdef double btdtr(double x0, double x1, double x2) noexcept nogil:
-    """See the documentation for scipy.special.btdtr"""
-    return xsf_btdtr(x0, x1, x2)
-
-cpdef double btdtri(double x0, double x1, double x2) noexcept nogil:
-    """See the documentation for scipy.special.btdtri"""
-    return xsf_btdtri(x0, x1, x2)
 
 cpdef double btdtria(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.btdtria"""
@@ -3458,7 +3440,7 @@ cpdef double rel_entr(double x0, double x1) noexcept nogil:
 cpdef Dd_number_t rgamma(Dd_number_t x0) noexcept nogil:
     """See the documentation for scipy.special.rgamma"""
     if Dd_number_t is double_complex:
-        return _complexstuff.double_complex_from_npy_cdouble(special_crgamma(_complexstuff.npy_cdouble_from_double_complex(x0))) 
+        return _complexstuff.double_complex_from_npy_cdouble(special_crgamma(_complexstuff.npy_cdouble_from_double_complex(x0)))
     elif Dd_number_t is double:
         return special_rgamma(x0)
     else:

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -134,16 +134,6 @@
             "boxcox1p": "dd->d"
         }
     },
-    "btdtr": {
-        "xsf_wrappers.h": {
-            "xsf_btdtr": "ddd->d"
-        }
-    },
-    "btdtri": {
-        "xsf_wrappers.h": {
-            "xsf_btdtri": "ddd->d"
-        }
-    },
     "btdtria": {
         "_cdflib_wrappers.pxd": {
             "btdtria": "ddd->d"

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -177,16 +177,6 @@ class TestCephes:
     def test_besselpoly(self):
         assert_equal(cephes.besselpoly(0,0,0),1.0)
 
-    def test_btdtr(self):
-        with pytest.deprecated_call(match='deprecated in SciPy 1.12.0'):
-            y = special.btdtr(1, 1, 1)
-        assert_equal(y, 1.0)
-
-    def test_btdtri(self):
-        with pytest.deprecated_call(match='deprecated in SciPy 1.12.0'):
-            y = special.btdtri(1, 1, 1)
-        assert_equal(y, 1.0)
-
     def test_btdtria(self):
         assert_equal(cephes.btdtria(1,1,1),5.0)
 

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -63,8 +63,6 @@ PARAMS: list[tuple[Callable, Callable, tuple[str, ...], str | None]] = [
     (special.binom, cython_special.binom, ('dd',), None),
     (special.boxcox, cython_special.boxcox, ('dd',), None),
     (special.boxcox1p, cython_special.boxcox1p, ('dd',), None),
-    (special.btdtr, cython_special.btdtr, ('ddd',), None),
-    (special.btdtri, cython_special.btdtri, ('ddd',), None),
     (special.btdtria, cython_special.btdtria, ('ddd',), None),
     (special.btdtrib, cython_special.btdtrib, ('ddd',), None),
     (special.cbrt, cython_special.cbrt, ('d',), None),

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -13,7 +13,7 @@ from scipy.special import (
     ellipe, ellipeinc, ellipk, ellipkm1, ellipkinc,
     elliprc, elliprd, elliprf, elliprg, elliprj,
     erf, erfc, erfinv, erfcinv, exp1, expi, expn,
-    bdtrik, btdtr, btdtri, btdtria, btdtrib, chndtr, gdtr, gdtrc, gdtrix, gdtrib,
+    bdtrik, btdtria, btdtrib, chndtr, gdtr, gdtrc, gdtrix, gdtrib,
     nbdtrik, pdtrik, owens_t,
     mathieu_a, mathieu_b, mathieu_cem, mathieu_sem, mathieu_modcem1,
     mathieu_modsem1, mathieu_modcem2, mathieu_modsem2,
@@ -144,9 +144,6 @@ def eval_genlaguerre_ddd(n, a, x):
 def bdtrik_comp(y, n, p):
     return bdtrik(1-y, n, p)
 
-def btdtri_comp(a, b, p):
-    return btdtri(a, b, 1-p)
-
 def btdtria_comp(p, b, x):
     return btdtria(1-p, b, x)
 
@@ -254,20 +251,6 @@ BOOST_TESTS = [
 
         data(betaincinv, 'ibeta_inv_data_ipp-ibeta_inv_data',
              (0,1,2), 3, rtol=1e-5),
-
-        data(btdtr, 'ibeta_small_data_ipp-ibeta_small_data',
-             (0,1,2), 5, rtol=6e-15),
-        data(btdtr, 'ibeta_data_ipp-ibeta_data',
-             (0,1,2), 5, rtol=4e-13),
-        data(btdtr, 'ibeta_int_data_ipp-ibeta_int_data',
-             (0,1,2), 5, rtol=2e-14),
-        data(btdtr, 'ibeta_large_data_ipp-ibeta_large_data',
-             (0,1,2), 5, rtol=4e-10),
-
-        data(btdtri, 'ibeta_inv_data_ipp-ibeta_inv_data',
-             (0,1,2), 3, rtol=1e-5),
-        data(btdtri_comp, 'ibeta_inv_data_ipp-ibeta_inv_data',
-             (0,1,2), 4, rtol=8e-7),
 
         data(btdtria, 'ibeta_inva_data_ipp-ibeta_inva_data',
              (2,0,1), 3, rtol=5e-9),
@@ -665,12 +648,7 @@ BOOST_TESTS = [
 
 @pytest.mark.parametrize('test', BOOST_TESTS, ids=repr)
 def test_boost(test):
-    # Filter deprecation warnings of any deprecated functions.
-    if test.func in [btdtr, btdtri, btdtri_comp]:
-        with pytest.deprecated_call():
-            _test_factory(test)
-    else:
-        _test_factory(test)
+     _test_factory(test)
 
 
 GSL_TESTS = [

--- a/scipy/special/xsf/stats.h
+++ b/scipy/special/xsf/stats.h
@@ -22,10 +22,6 @@ inline double bdtri(double k, int n, double y) { return cephes::bdtri(k, n, y); 
 
 inline double bdtrc(double k, int n, double p) { return cephes::bdtrc(k, n, p); }
 
-inline double btdtri(double aa, double bb, double yy0) { return cephes::incbi(aa, bb, yy0); }
-
-inline double btdtr(double a, double b, double x) { return cephes::incbet(a, b, x); }
-
 inline double chdtr(double df, double x) { return cephes::chdtr(df, x); }
 
 inline double chdtrc(double df, double x) { return cephes::chdtrc(df, x); }

--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -556,10 +556,6 @@ double xsf_bdtri(double k, int n, double y) { return xsf::bdtri(k, n, y); }
 
 double xsf_bdtrc(double k, int n, double p) { return xsf::bdtrc(k, n, p); }
 
-double xsf_btdtri(double aa, double bb, double yy0) { return xsf::btdtri(aa, bb, yy0); }
-
-double xsf_btdtr(double a, double b, double x) { return xsf::btdtr(a, b, x); }
-
 double xsf_chdtr(double df, double x) { return xsf::chdtr(df, x); }
 
 double xsf_chdtrc(double df, double x) { return xsf::chdtrc(df, x); }

--- a/scipy/special/xsf_wrappers.h
+++ b/scipy/special/xsf_wrappers.h
@@ -307,8 +307,6 @@ npy_cdouble special_csph_bessel_k_jac(long n, npy_cdouble z);
 double xsf_bdtr(double k, int n, double p);
 double xsf_bdtri(double k, int n, double y);
 double xsf_bdtrc(double k, int n, double p);
-double xsf_btdtri(double aa, double bb, double yy0);
-double xsf_btdtr(double a, double b, double x);
 double xsf_chdtr(double df, double x);
 double xsf_chdtrc(double df, double x);
 double xsf_chdtri(double df, double y);


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #21759.

#### What does this implement/fix?
<!--Please explain your changes.-->

Remove references to `special.btdtr` and `special.btdtri`. Scheduled to be removed in 1.14.0.

#### Additional information
<!--Any additional information you think is important.-->
