### PR TITLE
DEV: `gh_lists`: fix asterisk sanitisation

### DIFF
--- a/tools/gh_lists.py
+++ b/tools/gh_lists.py
@@ -53,6 +53,11 @@ def main():
             else:
                 post = matchobj.group(2)
             return '``' + matchobj.group(1) + '``' + post
+        
+        def asterisk_repl(matchobj):
+            """repl to un-escape asterisks in code blocks"""
+            code = matchobj.group(1).replace("\\*", "*")
+            return '``' + code + '``'
 
         for issue in items:
             msg = "* `#{0} <{1}>`__: {2}"
@@ -69,6 +74,8 @@ def main():
 
             # sanitize asterisks
             title = title.replace('*', '\\*')
+            # except those in code blocks
+            title = re.sub("``(.*?)``", asterisk_repl, title)
 
             if len(title) > 60:
                 remainder = re.sub("\\s.*$", "...", title[60:])


### PR DESCRIPTION
@tylerjereddy this seems to work!

```
(scipy) lucascolley@arm64-apple-darwin20 scipy % python tools/gh_lists.py 1.15.0 | rg '\*.*\*'
[gh_lists] using gh_cache.json as cache (remove it if you want fresh data)
[gh_lists] (cached): https://api.github.com/repos/scipy/scipy/milestones
[gh_lists] (cached): https://api.github.com/repos/scipy/scipy/milestones
[gh_lists] (cached): https://api.github.com/repos/scipy/scipy/issues?milestone=85&state=closed&sort=created&direction=asc
* `#4517 <https://github.com/scipy/scipy/issues/4517>`__: MAINT: special.hankel2: ``(0, 0)`` delivers (nan+nan\*j) instead...
* `#21044 <https://github.com/scipy/scipy/issues/21044>`__: RFC: quo vadis, ``xp_assert_*`` infrastructure?
* `#21296 <https://github.com/scipy/scipy/issues/21296>`__: DOC: optimize.root: fix docs for ``inner_*`` parameters
* `#21512 <https://github.com/scipy/scipy/pull/21512>`__: TST: signal: convert to ``xp_assert_*`` infrastructure (pt. 1)
* `#21530 <https://github.com/scipy/scipy/pull/21530>`__: TST: signal: convert to ``xp_assert_*`` infrastructure, pt 2
* `#21544 <https://github.com/scipy/scipy/pull/21544>`__: DOC: optimize: document recipe for ``*args`` and ``**kwargs``
* `#21937 <https://github.com/scipy/scipy/pull/21937>`__: TST: linalg.blas: fix test concurrency, mark ``*ger`` as unsafe
* `#21985 <https://github.com/scipy/scipy/pull/21985>`__: DOC: optimize.root: fix docs for ``inner_*`` parameters
```