### PR TITLE
ENH: BLD: allow building OpenBLAS from source in a SciPy wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ pip-wheel-metadata
 installdir/
 build-install/
 .mesonpy/
+subprojects/wrapdb.json
 
 # doit
 ######
@@ -322,3 +323,5 @@ scipy/optimize/_group_columns.c
 scipy/optimize/cython_optimize/_zeros.c
 scipy/optimize/cython_optimize/_zeros.pyx
 scipy/optimize/lbfgsb/_lbfgsbmodule.c
+
+subprojects/OpenBLAS-0.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ tracker = "https://github.com/scipy/scipy/issues"
 dodoFile = "dev.py"
 
 [tool.meson-python.args]
-install = ['--skip-subprojects']
+install = ['--skip-subprojects=highs']
 
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -271,7 +271,37 @@ endif
 # pkg-config uses a lower-case name while CMake uses a capitalized name, so try
 # that too to make the fallback detection with CMake work
 if blas_name == 'openblas'
-  blas = dependency(['openblas', 'OpenBLAS'])
+  # Use `required: false` only to improve the error message
+  blas = dependency(['openblas', 'OpenBLAS'], required: false)
+  if not blas.found()
+    _msg_blasnotfound = '''OpenBLAS not found.
+
+SciPy needs a BLAS library. By default it looks for OpenBLAS, you can
+customize this, see http://scipy.github.io/devdocs/building/ for how.
+Please ensure you have a BLAS library installed (use your system package
+manager for this) and try again.
+'''
+
+    # This is what is tested in CI now, so let's start here.
+    if host_machine.cpu_family() in ['x86_64', 'arm64'] and host_machine.system() in ['linux', 'darwin']
+      _msg_blasnotfound += '''
+Alternatively, you can ask to build OpenBLAS itself as part of the SciPy
+build, so you don't have to install an external one, with:
+
+    # `uv` or other installers will work too, the `-Csetup-args=...` part
+    # is what matters here:
+    pip install scipy -Csetup-args=-Dblas=openblas-src
+'''
+    endif
+    error(_msg_blasnotfound)
+  endif
+elif blas_name == 'openblas-src'
+  openblas_subproj = subproject('openblas',
+      default_options: {
+        'build_without_lapack': true,
+        'netlib_lapack_name': 'scipy_lapack',
+      })
+  blas = openblas_subproj.get_variable('openblas_dep')
 elif blas_name != 'scipy-openblas'  # if so, we found it already
   blas = dependency(blas_name)
 endif
@@ -290,10 +320,12 @@ else
   cblas = []
 endif
 
-if 'mkl' in blas.name() or blas.name().to_lower() == 'accelerate' or blas_name == 'scipy-openblas'
+if 'mkl' in blas.name() or blas.name().to_lower() == 'accelerate' or blas_name in ['scipy-openblas', 'openblas-src']
   # For these libraries we know that they contain LAPACK, and it's desirable to
   # use that - no need to run the full detection twice.
   lapack = blas
+elif blas_name == 'openblas-src'
+  lapack = openblas_subproj.get_variable('netlib_lapack_dep')
 elif lapack_name == 'openblas'
   lapack = dependency(['openblas', 'OpenBLAS'])
 else

--- a/subprojects/openblas.wrap
+++ b/subprojects/openblas.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = OpenBLAS-0.3.28
+source_url = https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.28/OpenBLAS-0.3.28.tar.gz
+source_filename = OpenBLAS-0.3.28.tar.gz
+source_hash = f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
+patch_filename = openblas_0.3.28-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openblas_0.3.28-2/get_patch
+patch_hash = 0dae8341551cba0e985dd13ec58a5ee6cbdafd6b69004317f13c880bd8d290af
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/openblas_0.3.28-2/OpenBLAS-0.3.28.tar.gz
+wrapdb_version = 0.3.28-2
+
+[provide]
+openblas = openblas_dep


### PR DESCRIPTION
#### Reference issue

Closes gh-21396

#### What does this implement/fix?

Implements the feature suggested in gh-21396. See https://github.com/scipy/scipy/issues/21396#issuecomment-2508881099 for a detailed rationale.

Improves the error message for the all-too-common _" ERROR: Dependency "openblas" not found"_ end to an build attempt. There are [72 issues](https://github.com/scipy/scipy/issues?q=is%3Aissue+%22OpenBLAS+not+found%22+is%3Aclosed) with that message currently, with gh-16308 the most high-traffic recent one.

#### Additional information

Passes all tests for me on Linux x86-64 and macOS arm64.

Requires a fix for [meson-python#711](https://github.com/mesonbuild/meson-python/issues/711) still and that fix being released in a new `meson-python` version. Until that is done, the problem can be worked around for testing purposes with: `LD_LIBRARY_PATH=/path/to/site-packages/scipy/special`. 

Opening the PR as draft now to support the discussion in gh-21396. It's ~20 lines of code, and that's as concise as it should stay (unless we want to add a CI job here rather than in a separate repo - but happy to keep it separate for now). All the complexity to support this is part of other repos.

Also, the `highs` subproject hasn't given us any problems so far, which is nice. `openblas` will be the second subproject; more may follow after (xref gh-17751).