### PR TITLE
MAINT: stats.qmc: transition to rng (SPEC 7)

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1283,228 +1283,228 @@ class Halton(QMCEngine):
 class LatinHypercube(QMCEngine):
     r"""Latin hypercube sampling (LHS).
 
-        A Latin hypercube sample [1]_ generates :math:`n` points in
-        :math:`[0,1)^{d}`. Each univariate marginal distribution is stratified,
-        placing exactly one point in :math:`[j/n, (j+1)/n)` for
-        :math:`j=0,1,...,n-1`. They are still applicable when :math:`n << d`.
+    A Latin hypercube sample [1]_ generates :math:`n` points in
+    :math:`[0,1)^{d}`. Each univariate marginal distribution is stratified,
+    placing exactly one point in :math:`[j/n, (j+1)/n)` for
+    :math:`j=0,1,...,n-1`. They are still applicable when :math:`n << d`.
 
-        Parameters
-        ----------
-        d : int
-            Dimension of the parameter space.
-        scramble : bool, optional
-            When False, center samples within cells of a multi-dimensional grid.
-            Otherwise, samples are randomly placed within cells of the grid.
+    Parameters
+    ----------
+    d : int
+        Dimension of the parameter space.
+    scramble : bool, optional
+        When False, center samples within cells of a multi-dimensional grid.
+        Otherwise, samples are randomly placed within cells of the grid.
 
-            .. note::
-                Setting ``scramble=False`` does not ensure deterministic output.
-                For that, use the `rng` parameter.
+        .. note::
+            Setting ``scramble=False`` does not ensure deterministic output.
+            For that, use the `rng` parameter.
 
-            Default is True.
+        Default is True.
 
-            .. versionadded:: 1.10.0
+        .. versionadded:: 1.10.0
 
-        optimization : {None, "random-cd", "lloyd"}, optional
-            Whether to use an optimization scheme to improve the quality after
-            sampling. Note that this is a post-processing step that does not
-            guarantee that all properties of the sample will be conserved.
-            Default is None.
+    optimization : {None, "random-cd", "lloyd"}, optional
+        Whether to use an optimization scheme to improve the quality after
+        sampling. Note that this is a post-processing step that does not
+        guarantee that all properties of the sample will be conserved.
+        Default is None.
 
-            * ``random-cd``: random permutations of coordinates to lower the
-              centered discrepancy. The best sample based on the centered
-              discrepancy is constantly updated. Centered discrepancy-based
-              sampling shows better space-filling robustness toward 2D and 3D
-              subprojections compared to using other discrepancy measures.
-            * ``lloyd``: Perturb samples using a modified Lloyd-Max algorithm.
-              The process converges to equally spaced samples.
+        * ``random-cd``: random permutations of coordinates to lower the
+          centered discrepancy. The best sample based on the centered
+          discrepancy is constantly updated. Centered discrepancy-based
+          sampling shows better space-filling robustness toward 2D and 3D
+          subprojections compared to using other discrepancy measures.
+        * ``lloyd``: Perturb samples using a modified Lloyd-Max algorithm.
+          The process converges to equally spaced samples.
 
-            .. versionadded:: 1.8.0
-            .. versionchanged:: 1.10.0
-                Add ``lloyd``.
+        .. versionadded:: 1.8.0
+        .. versionchanged:: 1.10.0
+            Add ``lloyd``.
 
-        strength : {1, 2}, optional
-            Strength of the LHS. ``strength=1`` produces a plain LHS while
-            ``strength=2`` produces an orthogonal array based LHS of strength 2
-            [7]_, [8]_. In that case, only ``n=p**2`` points can be sampled,
-            with ``p`` a prime number. It also constrains ``d <= p + 1``.
-            Default is 1.
+    strength : {1, 2}, optional
+        Strength of the LHS. ``strength=1`` produces a plain LHS while
+        ``strength=2`` produces an orthogonal array based LHS of strength 2
+        [7]_, [8]_. In that case, only ``n=p**2`` points can be sampled,
+        with ``p`` a prime number. It also constrains ``d <= p + 1``.
+        Default is 1.
 
-            .. versionadded:: 1.8.0
+        .. versionadded:: 1.8.0
 
-        rng : `numpy.random.Generator`, optional
-            Pseudorandom number generator state. When `rng` is None, a new
-            `numpy.random.Generator` is created using entropy from the
-            operating system. Types other than `numpy.random.Generator` are
-            passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
-            .. versionchanged:: 1.15.0
+        .. versionchanged:: 1.15.0
 
-                As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
-                transition from use of `numpy.random.RandomState` to
-                `numpy.random.Generator`, this keyword was changed from `seed` to
-                `rng`. For an interim period, both keywords will continue to work, although
-                only one may be specified at a time. After the interim period, function
-                calls using the `seed` keyword will emit warnings. Following a
-                deprecation period, the `seed` keyword will be removed.
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
-        See Also
-        --------
-        :ref:`quasi-monte-carlo`
+    See Also
+    --------
+    :ref:`quasi-monte-carlo`
 
-        Notes
-        -----
+    Notes
+    -----
 
-        When LHS is used for integrating a function :math:`f` over :math:`n`,
-        LHS is extremely effective on integrands that are nearly additive [2]_.
-        With a LHS of :math:`n` points, the variance of the integral is always
-        lower than plain MC on :math:`n-1` points [3]_. There is a central limit
-        theorem for LHS on the mean and variance of the integral [4]_, but not
-        necessarily for optimized LHS due to the randomization.
+    When LHS is used for integrating a function :math:`f` over :math:`n`,
+    LHS is extremely effective on integrands that are nearly additive [2]_.
+    With a LHS of :math:`n` points, the variance of the integral is always
+    lower than plain MC on :math:`n-1` points [3]_. There is a central limit
+    theorem for LHS on the mean and variance of the integral [4]_, but not
+    necessarily for optimized LHS due to the randomization.
 
-        :math:`A` is called an orthogonal array of strength :math:`t` if in each
-        n-row-by-t-column submatrix of :math:`A`: all :math:`p^t` possible
-        distinct rows occur the same number of times. The elements of :math:`A`
-        are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
-        The constraint that :math:`p` must be a prime number is to allow modular
-        arithmetic. Increasing strength adds some symmetry to the sub-projections
-        of a sample. With strength 2, samples are symmetric along the diagonals of
-        2D sub-projections. This may be undesirable, but on the other hand, the
-        sample dispersion is improved.
+    :math:`A` is called an orthogonal array of strength :math:`t` if in each
+    n-row-by-t-column submatrix of :math:`A`: all :math:`p^t` possible
+    distinct rows occur the same number of times. The elements of :math:`A`
+    are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
+    The constraint that :math:`p` must be a prime number is to allow modular
+    arithmetic. Increasing strength adds some symmetry to the sub-projections
+    of a sample. With strength 2, samples are symmetric along the diagonals of
+    2D sub-projections. This may be undesirable, but on the other hand, the
+    sample dispersion is improved.
 
-        Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
-        strength 2 is a useful increment over strength 1. Going to strength 3 is
-        a smaller increment and scrambled QMC like Sobol', Halton are more
-        performant [7]_.
+    Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
+    strength 2 is a useful increment over strength 1. Going to strength 3 is
+    a smaller increment and scrambled QMC like Sobol', Halton are more
+    performant [7]_.
 
-        To create a LHS of strength 2, the orthogonal array :math:`A` is
-        randomized by applying a random, bijective map of the set of symbols onto
-        itself. For example, in column 0, all 0s might become 2; in column 1,
-        all 0s might become 1, etc.
-        Then, for each column :math:`i` and symbol :math:`j`, we add a plain,
-        one-dimensional LHS of size :math:`p` to the subarray where
-        :math:`A^i = j`. The resulting matrix is finally divided by :math:`p`.
+    To create a LHS of strength 2, the orthogonal array :math:`A` is
+    randomized by applying a random, bijective map of the set of symbols onto
+    itself. For example, in column 0, all 0s might become 2; in column 1,
+    all 0s might become 1, etc.
+    Then, for each column :math:`i` and symbol :math:`j`, we add a plain,
+    one-dimensional LHS of size :math:`p` to the subarray where
+    :math:`A^i = j`. The resulting matrix is finally divided by :math:`p`.
 
-        References
-        ----------
-        .. [1] Mckay et al., "A Comparison of Three Methods for Selecting Values
-           of Input Variables in the Analysis of Output from a Computer Code."
-           Technometrics, 1979.
-        .. [2] M. Stein, "Large sample properties of simulations using Latin
-           hypercube sampling." Technometrics 29, no. 2: 143-151, 1987.
-        .. [3] A. B. Owen, "Monte Carlo variance of scrambled net quadrature."
-           SIAM Journal on Numerical Analysis 34, no. 5: 1884-1910, 1997
-        .. [4]  Loh, W.-L. "On Latin hypercube sampling." The annals of statistics
-           24, no. 5: 2058-2080, 1996.
-        .. [5] Fang et al. "Design and modeling for computer experiments".
-           Computer Science and Data Analysis Series, 2006.
-        .. [6] Damblin et al., "Numerical studies of space filling designs:
-           optimization of Latin Hypercube Samples and subprojection properties."
-           Journal of Simulation, 2013.
-        .. [7] A. B. Owen , "Orthogonal arrays for computer experiments,
-           integration and visualization." Statistica Sinica, 1992.
-        .. [8] B. Tang, "Orthogonal Array-Based Latin Hypercubes."
-           Journal of the American Statistical Association, 1993.
-        .. [9] Seaholm, Susan K. et al. (1988). Latin hypercube sampling and the
-           sensitivity analysis of a Monte Carlo epidemic model. Int J Biomed
-           Comput, 23(1-2), 97-112. :doi:`10.1016/0020-7101(88)90067-0`
+    References
+    ----------
+    .. [1] Mckay et al., "A Comparison of Three Methods for Selecting Values
+       of Input Variables in the Analysis of Output from a Computer Code."
+       Technometrics, 1979.
+    .. [2] M. Stein, "Large sample properties of simulations using Latin
+       hypercube sampling." Technometrics 29, no. 2: 143-151, 1987.
+    .. [3] A. B. Owen, "Monte Carlo variance of scrambled net quadrature."
+       SIAM Journal on Numerical Analysis 34, no. 5: 1884-1910, 1997
+    .. [4]  Loh, W.-L. "On Latin hypercube sampling." The annals of statistics
+       24, no. 5: 2058-2080, 1996.
+    .. [5] Fang et al. "Design and modeling for computer experiments".
+       Computer Science and Data Analysis Series, 2006.
+    .. [6] Damblin et al., "Numerical studies of space filling designs:
+       optimization of Latin Hypercube Samples and subprojection properties."
+       Journal of Simulation, 2013.
+    .. [7] A. B. Owen , "Orthogonal arrays for computer experiments,
+       integration and visualization." Statistica Sinica, 1992.
+    .. [8] B. Tang, "Orthogonal Array-Based Latin Hypercubes."
+       Journal of the American Statistical Association, 1993.
+    .. [9] Seaholm, Susan K. et al. (1988). Latin hypercube sampling and the
+       sensitivity analysis of a Monte Carlo epidemic model. Int J Biomed
+       Comput, 23(1-2), 97-112. :doi:`10.1016/0020-7101(88)90067-0`
 
-        Examples
-        --------
-        Generate samples from a Latin hypercube generator.
+    Examples
+    --------
+    Generate samples from a Latin hypercube generator.
 
-        >>> from scipy.stats import qmc
-        >>> sampler = qmc.LatinHypercube(d=2)
-        >>> sample = sampler.random(n=5)
-        >>> sample
-        array([[0.1545328 , 0.53664833], # random
-                [0.84052691, 0.06474907],
-                [0.52177809, 0.93343721],
-                [0.68033825, 0.36265316],
-                [0.26544879, 0.61163943]])
+    >>> from scipy.stats import qmc
+    >>> sampler = qmc.LatinHypercube(d=2)
+    >>> sample = sampler.random(n=5)
+    >>> sample
+    array([[0.1545328 , 0.53664833], # random
+            [0.84052691, 0.06474907],
+            [0.52177809, 0.93343721],
+            [0.68033825, 0.36265316],
+            [0.26544879, 0.61163943]])
 
-        Compute the quality of the sample using the discrepancy criterion.
+    Compute the quality of the sample using the discrepancy criterion.
 
-        >>> qmc.discrepancy(sample)
-        0.0196... # random
+    >>> qmc.discrepancy(sample)
+    0.0196... # random
 
-        Samples can be scaled to bounds.
+    Samples can be scaled to bounds.
 
-        >>> l_bounds = [0, 2]
-        >>> u_bounds = [10, 5]
-        >>> qmc.scale(sample, l_bounds, u_bounds)
-        array([[1.54532796, 3.609945 ], # random
-                [8.40526909, 2.1942472 ],
-                [5.2177809 , 4.80031164],
-                [6.80338249, 3.08795949],
-                [2.65448791, 3.83491828]])
+    >>> l_bounds = [0, 2]
+    >>> u_bounds = [10, 5]
+    >>> qmc.scale(sample, l_bounds, u_bounds)
+    array([[1.54532796, 3.609945 ], # random
+            [8.40526909, 2.1942472 ],
+            [5.2177809 , 4.80031164],
+            [6.80338249, 3.08795949],
+            [2.65448791, 3.83491828]])
 
-        Below are other examples showing alternative ways to construct LHS with
-        even better coverage of the space.
+    Below are other examples showing alternative ways to construct LHS with
+    even better coverage of the space.
 
-        Using a base LHS as a baseline.
+    Using a base LHS as a baseline.
 
-        >>> sampler = qmc.LatinHypercube(d=2)
-        >>> sample = sampler.random(n=5)
-        >>> qmc.discrepancy(sample)
-        0.0196...  # random
+    >>> sampler = qmc.LatinHypercube(d=2)
+    >>> sample = sampler.random(n=5)
+    >>> qmc.discrepancy(sample)
+    0.0196...  # random
 
-        Use the `optimization` keyword argument to produce a LHS with
-        lower discrepancy at higher computational cost.
+    Use the `optimization` keyword argument to produce a LHS with
+    lower discrepancy at higher computational cost.
 
-        >>> sampler = qmc.LatinHypercube(d=2, optimization="random-cd")
-        >>> sample = sampler.random(n=5)
-        >>> qmc.discrepancy(sample)
-        0.0176...  # random
+    >>> sampler = qmc.LatinHypercube(d=2, optimization="random-cd")
+    >>> sample = sampler.random(n=5)
+    >>> qmc.discrepancy(sample)
+    0.0176...  # random
 
-        Use the `strength` keyword argument to produce an orthogonal array based
-        LHS of strength 2. In this case, the number of sample points must be the
-        square of a prime number.
+    Use the `strength` keyword argument to produce an orthogonal array based
+    LHS of strength 2. In this case, the number of sample points must be the
+    square of a prime number.
 
-        >>> sampler = qmc.LatinHypercube(d=2, strength=2)
-        >>> sample = sampler.random(n=9)
-        >>> qmc.discrepancy(sample)
-        0.00526...  # random
+    >>> sampler = qmc.LatinHypercube(d=2, strength=2)
+    >>> sample = sampler.random(n=9)
+    >>> qmc.discrepancy(sample)
+    0.00526...  # random
 
-        Options could be combined to produce an optimized centered
-        orthogonal array based LHS. After optimization, the result would not
-        be guaranteed to be of strength 2.
+    Options could be combined to produce an optimized centered
+    orthogonal array based LHS. After optimization, the result would not
+    be guaranteed to be of strength 2.
 
-        **Real-world example**
+    **Real-world example**
 
-        In [9]_, a Latin Hypercube sampling (LHS) strategy was used to sample a
-        parameter space to study the importance of each parameter of an epidemic
-        model. Such analysis is also called a sensitivity analysis.
+    In [9]_, a Latin Hypercube sampling (LHS) strategy was used to sample a
+    parameter space to study the importance of each parameter of an epidemic
+    model. Such analysis is also called a sensitivity analysis.
 
-        Since the dimensionality of the problem is high (6), it is computationally
-        expensive to cover the space. When numerical experiments are costly, QMC
-        enables analysis that may not be possible if using a grid.
+    Since the dimensionality of the problem is high (6), it is computationally
+    expensive to cover the space. When numerical experiments are costly, QMC
+    enables analysis that may not be possible if using a grid.
 
-        The six parameters of the model represented the probability of illness,
-        the probability of withdrawal, and four contact probabilities. The
-        authors assumed uniform distributions for all parameters and generated
-        50 samples.
+    The six parameters of the model represented the probability of illness,
+    the probability of withdrawal, and four contact probabilities. The
+    authors assumed uniform distributions for all parameters and generated
+    50 samples.
 
-        Using `scipy.stats.qmc.LatinHypercube` to replicate the protocol,
-        the first step is to create a sample in the unit hypercube:
+    Using `scipy.stats.qmc.LatinHypercube` to replicate the protocol,
+    the first step is to create a sample in the unit hypercube:
 
-        >>> from scipy.stats import qmc
-        >>> sampler = qmc.LatinHypercube(d=6)
-        >>> sample = sampler.random(n=50)
+    >>> from scipy.stats import qmc
+    >>> sampler = qmc.LatinHypercube(d=6)
+    >>> sample = sampler.random(n=50)
 
-        Then the sample can be scaled to the appropriate bounds:
+    Then the sample can be scaled to the appropriate bounds:
 
-        >>> l_bounds = [0.000125, 0.01, 0.0025, 0.05, 0.47, 0.7]
-        >>> u_bounds = [0.000375, 0.03, 0.0075, 0.15, 0.87, 0.9]
-        >>> sample_scaled = qmc.scale(sample, l_bounds, u_bounds)
+    >>> l_bounds = [0.000125, 0.01, 0.0025, 0.05, 0.47, 0.7]
+    >>> u_bounds = [0.000375, 0.03, 0.0075, 0.15, 0.87, 0.9]
+    >>> sample_scaled = qmc.scale(sample, l_bounds, u_bounds)
 
-        Such a sample was used to run the model 50 times, and a polynomial
-        response surface was constructed. This allowed the authors to study the
-        relative importance of each parameter across the range of possibilities
-        of every other parameter.
+    Such a sample was used to run the model 50 times, and a polynomial
+    response surface was constructed. This allowed the authors to study the
+    relative importance of each parameter across the range of possibilities
+    of every other parameter.
 
-        In this computer experiment, they showed a 14-fold reduction in the
-        number of samples required to maintain an error below 2% on their
-        response surface when compared to a grid sampling.
+    In this computer experiment, they showed a 14-fold reduction in the
+    number of samples required to maintain an error below 2% on their
+    response surface when compared to a grid sampling.
 
     """
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     )
 
 import scipy.stats as stats
-from scipy._lib._util import rng_integers, _rng_spawn
+from scipy._lib._util import rng_integers, _rng_spawn, _transition_to_rng
 from scipy.sparse.csgraph import minimum_spanning_tree
 from scipy.spatial import distance, Voronoi
 from scipy.special import gammainc
@@ -60,6 +60,8 @@ def check_random_state(seed: GeneratorType) -> GeneratorType:
 
 
 # Based on scipy._lib._util.check_random_state
+# This is going to be removed at the end of the SPEC 7 transition,
+# so I'll just leave the argument name `seed` alone
 def check_random_state(seed=None):
     """Turn `seed` into a `numpy.random.Generator` instance.
 
@@ -396,7 +398,7 @@ def geometric_discrepancy(
     >>> import numpy as np
     >>> from scipy.stats import qmc
     >>> rng = np.random.default_rng(191468432622931918890291693003068437394)
-    >>> sample = qmc.LatinHypercube(d=2, seed=rng).random(50)
+    >>> sample = qmc.LatinHypercube(d=2, rng=rng).random(50)
     >>> qmc.geometric_discrepancy(sample)
     0.03708161435687876
 
@@ -682,7 +684,7 @@ def n_primes(n: IntNumber) -> list[int]:
 
 
 def _van_der_corput_permutations(
-    base: IntNumber, *, random_state: SeedType = None
+    base: IntNumber, *, rng: SeedType = None
 ) -> np.ndarray:
     """Permutations for scrambling a Van der Corput sequence.
 
@@ -690,11 +692,20 @@ def _van_der_corput_permutations(
     ----------
     base : int
         Base of the sequence.
-    random_state : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. During the transition, the behavior documented above is not
+            accurate; see `check_random_state` for actual behavior. After the
+            transition, this admonition can be removed.
 
     Returns
     -------
@@ -710,7 +721,7 @@ def _van_der_corput_permutations(
     2**-54``, which makes it more apparent how many permutations we need
     to create.
     """
-    rng = check_random_state(random_state)
+    rng = check_random_state(rng)
     count = math.ceil(54 / math.log2(base)) - 1
     permutations = np.repeat(np.arange(base)[None], count, axis=0)
     for perm in permutations:
@@ -726,7 +737,7 @@ def van_der_corput(
         start_index: IntNumber = 0,
         scramble: bool = False,
         permutations: npt.ArrayLike | None = None,
-        seed: SeedType = None,
+        rng: SeedType = None,
         workers: IntNumber = 1) -> np.ndarray:
     """Van der Corput sequence.
 
@@ -749,11 +760,11 @@ def van_der_corput(
         Default is True.
     permutations : array_like, optional
         Permutations used for scrambling.
-    seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
     workers : int, optional
         Number of workers to use for parallel processing. If -1 is
         given all CPU threads are used. Default is 1.
@@ -775,7 +786,7 @@ def van_der_corput(
     if scramble:
         if permutations is None:
             permutations = _van_der_corput_permutations(
-                base=base, random_state=seed
+                base=base, rng=rng
             )
         else:
             permutations = np.asarray(permutations)
@@ -813,26 +824,36 @@ class QMCEngine(ABC):
           The process converges to equally spaced samples.
 
         .. versionadded:: 1.10.0
-    seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     Notes
     -----
     By convention samples are distributed over the half-open interval
     ``[0, 1)``. Instances of the class can access the attributes: ``d`` for
-    the dimension; and ``rng`` for the random number generator (used for the
-    ``seed``).
+    the dimension; and ``rng`` for the random number generator.
 
     **Subclassing**
 
     When subclassing `QMCEngine` to create a new sampler,  ``__init__`` and
     ``random`` must be redefined.
 
-    * ``__init__(d, seed=None)``: at least fix the dimension. If the sampler
-      does not take advantage of a ``seed`` (deterministic methods like
+    * ``__init__(d, rng=None)``: at least fix the dimension. If the sampler
+      does not take advantage of a ``rng`` (deterministic methods like
       Halton), this parameter can be omitted.
     * ``_random(n, *, workers=1)``: draw ``n`` from the engine. ``workers``
       is used for parallelism. See `Halton` for example.
@@ -850,8 +871,8 @@ class QMCEngine(ABC):
 
     >>> from scipy.stats import qmc
     >>> class RandomEngine(qmc.QMCEngine):
-    ...     def __init__(self, d, seed=None):
-    ...         super().__init__(d=d, seed=seed)
+    ...     def __init__(self, d, rng=None):
+    ...         super().__init__(d=d, rng=rng)
     ...
     ...
     ...     def _random(self, n=1, *, workers=1):
@@ -859,7 +880,7 @@ class QMCEngine(ABC):
     ...
     ...
     ...     def reset(self):
-    ...         super().__init__(d=self.d, seed=self.rng_seed)
+    ...         super().__init__(d=self.d, rng=self.rng_seed)
     ...         return self
     ...
     ...
@@ -891,25 +912,41 @@ class QMCEngine(ABC):
     """
 
     @abstractmethod
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self,
         d: IntNumber,
         *,
         optimization: Literal["random-cd", "lloyd"] | None = None,
-        seed: SeedType = None
+        rng: SeedType = None
+    ) -> None:
+        self._initialize(d, optimization=optimization, rng=rng)
+
+    # During SPEC 7 transition:
+    # `__init__` has to be wrapped with @_transition_to_rng decorator
+    # because it is public. Subclasses previously called `__init__`
+    # directly, but this was problematic because arguments passed to
+    # subclass `__init__` as `seed` would get passed to superclass
+    # `__init__` as `rng`, rejecting `RandomState` arguments.
+    def _initialize(
+        self,
+        d: IntNumber,
+        *,
+        optimization: Literal["random-cd", "lloyd"] | None = None,
+        rng: SeedType = None
     ) -> None:
         if not np.issubdtype(type(d), np.integer) or d < 0:
             raise ValueError('d must be a non-negative integer value')
 
         self.d = d
 
-        if isinstance(seed, np.random.Generator):
+        if isinstance(rng, np.random.Generator):
             # Spawn a Generator that we can own and reset.
-            self.rng = _rng_spawn(seed, 1)[0]
+            self.rng = _rng_spawn(rng, 1)[0]
         else:
             # Create our instance of Generator, does not need spawning
             # Also catch RandomState which cannot be spawned
-            self.rng = check_random_state(seed)
+            self.rng = check_random_state(rng)
         self.rng_seed = copy.deepcopy(self.rng)
 
         self.num_generated = 0
@@ -1053,8 +1090,8 @@ class QMCEngine(ABC):
             Engine reset to its base state.
 
         """
-        seed = copy.deepcopy(self.rng_seed)
-        self.rng = check_random_state(seed)
+        rng = copy.deepcopy(self.rng_seed)
+        self.rng = check_random_state(rng)
         self.num_generated = 0
         return self
 
@@ -1106,11 +1143,22 @@ class Halton(QMCEngine):
           The process converges to equally spaced samples.
 
         .. versionadded:: 1.10.0
-    seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     Notes
     -----
@@ -1170,17 +1218,16 @@ class Halton(QMCEngine):
            [4.375     , 4.44444444]])
 
     """
-
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self, d: IntNumber, *, scramble: bool = True,
         optimization: Literal["random-cd", "lloyd"] | None = None,
-        seed: SeedType = None
+        rng: SeedType = None
     ) -> None:
         # Used in `scipy.integrate.qmc_quad`
         self._init_quad = {'d': d, 'scramble': True,
                            'optimization': optimization}
-        super().__init__(d=d, optimization=optimization, seed=seed)
-        self.seed = seed
+        super()._initialize(d=d, optimization=optimization, rng=rng)
 
         # important to have ``type(bdim) == int`` for performance reason
         self.base = [int(bdim) for bdim in n_primes(d)]
@@ -1197,7 +1244,7 @@ class Halton(QMCEngine):
         if self.scramble:
             for i, bdim in enumerate(self.base):
                 permutations = _van_der_corput_permutations(
-                    base=bdim, random_state=self.rng
+                    base=bdim, rng=self.rng
                 )
 
                 self._permutations[i] = permutations
@@ -1251,7 +1298,7 @@ class LatinHypercube(QMCEngine):
 
             .. note::
                 Setting ``scramble=False`` does not ensure deterministic output.
-                For that, use the `seed` parameter.
+                For that, use the `rng` parameter.
 
             Default is True.
 
@@ -1284,11 +1331,21 @@ class LatinHypercube(QMCEngine):
 
             .. versionadded:: 1.8.0
 
-        seed : {None, int, `numpy.random.Generator`}, optional
-            If `seed` is an int or None, a new `numpy.random.Generator` is
-            created using ``np.random.default_rng(seed)``.
-            If `seed` is already a ``Generator`` instance, then the provided
-            instance is used.
+        rng : `numpy.random.Generator`, optional
+            Pseudorandom number generator state. When `rng` is None, a new
+            `numpy.random.Generator` is created using entropy from the
+            operating system. Types other than `numpy.random.Generator` are
+            passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+            .. versionchanged:: 1.15.0
+
+                As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+                transition from use of `numpy.random.RandomState` to
+                `numpy.random.Generator`, this keyword was changed from `seed` to
+                `rng`. For an interim period, both keywords will continue to work, although
+                only one may be specified at a time. After the interim period, function
+                calls using the `seed` keyword will emit warnings. Following a
+                deprecation period, the `seed` keyword will be removed.
 
         See Also
         --------
@@ -1451,17 +1508,18 @@ class LatinHypercube(QMCEngine):
 
     """
 
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self, d: IntNumber, *,
         scramble: bool = True,
         strength: int = 1,
         optimization: Literal["random-cd", "lloyd"] | None = None,
-        seed: SeedType = None
+        rng: SeedType = None
     ) -> None:
         # Used in `scipy.integrate.qmc_quad`
         self._init_quad = {'d': d, 'scramble': True, 'strength': strength,
                            'optimization': optimization}
-        super().__init__(d=d, seed=seed, optimization=optimization)
+        super()._initialize(d=d, rng=rng, optimization=optimization)
         self.scramble = scramble
 
         lhs_method_strength = {
@@ -1533,7 +1591,7 @@ class LatinHypercube(QMCEngine):
         # following is making a scrambled OA into an OA-LHS
         oa_lhs_sample = np.zeros(shape=(n_row, n_col))
         lhs_engine = LatinHypercube(d=1, scramble=self.scramble, strength=1,
-                                    seed=self.rng)  # type: QMCEngine
+                                    rng=self.rng)  # type: QMCEngine
         for j in range(n_col):
             for k in range(p):
                 idx = oa_sample[:, j] == k
@@ -1586,11 +1644,22 @@ class Sobol(QMCEngine):
           The process converges to equally spaced samples.
 
         .. versionadded:: 1.10.0
-    seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     Notes
     -----
@@ -1686,16 +1755,17 @@ class Sobol(QMCEngine):
 
     MAXDIM: ClassVar[int] = _MAXDIM
 
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self, d: IntNumber, *, scramble: bool = True,
-        bits: IntNumber | None = None, seed: SeedType = None,
+        bits: IntNumber | None = None, rng: SeedType = None,
         optimization: Literal["random-cd", "lloyd"] | None = None
     ) -> None:
         # Used in `scipy.integrate.qmc_quad`
         self._init_quad = {'d': d, 'scramble': True, 'bits': bits,
                            'optimization': optimization}
 
-        super().__init__(d=d, optimization=optimization, seed=seed)
+        super()._initialize(d=d, optimization=optimization, rng=rng)
         if d > self.MAXDIM:
             raise ValueError(
                 f"Maximum supported dimensionality is {self.MAXDIM}."
@@ -1917,11 +1987,22 @@ class PoissonDisk(QMCEngine):
           The process converges to equally spaced samples.
 
         .. versionadded:: 1.10.0
-    seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     l_bounds, u_bounds : array_like (d,)
         Lower and upper bounds of target sample data.
@@ -1970,7 +2051,7 @@ class PoissonDisk(QMCEngine):
     >>>
     >>> rng = np.random.default_rng()
     >>> radius = 0.2
-    >>> engine = qmc.PoissonDisk(d=2, radius=radius, seed=rng)
+    >>> engine = qmc.PoissonDisk(d=2, radius=radius, rng=rng)
     >>> sample = engine.random(20)
 
     Visualizing the 2D sample and showing that no points are closer than
@@ -1998,6 +2079,7 @@ class PoissonDisk(QMCEngine):
 
     """
 
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self,
         d: IntNumber,
@@ -2006,7 +2088,7 @@ class PoissonDisk(QMCEngine):
         hypersphere: Literal["volume", "surface"] = "volume",
         ncandidates: IntNumber = 30,
         optimization: Literal["random-cd", "lloyd"] | None = None,
-        seed: SeedType = None,
+        rng: SeedType = None,
         l_bounds: npt.ArrayLike | None = None,
         u_bounds: npt.ArrayLike | None = None
     ) -> None:
@@ -2015,7 +2097,7 @@ class PoissonDisk(QMCEngine):
                            'hypersphere': hypersphere,
                            'ncandidates': ncandidates,
                            'optimization': optimization}
-        super().__init__(d=d, optimization=optimization, seed=seed)
+        super()._initialize(d=d, optimization=optimization, rng=rng)
 
         hypersphere_sample = {
             "volume": self._hypersphere_volume_sample,
@@ -2240,12 +2322,21 @@ class MultivariateNormalQMC:
         If True, use inverse transform instead of Box-Muller. Default is True.
     engine : QMCEngine, optional
         Quasi-Monte Carlo engine sampler. If None, `Sobol` is used.
-    seed : {None, int, `numpy.random.Generator`}, optional
-        Used only if `engine` is None.
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     Examples
     --------
@@ -2258,12 +2349,13 @@ class MultivariateNormalQMC:
 
     """
 
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
             self, mean: npt.ArrayLike, cov: npt.ArrayLike | None = None, *,
             cov_root: npt.ArrayLike | None = None,
             inv_transform: bool = True,
             engine: QMCEngine | None = None,
-            seed: SeedType = None
+            rng: SeedType = None
     ) -> None:
         mean = np.asarray(np.atleast_1d(mean))
         d = mean.shape[0]
@@ -2305,7 +2397,7 @@ class MultivariateNormalQMC:
             engine_dim = d
         if engine is None:
             self.engine = Sobol(
-                d=engine_dim, scramble=True, bits=30, seed=seed
+                d=engine_dim, scramble=True, bits=30, rng=rng
             )  # type: QMCEngine
         elif isinstance(engine, QMCEngine):
             if engine.d != engine_dim:
@@ -2392,12 +2484,21 @@ class MultinomialQMC:
         Number of trials.
     engine : QMCEngine, optional
         Quasi-Monte Carlo engine sampler. If None, `Sobol` is used.
-    seed : {None, int, `numpy.random.Generator`}, optional
-        Used only if `engine` is None.
-        If `seed` is an int or None, a new `numpy.random.Generator` is
-        created using ``np.random.default_rng(seed)``.
-        If `seed` is already a ``Generator`` instance, then the provided
-        instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
+        .. versionchanged:: 1.15.0
+
+            As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
+            transition from use of `numpy.random.RandomState` to
+            `numpy.random.Generator`, this keyword was changed from `seed` to
+            `rng`. For an interim period, both keywords will continue to work, although
+            only one may be specified at a time. After the interim period, function
+            calls using the `seed` keyword will emit warnings. Following a
+            deprecation period, the `seed` keyword will be removed.
 
     Examples
     --------
@@ -2425,10 +2526,11 @@ class MultinomialQMC:
 
     """
 
+    @_transition_to_rng('seed', replace_doc=False)
     def __init__(
         self, pvals: npt.ArrayLike, n_trials: IntNumber,
         *, engine: QMCEngine | None = None,
-        seed: SeedType = None
+        rng: SeedType = None
     ) -> None:
         self.pvals = np.atleast_1d(np.asarray(pvals))
         if np.min(pvals) < 0:
@@ -2438,7 +2540,7 @@ class MultinomialQMC:
         self.n_trials = n_trials
         if engine is None:
             self.engine = Sobol(
-                d=1, scramble=True, bits=30, seed=seed
+                d=1, scramble=True, bits=30, rng=rng
             )  # type: QMCEngine
         elif isinstance(engine, QMCEngine):
             if engine.d != 1:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -218,7 +218,7 @@ class TestUtils:
         )
 
         rng = np.random.default_rng(191468432622931918890291693003068437394)
-        sample = qmc.LatinHypercube(d=3, seed=rng).random(50)
+        sample = qmc.LatinHypercube(d=3, rng=rng).random(50)
         assert_allclose(qmc.geometric_discrepancy(sample), 0.05106012076093356)
         assert_allclose(
             qmc.geometric_discrepancy(sample, method='mst'), 0.19704396643366182
@@ -276,7 +276,7 @@ class TestUtils:
 
     def test_perm_discrepancy(self):
         rng = np.random.default_rng(46449423132557934943847369749645759997)
-        qmc_gen = qmc.LatinHypercube(5, seed=rng)
+        qmc_gen = qmc.LatinHypercube(5, rng=rng)
         sample = qmc_gen.random(10)
         disc = qmc.discrepancy(sample)
 
@@ -398,19 +398,19 @@ class TestVDC:
         assert_allclose(sample, out[3:])
 
     def test_van_der_corput_scramble(self):
-        seed = 338213789010180879520345496831675783177
-        out = van_der_corput(10, scramble=True, seed=seed)
+        rng = 338213789010180879520345496831675783177
+        out = van_der_corput(10, scramble=True, rng=rng)
 
-        sample = van_der_corput(7, start_index=3, scramble=True, seed=seed)
+        sample = van_der_corput(7, start_index=3, scramble=True, rng=rng)
         assert_allclose(sample, out[3:])
 
         sample = van_der_corput(
-            7, start_index=3, scramble=True, seed=seed, workers=4
+            7, start_index=3, scramble=True, rng=rng, workers=4
         )
         assert_allclose(sample, out[3:])
 
         sample = van_der_corput(
-            7, start_index=3, scramble=True, seed=seed, workers=8
+            7, start_index=3, scramble=True, rng=rng, workers=8
         )
         assert_allclose(sample, out[3:])
 
@@ -420,8 +420,8 @@ class TestVDC:
 
 
 class RandomEngine(qmc.QMCEngine):
-    def __init__(self, d, optimization=None, seed=None):
-        super().__init__(d=d, optimization=optimization, seed=seed)
+    def __init__(self, d, optimization=None, rng=None):
+        super().__init__(d=d, optimization=optimization, rng=rng)
 
     def _random(self, n=1, *, workers=1):
         sample = self.rng.random((n, self.d))
@@ -429,7 +429,7 @@ class RandomEngine(qmc.QMCEngine):
 
 
 def test_subclassing_QMCEngine():
-    engine = RandomEngine(2, seed=175180605424926556207367152557812293274)
+    engine = RandomEngine(2, rng=175180605424926556207367152557812293274)
 
     sample_1 = engine.random(n=5)
     sample_2 = engine.random(n=7)
@@ -466,7 +466,7 @@ def test_raises():
 
 
 def test_integers():
-    engine = RandomEngine(1, seed=231195739755290648063853336582377368684)
+    engine = RandomEngine(1, rng=231195739755290648063853336582377368684)
 
     # basic tests
     sample = engine.integers(1, n=10)
@@ -504,7 +504,7 @@ def test_integers_nd():
     rng = np.random.default_rng(3716505122102428560615700415287450951)
     low = rng.integers(low=-5, high=-1, size=d)
     high = rng.integers(low=1, high=5, size=d, endpoint=True)
-    engine = RandomEngine(d, seed=rng)
+    engine = RandomEngine(d, rng=rng)
 
     sample = engine.integers(low, u_bounds=high, n=100, endpoint=False)
     assert_equal(sample.min(axis=0), low)
@@ -527,16 +527,19 @@ class QMCEngineTests:
 
     def engine(
         self, scramble: bool,
-        seed=170382760648021597650530316304495310428,
+        rng=170382760648021597650530316304495310428,
         **kwargs
     ) -> QMCEngine:
+        # preserve use of `seed` during SPEC 7 transition because
+        # some tests rely on behavior with integer `seed` (which is
+        # different from behavior with integer `rng`)
         if self.can_scramble:
-            return self.qmce(scramble=scramble, seed=seed, **kwargs)
+            return self.qmce(scramble=scramble, seed=rng, **kwargs)
         else:
             if scramble:
                 pytest.skip()
             else:
-                return self.qmce(seed=seed, **kwargs)
+                return self.qmce(seed=rng, **kwargs)
 
     def reference(self, scramble: bool) -> np.ndarray:
         return self.scramble_nd if scramble else self.unscramble_nd
@@ -590,15 +593,15 @@ class QMCEngineTests:
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
     @pytest.mark.parametrize(
-        "seed",
+        "rng",
         (
             170382760648021597650530316304495310428,
             np.random.default_rng(170382760648021597650530316304495310428),
             None,
         ),
     )
-    def test_reset(self, scramble, seed):
-        engine = self.engine(d=2, scramble=scramble, seed=seed)
+    def test_reset(self, scramble, rng):
+        engine = self.engine(d=2, scramble=scramble, rng=rng)
         ref_sample = engine.random(n=8)
 
         engine.reset()
@@ -674,7 +677,7 @@ class QMCEngineTests:
         rng = np.random.default_rng(0xa29cabb11cfdf44ff6cac8bec254c2a0)
         sample = []
         for i in range(3):
-            engine = self.engine(d=2, scramble=True, seed=rng)
+            engine = self.engine(d=2, scramble=True, rng=rng)
             sample.append(engine.random(4))
 
         with pytest.raises(AssertionError, match="Arrays are not equal"):
@@ -734,7 +737,7 @@ class TestLHS(QMCEngineTests):
     @pytest.mark.parametrize("scramble", [False, True])
     @pytest.mark.parametrize("optimization", [None, "random-CD"])
     def test_sample_stratified(self, optimization, scramble, strength):
-        seed = np.random.default_rng(37511836202578819870665127532742111260)
+        rng = np.random.default_rng(37511836202578819870665127532742111260)
         p = 5
         n = p**2
         d = 6
@@ -742,7 +745,7 @@ class TestLHS(QMCEngineTests):
         engine = qmc.LatinHypercube(d=d, scramble=scramble,
                                     strength=strength,
                                     optimization=optimization,
-                                    seed=seed)
+                                    rng=rng)
         sample = engine.random(n=n)
         assert sample.shape == (n, d)
         assert engine.num_generated == n
@@ -923,7 +926,7 @@ class TestPoisson(QMCEngineTests):
 
         for d, radius, hypersphere in gen:
             engine = self.qmce(
-                d=d, radius=radius, hypersphere=hypersphere, seed=rng
+                d=d, radius=radius, hypersphere=hypersphere, rng=rng
             )
             sample = engine.random(ns)
 
@@ -1018,17 +1021,18 @@ class TestMultinomialQMC:
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_MultinomialBasicDraw(self):
-        seed = np.random.default_rng(6955663962957011631562466584467607969)
+        rng = np.random.default_rng(6955663962957011631562466584467607969)
         p = np.array([0.12, 0.26, 0.05, 0.35, 0.22])
         n_trials = 100
         expected = np.atleast_2d(n_trials * p).astype(int)
-        engine = qmc.MultinomialQMC(p, n_trials=n_trials, seed=seed)
+        # preserve use of legacy keyword during SPEC 7 transition
+        engine = qmc.MultinomialQMC(p, n_trials=n_trials, seed=rng)
         assert_allclose(engine.random(1), expected, atol=1)
 
     def test_MultinomialDistribution(self):
-        seed = np.random.default_rng(77797854505813727292048130876699859000)
+        rng = np.random.default_rng(77797854505813727292048130876699859000)
         p = np.array([0.12, 0.26, 0.05, 0.35, 0.22])
-        engine = qmc.MultinomialQMC(p, n_trials=8192, seed=seed)
+        engine = qmc.MultinomialQMC(p, n_trials=8192, rng=rng)
         draws = engine.random(1)
         assert_allclose(draws / np.sum(draws), np.atleast_2d(p), atol=1e-4)
 
@@ -1044,13 +1048,13 @@ class TestMultinomialQMC:
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_other_engine(self):
         # same as test_MultinomialBasicDraw with different engine
-        seed = np.random.default_rng(283753519042773243071753037669078065412)
+        rng = np.random.default_rng(283753519042773243071753037669078065412)
         p = np.array([0.12, 0.26, 0.05, 0.35, 0.22])
         n_trials = 100
         expected = np.atleast_2d(n_trials * p).astype(int)
-        base_engine = qmc.Sobol(1, scramble=True, seed=seed)
+        base_engine = qmc.Sobol(1, scramble=True, rng=rng)
         engine = qmc.MultinomialQMC(p, n_trials=n_trials, engine=base_engine,
-                                    seed=seed)
+                                    rng=rng)
         assert_allclose(engine.random(1), expected, atol=1)
 
 
@@ -1087,29 +1091,30 @@ class TestNormalQMC:
 
     def test_NormalQMCSeeded(self):
         # test even dimension
-        seed = np.random.default_rng(274600237797326520096085022671371676017)
+        rng = np.random.default_rng(274600237797326520096085022671371676017)
+        # preserve use of legacy keyword during SPEC 7 transition
         engine = qmc.MultivariateNormalQMC(
-            mean=np.zeros(2), inv_transform=False, seed=seed)
+            mean=np.zeros(2), inv_transform=False, seed=rng)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.932001, -0.522923],
                                      [-1.477655, 0.846851]])
         assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
-        seed = np.random.default_rng(274600237797326520096085022671371676017)
+        rng = np.random.default_rng(274600237797326520096085022671371676017)
         engine = qmc.MultivariateNormalQMC(
-            mean=np.zeros(3), inv_transform=False, seed=seed)
+            mean=np.zeros(3), inv_transform=False, rng=rng)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.932001, -0.522923, 0.036578],
                                      [-1.778011, 0.912428, -0.065421]])
         assert_allclose(samples, samples_expected, atol=1e-4)
 
         # same test with another engine
-        seed = np.random.default_rng(274600237797326520096085022671371676017)
-        base_engine = qmc.Sobol(4, scramble=True, seed=seed)
+        rng = np.random.default_rng(274600237797326520096085022671371676017)
+        base_engine = qmc.Sobol(4, scramble=True, rng=rng)
         engine = qmc.MultivariateNormalQMC(
             mean=np.zeros(3), inv_transform=False,
-            engine=base_engine, seed=seed
+            engine=base_engine, rng=rng
         )
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.932001, -0.522923, 0.036578],
@@ -1118,18 +1123,18 @@ class TestNormalQMC:
 
     def test_NormalQMCSeededInvTransform(self):
         # test even dimension
-        seed = np.random.default_rng(288527772707286126646493545351112463929)
+        rng = np.random.default_rng(288527772707286126646493545351112463929)
         engine = qmc.MultivariateNormalQMC(
-            mean=np.zeros(2), seed=seed, inv_transform=True)
+            mean=np.zeros(2), rng=rng, inv_transform=True)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.913237, -0.964026],
                                      [0.255904, 0.003068]])
         assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
-        seed = np.random.default_rng(288527772707286126646493545351112463929)
+        rng = np.random.default_rng(288527772707286126646493545351112463929)
         engine = qmc.MultivariateNormalQMC(
-            mean=np.zeros(3), seed=seed, inv_transform=True)
+            mean=np.zeros(3), rng=rng, inv_transform=True)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.913237, -0.964026, 0.355501],
                                      [0.699261, 2.90213 , -0.6418]])
@@ -1146,7 +1151,7 @@ class TestNormalQMC:
 
     def test_NormalQMCShapiro(self):
         rng = np.random.default_rng(13242)
-        engine = qmc.MultivariateNormalQMC(mean=np.zeros(2), seed=rng)
+        engine = qmc.MultivariateNormalQMC(mean=np.zeros(2), rng=rng)
         samples = engine.random(n=256)
         assert all(np.abs(samples.mean(axis=0)) < 1e-2)
         assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
@@ -1161,7 +1166,7 @@ class TestNormalQMC:
     def test_NormalQMCShapiroInvTransform(self):
         rng = np.random.default_rng(32344554)
         engine = qmc.MultivariateNormalQMC(
-            mean=np.zeros(2), inv_transform=True, seed=rng)
+            mean=np.zeros(2), inv_transform=True, rng=rng)
         samples = engine.random(n=256)
         assert all(np.abs(samples.mean(axis=0)) < 1e-2)
         assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
@@ -1265,7 +1270,7 @@ class TestMultivariateNormalQMC:
         a = rng.standard_normal((2, 2))
         A = a @ a.transpose() + np.diag(rng.random(2))
         engine = qmc.MultivariateNormalQMC(np.array([0, 0]), A,
-                                           inv_transform=False, seed=rng)
+                                           inv_transform=False, rng=rng)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.64419, -0.882413],
                                      [0.837199, 2.045301]])
@@ -1276,7 +1281,7 @@ class TestMultivariateNormalQMC:
         a = rng.standard_normal((3, 3))
         A = a @ a.transpose() + np.diag(rng.random(3))
         engine = qmc.MultivariateNormalQMC(np.array([0, 0, 0]), A,
-                                           inv_transform=False, seed=rng)
+                                           inv_transform=False, rng=rng)
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.693853, -1.265338, -0.088024],
                                      [1.620193, 2.679222, 0.457343]])
@@ -1288,7 +1293,7 @@ class TestMultivariateNormalQMC:
         a = rng.standard_normal((2, 2))
         A = a @ a.transpose() + np.diag(rng.random(2))
         engine = qmc.MultivariateNormalQMC(
-            np.array([0, 0]), A, seed=rng, inv_transform=True
+            np.array([0, 0]), A, rng=rng, inv_transform=True
         )
         samples = engine.random(n=2)
         samples_expected = np.array([[0.682171, -3.114233],
@@ -1300,7 +1305,7 @@ class TestMultivariateNormalQMC:
         a = rng.standard_normal((3, 3))
         A = a @ a.transpose() + np.diag(rng.random(3))
         engine = qmc.MultivariateNormalQMC(
-            np.array([0, 0, 0]), A, seed=rng, inv_transform=True
+            np.array([0, 0, 0]), A, rng=rng, inv_transform=True
         )
         samples = engine.random(n=2)
         samples_expected = np.array([[0.988061, -1.644089, -0.877035],
@@ -1309,9 +1314,9 @@ class TestMultivariateNormalQMC:
 
     def test_MultivariateNormalQMCShapiro(self):
         # test the standard case
-        seed = np.random.default_rng(188960007281846377164494575845971640)
+        rng = np.random.default_rng(188960007281846377164494575845971640)
         engine = qmc.MultivariateNormalQMC(
-            mean=[0, 0], cov=[[1, 0], [0, 1]], seed=seed
+            mean=[0, 0], cov=[[1, 0], [0, 1]], rng=rng
         )
         samples = engine.random(n=256)
         assert all(np.abs(samples.mean(axis=0)) < 1e-2)
@@ -1326,7 +1331,7 @@ class TestMultivariateNormalQMC:
 
         # test the correlated, non-zero mean case
         engine = qmc.MultivariateNormalQMC(
-            mean=[1.0, 2.0], cov=[[1.5, 0.5], [0.5, 1.5]], seed=seed
+            mean=[1.0, 2.0], cov=[[1.5, 0.5], [0.5, 1.5]], rng=rng
         )
         samples = engine.random(n=256)
         assert all(np.abs(samples.mean(axis=0) - [1, 2]) < 1e-2)
@@ -1341,9 +1346,9 @@ class TestMultivariateNormalQMC:
 
     def test_MultivariateNormalQMCShapiroInvTransform(self):
         # test the standard case
-        seed = np.random.default_rng(200089821034563288698994840831440331329)
+        rng = np.random.default_rng(200089821034563288698994840831440331329)
         engine = qmc.MultivariateNormalQMC(
-            mean=[0, 0], cov=[[1, 0], [0, 1]], seed=seed, inv_transform=True
+            mean=[0, 0], cov=[[1, 0], [0, 1]], rng=rng, inv_transform=True
         )
         samples = engine.random(n=256)
         assert all(np.abs(samples.mean(axis=0)) < 1e-2)
@@ -1360,7 +1365,7 @@ class TestMultivariateNormalQMC:
         engine = qmc.MultivariateNormalQMC(
             mean=[1.0, 2.0],
             cov=[[1.5, 0.5], [0.5, 1.5]],
-            seed=seed,
+            rng=rng,
             inv_transform=True,
         )
         samples = engine.random(n=256)
@@ -1376,11 +1381,11 @@ class TestMultivariateNormalQMC:
 
     def test_MultivariateNormalQMCDegenerate(self):
         # X, Y iid standard Normal and Z = X + Y, random vector (X, Y, Z)
-        seed = np.random.default_rng(16320637417581448357869821654290448620)
+        rng = np.random.default_rng(16320637417581448357869821654290448620)
         engine = qmc.MultivariateNormalQMC(
             mean=[0.0, 0.0, 0.0],
             cov=[[1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 2.0]],
-            seed=seed,
+            rng=rng,
         )
         samples = engine.random(n=512)
         assert all(np.abs(samples.mean(axis=0)) < 1e-2)
@@ -1457,3 +1462,28 @@ class TestLloyd:
 # mindist
 def l2_norm(sample):
     return distance.pdist(sample).min()
+
+
+@pytest.mark.parametrize('engine', [qmc.Halton, qmc.Sobol,
+                                    qmc.LatinHypercube, qmc.PoissonDisk])
+def test_deterministic(engine):
+    seed_number = 2359834584
+
+    rng = np.random.RandomState(seed_number)
+    res1 = engine(d=1, seed=rng).random(4)
+    rng = np.random.RandomState(seed_number)
+    res2 = engine(d=1, seed=rng).random(4)
+    assert_equal(res1, res2)
+
+    rng = np.random.default_rng(seed_number)
+    res1 = engine(d=1, seed=rng).random(4)
+    res2 = engine(d=1, rng=seed_number).random(4)
+    assert_equal(res1, res2)
+    rng = np.random.default_rng(seed_number)
+    res3 = engine(d=1, rng=rng).random(4)
+    assert_equal(res2, res1)
+    assert_equal(res3, res1)
+
+    message = "got multiple values for argument now known as `rng`"
+    with pytest.raises(TypeError, match=message):
+        engine(d=1, rng=seed_number, seed=seed_number)


### PR DESCRIPTION
#### Reference issue
Toward gh-21833

#### What does this implement/fix?
To prepare for the deprecation and removal of `seed` and its legacy behavior from `stats.qmc` classes., this allows for use of the new keyword `rng` alongside `seed`.

#### Additional information
Note that when the `_transition_to_rng` decorator receives an integer as the `rng` argument, it normalizes it using `default_rng` before passing it to the wrapped function. Also, if a `QMCEngine` is passed a `np.random.default_rng` directly, it doesn't use it; rather, it spawns a new RNG from it.  Therefore, with the decorator in place, both of the following happen in sequence: the `rng` argument is always normalized, and a new Generator is spawned from it.

So as-written, if we want to preserve the stream of numbers when the `_transition_to_rng` decorator is removed, we would always need to normalize the argument `rng` argument with `default_rng` AND spawn a new Generator from that; we would not keep the current logic that "if the argument is an instance of `Generator`, spawn; otherwise, normalize".

There is no *problem* with this; it's just a bit peculiar. A motivated individual is welcome to adjust the current implementation after this PR merges if this is not the desired long-term behavior.