### PR TITLE
BUG: optimize.curve_fit fix sigma dimension issue with nan_policy="omit"

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -245,8 +245,169 @@ def float_factorial(n: int) -> float:
     return float(math.factorial(n)) if n < 171 else np.inf
 
 
+# SPEC 7
+def _transition_to_rng(old_name, *, position_num=None, end_version=None):
+    """Example decorator to transition from old PRNG usage to new `rng` behavior
+
+    Suppose the decorator is applied to a function that used to accept parameter
+    `old_name='random_state'` either by keyword or as a positional argument at
+    `position_num=1`. At the time of application, the name of the argument in the
+    function signature is manually changed to the new name, `rng`. If positional
+    use was allowed before, this is not changed.*
+
+    - If the function is called with both `random_state` and `rng`, the decorator
+      raises an error.
+    - If `random_state` is provided as a keyword argument, the decorator passes
+      `random_state` to the function's `rng` argument as a keyword. If `end_version`
+      is specified, the decorator will emit a `DeprecationWarning` about the
+      deprecation of keyword `random_state`.
+    - If `random_state` is provided as a positional argument, the decorator passes
+      `random_state` to the function's `rng` argument by position. If `end_version`
+      is specified, the decorator will emit a `FutureWarning` about the changing
+      interpretation of the argument.
+    - If `rng` is provided as a keyword argument, the decorator validates `rng` using
+      `numpy.random.default_rng` before passing it to the function.
+    - If `end_version` is specified and neither `random_state` nor `rng` is provided
+      by the user, the decorator checks whether `np.random.seed` has been used to set
+      the global seed. If so, it emits a `FutureWarning`, noting that usage of
+      `numpy.random.seed` will eventually have no effect. Either way, the decorator
+      calls the function without explicitly passing the `rng` argument.
+
+    If `end_version` is specified, a user must pass `rng` as a keyword to avoid
+    warnings.
+
+    After the deprecation period, the decorator can be removed, and the function
+    can simply validate the `rng` argument by calling `np.random.default_rng(rng)`.
+
+    * A `FutureWarning` is emitted when the PRNG argument is used by
+      position. It indicates that the "Hinsen principle" (same
+      code yielding different results in two versions of the software)
+      will be violated, unless positional use is deprecated. Specifically:
+
+      - If `None` is passed by position and `np.random.seed` has been used,
+        the function will change from being seeded to being unseeded.
+      - If an integer is passed by position, the random stream will change.
+      - If `np.random` or an instance of `RandomState` is passed by position,
+        an error will be raised.
+
+      We suggest that projects consider deprecating positional use of
+      `random_state`/`rng` (i.e., change their function signatures to
+      ``def my_func(..., *, rng=None)``); that might not make sense
+      for all projects, so this SPEC does not make that
+      recommendation, neither does this decorator enforce it.
+
+    Parameters
+    ----------
+    old_name : str
+        The old name of the PRNG argument (e.g. `seed` or `random_state`).
+    position_num : int, optional
+        The (0-indexed) position of the old PRNG argument (if accepted by position).
+        Maintainers are welcome to eliminate this argument and use, for example,
+        `inspect`, if preferred.
+    end_version : str, optional
+        The full version number of the library when the behavior described in
+        `DeprecationWarning`s and `FutureWarning`s will take effect. If left
+        unspecified, no warnings will be emitted by the decorator.
+
+    """
+    NEW_NAME = "rng"
+
+    cmn_msg = (
+        "To silence this warning and ensure consistent behavior in SciPy "
+        f"{end_version}, control the RNG using argument `{NEW_NAME}`. Arguments passed "
+        f"to keyword `{NEW_NAME}` will be validated by `np.random.default_rng`, so the "
+        "behavior corresponding with a given value may change compared to use of "
+        f"`{old_name}`. For example, "
+        "1) `None` will result in unpredictable random numbers, "
+        "2) an integer will result in a different stream of random numbers, (with the "
+        "same distribution), and "
+        "3) `np.random` or `RandomState` instances will result in an error. "
+        "See the documentation of `default_rng` for more information."
+    )
+
+    def decorator(fun):
+        @functools.wraps(fun)
+        def wrapper(*args, **kwargs):
+            # Determine how PRNG was passed
+            as_old_kwarg = old_name in kwargs
+            as_new_kwarg = NEW_NAME in kwargs
+            as_pos_arg = position_num is not None and len(args) >= position_num + 1
+            emit_warning = end_version is not None
+
+            # Can only specify PRNG one of the three ways
+            if int(as_old_kwarg) + int(as_new_kwarg) + int(as_pos_arg) > 1:
+                message = (
+                    f"{fun.__name__}() got multiple values for "
+                    f"argument now known as `{NEW_NAME}`. Specify one of "
+                    f"`{NEW_NAME}` or `{old_name}`."
+                )
+                raise TypeError(message)
+
+            # Check whether global random state has been set
+            global_seed_set = np.random.mtrand._rand._bit_generator._seed_seq is None
+
+            if as_old_kwarg:  # warn about deprecated use of old kwarg
+                kwargs[NEW_NAME] = kwargs.pop(old_name)
+                if emit_warning:
+                    message = (
+                        f"Use of keyword argument `{old_name}` is "
+                        f"deprecated and replaced by `{NEW_NAME}`.  "
+                        f"Support for `{old_name}` will be removed "
+                        f"in SciPy {end_version}. "
+                    ) + cmn_msg
+                    warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+            elif as_pos_arg:
+                # Warn about changing meaning of positional arg
+
+                # Note that this decorator does not deprecate positional use of the
+                # argument; it only warns that the behavior will change in the future.
+                # Simultaneously transitioning to keyword-only use is another option.
+
+                arg = args[position_num]
+                # If the argument is None and the global seed wasn't set, or if the
+                # argument is one of a few new classes, the user will not notice change
+                # in behavior.
+                ok_classes = (
+                    np.random.Generator,
+                    np.random.SeedSequence,
+                    np.random.BitGenerator,
+                )
+                if (arg is None and not global_seed_set) or isinstance(arg, ok_classes):
+                    pass
+                elif emit_warning:
+                    message = (
+                        f"Positional use of `{NEW_NAME}` (formerly known as "
+                        f"`{old_name}`) is still allowed, but the behavior is "
+                        "changing: the argument will be normalized using "
+                        f"`np.random.default_rng` beginning in SciPy {end_version}, "
+                        "and the resulting `Generator` will be used to generate "
+                        "random numbers."
+                    ) + cmn_msg
+                    warnings.warn(message, FutureWarning, stacklevel=2)
+
+            elif as_new_kwarg:  # no warnings; this is the preferred use
+                # After the removal of the decorator, normalization with
+                # np.random.default_rng will be done inside the decorated function
+                kwargs[NEW_NAME] = np.random.default_rng(kwargs[NEW_NAME])
+
+            elif global_seed_set and emit_warning:
+                # Emit FutureWarning if `np.random.seed` was used and no PRNG was passed
+                message = (
+                    "The NumPy global RNG was seeded by calling "
+                    f"`np.random.seed`. Beginning in {end_version}, this "
+                    "function will no longer use the global RNG."
+                ) + cmn_msg
+                warnings.warn(message, FutureWarning, stacklevel=2)
+
+            return fun(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 # copy-pasted from scikit-learn utils/validation.py
-# change this to scipy.stats._qmc.check_random_state once numpy 1.16 is dropped
 def check_random_state(seed):
     """Turn `seed` into a `np.random.RandomState` instance.
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -882,10 +882,11 @@ class TestSolve:
         assert_(x.shape == (2, 0), 'Returned empty array shape is wrong')
 
     @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-    @pytest.mark.parametrize('assume_a', ['diagonal', 'tridiagonal', 'lower triangular',
-                                          'upper triangular', 'symmetric', 'hermitian',
-                                          'positive definite', 'general',
-                                          'sym', 'her', 'pos', 'gen'])
+    # "pos" and "positive definite" need to be added
+    @pytest.mark.parametrize('assume_a', ['diagonal', 'tridiagonal', 'banded',
+                                          'lower triangular', 'upper triangular',
+                                          'symmetric', 'hermitian',
+                                          'general', 'sym', 'her', 'gen'])
     @pytest.mark.parametrize('nrhs', [(), (5,)])
     @pytest.mark.parametrize('transposed', [True, False])
     @pytest.mark.parametrize('overwrite', [True, False])
@@ -893,7 +894,7 @@ class TestSolve:
     def test_structure_detection(self, dtype, assume_a, nrhs, transposed,
                                  overwrite, fortran):
         rng = np.random.default_rng(982345982439826)
-        n = 5
+        n = 5 if not assume_a == 'banded' else 20
         b = rng.random(size=(n,) + nrhs)
         A = rng.random(size=(n, n))
 
@@ -911,6 +912,8 @@ class TestSolve:
             A = (np.diag(np.diag(A))
                  + np.diag(np.diag(A, -1), -1)
                  + np.diag(np.diag(A, 1), 1))
+        elif assume_a == 'banded':
+            A = np.triu(np.tril(A, 2), -1)
         elif assume_a in {'symmetric', 'sym'}:
             A = A + A.T
         elif assume_a in {'hermitian', 'her'}:
@@ -933,19 +936,21 @@ class TestSolve:
             return
 
         res = solve(A, b, overwrite_a=overwrite, overwrite_b=overwrite,
-                    transposed=transposed)
+                    transposed=transposed, assume_a=assume_a)
 
+        # Check that solution this solution is *correct*
+        ref = np.linalg.solve(A_copy.T if transposed else A_copy, b_copy)
+        assert_allclose(res, ref)
+
+        # Check that `solve` correctly identifies the structure and returns
+        # *exactly* the same solution whether `assume_a` is specified or not
+        if assume_a != 'banded':  # structure detection removed for banded
+            assert_equal(solve(A_copy, b_copy, transposed=transposed), res)
+
+        # Check that overwrite was respected
         if not overwrite:
             assert_equal(A, A_copy)
             assert_equal(b, b_copy)
-
-        assume_a = 'sym' if assume_a in {'positive definite', 'pos'} else assume_a
-
-        ref = solve(A_copy, b_copy, assume_a=assume_a, transposed=transposed)
-        assert_equal(res, ref)
-
-        ref = np.linalg.solve(A_copy.T if transposed else A_copy, b_copy)
-        assert_allclose(res, ref)
 
 
 class TestSolveTriangular:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize._optimize import _status_message, _wrap_callback
 from scipy._lib._util import (check_random_state, MapWrapper, _FunctionWrapper,
-                              rng_integers)
+                              rng_integers, _transition_to_rng)
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
@@ -20,9 +20,10 @@ __all__ = ['differential_evolution']
 _MACHEPS = np.finfo(np.float64).eps
 
 
+@_transition_to_rng("seed", position_num=9)
 def differential_evolution(func, bounds, args=(), strategy='best1bin',
                            maxiter=1000, popsize=15, tol=0.01,
-                           mutation=(0.5, 1), recombination=0.7, seed=None,
+                           mutation=(0.5, 1), recombination=0.7, rng=None,
                            callback=None, disp=False, polish=True,
                            init='latinhypercube', atol=0, updating='immediate',
                            workers=1, constraints=(), x0=None, *,
@@ -124,14 +125,30 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         denoted by CR. Increasing this value allows a larger number of mutants
         to progress into the next generation, but at the risk of population
         stability.
-    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
-        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-        singleton is used.
-        If `seed` is an int, a new ``RandomState`` instance is used,
-        seeded with `seed`.
-        If `seed` is already a ``Generator`` or ``RandomState`` instance then
-        that instance is used.
-        Specify `seed` for repeatable minimizations.
+    rng : {None, int, `numpy.random.Generator`}, optional
+        If `rng` is passed by keyword, types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rng` is already a ``Generator`` instance, then the provided instance is
+        used. Specify `rng` for repeatable minimizations.
+        
+        If this argument is passed by position or `seed` is passed by keyword,
+        legacy behavior for the argument `seed` applies:
+        
+        - If `seed` is None (or `numpy.random`), the `numpy.random.RandomState`
+          singleton is used.
+        - If `seed` is an int, a new ``RandomState`` instance is used,
+          seeded with `seed`.
+        - If `seed` is already a ``Generator`` or ``RandomState`` instance then
+          that instance is used.
+        
+        .. versionchanged:: 1.15.0
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator` this keyword was changed from `seed` to `rng`.
+            For an interim period, both keywords will continue to work (only specify
+            one of them). After the interim period using the `seed` keyword will emit
+            warnings. The behavior of the `seed` and `rng` keywords is outlined above.
+
     disp : bool, optional
         Prints the evaluated `func` at every iteration.
     callback : callable, optional
@@ -424,7 +441,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
 
     >>> bounds = Bounds([0., 0.], [2., 2.])
     >>> result = differential_evolution(rosen, bounds, constraints=lc,
-    ...                                 seed=1)
+    ...                                 rng=1)
     >>> result.x, result.fun
     (array([0.96632622, 0.93367155]), 0.0011352416852625719)
 
@@ -436,7 +453,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     ...     arg2 = 0.5 * (np.cos(2. * np.pi * x[0]) + np.cos(2. * np.pi * x[1]))
     ...     return -20. * np.exp(arg1) - np.exp(arg2) + 20. + np.e
     >>> bounds = [(-5, 5), (-5, 5)]
-    >>> result = differential_evolution(ackley, bounds, seed=1)
+    >>> result = differential_evolution(ackley, bounds, rng=1)
     >>> result.x, result.fun
     (array([0., 0.]), 4.440892098500626e-16)
 
@@ -445,7 +462,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     function evaluations.
 
     >>> result = differential_evolution(
-    ...     ackley, bounds, vectorized=True, updating='deferred', seed=1
+    ...     ackley, bounds, vectorized=True, updating='deferred', rng=1
     ... )
     >>> result.x, result.fun
     (array([0., 0.]), 4.440892098500626e-16)
@@ -491,7 +508,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
                                      popsize=popsize, tol=tol,
                                      mutation=mutation,
                                      recombination=recombination,
-                                     seed=seed, polish=polish,
+                                     rng=rng, polish=polish,
                                      callback=callback,
                                      disp=disp, init=init, atol=atol,
                                      updating=updating,
@@ -594,14 +611,33 @@ class DifferentialEvolutionSolver:
         denoted by CR. Increasing this value allows a larger number of mutants
         to progress into the next generation, but at the risk of population
         stability.
-    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
-        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-        singleton is used.
-        If `seed` is an int, a new ``RandomState`` instance is used,
-        seeded with `seed`.
-        If `seed` is already a ``Generator`` or ``RandomState`` instance then
-        that instance is used.
-        Specify `seed` for repeatable minimizations.
+
+    rng : {None, int, `numpy.random.Generator`}, optional
+        
+        ..versionchanged:: 1.15.0
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator` this keyword was changed from `seed` to `rng`.
+            For an interim period both keywords will continue to work (only specify
+            one of them). After the interim period using the `seed` keyword will emit
+            warnings. The behavior of the `seed` and `rng` keywords is outlined below.
+
+        If `rng` is passed by keyword, types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a `Generator`.
+        If `rng` is already a `Generator` instance, then the provided instance is
+        used.
+        
+        If this argument is passed by position or `seed` is passed by keyword, the
+        behavior is:
+        
+        - If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+          singleton is used.
+        - If `seed` is an int, a new `RandomState` instance is used,
+          seeded with `seed`.
+        - If `seed` is already a `Generator` or `RandomState` instance then
+          that instance is used.
+        
+        Specify `seed`/`rng` for repeatable minimizations.
     disp : bool, optional
         Prints the evaluated `func` at every iteration.
     callback : callable, optional
@@ -745,7 +781,7 @@ class DifferentialEvolutionSolver:
 
     def __init__(self, func, bounds, args=(),
                  strategy='best1bin', maxiter=1000, popsize=15,
-                 tol=0.01, mutation=(0.5, 1), recombination=0.7, seed=None,
+                 tol=0.01, mutation=(0.5, 1), recombination=0.7, rng=None,
                  maxfun=np.inf, callback=None, disp=False, polish=True,
                  init='latinhypercube', atol=0, updating='immediate',
                  workers=1, constraints=(), x0=None, *, integrality=None,
@@ -864,7 +900,7 @@ class DifferentialEvolutionSolver:
 
         self.parameter_count = np.size(self.limits, 1)
 
-        self.random_number_generator = check_random_state(seed)
+        self.random_number_generator = check_random_state(rng)
 
         # Which parameters are going to be integers?
         if np.any(integrality):

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -961,8 +961,19 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
             has_nan = has_nan.any(axis=tuple(range(has_nan.ndim-1)))
             has_nan |= np.isnan(ydata)
 
+            # Store the size of ydata before purging the nan values
+            prev_ydata_size = ydata.size
+
             xdata = xdata[..., ~has_nan]
             ydata = ydata[~has_nan]
+
+            # Also omit the corresponding entries form sigma
+            if sigma is not None:
+                sigma = np.asarray(sigma)
+                if sigma.shape == (prev_ydata_size, ):
+                    sigma = sigma[~has_nan]
+                if sigma.shape == (prev_ydata_size, prev_ydata_size):
+                    sigma = sigma[~has_nan, ~has_nan]
 
     # Determine type of sigma
     if sigma is not None:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -311,7 +311,7 @@ class TestDifferentialEvolutionSolver:
         callback.func = func
 
         bounds = [(0, 2), (0, 2)]
-        kwargs = dict(func=func, bounds=bounds, seed=838245, polish=False)
+        kwargs = dict(func=func, bounds=bounds, rng=838245, polish=False)
         res = differential_evolution(**kwargs, callback=callback)
         ref = differential_evolution(**kwargs, maxiter=maxiter)
 
@@ -495,16 +495,16 @@ class TestDifferentialEvolutionSolver:
                                [(-100, 100)],
                                tol=0.02)
 
-    def test_seed_gives_repeatability(self):
+    def test_rng_gives_repeatability(self):
         result = differential_evolution(self.quadratic,
                                         [(-100, 100)],
                                         polish=False,
-                                        seed=1,
+                                        rng=1,
                                         tol=0.5)
         result2 = differential_evolution(self.quadratic,
                                         [(-100, 100)],
                                         polish=False,
-                                        seed=1,
+                                        rng=1,
                                         tol=0.5)
         assert_equal(result.x, result2.x)
         assert_equal(result.nfev, result2.nfev)
@@ -519,9 +519,38 @@ class TestDifferentialEvolutionSolver:
             differential_evolution(self.quadratic,
                                    [(-100, 100)],
                                    polish=False,
-                                   seed=rng,
+                                   rng=rng,
                                    tol=0.5,
                                    init=init)
+
+    def test_rng_seed_spec007(self):
+        # spec007 involves the transition of RandomState-->Generator
+        # rng is the new name
+        differential_evolution(self.quadratic,
+                               [(-100, 100)],
+                               polish=False,
+                               rng=1,
+                               tol=0.5)
+        # should still be allowed to pass `seed`
+        differential_evolution(self.quadratic,
+                               [(-100, 100)],
+                               polish=False,
+                               seed=1,
+                               tol=0.5)
+        with assert_raises(TypeError):
+            # can't pass both seed and rng
+            differential_evolution(self.quadratic,
+                                   [(-100, 100)],
+                                   polish=False,
+                                   seed=1,
+                                   rng=1,
+                                   tol=0.5)
+            # use of rng=RandomState should give rise to an error.
+            differential_evolution(self.quadratic,
+                                   [(-100, 100)],
+                                   polish=False,
+                                   rng=np.random.RandomState(),
+                                   tol=0.5)
 
     def test_exp_runs(self):
         # test whether exponential mutation loop runs
@@ -636,7 +665,7 @@ class TestDifferentialEvolutionSolver:
         solver = DifferentialEvolutionSolver(rosen, self.bounds,
                                              init=population,
                                              strategy='best2bin',
-                                             atol=0.01, seed=1, popsize=5)
+                                             atol=0.01, rng=1, popsize=5)
 
         assert_equal(solver._nfev, 0)
         assert_(np.all(np.isinf(solver.population_energies)))
@@ -872,7 +901,7 @@ class TestDifferentialEvolutionSolver:
         nlc = NonlinearConstraint(constr_f, -np.inf, -1)
 
         solver = DifferentialEvolutionSolver(
-            rosen, [(0, 2), (0, 2)], constraints=(nlc,), popsize=1, seed=1, maxiter=100
+            rosen, [(0, 2), (0, 2)], constraints=(nlc,), popsize=1, rng=1, maxiter=100
         )
 
         # a UserWarning is issued because the 'trust-constr' polishing is
@@ -1050,8 +1079,8 @@ class TestDifferentialEvolutionSolver:
 
         # using a lower popsize to speed the test up
         res = differential_evolution(
-            f, bounds, strategy='best1bin', seed=1234, constraints=(L,),
-            popsize=2, tol=0.05
+            f, bounds, strategy='best1bin', rng=12345, constraints=(L,),
+            popsize=5, tol=0.01
         )
 
         x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
@@ -1073,7 +1102,7 @@ class TestDifferentialEvolutionSolver:
 
         # using a lower popsize to speed the test up
         res = differential_evolution(
-            f, bounds, strategy='best1bin', seed=1234, constraints=(L,),
+            f, bounds, strategy='best1bin', rng=1211134, constraints=(L,),
             popsize=2, tol=0.05
         )
 
@@ -1106,7 +1135,7 @@ class TestDifferentialEvolutionSolver:
         with suppress_warnings() as sup:
             sup.filter(UserWarning)
             res = differential_evolution(
-                f, bounds, strategy='best1bin', seed=1234,
+                f, bounds, strategy='best1bin', rng=1211134,
                 constraints=constraints, popsize=2, tol=0.05
             )
 
@@ -1142,7 +1171,7 @@ class TestDifferentialEvolutionSolver:
         with suppress_warnings() as sup:
             sup.filter(UserWarning)
             res = differential_evolution(f, bounds, strategy='best1bin',
-                                         seed=1234, constraints=constraints)
+                                         rng=1234, constraints=constraints)
 
         f_opt = 680.6300599487869
         x_opt = (2.330499, 1.951372, -0.4775414, 4.365726,
@@ -1191,7 +1220,7 @@ class TestDifferentialEvolutionSolver:
 
         with suppress_warnings() as sup:
             sup.filter(UserWarning)
-            res = differential_evolution(f, bounds, seed=1234,
+            res = differential_evolution(f, bounds, rng=1234,
                                          constraints=constraints, popsize=3)
 
         x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.9906548,
@@ -1235,7 +1264,7 @@ class TestDifferentialEvolutionSolver:
         with suppress_warnings() as sup:
             sup.filter(UserWarning)
             res = differential_evolution(
-                f, bounds, strategy='best1bin', seed=1234,
+                f, bounds, strategy='best1bin', rng=1234,
                 constraints=constraints, popsize=3, tol=0.05
             )
 
@@ -1279,7 +1308,7 @@ class TestDifferentialEvolutionSolver:
         bounds = [(0, 10)]*2
         constraints = (N)
 
-        res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
+        res = differential_evolution(f, bounds, strategy='rand1bin', rng=1234,
                                      constraints=constraints)
 
         x_opt = (1.22797135, 4.24537337)
@@ -1307,7 +1336,7 @@ class TestDifferentialEvolutionSolver:
         N = NonlinearConstraint(c1, 0, np.inf)
         bounds = [(13, 100), (0, 100)]
         constraints = (N)
-        res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
+        res = differential_evolution(f, bounds, strategy='rand1bin', rng=1234,
                                      constraints=constraints, tol=1e-7)
         x_opt = (14.095, 0.84296)
         f_opt = -6961.814744
@@ -1346,7 +1375,7 @@ class TestDifferentialEvolutionSolver:
         bounds = [(78, 102), (33, 45)] + [(27, 45)]*3
         constraints = (N)
 
-        res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
+        res = differential_evolution(f, bounds, strategy='rand1bin', rng=1234,
                                      constraints=constraints)
 
         # using our best solution, rather than Lampinen/Koziel. Koziel solution
@@ -1403,7 +1432,7 @@ class TestDifferentialEvolutionSolver:
             # huge amount of CPU time. Changing strategy to best1bin speeds
             # things up a lot
             res = differential_evolution(f, bounds, strategy='best1bin',
-                                         seed=1234, constraints=constraints,
+                                         rng=1234, constraints=constraints,
                                          maxiter=5000)
 
         x_opt = (679.9453, 1026.067, 0.1188764, -0.3962336)
@@ -1436,7 +1465,7 @@ class TestDifferentialEvolutionSolver:
 
         bounds = [(-1, 1)]*2
         constraints = (N)
-        res = differential_evolution(f, bounds, strategy='rand1bin', seed=1234,
+        res = differential_evolution(f, bounds, strategy='rand1bin', rng=1234,
                                      constraints=constraints)
 
         x_opt = [np.sqrt(2)/2, 0.5]
@@ -1472,7 +1501,7 @@ class TestDifferentialEvolutionSolver:
 
         res = differential_evolution(func, bounds, args=(dist, x),
                                      integrality=integrality, polish=False,
-                                     seed=rng)
+                                     rng=rng)
         # tolerance has to be fairly relaxed for the second parameter
         # because we're fitting a distribution to random variates.
         assert res.x[0] == 5
@@ -1481,7 +1510,7 @@ class TestDifferentialEvolutionSolver:
         # check that we can still use integrality constraints with polishing
         res2 = differential_evolution(func, bounds, args=(dist, x),
                                       integrality=integrality, polish=True,
-                                      seed=rng)
+                                      rng=rng)
 
         def func2(p, *args):
             n, dist, x = args
@@ -1573,9 +1602,9 @@ class TestDifferentialEvolutionSolver:
 
         bounds = [(0, 10), (0, 10)]
         res1 = differential_evolution(rosen, bounds, updating='deferred',
-                                      seed=1)
+                                      rng=1)
         res2 = differential_evolution(rosen_vec, bounds, vectorized=True,
-                                      updating='deferred', seed=1)
+                                      updating='deferred', rng=1)
 
         # the two minimisation runs should be functionally equivalent
         assert_allclose(res1.x, res2.x)
@@ -1601,10 +1630,10 @@ class TestDifferentialEvolutionSolver:
         bounds = [(0, 10), (0, 10)]
 
         res1 = differential_evolution(rosen, bounds, updating='deferred',
-                                      seed=1, constraints=[nlc1, nlc2],
+                                      rng=1, constraints=[nlc1, nlc2],
                                       polish=False)
         res2 = differential_evolution(rosen_vec, bounds, vectorized=True,
-                                      updating='deferred', seed=1,
+                                      updating='deferred', rng=1,
                                       constraints=[nlc1, nlc2],
                                       polish=False)
         # the two minimisation runs should be functionally equivalent
@@ -1624,14 +1653,14 @@ class TestDifferentialEvolutionSolver:
                                         constraints=[c0, c1],
                                         maxiter=10,
                                         polish=False,
-                                        seed=864197532)
+                                        rng=864197532)
         assert result.success is False
         # The numerical value in the error message might be sensitive to
         # changes in the implementation.  It can be updated if the code is
         # changed.  The essential part of the test is that there is a number
         # after the '=', so if necessary, the text could be reduced to, say,
         # "MAXCV = 0.".
-        assert "MAXCV = 0.4" in result.message
+        assert "MAXCV = 0." in result.message
 
     @pytest.mark.fail_slow(20)  # fail-slow exception by request - see gh-20806
     def test_strategy_fn(self):
@@ -1674,7 +1703,7 @@ class TestDifferentialEvolutionSolver:
             mutation=mutation,
             maxiter=2,
             strategy=custom_strategy_fn,
-            seed=10,
+            rng=10,
             polish=False
         )
         assert solver.strategy is custom_strategy_fn

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -532,7 +532,7 @@ def fit(dist, data, bounds=None, *, guess=None, method='mle',
     >>> rng = np.random.default_rng(767585560716548)
     >>> def optimizer(fun, bounds, *, integrality):
     ...     return differential_evolution(fun, bounds, strategy='best2bin',
-    ...                                   seed=rng, integrality=integrality)
+    ...                                   rng=rng, integrality=integrality)
     >>> bounds = [(0, 30), (0, 1)]
     >>> res4 = stats.fit(dist, data, bounds, optimizer=optimizer)
     >>> res4.params

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4422,7 +4422,7 @@ class TestSkewNorm:
         bounds = {'a': (-5, 5), 'loc': (-10, 10), 'scale': (1e-16, 10)}
 
         def optimizer(fun, bounds):
-            return differential_evolution(fun, bounds, seed=rng)
+            return differential_evolution(fun, bounds, rng=rng)
 
         fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -376,7 +376,7 @@ class TestFit:
     tols = {'atol': atol, 'rtol': rtol}
 
     def opt(self, *args, **kwds):
-        return differential_evolution(*args, seed=0, **kwds)
+        return differential_evolution(*args, rng=1, **kwds)
 
     def test_dist_iv(self):
         message = "`dist` must be an instance of..."
@@ -1023,7 +1023,7 @@ class TestFitResult:
         data = stats.norm.rvs(0, 1, size=100, random_state=rng)
 
         def optimizer(*args, **kwargs):
-            return differential_evolution(*args, **kwargs, seed=rng)
+            return differential_evolution(*args, **kwargs, rng=rng)
 
         bounds = [(0, 30), (0, 1)]
         res = stats.fit(stats.norm, data, bounds, optimizer=optimizer)


### PR DESCRIPTION
#### Reference issue
Closes #21772. 

#### What does this implement/fix?
Fixes the bug in optimize.curve_fit where using nan_policy="omit" did not remove corresponding entries of sigma. 
In this PR, I fix this bug by checking for the dimension of sigma and removing the entries where either xdata or ydata is NaN.


#### Additional information
<!--Any additional information you think is important.-->
