### PR TITLE
ENH: sparse.csgraph: migrate to use sparray (code changes only)

### DIFF
--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from scipy.sparse import csr_array, issparse
+from scipy.sparse import csr_array, issparse, csr_matrix
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy, is_pydata_spmatrix
 
 from ._tools import _safe_downcast_indices
@@ -227,10 +227,11 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     modifying the capacities of the new graph appropriately.
 
     """
+    csgraph_orig = csgraph
     is_pydata_sparse = is_pydata_spmatrix(csgraph)
     if is_pydata_sparse:
         pydata_sparse_cls = csgraph.__class__
-    csgraph = convert_pydata_sparse_to_scipy(csgraph, target_format="csr")
+        csgraph = convert_pydata_sparse_to_scipy(csgraph, target_format="csr")
     if not (issparse(csgraph) and csgraph.format == "csr"):
         raise TypeError("graph must be in CSR format")
     if not issubclass(csgraph.dtype.type, np.integer):
@@ -277,6 +278,8 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     flow_matrix = csr_array((flow_array, m.indices, m.indptr), shape=m.shape)
     if is_pydata_sparse:
         flow_matrix = pydata_sparse_cls.from_scipy_sparse(flow_matrix)
+    elif isinstance(csgraph_orig, csr_matrix):
+        flow_matrix = csr_matrix(flow_matrix)
     source_flow = flow_array[m.indptr[source]:m.indptr[source + 1]]
     return MaximumFlowResult(source_flow.sum(), flow_matrix)
 

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -2,8 +2,10 @@
 
 import numpy as np
 
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import csr_array, issparse
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy, is_pydata_spmatrix
+
+from ._tools import _safe_downcast_indices
 
 cimport numpy as np
 
@@ -251,6 +253,8 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     if not csgraph.has_sorted_indices:
         csgraph = csgraph.sorted_indices()
 
+    csgraph.indices, csgraph.indptr = _safe_downcast_indices(csgraph)
+
     # Our maximum flow solvers assume that edges always exist
     # in both directions, so we start by adding the reversed edges whenever
     # they are missing.
@@ -266,8 +270,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     else:
         raise ValueError('{} method is not supported yet.'.format(method))
     flow_array = np.asarray(flow)
-    flow_matrix = csr_matrix((flow_array, m.indices, m.indptr),
-                             shape=m.shape)
+    flow_matrix = csr_array((flow_array, m.indices, m.indptr), shape=m.shape)
     if is_pydata_sparse:
         flow_matrix = pydata_sparse_cls.from_scipy_sparse(flow_matrix)
     source_flow = flow_array[m.indptr[source]:m.indptr[source + 1]]
@@ -302,7 +305,7 @@ def _add_reverse_edges(a):
     # arrays for the addition of reverse edges with zero capacity. In
     # particular, we do not actually use the values in the transpose;
     # only the fact that the indices exist.
-    at = csr_matrix(a.transpose())
+    at = csr_array(a.transpose())
     cdef ITYPE_t[:] at_indices_view = at.indices
     cdef ITYPE_t[:] at_indptr_view = at.indptr
 
@@ -351,16 +354,15 @@ def _add_reverse_edges(a):
             res_ptr += 1
         i += 1
         res_indptr_view[i] = res_ptr
-    return csr_matrix((res_data, res_indices, res_indptr), shape=(n, n))
+    return csr_array((res_data, res_indices, res_indptr), shape=(n, n))
 
 
 def _make_edge_pointers(a):
     """Create for each edge pointers to its reverse."""
     cdef int n = a.shape[0]
     b_data = np.arange(a.data.shape[0], dtype=ITYPE)
-    b = csr_matrix(
-        (b_data, a.indices, a.indptr), shape=(n, n), dtype=ITYPE)
-    b = csr_matrix(b.transpose())
+    b = csr_array((b_data, a.indices, a.indptr), shape=(n, n), dtype=ITYPE)
+    b = csr_array(b.transpose())
     return b.data
 
 

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -253,16 +253,16 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     if not csgraph.has_sorted_indices:
         csgraph = csgraph.sorted_indices()
 
-    csgraphT = csr_array(csgraph.transpose())
     csgraph_indices, csgraph_indptr = _safe_downcast_indices(csgraph)
-    csgraphT_indices, csgraphT_indptr = _safe_downcast_indices(csgraphT)
+    if csgraph_indices is not csgraph.indices:
+        # create a new object without copying data
+        csgraph = csr_array((csgraph.data, csgraph_indices, csgraph_indptr),
+                            shape=csgraph.shape, dtype=csgraph.dtype)
 
     # Our maximum flow solvers assume that edges always exist
     # in both directions, so we start by adding the reversed edges whenever
     # they are missing.
-    #m = _add_reverse_edges(csgraph)
-    m = _add_reverse_edges(csgraph.shape, csgraph.data, csgraph_indices, csgraph_indptr,
-                           csgraph.nnz, csgraphT_indices, csgraphT_indptr)
+    m = _add_reverse_edges(csgraph)
     rev_edge_ptr = _make_edge_pointers(m)
     if method == 'edmonds_karp':
         tails = _make_tails(m)
@@ -281,7 +281,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     return MaximumFlowResult(source_flow.sum(), flow_matrix)
 
 
-def _add_reverse_edges(shape, data, indices, indptr, nnz, at_indices, at_indptr):
+def _add_reverse_edges(a):
     """Add reversed edges to all edges in a graph.
 
     This adds to a given directed weighted graph all edges in the reverse
@@ -299,19 +299,19 @@ def _add_reverse_edges(shape, data, indices, indptr, nnz, at_indices, at_indptr)
         by explicit zeros.
 
     """
-    # Matrix attributes are input to allow easy downcasting before calling cython
     # Reference arrays of the input matrix.
-    cdef ITYPE_t n = shape[0]
-    cdef ITYPE_t[:] a_data_view = data
-    cdef ITYPE_t[:] a_indices_view = indices
-    cdef ITYPE_t[:] a_indptr_view = indptr
+    cdef ITYPE_t n = a.shape[0]
+    cdef ITYPE_t[:] a_data_view = a.data
+    cdef ITYPE_t[:] a_indices_view = a.indices
+    cdef ITYPE_t[:] a_indptr_view = a.indptr
 
     # Create the transpose with the intent of using the resulting index
     # arrays for the addition of reverse edges with zero capacity. In
     # particular, we do not actually use the values in the transpose;
     # only the fact that the indices exist.
-    cdef ITYPE_t[:] at_indices_view = at_indices
-    cdef ITYPE_t[:] at_indptr_view = at_indptr
+    at = csr_array(a.transpose())
+    cdef ITYPE_t[:] at_indices_view = at.indices
+    cdef ITYPE_t[:] at_indptr_view = at.indptr
 
     # Create arrays for the result matrix with added reverse edges. We
     # allocate twice the number of non-zeros in `a` for the data, which
@@ -319,9 +319,9 @@ def _add_reverse_edges(shape, data, indices, indptr, nnz, at_indices, at_indptr)
     # some reverse edges already; in that case, over-allocating is not
     # a problem since csr_matrix implicitly truncates elements of data
     # and indices that go beyond the indices given by indptr.
-    res_data = np.zeros(2 * nnz, ITYPE)
+    res_data = np.zeros(2 * a.nnz, ITYPE)
     cdef ITYPE_t[:] res_data_view = res_data
-    res_indices = np.zeros(2 * nnz, ITYPE)
+    res_indices = np.zeros(2 * a.nnz, ITYPE)
     cdef ITYPE_t[:] res_indices_view = res_indices
     res_indptr = np.zeros(n + 1, ITYPE)
     cdef ITYPE_t[:] res_indptr_view = res_indptr

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -486,7 +486,7 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
     if biadj_indices is not biadjacency.indices:
         # create a new object without copying data
         biadjacency = csr_array((biadjacency.data, biadj_indices, biadj_indptr),
-                            shape=biadjacency.shape, dtype=biadjacency.dtype)
+                                shape=biadjacency.shape, dtype=biadjacency.dtype)
 
     # The algorithm expects more columns than rows in the graph, so
     # we use the transpose if that is not already the case. We also

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -8,6 +8,7 @@ from libc.math cimport INFINITY
 
 from scipy.sparse import issparse
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
+from ._tools import _safe_downcast_indices
 
 np.import_array()
 
@@ -141,7 +142,8 @@ def maximum_bipartite_matching(graph, perm_type='row'):
         raise TypeError("graph must be in CSC, CSR, or COO format.")
     graph = graph.tocsr()
     i, j = graph.shape
-    x, y = _hopcroft_karp(graph.indices, graph.indptr, i, j)
+    indices, indptr = _safe_downcast_indices(graph)
+    x, y = _hopcroft_karp(indices, indptr, i, j)
     return np.asarray(x if perm_type == 'column' else y)
 
 
@@ -285,9 +287,9 @@ cdef tuple _hopcroft_karp(const ITYPE_t[:] indices, const ITYPE_t[:] indptr,
     return x, y
 
 
-def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
+def min_weight_full_bipartite_matching(biadjacency, maximize=False):
     r"""
-    min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False)
+    min_weight_full_bipartite_matching(biadjacency, maximize=False)
 
     Returns the minimum weight full matching of a bipartite graph.
 
@@ -295,7 +297,7 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
 
     Parameters
     ----------
-    biadjacency_matrix : sparse matrix
+    biadjacency : sparse matrix
         Biadjacency matrix of the bipartite graph: A sparse matrix in CSR, CSC,
         or COO format whose rows represent one partition of the graph and whose
         columns represent the other partition. An edge between two vertices is
@@ -376,11 +378,11 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
 
     Let us first consider an example in which all weights are equal:
 
-    >>> biadjacency_matrix = csr_matrix([[1, 1, 1], [1, 0, 0], [0, 1, 0]])
+    >>> biadjacency = csr_matrix([[1, 1, 1], [1, 0, 0], [0, 1, 0]])
 
     Here, all we get is a perfect matching of the graph:
 
-    >>> print(min_weight_full_bipartite_matching(biadjacency_matrix)[1])
+    >>> print(min_weight_full_bipartite_matching(biadjacency)[1])
     [2 0 1]
 
     That is, the first, second, and third rows are matched with the third,
@@ -452,33 +454,35 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
     28.0
 
     """
-    biadjacency_matrix = convert_pydata_sparse_to_scipy(biadjacency_matrix)
-    if not issparse(biadjacency_matrix):
+    biadjacency = convert_pydata_sparse_to_scipy(biadjacency)
+    if not issparse(biadjacency):
         raise TypeError("graph must be sparse")
-    if biadjacency_matrix.format not in ("csr", "csc", "coo"):
+    if biadjacency.format not in ("csr", "csc", "coo"):
         raise TypeError("graph must be in CSC, CSR, or COO format.")
 
-    if not (np.issubdtype(biadjacency_matrix.dtype, np.number) or
-            biadjacency_matrix.dtype == np.dtype(np.bool_)):
+    if not (np.issubdtype(biadjacency.dtype, np.number) or
+            biadjacency.dtype == np.dtype(np.bool_)):
         raise ValueError("expected a matrix containing numerical entries, " +
-                         "got %s" % (biadjacency_matrix.dtype,))
+                         "got %s" % (biadjacency.dtype,))
 
-    biadjacency_matrix = biadjacency_matrix.astype(np.double)
+    biadjacency = biadjacency.astype(np.double)
 
     if maximize:
-        biadjacency_matrix = -biadjacency_matrix
+        biadjacency = -biadjacency
 
     # Change all infinities to zeros, then remove those zeros, but warn the
     # user if any zeros were present in the first place.
-    if not np.all(biadjacency_matrix.data):
+    if not np.all(biadjacency.data):
         warnings.warn('explicit zero weights are removed before matching')
 
-    biadjacency_matrix.data[np.isposinf(biadjacency_matrix.data)] = 0
-    biadjacency_matrix.eliminate_zeros()
+    biadjacency.indices, biadjacency.indptr = _safe_downcast_indices(biadjacency)
 
-    i, j = biadjacency_matrix.shape
+    biadjacency.data[np.isposinf(biadjacency.data)] = 0
+    biadjacency.eliminate_zeros()
 
-    a = np.arange(np.min(biadjacency_matrix.shape))
+    i, j = biadjacency.shape
+
+    a = np.arange(np.min(biadjacency.shape))
 
     # The algorithm expects more columns than rows in the graph, so
     # we use the transpose if that is not already the case. We also
@@ -487,33 +491,33 @@ def min_weight_full_bipartite_matching(biadjacency_matrix, maximize=False):
     # checking for infeasibility during the execution of _lapjvsp below
     # instead, but some cases are not yet handled there.
     if j < i:
-        biadjacency_matrix_t = biadjacency_matrix.T
-        if biadjacency_matrix_t.format != "csr":
-            biadjacency_matrix_t = biadjacency_matrix_t.tocsr()
-        matching, _ = _hopcroft_karp(biadjacency_matrix_t.indices,
-                                     biadjacency_matrix_t.indptr,
+        biadjacency_t = biadjacency.T
+        if biadjacency_t.format != "csr":
+            biadjacency_t = biadjacency_t.tocsr()
+        matching, _ = _hopcroft_karp(biadjacency_t.indices,
+                                     biadjacency_t.indptr,
                                      j, i)
         matching = np.asarray(matching)
         if np.sum(matching != -1) != min(i, j):
             raise ValueError('no full matching exists')
-        b = np.asarray(_lapjvsp(biadjacency_matrix_t.indptr,
-                                biadjacency_matrix_t.indices,
-                                biadjacency_matrix_t.data,
+        b = np.asarray(_lapjvsp(biadjacency_t.indptr,
+                                biadjacency_t.indices,
+                                biadjacency_t.data,
                                 j, i))
         indices = np.argsort(b)
         return (b[indices], a[indices])
     else:
-        if biadjacency_matrix.format != "csr":
-            biadjacency_matrix = biadjacency_matrix.tocsr()
-        matching, _ = _hopcroft_karp(biadjacency_matrix.indices,
-                                     biadjacency_matrix.indptr,
+        if biadjacency.format != "csr":
+            biadjacency = biadjacency.tocsr()
+        matching, _ = _hopcroft_karp(biadjacency.indices,
+                                     biadjacency.indptr,
                                      i, j)
         matching = np.asarray(matching)
         if np.sum(matching != -1) != min(i, j):
             raise ValueError('no full matching exists')
-        b = np.asarray(_lapjvsp(biadjacency_matrix.indptr,
-                                biadjacency_matrix.indices,
-                                biadjacency_matrix.data,
+        b = np.asarray(_lapjvsp(biadjacency.indptr,
+                                biadjacency.indices,
+                                biadjacency.data,
                                 i, j))
         return (a, b)
 

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array, csr_matrix, spmatrix
 from scipy.sparse.csgraph._validation import validate_graph
 from scipy.sparse._sputils import is_pydata_spmatrix
 
@@ -94,10 +94,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     """
     global NULL_IDX
 
-    is_pydata_sparse = is_pydata_spmatrix(csgraph)
-    if is_pydata_sparse:
-        pydata_sparse_cls = csgraph.__class__
-        pydata_sparse_fill_value = csgraph.fill_value
+    csgraph_orig = csgraph
     csgraph = validate_graph(csgraph, True, DTYPE, dense_output=False,
                              copy_if_sparse=not overwrite)
     cdef int N = csgraph.shape[0]
@@ -117,10 +114,17 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     _min_spanning_tree(data, indices, indptr, i_sort,
                        row_indices, predecessors, rank)
 
-    sp_tree = csr_matrix((data, indices, indptr), (N, N))
+    if isinstance(csgraph_orig, (np.matrix, spmatrix)):
+        sp_tree = csr_matrix((data, indices, indptr), shape=(N, N))
+        sp_tree.eliminate_zeros()
+        return sp_tree
+
+    sp_tree = csr_array((data, indices, indptr), shape=(N, N))
     sp_tree.eliminate_zeros()
 
-    if is_pydata_sparse:
+    if is_pydata_spmatrix(csgraph_orig):
+        pydata_sparse_cls = csgraph_orig.__class__
+        pydata_sparse_fill_value = csgraph_orig.fill_value
         # The `fill_value` keyword is new in PyData Sparse 0.15.4 (May 2024),
         # remove the `except` once the minimum supported version is >=0.15.4
         try:

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -5,7 +5,7 @@
 import numpy as np
 cimport numpy as np
 from warnings import warn
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 from . import maximum_bipartite_matching
 
@@ -76,7 +76,7 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     if not issparse(graph):
         raise TypeError("Input graph must be sparse")
     if graph.format not in ("csc", "csr"):
-        raise TypeError('Input must be in CSC or CSR sparse matrix format.')
+        raise TypeError('Input must be in CSC or CSR sparse format.')
     nrows = graph.shape[0]
     if not symmetric_mode:
         graph = graph+graph.transpose()
@@ -236,12 +236,12 @@ def structural_rank(graph):
     """
     graph = convert_pydata_sparse_to_scipy(graph)
     if not issparse(graph):
-        raise TypeError('Input must be a sparse matrix')
+        raise TypeError('Input must be sparse')
     if graph.format != "csr":
         if graph.format not in ("csc", "coo"):
             warn('Input matrix should be in CSC, CSR, or COO matrix format',
                     SparseEfficiencyWarning)
-        graph = csr_matrix(graph)
+        graph = csr_array(graph)
     # If A is a tall matrix, then transpose.
     if graph.shape[0] > graph.shape[1]:
         graph = graph.T.tocsr()

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -17,9 +17,10 @@ import warnings
 import numpy as np
 cimport numpy as np
 
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import csr_array, issparse
 from scipy.sparse.csgraph._validation import validate_graph
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
+from ._tools import _safe_downcast_indices
 
 cimport cython
 
@@ -610,12 +611,7 @@ def dijkstra(csgraph, directed=True, indices=None,
     else:
         csr_data = csgraph.data
 
-    csgraph_indices = csgraph.indices
-    csgraph_indptr = csgraph.indptr
-    if csgraph_indices.dtype != ITYPE:
-        csgraph_indices = csgraph_indices.astype(ITYPE)
-    if csgraph_indptr.dtype != ITYPE:
-        csgraph_indptr = csgraph_indptr.astype(ITYPE)
+    csgraph_indices, csgraph_indptr = _safe_downcast_indices(csgraph)
     if directed:
         if min_only:
             _dijkstra_directed_multi(indices,
@@ -629,6 +625,7 @@ def dijkstra(csgraph, directed=True, indices=None,
                                dist_matrix, predecessor_matrix, limitf)
     else:
         csgraphT = csgraph.T.tocsr()
+        csgraphT.indices, csgraphT.indptr = _safe_downcast_indices(csgraphT)
         if unweighted:
             csrT_data = csr_data
         else:
@@ -1078,15 +1075,17 @@ def bellman_ford(csgraph, directed=True, indices=None,
     else:
         csr_data = csgraph.data
 
+    csgraph_indices, csgraph_indptr = _safe_downcast_indices(csgraph)
+
     if directed:
         ret = _bellman_ford_directed(indices,
-                                     csr_data, csgraph.indices,
-                                     csgraph.indptr,
+                                     csr_data, csgraph_indices,
+                                     csgraph_indptr,
                                      dist_matrix, predecessor_matrix)
     else:
         ret = _bellman_ford_undirected(indices,
-                                       csr_data, csgraph.indices,
-                                       csgraph.indptr,
+                                       csr_data, csgraph_indices,
+                                       csgraph_indptr,
                                        dist_matrix, predecessor_matrix)
 
     if ret >= 0:
@@ -1325,36 +1324,37 @@ def johnson(csgraph, directed=True, indices=None,
     dist_array = np.zeros(N, dtype=DTYPE)
 
     csr_data = csgraph.data.copy()
+    csgraph_indices, csgraph_indptr = _safe_downcast_indices(csgraph)
 
     #------------------------------
     # here we first add a single node to the graph, connected by a
     # directed edge of weight zero to each node, and perform bellman-ford
     if directed:
-        ret = _johnson_directed(csr_data, csgraph.indices,
-                                csgraph.indptr, dist_array)
+        ret = _johnson_directed(csr_data, csgraph_indices,
+                                csgraph_indptr, dist_array)
     else:
-        ret = _johnson_undirected(csr_data, csgraph.indices,
-                                  csgraph.indptr, dist_array)
+        ret = _johnson_undirected(csr_data, csgraph_indices,
+                                  csgraph_indptr, dist_array)
 
     if ret >= 0:
         raise NegativeCycleError("Negative cycle detected on node %i" % ret)
 
     #------------------------------
     # add the bellman-ford weights to the data
-    _johnson_add_weights(csr_data, csgraph.indices,
-                         csgraph.indptr, dist_array)
+    _johnson_add_weights(csr_data, csgraph_indices,
+                         csgraph_indptr, dist_array)
 
     if directed:
         _dijkstra_directed(indices,
-                           csr_data, csgraph.indices, csgraph.indptr,
+                           csr_data, csgraph_indices, csgraph_indptr,
                            dist_matrix, predecessor_matrix, np.inf)
     else:
-        csgraphT = csr_matrix((csr_data, csgraph.indices, csgraph.indptr),
+        csgraphT = csr_array((csr_data, csgraph_indices, csgraph_indptr),
                                csgraph.shape).T.tocsr()
         _johnson_add_weights(csgraphT.data, csgraphT.indices,
                              csgraphT.indptr, dist_array)
         _dijkstra_undirected(indices,
-                             csr_data, csgraph.indices, csgraph.indptr,
+                             csr_data, csgraph_indices, csgraph_indptr,
                              csgraphT.data, csgraphT.indices, csgraphT.indptr,
                              dist_matrix, predecessor_matrix, np.inf)
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -625,7 +625,7 @@ def dijkstra(csgraph, directed=True, indices=None,
                                dist_matrix, predecessor_matrix, limitf)
     else:
         csgraphT = csgraph.T.tocsr()
-        csgraphT.indices, csgraphT.indptr = _safe_downcast_indices(csgraphT)
+        csgraphT_indices, csgraphT_indptr = _safe_downcast_indices(csgraphT)
         if unweighted:
             csrT_data = csr_data
         else:
@@ -634,14 +634,14 @@ def dijkstra(csgraph, directed=True, indices=None,
             _dijkstra_undirected_multi(indices,
                                        csr_data, csgraph_indices,
                                        csgraph_indptr,
-                                       csrT_data, csgraphT.indices,
-                                       csgraphT.indptr,
+                                       csrT_data, csgraphT_indices,
+                                       csgraphT_indptr,
                                        dist_matrix, predecessor_matrix,
                                        source_matrix, limitf)
         else:
             _dijkstra_undirected(indices,
                                  csr_data, csgraph_indices, csgraph_indptr,
-                                 csrT_data, csgraphT.indices, csgraphT.indptr,
+                                 csrT_data, csgraphT_indices, csgraphT_indptr,
                                  dist_matrix, predecessor_matrix, limitf)
 
     if return_predecessors:

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -8,7 +8,7 @@ Tools and utilities for working with compressed sparse graphs
 import numpy as np
 cimport numpy as np
 
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import csr_array, csr_matrix, spmatrix, issparse
 from scipy.sparse._sputils import is_pydata_spmatrix
 
 np.import_array()
@@ -51,13 +51,13 @@ def csgraph_from_masked(graph):
     ... fill_value = 0)
 
     >>> csgraph_from_masked(graph_masked)
-    <Compressed Sparse Row sparse matrix of dtype 'float64'
+    <Compressed Sparse Row sparse array of dtype 'float64'
         with 4 stored elements and shape (4, 4)>
 
     """
-    # check that graph is a square matrix
     graph = np.ma.asarray(graph)
 
+    # check that graph is a square matrix
     if graph.ndim != 2:
         raise ValueError("graph should have two dimensions")
     N = graph.shape[0]
@@ -77,7 +77,7 @@ def csgraph_from_masked(graph):
     indptr = np.zeros(N + 1, dtype=ITYPE)
     indptr[1:] = mask.sum(1).cumsum()
 
-    return csr_matrix((data, indices, indptr), (N, N))
+    return csr_array((data, indices, indptr), (N, N))
 
 
 def csgraph_masked_from_dense(graph,
@@ -209,14 +209,15 @@ def csgraph_from_dense(graph,
     ... ]
 
     >>> csgraph_from_dense(graph)
-    <Compressed Sparse Row sparse matrix of dtype 'float64'
+    <Compressed Sparse Row sparse array of dtype 'float64'
         with 4 stored elements and shape (4, 4)>
 
     """
-    return csgraph_from_masked(csgraph_masked_from_dense(graph,
-                                                         null_value,
-                                                         nan_null,
-                                                         infinity_null))
+    res = csgraph_masked_from_dense(graph, null_value, nan_null, infinity_null)
+    res = csgraph_from_masked(res)
+    if isinstance(graph, np.matrix):
+        return csr_matrix(res, copy=False)
+    return res
 
 
 def csgraph_to_dense(csgraph, null_value=0):
@@ -472,10 +473,7 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     """
     from ._validation import validate_graph
-    is_pydata_sparse = is_pydata_spmatrix(csgraph)
-    if is_pydata_sparse:
-        pydata_sparse_cls = csgraph.__class__
-        pydata_sparse_fill_value = csgraph.fill_value
+    csgraph_orig = csgraph
     csgraph = validate_graph(csgraph, directed, dense_output=False)
 
     N = csgraph.shape[0]
@@ -489,23 +487,30 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     data = csgraph[pind, indices]
 
     # Fix issue #4018:
-    # If `pind` and `indices` are empty arrays, `data` is a sparse matrix
+    # If `pind` and `indices` are empty arrays, `data` is sparse
     # (it is a numpy.matrix otherwise); handle this case separately.
     if issparse(data):
-        data = data.todense()
-    data = data.getA1()
+        data = data.toarray().ravel()
+    else:
+        data = np.asarray(data).ravel()
 
     if not directed:
         data2 = csgraph[indices, pind]
         if issparse(data2):
-            data2 = data2.todense()
-        data2 = data2.getA1()
+            data2 = data2.toarray().ravel()
+        else:
+            data2 = np.asarray(data2).ravel()
+
         data[data == 0] = np.inf
         data2[data2 == 0] = np.inf
         data = np.minimum(data, data2)
 
-    sctree = csr_matrix((data, indices, indptr), shape=(N, N))
-    if is_pydata_sparse:
+    if isinstance(csgraph_orig, spmatrix):
+        return csr_matrix((data, indices, indptr), shape=(N, N))
+    sctree = csr_array((data, indices, indptr), shape=(N, N))
+    if is_pydata_spmatrix(csgraph_orig):
+        pydata_sparse_cls = csgraph_orig.__class__
+        pydata_sparse_fill_value = csgraph_orig.fill_value
         # The `fill_value` keyword is new in PyData Sparse 0.15.4 (May 2024),
         # remove the `except` once the minimum supported version is >=0.15.4
         try:
@@ -647,3 +652,18 @@ cdef void _construct_dist_matrix(np.ndarray[DTYPE_t, ndim=2] graph,
                 k2 = k1
             if null_path and i != j:
                 dist[i, j] = null_value
+
+
+def _safe_downcast_indices(A):
+    # check for safe downcasting to ITYPE (==int32 set in parameters.pxi)
+    max_value = np.iinfo(ITYPE).max
+
+    if A.indptr[-1] > max_value:  # indptr[-1] is max b/c indptr always sorted
+        raise ValueError("indptr values too large for csgraph")
+    if max(*A.shape) > max_value:  # only check large enough arrays
+        if np.any(A.indices > max_value):
+            raise ValueError("indices values too large for csgraph")
+
+    indices = A.indices.astype(ITYPE, copy=False)
+    indptr = A.indptr.astype(ITYPE, copy=False)
+    return indices, indptr

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import issparse
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
 from scipy.sparse.csgraph._tools import (
     csgraph_to_dense, csgraph_from_dense,
@@ -32,7 +32,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
 
     if issparse(csgraph):
         if csr_output:
-            csgraph = csr_matrix(csgraph, dtype=DTYPE, copy=copy_if_sparse)
+            csgraph = csgraph.tocsr(copy=copy_if_sparse).astype(DTYPE, copy=False)
         else:
             csgraph = csgraph_to_dense(csgraph, null_value=null_value_out)
     elif np.ma.isMaskedArray(csgraph):

--- a/scipy/sparse/csgraph/tests/test_conversions.py
+++ b/scipy/sparse/csgraph/tests/test_conversions.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.sparse.csgraph import csgraph_from_dense, csgraph_to_dense
 
 
@@ -45,7 +45,7 @@ def test_multiple_edges():
     # create a random square matrix with an even number of elements
     np.random.seed(1234)
     X = np.random.random((10, 10))
-    Xcsr = csr_matrix(X)
+    Xcsr = csr_array(X)
 
     # now double-up every other column
     Xcsr.indices[::2] = Xcsr.indices[1::2]

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -5,7 +5,7 @@ import pytest
 from scipy.sparse import csr_array, csc_array
 from scipy.sparse.csgraph import maximum_flow
 from scipy.sparse.csgraph._flow import (
-    _add_reverse_edges, _make_edge_pointers, _make_tails, _safe_downcast_indices,
+    _add_reverse_edges, _make_edge_pointers, _make_tails
 )
 
 methods = ['edmonds_karp', 'dinic']
@@ -171,12 +171,7 @@ def test_add_reverse_edges(a, b_data_expected):
     as expected.
     """
     a = csr_array(a, dtype=np.int32, shape=(len(a), len(a)))
-    at = csr_array(a.transpose())
-    a_indices, a_indptr = _safe_downcast_indices(a)
-    at_indices, at_indptr = _safe_downcast_indices(at)
-    b = _add_reverse_edges(
-        a.shape, a.data, a_indices, a_indptr, a.nnz, at_indices, at_indptr,
-    )
+    b = _add_reverse_edges(a)
     assert_array_equal(b.data, b_data_expected)
 
 

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -5,7 +5,7 @@ import pytest
 from scipy.sparse import csr_array, csc_array
 from scipy.sparse.csgraph import maximum_flow
 from scipy.sparse.csgraph._flow import (
-    _add_reverse_edges, _make_edge_pointers, _make_tails
+    _add_reverse_edges, _make_edge_pointers, _make_tails, _safe_downcast_indices,
 )
 
 methods = ['edmonds_karp', 'dinic']
@@ -171,7 +171,12 @@ def test_add_reverse_edges(a, b_data_expected):
     as expected.
     """
     a = csr_array(a, dtype=np.int32, shape=(len(a), len(a)))
-    b = _add_reverse_edges(a)
+    at = csr_array(a.transpose())
+    a_indices, a_indptr = _safe_downcast_indices(a)
+    at_indices, at_indptr = _safe_downcast_indices(at)
+    b = _add_reverse_edges(
+        a.shape, a.data, a_indices, a_indptr, a.nnz, at_indices, at_indptr,
+    )
     assert_array_equal(b.data, b_data_expected)
 
 

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 
-from scipy.sparse import csr_matrix, csc_matrix
+from scipy.sparse import csr_array, csc_array
 from scipy.sparse.csgraph import maximum_flow
 from scipy.sparse.csgraph._flow import (
     _add_reverse_edges, _make_edge_pointers, _make_tails
@@ -19,27 +19,27 @@ def test_raises_on_dense_input():
 
 def test_raises_on_csc_input():
     with pytest.raises(TypeError):
-        graph = csc_matrix([[0, 1], [0, 0]])
+        graph = csc_array([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 1)
         maximum_flow(graph, 0, 1, method='edmonds_karp')
 
 
 def test_raises_on_floating_point_input():
     with pytest.raises(ValueError):
-        graph = csr_matrix([[0, 1.5], [0, 0]], dtype=np.float64)
+        graph = csr_array([[0, 1.5], [0, 0]], dtype=np.float64)
         maximum_flow(graph, 0, 1)
         maximum_flow(graph, 0, 1, method='edmonds_karp')
 
 
 def test_raises_on_non_square_input():
     with pytest.raises(ValueError):
-        graph = csr_matrix([[0, 1, 2], [2, 1, 0]])
+        graph = csr_array([[0, 1, 2], [2, 1, 0]])
         maximum_flow(graph, 0, 1)
 
 
 def test_raises_when_source_is_sink():
     with pytest.raises(ValueError):
-        graph = csr_matrix([[0, 1], [0, 0]])
+        graph = csr_array([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 0)
         maximum_flow(graph, 0, 0, method='edmonds_karp')
 
@@ -48,7 +48,7 @@ def test_raises_when_source_is_sink():
 @pytest.mark.parametrize('source', [-1, 2, 3])
 def test_raises_when_source_is_out_of_bounds(source, method):
     with pytest.raises(ValueError):
-        graph = csr_matrix([[0, 1], [0, 0]])
+        graph = csr_array([[0, 1], [0, 0]])
         maximum_flow(graph, source, 1, method=method)
 
 
@@ -56,7 +56,7 @@ def test_raises_when_source_is_out_of_bounds(source, method):
 @pytest.mark.parametrize('sink', [-1, 2, 3])
 def test_raises_when_sink_is_out_of_bounds(sink, method):
     with pytest.raises(ValueError):
-        graph = csr_matrix([[0, 1], [0, 0]])
+        graph = csr_array([[0, 1], [0, 0]])
         maximum_flow(graph, 0, sink, method=method)
 
 
@@ -64,7 +64,7 @@ def test_raises_when_sink_is_out_of_bounds(sink, method):
 def test_simple_graph(method):
     # This graph looks as follows:
     #     (0) --5--> (1)
-    graph = csr_matrix([[0, 5], [0, 0]])
+    graph = csr_array([[0, 5], [0, 0]])
     res = maximum_flow(graph, 0, 1, method=method)
     assert res.flow_value == 5
     expected_flow = np.array([[0, 5], [-5, 0]])
@@ -75,7 +75,7 @@ def test_simple_graph(method):
 def test_bottle_neck_graph(method):
     # This graph cannot use the full capacity between 0 and 1:
     #     (0) --5--> (1) --3--> (2)
-    graph = csr_matrix([[0, 5, 0], [0, 0, 3], [0, 0, 0]])
+    graph = csr_array([[0, 5, 0], [0, 0, 3], [0, 0, 0]])
     res = maximum_flow(graph, 0, 2, method=method)
     assert res.flow_value == 3
     expected_flow = np.array([[0, 3, 0], [-3, 0, 3], [0, -3, 0]])
@@ -88,14 +88,14 @@ def test_backwards_flow(method):
     # and so this test ensures that we handle that accordingly. See
     #     https://stackoverflow.com/q/38843963/5085211
     # for more information.
-    graph = csr_matrix([[0, 10, 0, 0, 10, 0, 0, 0],
-                        [0, 0, 10, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 10, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 10],
-                        [0, 0, 0, 10, 0, 10, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 10, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 10],
-                        [0, 0, 0, 0, 0, 0, 0, 0]])
+    graph = csr_array([[0, 10, 0, 0, 10, 0, 0, 0],
+                       [0, 0, 10, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 10, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0, 0, 10],
+                       [0, 0, 0, 10, 0, 10, 0, 0],
+                       [0, 0, 0, 0, 0, 0, 10, 0],
+                       [0, 0, 0, 0, 0, 0, 0, 10],
+                       [0, 0, 0, 0, 0, 0, 0, 0]])
     res = maximum_flow(graph, 0, 7, method=method)
     assert res.flow_value == 20
     expected_flow = np.array([[0, 10, 0, 0, 10, 0, 0, 0],
@@ -114,12 +114,12 @@ def test_example_from_clrs_chapter_26_1(method):
     # See page 659 in CLRS second edition, but note that the maximum flow
     # we find is slightly different than the one in CLRS; we push a flow of
     # 12 to v_1 instead of v_2.
-    graph = csr_matrix([[0, 16, 13, 0, 0, 0],
-                        [0, 0, 10, 12, 0, 0],
-                        [0, 4, 0, 0, 14, 0],
-                        [0, 0, 9, 0, 0, 20],
-                        [0, 0, 0, 7, 0, 4],
-                        [0, 0, 0, 0, 0, 0]])
+    graph = csr_array([[0, 16, 13, 0, 0, 0],
+                       [0, 0, 10, 12, 0, 0],
+                       [0, 4, 0, 0, 14, 0],
+                       [0, 0, 9, 0, 0, 20],
+                       [0, 0, 0, 7, 0, 4],
+                       [0, 0, 0, 0, 0, 0]])
     res = maximum_flow(graph, 0, 5, method=method)
     assert res.flow_value == 23
     expected_flow = np.array([[0, 12, 11, 0, 0, 0],
@@ -135,10 +135,10 @@ def test_example_from_clrs_chapter_26_1(method):
 def test_disconnected_graph(method):
     # This tests the following disconnected graph:
     #     (0) --5--> (1)    (2) --3--> (3)
-    graph = csr_matrix([[0, 5, 0, 0],
-                        [0, 0, 0, 0],
-                        [0, 0, 9, 3],
-                        [0, 0, 0, 0]])
+    graph = csr_array([[0, 5, 0, 0],
+                       [0, 0, 0, 0],
+                       [0, 0, 9, 3],
+                       [0, 0, 0, 0]])
     res = maximum_flow(graph, 0, 3, method=method)
     assert res.flow_value == 0
     expected_flow = np.zeros((4, 4), dtype=np.int32)
@@ -152,7 +152,7 @@ def test_add_reverse_edges_large_graph(method):
     indices = np.arange(1, n)
     indptr = np.array(list(range(n)) + [n - 1])
     data = np.ones(n - 1, dtype=np.int32)
-    graph = csr_matrix((data, indices, indptr), shape=(n, n))
+    graph = csr_array((data, indices, indptr), shape=(n, n))
     res = maximum_flow(graph, 0, n - 1, method=method)
     assert res.flow_value == 1
     expected_flow = graph - graph.transpose()
@@ -170,7 +170,7 @@ def test_add_reverse_edges(a, b_data_expected):
     """Test that the reversal of the edges of the input graph works
     as expected.
     """
-    a = csr_matrix(a, dtype=np.int32, shape=(len(a), len(a)))
+    a = csr_array(a, dtype=np.int32, shape=(len(a), len(a)))
     b = _add_reverse_edges(a)
     assert_array_equal(b.data, b_data_expected)
 
@@ -183,7 +183,7 @@ def test_add_reverse_edges(a, b_data_expected):
     ([[1, 0, 2], [0, 0, 3], [4, 5, 0]], [0, 3, 4, 1, 2])
 ])
 def test_make_edge_pointers(a, expected):
-    a = csr_matrix(a, dtype=np.int32)
+    a = csr_array(a, dtype=np.int32)
     rev_edge_ptr = _make_edge_pointers(a)
     assert_array_equal(rev_edge_ptr, expected)
 
@@ -196,6 +196,6 @@ def test_make_edge_pointers(a, expected):
     ([[1, 0, 2], [0, 0, 3], [4, 5, 0]], [0, 0, 1, 2, 2])
 ])
 def test_make_tails(a, expected):
-    a = csr_matrix(a, dtype=np.int32)
+    a = csr_array(a, dtype=np.int32)
     tails = _make_tails(a)
     assert_array_equal(tails, expected)

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 
-from scipy.sparse import csr_array, csc_array
+from scipy.sparse import csr_array, csc_array, csr_matrix
 from scipy.sparse.csgraph import maximum_flow
 from scipy.sparse.csgraph._flow import (
     _add_reverse_edges, _make_edge_pointers, _make_tails
@@ -69,6 +69,14 @@ def test_simple_graph(method):
     assert res.flow_value == 5
     expected_flow = np.array([[0, 5], [-5, 0]])
     assert_array_equal(res.flow.toarray(), expected_flow)
+
+
+@pytest.mark.parametrize('method', methods)
+def test_return_type(method):
+    graph = csr_array([[0, 5], [0, 0]])
+    assert isinstance(maximum_flow(graph, 0, 1, method=method).flow, csr_array)
+    graph = csr_matrix([[0, 5], [0, 0]])
+    assert isinstance(maximum_flow(graph, 0, 1, method=method).flow, csr_matrix)
 
 
 @pytest.mark.parametrize('method', methods)

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -47,10 +47,10 @@ def _check_symmetric_graph_laplacian(mat, normed, copy=True):
         sp_mat = mat
         mat = sp_mat.toarray()
     else:
-        sp_mat = sparse.csr_matrix(mat)
+        sp_mat = sparse.csr_array(mat)
 
     mat_copy = np.copy(mat)
-    sp_mat_copy = sparse.csr_matrix(sp_mat, copy=True)
+    sp_mat_copy = sparse.csr_array(sp_mat, copy=True)
 
     n_nodes = mat.shape[0]
     explicit_laplacian = _explicit_laplacian(mat, normed=normed)
@@ -241,7 +241,7 @@ def test_asymmetric_laplacian(use_out_degree, normed,
 @pytest.mark.parametrize("normed", [True, False])
 @pytest.mark.parametrize("copy", [True, False])
 def test_sparse_formats(fmt, normed, copy):
-    mat = sparse.diags([1, 1], [-1, 1], shape=(4, 4), format=fmt)
+    mat = sparse.diags_array([1, 1], offsets=[-1, 1], shape=(4, 4), format=fmt)
     _check_symmetric_graph_laplacian(mat, normed, copy)
 
 

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
 import pytest
 
-from scipy.sparse import csr_matrix, coo_matrix, diags
+from scipy.sparse import csr_array, diags_array
 from scipy.sparse.csgraph import (
     maximum_bipartite_matching, min_weight_full_bipartite_matching
 )
@@ -17,7 +17,7 @@ def test_maximum_bipartite_matching_raises_on_dense_input():
 
 
 def test_maximum_bipartite_matching_empty_graph():
-    graph = csr_matrix((0, 0))
+    graph = csr_array((0, 0))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     expected_matching = np.array([])
@@ -26,7 +26,7 @@ def test_maximum_bipartite_matching_empty_graph():
 
 
 def test_maximum_bipartite_matching_empty_left_partition():
-    graph = csr_matrix((2, 0))
+    graph = csr_array((2, 0))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     assert_array_equal(np.array([]), x)
@@ -34,7 +34,7 @@ def test_maximum_bipartite_matching_empty_left_partition():
 
 
 def test_maximum_bipartite_matching_empty_right_partition():
-    graph = csr_matrix((0, 3))
+    graph = csr_array((0, 3))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     assert_array_equal(np.array([-1, -1, -1]), x)
@@ -42,7 +42,7 @@ def test_maximum_bipartite_matching_empty_right_partition():
 
 
 def test_maximum_bipartite_matching_graph_with_no_edges():
-    graph = csr_matrix((2, 2))
+    graph = csr_array((2, 2))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     assert_array_equal(np.array([-1, -1]), x)
@@ -52,7 +52,7 @@ def test_maximum_bipartite_matching_graph_with_no_edges():
 def test_maximum_bipartite_matching_graph_that_causes_augmentation():
     # In this graph, column 1 is initially assigned to row 1, but it should be
     # reassigned to make room for row 2.
-    graph = csr_matrix([[1, 1], [1, 0]])
+    graph = csr_array([[1, 1], [1, 0]])
     x = maximum_bipartite_matching(graph, perm_type='column')
     y = maximum_bipartite_matching(graph, perm_type='row')
     expected_matching = np.array([1, 0])
@@ -61,7 +61,7 @@ def test_maximum_bipartite_matching_graph_that_causes_augmentation():
 
 
 def test_maximum_bipartite_matching_graph_with_more_rows_than_columns():
-    graph = csr_matrix([[1, 1], [1, 0], [0, 1]])
+    graph = csr_array([[1, 1], [1, 0], [0, 1]])
     x = maximum_bipartite_matching(graph, perm_type='column')
     y = maximum_bipartite_matching(graph, perm_type='row')
     assert_array_equal(np.array([0, -1, 1]), x)
@@ -69,7 +69,7 @@ def test_maximum_bipartite_matching_graph_with_more_rows_than_columns():
 
 
 def test_maximum_bipartite_matching_graph_with_more_columns_than_rows():
-    graph = csr_matrix([[1, 1, 0], [0, 0, 1]])
+    graph = csr_array([[1, 1, 0], [0, 0, 1]])
     x = maximum_bipartite_matching(graph, perm_type='column')
     y = maximum_bipartite_matching(graph, perm_type='row')
     assert_array_equal(np.array([0, 2]), x)
@@ -80,7 +80,7 @@ def test_maximum_bipartite_matching_explicit_zeros_count_as_edges():
     data = [0, 0]
     indices = [1, 0]
     indptr = [0, 1, 2]
-    graph = csr_matrix((data, indices, indptr), shape=(2, 2))
+    graph = csr_array((data, indices, indptr), shape=(2, 2))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     expected_matching = np.array([1, 0])
@@ -96,7 +96,7 @@ def test_maximum_bipartite_matching_feasibility_of_result():
                10, 5, 6, 11, 12, 13, 5, 13, 14, 20, 22, 3, 15, 3, 13, 14]
     indptr = [0, 5, 7, 10, 10, 15, 20, 22, 22, 23, 25, 30, 32, 35, 35, 40, 45,
               47, 47, 48, 50]
-    graph = csr_matrix((data, indices, indptr), shape=(20, 25))
+    graph = csr_array((data, indices, indptr), shape=(20, 25))
     x = maximum_bipartite_matching(graph, perm_type='row')
     y = maximum_bipartite_matching(graph, perm_type='column')
     assert (x != -1).sum() == 13
@@ -112,37 +112,37 @@ def test_maximum_bipartite_matching_feasibility_of_result():
 
 def test_matching_large_random_graph_with_one_edge_incident_to_each_vertex():
     np.random.seed(42)
-    A = diags(np.ones(25), offsets=0, format='csr')
+    A = diags_array(np.ones(25), offsets=0, format='csr')
     rand_perm = np.random.permutation(25)
     rand_perm2 = np.random.permutation(25)
 
     Rrow = np.arange(25)
     Rcol = rand_perm
     Rdata = np.ones(25, dtype=int)
-    Rmat = coo_matrix((Rdata, (Rrow, Rcol))).tocsr()
+    Rmat = csr_array((Rdata, (Rrow, Rcol)))
 
     Crow = rand_perm2
     Ccol = np.arange(25)
     Cdata = np.ones(25, dtype=int)
-    Cmat = coo_matrix((Cdata, (Crow, Ccol))).tocsr()
+    Cmat = csr_array((Cdata, (Crow, Ccol)))
     # Randomly permute identity matrix
-    B = Rmat * A * Cmat
+    B = Rmat @ A @ Cmat
 
     # Row permute
     perm = maximum_bipartite_matching(B, perm_type='row')
     Rrow = np.arange(25)
     Rcol = perm
     Rdata = np.ones(25, dtype=int)
-    Rmat = coo_matrix((Rdata, (Rrow, Rcol))).tocsr()
-    C1 = Rmat * B
+    Rmat = csr_array((Rdata, (Rrow, Rcol)))
+    C1 = Rmat @ B
 
     # Column permute
     perm2 = maximum_bipartite_matching(B, perm_type='column')
     Crow = perm2
     Ccol = np.arange(25)
     Cdata = np.ones(25, dtype=int)
-    Cmat = coo_matrix((Cdata, (Crow, Ccol))).tocsr()
-    C2 = B * Cmat
+    Cmat = csr_array((Cdata, (Crow, Ccol)))
+    C2 = B @ Cmat
 
     # Should get identity matrix back
     assert_equal(any(C1.diagonal() == 0), False)
@@ -151,13 +151,13 @@ def test_matching_large_random_graph_with_one_edge_incident_to_each_vertex():
 
 @pytest.mark.parametrize('num_rows,num_cols', [(0, 0), (2, 0), (0, 3)])
 def test_min_weight_full_matching_trivial_graph(num_rows, num_cols):
-    biadjacency_matrix = csr_matrix((num_cols, num_rows))
-    row_ind, col_ind = min_weight_full_bipartite_matching(biadjacency_matrix)
+    biadjacency = csr_array((num_cols, num_rows))
+    row_ind, col_ind = min_weight_full_bipartite_matching(biadjacency)
     assert len(row_ind) == 0
     assert len(col_ind) == 0
 
 
-@pytest.mark.parametrize('biadjacency_matrix',
+@pytest.mark.parametrize('biadjacency',
                          [
                             [[1, 1, 1], [1, 0, 0], [1, 0, 0]],
                             [[1, 1, 1], [0, 0, 1], [0, 0, 1]],
@@ -166,9 +166,9 @@ def test_min_weight_full_matching_trivial_graph(num_rows, num_cols):
                             [[0, 1, 0], [0, 2, 0]],
                             [[1, 0], [2, 0], [5, 0]]
                          ])
-def test_min_weight_full_matching_infeasible_problems(biadjacency_matrix):
+def test_min_weight_full_matching_infeasible_problems(biadjacency):
     with pytest.raises(ValueError):
-        min_weight_full_bipartite_matching(csr_matrix(biadjacency_matrix))
+        min_weight_full_bipartite_matching(csr_array(biadjacency))
 
 
 def test_min_weight_full_matching_large_infeasible():
@@ -222,13 +222,13 @@ def test_min_weight_full_matching_large_infeasible():
          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         ])
     with pytest.raises(ValueError, match='no full matching exists'):
-        min_weight_full_bipartite_matching(csr_matrix(a))
+        min_weight_full_bipartite_matching(csr_array(a))
 
 
 def test_explicit_zero_causes_warning():
     with pytest.warns(UserWarning):
-        biadjacency_matrix = csr_matrix(((2, 0, 3), (0, 1, 1), (0, 2, 3)))
-        min_weight_full_bipartite_matching(biadjacency_matrix)
+        biadjacency = csr_array(((2, 0, 3), (0, 1, 1), (0, 2, 3)))
+        min_weight_full_bipartite_matching(biadjacency)
 
 
 # General test for linear sum assignment solvers to make it possible to rely
@@ -291,4 +291,4 @@ linear_sum_assignment_test_cases = product(
 @pytest.mark.parametrize('sign,test_case', linear_sum_assignment_test_cases)
 def test_min_weight_full_matching_small_inputs(sign, test_case):
     linear_sum_assignment_assertions(
-        min_weight_full_bipartite_matching, csr_matrix, sign, test_case)
+        min_weight_full_bipartite_matching, csr_array, sign, test_case)

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -67,7 +67,7 @@ def graphs(sparse_cls):
 def test_csgraph_equiv(func, graphs):
     A_dense, A_sparse = graphs
     actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
+    desired = func(sp.csc_array(A_dense))
     assert_equal(actual, desired)
 
 
@@ -76,7 +76,7 @@ def test_connected_components(graphs):
     func = spgraph.connected_components
 
     actual_comp, actual_labels = func(A_sparse)
-    desired_comp, desired_labels, = func(sp.csc_matrix(A_dense))
+    desired_comp, desired_labels, = func(sp.csc_array(A_dense))
 
     assert actual_comp == desired_comp
     assert_equal(actual_labels, desired_labels)
@@ -88,7 +88,7 @@ def test_laplacian(graphs):
     func = spgraph.laplacian
 
     actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
+    desired = func(sp.csc_array(A_dense))
 
     assert isinstance(actual, sparse_cls)
 
@@ -102,7 +102,7 @@ def test_order_search(graphs, func):
     A_dense, A_sparse = graphs
 
     actual = func(A_sparse, 0)
-    desired = func(sp.csc_matrix(A_dense), 0)
+    desired = func(sp.csc_array(A_dense), 0)
 
     assert_equal(actual, desired)
 
@@ -115,7 +115,7 @@ def test_tree_search(graphs, func):
     sparse_cls = type(A_sparse)
 
     actual = func(A_sparse, 0)
-    desired = func(sp.csc_matrix(A_dense), 0)
+    desired = func(sp.csc_array(A_dense), 0)
 
     assert isinstance(actual, sparse_cls)
 
@@ -128,7 +128,7 @@ def test_minimum_spanning_tree(graphs):
     func = spgraph.minimum_spanning_tree
 
     actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
+    desired = func(sp.csc_array(A_dense))
 
     assert isinstance(actual, sparse_cls)
 
@@ -141,7 +141,7 @@ def test_maximum_flow(graphs):
     func = spgraph.maximum_flow
 
     actual = func(A_sparse, 0, 2)
-    desired = func(sp.csr_matrix(A_dense), 0, 2)
+    desired = func(sp.csr_array(A_dense), 0, 2)
 
     assert actual.flow_value == desired.flow_value
     assert isinstance(actual.flow, sparse_cls)
@@ -154,7 +154,7 @@ def test_min_weight_full_bipartite_matching(graphs):
     func = spgraph.min_weight_full_bipartite_matching
 
     actual = func(A_sparse[0:2, 1:3])
-    desired = func(sp.csc_matrix(A_dense)[0:2, 1:3])
+    desired = func(sp.csc_array(A_dense)[0:2, 1:3])
 
     assert_equal(actual, desired)
 
@@ -182,7 +182,7 @@ def test_nonzero_fill_value(graphs, func, fill_value, comp_func):
     sparse_cls = type(A_sparse)
 
     actual = func(A_sparse)
-    desired = func(sp.csc_matrix(A_dense))
+    desired = func(sp.csc_array(A_dense))
 
     if func == spgraph.minimum_spanning_tree:
         assert isinstance(actual, sparse_cls)

--- a/scipy/sparse/csgraph/tests/test_reordering.py
+++ b/scipy/sparse/csgraph/tests/test_reordering.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal
 from scipy.sparse.csgraph import reverse_cuthill_mckee, structural_rank
-from scipy.sparse import csc_matrix, csr_matrix, coo_matrix
+from scipy.sparse import csc_array, csr_array, coo_array
 
 
 def test_graph_reverse_cuthill_mckee():
@@ -14,7 +14,7 @@ def test_graph_reverse_cuthill_mckee():
                 [0, 0, 0, 1, 0, 0, 1, 0],
                 [0, 1, 0, 0, 0, 1, 0, 1]], dtype=int)
     
-    graph = csr_matrix(A)
+    graph = csr_array(A)
     perm = reverse_cuthill_mckee(graph)
     correct_perm = np.array([6, 3, 7, 5, 1, 2, 4, 0])
     assert_equal(perm, correct_perm)
@@ -40,7 +40,7 @@ def test_graph_reverse_cuthill_mckee_ordering():
                 1, 9, 11, 0, 2, 8, 10, 15, 1, 3, 9, 11,
                 4, 12, 14, 5, 8, 13, 15, 4, 6, 12, 14,
                 5, 7, 10, 13, 15])
-    graph = coo_matrix((data, (rows,cols))).tocsr()
+    graph = csr_array((data, (rows,cols)))
     perm = reverse_cuthill_mckee(graph)
     correct_perm = np.array([12, 14, 4, 6, 10, 8, 2, 15,
                 0, 13, 7, 5, 9, 11, 1, 3])
@@ -49,21 +49,21 @@ def test_graph_reverse_cuthill_mckee_ordering():
 
 def test_graph_structural_rank():
     # Test square matrix #1
-    A = csc_matrix([[1, 1, 0], 
-                    [1, 0, 1],
-                    [0, 1, 0]])
+    A = csc_array([[1, 1, 0],
+                   [1, 0, 1],
+                   [0, 1, 0]])
     assert_equal(structural_rank(A), 3)
     
     # Test square matrix #2
     rows = np.array([0,0,0,0,0,1,1,2,2,3,3,3,3,3,3,4,4,5,5,6,6,7,7])
     cols = np.array([0,1,2,3,4,2,5,2,6,0,1,3,5,6,7,4,5,5,6,2,6,2,4])
     data = np.ones_like(rows)
-    B = coo_matrix((data,(rows,cols)), shape=(8,8))
+    B = coo_array((data,(rows,cols)), shape=(8,8))
     assert_equal(structural_rank(B), 6)
     
     #Test non-square matrix
-    C = csc_matrix([[1, 0, 2, 0], 
-                    [2, 0, 4, 0]])
+    C = csc_array([[1, 0, 2, 0],
+                   [2, 0, 4, 0]])
     assert_equal(structural_rank(C), 2)
     
     #Test tall matrix

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -33,7 +33,7 @@ directed_SP = [[0, 3, 3, 5, 7],
 directed_2SP_0_to_3 = [[-9999, 0, -9999, 1, -9999],
                        [-9999, 0, -9999, 4, 1]]
 
-directed_sparse_zero_G = scipy.sparse.csr_matrix(
+directed_sparse_zero_G = scipy.sparse.csr_array(
     (
         [0, 1, 2, 3, 1],
         ([0, 1, 2, 3, 4], [1, 2, 0, 4, 3]),
@@ -47,7 +47,7 @@ directed_sparse_zero_SP = [[0, 0, 1, np.inf, np.inf],
                       [np.inf, np.inf, np.inf, 0, 3],
                       [np.inf, np.inf, np.inf, 1, 0]]
 
-undirected_sparse_zero_G = scipy.sparse.csr_matrix(
+undirected_sparse_zero_G = scipy.sparse.csr_array(
     (
         [0, 0, 1, 1, 2, 2, 1, 1],
         ([0, 1, 1, 2, 2, 0, 3, 4], [1, 0, 2, 1, 0, 2, 4, 3])
@@ -197,8 +197,8 @@ def test_dijkstra_indices_min_only(directed, SP_ans, indices):
 @pytest.mark.parametrize('n', (10, 100, 1000))
 def test_dijkstra_min_only_random(n):
     np.random.seed(1234)
-    data = scipy.sparse.rand(n, n, density=0.5, format='lil',
-                             random_state=42, dtype=np.float64)
+    data = scipy.sparse.random_array((n, n), density=0.5, format='lil',
+                                     random_state=42, dtype=np.float64)
     data.setdiag(np.zeros(n, dtype=np.bool_))
     # choose some random vertices
     v = np.arange(n)
@@ -225,7 +225,7 @@ def test_dijkstra_random():
     data = [0.33629, 0.40458, 0.47493, 0.42757, 0.11497, 0.91653, 0.69084,
             0.64979, 0.62555, 0.743, 0.01724, 0.99945, 0.31095, 0.15557,
             0.02439, 0.65814, 0.23478, 0.24072]
-    graph = scipy.sparse.csr_matrix((data, indices, indptr), shape=(n, n))
+    graph = scipy.sparse.csr_array((data, indices, indptr), shape=(n, n))
     dijkstra(graph, directed=True, return_predecessors=True)
 
 
@@ -379,7 +379,7 @@ def test_buffer(method):
     #
     #     ValueError: buffer source array is read-only
     #
-    G = scipy.sparse.csr_matrix([[1.]])
+    G = scipy.sparse.csr_array([[1.]])
     G.data.flags['WRITEABLE'] = False
     shortest_path(G, method=method)
 
@@ -399,9 +399,9 @@ def test_sparse_matrices():
                         [0, 0, 0, 0, 4],
                         [0, 0, 0, 0, 0]], dtype=float)
     SP = shortest_path(G_dense)
-    G_csr = scipy.sparse.csr_matrix(G_dense)
-    G_csc = scipy.sparse.csc_matrix(G_dense)
-    G_lil = scipy.sparse.lil_matrix(G_dense)
+    G_csr = scipy.sparse.csr_array(G_dense)
+    G_csc = scipy.sparse.csc_array(G_dense)
+    G_lil = scipy.sparse.lil_array(G_dense)
     assert_array_almost_equal(SP, shortest_path(G_csr))
     assert_array_almost_equal(SP, shortest_path(G_csc))
     assert_array_almost_equal(SP, shortest_path(G_lil))
@@ -467,7 +467,7 @@ def test_yen_negative_weights():
 @pytest.mark.parametrize("indices", (None, [1]))
 def test_20904(min_only, directed, return_predecessors, index_dtype, indices):
     """Test two failures from gh-20904: int32 and indices-as-None."""
-    adj_mat = scipy.sparse.eye(4, format="csr")
+    adj_mat = scipy.sparse.eye_array(4, format="csr")
     adj_mat = scipy.sparse.csr_array(
         (
             adj_mat.data,

--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_
 import numpy.testing as npt
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.sparse.csgraph import minimum_spanning_tree
 
 
@@ -25,7 +25,7 @@ def test_minimum_spanning_tree():
     expected = np.asarray(expected)
 
     # Ensure minimum spanning tree code gives this expected output.
-    csgraph = csr_matrix(graph)
+    csgraph = csr_array(graph)
     mintree = minimum_spanning_tree(csgraph)
     mintree_array = mintree.toarray()
     npt.assert_array_equal(mintree_array, expected,
@@ -45,7 +45,7 @@ def test_minimum_spanning_tree():
 
         # Create a random graph.
         graph = 3 + np.random.random((N, N))
-        csgraph = csr_matrix(graph)
+        csgraph = csr_array(graph)
 
         # The spanning tree has at most N - 1 edges.
         mintree = minimum_spanning_tree(csgraph)
@@ -54,7 +54,7 @@ def test_minimum_spanning_tree():
         # Set the sub diagonal to 1 to create a known spanning tree.
         idx = np.arange(N-1)
         graph[idx,idx+1] = 1
-        csgraph = csr_matrix(graph)
+        csgraph = csr_array(graph)
         mintree = minimum_spanning_tree(csgraph)
 
         # We expect to see this pattern in the spanning tree and otherwise

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
-from scipy.sparse import csr_array
+from scipy.sparse import csr_array, csr_matrix, coo_array, coo_matrix
 from scipy.sparse.csgraph import (breadth_first_tree, depth_first_tree,
-    csgraph_to_dense, csgraph_from_dense)
+    csgraph_to_dense, csgraph_from_dense, csgraph_masked_from_dense)
 
 
 def test_graph_breadth_first():
@@ -42,8 +42,75 @@ def test_graph_depth_first():
 
     for directed in [True, False]:
         dfirst_test = depth_first_tree(csgraph, 0, directed)
-        assert_array_almost_equal(csgraph_to_dense(dfirst_test),
-                                  dfirst)
+        assert_array_almost_equal(csgraph_to_dense(dfirst_test), dfirst)
+
+
+def test_return_type():
+    from .._laplacian import laplacian
+    from .._min_spanning_tree import minimum_spanning_tree
+
+    np_csgraph = np.array([[0, 1, 2, 0, 0],
+                           [1, 0, 0, 0, 3],
+                           [2, 0, 0, 7, 0],
+                           [0, 0, 7, 0, 1],
+                           [0, 3, 0, 1, 0]])
+    csgraph = csr_array(np_csgraph)
+    assert isinstance(laplacian(csgraph), coo_array)
+    assert isinstance(minimum_spanning_tree(csgraph), csr_array)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_array)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_array)
+
+    csgraph = csgraph_from_dense(np_csgraph, null_value=0)
+    assert isinstance(csgraph, csr_array)
+    assert isinstance(laplacian(csgraph), coo_array)
+    assert isinstance(minimum_spanning_tree(csgraph), csr_array)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_array)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_array)
+
+    csgraph = csgraph_masked_from_dense(np_csgraph, null_value=0)
+    assert isinstance(csgraph, np.ma.MaskedArray)
+    assert csgraph._baseclass is np.ndarray
+    # laplacian doesnt work with masked arrays so not here
+    assert isinstance(minimum_spanning_tree(csgraph), csr_array)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_array)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_array)
+
+    # start of testing with matrix/spmatrix types
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "the matrix subclass.*")
+        sup.filter(PendingDeprecationWarning, "the matrix subclass.*")
+
+        nm_csgraph = np.matrix([[0, 1, 2, 0, 0],
+                        [1, 0, 0, 0, 3],
+                        [2, 0, 0, 7, 0],
+                        [0, 0, 7, 0, 1],
+                        [0, 3, 0, 1, 0]])
+    csgraph = csr_matrix(nm_csgraph)
+    assert isinstance(laplacian(csgraph), coo_matrix)
+    assert isinstance(minimum_spanning_tree(csgraph), csr_matrix)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_matrix)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_matrix)
+
+    csgraph = csgraph_from_dense(nm_csgraph, null_value=0)
+    assert isinstance(csgraph, csr_matrix)
+    assert isinstance(laplacian(csgraph), coo_matrix)
+    assert isinstance(minimum_spanning_tree(csgraph), csr_matrix)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_matrix)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_matrix)
+
+    mm_csgraph = csgraph_masked_from_dense(nm_csgraph, null_value=0)
+    assert isinstance(mm_csgraph, np.ma.MaskedArray)
+    # laplacian doesnt work with masked arrays so not here
+    assert isinstance(minimum_spanning_tree(csgraph), csr_matrix)
+    for directed in [True, False]:
+        assert isinstance(depth_first_tree(csgraph, 0, directed), csr_matrix)
+        assert isinstance(breadth_first_tree(csgraph, 0, directed), csr_matrix)
+    # end of testing with matrix/spmatrix types
 
 
 def test_graph_breadth_first_trivial_graph():
@@ -54,8 +121,7 @@ def test_graph_breadth_first_trivial_graph():
 
     for directed in [True, False]:
         bfirst_test = breadth_first_tree(csgraph, 0, directed)
-        assert_array_almost_equal(csgraph_to_dense(bfirst_test),
-                                  bfirst)
+        assert_array_almost_equal(csgraph_to_dense(bfirst_test), bfirst)
 
 
 def test_graph_depth_first_trivial_graph():


### PR DESCRIPTION
This PR migrates `sparse.csgraph` to use sparse arrays internally. In the few functions that return sparse, we now return sparse arrays UNLESS the input argument is a sparse matrix or in rare cases when the function supports np.matrix input. 

Other changes:
- in `_tools.pyx` I added a function `_safe_downcast_indices` to check for too large values before downcasting to `ITYPE` for a cython function. This is similar to the function in `sparse.linalg._dsolve.linsolve.py` which does the same to 'intc`.
- with the new code to figure out which type to return, the pydata_sparse appears as well and it is convenient to move ithe logic together near the end rather than pydata half at the beginning and half at the end.
- I added tests of output type for various input types.
- I got frustrated with the variable name `biadjacency_matrix` due to difficulty reading it as it recurred many times in a short span. So I changed it to `biadjaacency`. I can change back easily if desired.


I know this is long, so I left the changes to the docs for another PR. Mostly, the doc-tests should still work even though they use spmatrix, because the code can still accept spmatrix input. Another PR will go through the docs and examples to shift to sparray. If you want I can add that here, but it makes it hard to find the code changes that way.

