### PR TITLE
BUG: `stats.sobol_indices`: fix mutation of input parameters

### DIFF
--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -664,9 +664,9 @@ def sobol_indices(
             "should have a shape ``(d, s, n)``."
         )
         try:
-            f_A, f_B, f_AB = np.atleast_2d(
+            f_A, f_B, f_AB = map(lambda arr: arr.copy(), np.atleast_2d(
                 func['f_A'], func['f_B'], func['f_AB']
-            )
+            ))
         except KeyError as exc:
             raise ValueError(message) from exc
 

--- a/scipy/stats/tests/test_sensitivity_analysis.py
+++ b/scipy/stats/tests/test_sensitivity_analysis.py
@@ -163,6 +163,14 @@ class TestSobolIndices:
             rng=rng
         )
         assert_allclose(res.first_order, ishigami_ref_indices[0], atol=1e-2)
+        # Ideally should be exactly equal but since f_ishigami
+        # uses floating point operations, so exact equality
+        # might not be possible (due to flakiness in computation).
+        # So, assert_allclose is used with default parameters
+        # Regression test for https://github.com/scipy/scipy/issues/21383
+        assert_allclose(f_ishigami(A).reshape(1, -1), func['f_A'])
+        assert_allclose(f_ishigami(B).reshape(1, -1), func['f_B'])
+        assert_allclose(f_ishigami(AB).reshape((3, 1, -1)), func['f_AB'])
 
     def test_method(self, ishigami_ref_indices):
         def jansen_sobol(f_A, f_B, f_AB):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/21383

#### What does this implement/fix?
<!--Please explain your changes.-->

Quoting https://github.com/scipy/scipy/issues/21383#issuecomment-2513867026,

> I will be working on it if somebody else is already not. Please let me know if anyone is already working on it, I will work on other issues then.
> Meanwhile, I am able to reproduce this bug. The modification happens in the following line (I commented these out and then the `bar` remains same before and after calling the function),
> https://github.com/scipy/scipy/blob/82ee02556872b9f91576b835a8f40f1d9eb1fd8d/scipy/stats/_sensitivity_analysis.py#L682-L684
> I guess we can just deepcopy `f_A`, `f_B`, `f_AB` in the following line,
> https://github.com/scipy/scipy/blob/82ee02556872b9f91576b835a8f40f1d9eb1fd8d/scipy/stats/_sensitivity_analysis.py#L667-L669
> I think `f_A`, `f_B`, `f_AB` are required to be mutated so deepcopying them from input dictionary is the only way I can think of to preserve the input arrays. Let me know if you there is a better way to achieve the same.



#### Additional information
<!--Any additional information you think is important.-->
