### PR TITLE
MAINT: `_lib`: co-vendor array-api-extra and array-api-compat

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -32,7 +32,7 @@ env:
     -t scipy.stats
     -t scipy.ndimage
     -t scipy.integrate.tests.test_quadrature
-    -t scipy/signal/tests/test_signaltools.py
+    -t scipy.signal.tests.test_signaltools
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/scipy/_lib/_array_api_compat_vendor.py
+++ b/scipy/_lib/_array_api_compat_vendor.py
@@ -2,10 +2,8 @@
 # This is a hook for array_api_extra/src/array_api_extra/_lib/_compat.py
 # to override functions of array_api_compat.
 
-from __future__ import annotations
-
 from .array_api_compat import *  # noqa: F403
 from ._array_api import array_namespace as scipy_array_namespace
 
 # overrides array_api_compat.array_namespace inside array-api-extra
-array_namespace = scipy_array_namespace
+array_namespace = scipy_array_namespace  # type: ignore[assignment]

--- a/scipy/_lib/_array_api_compat_vendor.py
+++ b/scipy/_lib/_array_api_compat_vendor.py
@@ -1,0 +1,11 @@
+# DO NOT RENAME THIS FILE
+# This is a hook for array_api_extra/src/array_api_extra/_lib/_compat.py
+# to override functions of array_api_compat.
+
+from __future__ import annotations
+
+from .array_api_compat import *  # noqa: F403
+from ._array_api import array_namespace as scipy_array_namespace
+
+# overrides array_api_compat.array_namespace inside array-api-extra
+array_namespace = scipy_array_namespace

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -113,6 +113,7 @@ py3.extension_module('messagestream',
 python_sources = [
   '__init__.py',
   '_array_api.py',
+  '_array_api_compat_vendor.py',
   '_array_api_no_0d.py',
   '_bunch.py',
   '_ccallback.py',
@@ -218,9 +219,17 @@ py3.install_sources(
 
 py3.install_sources(
   [
+    'array_api_extra/src/array_api_extra/_lib/_compat.py',
+    'array_api_extra/src/array_api_extra/_lib/_utils.py',
+    'array_api_extra/src/array_api_extra/_lib/_typing.py',
+  ],
+  subdir: 'scipy/_lib/array_api_extra/_lib',
+)
+
+py3.install_sources(
+  [
     'array_api_extra/src/array_api_extra/__init__.py',
     'array_api_extra/src/array_api_extra/_funcs.py',
-    'array_api_extra/src/array_api_extra/_typing.py',
   ],
   subdir: 'scipy/_lib/array_api_extra',
 )

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -220,6 +220,7 @@ py3.install_sources(
 py3.install_sources(
   [
     'array_api_extra/src/array_api_extra/_lib/_compat.py',
+    'array_api_extra/src/array_api_extra/_lib/_compat.pyi',    
     'array_api_extra/src/array_api_extra/_lib/_utils.py',
     'array_api_extra/src/array_api_extra/_lib/_typing.py',
   ],

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -219,6 +219,7 @@ py3.install_sources(
 
 py3.install_sources(
   [
+    'array_api_extra/src/array_api_extra/_lib/__init__.py',
     'array_api_extra/src/array_api_extra/_lib/_compat.py',
     'array_api_extra/src/array_api_extra/_lib/_compat.pyi',    
     'array_api_extra/src/array_api_extra/_lib/_utils.py',

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -6,6 +6,7 @@ from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
     np_compat,
 )
+from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
 
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -53,6 +54,14 @@ class TestArrayAPI:
         array_namespace([0, 1, 2])
         array_namespace(1, 2, 3)
         array_namespace(1)
+
+    def test_array_api_extra_hook(self):
+        """Test that the `array_namespace` function used by
+        array-api-extra has been overridden by scipy
+        """
+        msg = "only boolean and numerical dtypes are supported"
+        with pytest.raises(TypeError, match=msg):
+            xpx.atleast_nd("abc", ndim=0)
 
     @skip_xp_backends('jax.numpy',
                       reason="JAX arrays do not support item assignment")
@@ -112,7 +121,6 @@ class TestArrayAPI:
             with pytest.raises(AssertionError, match="Array-ness does not match."):
                 xp_assert_equal(x, y, **options)
 
-
     @array_api_compatible
     def test_check_scalar(self, xp):
         if not is_numpy(xp):
@@ -146,7 +154,6 @@ class TestArrayAPI:
 
         # as an alternative to `check_0d=False`, explicitly expect scalar
         xp_assert_equal(xp.float64(0), xp.asarray(0.)[()])
-
 
     @array_api_compatible
     def test_check_scalar_no_0d(self, xp):


### PR DESCRIPTION
array-api-extra has introduced a dependency to array-api-compat (https://github.com/data-apis/array-api-extra/pull/47).
