### PR TITLE
ENH: sparse: Add safe casting function for sparse index to sputils

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -152,7 +152,7 @@ def getdata(obj, dtype=None, copy=False) -> np.ndarray:
 
 
 def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
-    """Return cast index arrays of `A` to idx_dtype safely.
+    """Safely cast sparse array indices to `idx_dtype`.
 
     Check the shape of `A` to determine if it is safe to cast its index
     arrays to dtype `idx_dtype`. If any dimension in shape is larger than
@@ -161,8 +161,8 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     without changing the input `A`. The caller can assign results to `A`
     attributes if desired or use the recast index arrays directly.
 
-    If downcasting is not needed, no copy is made.
-    You can test e.g. ``A.indptr is indptr`` to see if downcasting occurred.
+    Unless downcasting is needed, the original index arrays are returned.
+    You can test e.g. ``A.indptr is new_indptr`` to see if downcasting occurred.
 
     .. versionadded:: 1.15.0
 
@@ -170,8 +170,8 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     ----------
     A : sparse array or matrix
         The array for which index arrays should be downcast.
-    idx_dtype : the index dtype desired to downcast to.
-        Should be an integer dtype. default: np.int32
+    idx_dtype : dtype
+        Desired dtype. Should be an integer dtype (default: ``np.int32``).
     msg : string
         A string to be added to the end of the ValueError message
         if the array shape is too big to fit in `idx_dtype`.
@@ -181,15 +181,16 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     Returns
     -------
     idx_arrays : ndarray or tuple of ndarrays
-        Based on ``A.format``, index arrays are returned after casting to idx_dtype.
+        Based on ``A.format``, index arrays are returned after casting to `idx_dtype`.
         For CSC/CSR, returns ``(indices, indptr)``.
         For COO, returns ``coords``.
         For DIA, returns ``offsets``.
-        For BSR, returns ``(indices, indtr)``.
+        For BSR, returns ``(indices, indptr)``.
 
     Raises
     ------
-    ValueError : if the array has shape that would not fit in the new dtype.
+    ValueError
+        If the array has shape that would not fit in the new dtype.
     """
     if not msg:
         msg = f"dtype {idx_dtype}"

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -192,19 +192,19 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     ValueError : if the array has shape that would not fit in the new dtype.
     """
     if msg == "":
-        msg = f"dtype {idx_dtype}"
+        msg = f"for dtype {idx_dtype}"
     # check for safe downcasting
     max_value = np.iinfo(idx_dtype).max
 
     if A.format in ("csc", "csr"):
         # indptr[-1] is max b/c indptr always sorted
         if A.indptr[-1] > max_value:
-            raise ValueError("indptr values too large for", msg)
+            raise ValueError("indptr values too large", msg)
 
         # check shape vs dtype
         if max(*A.shape) > max_value:
             if np.any(A.indices > max_value):
-                raise ValueError("indices values too large for", msg)
+                raise ValueError("indices values too large", msg)
 
         indices = A.indices.astype(idx_dtype, copy=False)
         indptr = A.indptr.astype(idx_dtype, copy=False)
@@ -213,24 +213,24 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     elif A.format == "coo":
         if max(*A.shape) > max_value:
             if any(np.any(co > max_value) for co in A.coords):
-                raise ValueError("coords values too large for", msg)
+                raise ValueError("coords values too large", msg)
         coords = tuple(co.astype(idx_dtype, copy=False) for co in A.coords)
         return coords
 
     elif A.format == "dia":
         if max(*A.shape) > max_value:
             if np.any(A.offsets > max_value):
-                raise ValueError("offsets values too large for", msg)
+                raise ValueError("offsets values too large", msg)
         offsets = A.offsets.astype(idx_dtype, copy=False)
         return offsets
 
     elif A.format == 'bsr':
         R, C = A.blocksize
         if A.indptr[-1] * R > max_value:
-            raise ValueError("indptr values too large for", msg)
+            raise ValueError("indptr values too large", msg)
         if max(*A.shape) > max_value:
             if np.any(A.indices * C > max_value):
-                raise ValueError("indices values too large for", msg)
+                raise ValueError("indices values too large", msg)
         indices = A.indices.astype(idx_dtype, copy=False)
         indptr = A.indptr.astype(idx_dtype, copy=False)
         return indices, indptr

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -203,7 +203,7 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
 
         # check shape vs dtype
         if max(*A.shape) > max_value:
-            if np.any(A.indices > max_value):
+            if (A.indices > max_value).any():
                 raise ValueError(f"indices values too large for {msg}")
 
         indices = A.indices.astype(idx_dtype, copy=False)
@@ -218,7 +218,7 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
 
     elif A.format == "dia":
         if max(*A.shape) > max_value:
-            if np.any(A.offsets > max_value):
+            if (A.offsets > max_value).any():
                 raise ValueError(f"offsets values too large for {msg}")
         offsets = A.offsets.astype(idx_dtype, copy=False)
         return offsets
@@ -228,7 +228,7 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
         if A.indptr[-1] * R > max_value:
             raise ValueError("indptr values too large for {msg}")
         if max(*A.shape) > max_value:
-            if np.any(A.indices * C > max_value):
+            if (A.indices * C > max_value).any():
                 raise ValueError(f"indices values too large for {msg}")
         indices = A.indices.astype(idx_dtype, copy=False)
         indptr = A.indptr.astype(idx_dtype, copy=False)

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -156,7 +156,7 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
 
     Check the shape of `A` to determine if it is safe to cast its index
     arrays to dtype `idx_dtype`. If any dimension in shape is larger than
-    fits in the dtype, casting is unsafe so raise ``ValueError(msg)``.
+    fits in the dtype, casting is unsafe so raise ``ValueError``.
     If safe, cast the index arrays to `idx_dtype` and return the result
     without changing the input `A`. The caller can assign results to `A`
     attributes if desired or use the recast index arrays directly.
@@ -172,11 +172,12 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
         The array for which index arrays should be downcast.
     idx_dtype : dtype
         Desired dtype. Should be an integer dtype (default: ``np.int32``).
-    msg : string
+    msg : string, optional
         A string to be added to the end of the ValueError message
         if the array shape is too big to fit in `idx_dtype`.
-        It should indicate why the downcasting is needed and
-        defaults to f"dtype {idx_dtype}".
+        The error message is ``f"<index> values too large for {msg}"``
+        It should indicate why the downcasting is needed, e.g. "SuperLU",
+        and defaults to f"dtype {idx_dtype}".
 
     Returns
     -------

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -191,7 +191,8 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     Raises
     ------
     ValueError
-        If the array has shape that would not fit in the new dtype.
+        If the array has shape that would not fit in the new dtype, or if
+        the sparse format does not use index arrays.
     """
     if not msg:
         msg = f"dtype {idx_dtype}"

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -3,9 +3,8 @@
 import numpy as np
 
 from scipy.sparse import csr_array, issparse, csr_matrix
-from scipy.sparse._sputils import convert_pydata_sparse_to_scipy, is_pydata_spmatrix
-
-from ._tools import _safe_downcast_indices
+from scipy.sparse._sputils import (convert_pydata_sparse_to_scipy, is_pydata_spmatrix,
+                                   safely_cast_index_arrays)
 
 cimport numpy as np
 
@@ -254,10 +253,10 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     if not csgraph.has_sorted_indices:
         csgraph = csgraph.sorted_indices()
 
-    csgraph_indices, csgraph_indptr = _safe_downcast_indices(csgraph)
-    if csgraph_indices is not csgraph.indices:
+    indices, indptr = safely_cast_index_arrays(csgraph, idx_dtype=ITYPE, msg="csgraph")
+    if indices is not csgraph.indices:
         # create a new object without copying data
-        csgraph = csr_array((csgraph.data, csgraph_indices, csgraph_indptr),
+        csgraph = csr_array((csgraph.data, indices, indptr),
                             shape=csgraph.shape, dtype=csgraph.dtype)
 
     # Our maximum flow solvers assume that edges always exist

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -7,8 +7,8 @@ from libc.math cimport INFINITY
 
 
 from scipy.sparse import issparse, csr_array
-from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
-from ._tools import _safe_downcast_indices
+from scipy.sparse._sputils import (convert_pydata_sparse_to_scipy,
+                                   safely_cast_index_arrays)
 
 np.import_array()
 
@@ -142,7 +142,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
         raise TypeError("graph must be in CSC, CSR, or COO format.")
     graph = graph.tocsr()
     i, j = graph.shape
-    indices, indptr = _safe_downcast_indices(graph)
+    indices, indptr = safely_cast_index_arrays(graph, ITYPE, msg="csgraph")
     x, y = _hopcroft_karp(indices, indptr, i, j)
     return np.asarray(x if perm_type == 'column' else y)
 
@@ -482,10 +482,10 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
 
     a = np.arange(np.min(biadjacency.shape))
 
-    biadj_indices, biadj_indptr = _safe_downcast_indices(biadjacency)
-    if biadj_indices is not biadjacency.indices:
+    indices, indptr = safely_cast_index_arrays(biadjacency, ITYPE, msg="csgraph")
+    if indices is not biadjacency.indices:
         # create a new object without copying data
-        biadjacency = csr_array((biadjacency.data, biadj_indices, biadj_indptr),
+        biadjacency = csr_array((biadjacency.data, indices, indptr),
                                 shape=biadjacency.shape, dtype=biadjacency.dtype)
 
     # The algorithm expects more columns than rows in the graph, so

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -652,18 +652,3 @@ cdef void _construct_dist_matrix(np.ndarray[DTYPE_t, ndim=2] graph,
                 k2 = k1
             if null_path and i != j:
                 dist[i, j] = null_value
-
-
-def _safe_downcast_indices(A):
-    # check for safe downcasting to ITYPE (==int32 set in parameters.pxi)
-    max_value = np.iinfo(ITYPE).max
-
-    if A.indptr[-1] > max_value:  # indptr[-1] is max b/c indptr always sorted
-        raise ValueError("indptr values too large for csgraph")
-    if max(*A.shape) > max_value:  # only check large enough arrays
-        if np.any(A.indices > max_value):
-            raise ValueError("indices values too large for csgraph")
-
-    indices = A.indices.astype(ITYPE, copy=False)
-    indptr = A.indptr.astype(ITYPE, copy=False)
-    return indices, indptr

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -414,7 +414,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices, indptr = safely_cast_index_arrays(A, np.intc, "for SuperLU")
+    indices, indptr = safely_cast_index_arrays(A, np.intc, "SuperLU")
 
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
@@ -510,7 +510,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices, indptr = safely_cast_index_arrays(A, np.intc, "for SuperLU")
+    indices, indptr = safely_cast_index_arrays(A, np.intc, "SuperLU")
 
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -5,7 +5,7 @@ from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
                           csr_array, csc_array, eye_array, diags_array)
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
-                                   get_index_dtype)
+                                   get_index_dtype, safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
 import copy
 import threading
@@ -129,21 +129,6 @@ def _get_umf_family(A):
     A_new.indices = np.asarray(A.indices, dtype=np.int64)
 
     return family, A_new
-
-def _safe_downcast_indices(A):
-    # check for safe downcasting
-    max_value = np.iinfo(np.intc).max
-
-    if A.indptr[-1] > max_value:  # indptr[-1] is max b/c indptr always sorted
-        raise ValueError("indptr values too large for SuperLU")
-
-    if max(*A.shape) > max_value:  # only check large enough arrays
-        if np.any(A.indices > max_value):
-            raise ValueError("indices values too large for SuperLU")
-
-    indices = A.indices.astype(np.intc, copy=False)
-    indptr = A.indptr.astype(np.intc, copy=False)
-    return indices, indptr
 
 def spsolve(A, b, permc_spec=None, use_umfpack=True):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
@@ -429,7 +414,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices, indptr = _safe_downcast_indices(A)
+    indices, indptr = safely_cast_index_arrays(A, np.intc, "for SuperLU")
 
     _options = dict(DiagPivotThresh=diag_pivot_thresh, ColPerm=permc_spec,
                     PanelSize=panel_size, Relax=relax)
@@ -525,7 +510,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     if (M != N):
         raise ValueError("can only factor square matrices")  # is this true?
 
-    indices, indptr = _safe_downcast_indices(A)
+    indices, indptr = safely_cast_index_arrays(A, np.intc, "for SuperLU")
 
     _options = dict(ILU_DropRule=drop_rule, ILU_DropTol=drop_tol,
                     ILU_FillFactor=fill_factor,

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_equal
 import pytest
 from pytest import raises as assert_raises
-from scipy.sparse import _sputils as sputils
+from scipy.sparse import _sputils as sputils, csr_array, bsr_array, dia_array, coo_array
 from scipy.sparse._sputils import matrix
 
 
@@ -114,6 +114,139 @@ class TestSparseUtils:
         # These function calls should not raise errors
         for axis in (-2, -1, 0, 1, None):
             sputils.validateaxis(axis)
+
+    @pytest.mark.parametrize("container", [csr_array, bsr_array])
+    def test_safely_cast_index_compressed(self, container):
+        # This is slow to test completely as nnz > imax is big
+        # and indptr is big for some shapes
+        # So we don't test large nnz, nor csc_array (same code as csr_array)
+        imax = np.int64(np.iinfo(np.int32).max)
+
+        # Shape 32bit
+        A32 = container((1, imax))
+        # indices big type, small values
+        B32 = A32.copy()
+        B32.indices = B32.indices.astype(np.int64)
+        B32.indptr = B32.indptr.astype(np.int64)
+
+        # Shape 64bit
+        # indices big type, small values
+        A64 = csr_array((1, imax + 1))
+        # indices small type, small values
+        B64 = A64.copy()
+        B64.indices = B64.indices.astype(np.int32)
+        B64.indptr = B64.indptr.astype(np.int32)
+        # indices big type, big values
+        C64 = A64.copy()
+        C64.indices = np.array([imax + 1], dtype=np.int64)
+        C64.indptr = np.array([0, 1], dtype=np.int64)
+        C64.data = np.array([2.2])
+
+        assert (A32.indices.dtype, A32.indptr.dtype) == (np.int32, np.int32)
+        assert (B32.indices.dtype, B32.indptr.dtype) == (np.int64, np.int64)
+        assert (A64.indices.dtype, A64.indptr.dtype) == (np.int64, np.int64)
+        assert (B64.indices.dtype, B64.indptr.dtype) == (np.int32, np.int32)
+        assert (C64.indices.dtype, C64.indptr.dtype) == (np.int64, np.int64)
+
+        for A in [A32, B32, A64, B64]:
+            indices, indptr = sputils.safely_cast_index_arrays(A, np.int32)
+            assert (indices.dtype, indptr.dtype) == (np.int32, np.int32)
+            indices, indptr = sputils.safely_cast_index_arrays(A, np.int64)
+            assert (indices.dtype, indptr.dtype) == (np.int64, np.int64)
+
+            indices, indptr = sputils.safely_cast_index_arrays(A, A.indices.dtype)
+            assert indices is A.indices
+            assert indptr is A.indptr
+
+        with assert_raises(ValueError):
+            sputils.safely_cast_index_arrays(C64, np.int32)
+        indices, indptr = sputils.safely_cast_index_arrays(C64, np.int64)
+        assert indices is C64.indices
+        assert indptr is C64.indptr
+
+    def test_safely_cast_index_coo(self):
+        # This is slow to test completely as nnz > imax is big
+        # So we don't test large nnz
+        imax = np.int64(np.iinfo(np.int32).max)
+
+        # Shape 32bit
+        A32 = coo_array((1, imax))
+        # coords big type, small values
+        B32 = A32.copy()
+        B32.coords = tuple(co.astype(np.int64) for co in B32.coords)
+
+        # Shape 64bit
+        # coords big type, small values
+        A64 = coo_array((1, imax + 1))
+        # coords small type, small values
+        B64 = A64.copy()
+        B64.coords = tuple(co.astype(np.int32) for co in B64.coords)
+        # coords big type, big values
+        C64 = A64.copy()
+        C64.coords = (np.array([imax + 1]), np.array([0]))
+        C64.data = np.array([2.2])
+
+        assert A32.coords[0].dtype == np.int32
+        assert B32.coords[0].dtype == np.int64
+        assert A64.coords[0].dtype == np.int64
+        assert B64.coords[0].dtype == np.int32
+        assert C64.coords[0].dtype == np.int64
+
+        for A in [A32, B32, A64, B64]:
+            coords = sputils.safely_cast_index_arrays(A, np.int32)
+            assert coords[0].dtype == np.int32
+            coords = sputils.safely_cast_index_arrays(A, np.int64)
+            assert coords[0].dtype == np.int64
+
+            coords = sputils.safely_cast_index_arrays(A, A.coords[0].dtype)
+            assert coords[0] is A.coords[0]
+
+        with assert_raises(ValueError):
+            sputils.safely_cast_index_arrays(C64, np.int32)
+        coords = sputils.safely_cast_index_arrays(C64, np.int64)
+        assert coords[0] is C64.coords[0]
+
+    def test_safely_cast_index_dia(self):
+        # This is slow to test completely as nnz > imax is big
+        # So we don't test large nnz
+        imax = np.int64(np.iinfo(np.int32).max)
+
+        # Shape 32bit
+        A32 = dia_array((1, imax))
+        # offsets big type, small values
+        B32 = A32.copy()
+        B32.offsets = B32.offsets.astype(np.int64)
+
+        # Shape 64bit
+        # offsets big type, small values
+        A64 = dia_array((1, imax + 2))
+        # offsets small type, small values
+        B64 = A64.copy()
+        B64.offsets = B64.offsets.astype(np.int32)
+        # offsets big type, big values
+        C64 = A64.copy()
+        C64.offsets = np.array([imax + 1])
+        C64.data = np.array([2.2])
+
+        assert A32.offsets.dtype == np.int32
+        assert B32.offsets.dtype == np.int64
+        assert A64.offsets.dtype == np.int64
+        assert B64.offsets.dtype == np.int32
+        assert C64.offsets.dtype == np.int64
+
+        for A in [A32, B32, A64, B64]:
+            offsets = sputils.safely_cast_index_arrays(A, np.int32)
+            assert offsets.dtype == np.int32
+            offsets = sputils.safely_cast_index_arrays(A, np.int64)
+            assert offsets.dtype == np.int64
+
+            offsets = sputils.safely_cast_index_arrays(A, A.offsets.dtype)
+            assert offsets is A.offsets
+
+        with assert_raises(ValueError):
+            sputils.safely_cast_index_arrays(C64, np.int32)
+        offsets = sputils.safely_cast_index_arrays(C64, np.int64)
+        assert offsets is C64.offsets
 
     def test_get_index_dtype(self):
         imax = np.int64(np.iinfo(np.int32).max)


### PR DESCRIPTION
Combine two similar helper functions from `sparse.linalg` and `csgraph._tools.py` and put it in `sparse._sputils.py`. These helper functions provide safe downcasting of sparse index arrays which will presumably be needed by other libraries. 

The new public function is `safely_cast_index_arrays(A, idx_dtype)`. 
- It raises a ValueError if casting is not safe. 
- It returns recast index arrays rather than making the change "in-place".  
- If no casting is needed, the original arrays are returned. Checking `original is not result` tells if casting was done.
- An optional `msg` input is added to the error messages to inform why the restriction is needed (e.g. SuperLU, or csgraph, etc).

Question:
- would this be better as a sparse method? The code essentially splits into handling each format. But a single function was easier to write and then split to methods if desired.
- should I remove the optional `msg` input and use a generic ValueError message? I only included it because the linalg error messages said casting was needed for SuperLU, and that doesn't work for csgraph. This allows users to customize the error messages. Probably not needed.