### PR TITLE
MAINT: stats.Mixture: fix default `weights`

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4240,9 +4240,10 @@ class Mixture(_ProbabilityDistribution):
         The underlying instances of `ContinuousDistribution`.
         All must have scalar shape parameters (if any); e.g., the `pdf` evaluated
         at a scalar argument must return a scalar.
-    weights : sequence of floats
+    weights : sequence of floats, optional
         The corresponding probabilities of selecting each random variable.
-        Must be non-negative and sum to one.
+        Must be non-negative and sum to one. The default behavior is to weight
+        all components equally.
 
     Attributes
     ----------
@@ -4302,7 +4303,6 @@ class Mixture(_ProbabilityDistribution):
 
     """
     # Todo:
-    # Fix Normal(mu=0.5).logentropy() runtime warning
     # Add support for array shapes, weights
 
     def _input_validation(self, components, weights):
@@ -4322,7 +4322,7 @@ class Mixture(_ProbabilityDistribution):
                 raise ValueError(message)
 
         if weights is None:
-            return
+            return components, weights
 
         weights = np.asarray(weights)
         if weights.shape != (len(components),):

--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -86,7 +86,10 @@ class Normal(ContinuousDistribution):
 
     def _logentropy_formula(self, *, mu, sigma, **kwargs):
         lH0 = StandardNormal._logentropy_formula(self)
-        lls = np.log(np.log(abs(sigma))+0j)
+        with np.errstate(divide='ignore'):
+            # sigma = 1 -> log(sigma) = 0 -> log(log(sigma)) = -inf
+            # Silence the unnecessary runtime warning
+            lls = np.log(np.log(abs(sigma))+0j)
         return special.logsumexp(np.broadcast_arrays(lH0, lls), axis=0)
 
     def _median_formula(self, *, mu, sigma, **kwargs):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1652,6 +1652,14 @@ class TestMixture:
         assert y.shape == shape
         assert stats.ks_1samp(y.ravel(), X.cdf).pvalue > 0.05
 
+    def test_default_weights(self):
+        a = 1.1
+        Gamma = stats.make_distribution(stats.gamma)
+        X = Gamma(a=a)
+        Y = stats.Mixture((X, -X))
+        x = np.linspace(-4, 4, 300)
+        assert_allclose(Y.pdf(x), stats.dgamma(a=a).pdf(x))
+
     def test_properties(self):
         components = [Normal(mu=-0.25, sigma=1.1), Normal(mu=0.5, sigma=0.9)]
         weights = (0.4, 0.6)


### PR DESCRIPTION
#### Reference issue
gh-21700

#### What does this implement/fix?
In gh-21700, there was a bit of back and forth about whether `weights` should have a default value. In the end, we decided "yes", but we didn't add a unit tests. This adds the test and fixes a mistake that crept in during a refactoring.

#### Additional information
Also silences an unnecessary runtime warning in `Normal.logentropy`.

Incidentally, I discovered another very useful case of equal weights: double distributions (e.g. `dgamma`, `dweibull`)
```python3
import numpy as np
import matplotlib.pyplot as plt
from scipy import stats
a = 1.1
Gamma = stats.make_distribution(stats.gamma)
X = Gamma(a=a)
Y = stats.Mixture([X, -X])
x = np.linspace(-4, 4, 300)

plt.plot(x, Y.pdf(x), '-', label='equal weight mixture')
plt.plot(x, stats.dgamma(a=a).pdf(x), '--', label='dgamma')
plt.legend()
plt.title('PDF of double gamma distribution')
plt.show()
```
![image](https://github.com/user-attachments/assets/fb7ed9e7-87a4-44b5-951a-a696c31a0a8f)
