### PR TITLE
CI: constrain array-api-strict version to allow conversion to NumPy array

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis array-api-strict
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool pooch hypothesis array-api-strict==2.1.0
 
     - name: Install PyTorch CPU
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - pytest-timeout
   - asv >=0.6
   - hypothesis
-  - array-api-strict
+  - array-api-strict<2.1.1
   # For type annotations
   - mypy
   - typing_extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
     "scikit-umfpack",
     "pooch",
     "hypothesis>=6.30",
-    "array-api-strict>=2.0",
+    "array-api-strict>=2.0,<2.1.1",
     "Cython",
     "meson",
     'ninja; sys_platform != "emscripten"',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch
 hypothesis>=6.30
-array-api-strict>=2.0
+array-api-strict>=2.0,<2.1.1
 Cython
 meson
 ninja; sys_platform != "emscripten"


### PR DESCRIPTION
#### Reference issue
gh-21828

#### What does this implement/fix?
Constrains version of `array-api-strict ` used in CI to avoid failure during conversion to NumPy array. 

#### Additional information
Probably a temporary fix to get CI working while we figure out / implement whatever needs to be done.