### PR TITLE
BUG: sparse: fix Asp @ vsp for 1D sparse vector and add tests

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -550,6 +550,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             new_shape += (M,)
         if o_ndim == 2:
             new_shape += (N,)
+        faux_shape = (M if self.ndim == 2 else 1, N if o_ndim == 2 else 1)
 
         major_dim = self._swap((M, N))[0]
         other = self.__class__(other)  # convert to this format
@@ -587,7 +588,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         if new_shape == ():
             return np.array(data[0])
-        return self.__class__((data, indices, indptr), shape=new_shape)
+        res = self.__class__((data, indices, indptr), shape=faux_shape)
+        if faux_shape != new_shape:
+            if res.format != 'csr':
+                res = res.tocsr()
+            res = res.reshape(new_shape)
+        return res
 
     def diagonal(self, k=0):
         rows, cols = self.shape

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -342,6 +342,27 @@ class TestCommon1D:
             # test broadcasting
             assert_equal(dat[:1] - datsp, dat[:1] - dat)
 
+    def test_matmul_basic(self, spcreator):
+        A = np.array([[2, 0, 3.0], [0, 0, 0], [0, 1, 2]])
+        v = np.array([1, 0, 3])
+        Asp = spcreator(A)
+        vsp = spcreator(v)
+
+        # sparse result when both args are sparse and result not scalar
+        assert_equal((Asp @ vsp).toarray(), A @ v)
+        assert_equal(A @ vsp, A @ v)
+        assert_equal(Asp @ v, A @ v)
+        assert_equal((vsp @ Asp).toarray(), v @ A)
+        assert_equal(vsp @ A, v @ A)
+        assert_equal(v @ Asp, v @ A)
+
+        assert_equal(vsp @ vsp, v @ v)
+        assert_equal(v @ vsp, v @ v)
+        assert_equal(vsp @ v, v @ v)
+        assert_equal((Asp @ Asp).toarray(), A @ A)
+        assert_equal(A @ Asp, A @ A)
+        assert_equal(Asp @ A, A @ A)
+
     def test_matvec(self, spcreator):
         A = np.array([2, 0, 3.0])
         Asp = spcreator(A)
@@ -360,7 +381,7 @@ class TestCommon1D:
         bad_vecs = [np.array([1, 2]), np.array([1, 2, 3, 4]), np.array([[1], [2]])]
         for x in bad_vecs:
             with pytest.raises(ValueError, match='dimension mismatch'):
-                Asp.__matmul__(x)
+                Asp @ x
 
         # The current relationship between sparse matrix products and array
         # products is as follows:


### PR DESCRIPTION
Fixes #21775 

`Asp @ vsp` with sparse vector `vsp` tried to construct a 1D shape using the 2D indices from `csr_matmat` directly. Needs post-processing: construct with 2D shape using the data and then reshape to make the 1D result.

Added tests of basic matmul ops. 