### PR TITLE
MAINT: special: remove dependence of `xsf::numpy` on `sf_error`

### DIFF
--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -11,11 +11,6 @@ extern const char *rctj_doc;
 extern const char *rcty_doc;
 extern const char *sph_harm_all_doc;
 
-// This is needed by sf_error, it is defined in the Cython "_ufuncs_extra_code_common.pxi" for "_generate_pyx.py".
-// It exists to "call PyUFunc_getfperr in a context where PyUFunc_API array is initialized", but here we are
-// already in such a context.
-extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
-
 static PyModuleDef _gufuncs_def = {PyModuleDef_HEAD_INIT, "_gufuncs", NULL, -1, NULL, NULL, NULL, NULL, NULL};
 
 template <size_t NOut>

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -169,11 +169,6 @@ extern const char *yv_doc;
 extern const char *yve_doc;
 extern const char *zetac_doc;
 
-// This is needed by sf_error, it is defined in the Cython "_ufuncs_extra_code_common.pxi" for "_generate_pyx.py".
-// It exists to "call PyUFunc_getfperr in a context where PyUFunc_API array is initialized", but here we are
-// already in such a context.
-extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
-
 static PyModuleDef _special_ufuncs_def = {
     PyModuleDef_HEAD_INIT, "_special_ufuncs", NULL, -1, NULL, NULL, NULL, NULL, NULL};
 

--- a/scipy/special/xsf/numpy.h
+++ b/scipy/special/xsf/numpy.h
@@ -24,9 +24,9 @@
 namespace xsf {
 namespace numpy {
 
-    // This is needed by sf_error, it is defined in the Cython "_ufuncs_extra_code_common.pxi" for "_generate_pyx.py".
-    // It exists to "call PyUFunc_getfperr in a context where PyUFunc_API array is initialized", but here we are
-    // already in such a context.
+    /* PyUFunc_getfperr gets bits for current floating point error (fpe) status codes so we
+     * can check for floating point errors and make proper calls to set_error in ufunc loops.
+     * Define a wrapper so it can be given C linkage within this C++ header. */
     extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
 
     void set_error_check_fpe(const char *func_name) {

--- a/scipy/special/xsf/numpy.h
+++ b/scipy/special/xsf/numpy.h
@@ -21,13 +21,13 @@
 #include "error.h"
 #include "third_party/kokkos/mdspan.hpp"
 
+/* PyUFunc_getfperr gets bits for current floating point error (fpe) status codes so we
+ * can check for floating point errors and make proper calls to set_error in ufunc loops.
+ * Define a wrapper so it can be given C linkage within this C++ header. */
+extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
+
 namespace xsf {
 namespace numpy {
-
-    /* PyUFunc_getfperr gets bits for current floating point error (fpe) status codes so we
-     * can check for floating point errors and make proper calls to set_error in ufunc loops.
-     * Define a wrapper so it can be given C linkage within this C++ header. */
-    extern "C" int wrap_PyUFunc_getfperr() { return PyUFunc_getfperr(); }
 
     void set_error_check_fpe(const char *func_name) {
 	int status = wrap_PyUFunc_getfperr();


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR makes it so `scipy/special/xsf/numpy.h` no longer depends on `scipy/special/sf_error.cc`, which is outside of the `xsf` codebase. This is the last structural barrier in the way of beginning the migration of the scipy special C++ headers into the `xsf` library, as described here: https://github.com/scipy/xsf/issues/1.

#### Additional information
<!--Any additional information you think is important.-->
@izaid, the change here is pretty straightforward, let me know if everything looks good to you. @mdhaber, would you be willing to merge with @izaid's approval?
