### PR TITLE
MAINT: `stats.FoldedDistribution`: accommodate for private methods of distributions being invalid outside support

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4684,30 +4684,40 @@ class FoldedDistribution(TransformedDistribution):
         a_[i] = 0
         return a_[()], b_[()]
 
-    def _logpdf_dispatch(self, x, *args, **params):
-        logpdfs = np.stack([self._dist._logpdf_dispatch(x, *args, **params),
-                            self._dist._logpdf_dispatch(-x, *args, **params)])
+    def _logpdf_dispatch(self, x, *args, method=None, **params):
+        right = self._dist._logpdf_dispatch(x, *args, method=method, **params)
+        left = self._dist._logpdf_dispatch(-x, *args, method=method, **params)
+        left = np.asarray(left)
+        left[-x < self._dist._support(**params)[0]] = -np.inf
+        logpdfs = np.stack([left, right])
         return special.logsumexp(logpdfs, axis=0)
 
-    def _pdf_dispatch(self, x, *args, **params):
-        return (self._dist._pdf_dispatch(x, *args, **params)
-                + self._dist._pdf_dispatch(-x, *args, **params))
+    def _pdf_dispatch(self, x, *args, method=None, **params):
+        right = self._dist._pdf_dispatch(x, *args, method=method, **params)
+        left = self._dist._pdf_dispatch(-x, *args, method=method, **params)
+        left = np.asarray(left)
+        left[-x < self._dist._support(**params)[0]] = 0
+        return left + right
 
-    def _logcdf_dispatch(self, x, *args, **params):
+    def _logcdf_dispatch(self, x, *args, method=None, **params):
         x = np.abs(x)
-        return self._dist._logcdf2_dispatch(-x, x, *args, **params).real
+        a = np.maximum(-x, self._dist._support(**params)[0])
+        return self._dist._logcdf2_dispatch(a, x, *args, method=method, **params).real
 
-    def _cdf_dispatch(self, x, *args, **params):
+    def _cdf_dispatch(self, x, *args, method=None, **params):
         x = np.abs(x)
-        return self._dist._cdf2_dispatch(-x, x, *args, **params)
+        a = np.maximum(-x, self._dist._support(**params)[0])
+        return self._dist._cdf2_dispatch(a, x, *args, method=method, **params)
 
-    def _logccdf_dispatch(self, x, *args, **params):
+    def _logccdf_dispatch(self, x, *args, method=None, **params):
         x = np.abs(x)
-        return self._dist._logccdf2_dispatch(-x, x, *args, **params).real
+        a = np.maximum(-x, self._dist._support(**params)[0])
+        return self._dist._logccdf2_dispatch(a, x, *args, method=method, **params).real
 
-    def _ccdf_dispatch(self, x, *args, **params):
+    def _ccdf_dispatch(self, x, *args, method=None, **params):
         x = np.abs(x)
-        return self._dist._ccdf2_dispatch(-x, x, *args, **params)
+        a = np.maximum(-x, self._dist._support(**params)[0])
+        return self._dist._ccdf2_dispatch(a, x, *args, method=method, **params)
 
     def _sample_dispatch(self, sample_shape, full_shape, *,
                          method, rng, **params):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4726,7 +4726,8 @@ class FoldedDistribution(TransformedDistribution):
         a, b = self._dist._support(**params)
         xl = np.maximum(-x, a)
         xr = np.minimum(x, b)
-        return self._dist._logccdf2_dispatch(xl, xr, *args, method=method, **params).real
+        return self._dist._logccdf2_dispatch(xl, xr, *args, method=method, 
+                                             **params).real
 
     def _ccdf_dispatch(self, x, *args, method=None, **params):
         x = np.abs(x)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1427,6 +1427,20 @@ class TestTransforms:
         sample = Y.sample(10)
         assert np.all(sample > 0)
 
+    def test_abs_finite_support(self):
+        # The original implementation of `FoldedDistribution` might evaluate
+        # the private distribution methods outside the support. Check that this
+        # is resolved.
+        Weibull = stats.make_distribution(stats.weibull_min)
+        X = Weibull(c=2)
+        Y = abs(-X)
+        assert_equal(X.logpdf(1), Y.logpdf(1))
+        assert_equal(X.pdf(1), Y.pdf(1))
+        assert_equal(X.logcdf(1), Y.logcdf(1))
+        assert_equal(X.cdf(1), Y.cdf(1))
+        assert_equal(X.logccdf(1), Y.logccdf(1))
+        assert_equal(X.ccdf(1), Y.ccdf(1))
+
     def test_pow(self):
         rng = np.random.default_rng(81345982345826)
 


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
`FoldedDistribution` could evaluate private methods of distributions outside their support. Depending on the distribution, this can produce garbage. (For example, `weibull_min._pdf` is an odd function, and this is a problem because the PDF must be non-negative.) This fixes the problem by ensuring that these out-of-bounds results are never used.
