### PR TITLE
CI: Replace deadsnakes 3.13t by Quansight-Labs/setup-python action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -460,10 +460,10 @@ jobs:
         submodules: recursive
         fetch-tags: true
     # TODO: replace with setup-python when there is support
-    - uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
+    - uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796  # v5.3.1
       with:
-          python-version: '3.13-dev'
-          nogil: true
+        python-version: '3.13t'
+
     - name: Install Ubuntu dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See https://github.com/Quansight-Labs/free-threaded-compatibility/issues/107

#### What does this implement/fix?
<!--Please explain your changes.-->

As taken from https://github.com/numpy/numpy/pull/27707: _We've forked actions/setup-python to enable installing free-threaded python on more platforms. See https://github.com/Quansight-Labs/free-threaded-compatibility/issues/107 for context._

#### Additional information
<!--Any additional information you think is important.-->