### PR TITLE
DOC: replace only first paragraph of rng documentation

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -342,10 +342,11 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
         Whether the decorator should replace the documentation for parameter `rng` with
         `_rng_desc` (defined above), which documents both new `rng` keyword behavior
         and typical legacy `random_state`/`seed` behavior. If True, manually replace
-        the function's old `random_state`/`seed` documentation with the desired *final*
-        `rng` documentation; this way, no changes to documentation are needed when the
-        decorator is removed. Use False if the function's old `random_state`/`seed`
-        behavior does not match that described by `_rng_desc`.
+        the first paragraph of the function's old `random_state`/`seed` documentation
+        with the desired *final* `rng` documentation; this way, no changes to
+        documentation are needed when the decorator is removed. Documentation of `rng`
+        after the first blank line is preserved. Use False if the function's old
+        `random_state`/`seed` behavior does not match that described by `_rng_desc`.
 
     """
     NEW_NAME = "rng"
@@ -446,10 +447,13 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
             if 'rng' in parameter_names:
                 _type = "{None, int, `numpy.random.Generator`}, optional"
                 _desc = _rng_desc.replace("{old_name}", old_name)
-                _rng_parameter_doc = Parameter('rng', _type, [_desc])
+                old_doc = doc['Parameters'][parameter_names.index('rng')].desc
+                old_doc_keep = old_doc[old_doc.index("") + 1:] if "" in old_doc else []
+                new_doc = [_desc] + old_doc_keep
+                _rng_parameter_doc = Parameter('rng', _type, new_doc)
                 doc['Parameters'][parameter_names.index('rng')] = _rng_parameter_doc
-            doc = str(doc).split("\n", 1)[1]  # remove signature
-            wrapper.__doc__ = str(doc)
+                doc = str(doc).split("\n", 1)[1]  # remove signature
+                wrapper.__doc__ = str(doc)
         return wrapper
 
     return decorator


### PR DESCRIPTION
#### Reference issue
gh-21823

#### What does this implement/fix?
Currently, the `_transition_to_rng` decorator replaces the entirety of a function's `rng` decumentation with boilerplate, but sometimes additional information is desired. This PR changes the logic so that only the first paragraph is replaced; anything after the first blank line is preserved.

#### Additional information
For example, in gh-21823, we'd like for this text to be included in the `rng` description:

> Specify `rng` for repeatable minimizations. The random numbers generated only affect the visiting distribution function and new coordinates generation.

but currently it is [omitted](https://scipy.github.io/devdocs/reference/generated/scipy.optimize.dual_annealing.html). Compare against [docs rendered with this PR](https://output.circle-artifacts.com/output/job/d0b49c36-573f-4a84-aafd-d024f7f349bb/artifacts/0/html/reference/generated/scipy.optimize.dual_annealing.html).