### PR TITLE
TST: optimize: mark MIP6 tests xslow

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2351,8 +2351,7 @@ class TestLinprogHiGHSMIP:
         assert res.get("mip_dual_bound", None) is not None
         assert res.get("mip_gap", None) is not None
 
-    @pytest.mark.slow
-    @pytest.mark.timeout(120)  # prerelease_deps_coverage_64bit_blas job
+    @pytest.mark.xslow
     def test_mip6(self):
         # solve a larger MIP with only equality constraints
         # source: https://www.mathworks.com/help/optim/ug/intlinprog.html

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -252,8 +252,7 @@ def test_milp_5():
     assert_allclose(res.fun, -12)
 
 
-@pytest.mark.slow
-@pytest.mark.timeout(120)  # prerelease_deps_coverage_64bit_blas job
+@pytest.mark.xslow
 def test_milp_6():
     # solve a larger MIP with only equality constraints
     # source: https://www.mathworks.com/help/optim/ug/intlinprog.html

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -92,7 +92,6 @@ def test_svdp(ctor, dtype, irl, which):
 @pytest.mark.xslow
 @pytest.mark.parametrize('dtype', _dtypes)
 @pytest.mark.parametrize('irl', (False, True))
-@pytest.mark.timeout(120)  # True, complex64 > 60 s: prerel deps cov 64bit blas
 def test_examples(dtype, irl):
     # Note: atol for complex64 bumped from 1e-4 to 1e-3 due to test failures
     # with BLIS, Netlib, and MKL+AVX512 - see


### PR DESCRIPTION
#### Reference issue
Closes gh-16494

#### What does this implement/fix?
This marks some a very slow `linprog`/`milp` test case as xslow. This addresses the remaining items in gh-16494 by removing the need for a 120s timeout mark. (It only takes a second or so locally... not sure why that was needed in the first place. But that is fair game for marking xslow, since it's slow and non-essential.)