### PR TITLE
MAINT: linalg.interpolative: normalize rng argument (SPEC7)

### DIFF
--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -132,7 +132,7 @@ __all__ = ['idd_estrank', 'idd_ldiv', 'idd_poweroftwo', 'idd_reconid', 'iddp_aid
            ]
 
 
-def idd_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
+def idd_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
     cdef int n = A.shape[1], j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v1
@@ -140,8 +140,6 @@ def idd_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] u1
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] u2
 
-    if not rng:
-        rng = np.random.default_rng()
     v1 = rng.uniform(low=-1., high=1., size=n)
     v1 /= dnrm2(&n, &v1[0], &intone)
 
@@ -163,7 +161,7 @@ def idd_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
 
 
 def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: float,
-                rng=None):
+                rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int intone = 1, n2, nsteps = 3, row, r, nstep, cols, k, nulls
     cdef cnp.float64_t h, alpha, beta
@@ -177,9 +175,6 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] rta
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] Fc
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] F
-
-    if not rng:
-        rng = np.random.default_rng()
 
     n2 = idd_poweroftwo(m)
 
@@ -281,7 +276,7 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
     return k, Fcopy
 
 
-def idd_findrank(A: LinearOperator, cnp.float64_t eps, rng=None):
+def idd_findrank(A: LinearOperator, cnp.float64_t eps, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
     cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
@@ -311,9 +306,6 @@ def idd_findrank(A: LinearOperator, cnp.float64_t eps, rng=None):
                           f"{no_of_cols*n*8} bytes for"
                           "'scipy.linalg.interpolative.idd_findrank()' "
                           "function.")
-
-    if not rng:
-        rng = np.random.default_rng()
 
     krank = 0
     try:
@@ -464,15 +456,13 @@ def idd_reconid(B, idx, proj):
     return approx
 
 
-def idd_snorm(A: LinearOperator, int its=20, rng=None):
+def idd_snorm(A: LinearOperator, rng, int its=20):
     cdef int n = A.shape[1]
     cdef int j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] u
 
-    if not rng:
-        rng = np.random.default_rng()
     v = rng.uniform(low=-1., high=1., size=n)
     v /= dnrm2(&n, &v[0], &intone)
 
@@ -488,7 +478,7 @@ def idd_snorm(A: LinearOperator, int its=20, rng=None):
     return snorm
 
 
-def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng=None):
+def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng):
     krank, proj = idd_estrank(a, eps, rng=rng)
     if krank != 0:
         proj = proj[:krank, :]
@@ -497,7 +487,7 @@ def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng=None
     return iddp_id(a, eps=eps)
 
 
-def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng=None):
+def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int krank, info, ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
@@ -680,12 +670,12 @@ def iddp_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a, cnp.float64_t eps
     return k + 1, taus, ind
 
 
-def iddp_rid(A: LinearOperator, cnp.float64_t eps, rng=None):
+def iddp_rid(A: LinearOperator, cnp.float64_t eps, rng):
     _, ret = idd_findrank(A, eps, rng)
     return iddp_id(ret, eps)
 
 
-def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, rng=None):
+def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, rng):
     cdef int n = A.shape[1]
     cdef int krank, j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
@@ -744,7 +734,7 @@ def iddp_svd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float):
 
 
 def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
-             rng=None):
+             rng):
     cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, row, r, nstep, L
     cdef cnp.float64_t h, alpha, beta
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=3] albetas
@@ -753,9 +743,6 @@ def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] giv2x2
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] rta
     cdef cnp.ndarray[cnp.npy_int64, mode='c', ndim=1] marker
-
-    if not rng:
-        rng = np.random.default_rng()
 
     # idd_aidi
     L = krank + 8
@@ -899,7 +886,7 @@ def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
 
 
 def iddr_asvd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
-              rng=None):
+              rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int info, ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
@@ -1057,13 +1044,10 @@ def iddr_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, krank: i
     return ind, taus
 
 
-def iddr_rid(A: LinearOperator, int krank, rng=None):
+def iddr_rid(A: LinearOperator, int krank, rng):
     cdef int m = A.shape[0], n = A.shape[1], k = 0
     cdef int L = min(krank+2, min(m, n))
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] r
-
-    if not rng:
-        rng = np.random.default_rng()
 
     r = cnp.PyArray_EMPTY(2, [L, n], cnp.NPY_FLOAT64, 0)
     for k in range(L):
@@ -1072,7 +1056,7 @@ def iddr_rid(A: LinearOperator, int krank, rng=None):
     return iddr_id(a=r, krank=krank)
 
 
-def iddr_rsvd(A: LinearOperator, int krank, rng=None):
+def iddr_rsvd(A: LinearOperator, int krank, rng):
     cdef int n = A.shape[1], j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
     cdef cnp.ndarray[cnp.float64_t, ndim=2] proj
@@ -1121,7 +1105,7 @@ def iddr_svd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank)
     return UU, S, V
 
 
-def idz_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
+def idz_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
     cdef int n = A.shape[1], j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v1
@@ -1129,8 +1113,6 @@ def idz_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] u1
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] u2
 
-    if not rng:
-        rng = np.random.default_rng()
     v1 = rng.uniform(low=-1, high=1, size=(n, 2)).view(np.complex128).ravel()
     v1 /= dznrm2(&n, &v1[0], &intone)
 
@@ -1152,7 +1134,7 @@ def idz_diffsnorm(A: LinearOperator, B: LinearOperator, int its=20, rng=None):
 
 
 def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float,
-                rng=None):
+                rng):
     cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, row, r, nstep, cols, k
     cdef cnp.float64_t h, alpha, beta
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=3] albetas
@@ -1162,9 +1144,6 @@ def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps:
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] giv2x2
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] rta
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] F
-
-    if not rng:
-        rng = np.random.default_rng()
 
     n2 = idd_poweroftwo(m)
     # This part is the initialization that is done via idz_frmi
@@ -1244,7 +1223,7 @@ def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps:
     return k, Fcopy
 
 
-def idz_findrank(A: LinearOperator, cnp.float64_t eps, rng=None):
+def idz_findrank(A: LinearOperator, cnp.float64_t eps, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
     cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
@@ -1276,9 +1255,6 @@ def idz_findrank(A: LinearOperator, cnp.float64_t eps, rng=None):
                           f"{no_of_cols*n*8} bytes for"
                           "'scipy.linalg.interpolative.idz_findrank()' "
                           "function.")
-
-    if not rng:
-        rng = np.random.default_rng()
 
     krank = 0
     try:
@@ -1416,15 +1392,12 @@ def idz_reconid(B, idx, proj):
     return approx
 
 
-def idz_snorm(A: LinearOperator, int its=20, rng=None):
+def idz_snorm(A: LinearOperator, rng, int its=20):
     cdef int n = A.shape[1]
     cdef int j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] u
-
-    if not rng:
-        rng = np.random.default_rng()
 
     v = rng.uniform(low=-1, high=1, size=(n, 2)).view(np.complex128).ravel()
     v /= dznrm2(&n, &v[0], &intone)
@@ -1442,7 +1415,7 @@ def idz_snorm(A: LinearOperator, int its=20, rng=None):
 
 
 def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float,
-             rng=None):
+             rng):
     krank, proj = idz_estrank(a, eps=eps, rng=rng)
     if krank != 0:
         proj = proj[:krank, :]
@@ -1452,7 +1425,7 @@ def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: fl
 
 
 def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t eps,
-              rng=None):
+              rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int krank, info, ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
@@ -1619,12 +1592,12 @@ def idzp_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t 
     return k+1, taus, ind
 
 
-def idzp_rid(A: LinearOperator, cnp.float64_t eps, rng=None):
+def idzp_rid(A: LinearOperator, cnp.float64_t eps, rng):
     _, ret = idz_findrank(A, eps, rng=rng)
     return idzp_id(ret, eps=eps)
 
 
-def idzp_rsvd(A: LinearOperator, cnp.float64_t eps, rng=None):
+def idzp_rsvd(A: LinearOperator, cnp.float64_t eps, rng):
     cdef int n = A.shape[1]
     cdef int krank, j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
@@ -1682,7 +1655,7 @@ def idzp_svd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t ep
 
 
 def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int krank,
-             rng=None):
+             rng):
     cdef int m = a.shape[0], n2, L, nblock, nsteps = 3, mb
     cdef cnp.float64_t twopi = 2*np.pi, fact
     cdef double complex twopii = twopi*1.j
@@ -1693,9 +1666,6 @@ def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int kra
     cdef cnp.ndarray[cnp.npy_float64, mode='c', ndim=3] albetas
     cdef cnp.ndarray[cnp.npy_float64, mode='c', ndim=2] rta
     cdef cnp.ndarray[cnp.npy_float64, mode='c', ndim=2] giv2x2
-
-    if not rng:
-        rng = np.random.default_rng()
 
     n2 = 0
     L = krank + 8
@@ -1771,7 +1741,7 @@ def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int kra
     return idzr_id(V, krank)
 
 
-def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, rng=None):
+def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int info, ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
@@ -1928,13 +1898,10 @@ def idzr_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
     return ind, taus
 
 
-def idzr_rid(A: LinearOperator, int krank, rng=None):
+def idzr_rid(A: LinearOperator, int krank, rng):
     cdef int m = A.shape[0], n = A.shape[1], k = 0
     cdef int L = min(krank+2, min(m, n))
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] r
-
-    if not rng:
-        rng = np.random.default_rng()
 
     r = cnp.PyArray_EMPTY(2, [L, n], cnp.NPY_COMPLEX128, 0)
     for k in range(L):
@@ -1943,7 +1910,7 @@ def idzr_rid(A: LinearOperator, int krank, rng=None):
     return idzr_id(a=r.conj(), krank=krank)
 
 
-def idzr_rsvd(A: LinearOperator, int krank, rng=None):
+def idzr_rsvd(A: LinearOperator, int krank, rng):
     cdef int n = A.shape[1], j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
     cdef cnp.ndarray[cnp.complex128_t, ndim=2] proj

--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -132,7 +132,7 @@ __all__ = ['idd_estrank', 'idd_ldiv', 'idd_poweroftwo', 'idd_reconid', 'iddp_aid
            ]
 
 
-def idd_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
+def idd_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
     cdef int n = A.shape[1], j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v1
@@ -160,7 +160,7 @@ def idd_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
     return snorm
 
 
-def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: float,
+def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: float, *,
                 rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int intone = 1, n2, nsteps = 3, row, r, nstep, cols, k, nulls
@@ -276,7 +276,7 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
     return k, Fcopy
 
 
-def idd_findrank(A: LinearOperator, cnp.float64_t eps, rng):
+def idd_findrank(A: LinearOperator, cnp.float64_t eps, *, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
     cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
@@ -456,7 +456,7 @@ def idd_reconid(B, idx, proj):
     return approx
 
 
-def idd_snorm(A: LinearOperator, rng, int its=20):
+def idd_snorm(A: LinearOperator, *, rng, int its=20):
     cdef int n = A.shape[1]
     cdef int j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
@@ -478,7 +478,7 @@ def idd_snorm(A: LinearOperator, rng, int its=20):
     return snorm
 
 
-def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng):
+def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, *, rng):
     krank, proj = idd_estrank(a, eps, rng=rng)
     if krank != 0:
         proj = proj[:krank, :]
@@ -487,7 +487,7 @@ def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng):
     return iddp_id(a, eps=eps)
 
 
-def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, rng):
+def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, *, rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int krank, info, ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
@@ -670,12 +670,12 @@ def iddp_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a, cnp.float64_t eps
     return k + 1, taus, ind
 
 
-def iddp_rid(A: LinearOperator, cnp.float64_t eps, rng):
-    _, ret = idd_findrank(A, eps, rng)
+def iddp_rid(A: LinearOperator, cnp.float64_t eps, *, rng):
+    _, ret = idd_findrank(A, eps, rng=rng)
     return iddp_id(ret, eps)
 
 
-def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, rng):
+def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, *, rng):
     cdef int n = A.shape[1]
     cdef int krank, j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
@@ -683,7 +683,7 @@ def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, rng):
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] col
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] x
 
-    krank, perms, proj = iddp_rid(A, eps, rng)
+    krank, perms, proj = iddp_rid(A, eps, rng=rng)
     if krank > 0:
         # idd_getcols
         col = cnp.PyArray_EMPTY(2, [n, krank], cnp.NPY_FLOAT64, 0)
@@ -733,7 +733,7 @@ def iddp_svd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float):
     return UU, S, V
 
 
-def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
+def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank, *,
              rng):
     cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, row, r, nstep, L
     cdef cnp.float64_t h, alpha, beta
@@ -885,7 +885,7 @@ def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
     return perms, proj
 
 
-def iddr_asvd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
+def iddr_asvd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank, *,
               rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int info, ci
@@ -1044,7 +1044,7 @@ def iddr_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, krank: i
     return ind, taus
 
 
-def iddr_rid(A: LinearOperator, int krank, rng):
+def iddr_rid(A: LinearOperator, int krank, *, rng):
     cdef int m = A.shape[0], n = A.shape[1], k = 0
     cdef int L = min(krank+2, min(m, n))
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] r
@@ -1056,13 +1056,13 @@ def iddr_rid(A: LinearOperator, int krank, rng):
     return iddr_id(a=r, krank=krank)
 
 
-def iddr_rsvd(A: LinearOperator, int krank, rng):
+def iddr_rsvd(A: LinearOperator, int krank, *, rng):
     cdef int n = A.shape[1], j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
     cdef cnp.ndarray[cnp.float64_t, ndim=2] proj
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] col
 
-    perms, proj = iddr_rid(A, krank, rng)
+    perms, proj = iddr_rid(A, krank, rng=rng)
     # idd_getcols
     col = cnp.PyArray_EMPTY(2, [n, krank], cnp.NPY_FLOAT64, 0)
     x = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
@@ -1105,7 +1105,7 @@ def iddr_svd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank)
     return UU, S, V
 
 
-def idz_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
+def idz_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
     cdef int n = A.shape[1], j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v1
@@ -1133,7 +1133,7 @@ def idz_diffsnorm(A: LinearOperator, B: LinearOperator, rng, int its=20):
     return snorm
 
 
-def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float,
+def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float, *,
                 rng):
     cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, row, r, nstep, cols, k
     cdef cnp.float64_t h, alpha, beta
@@ -1223,7 +1223,7 @@ def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps:
     return k, Fcopy
 
 
-def idz_findrank(A: LinearOperator, cnp.float64_t eps, rng):
+def idz_findrank(A: LinearOperator, cnp.float64_t eps, *, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
     cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
@@ -1392,7 +1392,7 @@ def idz_reconid(B, idx, proj):
     return approx
 
 
-def idz_snorm(A: LinearOperator, rng, int its=20):
+def idz_snorm(A: LinearOperator, *, rng, int its=20):
     cdef int n = A.shape[1]
     cdef int j = 0, intone = 1
     cdef cnp.float64_t snorm = 0.0
@@ -1414,7 +1414,7 @@ def idz_snorm(A: LinearOperator, rng, int its=20):
     return snorm
 
 
-def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float,
+def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float, *,
              rng):
     krank, proj = idz_estrank(a, eps=eps, rng=rng)
     if krank != 0:
@@ -1424,7 +1424,7 @@ def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: fl
     return idzp_id(a, eps=eps)
 
 
-def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t eps,
+def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t eps, *,
               rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int krank, info, ci
@@ -1442,7 +1442,7 @@ def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t e
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] p
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] col
 
-    krank, perms, proj = idzp_aid(a.copy(), eps, rng)
+    krank, perms, proj = idzp_aid(a.copy(), eps, rng=rng)
 
     if krank > 0:
         UU = cnp.PyArray_ZEROS(2, [m, krank], cnp.NPY_COMPLEX128, 0)
@@ -1592,12 +1592,12 @@ def idzp_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t 
     return k+1, taus, ind
 
 
-def idzp_rid(A: LinearOperator, cnp.float64_t eps, rng):
+def idzp_rid(A: LinearOperator, cnp.float64_t eps, *, rng):
     _, ret = idz_findrank(A, eps, rng=rng)
     return idzp_id(ret, eps=eps)
 
 
-def idzp_rsvd(A: LinearOperator, cnp.float64_t eps, rng):
+def idzp_rsvd(A: LinearOperator, cnp.float64_t eps, *, rng):
     cdef int n = A.shape[1]
     cdef int krank, j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
@@ -1654,7 +1654,7 @@ def idzp_svd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t ep
     return UU, S, V
 
 
-def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int krank,
+def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int krank, *,
              rng):
     cdef int m = a.shape[0], n2, L, nblock, nsteps = 3, mb
     cdef cnp.float64_t twopi = 2*np.pi, fact
@@ -1741,7 +1741,7 @@ def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int kra
     return idzr_id(V, krank)
 
 
-def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, rng):
+def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, *, rng):
     cdef int m = a.shape[0], n = a.shape[1]
     cdef int info, ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
@@ -1898,7 +1898,7 @@ def idzr_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
     return ind, taus
 
 
-def idzr_rid(A: LinearOperator, int krank, rng):
+def idzr_rid(A: LinearOperator, int krank, *, rng):
     cdef int m = A.shape[0], n = A.shape[1], k = 0
     cdef int L = min(krank+2, min(m, n))
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] r
@@ -1910,13 +1910,13 @@ def idzr_rid(A: LinearOperator, int krank, rng):
     return idzr_id(a=r.conj(), krank=krank)
 
 
-def idzr_rsvd(A: LinearOperator, int krank, rng):
+def idzr_rsvd(A: LinearOperator, int krank, *, rng):
     cdef int n = A.shape[1], j
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms
     cdef cnp.ndarray[cnp.complex128_t, ndim=2] proj
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] col
 
-    perms, proj = idzr_rid(A, krank, rng)
+    perms, proj = idzr_rid(A, krank, rng=rng)
     # idd_getcols
     col = cnp.PyArray_EMPTY(2, [n, krank], cnp.NPY_COMPLEX128, 0)
     x = cnp.PyArray_ZEROS(1, [n], cnp.NPY_COMPLEX128, 0)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -513,9 +513,12 @@ def interp_decomp(A, eps_or_k, rand=True, rng=None):
         Whether to use random sampling if `A` is of type :class:`numpy.ndarray`
         (randomized algorithms are always used if `A` is of type
         :class:`scipy.sparse.linalg.LinearOperator`).
-    rng : :class:`numpy.random.Generator`
-        NumPy generator for the randomization steps in the algorithm. If ``rand`` is
-        ``False``, the argument is ignored.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
@@ -528,7 +531,7 @@ def interp_decomp(A, eps_or_k, rand=True, rng=None):
         Interpolation coefficients.
     """  # numpy/numpydoc#87  # noqa: E501
     from scipy.sparse.linalg import LinearOperator
-
+    rng = np.random.default_rng(rng)
     real = _is_real(A)
 
     if isinstance(A, np.ndarray):
@@ -754,8 +757,12 @@ def estimate_spectral_norm(A, its=20, rng=None):
         `matvec` and `rmatvec` methods (to apply the matrix and its adjoint).
     its : int, optional
         Number of power method iterations.
-    rng : :class:`numpy.random.Generator`
-        NumPy generator for the randomization steps in the algorithm.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
@@ -763,6 +770,7 @@ def estimate_spectral_norm(A, its=20, rng=None):
         Spectral norm estimate.
     """
     from scipy.sparse.linalg import aslinearoperator
+    rng = np.random.default_rng(rng)
     A = aslinearoperator(A)
 
     if _is_real(A):
@@ -790,8 +798,12 @@ def estimate_spectral_norm_diff(A, B, its=20, rng=None):
         the `matvec` and `rmatvec` methods (to apply the matrix and its adjoint).
     its : int, optional
         Number of power method iterations.
-    rng : :class:`numpy.random.Generator`
-        NumPy generator for the randomization steps in the algorithm.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
@@ -799,6 +811,7 @@ def estimate_spectral_norm_diff(A, B, its=20, rng=None):
         Spectral norm estimate of matrix difference.
     """
     from scipy.sparse.linalg import aslinearoperator
+    rng = np.random.default_rng(rng)
     A = aslinearoperator(A)
     B = aslinearoperator(B)
 
@@ -845,9 +858,12 @@ def svd(A, eps_or_k, rand=True, rng=None):
         Whether to use random sampling if `A` is of type :class:`numpy.ndarray`
         (randomized algorithms are always used if `A` is of type
         :class:`scipy.sparse.linalg.LinearOperator`).
-    rng : :class:`numpy.random.Generator`
-        NumPy generator for the randomization steps in the algorithm. If ``rand`` is
-        ``False``, the argument is ignored.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
@@ -859,6 +875,7 @@ def svd(A, eps_or_k, rand=True, rng=None):
         2D array right singular vectors.
     """
     from scipy.sparse.linalg import LinearOperator
+    rng = np.random.default_rng(rng)
 
     real = _is_real(A)
 
@@ -936,8 +953,12 @@ def estimate_rank(A, eps, rng=None):
         with the `rmatvec` method (to apply the matrix adjoint).
     eps : float
         Relative error for numerical rank definition.
-    rng : :class:`numpy.random.Generator`
-        NumPy generator for the randomization steps in the algorithm.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
@@ -946,6 +967,7 @@ def estimate_rank(A, eps, rng=None):
     """
     from scipy.sparse.linalg import LinearOperator
 
+    rng = np.random.default_rng(rng)
     real = _is_real(A)
 
     if isinstance(A, np.ndarray):


### PR DESCRIPTION
Many of the functions in `linalg.interpolative` accept a generator via a `rng` argument. This pr normalizes this argument with `np.random.default_rng` as per SPEC7.