### PR TITLE
ENH: signal.windows: add array API support (take 2)

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -713,17 +713,17 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
     @skip_xp_backends(np_only=True)
-    def test_degenerate_signle_samples()
+    def test_degenerate_signle_samples(self, xp):
         # Single samples
         w = windows.dpss(1, 1.)
-        assert_array_equal(w, [1.])
+        xp_assert_equal(w, [1.])
         w, ratio = windows.dpss(1, 1., return_ratios=True)
-        assert_array_equal(w, [1.])
+        xp_assert_equal(w, [1.])
         assert ratio == 1.
         w, ratio = windows.dpss(1, 1., Kmax=4, return_ratios=True)
-        assert_array_equal(w, [1.])
+        xp_assert_equal(w, [1.])
         assert isinstance(ratio, np.ndarray)
-        assert_array_equal(ratio, [1.])
+        xp_assert_equal(ratio, [1.])
 
         assert_raises(ValueError, windows.dpss, 4, 1.5, -1, xp=xp)  # Bad Kmax
         assert_raises(ValueError, windows.dpss, 4, 1.5, -5, xp=xp)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -2,7 +2,7 @@ import math
 
 import numpy as np
 from numpy import array
-from numpy.testing import  suppress_warnings
+from numpy.testing import suppress_warnings
 import pytest
 from pytest import raises as assert_raises
 
@@ -187,9 +187,9 @@ class TestTaylor:
         BW_3dB = 2*np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
         BW_18dB = 2*np.argmax(spec <= -18.061799739838872) / N_fft * M_win
 
-        xp_assert_close(PSLL, -35.1672, atol=1)
-        xp_assert_close(BW_3dB, 1.1822, atol=0.1)
-        xp_assert_close(BW_18dB, 2.6112, atol=0.1)
+        assert math.isclose(PSLL, -35.1672, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.1822, abs_tol=0.1)
+        assert math.isclose(BW_18dB, 2.6112, abs_tol=0.1)
 
 
 class TestBohman:
@@ -763,8 +763,8 @@ class TestLanczos:
 
     def test_array_size(self, xp):
         for n in [0, 10, 11]:
-            xp_assert_equal(windows.lanczos(n, sym=False, xp=xp).shape[0], n)
-            xp_assert_equal(windows.lanczos(n, sym=True, xp=xp).shape[0], n)
+            assert windows.lanczos(n, sym=False, xp=xp).shape[0] == n
+            assert windows.lanczos(n, sym=True, xp=xp).shape[0] == n
 
 
 class TestGetWindow:
@@ -822,11 +822,11 @@ class TestGetWindow:
             resample(sig, len(sig) * osfactor, window=win)
 
     def test_general_cosine(self, xp):
-        xp_assert_close(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4),
-                        [0.4, 0.3, 1, 0.3])
-        xp_assert_close(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4,
+        xp_assert_close(get_window(('general_cosine', xp.asarray([0.5, 0.3, 0.2])), 4),
+                        xp.asarray([0.4, 0.3, 1, 0.3], dtype=xp.float64))
+        xp_assert_close(get_window(('general_cosine', xp.asarray([0.5, 0.3, 0.2])), 4,
                                    fftbins=False),
-                        [0.4, 0.55, 0.55, 0.4])
+                        xp.asarray([0.4, 0.55, 0.55, 0.4], dtype=xp.float64))
 
         with pytest.raises(ValueError):
             get_window(('general_cosine', [0.5, 0.3, 0.2]), 4, xp=xp)
@@ -872,10 +872,10 @@ def test_windowfunc_basics(xp):
             xp_assert_close(w1[:-1], w2)
 
             # Check that functions run and output lengths are correct
-            xp_assert_equal(window(6, *params, sym=True, xp=xp).shape[0], 6)
-            xp_assert_equal(window(6, *params, sym=False, xp=xp).shape[0], 6)
-            xp_assert_equal(window(7, *params, sym=True, xp=xp).shape[0], 7)
-            xp_assert_equal(window(7, *params, sym=False, xp=xp).shape[0], 7)
+            assert window(6, *params, sym=True, xp=xp).shape[0] == 6
+            assert window(6, *params, sym=False, xp=xp).shape[0] == 6
+            assert window(7, *params, sym=True, xp=xp).shape[0] == 7
+            assert window(7, *params, sym=False, xp=xp).shape[0] == 7
 
             # Check invalid lengths
             assert_raises(ValueError, window, 5.5, *params, xp=xp)
@@ -953,7 +953,7 @@ def test_not_needs_params(xp, winstr):
     if is_jax(xp) and winstr in ['taylor']:
         pytest.skip(reason=f'{winstr}: item assignment')
     win = get_window(winstr, 7, xp=xp)
-    xp_assert_equal(win.shape[0], 7)
+    assert win.shape[0] == 7
 
 
 def test_symmetric(xp):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -48,13 +48,14 @@ class TestBartHann:
     def test_basic(self, xp):
         xp_assert_close(windows.barthann(6, sym=True, xp=xp),
                         xp.asarray([0, 0.35857354213752, 0.8794264578624801,
-                         0.8794264578624801, 0.3585735421375199, 0]),
+                         0.8794264578624801, 0.3585735421375199, 0], dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.barthann(7, xp=xp),
-                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27, 0]),
+                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27, 0],
+                                   dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.barthann(6, False, xp=xp),
-                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27]),
+                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27], dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
 
 
@@ -62,29 +63,33 @@ class TestBartlett:
 
     def test_basic(self, xp):
         xp_assert_close(windows.bartlett(6, xp=xp),
-                        xp.asarray([0, 0.4, 0.8, 0.8, 0.4, 0]))
+                        xp.asarray([0, 0.4, 0.8, 0.8, 0.4, 0], dtype=xp.float64))
         xp_assert_close(windows.bartlett(7, xp=xp),
-                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3, 0]))
+                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3, 0], dtype=xp.float64))
         xp_assert_close(windows.bartlett(6, False, xp=xp),
-                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3]))
+                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3], dtype=xp.float64))
 
 
 class TestBlackman:
 
     def test_basic(self, xp):
         xp_assert_close(windows.blackman(6, sym=False, xp=xp),
-                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13]), atol=1e-14)
+                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13], dtype=xp.float64),
+                        atol=1e-14)
         xp_assert_close(windows.blackman(7, sym=False, xp=xp),
                         xp.asarray([0, 0.09045342435412804, 0.4591829575459636,
                                     0.9203636180999081, 0.9203636180999081,
-                                    0.4591829575459636, 0.09045342435412804]),
+                                    0.4591829575459636, 0.09045342435412804],
+                                    dtype=xp.float64),
                         atol=1e-8)
         xp_assert_close(windows.blackman(6, xp=xp),
                         xp.asarray([0, 0.2007701432625305, 0.8492298567374694,
-                                    0.8492298567374694, 0.2007701432625305, 0]),
+                                    0.8492298567374694, 0.2007701432625305, 0],
+                                    dtype=xp.float64),
                         atol=1e-14)
         xp_assert_close(windows.blackman(7, True, xp=xp),
-                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13, 0]), atol=1e-14)
+                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13, 0],
+                        dtype=xp.float64), atol=1e-14)
 
 
 class TestBlackmanHarris:
@@ -92,17 +97,19 @@ class TestBlackmanHarris:
     def test_basic(self, xp):
         xp_assert_close(windows.blackmanharris(6, False, xp=xp),
                         xp.asarray([6.0e-05, 0.055645, 0.520575,
-                                    1.0, 0.520575, 0.055645]))
+                                    1.0, 0.520575, 0.055645], dtype=xp.float64))
         xp_assert_close(windows.blackmanharris(7, sym=False, xp=xp),
                         xp.asarray([6.0e-05, 0.03339172347815117, 0.332833504298565,
                                     0.8893697722232837, 0.8893697722232838,
-                                    0.3328335042985652, 0.03339172347815122]))
+                                    0.3328335042985652, 0.03339172347815122],
+                                    dtype=xp.float64))
         xp_assert_close(windows.blackmanharris(6, xp=xp),
                         xp.asarray([6.0e-05, 0.1030114893456638, 0.7938335106543362,
-                                    0.7938335106543364, 0.1030114893456638, 6.0e-05]))
+                                    0.7938335106543364, 0.1030114893456638, 6.0e-05],
+                                    dtype=xp.float64))
         xp_assert_close(windows.blackmanharris(7, sym=True, xp=xp),
                         xp.asarray([6.0e-05, 0.055645, 0.520575, 1.0, 0.520575,
-                                    0.055645, 6.0e-05]))
+                                    0.055645, 6.0e-05], dtype=xp.float64))
 
 
 @skip_xp_backends('jax.numpy', reason='item assignment')
@@ -190,13 +197,16 @@ class TestBohman:
     def test_basic(self, xp):
         xp_assert_close(windows.bohman(6, xp=xp),
                         xp.asarray([0, 0.1791238937062839, 0.8343114522576858,
-                                    0.8343114522576858, 0.1791238937062838, 0]))
+                                    0.8343114522576858, 0.1791238937062838, 0],
+                                    dtype=xp.float64))
         xp_assert_close(windows.bohman(7, sym=True, xp=xp),
                         xp.asarray([0, 0.1089977810442293, 0.6089977810442293, 1.0,
-                                    0.6089977810442295, 0.1089977810442293, 0]))
+                                    0.6089977810442295, 0.1089977810442293, 0],
+                                    dtype=xp.float64))
         xp_assert_close(windows.bohman(6, False, xp=xp),
                         xp.asarray([0, 0.1089977810442293, 0.6089977810442293, 1.0,
-                                    0.6089977810442295, 0.1089977810442293]))
+                                    0.6089977810442295, 0.1089977810442293],
+                                    dtype=xp.float64))
 
 
 class TestBoxcar:
@@ -254,24 +264,27 @@ class TestChebWin:
             xp_assert_close(windows.chebwin(6, 100, xp=xp),
                             xp.asarray([0.1046401879356917, 0.5075781475823447,
                                         1.0, 1.0,
-                                        0.5075781475823447, 0.1046401879356917]),
+                                        0.5075781475823447, 0.1046401879356917],
+                                        dtype=xp.float64),
                             atol=1e-8
             )
             xp_assert_close(windows.chebwin(7, 100, xp=xp),
                             xp.asarray([0.05650405062850233, 0.316608530648474,
                                         0.7601208123539079, 1.0, 0.7601208123539079,
-                                        0.316608530648474, 0.05650405062850233]))
+                                        0.316608530648474, 0.05650405062850233],
+                                        dtype=xp.float64))
             xp_assert_close(windows.chebwin(6, 10, xp=xp),
                             xp.asarray([1.0, 0.6071201674458373, 0.6808391469897297,
-                                        0.6808391469897297, 0.6071201674458373, 1.0]))
+                                        0.6808391469897297, 0.6071201674458373, 1.0],
+                                        dtype=xp.float64))
             xp_assert_close(windows.chebwin(7, 10, xp=xp),
                             xp.asarray([1.0, 0.5190521247588651, 0.5864059018130382,
                                         0.6101519801307441, 0.5864059018130382,
-                                        0.5190521247588651, 1.0]))
+                                        0.5190521247588651, 1.0], dtype=xp.float64))
             xp_assert_close(windows.chebwin(6, 10, False, xp=xp),
                             xp.asarray([1.0, 0.5190521247588651, 0.5864059018130382,
                                         0.6101519801307441, 0.5864059018130382,
-                                        0.5190521247588651]))
+                                        0.5190521247588651], dtype=xp.float64))
 
     def test_cheb_odd_high_attenuation(self, xp):
         with suppress_warnings() as sup:
@@ -288,7 +301,7 @@ class TestChebWin:
     def test_cheb_odd_low_attenuation(self, xp):
         cheb_odd_low_at_true = xp.asarray([1.000000, 0.519052, 0.586405,
                                            0.610151, 0.586405, 0.519052,
-                                           1.000000])
+                                           1.000000], dtype=xp.float64)
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             cheb_odd = windows.chebwin(7, at=10, xp=xp)
@@ -297,7 +310,7 @@ class TestChebWin:
     def test_cheb_even_low_attenuation(self, xp):
         cheb_even_low_at_true = xp.asarray([1.000000, 0.451924, 0.51027,
                                             0.541338, 0.541338, 0.51027,
-                                            0.451924, 1.000000])
+                                            0.451924, 1.000000], dtype=xp.float64)
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             cheb_even = windows.chebwin(8, at=-10, xp=xp)
@@ -347,19 +360,21 @@ class TestFlatTop:
     def test_basic(self, xp):
         xp_assert_close(windows.flattop(6, sym=False, xp=xp),
                         xp.asarray([-0.000421051, -0.051263156, 0.19821053, 1.0,
-                                     0.19821053, -0.051263156]))
+                                     0.19821053, -0.051263156], dtype=xp.float64))
         xp_assert_close(windows.flattop(7, sym=False, xp=xp),
                         xp.asarray([-0.000421051, -0.03684078115492348,
                                      0.01070371671615342, 0.7808739149387698,
                                      0.7808739149387698, 0.01070371671615342,
-                                    -0.03684078115492348]))
+                                    -0.03684078115492348], dtype=xp.float64))
         xp_assert_close(windows.flattop(6, xp=xp),
                         xp.asarray([-0.000421051, -0.0677142520762119,
                                      0.6068721525762117, 0.6068721525762117,
-                                    -0.0677142520762119, -0.000421051]))
+                                    -0.0677142520762119, -0.000421051],
+                                    dtype=xp.float64))
         xp_assert_close(windows.flattop(7, True, xp=xp),
                         xp.asarray([-0.000421051, -0.051263156, 0.19821053, 1.0,
-                                     0.19821053, -0.051263156, -0.000421051]))
+                                     0.19821053, -0.051263156, -0.000421051],
+                                     dtype=xp.float64))
 
 
 class TestGaussian:
@@ -368,19 +383,22 @@ class TestGaussian:
         xp_assert_close(windows.gaussian(6, 1.0, xp=xp),
                         xp.asarray([0.04393693362340742, 0.3246524673583497,
                                     0.8824969025845955, 0.8824969025845955,
-                                    0.3246524673583497, 0.04393693362340742]))
+                                    0.3246524673583497, 0.04393693362340742],
+                                    dtype=xp.float64))
         xp_assert_close(windows.gaussian(7, 1.2, xp=xp),
                         xp.asarray([0.04393693362340742, 0.2493522087772962,
                                     0.7066482778577162, 1.0, 0.7066482778577162,
-                                    0.2493522087772962, 0.04393693362340742]))
+                                    0.2493522087772962, 0.04393693362340742],
+                                    dtype=xp.float64))
         xp_assert_close(windows.gaussian(7, 3, xp=xp),
                         xp.asarray([0.6065306597126334, 0.8007374029168081,
                                     0.9459594689067654, 1.0, 0.9459594689067654,
-                                    0.8007374029168081, 0.6065306597126334]))
+                                    0.8007374029168081, 0.6065306597126334],
+                                    dtype=xp.float64))
         xp_assert_close(windows.gaussian(6, 3, False, xp=xp),
                         xp.asarray([0.6065306597126334, 0.8007374029168081,
                                     0.9459594689067654, 1.0, 0.9459594689067654,
-                                    0.8007374029168081]))
+                                    0.8007374029168081], dtype=xp.float64))
 
 
 class TestGeneralCosine:
@@ -388,59 +406,66 @@ class TestGeneralCosine:
     def test_basic(self, xp):
         a = xp.asarray([0.5, 0.3, 0.2])
         xp_assert_close(windows.general_cosine(5, a),
-                        xp.asarray([0.4, 0.3, 1, 0.3, 0.4]))
+                        xp.asarray([0.4, 0.3, 1, 0.3, 0.4], dtype=xp.float64))
 
         a = xp.asarray([0.5, 0.3, 0.2])
         xp_assert_close(windows.general_cosine(4, a, sym=False),
-                        xp.asarray([0.4, 0.3, 1, 0.3]))
+                        xp.asarray([0.4, 0.3, 1, 0.3], dtype=xp.float64))
 
 
 class TestGeneralHamming:
 
     def test_basic(self, xp):
         xp_assert_close(windows.general_hamming(5, 0.7, xp=xp),
-                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4]))
+                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4], dtype=xp.float64))
         xp_assert_close(windows.general_hamming(5, 0.75, sym=False, xp=xp),
                         xp.asarray([0.5, 0.6727457514, 0.9522542486,
-                                    0.9522542486, 0.6727457514]))
+                                    0.9522542486, 0.6727457514], dtype=xp.float64))
         xp_assert_close(windows.general_hamming(6, 0.75, sym=True, xp=xp),
                         xp.asarray([0.5, 0.6727457514, 0.9522542486,
-                                    0.9522542486, 0.6727457514, 0.5]))
+                                    0.9522542486, 0.6727457514, 0.5], dtype=xp.float64))
 
 
 class TestHamming:
 
     def test_basic(self, xp):
         xp_assert_close(windows.hamming(6, False, xp=xp),
-                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31]))
+                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31],
+                                   dtype=xp.float64))
         xp_assert_close(windows.hamming(7, sym=False, xp=xp),
                         xp.asarray([0.08, 0.2531946911449826, 0.6423596296199047,
                                     0.9544456792351128, 0.9544456792351128,
-                                    0.6423596296199047, 0.2531946911449826]))
+                                    0.6423596296199047, 0.2531946911449826],
+                                    dtype=xp.float64))
         xp_assert_close(windows.hamming(6, xp=xp),
                         xp.asarray([0.08, 0.3978521825875242, 0.9121478174124757,
-                                    0.9121478174124757, 0.3978521825875242, 0.08]))
+                                    0.9121478174124757, 0.3978521825875242, 0.08],
+                                    dtype=xp.float64))
         xp_assert_close(windows.hamming(7, sym=True, xp=xp),
-                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08]))
+                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08],
+                                   dtype=xp.float64))
 
 
 class TestHann:
 
     def test_basic(self, xp):
         xp_assert_close(windows.hann(6, sym=False, xp=xp),
-                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25]),
+                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25], dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(7, sym=False, xp=xp),
                         xp.asarray([0, 0.1882550990706332, 0.6112604669781572,
                                     0.9504844339512095, 0.9504844339512095,
-                                    0.6112604669781572, 0.1882550990706332]),
+                                    0.6112604669781572, 0.1882550990706332],
+                                    dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(6, True, xp=xp),
                         xp.asarray([0, 0.3454915028125263, 0.9045084971874737,
-                                    0.9045084971874737, 0.3454915028125263, 0]),
+                                    0.9045084971874737, 0.3454915028125263, 0],
+                                    dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(7, xp=xp),
-                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25, 0]),
+                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25, 0],
+                        dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
 
 
@@ -450,23 +475,27 @@ class TestKaiser:
         xp_assert_close(windows.kaiser(6, 0.5, xp=xp),
                         xp.asarray([0.9403061933191572, 0.9782962393705389,
                                     0.9975765035372042, 0.9975765035372042,
-                                    0.9782962393705389, 0.9403061933191572]))
+                                    0.9782962393705389, 0.9403061933191572],
+                                    dtype=xp.float64))
         xp_assert_close(windows.kaiser(7, 0.5, xp=xp),
                         xp.asarray([0.9403061933191572, 0.9732402256999829,
                                     0.9932754654413773, 1.0, 0.9932754654413773,
-                                    0.9732402256999829, 0.9403061933191572]))
+                                    0.9732402256999829, 0.9403061933191572],
+                                    dtype=xp.float64))
         xp_assert_close(windows.kaiser(6, 2.7, xp=xp),
                         xp.asarray([0.2603047507678832, 0.6648106293528054,
                                     0.9582099802511439, 0.9582099802511439,
-                                    0.6648106293528054, 0.2603047507678832]))
+                                    0.6648106293528054, 0.2603047507678832],
+                                    dtype=xp.float64))
         xp_assert_close(windows.kaiser(7, 2.7, xp=xp),
                         xp.asarray([0.2603047507678832, 0.5985765418119844,
                                     0.8868495172060835, 1.0, 0.8868495172060835,
-                                    0.5985765418119844, 0.2603047507678832]))
+                                    0.5985765418119844, 0.2603047507678832],
+                                    dtype=xp.float64))
         xp_assert_close(windows.kaiser(6, 2.7, False, xp=xp),
                         xp.asarray([0.2603047507678832, 0.5985765418119844,
                                     0.8868495172060835, 1.0, 0.8868495172060835,
-                                    0.5985765418119844]))
+                                    0.5985765418119844], dtype=xp.float64))
 
 
 @skip_xp_backends("torch", reason="implementation needs 2023.12 standard")
@@ -493,10 +522,11 @@ class TestKaiserBesselDerived:
         xp_assert_close(actual, desired)
 
         xp_assert_close(windows.kaiser_bessel_derived(4, beta=np.pi / 2, xp=xp)[:2],
-                        xp.asarray([0.518562710536, 0.855039598640]))
+                        xp.asarray([0.518562710536, 0.855039598640], dtype=xp.float64))
 
         xp_assert_close(windows.kaiser_bessel_derived(6, beta=np.pi / 2, xp=xp)[:3],
-                        xp.asarray([0.436168993154, 0.707106781187, 0.899864772847]))
+                        xp.asarray([0.436168993154, 0.707106781187, 0.899864772847],
+                                   dtype=xp.float64))
 
     def test_exceptions(self, xp):
         M = 100
@@ -518,19 +548,20 @@ class TestNuttall:
     def test_basic(self, xp):
         xp_assert_close(windows.nuttall(6, sym=False, xp=xp),
                         xp.asarray([0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
-                                    0.0613345]))
+                                    0.0613345], dtype=xp.float64))
         xp_assert_close(windows.nuttall(7, sym=False, xp=xp),
                         xp.asarray([0.0003628, 0.03777576895352025,
                                     0.3427276199688195,
                                     0.8918518610776603, 0.8918518610776603,
-                                    0.3427276199688196, 0.0377757689535203]))
+                                    0.3427276199688196, 0.0377757689535203],
+                                    dtype=xp.float64))
         xp_assert_close(windows.nuttall(6, xp=xp),
                         xp.asarray([0.0003628, 0.1105152530498718,
                                     0.7982580969501282, 0.7982580969501283,
-                                    0.1105152530498719, 0.0003628]))
+                                    0.1105152530498719, 0.0003628], dtype=xp.float64))
         xp_assert_close(windows.nuttall(7, True, xp=xp),
                         xp.asarray([0.0003628, 0.0613345, 0.5292298, 1.0,
-                                    0.5292298, 0.0613345, 0.0003628]))
+                                    0.5292298, 0.0613345, 0.0003628], dtype=xp.float64))
 
 
 class TestParzen:
@@ -538,15 +569,17 @@ class TestParzen:
     def test_basic(self, xp):
         xp_assert_close(windows.parzen(6, xp=xp),
                         xp.asarray([0.009259259259259254, 0.25, 0.8611111111111112,
-                                    0.8611111111111112, 0.25, 0.009259259259259254]))
+                                    0.8611111111111112, 0.25, 0.009259259259259254],
+                                    dtype=xp.float64))
         xp_assert_close(windows.parzen(7, sym=True, xp=xp),
                         xp.asarray([0.00583090379008747, 0.1574344023323616,
                                     0.6501457725947521, 1.0, 0.6501457725947521,
-                                    0.1574344023323616, 0.00583090379008747]))
+                                    0.1574344023323616, 0.00583090379008747],
+                                    dtype=xp.float64))
         xp_assert_close(windows.parzen(6, False, xp=xp),
                         xp.asarray([0.00583090379008747, 0.1574344023323616,
                                     0.6501457725947521, 1.0, 0.6501457725947521,
-                                    0.1574344023323616]))
+                                    0.1574344023323616], dtype=xp.float64))
 
 
 class TestTriang:
@@ -554,11 +587,11 @@ class TestTriang:
     def test_basic(self, xp):
 
         xp_assert_close(windows.triang(6, True, xp=xp),
-                        xp.asarray([1/6, 1/2, 5/6, 5/6, 1/2, 1/6]))
+                        xp.asarray([1/6, 1/2, 5/6, 5/6, 1/2, 1/6], dtype=xp.float64))
         xp_assert_close(windows.triang(7, xp=xp),
-                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4]))
+                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4], dtype=xp.float64))
         xp_assert_close(windows.triang(6, sym=False, xp=xp),
-                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2]))
+                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2], dtype=xp.float64))
 
 
 tukey_data = {
@@ -715,17 +748,17 @@ class TestLanczos:
         xp_assert_close(windows.lanczos(6, sym=False, xp=xp),
                         xp.asarray([0., 0.413496672,
                                     0.826993343, 1., 0.826993343,
-                                    0.413496672]),
+                                    0.413496672], dtype=xp.float64),
                         atol=1e-9)
         xp_assert_close(windows.lanczos(6, xp=xp),
                         xp.asarray([0., 0.504551152,
                                     0.935489284, 0.935489284,
-                                    0.504551152, 0.]),
+                                    0.504551152, 0.], dtype=xp.float64),
                         atol=1e-9)
         xp_assert_close(windows.lanczos(7, sym=True, xp=xp),
                         xp.asarray([0., 0.413496672,
                                     0.826993343, 1., 0.826993343,
-                                    0.413496672, 0.]),
+                                    0.413496672, 0.], dtype=xp.float64),
                         atol=1e-9)
 
     def test_array_size(self, xp):
@@ -749,7 +782,9 @@ class TestGetWindow:
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             w = windows.get_window(('chebwin', -40), 53, fftbins=False, xp=xp)
-        assert_array_almost_equal(w, xp.asarray(cheb_odd_true), decimal=4)
+        assert_array_almost_equal(
+            w, xp.asarray(cheb_odd_true, dtype=xp.float64), decimal=4
+        )
 
     @skip_xp_backends('jax.numpy', reason='item assignment')
     def test_cheb_even(self, xp):
@@ -798,17 +833,18 @@ class TestGetWindow:
 
     def test_general_hamming(self, xp):
         xp_assert_close(get_window(('general_hamming', 0.7), 5, xp=xp),
-                        xp.asarray([0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949]))
+                        xp.asarray([0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949],
+                                   dtype=xp.float64))
         xp_assert_close(get_window(('general_hamming', 0.7), 5, fftbins=False, xp=xp),
-                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4]))
+                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4], dtype=xp.float64))
 
     def test_lanczos(self, xp):
         xp_assert_close(get_window('lanczos', 6, xp=xp),
                         xp.asarray([0., 0.413496672, 0.826993343, 1., 0.826993343,
-                                    0.413496672]), atol=1e-9)
+                                    0.413496672], dtype=xp.float64), atol=1e-9)
         xp_assert_close(get_window('lanczos', 6, fftbins=False, xp=xp),
                         xp.asarray([0., 0.504551152, 0.935489284, 0.935489284,
-                                    0.504551152, 0.]), atol=1e-9)
+                                    0.504551152, 0.], dtype=xp.float64), atol=1e-9)
         xp_assert_close(get_window('lanczos', 6, xp=xp),
                         get_window('sinc', 6, xp=xp))
 
@@ -846,10 +882,14 @@ def test_windowfunc_basics(xp):
             assert_raises(ValueError, window, -7, *params, xp=xp)
 
             # Check degenerate cases
-            xp_assert_equal(window(0, *params, sym=True, xp=xp), xp.asarray([]))
-            xp_assert_equal(window(0, *params, sym=False, xp=xp), xp.asarray([]))
-            xp_assert_equal(window(1, *params, sym=True, xp=xp), xp.asarray([1.]))
-            xp_assert_equal(window(1, *params, sym=False, xp=xp), xp.asarray([1.]))
+            xp_assert_equal(window(0, *params, sym=True, xp=xp),
+                            xp.asarray([], dtype=xp.float64))
+            xp_assert_equal(window(0, *params, sym=False, xp=xp),
+                            xp.asarray([], dtype=xp.float64))
+            xp_assert_equal(window(1, *params, sym=True, xp=xp),
+                            xp.asarray([1.], dtype=xp.float64))
+            xp_assert_equal(window(1, *params, sym=False, xp=xp),
+                            xp.asarray([1.], dtype=xp.float64))
 
             # Check dtype
             assert window(0, *params, sym=True, xp=xp).dtype == xp.float64

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -47,58 +47,62 @@ class TestBartHann:
 
     def test_basic(self, xp):
         xp_assert_close(windows.barthann(6, sym=True, xp=xp),
-                        [0, 0.35857354213752, 0.8794264578624801,
-                         0.8794264578624801, 0.3585735421375199, 0],
+                        xp.asarray([0, 0.35857354213752, 0.8794264578624801,
+                         0.8794264578624801, 0.3585735421375199, 0]),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.barthann(7, xp=xp),
-                        [0, 0.27, 0.73, 1.0, 0.73, 0.27, 0],
+                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27, 0]),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.barthann(6, False, xp=xp),
-                        [0, 0.27, 0.73, 1.0, 0.73, 0.27],
+                        xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27]),
                         rtol=1e-15, atol=1e-15)
 
 
 class TestBartlett:
 
     def test_basic(self, xp):
-        xp_assert_close(windows.bartlett(6, xp=xp), [0, 0.4, 0.8, 0.8, 0.4, 0])
-        xp_assert_close(windows.bartlett(7, xp=xp), [0, 1/3, 2/3, 1.0, 2/3, 1/3, 0])
+        xp_assert_close(windows.bartlett(6, xp=xp),
+                        xp.asarray([0, 0.4, 0.8, 0.8, 0.4, 0]))
+        xp_assert_close(windows.bartlett(7, xp=xp),
+                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3, 0]))
         xp_assert_close(windows.bartlett(6, False, xp=xp),
-                        [0, 1/3, 2/3, 1.0, 2/3, 1/3])
+                        xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3]))
 
 
 class TestBlackman:
 
     def test_basic(self, xp):
         xp_assert_close(windows.blackman(6, sym=False, xp=xp),
-                        [0, 0.13, 0.63, 1.0, 0.63, 0.13], atol=1e-14)
+                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13]), atol=1e-14)
         xp_assert_close(windows.blackman(7, sym=False, xp=xp),
-                        [0, 0.09045342435412804, 0.4591829575459636,
-                         0.9203636180999081, 0.9203636180999081,
-                         0.4591829575459636, 0.09045342435412804], atol=1e-8)
+                        xp.asarray([0, 0.09045342435412804, 0.4591829575459636,
+                                    0.9203636180999081, 0.9203636180999081,
+                                    0.4591829575459636, 0.09045342435412804]),
+                        atol=1e-8)
         xp_assert_close(windows.blackman(6, xp=xp),
-                        [0, 0.2007701432625305, 0.8492298567374694,
-                         0.8492298567374694, 0.2007701432625305, 0],
+                        xp.asarray([0, 0.2007701432625305, 0.8492298567374694,
+                                    0.8492298567374694, 0.2007701432625305, 0]),
                         atol=1e-14)
         xp_assert_close(windows.blackman(7, True, xp=xp),
-                        [0, 0.13, 0.63, 1.0, 0.63, 0.13, 0], atol=1e-14)
+                        xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13, 0]), atol=1e-14)
 
 
 class TestBlackmanHarris:
 
     def test_basic(self, xp):
         xp_assert_close(windows.blackmanharris(6, False, xp=xp),
-                        [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645])
+                        xp.asarray([6.0e-05, 0.055645, 0.520575,
+                                    1.0, 0.520575, 0.055645]))
         xp_assert_close(windows.blackmanharris(7, sym=False, xp=xp),
-                        [6.0e-05, 0.03339172347815117, 0.332833504298565,
-                         0.8893697722232837, 0.8893697722232838,
-                         0.3328335042985652, 0.03339172347815122])
+                        xp.asarray([6.0e-05, 0.03339172347815117, 0.332833504298565,
+                                    0.8893697722232837, 0.8893697722232838,
+                                    0.3328335042985652, 0.03339172347815122]))
         xp_assert_close(windows.blackmanharris(6, xp=xp),
-                        [6.0e-05, 0.1030114893456638, 0.7938335106543362,
-                         0.7938335106543364, 0.1030114893456638, 6.0e-05])
+                        xp.asarray([6.0e-05, 0.1030114893456638, 0.7938335106543362,
+                                    0.7938335106543364, 0.1030114893456638, 6.0e-05]))
         xp_assert_close(windows.blackmanharris(7, sym=True, xp=xp),
-                        [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645,
-                         6.0e-05])
+                        xp.asarray([6.0e-05, 0.055645, 0.520575, 1.0, 0.520575,
+                                    0.055645, 6.0e-05]))
 
 
 @skip_xp_backends('jax.numpy', reason='item assignment')
@@ -185,14 +189,14 @@ class TestBohman:
 
     def test_basic(self, xp):
         xp_assert_close(windows.bohman(6, xp=xp),
-                        [0, 0.1791238937062839, 0.8343114522576858,
-                         0.8343114522576858, 0.1791238937062838, 0])
+                        xp.asarray([0, 0.1791238937062839, 0.8343114522576858,
+                                    0.8343114522576858, 0.1791238937062838, 0]))
         xp_assert_close(windows.bohman(7, sym=True, xp=xp),
-                        [0, 0.1089977810442293, 0.6089977810442293, 1.0,
-                         0.6089977810442295, 0.1089977810442293, 0])
+                        xp.asarray([0, 0.1089977810442293, 0.6089977810442293, 1.0,
+                                    0.6089977810442295, 0.1089977810442293, 0]))
         xp_assert_close(windows.bohman(6, False, xp=xp),
-                        [0, 0.1089977810442293, 0.6089977810442293, 1.0,
-                         0.6089977810442295, 0.1089977810442293])
+                        xp.asarray([0, 0.1089977810442293, 0.6089977810442293, 1.0,
+                                    0.6089977810442295, 0.1089977810442293]))
 
 
 class TestBoxcar:
@@ -248,37 +252,38 @@ class TestChebWin:
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             xp_assert_close(windows.chebwin(6, 100, xp=xp),
-                            [0.1046401879356917, 0.5075781475823447, 1.0, 1.0,
-                             0.5075781475823447, 0.1046401879356917],
+                            xp.asarray([0.1046401879356917, 0.5075781475823447,
+                                        1.0, 1.0,
+                                        0.5075781475823447, 0.1046401879356917]),
                             atol=1e-8
             )
             xp_assert_close(windows.chebwin(7, 100, xp=xp),
-                            [0.05650405062850233, 0.316608530648474,
-                             0.7601208123539079, 1.0, 0.7601208123539079,
-                             0.316608530648474, 0.05650405062850233])
+                            xp.asarray([0.05650405062850233, 0.316608530648474,
+                                        0.7601208123539079, 1.0, 0.7601208123539079,
+                                        0.316608530648474, 0.05650405062850233]))
             xp_assert_close(windows.chebwin(6, 10, xp=xp),
-                            [1.0, 0.6071201674458373, 0.6808391469897297,
-                             0.6808391469897297, 0.6071201674458373, 1.0])
+                            xp.asarray([1.0, 0.6071201674458373, 0.6808391469897297,
+                                        0.6808391469897297, 0.6071201674458373, 1.0]))
             xp_assert_close(windows.chebwin(7, 10, xp=xp),
-                            [1.0, 0.5190521247588651, 0.5864059018130382,
-                             0.6101519801307441, 0.5864059018130382,
-                             0.5190521247588651, 1.0])
+                            xp.asarray([1.0, 0.5190521247588651, 0.5864059018130382,
+                                        0.6101519801307441, 0.5864059018130382,
+                                        0.5190521247588651, 1.0]))
             xp_assert_close(windows.chebwin(6, 10, False, xp=xp),
-                            [1.0, 0.5190521247588651, 0.5864059018130382,
-                             0.6101519801307441, 0.5864059018130382,
-                             0.5190521247588651])
+                            xp.asarray([1.0, 0.5190521247588651, 0.5864059018130382,
+                                        0.6101519801307441, 0.5864059018130382,
+                                        0.5190521247588651]))
 
     def test_cheb_odd_high_attenuation(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             cheb_odd = windows.chebwin(53, at=-40, xp=xp)
-        assert_array_almost_equal(cheb_odd, cheb_odd_true, decimal=4)
+        assert_array_almost_equal(cheb_odd, xp.asarray(cheb_odd_true), decimal=4)
 
     def test_cheb_even_high_attenuation(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             cheb_even = windows.chebwin(54, at=40, xp=xp)
-        assert_array_almost_equal(cheb_even, cheb_even_true, decimal=4)
+        assert_array_almost_equal(cheb_even, xp.asarray(cheb_even_true), decimal=4)
 
     def test_cheb_odd_low_attenuation(self, xp):
         cheb_odd_low_at_true = xp.asarray([1.000000, 0.519052, 0.586405,
@@ -341,41 +346,41 @@ class TestFlatTop:
 
     def test_basic(self, xp):
         xp_assert_close(windows.flattop(6, sym=False, xp=xp),
-                        [-0.000421051, -0.051263156, 0.19821053, 1.0,
-                         0.19821053, -0.051263156])
+                        xp.asarray([-0.000421051, -0.051263156, 0.19821053, 1.0,
+                                     0.19821053, -0.051263156]))
         xp_assert_close(windows.flattop(7, sym=False, xp=xp),
-                        [-0.000421051, -0.03684078115492348,
-                         0.01070371671615342, 0.7808739149387698,
-                         0.7808739149387698, 0.01070371671615342,
-                         -0.03684078115492348])
+                        xp.asarray([-0.000421051, -0.03684078115492348,
+                                     0.01070371671615342, 0.7808739149387698,
+                                     0.7808739149387698, 0.01070371671615342,
+                                    -0.03684078115492348]))
         xp_assert_close(windows.flattop(6, xp=xp),
-                        [-0.000421051, -0.0677142520762119, 0.6068721525762117,
-                         0.6068721525762117, -0.0677142520762119,
-                         -0.000421051])
+                        xp.asarray([-0.000421051, -0.0677142520762119,
+                                     0.6068721525762117, 0.6068721525762117,
+                                    -0.0677142520762119, -0.000421051]))
         xp_assert_close(windows.flattop(7, True, xp=xp),
-                        [-0.000421051, -0.051263156, 0.19821053, 1.0,
-                         0.19821053, -0.051263156, -0.000421051])
+                        xp.asarray([-0.000421051, -0.051263156, 0.19821053, 1.0,
+                                     0.19821053, -0.051263156, -0.000421051]))
 
 
 class TestGaussian:
 
     def test_basic(self, xp):
         xp_assert_close(windows.gaussian(6, 1.0, xp=xp),
-                        [0.04393693362340742, 0.3246524673583497,
-                         0.8824969025845955, 0.8824969025845955,
-                         0.3246524673583497, 0.04393693362340742])
+                        xp.asarray([0.04393693362340742, 0.3246524673583497,
+                                    0.8824969025845955, 0.8824969025845955,
+                                    0.3246524673583497, 0.04393693362340742]))
         xp_assert_close(windows.gaussian(7, 1.2, xp=xp),
-                        [0.04393693362340742, 0.2493522087772962,
-                         0.7066482778577162, 1.0, 0.7066482778577162,
-                         0.2493522087772962, 0.04393693362340742])
+                        xp.asarray([0.04393693362340742, 0.2493522087772962,
+                                    0.7066482778577162, 1.0, 0.7066482778577162,
+                                    0.2493522087772962, 0.04393693362340742]))
         xp_assert_close(windows.gaussian(7, 3, xp=xp),
-                        [0.6065306597126334, 0.8007374029168081,
-                         0.9459594689067654, 1.0, 0.9459594689067654,
-                         0.8007374029168081, 0.6065306597126334])
+                        xp.asarray([0.6065306597126334, 0.8007374029168081,
+                                    0.9459594689067654, 1.0, 0.9459594689067654,
+                                    0.8007374029168081, 0.6065306597126334]))
         xp_assert_close(windows.gaussian(6, 3, False, xp=xp),
-                        [0.6065306597126334, 0.8007374029168081,
-                         0.9459594689067654, 1.0, 0.9459594689067654,
-                         0.8007374029168081])
+                        xp.asarray([0.6065306597126334, 0.8007374029168081,
+                                    0.9459594689067654, 1.0, 0.9459594689067654,
+                                    0.8007374029168081]))
 
 
 class TestGeneralCosine:
@@ -383,59 +388,59 @@ class TestGeneralCosine:
     def test_basic(self, xp):
         a = xp.asarray([0.5, 0.3, 0.2])
         xp_assert_close(windows.general_cosine(5, a),
-                        [0.4, 0.3, 1, 0.3, 0.4])
+                        xp.asarray([0.4, 0.3, 1, 0.3, 0.4]))
 
         a = xp.asarray([0.5, 0.3, 0.2])
         xp_assert_close(windows.general_cosine(4, a, sym=False),
-                        [0.4, 0.3, 1, 0.3])
+                        xp.asarray([0.4, 0.3, 1, 0.3]))
 
 
 class TestGeneralHamming:
 
     def test_basic(self, xp):
         xp_assert_close(windows.general_hamming(5, 0.7, xp=xp),
-                        [0.4, 0.7, 1.0, 0.7, 0.4])
+                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4]))
         xp_assert_close(windows.general_hamming(5, 0.75, sym=False, xp=xp),
-                        [0.5, 0.6727457514, 0.9522542486,
-                         0.9522542486, 0.6727457514])
+                        xp.asarray([0.5, 0.6727457514, 0.9522542486,
+                                    0.9522542486, 0.6727457514]))
         xp_assert_close(windows.general_hamming(6, 0.75, sym=True, xp=xp),
-                        [0.5, 0.6727457514, 0.9522542486,
-                        0.9522542486, 0.6727457514, 0.5])
+                        xp.asarray([0.5, 0.6727457514, 0.9522542486,
+                                    0.9522542486, 0.6727457514, 0.5]))
 
 
 class TestHamming:
 
     def test_basic(self, xp):
         xp_assert_close(windows.hamming(6, False, xp=xp),
-                        [0.08, 0.31, 0.77, 1.0, 0.77, 0.31])
+                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31]))
         xp_assert_close(windows.hamming(7, sym=False, xp=xp),
-                        [0.08, 0.2531946911449826, 0.6423596296199047,
-                         0.9544456792351128, 0.9544456792351128,
-                         0.6423596296199047, 0.2531946911449826])
+                        xp.asarray([0.08, 0.2531946911449826, 0.6423596296199047,
+                                    0.9544456792351128, 0.9544456792351128,
+                                    0.6423596296199047, 0.2531946911449826]))
         xp_assert_close(windows.hamming(6, xp=xp),
-                        [0.08, 0.3978521825875242, 0.9121478174124757,
-                         0.9121478174124757, 0.3978521825875242, 0.08])
+                        xp.asarray([0.08, 0.3978521825875242, 0.9121478174124757,
+                                    0.9121478174124757, 0.3978521825875242, 0.08]))
         xp_assert_close(windows.hamming(7, sym=True, xp=xp),
-                        [0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08])
+                        xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08]))
 
 
 class TestHann:
 
     def test_basic(self, xp):
         xp_assert_close(windows.hann(6, sym=False, xp=xp),
-                        [0, 0.25, 0.75, 1.0, 0.75, 0.25],
+                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25]),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(7, sym=False, xp=xp),
-                        [0, 0.1882550990706332, 0.6112604669781572,
-                         0.9504844339512095, 0.9504844339512095,
-                         0.6112604669781572, 0.1882550990706332],
+                        xp.asarray([0, 0.1882550990706332, 0.6112604669781572,
+                                    0.9504844339512095, 0.9504844339512095,
+                                    0.6112604669781572, 0.1882550990706332]),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(6, True, xp=xp),
-                        [0, 0.3454915028125263, 0.9045084971874737,
-                         0.9045084971874737, 0.3454915028125263, 0],
+                        xp.asarray([0, 0.3454915028125263, 0.9045084971874737,
+                                    0.9045084971874737, 0.3454915028125263, 0]),
                         rtol=1e-15, atol=1e-15)
         xp_assert_close(windows.hann(7, xp=xp),
-                        [0, 0.25, 0.75, 1.0, 0.75, 0.25, 0],
+                        xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25, 0]),
                         rtol=1e-15, atol=1e-15)
 
 
@@ -443,25 +448,25 @@ class TestKaiser:
 
     def test_basic(self, xp):
         xp_assert_close(windows.kaiser(6, 0.5, xp=xp),
-                        [0.9403061933191572, 0.9782962393705389,
-                         0.9975765035372042, 0.9975765035372042,
-                         0.9782962393705389, 0.9403061933191572])
+                        xp.asarray([0.9403061933191572, 0.9782962393705389,
+                                    0.9975765035372042, 0.9975765035372042,
+                                    0.9782962393705389, 0.9403061933191572]))
         xp_assert_close(windows.kaiser(7, 0.5, xp=xp),
-                        [0.9403061933191572, 0.9732402256999829,
-                         0.9932754654413773, 1.0, 0.9932754654413773,
-                         0.9732402256999829, 0.9403061933191572])
+                        xp.asarray([0.9403061933191572, 0.9732402256999829,
+                                    0.9932754654413773, 1.0, 0.9932754654413773,
+                                    0.9732402256999829, 0.9403061933191572]))
         xp_assert_close(windows.kaiser(6, 2.7, xp=xp),
-                        [0.2603047507678832, 0.6648106293528054,
-                         0.9582099802511439, 0.9582099802511439,
-                         0.6648106293528054, 0.2603047507678832])
+                        xp.asarray([0.2603047507678832, 0.6648106293528054,
+                                    0.9582099802511439, 0.9582099802511439,
+                                    0.6648106293528054, 0.2603047507678832]))
         xp_assert_close(windows.kaiser(7, 2.7, xp=xp),
-                        [0.2603047507678832, 0.5985765418119844,
-                         0.8868495172060835, 1.0, 0.8868495172060835,
-                         0.5985765418119844, 0.2603047507678832])
+                        xp.asarray([0.2603047507678832, 0.5985765418119844,
+                                    0.8868495172060835, 1.0, 0.8868495172060835,
+                                    0.5985765418119844, 0.2603047507678832]))
         xp_assert_close(windows.kaiser(6, 2.7, False, xp=xp),
-                        [0.2603047507678832, 0.5985765418119844,
-                         0.8868495172060835, 1.0, 0.8868495172060835,
-                         0.5985765418119844])
+                        xp.asarray([0.2603047507678832, 0.5985765418119844,
+                                    0.8868495172060835, 1.0, 0.8868495172060835,
+                                    0.5985765418119844]))
 
 
 @skip_xp_backends("torch", reason="implementation needs 2023.12 standard")
@@ -488,10 +493,10 @@ class TestKaiserBesselDerived:
         xp_assert_close(actual, desired)
 
         xp_assert_close(windows.kaiser_bessel_derived(4, beta=np.pi / 2, xp=xp)[:2],
-                        [0.518562710536, 0.855039598640])
+                        xp.asarray([0.518562710536, 0.855039598640]))
 
         xp_assert_close(windows.kaiser_bessel_derived(6, beta=np.pi / 2, xp=xp)[:3],
-                        [0.436168993154, 0.707106781187, 0.899864772847])
+                        xp.asarray([0.436168993154, 0.707106781187, 0.899864772847]))
 
     def test_exceptions(self, xp):
         M = 100
@@ -512,34 +517,36 @@ class TestNuttall:
 
     def test_basic(self, xp):
         xp_assert_close(windows.nuttall(6, sym=False, xp=xp),
-                        [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
-                         0.0613345])
+                        xp.asarray([0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
+                                    0.0613345]))
         xp_assert_close(windows.nuttall(7, sym=False, xp=xp),
-                        [0.0003628, 0.03777576895352025, 0.3427276199688195,
-                         0.8918518610776603, 0.8918518610776603,
-                         0.3427276199688196, 0.0377757689535203])
+                        xp.asarray([0.0003628, 0.03777576895352025,
+                                    0.3427276199688195,
+                                    0.8918518610776603, 0.8918518610776603,
+                                    0.3427276199688196, 0.0377757689535203]))
         xp_assert_close(windows.nuttall(6, xp=xp),
-                        [0.0003628, 0.1105152530498718, 0.7982580969501282,
-                         0.7982580969501283, 0.1105152530498719, 0.0003628])
+                        xp.asarray([0.0003628, 0.1105152530498718,
+                                    0.7982580969501282, 0.7982580969501283,
+                                    0.1105152530498719, 0.0003628]))
         xp_assert_close(windows.nuttall(7, True, xp=xp),
-                        [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
-                         0.0613345, 0.0003628])
+                        xp.asarray([0.0003628, 0.0613345, 0.5292298, 1.0,
+                                    0.5292298, 0.0613345, 0.0003628]))
 
 
 class TestParzen:
 
     def test_basic(self, xp):
         xp_assert_close(windows.parzen(6, xp=xp),
-                        [0.009259259259259254, 0.25, 0.8611111111111112,
-                         0.8611111111111112, 0.25, 0.009259259259259254])
+                        xp.asarray([0.009259259259259254, 0.25, 0.8611111111111112,
+                                    0.8611111111111112, 0.25, 0.009259259259259254]))
         xp_assert_close(windows.parzen(7, sym=True, xp=xp),
-                        [0.00583090379008747, 0.1574344023323616,
-                         0.6501457725947521, 1.0, 0.6501457725947521,
-                         0.1574344023323616, 0.00583090379008747])
+                        xp.asarray([0.00583090379008747, 0.1574344023323616,
+                                    0.6501457725947521, 1.0, 0.6501457725947521,
+                                    0.1574344023323616, 0.00583090379008747]))
         xp_assert_close(windows.parzen(6, False, xp=xp),
-                        [0.00583090379008747, 0.1574344023323616,
-                         0.6501457725947521, 1.0, 0.6501457725947521,
-                         0.1574344023323616])
+                        xp.asarray([0.00583090379008747, 0.1574344023323616,
+                                    0.6501457725947521, 1.0, 0.6501457725947521,
+                                    0.1574344023323616]))
 
 
 class TestTriang:
@@ -547,11 +554,11 @@ class TestTriang:
     def test_basic(self, xp):
 
         xp_assert_close(windows.triang(6, True, xp=xp),
-                        [1/6, 1/2, 5/6, 5/6, 1/2, 1/6])
+                        xp.asarray([1/6, 1/2, 5/6, 5/6, 1/2, 1/6]))
         xp_assert_close(windows.triang(7, xp=xp),
-                        [1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4])
+                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4]))
         xp_assert_close(windows.triang(6, sym=False, xp=xp),
-                        [1/4, 1/2, 3/4, 1, 3/4, 1/2])
+                        xp.asarray([1/4, 1/2, 3/4, 1, 3/4, 1/2]))
 
 
 tukey_data = {
@@ -706,19 +713,19 @@ class TestLanczos:
         # sinc(3 pi / 5) = 0.504551152
         # sinc(pi / 5) = 0.935489284
         xp_assert_close(windows.lanczos(6, sym=False, xp=xp),
-                        [0., 0.413496672,
-                         0.826993343, 1., 0.826993343,
-                         0.413496672],
+                        xp.asarray([0., 0.413496672,
+                                    0.826993343, 1., 0.826993343,
+                                    0.413496672]),
                         atol=1e-9)
         xp_assert_close(windows.lanczos(6, xp=xp),
-                        [0., 0.504551152,
-                         0.935489284, 0.935489284,
-                         0.504551152, 0.],
+                        xp.asarray([0., 0.504551152,
+                                    0.935489284, 0.935489284,
+                                    0.504551152, 0.]),
                         atol=1e-9)
         xp_assert_close(windows.lanczos(7, sym=True, xp=xp),
-                        [0., 0.413496672,
-                         0.826993343, 1., 0.826993343,
-                         0.413496672, 0.],
+                        xp.asarray([0., 0.413496672,
+                                    0.826993343, 1., 0.826993343,
+                                    0.413496672, 0.]),
                         atol=1e-9)
 
     def test_array_size(self, xp):
@@ -742,14 +749,14 @@ class TestGetWindow:
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             w = windows.get_window(('chebwin', -40), 53, fftbins=False, xp=xp)
-        assert_array_almost_equal(w, cheb_odd_true, decimal=4)
+        assert_array_almost_equal(w, xp.asarray(cheb_odd_true), decimal=4)
 
     @skip_xp_backends('jax.numpy', reason='item assignment')
     def test_cheb_even(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             w = windows.get_window(('chebwin', 40), 54, fftbins=False, xp=xp)
-        assert_array_almost_equal(w, cheb_even_true, decimal=4)
+        assert_array_almost_equal(w, xp.asarray(cheb_even_true), decimal=4)
 
     @skip_xp_backends(cpu_only=True, reason='eigh_tridiagonal is CPU-only')
     def test_dpss(self, xp):
@@ -791,17 +798,17 @@ class TestGetWindow:
 
     def test_general_hamming(self, xp):
         xp_assert_close(get_window(('general_hamming', 0.7), 5, xp=xp),
-                        [0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949])
+                        xp.asarray([0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949]))
         xp_assert_close(get_window(('general_hamming', 0.7), 5, fftbins=False, xp=xp),
-                        [0.4, 0.7, 1.0, 0.7, 0.4])
+                        xp.asarray([0.4, 0.7, 1.0, 0.7, 0.4]))
 
     def test_lanczos(self, xp):
         xp_assert_close(get_window('lanczos', 6, xp=xp),
-                        [0., 0.413496672, 0.826993343, 1., 0.826993343,
-                         0.413496672], atol=1e-9)
+                        xp.asarray([0., 0.413496672, 0.826993343, 1., 0.826993343,
+                                    0.413496672]), atol=1e-9)
         xp_assert_close(get_window('lanczos', 6, fftbins=False, xp=xp),
-                        [0., 0.504551152, 0.935489284, 0.935489284,
-                         0.504551152, 0.], atol=1e-9)
+                        xp.asarray([0., 0.504551152, 0.935489284, 0.935489284,
+                                    0.504551152, 0.]), atol=1e-9)
         xp_assert_close(get_window('lanczos', 6, xp=xp),
                         get_window('sinc', 6, xp=xp))
 
@@ -839,10 +846,10 @@ def test_windowfunc_basics(xp):
             assert_raises(ValueError, window, -7, *params, xp=xp)
 
             # Check degenerate cases
-            xp_assert_equal(window(0, *params, sym=True, xp=xp), [])
-            xp_assert_equal(window(0, *params, sym=False, xp=xp), [])
-            xp_assert_equal(window(1, *params, sym=True, xp=xp), [1])
-            xp_assert_equal(window(1, *params, sym=False, xp=xp), [1])
+            xp_assert_equal(window(0, *params, sym=True, xp=xp), xp.asarray([]))
+            xp_assert_equal(window(0, *params, sym=False, xp=xp), xp.asarray([]))
+            xp_assert_equal(window(1, *params, sym=True, xp=xp), xp.asarray([1.]))
+            xp_assert_equal(window(1, *params, sym=False, xp=xp), xp.asarray([1.]))
 
             # Check dtype
             assert window(0, *params, sym=True, xp=xp).dtype == xp.float64

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -1,13 +1,18 @@
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_allclose,
-                           assert_equal, assert_, assert_array_less,
-                           suppress_warnings)
+                           assert_, assert_array_less, suppress_warnings)
+import pytest
 from pytest import raises as assert_raises
 
 from scipy.fft import fft
 from scipy.signal import windows, get_window, resample
+from scipy._lib._array_api import (
+     xp_assert_close, xp_assert_equal, array_namespace, is_torch, is_jax, is_cupy,
+     assert_array_almost_equal, SCIPY_DEVICE,
+)
+
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 window_funcs = [
@@ -38,101 +43,101 @@ window_funcs = [
 
 class TestBartHann:
 
-    def test_basic(self):
-        assert_allclose(windows.barthann(6, sym=True),
+    def test_basic(self, xp):
+        xp_assert_close(windows.barthann(6, sym=True, xp=xp),
                         [0, 0.35857354213752, 0.8794264578624801,
                          0.8794264578624801, 0.3585735421375199, 0],
                         rtol=1e-15, atol=1e-15)
-        assert_allclose(windows.barthann(7),
+        xp_assert_close(windows.barthann(7, xp=xp),
                         [0, 0.27, 0.73, 1.0, 0.73, 0.27, 0],
                         rtol=1e-15, atol=1e-15)
-        assert_allclose(windows.barthann(6, False),
+        xp_assert_close(windows.barthann(6, False, xp=xp),
                         [0, 0.27, 0.73, 1.0, 0.73, 0.27],
                         rtol=1e-15, atol=1e-15)
 
 
 class TestBartlett:
 
-    def test_basic(self):
-        assert_allclose(windows.bartlett(6), [0, 0.4, 0.8, 0.8, 0.4, 0])
-        assert_allclose(windows.bartlett(7), [0, 1/3, 2/3, 1.0, 2/3, 1/3, 0])
-        assert_allclose(windows.bartlett(6, False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.bartlett(6, xp=xp), [0, 0.4, 0.8, 0.8, 0.4, 0])
+        xp_assert_close(windows.bartlett(7, xp=xp), [0, 1/3, 2/3, 1.0, 2/3, 1/3, 0])
+        xp_assert_close(windows.bartlett(6, False, xp=xp),
                         [0, 1/3, 2/3, 1.0, 2/3, 1/3])
 
 
 class TestBlackman:
 
-    def test_basic(self):
-        assert_allclose(windows.blackman(6, sym=False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.blackman(6, sym=False, xp=xp),
                         [0, 0.13, 0.63, 1.0, 0.63, 0.13], atol=1e-14)
-        assert_allclose(windows.blackman(7, sym=False),
+        xp_assert_close(windows.blackman(7, sym=False, xp=xp),
                         [0, 0.09045342435412804, 0.4591829575459636,
                          0.9203636180999081, 0.9203636180999081,
                          0.4591829575459636, 0.09045342435412804], atol=1e-8)
-        assert_allclose(windows.blackman(6),
+        xp_assert_close(windows.blackman(6, xp=xp),
                         [0, 0.2007701432625305, 0.8492298567374694,
                          0.8492298567374694, 0.2007701432625305, 0],
                         atol=1e-14)
-        assert_allclose(windows.blackman(7, True),
+        xp_assert_close(windows.blackman(7, True, xp=xp),
                         [0, 0.13, 0.63, 1.0, 0.63, 0.13, 0], atol=1e-14)
 
 
 class TestBlackmanHarris:
 
-    def test_basic(self):
-        assert_allclose(windows.blackmanharris(6, False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.blackmanharris(6, False, xp=xp),
                         [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645])
-        assert_allclose(windows.blackmanharris(7, sym=False),
+        xp_assert_close(windows.blackmanharris(7, sym=False, xp=xp),
                         [6.0e-05, 0.03339172347815117, 0.332833504298565,
                          0.8893697722232837, 0.8893697722232838,
                          0.3328335042985652, 0.03339172347815122])
-        assert_allclose(windows.blackmanharris(6),
+        xp_assert_close(windows.blackmanharris(6, xp=xp),
                         [6.0e-05, 0.1030114893456638, 0.7938335106543362,
                          0.7938335106543364, 0.1030114893456638, 6.0e-05])
-        assert_allclose(windows.blackmanharris(7, sym=True),
+        xp_assert_close(windows.blackmanharris(7, sym=True, xp=xp),
                         [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645,
                          6.0e-05])
 
 
 class TestTaylor:
 
-    def test_normalized(self):
+    def test_normalized(self, xp):
         """Tests windows of small length that are normalized to 1. See the
         documentation for the Taylor window for more information on
         normalization.
         """
-        assert_allclose(windows.taylor(1, 2, 15), 1.0)
-        assert_allclose(
-            windows.taylor(5, 2, 15),
+        xp_assert_close(windows.taylor(1, 2, 15, xp=xp), 1.0)
+        xp_assert_close(
+            windows.taylor(5, 2, 15, xp=xp),
             np.array([0.75803341, 0.90757699, 1.0, 0.90757699, 0.75803341])
         )
-        assert_allclose(
-            windows.taylor(6, 2, 15),
+        xp_assert_close(
+            windows.taylor(6, 2, 15, xp=xp),
             np.array([
                 0.7504082, 0.86624416, 0.98208011, 0.98208011, 0.86624416,
                 0.7504082
             ])
         )
 
-    def test_non_normalized(self):
+    def test_non_normalized(self, xp):
         """Test windows of small length that are not normalized to 1. See
         the documentation for the Taylor window for more information on
         normalization.
         """
-        assert_allclose(
-            windows.taylor(5, 2, 15, norm=False),
+        xp_assert_close(
+            windows.taylor(5, 2, 15, norm=False, xp=xp),
             np.array([
                 0.87508054, 1.04771499, 1.15440894, 1.04771499, 0.87508054
             ])
         )
-        assert_allclose(
-            windows.taylor(6, 2, 15, norm=False),
+        xp_assert_close(
+            windows.taylor(6, 2, 15, norm=False, xp=xp),
             np.array([
                 0.86627793, 1.0, 1.13372207, 1.13372207, 1.0, 0.86627793
             ])
         )
 
-    def test_correctness(self):
+    def test_correctness(self, xp):
         """This test ensures the correctness of the implemented Taylor
         Windowing function. A Taylor Window of 1024 points is created, its FFT
         is taken, and the Peak Sidelobe Level (PSLL) and 3dB and 18dB bandwidth
@@ -152,7 +157,7 @@ class TestTaylor:
         # Set norm=False for correctness as the values obtained from the
         # scientific publication do not normalize the values. Normalizing
         # changes the sidelobe level from the desired value.
-        w = windows.taylor(M_win, nbar=4, sll=35, norm=False, sym=False)
+        w = windows.taylor(M_win, nbar=4, sll=35, norm=False, sym=False, xp=xp)
         f = fft(w, N_fft)
         spec = 20 * np.log10(np.abs(f / np.amax(f)))
 
@@ -163,31 +168,31 @@ class TestTaylor:
         BW_3dB = 2*np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
         BW_18dB = 2*np.argmax(spec <= -18.061799739838872) / N_fft * M_win
 
-        assert_allclose(PSLL, -35.1672, atol=1)
-        assert_allclose(BW_3dB, 1.1822, atol=0.1)
-        assert_allclose(BW_18dB, 2.6112, atol=0.1)
+        xp_assert_close(PSLL, -35.1672, atol=1)
+        xp_assert_close(BW_3dB, 1.1822, atol=0.1)
+        xp_assert_close(BW_18dB, 2.6112, atol=0.1)
 
 
 class TestBohman:
 
-    def test_basic(self):
-        assert_allclose(windows.bohman(6),
+    def test_basic(self, xp):
+        xp_assert_close(windows.bohman(6, xp=xp),
                         [0, 0.1791238937062839, 0.8343114522576858,
                          0.8343114522576858, 0.1791238937062838, 0])
-        assert_allclose(windows.bohman(7, sym=True),
+        xp_assert_close(windows.bohman(7, sym=True, xp=xp),
                         [0, 0.1089977810442293, 0.6089977810442293, 1.0,
                          0.6089977810442295, 0.1089977810442293, 0])
-        assert_allclose(windows.bohman(6, False),
+        xp_assert_close(windows.bohman(6, False, xp=xp),
                         [0, 0.1089977810442293, 0.6089977810442293, 1.0,
                          0.6089977810442295, 0.1089977810442293])
 
 
 class TestBoxcar:
 
-    def test_basic(self):
-        assert_allclose(windows.boxcar(6), [1, 1, 1, 1, 1, 1])
-        assert_allclose(windows.boxcar(7), [1, 1, 1, 1, 1, 1, 1])
-        assert_allclose(windows.boxcar(6, False), [1, 1, 1, 1, 1, 1])
+    def test_basic(self, xp):
+        xp_assert_close(windows.boxcar(6, xp=xp), [1, 1, 1, 1, 1, 1])
+        xp_assert_close(windows.boxcar(7, xp=xp), [1, 1, 1, 1, 1, 1, 1])
+        xp_assert_close(windows.boxcar(6, False, xp=xp), [1, 1, 1, 1, 1, 1])
 
 
 cheb_odd_true = array([0.200938, 0.107729, 0.134941, 0.165348,
@@ -227,56 +232,56 @@ cheb_even_true = array([0.203894, 0.107279, 0.133904,
 
 class TestChebWin:
 
-    def test_basic(self):
+    def test_basic(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            assert_allclose(windows.chebwin(6, 100),
+            xp_assert_close(windows.chebwin(6, 100, xp=xp),
                             [0.1046401879356917, 0.5075781475823447, 1.0, 1.0,
                              0.5075781475823447, 0.1046401879356917])
-            assert_allclose(windows.chebwin(7, 100),
+            xp_assert_close(windows.chebwin(7, 100, xp=xp),
                             [0.05650405062850233, 0.316608530648474,
                              0.7601208123539079, 1.0, 0.7601208123539079,
                              0.316608530648474, 0.05650405062850233])
-            assert_allclose(windows.chebwin(6, 10),
+            xp_assert_close(windows.chebwin(6, 10, xp=xp),
                             [1.0, 0.6071201674458373, 0.6808391469897297,
                              0.6808391469897297, 0.6071201674458373, 1.0])
-            assert_allclose(windows.chebwin(7, 10),
+            xp_assert_close(windows.chebwin(7, 10, xp=xp),
                             [1.0, 0.5190521247588651, 0.5864059018130382,
                              0.6101519801307441, 0.5864059018130382,
                              0.5190521247588651, 1.0])
-            assert_allclose(windows.chebwin(6, 10, False),
+            xp_assert_close(windows.chebwin(6, 10, False, xp=xp),
                             [1.0, 0.5190521247588651, 0.5864059018130382,
                              0.6101519801307441, 0.5864059018130382,
                              0.5190521247588651])
 
-    def test_cheb_odd_high_attenuation(self):
+    def test_cheb_odd_high_attenuation(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            cheb_odd = windows.chebwin(53, at=-40)
+            cheb_odd = windows.chebwin(53, at=-40, xp=xp)
         assert_array_almost_equal(cheb_odd, cheb_odd_true, decimal=4)
 
-    def test_cheb_even_high_attenuation(self):
+    def test_cheb_even_high_attenuation(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            cheb_even = windows.chebwin(54, at=40)
+            cheb_even = windows.chebwin(54, at=40, xp=xp)
         assert_array_almost_equal(cheb_even, cheb_even_true, decimal=4)
 
-    def test_cheb_odd_low_attenuation(self):
+    def test_cheb_odd_low_attenuation(self, xp):
         cheb_odd_low_at_true = array([1.000000, 0.519052, 0.586405,
                                       0.610151, 0.586405, 0.519052,
                                       1.000000])
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            cheb_odd = windows.chebwin(7, at=10)
+            cheb_odd = windows.chebwin(7, at=10, xp=xp)
         assert_array_almost_equal(cheb_odd, cheb_odd_low_at_true, decimal=4)
 
-    def test_cheb_even_low_attenuation(self):
+    def test_cheb_even_low_attenuation(self, xp):
         cheb_even_low_at_true = array([1.000000, 0.451924, 0.51027,
                                        0.541338, 0.541338, 0.51027,
                                        0.451924, 1.000000])
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            cheb_even = windows.chebwin(8, at=-10)
+            cheb_even = windows.chebwin(8, at=-10, xp=xp)
         assert_array_almost_equal(cheb_even, cheb_even_low_at_true, decimal=4)
 
 
@@ -309,51 +314,51 @@ exponential_data = {
 }
 
 
-def test_exponential():
+def test_exponential(xp):
     for k, v in exponential_data.items():
         if v is None:
-            assert_raises(ValueError, windows.exponential, *k)
+            assert_raises(ValueError, windows.exponential, *k, xp=xp)
         else:
-            win = windows.exponential(*k)
-            assert_allclose(win, v, rtol=1e-14)
+            win = windows.exponential(*k, xp=xp)
+            xp_assert_close(win, v, rtol=1e-14)
 
 
 class TestFlatTop:
 
-    def test_basic(self):
-        assert_allclose(windows.flattop(6, sym=False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.flattop(6, sym=False, xp=xp),
                         [-0.000421051, -0.051263156, 0.19821053, 1.0,
                          0.19821053, -0.051263156])
-        assert_allclose(windows.flattop(7, sym=False),
+        xp_assert_close(windows.flattop(7, sym=False, xp=xp),
                         [-0.000421051, -0.03684078115492348,
                          0.01070371671615342, 0.7808739149387698,
                          0.7808739149387698, 0.01070371671615342,
                          -0.03684078115492348])
-        assert_allclose(windows.flattop(6),
+        xp_assert_close(windows.flattop(6, xp=xp),
                         [-0.000421051, -0.0677142520762119, 0.6068721525762117,
                          0.6068721525762117, -0.0677142520762119,
                          -0.000421051])
-        assert_allclose(windows.flattop(7, True),
+        xp_assert_close(windows.flattop(7, True, xp=xp),
                         [-0.000421051, -0.051263156, 0.19821053, 1.0,
                          0.19821053, -0.051263156, -0.000421051])
 
 
 class TestGaussian:
 
-    def test_basic(self):
-        assert_allclose(windows.gaussian(6, 1.0),
+    def test_basic(self, xp):
+        xp_assert_close(windows.gaussian(6, 1.0, xp=xp),
                         [0.04393693362340742, 0.3246524673583497,
                          0.8824969025845955, 0.8824969025845955,
                          0.3246524673583497, 0.04393693362340742])
-        assert_allclose(windows.gaussian(7, 1.2),
+        xp_assert_close(windows.gaussian(7, 1.2, xp=xp),
                         [0.04393693362340742, 0.2493522087772962,
                          0.7066482778577162, 1.0, 0.7066482778577162,
                          0.2493522087772962, 0.04393693362340742])
-        assert_allclose(windows.gaussian(7, 3),
+        xp_assert_close(windows.gaussian(7, 3, xp=xp),
                         [0.6065306597126334, 0.8007374029168081,
                          0.9459594689067654, 1.0, 0.9459594689067654,
                          0.8007374029168081, 0.6065306597126334])
-        assert_allclose(windows.gaussian(6, 3, False),
+        xp_assert_close(windows.gaussian(6, 3, False, xp=xp),
                         [0.6065306597126334, 0.8007374029168081,
                          0.9459594689067654, 1.0, 0.9459594689067654,
                          0.8007374029168081])
@@ -361,82 +366,82 @@ class TestGaussian:
 
 class TestGeneralCosine:
 
-    def test_basic(self):
-        assert_allclose(windows.general_cosine(5, [0.5, 0.3, 0.2]),
+    def test_basic(self, xp):
+        xp_assert_close(windows.general_cosine(5, [0.5, 0.3, 0.2], xp=xp),
                         [0.4, 0.3, 1, 0.3, 0.4])
-        assert_allclose(windows.general_cosine(4, [0.5, 0.3, 0.2], sym=False),
+        xp_assert_close(windows.general_cosine(4, [0.5, 0.3, 0.2], sym=False, xp=xp),
                         [0.4, 0.3, 1, 0.3])
 
 
 class TestGeneralHamming:
 
-    def test_basic(self):
-        assert_allclose(windows.general_hamming(5, 0.7),
+    def test_basic(self, xp):
+        xp_assert_close(windows.general_hamming(5, 0.7, xp=xp),
                         [0.4, 0.7, 1.0, 0.7, 0.4])
-        assert_allclose(windows.general_hamming(5, 0.75, sym=False),
+        xp_assert_close(windows.general_hamming(5, 0.75, sym=False, xp=xp),
                         [0.5, 0.6727457514, 0.9522542486,
                          0.9522542486, 0.6727457514])
-        assert_allclose(windows.general_hamming(6, 0.75, sym=True),
+        xp_assert_close(windows.general_hamming(6, 0.75, sym=True, xp=xp),
                         [0.5, 0.6727457514, 0.9522542486,
                         0.9522542486, 0.6727457514, 0.5])
 
 
 class TestHamming:
 
-    def test_basic(self):
-        assert_allclose(windows.hamming(6, False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.hamming(6, False, xp=xp),
                         [0.08, 0.31, 0.77, 1.0, 0.77, 0.31])
-        assert_allclose(windows.hamming(7, sym=False),
+        xp_assert_close(windows.hamming(7, sym=False, xp=xp),
                         [0.08, 0.2531946911449826, 0.6423596296199047,
                          0.9544456792351128, 0.9544456792351128,
                          0.6423596296199047, 0.2531946911449826])
-        assert_allclose(windows.hamming(6),
+        xp_assert_close(windows.hamming(6, xp=xp),
                         [0.08, 0.3978521825875242, 0.9121478174124757,
                          0.9121478174124757, 0.3978521825875242, 0.08])
-        assert_allclose(windows.hamming(7, sym=True),
+        xp_assert_close(windows.hamming(7, sym=True, xp=xp),
                         [0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08])
 
 
 class TestHann:
 
-    def test_basic(self):
-        assert_allclose(windows.hann(6, sym=False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.hann(6, sym=False, xp=xp),
                         [0, 0.25, 0.75, 1.0, 0.75, 0.25],
                         rtol=1e-15, atol=1e-15)
-        assert_allclose(windows.hann(7, sym=False),
+        xp_assert_close(windows.hann(7, sym=False, xp=xp),
                         [0, 0.1882550990706332, 0.6112604669781572,
                          0.9504844339512095, 0.9504844339512095,
                          0.6112604669781572, 0.1882550990706332],
                         rtol=1e-15, atol=1e-15)
-        assert_allclose(windows.hann(6, True),
+        xp_assert_close(windows.hann(6, True, xp=xp),
                         [0, 0.3454915028125263, 0.9045084971874737,
                          0.9045084971874737, 0.3454915028125263, 0],
                         rtol=1e-15, atol=1e-15)
-        assert_allclose(windows.hann(7),
+        xp_assert_close(windows.hann(7, xp=xp),
                         [0, 0.25, 0.75, 1.0, 0.75, 0.25, 0],
                         rtol=1e-15, atol=1e-15)
 
 
 class TestKaiser:
 
-    def test_basic(self):
-        assert_allclose(windows.kaiser(6, 0.5),
+    def test_basic(self, xp):
+        xp_assert_close(windows.kaiser(6, 0.5, xp=xp),
                         [0.9403061933191572, 0.9782962393705389,
                          0.9975765035372042, 0.9975765035372042,
                          0.9782962393705389, 0.9403061933191572])
-        assert_allclose(windows.kaiser(7, 0.5),
+        xp_assert_close(windows.kaiser(7, 0.5, xp=xp),
                         [0.9403061933191572, 0.9732402256999829,
                          0.9932754654413773, 1.0, 0.9932754654413773,
                          0.9732402256999829, 0.9403061933191572])
-        assert_allclose(windows.kaiser(6, 2.7),
+        xp_assert_close(windows.kaiser(6, 2.7, xp=xp),
                         [0.2603047507678832, 0.6648106293528054,
                          0.9582099802511439, 0.9582099802511439,
                          0.6648106293528054, 0.2603047507678832])
-        assert_allclose(windows.kaiser(7, 2.7),
+        xp_assert_close(windows.kaiser(7, 2.7, xp=xp),
                         [0.2603047507678832, 0.5985765418119844,
                          0.8868495172060835, 1.0, 0.8868495172060835,
                          0.5985765418119844, 0.2603047507678832])
-        assert_allclose(windows.kaiser(6, 2.7, False),
+        xp_assert_close(windows.kaiser(6, 2.7, False, xp=xp),
                         [0.2603047507678832, 0.5985765418119844,
                          0.8868495172060835, 1.0, 0.8868495172060835,
                          0.5985765418119844])
@@ -444,74 +449,74 @@ class TestKaiser:
 
 class TestKaiserBesselDerived:
 
-    def test_basic(self):
+    def test_basic(self, xp):
         M = 100
-        w = windows.kaiser_bessel_derived(M, beta=4.0)
+        w = windows.kaiser_bessel_derived(M, beta=4.0, xp=xp)
         w2 = windows.get_window(('kaiser bessel derived', 4.0),
-                                M, fftbins=False)
-        assert_allclose(w, w2)
+                                M, fftbins=False, xp=xp)
+        xp_assert_close(w, w2)
 
         # Test for Princen-Bradley condition
-        assert_allclose(w[:M // 2] ** 2 + w[-M // 2:] ** 2, 1.)
+        xp_assert_close(w[:M // 2] ** 2 + w[-M // 2:] ** 2, 1.)
 
         # Test actual values from other implementations
         # M = 2:  sqrt(2) / 2
         # M = 4:  0.518562710536, 0.855039598640
         # M = 6:  0.436168993154, 0.707106781187, 0.899864772847
         # Ref:https://github.com/scipy/scipy/pull/4747#issuecomment-172849418
-        assert_allclose(windows.kaiser_bessel_derived(2, beta=np.pi / 2)[:1],
+        xp_assert_close(windows.kaiser_bessel_derived(2, beta=np.pi / 2, xp=xp)[:1],
                         np.sqrt(2) / 2)
 
-        assert_allclose(windows.kaiser_bessel_derived(4, beta=np.pi / 2)[:2],
+        xp_assert_close(windows.kaiser_bessel_derived(4, beta=np.pi / 2, xp=xp)[:2],
                         [0.518562710536, 0.855039598640])
 
-        assert_allclose(windows.kaiser_bessel_derived(6, beta=np.pi / 2)[:3],
+        xp_assert_close(windows.kaiser_bessel_derived(6, beta=np.pi / 2, xp=xp)[:3],
                         [0.436168993154, 0.707106781187, 0.899864772847])
 
-    def test_exceptions(self):
+    def test_exceptions(self, xp):
         M = 100
         # Assert ValueError for odd window length
         msg = ("Kaiser-Bessel Derived windows are only defined for even "
                "number of points")
         with assert_raises(ValueError, match=msg):
-            windows.kaiser_bessel_derived(M + 1, beta=4.)
+            windows.kaiser_bessel_derived(M + 1, beta=4., xp=xp)
 
         # Assert ValueError for non-symmetric setting
         msg = ("Kaiser-Bessel Derived windows are only defined for "
                "symmetric shapes")
         with assert_raises(ValueError, match=msg):
-            windows.kaiser_bessel_derived(M + 1, beta=4., sym=False)
+            windows.kaiser_bessel_derived(M + 1, beta=4., sym=False, xp=xp)
 
 
 class TestNuttall:
 
-    def test_basic(self):
-        assert_allclose(windows.nuttall(6, sym=False),
+    def test_basic(self, xp):
+        xp_assert_close(windows.nuttall(6, sym=False, xp=xp),
                         [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
                          0.0613345])
-        assert_allclose(windows.nuttall(7, sym=False),
+        xp_assert_close(windows.nuttall(7, sym=False, xp=xp),
                         [0.0003628, 0.03777576895352025, 0.3427276199688195,
                          0.8918518610776603, 0.8918518610776603,
                          0.3427276199688196, 0.0377757689535203])
-        assert_allclose(windows.nuttall(6),
+        xp_assert_close(windows.nuttall(6, xp=xp),
                         [0.0003628, 0.1105152530498718, 0.7982580969501282,
                          0.7982580969501283, 0.1105152530498719, 0.0003628])
-        assert_allclose(windows.nuttall(7, True),
+        xp_assert_close(windows.nuttall(7, True, xp=xp),
                         [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
                          0.0613345, 0.0003628])
 
 
 class TestParzen:
 
-    def test_basic(self):
-        assert_allclose(windows.parzen(6),
+    def test_basic(self, xp):
+        xp_assert_close(windows.parzen(6, xp=xp),
                         [0.009259259259259254, 0.25, 0.8611111111111112,
                          0.8611111111111112, 0.25, 0.009259259259259254])
-        assert_allclose(windows.parzen(7, sym=True),
+        xp_assert_close(windows.parzen(7, sym=True, xp=xp),
                         [0.00583090379008747, 0.1574344023323616,
                          0.6501457725947521, 1.0, 0.6501457725947521,
                          0.1574344023323616, 0.00583090379008747])
-        assert_allclose(windows.parzen(6, False),
+        xp_assert_close(windows.parzen(6, False, xp=xp),
                         [0.00583090379008747, 0.1574344023323616,
                          0.6501457725947521, 1.0, 0.6501457725947521,
                          0.1574344023323616])
@@ -519,13 +524,13 @@ class TestParzen:
 
 class TestTriang:
 
-    def test_basic(self):
+    def test_basic(self, xp):
 
-        assert_allclose(windows.triang(6, True),
+        xp_assert_close(windows.triang(6, True, xp=xp),
                         [1/6, 1/2, 5/6, 5/6, 1/2, 1/6])
-        assert_allclose(windows.triang(7),
+        xp_assert_close(windows.triang(7, xp=xp),
                         [1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4])
-        assert_allclose(windows.triang(6, sym=False),
+        xp_assert_close(windows.triang(6, sym=False, xp=xp),
                         [1/4, 1/2, 3/4, 1, 3/4, 1/2])
 
 
@@ -560,24 +565,24 @@ tukey_data = {
 
 class TestTukey:
 
-    def test_basic(self):
+    def test_basic(self, xp):
         # Test against hardcoded data
         for k, v in tukey_data.items():
             if v is None:
-                assert_raises(ValueError, windows.tukey, *k)
+                assert_raises(ValueError, windows.tukey, *k, xp=xp)
             else:
-                win = windows.tukey(*k)
-                assert_allclose(win, v, rtol=1e-15, atol=1e-15)
+                win = windows.tukey(*k, xp=xp)
+                xp_assert_close(win, v, rtol=1e-15, atol=1e-15)
 
-    def test_extremes(self):
+    def test_extremes(self, xp):
         # Test extremes of alpha correspond to boxcar and hann
-        tuk0 = windows.tukey(100, 0)
-        box0 = windows.boxcar(100)
-        assert_array_almost_equal(tuk0, box0)
+        tuk0 = windows.tukey(100, 0, xp=xp)
+        box0 = windows.boxcar(100, xp=xp)
+        xp_assert_close(tuk0, box0)
 
-        tuk1 = windows.tukey(100, 1)
-        han1 = windows.hann(100)
-        assert_array_almost_equal(tuk1, han1)
+        tuk1 = windows.tukey(100, 1, xp=xp)
+        han1 = windows.hann(100, xp=xp)
+        xp_assert_close(tuk1, han1)
 
 
 dpss_data = {
@@ -593,44 +598,44 @@ dpss_data = {
 
 class TestDPSS:
 
-    def test_basic(self):
+    def test_basic(self, xp):
         # Test against hardcoded data
         for k, v in dpss_data.items():
-            win, ratios = windows.dpss(*k, return_ratios=True)
-            assert_allclose(win, v[0], atol=1e-7, err_msg=k)
-            assert_allclose(ratios, v[1], rtol=1e-5, atol=1e-7, err_msg=k)
+            win, ratios = windows.dpss(*k, return_ratios=True, xp=xp)
+            xp_assert_close(win, v[0], atol=1e-7, err_msg=k)
+            xp_assert_close(ratios, v[1], rtol=1e-5, atol=1e-7, err_msg=k)
 
-    def test_unity(self):
+    def test_unity(self, xp):
         # Test unity value handling (gh-2221)
         for M in range(1, 21):
             # corrected w/approximation (default)
-            win = windows.dpss(M, M / 2.1)
+            win = windows.dpss(M, M / 2.1, xp=xp)
             expected = M % 2  # one for odd, none for even
-            assert_equal(np.isclose(win, 1.).sum(), expected,
+            xp_assert_equal(np.isclose(win, 1.).sum(), expected,
                          err_msg=f'{win}')
             # corrected w/subsample delay (slower)
-            win_sub = windows.dpss(M, M / 2.1, norm='subsample')
+            win_sub = windows.dpss(M, M / 2.1, norm='subsample', xp=xp)
             if M > 2:
                 # @M=2 the subsample doesn't do anything
-                assert_equal(np.isclose(win_sub, 1.).sum(), expected,
+                xp_assert_equal(np.isclose(win_sub, 1.).sum(), expected,
                              err_msg=f'{win_sub}')
-                assert_allclose(win, win_sub, rtol=0.03)  # within 3%
+                xp_assert_close(win, win_sub, rtol=0.03)  # within 3%
             # not the same, l2-norm
-            win_2 = windows.dpss(M, M / 2.1, norm=2)
+            win_2 = windows.dpss(M, M / 2.1, norm=2, xp=xp)
             expected = 1 if M == 1 else 0
-            assert_equal(np.isclose(win_2, 1.).sum(), expected,
+            xp_assert_equal(np.isclose(win_2, 1.).sum(), expected,
                          err_msg=f'{win_2}')
 
-    def test_extremes(self):
+    def test_extremes(self, xp):
         # Test extremes of alpha
-        lam = windows.dpss(31, 6, 4, return_ratios=True)[1]
-        assert_array_almost_equal(lam, 1.)
-        lam = windows.dpss(31, 7, 4, return_ratios=True)[1]
-        assert_array_almost_equal(lam, 1.)
-        lam = windows.dpss(31, 8, 4, return_ratios=True)[1]
-        assert_array_almost_equal(lam, 1.)
+        lam = windows.dpss(31, 6, 4, return_ratios=True, xp=xp)[1]
+        xp_assert_close(lam, 1.)
+        lam = windows.dpss(31, 7, 4, return_ratios=True, xp=xp)[1]
+        xp_assert_close(lam, 1.)
+        lam = windows.dpss(31, 8, 4, return_ratios=True, xp=xp)[1]
+        xp_assert_close(lam, 1.)
 
-    def test_degenerate(self):
+    def test_degenerate(self, xp):
         # Test failures
         assert_raises(ValueError, windows.dpss, 4, 1.5, -1)  # Bad Kmax
         assert_raises(ValueError, windows.dpss, 4, 1.5, -5)
@@ -639,6 +644,9 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, 3, -1, 3)  # NW must be pos
         assert_raises(ValueError, windows.dpss, 3, 0, 3)
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
+
+    @skip_xp_backends(np_only=True)
+    def test_degenerate_signle_samples()
         # Single samples
         w = windows.dpss(1, 1.)
         assert_array_equal(w, [1.])
@@ -650,10 +658,18 @@ class TestDPSS:
         assert isinstance(ratio, np.ndarray)
         assert_array_equal(ratio, [1.])
 
+        assert_raises(ValueError, windows.dpss, 4, 1.5, -1, xp=xp)  # Bad Kmax
+        assert_raises(ValueError, windows.dpss, 4, 1.5, -5, xp=xp)
+        assert_raises(TypeError, windows.dpss, 4, 1.5, 1.1, xp=xp)
+        assert_raises(ValueError, windows.dpss, 3, 1.5, 3, xp=xp)  # NW must be < N/2.
+        assert_raises(ValueError, windows.dpss, 3, -1, 3, xp=xp)  # NW must be pos
+        assert_raises(ValueError, windows.dpss, 3, 0, 3, xp=xp)
+        assert_raises(ValueError, windows.dpss, -1, 1, 3, xp=xp)  # negative M
+
 
 class TestLanczos:
 
-    def test_basic(self):
+    def test_basic(self, xp):
         # Analytical results:
         # sinc(x) = sinc(-x)
         # sinc(pi) = 0, sinc(0) = 1
@@ -662,151 +678,152 @@ class TestLanczos:
         # sinc(pi / 3) = 0.826993343
         # sinc(3 pi / 5) = 0.504551152
         # sinc(pi / 5) = 0.935489284
-        assert_allclose(windows.lanczos(6, sym=False),
+        xp_assert_close(windows.lanczos(6, sym=False, xp=xp),
                         [0., 0.413496672,
                          0.826993343, 1., 0.826993343,
                          0.413496672],
                         atol=1e-9)
-        assert_allclose(windows.lanczos(6),
+        xp_assert_close(windows.lanczos(6, xp=xp),
                         [0., 0.504551152,
                          0.935489284, 0.935489284,
                          0.504551152, 0.],
                         atol=1e-9)
-        assert_allclose(windows.lanczos(7, sym=True),
+        xp_assert_close(windows.lanczos(7, sym=True, xp=xp),
                         [0., 0.413496672,
                          0.826993343, 1., 0.826993343,
                          0.413496672, 0.],
                         atol=1e-9)
 
-    def test_array_size(self):
+    def test_array_size(self, xp):
         for n in [0, 10, 11]:
-            assert_equal(len(windows.lanczos(n, sym=False)), n)
-            assert_equal(len(windows.lanczos(n, sym=True)), n)
+            xp_assert_equal(len(windows.lanczos(n, sym=False, xp=xp)), n)
+            xp_assert_equal(len(windows.lanczos(n, sym=True, xp=xp)), n)
 
 
 class TestGetWindow:
 
-    def test_boxcar(self):
-        w = windows.get_window('boxcar', 12)
+    def test_boxcar(self, xp):
+        w = windows.get_window('boxcar', 12, xp=xp)
         assert_array_equal(w, np.ones_like(w))
 
         # window is a tuple of len 1
-        w = windows.get_window(('boxcar',), 16)
+        w = windows.get_window(('boxcar',), 16, xp=xp)
         assert_array_equal(w, np.ones_like(w))
 
-    def test_cheb_odd(self):
+    def test_cheb_odd(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            w = windows.get_window(('chebwin', -40), 53, fftbins=False)
+            w = windows.get_window(('chebwin', -40), 53, fftbins=False, xp=xp)
         assert_array_almost_equal(w, cheb_odd_true, decimal=4)
 
-    def test_cheb_even(self):
+    def test_cheb_even(self, xp):
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            w = windows.get_window(('chebwin', 40), 54, fftbins=False)
+            w = windows.get_window(('chebwin', 40), 54, fftbins=False, xp=xp)
         assert_array_almost_equal(w, cheb_even_true, decimal=4)
 
-    def test_dpss(self):
-        win1 = windows.get_window(('dpss', 3), 64, fftbins=False)
-        win2 = windows.dpss(64, 3)
+    def test_dpss(self, xp):
+        win1 = windows.get_window(('dpss', 3), 64, fftbins=False, xp=xp)
+        win2 = windows.dpss(64, 3, xp=xp)
         assert_array_almost_equal(win1, win2, decimal=4)
 
-    def test_kaiser_float(self):
-        win1 = windows.get_window(7.2, 64)
-        win2 = windows.kaiser(64, 7.2, False)
-        assert_allclose(win1, win2)
+    def test_kaiser_float(self, xp):
+        win1 = windows.get_window(7.2, 64, xp=xp)
+        win2 = windows.kaiser(64, 7.2, False, xp=xp)
+        xp_assert_close(win1, win2)
 
-    def test_invalid_inputs(self):
+    def test_invalid_inputs(self, xp):
         # Window is not a float, tuple, or string
-        assert_raises(ValueError, windows.get_window, set('hann'), 8)
+        assert_raises(ValueError, windows.get_window, set('hann'), 8, xp=xp)
 
         # Unknown window type error
-        assert_raises(ValueError, windows.get_window, 'broken', 4)
+        assert_raises(ValueError, windows.get_window, 'broken', 4, xp=xp)
 
-    def test_array_as_window(self):
-        # GitHub issue 3603
+    def test_array_as_window(self, xp):
+        # github issue 3603
         osfactor = 128
-        sig = np.arange(128)
+        sig = xp.arange(128)
 
-        win = windows.get_window(('kaiser', 8.0), osfactor // 2)
+        win = windows.get_window(('kaiser', 8.0), osfactor // 2, xp=xp)
         with assert_raises(ValueError, match='must have the same length'):
             resample(sig, len(sig) * osfactor, window=win)
 
-    def test_general_cosine(self):
-        assert_allclose(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4),
+    def test_general_cosine(self, xp):
+        xp_assert_close(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4, xp=xp),
                         [0.4, 0.3, 1, 0.3])
-        assert_allclose(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4,
-                                   fftbins=False),
+        xp_assert_close(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4,
+                                   fftbins=False, xp=xp),
                         [0.4, 0.55, 0.55, 0.4])
 
-    def test_general_hamming(self):
-        assert_allclose(get_window(('general_hamming', 0.7), 5),
+    def test_general_hamming(self, xp):
+        xp_assert_close(get_window(('general_hamming', 0.7), 5, xp=xp),
                         [0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949])
-        assert_allclose(get_window(('general_hamming', 0.7), 5, fftbins=False),
+        xp_assert_close(get_window(('general_hamming', 0.7), 5, fftbins=False, xp=xp),
                         [0.4, 0.7, 1.0, 0.7, 0.4])
 
-    def test_lanczos(self):
-        assert_allclose(get_window('lanczos', 6),
+    def test_lanczos(self, xp):
+        xp_assert_close(get_window('lanczos', 6, xp=xp),
                         [0., 0.413496672, 0.826993343, 1., 0.826993343,
                          0.413496672], atol=1e-9)
-        assert_allclose(get_window('lanczos', 6, fftbins=False),
+        xp_assert_close(get_window('lanczos', 6, fftbins=False, xp=xp),
                         [0., 0.504551152, 0.935489284, 0.935489284,
                          0.504551152, 0.], atol=1e-9)
-        assert_allclose(get_window('lanczos', 6), get_window('sinc', 6))
+        xp_assert_close(get_window('lanczos', 6, xp=xp),
+                        get_window('sinc', 6, xp=xp))
 
 
-def test_windowfunc_basics():
+def test_windowfunc_basics(xp):
     for window_name, params in window_funcs:
         window = getattr(windows, window_name)
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
             # Check symmetry for odd and even lengths
-            w1 = window(8, *params, sym=True)
-            w2 = window(7, *params, sym=False)
-            assert_array_almost_equal(w1[:-1], w2)
+            w1 = window(8, *params, sym=True, xp=xp)
+            w2 = window(7, *params, sym=False, xp=xp)
+            xp_assert_close(w1[:-1], w2)
 
-            w1 = window(9, *params, sym=True)
-            w2 = window(8, *params, sym=False)
-            assert_array_almost_equal(w1[:-1], w2)
+            w1 = window(9, *params, sym=True, xp=xp)
+            w2 = window(8, *params, sym=False, xp=xp)
+            xp_assert_close(w1[:-1], w2)
 
             # Check that functions run and output lengths are correct
-            assert_equal(len(window(6, *params, sym=True)), 6)
-            assert_equal(len(window(6, *params, sym=False)), 6)
-            assert_equal(len(window(7, *params, sym=True)), 7)
-            assert_equal(len(window(7, *params, sym=False)), 7)
+            xp_assert_equal(len(window(6, *params, sym=True, xp=xp)), 6)
+            xp_assert_equal(len(window(6, *params, sym=False, xp=xp)), 6)
+            xp_assert_equal(len(window(7, *params, sym=True, xp=xp)), 7)
+            xp_assert_equal(len(window(7, *params, sym=False, xp=xp)), 7)
 
             # Check invalid lengths
-            assert_raises(ValueError, window, 5.5, *params)
-            assert_raises(ValueError, window, -7, *params)
+            assert_raises(ValueError, window, 5.5, *params, xp=xp)
+            assert_raises(ValueError, window, -7, *params, xp=xp)
 
             # Check degenerate cases
-            assert_array_equal(window(0, *params, sym=True), [])
-            assert_array_equal(window(0, *params, sym=False), [])
-            assert_array_equal(window(1, *params, sym=True), [1])
-            assert_array_equal(window(1, *params, sym=False), [1])
+            assert_array_equal(window(0, *params, sym=True, xp=xp), [])
+            assert_array_equal(window(0, *params, sym=False, xp=xp), [])
+            assert_array_equal(window(1, *params, sym=True, xp=xp), [1])
+            assert_array_equal(window(1, *params, sym=False, xp=xp), [1])
 
             # Check dtype
-            assert_(window(0, *params, sym=True).dtype == 'float')
-            assert_(window(0, *params, sym=False).dtype == 'float')
-            assert_(window(1, *params, sym=True).dtype == 'float')
-            assert_(window(1, *params, sym=False).dtype == 'float')
-            assert_(window(6, *params, sym=True).dtype == 'float')
-            assert_(window(6, *params, sym=False).dtype == 'float')
+            assert_(window(0, *params, sym=True, xp=xp).dtype == 'float')
+            assert_(window(0, *params, sym=False, xp=xp).dtype == 'float')
+            assert_(window(1, *params, sym=True, xp=xp).dtype == 'float')
+            assert_(window(1, *params, sym=False, xp=xp).dtype == 'float')
+            assert_(window(6, *params, sym=True, xp=xp).dtype == 'float')
+            assert_(window(6, *params, sym=False, xp=xp).dtype == 'float')
 
             # Check normalization
-            assert_array_less(window(10, *params, sym=True), 1.01)
-            assert_array_less(window(10, *params, sym=False), 1.01)
-            assert_array_less(window(9, *params, sym=True), 1.01)
-            assert_array_less(window(9, *params, sym=False), 1.01)
+            assert_array_less(window(10, *params, sym=True, xp=xp), 1.01)
+            assert_array_less(window(10, *params, sym=False, xp=xp), 1.01)
+            assert_array_less(window(9, *params, sym=True, xp=xp), 1.01)
+            assert_array_less(window(9, *params, sym=False, xp=xp), 1.01)
 
             # Check that DFT-even spectrum is purely real for odd and even
-            assert_allclose(fft(window(10, *params, sym=False)).imag,
+            xp_assert_close(fft(window(10, *params, sym=False, xp=xp)).imag,
                             0, atol=1e-14)
-            assert_allclose(fft(window(11, *params, sym=False)).imag,
+            xp_assert_close(fft(window(11, *params, sym=False, xp=xp)).imag,
                             0, atol=1e-14)
 
 
-def test_needs_params():
+def test_needs_params(xp):
     for winstr in ['kaiser', 'ksr', 'kaiser_bessel_derived', 'kbd',
                    'gaussian', 'gauss', 'gss',
                    'general gaussian', 'general_gaussian',
@@ -814,10 +831,10 @@ def test_needs_params():
                    'dss', 'dpss', 'general cosine', 'general_cosine',
                    'chebwin', 'cheb', 'general hamming', 'general_hamming',
                    ]:
-        assert_raises(ValueError, get_window, winstr, 7)
+        assert_raises(ValueError, get_window, winstr, 7, xp=xp)
 
 
-def test_not_needs_params():
+def test_not_needs_params(xp):
     for winstr in ['barthann',
                    'bartlett',
                    'blackman',
@@ -838,19 +855,19 @@ def test_not_needs_params():
                    'lanczos',
                    'sinc',
                    ]:
-        win = get_window(winstr, 7)
-        assert_equal(len(win), 7)
+        win = get_window(winstr, 7, xp=xp)
+        xp_assert_equal(len(win), 7)
 
 
-def test_symmetric():
+def test_symmetric(xp):
 
     for win in [windows.lanczos]:
         # Even sampling points
-        w = win(4096)
+        w = win(4096, xp=xp)
         error = np.max(np.abs(w-np.flip(w)))
-        assert_equal(error, 0.0)
+        xp_assert_equal(error, 0.0)
 
         # Odd sampling points
-        w = win(4097)
+        w = win(4097, xp=xp)
         error = np.max(np.abs(w-np.flip(w)))
-        assert_equal(error, 0.0)
+        xp_assert_equal(error, 0.0)

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1,10 +1,11 @@
 """The suite of window functions."""
 
+import math
 import operator
 import warnings
 
-import numpy as np
 from scipy import linalg, special, fft as sp_fft
+from scipy._lib.array_api_compat import numpy as np_compat
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'barthann',
@@ -37,7 +38,7 @@ def _truncate(w, needed):
         return w
 
 
-def general_cosine(M, a, sym=True):
+def general_cosine(M, a, sym=True, *, xp=None, device=None):
     r"""
     Generic weighted sum of cosine terms window
 
@@ -53,6 +54,10 @@ def general_cosine(M, a, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optionaloptional array API namespace (default: numpy)
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -113,19 +118,21 @@ def general_cosine(M, a, sym=True):
     >>> plt.axhline(-90.2, color='red')
     >>> plt.show()
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    fac = np.linspace(-np.pi, np.pi, M)
-    w = np.zeros(M)
+    fac = xp.linspace(-xp.pi, xp.pi, M)
+    w = xp.zeros(M)
     for k in range(len(a)):
-        w += a[k] * np.cos(k * fac)
+        w += a[k] * xp.cos(k * fac)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def boxcar(M, sym=True):
+def boxcar(M, sym=True, *, xp=None, device=None):
     """Return a boxcar or rectangular window.
 
     Also known as a rectangular window or Dirichlet window, this is equivalent
@@ -138,6 +145,11 @@ def boxcar(M, sym=True):
         is returned. An exception is thrown when it is negative.
     sym : bool, optional
         Whether the window is symmetric. (Has no effect for boxcar.)
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -170,16 +182,18 @@ def boxcar(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = np.ones(M, float)
+    w = xp.ones(M, dtype=float)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def triang(M, sym=True):
+def triang(M, sym=True, *, xp=None, device=None):
     """Return a triangular window.
 
     Parameters
@@ -191,6 +205,11 @@ def triang(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -229,22 +248,24 @@ def triang(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(1, (M + 1) // 2 + 1)
+    n = xp.arange(1, (M + 1) // 2 + 1)
     if M % 2 == 0:
         w = (2 * n - 1.0) / M
-        w = np.r_[w, w[::-1]]
+        w = xp.concat([w, w[::-1]])
     else:
         w = 2 * n / (M + 1.0)
-        w = np.r_[w, w[-2::-1]]
+        w = xp.concat([w, w[-2::-1]])
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def parzen(M, sym=True):
+def parzen(M, sym=True, *, xp=None, device=None):
     """Return a Parzen window.
 
     Parameters
@@ -256,6 +277,11 @@ def parzen(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -294,22 +320,21 @@ def parzen(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0)
-    na = np.extract(n < -(M - 1) / 4.0, n)
-    nb = np.extract(abs(n) <= (M - 1) / 4.0, n)
-    wa = 2 * (1 - np.abs(na) / (M / 2.0)) ** 3.0
-    wb = (1 - 6 * (np.abs(nb) / (M / 2.0)) ** 2.0 +
-          6 * (np.abs(nb) / (M / 2.0)) ** 3.0)
-    w = np.r_[wa, wb, wa[::-1]]
-
-    return _truncate(w, needs_trunc)
+    n = xp.arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0)
+    w = xp.where(abs(n) <= (M - 1) / 4.0,
+                 (1 - 6 * (abs(n) / (M / 2.0)) ** 2.0 +
+                  6 * (abs(n) / (M / 2.0)) ** 3.0),
+                 2 * (1 - abs(n) / (M / 2.0)) ** 3.0)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def bohman(M, sym=True):
+def bohman(M, sym=True, *, xp=None, device=None):
     """Return a Bohman window.
 
     Parameters
@@ -321,6 +346,11 @@ def bohman(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -354,18 +384,20 @@ def bohman(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    fac = np.abs(np.linspace(-1, 1, M)[1:-1])
-    w = (1 - fac) * np.cos(np.pi * fac) + 1.0 / np.pi * np.sin(np.pi * fac)
-    w = np.r_[0, w, 0]
+    fac = abs(xp.linspace(-1, 1, M)[1:-1])
+    w = (1 - fac) * xp.cos(xp.pi * fac) + 1.0 / xp.pi * xp.sin(xp.pi * fac)
+    w = xp.concat([xp.zeros(1), w, xp.zeros(1)])
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def blackman(M, sym=True):
+def blackman(M, sym=True, *, xp=None, device=None):
     r"""
     Return a Blackman window.
 
@@ -383,6 +415,11 @@ def blackman(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -448,10 +485,11 @@ def blackman(M, sym=True):
 
     """
     # Docstring adapted from NumPy's blackman function
-    return general_cosine(M, [0.42, 0.50, 0.08], sym)
+    return general_cosine(M, [0.42, 0.50, 0.08], sym,
+                          xp=xp, device=device)
 
 
-def nuttall(M, sym=True):
+def nuttall(M, sym=True, *, xp=None, device=None):
     """Return a minimum 4-term Blackman-Harris window according to Nuttall.
 
     This variation is called "Nuttall4c" by Heinzel. [2]_
@@ -465,6 +503,11 @@ def nuttall(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -508,10 +551,11 @@ def nuttall(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    return general_cosine(M, [0.3635819, 0.4891775, 0.1365995, 0.0106411], sym)
+    return general_cosine(M, [0.3635819, 0.4891775, 0.1365995, 0.0106411], sym,
+                          xp=xp, device=device)
 
 
-def blackmanharris(M, sym=True):
+def blackmanharris(M, sym=True, *, xp=None, device=None):
     """Return a minimum 4-term Blackman-Harris window.
 
     Parameters
@@ -523,6 +567,11 @@ def blackmanharris(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -556,10 +605,11 @@ def blackmanharris(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    return general_cosine(M, [0.35875, 0.48829, 0.14128, 0.01168], sym)
+    return general_cosine(M, [0.35875, 0.48829, 0.14128, 0.01168], sym,
+                          xp=xp, device=device)
 
 
-def flattop(M, sym=True):
+def flattop(M, sym=True, *, xp=None, device=None):
     """Return a flat top window.
 
     Parameters
@@ -571,6 +621,11 @@ def flattop(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -619,10 +674,10 @@ def flattop(M, sym=True):
 
     """
     a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
-    return general_cosine(M, a, sym)
+    return general_cosine(M, a, sym, xp=xp, device=device)
 
 
-def bartlett(M, sym=True):
+def bartlett(M, sym=True, *, xp=None, device=None):
     r"""
     Return a Bartlett window.
 
@@ -640,6 +695,11 @@ def bartlett(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -710,18 +770,20 @@ def bartlett(M, sym=True):
 
     """
     # Docstring adapted from NumPy's bartlett function
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    w = np.where(np.less_equal(n, (M - 1) / 2.0),
+    n = xp.arange(0, M)
+    w = xp.where(xp.less_equal(n, (M - 1) / 2.0),
                  2.0 * n / (M - 1), 2.0 - 2.0 * n / (M - 1))
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def hann(M, sym=True):
+def hann(M, sym=True, *, xp=None, device=None):
     r"""
     Return a Hann window.
 
@@ -737,6 +799,11 @@ def hann(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -801,10 +868,10 @@ def hann(M, sym=True):
 
     """
     # Docstring adapted from NumPy's hanning function
-    return general_hamming(M, 0.5, sym)
+    return general_hamming(M, 0.5, sym, xp=xp, device=device)
 
 
-def tukey(M, alpha=0.5, sym=True):
+def tukey(M, alpha=0.5, sym=True, *, xp=None, device=None):
     r"""Return a Tukey window, also known as a tapered cosine window.
 
     Parameters
@@ -821,6 +888,11 @@ def tukey(M, alpha=0.5, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -863,32 +935,34 @@ def tukey(M, alpha=0.5, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
 
     if alpha <= 0:
-        return np.ones(M, 'd')
+        return xp.ones(M, dtype=float)
     elif alpha >= 1.0:
-        return hann(M, sym=sym)
+        return hann(M, sym=sym, xp=xp, device=device)
 
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    width = int(np.floor(alpha*(M-1)/2.0))
+    n = xp.arange(0, M)
+    width = int(math.floor(alpha*(M-1)/2.0))
     n1 = n[0:width+1]
     n2 = n[width+1:M-width-1]
     n3 = n[M-width-1:]
 
-    w1 = 0.5 * (1 + np.cos(np.pi * (-1 + 2.0*n1/alpha/(M-1))))
-    w2 = np.ones(n2.shape)
-    w3 = 0.5 * (1 + np.cos(np.pi * (-2.0/alpha + 1 + 2.0*n3/alpha/(M-1))))
+    w1 = 0.5 * (1 + xp.cos(xp.pi * (-1 + 2.0*n1/alpha/(M-1))))
+    w2 = xp.ones(n2.shape)
+    w3 = 0.5 * (1 + xp.cos(xp.pi * (-2.0/alpha + 1 + 2.0*n3/alpha/(M-1))))
 
-    w = np.concatenate((w1, w2, w3))
+    w = xp.concat((w1, w2, w3))
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def barthann(M, sym=True):
+def barthann(M, sym=True, *, xp=None, device=None):
     """Return a modified Bartlett-Hann window.
 
     Parameters
@@ -900,6 +974,11 @@ def barthann(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -933,18 +1012,20 @@ def barthann(M, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    fac = np.abs(n / (M - 1.0) - 0.5)
-    w = 0.62 - 0.48 * fac + 0.38 * np.cos(2 * np.pi * fac)
+    n = xp.arange(0, M)
+    fac = abs(n / (M - 1.0) - 0.5)
+    w = 0.62 - 0.48 * fac + 0.38 * xp.cos(2 * xp.pi * fac)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def general_hamming(M, alpha, sym=True):
+def general_hamming(M, alpha, sym=True, *, xp=None, device=None):
     r"""Return a generalized Hamming window.
 
     The generalized Hamming window is constructed by multiplying a rectangular
@@ -961,6 +1042,11 @@ def general_hamming(M, alpha, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1030,10 +1116,10 @@ def general_hamming(M, alpha, sym=True):
     >>> spatial_plot.legend(loc="upper right")
 
     """
-    return general_cosine(M, [alpha, 1. - alpha], sym)
+    return general_cosine(M, [alpha, 1. - alpha], sym, xp=xp, device=device)
 
 
-def hamming(M, sym=True):
+def hamming(M, sym=True, *, xp=None, device=None):
     r"""Return a Hamming window.
 
     The Hamming window is a taper formed by using a raised cosine with
@@ -1048,6 +1134,11 @@ def hamming(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1109,10 +1200,10 @@ def hamming(M, sym=True):
 
     """
     # Docstring adapted from NumPy's hamming function
-    return general_hamming(M, 0.54, sym)
+    return general_hamming(M, 0.54, sym, xp=xp, device=device)
 
 
-def kaiser(M, beta, sym=True):
+def kaiser(M, beta, sym=True, *, xp=None, device=None):
     r"""Return a Kaiser window.
 
     The Kaiser window is a taper formed by using a Bessel function.
@@ -1129,6 +1220,11 @@ def kaiser(M, beta, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1218,20 +1314,22 @@ def kaiser(M, beta, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     # Docstring adapted from NumPy's kaiser function
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
+    n = xp.arange(0, M)
     alpha = (M - 1) / 2.0
-    w = (special.i0(beta * np.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
+    w = (special.i0(beta * xp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
          special.i0(beta))
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def kaiser_bessel_derived(M, beta, *, sym=True):
+def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
     """Return a Kaiser-Bessel derived window.
 
     Parameters
@@ -1248,6 +1346,11 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
         the other window functions and to be callable by `get_window`.
         When True (default), generates a symmetric window, for use in filter
         design.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1297,27 +1400,32 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     >>> fig.tight_layout()
     >>> fig.show()
     """
+    xp = np_compat if xp is None else xp
+
+    # cumulative_sum added in the 2023.12 Array API standard
+    cumulative_sum = xp.cumulative_sum if hasattr(xp, "cumulative_sum") else xp.cumsum
+
     if not sym:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for symmetric "
             "shapes"
         )
     elif M < 1:
-        return np.array([])
+        return xp.array([])
     elif M % 2:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for even number "
             "of points"
         )
 
-    kaiser_window = kaiser(M // 2 + 1, beta)
-    csum = np.cumsum(kaiser_window)
-    half_window = np.sqrt(csum[:-1] / csum[-1])
-    w = np.concatenate((half_window, half_window[::-1]), axis=0)
-    return w
+    kaiser_window = kaiser(M // 2 + 1, beta, xp=xp, device=device)
+    csum = cumulative_sum(kaiser_window)
+    half_window = xp.sqrt(csum[:-1] / csum[-1])
+    w = xp.concat((half_window, half_window[::-1]), axis=0)
+    return xp.asarray(w, device=device)
 
 
-def gaussian(M, std, sym=True):
+def gaussian(M, std, sym=True, *, xp=None, device=None):
     r"""Return a Gaussian window.
 
     Parameters
@@ -1331,6 +1439,11 @@ def gaussian(M, std, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1370,18 +1483,20 @@ def gaussian(M, std, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M) - (M - 1.0) / 2.0
+    n = xp.arange(0, M) - (M - 1.0) / 2.0
     sig2 = 2 * std * std
-    w = np.exp(-n ** 2 / sig2)
+    w = xp.exp(-n ** 2 / sig2)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def general_gaussian(M, p, sig, sym=True):
+def general_gaussian(M, p, sig, sym=True, *, xp=None, device=None):
     r"""Return a window with a generalized Gaussian shape.
 
     Parameters
@@ -1398,6 +1513,11 @@ def general_gaussian(M, p, sig, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1442,18 +1562,20 @@ def general_gaussian(M, p, sig, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M) - (M - 1.0) / 2.0
-    w = np.exp(-0.5 * np.abs(n / sig) ** (2 * p))
+    n = xp.arange(0, M) - (M - 1.0) / 2.0
+    w = xp.exp(-0.5 * abs(n / sig) ** (2 * p))
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
 # `chebwin` contributed by Kumar Appaiah.
-def chebwin(M, at, sym=True):
+def chebwin(M, at, sym=True, *, xp=None, device=None):
     r"""Return a Dolph-Chebyshev window.
 
     Parameters
@@ -1467,6 +1589,11 @@ def chebwin(M, at, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1539,7 +1666,9 @@ def chebwin(M, at, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    if np.abs(at) < 45:
+    xp = np_compat if xp is None else xp
+
+    if abs(at) < 45:
         warnings.warn("This window is not suitable for spectral analysis "
                       "for attenuation values lower than about 45dB because "
                       "the equivalent noise bandwidth of a Chebyshev window "
@@ -1548,40 +1677,40 @@ def chebwin(M, at, sym=True):
                       "about 45 dB.",
                       stacklevel=2)
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     # compute the parameter beta
     order = M - 1.0
-    beta = np.cosh(1.0 / order * np.arccosh(10 ** (np.abs(at) / 20.)))
-    k = np.r_[0:M] * 1.0
-    x = beta * np.cos(np.pi * k / M)
+    beta = xp.cosh(1.0 / order * xp.acosh(10 ** (abs(at) / 20.)))
+    k = xp.arange(M) * 1.0
+    x = beta * xp.cos(xp.pi * k / M)
     # Find the window's DFT coefficients
     # Use analytic definition of Chebyshev polynomial instead of expansion
     # from scipy.special. Using the expansion in scipy.special leads to errors.
-    p = np.zeros(x.shape)
-    p[x > 1] = np.cosh(order * np.arccosh(x[x > 1]))
-    p[x < -1] = (2 * (M % 2) - 1) * np.cosh(order * np.arccosh(-x[x < -1]))
-    p[np.abs(x) <= 1] = np.cos(order * np.arccos(x[np.abs(x) <= 1]))
+    p = xp.zeros(x.shape)
+    p[x > 1] = xp.cosh(order * xp.acosh(x[x > 1]))
+    p[x < -1] = (2 * (M % 2) - 1) * xp.cosh(order * xp.acosh(-x[x < -1]))
+    p[abs(x) <= 1] = xp.cos(order * xp.acos(x[abs(x) <= 1]))
 
     # Appropriate IDFT and filling up
     # depending on even/odd M
     if M % 2:
-        w = np.real(sp_fft.fft(p))
+        w = xp.real(sp_fft.fft(p))
         n = (M + 1) // 2
         w = w[:n]
-        w = np.concatenate((w[n - 1:0:-1], w))
+        w = xp.concat((w[n - 1:0:-1], w))
     else:
-        p = p * np.exp(1.j * np.pi / M * np.r_[0:M])
-        w = np.real(sp_fft.fft(p))
+        p = p * xp.exp(1.j * xp.pi / M * xp.arange(M))
+        w = xp.real(sp_fft.fft(p))
         n = M // 2 + 1
-        w = np.concatenate((w[n - 1:0:-1], w[1:n]))
-    w = w / max(w)
+        w = xp.concat((w[n - 1:0:-1], w[1:n]))
+    w = w / xp.max(w)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def cosine(M, sym=True):
+def cosine(M, sym=True, *, xp=None, device=None):
     """Return a window with a simple cosine shape.
 
     Parameters
@@ -1593,6 +1722,11 @@ def cosine(M, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1632,16 +1766,18 @@ def cosine(M, sym=True):
     >>> plt.show()
 
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = np.sin(np.pi / M * (np.arange(0, M) + .5))
+    w = xp.sin(xp.pi / M * (xp.arange(M) + .5))
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def exponential(M, center=None, tau=1., sym=True):
+def exponential(M, center=None, tau=1., sym=True, *, xp=None, device=None):
     r"""Return an exponential (or Poisson) window.
 
     Parameters
@@ -1661,6 +1797,11 @@ def exponential(M, center=None, tau=1., sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1715,22 +1856,24 @@ def exponential(M, center=None, tau=1., sym=True):
     >>> plt.ylabel("Amplitude")
     >>> plt.xlabel("Sample")
     """
+    xp = np_compat if xp is None else xp
+
     if sym and center is not None:
         raise ValueError("If sym==True, center must be None.")
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     if center is None:
         center = (M-1) / 2
 
-    n = np.arange(0, M)
-    w = np.exp(-np.abs(n-center) / tau)
+    n = xp.arange(0, M)
+    w = xp.exp(-abs(n-center) / tau)
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def taylor(M, nbar=4, sll=30, norm=True, sym=True):
+def taylor(M, nbar=4, sll=30, norm=True, sym=True, *, xp=None, device=None):
     """
     Return a Taylor window.
 
@@ -1763,6 +1906,11 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -1810,43 +1958,46 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """  # noqa: E501
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     # Original text uses a negative sidelobe level parameter and then negates
     # it in the calculation of B. To keep consistent with other methods we
     # assume the sidelobe level parameter to be positive.
     B = 10**(sll / 20)
-    A = np.arccosh(B) / np.pi
+    A = xp.acosh(B) / xp.pi
     s2 = nbar**2 / (A**2 + (nbar - 0.5)**2)
-    ma = np.arange(1, nbar)
+    ma = xp.arange(1, nbar)
 
-    Fm = np.empty(nbar-1)
-    signs = np.empty_like(ma)
+    Fm = xp.empty(nbar-1)
+    signs = xp.empty_like(ma)
     signs[::2] = 1
     signs[1::2] = -1
     m2 = ma*ma
     for mi, m in enumerate(ma):
-        numer = signs[mi] * np.prod(1 - m2[mi]/s2/(A**2 + (ma - 0.5)**2))
-        denom = 2 * np.prod(1 - m2[mi]/m2[:mi]) * np.prod(1 - m2[mi]/m2[mi+1:])
+        numer = signs[mi] * xp.prod(1 - m2[mi]/s2/(A**2 + (ma - 0.5)**2))
+        denom = 2 * xp.prod(1 - m2[mi]/m2[:mi]) * xp.prod(1 - m2[mi]/m2[mi+1:])
         Fm[mi] = numer / denom
 
     def W(n):
-        return 1 + 2*np.dot(Fm, np.cos(
-            2*np.pi*ma[:, np.newaxis]*(n-M/2.+0.5)/M))
+        return 1 + 2*xp.matmul(Fm, xp.cos(
+            2*xp.pi*ma[:, xp.newaxis]*(n-M/2.+0.5)/M))
 
-    w = W(np.arange(M))
+    w = W(xp.arange(M))
 
     # normalize (Note that this is not described in the original text [1])
     if norm:
         scale = 1.0 / W((M - 1) / 2)
         w *= scale
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
-def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
+def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
+         *, xp=None, device=None):
     """
     Compute the Discrete Prolate Spheroidal Sequences (DPSS).
 
@@ -1880,6 +2031,11 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     return_ratios : bool, optional
         If True, also return the concentration ratios in addition to the
         windows.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -2009,6 +2165,8 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     >>> fig.tight_layout()
 
     """
+    xp = np_compat if xp is None else xp
+
     if norm is None:
         norm = 'approximate' if Kmax is None else 2
     known_norms = (2, 'approximate', 'subsample')
@@ -2035,7 +2193,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
         raise ValueError('NW must be positive')
     M, needs_trunc = _extend(M, sym)
     W = float(NW) / M
-    nidx = np.arange(M)
+    nidx = xp.arange(M)
 
     # Here we want to set up an optimization problem to find a sequence
     # whose energy is maximally concentrated within band [-W,W].
@@ -2055,7 +2213,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     # the main diagonal = ([M-1-2*t]/2)**2 cos(2PIW), t=[0,1,2,...,M-1]
     # and the first off-diagonal = t(M-t)/2, t=[1,2,...,M-1]
     # [see Percival and Walden, 1993]
-    d = ((M - 1 - 2 * nidx) / 2.) ** 2 * np.cos(2 * np.pi * W)
+    d = ((M - 1 - 2 * nidx) / 2.) ** 2 * xp.cos(2 * xp.pi * W)
     e = nidx[1:] * (M - nidx[1:]) / 2.
 
     # only calculate the highest Kmax eigenvalues
@@ -2085,11 +2243,12 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     # Use the autocorr sequence technique from Percival and Walden, 1993 pg 390
     if return_ratios:
         dpss_rxx = _fftautocorr(windows)
-        r = 4 * W * np.sinc(2 * W * nidx)
+        r = 4 * W * xp.sinc(2 * W * nidx)
         r[0] = 2 * W
-        ratios = np.dot(dpss_rxx, r)
+        ratios = xp.matmul(dpss_rxx, r)
         if singleton:
             ratios = ratios[0]
+        ratios = xp.asarray(ratios, device=device)
     # Deal with sym and Kmax=None
     if norm != 2:
         windows /= windows.max()
@@ -2098,8 +2257,8 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
                 correction = M**2 / float(M**2 + NW)
             else:
                 s = sp_fft.rfft(windows[0])
-                shift = -(1 - 1./M) * np.arange(1, M//2 + 1)
-                s[1:] *= 2 * np.exp(-1j * np.pi * shift)
+                shift = -(1 - 1./M) * xp.arange(1, M//2 + 1)
+                s[1:] *= 2 * xp.exp(-1j * xp.pi * shift)
                 correction = M / s.real.sum()
             windows *= correction
     # else we're already l2 normed, so do nothing
@@ -2107,10 +2266,11 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
         windows = windows[:, :-1]
     if singleton:
         windows = windows[0]
+    windows = xp.asarray(windows, device=device)
     return (windows, ratios) if return_ratios else windows
 
 
-def lanczos(M, *, sym=True):
+def lanczos(M, *, sym=True, xp=None, device=None):
     r"""Return a Lanczos window also known as a sinc window.
 
     Parameters
@@ -2122,6 +2282,11 @@ def lanczos(M, *, sym=True):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -2188,24 +2353,26 @@ def lanczos(M, *, sym=True):
     >>> fig.tight_layout()
     >>> plt.show()
     """
+    xp = np_compat if xp is None else xp
+
     if _len_guards(M):
-        return np.ones(M)
+        return xp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     # To make sure that the window is symmetric, we concatenate the right hand
     # half of the window and the flipped one which is the left hand half of
     # the window.
     def _calc_right_side_lanczos(n, m):
-        return np.sinc(2. * np.arange(n, m) / (m - 1) - 1.0)
+        return xp.sinc(2. * xp.arange(n, m) / (m - 1) - 1.0)
 
     if M % 2 == 0:
         wh = _calc_right_side_lanczos(M/2, M)
-        w = np.r_[np.flip(wh), wh]
+        w = xp.concat([xp.flip(wh), wh])
     else:
         wh = _calc_right_side_lanczos((M+1)/2, M)
-        w = np.r_[np.flip(wh), 1.0, wh]
+        w = xp.concat([xp.flip(wh), xp.ones(1), wh])
 
-    return _truncate(w, needs_trunc)
+    return xp.asarray(_truncate(w, needs_trunc), device=device)
 
 
 def _fftautocorr(x):
@@ -2215,7 +2382,7 @@ def _fftautocorr(x):
     x_fft = sp_fft.rfft(x, use_N, axis=-1)
     cxy = sp_fft.irfft(x_fft * x_fft.conj(), n=use_N)[:, :N]
     # Or equivalently (but in most cases slower):
-    # cxy = np.array([np.convolve(xx, yy[::-1], mode='full')
+    # cxy = xp.array([xp.convolve(xx, yy[::-1], mode='full')
     #                 for xx, yy in zip(x, x)])[:, N-1:2*N-1]
     return cxy
 
@@ -2263,7 +2430,7 @@ for k, v in _win_equiv_raw.items():
         _needs_param.update(k)
 
 
-def get_window(window, Nx, fftbins=True):
+def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
     """
     Return a window of a given length and type.
 
@@ -2278,6 +2445,11 @@ def get_window(window, Nx, fftbins=True):
         `ifftshift` and be multiplied by the result of an FFT (see also
         :func:`~scipy.fft.fftfreq`).
         If False, create a "symmetric" window, for use in filter design.
+    xp : module, optional
+        Optional array API namespace. defaults to NumPy.
+    device: any
+        optional device specification for output. Should match one of the
+        supported device specification in ``xp``.
 
     Returns
     -------
@@ -2376,4 +2548,4 @@ def get_window(window, Nx, fftbins=True):
         winfunc = kaiser
         params = (Nx, beta)
 
-    return winfunc(*params, sym=sym)
+    return winfunc(*params, sym=sym, xp=xp, device=device)

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2121,11 +2121,11 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
         singleton = False
     if _len_guards(M):
         if not return_ratios:
-            return xp.ones(M)
+            return xp.ones(M, dtype=xp.float64)
         elif singleton:
-            return xp.ones(M), 1.
+            return xp.ones(M, dtype=xp.float64), 1.
         else:
-            return xp.ones(M), xp.ones(1)
+            return xp.ones(M, dtype=xp.float64), xp.ones(1, dtype=xp.float64)
     Kmax = operator.index(Kmax)
     if not 0 < Kmax <= M:
         raise ValueError('Kmax must be greater than 0 and less than M')

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -3,9 +3,12 @@
 import math
 import operator
 import warnings
+from scipy._lib import doccer
 
 from scipy import linalg, special, fft as sp_fft
 from scipy._lib.array_api_compat import numpy as np_compat
+from scipy._lib._array_api import array_namespace, xp_device
+from scipy._lib import array_api_extra as xpx
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'barthann',
@@ -38,7 +41,29 @@ def _truncate(w, needed):
         return w
 
 
-def general_cosine(M, a, sym=True, *, xp=None, device=None):
+def _namespace(xp):
+    """A shim for the `device` arg of `np.asarray(x, device=device)` and acos/arccos.
+
+    Will be able to replace with `np_compat if xp is None else xp` when we drop
+    support for numpy 1.x and cupy 13.x
+    """
+    return np_compat if xp is None else array_namespace(xp.empty(0))
+
+
+def _general_cosine_impl(M, a, xp, device, sym=True):
+    if _len_guards(M):
+        return xp.ones(M, dtype=xp.float64, device=device)
+    M, needs_trunc = _extend(M, sym)
+
+    fac = xp.linspace(-xp.pi, xp.pi, M, dtype=xp.float64, device=device)
+    w = xp.zeros(M, dtype=xp.float64, device=device)
+    for k in range(a.shape[0]):
+        w += a[k] * xp.cos(k * fac)
+
+    return _truncate(w, needs_trunc)
+
+
+def general_cosine(M, a, sym=True):
     r"""
     Generic weighted sum of cosine terms window
 
@@ -54,10 +79,6 @@ def general_cosine(M, a, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optionaloptional array API namespace (default: numpy)
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
 
     Returns
     -------
@@ -118,18 +139,10 @@ def general_cosine(M, a, sym=True, *, xp=None, device=None):
     >>> plt.axhline(-90.2, color='red')
     >>> plt.show()
     """
-    xp = np_compat if xp is None else xp
-
-    if _len_guards(M):
-        return xp.ones(M)
-    M, needs_trunc = _extend(M, sym)
-
-    fac = xp.linspace(-xp.pi, xp.pi, M)
-    w = xp.zeros(M)
-    for k in range(len(a)):
-        w += a[k] * xp.cos(k * fac)
-
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    xp = array_namespace(a)
+    a = xp.asarray(a)
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def boxcar(M, sym=True, *, xp=None, device=None):
@@ -145,11 +158,7 @@ def boxcar(M, sym=True, *, xp=None, device=None):
         is returned. An exception is thrown when it is negative.
     sym : bool, optional
         Whether the window is symmetric. (Has no effect for boxcar.)
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -182,15 +191,15 @@ def boxcar(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    w = xp.ones(M, dtype=float)
+    w = xp.ones(M, dtype=xp.float64, device=device)
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def triang(M, sym=True, *, xp=None, device=None):
@@ -205,11 +214,7 @@ def triang(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -248,21 +253,21 @@ def triang(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(1, (M + 1) // 2 + 1)
+    n = xp.arange(1, (M + 1) // 2 + 1, dtype=xp.float64, device=device)
     if M % 2 == 0:
         w = (2 * n - 1.0) / M
-        w = xp.concat([w, w[::-1]])
+        w = xp.concat([w, xp.flip(w)])
     else:
         w = 2 * n / (M + 1.0)
-        w = xp.concat([w, w[-2::-1]])
+        w = xp.concat([w, xp.flip(w[:-1])])
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def parzen(M, sym=True, *, xp=None, device=None):
@@ -277,11 +282,7 @@ def parzen(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -320,18 +321,19 @@ def parzen(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0)
+    n = xp.arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0,
+                  dtype=xp.float64, device=device)
     w = xp.where(abs(n) <= (M - 1) / 4.0,
                  (1 - 6 * (abs(n) / (M / 2.0)) ** 2.0 +
                   6 * (abs(n) / (M / 2.0)) ** 3.0),
                  2 * (1 - abs(n) / (M / 2.0)) ** 3.0)
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def bohman(M, sym=True, *, xp=None, device=None):
@@ -346,11 +348,7 @@ def bohman(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -384,17 +382,18 @@ def bohman(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    fac = abs(xp.linspace(-1, 1, M)[1:-1])
+    fac = abs(xp.linspace(-1, 1, M, dtype=xp.float64, device=device)[1:-1])
     w = (1 - fac) * xp.cos(xp.pi * fac) + 1.0 / xp.pi * xp.sin(xp.pi * fac)
-    w = xp.concat([xp.zeros(1), w, xp.zeros(1)])
+    one = xp.zeros(1, dtype=xp.float64, device=device)
+    w = xp.concat([one, w, one])
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def blackman(M, sym=True, *, xp=None, device=None):
@@ -415,11 +414,7 @@ def blackman(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -485,8 +480,10 @@ def blackman(M, sym=True, *, xp=None, device=None):
 
     """
     # Docstring adapted from NumPy's blackman function
-    return general_cosine(M, [0.42, 0.50, 0.08], sym,
-                          xp=xp, device=device)
+    xp = _namespace(xp)
+    a = xp.asarray([0.42, 0.50, 0.08], dtype=xp.float64, device=device)
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def nuttall(M, sym=True, *, xp=None, device=None):
@@ -503,11 +500,7 @@ def nuttall(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -551,8 +544,12 @@ def nuttall(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    return general_cosine(M, [0.3635819, 0.4891775, 0.1365995, 0.0106411], sym,
-                          xp=xp, device=device)
+    xp = _namespace(xp)
+    a = xp.asarray(
+        [0.3635819, 0.4891775, 0.1365995, 0.0106411], dtype=xp.float64, device=device
+    )
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def blackmanharris(M, sym=True, *, xp=None, device=None):
@@ -567,11 +564,7 @@ def blackmanharris(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -605,8 +598,12 @@ def blackmanharris(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    return general_cosine(M, [0.35875, 0.48829, 0.14128, 0.01168], sym,
-                          xp=xp, device=device)
+    xp = _namespace(xp)
+    a = xp.asarray(
+        [0.35875, 0.48829, 0.14128, 0.01168], dtype=xp.float64, device=device
+    )
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def flattop(M, sym=True, *, xp=None, device=None):
@@ -621,11 +618,7 @@ def flattop(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -673,8 +666,13 @@ def flattop(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
-    return general_cosine(M, a, sym, xp=xp, device=device)
+    xp = _namespace(xp)
+    a = xp.asarray(
+        [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368],
+        dtype=xp.float64, device=device
+    )
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def bartlett(M, sym=True, *, xp=None, device=None):
@@ -695,11 +693,7 @@ def bartlett(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -770,17 +764,19 @@ def bartlett(M, sym=True, *, xp=None, device=None):
 
     """
     # Docstring adapted from NumPy's bartlett function
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M)
-    w = xp.where(xp.less_equal(n, (M - 1) / 2.0),
+    n = xp.arange(0, M, dtype=xp.float64, device=device)
+
+    # cf https://github.com/data-apis/array-api-strict/issues/77
+    w = xp.where(n <= (M - 1) / 2.0,
                  2.0 * n / (M - 1), 2.0 - 2.0 * n / (M - 1))
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def hann(M, sym=True, *, xp=None, device=None):
@@ -799,11 +795,7 @@ def hann(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -888,11 +880,7 @@ def tukey(M, alpha=0.5, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -935,31 +923,31 @@ def tukey(M, alpha=0.5, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
 
     if alpha <= 0:
-        return xp.ones(M, dtype=float)
+        return xp.ones(M, dtype=xp.float64, device=device)
     elif alpha >= 1.0:
         return hann(M, sym=sym, xp=xp, device=device)
 
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M)
+    n = xp.arange(0, M, dtype=xp.float64, device=device)
     width = int(math.floor(alpha*(M-1)/2.0))
     n1 = n[0:width+1]
     n2 = n[width+1:M-width-1]
     n3 = n[M-width-1:]
 
     w1 = 0.5 * (1 + xp.cos(xp.pi * (-1 + 2.0*n1/alpha/(M-1))))
-    w2 = xp.ones(n2.shape)
+    w2 = xp.ones(n2.shape, device=device)
     w3 = 0.5 * (1 + xp.cos(xp.pi * (-2.0/alpha + 1 + 2.0*n3/alpha/(M-1))))
 
     w = xp.concat((w1, w2, w3))
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def barthann(M, sym=True, *, xp=None, device=None):
@@ -974,11 +962,7 @@ def barthann(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1012,17 +996,17 @@ def barthann(M, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M)
+    n = xp.arange(0, M, dtype=xp.float64, device=device)
     fac = abs(n / (M - 1.0) - 0.5)
     w = 0.62 - 0.48 * fac + 0.38 * xp.cos(2 * xp.pi * fac)
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def general_hamming(M, alpha, sym=True, *, xp=None, device=None):
@@ -1042,11 +1026,7 @@ def general_hamming(M, alpha, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1116,7 +1096,10 @@ def general_hamming(M, alpha, sym=True, *, xp=None, device=None):
     >>> spatial_plot.legend(loc="upper right")
 
     """
-    return general_cosine(M, [alpha, 1. - alpha], sym, xp=xp, device=device)
+    xp = _namespace(xp)
+    a = xp.asarray([alpha, 1. - alpha], dtype=xp.float64, device=device)
+    device = xp_device(a)
+    return _general_cosine_impl(M, a, xp, device, sym=sym)
 
 
 def hamming(M, sym=True, *, xp=None, device=None):
@@ -1134,11 +1117,7 @@ def hamming(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1220,11 +1199,7 @@ def kaiser(M, beta, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1314,19 +1289,19 @@ def kaiser(M, beta, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     # Docstring adapted from NumPy's kaiser function
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M)
+    n = xp.arange(0, M, dtype=xp.float64, device=device)
     alpha = (M - 1) / 2.0
     w = (special.i0(beta * xp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
          special.i0(beta))
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
@@ -1346,11 +1321,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
         the other window functions and to be callable by `get_window`.
         When True (default), generates a symmetric window, for use in filter
         design.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1400,10 +1371,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
     >>> fig.tight_layout()
     >>> fig.show()
     """
-    xp = np_compat if xp is None else xp
-
-    # cumulative_sum added in the 2023.12 Array API standard
-    cumulative_sum = xp.cumulative_sum if hasattr(xp, "cumulative_sum") else xp.cumsum
+    xp = _namespace(xp)
 
     if not sym:
         raise ValueError(
@@ -1419,9 +1387,9 @@ def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
         )
 
     kaiser_window = kaiser(M // 2 + 1, beta, xp=xp, device=device)
-    csum = cumulative_sum(kaiser_window)
+    csum = xp.cumulative_sum(kaiser_window)
     half_window = xp.sqrt(csum[:-1] / csum[-1])
-    w = xp.concat((half_window, half_window[::-1]), axis=0)
+    w = xp.concat((half_window, xp.flip(half_window)), axis=0)
     return xp.asarray(w, device=device)
 
 
@@ -1439,11 +1407,7 @@ def gaussian(M, std, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1483,17 +1447,17 @@ def gaussian(M, std, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M) - (M - 1.0) / 2.0
+    n = xp.arange(0, M, dtype=xp.float64, device=device) - (M - 1.0) / 2.0
     sig2 = 2 * std * std
     w = xp.exp(-n ** 2 / sig2)
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def general_gaussian(M, p, sig, sym=True, *, xp=None, device=None):
@@ -1513,11 +1477,7 @@ def general_gaussian(M, p, sig, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1562,16 +1522,16 @@ def general_gaussian(M, p, sig, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    n = xp.arange(0, M) - (M - 1.0) / 2.0
+    n = xp.arange(0, M, dtype=xp.float64, device=device) - (M - 1.0) / 2.0
     w = xp.exp(-0.5 * abs(n / sig) ** (2 * p))
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 # `chebwin` contributed by Kumar Appaiah.
@@ -1589,11 +1549,7 @@ def chebwin(M, at, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1666,7 +1622,7 @@ def chebwin(M, at, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if abs(at) < 45:
         warnings.warn("This window is not suitable for spectral analysis "
@@ -1677,18 +1633,19 @@ def chebwin(M, at, sym=True, *, xp=None, device=None):
                       "about 45 dB.",
                       stacklevel=2)
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
     # compute the parameter beta
     order = M - 1.0
-    beta = xp.cosh(1.0 / order * xp.acosh(10 ** (abs(at) / 20.)))
-    k = xp.arange(M) * 1.0
+    _val = xp.asarray(10 ** (abs(at) / 20.), dtype=xp.float64, device=device)
+    beta = xp.cosh(1.0 / order * xp.acosh(_val))
+    k = xp.arange(M, dtype=xp.float64, device=device)
     x = beta * xp.cos(xp.pi * k / M)
     # Find the window's DFT coefficients
     # Use analytic definition of Chebyshev polynomial instead of expansion
     # from scipy.special. Using the expansion in scipy.special leads to errors.
-    p = xp.zeros(x.shape)
+    p = xp.zeros_like(x)
     p[x > 1] = xp.cosh(order * xp.acosh(x[x > 1]))
     p[x < -1] = (2 * (M % 2) - 1) * xp.cosh(order * xp.acosh(-x[x < -1]))
     p[abs(x) <= 1] = xp.cos(order * xp.acos(x[abs(x) <= 1]))
@@ -1699,15 +1656,16 @@ def chebwin(M, at, sym=True, *, xp=None, device=None):
         w = xp.real(sp_fft.fft(p))
         n = (M + 1) // 2
         w = w[:n]
-        w = xp.concat((w[n - 1:0:-1], w))
+        w = xp.concat((xp.flip(w[1:n]), w))
     else:
-        p = p * xp.exp(1.j * xp.pi / M * xp.arange(M))
+        I = xp.asarray(1j, device=device)
+        p = p * xp.exp(I * xp.pi / M * xp.arange(M, dtype=xp.float64, device=device))
         w = xp.real(sp_fft.fft(p))
         n = M // 2 + 1
-        w = xp.concat((w[n - 1:0:-1], w[1:n]))
+        w = xp.concat((xp.flip(w[1:n]), w[1:n]))
     w = w / xp.max(w)
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def cosine(M, sym=True, *, xp=None, device=None):
@@ -1722,11 +1680,7 @@ def cosine(M, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1766,15 +1720,15 @@ def cosine(M, sym=True, *, xp=None, device=None):
     >>> plt.show()
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
-    w = xp.sin(xp.pi / M * (xp.arange(M) + .5))
+    w = xp.sin(xp.pi / M * (xp.arange(M, dtype=xp.float64, device=device) + .5))
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def exponential(M, center=None, tau=1., sym=True, *, xp=None, device=None):
@@ -1797,11 +1751,7 @@ def exponential(M, center=None, tau=1., sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1856,21 +1806,21 @@ def exponential(M, center=None, tau=1., sym=True, *, xp=None, device=None):
     >>> plt.ylabel("Amplitude")
     >>> plt.xlabel("Sample")
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if sym and center is not None:
         raise ValueError("If sym==True, center must be None.")
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
     if center is None:
         center = (M-1) / 2
 
-    n = xp.arange(0, M)
+    n = xp.arange(0, M, dtype=xp.float64, device=device)
     w = xp.exp(-abs(n-center) / tau)
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def taylor(M, nbar=4, sll=30, norm=True, sym=True, *, xp=None, device=None):
@@ -1906,11 +1856,7 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True, *, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -1958,21 +1904,21 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True, *, xp=None, device=None):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """  # noqa: E501
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
     # Original text uses a negative sidelobe level parameter and then negates
     # it in the calculation of B. To keep consistent with other methods we
     # assume the sidelobe level parameter to be positive.
-    B = 10**(sll / 20)
+    B = xp.asarray(10**(sll / 20), device=device)
     A = xp.acosh(B) / xp.pi
     s2 = nbar**2 / (A**2 + (nbar - 0.5)**2)
-    ma = xp.arange(1, nbar)
+    ma = xp.arange(1, nbar, dtype=xp.float64, device=device)
 
-    Fm = xp.empty(nbar-1)
+    Fm = xp.empty(nbar - 1, dtype=xp.float64, device=device)
     signs = xp.empty_like(ma)
     signs[::2] = 1
     signs[1::2] = -1
@@ -1986,14 +1932,14 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True, *, xp=None, device=None):
         return 1 + 2*xp.matmul(Fm, xp.cos(
             2*xp.pi*ma[:, xp.newaxis]*(n-M/2.+0.5)/M))
 
-    w = W(xp.arange(M))
+    w = W(xp.arange(M, dtype=xp.float64, device=device))
 
     # normalize (Note that this is not described in the original text [1])
     if norm:
         scale = 1.0 / W((M - 1) / 2)
         w *= scale
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
@@ -2031,11 +1977,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     return_ratios : bool, optional
         If True, also return the concentration ratios in addition to the
         windows.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -2093,12 +2035,12 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     ...     for win, c in ((win_dpss, 'k'), (win_kaiser, 'r')):
     ...         win /= win.sum()
     ...         axes[ai, 0].plot(win, color=c, lw=1.)
-    ...         axes[ai, 0].set(xlim=[0, M-1], title=r'$\\alpha$ = %s' % alpha,
+    ...         axes[ai, 0].set(xlim=[0, M-1], title=rf'$\\alpha$ = {alpha}',
     ...                         ylabel='Amplitude')
     ...         w, h = freqz(win)
     ...         axes[ai, 1].plot(w, 20 * np.log10(np.abs(h)), color=c, lw=1.)
     ...         axes[ai, 1].set(xlim=[0, np.pi],
-    ...                         title=r'$\\beta$ = %0.2f' % beta,
+    ...                         title=rf'$\\beta$ = {beta:0.2f}',
     ...                         ylabel='Magnitude (dB)')
     >>> for ax in axes.ravel():
     ...     ax.grid(True)
@@ -2115,8 +2057,8 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     >>> fig, ax = plt.subplots(1)
     >>> ax.plot(win.T, linewidth=1.)
     >>> ax.set(xlim=[0, M-1], ylim=[-0.1, 0.1], xlabel='Samples',
-    ...        title='DPSS, M=%d, NW=%0.1f' % (M, NW))
-    >>> ax.legend(['win[%d] (%0.4f)' % (ii, ratio)
+    ...        title=f'DPSS, {M:d}, {NW:0.1f}')
+    >>> ax.legend([f'win[{ii}] ({ratio:0.4f})'
     ...            for ii, ratio in enumerate(eigvals)])
     >>> fig.tight_layout()
     >>> plt.show()
@@ -2165,7 +2107,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     >>> fig.tight_layout()
 
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if norm is None:
         norm = 'approximate' if Kmax is None else 2
@@ -2179,11 +2121,11 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
         singleton = False
     if _len_guards(M):
         if not return_ratios:
-            return np.ones(M)
+            return xp.ones(M)
         elif singleton:
-            return np.ones(M), 1.
+            return xp.ones(M), 1.
         else:
-            return np.ones(M), np.ones(1)
+            return xp.ones(M), xp.ones(1)
     Kmax = operator.index(Kmax)
     if not 0 < Kmax <= M:
         raise ValueError('Kmax must be greater than 0 and less than M')
@@ -2193,7 +2135,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
         raise ValueError('NW must be positive')
     M, needs_trunc = _extend(M, sym)
     W = float(NW) / M
-    nidx = xp.arange(M)
+    nidx = xp.arange(M, dtype=xp.float64, device=device)
 
     # Here we want to set up an optimization problem to find a sequence
     # whose energy is maximally concentrated within band [-W,W].
@@ -2213,7 +2155,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     # the main diagonal = ([M-1-2*t]/2)**2 cos(2PIW), t=[0,1,2,...,M-1]
     # and the first off-diagonal = t(M-t)/2, t=[1,2,...,M-1]
     # [see Percival and Walden, 1993]
-    d = ((M - 1 - 2 * nidx) / 2.) ** 2 * xp.cos(2 * xp.pi * W)
+    d = ((M - 1 - 2 * nidx) / 2.) ** 2 * xp.cos(xp.asarray(2 * xp.pi * W))
     e = nidx[1:] * (M - nidx[1:]) / 2.
 
     # only calculate the highest Kmax eigenvalues
@@ -2224,7 +2166,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
 
     # By convention (Percival and Walden, 1993 pg 379)
     # * symmetric tapers (k=0,2,4,...) should have a positive average.
-    fix_even = (windows[::2].sum(axis=1) < 0)
+    fix_even = (windows[::2, ...].sum(axis=1) < 0)
     for i, f in enumerate(fix_even):
         if f:
             windows[2 * i] *= -1
@@ -2235,15 +2177,15 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     #   algorithm that uses max(abs(w)), which is susceptible to numerical
     #   noise problems)
     thresh = max(1e-7, 1. / M)
-    for i, w in enumerate(windows[1::2]):
+    for i, w in enumerate(windows[1::2, ...]):
         if w[w * w > thresh][0] < 0:
             windows[2 * i + 1] *= -1
 
     # Now find the eigenvalues of the original spectral concentration problem
     # Use the autocorr sequence technique from Percival and Walden, 1993 pg 390
     if return_ratios:
-        dpss_rxx = _fftautocorr(windows)
-        r = 4 * W * xp.sinc(2 * W * nidx)
+        dpss_rxx = _fftautocorr(xp.asarray(windows))
+        r = 4 * W * xpx.sinc(xp.asarray(2 * W * nidx), xp=xp)
         r[0] = 2 * W
         ratios = xp.matmul(dpss_rxx, r)
         if singleton:
@@ -2257,8 +2199,9 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
                 correction = M**2 / float(M**2 + NW)
             else:
                 s = sp_fft.rfft(windows[0])
-                shift = -(1 - 1./M) * xp.arange(1, M//2 + 1)
-                s[1:] *= 2 * xp.exp(-1j * xp.pi * shift)
+                shift = -(1 - 1./M) * xp.arange(1, M//2 + 1, dtype=xp.float64)
+                I = xp.asarray(1j)
+                s[1:] *= 2 * xp.exp(-I * xp.pi * shift)
                 correction = M / s.real.sum()
             windows *= correction
     # else we're already l2 normed, so do nothing
@@ -2282,11 +2225,7 @@ def lanczos(M, *, sym=True, xp=None, device=None):
         When True (default), generates a symmetric window, for use in filter
         design.
         When False, generates a periodic window, for use in spectral analysis.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -2353,17 +2292,17 @@ def lanczos(M, *, sym=True, xp=None, device=None):
     >>> fig.tight_layout()
     >>> plt.show()
     """
-    xp = np_compat if xp is None else xp
+    xp = _namespace(xp)
 
     if _len_guards(M):
-        return xp.ones(M)
+        return xp.ones(M, dtype=xp.float64, device=device)
     M, needs_trunc = _extend(M, sym)
 
     # To make sure that the window is symmetric, we concatenate the right hand
     # half of the window and the flipped one which is the left hand half of
     # the window.
     def _calc_right_side_lanczos(n, m):
-        return xp.sinc(2. * xp.arange(n, m) / (m - 1) - 1.0)
+        return xpx.sinc(2. * xp.arange(n, m, dtype=xp.float64) / (m - 1) - 1.0, xp=xp)
 
     if M % 2 == 0:
         wh = _calc_right_side_lanczos(M/2, M)
@@ -2372,7 +2311,7 @@ def lanczos(M, *, sym=True, xp=None, device=None):
         wh = _calc_right_side_lanczos((M+1)/2, M)
         w = xp.concat([xp.flip(wh), xp.ones(1), wh])
 
-    return xp.asarray(_truncate(w, needs_trunc), device=device)
+    return _truncate(w, needs_trunc)
 
 
 def _fftautocorr(x):
@@ -2445,11 +2384,7 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
         `ifftshift` and be multiplied by the result of an FFT (see also
         :func:`~scipy.fft.fftfreq`).
         If False, create a "symmetric" window, for use in filter design.
-    xp : module, optional
-        Optional array API namespace. defaults to NumPy.
-    device: any
-        optional device specification for output. Should match one of the
-        supported device specification in ``xp``.
+    %(xp_device_snippet)s
 
     Returns
     -------
@@ -2535,6 +2470,11 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
             raise ValueError(
                 f"{str(type(window))} as window type is not supported.") from e
 
+        if winstr == 'general_cosine' and (xp is not None or device is not None):
+            raise ValueError(
+                'general_cosine window does not accept xp and device kwargs '
+            )
+
         try:
             winfunc = _win_equiv[winstr]
         except KeyError as e:
@@ -2548,4 +2488,28 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
         winfunc = kaiser
         params = (Nx, beta)
 
-    return winfunc(*params, sym=sym, xp=xp, device=device)
+    if winfunc == general_cosine:
+        return winfunc(*params, sym=sym)
+    else:
+        return winfunc(*params, sym=sym, xp=xp, device=device)
+
+
+########## complete the docstrings, on import
+_xp_device_snippet = {'xp_device_snippet':
+"""\
+xp : array_namespace, optional
+    Optional array namespace.
+    Should be compatible with the array API standard, or supported by array-api-compat.
+    Default: ``numpy``
+device: any
+    optional device specification for output. Should match one of the
+    supported device specification in ``xp``.
+"""
+}
+
+
+_names = [x for x in __all__ if x != 'general_cosine']
+for name in _names:
+    window = vars()[name]
+    window.__doc__ = doccer.docformat(window.__doc__, _xp_device_snippet)
+


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

supersedes https://github.com/scipy/scipy/pull/20668

#### What does this implement/fix?
<!--Please explain your changes.-->

Finish up gh-20688 : make `signal.windows` array api compatible.

Had to add several small shims:

- `acos / arccos` renames in numpy 2.0; We'll be able to drop the shims when we drop numpy < 2 and cupy < 14
- `asarray` accepting / not accepting the `device=` kwarg
- To minimize the churn in tests, also added a small bit to `xp_assert_*` functions: if `desired` is a list, deduce its array namespace from `array_namespace(actual)`. 

The rest is fairly straightforward

cc @jakevdp : can push additional commits into your branch if you prefer.

#### Additional information
<!--Any additional information you think is important.-->

Needed to add delegation to several signal functions which only accepts scalars, not arrays; wanted to follow the prior art, found gh-20668; noticed that the CI is red and logs are gone; and here we are, several frustrating hours later.

