### PR TITLE
CI: use stable NumPy for "old build"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Setup Python build deps
         run: |
-          pip install build meson-python ninja pythran pybind11 cython "numpy>=2.0.0b1"
+          pip install build meson-python ninja pythran pybind11 cython numpy
 
       - name: Build wheel and install
         run: |


### PR DESCRIPTION
* Fixes gh-21957, causing current CI fail.

* Avoid using pre-release versions of NumPy for the "Oldest GCC ..." CI job. Based on the comments in that issue and the NumPy issue related to it, I think we want to use latest stable release of NumPy at build time and the oldest supported version of NumPy at runtime.

* I think we already have separate pre-release NumPy CI jobs. We may want to consider setting `PYTHONOPTIMIZE=2` in one of those pre-release jobs, although NumPy has turned this on upstream in any case, in response to the fix for the original problem.

[skip circle] [skip cirrus]