### PR TITLE
ENH: signal.vectorstrength: add array API standard support

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3910,6 +3910,37 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     return y_keep
 
 
+def _angle(z, xp):
+    """np.angle replacement
+    """
+    # XXX: https://github.com/data-apis/array-api/issues/595
+    if xp.isdtype(z.dtype, 'complex floating'):
+        zreal, zimag = xp.real(z), xp.imag(z)
+    else:
+        zreal, zimag = z, 0
+
+    a = xp.atan2(zimag, zreal)
+    return a
+
+
+def _skip_if_float(arg):
+    # XXX: remove when https://github.com/data-apis/array-api-compat/pull/147
+    # is available
+    return None if isinstance(arg, (int, float)) else arg
+
+
+def _mean(x, *args, xp, **kwds):
+    # https://github.com/data-apis/array-api/pull/850
+    if xp.isdtype(x.dtype, 'complex floating'):
+        I = xp.asarray(1j, dtype=xp.complex64
+                                 if x.dtype == xp.float32
+                                 else xp.complex128)
+        return (xp.mean(xp.real(x), *args, **kwds) +
+                I * xp.mean(xp.imag(x), *args, **kwds))
+    else:
+        return xp.mean(x, *args, **kwds)
+
+
 def vectorstrength(events, period):
     '''
     Determine the vector strength of the events corresponding to the given
@@ -3957,8 +3988,16 @@ def vectorstrength(events, period):
         fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
         :doi:`10.1007/s00422-013-0560-8`.
     '''
-    events = np.asarray(events)
-    period = np.asarray(period)
+    if isinstance(events, (int, float)) and isinstance(period, (int, float)):
+        xp = np_compat
+    else:
+        xp = array_namespace(_skip_if_float(events), _skip_if_float(period))
+
+    events = xp.asarray(events)
+    period = xp.asarray(period)
+    if xp.isdtype(period.dtype, 'integral'):
+        period = xp.astype(period, xp.float64)
+
     if events.ndim > 1:
         raise ValueError('events cannot have dimensions more than 1')
     if period.ndim > 1:
@@ -3967,19 +4006,23 @@ def vectorstrength(events, period):
     # we need to know later if period was originally a scalar
     scalarperiod = not period.ndim
 
-    events = np.atleast_2d(events)
-    period = np.atleast_2d(period)
-    if (period <= 0).any():
+    events = xpx.atleast_nd(events, ndim=2, xp=xp)
+    period = xpx.atleast_nd(period, ndim=2, xp=xp)
+    if xp.any(period <= 0):
         raise ValueError('periods must be positive')
 
     # this converts the times to vectors
-    vectors = np.exp(np.dot(2j*np.pi/period.T, events))
+    I2pi = xp.asarray(2j*xp.pi, dtype=xp.complex64
+                        if period.dtype == xp.float32
+                        else xp.complex128)
+    events_ = xp.astype(events, I2pi.dtype) if is_torch(xp) else events
+    vectors = xp.exp(I2pi/period.T @ events_)
 
     # the vector strength is just the magnitude of the mean of the vectors
     # the vector phase is the angle of the mean of the vectors
-    vectormean = np.mean(vectors, axis=1)
-    strength = abs(vectormean)
-    phase = np.angle(vectormean)
+    vectormean = _mean(vectors, axis=1, xp=xp)
+    strength = xp.abs(vectormean)
+    phase = _angle(vectormean, xp)
 
     # if the original period was a scalar, return scalars
     if scalarperiod:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3923,12 +3923,6 @@ def _angle(z, xp):
     return a
 
 
-def _skip_if_float(arg):
-    # XXX: remove when https://github.com/data-apis/array-api-compat/pull/147
-    # is available
-    return None if isinstance(arg, (int, float)) else arg
-
-
 def _mean(x, *args, xp, **kwds):
     # https://github.com/data-apis/array-api/pull/850
     if xp.isdtype(x.dtype, 'complex floating'):
@@ -3988,10 +3982,7 @@ def vectorstrength(events, period):
         fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
         :doi:`10.1007/s00422-013-0560-8`.
     '''
-    if isinstance(events, (int, float)) and isinstance(period, (int, float)):
-        xp = np_compat
-    else:
-        xp = array_namespace(_skip_if_float(events), _skip_if_float(period))
+    xp = array_namespace(events, period)
 
     events = xp.asarray(events)
     period = xp.asarray(period)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3919,8 +3919,6 @@ class TestVectorstrength:
         assert math.isclose(strength, targ_strength)
         assert math.isclose(phase, 2 * math.pi * targ_phase)
 
-#        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
-#        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
 
     @xfail_xp_backends("torch", reason="phase modulo 2*pi")
     def test_partial_2dperiod(self, xp):
@@ -3945,7 +3943,6 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-#        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
         assert math.isclose(strength, targ_strength, abs_tol=1.5e-7)
 
     def test_opposite_2dperiod(self, xp):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3833,22 +3833,22 @@ class TestVectorstrength:
         assert strength.ndim == 0
         assert phase.ndim == 0
 
-        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
-        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
+        assert math.isclose(strength, targ_strength, abs_tol=1.5e-7)
+        assert math.isclose(phase, 2 * math.pi * targ_phase, abs_tol=1.5e-7)
 
     @xfail_xp_backends('torch', reason="phase modulo 2*pi")
     def test_single_2dperiod(self, xp):
         events = xp.asarray([.5])
         period = xp.asarray([1, 2, 5.])
-        targ_strength = [1.] * 3
+        targ_strength = xp.asarray([1.] * 3)
         targ_phase = xp.asarray([.5, .25, .1])
 
         strength, phase = vectorstrength(events, period)
 
         assert strength.ndim == 1
         assert phase.ndim == 1
-        assert_array_almost_equal(strength, xp.asarray(targ_strength))
-        assert_almost_equal(phase, xp.asarray(2 * xp.pi * targ_phase))
+        assert_array_almost_equal(strength, targ_strength)
+        assert_almost_equal(phase, 2 * xp.pi * targ_phase)
 
     def test_equal_1dperiod(self, xp):
         events = xp.asarray([.25, .25, .25, .25, .25, .25])
@@ -3860,8 +3860,9 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
-        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
+
+        assert math.isclose(strength, targ_strength, abs_tol=1.5e-7)
+        assert math.isclose(phase, 2 * math.pi * targ_phase, abs_tol=1.5e-7)
 
     def test_equal_2dperiod(self, xp):
         events = xp.asarray([.25, .25, .25, .25, .25, .25])
@@ -3886,11 +3887,9 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
-        rtol_kw = {'rtol': 5e-7} if is_torch(xp) else {}
-        xp_assert_close(xp.asarray(phase, dtype=xp.float64),
-                        xp.asarray(2 * xp.pi * targ_phase, dtype=xp.float64),
-                        **rtol_kw)
+
+        assert math.isclose(strength, targ_strength, abs_tol=1.5e-7)
+        assert math.isclose(phase, 2 * math.pi * targ_phase, abs_tol=1.5e-6)
 
     def test_spaced_2dperiod(self, xp):
         events = xp.asarray([.1, 1.1, 2.1, 4.1, 10.1])
@@ -3903,7 +3902,7 @@ class TestVectorstrength:
         assert strength.ndim == 1
         assert phase.ndim == 1
         assert_almost_equal(strength, targ_strength)
-        rtol_kw = {'rtol': 2e-6} if is_torch(xp) else {}
+        rtol_kw = {'rtol': 2e-6} if xp_default_dtype(xp) == xp.float32 else {}
         xp_assert_close(phase, 2 * xp.pi * targ_phase, **rtol_kw)
 
     def test_partial_1dperiod(self, xp):
@@ -3916,8 +3915,12 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
-        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
+
+        assert math.isclose(strength, targ_strength)
+        assert math.isclose(phase, 2 * math.pi * targ_phase)
+
+#        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+#        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
 
     @xfail_xp_backends("torch", reason="phase modulo 2*pi")
     def test_partial_2dperiod(self, xp):
@@ -3942,7 +3945,8 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+#        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+        assert math.isclose(strength, targ_strength, abs_tol=1.5e-7)
 
     def test_opposite_2dperiod(self, xp):
         events = xp.asarray([0, .25, .5, .75])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3820,11 +3820,10 @@ class TestPartialFractionExpansion:
         assert_almost_equal(a, [1, -1])
 
 
-@skip_xp_backends(np_only=True)
 class TestVectorstrength:
 
     def test_single_1dperiod(self, xp):
-        events = np.array([.5])
+        events = xp.asarray([.5])
         period = 5.
         targ_strength = 1.
         targ_phase = .1
@@ -3833,24 +3832,26 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
 
+        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
+
+    @xfail_xp_backends('torch', reason="phase modulo 2*pi")
     def test_single_2dperiod(self, xp):
-        events = np.array([.5])
-        period = [1, 2, 5.]
+        events = xp.asarray([.5])
+        period = xp.asarray([1, 2, 5.])
         targ_strength = [1.] * 3
-        targ_phase = np.array([.5, .25, .1])
+        targ_phase = xp.asarray([.5, .25, .1])
 
         strength, phase = vectorstrength(events, period)
 
         assert strength.ndim == 1
         assert phase.ndim == 1
-        assert_array_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_array_almost_equal(strength, xp.asarray(targ_strength))
+        assert_almost_equal(phase, xp.asarray(2 * xp.pi * targ_phase))
 
     def test_equal_1dperiod(self, xp):
-        events = np.array([.25, .25, .25, .25, .25, .25])
+        events = xp.asarray([.25, .25, .25, .25, .25, .25])
         period = 2
         targ_strength = 1.
         targ_phase = .125
@@ -3859,24 +3860,24 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
 
     def test_equal_2dperiod(self, xp):
-        events = np.array([.25, .25, .25, .25, .25, .25])
-        period = [1, 2, ]
-        targ_strength = [1.] * 2
-        targ_phase = np.array([.25, .125])
+        events = xp.asarray([.25, .25, .25, .25, .25, .25])
+        period = xp.asarray([1, 2, ])
+        targ_strength = xp.asarray([1.] * 2)
+        targ_phase = xp.asarray([.25, .125])
 
         strength, phase = vectorstrength(events, period)
 
         assert strength.ndim == 1
         assert phase.ndim == 1
         assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_almost_equal(phase, 2 * xp.pi * targ_phase)
 
     def test_spaced_1dperiod(self, xp):
-        events = np.array([.1, 1.1, 2.1, 4.1, 10.1])
+        events = xp.asarray([.1, 1.1, 2.1, 4.1, 10.1])
         period = 1
         targ_strength = 1.
         targ_phase = .1
@@ -3885,24 +3886,28 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+        rtol_kw = {'rtol': 5e-7} if is_torch(xp) else {}
+        xp_assert_close(xp.asarray(phase, dtype=xp.float64),
+                        xp.asarray(2 * xp.pi * targ_phase, dtype=xp.float64),
+                        **rtol_kw)
 
     def test_spaced_2dperiod(self, xp):
-        events = np.array([.1, 1.1, 2.1, 4.1, 10.1])
-        period = [1, .5]
-        targ_strength = [1.] * 2
-        targ_phase = np.array([.1, .2])
+        events = xp.asarray([.1, 1.1, 2.1, 4.1, 10.1])
+        period = xp.asarray([1, .5])
+        targ_strength = xp.asarray([1.] * 2)
+        targ_phase = xp.asarray([.1, .2])
 
         strength, phase = vectorstrength(events, period)
 
         assert strength.ndim == 1
         assert phase.ndim == 1
         assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        rtol_kw = {'rtol': 2e-6} if is_torch(xp) else {}
+        xp_assert_close(phase, 2 * xp.pi * targ_phase, **rtol_kw)
 
     def test_partial_1dperiod(self, xp):
-        events = np.array([.25, .5, .75])
+        events = xp.asarray([.25, .5, .75])
         period = 1
         targ_strength = 1. / 3.
         targ_phase = .5
@@ -3911,24 +3916,25 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
+        assert_almost_equal(xp.asarray(phase), xp.asarray(2 * xp.pi * targ_phase))
 
+    @xfail_xp_backends("torch", reason="phase modulo 2*pi")
     def test_partial_2dperiod(self, xp):
-        events = np.array([.25, .5, .75])
-        period = [1., 1., 1., 1.]
-        targ_strength = [1. / 3.] * 4
-        targ_phase = np.array([.5, .5, .5, .5])
+        events = xp.asarray([.25, .5, .75])
+        period = xp.asarray([1., 1., 1., 1.])
+        targ_strength = xp.asarray([1. / 3.] * 4)
+        targ_phase = xp.asarray([.5, .5, .5, .5])
 
         strength, phase = vectorstrength(events, period)
 
         assert strength.ndim == 1
         assert phase.ndim == 1
         assert_almost_equal(strength, targ_strength)
-        assert_almost_equal(phase, 2 * np.pi * targ_phase)
+        assert_almost_equal(phase, 2 * xp.pi * targ_phase)
 
     def test_opposite_1dperiod(self, xp):
-        events = np.array([0, .25, .5, .75])
+        events = xp.asarray([0, .25, .5, .75])
         period = 1.
         targ_strength = 0
 
@@ -3936,12 +3942,12 @@ class TestVectorstrength:
 
         assert strength.ndim == 0
         assert phase.ndim == 0
-        assert_almost_equal(strength, targ_strength)
+        assert_almost_equal(xp.asarray(strength), xp.asarray(targ_strength))
 
     def test_opposite_2dperiod(self, xp):
-        events = np.array([0, .25, .5, .75])
-        period = [1.] * 10
-        targ_strength = [0.] * 10
+        events = xp.asarray([0, .25, .5, .75])
+        period = xp.asarray([1.] * 10)
+        targ_strength = xp.asarray([0.] * 10)
 
         strength, phase = vectorstrength(events, period)
 
@@ -3950,13 +3956,13 @@ class TestVectorstrength:
         assert_almost_equal(strength, targ_strength)
 
     def test_2d_events_ValueError(self, xp):
-        events = np.array([[1, 2]])
+        events = xp.asarray([[1, 2]])
         period = 1.
         assert_raises(ValueError, vectorstrength, events, period)
 
     def test_2d_period_ValueError(self, xp):
         events = 1.
-        period = np.array([[1]])
+        period = xp.asarray([[1]])
         assert_raises(ValueError, vectorstrength, events, period)
 
     def test_zero_period_ValueError(self, xp):


### PR DESCRIPTION
<s>On top of gh-20772: while I believe gh-20772 is ready or nearly so, converting `vectorstrength` basically devolved into a showroom of deficiencies of our current tooling. Only the last two commits here are relevant. </s>

Convert `signal.vectorstrength` to be array API compatible. Basically this now is pretty much a collection of small examples to motivate discussions of the 2024.12 array api spec. Primarily around  1) complex-valued arithmetics, and 2) mixing arrays and scalars.