### PR TITLE
DOC: Unhide `toctree` in `scipy.cluster` with `maxdepth` set to 1

### DIFF
--- a/scipy/cluster/__init__.py
+++ b/scipy/cluster/__init__.py
@@ -5,12 +5,6 @@ Clustering package (:mod:`scipy.cluster`)
 
 .. currentmodule:: scipy.cluster
 
-.. toctree::
-   :hidden:
-
-   cluster.vq
-   cluster.hierarchy
-
 Clustering algorithms are useful in information theory, target detection,
 communications, compression, and other areas. The `vq` module only
 supports vector quantization and the k-means algorithms.
@@ -20,6 +14,12 @@ agglomerative clustering.  Its features include generating hierarchical
 clusters from distance matrices,
 calculating statistics on clusters, cutting linkages
 to generate flat clusters, and visualizing clusters with dendrograms.
+
+.. toctree::
+   :maxdepth: 1
+
+   cluster.vq
+   cluster.hierarchy
 
 """
 __all__ = ['vq', 'hierarchy']


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/21556

#### What does this implement/fix?
<!--Please explain your changes.-->

A small change which unhides the TOC under `scipy.cluster` module. Maximum depth is set to 1 so that only submodule names are visible. Following is the screenshot,

<img width="1352" alt="Screenshot 2024-12-03 at 5 19 47 PM" src="https://github.com/user-attachments/assets/22f1d41b-b908-4b7f-9219-5e7094443ec1">


#### Additional information
<!--Any additional information you think is important.-->
