### PR TITLE
REL: set version to 1.16.0.dev0

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.16.0-notes
    release/1.15.0-notes
    release/1.14.1-notes
    release/1.14.0-notes

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -1,0 +1,112 @@
+==========================
+SciPy 1.16.0 Release Notes
+==========================
+
+.. note:: SciPy 1.16.0 is not released yet!
+
+.. contents::
+
+SciPy 1.16.0 is the culmination of X months of hard work. It contains
+many new features, numerous bug-fixes, improved test coverage and better
+documentation. There have been a number of deprecations and API changes
+in this release, which are documented below. All users are encouraged to
+upgrade to this release, as there are a large number of bug-fixes and
+optimizations. Before upgrading, we recommend that users check that
+their own code does not use deprecated SciPy functionality (to do so,
+run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
+Our development attention will now shift to bug-fix releases on the
+1.16.x branch, and on adding new features on the main branch.
+
+This release requires Python 3.11-3.13 and NumPy 1.24.4 or greater.
+
+
+**************************
+Highlights of this release
+**************************
+
+
+************
+New features
+************
+
+`scipy.cluster` improvements
+============================
+
+
+`scipy.interpolate` improvements
+================================
+
+
+`scipy.linalg` improvements
+===========================
+
+
+`scipy.ndimage` improvements
+============================
+
+
+`scipy.optimize` improvements
+=============================
+
+
+`scipy.signal` improvements
+===========================
+
+
+`scipy.sparse` improvements
+===========================
+
+
+
+`scipy.spatial` improvements
+============================
+
+
+`scipy.special` improvements
+============================
+
+
+`scipy.stats` improvements
+==========================
+
+
+
+*******************
+Deprecated features
+*******************
+
+`scipy.linalg` deprecations
+===========================
+
+
+`scipy.spatial` deprecations
+============================
+
+
+
+******************************
+Backwards incompatible changes
+******************************
+
+*************
+Other changes
+*************
+
+
+
+*******
+Authors
+*******
+
+
+
+************************
+Issues closed for 1.16.0
+************************
+
+
+************************
+Pull requests for 1.16.0
+************************
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.15.0.dev0"
+version = "1.16.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Don't merge until the `1.15.0` release notes updates have been merged and the `maintenance/1.15.x` branch has been pushed up (I'll probably merge when the time is right).

* The changed dependency versions in the `1.16.0` release notes are just drafts/subject to change. Note that I've not taken on the task of actually updating those dependencies in places where they may get checked programmatically (i.e., `pyproject.toml`), since that may be a larger project that can happen after branching.

* It looks like our version handling has actually simplified since the previous release--see the matching PR from previous release at gh-20827.

[docs only]
