### PR TITLE
BUG: `signal.correlation_lags`: fail with meaningful error message if the mode is unknown

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -405,6 +405,8 @@ def correlation_lags(in1_len, in2_len, mode='full'):
             lags = np.arange(lag_bound + 1)
         else:
             lags = np.arange(lag_bound, 1)
+    else:
+        raise ValueError(f"Mode {mode} is invalid")
     return lags
 
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2135,6 +2135,11 @@ def test_correlation_lags(mode, behind, input_size):
     assert_equal(lags.shape, correlation.shape)
 
 
+def test_correlation_lags_invalid_mode():
+    with pytest.raises(ValueError, match="Mode asdfgh is invalid"):
+        correlation_lags(100, 100, mode="asdfgh")
+
+
 @pytest.mark.parametrize('dt', [np.csingle, np.cdouble,
                                 pytest.param(np.clongdouble, marks=_pmf)])
 class TestCorrelateComplex:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #21807

#### What does this implement/fix?
A simple `else` at the end of the `if` clause selecting the modes, that fails with a meaningful error message
