### PR TITLE
DOC/MAINT: Fix some typos regarding GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,7 @@ doc/source/.jupyterlite.doit.db
 .cache/
 .pytest_cache/
 
-# github cache #
+# GitHub cache #
 ################
 gh_cache.json
 

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -44,7 +44,7 @@ Before Implementation
    distributions to SciPy is not supported,  mainly due to the increase in user
    confusion resulting from such additions.
 
-2. Create a `SciPy Issue on github <https://github.com/scipy/scipy/issues>`_,
+2. Create a `SciPy Issue on GitHub <https://github.com/scipy/scipy/issues>`_,
    listing the distribution, references and reasons for its inclusion.
 
 

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -147,7 +147,7 @@ The Action runs:
 * when the commit message contains the text ``[wheel build]``
 * on a scheduled basis once a week
 * when it is started manually.
-* when there is a push to the repository with a github reference starting with ``refs/tags/v`` (and not ending with ``dev0``)
+* when there is a push to the repository with a GitHub reference starting with ``refs/tags/v`` (and not ending with ``dev0``)
 
 The action does not run on forks of the main SciPy repository. The wheels that
 are created are available as artifacts associated with a successful run of the

--- a/doc/source/dev/gitwash/useful_git.rst
+++ b/doc/source/dev/gitwash/useful_git.rst
@@ -169,7 +169,7 @@ Deleting a branch on github_
    git checkout main
    # delete branch locally
    git branch -D my-unwanted-branch
-   # delete branch on github
+   # delete branch on GitHub
    git push origin :my-unwanted-branch
 
 (Note the colon ``:`` before ``test-branch``.  See also:
@@ -185,7 +185,7 @@ share it via github_.
 
 First fork SciPy into your account, as from :ref:`forking`.
 
-Then, go to your forked repository github page, say
+Then, go to your forked repository GitHub page, say
 ``https://github.com/your-user-name/scipy``
 
 Click on the 'Admin' button, and add anyone else to the repo as a

--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -40,7 +40,7 @@ into the particular dataset method documentation above.
 How dataset retrieval and storage works
 =======================================
 
-SciPy dataset files are stored within individual github repositories under the
+SciPy dataset files are stored within individual GitHub repositories under the
 SciPy GitHub organization, following a naming convention as
 ``'dataset-<name>'``, for example `scipy.datasets.face` files live at
 https://github.com/scipy/dataset-face.  The `scipy.datasets` submodule utilizes

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -56,7 +56,7 @@ class TestRoot:
                 options={"tol_norm": norm})
 
     def test_minimize_scalar_coerce_args_param(self):
-        # github issue #3503
+        # GitHub issue #3503
         def func(z, f=1):
             x, y = z
             return np.array([x**3 - 1, y**3 - f])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -1118,7 +1118,7 @@ class TestFixedPoint:
         assert_allclose(xxroot, lambertw(1)/2)
 
     def test_no_acceleration(self):
-        # github issue 5460
+        # GitHub issue 5460
         ks = 2
         kl = 6
         m = 1.3

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3113,7 +3113,7 @@ class TestPartialFractionExpansion:
             residuez(1, [0, 1, 2, 3])
 
     def test_inverse_unique_roots_different_rtypes(self):
-        # This test was inspired by github issue 2496.
+        # This test was inspired by GitHub issue 2496.
         r = [3 / 10, -1 / 6, -2 / 15]
         p = [0, -2, -5]
         k = []

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -714,7 +714,7 @@ class TestGetWindow:
         assert_raises(ValueError, windows.get_window, 'broken', 4)
 
     def test_array_as_window(self):
-        # github issue 3603
+        # GitHub issue 3603
         osfactor = 128
         sig = np.arange(128)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1462,7 +1462,7 @@ class _TestCommon:
         for dtype in self.math_dtypes:
             check(dtype)
 
-    # github issue #15210
+    # GitHub issue #15210
     def test_rmul_scalar_type_error(self):
         datsp = self.datsp_dtypes[np.float64]
         with assert_raises(TypeError):
@@ -2502,7 +2502,7 @@ class _TestGetSet:
             check(np.dtype(dtype))
 
     def test_negative_index_assignment(self):
-        # Regression test for github issue 4428.
+        # Regression test for GitHub issue 4428.
 
         def check(dtype):
             A = self.spcreator((3, 10), dtype=dtype)
@@ -5055,7 +5055,7 @@ class TestBSR(sparse_test_class(getset=False,
         assert_array_equal(asp.nnz, 3*4)
         assert_array_equal(asp.toarray(), bsp.toarray())
 
-    # github issue #9687
+    # GitHub issue #9687
     def test_eliminate_zeros_all_zero(self):
         np.random.seed(0)
         m = self.bsr_container(np.random.random((12, 12)), blocksize=(2, 3))

--- a/scipy/special/_precompute/gammainc_data.py
+++ b/scipy/special/_precompute/gammainc_data.py
@@ -36,7 +36,7 @@ def gammainc(a, x, dps=50, maxterms=10**8):
 
     mpmath/functions/expintegrals.py#L134
 
-    in the mpmath github repository.
+    in the mpmath GitHub repository.
 
     """
     with mp.workdps(dps):
@@ -58,7 +58,7 @@ def gammaincc(a, x, dps=50, maxterms=10**8):
 
     mpmath/functions/expintegrals.py#L187
 
-    in the mpmath github repository.
+    in the mpmath GitHub repository.
 
     """
     with mp.workdps(dps):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2024,7 +2024,7 @@ class TestBoxcox_llf:
         xp_assert_close(llf, xp.asarray(-15.32401272869016598, dtype=xp.float64))
 
 
-# This is the data from github user Qukaiyi, given as an example
+# This is the data from GitHub user Qukaiyi, given as an example
 # of a data set that caused boxcox to fail.
 _boxcox_data = [
     15957, 112079, 1039553, 711775, 173111, 307382, 183155, 53366, 760875,


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
The name `GitHub` is written by using capital letters, but throughout the repository it is often written in lowercase like `github`.
This PR irons this out where senseful.

#### Additional information
