### PR TITLE
TST: temp skip of extending tests

### DIFF
--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sysconfig
 
 import numpy as np
 import pytest
@@ -13,6 +14,9 @@ from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')
+@pytest.mark.skipif((platform.system() == 'Windows' and
+                     sysconfig.get_config_var('Py_GIL_DISABLED')),
+                    reason='gh-22039')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")

--- a/scipy/optimize/tests/test_extending.py
+++ b/scipy/optimize/tests/test_extending.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sysconfig
 
 import pytest
 
@@ -10,6 +11,9 @@ from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')
+@pytest.mark.skipif((platform.system() == 'Windows' and
+                     sysconfig.get_config_var('Py_GIL_DISABLED')),
+                    reason='gh-22039')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")

--- a/scipy/special/tests/test_extending.py
+++ b/scipy/special/tests/test_extending.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sysconfig
 
 import pytest
 
@@ -11,6 +12,9 @@ from scipy.special import beta, gamma
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,
                     reason='Editable install cannot find .pxd headers.')
+@pytest.mark.skipif((platform.system() == 'Windows' and
+                     sysconfig.get_config_var('Py_GIL_DISABLED')),
+                    reason='gh-22039')
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"],
                     reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")


### PR DESCRIPTION
* Temporarily skip the tests flagged in gh-22039 on free-threaded Windows CPython. Note that free-threading itself may be a red herring here, and the issue may ultimately be some combination of the disabling of build isolation for free-threaded wheels with the Windows platform.

* Note that the error messages reported by these test meson builds are identical to those reported by in-place builds of SciPy, for which we already have skips on these tests. Even for the case of the in-place build test failure, which simplifies down to a single-line reproducer, `cimport scipy.linalg`, we still don't have a workaround, so it seems like we may not want to hold up the release candidate for an even more challenging-to-reproduce scenario that has the same error message. Also, if there were fundamental issues with free threading on this platform/Python combination, they would presumably show up somewhere other than just these in-place-sensitive tests.

[skip circle] [skip cirrus]