### PR TITLE
ENH: integrate.nsum: add array API standard support

### DIFF
--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -1105,20 +1105,20 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
 
     >>> import numpy as np
     >>> from scipy.integrate import nsum
-    >>> res = nsum(lambda k: 1/k**2, 1, np.inf, maxterms=1e3)
+    >>> res = nsum(lambda k: 1/k**2, 1, np.inf)
     >>> ref = np.pi**2/6  # true value
     >>> res.error  # estimated error
-    4.990061275730517e-07
+    np.float64(7.448762306416137e-09)
     >>> (res.sum - ref)/ref  # true error
-    -1.0104163408712734e-10
+    np.float64(-1.839871898894426e-13)
     >>> res.nfev  # number of points at which callable was evaluated
-    1209
+    np.int32(8561)
 
     Compute the infinite sums of the reciprocals of integers raised to powers ``p``,
     where ``p`` is an array.
 
     >>> from scipy import special
-    >>> p = np.arange(2, 10)
+    >>> p = np.arange(3, 10)
     >>> res = nsum(lambda k, p: 1/k**p, 1, np.inf, maxterms=1e3, args=(p,))
     >>> ref = special.zeta(p, 1)
     >>> np.allclose(res.sum, ref)
@@ -1128,7 +1128,7 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
 
     >>> res = nsum(lambda x: 1/x - 1/(x+1), 1, np.inf, step=2)
     >>> res.sum, res.sum - np.log(2)  # result, difference vs analytical sum
-    (0.6931471805598691, -7.616129948928574e-14)
+    (np.float64(0.6931471805598691), np.float64(-7.616129948928574e-14))
 
     """ # noqa: E501
     # Potential future work:

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -889,18 +889,20 @@ def _tanhsinh_iv(f, a, b, log, maxfun, maxlevel, minlevel,
 def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
     # Input validation and standardization
 
+    xp = array_namespace(a, b)
+
     message = '`f` must be callable.'
     if not callable(f):
         raise ValueError(message)
 
     message = 'All elements of `a`, `b`, and `step` must be real numbers.'
-    a, b, step = np.broadcast_arrays(a, b, step)
-    dtype = np.result_type(a.dtype, b.dtype, step.dtype)
-    if not np.issubdtype(dtype, np.number) or np.issubdtype(dtype, np.complexfloating):
+    a, b, step = xp.broadcast_arrays(xp.asarray(a), xp.asarray(b), xp.asarray(step))
+    dtype = xp.result_type(a.dtype, b.dtype, step.dtype)
+    if not xp.isdtype(dtype, 'numeric') or xp.isdtype(dtype, 'complex floating'):
         raise ValueError(message)
 
     valid_b = b >= a  # NaNs will be False
-    valid_step = np.isfinite(step) & (step > 0)
+    valid_step = xp.isfinite(step) & (step > 0)
     valid_abstep = valid_b & valid_step
 
     message = '`log` must be True or False.'
@@ -911,11 +913,12 @@ def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
 
     atol = tolerances.get('atol', None)
     if atol is None:
-        atol = -np.inf if log else 0
+        atol = -xp.inf if log else 0
 
     rtol = tolerances.get('rtol', None)
     rtol_temp = rtol if rtol is not None else 0.
 
+    # using NumPy for convenience here; these are just floats, not arrays
     params = np.asarray([atol, rtol_temp, 0.])
     message = "`atol` and `rtol` must be real numbers."
     if not np.issubdtype(params.dtype, np.floating):
@@ -940,7 +943,7 @@ def _nsum_iv(f, a, b, step, args, log, maxterms, tolerances):
     if not np.iterable(args):
         args = (args,)
 
-    return f, a, b, step, valid_abstep, args, log, maxterms_int, atol, rtol
+    return f, a, b, step, valid_abstep, args, log, maxterms_int, atol, rtol, xp
 
 
 def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances=None):
@@ -1138,66 +1141,66 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
 
     # Function-specific input validation / standardization
     tmp = _nsum_iv(f, a, b, step, args, log, maxterms, tolerances)
-    f, a, b, step, valid_abstep, args, log, maxterms, atol, rtol = tmp
+    f, a, b, step, valid_abstep, args, log, maxterms, atol, rtol, xp = tmp
 
     # Additional elementwise algorithm input validation / standardization
-    tmp = eim._initialize(f, (a,), args, complex_ok=False)
+    tmp = eim._initialize(f, (a,), args, complex_ok=False, xp=xp)
     f, xs, fs, args, shape, dtype, xp = tmp
 
     # Finish preparing `a`, `b`, and `step` arrays
     a = xs[0]
-    b = np.broadcast_to(b, shape).ravel().astype(dtype)
-    step = np.broadcast_to(step, shape).ravel().astype(dtype)
-    valid_abstep = np.broadcast_to(valid_abstep, shape).ravel()
-    nterms = np.floor((b - a) / step)
-    finite_terms = np.isfinite(nterms)
+    b = xp.broadcast_to(b, shape).ravel().astype(dtype)
+    step = xp.broadcast_to(step, shape).ravel().astype(dtype)
+    valid_abstep = xp.broadcast_to(valid_abstep, shape).ravel()
+    nterms = xp.floor((b - a) / step)
+    finite_terms = xp.isfinite(nterms)
     b[finite_terms] = a[finite_terms] + nterms[finite_terms]*step[finite_terms]
 
     # Define constants
-    eps = np.finfo(dtype).eps
-    zero = np.asarray(-np.inf if log else 0, dtype=dtype)[()]
+    eps = xp.finfo(dtype).eps
+    zero = xp.asarray(-xp.inf if log else 0, dtype=dtype)[()]
     if rtol is None:
-        rtol = 0.5*np.log(eps) if log else eps**0.5
+        rtol = 0.5*math.log(eps) if log else eps**0.5
     constants = (dtype, log, eps, zero, rtol, atol, maxterms)
 
     # Prepare result arrays
-    S = np.empty_like(a)
-    E = np.empty_like(a)
-    status = np.zeros(len(a), dtype=int)
-    nfev = np.ones(len(a), dtype=int)  # one function evaluation above
+    S = xp.empty_like(a)
+    E = xp.empty_like(a)
+    status = xp.zeros(len(a), dtype=int)
+    nfev = xp.ones(len(a), dtype=int)  # one function evaluation above
 
     # Branch for direct sum evaluation / integral approximation / invalid input
     i0 = ~valid_abstep                     # invalid
     i1 = (nterms + 1 <= maxterms) & ~i0    # direct sum evaluation
-    i2 = np.isfinite(a) & ~i1 & ~i0        # infinite sum to the right
-    i3 = np.isfinite(b) & ~i2 & ~i1 & ~i0  # infinite sum to the left
+    i2 = xp.isfinite(a) & ~i1 & ~i0        # infinite sum to the right
+    i3 = xp.isfinite(b) & ~i2 & ~i1 & ~i0  # infinite sum to the left
     i4 = ~i3 & ~i2 & ~i1 & ~i0             # infinite sum on both sides
 
-    if np.any(i0):
-        S[i0], E[i0] = np.nan, np.nan
+    if xp.any(i0):
+        S[i0], E[i0] = xp.nan, xp.nan
         status[i0] = -1
 
-    if np.any(i1):
+    if xp.any(i1):
         args_direct = [arg[i1] for arg in args]
-        tmp = _direct(f, a[i1], b[i1], step[i1], args_direct, constants)
+        tmp = _direct(f, a[i1], b[i1], step[i1], args_direct, constants, xp)
         S[i1], E[i1] = tmp[:-1]
         nfev[i1] += tmp[-1]
-        status[i1] = -3 * (~np.isfinite(S[i1]))
+        status[i1] = -3 * (~xp.isfinite(S[i1]))
 
-    if np.any(i2):
+    if xp.any(i2):
         args_indirect = [arg[i2] for arg in args]
-        tmp = _integral_bound(f, a[i2], b[i2], step[i2], args_indirect, constants)
+        tmp = _integral_bound(f, a[i2], b[i2], step[i2], args_indirect, constants, xp)
         S[i2], E[i2], status[i2] = tmp[:-1]
         nfev[i2] += tmp[-1]
 
-    if np.any(i3):
+    if xp.any(i3):
         args_indirect = [arg[i3] for arg in args]
         def _f(x, *args): return f(-x, *args)
-        tmp = _integral_bound(_f, -b[i3], -a[i3], step[i3], args_indirect, constants)
+        tmp = _integral_bound(_f, -b[i3], -a[i3], step[i3], args_indirect, constants, xp)
         S[i3], E[i3], status[i3] = tmp[:-1]
         nfev[i3] += tmp[-1]
 
-    if np.any(i4):
+    if xp.any(i4):
         args_indirect = [arg[i4] for arg in args]
 
         # There are two obvious high-level strategies:
@@ -1212,17 +1215,17 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         # (especially getting the status message right)
         if log:
             def _f(x, *args):
-                log_factor = np.where(x==0, np.log(0.5), 0)
-                out = np.stack([f(x, *args), f(-x, *args)], axis=0)
+                log_factor = xp.where(x==0, math.log(0.5), 0)
+                out = xp.stack([f(x, *args), f(-x, *args)], axis=0)
                 return special.logsumexp(out, axis=0) + log_factor
 
         else:
             def _f(x, *args):
-                factor = np.where(x==0, 0.5, 1)
+                factor = xp.where(x==0, 0.5, 1)
                 return (f(x, *args) + f(-x, *args)) * factor
 
-        zero = np.zeros_like(a[i4])
-        tmp = _integral_bound(_f, zero, b[i4], step[i4], args_indirect, constants)
+        zero = xp.zeros_like(a[i4])
+        tmp = _integral_bound(_f, zero, b[i4], step[i4], args_indirect, constants, xp)
         S[i4], E[i4], status[i4] = tmp[:-1]
         nfev[i4] += 2*tmp[-1]
 
@@ -1233,7 +1236,7 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
                        nfev=nfev)
 
 
-def _direct(f, a, b, step, args, constants, inclusive=True):
+def _direct(f, a, b, step, args, constants, xp, inclusive=True):
     # Directly evaluate the sum.
 
     # When used in the context of distributions, `args` would contain the
@@ -1254,20 +1257,20 @@ def _direct(f, a, b, step, args, constants, inclusive=True):
     # I didn't think it was great style to use `True` as `1` in Python, so I
     # explicitly converted it to an `int` before using it.
     inclusive_adjustment = int(inclusive)
-    steps = np.round((b - a) / step) + inclusive_adjustment
-    # Equivalently, steps = np.round((b - a) / step) + inclusive
-    max_steps = int(np.max(steps))
+    steps = xp.round((b - a) / step) + inclusive_adjustment
+    # Equivalently, steps = xp.round((b - a) / step) + inclusive
+    max_steps = int(xp.max(steps))
 
     # In each slice, the function will be evaluated at the same number of points,
     # but excessive points (those beyond the right sum limit `b`) are replaced
     # with NaN to (potentially) reduce the time of these unnecessary calculations.
     # Use a new last axis for these calculations for consistency with other
     # elementwise algorithms.
-    a2, b2, step2 = a[:, np.newaxis], b[:, np.newaxis], step[:, np.newaxis]
-    args2 = [arg[:, np.newaxis] for arg in args]
-    ks = a2 + np.arange(max_steps, dtype=dtype) * step2
+    a2, b2, step2 = a[:, xp.newaxis], b[:, xp.newaxis], step[:, xp.newaxis]
+    args2 = [arg[:, xp.newaxis] for arg in args]
+    ks = a2 + xp.arange(max_steps, dtype=dtype) * step2
     i_nan = ks >= (b2 + inclusive_adjustment*step2/2)
-    ks[i_nan] = np.nan
+    ks[i_nan] = xp.nan
     fs = f(ks, *args2)
 
     # The function evaluated at NaN is NaN, and NaNs are zeroed in the sum.
@@ -1275,45 +1278,46 @@ def _direct(f, a, b, step, args, constants, inclusive=True):
     # like this. This is an optimization that can be added later.
     fs[i_nan] = zero
     nfev = max_steps - i_nan.sum(axis=-1)
-    S = special.logsumexp(fs, axis=-1) if log else np.sum(fs, axis=-1)
+    S = special.logsumexp(fs, axis=-1) if log else xp.sum(fs, axis=-1)
     # Rough, non-conservative error estimate. See gh-19667 for improvement ideas.
-    E = np.real(S) + np.log(eps) if log else eps * abs(S)
+    E = xp_real(S) + math.log(eps) if log else eps * abs(S)
     return S, E, nfev
 
 
-def _integral_bound(f, a, b, step, args, constants):
+def _integral_bound(f, a, b, step, args, constants, xp):
     # Estimate the sum with integral approximation
     dtype, log, _, _, rtol, atol, maxterms = constants
-    log2 = np.log(2, dtype=dtype)
+    log2 = xp.log(2, dtype=dtype)
 
     # Get a lower bound on the sum and compute effective absolute tolerance
     lb = _tanhsinh(f, a, b, args=args, atol=atol, rtol=rtol, log=log)
-    tol = np.broadcast_to(atol, lb.integral.shape)
+    tol = xp.broadcast_to(xp.asarray(atol), lb.integral.shape)
     if log:
-        tol = special.logsumexp((tol, rtol + lb.integral), axis=0)
+        tol = special.logsumexp(xp.stack((tol, rtol + lb.integral)), axis=0)
     else:
         tol = tol + rtol*lb.integral
     i_skip = lb.status < 0  # avoid unnecessary f_evals if integral is divergent
-    tol[i_skip] = np.nan
+    tol[i_skip] = xp.nan
     status = lb.status
 
     # As in `_direct`, we'll need a temporary new axis for points
     # at which to evaluate the function. Append axis at the end for
     # consistency with other elementwise algorithms.
-    a2 = a[..., np.newaxis]
-    step2 = step[..., np.newaxis]
-    args2 = [arg[..., np.newaxis] for arg in args]
+    a2 = a[..., xp.newaxis]
+    step2 = step[..., xp.newaxis]
+    args2 = [arg[..., xp.newaxis] for arg in args]
 
     # Find the location of a term that is less than the tolerance (if possible)
-    log2maxterms = np.floor(np.log2(maxterms)) if maxterms else 0
-    n_steps = np.concatenate([2**np.arange(0, log2maxterms), [maxterms]], dtype=dtype)
+    log2maxterms = math.floor(math.log2(maxterms)) if maxterms else 0
+    n_steps = xp.concat([2**xp.arange(0, log2maxterms), xp.asarray([maxterms])],
+                        dtype=dtype)
     nfev = len(n_steps) * 2
     ks = a2 + n_steps * step2
     fks = f(ks, *args2)
     fksp1 = f(ks + step2, *args2)  # check that the function is decreasing
-    fk_insufficient = (fks > tol[:, np.newaxis]) | (fksp1 > fks)
-    n_fk_insufficient = np.sum(fk_insufficient, axis=-1)
-    nt = np.minimum(n_fk_insufficient, n_steps.shape[-1]-1)
+    fk_insufficient = (fks > tol[:, xp.newaxis]) | (fksp1 > fks)
+    n_fk_insufficient = xp.sum(fk_insufficient, axis=-1)
+    nt = xp.minimum(n_fk_insufficient, n_steps.shape[-1]-1)
     n_steps = n_steps[nt]
 
     # If `maxterms` is insufficient (i.e. either the magnitude of the last term of the
@@ -1325,37 +1329,38 @@ def _integral_bound(f, a, b, step, args, constants):
     # Directly evaluate the sum up to this term
     k = a + n_steps * step
     left, left_error, left_nfev = _direct(f, a, k, step, args,
-                                          constants, inclusive=False)
-    i_skip |= np.isposinf(left)  # if sum is not finite, no sense in continuing
-    status[np.isposinf(left)] = -3
-    k[i_skip] = np.nan
+                                          constants, xp, inclusive=False)
+    left_is_pos_inf = xp.isinf(left) & (left > 0)
+    i_skip |= left_is_pos_inf  # if sum is infinite, no sense in continuing
+    status[left_is_pos_inf] = -3
+    k[i_skip] = xp.nan
 
     # Use integration to estimate the remaining sum
     # Possible optimization for future work: if there were no terms less than
     # the tolerance, there is no need to compute the integral to better accuracy.
     # Something like:
-    # atol = np.maximum(atol, np.minimum(fk/2 - fb/2))
-    # rtol = np.maximum(rtol, np.minimum((fk/2 - fb/2)/left))
+    # atol = xp.maximum(atol, xp.minimum(fk/2 - fb/2))
+    # rtol = xp.maximum(rtol, xp.minimum((fk/2 - fb/2)/left))
     # where `fk`/`fb` are currently calculated below.
     right = _tanhsinh(f, k, b, args=args, atol=atol, rtol=rtol, log=log)
 
     # Calculate the full estimate and error from the pieces
-    fk = fks[np.arange(len(fks)), nt]
+    fk = fks[xp.arange(len(fks)), nt]
 
     # fb = f(b, *args), but some functions return NaN at infinity.
     # instead of 0 like they must (for the sum to be convergent).
-    fb = np.full_like(fk, -np.inf) if log else np.zeros_like(fk)
-    i = np.isfinite(b)
-    if np.any(i):  # better not call `f` with empty arrays
+    fb = xp.full_like(fk, -xp.inf) if log else xp.zeros_like(fk)
+    i = xp.isfinite(b)
+    if xp.any(i):  # better not call `f` with empty arrays
         fb[i] = f(b[i], *[arg[i] for arg in args])
-    nfev = nfev + np.asarray(i, dtype=left_nfev.dtype)
+    nfev = nfev + xp.asarray(i, dtype=left_nfev.dtype)
 
     if log:
-        log_step = np.log(step)
+        log_step = xp.log(step)
         S_terms = (left, right.integral - log_step, fk - log2, fb - log2)
-        S = special.logsumexp(S_terms, axis=0)
-        E_terms = (left_error, right.error - log_step, fk-log2, fb-log2+np.pi*1j)
-        E = special.logsumexp(E_terms, axis=0).real
+        S = special.logsumexp(xp.stack(S_terms), axis=0)
+        E_terms = (left_error, right.error - log_step, fk-log2, fb-log2+xp.pi*1j)
+        E = xp_real(special.logsumexp(xp.stack(E_terms), axis=0))
     else:
         S = left + right.integral/step + fk/2 + fb/2
         E = left_error + right.error/step + fk/2 - fb/2

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -51,9 +51,6 @@ def _vectorize(xp):
 @pytest.mark.skip_xp_backends(
     'jax.numpy', reason='JAX arrays do not support item assignment.'
 )
-@pytest.mark.skip_xp_backends(
-    'cupy', reason='cupy/cupy#8391'
-)
 class TestTanhSinh:
 
     # Test problems from [1] Section 6
@@ -747,6 +744,10 @@ class TestTanhSinh:
             assert res[attr].shape == shape
 
 
+@array_api_compatible
+@pytest.mark.usefixtures("skip_xp_backends")
+@pytest.mark.skip_xp_backends('array_api_strict', reason='No fancy indexing.')
+@pytest.mark.skip_xp_backends('jax.numpy', reason='No mutation.')
 class TestNSum:
     rng = np.random.default_rng(5895448232066142650)
     p = rng.uniform(1, 10, size=10)
@@ -777,95 +778,100 @@ class TestNSum:
     f3.ref = _gen_harmonic_gt1(f3.b, p)
     f3.args = (p,)
 
-    def test_input_validation(self):
+    def test_input_validation(self, xp):
         f = self.f1
+        a, b = xp.asarray(f.a), xp.asarray(f.b)
 
         message = '`f` must be callable.'
         with pytest.raises(ValueError, match=message):
-            nsum(42, f.a, f.b)
+            nsum(42, a, b)
 
         message = '...must be True or False.'
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, log=2)
+            nsum(f, a, b, log=2)
 
         message = '...must be real numbers.'
         with pytest.raises(ValueError, match=message):
-            nsum(f, 1+1j, f.b)
+            nsum(f, xp.asarray(1+1j), b)
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, None)
+            nsum(f, a, xp.asarray(1+1j))
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, step=object())
+            nsum(f, a, b, step=xp.asarray(1+1j))
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(atol='ekki'))
+            nsum(f, a, b, tolerances=dict(atol='ekki'))
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(rtol=pytest))
+            nsum(f, a, b, tolerances=dict(rtol=pytest))
 
         with np.errstate(all='ignore'):
-            res = nsum(f, [np.nan, np.inf], 1)
+            res = nsum(f, xp.asarray([np.nan, np.inf]), xp.asarray(1.))
             assert np.all((res.status == -1) & np.isnan(res.sum)
                           & np.isnan(res.error) & ~res.success & res.nfev == 1)
-            res = nsum(f, 10, [np.nan, 1])
+            res = nsum(f, xp.asarray(10.), xp.asarray([np.nan, 1]))
             assert np.all((res.status == -1) & np.isnan(res.sum)
                           & np.isnan(res.error) & ~res.success & res.nfev == 1)
-            res = nsum(f, 1, 10, step=[np.nan, -np.inf, np.inf, -1, 0])
+            res = nsum(f, xp.asarray(1.), xp.asarray(10.),
+                       step=xp.asarray([np.nan, -np.inf, np.inf, -1, 0]))
             assert np.all((res.status == -1) & np.isnan(res.sum)
                           & np.isnan(res.error) & ~res.success & res.nfev == 1)
 
         message = '...must be non-negative and finite.'
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(rtol=-1))
+            nsum(f, a, b, tolerances=dict(rtol=-1))
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(atol=np.inf))
+            nsum(f, a, b, tolerances=dict(atol=np.inf))
 
         message = '...may not be positive infinity.'
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(rtol=np.inf), log=True)
+            nsum(f, a, b, tolerances=dict(rtol=np.inf), log=True)
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, tolerances=dict(atol=np.inf), log=True)
+            nsum(f, a, b, tolerances=dict(atol=np.inf), log=True)
 
         message = '...must be a non-negative integer.'
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, maxterms=3.5)
+            nsum(f, a, b, maxterms=3.5)
         with pytest.raises(ValueError, match=message):
-            nsum(f, f.a, f.b, maxterms=-2)
+            nsum(f, a, b, maxterms=-2)
 
     @pytest.mark.parametrize('f_number', range(1, 4))
-    def test_basic(self, f_number):
+    def test_basic(self, f_number, xp):
         f = getattr(self, f"f{f_number}")
-        res = nsum(f, f.a, f.b, args=f.args)
-        assert_allclose(res.sum, f.ref)
-        assert_equal(res.status, 0)
-        assert_equal(res.success, True)
+        a, b, args = xp.asarray(f.a), xp.asarray(f.b), xp.asarray(f.args)
+        ref = xp.asarray(f.ref)
+        res = nsum(f, a, b, args=args)
+        xp_assert_close(res.sum, ref)
+        xp_assert_equal(res.status, xp.zeros(ref.shape, dtype=xp.int64))
+        xp_test = array_namespace(a)  # CuPy doesn't have `bool`
+        xp_assert_equal(res.success, xp.ones(ref.shape, dtype=xp_test.bool))
 
         with np.errstate(divide='ignore'):
-            logres = nsum(lambda *args: np.log(f(*args)),
-                           f.a, f.b, log=True, args=f.args)
-        assert_allclose(np.exp(logres.sum), res.sum)
-        assert_allclose(np.exp(logres.error), res.error, atol=1e-15)
-        assert_equal(logres.status, 0)
-        assert_equal(logres.success, True)
+            logres = nsum(lambda *args: xp.log(f(*args)),
+                           a, b, log=True, args=args)
+        xp_assert_close(np.exp(logres.sum), res.sum)
+        xp_assert_close(np.exp(logres.error), res.error, atol=1e-15)
+        xp_assert_equal(logres.status, res.status)
+        xp_assert_equal(logres.success, res.success)
 
     @pytest.mark.parametrize('maxterms', [0, 1, 10, 20, 100])
-    def test_integral(self, maxterms):
+    def test_integral(self, maxterms, xp):
         # test precise behavior of integral approximation
         f = self.f1
 
         def logf(x):
-            return -2*np.log(x)
+            return -2*xp.log(x)
 
         def F(x):
             return -1 / x
 
-        a = np.asarray([1, 5])[:, np.newaxis]
-        b = np.asarray([20, 100, np.inf])[:, np.newaxis, np.newaxis]
-        step = np.asarray([0.5, 1, 2]).reshape((-1, 1, 1, 1))
-        nsteps = np.floor((b - a)/step)
+        a = xp.asarray([1, 5])[:, xp.newaxis]
+        b = xp.asarray([20, 100, xp.inf])[:, xp.newaxis, xp.newaxis]
+        step = xp.asarray([0.5, 1, 2]).reshape((-1, 1, 1, 1))
+        nsteps = xp.floor((b - a)/step)
         b_original = b
         b = a + nsteps*step
 
         k = a + maxterms*step
         # partial sum
-        direct = f(a + np.arange(maxterms)*step).sum(axis=-1, keepdims=True)
+        direct = xp.sum(f(a + xp.arange(maxterms)*step), axis=-1, keepdims=True)
         integral = (F(b) - F(k))/step  # integral approximation of remainder
         low = direct + integral + f(b)  # theoretical lower bound
         high = direct + integral + f(k)  # theoretical upper bound
@@ -873,31 +879,31 @@ class TestNSum:
         ref_err = (high - low)/2  # error (assuming perfect quadrature)
 
         # correct reference values where number of terms < maxterms
-        a, b, step = np.broadcast_arrays(a, b, step)
+        a, b, step = xp.broadcast_arrays(a, b, step)
         for i in np.ndindex(a.shape):
-            ai, bi, stepi = a[i], b[i], step[i]
+            ai, bi, stepi = float(a[i]), float(b[i]), float(step[i])
             if (bi - ai)/stepi + 1 <= maxterms:
-                direct = f(np.arange(ai, bi+stepi, stepi)).sum()
+                direct = xp.sum(f(xp.arange(ai, bi+stepi, stepi)))
                 ref_sum[i] = direct
-                ref_err[i] = direct * np.finfo(direct).eps
+                ref_err[i] = direct * xp.finfo(direct).eps
 
         rtol = 1e-12
         res = nsum(f, a, b_original, step=step, maxterms=maxterms,
                    tolerances=dict(rtol=rtol))
-        assert_allclose(res.sum, ref_sum, rtol=10*rtol)
-        assert_allclose(res.error, ref_err, rtol=100*rtol)
+        xp_assert_close(res.sum, ref_sum, rtol=10*rtol)
+        xp_assert_close(res.error, ref_err, rtol=100*rtol)
 
         i = ((b_original - a)/step + 1 <= maxterms)
-        assert_allclose(res.sum[i], ref_sum[i], rtol=1e-15)
-        assert_allclose(res.error[i], ref_err[i], rtol=1e-15)
+        xp_assert_close(res.sum[i], ref_sum[i], rtol=1e-15)
+        xp_assert_close(res.error[i], ref_err[i], rtol=1e-15)
 
         logres = nsum(logf, a, b_original, step=step, log=True,
-                      tolerances=dict(rtol=np.log(rtol)), maxterms=maxterms)
-        assert_allclose(np.exp(logres.sum), res.sum)
-        assert_allclose(np.exp(logres.error), res.error)
+                      tolerances=dict(rtol=math.log(rtol)), maxterms=maxterms)
+        xp_assert_close(np.exp(logres.sum), res.sum)
+        xp_assert_close(np.exp(logres.error), res.error)
 
     @pytest.mark.parametrize('shape', [tuple(), (12,), (3, 4), (3, 2, 2)])
-    def test_vectorization(self, shape):
+    def test_vectorization(self, shape, xp):
         # Test for correct functionality, output shapes, and dtypes for various
         # input shapes.
         rng = np.random.default_rng(82456839535679456794)
@@ -907,7 +913,7 @@ class TestNSum:
         # between vectorized call and looping.
         b = np.inf
         p = rng.random(shape) + 1
-        n = np.prod(shape)
+        n = math.prod(shape)
 
         def f(x, p):
             f.feval += 1 if (x.size == n or x.ndim <= 1) else x.shape[-1]
@@ -919,83 +925,91 @@ class TestNSum:
         def nsum_single(a, b, p, maxterms):
             return nsum(lambda x: 1 / x**p, a, b, maxterms=maxterms)
 
-        res = nsum(f, a, b, maxterms=1000, args=(p,))
+        res = nsum(f, xp.asarray(a), xp.asarray(b), maxterms=1000,
+                   args=(xp.asarray(p),))
         refs = nsum_single(a, b, p, maxterms=1000).ravel()
 
         attrs = ['sum', 'error', 'success', 'status', 'nfev']
         for attr in attrs:
             ref_attr = [getattr(ref, attr) for ref in refs]
             res_attr = getattr(res, attr)
-            assert_allclose(res_attr.ravel(), ref_attr, rtol=1e-15)
-            assert_equal(res_attr.shape, shape)
+            xp_assert_close(res_attr.ravel(), xp.asarray(ref_attr), rtol=1e-15)
+            assert res_attr.shape == shape
 
-        assert np.issubdtype(res.success.dtype, np.bool_)
-        assert np.issubdtype(res.status.dtype, np.integer)
-        assert np.issubdtype(res.nfev.dtype, np.integer)
-        assert_equal(np.max(res.nfev), f.feval)
+        xp_test = array_namespace(xp.asarray(1.))
+        assert xp_test.isdtype(res.success.dtype, 'bool')
+        assert xp_test.isdtype(res.status.dtype, 'integral')
+        assert xp_test.isdtype(res.nfev.dtype, 'integral')
+        assert int(xp.max(res.nfev)) == f.feval
 
-    def test_status(self):
+    def test_status(self, xp):
         f = self.f2
 
         p = [2, 2, 0.9, 1.1, 2, 2]
-        a = [0, 0, 1, 1, 1, np.nan]
-        b = [10, np.inf, np.inf, np.inf, np.inf, np.inf]
+        a = xp.asarray([0, 0, 1, 1, 1, np.nan])
+        b = xp.asarray([10, np.inf, np.inf, np.inf, np.inf, np.inf])
         ref = special.zeta(p, 1)
+        p = xp.asarray(p)
 
         with np.errstate(divide='ignore'):  # intentionally dividing by zero
             res = nsum(f, a, b, args=(p,))
 
-        assert_equal(res.success, [False, False, False, False, True, False])
-        assert_equal(res.status, [-3, -3, -2, -4, 0, -1])
-        assert_allclose(res.sum[res.success], ref[res.success])
+        xp_assert_equal(res.success, xp.asarray([False, False, False, False, True, False]))
+        xp_assert_equal(res.status, xp.asarray([-3, -3, -2, -4, 0, -1]))
+        xp_assert_close(res.sum[res.success], xp.asarray(ref)[res.success])
 
-    def test_nfev(self):
+    def test_nfev(self, xp):
         def f(x):
             f.nfev += np.size(x)
             return 1 / x**2
 
         f.nfev = 0
-        res = nsum(f, 1, 10)
-        assert_equal(res.nfev, f.nfev)
+        res = nsum(f, xp.asarray(1), xp.asarray(10))
+        assert res.nfev == f.nfev
 
         f.nfev = 0
-        res = nsum(f, 1, np.inf, tolerances=dict(atol=1e-6))
-        assert_equal(res.nfev, f.nfev)
+        res = nsum(f, xp.asarray(1), xp.asarray(xp.inf), tolerances=dict(atol=1e-6))
+        assert res.nfev == f.nfev
 
-    def test_inclusive(self):
+    def test_inclusive(self, xp):
         # There was an edge case off-by one bug when `_direct` was called with
         # `inclusive=True`. Check that this is resolved.
-        res = nsum(lambda k: 1 / k ** 2, [1, 4], np.inf,
+        a = xp.asarray([1, 4])
+        b = xp.asarray(xp.inf)
+        res = nsum(lambda k: 1 / k ** 2, a, b,
                    maxterms=500, tolerances=dict(atol=0.1))
-        ref = nsum(lambda k: 1 / k ** 2, [1, 4], np.inf)
-        assert np.all(res.sum > (ref.sum - res.error))
-        assert np.all(res.sum < (ref.sum + res.error))
+        ref = nsum(lambda k: 1 / k ** 2, a, b)
+        assert xp.all(res.sum > (ref.sum - res.error))
+        assert xp.all(res.sum < (ref.sum + res.error))
 
     @pytest.mark.parametrize('log', [True, False])
-    def test_infinite_bounds(self, log):
-        a = [1, -np.inf, -np.inf]
-        b = [np.inf, -1, np.inf]
-        c = [1, 2, 3]
+    def test_infinite_bounds(self, log, xp):
+        a = xp.asarray([1, -np.inf, -np.inf])
+        b = xp.asarray([np.inf, -1, np.inf])
+        c = xp.asarray([1, 2, 3])
 
         def f(x, a):
-            return (np.log(np.tanh(a / 2)) - a*np.abs(x) if log
-                    else np.tanh(a/2) * np.exp(-a*np.abs(x)))
+            return (xp.log(xp.tanh(a / 2)) - a*xp.abs(x) if log
+                    else xp.tanh(a/2) * xp.exp(-a*xp.abs(x)))
 
         res = nsum(f, a, b, args=(c,), log=log)
-        ref = [stats.dlaplace.sf(0, 1), stats.dlaplace.sf(0, 2), 1]
-        ref = np.log(ref) if log else ref
+        ref = xp.asarray([stats.dlaplace.sf(0, 1), stats.dlaplace.sf(0, 2), 1])
+        ref = xp.log(ref) if log else ref
         atol = 1e-10 if log else 0
-        assert_allclose(res.sum, ref, atol=atol)
+        xp_assert_close(res.sum, ref, atol=atol)
 
-        # Make sure the sign of `x` passed into `f` is correct.
+        # # Make sure the sign of `x` passed into `f` is correct.
         def f(x, c):
-            return -3*np.log(c*x) if log else 1 / (c*x)**3
+            return -3*xp.log(c*x) if log else 1 / (c*x)**3
 
-        res = nsum(f, [1, -np.inf], [np.inf, -1], args=([1, -1],), log=log)
+        a = xp.asarray([1, -np.inf])
+        b = xp.asarray([np.inf, -1])
+        arg = xp.asarray([1, -1])
+        res = nsum(f, a, b, args=(arg,), log=log)
         ref = np.log(special.zeta(3)) if log else special.zeta(3)
-        assert_allclose(res.sum, ref)
+        xp_assert_close(res.sum, xp.full(a.shape, ref))
 
-    def test_decreasing_check(self):
+    def test_decreasing_check(self, xp):
         # Test accuracy when we start sum on an uphill slope.
         # Without the decreasing check, the terms would look small enough to
         # use the integral approximation. Because the function is not decreasing,
@@ -1003,34 +1017,34 @@ class TestNSum:
         # partial sum. In this case, the error would be  ~1e-4, causing the test
         # to fail.
         def f(x):
-            return np.exp(-x ** 2)
+            return xp.exp(-x ** 2)
 
-        res = nsum(f, -25, np.inf)
+        res = nsum(f, xp.asarray(-25), xp.asarray(np.inf))
 
         # Reference computed with mpmath:
         # from mpmath import mp
         # mp.dps = 50
         # def fmp(x): return mp.exp(-x**2)
         # ref = mp.nsum(fmp, (-25, 0)) + mp.nsum(fmp, (1, mp.inf))
-        ref = 1.772637204826652
+        ref = xp.asarray(1.772637204826652)
 
-        np.testing.assert_allclose(res.sum, ref, rtol=1e-15)
+        xp_assert_close(res.sum, ref, rtol=1e-15)
 
-    def test_special_case(self):
+    def test_special_case(self, xp):
         # test equal lower/upper limit
         f = self.f1
-        a = b = 2
+        a = b = xp.asarray(2)
         res = nsum(f, a, b)
-        assert_equal(res.sum, f(a))
+        xp_assert_equal(res.sum, xp.asarray(f(2)))
 
         # Test scalar `args` (not in tuple)
-        res = nsum(self.f2, 1, np.inf, args=2)
-        assert_allclose(res.sum, self.f1.ref)  # f1.ref is correct w/ args=2
+        res = nsum(self.f2, xp.asarray(1), xp.asarray(np.inf), args=xp.asarray(2))
+        xp_assert_close(res.sum, xp.asarray(self.f1.ref))  # f1.ref is correct w/ args=2
 
         # Test 0 size input
-        a = np.empty((3, 1, 1))  # arbitrary broadcastable shapes
-        b = np.empty((0, 1))  # could use Hypothesis
-        p = np.empty(4)  # but it's overkill
+        a = xp.empty((3, 1, 1))  # arbitrary broadcastable shapes
+        b = xp.empty((0, 1))  # could use Hypothesis
+        p = xp.empty(4)  # but it's overkill
         shape = np.broadcast_shapes(a.shape, b.shape, p.shape)
         res = nsum(self.f2, a, b, args=(p,))
         assert res.sum.shape == shape
@@ -1042,47 +1056,49 @@ class TestNSum:
             with np.errstate(divide='ignore'):
                 return 1 / x
 
-        res = nsum(f, 0, 10, maxterms=0)
-        assert np.isnan(res.sum)
-        assert np.isnan(res.error)
+        res = nsum(f, xp.asarray(0), xp.asarray(10), maxterms=0)
+        assert xp.isnan(res.sum)
+        assert xp.isnan(res.error)
         assert res.status == -2
 
-        res = nsum(f, 0, 10, maxterms=1)
-        assert np.isnan(res.sum)
-        assert np.isnan(res.error)
+        res = nsum(f, xp.asarray(0), xp.asarray(10), maxterms=1)
+        assert xp.isnan(res.sum)
+        assert xp.isnan(res.error)
         assert res.status == -3
 
         # Test NaNs
         # should skip both direct and integral methods if there are NaNs
-        a = [np.nan, 1, 1, 1]
-        b = [np.inf, np.nan, np.inf, np.inf]
-        p = [2, 2, np.nan, 2]
+        a = xp.asarray([xp.nan, 1, 1, 1])
+        b = xp.asarray([xp.inf, xp.nan, xp.inf, xp.inf])
+        p = xp.asarray([2, 2, xp.nan, 2])
         res = nsum(self.f2, a, b, args=(p,))
-        assert_allclose(res.sum, [np.nan, np.nan, np.nan, self.f1.ref])
-        assert_allclose(res.error[:3], np.nan)
-        assert_equal(res.status, [-1, -1, -3, 0])
-        assert_equal(res.success, [False, False, False, True])
+        xp_assert_close(res.sum, xp.asarray([xp.nan, xp.nan, xp.nan, self.f1.ref]))
+        xp_assert_close(res.error[:3], xp.full(3, xp.nan))
+        xp_assert_equal(res.status, xp.asarray([-1, -1, -3, 0]))
+        xp_assert_equal(res.success, xp.asarray([False, False, False, True]))
         # Ideally res.nfev[2] would be 1, but `tanhsinh` has some function evals
-        assert_equal(res.nfev[:2], 1)
+        xp_assert_equal(res.nfev[:2], xp.full(2, 1))
 
-    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-    def test_dtype(self, dtype):
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    def test_dtype(self, dtype, xp):
+        dtype = getattr(xp, dtype)
+
         def f(k):
             assert k.dtype == dtype
-            return 1 / k ** np.asarray(2, dtype=dtype)
+            return 1 / k ** xp.asarray(2, dtype=dtype)
 
-        a = np.asarray(1, dtype=dtype)
-        b = np.asarray([10, np.inf], dtype=dtype)
+        a = xp.asarray(1, dtype=dtype)
+        b = xp.asarray([10, xp.inf], dtype=dtype)
         res = nsum(f, a, b)
         assert res.sum.dtype == dtype
         assert res.error.dtype == dtype
 
-        rtol = 1e-12 if dtype == np.float64 else 1e-6
-        ref = _gen_harmonic_gt1(b, 2)
-        assert_allclose(res.sum, ref, rtol=rtol)
+        rtol = 1e-12 if dtype == xp.float64 else 1e-6
+        ref = _gen_harmonic_gt1(np.asarray([10, xp.inf]), 2)
+        xp_assert_close(res.sum, xp.asarray(ref, dtype=dtype), rtol=rtol)
 
     @pytest.mark.parametrize('case', [(10, 100), (100, 10)])
-    def test_nondivisible_interval(self, case):
+    def test_nondivisible_interval(self, case, xp):
         # When the limits of the sum are such that (b - a)/step
         # is not exactly integral, check that only floor((b - a)/step)
         # terms are included.
@@ -1096,13 +1112,16 @@ class TestNSum:
         b0 = a + n * step
         i = np.arange(-2, 3)
         b = b0 + i * np.spacing(b0)
-        res = nsum(f, a, b, step=step, maxterms=maxterms)
         ns = np.floor((b - a) / step)
-        assert_equal(np.diff(ns) > 0, np.diff(res.sum) > 0)
-        assert_allclose(res.sum[-1], res.sum[0] + f(b0))
         assert len(set(ns)) == 2
 
-    def test_logser_kurtosis_gh20648(self):
+        a, b, step, ns = xp.asarray(a), xp.asarray(b), xp.asarray(step), xp.asarray(ns)
+        res = nsum(f, a, b, step=step, maxterms=maxterms)
+        xp_assert_equal(xp.diff(ns) > 0, xp.diff(res.sum) > 0)
+        xp_assert_close(res.sum[-1], res.sum[0] + f(b0))
+
+    @pytest.mark.skip_xp_backends(np_only=True, reason='Needs beta function.')
+    def test_logser_kurtosis_gh20648(self, xp):
         # Some functions return NaN at infinity rather than 0 like they should.
         # Check that this is accounted for.
         ref = stats.yulesimon.moment(4, 5)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -853,7 +853,6 @@ class TestNSum:
         xp_assert_equal(logres.status, res.status)
         xp_assert_equal(logres.success, res.success)
 
-    @pytest.mark.skip_xp_backends('torch', reason='seems sensitive to arithmetic')
     @pytest.mark.parametrize('maxterms', [0, 1, 10, 20, 100])
     def test_integral(self, maxterms, xp):
         # test precise behavior of integral approximation
@@ -865,9 +864,9 @@ class TestNSum:
         def F(x):
             return -1 / x
 
-        a = xp.asarray([1, 5])[:, xp.newaxis]
-        b = xp.asarray([20, 100, xp.inf])[:, xp.newaxis, xp.newaxis]
-        step = xp.asarray([0.5, 1, 2]).reshape((-1, 1, 1, 1))
+        a = xp.asarray([1, 5], dtype=xp.float64)[:, xp.newaxis]
+        b = xp.asarray([20, 100, xp.inf], dtype=xp.float64)[:, xp.newaxis, xp.newaxis]
+        step = xp.asarray([0.5, 1, 2], dtype=xp.float64).reshape((-1, 1, 1, 1))
         nsteps = xp.floor((b - a)/step)
         b_original = b
         b = a + nsteps*step
@@ -887,7 +886,7 @@ class TestNSum:
         for i in np.ndindex(a.shape):
             ai, bi, stepi = float(a[i]), float(b[i]), float(step[i])
             if (bi - ai)/stepi + 1 <= maxterms:
-                direct = xp.sum(f(xp.arange(ai, bi+stepi, stepi)))
+                direct = xp.sum(f(xp.arange(ai, bi+stepi, stepi, dtype=xp.float64)))
                 ref_sum[i] = direct
                 ref_err[i] = direct * xp.finfo(direct.dtype).eps
 


### PR DESCRIPTION
#### What does this implement/fix?
This adds support for alternative array input to `scipy.integrate.nsum`.