### PR TITLE
MAINT: mark f2py-generated extension modules as safe to run without GIL

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -49,7 +49,7 @@ linalg_cython_gen = generator(cython,
 fblas_module = custom_target('fblas_module',
   output: ['_fblasmodule.c'],
   input: 'fblas.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_freethreading_arg,
   depend_files:
     [
       'fblas_l1.pyf.src',
@@ -73,7 +73,7 @@ py3.extension_module('_fblas',
 flapack_module = custom_target('flapack_module',
   output: ['_flapackmodule.c'],
   input: 'flapack.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_freethreading_arg,
   depend_files:
     [
       'flapack_user.pyf.src',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -29,6 +29,19 @@ endif
 
 thread_dep = dependency('threads', required: false)
 
+
+# Uses the `numpy-config` executable (or a user's numpy.pc pkg-config file).
+# Will work for numpy>=2.0, hence not required (it'll be a while until 2.0 is
+# our minimum supported version). Using this now to be able to detect the
+# version easily for >=2.0.
+_numpy_dep = dependency('numpy', required: false)
+f2py_freethreading_arg = []
+if _numpy_dep.found()
+  if _numpy_dep.version().version_compare('>=2.1.0')
+    f2py_freethreading_arg = ['--free-threading']
+  endif
+endif
+
 # NumPy include directory - needed in all submodules
 # The chdir is needed because within numpy there's an `import signal`
 # statement, and we don't want that to pick up scipy's signal module rather
@@ -200,14 +213,12 @@ if f2py_version.version_compare('<'+min_numpy_version)
   error(f'Found f2py executable is too old: @f2py_version@')
 endif
 
-# Note: this generato cannot handle:
+# Note: this generator cannot handle:
 # 1. `.pyf.src` files, because `@BASENAME@` will still include .pyf
 # 2. targets with #include's (due to no `depend_files` - see feature request
 #    at meson#8295)
-# TODO: add argument to mark extension modules as safe to run without the GIL,
-#       once f2py supports that (see numpy#26157).
 f2py_gen = generator(generate_f2pymod,
-  arguments : ['@INPUT@', '-o', '@BUILD_DIR@'],
+  arguments : ['@INPUT@', '-o', '@BUILD_DIR@'] + f2py_freethreading_arg,
   output : ['_@BASENAME@module.c', '_@BASENAME@-f2pywrappers.f'],
 )
 

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -98,7 +98,7 @@ arpack_lib = static_library('arpack_lib',
 arpack_module = custom_target('arpack_module',
   output: ['_arpackmodule.c', '_arpack-f2pywrappers.f'],
   input: 'arpack.pyf.src',
-  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
+  command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_freethreading_arg,
 )
 
 _arpack = py3.extension_module('_arpack',

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -263,6 +263,9 @@ def main():
                         help="Path to the input file")
     parser.add_argument("-o", "--outdir", type=str,
                         help="Path to the output directory")
+    parser.add_argument("--free-threading",
+                        action=argparse.BooleanOptionalAction,
+                        help="Whether to add --free-threading-compatible")
     args = parser.parse_args()
 
     if not args.infile.endswith(('.pyf', '.pyf.src', '.f.src')):
@@ -281,12 +284,16 @@ def main():
     else:
         fname_pyf = args.infile
 
+    nogil_arg = []
+    if args.free_threading:
+        nogil_arg = ['--freethreading-compatible']
+
     # Now invoke f2py to generate the C API module file
     if args.infile.endswith(('.pyf.src', '.pyf')):
-        p = subprocess.Popen(['f2py', fname_pyf,
-                            '--build-dir', outdir_abs], #'--quiet'],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            cwd=os.getcwd())
+        p = subprocess.Popen(
+            ['f2py', fname_pyf, '--build-dir', outdir_abs] + nogil_arg,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=os.getcwd()
+        )
         out, err = p.communicate()
         if not (p.returncode == 0):
             raise RuntimeError(f"Processing {fname_pyf} with f2py failed!\n"


### PR DESCRIPTION
This is possible for `numpy>=2.1.0`, which is the first NumPy version to (a) support free-threading, and (b) where `f2py` accepts the `--freethreading-compatible` flag.

Almost all the f2py-generated extension modules have been tested fairly heavily with `pytest-run-parallel` now and are safe, the last ones will follow soon.

Note that the GIL will still be re-enabled upon importing pretty much any SciPy submodule, because we can't yet mark Pythran-generated modules as safe. This will need work on the Pythran side and a new Pythran release, so that may miss the 1.15.0 release. Users can still disable the GIL manually with `python -Xgil=0` or with the `PYTHON_GIL=0` environment variable.