### PR TITLE
BLD: Remove `ld_classic` usage on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,10 +91,6 @@ if ff.has_argument('-Wno-conversion')
 endif
 
 if host_machine.system() == 'darwin'
-  if cc.has_link_argument('-Wl,-ld_classic')
-    # New linker introduced in macOS 14 not working yet, see gh-19357 and gh-19387
-    add_project_link_arguments('-Wl,-ld_classic', language : ['c', 'cpp', 'fortran'])
-  endif
   if cc.has_link_argument('-Wl,-dead_strip')
     # Allow linker to strip unused symbols
     add_project_link_arguments('-Wl,-dead_strip', language : ['c', 'cpp', 'fortran'])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/21660

#### What does this implement/fix?
<!--Please explain your changes.-->

It removes the usage of `ld_classic` flag on macOS. I tested locally on my system (macOS with `Apple clang version 16.0.0 (clang-1600.0.26.4)`) and on CI (see https://github.com/czgdp1807/scipy/pull/10). It works fine and doesn't give any warnings. Tests also pass.


#### Additional information
<!--Any additional information you think is important.-->

cc: @tylerjereddy @rgommers @andyfaff 