### PR TITLE
TST: optimize: fix CuPy failure for `bracket_minimum`

### DIFF
--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -471,10 +471,10 @@ class TestBracketMinimum:
             funcs = [lambda x: (x - 1.5)**2,
                      lambda x: x,
                      lambda x: x,
-                     lambda x: xp.nan,
+                     lambda x: xp.asarray(xp.nan),
                      lambda x: x**2]
 
-            return [funcs[j](x) for x, j in zip(xs, js)]
+            return [funcs[int(j)](x) for x, j in zip(xs, js)]
 
         args = (xp.arange(5, dtype=xp.int64),)
         xl0 = xp.asarray([-1.0, -1.0, -1.0, -1.0, 6.0])


### PR DESCRIPTION
#### Reference issue
Closes gh-22044

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
