### PR TITLE
MAINT: `stats.order_statistic`: override `support`

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4239,6 +4239,11 @@ class OrderStatisticDistribution(TransformedDistribution):
     def _support(self, *args, r, n, **kwargs):
         return self._dist._support(*args, **kwargs)
 
+    def _process_parameters(self, r=None, n=None, **params):
+        parameters = self._dist._process_parameters(**params)
+        parameters.update(dict(r=r, n=n))
+        return parameters
+
     def _overrides(self, method_name):
         return method_name in {'_logpdf_formula', '_pdf_formula',
                                '_cdf_formula', '_ccdf_formula',

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4236,6 +4236,9 @@ class OrderStatisticDistribution(TransformedDistribution):
     def __init__(self, dist, /, *args, r, n, **kwargs):
         super().__init__(dist, *args, r=r, n=n, **kwargs)
 
+    def _support(self, *args, r, n, **kwargs):
+        return self._dist._support(*args, **kwargs)
+
     def _overrides(self, method_name):
         return method_name in {'_logpdf_formula', '_pdf_formula',
                                '_cdf_formula', '_ccdf_formula',

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1541,13 +1541,31 @@ class TestOrderStatistic:
             stats.order_statistic(X, n=1.5, r=r)
 
     def test_support_gh22037(self):
-        # During review of gh-22037, it was noted that the `support`
-        # of OrderStatisticDistribution was not overridden properly
+        # During review of gh-22037, it was noted that the `support` of
+        # an `OrderStatisticDistribution` returned incorrect results;
+        # this was resolved by overriding `_support`.
         Uniform = stats.make_distribution(stats.uniform)
         X = Uniform()
         Y = X*5 + 2
         Z = stats.order_statistic(Y, r=3, n=5)
         assert_allclose(Z.support(), Y.support())
+
+    def test_composition_gh22037(self):
+        # During review of gh-22037, it was noted that an error was
+        # raised when creating an `OrderStatisticDistribution` from
+        # a `TruncatedDistribution`. This was resolved by overriding
+        # `_update_parameters`.
+        Normal = stats.make_distribution(stats.norm)
+        TruncatedNormal = stats.make_distribution(stats.truncnorm)
+        a, b = [-2, -1], 1
+        r, n = 3, [[4], [5]]
+        x = [[[-0.3]], [[0.1]]]
+        X1 = Normal()
+        Y1 = stats.truncate(X1, a, b)
+        Z1 = stats.order_statistic(Y1, r=r, n=n)
+        X2 = TruncatedNormal(a=a, b=b)
+        Z2 = stats.order_statistic(X2, r=r, n=n)
+        np.testing.assert_allclose(Z1.cdf(x), Z2.cdf(x))
 
 
 class TestFullCoverage:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1496,6 +1496,7 @@ class TestTransforms:
         sample = Y.sample(10)
         assert np.all(sample > 0)
 
+class TestOrderStatistic:
     @pytest.mark.fail_slow(20)  # Moments require integration
     def test_order_statistic(self):
         rng = np.random.default_rng(7546349802439582)
@@ -1538,6 +1539,15 @@ class TestTransforms:
             stats.order_statistic(X, n=n, r=1.5)
         with pytest.raises(ValueError, match=message):
             stats.order_statistic(X, n=1.5, r=r)
+
+    def test_support_gh22037(self):
+        # During review of gh-22037, it was noted that the `support`
+        # of OrderStatisticDistribution was not overridden properly
+        Uniform = stats.make_distribution(stats.uniform)
+        X = Uniform()
+        Y = X*5 + 2
+        Z = stats.order_statistic(Y, r=3, n=5)
+        assert_allclose(Z.support(), Y.support())
 
 
 class TestFullCoverage:


### PR DESCRIPTION
#### Reference issue
gh-22037

#### What does this implement/fix?
During review of gh-22037, I found that `support` of an `OrderStatisticDistribution` was not returning the correct support; this fixes that by overriding `_support`.  Also, I noticed that `order_statistic` raised an error when provided an object that involved a `TruncatedDistribution`; this fixes that by overriding `_update_parameters`.

#### Additional information
Example: lots of composition.

```python3
import numpy as np
import matplotlib.pyplot as plt
from scipy import stats
Uniform = stats.make_distribution(stats.uniform)
X = Uniform()
Y = X*5 + 2
Z = stats.truncate(Y, 3, 6)
W = 1 / Z
Q = stats.exp(W)
T = stats.order_statistic(Q, r=np.arange(1, 6), n=5)
T.plot(y='cdf')
plt.show()
```
<img width="902" alt="image" src="https://github.com/user-attachments/assets/e96f821b-1d31-472d-9f21-ed10a96285f1">

