### PR TITLE
DOC: fixup `_transition_to_rng` Oldest GCC `"'rng' is not in list"` error

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -443,10 +443,11 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
         if replace_doc:
             doc = FunctionDoc(wrapper)
             parameter_names = [param.name for param in doc['Parameters']]
-            _type = "{None, int, `numpy.random.Generator`}, optional"
-            _desc = _rng_desc.replace("{old_name}", old_name)
-            _rng_parameter_doc = Parameter('rng', _type, [_desc])
-            doc['Parameters'][parameter_names.index('rng')] = _rng_parameter_doc
+            if 'rng' in parameter_names:
+                _type = "{None, int, `numpy.random.Generator`}, optional"
+                _desc = _rng_desc.replace("{old_name}", old_name)
+                _rng_parameter_doc = Parameter('rng', _type, [_desc])
+                doc['Parameters'][parameter_names.index('rng')] = _rng_parameter_doc
             doc = str(doc).split("\n", 1)[1]  # remove signature
             wrapper.__doc__ = str(doc)
         return wrapper


### PR DESCRIPTION
#### Reference issue
gh-21823, gh-21812

#### What does this implement/fix?
Besides the failures related to gh-21828, the "Oldest GCC" job in main is failing with "'rng' is not in list" messages. The cause is unclear, but let's see if this fixes it.
