### PR TITLE
CI: fix `Intel oneAPI tests` job

### DIFF
--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -35,7 +35,7 @@ jobs:
     #        (b) it does run with Act locally (`github` doesn't exist there)
     if: >
       needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'czgdp1807/scipy' || github.repository == '')
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -35,7 +35,7 @@ jobs:
     #        (b) it does run with Act locally (`github` doesn't exist there)
     if: >
       needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'scipy/scipy' || github.repository == '')
+      && (github.repository == 'czgdp1807/scipy' || github.repository == '')
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -60,8 +60,10 @@ jobs:
           use-mamba: true
 
       - name: Update Conda Environment
+        shell: bash -l {0}
         run: |
-          mamba env update -n scipy-dev -f environment.yml
+          conda activate scipy-dev
+          conda install -c conda-forge pkg-config meson meson-python ninja numpy cython pybind11 pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich-click click doit pydevtool hypothesis
 
       - name: cache install
         id: cache-install
@@ -86,7 +88,7 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh --force
           conda activate scipy-dev
-          conda remove -y compilers
+          pip install pythran
           unset FFLAGS
           CC=icx CXX=icpx FC=ifx python dev.py build -C-Dblas=mkl-dynamic-lp64-iomp -C-Dlapack=mkl-dynamic-lp64-iomp
 

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -88,6 +88,9 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh --force
           conda activate scipy-dev
+          # Note that we have to install Pythran from PyPI to avoid pulling in compilers
+          # from conda-forge (those may break Intel Fortran, which rely on system GCC/Clang,
+          # xref https://github.com/conda-forge/pythran-feedstock/issues/77).
           pip install pythran
           unset FFLAGS
           CC=icx CXX=icpx FC=ifx python dev.py build -C-Dblas=mkl-dynamic-lp64-iomp -C-Dlapack=mkl-dynamic-lp64-iomp


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/21934

#### What does this implement/fix?
<!--Please explain your changes.-->

The reason for `meson.build:1:0: ERROR: Compiler icx cannot compile programs` https://github.com/scipy/scipy/issues/21934, is due to issues with installing `pythran` and `compilers` from `conda`. Some dependencies of these two conda packages mess up the linker search path i.e., `/usr/lib/gcc` isn't there in the linker search path. So, I have followed the windows way for installing conda packages for this job, i.e., listing minimal set of packages by hand. `pythran` is installed via `pip`. We don't need `compilers` package because we need `icx`, `ifx`, `icpx` which are installed from Intel website.

#### Additional information
<!--Any additional information you think is important.-->
