### PR TITLE
Remove UP031 form lnit.toml and refactor string formatting

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -105,7 +105,7 @@ def run_monitored_wait4(code):
     max_rss_bytes = get_max_rss_bytes(rusage)
 
     if returncode != 0:
-        raise AssertionError("Running failed:\n%s" % code)
+        raise AssertionError(f"Running failed:\n{code}")
 
     return duration, max_rss_bytes
 
@@ -136,7 +136,7 @@ def run_monitored_proc(code):
         if ret is not None:
             break
 
-        with open('/proc/%d/status' % process.pid) as f:
+        with open(f'/proc/{process.pid}/status') as f:
             procdata = f.read()
 
         m = re.search(r'VmRSS:\s*(\d+)\s*kB', procdata, re.S | re.I)
@@ -151,7 +151,7 @@ def run_monitored_proc(code):
     duration = time.time() - start
 
     if process.returncode != 0:
-        raise AssertionError("Running failed:\n%s" % code)
+        raise AssertionError(f"Running failed:\n{code}")
 
     return duration, peak_memusage
 

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -23,7 +23,7 @@ class Leaks(Benchmark):
         peak_mems = []
 
         for repeat in repeats:
-            code = """
+            code = f"""
             import numpy as np
             from scipy.interpolate import griddata
 
@@ -34,11 +34,10 @@ class Leaks(Benchmark):
             points = np.random.rand(1000, 2)
             values = func(points[:,0], points[:,1])
 
-            for t in range(%(repeat)d):
+            for t in range({repeat}):
                 for method in ['nearest', 'linear', 'cubic']:
                     griddata(points, values, (grid_x, grid_y), method=method)
-
-            """ % dict(repeat=repeat)
+            """
 
             _, peak_mem = run_monitored(code)
             peak_mems.append(peak_mem)

--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -73,13 +73,14 @@ class MemUsage(Benchmark):
     def track_savemat(self, size, compressed):
         size = int(self.sizes[size])
 
-        code = """
+        code = f"""
         import numpy as np
         from scipy.io import savemat
-        x = np.random.rand(%d//8).view(dtype=np.uint8)
-        savemat('%s', dict(x=x), do_compression=%r, oned_as='row')
-        """ % (size, self.filename, compressed)
+        x = np.random.rand({size}//8).view(dtype=np.uint8)
+        savemat('{self.filename}', dict(x=x), do_compression={compressed}, oned_as='row')
+        """
         time, peak_mem = run_monitored(code)
+
         return peak_mem / size
 
 
@@ -94,8 +95,8 @@ class StructArr(Benchmark):
     def make_structarr(n_vars, n_fields, n_structs):
         var_dict = {}
         for vno in range(n_vars):
-            vname = 'var%00d' % vno
-            end_dtype = [('f%d' % d, 'i4', 10) for d in range(n_fields)]
+            vname = f'var{vno:03d}'
+            end_dtype = [(f'f{d}', 'i4', 10) for d in range(n_fields)]
             s_arrs = np.zeros((n_structs,), dtype=end_dtype)
             var_dict[vname] = s_arrs
         return var_dict

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -89,15 +89,13 @@ class _BenchOptimizers(Benchmark):
         print("")
         print("=========================================================")
         print(f"Optimizer benchmark: {self.function_name}")
-        print("dimensions: %d, extra kwargs: %s" %
-              (results[0].ndim, str(self.minimizer_kwargs)))
-        print("averaged over %d starting configurations" % (results[0].ntrials))
+        print(f"dimensions: {results[0].ndim}, extra kwargs: {str(self.minimizer_kwargs)}")
+        print(f"averaged over {results[0].ntrials} starting configurations")
         print("  Optimizer    nfail   nfev    njev    nhev    time")
         print("---------------------------------------------------------")
         for res in results:
-            print("%11s  | %4d  | %4d  | %4d  | %4d  | %.6g" %
-                  (res.name, res.nfail, res.mean_nfev,
-                   res.mean_njev, res.mean_nhev, res.mean_time))
+            print(f"{res.name:11s}  | {res.nfail:4d}  | {res.mean_nfev:4d}  | {res.mean_njev:4d}  | {res.mean_nhev:4d}  | {res.mean_time:.6g}")
+
 
     def average_results(self):
         """group the results by minimizer and average over the runs"""
@@ -429,8 +427,9 @@ class BenchSmoothUnbounded(Benchmark):
         # scipy.optimize.check_grad(s.get_energy, s.get_gradient,
         #                           np.random.uniform(-2,2,3*4))
         natoms = 4
-        b = _BenchOptimizers("%d atom Lennard Jones potential" % (natoms),
+        b = _BenchOptimizers(f"{natoms} atom Lennard Jones potential",
                              fun=s.fun, der=s.der, hess=None)
+
         for i in range(10):
             b.bench_run(np.random.uniform(-2, 2, natoms*3), methods=methods)
         return b

--- a/doc/source/tutorial/examples/signal_SpectralAnalysis_MagnitudeSpectrum_Hann_3x.py
+++ b/doc/source/tutorial/examples/signal_SpectralAnalysis_MagnitudeSpectrum_Hann_3x.py
@@ -37,6 +37,6 @@ for c_, (ax_, X_, Y_, fx_) in enumerate(zip(axx, XX, YY, fcc)):
             ylim=(0, 0.59))
 
 axx[0].set(ylabel=r'Magnitude $|X(f)/\tau|$')
-fg1.suptitle(r"Magnitude Spectrum (Hann window, $%d\times$oversampled)" % q,
+fg1.suptitle(rf"Magnitude Spectrum (Hann window, ${q}\times$oversampled)", 
              x=0.55, y=0.93)
 plt.show()

--- a/scipy/_build_utils/tempita/_looper.py
+++ b/scipy/_build_utils/tempita/_looper.py
@@ -41,8 +41,7 @@ class looper:
         return looper_iter(self.seq)
 
     def __repr__(self):
-        return '<%s for %r>' % (
-            self.__class__.__name__, self.seq)
+        return f'<{self.__class__.__name__} for {self.seq!r}>'
 
 
 class looper_iter:
@@ -69,8 +68,7 @@ class loop_pos:
         self.pos = pos
 
     def __repr__(self):
-        return '<loop pos=%r at %r>' % (
-            self.seq[self.pos], self.pos)
+        return f'<loop pos={self.seq[self.pos]!r} at {self.pos!r}>'
 
     def index(self):
         return self.pos

--- a/scipy/_build_utils/tempita/_tempita.py
+++ b/scipy/_build_utils/tempita/_tempita.py
@@ -64,11 +64,11 @@ class TemplateError(Exception):
     def __str__(self):
         msg = ' '.join(self.args)
         if self.position:
-            msg = '%s at line %s column %s' % (
-                msg, self.position[0], self.position[1])
+            msg = f'{msg} at line {self.position[0]} column {self.position[1]}'
         if self.name:
-            msg += ' in %s' % self.name
+            msg += f' in {self.name}'
         return msg
+
 
 
 class _TemplateContinue(Exception):
@@ -141,7 +141,8 @@ class Template:
                 else:
                     name = '<string>'
                 if lineno:
-                    name += ':%s' % lineno
+                    name += f':{lineno}'
+
         self.name = name
         self._parsed = parse(content, name=name, line_offset=line_offset, delimiters=self.delimiters)
         if namespace is None:
@@ -163,9 +164,8 @@ class Template:
     from_filename = classmethod(from_filename)
 
     def __repr__(self):
-        return '<%s %s name=%r>' % (
-            self.__class__.__name__,
-            hex(id(self))[2:], self.name)
+        return f'<{self.__class__.__name__} {hex(id(self))[2:]} name={self.name!r}>'
+
 
     def substitute(self, *args, **kw):
         if args:
@@ -177,8 +177,9 @@ class Template:
                     "You can only give one positional argument")
             if not hasattr(args[0], 'items'):
                 raise TypeError(
-                    "If you pass in a single argument, you must pass in a dictionary-like object (with a .items() method); you gave %r"
-                    % (args[0],))
+                    f"If you pass in a single argument, you must pass in a dictionary-like object (with a .items() method); you gave {args[0]!r}"
+                )
+
             kw = args[0]
         ns = kw
         ns['__template_name__'] = self.name
@@ -266,7 +267,7 @@ class Template:
         elif name == 'comment':
             return
         else:
-            assert 0, "Unknown code: %r" % name
+            assert 0, f"Unknown code: {name!r}"
 
     def _interpret_for(self, vars, expr, content, ns, out, defs):
         __traceback_hide__ = True
@@ -276,8 +277,9 @@ class Template:
             else:
                 if len(vars) != len(item):
                     raise ValueError(
-                        'Need %i items to unpack (got %i items)'
-                        % (len(vars), len(item)))
+                        f'Need {len(vars)} items to unpack (got {len(item)} items)'
+                    )
+
                 for name, value in zip(vars, item):
                     ns[name] = value
             try:
@@ -308,7 +310,9 @@ class Template:
                 value = eval(code, self.default_namespace, ns)
             except SyntaxError as e:
                 raise SyntaxError(
-                    'invalid syntax in expression: %s' % code)
+                    f'invalid syntax in expression: {code}'
+                )
+
             return value
         except Exception as e:
             if getattr(e, 'args', None):
@@ -352,8 +356,10 @@ class Template:
             if self._unicode and isinstance(value, bytes):
                 if not self.default_encoding:
                     raise UnicodeDecodeError(
-                        'Cannot decode bytes value %r into unicode '
-                        '(no default_encoding provided)' % value)
+                        f'Cannot decode bytes value {value!r} into unicode '
+                        '(no default_encoding provided)'
+                    )
+
                 try:
                     value = value.decode(self.default_encoding)
                 except UnicodeDecodeError as e:
@@ -362,21 +368,24 @@ class Template:
                         e.object,
                         e.start,
                         e.end,
-                        e.reason + ' in string %r' % value)
+                        e.reason + f' in string {value!r}'
+                    )
+
             elif not self._unicode and isinstance(value, str):
                 if not self.default_encoding:
                     raise UnicodeEncodeError(
-                        'Cannot encode unicode value %r into bytes '
-                        '(no default_encoding provided)' % value)
+                        f'Cannot encode unicode value {value!r} into bytes '
+                        '(no default_encoding provided)')
+
                 value = value.encode(self.default_encoding)
             return value
 
     def _add_line_info(self, msg, pos):
-        msg = "%s at line %s column %s" % (
-            msg, pos[0], pos[1])
+        msg = f"{msg} at line {pos[0]} column {pos[1]}"
         if self.name:
-            msg += " in file %s" % self.name
+            msg += f" in file {self.name}"
         return msg
+
 
 
 def sub(content, delimiters=None, **kw):
@@ -416,9 +425,8 @@ class bunch(dict):
             return dict.__getitem__(self, key)
 
     def __repr__(self):
-        return '<%s %s>' % (
-            self.__class__.__name__,
-            ' '.join(['%s=%r' % (k, v) for k, v in sorted(self.items())]))
+        return f'<{self.__class__.__name__} ' + ' '.join([f'{k}={v!r}' for k, v in sorted(self.items())]) + '>'
+
 
 
 class TemplateDef:
@@ -433,9 +441,8 @@ class TemplateDef:
         self._bound_self = bound_self
 
     def __repr__(self):
-        return '<tempita function %s(%s) at %s:%s>' % (
-            self._func_name, self._func_signature,
-            self._template.name, self._pos)
+        return f'<tempita function {self._func_name}({self._func_signature}) at {self._template.name}:{self._pos}>'
+
 
     def __str__(self):
         return self()
@@ -465,7 +472,8 @@ class TemplateDef:
         for name, value in kw.items():
             if not var_kw and name not in sig_args:
                 raise TypeError(
-                    'Unexpected argument %s' % name)
+                    f'Unexpected argument {name}')
+
             if name in sig_args:
                 values[sig_args] = value
             else:
@@ -483,8 +491,8 @@ class TemplateDef:
                 break
             else:
                 raise TypeError(
-                    'Extra position arguments: %s'
-                    % ', '.join([repr(v) for v in args]))
+                    f'Extra position arguments: {", ".join([repr(v) for v in args])}')
+
         for name, value_expr in defaults.items():
             if name not in values:
                 values[name] = self._template._eval(
@@ -492,7 +500,8 @@ class TemplateDef:
         for name in sig_args:
             if name not in values:
                 raise TypeError(
-                    'Missing argument: %s' % name)
+                    f'Missing argument: {name}')
+
         if var_kw:
             values[var_kw] = extra_kw
         return values
@@ -505,7 +514,7 @@ class TemplateObject:
         self.get = TemplateObjectGetter(self)
 
     def __repr__(self):
-        return '<%s %s>' % (self.__class__.__name__, self.__name)
+        return f'<{self.__class__.__name__} {self.__name}>'
 
 
 class TemplateObjectGetter:
@@ -517,7 +526,7 @@ class TemplateObjectGetter:
         return getattr(self.__template_obj, attr, Empty)
 
     def __repr__(self):
-        return '<%s around %r>' % (self.__class__.__name__, self.__template_obj)
+        return f'<{self.__class__.__name__} around {self.__template_obj!r}>'
 
 
 class _Empty:
@@ -577,19 +586,21 @@ def lex(s, name=None, trim_whitespace=True, line_offset=0, delimiters=None):
     last = 0
     last_pos = (line_offset + 1, 1)
 
-    token_re = re.compile(r'%s|%s' % (re.escape(delimiters[0]),
-                                      re.escape(delimiters[1])))
+    token_re = re.compile(rf'{re.escape(delimiters[0])}|{re.escape(delimiters[1])}')
+
     for match in token_re.finditer(s):
         expr = match.group(0)
         pos = find_position(s, match.end(), last, last_pos)
         if expr == delimiters[0] and in_expr:
-            raise TemplateError('%s inside expression' % delimiters[0],
+            raise TemplateError(f'{delimiters[0]} inside expression',
                                 position=pos,
                                 name=name)
+
         elif expr == delimiters[1] and not in_expr:
-            raise TemplateError('%s outside expression' % delimiters[1],
+            raise TemplateError(f'{delimiters[1]} outside expression',
                                 position=pos,
                                 name=name)
+
         if expr == delimiters[0]:
             part = s[last:match.start()]
             if part:
@@ -601,8 +612,9 @@ def lex(s, name=None, trim_whitespace=True, line_offset=0, delimiters=None):
         last = match.end()
         last_pos = pos
     if in_expr:
-        raise TemplateError('No %s to finish last expression' % delimiters[1],
+        raise TemplateError(f'No {delimiters[1]} to finish last expression',
                             name=name, position=last_pos)
+
     part = s[last:]
     if part:
         chunks.append(part)
@@ -775,16 +787,19 @@ def parse_expr(tokens, name, context=()):
     elif (expr.startswith('elif ')
           or expr == 'else'):
         raise TemplateError(
-            '%s outside of an if block' % expr.split()[0],
+            f'{expr.split()[0]} outside of an if block',
             position=pos, name=name)
+
     elif expr in ('if', 'elif', 'for'):
         raise TemplateError(
-            '%s with no expression' % expr,
+            f'{expr} with no expression',
             position=pos, name=name)
+
     elif expr in ('endif', 'endfor', 'enddef'):
         raise TemplateError(
-            'Unexpected %s' % expr,
+            f'Unexpected {expr}',
             position=pos, name=name)
+
     elif expr.startswith('for '):
         return parse_for(tokens, name, context)
     elif expr.startswith('default '):
@@ -826,7 +841,7 @@ def parse_one_cond(tokens, name, context):
     elif first == 'else':
         part = ('else', pos, None, content)
     else:
-        assert 0, "Unexpected token %r at %s" % (first, pos)
+        assert 0, f"Unexpected token {first!r} at {pos}"
     while 1:
         if not tokens:
             raise TemplateError(
@@ -853,13 +868,15 @@ def parse_for(tokens, name, context):
     match = in_re.search(first)
     if not match:
         raise TemplateError(
-            'Bad for (no "in") in %r' % first,
+            f'Bad for (no "in") in {first!r}',
             position=pos, name=name)
+
     vars = first[:match.start()]
     if '(' in vars:
         raise TemplateError(
-            'You cannot have () in the variable section of a for loop (%r)'
-            % vars, position=pos, name=name)
+            f'You cannot have () in the variable section of a for loop ({vars!r})',
+            position=pos, name=name)
+
     vars = tuple([
         v.strip() for v in first[:match.start()].split(',')
         if v.strip()])
@@ -883,8 +900,9 @@ def parse_default(tokens, name, context):
     parts = first.split('=', 1)
     if len(parts) == 1:
         raise TemplateError(
-            "Expression must be {{default var=value}}; no = found in %r" % first,
+            f"Expression must be {{default var=value}}; no = found in {first!r}",
             position=pos, name=name)
+
     var = parts[0].strip()
     if ',' in var:
         raise TemplateError(
@@ -892,8 +910,9 @@ def parse_default(tokens, name, context):
             position=pos, name=name)
     if not var_re.search(var):
         raise TemplateError(
-            "Not a valid variable name for {{default}}: %r"
-            % var, position=pos, name=name)
+            f"Not a valid variable name for {{default}}: {var!r}",
+            position=pos, name=name)
+
     expr = parts[1].strip()
     return ('default', pos, var, expr), tokens[1:]
 
@@ -916,8 +935,9 @@ def parse_def(tokens, name, context):
         func_name = first
         sig = ((), None, None, {})
     elif not first.endswith(')'):
-        raise TemplateError("Function definition doesn't end with ): %s" % first,
+        raise TemplateError(f"Function definition doesn't end with ): {first}",
                             position=start, name=name)
+
     else:
         first = first[:-1]
         func_name, sig_text = first.split('(', 1)
@@ -961,8 +981,9 @@ def parse_signature(sig_text, name, pos):
             var_arg_type = tok_string
             tok_type, tok_string = get_token()
         if tok_type != tokenize.NAME:
-            raise TemplateError('Invalid signature: (%s)' % sig_text,
+            raise TemplateError(f'Invalid signature: ({sig_text})',
                                 position=pos, name=name)
+
         var_name = tok_string
         tok_type, tok_string = get_token()
         if tok_type == tokenize.ENDMARKER or (tok_type == tokenize.OP and tok_string == ','):
@@ -976,8 +997,9 @@ def parse_signature(sig_text, name, pos):
                 break
             continue
         if var_arg_type is not None:
-            raise TemplateError('Invalid signature: (%s)' % sig_text,
+            raise TemplateError(f'Invalid signature: ({sig_text})',
                                 position=pos, name=name)
+
         if tok_type == tokenize.OP and tok_string == '=':
             nest_type = None
             unnest_type = None
@@ -990,8 +1012,9 @@ def parse_signature(sig_text, name, pos):
                     start_pos = s
                 end_pos = e
                 if tok_type == tokenize.ENDMARKER and nest_count:
-                    raise TemplateError('Invalid signature: (%s)' % sig_text,
+                    raise TemplateError(f'Invalid signature: ({sig_text})',
                                         position=pos, name=name)
+
                 if (not nest_count and
                         (tok_type == tokenize.ENDMARKER or (tok_type == tokenize.OP and tok_string == ','))):
                     default_expr = isolate_expression(sig_text, start_pos, end_pos)
@@ -1067,7 +1090,7 @@ def fill_command(args=None):
         vars.update(os.environ)
     for value in args:
         if '=' not in value:
-            print('Bad argument: %r' % value)
+            print(f'Bad argument: {value!r}')
             sys.exit(2)
         name, value = value.split('=', 1)
         if name.startswith('py:'):

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -320,10 +320,11 @@ class NumpyDocString(Mapping):
                 description = line_match.group("desc")
                 if line_match.group("trailing") and description:
                     self._error_location(
-                        "Unexpected comma or period after function list at index %d of "
-                        'line "%s"' % (line_match.end("trailing"), line),
+                        f"Unexpected comma or period after function list at index {line_match.end('trailing')} of "
+                        f'line "{line}"',
                         error=False,
                     )
+
             if not description and line.startswith(" "):
                 rest.append(line.strip())
             elif line_match:
@@ -404,9 +405,9 @@ class NumpyDocString(Mapping):
                 section = " ".join(section)
                 if self.get(section):
                     self._error_location(
-                        "The section %s appears twice in  %s"
-                        % (section, "\n".join(self._doc._str))
-                    )
+                    f"The section {section} appears twice in  {''.join(self._doc._str)}"
+                )
+
 
             if section in ("Parameters", "Other Parameters", "Attributes", "Methods"):
                 self[section] = self._parse_param_list(content)

--- a/scipy/_lib/decorator.py
+++ b/scipy/_lib/decorator.py
@@ -89,7 +89,7 @@ class FunctionMaker:
                           'kwonlydefaults'):
                     setattr(self, a, getattr(argspec, a))
                 for i, arg in enumerate(self.args):
-                    setattr(self, 'arg%d' % i, arg)
+                    setattr(self, f'arg{i}', arg)
                 allargs = list(self.args)
                 allshortargs = list(self.args)
                 if self.varargs:
@@ -160,7 +160,7 @@ class FunctionMaker:
         # Ensure each generated function has a unique filename for profilers
         # (such as cProfile) that depend on the tuple of (<filename>,
         # <definition line>, <function name>) being unique.
-        filename = '<decorator-gen-%d>' % (next(self._compile_count),)
+        filename = f'<decorator-gen-{next(self._compile_count)}>'
         try:
             code = compile(src, filename, 'single')
             exec(code, evaldict)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1451,19 +1451,22 @@ def to_tree(Z, rd=False):
         fi = int_floor(row[0], xp)
         fj = int_floor(row[1], xp)
         if fi > i + n:
-            raise ValueError(('Corrupt matrix Z. Index to derivative cluster '
-                              'is used before it is formed. See row %d, '
-                              'column 0') % fi)
+            raise ValueError(f'Corrupt matrix Z. Index to derivative cluster '
+                            f'is used before it is formed. See row {fi}, '
+                            f'column 0')
+
         if fj > i + n:
-            raise ValueError(('Corrupt matrix Z. Index to derivative cluster '
-                              'is used before it is formed. See row %d, '
-                              'column 1') % fj)
+            raise ValueError(f'Corrupt matrix Z. Index to derivative cluster '
+                            f'is used before it is formed. See row {fj}, '
+                            f'column 1')
+
 
         nd = ClusterNode(i + n, d[fi], d[fj], row[2])
         #                ^ id   ^ left ^ right ^ dist
         if row[3] != nd.count:
-            raise ValueError(('Corrupt matrix Z. The count Z[%d,3] is '
-                              'incorrect.') % i)
+            raise ValueError(f'Corrupt matrix Z. The count Z[{i},3] is '
+                              f'incorrect.')
+
         d[n + i] = nd
 
     if rd:
@@ -4165,7 +4168,8 @@ def leaders(Z, T):
     T = np.asarray(T, dtype=np.int32)
     s = _hierarchy.leaders(Z, T, L, M, n_clusters, n_obs)
     if s >= 0:
-        raise ValueError(('T is not a valid assignment vector. Error found '
-                          'when examining linkage node %d (< 2n-1).') % s)
+        raise ValueError(f'T is not a valid assignment vector. Error found '
+                          f'when examining linkage node {s} (< 2n-1).')
+
     L, M = xp.asarray(L), xp.asarray(M)
     return (L, M)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -480,7 +480,7 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
     if k != guess:
         raise ValueError("If k_or_guess is a scalar, it must be an integer.")
     if k < 1:
-        raise ValueError("Asked for %d clusters." % k)
+        raise ValueError(f"Asked for {k} clusters.")
 
     rng = check_random_state(rng)
 
@@ -799,8 +799,9 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         nc = int(code_book)
 
         if nc < 1:
-            raise ValueError("Cannot ask kmeans2 for %d clusters"
-                             " (k was %s)" % (nc, code_book))
+            raise ValueError(f"Cannot ask kmeans2 for {nc} clusters"
+                              f" (k was {code_book})")
+
         elif nc != code_book:
             warnings.warn("k was not an integer, was converted.", stacklevel=2)
 

--- a/scipy/constants/tests/test_codata.py
+++ b/scipy/constants/tests/test_codata.py
@@ -31,9 +31,9 @@ def test_basic_table_parse():
 
 
 def test_basic_lookup():
-    assert_equal('%d %s' % (_cd.value('speed of light in vacuum'),
-                            _cd.unit('speed of light in vacuum')),
+    assert_equal(f'{_cd.value("speed of light in vacuum")} {_cd.unit("speed of light in vacuum")}',
                  '299792458 m s^-1')
+
 
 
 def test_find_all():

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -407,9 +407,10 @@ class _TestIRFFTBase:
             assert_equal(y1.dtype, self.rdt)
             assert_equal(y2.dtype, self.cdt)
             assert_array_almost_equal(y1, x, decimal=self.ndec,
-                                       err_msg="size=%d" % size)
+                                    err_msg=f"size={size}")
             assert_array_almost_equal(y2, x, decimal=self.ndec,
-                                       err_msg="size=%d" % size)
+                                    err_msg=f"size={size}")
+
 
     def test_size_accuracy(self):
         # Sanity check for the accuracy for prime and non-prime sized inputs

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -30,8 +30,9 @@ def is_longdouble_binary_compatible():
 def reference_data():
     # Matlab reference data
     MDATA = np.load(join(fftpack_test_dir, 'test.npz'))
-    X = [MDATA['x%d' % i] for i in range(MDATA_COUNT)]
-    Y = [MDATA['y%d' % i] for i in range(MDATA_COUNT)]
+    X = [MDATA[f'x{i}'] for i in range(MDATA_COUNT)]
+    Y = [MDATA[f'y{i}'] for i in range(MDATA_COUNT)]
+
 
     # FFTW reference data: the data are organized as follows:
     #    * SIZES is an array containing all available sizes
@@ -100,7 +101,7 @@ def fftw_dct_ref(type, size, dt, reference_data):
         data = reference_data['FFTWDATA_LONGDOUBLE']
     else:
         raise ValueError()
-    y = (data['dct_%d_%d' % (type, size)]).astype(dt)
+    y = (data[f'dct_{type}_{size}']).astype(dt)
     return x, y, dt
 
 
@@ -115,7 +116,7 @@ def fftw_dst_ref(type, size, dt, reference_data):
         data = reference_data['FFTWDATA_LONGDOUBLE']
     else:
         raise ValueError()
-    y = (data['dst_%d_%d' % (type, size)]).astype(dt)
+    y = (data[f'dst_{type}_{size}']).astype(dt)
     return x, y, dt
 
 

--- a/scipy/fftpack/tests/gen_fftw_ref.py
+++ b/scipy/fftpack/tests/gen_fftw_ref.py
@@ -34,12 +34,12 @@ filename = 'fftw_single_ref'
 d = {'sizes': SZ}
 for type in [1, 2, 3, 4]:
     for sz in SZ:
-        d['dct_%d_%d' % (type, sz)] = data[type][sz]
+        d[f'dct_{type}_{sz}'] = data[type][sz]
 
 d['sizes'] = SZ
 for type in [5, 6, 7, 8]:
     for sz in SZ:
-        d['dst_%d_%d' % (type-4, sz)] = data[type][sz]
+        d[f'dst_{type-4}_{sz}'] = data[type][sz]
 np.savez(filename, **d)
 
 
@@ -50,12 +50,12 @@ filename = 'fftw_double_ref'
 d = {'sizes': SZ}
 for type in [1, 2, 3, 4]:
     for sz in SZ:
-        d['dct_%d_%d' % (type, sz)] = data[type][sz]
+        d[f'dct_{type}_{sz}'] = data[type][sz]
 
 d['sizes'] = SZ
 for type in [5, 6, 7, 8]:
     for sz in SZ:
-        d['dst_%d_%d' % (type-4, sz)] = data[type][sz]
+        d[f'dst_{type-4}_{sz}'] = data[type][sz]
 np.savez(filename, **d)
 
 # generate long double precision data
@@ -65,10 +65,10 @@ filename = 'fftw_longdouble_ref'
 d = {'sizes': SZ}
 for type in [1, 2, 3, 4]:
     for sz in SZ:
-        d['dct_%d_%d' % (type, sz)] = data[type][sz]
+        d[f'dct_{type}_{sz}'] = data[type][sz]
 
 d['sizes'] = SZ
 for type in [5, 6, 7, 8]:
     for sz in SZ:
-        d['dst_%d_%d' % (type-4, sz)] = data[type][sz]
+        d[f'dst_{type-4}_{sz}'] = data[type][sz]
 np.savez(filename, **d)

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -351,9 +351,10 @@ class _TestIRFFTBase:
             assert_equal(y1.dtype, self.rdt)
             assert_equal(y2.dtype, self.rdt)
             assert_array_almost_equal(y1, x, decimal=self.ndec,
-                                       err_msg="size=%d" % size)
+                                    err_msg=f"size={size}")
             assert_array_almost_equal(y2, x, decimal=self.ndec,
-                                       err_msg="size=%d" % size)
+                                    err_msg=f"size={size}")
+
 
     def test_size_accuracy(self):
         # Sanity check for the accuracy for prime and non-prime sized inputs

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -11,8 +11,8 @@ from scipy.fftpack._realtransforms import (
 
 # Matlab reference data
 MDATA = np.load(join(dirname(__file__), 'test.npz'))
-X = [MDATA['x%d' % i] for i in range(8)]
-Y = [MDATA['y%d' % i] for i in range(8)]
+X = [MDATA[f'x{i}'] for i in range(8)]
+Y = [MDATA[f'y{i}'] for i in range(8)]
 
 # FFTW reference data: the data are organized as follows:
 #    * SIZES is an array containing all available sizes
@@ -33,7 +33,7 @@ def fftw_dct_ref(type, size, dt):
         data = FFTWDATA_SINGLE
     else:
         raise ValueError()
-    y = (data['dct_%d_%d' % (type, size)]).astype(dt)
+    y = (data[f'dct_{type}_{size}']).astype(dt)
     return x, y, dt
 
 
@@ -46,7 +46,7 @@ def fftw_dst_ref(type, size, dt):
         data = FFTWDATA_SINGLE
     else:
         raise ValueError()
-    y = (data['dst_%d_%d' % (type, size)]).astype(dt)
+    y = (data[f'dst_{type}_{size}']).astype(dt)
     return x, y, dt
 
 
@@ -208,7 +208,8 @@ class _TestDCTBase:
             # difference is due to fftw using a better algorithm w.r.t error
             # propagation compared to the ones from fftpack.
             assert_array_almost_equal(y / np.max(y), yr / np.max(y), decimal=self.dec,
-                    err_msg="Size %d failed" % i)
+                                      err_msg=f"Size {i} failed")
+
 
     def test_axis(self):
         nt = 2
@@ -381,7 +382,8 @@ class _TestIDCTBase:
             # difference is due to fftw using a better algorithm w.r.t error
             # propagation compared to the ones from fftpack.
             assert_array_almost_equal(x / np.max(x), xr / np.max(x), decimal=self.dec,
-                    err_msg="Size %d failed" % i)
+                                      err_msg=f"Size {i} failed")
+
 
 
 class TestIDCTIDouble(_TestIDCTBase):
@@ -487,7 +489,8 @@ class _TestDSTBase:
             # difference is due to fftw using a better algorithm w.r.t error
             # propagation compared to the ones from fftpack.
             assert_array_almost_equal(y / np.max(y), yr / np.max(y), decimal=self.dec,
-                    err_msg="Size %d failed" % i)
+                                      err_msg=f"Size {i} failed")
+
 
 
 class _TestDSTIBase(_TestDSTBase):
@@ -621,7 +624,8 @@ class _TestIDSTBase:
             # difference is due to fftw using a better algorithm w.r.t error
             # propagation compared to the ones from fftpack.
             assert_array_almost_equal(x / np.max(x), xr / np.max(x), decimal=self.dec,
-                    err_msg="Size %d failed" % i)
+                                      err_msg=f"Size {i} failed")
+
 
 
 class TestIDSTIDouble(_TestIDSTBase):

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -894,7 +894,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
                 width = show[1]
             except (TypeError, IndexError):
                 width = 8
-            formstr = "%%%d.%df" % (width, precis)
+            formstr = f"%{width}.{precis}f"
 
             title = "Richardson Extrapolation Table for Romberg Integration"
             print(title, "=" * len(title), sep="\n", end="\n")

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -237,8 +237,7 @@ class BSpline:
         if self.t.ndim != 1:
             raise ValueError("Knot vector must be one-dimensional.")
         if n < self.k + 1:
-            raise ValueError("Need at least %d knots for degree %d" %
-                             (2*k + 2, k))
+            raise ValueError(f"Need at least {2*k + 2} knots for degree {k}")
         if (np.diff(self.t) < 0).any():
             raise ValueError("Knots must be in a non-decreasing order.")
         if len(np.unique(self.t[k:n+1])) < 2:
@@ -1565,8 +1564,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if t.ndim != 1 or np.any(t[1:] < t[:-1]):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
     if t.size < x.size + k + 1:
-        raise ValueError('Got %d knots, need at least %d.' %
-                         (t.size, x.size + k + 1))
+        raise ValueError(f'Got {t.size} knots, need at least {x.size + k + 1}.')
     if (x[0] < t[k]) or (x[-1] > t[-k]):
         raise ValueError(f'Out of bounds w/ x = {x}.')
 
@@ -1632,7 +1630,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if info > 0:
         raise LinAlgError("Colocation matrix is singular.")
     elif info < 0:
-        raise ValueError('illegal value in %d-th argument of internal gbsv' % -info)
+        raise ValueError(f'illegal value in {-info}-th argument of internal gbsv')
 
     c = np.ascontiguousarray(c.reshape((nt,) + y.shape[1:]))
     return BSpline.construct_fast(t, c, k, axis=axis)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1131,8 +1131,8 @@ class _BivariateSplineBase:
                 newc, ier = dfitpack.pardtc(tx, ty, c, kx, ky, dx, dy)
             if ier != 0:
                 # This should not happen under normal conditions.
-                raise ValueError("Unexpected error code returned by"
-                                 " pardtc: %d" % ier)
+                raise ValueError(f"Unexpected error code returned by pardtc: {ier}")
+
             nx = len(tx)
             ny = len(ty)
             newtx = tx[dx:nx - dx]

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -117,9 +117,9 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
         for i in range(idim):
             if x[i][0] != x[i][-1]:
                 if not quiet:
-                    warnings.warn(RuntimeWarning('Setting x[%d][%d]=x[%d][0]' %
-                                                 (i, m, i)),
+                    warnings.warn(RuntimeWarning(f'Setting x[{i}][{m}]=x[{i}][0]'),
                                   stacklevel=2)
+
                 x[i][-1] = x[i][0]
     if not 0 < idim < 11:
         raise TypeError('0 < idim < 11 must hold')
@@ -141,7 +141,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     else:
         _parcur_cache['u'] = zeros(m, float)
     if not (1 <= k <= 5):
-        raise TypeError('1 <= k= %d <=5 must hold' % k)
+        raise TypeError(f"1 <= k= {k} <= 5 must hold")
     if not (-1 <= task <= 1):
         raise TypeError('task must be -1, 0 or 1')
     if (not len(w) == m) or (ipar == 1 and (not len(u) == m)):
@@ -188,9 +188,9 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     tcku = [t, list(c), k], u
     if ier <= 0 and not quiet:
         warnings.warn(RuntimeWarning(_iermess[ier][0] +
-                                     "\tk=%d n=%d m=%d fp=%f s=%f" %
-                                     (k, len(t), m, fp, s)),
-                      stacklevel=2)
+                                    f"\tk={k} n={len(t)} m={m} fp={fp} s={s}"),
+                                    stacklevel=2)
+
     if ier > 0 and not full_output:
         if ier in [1, 2, 3]:
             warnings.warn(RuntimeWarning(_iermess[ier][0]), stacklevel=2)
@@ -228,13 +228,13 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
         if s is None:
             s = m - sqrt(2*m)
     if not len(w) == m:
-        raise TypeError('len(w)=%d is not equal to m=%d' % (len(w), m))
+        raise TypeError(f"len(w)={len(w)} is not equal to m={m}")
     if (m != len(y)) or (m != len(w)):
         raise TypeError('Lengths of the first three arguments (x,y,w) must '
                         'be equal')
     if not (1 <= k <= 5):
-        raise TypeError('Given degree of the spline (k=%d) is not supported. '
-                        '(1<=k<=5)' % k)
+        raise TypeError(f"Given degree of the spline (k={k}) is not supported. (1<=k<=5)")
+
     if m <= k:
         raise TypeError('m > k must hold')
     if xb is None:
@@ -279,8 +279,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
         n, c, fp, ier = dfitpack.percur(task, x, y, w, t, wrk, iwrk, k, s)
     tck = (t[:n], c[:n], k)
     if ier <= 0 and not quiet:
-        _mess = (_iermess[ier][0] + "\tk=%d n=%d m=%d fp=%f s=%f" %
-                 (k, len(t), m, fp, s))
+        _mess = (_iermess[ier][0] + f"\tk={k} n={len(t)} m={m} fp={fp} s={s}")
         warnings.warn(RuntimeWarning(_mess), stacklevel=2)
     if ier > 0 and not full_output:
         if ier in [1, 2, 3]:
@@ -312,7 +311,7 @@ def splev(x, tck, der=0, ext=0):
                         splev(x, [t, c, k], der, ext), c))
     else:
         if not (0 <= der <= k):
-            raise ValueError("0<=der=%d<=k=%d must hold" % (der, k))
+            raise ValueError(f"0<=der={der}<=k={k} must hold")
         if ext not in (0, 1, 2, 3):
             raise ValueError(f"ext = {ext} not in (0, 1, 2, 3) ")
 
@@ -516,7 +515,7 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     else:
         w = atleast_1d(w)
     if not len(w) == m:
-        raise TypeError('len(w)=%d is not equal to m=%d' % (len(w), m))
+        raise TypeError(f"len(w)={len(w)} is not equal to m={m}")
     if xb is None:
         xb = x.min()
     if xe is None:
@@ -544,8 +543,8 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     if task == -1 and ny < 2*ky+2:
         raise TypeError('There must be at least 2*ky+2 knots_x for task=-1')
     if not ((1 <= kx <= 5) and (1 <= ky <= 5)):
-        raise TypeError('Given degree of the spline (kx,ky=%d,%d) is not '
-                        'supported. (1<=k<=5)' % (kx, ky))
+        raise TypeError(f"Given degree of the spline (kx,ky={kx},{ky}) is not supported. (1<=k<=5)")
+
     if m < (kx + 1)*(ky + 1):
         raise TypeError('m >= (kx+1)(ky+1) must hold')
     if nxest is None:
@@ -587,13 +586,12 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     ierm = min(11, max(-3, ier))
     if ierm <= 0 and not quiet:
         _mess = (_iermess2[ierm][0] +
-                 "\tkx,ky=%d,%d nx,ny=%d,%d m=%d fp=%f s=%f" %
-                 (kx, ky, len(tx), len(ty), m, fp, s))
+                f"\tkx,ky={kx},{ky} nx,ny={len(tx)},{len(ty)} m={m} fp={fp} s={s}")
+
         warnings.warn(RuntimeWarning(_mess), stacklevel=2)
     if ierm > 0 and not full_output:
         if ier in [1, 2, 3, 4, 5]:
-            _mess = ("\n\tkx,ky=%d,%d nx,ny=%d,%d m=%d fp=%f s=%f" %
-                     (kx, ky, len(tx), len(ty), m, fp, s))
+            _mess = f"\n\tkx,ky={kx},{ky} nx,ny={len(tx)},{len(ty)} m={m} fp={fp} s={s}"
             warnings.warn(RuntimeWarning(_iermess2[ierm][0] + _mess), stacklevel=2)
         else:
             try:
@@ -663,9 +661,9 @@ def bisplev(x, y, tck, dx=0, dy=0):
     """
     tx, ty, c, kx, ky = tck
     if not (0 <= dx < kx):
-        raise ValueError("0 <= dx = %d < kx = %d must hold" % (dx, kx))
+        raise ValueError(f"0 <= dx = {dx} < kx = {kx} must hold")
     if not (0 <= dy < ky):
-        raise ValueError("0 <= dy = %d < ky = %d must hold" % (dy, ky))
+        raise ValueError(f"0 <= dy = {dy} < ky = {ky} must hold")
     x, y = map(atleast_1d, [x, y])
     if (len(x.shape) != 1) or (len(y.shape) != 1):
         raise ValueError("First two entries should be rank-1 arrays.")
@@ -771,8 +769,8 @@ def splder(tck, n=1):
                 t = t[1:-1]
                 k -= 1
         except FloatingPointError as e:
-            raise ValueError(("The spline has internal repeated knots "
-                              "and is not differentiable %d times") % n) from e
+            raise ValueError(f"The spline has internal repeated knots and is not differentiable {n} times") from e
+
 
     return t, c, k
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -402,8 +402,8 @@ class interp1d(_Interpolator1D):
                 self._call = self.__class__._call_spline
 
         if len(self.x) < minval:
-            raise ValueError("x and y arrays must have at "
-                             "least %d entries" % minval)
+            raise ValueError(f"x and y arrays must have at least {minval} entries")
+
 
         self.fill_value = fill_value  # calls the setter, can modify bounds_err
 
@@ -1668,9 +1668,10 @@ class BPoly(_PPolyBase):
                 n2 = min(n - n1, len(y2))
                 n1 = min(n - n2, len(y2))
                 if n1+n2 != n:
-                    mesg = ("Point %g has %d derivatives, point %g"
-                            " has %d derivatives, but order %d requested" % (
-                               xi[i], len(y1), xi[i+1], len(y2), orders[i]))
+                    mesg = (f"Point {xi[i]:g} has {len(y1)} derivatives, "
+                            f"point {xi[i+1]:g} has {len(y2)} derivatives, "
+                            f"but order {orders[i]} requested")
+
                     raise ValueError(mesg)
 
                 if not (n1 <= len(y1) and n2 <= len(y2)):

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -328,5 +328,5 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
                                         rescale=rescale)
         return ip(xi)
     else:
-        raise ValueError("Unknown interpolation method %r for "
-                         "%d dimensional data" % (method, ndim))
+        raise ValueError(f"Unknown interpolation method {method!r} for {ndim} dimensional data")
+

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -27,9 +27,7 @@ def _check_points(points):
                 descending_dimensions.append(i)
                 p = np.flip(p)
             else:
-                raise ValueError(
-                    "The points in dimension %d must be strictly "
-                    "ascending or descending" % i)
+                raise ValueError(f"The points in dimension {i} must be strictly ascending or descending")
         # see https://github.com/scipy/scipy/issues/17716
         p = np.ascontiguousarray(p)
         grid.append(p)
@@ -38,15 +36,12 @@ def _check_points(points):
 
 def _check_dimensionality(points, values):
     if len(points) > values.ndim:
-        raise ValueError("There are %d point arrays, but values has %d "
-                         "dimensions" % (len(points), values.ndim))
+        raise ValueError(f"There are {len(points)} point arrays, but values has {values.ndim} dimensions")
     for i, p in enumerate(points):
         if not np.asarray(p).ndim == 1:
-            raise ValueError("The points in dimension %d must be "
-                             "1-dimensional" % i)
+            raise ValueError(f"The points in dimension {i} must be 1-dimensional")
         if not values.shape[i] == len(p):
-            raise ValueError("There are %d points and %d values in "
-                             "dimension %d" % (len(p), values.shape[i], i))
+            raise ValueError(f"There are {len(p)} points and {values.shape[i]} values in dimension {i}")
 
 
 class RegularGridInterpolator:
@@ -459,8 +454,7 @@ class RegularGridInterpolator:
             for i, p in enumerate(xi.T):
                 if not np.logical_and(np.all(self.grid[i][0] <= p),
                                       np.all(p <= self.grid[i][-1])):
-                    raise ValueError("One of the requested xi is out of bounds "
-                                     "in dimension %d" % i)
+                    raise ValueError(f"One of the requested xi is out of bounds in dimension {i}")
             out_of_bounds = None
         else:
             out_of_bounds = self._find_out_of_bounds(xi.T)
@@ -710,8 +704,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
 
     # sanity check consistency of input dimensions
     if len(points) > ndim:
-        raise ValueError("There are %d point arrays, but values has %d "
-                         "dimensions" % (len(points), ndim))
+        raise ValueError(f"There are {len(points)} point arrays, but values has {ndim} dimensions")
     if len(points) != ndim and method == 'splinef2d':
         raise ValueError("The method splinef2d can only be used for "
                          "scalar data with one point per coordinate")
@@ -722,16 +715,13 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     # sanity check requested xi
     xi = _ndim_coords_from_arrays(xi, ndim=len(grid))
     if xi.shape[-1] != len(grid):
-        raise ValueError("The requested sample points xi have dimension "
-                         "%d, but this RegularGridInterpolator has "
-                         "dimension %d" % (xi.shape[-1], len(grid)))
+        raise ValueError(f"The requested sample points xi have dimension {xi.shape[-1]}, but this RegularGridInterpolator has dimension {len(grid)}")
 
     if bounds_error:
         for i, p in enumerate(xi.T):
             if not np.logical_and(np.all(grid[i][0] <= p),
                                   np.all(p <= grid[i][-1])):
-                raise ValueError("One of the requested xi is out of bounds "
-                                 "in dimension %d" % i)
+                raise ValueError(f"One of the requested xi is out of bounds in dimension {i}")
 
     # perform interpolation
     if method in RegularGridInterpolator._ALL_METHODS:

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -238,8 +238,9 @@ class TestEstimateGradients2DGlobal:
             dz = interpnd.estimate_gradients_2d_global(tri, z, tol=1e-6)
 
             assert dz.shape == (6, 2)
-            xp_assert_close(dz, np.array(grad)[None,:] + 0*dz,
-                            rtol=1e-5, atol=1e-5, err_msg="item %d" % j)
+            xp_assert_close(dz, np.array(grad)[None, :] + 0 * dz,
+                            rtol=1e-5, atol=1e-5, err_msg=f"item {j}")
+
 
     def test_regression_2359(self):
         # Check regression --- for certain point sets, gradient
@@ -301,16 +302,17 @@ class TestCloughTocher2DInterpolator:
 
         for j, func in enumerate(funcs):
             self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
-                                 err_msg="Function %d" % j)
+                                err_msg=f"Function {j}")
             self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
-                                 alternate=True,
-                                 err_msg="Function (alternate) %d" % j)
+                                alternate=True,
+                                err_msg=f"Function (alternate) {j}")
             # check rescaling
             self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
-                                 err_msg="Function (rescaled) %d" % j, rescale=True)
+                                err_msg=f"Function (rescaled) {j}", rescale=True)
             self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
-                                 alternate=True, rescale=True,
-                                 err_msg="Function (alternate, rescaled) %d" % j)
+                                alternate=True, rescale=True,
+                                err_msg=f"Function (alternate, rescaled) {j}")
+
 
     def test_quadratic_smoketest(self):
         # Should be reasonably accurate for quadratic functions
@@ -323,9 +325,10 @@ class TestCloughTocher2DInterpolator:
 
         for j, func in enumerate(funcs):
             self._check_accuracy(func, tol=1e-9, atol=0.22, rtol=0,
-                                 err_msg="Function %d" % j)
+                                err_msg=f"Function {j}")
             self._check_accuracy(func, tol=1e-9, atol=0.22, rtol=0,
-                                 err_msg="Function %d" % j, rescale=True)
+                                err_msg=f"Function {j}", rescale=True)
+
 
     def test_tri_input(self):
         # Test at single points
@@ -380,9 +383,10 @@ class TestCloughTocher2DInterpolator:
 
         for j, func in enumerate(funcs):
             self._check_accuracy(func, x=grid, tol=1e-9, atol=5e-3, rtol=1e-2,
-                                 err_msg="Function %d" % j)
+                                err_msg=f"Function {j}")
             self._check_accuracy(func, x=grid, tol=1e-9, atol=5e-3, rtol=1e-2,
-                                 err_msg="Function %d" % j, rescale=True)
+                                err_msg=f"Function {j}", rescale=True)
+
 
     def test_wrong_ndim(self):
         x = np.random.randn(30, 3)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1355,7 +1355,8 @@ class TestPPoly:
         xi = np.linspace(0, 1, 200)
         for dx in range(0, 10):
             xp_assert_close(pp(xi, dx), pp.derivative(dx)(xi),
-                            err_msg="dx=%d" % (dx,))
+                            err_msg=f"dx={dx}")
+
 
     def test_antiderivative_of_constant(self):
         # https://github.com/scipy/scipy/issues/4216
@@ -1419,7 +1420,8 @@ class TestPPoly:
                 endpoint = r*pp2.x[:-1] + (1 - r)*pp2.x[1:]
 
                 xp_assert_close(pp2(pp2.x[1:]), pp2(endpoint),
-                                rtol=1e-7, err_msg="dx=%d k=%d" % (dx, k))
+                                rtol=1e-7, err_msg=f"dx={dx} k={k}")
+
 
     def test_antiderivative_vs_spline(self):
         rng = np.random.RandomState(1234)

--- a/scipy/io/_harwell_boeing/_fortran_format_parser.py
+++ b/scipy/io/_harwell_boeing/_fortran_format_parser.py
@@ -72,21 +72,23 @@ class IntFormat:
     def __repr__(self):
         r = "IntFormat("
         if self.repeat:
-            r += "%d" % self.repeat
-        r += "I%d" % self.width
+            r += f"{self.repeat:d}"
+        r += f"I{self.width}"
         if self.min:
-            r += ".%d" % self.min
+            r += f".{self.min}"
         return r + ")"
+
 
     @property
     def fortran_format(self):
         r = "("
         if self.repeat:
-            r += "%d" % self.repeat
-        r += "I%d" % self.width
+            r += f"{self.repeat:d}"
+        r += f"I{self.width}"
         if self.min:
-            r += ".%d" % self.min
+            r += f".{self.min}"
         return r + ")"
+
 
     @property
     def python_format(self):
@@ -145,21 +147,23 @@ class ExpFormat:
     def __repr__(self):
         r = "ExpFormat("
         if self.repeat:
-            r += "%d" % self.repeat
-        r += "E%d.%d" % (self.width, self.significand)
+            r += f"{self.repeat:d}"
+        r += f"E{self.width}.{self.significand}"
         if self.min:
-            r += "E%d" % self.min
+            r += f"E{self.min}"
         return r + ")"
+
 
     @property
     def fortran_format(self):
         r = "("
         if self.repeat:
-            r += "%d" % self.repeat
-        r += "E%d.%d" % (self.width, self.significand)
+            r += f"{self.repeat:d}"
+        r += f"E{self.width}.{self.significand}"
         if self.min:
-            r += "E%d" % self.min
+            r += f"E{self.min}"
         return r + ")"
+
 
     @property
     def python_format(self):
@@ -200,8 +204,7 @@ class Tokenizer:
                 else:
                     self.curpos = m.end()
                     return Token(self.tokens[i], m.group(), self.curpos)
-            raise SyntaxError("Unknown character at position %d (%s)"
-                              % (self.curpos, self.data[curpos]))
+            raise SyntaxError(f"Unknown character at position {self.curpos} ({self.data[self.curpos]})")
 
 
 # Grammar for fortran format:
@@ -263,8 +266,7 @@ class FortranFormatParser:
 
     def _parse_format(self, tokens):
         if not tokens[0].type == "LPAR":
-            raise SyntaxError("Expected left parenthesis at position "
-                              "%d (got '%s')" % (0, tokens[0].value))
+            raise SyntaxError(f"Expected left parenthesis at position {0} (got '{tokens[0].value}')")
         elif not tokens[-1].type == "RPAR":
             raise SyntaxError("Expected right parenthesis at position "
                               f"{len(tokens)} (got '{tokens[-1].value}')")

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -189,8 +189,7 @@ class HBInfo:
         nnon_zeros = _expect_int(line[42:56])
         nelementals = _expect_int(line[56:70])
         if not nelementals == 0:
-            raise ValueError("Unexpected value %d for nltvl (last entry of line 3)"
-                             % nelementals)
+            raise ValueError(f"Unexpected value {nelementals} for nltvl (last entry of line 3)")
 
         # Fourth line
         line = fid.readline().strip("\n")
@@ -282,18 +281,13 @@ class HBInfo:
         """Gives the header corresponding to this instance as a string."""
         header = [self.title.ljust(72) + self.key.ljust(8)]
 
-        header.append("%14d%14d%14d%14d" %
-                      (self.total_nlines, self.pointer_nlines,
-                       self.indices_nlines, self.values_nlines))
-        header.append("%14s%14d%14d%14d%14d" %
-                      (self.mxtype.fortran_format.ljust(14), self.nrows,
-                       self.ncols, self.nnon_zeros, 0))
+        header.append(f"{self.total_nlines:14d}{self.pointer_nlines:14d}{self.indices_nlines:14d}{self.values_nlines:14d}")
+        header.append(f"{self.mxtype.fortran_format.ljust(14)}{self.nrows:14d}{self.ncols:14d}{self.nnon_zeros:14d}{0:14d}")
 
         pffmt = self.pointer_format.fortran_format
         iffmt = self.indices_format.fortran_format
         vffmt = self.values_format.fortran_format
-        header.append("%16s%16s%20s" %
-                      (pffmt.ljust(16), iffmt.ljust(16), vffmt.ljust(20)))
+        header.append(f"{pffmt.ljust(16)}{iffmt.ljust(16)}{vffmt.ljust(20)}")
         return "\n".join(header)
 
 

--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -217,7 +217,7 @@ def _read_data(f, dtype):
     elif dtype == 15:
         return _read_uint64(f)
     else:
-        raise Exception("Unknown IDL type: %i - please report this" % dtype)
+        raise Exception(f"Unknown IDL type: {dtype} - please report this")
 
 
 def _read_structure(f, array_desc, struct_desc):
@@ -238,8 +238,7 @@ def _read_structure(f, array_desc, struct_desc):
                 dtype.append(((col['name'].lower(), col['name']),
                                     DTYPE_DICT[col['typecode']]))
             else:
-                raise Exception("Variable type %i not implemented" %
-                                                            col['typecode'])
+                raise Exception(f"Variable type {col['typecode']} not implemented")
 
     structure = np.rec.recarray((nrows, ), dtype=dtype)
 
@@ -324,7 +323,7 @@ def _read_record(f):
     _skip_bytes(f, 4)
 
     if record['rectype'] not in RECTYPE_DICT:
-        raise Exception("Unknown RECTYPE: %i" % record['rectype'])
+        raise Exception(f"Unknown RECTYPE: {record['rectype']}")
 
     record['rectype'] = RECTYPE_DICT[record['rectype']]
 
@@ -483,7 +482,7 @@ def _read_arraydesc(f):
 
     else:
 
-        raise Exception("Unknown ARRSTART: %i" % arraydesc['arrstart'])
+        raise Exception(f"Unknown ARRSTART: {arraydesc['arrstart']}")
 
     return arraydesc
 
@@ -902,7 +901,7 @@ def readsav(file_name, idict=None, python_dict=False,
 
         for rt in set(rectypes):
             if rt != 'END_MARKER':
-                print(" - %i are of type %s" % (rectypes.count(rt), rt))
+                print(f" - {rectypes.count(rt)} are of type {rt}")
         print("-"*50)
 
         if 'VARIABLE' in rectypes:

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -549,12 +549,13 @@ class MMFile:
     # -------------------------------------------------------------------------
     @staticmethod
     def _field_template(field, precision):
-        return {MMFile.FIELD_REAL: '%%.%ie\n' % precision,
-                MMFile.FIELD_INTEGER: '%i\n',
-                MMFile.FIELD_UNSIGNED: '%u\n',
-                MMFile.FIELD_COMPLEX: '%%.%ie %%.%ie\n' %
-                    (precision, precision)
-                }.get(field, None)
+        return {
+                MMFile.FIELD_REAL: f"%.{precision}e\n",
+                MMFile.FIELD_INTEGER: f"{int()}\n",
+                MMFile.FIELD_UNSIGNED: f"{int()}u\n",
+                MMFile.FIELD_COMPLEX: f"%.{precision}e %.{precision}e\n"
+            }.get(field, None)
+
 
     # -------------------------------------------------------------------------
     def __init__(self, **kwargs):
@@ -865,7 +866,7 @@ class MMFile:
         # write dense format
         if rep == self.FORMAT_ARRAY:
             # write shape spec
-            data = '%i %i\n' % (rows, cols)
+            data = f"{rows} {cols}\n"
             stream.write(data.encode('latin1'))
 
             if field in (self.FIELD_INTEGER, self.FIELD_REAL,
@@ -922,23 +923,23 @@ class MMFile:
                                 shape=coo.shape)
 
             # write shape spec
-            data = '%i %i %i\n' % (rows, cols, coo.nnz)
+            data = f"{rows} {cols} {coo.nnz}\n"
             stream.write(data.encode('latin1'))
 
             template = self._field_template(field, precision-1)
 
             if field == self.FIELD_PATTERN:
                 for r, c in zip(coo.row+1, coo.col+1):
-                    data = "%i %i\n" % (r, c)
+                    data = f"{r} {c}\n"
                     stream.write(data.encode('latin1'))
             elif field in (self.FIELD_INTEGER, self.FIELD_REAL,
                            self.FIELD_UNSIGNED):
                 for r, c, d in zip(coo.row+1, coo.col+1, coo.data):
-                    data = ("%i %i " % (r, c)) + (template % d)
+                    data = f"{r} {c} " + (template % d)
                     stream.write(data.encode('latin1'))
             elif field == self.FIELD_COMPLEX:
                 for r, c, d in zip(coo.row+1, coo.col+1, coo.data):
-                    data = ("%i %i " % (r, c)) + (template % (d.real, d.imag))
+                    data = f"{r} {c} " + (template % (d.real, d.imag))
                     stream.write(data.encode('latin1'))
             else:
                 raise TypeError(f'Unknown field type {field}')

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -682,8 +682,8 @@ class netcdf_file:
                     actual_size = reduce(mul, (1,) + shape[1:]) * size
                     padding = -actual_size % 4
                     if padding:
-                        dtypes['names'].append('_padding_%d' % var)
-                        dtypes['formats'].append('(%d,)>b' % padding)
+                        dtypes['names'].append(f'_padding_{var}')
+                        dtypes['formats'].append(f'({padding},)>b')
 
                 # Data will be set later.
                 data = None

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -147,7 +147,7 @@ class TestHeader:
         # Test numerical attributes
         assert_(len(attrs) == 5)
         for i in range(4):
-            assert_(attrs[i].name == 'attr%d' % i)
+            assert_(attrs[i].name == f'attr{i}')
             assert_(attrs[i].type_name == 'numeric')
 
         # Test nominal attribute

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -221,7 +221,7 @@ class MatFile5Reader(MatFileReader):
         hdict['__header__'] = hdr['description'].item().strip(b' \t\n\000')
         v_major = hdr['version'] >> 8
         v_minor = hdr['version'] & 0xFF
-        hdict['__version__'] = '%d.%d' % (v_major, v_minor)
+        hdict['__version__'] = f'{v_major}.{v_minor}'
         return hdict
 
     def initialize_read(self):
@@ -267,7 +267,7 @@ class MatFile5Reader(MatFileReader):
             check_stream_limit = False
             self._matrix_reader.set_stream(self.mat_stream)
         if not mdtype == miMATRIX:
-            raise TypeError('Expecting miMATRIX type here, got %d' % mdtype)
+            raise TypeError(f'Expecting miMATRIX type here, got {mdtype}')
         header = self._matrix_reader.read_header(check_stream_limit)
         return header, next_pos
 
@@ -789,12 +789,13 @@ class VarWriter5:
         length = max([len(fieldname) for fieldname in fieldnames])+1
         max_length = (self.long_field_names and 64) or 32
         if length > max_length:
-            raise ValueError("Field names are restricted to %d characters" %
-                             (max_length-1))
+            raise ValueError(f"Field names are restricted to {max_length-1} characters")
+
         self.write_element(np.array([length], dtype='i4'))
         self.write_element(
-            np.array(fieldnames, dtype='S%d' % (length)),
+            np.array(fieldnames, dtype=f'S{length}'),
             mdtype=miINT8)
+
         A = np.atleast_2d(arr).flatten('F')
         for el in A:
             for f in fieldnames:

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -270,7 +270,7 @@ def _check_level(label, expected, actual):
         if isinstance(expected, MatlabObject):
             assert_equal(expected.classname, actual.classname)
         for i, ev in enumerate(expected):
-            level_label = "%s, [%d], " % (label, i)
+            level_label = f"{label}, [{i}], "
             _check_level(level_label, ev, actual[i])
         return
     if ex_dtype.fields:  # probably recarray

--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -18,7 +18,7 @@ def read_minimat_vars(rdr):
         hdr, next_position = rdr.read_var_header()
         name = 'None' if hdr.name is None else hdr.name.decode('latin1')
         if name == '':
-            name = 'var_%d' % i
+            name = f'var_{i}'
             i += 1
         res = rdr.read_var_array(hdr, process=False)
         rdr.mat_stream.seek(next_position)

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -759,7 +759,7 @@ class TestMMIOCoordinate:
                 # check for right entries in matrix
                 assert_array_equal(A.row, [n-1])
                 assert_array_equal(A.col, [n-1])
-                assert_allclose(A.data, [float('%%.%dg' % precision % value)])
+                assert_allclose(A.data, [float(f"%.{precision}g" % value)])
 
     def test_bad_number_of_coordinate_header_fields(self):
         s = """\

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -515,10 +515,10 @@ def _solve_triangular(a1, b1, trans=0, lower=False, unit_diagonal=False,
     if info == 0:
         return x, info
     if info > 0:
-        raise LinAlgError("singular matrix: resolution failed at diagonal %d" %
-                          (info-1))
-    raise ValueError('illegal value in %dth argument of internal trtrs' %
-                     (-info))
+        raise LinAlgError(f"singular matrix: resolution failed at diagonal {info-1}")
+
+    raise ValueError(f'illegal value in {-info}th argument of internal trtrs')
+
 
 
 def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
@@ -600,9 +600,9 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
 
     (nlower, nupper) = l_and_u
     if nlower + nupper + 1 != a1.shape[0]:
-        raise ValueError("invalid values for the number of lower and upper "
-                         "diagonals: l+u+1 (%d) does not equal ab.shape[0] "
-                         "(%d)" % (nlower + nupper + 1, ab.shape[0]))
+        raise ValueError(f"invalid values for the number of lower and upper diagonals: "
+                 f"l+u+1 ({nlower + nupper + 1}) does not equal ab.shape[0] "
+                 f"({ab.shape[0]})")
 
     # accommodate empty arrays
     if b1.size == 0:
@@ -637,8 +637,8 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         return x
     if info > 0:
         raise LinAlgError("singular matrix")
-    raise ValueError('illegal value in %d-th argument of internal '
-                     'gbsv/gtsv' % -info)
+    raise ValueError(f'illegal value in {-info}-th argument of internal gbsv/gtsv')
+
 
 
 def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
@@ -774,10 +774,10 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
         c, x, info = pbsv(a1, b1, lower=lower, overwrite_ab=overwrite_ab,
                           overwrite_b=overwrite_b)
     if info > 0:
-        raise LinAlgError("%dth leading minor not positive definite" % info)
+        raise LinAlgError(f"{info}th leading minor not positive definite")
     if info < 0:
-        raise ValueError('illegal value in %dth argument of internal '
-                         'pbsv' % -info)
+        raise ValueError(f'illegal value in {-info}th argument of internal pbsv')
+
     return x
 
 
@@ -1157,8 +1157,8 @@ def inv(a, overwrite_a=False, check_finite=True):
     if info > 0:
         raise LinAlgError("singular matrix")
     if info < 0:
-        raise ValueError('illegal value in %d-th argument of internal '
-                         'getrf|getri' % -info)
+        raise ValueError(f'illegal value in {-info}-th argument of internal getrf|getri')
+
     return inv_a
 
 
@@ -1472,8 +1472,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         if info > 0:
             raise LinAlgError("SVD did not converge in Linear Least Squares")
         if info < 0:
-            raise ValueError('illegal value in %d-th argument of internal %s'
-                             % (-info, lapack_driver))
+            raise ValueError(f'illegal value in {-info}-th argument of internal {lapack_driver}')
+
         resids = np.asarray([], dtype=x.dtype)
         if m > n:
             x1 = x[:n]
@@ -1488,8 +1488,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         v, x, j, rank, info = lapack_func(a1, b1, jptv, cond,
                                           lwork, False, False)
         if info < 0:
-            raise ValueError("illegal value in %d-th argument of internal "
-                             "gelsy" % -info)
+            raise ValueError(f"illegal value in {-info}-th argument of internal gelsy")
+
         if m > n:
             x1 = x[:n]
             x = x1

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1384,8 +1384,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
 def _check_info(info, driver, positive='did not converge (LAPACK info=%d)'):
     """Check info return value."""
     if info < 0:
-        raise ValueError('illegal value in argument %d of internal %s'
-                         % (-info, driver))
+        raise ValueError(f'illegal value in argument {-info} of internal {driver}')
     if info > 0 and positive:
         raise LinAlgError(("%s " + positive) % (driver, info,))
 

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -35,8 +35,8 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
     potrf, = get_lapack_funcs(('potrf',), (a1,))
     c, info = potrf(a1, lower=lower, overwrite_a=overwrite_a, clean=clean)
     if info > 0:
-        raise LinAlgError("%d-th leading minor of the array is not positive "
-                          "definite" % info)
+        raise LinAlgError(f"{info}-th leading minor of the array is not positive definite")
+
     if info < 0:
         raise ValueError(f'LAPACK reported an illegal value in {-info}-th argument'
                          'on entry to "POTRF".')
@@ -239,8 +239,8 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     potrs, = get_lapack_funcs(('potrs',), (c, b1))
     x, info = potrs(c, b1, lower=lower, overwrite_b=overwrite_b)
     if info != 0:
-        raise ValueError('illegal value in %dth argument of internal potrs'
-                         % -info)
+        raise ValueError(f'illegal value in {-info}th argument of internal potrs')
+
     return x
 
 
@@ -317,10 +317,9 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     pbtrf, = get_lapack_funcs(('pbtrf',), (ab,))
     c, info = pbtrf(ab, lower=lower, overwrite_ab=overwrite_ab)
     if info > 0:
-        raise LinAlgError("%d-th leading minor not positive definite" % info)
+        raise LinAlgError(f"{info}-th leading minor not positive definite")
     if info < 0:
-        raise ValueError('illegal value in %d-th argument of internal pbtrf'
-                         % -info)
+        raise ValueError(f'illegal value in {-info}-th argument of internal pbtrf')
     return c
 
 
@@ -391,8 +390,7 @@ def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
     pbtrs, = get_lapack_funcs(('pbtrs',), (cb, b))
     x, info = pbtrs(cb, b, lower=lower, overwrite_b=overwrite_b)
     if info > 0:
-        raise LinAlgError("%dth leading minor not positive definite" % info)
+        raise LinAlgError(f'{info}th leading minor not positive definite')
     if info < 0:
-        raise ValueError('illegal value in %dth argument of internal pbtrs'
-                         % -info)
+        raise ValueError(f'illegal value in {-info}th argument of internal pbtrs')
     return x

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -118,11 +118,9 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     getrf, = get_lapack_funcs(('getrf',), (a1,))
     lu, piv, info = getrf(a1, overwrite_a=overwrite_a)
     if info < 0:
-        raise ValueError('illegal value in %dth argument of '
-                         'internal getrf (lu_factor)' % -info)
+        raise ValueError(f'illegal value in {-info}th argument of internal getrf (lu_factor)')
     if info > 0:
-        warn("Diagonal number %d is exactly zero. Singular matrix." % info,
-             LinAlgWarning, stacklevel=2)
+        warn(f"Diagonal number {info} is exactly zero. Singular matrix.", LinAlgWarning, stacklevel=2)
     return lu, piv
 
 
@@ -194,8 +192,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     x, info = getrs(lu, piv, b1, trans=trans, overwrite_b=overwrite_b)
     if info == 0:
         return x
-    raise ValueError('illegal value in %dth argument of internal gesv|posv'
-                     % -info)
+    raise ValueError(f'illegal value in {-info}th argument of internal gesv|posv')
 
 
 def lu(a, permute_l=False, overwrite_a=False, check_finite=True,

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -18,8 +18,7 @@ def safecall(f, name, *args, **kwargs):
         kwargs['lwork'] = ret[-2][0].real.astype(np.int_)
     ret = f(*args, **kwargs)
     if ret[-1] < 0:
-        raise ValueError("illegal value in %dth argument of internal %s"
-                         % (-ret[-1], name))
+        raise ValueError(f"illegal value in {-ret[-1]}th argument of internal {name}")
     return ret[:-2]
 
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -165,8 +165,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if info > 0:
         raise LinAlgError("SVD did not converge")
     if info < 0:
-        raise ValueError('illegal value in %dth argument of internal gesdd'
-                         % -info)
+        raise ValueError(f'illegal value in {-info}th argument of internal gesdd')
     if compute_uv:
         return u, s, v
     else:

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -106,8 +106,7 @@ def solve_sylvester(a, b, q):
     y = scale*y
 
     if info < 0:
-        raise LinAlgError("Illegal value encountered in "
-                          "the %d term" % (-info,))
+        raise LinAlgError(f"Illegal value encountered in the {-info} term")
 
     return np.dot(np.dot(u, y), v.conj().transpose())
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1026,8 +1026,7 @@ def _compute_lwork(routine, *args, **kwargs):
     int_dtype = getattr(routine, 'int_dtype', None)
     ret = routine(*args, **kwargs)
     if ret[-1] != 0:
-        raise ValueError("Internal work array size computation failed: "
-                         "%d" % (ret[-1],))
+        raise ValueError(f"Internal work array size computation failed: {ret[-1]}")
 
     if len(ret) == 2:
         return _check_work_float(ret[0].real, dtype, int_dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -502,8 +502,7 @@ class TestDlasd4:
             res = lasd4(i, sgm, mvc)
             roots.append(res[1])
 
-            assert_((res[3] <= 0), "LAPACK root finding dlasd4 failed to find \
-                                    the singular value %i" % i)
+            assert_((res[3] <= 0), f"LAPACK root finding dlasd4 failed to find the singular value {i}")
         roots = np.array(roots)[::-1]
 
         assert_((not np.any(np.isnan(roots)), "There are NaN roots"))

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -504,8 +504,7 @@ def test_invpascal():
         # precision when n is greater than 18.  Instead we'll cast both to
         # object arrays, and then multiply.
         e = ip.astype(object).dot(p.astype(object))
-        assert_array_equal(e, eye(n), err_msg="n=%d  kind=%r exact=%r" %
-                                              (n, kind, exact))
+        assert_array_equal(e, eye(n), err_msg=f"n={n}  kind={kind} exact={exact}")
 
     kinds = ['symmetric', 'lower', 'upper']
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -84,7 +84,7 @@ class BasinHoppingRunner:
         self.energy = minres.fun
         self.incumbent_minres = minres  # best minimize result found so far
         if self.disp:
-            print("basinhopping step %d: f %g" % (self.nstep, self.energy))
+            print(f"basinhopping step {self.nstep}: f {self.energy}")
 
         # initialize storage class
         self.storage = Storage(minres)
@@ -171,8 +171,7 @@ class BasinHoppingRunner:
         if self.disp:
             self.print_report(minres.fun, accept)
             if new_global_min:
-                print("found new global minimum on step %d with function"
-                      " value %g" % (self.nstep, self.energy))
+                print(f"found new global minimum on step {self.nstep} with function value {self.energy}")
 
         # save some variables as BasinHoppingRunner attributes
         self.xtrial = minres.x
@@ -184,9 +183,7 @@ class BasinHoppingRunner:
     def print_report(self, energy_trial, accept):
         """print a status update"""
         minres = self.storage.get_lowest()
-        print("basinhopping step %d: f %g trial_f %g accepted %d "
-              " lowest_f %g" % (self.nstep, self.energy, energy_trial,
-                                accept, minres.fun))
+        print(f"basinhopping step {self.nstep}: f {self.energy} trial_f {energy_trial} accepted {accept} lowest_f {minres.fun}")
 
 
 class AdaptiveStepsize:

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -240,7 +240,7 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         try:
             ctype = con['type'].lower()
         except KeyError as e:
-            raise KeyError('Constraint %d has no type defined.' % ic) from e
+            raise KeyError(f'Constraint {ic} has no type defined.') from e
         except TypeError as e:
             raise TypeError('Constraints must be defined using a '
                             'dictionary.') from e
@@ -253,7 +253,7 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
 
         # check function
         if 'fun' not in con:
-            raise KeyError('Constraint %d has no function defined.' % ic)
+            raise KeyError(f'Constraint {ic} has no function defined.')
 
         # check extra arguments
         if 'args' not in con:

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -559,7 +559,7 @@ def old_constraint_to_new(ic, con):
     try:
         ctype = con['type'].lower()
     except KeyError as e:
-        raise KeyError('Constraint %d has no type defined.' % ic) from e
+        raise KeyError(f'Constraint {ic} has no type defined.') from e
     except TypeError as e:
         raise TypeError(
             'Constraints must be a sequence of dictionaries.'
@@ -570,7 +570,7 @@ def old_constraint_to_new(ic, con):
         if ctype not in ['eq', 'ineq']:
             raise ValueError(f"Unknown constraint type '{con['type']}'.")
     if 'fun' not in con:
-        raise ValueError('Constraint %d has no function defined.' % ic)
+        raise ValueError(f'Constraint {ic} has no function defined.')
 
     lb = 0
     if ctype == 'eq':

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -259,8 +259,7 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     errors = {0: "Improper input parameters were entered.",
               1: "The solution converged.",
-              2: "The number of calls to function has "
-                  "reached maxfev = %d." % maxfev,
+              2: f"The number of calls to function has reached maxfev = {maxfev}.",
               3: f"xtol={xtol:f} is too small, no further improvement "
                   "in the approximate\n solution is possible.",
               4: "The iteration is not making good progress, as measured "
@@ -460,8 +459,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=False,
               4: ["The cosine of the angle between func(x) and any "
                   f"column of the\n  Jacobian is at most {gtol:f} in "
                   "absolute value", None],
-              5: ["Number of calls to function has reached "
-                  "maxfev = %d." % maxfev, ValueError],
+              5: [f"Number of calls to function has reached maxfev = {maxfev}.", ValueError],
               6: [f"ftol={ftol:f} is too small, no further reduction "
                   "in the sum of squares\n  is possible.",
                   ValueError],
@@ -1120,7 +1118,7 @@ def _fixed_point_helper(func, x0, args, xtol, maxiter, use_accel):
         if np.all(np.abs(relerr) < xtol):
             return p
         p0 = p
-    msg = "Failed to converge after %d iterations, value is %s" % (maxiter, p)
+    msg = f"Failed to converge after {maxiter} iterations, value is {p}"
     raise RuntimeError(msg)
 
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -241,8 +241,7 @@ def nonlin_solve(F, x0, jacobian='krylov', iter=None, verbose=False,
 
         # Print status
         if verbose:
-            sys.stdout.write("%d:  |F(x)| = %g; step %g\n" % (
-                n, tol_norm(Fx), s))
+            sys.stdout.write(f"{n}:  |F(x)| = {tol_norm(Fx)}; step {s}\n")
             sys.stdout.flush()
     else:
         if raise_exception:

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -939,8 +939,9 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         if disp:
             print(msg)
             print(f"         Current function value: {fval:f}")
-            print("         Iterations: %d" % iterations)
-            print("         Function evaluations: %d" % fcalls[0])
+            print(f"         Iterations: {iterations}")
+            print(f"         Function evaluations: {fcalls[0]}")
+
 
     result = OptimizeResult(fun=fval, nit=iterations, nfev=fcalls[0],
                             status=warnflag, success=(warnflag == 0),
@@ -1489,9 +1490,10 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     if disp:
         _print_success_message_or_warn(warnflag, msg)
         print(f"         Current function value: {fval:f}")
-        print("         Iterations: %d" % k)
-        print("         Function evaluations: %d" % sf.nfev)
-        print("         Gradient evaluations: %d" % sf.ngev)
+        print(f"         Iterations: {k}")
+        print(f"         Function evaluations: {sf.nfev}")
+        print(f"         Gradient evaluations: {sf.ngev}")
+
 
     result = OptimizeResult(fun=fval, jac=gfk, hess_inv=Hk, nfev=sf.nfev,
                             njev=sf.ngev, status=warnflag,
@@ -1833,9 +1835,10 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     if disp:
         _print_success_message_or_warn(warnflag, msg)
         print(f"         Current function value: {fval:f}")
-        print("         Iterations: %d" % k)
-        print("         Function evaluations: %d" % sf.nfev)
-        print("         Gradient evaluations: %d" % sf.ngev)
+        print(f"         Iterations: {k}")
+        print(f"         Function evaluations: {sf.nfev}")
+        print(f"         Gradient evaluations: {sf.ngev}")
+
 
     result = OptimizeResult(fun=fval, jac=gfk, nfev=sf.nfev,
                             njev=sf.ngev, status=warnflag,
@@ -2036,10 +2039,11 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         if disp:
             _print_success_message_or_warn(warnflag, msg)
             print(f"         Current function value: {old_fval:f}")
-            print("         Iterations: %d" % k)
-            print("         Function evaluations: %d" % sf.nfev)
-            print("         Gradient evaluations: %d" % sf.ngev)
-            print("         Hessian evaluations: %d" % hcalls)
+            print(f"         Iterations: {k}")
+            print(f"         Function evaluations: {sf.nfev}")
+            print(f"         Gradient evaluations: {sf.ngev}")
+            print(f"         Hessian evaluations: {hcalls}")
+
         fval = old_fval
         result = OptimizeResult(fun=fval, jac=gfk, nfev=sf.nfev,
                                 njev=sf.ngev, nhev=hcalls, status=warnflag,
@@ -3604,8 +3608,9 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     if disp:
         _print_success_message_or_warn(warnflag, msg, RuntimeWarning)
         print(f"         Current function value: {fval:f}")
-        print("         Iterations: %d" % iter)
-        print("         Function evaluations: %d" % fcalls[0])
+        print(f"         Iterations: {iter}")
+        print(f"         Function evaluations: {fcalls[0]}")
+
     result = OptimizeResult(fun=fval, direc=direc, nit=iter, nfev=fcalls[0],
                             status=warnflag, success=(warnflag == 0),
                             message=msg, x=x)

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -277,7 +277,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         try:
             ctype = con['type'].lower()
         except KeyError as e:
-            raise KeyError('Constraint %d has no type defined.' % ic) from e
+            raise KeyError(f'Constraint {ic} has no type defined.') from e
         except TypeError as e:
             raise TypeError('Constraints must be defined using a '
                             'dictionary.') from e
@@ -289,7 +289,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
         # check function
         if 'fun' not in con:
-            raise ValueError('Constraint %d has no function defined.' % ic)
+            raise ValueError(f'Constraint {ic} has no function defined.')
 
         # check Jacobian
         cjac = con.get('jac')
@@ -414,7 +414,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
     # Print the header if iprint >= 2
     if iprint >= 2:
-        print("%5s %5s %16s %16s" % ("NIT", "FC", "OBJFUN", "GNORM"))
+        print(f"{'NIT':5s} {'FC':5s} {'OBJFUN':16s} {'GNORM':16s}")
 
     # mode is zero on entry, so call objective, constraints and gradients
     # there should be no func evaluations here because it's cached from
@@ -446,8 +446,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
             # Print the status of the current iterate if iprint > 2
             if iprint >= 2:
-                print("%5i %5i % 16.6E % 16.6E" % (majiter, sf.nfev,
-                                                   fx, linalg.norm(g)))
+                print(f"{majiter:5d} {sf.nfev:5d} {fx:16.6E} {linalg.norm(g):16.6E}")
 
         # If exit mode is not -1 or 1, slsqp has completed
         if abs(mode) != 1:

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -107,7 +107,7 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
         F_k_norm = fnorm(F_k)
 
         if disp:
-            print("iter %d: ||F|| = %g, sigma = %g" % (k, F_k_norm, sigma_k))
+            print(f"iter {k}: ||F|| = {F_k_norm}, sigma = {sigma_k}")
 
         if callback is not None:
             callback(x_k, F_k)

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -285,10 +285,11 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         else:
             warnings.warn(status_messages[warnflag], RuntimeWarning, stacklevel=3)
         print(f"         Current function value: {m.fun:f}")
-        print("         Iterations: %d" % k)
-        print("         Function evaluations: %d" % sf.nfev)
-        print("         Gradient evaluations: %d" % sf.ngev)
-        print("         Hessian evaluations: %d" % (sf.nhev + nhessp[0]))
+        print(f"         Iterations: {k}")
+        print(f"         Function evaluations: {sf.nfev}")
+        print(f"         Gradient evaluations: {sf.ngev}")
+        print(f"         Hessian evaluations: {sf.nhev + nhessp[0]}")
+
 
     result = OptimizeResult(x=x, success=(warnflag == 0), status=warnflag,
                             fun=m.fun, jac=m.jac, nfev=sf.nfev, njev=sf.ngev,

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -316,9 +316,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             if fder == 0:
                 msg = "Derivative was zero."
                 if disp:
-                    msg += (
-                        " Failed to converge after %d iterations, value is %s."
-                        % (itr + 1, p0))
+                    msg += f" Failed to converge after {itr + 1} iterations, value is {p0}."
                     raise RuntimeError(msg)
                 warnings.warn(msg, RuntimeWarning, stacklevel=2)
                 return _results_select(
@@ -364,9 +362,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 if p1 != p0:
                     msg = f"Tolerance of {p1 - p0} reached."
                     if disp:
-                        msg += (
-                            " Failed to converge after %d iterations, value is %s."
-                            % (itr + 1, p1))
+                        msg += f" Failed to converge after {itr + 1} iterations, value is {p1}."
                         raise RuntimeError(msg)
                     warnings.warn(msg, RuntimeWarning, stacklevel=2)
                 p = (p1 + p0) / 2.0
@@ -386,8 +382,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
             funcalls += 1
 
     if disp:
-        msg = ("Failed to converge after %d iterations, value is %s."
-               % (itr + 1, p))
+        msg = f"Failed to converge after {itr + 1} iterations, value is {p}."
+
         raise RuntimeError(msg)
 
     return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERR), method)
@@ -1089,7 +1085,7 @@ class TOMS748Solver:
         self.k = max(k, self._K_MIN)
         # Noisily replace a high value of k with self._K_MAX
         if self.k > self._K_MAX:
-            msg = "toms748: Overriding k: ->%d" % self._K_MAX
+            msg = f"toms748: Overriding k: ->{self._K_MAX}"
             warnings.warn(msg, RuntimeWarning, stacklevel=3)
             self.k = self._K_MAX
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -308,7 +308,7 @@ class TestLeastSq:
         p0 = array([0,0,0])
         params_fit, ier = leastsq(self.residuals, p0,
                                   args=(self.y_meas, self.x))
-        assert_(ier in (1,2,3,4), 'solution not found (ier=%d)' % ier)
+        assert ier in (1, 2, 3, 4), f'solution not found (ier={ier})'
         # low precision due to random
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 
@@ -317,7 +317,7 @@ class TestLeastSq:
         params_fit, ier = leastsq(self.residuals, p0,
                                   args=(self.y_meas, self.x),
                                   Dfun=self.residuals_jacobian)
-        assert_(ier in (1,2,3,4), 'solution not found (ier=%d)' % ier)
+        assert ier in (1, 2, 3, 4), f'solution not found (ier={ier})'
         # low precision due to random
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 
@@ -405,7 +405,7 @@ class TestLeastSq:
         p0 = array([0,0,0])
         params_fit, ier = leastsq(func, p0,
                                   args=(self.y_meas, self.x))
-        assert_(ier in (1,2,3,4), 'solution not found (ier=%d)' % ier)
+        assert ier in (1, 2, 3, 4), f'solution not found (ier={ier})'
         # low precision due to random
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 
@@ -418,7 +418,7 @@ class TestLeastSq:
         params_fit, ier = leastsq(self.residuals, p0,
                                   args=(self.y_meas, self.x),
                                   Dfun=deriv_func)
-        assert_(ier in (1,2,3,4), 'solution not found (ier=%d)' % ier)
+        assert ier in (1, 2, 3, 4), f'solution not found (ier={ier})'
         # low precision due to random
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -428,7 +428,7 @@ class TestNewton(TestScalarRootFinders):
             if derivs == 1:
                 # Check that the correct Exception is raised and
                 # validate the start of the message.
-                msg = 'Failed to converge after %d iterations, value is .*' % (iters)
+                msg = f'Failed to converge after {iters} iterations, value is .*'
                 with pytest.raises(RuntimeError, match=msg):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -579,9 +579,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
         raise ValueError('freq and gain must be of same length.')
 
     if nfreqs is not None and numtaps >= nfreqs:
-        raise ValueError(('ntaps must be less than nfreqs, but firwin2 was '
-                          'called with ntaps=%d and nfreqs=%s') %
-                         (numtaps, nfreqs))
+        raise ValueError(f"ntaps must be less than nfreqs, but firwin2 was called with ntaps={numtaps} and nfreqs={nfreqs}")
 
     if freq[0] != 0 or freq[-1] != nyq:
         raise ValueError('freq must start with 0 and end with fs/2.')

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2317,11 +2317,11 @@ def _valid_inputs(A, B, poles, method, rtol, maxiter):
     if A.shape[0] != A.shape[1]:
         raise ValueError("A must be square")
     if len(poles) > A.shape[0]:
-        raise ValueError("maximum number of poles is %d but you asked for %d" %
-                         (A.shape[0], len(poles)))
+        raise ValueError(f"maximum number of poles is {A.shape[0]} but you asked for {len(poles)}")
+
     if len(poles) < A.shape[0]:
-        raise ValueError("number of poles is %d but you should provide %d" %
-                         (len(poles), A.shape[0]))
+        raise ValueError(f"number of poles is {len(poles)} but you should provide {A.shape[0]}")
+
     r = np.linalg.matrix_rank(B)
     for p in poles:
         if sum(p == poles) > r:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4571,8 +4571,9 @@ def _validate_pad(padtype, padlen, x, axis, ntaps):
 
     # x's 'axis' dimension must be bigger than edge.
     if x.shape[axis] <= edge:
-        raise ValueError("The length of the input vector x must be greater "
-                         "than padlen, which is %d." % edge)
+        raise ValueError(f"The length of the input vector x must be greater "
+                        f"than padlen, which is {edge}.")
+
 
     if padtype is not None and edge > 0:
         # Make an extension of length `edge` at each
@@ -4684,10 +4685,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     if zi is not None:
         zi = np.array(zi, dtype)  # make a copy so that we can operate in place
         if zi.shape != x_zi_shape:
-            raise ValueError('Invalid zi shape. With axis=%r, an input with '
-                             'shape %r, and an sos array with %d sections, zi '
-                             'must have shape %r, got %r.' %
-                             (axis, x.shape, n_sections, x_zi_shape, zi.shape))
+            raise ValueError(f'Invalid zi shape. With axis={axis}, an input with '
+                            f'shape {x.shape}, and an sos array with {n_sections} sections, '
+                            f'zi must have shape {x_zi_shape}, got {zi.shape}.')
+
         return_zi = True
     else:
         zi = np.zeros(x_zi_shape, dtype=dtype)

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -84,8 +84,8 @@ def compare_coeffs_to_alt(window_length, order):
         h1 = savgol_coeffs(window_length, order, pos=pos, use='dot')
         h2 = alt_sg_coeffs(window_length, order, pos=pos)
         xp_assert_close(h1, h2, atol=1e-10,
-                        err_msg=("window_length = %d, order = %d, pos = %s" %
-                                 (window_length, order, pos)))
+                        err_msg=f"window_length = {window_length}, order = {order}, pos = {pos}")
+
 
 
 def test_sg_coeffs_compare():

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2449,8 +2449,8 @@ def filtfilt_gust_opt(b, a, x):
                   full_output=True, disp=False)
     opt, fopt, niter, funcalls, warnflag = result
     if warnflag > 0:
-        raise RuntimeError("minimization failed in filtfilt_gust_opt: "
-                           "warnflag=%d" % warnflag)
+        raise RuntimeError(f"minimization failed in filtfilt_gust_opt: warnflag={warnflag}")
+
     z0f = opt[:m]
     z0b = opt[m:]
 

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -172,8 +172,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
 
         # check index pointer
         if (len(self.indptr) != M//R + 1):
-            raise ValueError("index pointer size (%d) should be (%d)" %
-                                (len(self.indptr), M//R + 1))
+            raise ValueError(f"index pointer size ({len(self.indptr)}) should be ({M//R + 1})")
         if (self.indptr[0] != 0):
             raise ValueError("index pointer should start with 0")
 
@@ -190,8 +189,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
             # check format validity (more expensive)
             if self.nnz > 0:
                 if self.indices.max() >= N//C:
-                    raise ValueError("column index values must be < %d (now max %d)"
-                                     % (N//C, self.indices.max()))
+                    raise ValueError(f"column index values must be < {N//C} (now max {self.indices.max()})")
                 if self.indices.min() < 0:
                     raise ValueError("column index values must be >= 0")
                 if np.diff(self.indptr).min() < 0:

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -100,7 +100,7 @@ class _csc_base(_cs_matrix):
         if i < 0:
             i += M
         if i < 0 or i >= M:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         return self._get_submatrix(minor=i).tocsr()
 
     def _getcol(self, i):
@@ -112,7 +112,7 @@ class _csc_base(_cs_matrix):
         if i < 0:
             i += N
         if i < 0 or i >= N:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         return self._get_submatrix(major=i, copy=True)
 
     def _get_intXarray(self, row, col):

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -168,7 +168,7 @@ class _csr_base(_cs_matrix):
         if i < 0:
             i += M
         if i < 0 or i >= M:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, i, i + 1, 0, N)
         return self.__class__((data, indices, indptr), shape=(1, N),
@@ -184,7 +184,7 @@ class _csr_base(_cs_matrix):
         if i < 0:
             i += N
         if i < 0 or i >= N:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, 0, M, i, i + 1)
         return self.__class__((data, indices, indptr), shape=(M, 1),

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -89,9 +89,8 @@ class _dia_base(_data_matrix):
             raise ValueError('data array must have rank 2')
 
         if self.data.shape[0] != len(self.offsets):
-            raise ValueError('number of diagonals (%d) '
-                    'does not match the number of offsets (%d)'
-                    % (self.data.shape[0], len(self.offsets)))
+            raise ValueError(f'number of diagonals ({self.data.shape[0]}) '
+                  f'does not match the number of offsets ({len(self.offsets)})')
 
         if len(np.unique(self.offsets)) != len(self.offsets):
             raise ValueError('offset array contains duplicate values')

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -315,12 +315,12 @@ class IndexMixin:
         # Check bounds
         max_indx = x.max()
         if max_indx >= length:
-            raise IndexError('index (%d) out of range' % max_indx)
+            raise IndexError(f'index ({max_indx}) out of range')
 
         min_indx = x.min()
         if min_indx < 0:
             if min_indx < -length:
-                raise IndexError('index (%d) out of range' % min_indx)
+                raise IndexError(f'index ({min_indx}) out of range')
             if x is idx or not x.flags.owndata:
                 x = x.copy()
             x[x < 0] += length
@@ -332,7 +332,7 @@ class IndexMixin:
         M, N = self.shape
         i = int(i)
         if i < -M or i >= M:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         if i < 0:
             i += M
         return self._get_intXslice(i, slice(None))
@@ -343,7 +343,7 @@ class IndexMixin:
         M, N = self.shape
         i = int(i)
         if i < -N or i >= N:
-            raise IndexError('index (%d) out of range' % i)
+            raise IndexError(f'index ({i}) out of range')
         if i < 0:
             i += N
         return self._get_sliceXint(slice(None), i)

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -279,7 +279,7 @@ class ArpackError(RuntimeError):
 
     def __init__(self, info, infodict=_NAUPD_ERRORS):
         msg = infodict.get(info, "Unknown error")
-        RuntimeError.__init__(self, "ARPACK error %d: %s" % (info, msg))
+        RuntimeError.__init__(self, f"ARPACK error {info}: {msg}")
 
 
 class ArpackNoConvergence(ArpackError):
@@ -313,12 +313,12 @@ class _ArpackParams:
     def __init__(self, n, k, tp, mode=1, sigma=None,
                  ncv=None, v0=None, maxiter=None, which="LM", tol=0):
         if k <= 0:
-            raise ValueError("k must be positive, k=%d" % k)
+            raise ValueError(f"k must be positive, k={k}")
 
         if maxiter is None:
             maxiter = n * 10
         if maxiter <= 0:
-            raise ValueError("maxiter must be positive, maxiter=%d" % maxiter)
+            raise ValueError(f"maxiter must be positive, maxiter={maxiter}")
 
         if tp not in 'fdFD':
             # Use `float64` libraries from integer dtypes.
@@ -508,12 +508,12 @@ class _SymmetricArpackParams(_ArpackParams):
                 self.B = M_matvec
                 self.bmat = 'G'
         else:
-            raise ValueError("mode=%i not implemented" % mode)
+            raise ValueError(f"mode={mode} not implemented")
 
         if which not in _SEUPD_WHICH:
             raise ValueError(f"which must be one of {' '.join(_SEUPD_WHICH)}")
         if k >= n:
-            raise ValueError("k must be less than ndim(A), k=%d" % k)
+            raise ValueError(f"k must be less than ndim(A), k={k}")
 
         _ArpackParams.__init__(self, n, k, tp, mode, sigma,
                                ncv, v0, maxiter, which, tol)
@@ -690,12 +690,12 @@ class _UnsymmetricArpackParams(_ArpackParams):
                 self.bmat = 'G'
                 self.OP = lambda x: self.OPa(M_matvec(x))
         else:
-            raise ValueError("mode=%i not implemented" % mode)
+            raise ValueError(f"mode={mode} not implemented")
 
         if which not in _NEUPD_WHICH:
             raise ValueError(f"Parameter which must be one of {' '.join(_NEUPD_WHICH)}")
         if k >= n - 1:
-            raise ValueError("k must be less than ndim(A)-1, k=%d" % k)
+            raise ValueError(f"k must be less than ndim(A)-1, k={k}")
 
         _ArpackParams.__init__(self, n, k, tp, mode, sigma,
                                ncv, v0, maxiter, which, tol)
@@ -977,9 +977,9 @@ class IterInv(LinearOperator):
     def _matvec(self, x):
         b, info = self.ifunc(self.M, x, tol=self.tol)
         if info != 0:
-            raise ValueError("Error in inverting M: function "
-                             "%s did not converge (info = %i)."
-                             % (self.ifunc.__name__, info))
+            raise ValueError(f"Error in inverting M: function "
+                            f"{self.ifunc.__name__} did not converge (info = {info}).")
+
         return b
 
 
@@ -1024,9 +1024,9 @@ class IterOpInv(LinearOperator):
     def _matvec(self, x):
         b, info = self.ifunc(self.OP, x, tol=self.tol)
         if info != 0:
-            raise ValueError("Error in inverting [A-sigma*M]: function "
-                             "%s did not converge (info = %i)."
-                             % (self.ifunc.__name__, info))
+            raise ValueError(f"Error in inverting [A-sigma*M]: function "
+                            f"{self.ifunc.__name__} did not converge (info = {info}).")
+
         return b
 
     @property
@@ -1266,7 +1266,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     n = A.shape[0]
 
     if k <= 0:
-        raise ValueError("k=%d must be greater than 0." % k)
+        raise ValueError(f"k={k} must be greater than 0.")
 
     if k >= n - 1:
         warnings.warn("k >= N - 1 for N * N square matrix. "

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -507,15 +507,16 @@ def lobpcg(
         if M is None:
             aux += "out"
         aux += " preconditioning\n\n"
-        aux += "matrix size %d\n" % n
-        aux += "block size %d\n\n" % sizeX
+        aux += f"matrix size {n}\n"
+        aux += f"block size {sizeX}\n\n"
+
         if blockVectorY is None:
             aux += "No constraints\n\n"
         else:
             if sizeY > 1:
-                aux += "%d constraints\n\n" % sizeY
+                aux += f"{sizeY} constraints\n\n"
             else:
-                aux += "%d constraint\n\n" % sizeY
+                aux += f"{sizeY} constraint\n\n"
         print(aux)
 
     if (n - sizeY) < (5 * sizeX):

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -399,8 +399,7 @@ class LinearOperator:
             X = np.asanyarray(X)
 
         if X.ndim != 2:
-            raise ValueError('expected 2-d ndarray or matrix, not %d-d'
-                             % X.ndim)
+            raise ValueError(f"expected 2-d ndarray or matrix, not {X.ndim}-d")
 
         if X.shape[0] != self.shape[0]:
             raise ValueError(f'dimension mismatch: {self.shape}, {X.shape}')
@@ -548,7 +547,8 @@ class LinearOperator:
         else:
             dt = 'dtype=' + str(self.dtype)
 
-        return '<%dx%d %s with %s>' % (M, N, self.__class__.__name__, dt)
+        return f"<{M}x{N} {self.__class__.__name__} with {dt}>"
+
 
     def adjoint(self):
         """Hermitian adjoint.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -223,8 +223,9 @@ def _validate_hamming_kwargs(X, m, n, **kwargs):
 
     if w.ndim != 1 or w.shape[0] != n:
         raise ValueError(
-            "Weights must have same size as input vector. %d vs. %d" % (w.shape[0], n)
+            f"Weights must have the same size as the input vector. {w.shape[0]} vs. {n}"
         )
+
 
     kwargs['w'] = _validate_weights(w)
     return kwargs
@@ -236,11 +237,12 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
         if m <= n:
             # There are fewer observations than the dimension of
             # the observations.
-            raise ValueError("The number of observations (%d) is too "
-                             "small; the covariance matrix is "
-                             "singular. For observations with %d "
-                             "dimensions, at least %d observations "
-                             "are required." % (m, n, n + 1))
+            raise ValueError(
+                f"The number of observations ({m}) is too small; the covariance matrix is "
+                f"singular. For observations with {n} dimensions, at least {n + 1} observations "
+                f"are required."
+            )
+
         if isinstance(X, tuple):
             X = np.vstack(X)
         CV = np.atleast_2d(np.cov(X.astype(np.float64, copy=False).T))

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -111,7 +111,7 @@ def _add_inc_data(name, chunksize):
     for j in range(nmin, len(points), chunksize):
         chunks.append(points[j:j+chunksize])
 
-    new_name = "%s-chunk-%d" % (name, chunksize)
+    new_name = f"{name}-chunk-{chunksize}"
     assert new_name not in INCREMENTAL_DATASETS
     INCREMENTAL_DATASETS[new_name] = (chunks, opts)
 
@@ -362,7 +362,7 @@ class TestUtilities:
                 list(map(np.ravel, np.broadcast_arrays(*np.ix_(*([x]*ndim)))))
             ].T
 
-            err_msg = "ndim=%d" % ndim
+            err_msg = f"ndim={ndim}"
 
             # Check using regular grid
             tri = qhull.Delaunay(grid)

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -11,7 +11,7 @@ from scipy.spatial import cKDTree
 
 TOL = 1E-12
 NS = range(1, 13)
-NAMES = ["I", "O", "T"] + ["C%d" % n for n in NS] + ["D%d" % n for n in NS]
+NAMES = ["I", "O", "T"] + [f"C{n}" for n in NS] + [f"D{n}" for n in NS]
 SIZES = [60, 24, 12] + list(NS) + [2 * n for n in NS]
 
 
@@ -117,7 +117,7 @@ def test_dicyclic(n, axis):
     """Test that the dicyclic group correctly fixes the rotations of a
     prism."""
     P = _generate_prism(n, axis='XYZ'.index(axis))
-    for g in Rotation.create_group("D%d" % n, axis=axis):
+    for g in Rotation.create_group(f"D{n}", axis=axis):
         assert _calculate_rmsd(P, g.apply(P)) < TOL
 
 
@@ -127,7 +127,7 @@ def test_cyclic(n, axis):
     """Test that the cyclic group correctly fixes the rotations of a
     pyramid."""
     P = _generate_pyramid(n, axis='XYZ'.index(axis))
-    for g in Rotation.create_group("C%d" % n, axis=axis):
+    for g in Rotation.create_group(f"C{n}", axis=axis):
         assert _calculate_rmsd(P, g.apply(P)) < TOL
 
 

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -295,18 +295,16 @@ def generate_loop(func_inputs, func_outputs, func_retval,
     body += "    cdef char *func_name = <char*>(<void**>data)[1]\n"
 
     for j in range(len(ufunc_inputs)):
-        body += "    cdef char *ip%d = args[%d]\n" % (j, j)
+        body += f"    cdef char *ip{j} = args[{j}]\n"
     for j in range(len(ufunc_outputs)):
-        body += "    cdef char *op%d = args[%d]\n" % (j, j + len(ufunc_inputs))
+        body += f"    cdef char *op{j} = args[{j + len(ufunc_inputs)}]\n"
 
     ftypes = []
     fvars = []
     outtypecodes = []
     for j in range(len(func_inputs)):
         ftypes.append(CY_TYPES[func_inputs[j]])
-        fvars.append("<%s>(<%s*>ip%d)[0]" % (
-            CY_TYPES[func_inputs[j]],
-            CY_TYPES[ufunc_inputs[j]], j))
+        fvars.append(f"<{CY_TYPES[func_inputs[j]]}>(<{CY_TYPES[ufunc_inputs[j]]}*>ip{j})[0]")
 
     if len(func_outputs)+1 == len(ufunc_outputs):
         func_joff = 1
@@ -316,9 +314,9 @@ def generate_loop(func_inputs, func_outputs, func_retval,
         func_joff = 0
 
     for j, outtype in enumerate(func_outputs):
-        body += "    cdef %s ov%d\n" % (CY_TYPES[outtype], j+func_joff)
+        body += f"    cdef {CY_TYPES[outtype]} ov{j + func_joff}\n"
         ftypes.append(f"{CY_TYPES[outtype]} *")
-        fvars.append("&ov%d" % (j+func_joff))
+        fvars.append(f"&ov{j + func_joff}")
         outtypecodes.append(outtype)
 
     body += "    for i in range(n):\n"
@@ -336,9 +334,7 @@ def generate_loop(func_inputs, func_outputs, func_retval,
     input_checks = []
     for j in range(len(func_inputs)):
         if (ufunc_inputs[j], func_inputs[j]) in DANGEROUS_DOWNCAST:
-            chk = "<%s>(<%s*>ip%d)[0] == (<%s*>ip%d)[0]" % (
-                CY_TYPES[func_inputs[j]], CY_TYPES[ufunc_inputs[j]], j,
-                CY_TYPES[ufunc_inputs[j]], j)
+            chk = f"<{CY_TYPES[func_inputs[j]]}>(<{CY_TYPES[ufunc_inputs[j]]}*>ip{j})[0] == (<{CY_TYPES[ufunc_inputs[j]]}*>ip{j})[0]"
             input_checks.append(chk)
 
     if input_checks:
@@ -348,29 +344,27 @@ def generate_loop(func_inputs, func_outputs, func_retval,
         body += ("            sf_error.error(func_name, sf_error.DOMAIN, "
                  "\"invalid input argument\")\n")
         for j, outtype in enumerate(outtypecodes):
-            body += "            ov%d = <%s>%s\n" % (
-                j, CY_TYPES[outtype], NAN_VALUE[outtype])
+            body += f"            ov{j} = <{CY_TYPES[outtype]}>{NAN_VALUE[outtype]}\n"
+
     else:
         body += funcall
 
     # Assign and cast-check output values
     for j, (outtype, fouttype) in enumerate(zip(ufunc_outputs, outtypecodes)):
         if (fouttype, outtype) in DANGEROUS_DOWNCAST:
-            body += "        if ov%d == <%s>ov%d:\n" % (j, CY_TYPES[outtype], j)
-            body += "            (<%s *>op%d)[0] = <%s>ov%d\n" % (
-                CY_TYPES[outtype], j, CY_TYPES[outtype], j)
+            body += f"        if ov{j} == <{CY_TYPES[outtype]}>ov{j}:\n"
+            body += f"            (<{CY_TYPES[outtype]} *>op{j})[0] = <{CY_TYPES[outtype]}>ov{j}\n"
             body += "        else:\n"
-            body += ("            sf_error.error(func_name, sf_error.DOMAIN, "
-                     "\"invalid output\")\n")
-            body += "            (<%s *>op%d)[0] = <%s>%s\n" % (
-                CY_TYPES[outtype], j, CY_TYPES[outtype], NAN_VALUE[outtype])
+            body += "            sf_error.error(func_name, sf_error.DOMAIN, \"invalid output\")\n"
+            body += f"            (<{CY_TYPES[outtype]} *>op{j})[0] = <{CY_TYPES[outtype]}>NAN_VALUE[{outtype}]\n"
+
         else:
-            body += "        (<%s *>op%d)[0] = <%s>ov%d\n" % (
-                CY_TYPES[outtype], j, CY_TYPES[outtype], j)
+            body += f"        (<{CY_TYPES[outtype]} *>op{j})[0] = <{CY_TYPES[outtype]}>ov{j}\n"
+
     for j in range(len(ufunc_inputs)):
-        body += "        ip%d += steps[%d]\n" % (j, j)
+        body += f"        ip{j} += steps[{j}]\n"
     for j in range(len(ufunc_outputs)):
-        body += "        op%d += steps[%d]\n" % (j, j + len(ufunc_inputs))
+        body += f"        op{j} += steps[{j + len(ufunc_inputs)}]\n"
 
     body += "    sf_error.check_fpe(func_name)\n"
 
@@ -541,10 +535,9 @@ class Ufunc(Func):
                 raise ValueError(f"{self.name}: void signature {sig!r}")
             if len(inp) != inarg_num or len(outp) != outarg_num:
                 raise ValueError(
-                    "%s: signature %r does not have %d/%d input/output args" % (
-                        self.name, sig, inarg_num, outarg_num
-                    )
+                    f"{self.name}: signature {sig!r} does not have {inarg_num}/{outarg_num} input/output args"
                 )
+
 
             loop_name, loop = generate_loop(inarg, outarg, ret, inp, outp)
             all_loops[loop_name] = loop
@@ -596,7 +589,7 @@ class Ufunc(Func):
         toplevel += (
         f"cdef np.PyUFuncGenericFunction ufunc_{self.name}_loops[{len(loops)}]\n"
         )
-        toplevel += "cdef void *ufunc_%s_ptr[%d]\n" % (self.name, 2*len(funcs))
+        toplevel += f"cdef void *ufunc_{self.name}_ptr[{2 * len(funcs)}]\n"
         toplevel += f"cdef void *ufunc_{self.name}_data[{len(funcs)}]\n"
         toplevel += f"cdef char ufunc_{self.name}_types[{len(types)}]\n"
         toplevel += 'cdef char *ufunc_{}_doc = (\n    "{}")\n'.format(
@@ -606,26 +599,21 @@ class Ufunc(Func):
         )
 
         for j, function in enumerate(loops):
-            toplevel += ("ufunc_%s_loops[%d] = <np.PyUFuncGenericFunction>%s\n" %
-                         (self.name, j, function))
+            toplevel += f"ufunc_{self.name}_loops[{j}] = <np.PyUFuncGenericFunction>{function}\n"
         for j, type in enumerate(types):
-            toplevel += "ufunc_%s_types[%d] = <char>%s\n" % (self.name, j, type)
+            toplevel += f"ufunc_{self.name}_types[{j}] = <char>{type}\n"
         for j, func in enumerate(funcs):
-            toplevel += "ufunc_%s_ptr[2*%d] = <void*>%s\n" % (
-                self.name, j, self.cython_func_name(func, specialized=True)
-            )
-            toplevel += "ufunc_%s_ptr[2*%d+1] = <void*>(<char*>\"%s\")\n" % (
-                self.name, j, self.name
-            )
-        for j, func in enumerate(funcs):
-            toplevel += "ufunc_%s_data[%d] = &ufunc_%s_ptr[2*%d]\n" % (
-                self.name, j, self.name, j)
+            toplevel += f"ufunc_{self.name}_ptr[2*{j}] = <void*>{self.cython_func_name(func, specialized=True)}\n"
+            toplevel += f"ufunc_{self.name}_ptr[2*{j}+1] = <void*>(<char*>\"{self.name}\")\n"
 
-        toplevel += ('@ = np.PyUFunc_FromFuncAndData(ufunc_@_loops, '
-                     'ufunc_@_data, ufunc_@_types, %d, %d, %d, 0, '
-                     '"@", ufunc_@_doc, 0)\n' % (len(types)/(inarg_num+outarg_num),
-                                                 inarg_num, outarg_num)
-                     ).replace('@', self.name)
+        for j, func in enumerate(funcs):
+            toplevel += f"ufunc_{self.name}_data[{j}] = &ufunc_{self.name}_ptr[2*{j}]\n"
+
+        toplevel += (f"@ = np.PyUFunc_FromFuncAndData(ufunc_{self.name}_loops, "
+                    f"ufunc_{self.name}_data, ufunc_{self.name}_types, "
+                    f"{len(types) // (inarg_num + outarg_num)}, {inarg_num}, {outarg_num}, 0, "
+                    f"\"{self.name}\", ufunc_{self.name}_doc, 0)\n")
+
 
         return toplevel
 

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -294,13 +294,12 @@ class FuncData:
                 msg = [""]
                 msg.append(f"Max |adiff|: {diff[bad_j].max():g}")
                 msg.append(f"Max |rdiff|: {rdiff[bad_j].max():g}")
-                msg.append("Bad results (%d out of %d) for the following points "
-                           "(in output %d):"
-                           % (np.sum(bad_j), point_count, output_num,))
+                msg.append(f"Bad results ({np.sum(bad_j)} out of {point_count}) for the following points (in output {output_num}):")
+
                 for j in np.nonzero(bad_j)[0]:
                     j = int(j)
                     def fmt(x):
-                        return '%30s' % np.array2string(x[j], precision=18)
+                        return f'{np.array2string(x[j], precision=18):30}'
                     a = "  ".join(map(fmt, params))
                     b = "  ".join(map(fmt, got))
                     c = "  ".join(map(fmt, wanted))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3221,7 +3221,7 @@ class TestHyper:
         ]
         for i, (a, b, c, x, v) in enumerate(values):
             cv = special.hyp2f1(a, b, c, x)
-            assert_almost_equal(cv, v, 8, err_msg='test #%d' % i)
+            assert_almost_equal(cv, v, 8, err_msg=f'test #{i}')
 
     def test_hyperu(self):
         val1 = special.hyperu(1,0.1,100)
@@ -3287,7 +3287,8 @@ class TestBessel:
                   ]
         for i, (v, x, y) in enumerate(values):
             yc = special.jv(v, x)
-            assert_almost_equal(yc, y, 8, err_msg='test #%d' % i)
+            assert_almost_equal(yc, y, 8, err_msg=f'test #{i}')
+
 
     def test_negv_jve(self):
         assert_almost_equal(special.jve(-3,2), -special.jve(3,2), 14)
@@ -3359,7 +3360,7 @@ class TestBessel:
                 elif tt == 1:
                     assert_allclose(jnp(nn, zz), 0, atol=1e-6)
                 else:
-                    raise AssertionError("Invalid t return for nt=%d" % nt)
+                    raise AssertionError(f"Invalid t return for nt={nt}")
 
     def test_jnp_zeros(self):
         jnp = special.jnp_zeros(1,5)
@@ -3779,7 +3780,7 @@ class TestBessel:
                   ]
         for i, (x, v) in enumerate(values):
             cv = special.i0(x) * exp(-x)
-            assert_almost_equal(cv, v, 8, err_msg='test #%d' % i)
+            assert_almost_equal(cv, v, 8, err_msg=f'test #{i}')
 
     def test_i0e(self):
         oize = special.i0e(.1)
@@ -3797,7 +3798,7 @@ class TestBessel:
                   ]
         for i, (x, v) in enumerate(values):
             cv = special.i1(x) * exp(-x)
-            assert_almost_equal(cv, v, 8, err_msg='test #%d' % i)
+            assert_almost_equal(cv, v, 8, err_msg=f'test #{i}')
 
     def test_i1e(self):
         oi1e = special.i1e(.1)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -257,25 +257,27 @@ class TestCall:
     def test_call(self):
         poly = []
         for n in range(5):
-            poly.extend([x.strip() for x in
-                ("""
-                orth.jacobi(%(n)d,0.3,0.9)
-                orth.sh_jacobi(%(n)d,0.3,0.9)
-                orth.genlaguerre(%(n)d,0.3)
-                orth.laguerre(%(n)d)
-                orth.hermite(%(n)d)
-                orth.hermitenorm(%(n)d)
-                orth.gegenbauer(%(n)d,0.3)
-                orth.chebyt(%(n)d)
-                orth.chebyu(%(n)d)
-                orth.chebyc(%(n)d)
-                orth.chebys(%(n)d)
-                orth.sh_chebyt(%(n)d)
-                orth.sh_chebyu(%(n)d)
-                orth.legendre(%(n)d)
-                orth.sh_legendre(%(n)d)
-                """ % dict(n=n)).split()
+            poly.extend([
+                x.strip() for x in
+                f"""
+                orth.jacobi({n},0.3,0.9)
+                orth.sh_jacobi({n},0.3,0.9)
+                orth.genlaguerre({n},0.3)
+                orth.laguerre({n})
+                orth.hermite({n})
+                orth.hermitenorm({n})
+                orth.gegenbauer({n},0.3)
+                orth.chebyt({n})
+                orth.chebyu({n})
+                orth.chebyc({n})
+                orth.chebys({n})
+                orth.sh_chebyt({n})
+                orth.sh_chebyu({n})
+                orth.legendre({n})
+                orth.sh_legendre({n})
+                """.split()
             ])
+
         with np.errstate(all='ignore'):
             for pstr in poly:
                 p = eval(pstr)

--- a/scipy/special/utils/datafunc.py
+++ b/scipy/special/utils/datafunc.py
@@ -36,8 +36,9 @@ def run_test(filename, funcs, args=[0]):  # noqa: B006
 
     data = parse_txt_data(filename)
     if data.shape[1] != len(funcs) + nargs:
-        raise ValueError("data has %d items / row, but len(funcs) = %d and "
-                         "nargs = %d" % (data.shape[1], len(funcs), nargs))
+        raise ValueError(f"data has {data.shape[1]} items / row, but len(funcs) = {len(funcs)} "
+                        f"and nargs = {nargs}")
+
 
     if nargs > 1:
         f = funcs[0]

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2451,7 +2451,7 @@ class rv_continuous(rv_generic):
         args = list(args)
         Nargs = len(args)
         fixedn = []
-        names = ['f%d' % n for n in range(Nargs - 2)] + ['floc', 'fscale']
+        names = [f"f{n}" for n in range(Nargs - 2)] + ["floc", "fscale"]
         x0 = []
         for n, key in enumerate(names):
             if key in kwds:

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3863,12 +3863,13 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
     # Validate the sizes and shapes of the arguments.
     for k, d in enumerate(data):
         if d.size == 0:
-            raise ValueError("Sample %d is empty. All samples must "
-                             "contain at least one value." % (k + 1))
+            raise ValueError(f"Sample {k + 1} is empty. All samples must "
+                            f"contain at least one value.")
+
         if d.ndim != 1:
-            raise ValueError("Sample %d has %d dimensions.  All "
-                             "samples must be one-dimensional sequences." %
-                             (k + 1, d.ndim))
+            raise ValueError(f"Sample {k + 1} has {d.ndim} dimensions. All "
+                            "samples must be one-dimensional sequences.")
+
 
     cdata = np.concatenate(data)
     contains_nan, nan_policy = _contains_nan(cdata, nan_policy)
@@ -3913,9 +3914,10 @@ def median_test(*samples, ties='below', correction=True, lambda_=1,
         # check for that case here.
         zero_cols = np.nonzero((table == 0).all(axis=0))[0]
         if len(zero_cols) > 0:
-            msg = ("All values in sample %d are equal to the grand "
-                   "median (%r), so they are ignored, resulting in an "
-                   "empty sample." % (zero_cols[0] + 1, grand_median))
+            msg = (f"All values in sample {zero_cols[0] + 1} are equal to the grand "
+                f"median ({grand_median!r}), so they are ignored, resulting in an "
+                "empty sample.")
+
             raise ValueError(msg)
 
     stat, p, dof, expected = chi2_contingency(table, lambda_=lambda_,

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2263,8 +2263,8 @@ def trimmed_stde(a, limits=(0.1,0.1), inclusive=(1,1), axis=None):
         return _trimmed_stde_1D(a.ravel(),lolim,uplim,loinc,upinc)
     else:
         if a.ndim > 2:
-            raise ValueError("Array 'a' must be at most two dimensional, "
-                             "but got a.ndim = %d" % a.ndim)
+            raise ValueError(f"Array 'a' must be at most two dimensional, but got a.ndim = {a.ndim}")
+
         return ma.apply_along_axis(_trimmed_stde_1D, axis, a,
                                    lolim,uplim,loinc,upinc)
 
@@ -3016,8 +3016,8 @@ def stde_median(data, axis=None):
         return _stdemed_1D(data)
     else:
         if data.ndim > 2:
-            raise ValueError("Array 'data' must be at most two dimensional, "
-                             "but got data.ndim = %d" % data.ndim)
+            raise ValueError(f"Array 'data' must be at most two dimensional, but got data.ndim = {data.ndim}")
+
         return ma.apply_along_axis(_stdemed_1D, axis, data)
 
 
@@ -3068,8 +3068,10 @@ def skewtest(a, axis=0, alternative='two-sided'):
     n = a.count(axis)
     if np.min(n) < 8:
         raise ValueError(
-            "skewtest is not valid with less than 8 samples; %i samples"
-            " were given." % np.min(n))
+            f"skewtest is not valid with less than 8 samples; {np.min(n)} samples "
+            "were given."
+        )
+
 
     y = b2 * ma.sqrt(((n+1)*(n+3)) / (6.0*(n-2)))
     beta2 = (3.0*(n*n+27*n-70)*(n+1)*(n+3)) / ((n-2.0)*(n+5)*(n+7)*(n+9))
@@ -3126,11 +3128,12 @@ def kurtosistest(a, axis=0, alternative='two-sided'):
     n = a.count(axis=axis)
     if np.min(n) < 5:
         raise ValueError(
-            "kurtosistest requires at least 5 observations; %i observations"
-            " were given." % np.min(n))
+        f"kurtosistest requires at least 5 observations; {np.min(n)} observations "
+        "were given.")
+
     if np.min(n) < 20:
         warnings.warn(
-            "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" % np.min(n),
+            f"kurtosistest only valid for n>=20 ... continuing anyway, n={np.min(n)}",
             stacklevel=2,
         )
 
@@ -3535,8 +3538,8 @@ def friedmanchisquare(*args):
     data = argstoarray(*args).astype(float)
     k = len(data)
     if k < 3:
-        raise ValueError("Less than 3 groups (%i): " % k +
-                         "the Friedman test is NOT appropriate.")
+        raise ValueError(f"Less than 3 groups ({k}): the Friedman test is NOT appropriate.")
+
 
     ranked = ma.masked_values(rankdata(data, axis=0), 0)
     if ranked._mask is not nomask:

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -114,8 +114,9 @@ def hdquantiles(data, prob=(.25, .5, .75), axis=None, var=False,):
         result = _hd_1D(data, p, var)
     else:
         if data.ndim > 2:
-            raise ValueError("Array 'data' must be at most two dimensional, "
-                             "but got data.ndim = %d" % data.ndim)
+            raise ValueError(f"Array 'data' must be at most two dimensional, "
+                            f"but got data.ndim = {data.ndim}")
+
         result = ma.apply_along_axis(_hd_1D, axis, data, p, var)
 
     return ma.fix_invalid(result, copy=False)
@@ -203,8 +204,9 @@ def hdquantiles_sd(data, prob=(.25, .5, .75), axis=None):
         result = _hdsd_1D(data, p)
     else:
         if data.ndim > 2:
-            raise ValueError("Array 'data' must be at most two dimensional, "
-                             "but got data.ndim = %d" % data.ndim)
+            raise ValueError(f"Array 'data' must be at most two dimensional, "
+                            f"but got data.ndim = {data.ndim}")
+
         result = ma.apply_along_axis(_hdsd_1D, axis, data, p)
 
     return ma.fix_invalid(result, copy=False).ravel()
@@ -295,8 +297,9 @@ def mjci(data, prob=(0.25, 0.5, 0.75), axis=None):
 
     data = ma.array(data, copy=False)
     if data.ndim > 2:
-        raise ValueError("Array 'data' must be at most two dimensional, "
-                         "but got data.ndim = %d" % data.ndim)
+        raise ValueError(f"Array 'data' must be at most two dimensional, "
+                        f"but got data.ndim = {data.ndim}")
+
 
     p = np.atleast_1d(np.asarray(prob))
     # Computes quantiles along axis (or globally)
@@ -384,8 +387,9 @@ def median_cihs(data, alpha=0.05, axis=None):
         result = _cihs_1D(data, alpha)
     else:
         if data.ndim > 2:
-            raise ValueError("Array 'data' must be at most two dimensional, "
-                             "but got data.ndim = %d" % data.ndim)
+            raise ValueError(f"Array 'data' must be at most two dimensional, "
+                            f"but got data.ndim = {data.ndim}")
+
         result = ma.apply_along_axis(_cihs_1D, axis, data, alpha)
 
     return result

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -470,8 +470,8 @@ class multivariate_normal_gen(multi_rv_generic):
             cov = cov.reshape(1, 1)
 
         if mean.ndim != 1 or mean.shape[0] != dim:
-            raise ValueError("Array 'mean' must be a vector of length %d." %
-                             dim)
+            raise ValueError(f"Array 'mean' must be a vector of length {dim}.")
+
         if cov.ndim == 0:
             cov = cov * np.eye(dim)
         elif cov.ndim == 1:
@@ -487,8 +487,9 @@ class multivariate_normal_gen(multi_rv_generic):
                 msg = msg % (str(cov.shape), len(mean))
             raise ValueError(msg)
         elif cov.ndim > 2:
-            raise ValueError("Array 'cov' must be at most two-dimensional,"
-                             " but cov.ndim = %d" % cov.ndim)
+            raise ValueError(f"Array 'cov' must be at most two-dimensional, "
+                            f"but cov.ndim = {cov.ndim}")
+
 
         return dim, mean, cov
 
@@ -2011,8 +2012,9 @@ class wishart_gen(multi_rv_generic):
             raise ValueError("Array 'scale' must be square if it is two dimensional,"
                              f" but scale.scale = {str(scale.shape)}.")
         elif scale.ndim > 2:
-            raise ValueError("Array 'scale' must be at most two-dimensional,"
-                             " but scale.ndim = %d" % scale.ndim)
+            raise ValueError(f"Array 'scale' must be at most two-dimensional, "
+                            f"but scale.ndim = {scale.ndim}")
+
 
         dim = scale.shape[0]
 
@@ -2052,9 +2054,10 @@ class wishart_gen(multi_rv_generic):
                     "Quantiles must be square in the first two dimensions "
                     f"if they are three dimensional, but x.shape = {str(x.shape)}.")
         elif x.ndim > 3:
-            raise ValueError("Quantiles must be at most two-dimensional with"
-                             " an additional dimension for multiple"
-                             "components, but x.ndim = %d" % x.ndim)
+            raise ValueError(f"Quantiles must be at most two-dimensional with "
+                            f"an additional dimension for multiple components, "
+                            f"but x.ndim = {x.ndim}")
+
 
         # Now we have 3-dim array; should have shape [dim, dim, *]
         if not x.shape[0:2] == (dim, dim):
@@ -3291,9 +3294,9 @@ class multinomial_gen(multi_rv_generic):
             raise ValueError("x must be an array.")
 
         if xx.size != 0 and not xx.shape[-1] == p.shape[-1]:
-            raise ValueError("Size of each quantile should be size of p: "
-                             "received %d, but expected %d." %
-                             (xx.shape[-1], p.shape[-1]))
+            raise ValueError(f"Size of each quantile should be size of p: "
+                  f"received {xx.shape[-1]}, but expected {p.shape[-1]}.")
+
 
         # true for x out of the domain
         cond = np.any(xx != x, axis=-1)
@@ -4763,8 +4766,8 @@ class multivariate_t_gen(multi_rv_generic):
             shape = shape.reshape(1, 1)
 
         if loc.ndim != 1 or loc.shape[0] != dim:
-            raise ValueError("Array 'loc' must be a vector of length %d." %
-                             dim)
+            raise ValueError(f"Array 'loc' must be a vector of length {dim}.")
+
         if shape.ndim == 0:
             shape = shape * np.eye(dim)
         elif shape.ndim == 1:
@@ -4780,8 +4783,8 @@ class multivariate_t_gen(multi_rv_generic):
                 msg = msg % (str(shape.shape), len(loc))
             raise ValueError(msg)
         elif shape.ndim > 2:
-            raise ValueError("Array 'cov' must be at most two-dimensional,"
-                             " but cov.ndim = %d" % shape.ndim)
+            raise ValueError(f"Array 'cov' must be at most two-dimensional, but cov.ndim = {shape.ndim}")
+
 
         # Process degrees of freedom.
         if df is None:

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -183,8 +183,8 @@ class TestRankData:
             data = np.ones(n, dtype=int)
             r = rankdata(data)
             expected_rank = 0.5 * (n + 1)
-            assert_array_equal(r, expected_rank * data,
-                               "test failed with n=%d" % n)
+            assert_array_equal(r, expected_rank * data, f"test failed with n={n}")
+
 
     def test_axis(self):
         data = [[0, 2, 1],

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -54,7 +54,7 @@ def main():
             name = NAME_MAP.get(name, name)
             if disp:
                 if name not in names:
-                    stdout_b.write(("    - Author: %s\n" % name).encode('utf-8'))
+                    stdout_b.write(f"    - Author: {name}\n".encode('utf-8'))
             names.update((name,))
 
         # Look for "thanks to" messages in the commit log
@@ -68,7 +68,7 @@ def main():
             name = m.group(2)
             if name not in ('this',):
                 if disp:
-                    stdout_b.write("    - Log   : %s\n" % line.strip().encode('utf-8'))
+                    stdout_b.write(f"    - Log   : {line.strip()}\n".encode('utf-8'))
                 name = NAME_MAP.get(name, name)
                 names.update((name,))
 
@@ -111,7 +111,7 @@ def main():
         # Print some empty lines to separate
         stdout_b.write(b"\n\n")
         for author in n_authors:
-            stdout_b.write(("- %s\n" % author).encode('utf-8'))
+            stdout_b.write(f("- {author}\n".encode('utf-8')))
         # return for early exit so we only print new authors
         return
 
@@ -138,12 +138,14 @@ Authors
         else:
             stdout_b.write((f"* {author_clean} ({count}) +\n").encode())
 
-    stdout_b.write(("""
-A total of %(count)d people contributed to this release.
+    stdout_b.write((
+    f"""
+A total of {len(authors)} people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
-""" % dict(count=len(authors))).encode('utf-8'))
+""").encode('utf-8'))
+
 
     stdout_b.write(b"\nNOTE: Check this list manually! It is automatically generated "
                    b"and some names\n      may be missing.\n")
@@ -202,7 +204,7 @@ class Cmd:
     def __call__(self, command, *a, **kw):
         ret = self._call(command, a, {}, call=True, **kw)
         if ret != 0:
-            raise RuntimeError("%s failed" % self.executable)
+            raise RuntimeError(f"{self.executable} failed")
 
     def pipe(self, command, *a, **kw):
         stdin = kw.pop('stdin', None)
@@ -215,7 +217,7 @@ class Cmd:
                       call=False, **kw)
         out, err = p.communicate()
         if p.returncode != 0:
-            raise RuntimeError("%s failed" % self.executable)
+            raise RuntimeError(f"{self.executable} failed")
         return out
 
     def readlines(self, command, *a, **kw):

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -128,7 +128,7 @@ def unique_key(adict):
     done = False
     n = 1
     while not done:
-        newkey = '__l%s' % (n)
+        newkey = f"__l{n}"
         if newkey in allkeys:
             n += 1
         else:
@@ -146,7 +146,7 @@ def expand_sub(substr, names):
     def listrepl(mobj):
         thelist = conv(mobj.group(1).replace(r'\,', '@comma@'))
         if template_name_re.match(thelist):
-            return "<%s>" % (thelist)
+            return f"<{thelist}>"
         name = None
         for key in lnames.keys():    # see if list is already in dictionary
             if lnames[key] == thelist:
@@ -154,7 +154,7 @@ def expand_sub(substr, names):
         if name is None:      # this list is not in the dictionary yet
             name = unique_key(lnames)
             lnames[name] = thelist
-        return "<%s>" % name
+        return f"<{name}>"
 
     substr = list_re.sub(listrepl, substr) # convert all lists to named templates
                                            # newnames are constructed as needed
@@ -166,7 +166,7 @@ def expand_sub(substr, names):
         if r not in rules:
             thelist = lnames.get(r, names.get(r, None))
             if thelist is None:
-                raise ValueError('No replicates found for <%s>' % (r))
+                raise ValueError(f"No replicates found for <{r}>")
             if r not in names and not thelist.startswith('_'):
                 names[r] = thelist
             rule = [i.replace('@comma@', ',') for i in thelist.split(',')]

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -20,7 +20,7 @@ target-version = "py310"
 # `ICN001` added in gh-20382 to enforce common conventions for import.
 # `W292` added in gh-21023 to enforce newlines at end of files.
 select = ["E", "F", "PGH004", "UP", "B006", "B008", "B028", "ICN001", "W292"]
-ignore = ["E741", "UP038", "UP031"]
+ignore = ["E741", "UP038"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tools/ninjatracing.py
+++ b/tools/ninjatracing.py
@@ -46,9 +46,9 @@ def read_targets(log, show_all):
     time"""
     header = log.readline()
     m = re.search(r'^# ninja log v(\d+)\n$', header)
-    assert m, "unrecognized ninja log version %r" % header
+    assert m, f"unrecognized ninja log version {header!r}"
     version = int(m.group(1))
-    assert 5 <= version <= 6, "unsupported ninja log version %d" % version
+    assert 5 <= version <= 6, f"unsupported ninja log version {version}"
     if version == 6:
         # Skip header line
         next(log)
@@ -138,7 +138,7 @@ def log_to_dicts(log, pid, options):
         tid = threads.alloc(target)
 
         yield {
-            'name': '%0s' % ', '.join(target.targets), 'cat': 'targets',
+            'name': f"{', '.join(target.targets):0s}", 'cat': 'targets',
             'ph': 'X', 'ts': (target.start * 1000),
             'dur': ((target.end - target.start) * 1000),
             'pid': pid, 'tid': tid, 'args': {},

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -251,8 +251,8 @@ def check_items(all_dict, names, deprecated, others, module_name, dots=True):
 
     output = ""
 
-    output += "Non-deprecated objects in __all__: %i\n" % num_all
-    output += "Objects in refguide: %i\n\n" % num_ref
+    output += f"Non-deprecated objects in __all__: {num_all}\n"
+    output += f"Objects in refguide: {num_ref}\n\n"
 
     only_all, only_ref, missing = compare(all_dict, others, names, module_name)
     dep_in_ref = only_ref.intersection(deprecated)
@@ -368,7 +368,7 @@ def validate_rst_syntax(text, name, dots=True):
     if not success:
         output += "    " + "-"*72 + "\n"
         for lineno, line in enumerate(text.splitlines()):
-            output += "    %-4d    %s\n" % (lineno+1, line)
+            output += f"    {lineno + 1:<4}    {line}\n"
         output += "    " + "-"*72 + "\n\n"
 
     if dots:
@@ -537,7 +537,7 @@ def main(argv):
     success = True
     results = []
 
-    print("Running checks for %d modules:" % (len(modules),))
+    print(f"Running checks for {len(modules)} modules:")
 
     for module in modules:
         if dots:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
STY: fix and enable lint rule UP031 #21972

#### What does this implement/fix?
Remove UP031 from lint.toml and fix string format errors that follow

#### Additional information
ruff check . --target-version=py310 --select UP031  
All checks passed!
