### PR TITLE
MAINT: special: Use consistent std::isnan and std::isinf in a few C++ headers

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -73,7 +73,7 @@ Real ibeta_wrap(Real a, Real b, Real x)
 {
     Real y;
 
-    if (isnan(a) || isnan(b) || isnan(x)) {
+    if (std::isnan(a) || std::isnan(b) || std::isnan(x)) {
         return NAN;
     }
     if ((a <= 0) || (b <= 0) || (x < 0) || (x > 1)) {
@@ -117,7 +117,7 @@ Real ibetac_wrap(Real a, Real b, Real x)
 {
     Real y;
 
-    if (isnan(a) || isnan(b) || isnan(x)) {
+    if (std::isnan(a) || std::isnan(b) || std::isnan(x)) {
         return NAN;
     }
     if ((a <= 0) || (b <= 0) || (x < 0) || (x > 1)) {
@@ -161,7 +161,7 @@ Real ibeta_inv_wrap(Real a, Real b, Real p, const Policy& policy_)
 {
     Real y;
 
-    if (isnan(a) || isnan(b) || isnan(p)) {
+    if (std::isnan(a) || std::isnan(b) || std::isnan(p)) {
         return NAN;
     }
     if ((a <= 0) || (b <= 0) || (p < 0) || (p > 1)) {
@@ -205,7 +205,7 @@ Real ibetac_inv_wrap(Real a, Real b, Real p)
 {
     Real y;
 
-    if (isnan(a) || isnan(b) || isnan(p)) {
+    if (std::isnan(a) || std::isnan(b) || std::isnan(p)) {
         return NAN;
     }
     if ((a <= 0) || (b <= 0) || (p < 0) || (p > 1)) {
@@ -423,7 +423,7 @@ Real hyp1f1_wrap(Real a, Real b, Real x)
 {
     Real y;
 
-    if (isnan(a) || isnan(b) || isnan(x)) {
+    if (std::isnan(a) || std::isnan(b) || std::isnan(x)) {
         return NAN;
     }
     if (b <= 0 && std::trunc(b) == b) {

--- a/scipy/special/xsf/bessel.h
+++ b/scipy/special/xsf/bessel.h
@@ -605,7 +605,7 @@ inline std::complex<double> cyl_bessel_je(double v, std::complex<double> z) {
     cy_y.real(NAN);
     cy_y.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_j;
     }
     if (v < 0) {
@@ -658,7 +658,7 @@ inline std::complex<double> cyl_bessel_ye(double v, std::complex<double> z) {
     cy_y.real(NAN);
     cy_y.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_y;
     }
     if (v < 0) {
@@ -711,7 +711,7 @@ inline std::complex<double> cyl_bessel_ie(double v, std::complex<double> z) {
     cy_k.real(NAN);
     cy_k.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
     if (v < 0) {
@@ -755,7 +755,7 @@ T cyl_bessel_ie(T v, T x) {
 
 inline std::complex<double> cyl_bessel_ke(double v, std::complex<double> z) {
     std::complex<double> cy{NAN, NAN};
-    if (isnan(v) || isnan(std::real(z)) || isnan(std::imag(z))) {
+    if (std::isnan(v) || std::isnan(std::real(z)) || std::isnan(std::imag(z))) {
         return cy;
     }
 
@@ -808,7 +808,7 @@ inline std::complex<double> cyl_hankel_1e(double v, std::complex<double> z) {
     cy.real(NAN);
     cy.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
     if (v < 0) {
@@ -836,7 +836,7 @@ inline std::complex<double> cyl_hankel_2e(double v, std::complex<double> z) {
     int sign = 1;
 
     std::complex<double> cy{NAN, NAN};
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
 
@@ -877,7 +877,7 @@ inline std::complex<double> cyl_bessel_j(double v, std::complex<double> z) {
     cy_y.real(NAN);
     cy_y.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_j;
     }
     if (v < 0) {
@@ -935,7 +935,7 @@ inline std::complex<double> cyl_bessel_y(double v, std::complex<double> z) {
     cy_y.real(NAN);
     cy_y.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_y;
     }
     if (v < 0) {
@@ -1022,7 +1022,7 @@ inline std::complex<double> cyl_bessel_i(double v, std::complex<double> z) {
     cy_k.real(NAN);
     cy_k.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
     if (v < 0) {
@@ -1139,7 +1139,7 @@ inline std::complex<double> cyl_hankel_1(double v, std::complex<double> z) {
     cy.real(NAN);
     cy.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
     if (v < 0) {
@@ -1169,7 +1169,7 @@ inline std::complex<double> cyl_hankel_2(double v, std::complex<double> z) {
     cy.real(NAN);
     cy.imag(NAN);
 
-    if (isnan(v) || isnan(z.real()) || isnan(z.imag())) {
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy;
     }
     if (v == 0 && z == 0.0) {

--- a/scipy/special/xsf/sph_bessel.h
+++ b/scipy/special/xsf/sph_bessel.h
@@ -144,7 +144,7 @@ T sph_bessel_y(long n, T x) {
     T s0, s1, sn;
     int idx;
 
-    if (isnan(x)) {
+    if (std::isnan(x)) {
         return x;
     }
 
@@ -179,7 +179,7 @@ T sph_bessel_y(long n, T x) {
         sn = (2 * idx + 3) * s1 / x - s0;
         s0 = s1;
         s1 = sn;
-        if (isinf(sn)) {
+        if (std::isinf(sn)) {
             // Overflow occurred already: terminate recurrence.
             return sn;
         }
@@ -229,7 +229,7 @@ T sph_bessel_y_jac(long n, T x) {
 
 template <typename T>
 T sph_bessel_i(long n, T x) {
-    if (isnan(x)) {
+    if (std::isnan(x)) {
         return x;
     }
 
@@ -246,7 +246,7 @@ T sph_bessel_i(long n, T x) {
         return 0;
     }
 
-    if (isinf(x)) {
+    if (std::isinf(x)) {
         // https://dlmf.nist.gov/10.49.E8
         if (x == -std::numeric_limits<T>::infinity()) {
             return std::pow(-1, n) * std::numeric_limits<T>::infinity();
@@ -314,7 +314,7 @@ T sph_bessel_i_jac(long n, T z) {
 
 template <typename T>
 T sph_bessel_k(long n, T z) {
-    if (isnan(z)) {
+    if (std::isnan(z)) {
         return z;
     }
 
@@ -327,7 +327,7 @@ T sph_bessel_k(long n, T z) {
         return std::numeric_limits<T>::infinity();
     }
 
-    if (isinf(z)) {
+    if (std::isinf(z)) {
         // https://dlmf.nist.gov/10.52.E6
         if (z == std::numeric_limits<T>::infinity()) {
             return 0;


### PR DESCRIPTION
@rgommers Could you please review this? Referring to https://github.com/scipy/scipy/issues/21826#issuecomment-2466445083

It is a half of what I had to patch, but these looks rather straightforward, since the same files currently mix C99 style with C++ style randomly in C++ sources, apparently because in most cases compilers do not complain much and different committers chose different code style. 

I.e.,
https://github.com/scipy/scipy/blob/c45b3ba3df5ea9ebb517e98d62d138d0f9164724/scipy/special/boost_special_functions.h#L765
https://github.com/scipy/scipy/blob/c45b3ba3df5ea9ebb517e98d62d138d0f9164724/scipy/special/boost_special_functions.h#L813
But:
https://github.com/scipy/scipy/blob/c45b3ba3df5ea9ebb517e98d62d138d0f9164724/scipy/special/boost_special_functions.h#L76
Etc.

I am not including the rest, but if those look reasonable, I can add them too. See: https://github.com/barracuda156/scipy/commit/c8ea21327dbb48103bfa8d6349c6ee587f3b4a43
(Please ignore the old version of the patch which is currently in MacPorts, it was done for the old version of `scipy` and not in the best way possible.)