### PR TITLE
DEV: unified git submodule exclusion for tools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         set -euo pipefail
         python tools/lint.py --diff-against origin/$GITHUB_BASE_REF
-        python tools/unicode-check.py
+        python tools/check_unicode.py
         python tools/check_test_name.py
 
     - name: Check that Python.h is first in any file including it.

--- a/dev.py
+++ b/dev.py
@@ -1161,11 +1161,11 @@ def task_check_python_h_first():
     }
 
 
-def task_unicode_check():
-    # emit_cmdstr(os.path.join('tools', 'unicode-check.py'))
+def task_check_unicode():
+    # emit_cmdstr(os.path.join('tools', 'check_unicode.py'))
     return {
-        'basename': 'unicode-check',
-        'actions': [str(Dirs().root / 'tools' / 'unicode-check.py')],
+        'basename': 'check_unicode',
+        'actions': [str(Dirs().root / 'tools' / 'check_unicode.py')],
         'doc': 'Check for disallowed Unicode characters in the SciPy Python '
                'and Cython source code.',
     }
@@ -1192,7 +1192,7 @@ class Lint:
     def run(cls, fix):
         run_doit_task({
             'lint': {'fix': fix},
-            'unicode-check': {},
+            'check-unicode': {},
             'check-testname': {},
             'check_python_h_first': {},
         })

--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -26,10 +26,10 @@ Coding Style and Guidelines
 ---------------------------
 Note that docstrings should be generally made up of ASCII characters
 in spite of being Unicode. The following code block from the file
-``tools/unicode-check.py`` tells the linter which additional characters
+``tools/check_unicode.py`` tells the linter which additional characters
 are allowed:
 
-.. literalinclude:: ../../../tools/unicode-check.py
+.. literalinclude:: ../../../tools/check_unicode.py
     :start-after: # BEGIN_INCLUDE_RST
     :end-before: # END_INCLUDE_RST
     :lineno-match:

--- a/tools/check_installation.py
+++ b/tools/check_installation.py
@@ -21,6 +21,7 @@ meant for use in CI so it's not like many files will be missing at once.
 import os
 import glob
 import sys
+from get_submodule_paths import get_submodule_paths
 
 
 CUR_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
@@ -28,11 +29,7 @@ ROOT_DIR = os.path.dirname(CUR_DIR)
 SCIPY_DIR = os.path.join(ROOT_DIR, 'scipy')
 
 
-# Get the submodule paths so that we can ignore any tests in them or their submodules
-with open(os.path.join(ROOT_DIR, '.gitmodules')) as gitmodules:
-    data = gitmodules.read().split('\n')
-    submodule_paths = [datum.split(' = ')[1] for datum in data if \
-                       datum.startswith('\tpath = ')]
+submodule_paths = get_submodule_paths()
 
 
 # Files whose installation path will be different from original one

--- a/tools/check_test_name.py
+++ b/tools/check_test_name.py
@@ -32,8 +32,10 @@ from pathlib import Path
 import sys
 from collections.abc import Iterator, Sequence
 import itertools
+from get_submodule_paths import get_submodule_paths
 
 PRAGMA = "# skip name check"
+submodule_paths = get_submodule_paths()
 
 
 def _find_names(node: ast.Module) -> Iterator[str]:
@@ -161,7 +163,9 @@ if __name__ == "__main__":
     path = Path("scipy").rglob("**/tests/**/test*.py")
 
     for file in path:
-        filename = os.path.basename(file)
+        if any(submodule_path in str(file.absolute()) for submodule_path in
+               submodule_paths):
+            continue
         with open(file, encoding="utf-8") as fd:
             content = fd.read()
         ret |= main(content, file)

--- a/tools/check_unicode.py
+++ b/tools/check_unicode.py
@@ -23,7 +23,7 @@ allowed = latin1_letters | greek_letters | box_drawing_chars | extra_symbols
 # END_INCLUDE_RST (do not change this line!)
 
 
-def unicode_check(showall=False):
+def check_unicode(showall=False):
     """
     If showall is True, all non-ASCII characters are displayed.
     """
@@ -92,4 +92,4 @@ if __name__ == "__main__":
                         help=('Show non-ASCII Unicode characters from all '
                               'files.'))
     args = parser.parse_args()
-    sys.exit(unicode_check(args.showall) > 0)
+    sys.exit(check_unicode(args.showall) > 0)

--- a/tools/get_submodule_paths.py
+++ b/tools/get_submodule_paths.py
@@ -1,0 +1,21 @@
+import os
+
+
+def get_submodule_paths():
+    '''
+    Get paths to submodules so that we can exclude them from things like
+    check_test_name.py, check_unicode.py, etc.
+    '''
+    root_directory = os.path.dirname(os.path.dirname(__file__))
+    gitmodule_file = os.path.join(root_directory, '.gitmodules')
+    with open(gitmodule_file) as gitmodules:
+        data = gitmodules.read().split('\n')
+        submodule_paths = [datum.split(' = ')[1] for datum in data if
+                        datum.startswith('\tpath = ')]
+        submodule_paths = [os.path.join(root_directory, path) for path in
+                           submodule_paths]
+    return submodule_paths
+
+
+if __name__ == "__main__":
+    print('\n'.join(get_submodule_paths()))

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -4,6 +4,7 @@ import sys
 import subprocess
 import packaging.version
 from argparse import ArgumentParser
+from get_submodule_paths import get_submodule_paths
 
 
 CONFIG = os.path.join(
@@ -129,6 +130,12 @@ def main():
         files = diff_files(branch_point)
     else:
         files = args.files
+
+    # Remove any files from submodules
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    submodule_paths = get_submodule_paths()
+    files = [f for f in files if all(submodule_path not in os.path.join(root_dir, f)
+                                     for submodule_path in submodule_paths)]
 
     cython_exts = ('.pyx', '.pxd', '.pxi')
     cython_files = {f for f in files if any(f.endswith(ext) for ext in cython_exts)}

--- a/tools/pre-commit-hook.py
+++ b/tools/pre-commit-hook.py
@@ -21,9 +21,9 @@ linters = [
 linter = [f for f in linters if os.path.exists(f)][0]
 
 unicode_checks = [
-    '../../tools/unicode-check.py',
-    'tools/unicode-check.py',
-    'unicode-check.py'  # in case pre-commit hook is run from tools dir
+    '../../tools/check_unicode.py',
+    'tools/check_unicode.py',
+    'check_unicode.py'  # in case pre-commit hook is run from tools dir
 ]
 
 unicode_check = [f for f in unicode_checks if os.path.exists(f)][0]

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -5,6 +5,8 @@ from itertools import chain
 from glob import iglob
 import sys
 import argparse
+import os
+from get_submodule_paths import get_submodule_paths
 
 
 # The set of Unicode code points greater than 127 that we allow in the source code:
@@ -27,11 +29,16 @@ def unicode_check(showall=False):
     """
     # File encoding regular expression from PEP-263.
     encoding_pat = re.compile("^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    submodule_paths = get_submodule_paths()
 
     nbad = 0
-    for name in chain(iglob('scipy/**/*.py', recursive=True),
-                      iglob('scipy/**/*.pyx', recursive=True),
-                      iglob('scipy/**/*.px[di]', recursive=True)):
+    for name in chain(iglob(os.path.join(root_dir, 'scipy/**/*.py'), recursive=True),
+                      iglob(os.path.join(root_dir, 'scipy/**/*.pyx'), recursive=True),
+                      iglob(os.path.join(root_dir, 'scipy/**/*.px[di]'),
+                            recursive=True)):
+        if any(submodule_path in name for submodule_path in submodule_paths):
+            continue
         # Read the file as bytes, and check for any bytes greater than 127.
         with open(name, 'rb') as f:
             content = f.read()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This was brought up in https://github.com/scipy/scipy/pull/20964

#### What does this implement/fix?
<!--Please explain your changes.-->
For the various checks, we now make sure that we do not apply them to code found in submodules. Previously this was only applied to check_installation, but it is now applied to check_test_name and unicode-check. Submodules have their own rules and tests so it makes no sense to apply scipy rules to that code. And in the case of the above PR, the issue came from a submodule of a submodule, and so it makes even less sense to apply scipy rules that far away, and it's asking too much of submodule owners to clean up submodules which they aren't maintainers of.

#### Additional information
<!--Any additional information you think is important.-->
In addition, I renamed unicode-check to check_unicode because the inconsistency with the dash vs underscore and 'check' afterwards instead of beforehand was driving me nuts. I've made that change in a separate commit since it's unrelated to the work of checking submodule paths.

I validated that this still catches errors by improperly renaming a test and adding a uncode character to actual scipy code and the issues were caught.
