### PR TITLE
ENH: sparse.linalg: add `is_sptriangular` and `spbandwidth` functions

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -747,6 +747,8 @@ def is_sptriangular(A):
     lower triangular or upper triangular respectively. Diagonal ``A`` will
     result in both being True. Non-triangular structure results in False for both.
 
+    Only the sparse structure is used here. Values are not checked for zeros.
+
     This function will convert a copy of ``A`` to CSC format if it is not already
     CSR or CSC format. So it may be more efficient to convert it yourself if you
     have other uses for the CSR/CSC version.
@@ -824,6 +826,8 @@ def spbandwidth(A):
     of positive integers ``(lo, hi)``. A zero denotes no sub/super
     diagonal entries on that side (tringular). The maximum value
     for ``lo``(``hi``) is one less than the number of rows(cols).
+
+    Only the sparse structure is used here. Values are not checked for zeros.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -2,7 +2,6 @@ from warnings import warn, catch_warnings, simplefilter
 
 import numpy as np
 from numpy import asarray
-from scipy.sparse import (issparse,
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
                           csr_array, csc_array, eye_array, diags_array)
 from scipy.sparse._sputils import is_pydata_spmatrix, convert_pydata_sparse_to_scipy

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -780,7 +780,7 @@ def is_sptriangular(A):
     if not (issparse(A) and A.format in ("csc", "csr", "coo", "dia", "dok", "lil")):
         warn('is_sptriangular needs sparse and not BSR format. Converting to CSR.',
              SparseEfficiencyWarning, stacklevel=2)
-        A = csr_matrix(A)
+        A = csr_array(A)
 
     # bsr and lil are better off converting to csr
     if A.format == "dia":
@@ -852,7 +852,7 @@ def spbandwidth(A):
     if not (issparse(A) and A.format in ("csc", "csr", "coo", "dia", "dok")):
         warn('spbandwidth needs sparse format not LIL and BSR. Converting to CSR.',
              SparseEfficiencyWarning, stacklevel=2)
-        A = csr_matrix(A)
+        A = csr_array(A)
 
     # bsr and lil are better off converting to csr
     if A.format == "dia":

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -882,14 +882,15 @@ class TestSpsolveTriangular:
 
 @sup_sparse_efficiency
 @pytest.mark.parametrize("nnz", [10, 10**2, 10**3])
-@pytest.mark.parametrize("fmt", ["csr", "csc"])
+@pytest.mark.parametrize("fmt", ["csr", "csc", "coo", "dia", "dok", "lil"])
 def test_is_sptriangular_and_spbandwidth(nnz, fmt):
     rng = np.random.default_rng(42)
 
     N = nnz // 2
     dens = 0.1
-    A = scipy.sparse.random_array((N, N), density=dens, format=fmt, random_state=rng)
+    A = scipy.sparse.random_array((N, N), density=dens, format="csr", random_state=rng)
     A[1, 3] = A[3, 1] = 22  # ensure not upper or lower
+    A = A.asformat(fmt)
     AU = scipy.sparse.triu(A, format=fmt)
     AL = scipy.sparse.tril(A, format=fmt)
     D = 0.1 * scipy.sparse.eye_array(N, format=fmt)

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -881,22 +881,18 @@ class TestSpsolveTriangular:
 
 
 @sup_sparse_efficiency
-@pytest.mark.parametrize("nnz", [10, 10**2, 10^3])
+@pytest.mark.parametrize("nnz", [10, 10**2, 10**3])
 @pytest.mark.parametrize("fmt", ["csr", "csc"])
 def test_is_sptriangular_and_spbandwidth(nnz, fmt):
     rng = np.random.default_rng(42)
-    random_array = scipy.sparse.random_array
-    eye_array = scipy.sparse.eye_array
-    triu = scipy.sparse.triu
-    tril = scipy.sparse.tril
 
-    nshp = nnz // 2
+    N = nnz // 2
     dens = 0.1
-    A = random_array((nshp, nshp), density=dens, format=fmt, random_state=rng)
+    A = scipy.sparse.random_array((N, N), density=dens, format=fmt, random_state=rng)
     A[1, 3] = A[3, 1] = 22  # ensure not upper or lower
-    AU = triu(A, format=fmt)
-    AL = tril(A, format=fmt)
-    D = 0.1 * eye_array(nshp, format=fmt)
+    AU = scipy.sparse.triu(A, format=fmt)
+    AL = scipy.sparse.tril(A, format=fmt)
+    D = 0.1 * scipy.sparse.eye_array(N, format=fmt)
 
     assert is_sptriangular(A) == (False, False)
     assert is_sptriangular(AL) == (True, False)


### PR DESCRIPTION
This provides a performant upper/lower triangular detector for CSR/CSC sparse formats.

Addresses part of #21679 (check for triangular in `spsolve` and dispatch to `is_sptriangular`)

**Questions:** 
- names... `is_sptriangular` vs `is_triangular` and `spbandwidth` vs `bandwidth`. It seemed that a `sp` prefix is commonly used in `sparse.linalg`.  What is the preference?

- Should we even bother including a bandwidth checking function yet. There is no solver to take advantage of the structure. But it was easy to write it while writing the triangular check, so I included it. I'll remove it if that's better. 

Note: Since `spsolve` converts any other formats (and even dense input), these functions do too.

**Results:**

**`is_sptriangular(A) -> lower, upper`** indicating True/False for lower or upper triangular. Diagonal returns `(True, True)`. Unstructured returns (False, False). This implementation provides a shortcut check of the ~middle column and then 1st and last columns. These should catch most matrices of interest. (middle is "typical" and 1st and last are "often different" so can rule out almost-triangular. After the shortcut, we just check `cols >= rows` and `cols <= rows` using `numpy` tools to construct these arrays.

  The timing results below show checking is much faster than solving, as desired. Letting $t_g$ be the general solver time, $t_T$ be the special triangular solver time and $t_c$ be the checking time. Then $t_c \ll t_g$ for full matrices and $t_T + t_c \ll t_g$ and $T_c \ll t_T$ for triangular case. Note that $t_c$ can be much faster for full than for triangular matrices. But both are much faster than solving time. All the times depend on the sparse `nnz`, and scaling arguments show that the "much faster than" will only get even more-so as `nnz` increases. Timing reveal the theoretical $O(nnz^3)$ for general solver, $O(nnz^2)$ for triangular solver and $O(nnz)$ for checking.

  I include the timing for a checker assuming a canonical CSC structure. But because the loops are in Python, for the triangular case, it is actually slower than using the general case numpy tools. Since all these checking times are so much smaller than solving I don't think we should use canonical methods or implement in cython. But we obviously could.
```
For full matrix:
=================== ======== ======== ======== ========
task \ nnz           1000     2000     4000     8000
=================== ======== ======== ======== ========
spsolve (t_g)        0.028s   0.195s   1.71s    12.4s
check of tri (t_c)   2.48µs   2.54µs   2.48µs   2.53µs
canonical tri check  1.50µs   1.51µs   2.15µs   1.63µs
=================== ======== ======== ======== ========

- t_g >> t_c 
- canonical check is fast to reject full
- t_g = O(nnz^3)
- t_c = O(1) to reject most triangular. worst case O(nnz) 

For triangular matrix:
=================== ======== ======== ======== ========
task \ nnz           1000     2000     4000     8000
=================== ======== ======== ======== ========
spsolve (t_g)        6.10ms   61.3ms   582ms    5450ms
spsolve_tri (t_t)    229 µs   338 µs   526 µs   1070µs
check of tri (t_c)    15.0µs   21.1µs   33.0µs    64.2µs
canonical tri check   88.2µs  178µs    357µs     716µs
=================== ======== ======== ======== ========

 - t_T + t_c << t_g and t_c << t_T
 - canonical check is slow to accept without C/Cython
 - t_g = O(nnz^3)
 - t_T = O(nnz^2)
 - t_c = O(nnz) to accept triangular
```

**`spbandwidth(A) -> below, above`** indicating the max distance to main diagonal for nonzeros below and above the main diagonal. So, 0 means the matrix is triangular and `(0, 0)` means a diagonal matrix.  Timing for this is slower as expected than `is_sptriangular` but still $O(nnz)$. Here we need `subtract, min, max` over cols & rows instead of `>=, <=`. 

```
For Bandwidth function::
=================== ======= ======= ======= =======
task \ nnz           1000    2000    4000    8000
=================== ======= ======= ======= =======
time for bandwidth   17.1µs  29.0µs  58.8µs  112µs  
=================== ======= ======= ======= =======

- time is O(nnz) 
- time is slightly more than is_triangular (sub, min, max vs. >=, <=)
```