### PR TITLE
ENH: integrate.nsum: support unimodal functions and infinite lower limit of summation

### DIFF
--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -902,10 +902,9 @@ def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
     if not np.issubdtype(dtype, np.number) or np.issubdtype(dtype, np.complexfloating):
         raise ValueError(message)
 
-    valid_a = np.isfinite(a)
     valid_b = b >= a  # NaNs will be False
     valid_step = np.isfinite(step) & (step > 0)
-    valid_abstep = valid_a & valid_b & valid_step
+    valid_abstep = valid_b & valid_step
 
     message = '`log` must be True or False.'
     if log not in {True, False}:
@@ -950,7 +949,7 @@ def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
 def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances=None):
     r"""Evaluate a convergent, monotonically decreasing finite or infinite series.
 
-    For finite `b`, this evaluates::
+    For finite `a` and `b`, this evaluates::
 
         f(a + np.arange(n)*step).sum()
 
@@ -981,8 +980,13 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         are met and may return erroneous results if they are violated.
     a, b : float array_like
         Real lower and upper limits of summed terms. Must be broadcastable.
-        Each element of `a` must be finite and less than the corresponding
-        element in `b`, but elements of `b` may be infinite.
+        Each element of `a` must be less than the corresponding element in `b`.
+        
+        - If `a` is infinite, the series must be monotone increasing from `a` to `b`.
+        - If `b` is infinite, the series must be monotone decreasing from `a` to `b`.
+        - If `a` and `b` are infinite, the series must be monotone increasing from
+          `a` to the origin and monotone decreasing from the origin to `b`.
+
     step : float array_like
         Finite, positive, real step between summed terms. Must be broadcastable
         with `a` and `b`. Note that the number of terms included in the sum will
@@ -1127,7 +1131,6 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
     # Potential future work:
     # - improve error estimate of `_direct` sum
     # - add other methods for convergence acceleration (Richardson, epsilon)
-    # - support infinite lower limit?
     # - support negative monotone increasing functions?
     # - b < a / negative step?
     # - complex-valued function?
@@ -1147,7 +1150,8 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
     step = np.broadcast_to(step, shape).ravel().astype(dtype)
     valid_abstep = np.broadcast_to(valid_abstep, shape).ravel()
     nterms = np.floor((b - a) / step)
-    b = a + nterms*step
+    finite_terms = np.isfinite(nterms)
+    b[finite_terms] = a[finite_terms] + nterms[finite_terms]*step[finite_terms]
 
     # Define constants
     eps = np.finfo(dtype).eps
@@ -1163,9 +1167,15 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
     nfev = np.ones(len(a), dtype=int)  # one function evaluation above
 
     # Branch for direct sum evaluation / integral approximation / invalid input
-    i1 = (nterms + 1 <= maxterms) & valid_abstep
-    i2 = (nterms + 1 > maxterms) & valid_abstep
-    i3 = ~valid_abstep
+    i0 = ~valid_abstep                     # invalid
+    i1 = (nterms + 1 <= maxterms) & ~i0    # direct sum evaluation
+    i2 = np.isfinite(a) & ~i1 & ~i0        # infinite sum to the right
+    i3 = np.isfinite(b) & ~i2 & ~i1 & ~i0  # infinite sum to the left
+    i4 = ~i3 & ~i2 & ~i1 & ~i0             # infinite sum on both sides
+
+    if np.any(i0):
+        S[i0], E[i0] = np.nan, np.nan
+        status[i0] = -1
 
     if np.any(i1):
         args_direct = [arg[i1] for arg in args]
@@ -1181,8 +1191,40 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         nfev[i2] += tmp[-1]
 
     if np.any(i3):
-        S[i3], E[i3] = np.nan, np.nan
-        status[i3] = -1
+        args_indirect = [arg[i3] for arg in args]
+        def _f(x, *args): return f(-x, *args)
+        tmp = _integral_bound(_f, -b[i3], -a[i3], step[i3], args_indirect, constants)
+        S[i3], E[i3], status[i3] = tmp[:-1]
+        nfev[i3] += tmp[-1]
+
+    if np.any(i4):
+        args_indirect = [arg[i4] for arg in args]
+
+        # There are two obvious high-level strategies:
+        # - Do two separate half-infinite sums (e.g. from -inf to 0 and 1 to inf)
+        # - Make a callable that returns f(x) + f(-x) and do a single half-infinite sum
+        # I thought the latter would have about half the overhead, so I went that way.
+        # Then there are two ways of ensuring that f(0) doesn't get counted twice.
+        # - Evaluate the sum from 1 to inf and add f(0)
+        # - Evaluate the sum from 0 to inf and subtract f(0)
+        # - Evaluate the sum from 0 to inf, but apply a weight of 0.5 when `x = 0`
+        # The last option has more overhead, but is simpler to implement correctly
+        # (especially getting the status message right)
+        if log:
+            def _f(x, *args):
+                log_factor = np.where(x==0, np.log(0.5), 0)
+                out = np.stack([f(x, *args), f(-x, *args)], axis=0)
+                return special.logsumexp(out, axis=0) + log_factor
+
+        else:
+            def _f(x, *args):
+                factor = np.where(x==0, 0.5, 1)
+                return (f(x, *args) + f(-x, *args)) * factor
+
+        zero = np.zeros_like(a[i4])
+        tmp = _integral_bound(_f, zero, b[i4], step[i4], args_indirect, constants)
+        S[i4], E[i4], status[i4] = tmp[:-1]
+        nfev[i4] += 2*tmp[-1]
 
     # Return results
     S, E = S.reshape(shape)[()], E.reshape(shape)[()]

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -801,7 +801,7 @@ class TestNSum:
             nsum(f, f.a, f.b, tolerances=dict(rtol=pytest))
 
         with np.errstate(all='ignore'):
-            res = nsum(f, [np.nan, -np.inf, np.inf], 1)
+            res = nsum(f, [np.nan, np.inf], 1)
             assert np.all((res.status == -1) & np.isnan(res.sum)
                           & np.isnan(res.error) & ~res.success & res.nfev == 1)
             res = nsum(f, 10, [np.nan, 1])
@@ -970,6 +970,30 @@ class TestNSum:
         ref = nsum(lambda k: 1 / k ** 2, [1, 4], np.inf)
         assert np.all(res.sum > (ref.sum - res.error))
         assert np.all(res.sum < (ref.sum + res.error))
+
+    @pytest.mark.parametrize('log', [True, False])
+    def test_infinite_bounds(self, log):
+        a = [1, -np.inf, -np.inf]
+        b = [np.inf, -1, np.inf]
+        c = [1, 2, 3]
+
+        def f(x, a):
+            return (np.log(np.tanh(a / 2)) - a*np.abs(x) if log
+                    else np.tanh(a/2) * np.exp(-a*np.abs(x)))
+
+        res = nsum(f, a, b, args=(c,), log=log)
+        ref = [stats.dlaplace.sf(0, 1), stats.dlaplace.sf(0, 2), 1]
+        ref = np.log(ref) if log else ref
+        atol = 1e-10 if log else 0
+        assert_allclose(res.sum, ref, atol=atol)
+
+        # Make sure the sign of `x` passed into `f` is correct.
+        def f(x, c):
+            return -3*np.log(c*x) if log else 1 / (c*x)**3
+
+        res = nsum(f, [1, -np.inf], [np.inf, -1], args=([1, -1],), log=log)
+        ref = np.log(special.zeta(3)) if log else special.zeta(3)
+        assert_allclose(res.sum, ref)
 
     def test_special_case(self):
         # test equal lower/upper limit

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -995,6 +995,27 @@ class TestNSum:
         ref = np.log(special.zeta(3)) if log else special.zeta(3)
         assert_allclose(res.sum, ref)
 
+    def test_decreasing_check(self):
+        # Test accuracy when we start sum on an uphill slope.
+        # Without the decreasing check, the terms would look small enough to
+        # use the integral approximation. Because the function is not decreasing,
+        # the error is not bounded by the magnitude of the last term of the
+        # partial sum. In this case, the error would be  ~1e-4, causing the test
+        # to fail.
+        def f(x):
+            return np.exp(-x ** 2)
+
+        res = nsum(f, -25, np.inf)
+
+        # Reference computed with mpmath:
+        # from mpmath import mp
+        # mp.dps = 50
+        # def fmp(x): return mp.exp(-x**2)
+        # ref = mp.nsum(fmp, (-25, 0)) + mp.nsum(fmp, (1, mp.inf))
+        ref = 1.772637204826652
+
+        np.testing.assert_allclose(res.sum, ref, rtol=1e-15)
+
     def test_special_case(self):
         # test equal lower/upper limit
         f = self.f1


### PR DESCRIPTION
#### Reference issue
Toward gh-15928 

#### What does this implement/fix?
Previously, `scipy.integrate.nsum` was documented to support only monotone decreasing functions with finite lower limit of summation. This add support for unimodal functions, possibly with an infinite lower limit of summation.

#### Additional information
Besides making `nsum` more robust and fully-featured, these improvements will allow the new discrete distribution infrastructure to support two-tailed discrete distributions.