### PR TITLE
ENH: integrate.tanhsinh: make `_tanhsinh` public

### DIFF
--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -17,6 +17,7 @@ Integrating functions, given function object
    dblquad       -- General purpose double integration
    tplquad       -- General purpose triple integration
    nquad         -- General purpose N-D integration
+   tanhsinh      -- General purpose elementwise integration
    fixed_quad    -- Integrate func(x) using Gaussian quadrature of order n
    newton_cotes  -- Weights and error coefficient for Newton-Cotes integration
    lebedev_rule
@@ -107,7 +108,7 @@ from ._bvp import solve_bvp
 from ._ivp import (solve_ivp, OdeSolution, DenseOutput,
                    OdeSolver, RK23, RK45, DOP853, Radau, BDF, LSODA)
 from ._quad_vec import quad_vec
-from ._tanhsinh import nsum
+from ._tanhsinh import nsum, tanhsinh
 from ._cubature import cubature
 from ._lebedev import lebedev_rule
 

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -27,9 +27,8 @@ __all__ = ['nsum']
 #  make public?
 
 
-def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
-              minlevel=2, atol=None, rtol=None, preserve_shape=False,
-              callback=None):
+def tanhsinh(f, a, b, *, args=(), log=False, maxlevel=None, minlevel=2,
+             atol=None, rtol=None, preserve_shape=False, callback=None):
     """Evaluate a convergent integral numerically using tanh-sinh quadrature.
 
     In practice, tanh-sinh quadrature achieves quadratic convergence for
@@ -39,7 +38,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     Either or both of the limits of integration may be infinite, and
     singularities at the endpoints are acceptable. Divergent integrals and
     integrands with non-finite derivatives or singularities within an interval
-    are out of scope, but the latter may be evaluated be calling `_tanhsinh` on
+    are out of scope, but the latter may be evaluated be calling `tanhsinh` on
     each sub-interval separately.
 
     Parameters
@@ -131,7 +130,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
         similar to that returned by `_differentiate` (but containing the
         current iterate's values of all variables). If `callback` raises a
         ``StopIteration``, the algorithm will terminate immediately and
-        `_tanhsinh` will return a result object. `callback` must not mutate
+        `tanhsinh` will return a result object. `callback` must not mutate
         `res` or its attributes.
 
     Returns
@@ -199,10 +198,10 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     Evaluate the Gaussian integral:
 
     >>> import numpy as np
-    >>> from scipy.integrate._tanhsinh import _tanhsinh
+    >>> from scipy.integrate import tanhsinh
     >>> def f(x):
     ...     return np.exp(-x**2)
-    >>> res = _tanhsinh(f, -np.inf, np.inf)
+    >>> res = tanhsinh(f, -np.inf, np.inf)
     >>> res.integral  # true value is np.sqrt(np.pi), 1.7724538509055159
     1.7724538509055159
     >>> res.error  # actual error is 0
@@ -212,19 +211,19 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     arguments sufficiently far from zero, so the value of the integral
     over a finite interval is nearly the same.
 
-    >>> _tanhsinh(f, -20, 20).integral
+    >>> tanhsinh(f, -20, 20).integral
     1.772453850905518
 
     However, with unfavorable integration limits, the integration scheme
     may not be able to find the important region.
 
-    >>> _tanhsinh(f, -np.inf, 1000).integral
+    >>> tanhsinh(f, -np.inf, 1000).integral
     4.500490856616431
 
     In such cases, or when there are singularities within the interval,
     break the integral into parts with endpoints at the important points.
 
-    >>> _tanhsinh(f, -np.inf, 0).integral + _tanhsinh(f, 0, 1000).integral
+    >>> tanhsinh(f, -np.inf, 0).integral + tanhsinh(f, 0, 1000).integral
     1.772453850905404
 
     For integration involving very large or very small magnitudes, use
@@ -233,12 +232,12 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     limits of integration, log-integration would avoid the underflow
     experienced when evaluating the integral normally.)
 
-    >>> res = _tanhsinh(f, 20, 30, rtol=1e-10)
+    >>> res = tanhsinh(f, 20, 30, rtol=1e-10)
     >>> res.integral, res.error
     (4.7819613911309014e-176, 4.670364401645202e-187)
     >>> def log_f(x):
     ...     return -x**2
-    >>> res = _tanhsinh(log_f, 20, 30, log=True, rtol=np.log(1e-10))
+    >>> res = tanhsinh(log_f, 20, 30, log=True, rtol=np.log(1e-10))
     >>> np.exp(res.integral), np.exp(res.error)
     (4.7819613911306924e-176, 4.670364401645093e-187)
 
@@ -249,7 +248,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     >>> dist = stats.gausshyper(13.8, 3.12, 2.51, 5.18)
     >>> a, b = dist.support()
     >>> x = np.linspace(a, b, 100)
-    >>> res = _tanhsinh(dist.pdf, a, x)
+    >>> res = tanhsinh(dist.pdf, a, x)
     >>> ref = dist.cdf(x)
     >>> np.allclose(res.integral, ref)
     True
@@ -265,12 +264,12 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     ...    return np.sin(c*x)
     >>>
     >>> c = [1, 10, 30, 100]
-    >>> res = _tanhsinh(f, 0, 1, args=(c,), minlevel=1)
+    >>> res = tanhsinh(f, 0, 1, args=(c,), minlevel=1)
     >>> shapes
     [(4,), (4, 34), (4, 32), (3, 64), (2, 128), (1, 256)]
 
     To understand where these shapes are coming from - and to better
-    understand how `_tanhsinh` computes accurate results - note that
+    understand how `tanhsinh` computes accurate results - note that
     higher values of ``c`` correspond with higher frequency sinusoids.
     The higher frequency sinusoids make the integrand more complicated,
     so more function evaluations are required to achieve the target
@@ -298,7 +297,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     >>> def f(x):
     ...    return [x, np.sin(10*x), np.cos(30*x), x*np.sin(100*x)**2]
 
-    This integrand is not compatible with `_tanhsinh` as written; for instance,
+    This integrand is not compatible with `tanhsinh` as written; for instance,
     the shape of the output will not be the same as the shape of ``x``. Such a
     function *could* be converted to a compatible form with the introduction of
     additional parameters, but this would be inconvenient. In such cases,
@@ -311,7 +310,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     ...     return [x0, np.sin(10*x1), np.cos(30*x2), x3*np.sin(100*x3)]
     >>>
     >>> a = np.zeros(4)
-    >>> res = _tanhsinh(f, a, 1, preserve_shape=True)
+    >>> res = tanhsinh(f, a, 1, preserve_shape=True)
     >>> shapes
     [(4,), (4, 66), (4, 64), (4, 128), (4, 256)]
 
@@ -320,6 +319,7 @@ def _tanhsinh(f, a, b, *, args=(), log=False, maxfun=None, maxlevel=None,
     ``x`` of shape ``(4,)`` or ``(4, n)``, and this is what we observe.
 
     """
+    maxfun = None  # unused right now
     (f, a, b, log, maxfun, maxlevel, minlevel,
      atol, rtol, args, preserve_shape, callback, xp) = _tanhsinh_iv(
         f, a, b, log, maxfun, maxlevel, minlevel, atol,
@@ -1300,7 +1300,7 @@ def _integral_bound(f, a, b, step, args, constants, xp):
     log2 = xp.asarray(math.log(2), dtype=dtype)
 
     # Get a lower bound on the sum and compute effective absolute tolerance
-    lb = _tanhsinh(f, a, b, args=args, atol=atol, rtol=rtol, log=log)
+    lb = tanhsinh(f, a, b, args=args, atol=atol, rtol=rtol, log=log)
     tol = xp.broadcast_to(xp.asarray(atol), lb.integral.shape)
     if log:
         tol = special.logsumexp(xp.stack((tol, rtol + lb.integral)), axis=0)
@@ -1352,7 +1352,7 @@ def _integral_bound(f, a, b, step, args, constants, xp):
     # atol = xp.maximum(atol, xp.minimum(fk/2 - fb/2))
     # rtol = xp.maximum(rtol, xp.minimum((fk/2 - fb/2)/left))
     # where `fk`/`fb` are currently calculated below.
-    right = _tanhsinh(f, k, b, args=args, atol=atol, rtol=rtol, log=log)
+    right = tanhsinh(f, k, b, args=args, atol=atol, rtol=rtol, log=log)
 
     # Calculate the full estimate and error from the pieces
     fk = fks[xp.arange(len(fks)), nt]

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -11,8 +11,8 @@ import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy._lib._array_api import array_namespace, xp_size, xp_ravel, xp_copy, is_numpy
 from scipy import special, stats
-from scipy.integrate import quad_vec, nsum
-from scipy.integrate._tanhsinh import _tanhsinh, _pair_cache
+from scipy.integrate import quad_vec, nsum, tanhsinh as _tanhsinh
+from scipy.integrate._tanhsinh import _pair_cache
 from scipy.stats._discrete_distns import _gen_harmonic_gt1
 
 
@@ -192,16 +192,16 @@ class TestTanhSinh:
         message = '...must be integers.'
         with pytest.raises(ValueError, match=message):
             _tanhsinh(f, zero, f_b, maxlevel=object())
-        with pytest.raises(ValueError, match=message):
-            _tanhsinh(f, zero, f_b, maxfun=1+1j)
+        # with pytest.raises(ValueError, match=message):  # unused for now
+        #     _tanhsinh(f, zero, f_b, maxfun=1+1j)
         with pytest.raises(ValueError, match=message):
             _tanhsinh(f, zero, f_b, minlevel="migratory coconut")
 
         message = '...must be non-negative.'
         with pytest.raises(ValueError, match=message):
             _tanhsinh(f, zero, f_b, maxlevel=-1)
-        with pytest.raises(ValueError, match=message):
-            _tanhsinh(f, zero, f_b, maxfun=-1)
+        # with pytest.raises(ValueError, match=message):  # unused for now
+        #     _tanhsinh(f, zero, f_b, maxfun=-1)
         with pytest.raises(ValueError, match=message):
             _tanhsinh(f, zero, f_b, minlevel=-1)
 

--- a/scipy/special/tests/test_boost_ufuncs.py
+++ b/scipy/special/tests/test_boost_ufuncs.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import scipy.special._ufuncs as scu
-from scipy.integrate._tanhsinh import _tanhsinh
+from scipy.integrate import tanhsinh
 
 
 type_char_to_type_tol = {'f': (np.float32, 32*np.finfo(np.float32).eps),
@@ -50,7 +50,7 @@ def test_landau():
     # accuracy is tested by Boost.
     x = np.linspace(-3, 10, 10)
     args = (0, 1)
-    res = _tanhsinh(lambda x: scu._landau_pdf(x, *args), -np.inf, x)
+    res = tanhsinh(lambda x: scu._landau_pdf(x, *args), -np.inf, x)
     cdf = scu._landau_cdf(x, *args)
     assert_allclose(res.integral, cdf)
     sf = scu._landau_sf(x, *args)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -8,7 +8,7 @@ from numpy import inf
 from scipy._lib._util import _lazywhere
 from scipy._lib._docscrape import ClassDoc, NumpyDocString
 from scipy import special, stats
-from scipy.integrate._tanhsinh import _tanhsinh
+from scipy.integrate import tanhsinh as _tanhsinh
 from scipy.optimize._bracket import _bracket_root, _bracket_minimum
 from scipy.optimize._chandrupatla import _chandrupatla, _chandrupatla_minimize
 from scipy.stats._probability_distribution import _ProbabilityDistribution

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -31,7 +31,7 @@ from scipy.stats import (multivariate_normal, multivariate_hypergeom,
 from scipy.stats import _covariance, Covariance
 from scipy import stats
 
-from scipy.integrate._tanhsinh import _tanhsinh
+from scipy.integrate import tanhsinh
 from scipy.integrate import romb, qmc_quad, dblquad, tplquad
 from scipy.special import multigammaln
 
@@ -3870,7 +3870,7 @@ class TestNormalInverseGamma:
 
         # Test PDF
         x = np.linspace(-5, 5, 11)
-        res = _tanhsinh(lambda s2, x: norm_inv_gamma.pdf(x, s2), 0, np.inf, args=(x,))
+        res = tanhsinh(lambda s2, x: norm_inv_gamma.pdf(x, s2), 0, np.inf, args=(x,))
         ref = t.pdf(x)
         assert_allclose(res.integral, ref)
 
@@ -3891,8 +3891,8 @@ class TestNormalInverseGamma:
 
         # Test PDF
         s2 = np.linspace(0.1, 10, 10)
-        res = _tanhsinh(lambda x, s2: norm_inv_gamma.pdf(x, s2),
-                        -np.inf, np.inf, args=(s2,))
+        res = tanhsinh(lambda x, s2: norm_inv_gamma.pdf(x, s2),
+                       -np.inf, np.inf, args=(s2,))
         ref = inv_gamma.pdf(s2)
         assert_allclose(res.integral, ref)
 


### PR DESCRIPTION
#### Reference issue
gh-20252
gh-18650

#### What does this implement/fix?
`_tanhsinh` has existed as a private function for elementwise quadrature in SciPy since summer 2023; it is the workhorse behind `scipy.integrate.nsum` and the new continuous distribution infrastructure's quadrature. At the time, the plan was to make it public after the `quadrature` deprecation cycle was completed.

Shortly before `quadrature` was removed, gh-20252 proposed a more ambitious goal of adding a cubature function with univariate quadrature as a special case. The function `cubature` was added over the summer, and besides working for N-d integration domains, it matches (and sometimes exceeds) `tanhsinh` in several respects, e.g. support for non-NumPy backends, vector-valued integration, improved performance relative to `quad_vec`, etc.

However, there are still several features unique to `_tanhsinh` that users may appreciate.
- `_tanhsinh` supports N-d arrays as limits of integration for elementwise integral evaluation.
- `_tanhsinh` is organized for nested, order-adaptive (rather than partition-adaptive) quadrature rules, which may be more efficient for some problems. 
- the tanh-sinh rule tends to perform better than the existing rules in `cubature` for functions with endpoint singularities. For example, `tanhsinh(lambda x: 1/x**0.5, 0, 1)` takes ~0.5 ms to produce a result with 1 ULP error, whereas `cubature` takes 12x as long to produce a result accurate in only half of its digits.
- `_tanhsinh` supports "log-integration" - evaluation of the log of an integral given the log of the integrand - which is useful to avoid underflow and overflow.
- `_tanhsinh` converges and reports integration status elementwise, avoiding unnecessary function evaluations when some elements of the output take longer to converge than others.
- `_tanhsinh` has a callback interface that supports early termination.
 
`cubature` (or a 1-D variant) has the potential to add these features. However, it is unfortunate that these features have already waiting through three SciPy releases. We might as well make them public now, and if `cubature` or a follow-up function add them later, great. 

#### Additional information
@lucascolley Re: https://github.com/scipy/scipy/issues/20252#issuecomment-2361085827

IIUC, `cubature` supports vector-valued integration. Can you show me how to replicate this with `cubature`?
```python3
import numpy as np
from scipy import integrate

def f(x):
    return [np.sin(x), np.cos(x)]

# compare against integrate.quad_vec(f, 0, 1)
res = integrate.tanhsinh(f, 0, 1, preserve_shape=True)
#      success: [ True  True]
#       status: [0 0]
#     integral: [ 4.597e-01  8.415e-01]
#        error: [ 1.651e-13  5.532e-13]
#         nfev: [67 67]
#     maxlevel: [2 2]
err = res.integral - [1-np.cos(1), np.sin(1)]
# array([1.49880108e-15, 2.77555756e-15])
```