### PR TITLE
MAINT: version pins/prep for 1.15.0rc1

### DIFF
--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -28,7 +28,7 @@ cirrus_wheels_linux_aarch64_task:
     - env:
         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
   env:
-    CIBW_PRERELEASE_PYTHONS: True
+    CIBW_PRERELEASE_PYTHONS: False
     # The following settings are useful when targetting an unreleased Python version.
     #CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
     #CIBW_ENVIRONMENT: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,22 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.15.0",
-    "Cython>=3.0.8",        # when updating version, also update check in meson.build
-    "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
-    "pythran>=0.14.0",
+    # The upper bound on meson-python is pre-emptive only (looser
+    # on purpose, since chance of breakage in 0.18/0.19 is low with
+    # 0.17.1 working at time of writing)
+    "meson-python>=0.15.0,<0.20.0",
+    # we need at least Cython 3.1.0a1 for free-threaded CPython
+    # 3.13 wheel builds
+    "Cython>=3.1.0a1,<3.2.0; python_version=='3.13t'",        # when updating version, also update check in meson.build
+    # for other CPython versions, the regular pre-emptive
+    # Cython version bounds policy applies
+    "Cython>=3.0.8,<3.1.0; python_version!='3.13t'",
+    # The upper bound on pybind11 is pre-emptive only
+    "pybind11>=2.13.2,<2.14.0",     # when updating version, also update check in scipy/meson.build
+    # The upper bound on pythran is pre-emptive only; 0.17.0
+    # is released/working at time of writing, and 0.18.x may
+    # have desirable free-threaded CPython 3.13 support
+    "pythran>=0.14.0,<0.19.0",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -28,7 +40,10 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0rc1",
+    "numpy>=2.0.0,<2.5; python_version!='3.13t'",
+    # free-threaded CPython 3.13 support requires more
+    # recent NumPy release at build time
+    "numpy>=2.1.3,<2.5; python_version=='3.13t'",
 ]
 
 [project]
@@ -46,7 +61,10 @@ maintainers = [
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.23.5",
+    # free-threaded CPython 3.13 support requires more
+    # recent NumPy release at runtime
+    "numpy>=2.1.3,<2.5; python_version=='3.13t'",
+    "numpy>=1.23.5,<2.5; python_version!='3.13t'",
 ] # keep in sync with `min_numpy_version` in meson.build
 readme = "README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,15 @@ requires = [
     # on purpose, since chance of breakage in 0.18/0.19 is low with
     # 0.17.1 working at time of writing)
     "meson-python>=0.15.0,<0.20.0",
-    # we need at least Cython 3.1.0a1 for free-threaded CPython
-    # 3.13 wheel builds
-    "Cython>=3.1.0a1,<3.2.0; python_version=='3.13t'",        # when updating version, also update check in meson.build
+    # we need at least Cython 3.1.0a1 for free-threaded CPython;
     # for other CPython versions, the regular pre-emptive
     # Cython version bounds policy applies
-    "Cython>=3.0.8,<3.1.0; python_version!='3.13t'",
+    "Cython>=3.0.8,<3.1.0",
     # The upper bound on pybind11 is pre-emptive only
     "pybind11>=2.13.2,<2.14.0",     # when updating version, also update check in scipy/meson.build
     # The upper bound on pythran is pre-emptive only; 0.17.0
-    # is released/working at time of writing, and 0.18.x may
-    # have desirable free-threaded CPython 3.13 support
-    "pythran>=0.14.0,<0.19.0",
+    # is released/working at time of writing
+    "pythran>=0.14.0,<0.18.0",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -40,10 +37,8 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0,<2.5; python_version!='3.13t'",
-    # free-threaded CPython 3.13 support requires more
-    # recent NumPy release at build time
-    "numpy>=2.1.3,<2.5; python_version=='3.13t'",
+    # NOTE: need numpy>=2.1.3 from free-threaded CPython 3.13 support
+    "numpy>=2.0.0,<2.5",
 ]
 
 [project]
@@ -62,9 +57,8 @@ maintainers = [
 requires-python = ">=3.10"
 dependencies = [
     # free-threaded CPython 3.13 support requires more
-    # recent NumPy release at runtime
-    "numpy>=2.1.3,<2.5; python_version=='3.13t'",
-    "numpy>=1.23.5,<2.5; python_version!='3.13t'",
+    # recent NumPy release at runtime (>=2.1.3)
+    "numpy>=1.23.5,<2.5",
 ] # keep in sync with `min_numpy_version` in meson.build
 readme = "README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    # NOTE: need numpy>=2.1.3 from free-threaded CPython 3.13 support
+    # NOTE: need numpy>=2.1.3 for free-threaded CPython 3.13 support
     "numpy>=2.0.0,<2.5",
 ]
 

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -67,7 +67,7 @@ del _distributor_init
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
 np_minversion = '1.23.5'
-np_maxversion = '9.9.99'
+np_maxversion = '2.5.0'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
     import warnings


### PR DESCRIPTION
Important: CI is skipped completely for now because this will not work--it mostly demonstrates what I'd *like* to be able to do, but that apparently cannot be done because of the limited hooks available in https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers. I'm pretty sure our only option at the moment for free-threaded CPython `3.13` wheels will be to treat `pyproject.toml` more or less like free-threaded CPython doesn't exist, and disable build isolation for `cibuildwheel` (which is basically what we do on `main`). 

However, if you wanted to do a more formally-correct build-isolation-enabled CPython `3.13` free-threaded wheel build it looks like you'd be in trouble at the moment?

* Update dependency version ranges for build/runtime as we prepare for the SciPy `1.15.0rc1` pre-release, paying special attention to the complications related to free-threaded CPython `3.13` support.

* In addition to the differences caused by free-threading support, there are also some version handling changes that mean this update differs from the previous one performed in the last release cycle at gh-20831.

[skip ci] [ci skip] [skip cirrus] [skip circle]

TODO:

- [ ] regular CI passing
- [ ] wheels CI passing