### PR TITLE
DOC: signal.find_peaks: Document that widths are returned

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -798,7 +798,7 @@ def find_peaks(x, height=None, threshold=None, distance=None,
         * 'prominences', 'right_bases', 'left_bases'
               If `prominence` is given, these keys are accessible. See
               `peak_prominences` for a description of their content.
-        * 'width_heights', 'left_ips', 'right_ips'
+        * 'widths', 'width_heights', 'left_ips', 'right_ips'
               If `width` is given, these keys are accessible. See `peak_widths`
               for a description of their content.
         * 'plateau_sizes', left_edges', 'right_edges'


### PR DESCRIPTION
#### What does this implement/fix?

Document that widths is a key in the returned dict from find_peaks if width is given as an input argument. 

As can be seen below the key is added to the result dictionary so this looks like it's just a small omission. 

#### Additional information

I discovered that this was missing since the key is not included in the scipy-stubs package. 
It seems like a good idea to document it here too. 
