### PR TITLE
BUG: signal: Fix `ShortTimeFFT.extent()` for `fft_mode == 'centered'`

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1660,8 +1660,8 @@ class ShortTimeFFT:
         if self.onesided_fft:
             q0, q1 = 0, self.f_pts
         elif self.fft_mode == 'centered':
-            q0 = -self.mfft // 2
-            q1 = self.mfft // 2 - 1 if self.mfft % 2 == 0 else self.mfft // 2
+            q0 = -(self.mfft // 2)
+            q1 = self.mfft // 2 if self.mfft % 2 == 0 else self.mfft // 2 + 1
         else:
             raise ValueError(f"Attribute fft_mode={self.fft_mode} must be " +
                              "in ['centered', 'onesided', 'onesided2X']")

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1676,14 +1676,14 @@ class ShortTimeFFT:
         ...
         >>> fig, axx = plt.subplots(1, 2, tight_layout=True, figsize=(6., 4.))
         >>> for ax_, center_bins in zip(axx, (False, True)):
-        >>>     ax_.imshow(abs(Sxx), origin='lower', interpolation=None, aspect='equal',
-        >>>                cmap='viridis', extent=SFT.extent(n, 'tf', center_bins))
-        >>>     ax_.set_title(f"{center_bins=}")
-        >>>     ax_.set_xlabel(f"Time ({SFT.p_num(n)} points, Δt={SFT.delta_t})")
-        >>>     ax_.set_ylabel(f"Frequency ({SFT.f_pts} points, Δf={SFT.delta_f})")
-        >>>     ax_.set_xticks(SFT.t(n))  # vertical grid line are timestamps
-        >>>     ax_.set_yticks(SFT.f)  # horizontal grid line are frequency values
-        >>>     ax_.grid(True)
+        ...     ax_.imshow(abs(Sxx), origin='lower', interpolation=None, aspect='equal',
+        ...                cmap='viridis', extent=SFT.extent(n, 'tf', center_bins))
+        ...     ax_.set_title(f"{center_bins=}")
+        ...     ax_.set_xlabel(f"Time ({SFT.p_num(n)} points, Δt={SFT.delta_t})")
+        ...     ax_.set_ylabel(f"Frequency ({SFT.f_pts} points, Δf={SFT.delta_f})")
+        ...     ax_.set_xticks(SFT.t(n))  # vertical grid line are timestamps
+        ...     ax_.set_yticks(SFT.f)  # horizontal grid line are frequency values
+        ...     ax_.grid(True)
         >>> plt.show()
 
         Note that the step-like behavior with the constant colors is caused by passing

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1653,6 +1653,41 @@ class ShortTimeFFT:
         --------
         :func:`matplotlib.pyplot.imshow`: Display data as an image.
         :class:`scipy.signal.ShortTimeFFT`: Class this method belongs to.
+
+        Examples
+        --------
+        The following two plots illustrate the effect of the parameter `center_bins`:
+        The grid lines represent the three time and the four frequency values of the
+        STFT.
+        The left plot, where ``(t0, t1, f0, f1) = (0, 3, 0, 4)`` is passed as parameter
+        ``extent`` to `~matplotlib.pyplot.imshow`, shows the standard behavior of the
+        time and frequency values being at the lower edge of the corrsponding bin.
+        The right plot, with ``(t0, t1, f0, f1) = (-0.5, 2.5, -0.5, 3.5)``, shows that
+        the bins are centered over the respective values when passing
+        ``center_bins=True``.
+
+        >>> import matplotlib.pyplot as plt
+        >>> import numpy as np
+        >>> from scipy.signal import ShortTimeFFT
+        ...
+        >>> n, m = 12, 6
+        >>> SFT = ShortTimeFFT.from_window('hann', fs=m, nperseg=m, noverlap=0)
+        >>> Sxx = SFT.stft(np.cos(np.arange(n)))  # produces a colorful plot
+        ...
+        >>> fig, axx = plt.subplots(1, 2, tight_layout=True, figsize=(6., 4.))
+        >>> for ax_, center_bins in zip(axx, (False, True)):
+        >>>     ax_.imshow(abs(Sxx), origin='lower', interpolation=None, aspect='equal',
+        >>>                cmap='viridis', extent=SFT.extent(n, 'tf', center_bins))
+        >>>     ax_.set_title(f"{center_bins=}")
+        >>>     ax_.set_xlabel(f"Time ({SFT.p_num(n)} points, Δt={SFT.delta_t})")
+        >>>     ax_.set_ylabel(f"Frequency ({SFT.f_pts} points, Δf={SFT.delta_f})")
+        >>>     ax_.set_xticks(SFT.t(n))  # vertical grid line are timestamps
+        >>>     ax_.set_yticks(SFT.f)  # horizontal grid line are frequency values
+        >>>     ax_.grid(True)
+        >>> plt.show()
+
+        Note that the step-like behavior with the constant colors is caused by passing
+        ``interpolation=None`` to `~matplotlib.pyplot.imshow`.
         """
         if axes_seq not in ('tf', 'ft'):
             raise ValueError(f"Parameter {axes_seq=} not in ['tf', 'ft']!")

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -380,16 +380,25 @@ def test_f(fft_mode: FFT_MODE_TYPE, f):
     xp_assert_equal(SFT.f, f)
 
 
-def test_extent():
+@pytest.mark.parametrize('n', [20, 21])
+@pytest.mark.parametrize('m', [5, 6])
+@pytest.mark.parametrize('fft_mode', ['onesided', 'centered'])
+def test_extent(n, m, fft_mode: FFT_MODE_TYPE):
     """Ensure that the `extent()` method is correct. """
-    SFT = ShortTimeFFT(np.ones(32), hop=4, fs=32, fft_mode='onesided')
-    assert SFT.extent(100, 'tf', False) == (-0.375, 3.625, 0.0, 17.0)
-    assert SFT.extent(100, 'ft', False) == (0.0, 17.0, -0.375, 3.625)
-    assert SFT.extent(100, 'tf', True) == (-0.4375, 3.5625, -0.5, 16.5)
-    assert SFT.extent(100, 'ft', True) == (-0.5, 16.5, -0.4375, 3.5625)
+    SFT = ShortTimeFFT(np.ones(m), hop=m, fs=m, fft_mode=fft_mode)
 
-    SFT = ShortTimeFFT(np.ones(32), hop=4, fs=32, fft_mode='centered')
-    assert SFT.extent(100, 'tf', False) == (-0.375, 3.625, -16.0, 15.0)
+    t0 = SFT.t(n)[0]  # first timestamp
+    t1 = SFT.t(n)[-1] + SFT.delta_t  # last timestamp + 1
+    t0c, t1c = t0 - SFT.delta_t / 2, t1 - SFT.delta_t / 2  # centered timestamps
+
+    f0 = SFT.f[0]  # first frequency
+    f1 = SFT.f[-1] + SFT.delta_f  # last frequency + 1
+    f0c, f1c = f0 - SFT.delta_f / 2, f1 - SFT.delta_f / 2  # centered frequencies
+
+    assert SFT.extent(n, 'tf', False) == (t0, t1, f0, f1)
+    assert SFT.extent(n, 'ft', False) == (f0, f1, t0, t1)
+    assert SFT.extent(n, 'tf', True) == (t0c, t1c, f0c, f1c)
+    assert SFT.extent(n, 'ft', True) == (f0c, f1c, t0c, t1c)
 
 
 def test_spectrogram():


### PR DESCRIPTION
The frequency values of [ShortTimeFFT.extent()] are incorrect for ShortTimeFFT.fft_mode == 'centered'. This is fixed here and the relevant unit test is improved to cover all cases.

The following plot illustrates the problem, which utilizes [ShortTimeFFT.extent()] in its intended use case of producing the correct `extent` parameter for [imshow] .  
The grid lines indicate the times and the frequency values of the STFT. The first row (``ShortTimeFFT.fft_mode == 'onesided'``) depicts the expected result of the onsided FFT: In the left column (parameter ``center_bins=False``) the time and frequency values are at the beginning of the respective bin; in the right column they are at the center of the respective bin.
It can be seen in the second row, which depicts the two-sided FFT,  that the frequency grid lines are at the incorrect place:

![image](https://github.com/user-attachments/assets/e4cdaffd-425f-4de3-a361-5c386e086305)

The corrections in this PR produce the desired results:

![image](https://github.com/user-attachments/assets/a09a2332-000c-45e5-956b-f682f37c7f86)

The following script was used to produce the plots:
```python
import matplotlib.pyplot as plt
import numpy as np

from STFT import ShortTimeFFT

n, m = 12, 4
win = np.ones(m)
x = np.zeros(n)
x[m:2*m] = 1

fig0, axx = plt.subplots(2, 2, tight_layout=True)
for c_, fft_mode in enumerate(('onesided', 'centered')):
    SFT = ShortTimeFFT(win, fs=m, hop=m, scale_to='magnitude',
                       fft_mode=fft_mode)
    Sxx = SFT.spectrogram(x)
    for ax_, center_bins in zip(axx[c_, :], (False, True)):
        extent = SFT.extent(n, center_bins=center_bins)
        ax_.imshow(np.sqrt(Sxx), origin='lower', aspect='auto', interpolation=None,
                   extent=extent, cmap='viridis', vmax=1)
        ax_.set_xticks(SFT.t(n))
        ax_.set_yticks(SFT.f)
        ax_.grid(True)
        ax_.set(title=f"{fft_mode}, {center_bins=}",
                xlabel=f"Time ({SFT.p_num(n)} points)",
                ylabel=f"Frequency ({SFT.f_pts} points)")
plt.show()
```

[ShortTimeFFT.extent()]: https://scipy.github.io/devdocs/reference/generated/scipy.signal.ShortTimeFFT.extent.html
[imshow]: https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html#matplotlib.pyplot.imshow