### PR TITLE
MAINT: `stats.make_distribution`: support more existing distributions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9406,6 +9406,7 @@ class irwinhall_gen(rv_continuous):
         # see https://link.springer.com/content/pdf/10.1007/s10959-020-01050-9.pdf
         # page 640, with m=n, j=n+order
         def vmunp(order, n):
+            n = n.astype(np.int64, copy=False)
             return (sc.stirling2(n+order, n, exact=True)
                     / sc.comb(n+order, n, exact=True))
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5717,6 +5717,10 @@ class jf_skew_t_gen(rv_continuous):
         y = (1 + x / np.sqrt(a + b + x ** 2)) * 0.5
         return sc.betainc(a, b, y)
 
+    def _sf(self, x, a, b):
+        y = (1 + x / np.sqrt(a + b + x ** 2)) * 0.5
+        return sc.betaincc(a, b, y)
+
     def _ppf(self, q, a, b):
         d1 = beta.ppf(q, a, b)
         d2 = (2 * d1 - 1) * np.sqrt(a + b)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9406,7 +9406,7 @@ class irwinhall_gen(rv_continuous):
         # see https://link.springer.com/content/pdf/10.1007/s10959-020-01050-9.pdf
         # page 640, with m=n, j=n+order
         def vmunp(order, n):
-            n = n.astype(np.int64, copy=False)
+            n = np.asarray(n, dtype=np.int64)
             return (sc.stirling2(n+order, n, exact=True)
                     / sc.comb(n+order, n, exact=True))
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10778,7 +10778,7 @@ class truncpareto_gen(rv_continuous):
 
 
 truncpareto = truncpareto_gen(a=1.0, name='truncpareto')
-truncpareto._support = (0.0, 'c')
+truncpareto._support = (1.0, 'c')
 
 
 class tukeylambda_gen(rv_continuous):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3548,6 +3548,7 @@ _distribution_names = {
 }
 
 
+# beta, genextreme, gengamma, t, tukeylambda need work for 1D arrays
 def make_distribution(dist):
     """Generate a `ContinuousDistribution` from an instance of `rv_continuous`
 
@@ -3559,8 +3560,10 @@ def make_distribution(dist):
 
     .. note::
 
-        `make_distribution` does not work with all instances of `rv_continuous`.
-        Known failures include `levy_stable` and `vonmises`.
+        `make_distribution` does not work perfectly with all instances of
+        `rv_continuous`. Known failures include `levy_stable` and `vonmises`,
+        and some methods of some distributions will not support array shape
+        parameters.
 
     Parameters
     ----------
@@ -3602,7 +3605,7 @@ def make_distribution(dist):
         raise NotImplementedError(f"`{dist.name}` is not supported.")
 
     if not isinstance(dist, stats.rv_continuous):
-        message = f"The argument must be an instance of `rv_continuous`."
+        message = "The argument must be an instance of `rv_continuous`."
         raise ValueError(message)
 
     parameters = []
@@ -3694,7 +3697,8 @@ def make_distribution(dist):
                 is not getattr(stats.rv_continuous, method_name, None))
 
     if _overrides('_get_support'):
-        CustomDistribution._variable.domain.get_numerical_endpoints = get_numerical_endpoints
+        domain = CustomDistribution._variable.domain
+        domain.get_numerical_endpoints = get_numerical_endpoints
 
     if _overrides('_munp'):
         CustomDistribution._moment_raw_formula = _moment_raw_formula

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1234,9 +1234,11 @@ def _log_real_standardize(x):
     return y.reshape(shape)[()]
 
 
-def _combine_docs(dist_family):
+def _combine_docs(dist_family, *, include_examples=True):
     fields = set(NumpyDocString.sections)
     fields.remove('index')
+    if not include_examples:
+        fields.remove('Examples')
 
     doc = ClassDoc(dist_family)
     superdoc = ClassDoc(ContinuousDistribution)
@@ -3604,6 +3606,10 @@ def make_distribution(dist):
         if not _overrides('_munp'):
             CustomDistribution._moment_raw_formula = _moment_raw_formula_1
             CustomDistribution._moment_central_formula = _moment_central_formula
+
+    class_docs = _combine_docs(CustomDistribution, include_examples=False)
+    CustomDistribution.__doc__ = ("The PDF of this distribution "
+                                  f"is defined {class_docs.lstrip()}")
 
     return CustomDistribution
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3535,8 +3535,8 @@ def make_distribution(dist):
     def _sample_formula(self, _, full_shape=(), *, rng=None, **kwargs):
         return dist._rvs(size=full_shape, random_state=rng, **kwargs)
 
-    def _moment_raw_formula(self, n, **kwargs):
-        return dist._munp(int(n), **kwargs)
+    def _moment_raw_formula(self, order, **kwargs):
+        return dist._munp(int(order), **kwargs)
 
     def _moment_raw_formula_1(self, order, **kwargs):
         if order != 1:

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3471,6 +3471,82 @@ class ContinuousDistribution(_ProbabilityDistribution):
     # fit method removed for initial PR
 
 
+# Special case the names of some new-style distributions in `make_distribution`
+_distribution_names = {
+    'argus': 'ARGUS',
+    'betaprime': 'BetaPrime',
+    'chi2': 'ChiSquared',
+    'crystalball': 'CrystalBall',
+    'dgamma': 'DoubleGamma',
+    'dweibull': 'DoubleWeibull',
+    'expon': 'Exponential',
+    'exponnorm': 'ExponentiallyModifiedNormal',
+    'exponweib': 'ExponentialWeibull',
+    'exponpow': 'ExponentialPower',
+    'fatiguelife': 'FatigueLife',
+    'foldcauchy': 'FoldedCauchy',
+    'foldnorm': 'FoldedNormal',
+    'genlogistic': 'GeneralizedLogistic',
+    'gennorm': 'GeneralizedNormal',
+    'genpareto': 'GeneralizedPareto',
+    'genexpon': 'GeneralizedExponential',
+    'genextreme': 'GeneralizedExtremeValue',
+    'gausshyper': 'GaussHypergeometric',
+    'gengamma': 'GeneralizedGamma',
+    'genhalflogistic': 'GeneralizedHalfLogistic',
+    'geninvgauss': 'GeneralizedInverseGaussian',
+    'gumbel_r': 'Gumbel',
+    'gumbel_l': 'ReflectedGumbel',
+    'halfcauchy': 'HalfCauchy',
+    'halflogistic': 'HalfLogistic',
+    'halfnorm': 'HalfNormal',
+    'halfgennorm': 'HalfGeneralizedNormal',
+    'hypsecant': 'HyperbolicSecant',
+    'invgamma': 'InverseGammma',
+    'invgauss': 'InverseGaussian',
+    'invweibull': 'InverseWeibull',
+    'irwinhall': 'IrwinHall',
+    'jf_skew_t': 'JonesFaddySkewT',
+    'johnsonsb': 'JohnsonSB',
+    'johnsonsu': 'JohnsonSU',
+    'ksone': 'KSOneSided',
+    'kstwo': 'KSTwoSided',
+    'kstwobign': 'KSTwoSidedAsymptotic',
+    'laplace_asymmetric': 'LaplaceAsymmetric',
+    'levy_l': 'LevyLeft',
+    'levy_stable': 'LevyStable',
+    'loggamma': 'ExpGamma',  # really the Exponential Gamma Distribution
+    'loglaplace': 'LogLaplace',
+    'lognorm': 'LogNormal',
+    'loguniform': 'LogUniform',
+    'ncx2': 'NoncentralChiSquared',
+    'nct': 'NoncentralT',
+    'norm': 'Normal',
+    'norminvgauss': 'NormalInverseGaussian',
+    'powerlaw': 'PowerLaw',
+    'powernorm': 'PowerNormal',
+    'rdist': 'R',
+    'rel_breitwigner': 'RelativisticBreitWigner',
+    'recipinvgauss': 'ReciprocalInverseGaussian',
+    'semicircular': 'SemiCircular',
+    'skewcauchy': 'SkewCauchy',
+    'skewnorm': 'SkewNormal',
+    'studentized_range': 'StudentizedRange',
+    't': 'StudentT',
+    'trapezoid': 'Trapezoidal',
+    'triang': 'Triangular',
+    'truncexpon': 'TruncatedExponential',
+    'truncnorm': 'TruncatedNormal',
+    'truncpareto': 'TruncatedPareto',
+    'truncweibull_min': 'TruncatedWeibull',
+    'tukeylambda': 'TukeyLambda',
+    'vonmises_line': 'VonMisesLine',
+    'weibull_min': 'Weibull',
+    'weibull_max': 'ReflectedWeibull',
+    'wrapcauchy': 'WrappedCauchyLine',
+}
+
+
 def make_distribution(dist):
     """Generate a `ContinuousDistribution` from an instance of `rv_continuous`
 
@@ -3496,6 +3572,14 @@ def make_distribution(dist):
         A subclass of `ContinuousDistribution` corresponding with `dist`. The
         initializer requires all shape parameters to be passed as keyword arguments
         (using the same names as the instance of `rv_continuous`).
+
+    Notes
+    -----
+    The documentation of `ContinuousDistribution` is not rendered. See below for
+    an example of how to instantiate the class (i.e. pass all shape parameters of
+    `dist` to the initializer as keyword arguments). Documentation of all methods
+    is identical to that of `scipy.stats.Normal`. Use ``help`` on the returned
+    class or its methods for more information.
 
     Examples
     --------
@@ -3533,10 +3617,16 @@ def make_distribution(dist):
     _x_support = _RealDomain(endpoints=support, inclusive=(True, True))
     _x_param = _RealParameter('x', domain=_x_support, typical=(-1, 1))
 
+    repr_str = _distribution_names.get(dist.name, dist.name.capitalize())
+
     class CustomDistribution(ContinuousDistribution):
         _parameterizations = ([_Parameterization(*parameters)] if parameters
                               else [])
         _variable = _x_param
+
+        def __repr__(self):
+            s = super().__repr__()
+            return s.replace('CustomDistribution', repr_str)
 
     def _support(self, **kwargs):
         a, b = dist._get_support(**kwargs)
@@ -3614,9 +3704,14 @@ def make_distribution(dist):
             CustomDistribution._moment_raw_formula = _moment_raw_formula_1
             CustomDistribution._moment_central_formula = _moment_central_formula
 
-    class_docs = _combine_docs(CustomDistribution, include_examples=False)
-    CustomDistribution.__doc__ = ("The PDF of this distribution "
-                                  f"is defined {class_docs.lstrip()}")
+    support_etc = _combine_docs(CustomDistribution, include_examples=False).lstrip()
+    docs = [
+        f"This class represents `scipy.stats.{dist.name}` as a subclass of "
+        "`ContinuousDistribution`.",
+        f"The `repr`/`str` of instances class instances is `{repr_str}`.",
+        f"The PDF of the distribution is defined {support_etc}"
+    ]
+    CustomDistribution.__doc__ = ("\n".join(docs))
 
     return CustomDistribution
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3483,7 +3483,7 @@ def make_distribution(dist):
     .. note::
 
         `make_distribution` does not work with all instances of `rv_continuous`.
-        Known failures include 'levy_stable' and `vonmises`.
+        Known failures include `levy_stable` and `vonmises`.
 
     Parameters
     ----------
@@ -3513,6 +3513,13 @@ def make_distribution(dist):
     >>> plt.show()
 
     """
+    if dist in {stats.levy_stable, stats.vonmises}:
+        raise NotImplementedError(f"`{dist.name}` is not supported.")
+
+    if not isinstance(dist, stats.rv_continuous):
+        message = f"The argument must be an instance of `rv_continuous`."
+        raise ValueError(message)
+
     parameters = []
     names = []
     support = getattr(dist, '_support', (dist.a, dist.b))

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3572,7 +3572,12 @@ def make_distribution(dist):
                '_entropy': '_entropy_formula',
                '_median': '_median_formula'}
 
+    # These are not desirable overrides for the new infrastructure
+    skip_override = {'norminvgauss': {'_sf', '_isf'}}
+
     for old_method, new_method in methods.items():
+        if dist.name in skip_override and old_method in skip_override[dist.name]:
+            continue
         # If method of old distribution overrides generic implementation...
         method = getattr(dist.__class__, old_method, None)
         super_method = getattr(stats.rv_continuous, old_method, None)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3481,9 +3481,7 @@ def make_distribution(dist):
     .. note::
 
         `make_distribution` does not work with all instances of `rv_continuous`.
-        Known failures include 'genpareto', 'genextreme', 'genhalflogistic',
-        'irwinhall', 'kstwo', 'kappa4', 'levy_stable', 'norminvgauss',
-        'tukeylambda', and `vonmises`.
+        Known failures include 'levy_stable' and `vonmises`.
 
     Parameters
     ----------
@@ -3513,7 +3511,6 @@ def make_distribution(dist):
     >>> plt.show()
 
     """
-    # todo: check genpareto, genextreme, genhalflogistic, kstwo, kappa4, tukeylambda
     parameters = []
     names = []
     support = getattr(dist, '_support', (dist.a, dist.b))
@@ -3531,6 +3528,10 @@ def make_distribution(dist):
         _parameterizations = ([_Parameterization(*parameters)] if parameters
                               else [])
         _variable = _x_param
+
+    def _support(self, **kwargs):
+        a, b = dist._get_support(**kwargs)
+        return np.asarray(a)[()], np.asarray(b)[()]
 
     def _sample_formula(self, _, full_shape=(), *, rng=None, **kwargs):
         return dist._rvs(size=full_shape, random_state=rng, **kwargs)
@@ -3588,6 +3589,9 @@ def make_distribution(dist):
     def _overrides(method_name):
         return (getattr(dist.__class__, method_name, None)
                 is not getattr(stats.rv_continuous, method_name, None))
+
+    if _overrides('_get_support'):
+        CustomDistribution._support = _support
 
     if _overrides('_munp'):
         CustomDistribution._moment_raw_formula = _moment_raw_formula

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1029,12 +1029,11 @@ class TestMakeDistribution:
             'kstwo', 'kappa4', 'tukeylambda',  # complicated support
             'levy_stable',  # private methods seem to require >= 1d args
             'ksone',  # tolerance issues
-            'norminvgauss',  # private methods seem to have broadcasting issues
             'vonmises',  # circular distribution; shouldn't work
             'studentized_range',  # too slow
         }:
             return
-        # if distname != 'irwinhall':
+        # if distname != 'norminvgauss':
         #     pytest.skip()
 
         # skip single test, mostly due to slight disagreement

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1087,6 +1087,19 @@ class TestMakeDistribution:
                             Y.rvs(size=10, random_state=np.random.default_rng(seed)),
                             rtol=rtol)
 
+    def test_input_validation(self):
+        message = '`levy_stable` is not supported.'
+        with pytest.raises(NotImplementedError, match=message):
+            stats.make_distribution(stats.levy_stable)
+
+        message = '`vonmises` is not supported.'
+        with pytest.raises(NotImplementedError, match=message):
+            stats.make_distribution(stats.vonmises)
+
+        message = "The argument must be an instance of `rv_continuous`."
+        with pytest.raises(ValueError, match=message):
+            stats.make_distribution(object())
+
 
 class TestTransforms:
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1035,8 +1035,7 @@ class TestMakeDistribution:
         skip_skewness = {'exponpow', 'ksone'}  # tolerance issue
         skip_kurtosis = {'chi', 'exponpow', 'invgamma',  # tolerance issue
                          'johnsonsb', 'ksone', 'kstwo'}  # tolerance issue
-        skip_logccdf = {'jf_skew_t', # check this out later
-                        'arcsine', 'skewcauchy', 'trapezoid', 'triang'}  # tolerance
+        skip_logccdf = {'arcsine', 'skewcauchy', 'trapezoid', 'triang'}  # tolerance
         skip_raw = {2: {'alpha', 'foldcauchy', 'halfcauchy', 'levy', 'levy_l'},
                     3: {'pareto'},  # stats.pareto is just wrong
                     4: {'invgamma'}}  # tolerance issue

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1018,27 +1018,23 @@ class TestMakeDistribution:
         distname = distdata[0]
 
         slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz', 'halfgennorm',
-                'johnsonsb', 'ksone', 'kstwobign', 'powerlognorm', 'powernorm',
-                'recipinvgauss', 'studentized_range', 'vonmises_line'}
+                'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'powerlognorm',
+                'powernorm', 'recipinvgauss', 'studentized_range', 'vonmises_line'}
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 
         if distname in {  # skip these distributions
-            'genpareto', 'genextreme', 'genhalflogistic',  # complicated support
-            'kstwo', 'kappa4', 'tukeylambda',  # complicated support
             'levy_stable',  # private methods seem to require >= 1d args
             'vonmises',  # circular distribution; shouldn't work
         }:
             return
-        # if distname != 'truncpareto':
-        #     pytest.skip()
 
         # skip single test, mostly due to slight disagreement
-        custom_tolerances = {'ksone': 1e-5}  # discontinuous PDF
+        custom_tolerances = {'ksone': 1e-5, 'kstwo': 1e-5}  # discontinuous PDF
         skip_entropy = {'kstwobign', 'pearson3'}  # tolerance issue
         skip_skewness = {'exponpow', 'ksone'}  # tolerance issue
         skip_kurtosis = {'chi', 'exponpow', 'invgamma',  # tolerance issue
-                         'johnsonsb', 'ksone'}  # tolerance issue
+                         'johnsonsb', 'ksone', 'kstwo'}  # tolerance issue
         skip_logccdf = {'jf_skew_t', # check this out later
                         'arcsine', 'skewcauchy', 'trapezoid', 'triang'}  # tolerance
         skip_raw = {2: {'alpha', 'foldcauchy', 'halfcauchy', 'levy', 'levy_l'},

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1030,7 +1030,7 @@ class TestMakeDistribution:
             'vonmises',  # circular distribution; shouldn't work
         }:
             return
-        # if distname != 'genpareto':
+        # if distname != 'truncpareto':
         #     pytest.skip()
 
         # skip single test, mostly due to slight disagreement
@@ -1059,6 +1059,7 @@ class TestMakeDistribution:
 
         with np.errstate(divide='ignore', invalid='ignore'):
             m, v, s, k = Y.stats('mvsk')
+            assert_allclose(X.support(), Y.support())
             if distname not in skip_entropy:
                 assert_allclose(X.entropy(), Y.entropy(), rtol=rtol)
             assert_allclose(X.median(), Y.median(), rtol=rtol)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1100,6 +1100,19 @@ class TestMakeDistribution:
         with pytest.raises(ValueError, match=message):
             stats.make_distribution(object())
 
+    def test_repr_str_docs(self):
+        from scipy.stats._distribution_infrastructure import _distribution_names
+        for dist in _distribution_names.keys():
+            assert hasattr(stats, dist)
+
+        dist = stats.make_distribution(stats.gamma)
+        assert str(dist(a=2)) == "Gamma(a=2.0)"
+        assert 'Gamma' in dist.__doc__
+
+        dist = stats.make_distribution(stats.halfgennorm)
+        assert str(dist(beta=2)) == "HalfGeneralizedNormal(beta=2.0)"
+        assert 'HalfGeneralizedNormal' in dist.__doc__
+
 
 class TestTransforms:
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1027,14 +1027,15 @@ class TestMakeDistribution:
         if distname in {  # skip these distributions
             'genpareto', 'genextreme', 'genhalflogistic',  # complicated support
             'kstwo', 'kappa4', 'tukeylambda',  # complicated support
-            'levy_stable',  # levy_stable does things differently...
+            'levy_stable',  # private methods seem to require >= 1d args
             'ksone',  # tolerance issues
             'norminvgauss',  # private methods seem to have broadcasting issues
             'vonmises',  # circular distribution; shouldn't work
-            'irwinhall',  # requires dtype of shape parameter to be integer
             'studentized_range',  # too slow
         }:
             return
+        # if distname != 'irwinhall':
+        #     pytest.skip()
 
         # skip single test, mostly due to slight disagreement
         skip_entropy = {'kstwobign', 'pearson3'}  # tolerance issue


### PR DESCRIPTION
#### Reference issue
gh-21707

#### What does this implement/fix?
When adding `stats.make_distribution`, there were 10 old distributions that didn't seem to play nicely with the new infrastructure, and a few more that we omitted from the tests for one reason or another. This makes the little adjustments needed for `make_distribution` to support all but two distributions:
- `levy_stable` because it isn't obvious what the problem is
- `vonmises` because neither the old nor new infrastructure support circular distributions (yet)

