### PR TITLE
DOC: adapt to NumPy 2.2 changes for abbreviation of large arrays

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -114,7 +114,7 @@ def electrocardiogram():
     >>> from scipy.datasets import electrocardiogram
     >>> ecg = electrocardiogram()
     >>> ecg
-    array([-0.245, -0.215, -0.185, ..., -0.405, -0.395, -0.385])
+    array([-0.245, -0.215, -0.185, ..., -0.405, -0.395, -0.385], shape=(108000,))
     >>> ecg.shape, ecg.mean(), ecg.std()
     ((108000,), -0.16510875, 0.5992473991177294)
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -2063,7 +2063,7 @@ def matmul_toeplitz(c_or_cr, x, check_finite=False, workers=None):
 
     >>> n = 1000000
     >>> matmul_toeplitz([1] + [0]*(n-1), np.ones(n))
-    array([1., 1., 1., ..., 1., 1., 1.])
+    array([1., 1., 1., ..., 1., 1., 1.], shape=(1000000,))
 
     """
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -332,7 +332,7 @@ def lobpcg(
            ...,
            [  0,   0,   0, ...,  98,   0,   0],
            [  0,   0,   0, ...,   0,  99,   0],
-           [  0,   0,   0, ...,   0,   0, 100]], dtype=int16)
+           [  0,   0,   0, ...,   0,   0, 100]], shape=(100, 100), dtype=int16)
 
     The second mandatory input parameter `X` is a 2D array with the
     row dimension determining the number of requested eigenvalues.


### PR DESCRIPTION
NumPy 2.2 changed the rules for abbreviation of large arrays:

```
In [4]: np.arange(5000)
Out[4]: array([   0,    1,    2, ..., 4997, 4998, 4999], shape=(5000,))
```

the `shape=` part is new. This change needs two workarounds:
-  `scipy-doctest` needs to learn how to interpret this fake `shape=` kwarg --- https://github.com/scipy/scipy_doctest/pull/176
- our docstrings need to add the shape info (this PR).

https://github.com/scipy/scipy_doctest/pull/176 tries handle both "new" and "old" representations. This way, once 
scipy-doctest made a release, we and other doctest users only need to add `shapes=` once, and all doctests will work with both numpy < 2.2 and >= 2.2