### PR TITLE
BUG: special: Fix behavior of `gamma` and `gammasgn` at poles of the Gamma function

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -1572,10 +1572,35 @@ const char *gamma_doc = R"(
     which, combined with the fact that :math:`\Gamma(1) = 1`, implies
     the above identity for :math:`z = n`.
 
+    The gamma function has poles at non-negative integers and the sign
+    of infinity as z approaches each pole depends upon the direction in
+    which the pole is approached. For this reason, the consistent thing
+    is for gamma(z) to return NaN at negative integers, and to return
+    -inf when x = -0.0 and +inf when x = 0.0, using the signbit of zero
+    to signify the direction in which the origin is being approached. This
+    is for instance what is recommended for the gamma function in annex F
+    entry 9.5.4 of the Iso C 99 standard [isoc99]_.
+
+    Prior to SciPy version 1.15, ``scipy.special.gamma(z)`` returned ``+inf``
+    at each pole. This was fixed in version 1.15, but with the following
+    consequence. Expressions where gamma appears in the denominator of an
+    expression such as
+
+    ``gamma(u) * gamma(v) / (gamma(w) * gamma(x))``
+
+    no longer evaluate to 0 if the numerator is well defined but there is a
+    pole in the denominator. Instead such expressions evaluate to NaN. We
+    recommend instead using the function `rgamma` for the reciprocal gamma
+    function in such cases. The above expression could for instance be written
+    as
+
+    ``gamma(u) * gamma(v) * (rgamma(w) * rgamma(x))``
+
     References
     ----------
     .. [dlmf] NIST Digital Library of Mathematical Functions
               https://dlmf.nist.gov/5.2#E1
+    .. [isoc99]_ https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
 
     Examples
     --------

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -1600,7 +1600,7 @@ const char *gamma_doc = R"(
     ----------
     .. [dlmf] NIST Digital Library of Mathematical Functions
               https://dlmf.nist.gov/5.2#E1
-    .. [isoc99]_ https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
+    .. [isoc99] https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
 
     Examples
     --------

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -1583,8 +1583,8 @@ const char *gamma_doc = R"(
 
     Prior to SciPy version 1.15, ``scipy.special.gamma(z)`` returned ``+inf``
     at each pole. This was fixed in version 1.15, but with the following
-    consequence. Expressions where gamma appears in the denominator of an
-    expression such as
+    consequence. Expressions where gamma appears in the denominator
+    such as
 
     ``gamma(u) * gamma(v) / (gamma(w) * gamma(x))``
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3707,7 +3707,7 @@ class TestParabolicCylinder:
     def test_pbdv_points(self):
         # simple case
         eta = np.linspace(-10, 10, 5)
-        z = 2**(eta/2)*np.sqrt(np.pi)/special.gamma(.5-.5*eta)
+        z = 2**(eta/2)*np.sqrt(np.pi)*special.rgamma(.5-.5*eta)
         assert_allclose(special.pbdv(eta, 0.)[0], z, rtol=1e-14, atol=1e-14)
 
         # some points

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2718,6 +2718,24 @@ class TestGamma:
         assert_(np.isinf(special.gamma(-1)))
         assert_equal(special.rgamma(-1), 0)
 
+    @pytest.mark.parametrize(
+        "x,expected",
+        [
+            # infinities
+            ([-np.inf, np.inf], [np.nan, np.inf]),
+            # zeros
+            ([-0.0, 0.0], [-np.inf, np.inf]),
+            # small poles
+            (range(-32, 0), np.full(32, np.nan)),
+            # medium sized poles
+            (range(-1024, -32, 99), np.full(11, np.nan)),
+            # large pole
+            ([-4.141512231792294e+16], [np.nan]),
+        ]
+    )
+    def test_poles(self, x, expected):
+        assert_array_equal(special.gamma(x), expected)
+
 
 class TestHankel:
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -398,8 +398,9 @@ class TestCephes:
         cephes.gammaln(10)
 
     def test_gammasgn(self):
-        vals = np.array([-4, -3.5, -2.3, 1, 4.2], np.float64)
-        assert_array_equal(cephes.gammasgn(vals), np.sign(cephes.rgamma(vals)))
+        vals = np.array([-4, -3.5, -2.3, -0.0, 0.0, 1, 4.2], np.float64)
+        reference = np.array([np.nan, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0], np.float64)
+        assert_array_equal(cephes.gammasgn(vals), reference)
 
     def test_gdtr(self):
         assert_equal(cephes.gdtr(1,1,0),0.0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2727,7 +2727,7 @@ class TestGamma:
         [
             # infinities
             ([-np.inf, np.inf], [np.nan, np.inf]),
-            # zeros
+            # negative and positive zero
             ([-0.0, 0.0], [-np.inf, np.inf]),
             # small poles
             (range(-32, 0), np.full(32, np.nan)),

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -398,8 +398,12 @@ class TestCephes:
         cephes.gammaln(10)
 
     def test_gammasgn(self):
-        vals = np.array([-4, -3.5, -2.3, -0.0, 0.0, 1, 4.2], np.float64)
-        reference = np.array([np.nan, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0], np.float64)
+        vals = np.array(
+            [-np.inf, -4, -3.5, -2.3, -0.0, 0.0, 1, 4.2, np.inf], np.float64
+        )
+        reference = np.array(
+            [np.nan, np.nan, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0], np.float64
+        )
         assert_array_equal(cephes.gammasgn(vals), reference)
 
     def test_gdtr(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2715,7 +2715,6 @@ class TestGamma:
         assert_almost_equal(rgam,rlgam,8)
 
     def test_infinity(self):
-        assert_(np.isinf(special.gamma(-1)))
         assert_equal(special.rgamma(-1), 0)
 
     @pytest.mark.parametrize(

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -2506,6 +2506,7 @@ class TestHyp2f1:
         ]
     )
     def test_miscellaneous(self, hyp2f1_test_case ):
+        a, b, c, z, expected, rtol = hyp2f1_test_case
         assert_allclose(hyp2f1(a, b, c, z), expected, rtol=rtol)
 
     @pytest.mark.slow

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -2488,6 +2488,26 @@ class TestHyp2f1:
         )
         assert_allclose(hyp2f1(a, b, c, z), expected, rtol=rtol)
 
+
+    @pytest.mark.parametrize(
+        "hyp2f1_test_case",
+        [
+            # Broke when fixing gamma pole behavior in gh-21827
+            pytest.param(
+                Hyp2f1TestCase(
+                    a=1.3,
+                    b=-0.2,
+                    c=0.3,
+                    z=-2.1,
+                    expected=1.8202169687521206,
+                    rtol=5e-15,
+                ),
+            ),
+        ]
+    )
+    def test_miscellaneous(self, hyp2f1_test_case ):
+        assert_allclose(hyp2f1(a, b, c, z), expected, rtol=rtol)
+
     @pytest.mark.slow
     @check_version(mpmath, "1.0.0")
     def test_test_hyp2f1(self):

--- a/scipy/special/xsf/cephes/beta.h
+++ b/scipy/special/xsf/cephes/beta.h
@@ -53,6 +53,7 @@
 #include "../config.h"
 #include "const.h"
 #include "gamma.h"
+#include "rgamma.h"
 
 namespace xsf {
 namespace cephes {
@@ -155,17 +156,18 @@ namespace cephes {
             return (sign * std::exp(y));
         }
 
-        y = Gamma(y);
+        y = rgamma(y);
         a = Gamma(a);
         b = Gamma(b);
-        if (y == 0.0)
+        if (std::isinf(y)) {
             goto overflow;
+	}
 
-        if (std::abs(std::abs(a) - std::abs(y)) > std::abs(std::abs(b) - std::abs(y))) {
-            y = b / y;
+        if (std::abs(std::abs(a*y) - 1.0) > std::abs(std::abs(b*y) - 1.0)) {
+            y = b * y;
             y *= a;
         } else {
-            y = a / y;
+            y = a * y;
             y *= b;
         }
 
@@ -228,20 +230,20 @@ namespace cephes {
             return (y);
         }
 
-        y = Gamma(y);
+        y = rgamma(y);
         a = Gamma(a);
         b = Gamma(b);
-        if (y == 0.0) {
+        if (std::isinf(y)) {
         over:
             set_error("lbeta", SF_ERROR_OVERFLOW, NULL);
             return (sign * std::numeric_limits<double>::infinity());
         }
 
-        if (std::abs(std::abs(a) - std::abs(y)) > std::abs(std::abs(b) - std::abs(y))) {
-            y = b / y;
+        if (std::abs(std::abs(a*y) - 1.0) > std::abs(std::abs(b*y) - 1.0)) {
+            y = b * y;
             y *= a;
         } else {
-            y = a / y;
+            y = a * y;
             y *= b;
         }
 

--- a/scipy/special/xsf/cephes/expn.h
+++ b/scipy/special/xsf/cephes/expn.h
@@ -65,7 +65,7 @@
 #include "../config.h"
 #include "../error.h"
 #include "const.h"
-#include "gamma.h"
+#include "rgamma.h"
 #include "polevl.h"
 
 namespace xsf {
@@ -252,7 +252,7 @@ namespace cephes {
         k = xk;
         t = n;
         r = n - 1;
-        ans = (std::pow(z, r) * psi / Gamma(t)) - ans;
+        ans = (std::pow(z, r) * psi * rgamma(t)) - ans;
         return ans;
     }
 

--- a/scipy/special/xsf/cephes/gamma.h
+++ b/scipy/special/xsf/cephes/gamma.h
@@ -375,16 +375,18 @@ namespace cephes {
         }
         if (x > 0) {
             return 1.0;
-        } else {
-            fx = std::floor(x);
-            if (x - fx == 0.0) {
-                return 0.0;
-            } else if (static_cast<int>(fx) % 2) {
-                return -1.0;
-            } else {
-                return 1.0;
-            }
-        }
+	}
+	if (x == 0) {
+	    return std::copysign(1.0, x);
+	}
+	fx = std::floor(x);
+	if (x - fx == 0.0) {
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
+	if (static_cast<int>(fx) % 2) {
+	    return -1.0;
+	}
+	return 1.0;
     }
 
 } // namespace cephes

--- a/scipy/special/xsf/cephes/gamma.h
+++ b/scipy/special/xsf/cephes/gamma.h
@@ -170,7 +170,7 @@ namespace cephes {
             if (x < 0.0) {
                 p = std::floor(q);
                 if (p == q) {
-                gamnan:
+		    // x is a negative integer. This is a pole.
                     set_error("Gamma", SF_ERROR_SINGULAR, NULL);
                     return (std::numeric_limits<double>::quiet_NaN());
                 }
@@ -229,7 +229,8 @@ namespace cephes {
     small:
         if (x == 0.0) {
 	    /* For this to have happened, x must have started as a negative integer. */
-            goto gamnan;
+	    set_error("Gamma", SF_ERROR_SINGULAR, NULL);
+	    return (std::numeric_limits<double>::quiet_NaN());
         } else
             return (z / ((1.0 + 0.5772156649015329 * x) * x));
     }

--- a/scipy/special/xsf/cephes/gamma.h
+++ b/scipy/special/xsf/cephes/gamma.h
@@ -379,6 +379,10 @@ namespace cephes {
 	if (x == 0) {
 	    return std::copysign(1.0, x);
 	}
+	if (std::isinf(x)) {
+	    // x > 0 case handled, so x must be negative infinity.
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
 	fx = std::floor(x);
 	if (x - fx == 0.0) {
 	    return std::numeric_limits<double>::quiet_NaN();

--- a/scipy/special/xsf/cephes/gamma.h
+++ b/scipy/special/xsf/cephes/gamma.h
@@ -387,6 +387,7 @@ namespace cephes {
 	if (x - fx == 0.0) {
 	    return std::numeric_limits<double>::quiet_NaN();
 	}
+	// sign of gamma for x in (-n, -n+1) for positive integer n is (-1)^n.
 	if (static_cast<int>(fx) % 2) {
 	    return -1.0;
 	}

--- a/scipy/special/xsf/cephes/hyp2f1.h
+++ b/scipy/special/xsf/cephes/hyp2f1.h
@@ -293,10 +293,10 @@ namespace cephes {
                     }
                 nosum:
                     p = xsf::cephes::Gamma(c);
-                    y1 *= xsf::cephes::Gamma(e) * p /
-                          (xsf::cephes::Gamma(a + d1) * xsf::cephes::Gamma(b + d1));
+                    y1 *= xsf::cephes::Gamma(e) * p *
+                          (xsf::cephes::rgamma(a + d1) * xsf::cephes::rgamma(b + d1));
 
-                    y *= p / (xsf::cephes::Gamma(a + d2) * xsf::cephes::Gamma(b + d2));
+                    y *= p * (xsf::cephes::rgamma(a + d2) * xsf::cephes::rgamma(b + d2));
                     if ((aid & 1) != 0)
                         y = -y;
 
@@ -494,8 +494,8 @@ namespace cephes {
             p *= std::pow(-x, -a);
             q *= std::pow(-x, -b);
             t1 = Gamma(c);
-            s = t1 * Gamma(b - a) / (Gamma(b) * Gamma(c - a));
-            y = t1 * Gamma(a - b) / (Gamma(a) * Gamma(c - b));
+            s = t1 * Gamma(b - a) * (rgamma(b) * rgamma(c - a));
+            y = t1 * Gamma(a - b) * (rgamma(a) * rgamma(c - b));
             return s * p + y * q;
         } else if (x < -1.0) {
             if (std::abs(a) < std::abs(b)) {
@@ -533,7 +533,7 @@ namespace cephes {
                 }
                 if (d <= 0.0)
                     goto hypdiv;
-                y = Gamma(c) * Gamma(d) / (Gamma(p) * Gamma(r));
+                y = Gamma(c) * Gamma(d) * (rgamma(p) * rgamma(r));
                 goto hypdon;
             }
             if (d <= -1.0)

--- a/scipy/special/xsf/cephes/hyp2f1.h
+++ b/scipy/special/xsf/cephes/hyp2f1.h
@@ -75,6 +75,7 @@
 
 #include "const.h"
 #include "gamma.h"
+#include "rgamma.h"
 #include "psi.h"
 
 namespace xsf {
@@ -252,9 +253,9 @@ namespace cephes {
                     /* sum for t = 0 */
                     y = xsf::cephes::psi(1.0) + xsf::cephes::psi(1.0 + e) - xsf::cephes::psi(a + d1) -
                         xsf::cephes::psi(b + d1) - ax;
-                    y /= xsf::cephes::Gamma(e + 1.0);
+                    y *= xsf::cephes::rgamma(e + 1.0);
 
-                    p = (a + d1) * (b + d1) * s / xsf::cephes::Gamma(e + 2.0); /* Poch for t=1 */
+                    p = (a + d1) * (b + d1) * s * xsf::cephes::rgamma(e + 2.0); /* Poch for t=1 */
                     t = 1.0;
                     do {
                         r = xsf::cephes::psi(1.0 + t) + xsf::cephes::psi(1.0 + t + e) -

--- a/scipy/special/xsf/cephes/hyperg.h
+++ b/scipy/special/xsf/cephes/hyperg.h
@@ -67,6 +67,7 @@
 
 #include "const.h"
 #include "gamma.h"
+#include "rgamma.h"
 
 namespace xsf {
 namespace cephes {
@@ -203,14 +204,14 @@ namespace cephes {
 
             h1 = hyp2f0(a, a - b + 1, -1.0 / x, 1, &err1);
 
-            temp = std::exp(u) / xsf::cephes::Gamma(b - a);
+            temp = std::exp(u) * xsf::cephes::rgamma(b - a);
             h1 *= temp;
             err1 *= temp;
 
             h2 = hyp2f0(b - a, 1.0 - a, 1.0 / x, 2, &err2);
 
             if (a < 0)
-                temp = std::exp(t) / xsf::cephes::Gamma(a);
+                temp = std::exp(t) * xsf::cephes::rgamma(a);
             else
                 temp = std::exp(t - xsf::cephes::lgam(a));
 

--- a/scipy/special/xsf/cephes/jv.h
+++ b/scipy/special/xsf/cephes/jv.h
@@ -55,7 +55,7 @@
 
 #include "airy.h"
 #include "cbrt.h"
-#include "gamma.h"
+#include "rgamma.h"
 #include "j0.h"
 #include "j1.h"
 #include "polevl.h"
@@ -241,7 +241,7 @@ namespace cephes {
             t = std::frexp(0.5 * x, &ex);
             ex = ex * n;
             if ((ex > -1023) && (ex < 1023) && (n > 0.0) && (n < (MAXGAM - 1.0))) {
-                t = std::pow(0.5 * x, n) / xsf::cephes::Gamma(n + 1.0);
+                t = std::pow(0.5 * x, n) * xsf::cephes::rgamma(n + 1.0);
                 y *= t;
             } else {
                 t = n * std::log(0.5 * x) - lgam_sgn(n + 1.0, &sgngam);
@@ -592,13 +592,13 @@ namespace cephes {
 
         if (x == 0 && n < 0 && !nint) {
             set_error("Jv", SF_ERROR_OVERFLOW, NULL);
-            return std::numeric_limits<double>::infinity() / Gamma(n + 1);
+            return std::numeric_limits<double>::infinity() * rgamma(n + 1);
         }
 
         y = std::abs(x);
 
         if (y * y < std::abs(n + 1) * detail::MACHEP) {
-            return std::pow(0.5 * x, n) / Gamma(n + 1);
+            return std::pow(0.5 * x, n) * rgamma(n + 1);
         }
 
         k = 3.6 * std::sqrt(y);

--- a/scipy/special/xsf/cephes/rgamma.h
+++ b/scipy/special/xsf/cephes/rgamma.h
@@ -73,35 +73,21 @@ namespace cephes {
 
     XSF_HOST_DEVICE double rgamma(double x) {
         double w, y, z;
-        int sign;
 
-        if (x > 34.84425627277176174) {
-            return std::exp(-lgam(x));
-        }
-        if (x < -34.034) {
-            w = -x;
-            z = sinpi(w);
-            if (z == 0.0) {
-                return 0.0;
-            }
-            if (z < 0.0) {
-                sign = 1;
-                z = -z;
-            } else {
-                sign = -1;
-            }
+	if (x == 0) {
+	    // This case is separate from below to get correct sign for zero.
+	    return x;
+	}
 
-            y = std::log(w * z) - std::log(M_PI) + lgam(w);
-            if (y < -detail::MAXLOG) {
-                set_error("rgamma", SF_ERROR_UNDERFLOW, NULL);
-                return (sign * 0.0);
-            }
-            if (y > detail::MAXLOG) {
-                set_error("rgamma", SF_ERROR_OVERFLOW, NULL);
-                return (sign * std::numeric_limits<double>::infinity());
-            }
-            return (sign * std::exp(y));
-        }
+	if (x < 0 && x == std::floor(x)) {
+	    // Gamma poles.
+	    return 0.0;
+	}
+
+	if (std::abs(x) > 2.5) {
+	    return 1.0 / Gamma(x);
+	}
+
         z = 1.0;
         w = x;
 

--- a/scipy/special/xsf/cephes/rgamma.h
+++ b/scipy/special/xsf/cephes/rgamma.h
@@ -84,7 +84,7 @@ namespace cephes {
 	    return 0.0;
 	}
 
-	if (std::abs(x) > 2.5) {
+	if (std::abs(x) > 4.0) {
 	    return 1.0 / Gamma(x);
 	}
 

--- a/scipy/special/xsf/cephes/struve.h
+++ b/scipy/special/xsf/cephes/struve.h
@@ -88,6 +88,7 @@
 
 #include "dd_real.h"
 #include "gamma.h"
+#include "rgamma.h"
 #include "scipy_iv.h"
 
 namespace xsf {
@@ -306,7 +307,7 @@ namespace cephes {
                 if (v < -1) {
                     return xsf::cephes::gammasgn(v + 1.5) * std::numeric_limits<double>::infinity();
                 } else if (v == -1) {
-                    return 2 / std::sqrt(M_PI) / xsf::cephes::Gamma(0.5);
+                    return 2 / std::sqrt(M_PI) * xsf::cephes::rgamma(0.5);
                 } else {
                     return 0;
                 }

--- a/scipy/special/xsf/hyp2f1.h
+++ b/scipy/special/xsf/hyp2f1.h
@@ -207,7 +207,7 @@ namespace detail {
          * chosen empirically based on the relevant benchmarks in
          * scipy/special/_precompute/hyp2f1_data.py */
         if (std::abs(u) <= 100 && std::abs(v) <= 100 && std::abs(w) <= 100 && std::abs(x) <= 100) {
-            result = cephes::Gamma(u) * cephes::Gamma(v) / (cephes::Gamma(w) * cephes::Gamma(x));
+            result = cephes::Gamma(u) * cephes::Gamma(v) * (cephes::rgamma(w) * cephes::rgamma(x));
             if (std::isfinite(result) && result != 0.0) {
                 return result;
             }
@@ -486,8 +486,8 @@ namespace detail {
             auto series_generator1 = HypergeometricSeriesGenerator(a + m, b + m, 1 + m, 1.0 - z);
             result *= series_eval_fixed_length(series_generator1, std::complex<double>{0.0, 0.0},
                                                static_cast<std::uint64_t>(-m));
-            double prefactor = std::pow(-1.0, m + 1) * xsf::cephes::Gamma(c) /
-                               (xsf::cephes::Gamma(a + m) * xsf::cephes::Gamma(b + m));
+            double prefactor = std::pow(-1.0, m + 1) * xsf::cephes::Gamma(c) *
+                               (xsf::cephes::rgamma(a + m) * xsf::cephes::rgamma(b + m));
             auto series_generator2 = Hyp2f1Transform1LimitSeriesGenerator(a, b, -m, z);
             result += prefactor * series_eval(series_generator2, std::complex<double>{0.0, 0.0}, hyp2f1_EPS,
                                               hyp2f1_MAXITER, "hyp2f1");
@@ -503,7 +503,7 @@ namespace detail {
         std::complex<double> result = cephes::Gamma(c) * cephes::rgamma(a) * std::pow(-z, -b);
         result *=
             series_eval_fixed_length(series_generator1, std::complex<double>{0.0, 0.0}, static_cast<std::uint64_t>(m));
-        std::complex<double> prefactor = cephes::Gamma(c) / (cephes::Gamma(a) * cephes::Gamma(c - b) * std::pow(-z, a));
+        std::complex<double> prefactor = cephes::Gamma(c) * (cephes::rgamma(a) * cephes::rgamma(c - b) * std::pow(-z, -a));
         double n = c - a;
         if (abs(n - std::round(n)) < hyp2f1_EPS) {
             auto series_generator2 = Hyp2f1Transform2LimitSeriesCminusAIntGenerator(a, b, c, m, n, z);

--- a/scipy/special/xsf/hyp2f1.h
+++ b/scipy/special/xsf/hyp2f1.h
@@ -269,7 +269,7 @@ namespace detail {
         XSF_HOST_DEVICE Hyp2f1Transform1LimitSeriesGenerator(double a, double b, double m, std::complex<double> z)
             : d1_(xsf::digamma(a)), d2_(xsf::digamma(b)), d3_(xsf::digamma(1 + m)),
               d4_(xsf::digamma(1.0)), a_(a), b_(b), m_(m), z_(z), log_1_z_(std::log(1.0 - z)),
-              factor_(1.0 / cephes::Gamma(m + 1)), k_(0) {}
+              factor_(cephes::rgamma(m + 1)), k_(0) {}
 
         XSF_HOST_DEVICE std::complex<double> operator()() {
             std::complex<double> term_ = (d1_ + d2_ - d3_ - d4_ + log_1_z_) * factor_;
@@ -315,8 +315,8 @@ namespace detail {
                                                                  std::complex<double> z)
             : d1_(xsf::digamma(1.0)), d2_(xsf::digamma(1 + m)), d3_(xsf::digamma(a)),
               d4_(xsf::digamma(c - a)), a_(a), b_(b), c_(c), m_(m), z_(z), log_neg_z_(std::log(-z)),
-              factor_(xsf::cephes::poch(b, m) * xsf::cephes::poch(1 - c + b, m) /
-                      xsf::cephes::Gamma(m + 1)),
+              factor_(xsf::cephes::poch(b, m) * xsf::cephes::poch(1 - c + b, m) *
+                      xsf::cephes::rgamma(m + 1)),
               k_(0) {}
 
         XSF_HOST_DEVICE std::complex<double> operator()() {
@@ -345,8 +345,8 @@ namespace detail {
                                                                            double n, std::complex<double> z)
             : d1_(xsf::digamma(1.0)), d2_(xsf::digamma(1 + m)), d3_(xsf::digamma(a)),
               d4_(xsf::digamma(n)), a_(a), b_(b), c_(c), m_(m), n_(n), z_(z), log_neg_z_(std::log(-z)),
-              factor_(xsf::cephes::poch(b, m) * xsf::cephes::poch(1 - c + b, m) /
-                      xsf::cephes::Gamma(m + 1)),
+              factor_(xsf::cephes::poch(b, m) * xsf::cephes::poch(1 - c + b, m) *
+                      xsf::cephes::rgamma(m + 1)),
               k_(0) {}
 
         XSF_HOST_DEVICE std::complex<double> operator()() {
@@ -416,7 +416,7 @@ namespace detail {
       public:
         XSF_HOST_DEVICE Hyp2f1Transform2LimitFinitePartGenerator(double b, double c, double m,
                                                                      std::complex<double> z)
-            : b_(b), c_(c), m_(m), z_(z), term_(cephes::Gamma(m) / cephes::Gamma(c - b)), k_(0) {}
+            : b_(b), c_(c), m_(m), z_(z), term_(cephes::Gamma(m) * cephes::rgamma(c - b)), k_(0) {}
 
         XSF_HOST_DEVICE std::complex<double> operator()() {
             std::complex<double> output = term_;
@@ -500,7 +500,7 @@ namespace detail {
         /* 1 / z transform in limiting case where a - b approaches a non-negative integer m. Negative integer case
          * can be handled by swapping a and b. */
         auto series_generator1 = Hyp2f1Transform2LimitFinitePartGenerator(b, c, m, z);
-        std::complex<double> result = cephes::Gamma(c) / cephes::Gamma(a) * std::pow(-z, -b);
+        std::complex<double> result = cephes::Gamma(c) * cephes::rgamma(a) * std::pow(-z, -b);
         result *=
             series_eval_fixed_length(series_generator1, std::complex<double>{0.0, 0.0}, static_cast<std::uint64_t>(m));
         std::complex<double> prefactor = cephes::Gamma(c) / (cephes::Gamma(a) * cephes::Gamma(c - b) * std::pow(-z, a));


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-19071, gh-21810

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes the behavior of `special.gamma` and `special.gammasgn` at poles of the `gamma` function. As described in #21810, we currently have `special.gamma(n) == np.inf` for  every non-positive integer `n`, and bizarrely `special.gamma(-np.inf) == -np.inf`.  As described in #19710, `gammasgn(n) == 0.0` for every non-positive integer `n` and even more bizarrely, `gammasgn(-np.inf) == 1.0`.

The sign of $\Gamma(x)$ at each pole depends on the direction in which $x$ approaches the pole, so it doesn't make sense to return $+\infty$ at all poles. Accordingly, the [C99 standard](https://en.cppreference.com/w/c/numeric/math/tgamma) recommends the following behavior for the gamma function in special cases.

1. If the argument is $\pm 0$, $\pm \infty$ is returned.
2. If the argument is a negative integer, NaN is returned.
3. If the argument is $-\infty$, NaN is returned.
4. If the argument is $+\infty$, $+\infty$ is returned
5. If the argument is NaN, NaN is returned.

I've updated `special.gamma` to follow this standard. Note that signed zeros offer the ability to specify the sign of infinity of `gamma(x)` at `x == 0`. I've also updated `gammasgn` to be consistent with the above.

 Note that as described in #21810, the original cephes gamma function implementation gets these cases right, and `special.gamma`'s current behavior was a deliberate choice. I had speculated earlier that `gamma(x) == +inf` at poles may have been enforced so that `gamma` ratios can be computed naively without worrying about hitting a pole in the denominator. This seems to be born out, after making the above changes, I found that the `cephes` implementations of `beta` and `betaln` needed to be updated because they rely on this behavior. In addition, `test_pbvd_points` needed to be updated as well because it divides by `gamma` in the computation of reference values.

I think the preferred thing to do when computing gamma ratios should be to use `rgamma` for `gamma`s in the denominators, but I discovered that `rgamma(x)` can be much less accurate than `1.0/gamma(x)` for `x` away from 0. This caused test failures in `test_mpmath` for `betaln` when I switched `betaln`'s implementation to use `rgamma` internally. I fixed this by updating the scalar kernel of `rgamma` to just compute `1.0/gamma(x)` away from the origin, with special handling at the poles. 




The strange behavior of `gammasgn` at poles is currently enforced through a test which compares `special.gammasgn(x)` with `np.sign(special.rgamma(x)`.

https://github.com/scipy/scipy/blob/0f6de5836a9fa7bdd5121810ccd452bdde5295db/scipy/special/tests/test_basic.py#L400-L402

and since `rgamma(x) == 0` at poles, the test passes when `gammasgn(x) == 0` at poles. I'm not sure if there was a reason for deciding on this behavior. I've simply changed the test cases.

I've also added additional tests for `gamma` at poles and removed a test case enforcing `gamma(-1) == +inf`.

#### Additional information

The details section here contains the justification for choosing a cutoff for evaluating `rgamma` as `1/gamma` rather than following the current `rgamma` implementation.

<details>

Here's a plot of the log10 of relative error against an mpmath reference for both `rgamma` and `1/gamma` over the range `(-99.9, 99.9)` showing how bad things can be

![rgamma_inaccuracy_wide](https://github.com/user-attachments/assets/8583fd59-235a-4686-98f0-5eb7b0335561)

Here are the deciles for relative error

| method   |   min |   10% |         20% |         30% |         40% |         50% |         60% |         70% |         80% |         90% |         max |
|----------|-------|-------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|
| rgamma   |     0 |     0 | 1.68305e-16 | 3.08089e-16 | 2.56746e-15 | 7.53686e-15 | 1.32971e-14 | 1.95882e-14 | 2.8148e-14  | 4.31268e-14 | 1.35586e-13 |
| 1/gamma  |     0 |     0 | 0           | 0           | 1.22212e-16 | 1.43391e-16 | 1.67001e-16 | 1.92162e-16 | 2.24835e-16 | 3.22916e-16 | 1.07467e-15 |

zooming in, it looks like `rgamma` starts to do a little better near the origin

![rgaa](https://github.com/user-attachments/assets/1dc90841-a2b6-4ae3-9321-8f7bc5b2db75)

I eyeballed this plot, and chose a cutoff of `|x| < 4` for using the existing `rgamma`. Here's the deciles for relative error just for `|x| < 4`.

| method   |   min |   10% |   20% |   30% |   40% |   50% |         60% |         70% |         80% |        90% |         max |
|----------|-------|-------|-------|-------|-------|-------|-------------|-------------|-------------|------------|-------------|
| rgamma   |     0 |     0 |     0 |     0 |     0 |     0 | 0           | 1.26661e-16 | 1.58249e-16 | 2.0817e-16 | 3.13087e-16 |
| 1/gamma  |     0 |     0 |     0 |     0 |     0 |     0 | 1.26577e-16 | 1.51009e-16 | 1.92822e-16 | 2.2071e-16 | 4.24229e-16 |

I used the following function to calculate these plots and tables

```python
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd
import scipy.special as special

from mpmath import mp

def get_rgamma_table_and_plot(x):
    res1 = special.rgamma(x)
    res2 = 1.0 / special.gamma(x)
    reference = np.fromiter((float(mp.rgamma(t)) for t in x), dtype=np.float64)

    rel_err1 = abs(res1 - reference)/abs(reference)
    rel_err2 = abs(res2 - reference)/abs(reference)

    # rgamma deciles
    dec1 = np.quantile(rel_err1, np.linspace(0, 1, 11))
    # gamma deciles
    dec2 = np.quantile(rel_err2, np.linspace(0, 1, 11))

    table = pd.DataFrame(
        [
            ["rgamma"] + dec1.tolist(),
            ["1/gamma"] + dec2.tolist(),
        ],
        columns=["method", "min"] + [f"{n}%" for n in range(10, 91, 10)] + ["max"],
    ).to_markdown(index=False, tablefmt="github")

    fig, ax = plt.subplots()
    ax.plot(x, np.where(rel_err1 == 0, -16, np.log10(rel_err1)), label="rgamma")
    ax.plot(x, np.where(rel_err2 == 0, -16, np.log10(rel_err2)), label="1/gamma")
    ax.set_xlabel("x")
    ax.set_ylabel("log10(rel error)")
    ax.legend()
    return table, fig
```

</details>

##### Potential impact

I ran the command

```
ack Gamma --type=cc
```

from within the `scipy/scipy/special`

directory to identify places where `Gamma` is used to see if there are other places where it appears in a denominator. In most of the examples, changing the pole behavior in this PR won't matter, because these special cases are already handled. To make it so the reviewer doesn't have to check that these cases are already handled in each of the instances where `gamma` appears in the denominator,  I've decided to uniformly switch to `rgamma` whenever `gamma` appears in the denominator. The exception is when you have a product with a `gamma` function in the denominator. In that case, typically there was a specific choice made to multiply first before dividing, typically in order to get better numerical accuracy. I'll enumerate these cases below, and will work on verifying no issues will result from changing the pole behavior.

##### `besselpoly`

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/cephes/besselpoly.h#L31-L36

but we see that these cases are already handled, so it's not an issue.

##### real valued `hyp2f1`:

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/cephes/hyp2f1.h#L274-L276

This case above occurs within a branch

```C++
            if (x > 0.9 && !(neg_int_a || neg_int_b)) {
```

so `a` and `b` cannot be poles. The name `neg_int_a` is not quite right, it really means non-positive.  From lines 168-174

```C++
            if (a <= 0 && std::abs(a - ia) < hyp2f1_EPS) { /* a is a negative integer */
                neg_int_a = 1;
            }

            if (b <= 0 && std::abs(b - ib) < hyp2f1_EPS) { /* b is a negative integer */
                neg_int_b = 1;
            }
```

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/cephes/hyp2f1.h#L295-L298

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/cephes/hyp2f1.h#L496-L497

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/cephes/hyp2f1.h#L535


##### complex valued `hyp2f1`

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/hyp2f1.h#L210

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/hyp2f1.h#L477C13-L479

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/hyp2f1.h#L489-L490

https://github.com/scipy/scipy/blob/d1feb94fb2d8bdd845c79d276c9ca027f86e1841/scipy/special/xsf/hyp2f1.h#L506


#### Some thoughts

Seeing  cases where we rely on `gamma(n) == inf` for `n` a non-positive integer at least makes me realize why this convention was chosen. It does give a shortcut when evaluating gamma ratios, and for cases like

```python
gamma(a)*gamma(b)/(gamma(c)*gamma(d))
```

switching to using `rgamma` can result in reduced accuracy. I think it's better to follow the standard and most mathematically correct here way, but since we relied on this behavior internally, maybe there should be a deprecation period, or perhaps we should even keep a `kwarg` around permanently to switch between following the standard and returning `+inf` at the poles, changing the default after a deprecation period. If no one else sees an issue with it, I'm fine with treating this as a bug and just fixing it at once though.


<!--Any additional information you think is important.-->
