### PR TITLE
MAINT: bump array-api-extra to 0.2.0

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -38,7 +38,6 @@ __all__ = [
     'xp_copy', 'xp_copysign', 'xp_device',
     'xp_moveaxis_to_end', 'xp_ravel', 'xp_real', 'xp_sign', 'xp_size',
     'xp_take_along_axis', 'xp_unsupported_param_msg', 'xp_vector_norm',
-    'xp_create_diagonal'
 ]
 
 
@@ -591,12 +590,3 @@ def xp_float_to_complex(arr: Array, xp: ModuleType | None = None) -> Array:
         arr = xp.astype(arr, xp.complex128)
 
     return arr
-
-def xp_create_diagonal(x: Array, /, *, offset: int = 0,
-                       xp: ModuleType | None = None) -> Array:
-    xp = array_namespace(x) if xp is None else xp
-    n = x.shape[0] + abs(offset)
-    diag = xp.zeros(n**2, dtype=x.dtype)
-    i = offset if offset >= 0 else abs(offset) * n
-    diag[i:min(n*(n-offset), diag.shape[0]):n+1] = x
-    return xp.reshape(diag, (n, n))

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -4,10 +4,9 @@ import pytest
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
-    xp_create_diagonal
+    np_compat,
 )
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
-import scipy._lib.array_api_compat.numpy as np_compat
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -186,17 +185,3 @@ class TestArrayAPI:
         # scalars-vs-0d passes (if values match) also with regular python objects
         xp_assert_equal_no_0d(0., xp.asarray(0.))
         xp_assert_equal_no_0d(42, xp.asarray(42))
-
-    @skip_xp_backends('jax.numpy',
-                      reasons=["JAX arrays do not support item assignment"])
-    @pytest.mark.usefixtures("skip_xp_backends")
-    @array_api_compatible
-    @pytest.mark.parametrize('n', range(1, 10))
-    @pytest.mark.parametrize('offset', range(1, 10))
-    def test_create_diagonal(self, n, offset, xp):
-        rng = np.random.default_rng(2347823)
-        one = xp.asarray(1.)
-        x = rng.random(n)
-        A = xp_create_diagonal(xp.asarray(x, dtype=one.dtype), offset=offset, xp=xp)
-        B = xp.asarray(np.diag(x, offset), dtype=one.dtype)
-        xp_assert_equal(A, B)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -41,7 +41,7 @@ from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._util import (MapWrapper, check_random_state, _RichResult,
                               _call_callback_maybe_halt, _transition_to_rng)
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy._lib._array_api import array_namespace, xp_create_diagonal
+from scipy._lib._array_api import array_namespace
 from scipy._lib import array_api_extra as xpx
 
 
@@ -445,13 +445,13 @@ def rosen_hess(x):
     x = xpx.atleast_nd(x, ndim=1, xp=xp)
     if xp.isdtype(x.dtype, 'integral'):
         x = xp.astype(x, xp.asarray(1.).dtype)
-    H = (xp_create_diagonal(-400 * x[:-1], offset=1, xp=xp) 
-         - xp_create_diagonal(400 * x[:-1], offset=-1, xp=xp))
+    H = (xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp) 
+         - xpx.create_diagonal(400 * x[:-1], offset=-1, xp=xp))
     diagonal = xp.zeros(x.shape[0], dtype=x.dtype)
     diagonal[0] = 1200 * x[0]**2 - 400 * x[1] + 2
     diagonal[-1] = 200
     diagonal[1:-1] = 202 + 1200 * x[1:-1]**2 - 400 * x[2:]
-    return H + xp_create_diagonal(diagonal, xp=xp)
+    return H + xpx.create_diagonal(diagonal, xp=xp)
 
 
 def rosen_hess_prod(x, p):


### PR DESCRIPTION
No need to store our own `create_diagonal` any more.