### PR TITLE
BUG: spatial: guard `distance_wrap` directives

### DIFF
--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -33,7 +33,7 @@
  */
 
 #if !defined(__clang__) && defined(__GNUC__) && defined(__GNUC_MINOR__)
-#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+#if !defined(__APPLE__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4))
 /* enable auto-vectorizer */
 #pragma GCC optimize("tree-vectorize")
 /* float associativity required to vectorize reductions */


### PR DESCRIPTION
* Related to gh-21887, but not a full resolution, just for `spatial` test suite.

* This patch avoids the segfaults/hard crashes in the SciPy testsuite `spatial` module on MacOS when building with GNU toolchain (but doesn't fix all other modules).

* This incantation now passes locally on OS `14.7` M series with `homebrew` gcc `14.2.0`:
`CC=gcc-14 CXX=g++-14 FC=gfortran-14 python dev.py test -s spatial`

* Note that there are additional complications--it seems we'll need further shims for `xdist`-based testing in this scenario, though they appear to be minor, for assertios related to certain memory tracking properties. For example, `test_ckdtree_memuse` gets moody at really high `-j` values (2 is just fine locally, 16 makes it complain).

[skip cirrus] [skip circle]
