### PR TITLE
ENH: signal.filtfilt: add support for complex signals

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4261,10 +4261,10 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     # Backward filter.
     # Create y0 so zi*y0 broadcasts appropriately.
     y0 = axis_slice(y, start=-1, axis=axis)
-    (y, zf) = lfilter(b, a, axis_reverse(y, axis=axis), axis=axis, zi=zi * y0)
+    (y, zf) = lfilter(b, a, axis_reverse(y.conj(), axis=axis), axis=axis, zi=(zi * y0).conj())
 
     # Reverse y.
-    y = axis_reverse(y, axis=axis)
+    y = axis_reverse(y, axis=axis).conj()
 
     if edge > 0:
         # Slice the actual signal from the extended signal.
@@ -4297,9 +4297,15 @@ def _validate_pad(padtype, padlen, x, axis, ntaps):
         # Make an extension of length `edge` at each
         # end of the input array.
         if padtype == 'even':
-            ext = even_ext(x, edge, axis=axis)
+            if not np.iscomplexobj(x):
+                ext = even_ext(x, edge, axis=axis)
+            else:
+                ext = even_ext(x.real, edge, axis=axis) + 1.j*odd_ext(x.imag, edge, axis=axis)
         elif padtype == 'odd':
-            ext = odd_ext(x, edge, axis=axis)
+            if not np.iscomplexobj(x):
+                ext = odd_ext(x, edge, axis=axis)
+            else:
+                ext = odd_ext(x.real, edge, axis=axis) + 1.j*even_ext(x.imag, edge, axis=axis)
         else:
             ext = const_ext(x, edge, axis=axis)
     else:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2357,6 +2357,40 @@ class TestFiltFilt:
         y2dt = self.filtfilt(zpk, x2d.T, padlen=n, axis=0)
         assert_equal(y2d, y2dt.T)
 
+    def test_sine_complex(self):
+        rate = 2000
+        t = np.linspace(0, 1.0, rate + 1)
+        # A signal with low frequency and a high frequency.
+        xlow = np.exp(1.j * 5 * 2 * np.pi * t)
+        xhigh = np.exp(1.j * 250 * 2 * np.pi * t)
+        x = xlow + xhigh
+
+        zpk = butter(8, 0.125, output='zpk')
+        # r is the magnitude of the largest pole.
+        r = np.abs(zpk[1]).max()
+        eps = 1e-5
+        # n estimates the number of steps for the
+        # transient to decay by a factor of eps.
+        n = int(np.ceil(np.log(eps) / np.log(r)))
+
+        # High order lowpass filter...
+        y = self.filtfilt(zpk, x, padtype='even', padlen=n)
+        # Result should be just xlow.
+        err = np.abs(y - xlow).max()
+        assert_(err < 1e-4)
+
+        # A 2D case.
+        x2d = np.vstack([xlow, xlow + xhigh])
+        y2d = self.filtfilt(zpk, x2d, padtype='even', padlen=n, axis=1)
+        assert_equal(y2d.shape, x2d.shape)
+        err = np.abs(y2d - xlow).max()
+        assert_(err < 1e-4)
+
+        # Use the previous result to check the use of the axis keyword.
+        # (Regression test for ticket #1620)
+        y2dt = self.filtfilt(zpk, x2d.T, padtype='even', padlen=n, axis=0)
+        assert_equal(y2d, y2dt.T)
+
     def test_axis(self):
         # Test the 'axis' keyword on a 3D array.
         x = np.arange(10.0 * 11.0 * 12.0).reshape(10, 11, 12)


### PR DESCRIPTION
#### Reference issue
Partial solution to https://github.com/scipy/scipy/issues/17877 

#### What does this implement/fix?
Adds support for complex signals to filtfilt.

#### Additional information
Support for complex *filters* is also needed, and not addressed by this PR.
