### PR TITLE
MAINT: stats.wilcoxon: fix attempt to access np.AxisError

### DIFF
--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -57,7 +57,7 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
         raise ValueError(message)
 
     message = '`axis` must be compatible with the shape(s) of `x` (and `y`)'
-    AxisError = getattr(np, 'AxisError', np.exceptions.AxisError)
+    AxisError = getattr(np, 'AxisError', None) or np.exceptions.AxisError
     try:
         if y is None:
             x = np.asarray(x)

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -57,6 +57,7 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
         raise ValueError(message)
 
     message = '`axis` must be compatible with the shape(s) of `x` (and `y`)'
+    AxisError = getattr(np, 'AxisError', np.exceptions.AxisError)
     try:
         if y is None:
             x = np.asarray(x)
@@ -65,8 +66,8 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
             x, y = _broadcast_arrays((x, y), axis=axis)
             d = x - y
         d = np.moveaxis(d, axis, -1)
-    except np.AxisError as e:
-        raise ValueError(message) from e
+    except AxisError as e:
+        raise AxisError(message) from e
 
     message = "`x` and `y` must have the same length along `axis`."
     if y is not None and x.shape[axis] != y.shape[axis]:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1768,6 +1768,27 @@ class TestWilcoxon:
         res = stats.wilcoxon(np.zeros(5), method=method)
         assert_allclose(res, [0, 1])
 
+    def test_wilcoxon_axis_broadcasting_errors_gh22051(self):
+        # In previous versions of SciPy, `wilcoxon` gave an incorrect error
+        # message when `AxisError` was not found in the base NumPy namespace.
+        # Check that this is resolved with and without the ANP decorator.
+        message = "Array shapes are incompatible for broadcasting."
+        with pytest.raises(ValueError, match=message):
+            stats.wilcoxon([1, 2, 3], [4, 5])
+
+        message = "operands could not be broadcast together with..."
+        with pytest.raises(ValueError, match=message):
+            stats.wilcoxon([1, 2, 3], [4, 5], _no_deco=True)
+
+        AxisError = getattr(np, 'AxisError', np.exceptions.AxisError)
+        message = "source: axis 3 is out of bounds for array of dimension 1"
+        with pytest.raises(AxisError, match=message):
+            stats.wilcoxon([1, 2, 3], [4, 5, 6], axis=3)
+
+        message = "`axis` must be compatible with the shape..."
+        with pytest.raises(AxisError, match=message):
+            stats.wilcoxon([1, 2, 3], [4, 5, 6], axis=3, _no_deco=True)
+
 
 # data for k-statistics tests from
 # https://cran.r-project.org/web/packages/kStatistics/kStatistics.pdf

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1780,7 +1780,7 @@ class TestWilcoxon:
         with pytest.raises(ValueError, match=message):
             stats.wilcoxon([1, 2, 3], [4, 5], _no_deco=True)
 
-        AxisError = getattr(np, 'AxisError', np.exceptions.AxisError)
+        AxisError = getattr(np, 'AxisError', None) or np.exceptions.AxisError
         message = "source: axis 3 is out of bounds for array of dimension 1"
         with pytest.raises(AxisError, match=message):
             stats.wilcoxon([1, 2, 3], [4, 5, 6], axis=3)


### PR DESCRIPTION
#### Reference issue
Closes gh-22051

#### What does this implement/fix?
`scipy.stats.wilcoxon` attempted to raise `np.AxisError`, but `AxisError` is located in `np.exceptions` rather than the base NumPy namespace in recent versions of NumPy. This fixes the problem with ~~`getattr(np, 'AxisError', np.exceptions.AxisError)`~~`getattr(np, 'AxisError', None) or np.exceptions.AxisError`.
