### PR TITLE
BLD: fortran: only use `-std=legacy` for gfortran

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ project(
     'b_ndebug=if-release',
     'c_std=c17',
     'cpp_std=c++17',
-    'fortran_std=legacy',
     'blas=openblas',
     'lapack=openblas'
   ],
@@ -80,6 +79,13 @@ endif
 # Adding at project level causes many spurious -lgfortran flags.
 add_languages('fortran', native: false)
 ff = meson.get_compiler('fortran')
+if ff.get_id() == 'gcc'
+  # -std=legacy is not supported by all Fortran compilers, but very useful with
+  # gfortran since it avoids a ton of warnings that we don't care about.
+  # Needs fixing in Meson, see https://github.com/mesonbuild/meson/issues/11633.
+  add_project_arguments('-std=legacy', language: 'fortran')
+endif
+
 if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif


### PR DESCRIPTION
Support in other compilers for this flag is quite patchy, leading to build errors and requiring workarounds in distros - see for example:

- https://github.com/scipy/scipy/issues/19447
- https://github.com/mesonbuild/meson/issues/12306
- https://github.com/conda-forge/scipy-feedstock/blob/1a8ff378bebd3f0b0bc6a2d1662a77d194ac59a1/recipe/bld.bat#L25
- https://github.com/spack/spack/blob/73316c3e286d548b22dc65667810e4631479c3ea/var/spack/repos/builtin/packages/py-scipy/package.py#L235-L238

Compilers that do not support it include at least Flang and AOCC (the AMD Fortran compiler).

This should be fixed upstream in Meson by not passing the flag for compilers that don't support it, and then we can revert this change. But for now it's very useful to avoid bothering users of these compilers with having to override that flag manually.

This does give the following warning with `gfortran` now, but that can't be helped unfortunately:
```
WARNING: Consider using the built-in option for language standard version instead of using "-std=legacy".
```