### PR TITLE
MAINT: `interpolate.barycentric_interpolate`: add rng argument

### DIFF
--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -880,7 +880,7 @@ class BarycentricInterpolator(_Interpolator1DWithDerivatives):
         return self._diff_baryint._evaluate_derivatives(x, der-1, all_lower=False)
 
 
-def barycentric_interpolate(xi, yi, x, axis=0, *, der=0):
+def barycentric_interpolate(xi, yi, x, axis=0, *, der=0, rng=None):
     """
     Convenience function for polynomial interpolation.
 
@@ -905,13 +905,18 @@ def barycentric_interpolate(xi, yi, x, axis=0, *, der=0):
         The y coordinates of the points the polynomial should pass through.
     x : scalar or array_like
         Point or points at which to evaluate the interpolant.
+    axis : int, optional
+        Axis in the `yi` array corresponding to the x-coordinate values.
     der : int or list or None, optional
         How many derivatives to evaluate, or None for all potentially
         nonzero derivatives (that is, a number equal to the number
         of points), or a list of derivatives to evaluate. This number
         includes the function value as the '0th' derivative.
-    axis : int, optional
-        Axis in the `yi` array corresponding to the x-coordinate values.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
     Returns
     -------
@@ -947,7 +952,7 @@ def barycentric_interpolate(xi, yi, x, axis=0, *, der=0):
     >>> plt.show()
 
     """
-    P = BarycentricInterpolator(xi, yi, axis=axis)
+    P = BarycentricInterpolator(xi, yi, axis=axis, rng=rng)
     if der == 0:
         return P(x)
     elif _isscalar(der):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -467,13 +467,13 @@ class TestBarycentric:
         assert np.shape(P.derivatives([0, 1])) == (n, 2, 3)
 
     def test_wrapper(self):
-        P = BarycentricInterpolator(self.xs, self.ys)
+        P = BarycentricInterpolator(self.xs, self.ys, rng=1)
         bi = barycentric_interpolate
-        xp_assert_close(P(self.test_xs), bi(self.xs, self.ys, self.test_xs))
+        xp_assert_close(P(self.test_xs), bi(self.xs, self.ys, self.test_xs, rng=1))
         xp_assert_close(P.derivative(self.test_xs, 2),
-                            bi(self.xs, self.ys, self.test_xs, der=2))
+                        bi(self.xs, self.ys, self.test_xs, der=2, rng=1))
         xp_assert_close(P.derivatives(self.test_xs, 2),
-                            bi(self.xs, self.ys, self.test_xs, der=[0, 1]))
+                        bi(self.xs, self.ys, self.test_xs, der=[0, 1], rng=1))
 
     def test_int_input(self):
         x = 1000 * np.arange(1, 11)  # np.prod(x[-1] - x[:-1]) overflows


### PR DESCRIPTION
Currently the convenience function `barycentric_interpolate` has no way of seeding the randomness other than `np.random.seed`. This pr adds a `rng` argument.

Also reorders the docstring to match the function arguments 