### PR TITLE
CI: remove setting macOS 10.9 for SDK and deployment target

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,13 +115,6 @@ jobs:
         # optional test dependencies
         mamba install scikit-umfpack scikit-sparse
 
-        # Python.org installers still use 10.9, so let's use that too. Note
-        # that scikit-learn already changed to 10.13 in Jan 2021, so increasing
-        # this number in the future (if needed) should not be a problem.
-        # Conda-forge is still at 10.9, see:
-        # https://conda-forge.org/docs/maintainer/knowledge_base.html#requiring-newer-macos-sdks
-        export MACOSX_DEPLOYMENT_TARGET=10.9
-        export MACOSX_SDK_VERSION=10.9
         CC="ccache $CC" python dev.py build
 
     - name: Test SciPy


### PR DESCRIPTION
This avoids a ton of warnings like:
```
ld: warning: object file (/Users/runner/miniconda3/envs/scipy-dev/lib/gcc/arm64-apple-darwin20.0.0/13.2.0/libgcc.a(ldclr_1_2.o)) was built for newer macOS version (11.0) than being linked (10.9)
```

There hasn't been much value of manually setting these env vars and keeping them in sync between conda-forge and this CI file. In the unlikely case there is an issue in the future, we'll catch it in the wheel builds.