### PR TITLE
MAINT: optimize: migration to sparray pass 1 changes

### DIFF
--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1215,7 +1215,7 @@ def _get_Abc(lp, c0):
     if sparse:
         b = b.reshape(-1, 1)
         A = A.tocsc()
-        b -= (A[:, i_shift] * sps.diags(lb_shift)).sum(axis=1)
+        b -= (A[:, i_shift] @ sps.diags(lb_shift)).sum(axis=1)
         b = b.ravel()
     else:
         b -= (A[:, i_shift] * lb_shift).sum(axis=1)

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1249,7 +1249,7 @@ def _autoscale(A, b, c, x0):
             R = R.toarray().flatten()
         R[R == 0] = 1
         R = 1/_round_to_power_of_two(R)
-        A = sps.diags(R)*A if sps.issparse(A) else A*R.reshape(m, 1)
+        A = sps.diags(R)@A if sps.issparse(A) else A*R.reshape(m, 1)
         b = b*R
 
         C = np.max(np.abs(A), axis=0)
@@ -1257,7 +1257,7 @@ def _autoscale(A, b, c, x0):
             C = C.toarray().flatten()
         C[C == 0] = 1
         C = 1/_round_to_power_of_two(C)
-        A = A*sps.diags(C) if sps.issparse(A) else A*C
+        A = A@sps.diags(C) if sps.issparse(A) else A*C
         c = c*C
 
     b_scale = np.max(np.abs(b)) if b.size > 0 else 1

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -521,7 +521,7 @@ class LinprogCommonTests:
         ub = x_valid + np.random.rand(n)
         lb = x_valid - np.random.rand(n)
         bounds = np.column_stack((lb, ub))
-        b_eq = A_eq * x_valid
+        b_eq = A_eq @ x_valid
 
         if self.method in {'simplex', 'revised simplex'}:
             # simplex and revised simplex should raise error


### PR DESCRIPTION
This very small PR is the result of "Pass 1" for migration to sparse arrays. Can you review that it is in fact appropriate to use `@` here?  

Also, I am looking toward "pass 2" of the migration process. So, are there places where you have functions that return sparse matrices? I could not find any in my search. Are any of the solutions returned via `OptimizeResult` sparse representations?  And is there anything else you might think of as a potential tricky case for conversion from matrix to array?

This is part of my effort to get SciPy converted to using sparse arrays internally. The idea is to support input generally (sparse matrix or array), and to convert internal use of sparse matrices to sparse arrays especially in the docs. 

The "migration guide for conversion to sparse arrays" suggests a 2-pass process with the 1st pass creating code that will work for either sparray or spmatrix. This PR is the result. I only found one place where an `@` should replace the spmatrix `*`.  All other checks showed that the code has been kept up to date with recommendations -- no changes needed. Yay!

The 2nd pass will involve many changes to names, e.g. `csr_matrix -> csr_array`, and constructor functions `eye -> eye_array`. So that PR will be big and repetitive.  Comments and questions are welcome.

Thanks. 