### PR TITLE
BUG: Perform ``Py_DECREF`` on ``obj`` to avoid memory leak

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -53,11 +53,8 @@ static SuperLUGlobalObject *get_tls_global(void)
     PyDict_SetItemString(thread_dict, key, (PyObject *)obj);
 
     /*
-        Decrease reference count of obj because thread_dict
-        already holds one reference
-        (due to PyDict_SetItemString operation in the line above)
-        and the caller of get_tls_global doesn't steal reference to obj.
-        This helps in avoiding in memory leak due to dangling reference of obj.
+        Py_DECREF is added because get_tls_global returns
+        borrowed reference. This avoids memory leak of obj.
     */
     Py_DECREF(obj);
     return obj;

--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -52,6 +52,14 @@ static SuperLUGlobalObject *get_tls_global(void)
 
     PyDict_SetItemString(thread_dict, key, (PyObject *)obj);
 
+    /*
+        Decrease reference count of obj because thread_dict
+        already holds one reference
+        (due to PyDict_SetItemString operation in the line above)
+        and the caller of get_tls_global doesn't steal reference to obj.
+        This helps in avoiding in memory leak due to dangling reference of obj.
+    */
+    Py_DECREF(obj);
     return obj;
 #endif
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/16232

#### What does this implement/fix?
<!--Please explain your changes.-->

See, https://github.com/scipy/scipy/issues/16232#issuecomment-2527900151. Can't quote the whole comment (a little bit tricky).

I have performed `Py_DECREF` on `obj`. Tests seem to pass on my fork - https://github.com/czgdp1807/scipy/pull/11. Also regarding tests, `get_tls_global` is internal function so can't figure out Python tests. The maximum I could figure out is an assert check [`assert( Py_REFCNT((PyObject*) obj) == 1 );`](https://github.com/czgdp1807/scipy/pull/11/commits/c281cc77e0e29fe3ec2fc6aeba8a5829f07fee37). I can add it to my PR if folks agree on it.

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers @Snape3058
