### PR TITLE
DOC: make `_transition_to_rng` replace documentation of `rng`

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -14,6 +14,7 @@ from typing import (
 
 import numpy as np
 from scipy._lib._array_api import array_namespace, is_numpy, xp_size
+from scipy._lib._docscrape import FunctionDoc, Parameter
 
 
 AxisError: type[Exception]
@@ -245,8 +246,37 @@ def float_factorial(n: int) -> float:
     return float(math.factorial(n)) if n < 171 else np.inf
 
 
+_rng_desc = (
+    r"""If `rng` is passed by keyword, types other than `numpy.random.Generator` are
+    passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+    If `rng` is already a ``Generator`` instance, then the provided instance is
+    used. Specify `rng` for repeatable function behavior.
+
+    If this argument is passed by position or `{old_name}` is passed by keyword,
+    legacy behavior for the argument `{old_name}` applies:
+
+    - If `{old_name}` is None (or `numpy.random`), the `numpy.random.RandomState`
+      singleton is used.
+    - If `{old_name}` is an int, a new ``RandomState`` instance is used,
+      seeded with `seed`.
+    - If `{old_name}` is already a ``Generator`` or ``RandomState`` instance then
+      that instance is used.
+
+    .. versionchanged:: 1.15.0
+        As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+        transition from use of `numpy.random.RandomState` to
+        `numpy.random.Generator`, this keyword was changed from `{old_name}` to `rng`.
+        For an interim period, both keywords will continue to work, although only one
+        may be specified at a time. After the interim period, function calls using the
+        `{old_name}` keyword will emit warnings. The behavior of both `{old_name}` and
+        `rng` are outlined above, but only the `rng` keyword should be used in new code.
+        """
+)
+
+
 # SPEC 7
-def _transition_to_rng(old_name, *, position_num=None, end_version=None):
+def _transition_to_rng(old_name, *, position_num=None, end_version=None,
+                       replace_doc=True):
     """Example decorator to transition from old PRNG usage to new `rng` behavior
 
     Suppose the decorator is applied to a function that used to accept parameter
@@ -308,6 +338,14 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
         The full version number of the library when the behavior described in
         `DeprecationWarning`s and `FutureWarning`s will take effect. If left
         unspecified, no warnings will be emitted by the decorator.
+    replace_doc : bool, default: True
+        Whether the decorator should replace the documentation for parameter `rng` with
+        `_rng_desc` (defined above), which documents both new `rng` keyword behavior
+        and typical legacy `random_state`/`seed` behavior. If True, manually replace
+        the function's old `random_state`/`seed` documentation with the desired *final*
+        `rng` documentation; this way, no changes to documentation are needed when the
+        decorator is removed. Use False if the function's old `random_state`/`seed`
+        behavior does not match that described by `_rng_desc`.
 
     """
     NEW_NAME = "rng"
@@ -402,6 +440,15 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
 
             return fun(*args, **kwargs)
 
+        if replace_doc:
+            doc = FunctionDoc(wrapper)
+            parameter_names = [param.name for param in doc['Parameters']]
+            _type = "{None, int, `numpy.random.Generator`}, optional"
+            _desc = _rng_desc.replace("{old_name}", old_name)
+            _rng_parameter_doc = Parameter('rng', _type, [_desc])
+            doc['Parameters'][parameter_names.index('rng')] = _rng_parameter_doc
+            doc = str(doc).split("\n", 1)[1]  # remove signature
+            wrapper.__doc__ = str(doc)
         return wrapper
 
     return decorator

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -258,7 +258,7 @@ _rng_desc = (
     - If `{old_name}` is None (or `numpy.random`), the `numpy.random.RandomState`
       singleton is used.
     - If `{old_name}` is an int, a new ``RandomState`` instance is used,
-      seeded with `seed`.
+      seeded with `{old_name}`.
     - If `{old_name}` is already a ``Generator`` or ``RandomState`` instance then
       that instance is used.
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -125,30 +125,11 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         denoted by CR. Increasing this value allows a larger number of mutants
         to progress into the next generation, but at the risk of population
         stability.
-    rng : {None, int, `numpy.random.Generator`}, optional
-        If `rng` is passed by keyword, types other than `numpy.random.Generator` are
-        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
-        If `rng` is already a ``Generator`` instance, then the provided instance is
-        used. Specify `rng` for repeatable minimizations.
-        
-        If this argument is passed by position or `seed` is passed by keyword,
-        legacy behavior for the argument `seed` applies:
-        
-        - If `seed` is None (or `numpy.random`), the `numpy.random.RandomState`
-          singleton is used.
-        - If `seed` is an int, a new ``RandomState`` instance is used,
-          seeded with `seed`.
-        - If `seed` is already a ``Generator`` or ``RandomState`` instance then
-          that instance is used.
-        
-        .. versionchanged:: 1.15.0
-            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
-            transition from use of `numpy.random.RandomState` to
-            `numpy.random.Generator` this keyword was changed from `seed` to `rng`.
-            For an interim period, both keywords will continue to work (only specify
-            one of them). After the interim period using the `seed` keyword will emit
-            warnings. The behavior of the `seed` and `rng` keywords is outlined above.
-
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a `Generator`.
     disp : bool, optional
         Prints the evaluated `func` at every iteration.
     callback : callable, optional

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -129,7 +129,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         Pseudorandom number generator state. When `rng` is None, a new
         `numpy.random.Generator` is created using entropy from the
         operating system. Types other than `numpy.random.Generator` are
-        passed to `numpy.random.default_rng` to instantiate a `Generator`.
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     disp : bool, optional
         Prints the evaluated `func` at every iteration.
     callback : callable, optional


### PR DESCRIPTION
#### Reference issue
gh-21823 , gh-21812, gh-21774 

#### What does this implement/fix?
As part of the [SPEC 7](https://scientific-python.org/specs/spec-0007/) transition effort, several PRs are applying the `_transition_to_rng` decorator to existing functions. Current practice is to manually replace the old `seed`/`random_state` docstring with a temporary `rng` entry, which documents both old and new keyword behavior. This is over 20 lines long, and it requires that `seed`/`random_state` needs to be adjusted manually depending on the old keyword name. Besides being tedious to copy-paste, edit, and review for correctness (e.g. I found a copy-paste mistake in one of them), it will need to be manually replaced when the `_transition_to_rng` decorator is removed.

This PR allows the `_transition_to_rng` to automatically replace the documentation of the `rng` parameter with the desired boilerplate. Now, when applying `_transition_to_rng` decorator to functions, the documentation of `seed`/`random_state` only needs to be changed to the [recommened](https://scientific-python.org/specs/spec-0007/#implementation) *final* wording:
```
    rng : `numpy.random.Generator`, optional
        Pseudorandom number generator state. When `rng` is None, a new
        `numpy.random.Generator` is created using entropy from the
        operating system. Types other than `numpy.random.Generator` are
        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
```
which is identical for every function. This way, no adjustments are needed when the decorator is removed.