### PR TITLE
DOC: add docs on parallel execution and thread safety

### DIFF
--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -51,6 +51,9 @@ There are also additional user guides for these topics:
 
 For guidance on organizing and importing functions from SciPy subpackages, refer to the `Guidelines for Importing Functions from SciPy <https://scipy.github.io/devdocs/reference/index.html#guidelines-for-importing-functions-from-scipy>`_.
 
+For information on support for parallel execution and thread safety, see
+:ref:`scipy_parallel_execution` and :ref:`scipy_thread_safety`.
+
 .. raw:: latex
 
    \addtocontents{toc}{\protect\setcounter{tocdepth}{2}}
@@ -74,6 +77,9 @@ For guidance on organizing and importing functions from SciPy subpackages, refer
    stats
    arpack
    csgraph
+   parallel_execution
+   thread_safety
+
 
 .. raw:: latex
 

--- a/doc/source/tutorial/parallel_execution.rst
+++ b/doc/source/tutorial/parallel_execution.rst
@@ -1,0 +1,45 @@
+.. _scipy_parallel_execution:
+
+Parallel execution support in SciPy
+===================================
+
+SciPy aims to provide functionality that is performant, i.e. has good execution
+speed. On modern computing hardware, CPUs often have many CPU cores - and hence
+users may benefit from parallel execution. This page aims to give a brief
+overview of the options available to employ parallel execution.
+
+Some key points related to parallelism:
+
+- SciPy itself defaults to single-threaded execution.
+
+- The exception to that single-threaded default is code that calls into a BLAS
+  or LAPACK library for linear algebra functionality (either direct or via
+  NumPy). BLAS/LAPACK libraries almost always default to multi-threaded execution,
+  typically using all available CPU cores.
+
+  - Users can control the threading behavior of the BLAS/LAPACK library that
+    SciPy and NumPy are linked with through
+    `threadpoolctl <https://github.com/joblib/threadpoolctl>`__.
+
+- SciPy functionality may provide parallel execution in an opt-in manner. This
+  is exposed through a ``workers=`` keyword in individual APIs, which takes an
+  integer for the number of threads or processes to use, and in some cases also
+  a map-like callable (e.g., ``multiprocessing.Pool``). See `scipy.fft.fft` and
+  `scipy.optimize.differential_evolution` for examples.
+
+  - SciPy-internal threading is done with OS-level thread pools. OpenMP is not
+    used within SciPy.
+
+- SciPy works well with `multiprocessing` and with `threading`. The former has
+  higher overhead than the latter, but is widely used and robust. The latter may
+  offer performance benefits for some usage scenarios - however, please read
+  :ref:`scipy_thread_safety`.
+
+- SciPy has *experimental* support for free-threaded CPython, starting with
+  SciPy 1.15.0 (and Python 3.13.0, NumPy 2.1.0).
+
+- SciPy has *experimental* support in a growing number of submodules and
+  functions for array libraries other than NumPy, such as PyTorch, CuPy and
+  JAX. Those libraries default to parallel execution and may offer significant
+  performance benefits (and GPU execution). See :ref:`dev-arrayapi` for more
+  details.

--- a/doc/source/tutorial/thread_safety.rst
+++ b/doc/source/tutorial/thread_safety.rst
@@ -1,0 +1,63 @@
+.. _scipy_thread_safety:
+
+Thread Safety in SciPy
+======================
+
+SciPy supports use in a multithreaded context via the `threading` module in
+the standard library. Many SciPy operations release the GIL, as does NumPy (and
+a lot of SciPy functionality is implemented as calls to NumPy functions) - so
+unlike many situations in Python, it is possible to improve parallel
+performance by exploiting multithreaded parallelism in Python.
+
+The easiest performance gains happen when each worker thread owns its own array
+or set of array objects, with no data directly shared between threads. Threads
+that spend most of their time in low-level code will typically run in parallel.
+
+It is possible to share NumPy arrays between threads, but extreme care must be
+taken to avoid creating thread safety issues when mutating arrays that are
+shared between multiple threads - please see the NumPy documentation on thread
+safety for more details. SciPy functions will not mutate arrays that the user
+passes in, unless a function explicitly documents that it will do so (which is
+rare). Hence calling SciPy functions in a threaded fashion on the same NumPy array
+is safe.
+
+While most of SciPy consists of *functions*, more care has to be taken with
+*classes* and *data structures*.
+
+Classes that have state, such as some of the integration and interpolation
+objects in `scipy.integrate` and `scipy.interpolate`, are typically robust
+against being called in parallel. They either accept parallel calls or raise an
+informative error. For example, `scipy.integrate.ode` may raise an
+``IntegratorConcurrencyError`` for integration methods that do not support
+parallel execution.
+
+SciPy offers a couple of data structures, namely sparse arrays and matrices in
+`scipy.sparse`, and k-D trees in `scipy.spatial`. These data structures are
+*currently not thread-safe*. Please avoid in particular operations that mutate
+a data structure, like using item or slice assignment on sparse arrays, while
+the data is shared across multiple threads. That may result in data corruption,
+crashes, or other unwanted behavior.
+
+Note that operations that *do not* release the GIL will see no performance
+gains from use of the `threading` module, and instead might be better served
+with `multiprocessing`.
+
+
+Free-threaded Python
+--------------------
+
+.. versionadded:: 1.15.0
+
+Starting with SciPy 1.15.0 and CPython 3.13, SciPy has experimental support
+for Python runtimes with the GIL disabled on all platforms. See
+https://py-free-threading.github.io for more information about installing and
+using free-threaded Python.
+
+Because free-threaded Python does not have a global interpreter lock (GIL) to
+serialize access to Python objects, there are more opportunities for threads to
+mutate shared state and create thread safety issues. All SciPy functionality is
+tested for usage from parallel threads, however we expect there to be issues
+that are as yet undiscovered - if you run into a problem, please check the
+`GitHub issues with the free-threading label <https://github.com/scipy/scipy/issues?q=is%3Aopen+is%3Aissue+label%3Afree-threading>`__
+and open a new issue if one does not exist yet for the function that is
+misbehaving.

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2950,6 +2950,9 @@ def set_link_color_palette(palette):
     -----
     Ability to reset the palette with ``None`` added in SciPy 0.17.0.
 
+    Thread safety: using this function in a multi-threaded fashion may
+    result in `dendrogram` producing plots with unexpected colors.
+
     Examples
     --------
     >>> import numpy as np


### PR DESCRIPTION
The thread safety part is inspired by the NumPy docs on the same topic: https://numpy.org/devdocs/reference/thread_safety.html

The thread safety docs are added now because there will likely be significant interest in them from users and downstream projects testing free-threaded Python.


