### PR TITLE
ENH: linalg: Add condeig function (#21688)

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -14,7 +14,7 @@
 
 __all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
            'eig_banded', 'eigvals_banded',
-           'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf']
+           'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf', 'condeig']
 
 import numpy as np
 from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
@@ -1630,3 +1630,45 @@ def cdf2rdf(w, v):
     vr = einsum('...ij,...jk->...ik', v, u).real
 
     return wr, vr
+
+
+def condeig(a):
+    """
+    Calculate condition numbers for the eigenvalues of a matrix.
+
+    Condition numbers for the eigenvalues are calculated as the reciprocals
+    of the cosine of the angles between the left and right eigenvectors of
+    the matrix.
+
+    Parameters
+    ----------
+    a : (M, M) array_like
+        A complex or real matrix whose condition numbers with respect to
+        eigenvalues is to be computed.
+
+    Returns
+    -------
+    c : (M,) double or complex ndarray
+        The condition numbers of the matrix with respect to the
+        eigenvalues.
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue computation does not converge.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy import linalg
+    >>> a = np.array([[1., 2.],[3., 4.]])
+    >>> linalg.condeig(a)
+    >>> array([1.01503844, 1.01503844])
+
+    >>> a = np.array([[1.+1j, 2.+2j],[3.+3j, 4.+4j]])
+    >>> linalg.condeig(a)
+    >>> array([1.01503844+2.37909035e-17j, 1.01503844+2.47462652e-17j])
+
+    """
+    _, vl, vr = eig(a, left=True)
+    return np.reciprocal(np.sum(vl * vr, axis=0))

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -9,7 +9,7 @@ __all__ = [  # noqa: F822
     'eig', 'eigvals', 'eigh', 'eigvalsh',
     'eig_banded', 'eigvals_banded',
     'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf',
-    'LinAlgError', 'norm', 'get_lapack_funcs'
+    'condeig', 'LinAlgError', 'norm', 'get_lapack_funcs'
 ]
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-21688.
#### What does this implement/fix?
<!--Please explain your changes.-->
This adds a new function `condeig` to linalg. This is used to calculate the condition numbers of the matrix with respect to its eigenvalues. Condition numbers for the eigenvalues are calculated as the reciprocal of the cosine of the angles between the left and right eigenvectors of the matrix.
#### Additional information
<!--Any additional information you think is important.-->
References:
[1] Matlab's [condeig](https://uk.mathworks.com/help/matlab/ref/condeig.html)
[2] GNU Octave's [condeig](https://octave.sourceforge.io/octave/function/condeig.html)