### PR TITLE
BUG: stats.qmc: fix `get_poly_vinit` for multi-threading

### DIFF
--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -66,10 +66,13 @@ def get_poly_vinit(kind, dtype):
         poly_vinit = _vinit_dict.get(dtype)
 
     if poly_vinit is None:
-        _poly_dict[dtype] = np.empty((MAXDIM,), dtype=dtype)
-        _vinit_dict[dtype] = np.empty((MAXDIM, MAXDEG), dtype=dtype)
+        poly = np.empty((MAXDIM,), dtype=dtype)
+        vinit = np.empty((MAXDIM, MAXDEG), dtype=dtype)
 
-        _initialize_direction_numbers(_poly_dict[dtype], _vinit_dict[dtype], dtype)
+        _initialize_direction_numbers(poly, vinit, dtype)
+
+        _poly_dict[dtype] = poly
+        _vinit_dict[dtype] = vinit
 
         if kind == 'poly':
             poly_vinit = _poly_dict.get(dtype)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #21788

#### What does this implement/fix?
<!--Please explain your changes.-->

The original implementation of `get_poly_vinit` is not thread-safe. For example,

1. Thread 1: Add an empty array to `_poly_dict[dtype]`
2. Thread 2: Read the empty array from `_poly_dict[dtype]` (This is wrong!)
3. Thread 1: Write the initialized array to `_poly_dict[dtype]`



#### Additional information
<!--Any additional information you think is important.-->

The following code is the same as #21788.

##### Reproducing Code Example

```python
import scipy.stats.qmc as qmc
from concurrent.futures import ThreadPoolExecutor

futures = set()
with ThreadPoolExecutor(max_workers=2) as executor:
    for i in range(2):
        futures.add(executor.submit(qmc.Sobol, 2))
```

##### Error message

```shell
Traceback (most recent call last):
  File "<stringsource>", line 1294, in View.MemoryView.memoryview_copy_contents
  File "<stringsource>", line 1249, in View.MemoryView._err_extents
ValueError: got differing extents in dimension 0 (got 30 and 18)
Exception ignored in: 'scipy.stats._sobol._initialize_v'
Traceback (most recent call last):
  File "<stringsource>", line 1294, in View.MemoryView.memoryview_copy_contents
  File "<stringsource>", line 1249, in View.MemoryView._err_extents
ValueError: got differing extents in dimension 0 (got 30 and 18)
```

The error message seems to correspond to the following lines. I think `p` will be 0 and `m` will be `-1` with the multi-threading bug. So, `v[d, :m]` and `vinit[d, :m]` will have different shapes.

https://github.com/scipy/scipy/blob/170f9e69a5abf65a7c46d35626c4a3a64132246b/scipy/stats/_sobol.pyx#L264-L269