### PR TITLE
MAINT:sparse.linalg: Detach ARPACK and PROPACK code sharing

### DIFF
--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -53,7 +53,7 @@ z_src = [
   'PROPACK/complex16/dbsvd.F',
   'PROPACK/complex16/dgemm_ovwr.F',
   'PROPACK/complex16/printstat.F',
-  '../_eigen/arpack/ARPACK/SRC/zzdotc.f',
+  'PROPACK/complex16/zzdotc.f',
   'PROPACK/complex16/zblasext.F',
   'PROPACK/complex16/zgemm_ovwr.F',
   'PROPACK/complex16/zgetu0.F',


### PR DESCRIPTION
Towards #18566

This PR removes the link between the ARPACK F77 code and PROPACK that was shared using `zzdotc.f` file. The submodule is updated in https://github.com/scipy/PROPACK/pull/9 and the file now lives under PROPACK repo (it will be removed in v1.16 with a propack rewrite anyways).  