### PR TITLE
BLD: warn on accelerate + non-native

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -199,6 +199,9 @@ if blas_name == 'accelerate'
   if not macOS13_3_or_later
     error('macOS Accelerate is only supported on macOS >=13.3')
   endif
+  if cc.get_id() != 'clang'
+    warning('accelerate may not be properly detected with non-native Apple compiler due to https://github.com/mesonbuild/meson/issues/13608')
+  endif
   _args_blas_lapack += ['-DACCELERATE_NEW_LAPACK']
   generate_blas_wrappers = true
   accelerate_flag = '-a'


### PR DESCRIPTION
* Fixes gh-21829

* As discussed in above ticket, simply issue a warning that links to upstream issue when attempting to build SciPy from source with non-native compiler + accelerate linalg backend. When testing on MacOS ARM locally:

`CC=gcc-13 CXX=g++-13 FC=gfortran-13 python dev.py build -j 16 --with-accelerate`

now warns:

```
<snip>
Program f2py found: YES (/Users/treddy/python_venvs/py_312_scipy_dev/bin/f2py)
scipy/meson.build:203: WARNING: accelerate may not be properly detected with non-native Apple compiler due to https://github.com/mesonbuild/meson/issues/13608
Run-time dependency accelerate found: NO (tried pkgconfig and framework)

scipy/meson.build:225:9: ERROR: Dependency "accelerate" not found, tried pkgconfig and framework
<snip>
```

while building with AppleClang seems to proceed as usual with no warning.

[skip cirrus] [skip circle]
