### PR TITLE
MAINT: Hausdorff Generator handling

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -35,7 +35,11 @@ def directed_hausdorff(const double[:,::1] ar1, const double[:,::1] ar2, seed=0)
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
-    rng = np.random.RandomState(seed)
+    if isinstance(seed, int | None):
+        rng = np.random.RandomState(seed)
+    else:
+        # Generator passthrough
+        rng = seed
     resort1 = np.arange(N1, dtype=np.int64)
     resort2 = np.arange(N2, dtype=np.int64)
     rng.shuffle(resort1)

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -35,11 +35,11 @@ def directed_hausdorff(const double[:,::1] ar1, const double[:,::1] ar2, seed=0)
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
-    if isinstance(seed, int | None):
-        rng = np.random.RandomState(seed)
-    else:
+    if isinstance(seed, np.random.Generator):
         # Generator passthrough
         rng = seed
+    else:
+        rng = np.random.RandomState(seed)
     resort1 = np.arange(N1, dtype=np.int64)
     resort2 = np.arange(N2, dtype=np.int64)
     rng.shuffle(resort1)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -321,9 +321,10 @@ def directed_hausdorff(u, v, seed=0):
         Input array with M points in N dimensions.
     v : (O,N) array_like
         Input array with O points in N dimensions.
-    seed : int or None, optional
+    seed : int or `numpy.random.Generator` or None, optional
         Local `numpy.random.RandomState` seed. Default is 0, a random
-        shuffling of u and v that guarantees reproducibility.
+        shuffling of u and v that guarantees reproducibility. Also
+        accepts a `numpy.random.Generator` object.
 
     Returns
     -------

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -127,7 +127,7 @@ class TestHausdorff:
         # the two cases from gh-11332
         ([(0,0)],
          [(0,1), (0,0)],
-         0,
+         np.int64(0),
          (0.0, 0, 1)),
         ([(0,0)],
          [(0,1), (0,0)],

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -102,7 +102,7 @@ class TestHausdorff:
         new_global_state = rs2.get_state()
         assert_equal(new_global_state, old_global_state)
 
-    @pytest.mark.parametrize("seed", [None, 27870671])
+    @pytest.mark.parametrize("seed", [None, 27870671, np.random.default_rng(177)])
     def test_random_state_None_int(self, seed):
         # check that seed values of None or int do not alter global
         # random state
@@ -133,6 +133,15 @@ class TestHausdorff:
          [(0,1), (0,0)],
          1,
          (0.0, 0, 1)),
+        # gh-11332 cases with a Generator
+        ([(0,0)],
+         [(0,1), (0,0)],
+         np.random.default_rng(0),
+         (0.0, 0, 1)),
+        ([(0,0)],
+         [(0,1), (0,0)],
+         np.random.default_rng(1),
+         (0.0, 0, 1)),
         # slightly more complex case
         ([(-5, 3), (0,0)],
          [(0,1), (0,0), (-5, 3)],
@@ -141,6 +150,14 @@ class TestHausdorff:
          # be the last one found, but a unique
          # solution is not guaranteed more broadly
          (0.0, 1, 1)),
+        # repeated with Generator seeding
+        ([(-5, 3), (0,0)],
+         [(0,1), (0,0), (-5, 3)],
+         np.random.default_rng(77098),
+         # NOTE: using a Generator changes the
+         # indices but not the distance (unique solution
+         # not guaranteed)
+         (0.0, 0, 2)),
     ])
     def test_subsets(self, A, B, seed, expected):
         # verify fix for gh-11332


### PR DESCRIPTION
* This patch is a precursor to SPEC 7 compliance of `directed_hausdorff` requested in gh-21833. I believe the team prefers that I first add support for `Generator` handling here, and once they are happy with that they will follow up with the usual decorator magic.

* In addition to modernization of the source proper to accept a `Generator`, some test cases using a `Generator` with the "same" integer seed as the previous `RandomState` approach have been added. One such case demonstrates that defaulting to `Generator` in the long term will change some results, which SPEC 7 does acknowledge. For clarity, the returned Hausdorff distance will always remain identical, but the indices corresponding to that distance may vary according to the exact random status for this shuffling-reliant algorithm. Disruption is likely to be minimal if we follow the SPEC process/warnings timeline I'd say. Of course, if we follow the full procedure the indices returned for the same function call can change for some inputs.

* Note that there are type stub/`pyi` signature(s) that might in principle be changed here but `mypy` didn't seem to care locally and IIRC our recent philosophy has been to delegate typing improvements to an external package.

[skip cirrus] [skip circle]