### PR TITLE
TST: `optimize.elementwise.bracket_root`: fix torch test tolerance issue

### DIFF
--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -9,7 +9,7 @@ import scipy._lib._elementwise_iterative_method as eim
 from scipy import stats
 from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
                                          xp_assert_less, array_namespace)
-from scipy._lib._array_api import xp_ravel, is_torch
+from scipy._lib._array_api import xp_ravel
 from scipy.conftest import array_api_compatible
 
 
@@ -144,7 +144,7 @@ class TestBracketRoot:
     def test_vectorization(self, shape, xp):
         # Test for correct functionality, output shapes, and dtypes for various
         # input shapes.
-        p = np.linspace(-0.05, 1.05, 12).reshape(shape) if shape else 0.6
+        p = np.linspace(-0.05, 1.05, 12).reshape(shape) if shape else np.float64(0.6)
         args = (p,)
         maxiter = 10
 
@@ -179,8 +179,7 @@ class TestBracketRoot:
         for attr in attrs:
             ref_attr = [xp.asarray(getattr(ref, attr)) for ref in refs]
             res_attr = getattr(res, attr)
-            rtol = 5e-7 if is_torch(xp) else None  # consider looking into this
-            xp_assert_close(xp_ravel(res_attr, xp=xp), xp.stack(ref_attr), rtol=rtol)
+            xp_assert_close(xp_ravel(res_attr, xp=xp), xp.stack(ref_attr))
             xp_assert_equal(res_attr.shape, shape)
 
         xp_test = array_namespace(xp.asarray(1.))


### PR DESCRIPTION
#### Reference issue
gh-21920

#### What does this implement/fix?
In gh-21920, PyTorch was failing a test of `optimize.elementwise.bracket_root` with default tolerances. At the time, it was presumed that PyTorch's `float32` default dtype was sneaking into the test, but we didn't precisely locate the problem.

Indeed, a Python float `0.6` was being converted to PyTorch `float32`, and this loss of precision (`np.float32(0.6) - np.float64(0.6) = 2.384185793236071e-08`) in the test setup was causing the failure. 

This PR fixes the failure by ensuring that the parameter `0.6` is stored as a `np.float64` initially so it is never downcast to `float32`.