### PR TITLE
MAINT: improve handling of thread-local storage

### DIFF
--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -31,10 +31,12 @@ lib_cython_gen = generator(cython,
   output : '@BASENAME@.c',
   depends : [_cython_tree, _lib_pxd])
 
+ccallback_dep = declare_dependency(include_directories: ['..', 'src'])
+
 py3.extension_module('_ccallback_c',
   lib_cython_gen.process('_ccallback_c.pyx'),
   c_args: [cython_c_args, Wno_discarded_qualifiers],
-  include_directories: 'src',
+  dependencies: ccallback_dep,
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/_lib'
@@ -42,7 +44,7 @@ py3.extension_module('_ccallback_c',
 
 py3.extension_module('_test_ccallback',
   'src/_test_ccallback.c',
-  include_directories: 'src',
+  dependencies: ccallback_dep,
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/_lib',

--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -22,6 +22,8 @@
 #include <Python.h>
 #include <setjmp.h>
 
+#include "scipy_config.h"
+
 /* Default behavior */
 #define CCALLBACK_DEFAULTS 0x0
 /* Whether calling ccallback_obtain is enabled */
@@ -66,32 +68,9 @@ struct ccallback {
  * Thread-local storage
  */
 
-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4)))
+#if !defined(SCIPY_TLS_EMPTY)
 
-static __thread ccallback_t *_active_ccallback = NULL;
-
-static void *ccallback__get_thread_local(void)
-{
-    return (void *)_active_ccallback;
-}
-
-static int ccallback__set_thread_local(void *value)
-{
-    _active_ccallback = value;
-    return 0;
-}
-
-/*
- * Obtain a pointer to the current ccallback_t structure.
- */
-static ccallback_t *ccallback_obtain(void)
-{
-    return (ccallback_t *)ccallback__get_thread_local();
-}
-
-#elif defined(_MSC_VER)
-
-static __declspec(thread) ccallback_t *_active_ccallback = NULL;
+static SCIPY_TLS ccallback_t *_active_ccallback = NULL;
 
 static void *ccallback__get_thread_local(void)
 {

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -63,8 +63,7 @@ dop_lib = static_library('dop_lib',
 
 py3.extension_module('_quadpack',
   ['__quadpack.h', '__quadpack.c'],
-  include_directories: ['../_lib/src'],
-  dependencies: np_dep,
+  dependencies: [np_dep, ccallback_dep],
   install: true,
   subdir: 'scipy/integrate'
 )

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -136,11 +136,51 @@ fortranobject_dep = declare_dependency(
   link_with: fortranobject_lib,
   include_directories: [inc_np, inc_f2py],
 )
-# Workaround for numpy#24761 on numpy<1.26.1 (see also gh-20515)
-_f2py_c_args = []
-if is_mingw
-  _f2py_c_args = '-DNPY_OS_MINGW'
+
+cdata = configuration_data()
+
+# Test variable attribute to use for thread-local storage;
+# Adapted from `numpy/_core/meson.build`.
+check_tls_attrs = [
+  ['thread_local', 'HAVE_THREAD_LOCAL'],    # C23
+  ['_Thread_local', 'HAVE__THREAD_LOCAL'],  # C11/C17
+  ['__thread', 'HAVE__THREAD'],
+]
+if is_windows and not is_mingw
+  check_tls_attrs += ['__declspec(thread)', 'HAVE___DECLSPEC_THREAD_']
 endif
+f2py_tls_define = ''
+foreach tls_attrs: check_tls_attrs
+  attr = tls_attrs[0]
+  code = f'''
+    #pragma GCC diagnostic error "-Wattributes"
+    #pragma clang diagnostic error "-Wattributes"
+
+    int @attr@ foo;
+  '''
+  code += '''
+    int
+    main()
+    {
+      return 0;
+    }
+  '''
+  if cc.compiles(code, name: tls_attrs[0])
+    cdata.set10(tls_attrs[1], true)
+    f2py_tls_define = tls_attrs[0]
+  endif
+endforeach
+
+# Contains only TLS check results for now - name chosen for when more compiler
+# checks need adding in the future.
+scipy_config_h = configure_file(
+  input: 'scipy_config.h.in',
+  output: 'scipy_config.h',
+  configuration: cdata,
+  install: false
+)
+
+_f2py_c_args = [f'-DF2PY_THREAD_LOCAL_DECL=@f2py_tls_define@']
 fortranobject_dep = declare_dependency(
   dependencies: fortranobject_dep,
   compile_args: _f2py_c_args,

--- a/scipy/ndimage/meson.build
+++ b/scipy/ndimage/meson.build
@@ -9,8 +9,8 @@ py3.extension_module('_nd_image',
     'src/ni_splines.c',
     'src/ni_support.c'
   ],
-  include_directories: ['../_lib/src', '../_build_utils/src'],
-  dependencies: np_dep,
+  include_directories: ['../_build_utils/src'],
+  dependencies: [np_dep, ccallback_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/ndimage'

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -19,8 +19,7 @@ py3.extension_module('_minpack',
     '__minpack.h',
     '__minpack.c',
   ],
-  include_directories: '../_lib/src',
-  dependencies: np_dep,
+  dependencies: [np_dep, ccallback_dep],
   install: true,
   subdir: 'scipy/optimize'
 )

--- a/scipy/scipy_config.h.in
+++ b/scipy/scipy_config.h.in
@@ -1,0 +1,19 @@
+/* Thread-local storage */
+#mesondefine HAVE_THREAD_LOCAL
+#mesondefine HAVE__THREAD_LOCAL
+#mesondefine HAVE__THREAD
+#mesondefine HAVE___DECLSPEC_THREAD_
+
+#ifdef __cplusplus
+    #define SCIPY_TLS thread_local
+#elif defined(HAVE_THREAD_LOCAL)
+    #define SCIPY_TLS thread_local
+#elif defined(HAVE__THREAD_LOCAL)
+    #define SCIPY_TLS _Thread_local
+#elif defined(HAVE___THREAD)
+    #define SCIPY_TLS __thread
+#elif defined(HAVE___DECLSPEC_THREAD_)
+    #define SCIPY_TLS __declspec(thread)
+#else
+    #define SCIPY_TLS
+#endif

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -156,7 +156,6 @@ unuran_sources = [
 ]
 
 unuran_include_dirs = [
-  '../../_lib/src',  # for messagestream.h
   '../../_lib/unuran/unuran/src',
   '../../_lib/unuran/unuran/src/distr',
   '../../_lib/unuran/unuran/src/distributions',
@@ -228,7 +227,7 @@ py3.extension_module('unuran_wrapper',
   ],
   c_args: [unuran_defines, cython_c_args],
   include_directories: [unuran_include_dirs],
-  dependencies: np_dep,
+  dependencies: [np_dep, ccallback_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/stats/_unuran'


### PR DESCRIPTION
Avoids the problem in gh-21830 for macOS + GCC where `f2py` does the wrong thing, by doing compile checks for the correct syntax for using thread-local storage (TLS) and then adding the define `f2py` would otherwise guess at based on platform/compiler defines.

The only C code using TLS is in `scipy/_lib/src/ccallback.h`; it wasn't very generic but special-cased GCC and MSVC only, while Clang and other compilers would get a slower fallback through CPython's threading facilities. This PR makes the code more generic, while leaving the fallback in place (it should never be hit anymore though, but that's impossible to verify for niche platforms).

The introduction of `ccallback_dep` makes it easier to see what other modules depend on `ccallback.h`, compared to manually adding include paths.

The compile checks and config header content are borrowed from NumPy (code to support `NPY_TLS`). We cannot use `NPY_TLS` directly, because that would incorrectly assume that NumPy and SciPy are being built with the same compilers.

Closes gh-21830