### PR TITLE
DOC: integrate.tanhsinh: fix reference format; Examples heading

### DIFF
--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -136,10 +136,10 @@ def tanhsinh(f, a, b, *, args=(), log=False, maxlevel=None, minlevel=2,
     Returns
     -------
     res : _RichResult
-        An instance of `scipy._lib._util._RichResult` with the following
-        attributes. The descriptions are written as though the values will be
-        scalars; however, if `f` returns an array, the outputs will be
-        arrays of the same shape.
+        An object similar to an instance of `scipy.optimize.OptimizeResult` with the
+        following attributes. (The descriptions are written as though the values will
+        be scalars; however, if `f` returns an array, the outputs will be
+        arrays of the same shape.)
 
         success : bool array
             ``True`` when the algorithm terminated successfully (status ``0``).
@@ -166,7 +166,7 @@ def tanhsinh(f, a, b, *, args=(), log=False, maxlevel=None, minlevel=2,
 
     See Also
     --------
-    quad, quadrature
+    quad
 
     Notes
     -----
@@ -1019,8 +1019,8 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
     -------
     res : _RichResult
         An object similar to an instance of `scipy.optimize.OptimizeResult` with the
-        attributes. (The descriptions are written as though the values will be
-        scalars; however, if `f` returns an array, the outputs will be
+        following attributes. (The descriptions are written as though the values will
+        be scalars; however, if `f` returns an array, the outputs will be
         arrays of the same shape.)
 
         success : bool

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -180,21 +180,21 @@ def tanhsinh(f, a, b, *, args=(), log=False, maxlevel=None, minlevel=2,
 
     References
     ----------
-    [1] Bailey, David H., Karthik Jeyabalan, and Xiaoye S. Li. "A comparison of
-        three high-precision quadrature schemes." Experimental Mathematics 14.3
-        (2005): 317-329.
-    [2] Vanherck, Joren, Bart Sorée, and Wim Magnus. "Tanh-sinh quadrature for
-        single and multiple integration using floating-point arithmetic."
-        arXiv preprint arXiv:2007.15057 (2020).
-    [3] van Engelen, Robert A.  "Improving the Double Exponential Quadrature
-        Tanh-Sinh, Sinh-Sinh and Exp-Sinh Formulas."
-        https://www.genivia.com/files/qthsh.pdf
-    [4] Takahasi, Hidetosi, and Masatake Mori. "Double exponential formulas for
-        numerical integration." Publications of the Research Institute for
-        Mathematical Sciences 9.3 (1974): 721-741.
+    .. [1] Bailey, David H., Karthik Jeyabalan, and Xiaoye S. Li. "A comparison of
+           three high-precision quadrature schemes." Experimental Mathematics 14.3
+           (2005): 317-329.
+    .. [2] Vanherck, Joren, Bart Sorée, and Wim Magnus. "Tanh-sinh quadrature for
+           single and multiple integration using floating-point arithmetic."
+           arXiv preprint arXiv:2007.15057 (2020).
+    .. [3] van Engelen, Robert A.  "Improving the Double Exponential Quadrature
+           Tanh-Sinh, Sinh-Sinh and Exp-Sinh Formulas."
+           https://www.genivia.com/files/qthsh.pdf
+    .. [4] Takahasi, Hidetosi, and Masatake Mori. "Double exponential formulas for
+           numerical integration." Publications of the Research Institute for
+           Mathematical Sciences 9.3 (1974): 721-741.
 
-    Example
-    -------
+    Examples
+    --------
     Evaluate the Gaussian integral:
 
     >>> import numpy as np
@@ -1104,8 +1104,8 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
 
     References
     ----------
-    [1] Wikipedia. "Integral test for convergence."
-    https://en.wikipedia.org/wiki/Integral_test_for_convergence
+    .. [1] Wikipedia. "Integral test for convergence."
+           https://en.wikipedia.org/wiki/Integral_test_for_convergence
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue
Closes gh-21988

#### What does this implement/fix?
Looks like Cirrus didn't run in gh-21977, and doc build issues slipped through. This PR fixes it.

#### Additional information
I decided to run all tests, though, just to be sure there's nothing else.
