### PR TITLE
DOC: tone down the text of the "legacy" admonition

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -523,8 +523,9 @@ class LegacyDirective(Directive):
             # Argument is empty; use default text
             obj = "submodule"
         text = (f"This {obj} is considered legacy and will no longer receive "
-                "updates. This could also mean it will be removed in future "
-                "SciPy versions.")
+                "updates. While we currently have no plans to remove it, "
+                "we recommend that new code uses more modern alternatives instead."
+        )
 
         try:
             self.content[0] = text+" "+self.content[0]


### PR DESCRIPTION
The "may be removed in the future" phrase was making users panic and mix "legacy" and "deprecated". Thus try to be more precise in what message we are sending.

See, for instance, 
https://github.com/scipy/scipy/issues/21571, https://github.com/scipy/scipy/issues/21258, or an _"interp1d is not supported anymore"_ [comment on SO](https://stackoverflow.com/questions/78895025/fill-value-extrapolate-bounds-error-false-in-interp1d-still-raise-valueerror"), to name just a few.

