### PR TITLE
DOC: io.loadmat: document `uint16_codec` parameter

### DIFF
--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -141,7 +141,8 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
         The codec to use for decoding characters, which are stored as uint16
         values. The default uses the system encoding, but this can be manually
         set to other values such as 'ascii', 'latin1', and 'utf-8'. This
-        parameter is only relevant for Mat 5 files.
+        parameter is relevant only for files stored as v6 and above, and not
+        for files stored as v4.
 
     Returns
     -------

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -137,6 +137,11 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
         of the result and not its contents (which is identical for both output
         structures). If True, this automatically sets `struct_as_record` to
         False and `squeeze_me` to True, which is required to simplify cells.
+    uint16_codec : str, optional
+        The codec to use for decoding characters, which are stored as uint16
+        values. The default uses the system encoding, but this can be manually
+        set to other values such as 'ascii', 'latin1', and 'utf-8'. This
+        parameter is only relevant for Mat 5 files.
 
     Returns
     -------


### PR DESCRIPTION
We recently had a .mat file that contained characters that could not be decoded with the default codec (see https://github.com/mne-tools/mne-python/pull/12971). Since this could be a relatively common use case, I think that the already existing `uint16_codec` should be documented, which I tried to do in this PR.

I do have a question regarding terminology though: the `uint16_codec` only exists for the `MatFile5Reader` class, which is a "reader for Mat 5 mat files". However, the note in the `loadmat` documentation mentions that "v4 (Level 1.0), v6 and v7 to 7.2 matfiles are supported". I am now unsure how to refer to these Mat 5 files (obviously these are not equal to v5, because this version does not seem to be supported at all).