### PR TITLE
TST: integrate.tanhsinh: fix abscissae/weight "compression" bug

### DIFF
--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -134,7 +134,10 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
     ----------
     work : _RichResult
         All variables that need to be retained between iterations. Must
-        contain attributes `nit`, `nfev`, and `success`
+        contain attributes `nit`, `nfev`, and `success`. All arrays are
+        subject to being "compressed" if `preserve_shape is False`; nest
+        arrays that should not be compressed inside another object (e.g.
+        `dict` or `_RichResult`).
     callback : callable
         User-specified callback function
     shape : tuple of ints
@@ -175,6 +178,9 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
         copied to the appropriate indices of `res` when appropriate. The order
         determines the order in which _RichResult attributes will be
         pretty-printed.
+    preserve_shape : bool, default: False
+        Whether to compress the attributes of `work` (to avoid unnecessary
+        computation on elements that have already converged).
 
     Returns
     -------

--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -426,6 +426,8 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
                        atol=atol, rtol=rtol, nit=nit, nfev=nfev,
                        status=status, dtype=dtype, terms=(order+1)//2,
                        hdir=hdir, il=il, ic=ic, ir=ir, io=io,
+                       # Store the weights in an object so they can't get compressed
+                       # Using RichResult to allow dot notation, but a dict would work
                        diff_state=_RichResult(central=[], right=[], fac=None))
 
     # This is the correspondence between terms in the `work` object and the

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -382,7 +382,9 @@ def tanhsinh(f, a, b, *, args=(), log=False, maxlevel=None, minlevel=2,
         n=minlevel, nit=nit, nfev=nfev, status=status,  # iter/eval counts
         xr0=xr0, fr0=fr0, wr0=wr0, xl0=xl0, fl0=fl0, wl0=wl0, d4=d4,  # err est
         ainf=ainf, binf=binf, abinf=abinf, a0=xp.reshape(a0, (-1, 1)),  # transforms
-        pc_xjc=None, pc_wj=None, pc_indices=[0], pc_h0=None)  # pair cache
+        # Store the weights in an object so they can't get compressed
+        # Using RichResult to allow dot notation, but a dict would work
+        pair_cache=_RichResult(xjc=None, wj=None, indices=[0], h0=None))  # pair cache
 
     # Constant scalars don't need to be put in `work` unless they need to be
     # passed outside `tanhsinh`. Examples: atol, rtol, h0, minlevel.
@@ -559,36 +561,36 @@ def _pair_cache(k, h0, xp, work):
     # Abscissae and weights of consecutive levels are concatenated.
     # `index` records the indices that correspond with each level:
     # `xjc[index[k]:index[k+1]` extracts the level `k` abscissae.
-    if not isinstance(h0, type(work.pc_h0)) or h0 != work.pc_h0:
-        work.pc_xjc = xp.empty(0)
-        work.pc_wj = xp.empty(0)
-        work.pc_indices = [0]
+    if not isinstance(h0, type(work.pair_cache.h0)) or h0 != work.pair_cache.h0:
+        work.pair_cache.xjc = xp.empty(0)
+        work.pair_cache.wj = xp.empty(0)
+        work.pair_cache.indices = [0]
 
-    xjcs = [work.pc_xjc]
-    wjs = [work.pc_wj]
+    xjcs = [work.pair_cache.xjc]
+    wjs = [work.pair_cache.wj]
 
-    for i in range(len(work.pc_indices)-1, k + 1):
+    for i in range(len(work.pair_cache.indices)-1, k + 1):
         xjc, wj = _compute_pair(i, h0, xp)
         xjcs.append(xjc)
         wjs.append(wj)
-        work.pc_indices.append(work.pc_indices[-1] + xjc.shape[0])
+        work.pair_cache.indices.append(work.pair_cache.indices[-1] + xjc.shape[0])
 
-    work.pc_xjc = xp.concat(xjcs)
-    work.pc_wj = xp.concat(wjs)
-    work.pc_h0 = h0
+    work.pair_cache.xjc = xp.concat(xjcs)
+    work.pair_cache.wj = xp.concat(wjs)
+    work.pair_cache.h0 = h0
 
 
 def _get_pairs(k, h0, inclusive, dtype, xp, work):
     # Retrieve the specified abscissa-weight pairs from the cache
     # If `inclusive`, return all up to and including the specified level
-    if (len(work.pc_indices) <= k+2
-        or not isinstance (h0, type(work.pc_h0))
-        or h0 != work.pc_h0):
+    if (len(work.pair_cache.indices) <= k+2
+        or not isinstance (h0, type(work.pair_cache.h0))
+        or h0 != work.pair_cache.h0):
             _pair_cache(k, h0, xp, work)
 
-    xjc = work.pc_xjc
-    wj = work.pc_wj
-    indices = work.pc_indices
+    xjc = work.pair_cache.xjc
+    wj = work.pair_cache.wj
+    indices = work.pair_cache.indices
 
     start = 0 if inclusive else indices[k]
     end = indices[k+1]
@@ -715,7 +717,7 @@ def _estimate_error(work, xp):
         nan = xp.full_like(work.Sn, xp.nan)
         return nan, nan
 
-    indices = work.pc_indices
+    indices = work.pair_cache.indices
 
     n_active = work.Sn.shape[0]  # number of active elements
     axis_kwargs = dict(axis=-1, keepdims=True)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -743,6 +743,16 @@ class TestTanhSinh:
         for attr in attrs:
             assert res[attr].shape == shape
 
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_compress_nodes_weights_gh21496(self, xp):
+        # See discussion in:
+        # https://github.com/scipy/scipy/pull/21496#discussion_r1878681049
+        # This would cause "ValueError: attempt to get argmax of an empty sequence"
+        # Check that this has been resolved.
+        x = np.full(65, 3)
+        x[-1] = 1000
+        _tanhsinh(np.sin, 1, x)
+
 
 @array_api_compatible
 @pytest.mark.usefixtures("skip_xp_backends")


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/21496#discussion_r1878681049

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/21496#discussion_r1878681049 describes a bug in which the abscissae/weight pairs of `tanhsinh` get "compressed" along with other elements of the `work` object. 

The first commit attempts to provide a MWE as a unit test (so tests should fail). The second commit will fix the bug by nesting the abscissae/weight pair in another object so they do not get compressed with other arrays. It will also improve the `_elementwise_iterative_method` documentation to highlight this behavior of the `work` object.

#### Additional information
As the code already notes, we could improve the way the code detects whether arrays should be compressed, but that can wait until after release; this can't.
