### PR TITLE
BUG: integrate.trapezoid: fix broadcasting issue

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -136,11 +136,14 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
         d = dx
     else:
         x = _asarray(x, xp=xp, subok=True)
-        # reshape to correct shape
-        shape = [1] * y.ndim
-        shape[axis] = y.shape[axis]
-        x = xp.reshape(x, shape)
-        d = x[tuple(slice1)] - x[tuple(slice2)]
+        if x.ndim == 1:
+            d = x[1:] - x[:-1]
+            # make d broadcastable to y
+            slice3 = [None] * nd
+            slice3[axis] = slice(None)
+            d = d[tuple(slice3)]
+        else:
+            d = x[tuple(slice1)] - x[tuple(slice2)]
     try:
         ret = xp.sum(
             d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0,

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -143,6 +143,8 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
             slice3[axis] = slice(None)
             d = d[tuple(slice3)]
         else:
+            # if x is n-D it should be broadcastable to y
+            x = xp.broadcast_to(x, y.shape)
             d = x[tuple(slice1)] - x[tuple(slice2)]
     try:
         ret = xp.sum(

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -322,11 +322,11 @@ class TestTrapezoid:
     @pytest.mark.usefixtures("skip_xp_backends")
     def test_gh21908(self, xp):
         # extended testing for n-dim arrays
-        x = np.linspace(0, 29, 30).reshape(3, 10)
-        y = np.linspace(0, 29, 30).reshape(3, 10)
+        x = xp.reshape(xp.linspace(0, 29, 30), (3, 10))
+        y = xp.reshape(xp.linspace(0, 29, 30), (3, 10))
 
-        out0 = np.linspace(200, 380, 10)
-        assert_allclose(trapezoid(y, x=x, axis=0), out0)
+        out0 = xp.linspace(200, 380, 10)
+        xp_assert_close(trapezoid(y, x=x, axis=0), out0)
         assert_allclose(trapezoid(y, x=np.array([0, 10., 20.]), axis=0), out0)
         # x needs to be broadcastable against y
         assert_allclose(

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -327,20 +327,20 @@ class TestTrapezoid:
 
         out0 = xp.linspace(200, 380, 10)
         xp_assert_close(trapezoid(y, x=x, axis=0), out0)
-        assert_allclose(trapezoid(y, x=np.array([0, 10., 20.]), axis=0), out0)
+        xp_assert_close(trapezoid(y, x=xp.asarray([0, 10., 20.]), axis=0), out0)
         # x needs to be broadcastable against y
-        assert_allclose(
-            trapezoid(y, x=np.array([0, 10., 20.])[:, None], axis=0),
+        xp_assert_close(
+            trapezoid(y, x=xp.asarray([0, 10., 20.])[:, None], axis=0),
             out0
         )
         with pytest.raises(Exception):
             # x is not broadcastable against y
-            trapezoid(y, x=np.array([0, 10., 20.])[None, :], axis=0)
+            trapezoid(y, x=xp.asarray([0, 10., 20.])[None, :], axis=0)
 
-        out1 = np.array([ 40.5, 130.5, 220.5])
-        assert_allclose(trapezoid(y, x=x, axis=1), out1)
-        assert_allclose(
-            trapezoid(y, x=np.array(np.linspace(0, 9, 10)), axis=1),
+        out1 = xp.asarray([ 40.5, 130.5, 220.5])
+        xp_assert_close(trapezoid(y, x=x, axis=1), out1)
+        xp_assert_close(
+            trapezoid(y, x=xp.linspace(0, 9, 10), axis=1),
             out1
         )
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -309,14 +309,6 @@ class TestTrapezoid:
         r = trapezoid(q, x=z[None, None,:], axis=2)
         xp_assert_close(r, qz)
 
-        # n-d `x` but not the same as `y`
-        r = trapezoid(q, x=xp.reshape(x[:, None, None], (3, 1)), axis=0)
-        xp_assert_close(r, qx)
-        r = trapezoid(q, x=xp.reshape(y[None,:, None], (8, 1)), axis=1)
-        xp_assert_close(r, qy)
-        r = trapezoid(q, x=xp.reshape(z[None, None,:], (13, 1)), axis=2)
-        xp_assert_close(r, qz)
-
         # 1-d `x`
         r = trapezoid(q, x=x, axis=0)
         xp_assert_close(r, qx)
@@ -324,6 +316,25 @@ class TestTrapezoid:
         xp_assert_close(r, qy)
         r = trapezoid(q, x=z, axis=2)
         xp_assert_close(r, qz)
+
+    @skip_xp_backends('jax.numpy',
+                      reasons=["JAX arrays do not support item assignment"])
+    @pytest.mark.usefixtures("skip_xp_backends")
+    def test_gh21908(self, xp):
+        # extended testing for n-dim arrays
+        x = np.linspace(0, 29, 30).reshape(3, 10)
+        y = np.linspace(0, 29, 30).reshape(3, 10)
+
+        out0 = np.linspace(200, 380, 10)
+        assert_allclose(trapezoid(y, x=x, axis=0), out0)
+        assert_allclose(trapezoid(y, x=np.array([0, 10., 20.]), axis=0), out0)
+
+        out1 = np.array([ 40.5, 130.5, 220.5])
+        assert_allclose(trapezoid(y, x=x, axis=1), out1)
+        assert_allclose(
+            trapezoid(y, x=np.array(np.linspace(0, 9, 10)), axis=1),
+            out1
+        )
 
     @skip_xp_invalid_arg
     def test_masked(self, xp):

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -328,6 +328,13 @@ class TestTrapezoid:
         out0 = np.linspace(200, 380, 10)
         assert_allclose(trapezoid(y, x=x, axis=0), out0)
         assert_allclose(trapezoid(y, x=np.array([0, 10., 20.]), axis=0), out0)
+        # x needs to be broadcastable against y
+        assert_allclose(trapezoid(y, x=np.array([[0, 10., 20.]]), axis=0), out0)
+
+        with pytest.raises(ValueError):
+            # x is not broadcastable against y
+            trapezoid(y, x=np.array([[0, 10., 20.]])[:, None], axis=0)
+
 
         out1 = np.array([ 40.5, 130.5, 220.5])
         assert_allclose(trapezoid(y, x=x, axis=1), out1)
@@ -335,6 +342,8 @@ class TestTrapezoid:
             trapezoid(y, x=np.array(np.linspace(0, 9, 10)), axis=1),
             out1
         )
+
+
 
     @skip_xp_invalid_arg
     def test_masked(self, xp):

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -329,11 +329,13 @@ class TestTrapezoid:
         assert_allclose(trapezoid(y, x=x, axis=0), out0)
         assert_allclose(trapezoid(y, x=np.array([0, 10., 20.]), axis=0), out0)
         # x needs to be broadcastable against y
-        assert_allclose(trapezoid(y, x=np.array([[0, 10., 20.]]), axis=0), out0)
-
+        assert_allclose(
+            trapezoid(y, x=np.array([0, 10., 20.])[:, None], axis=0),
+            out0
+        )
         with pytest.raises(Exception):
             # x is not broadcastable against y
-            trapezoid(y, x=np.array([[0, 10., 20.]])[:, None], axis=0)
+            trapezoid(y, x=np.array([0, 10., 20.])[None, :], axis=0)
 
         out1 = np.array([ 40.5, 130.5, 220.5])
         assert_allclose(trapezoid(y, x=x, axis=1), out1)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -331,10 +331,9 @@ class TestTrapezoid:
         # x needs to be broadcastable against y
         assert_allclose(trapezoid(y, x=np.array([[0, 10., 20.]]), axis=0), out0)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             # x is not broadcastable against y
             trapezoid(y, x=np.array([[0, 10., 20.]])[:, None], axis=0)
-
 
         out1 = np.array([ 40.5, 130.5, 220.5])
         assert_allclose(trapezoid(y, x=x, axis=1), out1)
@@ -342,8 +341,6 @@ class TestTrapezoid:
             trapezoid(y, x=np.array(np.linspace(0, 9, 10)), axis=1),
             out1
         )
-
-
 
     @skip_xp_invalid_arg
     def test_masked(self, xp):


### PR DESCRIPTION
Closes #21908.

Fixes the 1-D case, and fixes another problem with the n-D case that wasn't picked up by our tests. The latter problem was that it wasn't possible to integrate with an `x` array that had exactly the same shape as `y`.

The only selection rule for `x` is that it needs to be broadcastable to `y` along the axis of integration.