### PR TITLE
MAINT: stats.lmoment: fixup keepdims behavior

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10279,7 +10279,7 @@ def _prk(r, k):
 
 
 @_axis_nan_policy_factory(  # noqa: E302
-    _moment_result_object, n_samples=1, result_to_tuple=lambda x: (x,),
+    _moment_result_object, n_samples=1, result_to_tuple=_moment_tuple,
     n_outputs=lambda kwds: _moment_outputs(kwds, [1, 2, 3, 4])
 )
 def lmoment(sample, order=None, *, axis=0, sorted=False, standardize=True):


### PR DESCRIPTION
#### Reference issue
gh-21307, gh-19475

#### What does this implement/fix?
gh-19475 just merged, but the last time CI ran on it was three months ago.

Two months ago, we found and fixed some issues with the `keepdims` argument of some stats functions (gh-21307). 

One of the bugs we found and fixed for `moment` applies to `lmoment`, too.

This PR applies the fix to `lmoment`. (And fixes an as-yet-unreported test failure in main.)
