### PR TITLE
DOC: add Array API Standard support directive

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -56,6 +56,16 @@ div.admonition-arrayapi {
   border-color: var(--pst-color-primary);
 }
 
+.admonition>.admonition-title::after,
+div.admonition>.admonition-title::after {
+  color: var(--pst-color-primary);
+}
+
+.admonition>.admonition-title,
+div.admonition>.admonition-title {
+  background-color: var(--pst-color-surface);
+}
+
 /* JupyterLite "Try Examples" directive */
 
 .try_examples_button {

--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -50,6 +50,12 @@ div.admonition>.admonition-title {
   background-color: var(--pst-color-warning-bg);
 }
 
+/* Array API admonition */
+
+div.admonition-arrayapi {
+  border-color: var(--pst-color-primary);
+}
+
 /* JupyterLite "Try Examples" directive */
 
 .try_examples_button {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -475,7 +475,7 @@ def linkcode_resolve(domain, info):
         lineno = None
 
     if lineno:
-        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -574,7 +574,8 @@ class ArrayAPIDirective(Directive):
         text = (f"This {obj} has experimental support for Python Array API Standard "
                 "compatible backends other than NumPy. Please consider testing this "
                 "feature by setting an environment variable ``SCIPY_ARRAY_API=1`` and "
-                "providing PyTorch, JAX, or CuPy arrays as array arguments.")
+                "providing PyTorch, JAX, or CuPy arrays as array arguments. See "
+                ":ref:`dev-arrayapi` for more information.")
 
         try:
             self.content[0] = text+" "+self.content[0]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -553,5 +553,58 @@ class LegacyDirective(Directive):
         return [admonition_node]
 
 
+class ArrayAPIDirective(Directive):
+    """
+    Adapted from LegacyDirective above
+
+    Uses a default text if the directive does not have contents. If it does,
+    the default text is concatenated to the contents.
+
+    """
+    has_content = True
+    node_class = nodes.admonition
+    optional_arguments = 1
+
+    def run(self):
+        try:
+            obj = self.arguments[0]
+        except IndexError:
+            # Argument is empty; use default text
+            obj = "submodule"
+        text = (f"This {obj} has experimental support for Python Array API Standard "
+                "compatible backends other than NumPy. Please consider testing this "
+                "feature by setting an environment variable ``SCIPY_ARRAY_API=1`` and "
+                "providing PyTorch, JAX, or CuPy arrays as array arguments.")
+
+        try:
+            self.content[0] = text+" "+self.content[0]
+        except IndexError:
+            # Content is empty; use the default text
+            source, lineno = self.state_machine.get_source_and_line(
+                self.lineno
+            )
+            self.content.append(
+                text,
+                source=source,
+                offset=lineno
+            )
+        text = '\n'.join(self.content)
+        # Create the admonition node, to be populated by `nested_parse`
+        admonition_node = self.node_class(rawsource=text)
+        # Set custom title
+        title_text = "Array API Standard Support"
+        textnodes, _ = self.state.inline_text(title_text, self.lineno)
+        title = nodes.title(title_text, '', *textnodes)
+        # Set up admonition node
+        admonition_node += title
+        # Select custom class for CSS styling
+        admonition_node['classes'] = ['admonition-arrayapi']
+        # Parse the directive contents
+        self.state.nested_parse(self.content, self.content_offset,
+                                admonition_node)
+        return [admonition_node]
+
+
 def setup(app):
     app.add_directive("legacy", LegacyDirective)
+    app.add_directive("arrayapi", ArrayAPIDirective)

--- a/scipy/differentiate/__init__.py
+++ b/scipy/differentiate/__init__.py
@@ -5,6 +5,8 @@ Finite Difference Differentiation (:mod:`scipy.differentiate`)
 
 .. currentmodule:: scipy.differentiate
 
+.. arrayapi::
+
 SciPy ``differentiate`` provides functions for performing finite difference
 numerical differentiation of black-box functions.
 

--- a/scipy/optimize/elementwise.py
+++ b/scipy/optimize/elementwise.py
@@ -5,6 +5,8 @@ Elementwise Scalar Optimization (:mod:`scipy.optimize.elementwise`)
 
 .. currentmodule:: scipy.optimize.elementwise
 
+.. arrayapi::
+
 This module provides a collection of functions for root finding and
 minimization of scalar, real-valued functions of one variable. Unlike their
 counterparts in the base :mod:`scipy.optimize` namespace, these functions work

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4286,6 +4286,8 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     producing datasets that have a Pearson correlation at least as extreme
     as the one computed from these datasets.
 
+    .. arrayapi:: function
+
     Parameters
     ----------
     x : array_like


### PR DESCRIPTION
#### Reference issue
gh-17597
gh-21255

#### What does this implement/fix?
This adds an admonition that advertises support for non-NumPy backends.

#### Additional information
Just an experiment; it's up for debate whether we want to do this yet.