### PR TITLE
API: integrate.simpson: allow `x` to be passed positionally

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -396,7 +396,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
     return result
 
 
-def simpson(y, *, x=None, dx=1.0, axis=-1):
+def simpson(y, x=None, *, dx=1.0, axis=-1):
     """
     Integrate y(x) using samples along the given axis and the composite
     Simpson's rule. If x is None, spacing of dx is assumed.


### PR DESCRIPTION
#### Reference issue
Closes gh-21300

#### What does this implement/fix?
`x` was made keyword-only since it is an optional parameter. However, forcing the user to write (something which will often look like) `simpson(y, x=x)` instead of `simpson(y, x)` seems like an overly-restrictive anti-pattern.

This PR relaxes to allow `x` to be passed positionally. While it isn't 100% obvious that this is the ideal move, there don't seem to be any strong opinions against it in the linked issue - whereas the current state of things has caused confusion for a user.

#### Additional information
<!--Any additional information you think is important.-->