### PR TITLE
MAINT, DOC: Use Jupytext's API, and fix cross-platform usage for `doc/convert_notebooks.py`

### DIFF
--- a/doc/convert_notebooks.py
+++ b/doc/convert_notebooks.py
@@ -14,13 +14,14 @@ def call_jupytext(md_files, _contents_path, _contents_cache_path):
         return True
 
     is_dirty = False
+
     for md_file in md_files:
         basename = os.path.splitext(os.path.basename(md_file))[0]
         output_path = os.path.join(_contents_path, f"{basename}.ipynb")
         cached_output_path = os.path.join(_contents_cache_path, f"{basename}.ipynb")
-        cmd_execution_time = os.path.getctime(cached_output_path)
-        md_file_modification_time = os.path.getmtime(md_file)
-        if cmd_execution_time <= md_file_modification_time:
+        cmd_execution_time = os.stat(cached_output_path).st_mtime
+        md_file_modification_time = os.stat(md_file).st_mtime
+        if cmd_execution_time < md_file_modification_time:
             nb = jupytext.read(md_file)
             jupytext.write(nb, output_path, fmt="ipynb", version=4)
             is_dirty = True
@@ -35,6 +36,7 @@ def call_jupytext(md_files, _contents_path, _contents_cache_path):
 if __name__ == '__main__':
     _contents_cache_path = os.path.join("build", "_contents")
     _contents_path = os.path.join("source", "_contents")
+
     os.makedirs(os.path.expanduser(_contents_path), exist_ok=True)
 
     md_files = glob.glob("source/tutorial/stats/*.md")

--- a/doc/convert_notebooks.py
+++ b/doc/convert_notebooks.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import jupytext
 
 def call_jupytext(md_files, _contents_path, _contents_cache_path):
     is_cached = os.path.exists(_contents_cache_path)
@@ -8,7 +9,8 @@ def call_jupytext(md_files, _contents_path, _contents_cache_path):
         for md_file in md_files:
             basename = os.path.splitext(os.path.basename(md_file))[0]
             output_name = os.path.join(_contents_path, f"{basename}.ipynb")
-            os.system(f"python3 -m jupytext --output {output_name} {md_file}")
+            nb = jupytext.read(md_file)
+            jupytext.write(jupytext.read(md_file), output_name, fmt="ipynb", version=4)
         return True
 
     is_dirty = False
@@ -19,7 +21,8 @@ def call_jupytext(md_files, _contents_path, _contents_cache_path):
         cmd_execution_time = os.path.getctime(cached_output_path)
         md_file_modification_time = os.path.getmtime(md_file)
         if cmd_execution_time <= md_file_modification_time:
-            os.system(f"python3 -m jupytext --output {output_path} {md_file}")
+            nb = jupytext.read(md_file)
+            jupytext.write(nb, output_path, fmt="ipynb", version=4)
             is_dirty = True
         else:
             shutil.copyfile(


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This came up when I was testing a greater change for these files via jupyterlite/jupyterlite-sphinx#221, so I thought it would be nice to fix what I noticed upstream with a quick PR until we roll out that feature and port it over here (should be soon).

#### What does this implement/fix?
<!--Please explain your changes.-->

- ed82988b4f358f1daeb0371f5d05b6cc17ad38d7 removes the usage of the Jupytext CLI being called, because we can use the Jupytext API directly. Further, even if we were to use the CLI and an API were not available, using `os.system("python3 <...>")` isn't really a good idea when we already have `subprocess.check_call([f"{sys.executable}])`.
- c5228f5a1d3ba7e1458aaeb68a2d9d7a75143256 drops the usage of [`os.path.getctime`](https://docs.python.org/3/library/os.path.html#os.path.getctime) for timestamp-based caching, because its behaviour is different across Unix and Windows:
     - Unix returns the last metadata change time, but Windows returns the creation time
     - We switch to [`os.stat().st_mtime`](https://docs.python.org/3/library/os.html#os.stat_result.st_mtime) instead because it's more consistent across platforms and directly measures what we care about here (the time between changes between the file contents across docs builds). We don't need to access the creation time for invalidating caches.
     - Also, this commit removes the equality expression from the check because it is an impossible condition to meet – one will modify the Markdown file(s) only after Jupytext has converted them.

#### Additional information
<!--Any additional information you think is important.-->

N/A