### PR TITLE
DEV: lint: disable UP031

### DIFF
--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -20,7 +20,7 @@ target-version = "py310"
 # `ICN001` added in gh-20382 to enforce common conventions for import.
 # `W292` added in gh-21023 to enforce newlines at end of files.
 select = ["E", "F", "PGH004", "UP", "B006", "B008", "B028", "ICN001", "W292"]
-ignore = ["E741", "UP038"]
+ignore = ["E741", "UP038", "UP031"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
#### Reference issue
gh-21972

#### What does this implement/fix?
`ruff` has improved their detection again (🎉) but that means we are once again exposed in the form of red CI :) so we disable the rule here and someone can fix the issues up to close gh-21972.

#### Additional information
<!--Any additional information you think is important.-->
