### PR TITLE
MAINT: `fft`: Remove outdated documentation workaround

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,9 +27,6 @@ old_isdesc = inspect.isdescriptor
 inspect.isdescriptor = (lambda obj: old_isdesc(obj)
                         and not isinstance(obj, ua._Function))
 
-# Currently required to build scipy.fft docs
-os.environ['_SCIPY_BUILDING_DOC'] = 'True'
-
 # -----------------------------------------------------------------------------
 # General configuration
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None filed.

#### What does this implement/fix?
In version 1.5.0 of SciPy, scipy.fft was a callable function. In order to support building Sphinx documentation, there was an environment variable `_SCIPY_BUILDING_DOC` which was used to disable this functionality because it interfered with building documentation somehow.

In #12558, this was deprecated and removed, and scipy.fft is no longer callable. The `_SCIPY_BUILDING_DOC` environment variable now has no purpose, and is [not referenced anywhere else in the codebase](https://github.com/search?q=repo%3Ascipy%2Fscipy%20_SCIPY_BUILDING_DOC&type=code). However, it was not removed from conf.py.

The docs still build correctly without this variable being defined.

Therefore, I propose that we remove it.

#### Additional information
<!--Any additional information you think is important.-->
