### PR TITLE
MAINT: sparse: add `broadcast_shapes` function to `_sputils.py`

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -995,12 +995,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         def check_bounds(indices, bound):
             idx = indices.max()
             if idx >= bound:
-                raise IndexError('index (%d) out of range (>= %d)' %
-                                 (idx, bound))
+                raise IndexError('index ({idx}) out of range (>= {bound})')
             idx = indices.min()
             if idx < -bound:
-                raise IndexError('index (%d) out of range (< -%d)' %
-                                 (idx, bound))
+                raise IndexError('index ({idx}) out of range (>= {bound})')
 
         i = np.atleast_1d(np.asarray(i, dtype=self.indices.dtype)).ravel()
         j = np.atleast_1d(np.asarray(j, dtype=self.indices.dtype)).ravel()

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -297,23 +297,23 @@ def parse_routine(name, args, types):
                 next_is_writeable = True
                 continue
             elif t == 'i':
-                args.append("*(%s*)a[%d]" % (const + I_type, j))
+                args.append(f"*({const + I_type}*)a[{j}]")
             elif t == 'I':
-                args.append("(%s*)a[%d]" % (const + I_type, j))
+                args.append(f"({const + I_type}*)a[{j}]")
             elif t == 'T':
-                args.append("(%s*)a[%d]" % (const + T_type, j))
+                args.append(f"({const + T_type}*)a[{j}]")
             elif t == 'B':
-                args.append("(npy_bool_wrapper*)a[%d]" % (j,))
+                args.append(f"(npy_bool_wrapper*)a[{j}]")
             elif t == 'V':
                 if const:
                     raise ValueError("'V' argument must be an output arg")
-                args.append("(std::vector<%s>*)a[%d]" % (I_type, j,))
+                args.append(f"(std::vector<{I_type}>*)a[{j}]")
             elif t == 'W':
                 if const:
                     raise ValueError("'W' argument must be an output arg")
-                args.append("(std::vector<%s>*)a[%d]" % (T_type, j,))
+                args.append(f"(std::vector<{T_type}>*)a[{j}]")
             elif t == 'l':
-                args.append("*(%snpy_int64*)a[%d]" % (const, j))
+                args.append(f"*({const}npy_int64*)a[{j}]")
             else:
                 raise ValueError(f"Invalid spec character {t!r}")
             j += 1

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -380,49 +380,8 @@ def broadcast_shapes(*shapes):
     new_shape : tuple of integers
         The shape that results from broadcasting th input shapes.
     """
-    # shortcut common case of 2 shapes
-    if len(shapes) == 2:
-        shape1, shape2 = shapes
-        if not isinstance(shape1, (tuple, list)):
-            shape1 = (shape1,)
-        if not isinstance(shape2, (tuple, list)):
-            shape2 = (shape2,)
-        len1, len2 = len(shape1), len(shape2)
-        if len1 >= len2:
-            out, shape = list(shape1), shape2
-            if not len2:
-                return shape1
-        else:
-            out, shape = list(shape2), shape1
-            if not len1:
-                return shape2
-        # shortcut common case of ndim 2
-        if len(out) == 2:
-            print(f"{shapes=}")
-            print(f"{out=} {shape=}")
-            if shape[-1] != 1 and shape[-1] != out[-1]:
-                if out[-1] != 1:
-                    raise ValueError("shapes cannot be broadcast to a single shape.")
-                out[-1] = shape[-1]
-            if len(shape) == 2 and shape[-2] != 1 and shape[-2] != out[-2]:
-                if out[-2] != 1:
-                    raise ValueError("shapes cannot be broadcast to a single shape.")
-                out[-2] = shape[-2]
-            print(f"Done: {out=} {shape=}")
-            return (*out,)
-        # ndim != 2
-        for i, x in enumerate(shape, start=-len(shape)):
-            if x != 1 and x != (outi := out[i]):
-                if outi != 1:
-                    raise ValueError("shapes cannot be broadcast to a single shape.")
-                out[i] = x
-        return (*out,)
-    # not 2 shapes
-    n_shapes = len(shapes)
-    if n_shapes == 0:
+    if not shapes:
         return ()
-    if n_shapes == 1:
-        return shapes[0]
     shapes = [shp if isinstance(shp, (tuple, list)) else (shp,) for shp in shapes]
     big_shp = max(shapes, key=len)
     out = list(big_shp)
@@ -430,8 +389,8 @@ def broadcast_shapes(*shapes):
         if shp is big_shp:
             continue
         for i, x in enumerate(shp, start=-len(shp)):
-            if x != 1 and x != (outi := out[i]):
-                if outi != 1:
+            if x != 1 and x != out[i]:
+                if out[i] != 1:
                     raise ValueError("shapes cannot be broadcast to a single shape.")
                 out[i] = x
     return (*out,)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -931,12 +931,12 @@ class _TestCommon:
                 # check that dense_setdiag worked
                 d = np.diag(a, k)
                 if np.asarray(v).ndim == 0:
-                    assert_array_equal(d, v, err_msg="%s %d" % (msg, r))
+                    assert_array_equal(d, v, err_msg="{msg} {r}")
                 else:
                     n = min(len(d), len(v))
-                    assert_array_equal(d[:n], v[:n], err_msg="%s %d" % (msg, r))
+                    assert_array_equal(d[:n], v[:n], err_msg="{msg} {r}")
                 # check that sparse setdiag worked
-                assert_array_equal(b.toarray(), a, err_msg="%s %d" % (msg, r))
+                assert_array_equal(b.toarray(), a, err_msg="{msg} {r}")
 
         # comprehensive test
         np.random.seed(1234)
@@ -945,7 +945,6 @@ class _TestCommon:
             for m,n in shapes:
                 ks = np.arange(-m+1, n-1)
                 for k in ks:
-                    msg = repr((dtype, m, n, k))
                     a = np.zeros((m, n), dtype=dtype)
                     b = self.spcreator((m, n), dtype=dtype)
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -584,7 +584,7 @@ def test_nd_add_sparse_with_inconsistent_shapes(a_shape, b_shape):
 
     arr_a = random_array((a_shape), density=0.6, rng=rng, dtype=int)
     arr_b = random_array((b_shape), density=0.6, rng=rng, dtype=int)
-    with pytest.raises(ValueError, match="inconsistent shapes"):
+    with pytest.raises(ValueError, match="Incompatible shapes|cannot be broadcast"):
         arr_a + arr_b
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -584,7 +584,8 @@ def test_nd_add_sparse_with_inconsistent_shapes(a_shape, b_shape):
 
     arr_a = random_array((a_shape), density=0.6, rng=rng, dtype=int)
     arr_b = random_array((b_shape), density=0.6, rng=rng, dtype=int)
-    with pytest.raises(ValueError, match="(Incompatible|inconsistent) shapes|cannot be broadcast"):
+    with pytest.raises(ValueError,
+                       match="(Incompatible|inconsistent) shapes|cannot be broadcast"):
         arr_a + arr_b
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -584,7 +584,7 @@ def test_nd_add_sparse_with_inconsistent_shapes(a_shape, b_shape):
 
     arr_a = random_array((a_shape), density=0.6, rng=rng, dtype=int)
     arr_b = random_array((b_shape), density=0.6, rng=rng, dtype=int)
-    with pytest.raises(ValueError, match="Incompatible shapes|cannot be broadcast"):
+    with pytest.raises(ValueError, match="(Incompatible|inconsistent) shapes|cannot be broadcast"):
         arr_a + arr_b
 
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from numpy.testing import assert_equal
+import pytest
 from pytest import raises as assert_raises
 from scipy.sparse import _sputils as sputils
 from scipy.sparse._sputils import matrix
@@ -171,70 +172,64 @@ class TestSparseUtils:
             np.dtype('int64')
         )
 
-    def test_broadcast_shapes(self):
-        # note np.broadcast_shapes raises index too large for these first 5 tests
-        #      sputils does not!
-        shapes = ((6, 5, 1, 4, 1, 1), (1, 2**32), (2**32, 1))
-        new_shape = (6, 5, 1, 4, 2**32, 2**32)
-        assert sputils.broadcast_shapes(*shapes) == new_shape
-        assert sputils.broadcast_shapes(*shapes[:2]) == (6, 5, 1, 4, 1, 2**32)
-        print(shapes[1:])
-        assert sputils.broadcast_shapes(*shapes[1:]) == (2**32, 2**32)
-        assert sputils.broadcast_shapes((2, 5), (5,)) == (2, 5)
-        assert sputils.broadcast_shapes((5,), (2, 5)) == (2, 5)
+    # tests public broadcast_shapes largely from
+    # numpy/numpy/lib/tests/test_stride_tricks.py
+    # first 3 cause np.broadcast to raise index too large, but not sputils
+    @pytest.mark.parametrize("input_shapes,target_shape", [
+        [((6, 5, 1, 4, 1, 1), (1, 2**32), (2**32, 1)), (6, 5, 1, 4, 2**32, 2**32)],
+        [((6, 5, 1, 4, 1, 1), (1, 2**32)), (6, 5, 1, 4, 1, 2**32)],
+        [((1, 2**32), (2**32, 1)), (2**32, 2**32)],
+        [[2, 2, 2], (2,)],
+        [[], ()],
+        [[()], ()],
+        [[(7,)], (7,)],
+        [[(1, 2), (2,)], (1, 2)],
+        [[(2,), (1, 2)], (1, 2)],
+        [[(1, 1)], (1, 1)],
+        [[(1, 1), (3, 4)], (3, 4)],
+        [[(6, 7), (5, 6, 1), (7,), (5, 1, 7)], (5, 6, 7)],
+        [[(5, 6, 1)], (5, 6, 1)],
+        [[(1, 3), (3, 1)], (3, 3)],
+        [[(1, 0), (0, 0)], (0, 0)],
+        [[(0, 1), (0, 0)], (0, 0)],
+        [[(1, 0), (0, 1)], (0, 0)],
+        [[(1, 1), (0, 0)], (0, 0)],
+        [[(1, 1), (1, 0)], (1, 0)],
+        [[(1, 1), (0, 1)], (0, 1)],
+        [[(), (0,)], (0,)],
+        [[(0,), (0, 0)], (0, 0)],
+        [[(0,), (0, 1)], (0, 0)],
+        [[(1,), (0, 0)], (0, 0)],
+        [[(), (0, 0)], (0, 0)],
+        [[(1, 1), (0,)], (1, 0)],
+        [[(1,), (0, 1)], (0, 1)],
+        [[(1,), (1, 0)], (1, 0)],
+        [[(), (1, 0)], (1, 0)],
+        [[(), (0, 1)], (0, 1)],
+        [[(1,), (3,)], (3,)],
+        [[2, (3, 2)], (3, 2)],
+        [[(1, 2)] * 32, (1, 2)],
+        [[(1, 2)] * 100, (1, 2)],
+        [[(2,)] * 32, (2,)],
+    ])
+    def test_broadcast_shapes_successes(self, input_shapes, target_shape):
+        assert_equal(sputils.broadcast_shapes(*input_shapes), target_shape)
 
-        # tests public broadcast_shapes
-        # from numpu/numpy/lib/tests/test_stride_tricks.py
-        data = [
-            [[], ()],
-            [[()], ()],
-            [[(7,)], (7,)],
-            [[(1, 2), (2,)], (1, 2)],
-            [[(1, 1)], (1, 1)],
-            [[(1, 1), (3, 4)], (3, 4)],
-            [[(6, 7), (5, 6, 1), (7,), (5, 1, 7)], (5, 6, 7)],
-            [[(5, 6, 1)], (5, 6, 1)],
-            [[(1, 3), (3, 1)], (3, 3)],
-            [[(1, 0), (0, 0)], (0, 0)],
-            [[(0, 1), (0, 0)], (0, 0)],
-            [[(1, 0), (0, 1)], (0, 0)],
-            [[(1, 1), (0, 0)], (0, 0)],
-            [[(1, 1), (1, 0)], (1, 0)],
-            [[(1, 1), (0, 1)], (0, 1)],
-            [[(), (0,)], (0,)],
-            [[(0,), (0, 0)], (0, 0)],
-            [[(0,), (0, 1)], (0, 0)],
-            [[(1,), (0, 0)], (0, 0)],
-            [[(), (0, 0)], (0, 0)],
-            [[(1, 1), (0,)], (1, 0)],
-            [[(1,), (0, 1)], (0, 1)],
-            [[(1,), (1, 0)], (1, 0)],
-            [[(), (1, 0)], (1, 0)],
-            [[(), (0, 1)], (0, 1)],
-            [[(1,), (3,)], (3,)],
-            [[2, (3, 2)], (3, 2)],
-            [[(1, 2)] * 32, (1, 2)],
-            [[(1, 2)] * 100, (1, 2)],
-            [[(2,)] * 32, (2,)],
-        ]
-        for input_shapes, target_shape in data:
-            assert_equal(sputils.broadcast_shapes(*input_shapes), target_shape)
-
-        # tests public broadcast_shapes failures
-        data = [
-            [(3,), (4,)],
-            [(2, 3), (2,)],
-            [2, (2, 3)],
-            [(3,), (3,), (4,)],
-            [(2, 5), (3, 5)],
-            [(2, 4), (2, 5)],
-            [(1, 3, 4), (2, 3, 3)],
-            [(1, 2), (3, 1), (3, 2), (10, 5)],
-            [(2,)] * 32 + [(3,)] * 32,
-        ]
-        for input_shapes in data:
-            with assert_raises(ValueError, match="cannot be broadcast"):
-                sputils.broadcast_shapes(*input_shapes)
+    # tests public broadcast_shapes failures
+    @pytest.mark.parametrize("input_shapes", [
+        [(3,), (4,)],
+        [(2, 3), (2,)],
+        [2, (2, 3)],
+        [(3,), (3,), (4,)],
+        [(2, 5), (3, 5)],
+        [(2, 4), (2, 5)],
+        [(1, 3, 4), (2, 3, 3)],
+        [(1, 2), (3, 1), (3, 2), (10, 5)],
+        [(2,)] * 32 + [(3,)] * 32,
+    ])
+    def test_broadcast_shapes_failures(self, input_shapes):
+        with assert_raises(ValueError, match="cannot be broadcast"):
+            sputils.broadcast_shapes(*input_shapes)
 
     def test_check_shape_overflow(self):
         new_shape = sputils.check_shape([(10, -1)], (65535, 131070))


### PR DESCRIPTION
The use of `numpy.broadcast_shapes` in scipy.sparse is fairly new (work on 1d and nd arrays).
But I have found that `np.broadcast_shapes` raises errors due to the resulting shape being too large to be created as a dense matrix. This is not relevant for sparse arrays where the resulting shape is fine. The size limits restrict `nnz` not `shape`.  For examples broadcasting `(1, 2**16)` with `(2**16, 1)` raises an exception for `np.broadcast_shapes` on a 32-bit system.  The sparse version results in `(2**16, 2**16)`.   Similarly there are limits for 64-bit systems. But the motivation to look at this was 32-bit system errors in the broadcasting PR #21925  

So I have created a function `broadcast_shapes` which is like `np.broadcast_shapes` except it does not check any shape limitations due to dense ravel indexing. The tests include all tests for numpy's version (successes and failures). This PR also includes some tests of what dense arrays would consider too large a shape. The sparse version should provide the resulting shape.

I also include here a linting commit due to changing code near places where the original code used `%`-string formatting. I think they are orthogonal to this PR, but they are needed for linting and make for more readable code. If they get in the way of review, I can remove them.
