### PR TITLE
BUG: io.matlab: expose `varmats_from_mat`

### DIFF
--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -450,10 +450,6 @@ def test_private_but_present_deprecation(module_name, correct_module):
     # Attributes that were formerly in `module_name` can still be imported from
     # `module_name`, albeit with a deprecation warning.
     for attr_name in module.__all__:
-        if attr_name == "varmats_from_mat":
-            # defer handling this case, see
-            # https://github.com/scipy/scipy/issues/19223
-            continue
         # ensure attribute is present where the warning is pointing
         assert getattr(correct_import, attr_name, None) is not None
         message = f"Please import `{attr_name}` from the `{import_name}`..."

--- a/scipy/io/matlab/__init__.py
+++ b/scipy/io/matlab/__init__.py
@@ -15,6 +15,7 @@ and writing MATLAB files.
    MatReadWarning - Warning class for read issues
    MatWriteError - Exception indicating a write issue
    mat_struct - Class used when ``struct_as_record=False``
+   varmats_from_mat - Pull variables out of mat 5 file as a sequence of mat file objects
 
 .. autosummary::
    :toctree: generated/
@@ -43,7 +44,7 @@ Drive, Natick, MA 01760-2098, USA.
 """
 # Matlab file read and write utilities
 from ._mio import loadmat, savemat, whosmat
-from ._mio5 import MatlabFunction
+from ._mio5 import MatlabFunction, varmats_from_mat
 from ._mio5_params import MatlabObject, MatlabOpaque, mat_struct
 from ._miobase import (matfile_version, MatReadError, MatReadWarning,
                       MatWriteError)
@@ -55,7 +56,7 @@ from .import (mio, mio5, mio5_params, mio4, byteordercodes,
 __all__ = [
     'loadmat', 'savemat', 'whosmat', 'MatlabObject',
     'matfile_version', 'MatReadError', 'MatReadWarning',
-    'MatWriteError', 'mat_struct', 'MatlabOpaque', 'MatlabFunction'
+    'MatWriteError', 'mat_struct', 'MatlabOpaque', 'MatlabFunction', 'varmats_from_mat',
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -314,7 +314,7 @@ class MatFile5Reader(MatFileReader):
                 msg = (
                     f'Duplicate variable name "{name}" in stream'
                     " - replacing previous with new\nConsider"
-                    "scipy.io.matlab._mio5.varmats_from_mat to split "
+                    "scipy.io.matlab.varmats_from_mat to split "
                     "file into single variable files"
                 )
                 warnings.warn(msg, MatReadWarning, stacklevel=2)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1347,3 +1347,6 @@ def test_large_m4():
              "Variable 'a' has byte length longer than largest possible")
     with pytest.raises(ValueError, match=match):
         loadmat(truncated_mat)
+
+def test_gh_19223():
+    from scipy.io.matlab import varmats_from_mat  # noqa: F401


### PR DESCRIPTION
#### Reference issue
Closes gh-19223

#### What does this implement/fix?

#### Additional information
When this is merged, a new issue should be opened to track the suggested 'real' fix, or the old one should be adjusted and reopened.
