### PR TITLE
BUG: immortalize uarray global strings in order to prevent negative refcounts

### DIFF
--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -156,7 +156,7 @@ using local_state_t = std::unordered_map<std::string, local_backends>;
 
 static py_ref BackendNotImplementedError;
 static immortal<global_state_t> global_domain_map;
-thread_local immortal<global_state_t> * current_global_state = &global_domain_map;
+thread_local global_state_t * current_global_state = &global_domain_map;
 thread_local global_state_t thread_local_domain_map;
 thread_local local_state_t local_domain_map;
 
@@ -1548,14 +1548,8 @@ PyObject * set_state(PyObject * /* self */, PyObject * args) {
   local_domain_map = state->locals;
   bool use_thread_local_globals =
       (!reset_allowed) || state->use_thread_local_globals;
-
-  if(use_thread_local_globals) {
-    static immortal<global_state_t> thread_local_copy = immortal<global_state_t>(
-      thread_local_domain_map);
-    current_global_state = &thread_local_copy;
-  } else {
-    current_global_state = &global_domain_map;
-  }
+  current_global_state =
+      use_thread_local_globals ? &thread_local_domain_map : global_domain_map.get();
 
   if (use_thread_local_globals)
     thread_local_domain_map = state->globals;

--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -156,7 +156,7 @@ using local_state_t = std::unordered_map<std::string, local_backends>;
 
 static py_ref BackendNotImplementedError;
 static immortal<global_state_t> global_domain_map;
-thread_local global_state_t * current_global_state = &*global_domain_map;
+thread_local global_state_t * current_global_state = global_domain_map.get();
 thread_local global_state_t thread_local_domain_map;
 thread_local local_state_t local_domain_map;
 
@@ -1525,7 +1525,7 @@ PyObject * get_state(PyObject * /* self */, PyObject * /* args */) {
 
   output->locals = local_domain_map;
   output->use_thread_local_globals =
-      (current_global_state != &*global_domain_map);
+      (current_global_state != global_domain_map.get());
   output->globals = *current_global_state;
 
   return ref.release();


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes https://github.com/scipy/scipy/issues/21214
Closes https://github.com/scipy/scipy/pull/21218

#### What does this implement/fix?
<!--Please explain your changes.-->
This is an alternative PR based off @peterbell10 comment https://github.com/scipy/scipy/pull/21218#pullrequestreview-2466103157 on the original PR that was opened to fix some segfaults that appeared when global `uarray` strings were being released when the Python interpreter was no longer existent.

#### Additional information
<!--Any additional information you think is important.-->
