### PR TITLE
DOC: `stats.order_statistic`: add 'Returns' section

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4184,6 +4184,7 @@ class OrderStatisticDistribution(TransformedDistribution):
     r : array_like
         The (integer) rank of the order statistic :math:`r`
 
+
     Notes
     -----
     If we make :math:`n` observations of a continuous random variable
@@ -4313,6 +4314,12 @@ def order_statistic(X, /, *, r, n):
         The (positive integer) rank of the order statistic :math:`r`
     n : array_like
         The (positive integer) sample size :math:`n`
+
+    Returns
+    -------
+    Y : `ContinuousDistribution`
+        A random variable that follows the distribution of the prescribed
+        order statistic.
 
     Notes
     -----
@@ -4935,6 +4942,7 @@ def exp(X, /):
     ----------
     X : `ContinuousDistribution`
         The random variable :math:`X`.
+
     Returns
     -------
     Y : `ContinuousDistribution`
@@ -4980,6 +4988,7 @@ def log(X, /):
     ----------
     X : `ContinuousDistribution`
         The random variable :math:`X` with positive support.
+
     Returns
     -------
     Y : `ContinuousDistribution`


### PR DESCRIPTION
#### Reference issue
Closes gh-22057

#### What does this implement/fix?
Adds the missing "Returns" section to the documentation of `scipy.stats.order_statistic`.

#### Additional information
It would be nice if we could figure out how to make `ContinuousDistribution` link to class documentation. Should we make `_ProbabilityDistribution`, the abstract base class, public and use that just to document the return type? That might address the problem with the doctests of method documentation not running (gh-22027), and it would give all these "Parameter" and "Return" types a link to the documentation.

Another thought is that these functions should probably check the type of input `X`. Users might try to pass instances of `rv_continuous` or `rv_frozen`, and I don't think the error message they'd get is great.

Looks like I need to update `__all__` for `_distribution_infrastructure.py`.

Oops, meant to use `[docs only]` : (