### PR TITLE
BUG: ndimage: convert array scalars on return

### DIFF
--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -13,6 +13,16 @@ __all__ = _ndimage_api.__all__
 MODULE_NAME = 'ndimage'
 
 
+def _maybe_convert_arg(arg, xp):
+    """Convert arrays/scalars hiding in the sequence `arg`."""
+    if isinstance(arg, (np.ndarray, np.generic)):
+        return xp.asarray(arg)
+    elif isinstance(arg, (list, tuple)):
+        return type(arg)(_maybe_convert_arg(x, xp) for x in arg)
+    else:
+        return arg
+
+
 def delegate_xp(delegator, module_name):
     def inner(func):
         @functools.wraps(func)
@@ -52,10 +62,7 @@ def delegate_xp(delegator, module_name):
                     return result
                 else:
                     # lists/tuples
-                    return type(result)(
-                        xp.asarray(x) if isinstance(x, np.ndarray) else x
-                        for x in result
-                    )
+                    return _maybe_convert_arg(result, xp)
         return wrapper
     return inner
 


### PR DESCRIPTION
fixes https://github.com/scipy/scipy/issues/22054

```
$ SCIPY_ARRAY_API=1 python dev.py ipytho

In [2]: from scipy import ndimage

In [3]: import array_api_strict as xp

In [4]: ndimage.extrema(xp.arange(3))
Out[4]: 
(Array(0, dtype=array_api_strict.int64),
 Array(2, dtype=array_api_strict.int64),
 (Array(0, dtype=array_api_strict.int64),),
 (Array(2, dtype=array_api_strict.int64),))
```

