### PR TITLE
TST: optimize: slight tolerance bump for a dual-annealing test

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -131,7 +131,7 @@ class TestDualAnnealing:
     def test_high_dim_no_ls(self):
         ret = dual_annealing(self.func, self.hd_bounds,
                              no_local_search=True, rng=self.seed)
-        assert_allclose(ret.fun, 0., atol=1e-4)
+        assert_allclose(ret.fun, 0., atol=1.2e-4)
 
     def test_nb_fun_call(self):
         self.nb_fun_call.c = 0


### PR DESCRIPTION
Failure on Linux x86-64 (conda env, GCC 12.4.0) was:
```
________________________________________________________ TestDualAnnealing.test_high_dim_no_ls _________________________________________________________
scipy/optimize/tests/test__dual_annealing.py:134: in test_high_dim_no_ls
    assert_allclose(ret.fun, 0., atol=1e-4)
        ret        =  message: ['Maximum number of iteration reached']
 success: True
  status: 0
     fun: 0.00010830095175151655
       x....142e-04 -7.726e-05
           -1.322e-04  2.552e-04  8.451e-05]
     nit: 1000
    nfev: 16001
    njev: 0
    nhev: 0
        self       = <scipy.optimize.tests.test__dual_annealing.TestDualAnnealing object at 0x4b8cc714b50>
../../../../../.pixi/envs/free-threading/lib/python3.13t/contextlib.py:85: in inner
    return func(*args, **kwds)
E   AssertionError:
E   Not equal to tolerance rtol=1e-07, atol=0.0001
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference among violations: 0.0001083
E   Max relative difference among violations: inf
E    ACTUAL: array(0.000108)
E    DESIRED: array(0.)
        args       = (<function assert_allclose.<locals>.compare at 0x4b8e41301e0>, array(0.0001083), array(0.))
        func       = <function assert_array_compare at 0x4b8cf91f820>
        kwds       = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0.0001', 'strict': False, ...}
        self       = <contextlib._GeneratorContextManager object at 0x4b8cc7e8120>
```

[ci skip]