### PR TITLE
BUG: linalg.svd: avoid segmentation fault

### DIFF
--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -133,16 +133,8 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if lapack_driver not in ('gesdd', 'gesvd'):
         message = f'lapack_driver must be "gesdd" or "gesvd", not "{lapack_driver}"'
         raise ValueError(message)
-    funcs = (lapack_driver, lapack_driver + '_lwork')
-    try:
-        gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,), ilp64=True)
-        ilp64_enabled = True
-    except RuntimeError:
-        # some debug warning here
-        gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,), ilp64=False)
-        ilp64_enabled = False
 
-    if compute_uv and not ilp64_enabled:
+    if compute_uv:
         # XXX: revisit int32 when ILP64 lapack becomes a thing
         max_mn, min_mn = (m, n) if m > n else (n, m)
         if full_matrices:
@@ -156,6 +148,11 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
                 raise ValueError(f"Indexing a matrix of {sz} elements would "
                                   "incur an in integer overflow in LAPACK. "
                                   "Try using numpy.linalg.svd instead.")
+
+    funcs = (lapack_driver, lapack_driver + '_lwork')
+    # XXX: As of 1.14.1 it isn't possible to build SciPy with ILP64,
+    # so the following line always yields a LP64 (32-bit pointer size) variant
+    gesXd, gesXd_lwork = get_lapack_funcs(funcs, (a1,), ilp64="preferred")
 
     # compute optimal lwork
     lwork = _compute_lwork(gesXd_lwork, a1.shape[0], a1.shape[1],

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -149,19 +149,13 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
             if max_mn*max_mn > np.iinfo(np.int32).max:
                 raise ValueError(f"Indexing a matrix size {max_mn} x {max_mn} "
                                   "would incur integer overflow in LAPACK. "
-                                  "A possible workaround is to 1. build NumPy "
-                                  "against ILP64 LAPACK (see https://numpy.org"
-                                  "/doc/stable/building/blas_lapack.html) "
-                                  "and then 2. use numpy.linalg.svd instead.")
+                                  "Try using numpy.linalg.svd instead.")
         else:
             sz = max(m * min_mn, n * min_mn)
             if max(m * min_mn, n * min_mn) > np.iinfo(np.int32).max:
                 raise ValueError(f"Indexing a matrix of {sz} elements would "
                                   "incur an in integer overflow in LAPACK. "
-                                  "A possible workaround is to 1. build NumPy "
-                                  "against ILP64 LAPACK (see https://numpy.org"
-                                  "/doc/stable/building/blas_lapack.html) "
-                                  "and then 2. use numpy.linalg.svd instead.")
+                                  "Try using numpy.linalg.svd instead.")
 
     # compute optimal lwork
     lwork = _compute_lwork(gesXd_lwork, a1.shape[0], a1.shape[1],


### PR DESCRIPTION
Catch segmentation fault caused by integer overflow when using 'gesvd'. Describe a possible workaround using numpy.linalg.svd

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes [gh-21837](https://github.com/scipy/scipy/issues/21837)

#### What does this implement/fix?
1. Check for presence of ILP64 LAPACK functions
2. If they are not available (i.e., 32-bit indexed LAPACK will be used) and `U, V` factors are to be computed, check the size of the resulting arrays and throw a ValueError (otherwise, a segfault would occur). The checks were already implemented in https://github.com/scipy/scipy/pull/20349, this change extends the condition when they are applied to also cover `'gesvd'`

Edit (after review):
- no check for presence of ILP64
- extend the condition to also throw ValueError when using `'gesvd'`

#### Additional information
<!--Any additional information you think is important.-->
