### PR TITLE
MAINT: Update `array_api_compat` submodule for the 2023.12 spec

### DIFF
--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -163,6 +163,7 @@ py3.install_sources(
     'array_api_compat/array_api_compat/cupy/__init__.py',
     'array_api_compat/array_api_compat/cupy/_aliases.py',
     'array_api_compat/array_api_compat/cupy/_typing.py',
+    'array_api_compat/array_api_compat/cupy/_info.py',
     'array_api_compat/array_api_compat/cupy/fft.py',
     'array_api_compat/array_api_compat/cupy/linalg.py',
   ],
@@ -180,6 +181,8 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/dask/array/__init__.py',
     'array_api_compat/array_api_compat/dask/array/_aliases.py',
+    'array_api_compat/array_api_compat/dask/array/_info.py',
+    'array_api_compat/array_api_compat/dask/array/fft.py',
     'array_api_compat/array_api_compat/dask/array/linalg.py',
   ],
   subdir: 'scipy/_lib/array_api_compat/dask/array',
@@ -190,6 +193,7 @@ py3.install_sources(
     'array_api_compat/array_api_compat/numpy/__init__.py',
     'array_api_compat/array_api_compat/numpy/_aliases.py',
     'array_api_compat/array_api_compat/numpy/_typing.py',
+    'array_api_compat/array_api_compat/numpy/_info.py',
     'array_api_compat/array_api_compat/numpy/fft.py',
     'array_api_compat/array_api_compat/numpy/linalg.py',
   ],
@@ -200,6 +204,7 @@ py3.install_sources(
   [
     'array_api_compat/array_api_compat/torch/__init__.py',
     'array_api_compat/array_api_compat/torch/_aliases.py',
+    'array_api_compat/array_api_compat/torch/_info.py',
     'array_api_compat/array_api_compat/torch/fft.py',
     'array_api_compat/array_api_compat/torch/linalg.py',
   ],

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -964,6 +964,10 @@ class TestDendrogram:
 
         plt.close()
 
+    @skip_xp_backends('torch',
+         reason='MPL 3.9.2 & torch DeprecationWarning from __array_wrap__'
+                ' and NumPy 2.0'
+    )
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_plot(self, xp):
         for orientation in ['top', 'bottom', 'left', 'right']:
@@ -1031,6 +1035,10 @@ class TestDendrogram:
         R2['dcoord'] = np.asarray(R2['dcoord'])
         assert_equal(R2, expected)
 
+    @skip_xp_backends('torch',
+          reason='MPL 3.9.2 & torch DeprecationWarning from __array_wrap__'
+                 ' and NumPy 2.0'
+     )
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_dendrogram_truncate_mode(self, xp):
         Z = linkage(xp.asarray(hierarchy_test_data.ytdist), 'single')


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes https://github.com/scipy/scipy/issues/21795

#### What does this implement/fix?
<!--Please explain your changes.-->

Update the array-api-compat submodule so that we can use the 2023.12 features.

#### Additional information
<!--Any additional information you think is important.-->

It's rather annoying that we need to track the submodule development, including implementation details in `_understored_py_sources.py`. But I guess it's the meson way, so `¯\_(ツ)_/¯`
