### PR TITLE
API: sparse.linalg.svds: transition to rng (SPEC 7)

### DIFF
--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -4,7 +4,7 @@ import numpy as np
 from .arpack import _arpack  # type: ignore[attr-defined]
 from . import eigsh
 
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, _transition_to_rng
 from scipy.sparse.linalg._interface import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg  # type: ignore[no-redef]
 from scipy.sparse.linalg._svdp import _svdp
@@ -19,7 +19,7 @@ def _herm(x):
 
 
 def _iv(A, k, ncv, tol, which, v0, maxiter,
-        return_singular, solver, random_state):
+        return_singular, solver, rng):
 
     # input validation/standardization for `solver`
     # out of order because it's needed for other parameters
@@ -90,15 +90,16 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
     if return_singular not in rs_options:
         raise ValueError(f"`return_singular_vectors` must be in {rs_options}.")
 
-    random_state = check_random_state(random_state)
+    rng = check_random_state(rng)
 
     return (A, k, ncv, tol, which, v0, maxiter,
-            return_singular, solver, random_state)
+            return_singular, solver, rng)
 
 
+@_transition_to_rng("random_state")
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True,
-         solver='arpack', random_state=None, options=None):
+         solver='arpack', rng=None, options=None):
     """
     Partial singular value decomposition of a sparse matrix.
 
@@ -158,17 +159,11 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'lobpcg' <sparse.linalg.svds-lobpcg>`, and
             :ref:`'propack' <sparse.linalg.svds-propack>` are supported.
             Default: `'arpack'`.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        Pseudorandom number generator state used to generate resamples.
-
-        If `random_state` is ``None`` (or `np.random`), the
-        `numpy.random.RandomState` singleton is used.
-        If `random_state` is an int, a new ``RandomState`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` or ``RandomState``
-        instance then that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     options : dict, optional
         A dictionary of solver-specific options. No solver-specific options
         are currently supported; this parameter is reserved for future use.
@@ -263,7 +258,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     >>> vT = v.T
     >>> A = u @ np.diag(s) @ vT
     >>> A = A.astype(np.float32)
-    >>> u2, s2, vT2 = svds(A, k=2, random_state=rng)
+    >>> u2, s2, vT2 = svds(A, k=2, rng=rng)
     >>> np.allclose(s2, s)
     True
 
@@ -294,7 +289,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     >>> X_dense = rng.random(size=(100, 100))
     >>> X_dense[:, 2 * np.arange(50)] = 0
     >>> X = sparse.csr_array(X_dense)
-    >>> _, singular_values, _ = svds(X, k=5, random_state=rng)
+    >>> _, singular_values, _ = svds(X, k=5, rng=rng)
     >>> print(singular_values)
     [ 4.3293...  4.4491...  4.5420...  4.5987... 35.2410...]
 
@@ -304,7 +299,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     >>> rng = np.random.default_rng(102524723947864966825913730119128190974)
     >>> G = sparse.random_array((8, 9), density=0.5, random_state=rng)
     >>> Glo = aslinearoperator(G)
-    >>> _, singular_values_svds, _ = svds(Glo, k=5, random_state=rng)
+    >>> _, singular_values_svds, _ = svds(Glo, k=5, rng=rng)
     >>> _, singular_values_svd, _ = linalg.svd(G.toarray())
     >>> np.allclose(singular_values_svds, singular_values_svd[-4::-1])
     True
@@ -436,9 +431,9 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     """
     args = _iv(A, k, ncv, tol, which, v0, maxiter, return_singular_vectors,
-               solver, random_state)
+               solver, rng)
     (A, k, ncv, tol, which, v0, maxiter,
-     return_singular_vectors, solver, random_state) = args
+     return_singular_vectors, solver, rng) = args
 
     largest = (which == 'LM')
     n, m = A.shape
@@ -477,7 +472,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         if k == 1 and v0 is not None:
             X = np.reshape(v0, (-1, 1))
         else:
-            X = random_state.standard_normal(size=(min(A.shape), k))
+            X = rng.standard_normal(size=(min(A.shape), k))
 
         _, eigvec = lobpcg(XH_X, X, tol=tol ** 2, maxiter=maxiter,
                            largest=largest)
@@ -488,7 +483,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         irl_mode = (which == 'SM')
         res = _svdp(A, k=k, tol=tol**2, which=which, maxiter=None,
                     compute_u=jobu, compute_v=jobv, irl_mode=irl_mode,
-                    kmax=maxiter, v0=v0, random_state=random_state)
+                    kmax=maxiter, v0=v0, random_state=rng)
 
         u, s, vh, _ = res  # but we'll ignore bnd, the last output
 
@@ -510,7 +505,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     elif solver == 'arpack' or solver is None:
         if v0 is None:
-            v0 = random_state.standard_normal(size=(min(A.shape),))
+            v0 = rng.standard_normal(size=(min(A.shape),))
         _, eigvec = eigsh(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
                           ncv=ncv, which=which, v0=v0)
         # arpack do not guarantee exactly orthonormal eigenvectors

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -285,13 +285,13 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     The next example follows that of 'sklearn.decomposition.TruncatedSVD'.
 
-    >>> rng = np.random.RandomState(0)
+    >>> rng = np.random.default_rng(0)
     >>> X_dense = rng.random(size=(100, 100))
     >>> X_dense[:, 2 * np.arange(50)] = 0
     >>> X = sparse.csr_array(X_dense)
-    >>> _, singular_values, _ = svds(X, k=5, random_state=rng)
+    >>> _, singular_values, _ = svds(X, k=5, rng=rng)
     >>> print(singular_values)
-    [ 4.3293...  4.4491...  4.5420...  4.5987... 35.2410...]
+    [ 4.3221...  4.4043...  4.4907...  4.5858... 35.4549...]
 
     The function can be called without the transpose of the input matrix
     ever explicitly constructed.
@@ -483,7 +483,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         irl_mode = (which == 'SM')
         res = _svdp(A, k=k, tol=tol**2, which=which, maxiter=None,
                     compute_u=jobu, compute_v=jobv, irl_mode=irl_mode,
-                    kmax=maxiter, v0=v0, random_state=rng)
+                    kmax=maxiter, v0=v0, rng=rng)
 
         u, s, vh, _ = res  # but we'll ignore bnd, the last output
 

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -96,7 +96,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
             return_singular, solver, rng)
 
 
-@_transition_to_rng("random_state")
+@_transition_to_rng("random_state", position_num=9)
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True,
          solver='arpack', rng=None, options=None):
@@ -289,7 +289,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     >>> X_dense = rng.random(size=(100, 100))
     >>> X_dense[:, 2 * np.arange(50)] = 0
     >>> X = sparse.csr_array(X_dense)
-    >>> _, singular_values, _ = svds(X, k=5, rng=rng)
+    >>> _, singular_values, _ = svds(X, k=5, random_state=rng)
     >>> print(singular_values)
     [ 4.3293...  4.4491...  4.5420...  4.5987... 35.2410...]
 

--- a/scipy/sparse/linalg/_eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/_eigen/_svds_doc.py
@@ -1,6 +1,6 @@
 def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                      maxiter=None, return_singular_vectors=True,
-                     solver='arpack', random_state=None):
+                     solver='arpack', rng=None):
     """
     Partial singular value decomposition of a sparse matrix using ARPACK.
 
@@ -54,17 +54,11 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'lobpcg' <sparse.linalg.svds-lobpcg>` and
             :ref:`'propack' <sparse.linalg.svds-propack>`
             are also supported.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        Pseudorandom number generator state used to generate resamples.
-
-        If `random_state` is ``None`` (or `np.random`), the
-        `numpy.random.RandomState` singleton is used.
-        If `random_state` is an int, a new ``RandomState`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` or ``RandomState``
-        instance then that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     options : dict, optional
         A dictionary of solver-specific options. No solver-specific options
         are currently supported; this parameter is reserved for future use.
@@ -134,7 +128,7 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
 def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                      maxiter=None, return_singular_vectors=True,
-                     solver='lobpcg', random_state=None):
+                     solver='lobpcg', rng=None):
     """
     Partial singular value decomposition of a sparse matrix using LOBPCG.
 
@@ -184,17 +178,11 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'arpack' <sparse.linalg.svds-arpack>` and
             :ref:`'propack' <sparse.linalg.svds-propack>`
             are also supported.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        Pseudorandom number generator state used to generate resamples.
-
-        If `random_state` is ``None`` (or `np.random`), the
-        `numpy.random.RandomState` singleton is used.
-        If `random_state` is an int, a new ``RandomState`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` or ``RandomState``
-        instance then that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     options : dict, optional
         A dictionary of solver-specific options. No solver-specific options
         are currently supported; this parameter is reserved for future use.
@@ -265,7 +253,7 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
 def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                       maxiter=None, return_singular_vectors=True,
-                      solver='propack', random_state=None):
+                      solver='propack', rng=None):
     """
     Partial singular value decomposition of a sparse matrix using PROPACK.
 
@@ -314,17 +302,11 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'arpack' <sparse.linalg.svds-arpack>` and
             :ref:`'lobpcg' <sparse.linalg.svds-lobpcg>`
             are also supported.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        Pseudorandom number generator state used to generate resamples.
-
-        If `random_state` is ``None`` (or `np.random`), the
-        `numpy.random.RandomState` singleton is used.
-        If `random_state` is an int, a new ``RandomState`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` or ``RandomState``
-        instance then that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     options : dict, optional
         A dictionary of solver-specific options. No solver-specific options
         are currently supported; this parameter is reserved for future use.

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -151,11 +151,9 @@ class SVDSCommonTests:
         A = np.asarray([[1, 2], [3, 4]])
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                res = svds(A, k=1, which=which, solver=self.solver,
-                           random_state=0)
+                res = svds(A, k=1, which=which, solver=self.solver, rng=0)
         else:
-            res = svds(A, k=1, which=which, solver=self.solver,
-                       random_state=0)
+            res = svds(A, k=1, which=which, solver=self.solver, rng=0)
         _check_svds(A, 1, *res, which=which, atol=8e-10)
 
     def test_svds_diff0_docstring_example(self):
@@ -191,7 +189,7 @@ class SVDSCommonTests:
 
         # propack can do complete SVD
         if self.solver == 'propack' and k == 3:
-            res = svds(A, k=k, solver=self.solver, random_state=0)
+            res = svds(A, k=k, solver=self.solver, rng=0)
             _check_svds(A, k, *res, check_usvh_A=True, check_svd=True)
             return
 
@@ -299,11 +297,9 @@ class SVDSCommonTests:
         A = rng.random((10, 10))
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                res = svds(A, k=k, which=which, solver=self.solver,
-                           random_state=0)
+                res = svds(A, k=k, which=which, solver=self.solver, rng=0)
         else:
-            res = svds(A, k=k, which=which, solver=self.solver,
-                       random_state=0)
+            res = svds(A, k=k, which=which, solver=self.solver, rng=0)
         _check_svds(A, k, *res, which=which, atol=1e-9, rtol=2e-13)
 
     @pytest.mark.filterwarnings("ignore:Exited",
@@ -330,7 +326,7 @@ class SVDSCommonTests:
 
         def err(tol):
             _, s2, _ = svds(A, k=k, v0=np.ones(n), maxiter=1000,
-                            solver=self.solver, tol=tol, random_state=0)
+                            solver=self.solver, tol=tol, rng=0)
             return np.linalg.norm((s2 - s[k-1::-1])/s[k-1::-1])
 
         tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
@@ -348,7 +344,7 @@ class SVDSCommonTests:
         n = 100
         k = 1
         # If k != 1, LOBPCG needs more initial vectors, which are generated
-        # with random_state, so it does not pass w/ k >= 2.
+        # with rng, so it does not pass w/ k >= 2.
         # For some other values of `n`, the AssertionErrors are not raised
         # with different v0s, which is reasonable.
 
@@ -356,18 +352,18 @@ class SVDSCommonTests:
         A = rng.random((n, n))
 
         # with the same v0, solutions are the same, and they are accurate
-        # v0 takes precedence over random_state
+        # v0 takes precedence over rng
         v0a = rng.random(n)
-        res1a = svds(A, k, v0=v0a, solver=self.solver, random_state=0)
-        res2a = svds(A, k, v0=v0a, solver=self.solver, random_state=1)
+        res1a = svds(A, k, v0=v0a, solver=self.solver, rng=0)
+        res2a = svds(A, k, v0=v0a, solver=self.solver, rng=1)
         for idx in range(3):
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
         # with the same v0, solutions are the same, and they are accurate
         v0b = rng.random(n)
-        res1b = svds(A, k, v0=v0b, solver=self.solver, random_state=2)
-        res2b = svds(A, k, v0=v0b, solver=self.solver, random_state=3)
+        res1b = svds(A, k, v0=v0b, solver=self.solver, rng=2)
+        res2b = svds(A, k, v0=v0b, solver=self.solver, rng=3)
         for idx in range(3):
             assert_allclose(res1b[idx], res2b[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1b)
@@ -377,8 +373,8 @@ class SVDSCommonTests:
         with pytest.raises(AssertionError, match=message):
             assert_equal(res1a, res1b)
 
-    def test_svd_random_state(self):
-        # check that the `random_state` parameter affects the solution
+    def test_svd_rng(self):
+        # check that the `rng` parameter affects the solution
         # Admittedly, `n` and `k` are chosen so that all solver pass all
         # these checks. That's a tall order, since LOBPCG doesn't want to
         # achieve the desired accuracy and ARPACK often returns the same
@@ -389,62 +385,62 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         A = rng.random((n, n))
 
-        # with the same random_state, solutions are the same and accurate
-        res1a = svds(A, k, solver=self.solver, random_state=0)
-        res2a = svds(A, k, solver=self.solver, random_state=0)
+        # with the same rng, solutions are the same and accurate
+        res1a = svds(A, k, solver=self.solver, rng=0)
+        res2a = svds(A, k, solver=self.solver, rng=0)
         for idx in range(3):
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
-        # with the same random_state, solutions are the same and accurate
-        res1b = svds(A, k, solver=self.solver, random_state=1)
-        res2b = svds(A, k, solver=self.solver, random_state=1)
+        # with the same rng, solutions are the same and accurate
+        res1b = svds(A, k, solver=self.solver, rng=1)
+        res2b = svds(A, k, solver=self.solver, rng=1)
         for idx in range(3):
             assert_allclose(res1b[idx], res2b[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1b)
 
-        # with different random_state, solutions can be numerically different
+        # with different rng, solutions can be numerically different
         message = "Arrays are not equal"
         with pytest.raises(AssertionError, match=message):
             assert_equal(res1a, res1b)
 
-    @pytest.mark.parametrize("random_state", (0, 1,
+    @pytest.mark.parametrize("rng", (0, 1,
                                               np.random.RandomState(0),
                                               np.random.default_rng(0)))
-    def test_svd_random_state_2(self, random_state):
+    def test_svd_rng(self, rng):
         n = 100
         k = 1
 
         rng = np.random.default_rng(0)
         A = rng.random((n, n))
 
-        random_state_2 = copy.deepcopy(random_state)
+        rng_2 = copy.deepcopy(rng)
 
-        # with the same random_state, solutions are the same and accurate
-        res1a = svds(A, k, solver=self.solver, random_state=random_state)
-        res2a = svds(A, k, solver=self.solver, random_state=random_state_2)
+        # with the same rng, solutions are the same and accurate
+        res1a = svds(A, k, solver=self.solver, rng=rng)
+        res2a = svds(A, k, solver=self.solver, rng=rng_2)
         for idx in range(3):
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
-    @pytest.mark.parametrize("random_state", (None,
+    @pytest.mark.parametrize("rng", (None,
                                               np.random.RandomState(0),
                                               np.random.default_rng(0)))
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
-    def test_svd_random_state_3(self, random_state):
+    def test_svd_rng_3(self, rng):
         n = 100
         k = 5
 
         rng = np.random.default_rng(0)
         A = rng.random((n, n))
 
-        random_state = copy.deepcopy(random_state)
+        rng = copy.deepcopy(rng)
 
-        # random_state in different state produces accurate - but not
+        # rng in different state produces accurate - but not
         # not necessarily identical - results
-        res1a = svds(A, k, solver=self.solver, random_state=random_state, maxiter=1000)
-        res2a = svds(A, k, solver=self.solver, random_state=random_state, maxiter=1000)
+        res1a = svds(A, k, solver=self.solver, rng=rng, maxiter=1000)
+        res2a = svds(A, k, solver=self.solver, rng=rng, maxiter=1000)
         _check_svds(A, k, *res1a, atol=2e-7)
         _check_svds(A, k, *res2a, atol=2e-7)
 
@@ -477,8 +473,7 @@ class SVDSCommonTests:
             with pytest.raises(np.linalg.LinAlgError, match=message):
                 svds(A, k, maxiter=1, solver=self.solver)
 
-        ud, sd, vhd = svds(A, k, solver=self.solver, maxiter=maxiter,
-                           random_state=0)
+        ud, sd, vhd = svds(A, k, solver=self.solver, maxiter=maxiter, rng=0)
         _check_svds(A, k, ud, sd, vhd, atol=1e-8)
         assert_allclose(np.abs(ud), np.abs(u), atol=1e-8)
         assert_allclose(np.abs(vhd), np.abs(vh), atol=1e-8)
@@ -501,23 +496,23 @@ class SVDSCommonTests:
             with pytest.warns(UserWarning, match="The problem size"):
                 if rsv is False:
                     s2 = svds(A, k, return_singular_vectors=rsv,
-                              solver=self.solver, random_state=rng)
+                              solver=self.solver, rng=rng)
                     assert_allclose(s2, s)
                 elif rsv == 'u' and respect_u:
                     u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                       solver=self.solver, random_state=rng)
+                                       solver=self.solver, rng=rng)
                     assert_allclose(np.abs(u2), np.abs(u))
                     assert_allclose(s2, s)
                     assert vh2 is None
                 elif rsv == 'vh' and respect_vh:
                     u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                       solver=self.solver, random_state=rng)
+                                       solver=self.solver, rng=rng)
                     assert u2 is None
                     assert_allclose(s2, s)
                     assert_allclose(np.abs(vh2), np.abs(vh))
                 else:
                     u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                       solver=self.solver, random_state=rng)
+                                       solver=self.solver, rng=rng)
                     if u2 is not None:
                         assert_allclose(np.abs(u2), np.abs(u))
                     assert_allclose(s2, s)
@@ -526,23 +521,23 @@ class SVDSCommonTests:
         else:
             if rsv is False:
                 s2 = svds(A, k, return_singular_vectors=rsv,
-                          solver=self.solver, random_state=rng)
+                          solver=self.solver, rng=rng)
                 assert_allclose(s2, s)
             elif rsv == 'u' and respect_u:
                 u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                   solver=self.solver, random_state=rng)
+                                   solver=self.solver, rng=rng)
                 assert_allclose(np.abs(u2), np.abs(u))
                 assert_allclose(s2, s)
                 assert vh2 is None
             elif rsv == 'vh' and respect_vh:
                 u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                   solver=self.solver, random_state=rng)
+                                   solver=self.solver, rng=rng)
                 assert u2 is None
                 assert_allclose(s2, s)
                 assert_allclose(np.abs(vh2), np.abs(vh))
             else:
                 u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
-                                   solver=self.solver, random_state=rng)
+                                   solver=self.solver, rng=rng)
                 if u2 is not None:
                     assert_allclose(np.abs(u2), np.abs(u))
                 assert_allclose(s2, s)
@@ -587,9 +582,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                u, s, vh = svds(A2, k, solver=self.solver, random_state=0)
+                u, s, vh = svds(A2, k, solver=self.solver, rng=0)
         else:
-            u, s, vh = svds(A2, k, solver=self.solver, random_state=0)
+            u, s, vh = svds(A2, k, solver=self.solver, rng=0)
         _check_svds(A, k, u, s, vh, atol=atol)
 
     def test_svd_linop(self):
@@ -615,15 +610,11 @@ class SVDSCommonTests:
                 v0 = np.ones(min(A.shape))
             if solver == 'lobpcg':
                 with pytest.warns(UserWarning, match="The problem size"):
-                    U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver,
-                                               random_state=0))
-                    U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver,
-                                               random_state=0))
+                    U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver, rng=0))
+                    U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver, rng=0))
             else:
-                U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver,
-                                           random_state=0))
-                U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver,
-                                           random_state=0))
+                U1, s1, VH1 = reorder(svds(A, k, v0=v0, solver=solver, rng=0))
+                U2, s2, VH2 = reorder(svds(L, k, v0=v0, solver=solver, rng=0))
 
             assert_allclose(np.abs(U1), np.abs(U2))
             assert_allclose(s1, s2)
@@ -640,14 +631,14 @@ class SVDSCommonTests:
             if self.solver == 'lobpcg':
                 with pytest.warns(UserWarning, match="The problem size"):
                     U1, s1, VH1 = reorder(svds(A, k, which="SM", solver=solver,
-                                               random_state=0, **kwargs))
+                                               rng=0, **kwargs))
                     U2, s2, VH2 = reorder(svds(L, k, which="SM", solver=solver,
-                                               random_state=0, **kwargs))
+                                               rng=0, **kwargs))
             else:
                 U1, s1, VH1 = reorder(svds(A, k, which="SM", solver=solver,
-                                           random_state=0, **kwargs))
+                                           rng=0, **kwargs))
                 U2, s2, VH2 = reorder(svds(L, k, which="SM", solver=solver,
-                                           random_state=0, **kwargs))
+                                           rng=0, **kwargs))
 
             assert_allclose(np.abs(U1), np.abs(U2))
             assert_allclose(s1 + 1, s2 + 1)
@@ -666,18 +657,14 @@ class SVDSCommonTests:
                         with pytest.warns(UserWarning,
                                           match="The problem size"):
                             U1, s1, VH1 = reorder(svds(A, k, which="LM",
-                                                       solver=solver,
-                                                       random_state=0))
+                                                       solver=solver, rng=0))
                             U2, s2, VH2 = reorder(svds(L, k, which="LM",
-                                                       solver=solver,
-                                                       random_state=0))
+                                                       solver=solver, rng=0))
                     else:
                         U1, s1, VH1 = reorder(svds(A, k, which="LM",
-                                                   solver=solver,
-                                                   random_state=0))
+                                                   solver=solver, rng=0))
                         U2, s2, VH2 = reorder(svds(L, k, which="LM",
-                                                   solver=solver,
-                                                   random_state=0))
+                                                   solver=solver, rng=0))
 
                     assert_allclose(np.abs(U1), np.abs(U2), rtol=eps)
                     assert_allclose(s1, s2, rtol=eps)
@@ -709,8 +696,7 @@ class SVDSCommonTests:
         e[0:5] *= 1e1 ** np.arange(-5, 0, 1)
         S = dia_array((e, 0), shape=(m, m)) @ S
         S = S.astype(dtype)
-        u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000,
-                        random_state=0)
+        u, s, vh = svds(S, k, which='SM', solver=solver, maxiter=1000, rng=0)
         c_svd = False  # partial SVD can be different from full SVD
         _check_svds_n(S, k, u, s, vh, which="SM", check_svd=c_svd, atol=2e-1)
 
@@ -727,9 +713,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                U, s, VH = svds(A, k, solver=self.solver, random_state=0)
+                U, s, VH = svds(A, k, solver=self.solver, rng=0)
         else:
-            U, s, VH = svds(A, k, solver=self.solver, random_state=0)
+            U, s, VH = svds(A, k, solver=self.solver, rng=0)
 
         _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
 
@@ -765,9 +751,9 @@ class SVDSCommonTests:
 
         if self.solver == 'lobpcg':
             with pytest.warns(UserWarning, match="The problem size"):
-                U, s, VH = svds(A, k, solver=self.solver, random_state=0)
+                U, s, VH = svds(A, k, solver=self.solver, rng=0)
         else:
-            U, s, VH = svds(A, k, solver=self.solver, random_state=0)
+            U, s, VH = svds(A, k, solver=self.solver, rng=0)
 
         # Check some generic properties of svd.
         _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
@@ -791,7 +777,7 @@ class SVDSCommonTests:
         t = e**(-np.arange(len(vh))).astype(dtype)
         A = (u*t).dot(vh)
         k = 4
-        u, s, vh = svds(A, k, solver=self.solver, maxiter=100, random_state=0)
+        u, s, vh = svds(A, k, solver=self.solver, maxiter=100, rng=0)
         t = np.sum(s > 0)
         assert_equal(t, k)
         # LOBPCG needs larger atol and rtol to pass
@@ -823,8 +809,7 @@ class SVDSCommonTests:
 
         # Smallest singular values should be 0
         sp_mat = csc_array(mat)
-        su, ss, svh = svds(sp_mat, k=dim, which='SM', solver=self.solver,
-                           random_state=0)
+        su, ss, svh = svds(sp_mat, k=dim, which='SM', solver=self.solver, rng=0)
         # Smallest dim singular values are 0:
         assert_allclose(ss, 0, atol=1e-5, rtol=1e0)
         # Smallest singular vectors via svds in null space:
@@ -855,7 +840,7 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         A = rng.random((6, 7))
         k = 3
         if ncv in {4, 5}:
-            u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver, random_state=0)
+            u, s, vh = svds(A, k=k, ncv=ncv, solver=self.solver, rng=0)
         # partial decomposition, so don't check that u@diag(s)@vh=A;
         # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
             _check_svds(A, k, u, s, vh)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -153,7 +153,7 @@ class SVDSCommonTests:
             with pytest.warns(UserWarning, match="The problem size"):
                 res = svds(A, k=1, which=which, solver=self.solver, rng=0)
         else:
-            res = svds(A, k=1, which=which, solver=self.solver, rng=0)
+            res = svds(A, k=1, which=which, solver=self.solver, random_state=0)
         _check_svds(A, 1, *res, which=which, atol=8e-10)
 
     def test_svds_diff0_docstring_example(self):
@@ -405,14 +405,13 @@ class SVDSCommonTests:
             assert_equal(res1a, res1b)
 
     @pytest.mark.parametrize("rng", (0, 1,
-                                     np.random.RandomState(0),
                                      np.random.default_rng(0)))
     def test_svd_rng_2(self, rng):
         n = 100
         k = 1
 
-        rng = np.random.default_rng(0)
-        A = rng.random((n, n))
+        tmp_rng = np.random.default_rng(0)
+        A = tmp_rng.random((n, n))
 
         rng_2 = copy.deepcopy(rng)
 
@@ -424,7 +423,6 @@ class SVDSCommonTests:
         _check_svds(A, k, *res1a)
 
     @pytest.mark.parametrize("rng", (None,
-                                     np.random.RandomState(0),
                                      np.random.default_rng(0)))
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
@@ -432,8 +430,8 @@ class SVDSCommonTests:
         n = 100
         k = 5
 
-        rng = np.random.default_rng(0)
-        A = rng.random((n, n))
+        tmp_rng = np.random.default_rng(0)
+        A = tmp_rng.random((n, n))
 
         rng = copy.deepcopy(rng)
 

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -153,7 +153,7 @@ class SVDSCommonTests:
             with pytest.warns(UserWarning, match="The problem size"):
                 res = svds(A, k=1, which=which, solver=self.solver, rng=0)
         else:
-            res = svds(A, k=1, which=which, solver=self.solver, random_state=0)
+            res = svds(A, k=1, which=which, solver=self.solver, rng=0)
         _check_svds(A, 1, *res, which=which, atol=8e-10)
 
     def test_svds_diff0_docstring_example(self):
@@ -175,7 +175,8 @@ class SVDSCommonTests:
                                   shape=(n - 1, n))
         n = 100
         diff0_func_aslo = diff0_func_aslo_def(n)
-        u, s, _ = svds(diff0_func_aslo, k=3, which='SM', rng=0)
+        # preserve a use of legacy keyword `random_state` during SPEC 7 transition
+        u, s, _ = svds(diff0_func_aslo, k=3, which='SM', random_state=0)
         se = 2. * np.sin(np.pi * np.arange(1, 4) / (2. * n))
         ue = np.sqrt(2 / n) * np.sin(np.pi * np.outer(np.arange(1, n),
                                      np.arange(1, 4)) / n)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -144,7 +144,7 @@ class SVDSCommonTests:
     def test_svds_input_validation_A(self, args):
         A, error_type, message = args
         with pytest.raises(error_type, match=message):
-            svds(A, k=1, solver=self.solver)
+            svds(A, k=1, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("which", ["LM", "SM"])
     def test_svds_int_A(self, which):
@@ -175,7 +175,7 @@ class SVDSCommonTests:
                                   shape=(n - 1, n))
         n = 100
         diff0_func_aslo = diff0_func_aslo_def(n)
-        u, s, _ = svds(diff0_func_aslo, k=3, which='SM')
+        u, s, _ = svds(diff0_func_aslo, k=3, which='SM', rng=0)
         se = 2. * np.sin(np.pi * np.arange(1, 4) / (2. * n))
         ue = np.sqrt(2 / n) * np.sin(np.pi * np.outer(np.arange(1, n),
                                      np.arange(1, 4)) / n)
@@ -195,31 +195,31 @@ class SVDSCommonTests:
 
         message = ("`k` must be an integer satisfying")
         with pytest.raises(ValueError, match=message):
-            svds(A, k=k, solver=self.solver)
+            svds(A, k=k, solver=self.solver, rng=0)
 
     def test_svds_input_validation_k_2(self):
         # I think the stack trace is reasonable when `k` can't be converted
         # to an int.
         message = "int() argument must be a"
         with pytest.raises(TypeError, match=re.escape(message)):
-            svds(np.eye(10), k=[], solver=self.solver)
+            svds(np.eye(10), k=[], solver=self.solver, rng=0)
 
         message = "invalid literal for int()"
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), k="hi", solver=self.solver)
+            svds(np.eye(10), k="hi", solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("tol", (-1, np.inf, np.nan))
     def test_svds_input_validation_tol_1(self, tol):
         message = "`tol` must be a non-negative floating point value."
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), tol=tol, solver=self.solver)
+            svds(np.eye(10), tol=tol, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("tol", ([], 'hi'))
     def test_svds_input_validation_tol_2(self, tol):
         # I think the stack trace is reasonable here
         message = "'<' not supported between instances"
         with pytest.raises(TypeError, match=message):
-            svds(np.eye(10), tol=tol, solver=self.solver)
+            svds(np.eye(10), tol=tol, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("which", ('LA', 'SA', 'ekki', 0))
     def test_svds_input_validation_which(self, which):
@@ -228,7 +228,7 @@ class SVDSCommonTests:
         # Function was not checking for eigenvalue type and unintended
         # values could be returned.
         with pytest.raises(ValueError, match="`which` must be in"):
-            svds(np.eye(10), which=which, solver=self.solver)
+            svds(np.eye(10), which=which, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("transpose", (True, False))
     @pytest.mark.parametrize("n", range(4, 9))
@@ -245,44 +245,44 @@ class SVDSCommonTests:
                            else min(A.shape))
         if n != required_length:
             with pytest.raises(ValueError, match=message):
-                svds(A, k=k, v0=v0, solver=self.solver)
+                svds(A, k=k, v0=v0, solver=self.solver, rng=0)
 
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
         message = "`v0` must have shape"
         with pytest.raises(ValueError, match=message):
-            svds(A, k=1, v0=v0, solver=self.solver)
+            svds(A, k=1, v0=v0, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("v0", ("hi", 1, np.ones(10, dtype=int)))
     def test_svds_input_validation_v0_3(self, v0):
         A = np.ones((10, 10))
         message = "`v0` must be of floating or complex floating data type."
         with pytest.raises(ValueError, match=message):
-            svds(A, k=1, v0=v0, solver=self.solver)
+            svds(A, k=1, v0=v0, solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("maxiter", (-1, 0, 5.5))
     def test_svds_input_validation_maxiter_1(self, maxiter):
         message = ("`maxiter` must be a positive integer.")
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), maxiter=maxiter, solver=self.solver)
+            svds(np.eye(10), maxiter=maxiter, solver=self.solver, rng=0)
 
     def test_svds_input_validation_maxiter_2(self):
         # I think the stack trace is reasonable when `k` can't be converted
         # to an int.
         message = "int() argument must be a"
         with pytest.raises(TypeError, match=re.escape(message)):
-            svds(np.eye(10), maxiter=[], solver=self.solver)
+            svds(np.eye(10), maxiter=[], solver=self.solver, rng=0)
 
         message = "invalid literal for int()"
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), maxiter="hi", solver=self.solver)
+            svds(np.eye(10), maxiter="hi", solver=self.solver, rng=0)
 
     @pytest.mark.parametrize("rsv", ('ekki', 10))
     def test_svds_input_validation_return_singular_vectors(self, rsv):
         message = "`return_singular_vectors` must be in"
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), return_singular_vectors=rsv, solver=self.solver)
+            svds(np.eye(10), return_singular_vectors=rsv, solver=self.solver, rng=0)
 
     # --- Test Parameters ---
 
@@ -459,17 +459,17 @@ class SVDSCommonTests:
         if self.solver == 'arpack':
             message = "ARPACK error -1: No convergence"
             with pytest.raises(ArpackNoConvergence, match=message):
-                svds(A, k, ncv=3, maxiter=1, solver=self.solver)
+                svds(A, k, ncv=3, maxiter=1, solver=self.solver, rng=0)
         elif self.solver == 'lobpcg':
             # Set maxiter higher so test passes without changing
             # default and breaking backward compatibility (gh-20221)
             maxiter = 30
             with pytest.warns(UserWarning, match="Exited at iteration"):
-                svds(A, k, maxiter=1, solver=self.solver)
+                svds(A, k, maxiter=1, solver=self.solver, rng=0)
         elif self.solver == 'propack':
             message = "k=1 singular triplets did not converge within"
             with pytest.raises(np.linalg.LinAlgError, match=message):
-                svds(A, k, maxiter=1, solver=self.solver)
+                svds(A, k, maxiter=1, solver=self.solver, rng=0)
 
         ud, sd, vhd = svds(A, k, solver=self.solver, maxiter=maxiter, rng=0)
         _check_svds(A, k, ud, sd, vhd, atol=1e-8)
@@ -824,7 +824,7 @@ class Test_SVDS_once:
     def test_svds_input_validation_solver(self, solver):
         message = "solver must be one of"
         with pytest.raises(ValueError, match=message):
-            svds(np.ones((3, 4)), k=2, solver=solver)
+            svds(np.ones((3, 4)), k=2, solver=solver, rng=0)
 
 
 class Test_SVDS_ARPACK(SVDSCommonTests):
@@ -845,18 +845,18 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         else:
             message = ("`ncv` must be an integer satisfying")
             with pytest.raises(ValueError, match=message):
-                svds(A, k=k, ncv=ncv, solver=self.solver)
+                svds(A, k=k, ncv=ncv, solver=self.solver, rng=0)
 
     def test_svds_input_validation_ncv_2(self):
         # I think the stack trace is reasonable when `ncv` can't be converted
         # to an int.
         message = "int() argument must be a"
         with pytest.raises(TypeError, match=re.escape(message)):
-            svds(np.eye(10), ncv=[], solver=self.solver)
+            svds(np.eye(10), ncv=[], solver=self.solver, rng=0)
 
         message = "invalid literal for int()"
         with pytest.raises(ValueError, match=message):
-            svds(np.eye(10), ncv="hi", solver=self.solver)
+            svds(np.eye(10), ncv="hi", solver=self.solver, rng=0)
 
     # I can't see a robust relationship between `ncv` and relevant outputs
     # (e.g. accuracy, time), so no test of the parameter.

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -405,9 +405,9 @@ class SVDSCommonTests:
             assert_equal(res1a, res1b)
 
     @pytest.mark.parametrize("rng", (0, 1,
-                                              np.random.RandomState(0),
-                                              np.random.default_rng(0)))
-    def test_svd_rng(self, rng):
+                                     np.random.RandomState(0),
+                                     np.random.default_rng(0)))
+    def test_svd_rng_2(self, rng):
         n = 100
         k = 1
 
@@ -424,8 +424,8 @@ class SVDSCommonTests:
         _check_svds(A, k, *res1a)
 
     @pytest.mark.parametrize("rng", (None,
-                                              np.random.RandomState(0),
-                                              np.random.default_rng(0)))
+                                     np.random.RandomState(0),
+                                     np.random.default_rng(0)))
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
     def test_svd_rng_3(self, rng):

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -17,7 +17,6 @@ __all__ = ['_svdp']
 
 import numpy as np
 
-from scipy._lib._util import check_random_state, _transition_to_rng
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg import LinAlgError
 
@@ -79,7 +78,6 @@ class _AProd:
             return self.A.matvec(np.zeros(self.A.shape[1])).dtype
 
 
-@_transition_to_rng("random_state", position_num=18)
 def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
           compute_u=True, compute_v=True, v0=None, full_output=False, tol=0,
           delta=None, eta=None, anorm=0, cgs=False, elr=True,
@@ -169,8 +167,6 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
-    rng = check_random_state(rng)
-
     which = which.upper()
     if which not in {'LM', 'SM'}:
         raise ValueError("`which` must be either 'LM' or 'SM'")

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -167,7 +167,7 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
-    if not isinstance(rng, np.random.Generator):
+    if rng is None:
         raise ValueError("`rng` must be a normalized numpy.random.Generator instance")
 
     which = which.upper()

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -167,7 +167,8 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
-    rng = np.random.default_rng(rng)
+    if not isinstance(rng, np.random.RandomState):
+        rng = np.random.default_rng(rng)
 
     which = which.upper()
     if which not in {'LM', 'SM'}:

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -17,7 +17,7 @@ __all__ = ['_svdp']
 
 import numpy as np
 
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, _transition_to_rng
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg import LinAlgError
 
@@ -79,10 +79,11 @@ class _AProd:
             return self.A.matvec(np.zeros(self.A.shape[1])).dtype
 
 
+@_transition_to_rng("random_state")
 def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
           compute_u=True, compute_v=True, v0=None, full_output=False, tol=0,
           delta=None, eta=None, anorm=0, cgs=False, elr=True,
-          min_relgap=0.002, shifts=None, maxiter=None, random_state=None):
+          min_relgap=0.002, shifts=None, maxiter=None, rng=None):
     """
     Compute the singular value decomposition of a linear operator using PROPACK
 
@@ -145,17 +146,11 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
     maxiter : int, optional
         Maximum number of restarts in IRL mode.  Default is ``1000``.
         Accessed only if ``irl_mode=True``.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        Pseudorandom number generator state used to generate resamples.
-
-        If `random_state` is ``None`` (or `np.random`), the
-        `numpy.random.RandomState` singleton is used.
-        If `random_state` is an int, a new ``RandomState`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` or ``RandomState``
-        instance then that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
     Returns
     -------
@@ -174,7 +169,7 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
-    random_state = check_random_state(random_state)
+    rng = check_random_state(rng)
 
     which = which.upper()
     if which not in {'LM', 'SM'}:
@@ -225,9 +220,9 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
     # a random starting vector: the random seed cannot be controlled in that
     # case, so we'll instead use numpy to generate a random vector
     if v0 is None:
-        u[:, 0] = random_state.uniform(size=m)
+        u[:, 0] = rng.uniform(size=m)
         if np.iscomplexobj(np.empty(0, dtype=typ)):  # complex type
-            u[:, 0] += 1j * random_state.uniform(size=m)
+            u[:, 0] += 1j * rng.uniform(size=m)
     else:
         try:
             u[:, 0] = v0

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -167,6 +167,8 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
+    rng = np.random.default_rng(rng)
+
     which = which.upper()
     if which not in {'LM', 'SM'}:
         raise ValueError("`which` must be either 'LM' or 'SM'")

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -79,7 +79,7 @@ class _AProd:
             return self.A.matvec(np.zeros(self.A.shape[1])).dtype
 
 
-@_transition_to_rng("random_state")
+@_transition_to_rng("random_state", position_num=18)
 def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
           compute_u=True, compute_v=True, v0=None, full_output=False, tol=0,
           delta=None, eta=None, anorm=0, cgs=False, elr=True,

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -167,8 +167,8 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         ``full_output=True``.
 
     """
-    if not isinstance(rng, np.random.RandomState):
-        rng = np.random.default_rng(rng)
+    if not isinstance(rng, np.random.Generator):
+        raise ValueError("`rng` must be a normalized numpy.random.Generator instance")
 
     which = which.upper()
     if which not in {'LM', 'SM'}:

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -115,7 +115,7 @@ def test_examples(dtype, irl):
             A = data['A_real'].item().astype(dtype)
 
     k = 200
-    u, s, vh, _ = _svdp(A, k, irl_mode=irl, random_state=0)
+    u, s, vh, _ = _svdp(A, k, irl_mode=irl, rng=0)
 
     # complex example matrix has many repeated singular values, so check only
     # beginning non-repeated singular vectors to avoid permutations

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -58,7 +58,7 @@ def check_svdp(n, m, constructor, dtype, k, irl_mode, which, f=0.8):
 
     u1, sigma1, vt1 = np.linalg.svd(M, full_matrices=False)
     u2, sigma2, vt2, _ = _svdp(Msp, k=k, which=which, irl_mode=irl_mode,
-                               tol=tol)
+                               tol=tol, rng=0)
 
     # check the which
     if which.upper() == 'SM':
@@ -142,24 +142,24 @@ def test_examples(dtype, irl):
 @pytest.mark.parametrize('shifts', (None, -10, 0, 1, 10, 70))
 @pytest.mark.parametrize('dtype', _dtypes[:2])
 def test_shifts(shifts, dtype):
-    np.random.seed(0)
+    rng = np.random.default_rng(0)
     n, k = 70, 10
-    A = np.random.random((n, n))
+    A = rng.random((n, n))
     if shifts is not None and ((shifts < 0) or (k > min(n-1-shifts, n))):
         with pytest.raises(ValueError):
-            _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True)
+            _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True, rng=rng)
     else:
-        _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True)
+        _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True, rng=rng)
 
 
 @pytest.mark.slow
 @pytest.mark.xfail()
 def test_shifts_accuracy():
-    np.random.seed(0)
+    rng = np.random.default_rng(0)
     n, k = 70, 10
-    A = np.random.random((n, n)).astype(np.float64)
-    u1, s1, vt1, _ = _svdp(A, k, shifts=None, which='SM', irl_mode=True)
-    u2, s2, vt2, _ = _svdp(A, k, shifts=32, which='SM', irl_mode=True)
+    A = rng.random((n, n)).astype(np.float64)
+    u1, s1, vt1, _ = _svdp(A, k, shifts=None, which='SM', irl_mode=True, rng=rng)
+    u2, s2, vt2, _ = _svdp(A, k, shifts=32, which='SM', irl_mode=True, rng=rng)
     # shifts <= 32 doesn't agree with shifts > 32
     # Does agree when which='LM' instead of 'SM'
     assert_allclose(s1, s2)

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -58,7 +58,7 @@ def check_svdp(n, m, constructor, dtype, k, irl_mode, which, f=0.8):
 
     u1, sigma1, vt1 = np.linalg.svd(M, full_matrices=False)
     u2, sigma2, vt2, _ = _svdp(Msp, k=k, which=which, irl_mode=irl_mode,
-                               tol=tol, rng=0)
+                               tol=tol, rng=np.random.default_rng(0))
 
     # check the which
     if which.upper() == 'SM':
@@ -115,7 +115,7 @@ def test_examples(dtype, irl):
             A = data['A_real'].item().astype(dtype)
 
     k = 200
-    u, s, vh, _ = _svdp(A, k, irl_mode=irl, rng=0)
+    u, s, vh, _ = _svdp(A, k, irl_mode=irl, rng=np.random.default_rng(0))
 
     # complex example matrix has many repeated singular values, so check only
     # beginning non-repeated singular vectors to avoid permutations


### PR DESCRIPTION
Reference issue
Toward https://github.com/scipy/scipy/issues/21833

What does this implement/fix?
This allows for use of new keyword rng alongside random_state in sparse.linalg.svds to prepare for the deprecation and removal of random_state and its legacy behavior.

In short:

if you pass the RNG argument by position or keyword random_state, it should work however it did before
if you pass a value val by keyword rng, it should behave as if you had passed np.random.default_rng(val) into the function.