### PR TITLE
ENH: `optimize.root`: warn when inner parameters are ignored with `method='krylov'`

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1512,13 +1512,15 @@ class KrylovJacobian(Jacobian):
         for key, value in kw.items():
             if not key.startswith('inner_'):
                 raise ValueError(f"Unknown parameter {key}")
-            if key[6:] not in valid_inner_params:
+            option = key[6:]
+            if option not in valid_inner_params:
                 warnings.warn(
-                    f"The option {key} is not valid for inner solver {method}."
-                    " Please see the solver's documentation for a list of valid"
-                    " options."
+                    f"The option {option} is not valid for inner solver {method}, "
+                    f"so it has been ignored."
+                    f"Please see the solver's documentation for a list of valid"
+                    f"options to append to `inner_`."
                 )
-            self.method_kw[key[6:]] = value
+            self.method_kw[option] = value
 
     def _update_diff_step(self):
         mx = abs(self.x0).max()

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1492,9 +1492,32 @@ class KrylovJacobian(Jacobian):
             self.method_kw.setdefault('store_outer_Av', False)
             self.method_kw.setdefault('atol', 0)
 
+        valid_inner_params = dict(
+            bicgstab=["rtol", "atol"],
+            gmres=["rtol", "atol", "restart"],
+            lgmres=[
+                "rtol",
+                "atol",
+                "inner_m",
+                "outer_k",
+                "outer_v",
+                "store_outer_Av",
+                "prepend_outer_v"
+            ],
+            cgs=["rtol", "atol", "show", "check"],
+            minres=["rtol", "shift"],
+            tfqmr=["rtol", "atol"],
+        ).get(method, method)
+
         for key, value in kw.items():
             if not key.startswith('inner_'):
                 raise ValueError(f"Unknown parameter {key}")
+            if key[6:] not in valid_inner_params:
+                warnings.warn(
+                    f"The option {key} is not valid for inner solver {method}."
+                    " Please see the solver's documentation for a list of valid"
+                    " options."
+                )
             self.method_kw[key[6:]] = value
 
     def _update_diff_step(self):


### PR DESCRIPTION
#### Reference issue
Closes #21986 

#### What does this implement/fix?
This PR emits warnings to the user if the Krylov solver in `optimize.root` is passed with invalid `inner_*` options which don't exist for the inner solver chosen. For example if provided with `inner_atol` with `solver="minres"`, the code will emit a warning to the user as `minres` solver doesn't accept `atol` parameter. 

#### Additional information
<!--Any additional information you think is important.-->
