### PR TITLE
TST: linalg: do not call `np.asarray_chkfinite(np.empty((3, 1, 1))`

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1215,7 +1215,7 @@ class TestDet:
         a = np.empty((3, 0, 0), dtype=dt)
         d = det(a)
         assert d.shape == (3,)
-        assert d.dtype == det(np.empty((3, 1, 1), dtype=dt)).dtype
+        assert d.dtype == det(np.zeros((3, 1, 1), dtype=dt)).dtype
 
     def test_overwrite_a(self):
         # If all conditions are met then input should be overwritten;


### PR DESCRIPTION
`np.empty` may contain infs or nans, so this test may fail randomly, depending on unrelated memory allocations etc.

(In fact, it did started failing in gh-21935 which did not touch `det`.)
