### PR TITLE
MAINT: transition from `np.asarray` to `from_dlpack`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -129,21 +129,26 @@ def xp_asarray(
         # it will not respect copy=False.
         array = np.array(array, order=order, dtype=dtype, copy=copy, subok=True)
     elif is_numpy(xp):
-        # Convert to NumPy array. Raise if copy is necessary and copy=False;
-        # otherwise, don't copy yet.
-        array = np_compat.from_dlpack(array, copy=None if copy is True else copy)
-        # Now apply all the options
-        array = np_compat.asarray(array, order=order, dtype=dtype, copy=copy)
-    else:
-        # data-apis/array-api-compat#204
         try:
+            array = np_compat.asarray(array, order=order, dtype=dtype, copy=copy)
+        except:
+            # Convert to NumPy array. Raise if copy is necessary and copy=False;
+            # otherwise, don't copy yet.
+            array = np_compat.from_dlpack(array, copy=None if copy is True else copy)
+            # Now apply all the options
+            array = np_compat.asarray(array, order=order, dtype=dtype, copy=copy)
+    else:
+        try:
+            array = xp.asarray(array, dtype=dtype, copy=copy)
+        # data-apis/array-api-compat#204
+        except:
             array = xp.from_dlpack(array) # data-apis/array-api-compat#204
             # xp.from_dlpack(array, copy=None if copy is True else copy)
             array = xp.asarray(array, dtype=dtype, copy=copy)
-        except TypeError:
-            xp = array_namespace(xp.empty(0))
-            array = xp.from_dlpack(array, copy=None if copy is True else copy)
-            array = xp.asarray(array, dtype=dtype, copy=copy)
+        # except TypeError:
+        #     xp = array_namespace(xp.empty(0))
+        #     array = xp.from_dlpack(array, copy=None if copy is True else copy)
+        #     array = xp.asarray(array, dtype=dtype, copy=copy)
 
     if check_finite:
         _check_finite(array, xp)

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -110,6 +110,86 @@ def _asarray(
     return array
 
 
+def _resolve_device(array, xp_out, device=None):
+    if device is not None:
+        return device
+
+    xp_in = array_namespace(array)
+
+    # Here is what the logic is intended to be
+    # if is_numpy(xp_out) or is_array_api_strict(xp_out) or is_cupy(xp_out):
+    #     # These libraries only support one type of device
+    #     return xp_out.__array_namespace_info__().default_device()
+    # else:
+    #     return xp_in.device(array)
+
+    # but there are many issues with device support right now. For example:
+    # - NumPy `from_dlpack` only understands device='cpu' (not a device object)
+    # - CuPy `from_dlpack` doesn't work
+    # - the format of the return of `device` seems different in different libraries
+
+    # So in the meantime:
+    if is_numpy(xp_out):
+        return "cpu"
+    elif is_array_api_strict(xp_out):
+        return xp_out.__array_namespace_info__().default_device()
+    else:
+        return None
+
+
+def xp_asarray(
+        array: ArrayLike,
+        dtype: Any = None,
+        order: Literal['K', 'A', 'C', 'F'] | None = None,
+        copy: bool | None = None,
+        *,
+        xp: ModuleType | None = None,
+        check_finite: bool = False,
+        subok: bool = False,
+    ) -> Array:
+    """SciPy-specific replacement for `xp.asarray` with `order`, `check_finite`,
+    `subok`, and automatic array type conversion and device transfer.
+    Memory layout parameter `order` is not exposed in the Array API standard.
+    `order` is only enforced if the input array implementation
+    is NumPy based, otherwise `order` is just silently ignored.
+    `check_finite` is also not a keyword in the array API standard; included
+    here for convenience rather than that having to be a separate function
+    call inside SciPy functions.
+    `subok` is included to allow this function to preserve the behaviour of
+    `np.asanyarray` for NumPy based inputs.
+    """
+    xp_in = array_namespace(array)
+    if xp is None:
+        xp = xp_in
+
+    if is_numpy(xp_in):
+        # If object is array-like (but not array), make it an ndarray; otherwise, no-op.
+        array = np.asanyarray(array)
+
+    if is_numpy(xp_in) and not array.__class__.__name__.endswith('ndarray') and subok:
+        # If it's a (strict) subclass of ndarray and we must preserve the subclass...
+        if not is_numpy(xp):
+            message = f"Array library {xp} cannot respect `subok=True`."
+            raise TypeError(message)
+        # This will do the right thing for NumPy 2.0+; for earlier versions of NumPy,
+        # it will not respect copy=False.
+        array = np.array(array, order=order, dtype=dtype, copy=copy, subok=True)
+    elif is_numpy(xp):
+        # Convert to NumPy array. Raise if copy is necessary and copy=False;
+        # otherwise, don't copy yet.
+        array = np_compat.from_dlpack(array, copy=None if copy is True else copy)
+        # Now apply all the options
+        array = np_compat.asarray(array, order=order, dtype=dtype, copy=copy)
+    else:
+        array = xp.from_dlpack(array, copy=None if copy is True else copy)
+        array = xp.asarray(array, dtype=dtype, copy=copy)
+
+    if check_finite:
+        _check_finite(array, xp)
+
+    return array
+
+
 def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array:
     """
     Copies an array.
@@ -244,7 +324,9 @@ def xp_assert_equal(actual, desired, *, check_namespace=True, check_dtype=True,
         err_msg = None if err_msg == '' else err_msg
         return xp.testing.assert_close(actual, desired, rtol=0, atol=0, equal_nan=True,
                                        check_dtype=False, msg=err_msg)
-    # JAX uses `np.testing`
+    # JAX uses `np.testing` natively; array-api-strict must be converted
+    actual = xp_asarray(actual, xp=np) if is_array_api_strict(xp) else actual
+    desired = xp_asarray(desired, xp=np) if is_array_api_strict(xp) else desired
     return np.testing.assert_array_equal(actual, desired, err_msg=err_msg)
 
 
@@ -275,7 +357,9 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
         err_msg = None if err_msg == '' else err_msg
         return xp.testing.assert_close(actual, desired, rtol=rtol, atol=atol,
                                        equal_nan=True, check_dtype=False, msg=err_msg)
-    # JAX uses `np.testing`
+    # JAX uses `np.testing` natively; array-api-strict must be converted
+    actual = xp_asarray(actual, xp=np) if is_array_api_strict(xp) else actual
+    desired = xp_asarray(desired, xp=np) if is_array_api_strict(xp) else desired
     return np.testing.assert_allclose(actual, desired, rtol=rtol,
                                       atol=atol, err_msg=err_msg)
 
@@ -298,7 +382,9 @@ def xp_assert_less(actual, desired, *, check_namespace=True, check_dtype=True,
             actual = actual.cpu()
         if desired.device.type != 'cpu':
             desired = desired.cpu()
-    # JAX uses `np.testing`
+    # JAX uses `np.testing` natively; array-api-strict must be converted
+    actual = xp_asarray(actual, xp=np) if is_array_api_strict(xp) else actual
+    desired = xp_asarray(desired, xp=np) if is_array_api_strict(xp) else desired
     return np.testing.assert_array_less(actual, desired,
                                         err_msg=err_msg, verbose=verbose)
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -166,7 +166,7 @@ def xp_asarray(
         # If object is array-like (but not array), make it an ndarray; otherwise, no-op.
         array = np.asanyarray(array)
 
-    if is_numpy(xp_in) and not array.__class__.__name__.endswith('ndarray') and subok:
+    if is_numpy(xp_in) and type(array) is not np.ndarray and subok:
         # If it's a (strict) subclass of ndarray and we must preserve the subclass...
         if not is_numpy(xp):
             message = f"Array library {xp} cannot respect `subok=True`."
@@ -181,7 +181,10 @@ def xp_asarray(
         # Now apply all the options
         array = np_compat.asarray(array, order=order, dtype=dtype, copy=copy)
     else:
-        array = xp.from_dlpack(array, copy=None if copy is True else copy)
+        if is_torch(xp):  # data-apis/array-api-compat#204
+            array = xp.from_dlpack(array)
+        else:
+            array = xp.from_dlpack(array, copy=None if copy is True else copy)
         array = xp.asarray(array, dtype=dtype, copy=copy)
 
     if check_finite:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -41,7 +41,7 @@ from scipy._lib._array_api_override import (
 from scipy._lib._docscrape import FunctionDoc
 
 __all__ = [
-    '_asarray', 'array_namespace', 'assert_almost_equal', 'assert_array_almost_equal',
+    'xp_asarray', 'array_namespace', 'assert_almost_equal', 'assert_array_almost_equal',
     'default_xp', 'eager_warns', 'is_lazy_array', 'is_marray',
     'is_array_api_strict', 'is_complex', 'is_cupy', 'is_jax', 'is_numpy', 'is_torch',
     'np_compat',
@@ -63,7 +63,7 @@ def _check_finite(array: Array, xp: ModuleType) -> None:
         msg = "array must not contain infs or NaNs"
         raise ValueError(msg)
 
-def _asarray(
+def xp_asarray(
         array: ArrayLike,
         dtype: Any = None,
         order: Literal['K', 'A', 'C', 'F'] | None = None,
@@ -214,11 +214,11 @@ def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array:
     `subok` and `order` keywords are not used.
     """
     # Note: for older NumPy versions, `np.asarray` did not support the `copy` kwarg,
-    # so this uses our other helper `_asarray`.
+    # so this uses our other helper `xp_asarray`.
     if xp is None:
         xp = array_namespace(x)
 
-    return _asarray(x, copy=True, xp=xp)
+    return xp_asarray(x, copy=True, xp=xp)
 
 
 _default_xp_ctxvar: ContextVar[ModuleType] = ContextVar("_default_xp")
@@ -505,7 +505,7 @@ def xp_result_type(*args, force_floating=False, xp):
     Typically, this function will be called shortly after `array_namespace`
     on a subset of the arguments passed to `array_namespace`.
     """
-    args = [(_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
+    args = [(xp_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
             for arg in args]
     args_not_none = [arg for arg in args if arg is not None]
     if force_floating:
@@ -553,12 +553,13 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     --------
     xp_result_type
     """
-    args = [(_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
+    args = [(xp_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
             for arg in args]  # solely to prevent double conversion of iterable to array
 
     dtype = xp_result_type(*args, force_floating=force_floating, xp=xp)
 
-    args = [(_asarray(arg, dtype=dtype, subok=True, xp=xp) if arg is not None else arg)
+    args = [(xp_asarray(arg, dtype=dtype, subok=True, xp=xp)
+             if arg is not None else arg)
             for arg in args]
 
     if not broadcast:

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from scipy._lib._array_api import (
-    SCIPY_ARRAY_API, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
+    SCIPY_ARRAY_API, array_namespace, xp_asarray, xp_copy, xp_assert_equal, is_numpy,
     np_compat, xp_default_dtype, xp_result_type, is_torch
 )
 from scipy._lib import array_api_extra as xpx
@@ -12,7 +12,7 @@ from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
 from scipy._lib.array_api_extra.testing import lazy_xp_function
 
 
-lazy_xp_function(_asarray)
+lazy_xp_function(xp_asarray)
 lazy_xp_function(xp_copy)
 
 
@@ -26,7 +26,7 @@ class TestArrayAPI:
         assert 'array_api_compat.numpy' in xp.__name__
 
     def test_asarray(self, xp):
-        x, y = _asarray([0, 1, 2], xp=xp), _asarray(np.arange(3), xp=xp)
+        x, y = xp_asarray([0, 1, 2], xp=xp), xp_asarray(np.arange(3), xp=xp)
         ref = xp.asarray([0, 1, 2])
         xp_assert_equal(x, ref)
         xp_assert_equal(y, ref)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2790,7 +2790,7 @@ def fclusterdata(X, t, criterion='inconsistent',
 
     """
     xp = array_namespace(X)
-    X = xp_asarray(X, order='C', dtype=np.float64, xp=np)
+    X = xp_asarray(X, order='C', dtype=xp.float64, xp=xp)
 
     if X.ndim != 2:
         raise TypeError('The observation matrix X must be an n by m array.')

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -134,7 +134,7 @@ from collections import deque
 import numpy as np
 from . import _hierarchy, _optimal_leaf_ordering
 import scipy.spatial.distance as distance
-from scipy._lib._array_api import (_asarray, array_namespace, is_dask,
+from scipy._lib._array_api import (xp_asarray, array_namespace, is_dask,
                                    is_lazy_array, xp_capabilities, xp_copy)
 from scipy._lib._disjoint_set import DisjointSet
 import scipy._lib.array_api_extra as xpx
@@ -1018,7 +1018,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     >>> plt.show()
     """
     xp = array_namespace(y)
-    y = _asarray(y, order='C', dtype=xp.float64, xp=xp)
+    y = xp_asarray(y, order='C', dtype=xp.float64, xp=xp)
     lazy = is_lazy_array(y)
 
     if method not in _LINKAGE_METHODS:
@@ -1454,7 +1454,7 @@ def to_tree(Z, rd=False):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', xp=xp)
+    Z = xp_asarray(Z, order='C', xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', materialize=True, xp=xp)
 
     # Number of original objects is equal to the number of rows plus 1.
@@ -1537,8 +1537,8 @@ def optimal_leaf_ordering(Z, y, metric='euclidean'):
 
     """
     xp = array_namespace(Z, y)
-    Z = _asarray(Z, order='C', xp=xp)
-    y = _asarray(y, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', xp=xp)
+    y = xp_asarray(y, order='C', dtype=xp.float64, xp=xp)
     lazy = is_lazy_array(Z)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
@@ -1683,7 +1683,7 @@ def cophenet(Z, Y=None):
     """
     xp = array_namespace(Z, Y)
     # Ensure float64 C-contiguous array. Cython code doesn't deal with striding.
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     def cy_cophenet(Z, validate):
@@ -1774,7 +1774,7 @@ def inconsistent(Z, d=2):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     if d != np.floor(d) or d < 0:
@@ -1866,7 +1866,7 @@ def from_mlab_linkage(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, dtype=xp.float64, order='C', xp=xp)
+    Z = xp_asarray(Z, dtype=xp.float64, order='C', xp=xp)
 
     # If it's empty, return it.
     if Z.shape in ((), (0, )):
@@ -1985,7 +1985,7 @@ def to_mlab_linkage(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, dtype=xp.float64, xp=xp)
     if Z.shape in ((), (0, )):
         return xp_copy(Z, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
@@ -2073,7 +2073,7 @@ def is_monotonic(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, xp=xp)
+    Z = xp_asarray(Z, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     # We expect the i'th value to be greater than its successor.
@@ -2175,7 +2175,7 @@ def is_valid_im(R, warning=False, throw=False, name=None):
 
     """
     xp = array_namespace(R)
-    R = _asarray(R, xp=xp)
+    R = xp_asarray(R, xp=xp)
     return _is_valid_im(R, warning=warning, throw=throw, name=name,
                         materialize=True, xp=xp)
 
@@ -2311,7 +2311,7 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, xp=xp)
+    Z = xp_asarray(Z, xp=xp)
     return _is_valid_linkage(Z, warning=warning, throw=throw,
                              name=name, materialize=True, xp=xp)
 
@@ -2450,7 +2450,7 @@ def num_obs_linkage(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, xp=xp)
+    Z = xp_asarray(Z, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
     return Z.shape[0] + 1
 
@@ -2506,8 +2506,8 @@ def correspond(Z, Y):
 
     """
     xp = array_namespace(Z, Y)
-    Z = _asarray(Z, xp=xp)
-    Y = _asarray(Y, xp=xp)
+    Z = xp_asarray(Z, xp=xp)
+    Y = xp_asarray(Y, xp=xp)
     _is_valid_linkage(Z, throw=True, xp=xp)
     distance.is_valid_y(Y, throw=True)
     return distance.num_obs_y(Y) == num_obs_linkage(Z)
@@ -2667,7 +2667,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', materialize=True, xp=xp)
 
     n = Z.shape[0] + 1
@@ -2683,7 +2683,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         if R is None:
             R = inconsistent(Z, depth)
         else:
-            R = _asarray(R, order='C', dtype=xp.float64, xp=xp)
+            R = xp_asarray(R, order='C', dtype=xp.float64, xp=xp)
             _is_valid_im(R, throw=True, name='R', materialize=True, xp=xp)
             # Since the C code does not support striding using strides.
             # The dimensions are used instead.
@@ -2800,7 +2800,7 @@ def fclusterdata(X, t, criterion='inconsistent',
     if R is None:
         R = inconsistent(Z, d=depth)
     else:
-        R = _asarray(R, order='C', xp=xp)
+        R = xp_asarray(R, order='C', xp=xp)
     T = fcluster(Z, criterion=criterion, depth=depth, R=R, t=t)
     return T
 
@@ -2855,7 +2855,7 @@ def leaves_list(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', xp=xp)
+    Z = xp_asarray(Z, order='C', xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     def cy_leaves_list(Z, validate):
@@ -3404,7 +3404,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     #         None orders leaf nodes based on the order they appear in the
     #         pre-order traversal.
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', xp=xp)
+    Z = xp_asarray(Z, order='C', xp=xp)
 
     if orientation not in ["top", "left", "bottom", "right"]:
         raise ValueError("orientation must be one of 'top', 'left', "
@@ -3880,8 +3880,8 @@ def is_isomorphic(T1, T2):
 
     """
     xp = array_namespace(T1, T2)
-    T1 = _asarray(T1, xp=xp)
-    T2 = _asarray(T2, xp=xp)
+    T1 = xp_asarray(T1, xp=xp)
+    T2 = xp_asarray(T2, xp=xp)
 
     if T1.ndim != 1:
         raise ValueError('T1 must be one-dimensional.')
@@ -3987,7 +3987,7 @@ def maxdists(Z):
 
     """
     xp = array_namespace(Z)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     def cy_maxdists(Z, validate):
@@ -4079,8 +4079,8 @@ def maxinconsts(Z, R):
 
     """
     xp = array_namespace(Z, R)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
-    R = _asarray(R, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    R = xp_asarray(R, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
     _is_valid_im(R, throw=True, name='R', xp=xp)
 
@@ -4181,8 +4181,8 @@ def maxRstat(Z, R, i):
 
     """
     xp = array_namespace(Z, R)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
-    R = _asarray(R, order='C', dtype=xp.float64, xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    R = xp_asarray(R, order='C', dtype=xp.float64, xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
     _is_valid_im(R, throw=True, name='R', xp=xp)
 
@@ -4321,8 +4321,8 @@ def leaders(Z, T):
     impossible to execute it inside `@jax.jit`.
     """
     xp = array_namespace(Z, T)
-    Z = _asarray(Z, order='C', dtype=xp.float64, xp=xp)
-    T = _asarray(T, order='C', xp=xp)
+    Z = xp_asarray(Z, order='C', dtype=xp.float64, xp=xp)
+    T = xp_asarray(T, order='C', xp=xp)
     _is_valid_linkage(Z, throw=True, name='Z', xp=xp)
 
     if T.dtype != xp.int32:

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1361,18 +1361,18 @@ def cut_tree(Z, n_clusters=None, height=None):
     elif height is None and n_clusters is None:  # return the full cut tree
         cols_idx = xp.arange(nobs)
     elif height is not None:
-        height = xp.asarray(height)
-        heights = xp.asarray([x.dist for x in nodes])
+        height = xp_asarray(height, xp=xp)
+        heights = xp_asarray([x.dist for x in nodes], xp=xp)
         cols_idx = xp.searchsorted(heights, height)
     else:
-        n_clusters = xp.asarray(n_clusters)
+        n_clusters = xp_asarray(n_clusters, xp=xp)
         cols_idx = nobs - xp.searchsorted(xp.arange(nobs), n_clusters)
 
     try:
         n_cols = len(cols_idx)
     except TypeError:  # scalar
         n_cols = 1
-        cols_idx = xp.asarray([cols_idx])
+        cols_idx = xp_asarray([cols_idx], xp=xp)
 
     groups = xp.zeros((n_cols, nobs), dtype=xp.int64)
     last_group = xp.arange(nobs)
@@ -1702,8 +1702,9 @@ def cophenet(Z, Y=None):
     if Y is None:
         return zz
 
-    Y = _asarray(Y, order='C', xp=xp)
+    Y = xp_asarray(Y, order='C', xp=np)
     distance.is_valid_y(Y, throw=True, name='Y')
+    Y = xp_asarray(Y, xp=xp)
 
     z = xp.mean(zz)
     y = xp.mean(Y)
@@ -2673,10 +2674,11 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
     T = np.zeros((n,), dtype='i')
 
     if monocrit is not None:
-        monocrit = np.asarray(monocrit, order='C', dtype=np.float64)
+        monocrit = xp_asarray(monocrit, order='C', dtype=np.float64, xp=np)
+    else:
+        monocrit = np.asarray(None)
 
-    Z = np.asarray(Z)
-    monocrit = np.asarray(monocrit)
+    Z = xp_asarray(Z, xp=np)
     if criterion == 'inconsistent':
         if R is None:
             R = inconsistent(Z, depth)
@@ -2685,7 +2687,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
             _is_valid_im(R, throw=True, name='R', materialize=True, xp=xp)
             # Since the C code does not support striding using strides.
             # The dimensions are used instead.
-            R = np.asarray(R)
+            R = xp_asarray(R, xp=np)
         _hierarchy.cluster_in(Z, R, T, float(t), int(n))
     elif criterion == 'distance':
         _hierarchy.cluster_dist(Z, T, float(t), int(n))
@@ -2697,7 +2699,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         _hierarchy.cluster_maxclust_monocrit(Z, monocrit, T, int(n), int(t))
     else:
         raise ValueError(f'Invalid cluster formation criterion: {str(criterion)}')
-    return xp.asarray(T)
+    return xp_asarray(T, xp=xp)
 
 
 @xp_capabilities(cpu_only=True, reason="Cython code",
@@ -2788,7 +2790,7 @@ def fclusterdata(X, t, criterion='inconsistent',
 
     """
     xp = array_namespace(X)
-    X = _asarray(X, order='C', dtype=xp.float64, xp=xp)
+    X = xp_asarray(X, order='C', dtype=np.float64, xp=np)
 
     if X.ndim != 2:
         raise TypeError('The observation matrix X must be an n by m array.')

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -320,14 +320,14 @@ class TestFcluster:
     def test_fcluster_maxclust_gh_12651(self, xp):
         y = xp.asarray([[1], [4], [5]])
         Z = single(y)
-        assert_array_equal(fcluster(Z, t=1, criterion="maxclust"),
-                           xp.asarray([1, 1, 1]))
-        assert_array_equal(fcluster(Z, t=2, criterion="maxclust"),
-                           xp.asarray([2, 1, 1]))
-        assert_array_equal(fcluster(Z, t=3, criterion="maxclust"),
-                           xp.asarray([1, 2, 3]))
-        assert_array_equal(fcluster(Z, t=5, criterion="maxclust"),
-                           xp.asarray([1, 2, 3]))
+        xp_assert_equal(fcluster(Z, t=1, criterion="maxclust"),
+                        xp.asarray([1, 1, 1], dtype=xp.int32))
+        xp_assert_equal(fcluster(Z, t=2, criterion="maxclust"),
+                        xp.asarray([2, 1, 1], dtype=xp.int32))
+        xp_assert_equal(fcluster(Z, t=3, criterion="maxclust"),
+                        xp.asarray([1, 2, 3], dtype=xp.int32))
+        xp_assert_equal(fcluster(Z, t=5, criterion="maxclust"),
+                        xp.asarray([1, 2, 3], dtype=xp.int32))
 
 
 @make_xp_test_case(leaders)
@@ -637,14 +637,15 @@ class TestLeavesList:
         # Tests leaves_list(Z) on a 1x4 linkage.
         Z = xp.asarray([[0, 1, 3.0, 2]], dtype=xp.float64)
         to_tree(Z)
-        assert_allclose(leaves_list(Z), [0, 1], rtol=1e-15)
+        xp_assert_close(leaves_list(Z), xp.asarray([0, 1], dtype=xp.int32), rtol=1e-15)
 
     def test_leaves_list_2x4(self, xp):
         # Tests leaves_list(Z) on a 2x4 linkage.
         Z = xp.asarray([[0, 1, 3.0, 2],
                         [3, 2, 4.0, 3]], dtype=xp.float64)
         to_tree(Z)
-        assert_allclose(leaves_list(Z), [0, 1, 2], rtol=1e-15)
+        xp_assert_close(leaves_list(Z), xp.asarray([0, 1, 2], dtype=xp.int32),
+                        rtol=1e-15)
 
     @pytest.mark.parametrize("method", 
         ['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward'])
@@ -653,7 +654,8 @@ class TestLeavesList:
         X = hierarchy_test_data.Q_X
         Z = xp.asarray(linkage(X, method))
         node = to_tree(Z)
-        assert_allclose(node.pre_order(), leaves_list(Z), rtol=1e-15)
+        xp_assert_close(leaves_list(Z), xp.asarray(node.pre_order(), dtype=xp.int32),
+                        rtol=1e-15)
 
     def test_Q_subtree_pre_order(self, xp):
         # Tests that pre_order() works when called on sub-trees.

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -67,7 +67,7 @@ code book.
 import warnings
 import numpy as np
 from collections import deque
-from scipy._lib._array_api import (_asarray, array_namespace, is_lazy_array,
+from scipy._lib._array_api import (xp_asarray, array_namespace, is_lazy_array,
                                    xp_capabilities, xp_copy, xp_size)
 from scipy._lib._util import (check_random_state, rng_integers,
                               _transition_to_rng)
@@ -136,7 +136,7 @@ def whiten(obs, check_finite=None):
     xp = array_namespace(obs)
     if check_finite is None:
         check_finite = not is_lazy_array(obs)
-    obs = _asarray(obs, check_finite=check_finite, xp=xp)
+    obs = xp_asarray(obs, check_finite=check_finite, xp=xp)
     std_dev = xp.std(obs, axis=0)
     zero_std_mask = std_dev == 0
     std_dev = xpx.at(std_dev, zero_std_mask).set(1.0)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -207,17 +207,17 @@ def vq(obs, code_book, check_finite=True):
 
     """
     xp = array_namespace(obs, code_book)
-    obs = _asarray(obs, xp=xp, check_finite=check_finite)
-    code_book = _asarray(code_book, xp=xp, check_finite=check_finite)
+    obs = xp_asarray(obs, xp=xp, check_finite=check_finite)
+    code_book = xp_asarray(code_book, xp=xp, check_finite=check_finite)
     ct = xp.result_type(obs, code_book)
 
     if xp.isdtype(ct, kind='real floating'):
         c_obs = xp.astype(obs, ct, copy=False)
         c_code_book = xp.astype(code_book, ct, copy=False)
-        c_obs = np.asarray(c_obs)
-        c_code_book = np.asarray(c_code_book)
+        c_obs = xp_asarray(c_obs, xp=np)
+        c_code_book = xp_asarray(c_code_book, xp=np)
         result = _vq.vq(c_obs, c_code_book)
-        return xp.asarray(result[0]), xp.asarray(result[1])
+        return xp_asarray(result[0], xp=xp), xp_asarray(result[1], xp=xp)
     return py_vq(obs, code_book, check_finite=False)
 
 
@@ -259,8 +259,8 @@ def py_vq(obs, code_book, check_finite=True):
 
     """
     xp = array_namespace(obs, code_book)
-    obs = _asarray(obs, xp=xp, check_finite=check_finite)
-    code_book = _asarray(code_book, xp=xp, check_finite=check_finite)
+    obs = xp_asarray(obs, xp=xp, check_finite=check_finite)
+    code_book = xp_asarray(code_book, xp=xp, check_finite=check_finite)
 
     if obs.ndim != code_book.ndim:
         raise ValueError("Observation and code_book should have the same rank")
@@ -269,8 +269,10 @@ def py_vq(obs, code_book, check_finite=True):
         obs = obs[:, xp.newaxis]
         code_book = code_book[:, xp.newaxis]
 
-    # Once `cdist` has array API support, this `xp.asarray` call can be removed
-    dist = xp.asarray(cdist(obs, code_book))
+    # Once `cdist` has array API support, these `xp_asarray` calls can be removed
+    obs = xp_asarray(obs, xp=np)
+    code_book = xp_asarray(code_book, xp=np)
+    dist = xp_asarray(cdist(obs, code_book), xp=xp)
     code = xp.argmin(dist, axis=1)
     min_dist = xp.min(dist, axis=1)
     return code, min_dist
@@ -319,7 +321,7 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
         obs_code, distort = vq(obs, code_book, check_finite=False)
         prev_avg_dists.append(xp.mean(distort, axis=-1))
         # recalc code_book as centroids of associated obs
-        obs_code = np.asarray(obs_code)
+        obs_code = xp_asarray(obs_code, xp=np)
         code_book, has_members = _vq.update_cluster_means(np_obs, obs_code,
                                                           code_book.shape[0])
         code_book = code_book[has_members]
@@ -465,8 +467,8 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
         xp = array_namespace(obs)
     else:
         xp = array_namespace(obs, k_or_guess)
-    obs = _asarray(obs, xp=xp, check_finite=check_finite)
-    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite)
+    obs = xp_asarray(obs, xp=xp, check_finite=check_finite)
+    guess = xp_asarray(k_or_guess, xp=xp, check_finite=check_finite)
     if iter < 1:
         raise ValueError(f"iter must be at least 1, got {iter}")
 
@@ -519,7 +521,7 @@ def _kpoints(data, k, rng, xp):
     """
     idx = rng.choice(data.shape[0], size=int(k), replace=False)
     # convert to array with default integer dtype (avoids numpy#25607)
-    idx = xp.asarray(idx, dtype=xp.asarray([1]).dtype)
+    idx = xp_asarray(idx, dtype=xp.asarray([1]).dtype, xp=xp)
     return xp.take(data, idx, axis=0)
 
 
@@ -547,18 +549,18 @@ def _krandinit(data, k, rng, xp):
 
     """
     mu = xp.mean(data, axis=0)
-    k = np.asarray(k)
+    k = xp_asarray(k, xp=np)
 
     if data.ndim == 1:
         _cov = xpx.cov(data, xp=xp)
         x = rng.standard_normal(size=k)
-        x = xp.asarray(x)
-        x *= xp.sqrt(_cov)
+        x = xp_asarray(x, xp=xp)
+        x = x * xp.sqrt(_cov)
     elif data.shape[1] > data.shape[0]:
         # initialize when the covariance matrix is rank deficient
         _, s, vh = xp.linalg.svd(data - mu, full_matrices=False)
         x = rng.standard_normal(size=(k, xp_size(s)))
-        x = xp.asarray(x)
+        x = xp_asarray(x, xp=xp)
         sVh = s[:, None] * vh / xp.sqrt(data.shape[0] - xp.asarray(1.))
         x = x @ sVh
     else:
@@ -567,7 +569,7 @@ def _krandinit(data, k, rng, xp):
         # k rows, d cols (one row = one obs)
         # Generate k sample of a random variable ~ Gaussian(mu, cov)
         x = rng.standard_normal(size=(k, xp_size(mu)))
-        x = xp.asarray(x)
+        x = xp_asarray(x, xp=xp)
         x = x @ xp.linalg.cholesky(_cov).T
 
     x += mu
@@ -606,12 +608,14 @@ def _kpp(data, k, rng, xp):
 
     dims = data.shape[1]
 
-    init = xp.empty((int(k), dims))
+    data = xp_asarray(data, xp=np)
+    init = np.empty((int(k), dims))
 
     for i in range(k):
         if i == 0:
             data_idx = rng_integers(rng, data.shape[0])
         else:
+            
             D2 = cdist(init[:i,:], data, metric='sqeuclidean').min(axis=0)
             probs = D2/D2.sum()
             cumprobs = probs.cumsum()
@@ -623,7 +627,7 @@ def _kpp(data, k, rng, xp):
 
     if ndim == 1:
         init = init[:, 0]
-    return init
+    return xp_asarray(init, xp=xp)
 
 
 _valid_init_meth = {'random': _krandinit, 'points': _kpoints, '++': _kpp}
@@ -779,7 +783,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         xp = array_namespace(data)
     else:
         xp = array_namespace(data, k)
-    data = _asarray(data, xp=xp, check_finite=check_finite)
+    data = xp_asarray(data, xp=xp, check_finite=check_finite)
     code_book = xp_copy(k, xp=xp)
     if data.ndim == 1:
         d = 1
@@ -816,8 +820,8 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
             rng = check_random_state(rng)
             code_book = init_meth(data, code_book, rng, xp)
 
-    data = np.asarray(data)
-    code_book = np.asarray(code_book)
+    data = xp_asarray(data, xp=np)
+    code_book = xp_asarray(code_book, xp=np)
     for _ in range(iter):
         # Compute the nearest neighbor for each obs using the current code book
         label = vq(data, code_book, check_finite=check_finite)[0]
@@ -829,4 +833,4 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
             new_code_book[~has_members] = code_book[~has_members]
         code_book = new_code_book
 
-    return xp.asarray(code_book), xp.asarray(label)
+    return xp_asarray(code_book, xp=xp), xp_asarray(label, xp=xp)

--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -15,7 +15,7 @@ from ._codata import value as _cd
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-from scipy._lib._array_api import array_namespace, _asarray, xp_capabilities
+from scipy._lib._array_api import array_namespace, xp_asarray, xp_capabilities
 
 
 """
@@ -271,7 +271,7 @@ def convert_temperature(
 
     """
     xp = array_namespace(val)
-    _val = _asarray(val, xp=xp, subok=True)
+    _val = xp_asarray(val, xp=xp, subok=True)
     # Convert from `old_scale` to Kelvin
     if old_scale.lower() in ['celsius', 'c']:
         tempo = _val + zero_Celsius
@@ -334,7 +334,7 @@ def lambda2nu(lambda_: "npt.ArrayLike") -> Any:
 
     """
     xp = array_namespace(lambda_)
-    return c / _asarray(lambda_, xp=xp, subok=True)
+    return c / xp_asarray(lambda_, xp=xp, subok=True)
 
 
 @xp_capabilities()
@@ -366,4 +366,4 @@ def nu2lambda(nu: "npt.ArrayLike") -> Any:
 
     """
     xp = array_namespace(nu)
-    return c / _asarray(nu, xp=xp, subok=True)
+    return c / xp_asarray(nu, xp=xp, subok=True)

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from scipy.special import roots_legendre
 from scipy.special import gammaln, logsumexp
 from scipy._lib._util import _rng_spawn
-from scipy._lib._array_api import _asarray, array_namespace, xp_result_type
+from scipy._lib._array_api import xp_asarray, array_namespace, xp_result_type
 
 
 __all__ = ['fixed_quad', 'romb',
@@ -120,7 +120,7 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     array([2.,  8.])
     """
     xp = array_namespace(y)
-    y = _asarray(y, xp=xp, subok=True)
+    y = xp_asarray(y, xp=xp, subok=True)
     # Cannot just use the broadcasted arrays that are returned
     # because trapezoid does not follow normal broadcasting rules
     # cf. https://github.com/scipy/scipy/pull/21524#issuecomment-2354105942
@@ -133,7 +133,7 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     if x is None:
         d = dx
     else:
-        x = _asarray(x, xp=xp, subok=True)
+        x = xp_asarray(x, xp=xp, subok=True)
         if x.ndim == 1:
             d = x[1:] - x[:-1]
             # make d broadcastable to y

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -580,8 +580,8 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     >>> correlate1d([2, 8, 0, 4, 1, 9, 9, 0], weights=[1, 3])
     array([ 8, 26,  8, 12,  7, 28, 36,  9])
     """
-    input = np.asarray(input)
-    weights = np.asarray(weights)
+    input = xp_asarray(input, xp=np)
+    weights = xp_asarray(weights, xp=np)
     complex_input = input.dtype.kind == 'c'
     complex_weights = weights.dtype.kind == 'c'
     if complex_input or complex_weights:
@@ -594,7 +594,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
                                             output, cval, **kwargs)
 
     output = _ni_support._get_output(output, input)
-    weights = np.asarray(weights, dtype=np.float64)
+    weights = xp_asarray(weights, dtype=np.float64, xp=np)
     if weights.ndim != 1 or weights.shape[0] < 1:
         raise RuntimeError('no filter weights given')
     if not weights.flags.contiguous:
@@ -640,7 +640,7 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
     >>> convolve1d([2, 8, 0, 4, 1, 9, 9, 0], weights=[1, 3])
     array([14, 24,  4, 13, 12, 36, 27,  0])
     """
-    weights = np.asarray(weights)
+    weights = xp_asarray(weights, xp=np)
     weights = weights[::-1]
     origin = -origin
     if not weights.shape[0] & 1:
@@ -837,7 +837,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _ni_support._get_output(output, input)
 
     axes = _ni_support._check_axes(axes, input.ndim)
@@ -909,7 +909,7 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     >>> plt.show()
 
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     axis = normalize_axis_index(axis, input.ndim)
     output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
@@ -967,7 +967,7 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     >>> plt.show()
 
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     axis = normalize_axis_index(axis, input.ndim)
     output = _ni_support._get_output(output, input)
     modes = _ni_support._normalize_sequence(mode, input.ndim)
@@ -1014,7 +1014,7 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     """
     if extra_keywords is None:
         extra_keywords = {}
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _ni_support._get_output(output, input)
     axes = _ni_support._check_axes(axes, input.ndim)
     if len(axes) > 0:
@@ -1111,7 +1111,7 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
 
     def derivative2(input, axis, output, mode, cval, sigma, **kwargs):
         order = [0] * input.ndim
@@ -1172,7 +1172,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
     """
     if extra_keywords is None:
         extra_keywords = {}
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _ni_support._get_output(output, input)
     axes = _ni_support._check_axes(axes, input.ndim)
     if len(axes) > 0:
@@ -1232,7 +1232,7 @@ def gaussian_gradient_magnitude(input, sigma, output=None,
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
 
     def derivative(input, axis, output, mode, cval, sigma, **kwargs):
         order = [0] * input.ndim
@@ -1247,8 +1247,8 @@ def gaussian_gradient_magnitude(input, sigma, output=None,
 
 def _correlate_or_convolve(input, weights, output, mode, cval, origin,
                            convolution, axes):
-    input = np.asarray(input)
-    weights = np.asarray(weights)
+    input = xp_asarray(input, xp=np)
+    weights = xp_asarray(weights, xp=np)
     complex_input = input.dtype.kind == 'c'
     complex_weights = weights.dtype.kind == 'c'
     if complex_input or complex_weights:
@@ -1264,7 +1264,7 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
                                             weights, output, cval, **kwargs)
 
     axes = _ni_support._check_axes(axes, input.ndim)
-    weights = np.asarray(weights, dtype=np.float64)
+    weights = xp_asarray(weights, dtype=np.float64, xp=np)
 
     # expand weights and origins if num_axes < input.ndim
     weights = _expand_footprint(input.ndim, axes, weights, "weights")
@@ -1523,7 +1523,7 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     >>> uniform_filter1d([2, 8, 0, 4, 1, 9, 9, 0], size=3)
     array([4, 3, 4, 1, 4, 6, 6, 3])
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     axis = normalize_axis_index(axis, input.ndim)
     if size < 1:
         raise RuntimeError('incorrect filter size')
@@ -1596,7 +1596,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     >>> ax2.imshow(result)
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _ni_support._get_output(output, input,
                                      complex_output=input.dtype.kind == 'c')
     axes = _ni_support._check_axes(axes, input.ndim)
@@ -1658,7 +1658,7 @@ def minimum_filter1d(input, size, axis=-1, output=None,
     >>> minimum_filter1d([2, 8, 0, 4, 1, 9, 9, 0], size=3)
     array([2, 0, 0, 0, 1, 1, 0, 0])
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     axis = normalize_axis_index(axis, input.ndim)
@@ -1715,7 +1715,7 @@ def maximum_filter1d(input, size, axis=-1, output=None,
     >>> maximum_filter1d([2, 8, 0, 4, 1, 9, 9, 0], size=3)
     array([8, 8, 8, 4, 9, 9, 9, 9])
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     axis = normalize_axis_index(axis, input.ndim)
@@ -1741,7 +1741,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
                 raise RuntimeError("no footprint provided")
             separable = True
         else:
-            footprint = np.asarray(footprint, dtype=bool)
+            footprint = xp_asarray(footprint, dtype=bool, xp=np)
             if not footprint.any():
                 raise ValueError("All-zero footprint is not supported.")
             if footprint.all():
@@ -1751,13 +1751,13 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
             else:
                 separable = False
     else:
-        structure = np.asarray(structure, dtype=np.float64)
+        structure = xp_asarray(structure, dtype=np.float64, xp=np)
         separable = False
         if footprint is None:
             footprint = np.ones(structure.shape, bool)
         else:
-            footprint = np.asarray(footprint, dtype=bool)
-    input = np.asarray(input)
+            footprint = xp_asarray(footprint, dtype=bool, xp=np)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError("Complex type not supported")
     output = _ni_support._get_output(output, input)
@@ -1926,7 +1926,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
     if (size is not None) and (footprint is not None):
         warnings.warn("ignoring size because footprint is set",
                       UserWarning, stacklevel=3)
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     axes = _ni_support._check_axes(axes, input.ndim)
@@ -1937,7 +1937,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         sizes = _ni_support._normalize_sequence(size, num_axes)
         footprint = np.ones(sizes, dtype=bool)
     else:
-        footprint = np.asarray(footprint, dtype=bool)
+        footprint = xp_asarray(footprint, dtype=bool, xp=np)
     # expand origins, footprint and modes if num_axes < input.ndim
     footprint = _expand_footprint(input.ndim, axes, footprint)
     origins = _expand_origin(input.ndim, axes, origin)
@@ -2244,7 +2244,7 @@ def generic_filter1d(input, function, filter_size, axis=-1,
     """
     if extra_keywords is None:
         extra_keywords = {}
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     output = _ni_support._get_output(output, input)
@@ -2379,7 +2379,7 @@ def generic_filter(input, function, size=None, footprint=None,
                       UserWarning, stacklevel=2)
     if extra_keywords is None:
         extra_keywords = {}
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     axes = _ni_support._check_axes(axes, input.ndim)
@@ -2390,7 +2390,7 @@ def generic_filter(input, function, size=None, footprint=None,
         sizes = _ni_support._normalize_sequence(size, num_axes)
         footprint = np.ones(sizes, dtype=bool)
     else:
-        footprint = np.asarray(footprint, dtype=bool)
+        footprint = xp_asarray(footprint, dtype=bool, xp=np)
 
     # expand origins, footprint if num_axes < input.ndim
     footprint = _expand_footprint(input.ndim, axes, footprint)

--- a/scipy/ndimage/_fourier.py
+++ b/scipy/ndimage/_fourier.py
@@ -30,6 +30,7 @@
 
 import numpy as np
 from scipy._lib._util import normalize_axis_index
+from scipy._lib._array_api import xp_asarray
 from . import _ni_support
 from . import _nd_image
 
@@ -114,7 +115,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
     >>> ax2.imshow(result.real)  # the imaginary part is an artifact
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _get_output_fourier(output, input)
     axis = normalize_axis_index(axis, input.ndim)
     sigmas = _ni_support._normalize_sequence(sigma, input.ndim)
@@ -172,7 +173,7 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
     >>> ax2.imshow(result.real)  # the imaginary part is an artifact
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _get_output_fourier(output, input)
     axis = normalize_axis_index(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
@@ -233,7 +234,7 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     >>> ax2.imshow(result.real)  # the imaginary part is an artifact
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if input.ndim > 3:
         raise NotImplementedError("Only 1d, 2d and 3d inputs are supported")
     output = _get_output_fourier(output, input)
@@ -295,7 +296,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     >>> ax2.imshow(result.real)  # the imaginary part is an artifact
     >>> plt.show()
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     output = _get_output_fourier_complex(output, input)
     axis = normalize_axis_index(axis, input.ndim)
     shifts = _ni_support._normalize_sequence(shift, input.ndim)

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -117,7 +117,7 @@ def spline_filter1d(input, order=3, axis=-1, output=np.float64,
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     complex_output = np.iscomplexobj(input)
     output = _ni_support._get_output(output, input,
                                      complex_output=complex_output)
@@ -192,7 +192,7 @@ def spline_filter(input, order=3, output=np.float64, mode='mirror'):
     """
     if order < 2 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     complex_output = np.iscomplexobj(input)
     output = _ni_support._get_output(output, input,
                                      complex_output=complex_output)
@@ -338,7 +338,7 @@ def geometric_transform(input, mapping, output_shape=None,
         extra_keywords = {}
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if output_shape is None:
         output_shape = input.shape
     if input.ndim < 1 or len(output_shape) < 1:
@@ -445,7 +445,7 @@ def map_coordinates(input, coordinates, output=None, order=3,
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     coordinates = np.asarray(coordinates)
     if np.iscomplexobj(coordinates):
         raise TypeError('Complex type not supported')
@@ -592,7 +592,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if output_shape is None:
         if isinstance(output, np.ndarray):
             output_shape = output.shape
@@ -730,7 +730,7 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if input.ndim < 1:
         raise RuntimeError('input and output rank must be > 0')
     complex_output = np.iscomplexobj(input)
@@ -833,7 +833,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if input.ndim < 1:
         raise RuntimeError('input and output rank must be > 0')
     zoom = _ni_support._normalize_sequence(zoom, input.ndim)

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from scipy._lib._array_api import xp_asarray
 from . import _ni_support
 from . import _ni_label
 from . import _nd_image
@@ -172,12 +173,12 @@ def label(input, structure=None, output=None):
            [0, 0, 0, 1, 0, 0]], dtype=int32)
 
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     if structure is None:
         structure = _morphology.generate_binary_structure(input.ndim, 1)
-    structure = np.asarray(structure, dtype=bool)
+    structure = xp_asarray(structure, dtype=bool, xp=np)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have equal rank')
     for ii in structure.shape:
@@ -298,7 +299,7 @@ def find_objects(input, max_label=0):
            [0, 0, 1]])
 
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')
 
@@ -495,7 +496,7 @@ def labeled_comprehension(input, labels, index, func, out_dtype, default,
     """
 
     as_scalar = np.isscalar(index)
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
 
     if pass_positions:
         positions = np.arange(input.size).reshape(input.shape)
@@ -508,7 +509,7 @@ def labeled_comprehension(input, labels, index, func, out_dtype, default,
         else:
             return func(input.ravel(), positions.ravel())
 
-    labels = np.asarray(labels)
+    labels = xp_asarray(labels, xp=np)
 
     try:
         input, labels = np.broadcast_arrays(input, labels)
@@ -626,12 +627,13 @@ def _stats(input, labels=None, index=None, centered=False):
         else:
             return vals.size, vals.sum()
 
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if labels is None:
         return single_group(input)
 
     labels = np.asarray(labels)
     # ensure input and labels match sizes
+    labels = xp_asarray(labels, xp=np)
     input, labels = np.broadcast_arrays(input, labels)
 
     if index is None:
@@ -639,6 +641,8 @@ def _stats(input, labels=None, index=None, centered=False):
 
     if np.isscalar(index):
         return single_group(input[labels == index])
+    
+    index = xp_asarray(index, xp=np)
 
     def _sum_centered(labels):
         # `labels` is expected to be an ndarray with the same shape as `input`.
@@ -921,7 +925,7 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
     """Returns min, max, or both, plus their positions (if requested), and
     median."""
 
-    input = np.asanyarray(input)
+    input = xp_asarray(input, xp=np, subok=True)
 
     find_positions = find_min_positions or find_max_positions
     positions = None
@@ -944,6 +948,8 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
 
     if labels is None:
         return single_group(input, positions)
+    
+    labels = xp_asarray(labels, xp=np, subok=True)
 
     labels = np.asarray(labels)
     # ensure input and labels match sizes
@@ -963,7 +969,7 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
             masked_positions = positions[mask]
         return single_group(input[mask], masked_positions)
 
-    index = np.asarray(index)
+    index = xp_asarray(index, xp=np)
 
     # remap labels to unique integers if necessary, or if the largest
     # label is larger than the number of values.
@@ -1306,7 +1312,7 @@ def minimum_position(input, labels=None, index=None):
     [(0, 0), (0, 3), (3, 1)]
 
     """
-    dims = np.array(np.asarray(input).shape)
+    dims = np.array(xp_asarray(input, xp=np).shape)
     # see np.unravel_index to understand this line.
     dim_prod = np.cumprod([1] + list(dims[:0:-1]))[::-1]
 
@@ -1391,7 +1397,7 @@ def maximum_position(input, labels=None, index=None):
     (0, 2)
 
     """
-    dims = np.array(np.asarray(input).shape)
+    dims = np.array(xp_asarray(input, xp=np).shape)
     # see np.unravel_index to understand this line.
     dim_prod = np.cumprod([1] + list(dims[:0:-1]))[::-1]
 
@@ -1457,7 +1463,7 @@ def extrema(input, labels=None, index=None):
     (1, 9, (0, 0), (3, 0))
 
     """
-    dims = np.array(np.asarray(input).shape)
+    dims = np.array(xp_asarray(input, xp=np).shape)
     # see np.unravel_index to understand this line.
     dim_prod = np.cumprod([1] + list(dims[:0:-1]))[::-1]
 
@@ -1543,7 +1549,7 @@ def center_of_mass(input, labels=None, index=None):
     >>> ndimage.center_of_mass(d)
     (inf,)
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     normalizer = sum_labels(input, labels, index)
     grids = np.ogrid[[slice(0, i) for i in input.shape]]
 
@@ -1649,13 +1655,13 @@ def watershed_ift(input, markers, structure=None, output=None):
            Pattern Analysis and Machine Intelligence, vol. 26, pp. 19-29, 2004.
 
     """
-    input = np.asarray(input)
+    input = xp_asarray(input, xp=np)
     if input.dtype.type not in [np.uint8, np.uint16]:
         raise TypeError('only 8 and 16 unsigned inputs are supported')
 
     if structure is None:
         structure = _morphology.generate_binary_structure(input.ndim, 1)
-    structure = np.asarray(structure, dtype=bool)
+    structure = xp_asarray(structure, dtype=bool, xp=np)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have equal rank')
     for ii in structure.shape:
@@ -1664,7 +1670,7 @@ def watershed_ift(input, markers, structure=None, output=None):
 
     if not structure.flags.contiguous:
         structure = structure.copy()
-    markers = np.asarray(markers)
+    markers = xp_asarray(markers, xp=np)
     if input.shape != markers.shape:
         raise RuntimeError('input and markers must have equal shape')
 

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 from numpy.testing import suppress_warnings
 from scipy._lib._array_api import (
-    _asarray, assert_array_almost_equal,
+    xp_asarray, assert_array_almost_equal,
     is_jax, np_compat,
     xp_assert_equal, xp_assert_close,
 )
@@ -547,9 +547,9 @@ class TestMapCoordinates:
 
     @skip_xp_backends("jax.numpy", reason="`order` is required in jax")
     def test_map_coordinates03(self, xp):
-        data = _asarray([[4, 1, 3, 2],
-                         [7, 6, 8, 5],
-                         [3, 5, 3, 6]], order='F', xp=xp)
+        data = xp_asarray([[4, 1, 3, 2],
+                           [7, 6, 8, 5],
+                           [3, 5, 3, 6]], order='F', xp=xp)
         idx = np.indices(data.shape) - 1
         idx = xp.asarray(idx)
         out = ndimage.map_coordinates(data, idx)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -532,7 +532,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(bf, out)
 
         # np-specific check
-        np_ft = np.asarray(ft)
+        np_ft = xp_asarray(ft, xp=np)
         dt = np_ft - np.indices(np_ft.shape[1:], dtype=np_ft.dtype)
         dt = dt.astype(np.float64)
         np.multiply(dt, dt, dt)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -113,7 +113,7 @@ from functools import partial
 
 import numpy as np
 
-from scipy._lib._array_api import _asarray
+from scipy._lib._array_api import xp_asarray
 from scipy._lib._util import _asarray_validated, _transition_to_rng
 from scipy._lib import array_api_extra as xpx
 from scipy._lib.deprecation import _deprecated
@@ -2292,7 +2292,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
     # between all pairs of vectors in X using the distance metric 'abc' but
     # with a more succinct, verifiable, but less efficient implementation.
 
-    X = _asarray(X)
+    X = xp_asarray(X)
     if X.ndim != 2:
         raise ValueError('A 2-dimensional array must be passed. '
                          f'(Shape was {X.shape}).')
@@ -2667,7 +2667,7 @@ def is_valid_y(y, warning=False, throw=False, name=None):
     False
 
     """
-    y = _asarray(y)
+    y = xp_asarray(y)
     name_str = f"'{name}' " if name else ""
     try:
         if len(y.shape) != 1:
@@ -2743,7 +2743,7 @@ def num_obs_y(Y):
     >>> num_obs_y(Y)
     4
     """
-    Y = _asarray(Y)
+    Y = xp_asarray(Y)
     is_valid_y(Y, throw=True, name='Y')
     k = Y.shape[0]
     if k == 0:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -65,7 +65,7 @@ from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
 from scipy.optimize import root_scalar
 from scipy._lib._array_api import (
-    _asarray,
+    xp_asarray,
     array_namespace,
     is_lazy_array,
     is_dask,
@@ -10640,7 +10640,7 @@ def _xp_mean(x, /, *, axis=None, weights=None, keepdims=False, nan_policy='propa
     """
     # ensure that `x` and `weights` are array-API compatible arrays of identical shape
     xp = array_namespace(x) if xp is None else xp
-    x = _asarray(x, dtype=dtype, subok=True)
+    x = xp_asarray(x, dtype=dtype, subok=True)
     weights = xp.asarray(weights, dtype=dtype) if weights is not None else weights
 
     # to ensure that this matches the behavior of decorated functions when one of the
@@ -10718,7 +10718,7 @@ def _xp_var(x, /, *, axis=None, correction=0, keepdims=False, nan_policy='propag
     # an array-api compatible function for variance with scipy.stats interface
     # and features (e.g. `nan_policy`).
     xp = array_namespace(x) if xp is None else xp
-    x = _asarray(x, subok=True)
+    x = xp_asarray(x, subok=True)
 
     # use `_xp_mean` instead of `xp.var` for desired warning behavior
     # it would be nice to combine this with `_var`, which uses `_moment`
@@ -10728,7 +10728,7 @@ def _xp_var(x, /, *, axis=None, correction=0, keepdims=False, nan_policy='propag
     # be easy.
     kwargs = dict(axis=axis, nan_policy=nan_policy, dtype=dtype, xp=xp)
     mean = _xp_mean(x, keepdims=True, **kwargs)
-    x = _asarray(x, dtype=mean.dtype, subok=True)
+    x = xp_asarray(x, dtype=mean.dtype, subok=True)
     x_mean = _demean(x, mean, axis, xp=xp)
     x_mean_conj = (xp.conj(x_mean) if xp.isdtype(x_mean.dtype, 'complex floating')
                    else x_mean)  # crossref data-apis/array-api#824


### PR DESCRIPTION
Continues gh-21890. Blocked on https://github.com/data-apis/array-api-strict/pull/108.

Around our codebase that has been converted to support standard arrays, we still widely rely on `__array__`, but it is not in the standard. Therefore, array-api-strict would like to remove it. @mdhaber wrote this `xp_asarray` which delegates to `from_dlpack` under the hood for library-interchange.

Here I get all tests passing for `constants` and `cluster`.

[An important consideration](https://github.com/scipy/scipy/pull/21890#discussion_r1842815823) from @mdhaber in the PR this continues:

> Outputs will typically be read-only after this step. This seems like a big disadvantage compared to `xp.asarray` using the array protocol. I don't think we want to return read-only results from special functions. Is there a general solution that is efficient (e.g. not just `copy` the output before returning it) or do we have to be very careful about using `from_dlpack` only when necessary?

Perhaps we could attempt to use `__array__` and only fall-back to `from_dlpack` (and thus copying read-only outputs) if that fails. But I think that would still require an array-level mutability check such as that described in https://github.com/data-apis/array-api/issues/845.