### PR TITLE
ENH: optimize: migrate to use sparray

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -60,9 +60,9 @@ def _wrapper_hess(hess, grad=None, x0=None, args=(), finite_diff_options=None):
         if sps.issparse(H):
             def wrapped(x, **kwds):
                 ncalls[0] += 1
-                return sps.csr_matrix(hess(np.copy(x), *args))
+                return sps.csr_array(hess(np.copy(x), *args))
 
-            H = sps.csr_matrix(H)
+            H = sps.csr_array(H)
 
         elif isinstance(H, LinearOperator):
             def wrapped(x, **kwds):
@@ -443,8 +443,8 @@ class VectorFunction:
                     sparse_jacobian is None and sps.issparse(self.J)):
                 def jac_wrapped(x):
                     self.njev += 1
-                    return sps.csr_matrix(jac(x))
-                self.J = sps.csr_matrix(self.J)
+                    return sps.csr_array(jac(x))
+                self.J = sps.csr_array(self.J)
                 self.sparse_jacobian = True
 
             elif sps.issparse(self.J):
@@ -473,10 +473,10 @@ class VectorFunction:
                     sparse_jacobian is None and sps.issparse(self.J)):
                 def update_jac():
                     self._update_fun()
-                    self.J = sps.csr_matrix(
+                    self.J = sps.csr_array(
                         approx_derivative(fun_wrapped, self.x, f0=self.f,
                                           **finite_diff_options))
-                self.J = sps.csr_matrix(self.J)
+                self.J = sps.csr_array(self.J)
                 self.sparse_jacobian = True
 
             elif sps.issparse(self.J):
@@ -507,8 +507,8 @@ class VectorFunction:
             if sps.issparse(self.H):
                 def hess_wrapped(x, v):
                     self.nhev += 1
-                    return sps.csr_matrix(hess(x, v))
-                self.H = sps.csr_matrix(self.H)
+                    return sps.csr_array(hess(x, v))
+                self.H = sps.csr_array(self.H)
 
             elif isinstance(self.H, LinearOperator):
                 def hess_wrapped(x, v):
@@ -625,7 +625,7 @@ class LinearVectorFunction:
     """
     def __init__(self, A, x0, sparse_jacobian):
         if sparse_jacobian or sparse_jacobian is None and sps.issparse(A):
-            self.J = sps.csr_matrix(A)
+            self.J = sps.csr_array(A)
             self.sparse_jacobian = True
         elif sps.issparse(A):
             self.J = A.toarray()
@@ -651,7 +651,7 @@ class LinearVectorFunction:
         self.f_updated = True
 
         self.v = np.zeros(self.m, dtype=float)
-        self.H = sps.csr_matrix((self.n, self.n))
+        self.H = sps.csr_array((self.n, self.n))
 
     def _update_x(self, x):
         if not np.array_equal(x, self.x):
@@ -686,7 +686,7 @@ class IdentityVectorFunction(LinearVectorFunction):
     def __init__(self, x0, sparse_jacobian):
         n = len(x0)
         if sparse_jacobian or sparse_jacobian is None:
-            A = sps.eye(n, format='csr')
+            A = sps.eye_array(n, format='csr')
             sparse_jacobian = True
         else:
             A = np.eye(n)

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -28,7 +28,7 @@ from ._highspy._core.simplex_constants import (
     SimplexStrategy,
     SimplexEdgeWeightStrategy,
 )
-from scipy.sparse import csc_matrix, vstack, issparse
+from scipy.sparse import csc_array, vstack, issparse
 
 
 def _highs_to_scipy_status_message(highs_status, highs_message):
@@ -318,7 +318,7 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
         A = vstack((A_ub, A_eq))
     else:
         A = np.vstack((A_ub, A_eq))
-    A = csc_matrix(A)
+    A = csc_array(A)
 
     options = {
         'presolve': presolve,

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -199,7 +199,7 @@ def _get_delta(A, b, c, x, y, z, tau, kappa, gamma, eta, sparse=False,
     if A.shape[0] == 0:
         # If there are no constraints, some solvers fail (understandably)
         # rather than returning empty solution. This gets the job done.
-        sparse, lstsq, sym_pos, cholesky = False, False, True, False
+        lstsq, sym_pos, cholesky = False, True, False
     n_x = len(x)
 
     # [4] Equation 8.8
@@ -212,7 +212,7 @@ def _get_delta(A, b, c, x, y, z, tau, kappa, gamma, eta, sparse=False,
     Dinv = x / z
 
     if sparse:
-        M = A.dot(sps.diags(Dinv, 0, format="csc").dot(A.T))
+        M = A.dot(sps.diags_array(Dinv, format="csc").dot(A.T))
     else:
         M = A.dot(Dinv.reshape(-1, 1) * A.T)
     solve = _get_solver(M, sparse, lstsq, sym_pos, cholesky, permc_spec)
@@ -723,7 +723,7 @@ def _ip_hsd(A, b, c, c0, alpha0, beta, maxiter, disp, tol, sparse, lstsq,
     message = "Optimization terminated successfully."
 
     if sparse:
-        A = sps.csc_matrix(A)
+        A = sps.csc_array(A)
 
     while go:
 

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1126,7 +1126,7 @@ def _get_Abc(lp, c0):
             return sps.vstack(blocks, format="csr")
 
         zeros = sps.csr_array
-        eye = sps.eye
+        eye = sps.eye_array
     else:
         sparse = False
         hstack = np.hstack
@@ -1176,7 +1176,7 @@ def _get_Abc(lp, c0):
         if sparse:
             idxs = (np.arange(n_bounds), i_newub)
             A_ub = vstack((A_ub, sps.csr_array((np.ones(n_bounds), idxs),
-                                                shape=shape)))
+                                               shape=shape)))
         else:
             A_ub = vstack((A_ub, np.zeros(shape)))
             A_ub[np.arange(m_ub, A_ub.shape[0]), i_newub] = 1
@@ -1213,10 +1213,8 @@ def _get_Abc(lp, c0):
     lb_shift = lbs[lb_some].astype(float)
     c0 += np.sum(lb_shift * c[i_shift])
     if sparse:
-        b = b.reshape(-1, 1)
         A = A.tocsc()
-        b -= (A[:, i_shift] @ sps.diags_array(lb_shift)).sum(axis=1).reshape(b.shape)
-        b = b.ravel()
+        b -= (A[:, i_shift] @ sps.diags_array(lb_shift)).sum(axis=1)
     else:
         b -= (A[:, i_shift] * lb_shift).sum(axis=1)
     if x0 is not None:

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -136,9 +136,9 @@ def _check_sparse_inputs(options, meth, A_ub, A_eq):
     # This is an undocumented option for unit testing sparse presolve
     _sparse_presolve = options.pop('_sparse_presolve', False)
     if _sparse_presolve and A_eq is not None:
-        A_eq = sps.coo_matrix(A_eq)
+        A_eq = sps.coo_array(A_eq)
     if _sparse_presolve and A_ub is not None:
-        A_ub = sps.coo_matrix(A_ub)
+        A_ub = sps.coo_array(A_ub)
 
     sparse_constraint = sps.issparse(A_eq) or sps.issparse(A_ub)
 
@@ -169,17 +169,17 @@ def _format_A_constraints(A, n_x, sparse_lhs=False):
         The number of variables in the linear programming problem.
     sparse_lhs : bool
         Whether either of `A_ub` or `A_eq` are sparse. If true return a
-        coo_matrix instead of a numpy array.
+        coo_array instead of a numpy array.
 
     Returns
     -------
-    np.ndarray or sparse.coo_matrix
+    np.ndarray or sparse.coo_array
         2-D array such that ``A @ x`` gives the values of the upper-bound
         (in)equality constraints at ``x``.
 
     """
     if sparse_lhs:
-        return sps.coo_matrix(
+        return sps.coo_array(
             (0, n_x) if A is None else A, dtype=float, copy=True
         )
     elif A is None:
@@ -1116,8 +1116,8 @@ def _get_Abc(lp, c0):
 
     if sps.issparse(A_eq):
         sparse = True
-        A_eq = sps.csr_matrix(A_eq)
-        A_ub = sps.csr_matrix(A_ub)
+        A_eq = sps.csr_array(A_eq)
+        A_ub = sps.csr_array(A_ub)
 
         def hstack(blocks):
             return sps.hstack(blocks, format="csr")
@@ -1125,7 +1125,7 @@ def _get_Abc(lp, c0):
         def vstack(blocks):
             return sps.vstack(blocks, format="csr")
 
-        zeros = sps.csr_matrix
+        zeros = sps.csr_array
         eye = sps.eye
     else:
         sparse = False
@@ -1175,7 +1175,7 @@ def _get_Abc(lp, c0):
         shape = (n_bounds, A_ub.shape[1])
         if sparse:
             idxs = (np.arange(n_bounds), i_newub)
-            A_ub = vstack((A_ub, sps.csr_matrix((np.ones(n_bounds), idxs),
+            A_ub = vstack((A_ub, sps.csr_array((np.ones(n_bounds), idxs),
                                                 shape=shape)))
         else:
             A_ub = vstack((A_ub, np.zeros(shape)))
@@ -1215,7 +1215,7 @@ def _get_Abc(lp, c0):
     if sparse:
         b = b.reshape(-1, 1)
         A = A.tocsc()
-        b -= (A[:, i_shift] @ sps.diags(lb_shift)).sum(axis=1)
+        b -= (A[:, i_shift] @ sps.diags_array(lb_shift)).sum(axis=1).reshape(b.shape)
         b = b.ravel()
     else:
         b -= (A[:, i_shift] * lb_shift).sum(axis=1)
@@ -1249,7 +1249,7 @@ def _autoscale(A, b, c, x0):
             R = R.toarray().flatten()
         R[R == 0] = 1
         R = 1/_round_to_power_of_two(R)
-        A = sps.diags(R)@A if sps.issparse(A) else A*R.reshape(m, 1)
+        A = sps.diags_array(R)@A if sps.issparse(A) else A*R.reshape(m, 1)
         b = b*R
 
         C = np.max(np.abs(A), axis=0)
@@ -1257,7 +1257,7 @@ def _autoscale(A, b, c, x0):
             C = C.toarray().flatten()
         C[C == 0] = 1
         C = 1/_round_to_power_of_two(C)
-        A = A@sps.diags(C) if sps.issparse(A) else A*C
+        A = A@sps.diags_array(C) if sps.issparse(A) else A*C
         c = c*C
 
     b_scale = np.max(np.abs(b)) if b.size > 0 else 1

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -283,7 +283,7 @@ def least_squares(
         always uses the '2-point' scheme. If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
-        is applied), a sparse matrix (csr_matrix preferred for performance) or
+        is applied), a sparse matrix (csr_array preferred for performance) or
         a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like or `Bounds`, optional
         There are two ways to specify bounds:
@@ -647,9 +647,9 @@ def least_squares(
     estimate it by finite differences and provide the sparsity structure of
     Jacobian to significantly speed up this process.
 
-    >>> from scipy.sparse import lil_matrix
+    >>> from scipy.sparse import lil_array
     >>> def sparsity_broyden(n):
-    ...     sparsity = lil_matrix((n, n), dtype=int)
+    ...     sparsity = lil_array((n, n), dtype=int)
     ...     i = np.arange(n)
     ...     sparsity[i, i] = 1
     ...     i = np.arange(1, n)

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -1,7 +1,7 @@
 """Linear least squares with bound constraints on independent variables."""
 import numpy as np
 from numpy.linalg import norm
-from scipy.sparse import issparse, csr_matrix
+from scipy.sparse import issparse, csr_array
 from scipy.sparse.linalg import LinearOperator, lsmr
 from scipy.optimize import OptimizeResult
 from scipy.optimize._minimize import Bounds
@@ -254,7 +254,7 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
         raise ValueError("`verbose` must be in [0, 1, 2].")
 
     if issparse(A):
-        A = csr_matrix(A)
+        A = csr_array(A)
     elif not isinstance(A, LinearOperator):
         A = np.atleast_2d(np.asarray(A))
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
-from ..sparse import issparse, csc_matrix, csr_matrix, coo_matrix, find
+from ..sparse import issparse, csc_array, csr_array, coo_array, find
 from ._group_columns import group_dense, group_sparse
 from scipy._lib._array_api import array_namespace
 from scipy._lib import array_api_extra as xpx
@@ -244,7 +244,7 @@ def group_columns(A, order=0):
            and its Applications, 13 (1974), pp. 117-120.
     """
     if issparse(A):
-        A = csc_matrix(A)
+        A = csc_array(A)
     else:
         A = np.atleast_2d(A)
         A = (A != 0).astype(np.int32)
@@ -364,7 +364,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         with shape (m, n). Otherwise it returns a dense array or sparse
         matrix depending on how `sparsity` is defined. If `sparsity`
         is None then a ndarray with shape (m, n) is returned. If
-        `sparsity` is not None returns a csr_matrix with shape (m, n).
+        `sparsity` is not None returns a csr_array with shape (m, n).
         For sparse matrices and linear operators it is always returned as
         a 2-D structure, for ndarrays, if m=1 it is returned
         as a 1-D gradient array with shape (n,).
@@ -530,7 +530,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
                 groups = group_columns(sparsity)
 
             if issparse(structure):
-                structure = csc_matrix(structure)
+                structure = csc_array(structure)
             else:
                 structure = np.atleast_2d(structure)
 
@@ -693,7 +693,7 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
             raise ValueError("Never be here.")
 
         # All that's left is to compute the fraction. We store i, j and
-        # fractions as separate arrays and later construct coo_matrix.
+        # fractions as separate arrays and later construct coo_array.
         row_indices.append(i)
         col_indices.append(j)
         fractions.append(df[i] / dx[j])
@@ -701,8 +701,8 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
     row_indices = np.hstack(row_indices)
     col_indices = np.hstack(col_indices)
     fractions = np.hstack(fractions)
-    J = coo_matrix((fractions, (row_indices, col_indices)), shape=(m, n))
-    return csr_matrix(J)
+    J = coo_array((fractions, (row_indices, col_indices)), shape=(m, n))
+    return csr_array(J)
 
 
 def check_derivative(fun, jac, x0, bounds=(-np.inf, np.inf), args=(),
@@ -772,7 +772,7 @@ def check_derivative(fun, jac, x0, bounds=(-np.inf, np.inf), args=(),
     if issparse(J_to_test):
         J_diff = approx_derivative(fun, x0, bounds=bounds, sparsity=J_to_test,
                                    args=args, kwargs=kwargs)
-        J_to_test = csr_matrix(J_to_test)
+        J_to_test = csr_array(J_to_test)
         abs_err = J_to_test - J_diff
         i, j, abs_err_data = find(abs_err)
         J_diff_data = np.asarray(J_diff[i, j]).ravel()

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -289,7 +289,7 @@ def _remove_redundancy_pivot_sparse(A, rhs):
     d = []                  # Indices of dependent rows
 
     A_orig = A
-    A = scipy.sparse.hstack((scipy.sparse.eye(m), A)).tocsc()
+    A = scipy.sparse.hstack((scipy.sparse.eye_array(m), A)).tocsc()
     e = np.zeros(m)
 
     # Implements basic algorithm from [2]

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -27,7 +27,7 @@ class CanonicalConstraint:
     jac : callable
         Function to evaluate the Jacobian of the constraint. The signature
         is ``jac(x) -> J_eq, J_ineq``, where ``J_eq`` and ``J_ineq`` are
-        either ndarray of csr_matrix of shapes (n_eq, n) and (n_ineq, n),
+        either ndarray of csr_array of shapes (n_eq, n) and (n_ineq, n),
         respectively.
     hess : callable
         Function to evaluate the Hessian of the constraints multiplied
@@ -77,7 +77,7 @@ class CanonicalConstraint:
         """
         empty_fun = np.empty(0)
         empty_jac = np.empty((0, n))
-        empty_hess = sps.csr_matrix((n, n))
+        empty_hess = sps.csr_array((n, n))
 
         def fun(x):
             return empty_fun, empty_fun
@@ -158,7 +158,7 @@ class CanonicalConstraint:
         keep_feasible = np.empty(0, dtype=bool)
 
         if cfun.sparse_jacobian:
-            empty_jac = sps.csr_matrix((0, n))
+            empty_jac = sps.csr_array((0, n))
         else:
             empty_jac = np.empty((0, n))
 
@@ -174,7 +174,7 @@ class CanonicalConstraint:
         empty_fun = np.empty(0)
         n = cfun.n
         if cfun.sparse_jacobian:
-            empty_jac = sps.csr_matrix((0, n))
+            empty_jac = sps.csr_array((0, n))
         else:
             empty_jac = np.empty((0, n))
 
@@ -185,7 +185,7 @@ class CanonicalConstraint:
         empty_fun = np.empty(0)
         n = cfun.n
         if cfun.sparse_jacobian:
-            empty_jac = sps.csr_matrix((0, n))
+            empty_jac = sps.csr_array((0, n))
         else:
             empty_jac = np.empty((0, n))
 
@@ -225,7 +225,7 @@ class CanonicalConstraint:
         empty_fun = np.empty(0)
         n = cfun.n
         if cfun.sparse_jacobian:
-            empty_jac = sps.csr_matrix((0, n))
+            empty_jac = sps.csr_array((0, n))
         else:
             empty_jac = np.empty((0, n))
 
@@ -379,7 +379,7 @@ def initial_constraints_as_canonical(n, prepared_constraints, sparse_jacobian):
 
     if sparse_jacobian:
         vstack = sps.vstack
-        empty = sps.csr_matrix((0, n))
+        empty = sps.csr_array((0, n))
     else:
         vstack = np.vstack
         empty = np.empty((0, n))

--- a/scipy/optimize/_trustregion_constr/equality_constrained_sqp.py
+++ b/scipy/optimize/_trustregion_constr/equality_constrained_sqp.py
@@ -1,6 +1,6 @@
 """Byrd-Omojokun Trust-Region SQP method."""
 
-from scipy.sparse import eye as speye
+from scipy.sparse import eye_array as speye
 from .projections import projections
 from .qp_subproblem import modified_dogleg, projected_cg, box_intersections
 import numpy as np

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -1,6 +1,6 @@
 """Basic linear factorizations needed by the solver."""
 
-from scipy.sparse import (bmat, csc_matrix, eye, issparse)
+from scipy.sparse import (block_array, csc_array, eye_array, issparse)
 from scipy.sparse.linalg import LinearOperator
 import scipy.linalg
 import scipy.sparse.linalg
@@ -92,7 +92,7 @@ def normal_equation_projections(A, m, n, orth_tol, max_refin, tol):
 def augmented_system_projections(A, m, n, orth_tol, max_refin, tol):
     """Return linear operators for matrix A - ``AugmentedSystem``."""
     # Form augmented system
-    K = csc_matrix(bmat([[eye(n), A.T], [A, None]]))
+    K = block_array([[eye_array(n), A.T], [A, None]], format="csc")
     # LU factorization
     # TODO: Use a symmetric indefinite factorization
     #       to solve the system twice as fast (because
@@ -367,7 +367,7 @@ def projections(A, method=None, orth_tol=1e-12, max_refin=3, tol=1e-15):
     # The factorization of an empty matrix
     # only works for the sparse representation.
     if m*n == 0:
-        A = csc_matrix(A)
+        A = csc_array(A)
 
     # Check Argument
     if issparse(A):

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -1,6 +1,6 @@
 """Basic linear factorizations needed by the solver."""
 
-from scipy.sparse import (block_array, csc_array, eye_array, issparse)
+from scipy.sparse import block_array, csc_array, eye_array, issparse
 from scipy.sparse.linalg import LinearOperator
 import scipy.linalg
 import scipy.sparse.linalg

--- a/scipy/optimize/_trustregion_constr/qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/qp_subproblem.py
@@ -1,6 +1,6 @@
 """Equality-constrained quadratic programming solvers."""
 
-from scipy.sparse import linalg, block_array, csc_array
+from scipy.sparse import linalg, block_array
 from math import copysign
 import numpy as np
 from numpy.linalg import norm

--- a/scipy/optimize/_trustregion_constr/qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/qp_subproblem.py
@@ -1,6 +1,6 @@
 """Equality-constrained quadratic programming solvers."""
 
-from scipy.sparse import (linalg, bmat, csc_matrix)
+from scipy.sparse import linalg, block_array, csc_array
 from math import copysign
 import numpy as np
 from numpy.linalg import norm
@@ -47,7 +47,7 @@ def eqp_kktfact(H, c, A, b):
     # Karush-Kuhn-Tucker matrix of coefficients.
     # Defined as in Nocedal/Wright "Numerical
     # Optimization" p.452 in Eq. (16.4).
-    kkt_matrix = csc_matrix(bmat([[H, A.T], [A, None]]))
+    kkt_matrix = block_array([[H, A.T], [A, None]], format="csc")
     # Vector of coefficients.
     kkt_vec = np.hstack([-c, -b])
 

--- a/scipy/optimize/_trustregion_constr/tests/test_projections.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_projections.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.linalg
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 from scipy.optimize._trustregion_constr.projections \
     import projections, orthogonality
 from numpy.testing import (TestCase, assert_array_almost_equal,
@@ -23,7 +23,7 @@ class TestProjections(TestCase):
                             [0, 8, 7, 0, 1, 5, 9, 0],
                             [1, 0, 0, 0, 0, 1, 2, 3]])
         At_dense = A_dense.T
-        A = csc_matrix(A_dense)
+        A = csc_array(A_dense)
         test_points = ([1, 2, 3, 4, 5, 6, 7, 8],
                        [1, 10, 3, 0, 1, 6, 7, 8],
                        [1.12, 10, 0, 0, 100000, 6, 0.7, 8])
@@ -45,7 +45,7 @@ class TestProjections(TestCase):
         A_dense = np.array([[1, 2, 3, 4, 0, 5, 0, 7],
                             [0, 8, 7, 0, 1, 5, 9, 0],
                             [1, 0, 0, 0, 0, 1, 2, 3]])
-        A = csc_matrix(A_dense)
+        A = csc_array(A_dense)
         test_points = ([1, 2, 3, 4, 5, 6, 7, 8],
                        [1, 10, 3, 0, 1, 6, 7, 8],
                        [1.12, 10, 0, 0, 100000, 6, 0.7, 8],
@@ -65,7 +65,7 @@ class TestProjections(TestCase):
         A_dense = np.array([[1, 2, 3, 4, 0, 5, 0, 7],
                             [0, 8, 7, 0, 1, 5, 9, 0],
                             [1, 0, 0, 0, 0, 1, 2, 3]])
-        A = csc_matrix(A_dense)
+        A = csc_array(A_dense)
         test_points = ([1, 2, 3],
                        [1, 10, 3],
                        [1.12, 10, 0])
@@ -106,7 +106,7 @@ class TestProjections(TestCase):
     def test_compare_dense_and_sparse(self):
         D = np.diag(range(1, 101))
         A = np.hstack([D, D, D, D])
-        A_sparse = csc_matrix(A)
+        A_sparse = csc_array(A)
         np.random.seed(0)
 
         Z, LS, Y = projections(A)
@@ -123,7 +123,7 @@ class TestProjections(TestCase):
         D2 = np.diag([1, -0.6, -0.3])
         D3 = np.diag([-0.3, -1.5, 2])
         A = np.hstack([D1, D2, D3])
-        A_sparse = csc_matrix(A)
+        A_sparse = csc_array(A)
         np.random.seed(0)
 
         Z, LS, Y = projections(A)
@@ -197,7 +197,7 @@ class TestOrthogonality(TestCase):
         A = np.array([[1, 2, 3, 4, 0, 5, 0, 7],
                       [0, 8, 7, 0, 1, 5, 9, 0],
                       [1, 0, 0, 0, 0, 1, 2, 3]])
-        A = csc_matrix(A)
+        A = csc_array(A)
         test_vectors = ([-1.98931144, -1.56363389,
                          -0.84115584, 2.2864762,
                          5.599141, 0.09286976,

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -19,10 +19,10 @@ class TestEQPDirectFactorization(TestCase):
     # Optimization" p.452.
     def test_nocedal_example(self):
         H = csc_array([[6, 2, 1],
-                        [2, 5, 2],
-                        [1, 2, 4]])
+                       [2, 5, 2],
+                       [1, 2, 4]])
         A = csc_array([[1, 0, 1],
-                        [0, 1, 1]])
+                       [0, 1, 1]])
         c = np.array([-8, -3, -3])
         b = -np.array([3, 0])
         x, lagrange_multipliers = eqp_kktfact(H, c, A, b)
@@ -425,10 +425,10 @@ class TestProjectCG(TestCase):
     # Optimization" p.452.
     def test_nocedal_example(self):
         H = csc_array([[6, 2, 1],
-                        [2, 5, 2],
-                        [1, 2, 4]])
+                       [2, 5, 2],
+                       [1, 2, 4]])
         A = csc_array([[1, 0, 1],
-                        [0, 1, 1]])
+                       [0, 1, 1]])
         c = np.array([-8, -3, -3])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -439,11 +439,11 @@ class TestProjectCG(TestCase):
 
     def test_compare_with_direct_fact(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -455,11 +455,11 @@ class TestProjectCG(TestCase):
 
     def test_trust_region_infeasible(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         trust_radius = 1
@@ -469,11 +469,11 @@ class TestProjectCG(TestCase):
 
     def test_trust_region_barely_feasible(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         trust_radius = 2.32379000772445021283
@@ -488,11 +488,11 @@ class TestProjectCG(TestCase):
 
     def test_hits_boundary(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         trust_radius = 3
@@ -506,11 +506,11 @@ class TestProjectCG(TestCase):
 
     def test_negative_curvature_unconstrained(self):
         H = csc_array([[1, 2, 1, 3],
-                        [2, 0, 2, 4],
-                        [1, 2, 0, 2],
-                        [3, 4, 2, 0]])
+                       [2, 0, 2, 4],
+                       [1, 2, 0, 2],
+                       [3, 4, 2, 0]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 0, 1]])
+                       [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -519,11 +519,11 @@ class TestProjectCG(TestCase):
 
     def test_negative_curvature(self):
         H = csc_array([[1, 2, 1, 3],
-                        [2, 0, 2, 4],
-                        [1, 2, 0, 2],
-                        [3, 4, 2, 0]])
+                       [2, 0, 2, 4],
+                       [1, 2, 0, 2],
+                       [3, 4, 2, 0]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 0, 1]])
+                       [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -539,11 +539,11 @@ class TestProjectCG(TestCase):
     # are active during the iterations.
     def test_inactive_box_constraints(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -561,11 +561,11 @@ class TestProjectCG(TestCase):
     # by maximum iterations (infeasible interaction).
     def test_active_box_constraints_maximum_iterations_reached(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)
@@ -583,11 +583,11 @@ class TestProjectCG(TestCase):
     # because it hits boundary (without infeasible interaction).
     def test_active_box_constraints_hits_boundaries(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         trust_radius = 3
@@ -605,11 +605,11 @@ class TestProjectCG(TestCase):
     # because it hits boundary (infeasible interaction).
     def test_active_box_constraints_hits_boundaries_infeasible_iter(self):
         H = csc_array([[6, 2, 1, 3],
-                        [2, 5, 2, 4],
-                        [1, 2, 4, 5],
-                        [3, 4, 5, 7]])
+                       [2, 5, 2, 4],
+                       [1, 2, 4, 5],
+                       [3, 4, 5, 7]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 1, 1]])
+                       [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         trust_radius = 4
@@ -627,11 +627,11 @@ class TestProjectCG(TestCase):
     # because it hits boundary (no infeasible interaction).
     def test_active_box_constraints_negative_curvature(self):
         H = csc_array([[1, 2, 1, 3],
-                        [2, 0, 2, 4],
-                        [1, 2, 0, 2],
-                        [3, 4, 2, 0]])
+                       [2, 0, 2, 4],
+                       [1, 2, 0, 2],
+                       [3, 4, 2, 0]])
         A = csc_array([[1, 0, 1, 0],
-                        [0, 1, 0, 1]])
+                       [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
         Z, _, Y = projections(A)

--- a/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_qp_subproblem.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 from scipy.optimize._trustregion_constr.qp_subproblem \
     import (eqp_kktfact,
             projected_cg,
@@ -18,10 +18,10 @@ class TestEQPDirectFactorization(TestCase):
     # From Example 16.2 Nocedal/Wright "Numerical
     # Optimization" p.452.
     def test_nocedal_example(self):
-        H = csc_matrix([[6, 2, 1],
+        H = csc_array([[6, 2, 1],
                         [2, 5, 2],
                         [1, 2, 4]])
-        A = csc_matrix([[1, 0, 1],
+        A = csc_array([[1, 0, 1],
                         [0, 1, 1]])
         c = np.array([-8, -3, -3])
         b = -np.array([3, 0])
@@ -424,10 +424,10 @@ class TestProjectCG(TestCase):
     # From Example 16.2 Nocedal/Wright "Numerical
     # Optimization" p.452.
     def test_nocedal_example(self):
-        H = csc_matrix([[6, 2, 1],
+        H = csc_array([[6, 2, 1],
                         [2, 5, 2],
                         [1, 2, 4]])
-        A = csc_matrix([[1, 0, 1],
+        A = csc_array([[1, 0, 1],
                         [0, 1, 1]])
         c = np.array([-8, -3, -3])
         b = -np.array([3, 0])
@@ -438,11 +438,11 @@ class TestProjectCG(TestCase):
         assert_array_almost_equal(x, [2, -1, 1])
 
     def test_compare_with_direct_fact(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -454,11 +454,11 @@ class TestProjectCG(TestCase):
         assert_array_almost_equal(x, x_kkt)
 
     def test_trust_region_infeasible(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -468,11 +468,11 @@ class TestProjectCG(TestCase):
             projected_cg(H, c, Z, Y, b, trust_radius=trust_radius)
 
     def test_trust_region_barely_feasible(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -487,11 +487,11 @@ class TestProjectCG(TestCase):
         assert_array_almost_equal(x, -Y.dot(b))
 
     def test_hits_boundary(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -505,11 +505,11 @@ class TestProjectCG(TestCase):
         assert_array_almost_equal(np.linalg.norm(x), trust_radius)
 
     def test_negative_curvature_unconstrained(self):
-        H = csc_matrix([[1, 2, 1, 3],
+        H = csc_array([[1, 2, 1, 3],
                         [2, 0, 2, 4],
                         [1, 2, 0, 2],
                         [3, 4, 2, 0]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -518,11 +518,11 @@ class TestProjectCG(TestCase):
             projected_cg(H, c, Z, Y, b, tol=0)
 
     def test_negative_curvature(self):
-        H = csc_matrix([[1, 2, 1, 3],
+        H = csc_array([[1, 2, 1, 3],
                         [2, 0, 2, 4],
                         [1, 2, 0, 2],
                         [3, 4, 2, 0]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -538,11 +538,11 @@ class TestProjectCG(TestCase):
     # The box constraints are inactive at the solution but
     # are active during the iterations.
     def test_inactive_box_constraints(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -560,11 +560,11 @@ class TestProjectCG(TestCase):
     # The box constraints active and the termination is
     # by maximum iterations (infeasible interaction).
     def test_active_box_constraints_maximum_iterations_reached(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -582,11 +582,11 @@ class TestProjectCG(TestCase):
     # The box constraints are active and the termination is
     # because it hits boundary (without infeasible interaction).
     def test_active_box_constraints_hits_boundaries(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -604,11 +604,11 @@ class TestProjectCG(TestCase):
     # The box constraints are active and the termination is
     # because it hits boundary (infeasible interaction).
     def test_active_box_constraints_hits_boundaries_infeasible_iter(self):
-        H = csc_matrix([[6, 2, 1, 3],
+        H = csc_array([[6, 2, 1, 3],
                         [2, 5, 2, 4],
                         [1, 2, 4, 5],
                         [3, 4, 5, 7]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 1, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])
@@ -626,11 +626,11 @@ class TestProjectCG(TestCase):
     # The box constraints are active and the termination is
     # because it hits boundary (no infeasible interaction).
     def test_active_box_constraints_negative_curvature(self):
-        H = csc_matrix([[1, 2, 1, 3],
+        H = csc_array([[1, 2, 1, 3],
                         [2, 0, 2, 4],
                         [1, 2, 0, 2],
                         [3, 4, 2, 0]])
-        A = csc_matrix([[1, 0, 1, 0],
+        A = csc_array([[1, 0, 1, 0],
                         [0, 1, 0, 1]])
         c = np.array([-2, -3, -3, 1])
         b = -np.array([3, 0])

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -204,7 +204,7 @@ class BarrierSubproblem:
         new_data[mask] = s
         new_data[~mask] = data
         J = sps.csr_array((new_data, new_indices, new_indptr),
-                           (n_eq + n_ineq, n_vars + n_ineq))
+                          (n_eq + n_ineq, n_vars + n_ineq))
         return J
 
     def lagrangian_hessian_x(self, z, v):

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -158,11 +158,11 @@ class BarrierSubproblem:
         else:
             if sps.issparse(J_eq) or sps.issparse(J_ineq):
                 # It is expected that J_eq and J_ineq
-                # are already `csr_matrix` because of
+                # are already `csr_array` because of
                 # the way ``BoxConstraint``, ``NonlinearConstraint``
                 # and ``LinearConstraint`` are defined.
-                J_eq = sps.csr_matrix(J_eq)
-                J_ineq = sps.csr_matrix(J_ineq)
+                J_eq = sps.csr_array(J_eq)
+                J_ineq = sps.csr_array(J_ineq)
                 return self._assemble_sparse_jacobian(J_eq, J_ineq, s)
             else:
                 S = np.diag(s)
@@ -203,7 +203,7 @@ class BarrierSubproblem:
         new_indices[~mask] = indices
         new_data[mask] = s
         new_data[~mask] = data
-        J = sps.csr_matrix((new_data, new_indices, new_indptr),
+        J = sps.csr_array((new_data, new_indices, new_indptr),
                            (n_eq + n_ineq, n_vars + n_ineq))
         return J
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -11,7 +11,7 @@ from scipy.optimize import differential_evolution, OptimizeResult
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen, minimize
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy import stats
 
 import numpy as np
@@ -965,7 +965,7 @@ class TestDifferentialEvolutionSolver:
             violations.append(pc.violation(x))
         np.testing.assert_allclose(pc.violation(xs.T), np.array(violations).T)
 
-        pc = _ConstraintWrapper(LinearConstraint(csr_matrix(A), -np.inf, 0),
+        pc = _ConstraintWrapper(LinearConstraint(csr_array(A), -np.inf, 0),
                                 x0)
         assert (pc.violation(x0) > 0).any()
         assert (pc.violation([-10, 2, -10, 4]) == 0).all()
@@ -1073,7 +1073,7 @@ class TestDifferentialEvolutionSolver:
         # but using a sparse matrix for the LinearConstraint instead of an
         # array
 
-        L = LinearConstraint(csr_matrix(A), -np.inf, b)
+        L = LinearConstraint(csr_array(A), -np.inf, b)
 
         # using a lower popsize to speed the test up
         res = differential_evolution(

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_
 from pytest import raises as assert_raises
 
-from scipy.sparse import csr_matrix, csc_matrix, lil_matrix
+from scipy.sparse import csr_array, csc_array, lil_array
 
 from scipy.optimize._numdiff import (
     _adjust_scheme_to_bounds, approx_derivative, check_derivative,
@@ -22,7 +22,7 @@ def test_group_columns():
         [0, 0, 0, 0, 1, 1],
         [0, 0, 0, 0, 0, 0]
     ]
-    for transform in [np.asarray, csr_matrix, csc_matrix, lil_matrix]:
+    for transform in [np.asarray, csr_array, csc_array, lil_array]:
         A = transform(structure)
         order = np.arange(6)
         groups_true = np.array([0, 1, 2, 0, 1, 2])
@@ -581,7 +581,7 @@ class TestApproxDerivativeSparse:
                 [-np.inf, self.lb], [np.inf, self.ub]):
             J = approx_derivative(self.fun, self.x0, method=method,
                                   bounds=(l, u), sparsity=(A, groups))
-            assert_(isinstance(J, csr_matrix))
+            assert_(isinstance(J, csr_array))
             assert_allclose(J.toarray(), self.J_true, rtol=1e-6)
 
             rel_step = np.full_like(self.x0, 1e-8)
@@ -607,7 +607,7 @@ class TestApproxDerivativeSparse:
 
     def test_check_derivative(self):
         def jac(x):
-            return csr_matrix(self.jac(x))
+            return csr_array(self.jac(x))
 
         accuracy = check_derivative(self.fun, jac, self.x0,
                                     bounds=(self.lb, self.ub))

--- a/scipy/optimize/tests/test__remove_redundancy.py
+++ b/scipy/optimize/tests/test__remove_redundancy.py
@@ -18,7 +18,7 @@ from scipy.optimize._remove_redundancy import _remove_redundancy_pivot_dense
 from scipy.optimize._remove_redundancy import _remove_redundancy_pivot_sparse
 from scipy.optimize._remove_redundancy import _remove_redundancy_id
 
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 
 
 def setup_module():
@@ -223,6 +223,6 @@ class TestRRID(RRCommonTests):
 
 class TestRRPivotSparse(RRCommonTests):
     def rr(self, A, b):
-        rr_res = _remove_redundancy_pivot_sparse(csc_matrix(A), b)
+        rr_res = _remove_redundancy_pivot_sparse(csc_array(A), b)
         A1, b1, status, message = rr_res
         return A1.toarray(), b1, status, message

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -97,7 +97,7 @@ def test_prepare_constraint_infeasible_x0():
         return A
 
     def hess(x, v):
-        return sps.csr_matrix((4, 4))
+        return sps.csr_array((4, 4))
 
     nonlinear = NonlinearConstraint(fun, -np.inf, 0, jac, hess,
                                     enforce_feasibility)

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -5,7 +5,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_equal, assert_, assert_allclose,
                            assert_equal)
 from scipy._lib._gcutils import assert_deallocated
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.sparse.linalg import LinearOperator
 from scipy.optimize._differentiable_functions import (ScalarFunction,
                                                       VectorFunction,
@@ -693,7 +693,7 @@ def test_LinearVectorFunction():
         [0, 4, 2]
     ])
     x0 = np.zeros(3)
-    A_sparse = csr_matrix(A_dense)
+    A_sparse = csr_array(A_dense)
     x = np.array([1, -1, 0])
     v = np.array([-1, 1])
     Ax = np.array([-3, -4])
@@ -800,6 +800,6 @@ def test_LinearVectorFunctionNoReferenceCycle():
         [0, 4, 2]
     ])
     x0 = np.zeros(3)
-    A_sparse = csr_matrix(A_dense)
+    A_sparse = csr_array(A_dense)
     with assert_deallocated(lambda: LinearVectorFunction(A_sparse, x0, None)):
         pass

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -6,7 +6,7 @@ from numpy.testing import (assert_, assert_allclose,
                            assert_equal, suppress_warnings)
 import pytest
 from pytest import raises as assert_raises
-from scipy.sparse import issparse, lil_matrix
+from scipy.sparse import issparse, lil_array
 from scipy.sparse.linalg import aslinearoperator
 
 from scipy.optimize import least_squares, Bounds
@@ -92,7 +92,7 @@ class BroydenTridiagonal:
         self.x0 = make_strictly_feasible(self.x0, self.lb, self.ub)
 
         if mode == 'sparse':
-            self.sparsity = lil_matrix((n, n), dtype=int)
+            self.sparsity = lil_array((n, n), dtype=int)
             i = np.arange(n)
             self.sparsity[i, i] = 1
             i = np.arange(1, n)
@@ -116,7 +116,7 @@ class BroydenTridiagonal:
         return f
 
     def _jac(self, x):
-        J = lil_matrix((self.n, self.n))
+        J = lil_array((self.n, self.n))
         i = np.arange(self.n)
         J[i, i] = 3 - 2 * x
         i = np.arange(1, self.n)

--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 
 from scipy.optimize import linear_sum_assignment
-from scipy.sparse import random
+from scipy.sparse import random_array
 from scipy.sparse._sputils import matrix
 from scipy.sparse.csgraph import min_weight_full_bipartite_matching
 from scipy.sparse.csgraph.tests.test_matching import (
@@ -93,8 +93,8 @@ def test_two_methods_give_same_result_on_many_sparse_inputs():
     for _ in range(100):
         lsa_raises = False
         mwfbm_raises = False
-        sparse = random(100, 100, density=0.06,
-                        data_rvs=lambda size: np.random.randint(1, 100, size))
+        sparse = random_array((100, 100), density=0.06,
+                              data_sampler=lambda size: np.random.randint(1, 100, size))
         # In csgraph, zeros correspond to missing edges, so we explicitly
         # replace those with infinities
         dense = np.full(sparse.shape, np.inf)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -220,7 +220,7 @@ def l1_regression_prob(seed=0, m=8, d=9, n=100):
     # construct the problem
     c = np.ones(m+n)
     c[:m] = 0
-    A_ub = scipy.sparse.lil_matrix((2*n, n+m))
+    A_ub = scipy.sparse.lil_array((2*n, n+m))
     idx = 0
     for ii in range(n):
         A_ub[idx, :m] = phi @ x[:, ii]
@@ -519,7 +519,7 @@ class LinprogCommonTests:
         rng = np.random.RandomState(0)
         m = 100
         n = 150
-        A_eq = scipy.sparse.rand(m, n, 0.5)
+        A_eq = scipy.sparse.random_array((m, n), density=0.5)
         x_valid = rng.randn(n)
         c = rng.randn(n)
         ub = x_valid + rng.rand(n)

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.linalg import lstsq
 from numpy.testing import assert_allclose, assert_equal, assert_
 
-from scipy.sparse import rand, coo_matrix
+from scipy.sparse import random_array, coo_array
 from scipy.sparse.linalg import aslinearoperator
 from scipy.optimize import lsq_linear
 from scipy.optimize._minimize import Bounds
@@ -177,7 +177,7 @@ class BaseMixin:
 
         assert_(abs(cost_bvls - cost_trf) < cost_trf*1e-10)
 
-    def test_convergence_small_matrix(self):
+    def test_convergence_small_array(self):
         A = np.array([[49.0, 41.0, -32.0],
                       [-19.0, -32.0, -8.0],
                       [-13.0, 10.0, 69.0]])
@@ -199,7 +199,7 @@ class SparseMixin:
         m = 5000
         n = 1000
         rng = np.random.RandomState(0)
-        A = rand(m, n, random_state=rng)
+        A = random_array((m, n), random_state=rng)
         b = rng.randn(m)
         res = lsq_linear(A, b)
         assert_allclose(res.optimality, 0, atol=1e-6)
@@ -213,7 +213,7 @@ class SparseMixin:
         m = 5000
         n = 1000
         rng = np.random.RandomState(0)
-        A = rand(m, n, random_state=rng)
+        A = random_array((m, n), random_state=rng)
         b = rng.randn(m)
         lb = rng.randn(n)
         ub = lb + 1
@@ -232,7 +232,7 @@ class SparseMixin:
         data = np.array([1., 1., 1., 1. + 1e-6, 1.])
         row = np.array([0, 0, 1, 2, 2])
         col = np.array([0, 2, 1, 0, 2])
-        A = coo_matrix((data, (row, col)), shape=(3, 3))
+        A = coo_array((data, (row, col)), shape=(3, 3))
 
         # Get the exact solution
         exact_sol = lsq_linear(A.toarray(), b, lsq_solver='exact')

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from scipy.linalg import block_diag
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_array
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_less, assert_,
                            suppress_warnings)
@@ -430,7 +430,7 @@ class Elec:
                 Jx = 2 * np.diag(x_coord)
                 Jy = 2 * np.diag(y_coord)
                 Jz = 2 * np.diag(z_coord)
-                return csc_matrix(np.hstack((Jx, Jy, Jz)))
+                return csc_array(np.hstack((Jx, Jy, Jz)))
         else:
             jac = self.constr_jac
 


### PR DESCRIPTION
This PR migrates the `optimize` package to use sparse arrays internally. These are only the changes to the code. Another PR will have the changes to the docs (to simplify review). Once these two PRs are merged, scipy will use sparray by default internally in all packages.

In the only public function in `optimize` that returns sparse, `approx_differentiation`, we now return sparse array (matrix) when the input sparsity argument is a sparse array (matrix). There are some private functions in the `linprog` tools that put a sparse array into an `_LPProblem` but in all cases those seem to be private implementation details. Also, there were no issues with index array dtypes being used by native code. 

There are a lot of changes, but each is straight-foward.