### PR TITLE
ENH: sparse: make two sputils public for easier index array casting

### DIFF
--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -464,7 +464,7 @@ and for ``safely_cast_index_arrays``::
 
    .. code-block:: python
 
-       # rescast after construction, raising exception before overflow
+       # rescast after construction, raising exception if shape too big
        indices, indptr = scipy.sparse.safely_cast_index_arrays(B, np.int32)
        B.indices, B.indptr = indices, indptr
 

--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -449,19 +449,23 @@ The function signatures are::
     def get_index_dtype(arrays=(), maxval=None, check_contents=False):
     def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
 
-Example idioms include the following::
+Example idioms include the following for ``get_index_dtype``::
 
    .. code-block:: python
 
        # select index dtype before construction based on shape
        shape = (3, 3)
-       idx_dtype = scipy.sparse._sputils.get_index_dtype(maxval=max(shape))
+       idx_dtype = scipy.sparse.get_index_dtype(maxval=max(shape))
        indices = np.array([0, 1, 0], dtype=idx_dtype)
        indptr = np.arange(3, dtype=idx_dtype)
        A = csr_array((data, indices, indptr), shape=shape)
 
+and for ``safely_cast_index_arrays``::
+
+   .. code-block:: python
+
        # rescast after construction, raising exception before overflow
-       indices, indptr = scipy.sparse._sputils.safely_cast_index_arrays(B, np.int32)
+       indices, indptr = scipy.sparse.safely_cast_index_arrays(B, np.int32)
        B.indices, B.indptr = indices, indptr
 
 Other

--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -194,8 +194,8 @@ and support several Array API compatible array libraries in addition to NumPy
   incompatible data types, such as ``float16``.
 - ``min``, ``max``, ``argmin``, and ``argmax`` now support computation
   over nonzero elements only via the new ``explicit`` argument.
-- New function ``safely_cast_index_arrays`` has been added
-  to facilitate casting challenges in ``sparse``.
+- New functions ``get_index_dtype`` and ``safely_cast_index_arrays`` are
+  available to facilitate index array casting in ``sparse``.
 
 
 `scipy.spatial` improvements

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -102,6 +102,8 @@ Sparse tools
    save_npz - Save a sparse array to a file using ``.npz`` format.
    load_npz - Load a sparse array from a file using ``.npz`` format.
    find - Return the indices and values of the nonzero elements
+   get_index_dtype - determine a good dtype for index arrays.
+   safely_cast_index_arrays - cast index array dtype or raise if shape too big
 
 Identifying sparse arrays
 -------------------------
@@ -307,6 +309,7 @@ from ._construct import *
 from ._extract import *
 from ._matrix import spmatrix
 from ._matrix_io import *
+from ._sputils import get_index_dtype, safely_cast_index_arrays
 
 # For backward compatibility with v0.19.
 from . import csgraph

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -198,15 +198,15 @@ def safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
     Examples
     --------
     >>> import numpy as np
-    >>> import scipy as sp
+    >>> from scipy import sparse
     >>> data = [3]
     >>> coords = (np.array([3]), np.array([1]))  # Note: int64 arrays
-    >>> A = sp.sparse.coo_array((data, coords))
+    >>> A = sparse.coo_array((data, coords))
     >>> A.coords[0].dtype
     dtype('int64')
 
     >>> # rescast after construction, raising exception if shape too big
-    >>> coords = sp.sparse.safely_cast_index_arrays(A, np.int32)
+    >>> coords = sparse.safely_cast_index_arrays(A, np.int32)
     >>> A.coords[0] is coords[0]  # False if casting is needed
     False
     >>> A.coords = coords  # set the index dtype of A
@@ -284,20 +284,20 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
     Examples
     --------
     >>> import numpy as np
-    >>> import scipy as sp
+    >>> from scipy import sparse
     >>> # select index dtype based on shape
     >>> shape = (3, 3)
-    >>> idx_dtype = sp.sparse.get_index_dtype(maxval=max(shape))
+    >>> idx_dtype = sparse.get_index_dtype(maxval=max(shape))
     >>> data = [1.1, 3.0, 1.5]
     >>> indices = np.array([0, 1, 0], dtype=idx_dtype)
     >>> indptr = np.array([0, 2, 3, 3], dtype=idx_dtype)
-    >>> A = sp.sparse.csr_array((data, indices, indptr), shape=shape)
+    >>> A = sparse.csr_array((data, indices, indptr), shape=shape)
     >>> A.indptr.dtype
     dtype('int32')
 
     >>> # select based on larger of existing arrays and shape
     >>> shape = (3, 3)
-    >>> idx_dtype = sp.sparse.get_index_dtype(A.indptr, maxval=max(shape))
+    >>> idx_dtype = sparse.get_index_dtype(A.indptr, maxval=max(shape))
     >>> idx_dtype
     <class 'numpy.int32'>
     """


### PR DESCRIPTION
Make `get_index_dtype` and `safely_cast_index_arrays` public functions in the `scipy.sparse` namespace.

These functions are useful for (re-)setting the dtype of the index arrays in sparse formats BSR, COO, CSC, CSR, and DIA. They are more important than previously because of the migration from `spmatrix` to `sparray`, and the related change to remove automatic value-based dtype selection for index arrays in the array constructors.  

The functions are used in example code in the Migration Guide from spmatrix to sparray.  Other sputils functions are referred to in the guide as part of suggestions for testing during the migration. But only for local and temporary testing to identify features for migration -- not as suggestions for new code to enact the migration. Those sputils are not intended to become public.

This PR includes suggested wording changes to the release notes for v1.15 and I've added a label for `backport-candidate`. The release note wording is a separate commit if someone needs to remove/change it. 