### PR TITLE
MAINT: `spatial.transform.Rotation.random`: transition to `rng` keyword (SPEC 7)

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3,7 +3,7 @@
 import re
 import warnings
 import numpy as np
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, _transition_to_rng
 from ._rotation_groups import create_group
 
 cimport numpy as np
@@ -3185,7 +3185,8 @@ cdef class Rotation:
 
     @cython.embedsignature(True)
     @classmethod
-    def random(cls, num=None, random_state=None):
+    @_transition_to_rng('random_state', position_num=2)
+    def random(cls, num=None, rng=None):
         """Generate uniformly distributed rotations.
 
         Parameters
@@ -3193,15 +3194,11 @@ cdef class Rotation:
         num : int or None, optional
             Number of random rotations to generate. If None (default), then a
             single rotation is generated.
-        random_state : {None, int, `numpy.random.Generator`,
-                        `numpy.random.RandomState`}, optional
-
-            If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-            singleton is used.
-            If `seed` is an int, a new ``RandomState`` instance is used,
-            seeded with `seed`.
-            If `seed` is already a ``Generator`` or ``RandomState`` instance
-            then that instance is used.
+        rng : `numpy.random.Generator`, optional
+            Pseudorandom number generator state. When `rng` is None, a new
+            `numpy.random.Generator` is created using entropy from the
+            operating system. Types other than `numpy.random.Generator` are
+            passed to `numpy.random.default_rng` to instantiate a `Generator`.
 
         Returns
         -------
@@ -3238,12 +3235,12 @@ cdef class Rotation:
         scipy.stats.special_ortho_group
 
        """
-        random_state = check_random_state(random_state)
+        rng = check_random_state(rng)
 
         if num is None:
-            sample = random_state.normal(size=4)
+            sample = rng.normal(size=4)
         else:
-            sample = random_state.normal(size=(num, 4))
+            sample = rng.normal(size=(num, 4))
 
         return cls(sample)
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -882,6 +882,7 @@ def test_as_euler_degenerate_compare_algorithms(seq_tuple, intrinsic):
 def test_inv():
     rnd = np.random.RandomState(0)
     n = 10
+    # preserve use of old random_state during SPEC 7 transition
     p = Rotation.random(num=n, random_state=rnd)
     q = p.inv()
 
@@ -898,8 +899,8 @@ def test_inv():
 
 
 def test_inv_single_rotation():
-    rnd = np.random.RandomState(0)
-    p = Rotation.random(random_state=rnd)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    p = Rotation.random(rng=rng)
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -912,7 +913,7 @@ def test_inv_single_rotation():
     assert_array_almost_equal(res1, eye)
     assert_array_almost_equal(res2, eye)
 
-    x = Rotation.random(num=1, random_state=rnd)
+    x = Rotation.random(num=1, rng=rng)
     y = x.inv()
 
     x_matrix = x.as_matrix()
@@ -940,7 +941,7 @@ def test_single_identity_magnitude():
 
 def test_identity_invariance():
     n = 10
-    p = Rotation.random(n, random_state=0)
+    p = Rotation.random(n, rng=0)
 
     result = p * Rotation.identity(n)
     assert_array_almost_equal(p.as_quat(), result.as_quat())
@@ -951,7 +952,7 @@ def test_identity_invariance():
 
 def test_single_identity_invariance():
     n = 10
-    p = Rotation.random(n, random_state=0)
+    p = Rotation.random(n, rng=0)
 
     result = p * Rotation.identity()
     assert_array_almost_equal(p.as_quat(), result.as_quat())
@@ -980,9 +981,9 @@ def test_magnitude_single_rotation():
 
 
 def test_approx_equal():
-    rng = np.random.RandomState(0)
-    p = Rotation.random(10, random_state=rng)
-    q = Rotation.random(10, random_state=rng)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    p = Rotation.random(10, rng=rng)
+    q = Rotation.random(10, rng=rng)
     r = p * q.inv()
     r_mag = r.magnitude()
     atol = np.median(r_mag)  # ensure we get mix of Trues and Falses
@@ -1046,10 +1047,10 @@ def test_reduction_none_indices():
 
 
 def test_reduction_scalar_calculation():
-    rng = np.random.RandomState(0)
-    l = Rotation.random(5, random_state=rng)
-    r = Rotation.random(10, random_state=rng)
-    p = Rotation.random(7, random_state=rng)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    l = Rotation.random(5, rng=rng)
+    r = Rotation.random(10, rng=rng)
+    p = Rotation.random(7, rng=rng)
     reduced, left_best, right_best = p.reduce(l, r, return_indices=True)
 
     # Loop implementation of the vectorized calculation in Rotation.reduce
@@ -1201,23 +1202,23 @@ def test_setitem_single():
 
 
 def test_setitem_slice():
-    rng = np.random.RandomState(seed=0)
-    r1 = Rotation.random(10, random_state=rng)
-    r2 = Rotation.random(5, random_state=rng)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    r1 = Rotation.random(10, rng=rng)
+    r2 = Rotation.random(5, rng=rng)
     r1[1:6] = r2
     assert_equal(r1[1:6].as_quat(), r2.as_quat())
 
 
 def test_setitem_integer():
-    rng = np.random.RandomState(seed=0)
-    r1 = Rotation.random(10, random_state=rng)
-    r2 = Rotation.random(random_state=rng)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    r1 = Rotation.random(10, rng=rng)
+    r2 = Rotation.random(rng=rng)
     r1[1] = r2
     assert_equal(r1[1].as_quat(), r2.as_quat())
 
 
 def test_setitem_wrong_type():
-    r = Rotation.random(10, random_state=0)
+    r = Rotation.random(10, rng=0)
     with pytest.raises(TypeError, match='Rotation object'):
         r[0] = 1
 
@@ -1241,12 +1242,12 @@ def test_n_rotations():
 
 
 def test_random_rotation_shape():
-    rnd = np.random.RandomState(0)
-    assert_equal(Rotation.random(random_state=rnd).as_quat().shape, (4,))
-    assert_equal(Rotation.random(None, random_state=rnd).as_quat().shape, (4,))
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    assert_equal(Rotation.random(rng=rng).as_quat().shape, (4,))
+    assert_equal(Rotation.random(None, rng=rng).as_quat().shape, (4,))
 
-    assert_equal(Rotation.random(1, random_state=rnd).as_quat().shape, (1, 4))
-    assert_equal(Rotation.random(5, random_state=rnd).as_quat().shape, (5, 4))
+    assert_equal(Rotation.random(1, rng=rng).as_quat().shape, (1, 4))
+    assert_equal(Rotation.random(5, rng=rng).as_quat().shape, (5, 4))
 
 
 def test_align_vectors_no_rotation():
@@ -1259,9 +1260,9 @@ def test_align_vectors_no_rotation():
 
 
 def test_align_vectors_no_noise():
-    rnd = np.random.RandomState(0)
-    c = Rotation.random(random_state=rnd)
-    b = rnd.normal(size=(5, 3))
+    rng = np.random.default_rng(14697284569885399755764481408308808739)
+    c = Rotation.random(rng=rng)
+    b = rng.normal(size=(5, 3))
     a = c.apply(b)
 
     est, rssd = Rotation.align_vectors(a, b)
@@ -1296,8 +1297,8 @@ def test_align_vectors_rssd_sensitivity():
 
 def test_align_vectors_scaled_weights():
     n = 10
-    a = Rotation.random(n, random_state=0).apply([1, 0, 0])
-    b = Rotation.random(n, random_state=1).apply([1, 0, 0])
+    a = Rotation.random(n, rng=0).apply([1, 0, 0])
+    b = Rotation.random(n, rng=1).apply([1, 0, 0])
     scale = 2
 
     est1, rssd1, cov1 = Rotation.align_vectors(a, b, np.ones(n), True)
@@ -1309,17 +1310,17 @@ def test_align_vectors_scaled_weights():
 
 
 def test_align_vectors_noise():
-    rnd = np.random.RandomState(0)
+    rng = np.random.default_rng(146972845698875399755764481408308808739)
     n_vectors = 100
-    rot = Rotation.random(random_state=rnd)
-    vectors = rnd.normal(size=(n_vectors, 3))
+    rot = Rotation.random(rng=rng)
+    vectors = rng.normal(size=(n_vectors, 3))
     result = rot.apply(vectors)
 
     # The paper adds noise as independently distributed angular errors
     sigma = np.deg2rad(1)
     tolerance = 1.5 * sigma
     noise = Rotation.from_rotvec(
-        rnd.normal(
+        rng.normal(
             size=(n_vectors, 3),
             scale=sigma
         )
@@ -1433,7 +1434,7 @@ def test_align_vectors_near_inf():
     n = 100
     mats = []
     for i in range(6):
-        mats.append(Rotation.random(n, random_state=10 + i).as_matrix())
+        mats.append(Rotation.random(n, rng=10 + i).as_matrix())
 
     for i in range(n):
         # Get random pairs of 3-element vectors
@@ -1491,7 +1492,7 @@ def test_align_vectors_antiparallel():
         assert_allclose(R.apply(b[0]), a[0], atol=atol)
 
     # Test exact rotations near 180 deg
-    Rs = Rotation.random(100, random_state=0)
+    Rs = Rotation.random(100, rng=0)
     dRs = Rotation.from_rotvec(Rs.as_rotvec()*1e-4)  # scale down to small angle
     a = [[ 1, 0, 0], [0, 1, 0]]
     b = [[-1, 0, 0], [0, 1, 0]]
@@ -1506,8 +1507,8 @@ def test_align_vectors_antiparallel():
 
 def test_align_vectors_primary_only():
     atol = 1e-12
-    mats_a = Rotation.random(100, random_state=0).as_matrix()
-    mats_b = Rotation.random(100, random_state=1).as_matrix()
+    mats_a = Rotation.random(100, rng=0).as_matrix()
+    mats_b = Rotation.random(100, rng=1).as_matrix()
     for mat_a, mat_b in zip(mats_a, mats_b):
         # Get random 3-element unit vectors
         a = mat_a[0]
@@ -1658,8 +1659,8 @@ def test_slerp_call_scalar_time():
 
 
 def test_multiplication_stability():
-    qs = Rotation.random(50, random_state=0)
-    rs = Rotation.random(1000, random_state=1)
+    qs = Rotation.random(50, rng=0)
+    rs = Rotation.random(1000, rng=1)
     for q in qs:
         rs *= q * rs
         assert_allclose(np.linalg.norm(rs.as_quat(), axis=1), 1)
@@ -1667,7 +1668,7 @@ def test_multiplication_stability():
 
 def test_pow():
     atol = 1e-14
-    p = Rotation.random(10, random_state=0)
+    p = Rotation.random(10, rng=0)
     p_inv = p.inv()
     # Test the short-cuts and other integers
     for n in [-5, -2, -1, 0, 1, 2, 5]:
@@ -1703,14 +1704,14 @@ def test_pow():
 
 
 def test_pow_errors():
-    p = Rotation.random(random_state=0)
+    p = Rotation.random(rng=0)
     with pytest.raises(NotImplementedError, match='modulus not supported'):
         pow(p, 1, 1)
 
 
 def test_rotation_within_numpy_array():
-    single = Rotation.random(random_state=0)
-    multiple = Rotation.random(2, random_state=1)
+    single = Rotation.random(rng=0)
+    multiple = Rotation.random(2, rng=1)
 
     array = np.array(single)
     assert_equal(array.shape, ())
@@ -1762,7 +1763,7 @@ def test_as_euler_contiguous():
 
 
 def test_concatenate():
-    rotation = Rotation.random(10, random_state=0)
+    rotation = Rotation.random(10, rng=0)
     sizes = [1, 2, 3, 1, 3]
     starts = [0] + list(np.cumsum(sizes))
     split = [rotation[i:i + n] for i, n in zip(starts, sizes)]


### PR DESCRIPTION
#### Reference issue
Toward gh-21833

#### What does this implement/fix?
This allows for use of new keyword `rng` alongside `random_state` in `spatial.transform.Rotation.random` to prepare for the deprecation and removal of `random_state` and its legacy behavior.