### PR TITLE
BUG: sparse: fix `idx_dtype` when building index arrays in many parts of sparse

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -470,7 +470,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 data = np.multiply(ret.data, other2d[:, ret.col])
             else:
                 raise ValueError("inconsistent shapes")
-            idx_dtype = self._get_index_dtype(ret.col, maxval=ret.nnz * other2d.shape[0])
+            idx_dtype = self._get_index_dtype(ret.col,
+                                              maxval=ret.nnz * other2d.shape[0])
             row = np.repeat(np.arange(other2d.shape[0], dtype=idx_dtype), ret.nnz)
             col = np.tile(ret.col.astype(idx_dtype, copy=False), other2d.shape[0])
             return self._coo_container(
@@ -486,7 +487,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 data = np.multiply(ret.data[:, None], other2d[ret.row])
             else:
                 raise ValueError("inconsistent shapes")
-            idx_dtype = self._get_index_dtype(ret.row, maxval=ret.nnz * other2d.shape[1])
+            idx_dtype = self._get_index_dtype(ret.row,
+                                              maxval=ret.nnz * other2d.shape[1])
             row = np.repeat(ret.row.astype(idx_dtype, copy=False), other2d.shape[1])
             col = np.tile(np.arange(other2d.shape[1], dtype=idx_dtype), ret.nnz)
             return self._coo_container(

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -998,10 +998,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         def check_bounds(indices, bound):
             idx = indices.max()
             if idx >= bound:
-                raise IndexError('index ({idx}) out of range (>= {bound})')
+                raise IndexError(f'index ({idx}) out of range (>= {bound})')
             idx = indices.min()
             if idx < -bound:
-                raise IndexError('index ({idx}) out of range (< -{bound})')
+                raise IndexError(f'index ({idx}) out of range (< -{bound})')
 
         i = np.atleast_1d(np.asarray(i, dtype=self.indices.dtype)).ravel()
         j = np.atleast_1d(np.asarray(j, dtype=self.indices.dtype)).ravel()

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -998,12 +998,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         def check_bounds(indices, bound):
             idx = indices.max()
             if idx >= bound:
-                raise IndexError('index (%d) out of range (>= %d)' %
-                                 (idx, bound))
+                raise IndexError('index ({idx}) out of range (>= {bound})')
             idx = indices.min()
             if idx < -bound:
-                raise IndexError('index (%d) out of range (< -%d)' %
-                                 (idx, bound))
+                raise IndexError('index ({idx}) out of range (< -{bound})')
 
         i = np.atleast_1d(np.asarray(i, dtype=self.indices.dtype)).ravel()
         j = np.atleast_1d(np.asarray(j, dtype=self.indices.dtype)).ravel()

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -197,15 +197,15 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
         k = max(0, offset)
         length = min(m + offset, n - offset, K)
         if length < 0:
-            raise ValueError("Offset %d (index %d) out of bounds" % (offset, j))
+            raise ValueError(f"Offset {offset} (index {j}) out of bounds")
         try:
             data_arr[j, k:k+length] = diagonal[...,:length]
         except ValueError as e:
             if len(diagonal) != length and len(diagonal) != 1:
                 raise ValueError(
-                    "Diagonal length (index %d: %d at offset %d) does not "
-                    "agree with array size (%d, %d)." % (
-                    j, len(diagonal), offset, m, n)) from e
+                    f"Diagonal length (index {j}: {len(diagonal)} at"
+                    f" offset {offset}) does not agree with array size ({m}, {n})."
+                ) from e
             raise
 
     return dia_array((data_arr, offsets), shape=(m, n)).asformat(format)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -151,6 +151,9 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             new_coords = np.unravel_index(flat_coords, shape, order=order)
 
+        idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.shape))
+        new_coords = tuple(np.asarray(co, dtype=idx_dtype) for co in new_coords)
+
         # Handle copy here rather than passing on to the constructor so that no
         # copy will be made of `new_coords` regardless.
         if copy:

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -187,7 +187,7 @@ class _minmax_mixin:
             value[not_full] = min_or_max(value[not_full], 0)
 
         mask = value != 0
-        major_index = np.compress(mask, major_index)
+        major_index = np.compress(mask, major_index).astype(idx_dtype, copy=False)
         value = np.compress(mask, value)
 
         if isinstance(self, sparray):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -682,7 +682,10 @@ class TestConstructUtils:
                           [0, 0, 6, 0],
                           [0, 0, 0, 7]])
 
-        assert_equal(construct.block_diag((A, B, C)).toarray(), expected)
+        ABC = construct.block_diag((A, B, C))
+        assert_equal(ABC.toarray(), expected)
+        assert ABC.coords[0].dtype == np.int32
+
 
     def test_block_diag_scalar_1d_args(self):
         """ block_diag with scalar and 1d arguments """
@@ -795,6 +798,10 @@ class TestConstructUtils:
         arr = construct.random_array((10, 10, 10, 10, 10), density=0.3, dtype=int,
                                      rng=0)
         assert arr.shape == (10, 10, 10, 10, 10)
+
+    def test_random_array_idx_dtype(self):
+        A = construct.random_array((10, 10))
+        assert A.coords[0].dtype == np.int32
 
     def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
         # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -465,6 +465,25 @@ class TestConstructUtils:
         assert_equal(result.indices.dtype, np.int32)
         assert_equal(result.indptr.dtype, np.int32)
 
+    def test_vstack_maintain64bit_idx_dtype(self):
+        # see gh-20389 v/hstack returns int32 idx_dtype with input int64 idx_dtype
+        X = csr_array([[1, 0, 0], [0, 1, 0], [0, 1, 0]])
+        X.indptr = X.indptr.astype(np.int64)
+        X.indices = X.indices.astype(np.int64)
+        assert construct.vstack([X, X]).indptr.dtype == np.int64
+        assert construct.hstack([X, X]).indptr.dtype == np.int64
+
+        X = csc_array([[1, 0, 0], [0, 1, 0], [0, 1, 0]])
+        X.indptr = X.indptr.astype(np.int64)
+        X.indices = X.indices.astype(np.int64)
+        assert construct.vstack([X, X]).indptr.dtype == np.int64
+        assert construct.hstack([X, X]).indptr.dtype == np.int64
+
+        X = coo_array([[1, 0, 0], [0, 1, 0], [0, 1, 0]])
+        X.coords = tuple(co.astype(np.int64) for co in X.coords)
+        assert construct.vstack([X, X]).coords[0].dtype == np.int64
+        assert construct.hstack([X, X]).coords[0].dtype == np.int64
+
     def test_vstack_matrix_or_array(self):
         A = [[1,2],[3,4]]
         B = [[5,6]]
@@ -686,6 +705,10 @@ class TestConstructUtils:
         assert_equal(ABC.toarray(), expected)
         assert ABC.coords[0].dtype == np.int32
 
+    def test_block_diag_idx_dtype(self):
+        X = coo_array([[1, 0, 0], [0, 1, 0], [0, 1, 0]])
+        X.coords = tuple(co.astype(np.int64) for co in X.coords)
+        assert construct.block_diag([X, X]).coords[0].dtype == np.int64
 
     def test_block_diag_scalar_1d_args(self):
         """ block_diag with scalar and 1d arguments """


### PR DESCRIPTION
This PR adds `idx_dtype=get_index_dtype` handling in `random_array()` and `block_diag()`. It also rewrites the `kron` upcasting to int64 so that it uses `get_index_dtype` instead of handling it locally via `np.iinfo.max` checks.

Previously `random_array` always used `int64` for the index dtype. I have been wondering why so many test arrays become `int64` when I switch to `sparray`. They are `int32` for `spmatrix`. It turns out `random_array()` was providing `int64` index arrays to the `coo_array` constructor even for very small arrays. `random()` does this too, but they get downcast to `int32` during the final `spmatrix` construction for which `_get_index_dtype` checks input array contents and downcasts for small values. `sparray` in `_get_index_dtype` does not check array contents to determine idx_dtype. So with sparse arrays we have to downcast manually before construction.

I checked all functions in `_construct.py` and they all handle `idx_dtype` fine except `random_array()` and `block_diag()`. While I have not found `int64` from `block_diag`, it could have been using `int64` when `int32` is sufficient without anyone noticing, so I fixed it too. In addition to those two functions, the `kron()` function handles `idx_dtype` locally rather than using `get_index_dtype`, so I changed that to use the centralized code for uniformity and better long term maintenance. Lastly, I noticed a few places where `A.astype(dtype)` was used without the `copy=False` keyword just after `A` was created. So there is no chance a copy was required. I changed those to use `copy=False`.

I added some tests that downcasting to int32 occurs when appropriate. There are existing tests that upcasting occurs correctly (that behavior has always been fine). If there are better tests you can think of let me know. I think these are pretty good.

The incorrect behavior this fixes is subtle. The numerical values are still correct. But the resulting arrays cannot be used with `int32` libraries (such as SuperLU and some of csgraph's cython routines) without downcasting first. For a while I thought it was necessary to make the user manually downcast, but I realized that the `_construct.py` code **is** the user in this case and we can set up the incoming index arrays for `sparray` handling as `int32`. While adjusting that, I realized that `random_array` was implemented at the same time that the `sparray` constructors were changing from `check_contents=True` to `False` (summer 2023). They were parallel PRs and the new `random_array` behavior didn't account for the change in `check_contents` behavior.

I don't think this should require any changes to the doc_strings. We don't claim any particular behavior for the dtype of the indexing arrays.  It should make migration to sparray easier. I will put changes to the migration guide in a separate PR focusing on that process.

Fixes #20389 