### PR TITLE
TST: stats.rdist: skip failing xslow test

### DIFF
--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -284,7 +284,7 @@ def cases_test_fit_mse():
                       'gausshyper', 'genhyperbolic',  # integration warnings
                       'tukeylambda',  # close, but doesn't meet tolerance
                       'vonmises',  # can have negative CDF; doesn't play nice
-                      'arcsine', 'argus', 'powerlaw',  # don't meet tolerance
+                      'arcsine', 'argus', 'powerlaw', 'rdist', # don't meet tolerance
                       'poisson_binom',  # vector-valued shape parameter
                       }
 
@@ -314,7 +314,7 @@ def cases_test_fit_mse():
                        'nakagami', 'ncf', 'nchypergeom_fisher',
                        'nchypergeom_wallenius', 'nct', 'ncx2',
                        'pearson3', 'powerlognorm',
-                       'rdist', 'reciprocal', 'rel_breitwigner', 'rice',
+                       'reciprocal', 'rel_breitwigner', 'rice',
                        'trapezoid', 'truncnorm', 'truncweibull_min',
                        'vonmises_line', 'zipfian'}
 


### PR DESCRIPTION
#### Reference issue
Closes gh-21949

#### What does this implement/fix?
gh-21949 reported an xslow fit test failure. ~~We changed from passing an integer seed to `differential_evolution` via `rng` instead of `random_state`, so it makes sense that we'd get some change in this test.~~ We already adjusted tests after that (gh-21822), so this is something different.

#### Additional information
This generic test is performed for all distributions, but since our optimization techniques do not guarantee convergence to the global optimum for all possible problems, some tests fail. Sometimes we'll skip the generic test for a distribution and replace it with another one that is slightly easier for the optimizer to solve, e.g.

```python3
import matplotlib.pyplot as plt
import numpy as np
from scipy import stats
from scipy.optimize import differential_evolution as de
from scipy.stats.tests.test_fit import assert_nlff_less_or_close

N = 1000
rng = np.random.default_rng(23854582452784625)
dist = stats.rdist
shapes = (1., 2., 3.)
data = dist.rvs(*shapes, size=N, random_state=rng)
shape_bounds = {'loc': (0.1, 10), 'scale': (0.1, 10), 'c': (0.1, 10)}
res = stats.fit(dist, data, shape_bounds, method='mse',
                optimizer=lambda *args, **kwds: de(*args, rng=rng, **kwds))
assert_nlff_less_or_close(dist, data, res.params, shapes, nlff_name='_penalized_nlpsf')
res.plot()
plt.show()
```

<img width="840" alt="image" src="https://github.com/user-attachments/assets/0868fab9-be18-4009-b479-005a04c9e5d6">

In this case, I think it's safe to just skip the test. `beta` has always had trouble, so it's not so surprising that `rdist` (symmetric beta) has trouble, and `beta` has a distribution-specific test, so I don't know that we need a separate one for a special case distribution. 
