### PR TITLE
ENH: `stats.ContinuousDistribution`: improve method resolution logic

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1103,7 +1103,6 @@ def _cdf2_input_validation(f):
         if func_name in {'_cdf2', '_ccdf2'}:
             res = np.clip(res, 0., 1.)
         else:
-            res = res.real  # exp(res) > 0
             res = np.clip(res, None, 0.)  # exp(res) < 1
 
         # Transform the result to account for swapped argument order
@@ -2299,7 +2298,8 @@ class ContinuousDistribution(_ProbabilityDistribution):
 
     @_cdf2_input_validation
     def _logcdf2(self, x, y, *, method):
-        return self._logcdf2_dispatch(x, y, method=method, **self._parameters)
+        out = self._logcdf2_dispatch(x, y, method=method, **self._parameters)
+        return (out + 0j) if not np.issubdtype(out.dtype, np.complexfloating) else out
 
     @_dispatch
     def _logcdf2_dispatch(self, x, y, *, method=None, **params):
@@ -2335,7 +2335,7 @@ class ContinuousDistribution(_ProbabilityDistribution):
         log_tail = np.logaddexp(logcdf_x, logccdf_y)[case_central]
         log_mass[case_central] = _log1mexp(log_tail)
         log_mass[flip_sign] += np.pi * 1j
-        return np.real_if_close(log_mass[()])
+        return log_mass[()]
 
     def _logcdf2_logexp(self, x, y, **params):
         expres = self._cdf2_dispatch(x, y, **params)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1809,7 +1809,7 @@ class ContinuousDistribution(_ProbabilityDistribution):
         return ShiftedScaledDistribution(self, loc=loc)
 
     def __sub__(self, loc):
-        return ShiftedScaledDistribution(self, loc=-self.loc)
+        return ShiftedScaledDistribution(self, loc=-loc)
 
     def __mul__(self, scale):
         return ShiftedScaledDistribution(self, scale=scale)

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -1285,6 +1285,11 @@ class _ProbabilityDistribution(ABC):
         Similarly, the term "logarithmic difference" of :math:`w` and :math:`z`
         is used here to mean :math:`\log(\exp(w)-\exp(z))`.
 
+        If ``y < x``, the CDF is negative, and therefore the log-CCDF
+        is complex with imaginary part :math:`\pi`. For
+        consistency, the result of this function always has complex dtype
+        when `y` is provided, regardless of the value of the imaginary part.
+
         References
         ----------
         .. [1] Cumulative distribution function, *Wikipedia*,
@@ -1477,7 +1482,6 @@ class _ProbabilityDistribution(ABC):
         is used here to mean the :math:`\log(\exp(w)+\exp(z))`, AKA
         :math:`\text{LogSumExp}(w, z)`.
 
-
         References
         ----------
         .. [1] Cumulative distribution function, *Wikipedia*,
@@ -1630,7 +1634,7 @@ class _ProbabilityDistribution(ABC):
         Notes
         -----
         If the entropy of a distribution is negative, then the log-entropy
-        is complex with imaginary part divisible by :math:`\pi`. For
+        is complex with imaginary part :math:`\pi`. For
         consistency, the result of this function always has complex dtype,
         regardless of the value of the imaginary part.
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -240,6 +240,20 @@ class TestDistributions:
         ax = X.plot()
         assert ax == plt.gca()
 
+    @pytest.mark.parametrize('method_name', ['cdf', 'ccdf'])
+    def test_complement_safe(self, method_name):
+        X = stats.Normal()
+        X.tol = 1e-8
+        p = np.asarray([1e-9, 1e-7])
+        func = getattr(X, method_name)
+        ifunc = getattr(X, 'i'+method_name)
+        x = ifunc(p, method='formula')
+        p1 = func(x, method='complement_safe')
+        p2 = func(x, method='complement')
+        assert_equal(p1[1], p2[1])
+        assert p1[0] != p2[0]
+        assert_allclose(p1[0], p[0], rtol=X.tol)
+
 
 def check_sample_shape_NaNs(dist, fname, sample_shape, result_shape, rng):
     full_shape = sample_shape + result_shape

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -321,7 +321,8 @@ class TestDistributions:
         i_fl = [0, -1]  # first and last
         assert np.isinf(res2[i_fl]).all()
         assert res1[1] == res2[1]
-        assert res1[1] != ref[1]
+        # quadrature happens to be perfectly accurate on some platforms
+        # assert res1[1] != ref[1]
         assert_equal(res1[i_fl], ref[i_fl])
 
     @pytest.mark.parametrize('method_name', ['logcdf', 'logccdf'])

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -167,7 +167,7 @@ class TestDistributions:
         rng = np.random.default_rng(seed)
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (1, 1, 1, 1)
+        proportions = (1, 0, 0, 0)
         tmp = draw_distribution_from_family(family, data, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
         sample_shape = data.draw(npst.array_shapes(min_dims=0, min_side=0,
@@ -204,7 +204,7 @@ class TestDistributions:
         rng = np.random.default_rng(seed)
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (1, 1, 1, 1)
+        proportions = (1, 0, 0, 0)
         tmp = draw_distribution_from_family(family, data, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 
@@ -515,7 +515,10 @@ def check_moment_funcs(dist, result_shape):
         assert ref.shape == result_shape
         check(i, 'raw','cache', ref, success=True)  # cached now
         check(i, 'raw', 'formula', ref, success=has_formula(i, 'raw'))
-        check(i, 'raw', 'general', ref, i == 0)
+        check(i, 'raw', 'general', ref, success=(i == 0))
+        if dist.__class__ == stats.Normal:
+            check(i, 'raw', 'quadrature_icdf', ref, success=True)
+
 
     # Clearing caches to better check their behavior
     dist.reset_cache()
@@ -542,6 +545,8 @@ def check_moment_funcs(dist, result_shape):
         check(i, 'central', 'cache', ref, success=True)
         check(i, 'central', 'formula', ref, success=has_formula(i, 'central'))
         check(i, 'central', 'general', ref, success=i <= 1)
+        if dist.__class__ == stats.Normal:
+            check(i, 'central', 'quadrature_icdf', ref, success=True)
         check(i, 'central', 'transform', ref,
               success=has_formula(i, 'raw') or (i <= 1))
         if not has_formula(i, 'raw'):
@@ -562,7 +567,7 @@ def check_moment_funcs(dist, result_shape):
         dist.moment(i, 'standardized')  # build up the cache
         check(i, 'central', 'normalize', ref)
 
-    ### Check Standard Moments ###
+    ### Check Standardized Moments ###
 
     var = dist.moment(2, 'central', method='quadrature')
     dist.reset_cache()

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -167,7 +167,7 @@ class TestDistributions:
         rng = np.random.default_rng(seed)
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (1, 0, 0, 0)
+        proportions = (1, 1, 1, 1)
         tmp = draw_distribution_from_family(family, data, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
         sample_shape = data.draw(npst.array_shapes(min_dims=0, min_side=0,
@@ -204,7 +204,7 @@ class TestDistributions:
         rng = np.random.default_rng(seed)
 
         # relative proportions of valid, endpoint, out of bounds, and NaN params
-        proportions = (1, 0, 0, 0)
+        proportions = (1, 1, 1, 1)
         tmp = draw_distribution_from_family(family, data, rng, proportions)
         dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -267,6 +267,28 @@ class TestDistributions:
         assert x1[0] != x2[0]
         assert_allclose(func(x1[0]), p[0], rtol=X.tol)
 
+    def test_subtraction_safe(self):
+        X = stats.Normal()
+        X.tol = 1e-12
+
+        # Regular subtraction is fine in either tail (and of course, across tails)
+        x = [-11, -10, 10, 11]
+        y = [-10, -11, 11, 10]
+        p0 = X.cdf(x, y, method='quadrature')
+        p1 = X.cdf(x, y, method='subtraction_safe')
+        p2 = X.cdf(x, y, method='subtraction')
+        assert_equal(p2, p1)
+        assert_allclose(p1, p0, rtol=X.tol)
+
+        # Safe subtraction is needed in special cases
+        x = np.asarray([-1e-20, -1e-21, 1e-20, 1e-21, -1e-20])
+        y = np.asarray([-1e-21, -1e-20, 1e-21, 1e-20, 1e-20])
+        p0 = X.pdf(0)*(y-x)
+        p1 = X.cdf(x, y, method='subtraction_safe')
+        p2 = X.cdf(x, y, method='subtraction')
+        assert_equal(p2, 0)
+        assert_allclose(p1, p0, rtol=X.tol)
+
 
 def check_sample_shape_NaNs(dist, fname, sample_shape, result_shape, rng):
     full_shape = sample_shape + result_shape

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -369,7 +369,7 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
         res = (np.exp(dist.logcdf(x, y, method=method)) if log
                else dist.cdf(x, y, method=method))
         np.testing.assert_allclose(res, ref, atol=1e-14)
-        if log and np.any(x > y) and ref.size:
+        if log:
             np.testing.assert_equal(res.dtype, (ref + 0j).dtype)
         else:
             np.testing.assert_equal(res.dtype, ref.dtype)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -306,7 +306,8 @@ class TestDistributions:
         i_fl = [0, -1]  # first and last
         assert np.isinf(res2[i_fl]).all()
         assert res1[1] == res2[1]
-        assert res1[1] != ref[1]
+        # quadrature happens to be perfectly accurate on some platforms
+        # assert res1[1] != ref[1]
         assert_equal(res1[i_fl], ref[i_fl])
 
     def test_logcdf2_safe(self):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -243,8 +243,8 @@ class TestDistributions:
     @pytest.mark.parametrize('method_name', ['cdf', 'ccdf'])
     def test_complement_safe(self, method_name):
         X = stats.Normal()
-        X.tol = 1e-8
-        p = np.asarray([1e-9, 1e-7])
+        X.tol = 1e-12
+        p = np.asarray([1e-4, 1e-3])
         func = getattr(X, method_name)
         ifunc = getattr(X, 'i'+method_name)
         x = ifunc(p, method='formula')
@@ -253,6 +253,19 @@ class TestDistributions:
         assert_equal(p1[1], p2[1])
         assert p1[0] != p2[0]
         assert_allclose(p1[0], p[0], rtol=X.tol)
+
+    @pytest.mark.parametrize('method_name', ['cdf', 'ccdf'])
+    def test_icomplement_safe(self, method_name):
+        X = stats.Normal()
+        X.tol = 1e-12
+        p = np.asarray([1e-4, 1e-3])
+        func = getattr(X, method_name)
+        ifunc = getattr(X, 'i'+method_name)
+        x1 = ifunc(p, method='complement_safe')
+        x2 = ifunc(p, method='complement')
+        assert_equal(x1[1], x2[1])
+        assert x1[0] != x2[0]
+        assert_allclose(func(x1[0]), p[0], rtol=X.tol)
 
 
 def check_sample_shape_NaNs(dist, fname, sample_shape, result_shape, rng):


### PR DESCRIPTION
#### Reference issue
Closes gh-2509

#### What does this implement/fix?
Previously, when the `tol` property of `ContinuousDistribution` was left unspecified, the CCDF/CDF could be calculated as the numerical complement of the CDF/CCDF. This logic was unusual because it ignored the *magnitude* of `tol`, and it was suboptimal because it did not protect against catastrophic cancellation in the default case (`tol` unspecified). 

This PR assesses the loss of precision when using the complement method to compute the CCDF/CDF and uses `quadrature` (in the appropriate tail) when the precision is worse than `tol`. It makes a similar adjustment to the logic of the inverse CCDF/CDF and 2-arg CDF.

There was similar logic in place for evaluating the log-CDF/CCDF as the logarithm of the CDF/CCDF. This is inaccurate when the CDF/CCDF underflows, so this PR checks for underflow and falls back to log-quadrature. It makes similar adjustments to the logic of `logexp` and 2-arg CDF.  

This PR also makes a few other small improvements/adjustments:
- The result dtype of 2-arg `logcdf` previously depended on the values of the arguments. Now, the result dtype is complex regardless of whether `y < x`.
- Fixes a copy-paste error in the `ContinuousDistribution.__sub__` method.
- Adds a private method for computing distribution moments by integrating the inverse CDF (rather than the PDF).

#### Additional information
Other obvious improvements to the default logic:

- ~~We could assess whether it is safe to compute a log-method as the logarithm of the non-log method depending on whether the non-log method over/under flows.~~ Done here.
- When the tolerance is quite strict, it might not be safe to compute a non-log method as the exponential of the log-method. We could detect this by checking `exp(logf(x)) - exp(logf(x) + np.nextafter(logf(x), np.inf)` (which is the absolute error corresponding to 1 ULP of error in `logf(x)`).
- There are also some situations in which it might be preferable to use numerical calculations rather than using log-complements or `logexpxmexpy`.
- For improvements when `locdf` and `logccdf` are not defined and the log CDF/CCDF probability is close to 0, we could apply the ideas from gh-21301 to the new infrastructure. (Note that the user can easily perform the main trick by choosing `method='complement'`; it's just not the default behavior.)

<details>
Regarding the safety of computing a non-log method as the exponential of the log-method:

```python3
import numpy as np
import matplotlib.pyplot as plt

x0 = np.logspace(-300, 300, 1000)
x1 = np.log(x0)
x2 = np.nextafter(x1, np.inf)
err = abs((np.exp(x2) - np.exp(x1))/np.exp(x2))
plt.semilogy(x1, err)
plt.xlabel('`x`')
plt.ylabel('Relative Error')
plt.title('Error in `exp(x)` corresponding with 1 ULP error in `x`')
plt.show()
```

![image](https://github.com/user-attachments/assets/a2167bea-8350-435c-9c0b-24c3815c5e4f)

The maximum relative error is ~1e-13. Exponentiation is only used if there is a formula for the log-method, so assuming the formula for the log-method is accurate, the exponential of the log-method will still be quite accurate.

</details>