### PR TITLE
ENH: optimize: implement Muller's method

### DIFF
--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -277,7 +277,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
                          'nor starting point provided.')
 
     meth = method.lower()
-    map2underlying = {'halley': 'newton', 'secant': 'newton'}
+    map2underlying = {'halley': 'newton', 'secant': 'newton', "muller" : "_muller"}
 
     try:
         methodc = getattr(optzeros, map2underlying.get(meth, meth))

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -14,7 +14,7 @@ from ._numdiff import approx_derivative
 __all__ = ['root_scalar']
 
 ROOT_SCALAR_METHODS = ['bisect', 'brentq', 'brenth', 'ridder', 'toms748',
-                       'newton', 'secant', 'halley']
+                       'newton', 'secant', 'halley', 'muller']
 
 
 class MemoizeDer:
@@ -61,7 +61,7 @@ class MemoizeDer:
 
 def root_scalar(f, args=(), method=None, bracket=None,
                 fprime=None, fprime2=None,
-                x0=None, x1=None,
+                x0=None, x1=None, x2=None,
                 xtol=None, rtol=None, maxiter=None,
                 options=None):
     """
@@ -91,6 +91,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
         - 'newton'    :ref:`(see here) <optimize.root_scalar-newton>`
         - 'secant'    :ref:`(see here) <optimize.root_scalar-secant>`
         - 'halley'    :ref:`(see here) <optimize.root_scalar-halley>`
+        - 'muller'    :ref:`(see here) <optimize.root_scalar-muller>`
 
     bracket: A sequence of 2 floats, optional
         An interval bracketing a root.  ``f(x, *args)`` must have different
@@ -99,6 +100,8 @@ def root_scalar(f, args=(), method=None, bracket=None,
         Initial guess.
     x1 : float, optional
         A second guess.
+    x2 : float, optional
+        A third guess.
     fprime : bool or callable, optional
         If `fprime` is a boolean and is True, `f` is assumed to return the
         value of the objective function and of the derivative.
@@ -148,25 +151,27 @@ def root_scalar(f, args=(), method=None, bracket=None,
 
     Arguments for each method are as follows (x=required, o=optional).
 
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    |                    method                     | f | args | bracket | x0 | x1 | fprime | fprime2 | xtol | rtol | maxiter | options |
-    +===============================================+===+======+=========+====+====+========+=========+======+======+=========+=========+
-    | :ref:`bisect <optimize.root_scalar-bisect>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`brentq <optimize.root_scalar-brentq>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`brenth <optimize.root_scalar-brenth>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`ridder <optimize.root_scalar-ridder>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`toms748 <optimize.root_scalar-toms748>` | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`secant <optimize.root_scalar-secant>`   | x |  o   |         | x  | o  |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`newton <optimize.root_scalar-newton>`   | x |  o   |         | x  |    |   o    |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`halley <optimize.root_scalar-halley>`   | x |  o   |         | x  |    |   x    |    x    |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    |                    method                     | f | args | bracket | x0 | x1 | x2 | fprime | fprime2 | xtol | rtol | maxiter | options |
+    +===============================================+===+======+=========+====+====+====+========+=========+======+======+=========+=========+
+    | :ref:`bisect <optimize.root_scalar-bisect>`   | x |  o   |    x    |    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`brentq <optimize.root_scalar-brentq>`   | x |  o   |    x    |    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`brenth <optimize.root_scalar-brenth>`   | x |  o   |    x    |    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`ridder <optimize.root_scalar-ridder>`   | x |  o   |    x    |    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`toms748 <optimize.root_scalar-toms748>` | x |  o   |    x    |    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`secant <optimize.root_scalar-secant>`   | x |  o   |         | x  | o  |    |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`newton <optimize.root_scalar-newton>`   | x |  o   |         | x  |    |    |   o    |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`halley <optimize.root_scalar-halley>`   | x |  o   |         | x  |    |    |   x    |    x    |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`muller <optimize.root_scalar-muller>`   | x |  o   |         | x  | x  | x  |        |         |  o   |  o   |    o    |   o     |
+    +-----------------------------------------------+---+------+---------+----+----+----+--------+---------+------+------+---------+---------+
 
     Examples
     --------
@@ -255,6 +260,8 @@ def root_scalar(f, args=(), method=None, bracket=None,
     if not method:
         if bracket is not None:
             method = 'brentq'
+        elif x2 is not None:
+            method = 'muller'
         elif x0 is not None:
             if fprime:
                 if fprime2:
@@ -336,6 +343,16 @@ def root_scalar(f, args=(), method=None, bracket=None,
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')
         r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=fprime2, **kwargs)
+    elif meth in ['muller']:
+        if x0 is None:
+            raise ValueError(f'x0 must not be None for {method}')
+        if x1 is None:
+            raise ValueError(f'x1 must not be None for {method}')
+        if x2 is None:
+            raise ValueError(f'x2 must not be None for {method}')
+        if 'xtol' in kwargs:
+            kwargs['tol'] = kwargs.pop('xtol')
+        r, sol = methodc(f, x0, x1, x2, args=args, **kwargs)
     else:
         raise ValueError(f'Unknown solver {method}')
 
@@ -436,6 +453,29 @@ def _root_scalar_secant_doc():
     """
     pass
 
+def _root_scalar_muller_doc():
+    r"""
+    Options
+    -------
+    args : tuple, optional
+        Extra arguments passed to the objective function.
+    xtol : float, optional
+        Tolerance (absolute) for termination.
+    rtol : float, optional
+        Tolerance (relative) for termination.
+    maxiter : int, optional
+        Maximum number of iterations.
+    x0 : float, required
+        Initial guess.
+    x1 : float, optional
+        A second guess. Must be different from `x0`.
+    x2 : float, optional
+        A second guess. Must be different from `x0` and `x1`.
+    options: dict, optional
+        Specifies any method-specific options not covered above.
+
+    """
+    pass
 
 def _root_scalar_newton_doc():
     r"""

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -11,7 +11,7 @@ _xtol = 2e-12
 _rtol = 4 * np.finfo(float).eps
 
 __all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748',
-           'muller', 'RootResults']
+           '_muller', 'RootResults']
 
 # Must agree with CONVERGED, SIGNERR, CONVERR, ...  in zeros.h
 _ECONVERGED = 0
@@ -1395,7 +1395,7 @@ def toms748(f, a, b, args=(), k=1,
                            "toms748")
 
 
-def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
+def _muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
            rtol=0.0, full_output=False, disp=True):
     """
     Find a root of a real or complex function using the Muller's method.
@@ -1407,11 +1407,6 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
     complex roots even with real starting points. As with other root-finding
     methods, initial guesses should be distinct.
 
-    If `x0`, `x1`, and `x2` are a sequence with more than one item, `muller`
-    returns an array of the roots of the function from each trio of starting points.
-    In this case, `func` must be vectorized to return a sequence or array of
-    the same shape as its first argument.
-
     `muller` is for finding roots of a scalar-valued functions of a single
     variable. For problems involving several variables, see `root`.
 
@@ -1421,13 +1416,14 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
         The function whose root is wanted. It must be a function of a
         single variable of the form ``f(x,a,b,c...)``, where ``a,b,c...``
         are extra arguments that can be passed in the `args` parameter.
-    x0 : float, complex, sequence, or ndarray
+        The function can be either real- or complex-valued, but it should 
+        support complex numbers, as intermediate guesses will be complex.
+    x0 : float, complex
         An initial estimate of the root that should be somewhere near the
-        actual root. If not scalar, then `func` must be vectorized and return
-        a sequence or array of the same shape as its first argument.
-    x1 : float, complex, sequence, or ndarray
+        actual root. 
+    x1 : float, complex
         Another estimate of the root.
-    x2 : float, complex, sequence, or ndarray
+    x2 : float, complex
         Another estimate of the root.
     args : tuple, optional
         Extra arguments to be used in the function call.
@@ -1480,16 +1476,6 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
     This is slightly faster than secant method, but slower than Newton's
     method which is quadratic.
 
-    When `muller` is used with arrays, it is best suited for the following
-    types of problems:
-
-    * The initial guesses are all relatively the same distance from
-      the roots.
-    * The size of the initial guesses is larger than O(100) elements.
-      Otherwise, a naive loop may perform as well or better than a vector.
-      You should test this for your usecase, as there's significant overhead
-      to using arrays.
-
     Examples
     --------
     >>> import numpy as np
@@ -1502,37 +1488,6 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
     >>> root
     -1.2168152957711588e-17+1j
 
-    When we want to find roots for a set of related starting values and/or
-    function parameters, we can provide both of those as an array of inputs:
-
-    >>> f2 = lambda x, a: x**3 + a
-    >>> a0 = np.linspace(0, 100, 1001)
-    >>> x0 = np.sqrt(5) * np.linspace(1, 10, 1001)
-    >>> x1 = np.sqrt(3) * np.linspace(1, 10, 1001) * 1j
-    >>> x2 = -np.sqrt(2) * np.linspace(1, 10, 1001)
-
-    >>> vec_res, converged, failed = muller(f2, x0, x1, x2, args=(a0, ), 
-    ...             maxiter=200, full_output=True)
-
-    The above is the equivalent of solving for each value in ``(x, a)``
-    separately in a for-loop, just faster:
-
-    >>> loop_res = [muller(f2, x_0, x_1, x_2, args=(a_0,), maxiter=200)
-    ...             for x_0, x_1, x_2, a_0 in zip(x0, x1, x2, a0)]
-    >>> np.allclose(vec_res, loop_res)
-    True
-
-    Note that in general some values in `vec_res` may not converge, or may 
-    fail as nan.nan due to a poor combination of starting points. These 
-    values are kept to ensure that the array size of `vec_res` is always 
-    identical to sizes of initial guesses.
-
-    In case where size compatibility of `vec_res` is irrelevant (e.g. when
-    searching a `np.linspace` of possible starting points to find different
-    roots), you can easily remove failed and non-converged results:
-
-    >>> vec_res[converged | ~failed]
-
     """
 
     if tol <= 0:
@@ -1541,10 +1496,7 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
     if np.size(x0) > 1:
-        if np.size(x0) == np.size(x1) == np.size(x2):
-            return _array_muller(f, x0, x1, x2, args, tol, rtol, maxiter, full_output)
-        else:
-           raise ValueError("x0, x1, x2 arrays must be of the same size")
+        raise ValueError("operations on arrays are not yet supported")
 
     funcalls = 0
 
@@ -1627,94 +1579,3 @@ def muller(f, x0, x1, x2, args=(), tol=1.48e-8, maxiter=50,
     return _results_select(full_output, (p, funcalls, itr + 1, _ECONVERR), method)
 
 
-def _array_muller(f, x0, x1, x2, args, tol, rtol,
-           maxiter, full_output):
-    """
-    A vectorized version of Muller method for arrays.
-
-    Do not use this method directly. This method is called from `muller`
-    when ``np.size(x0) > 1`` is ``True``. For docstring, see `muller`.
-    """
-
-    # Explicitly copy the arrays as `p`'s will be modified inplace, but the
-    # user's array should not be altered.
-    p0 = np.array(x0, dtype=complex, copy=True)
-    p1 = np.array(x1, dtype=complex, copy=True)
-    p2 = np.array(x2, dtype=complex, copy=True)
-
-    # Track convergence of individual terms.
-    converged = np.zeros_like(p0, dtype=bool)
-    failed = np.zeros_like(p0, dtype=bool)
-
-    # See the test_array_muller() test.
-    should_mask_args = any(isinstance(arg, np.ndarray) for arg in args)
-
-    f0, f1, f2 = f(p0, *args), f(p1, *args), f(p2, *args)
-
-    # Initialize all arrays so they are modified in place, instead
-    # of creating a new array every loop. Noticable difference only
-    # for very large arrays, 100k+.
-    f0_f1_diff = np.zeros_like(f0, dtype=complex)
-    f1_f2_diff = np.zeros_like(f0, dtype=complex)
-    f0_f2_diff = np.zeros_like(f0, dtype=complex)
-    w = np.zeros_like(f0, dtype=complex)
-    discriminant = np.zeros_like(f0, dtype=complex)
-    denominator = np.zeros_like(f0, dtype=complex)
-    h = np.zeros_like(f0, dtype=complex)
-    p = np.zeros_like(f0, dtype=complex)
-
-    for iteration in range(maxiter):
-        # This will occasionally fail for some initial guesses resulting in a nan.
-        # All failures are returned as bool array, and can be masked by user.
-        # Keeping track and masking failed values is computationally more 
-        # expensive than just keeping them as nans. Creating p1p0 etc. arrays
-        # analogous to non-vectorized version above adds significant overhead.
-        f0_f1_diff = (f0 - f1) / (p1 - p0)
-        f1_f2_diff = (f1 - f2) / (p2 - p1)
-        f0_f2_diff = (f0 - f2) / (p0 - p2)
-
-        w = f1_f2_diff + f0_f2_diff - f0_f1_diff
-
-        discriminant = np.sqrt(w**2 - 4 * f2 * f0_f2_diff)
-
-        # Chose maximal denominator for individual values.
-        denominator = np.where(
-            np.abs(w + discriminant) > np.abs(w - discriminant),
-            w + discriminant,
-            w - discriminant,
-        )
-
-        h = -2 * f2 / denominator
-        p = p2 + h
-
-        # Check convergence for all items.
-        new_converged = np.isclose(h, 0, rtol=rtol, atol=tol)
-        converged = converged | new_converged
-
-        if np.all(converged):
-            break
-
-        # Update points for next iteration only for those not yet converged.
-        p0[~converged], p1[~converged], p2[~converged] = (
-            p1[~converged],
-            p2[~converged],
-            p[~converged],
-        )
-
-        if should_mask_args:
-            args = tuple(arg[~converged] if isinstance(arg, np.ndarray)
-                                else arg for arg in args)
-
-        f0[~converged], f1[~converged], f2[~converged] = (
-            f1[~converged],
-            f2[~converged],
-            f(p2[~converged], *args),
-        )
-    
-    failed = np.isnan(p)
-
-    if full_output:
-        result = namedtuple('result', ('root', 'converged', 'failed'))
-        p = result(p, converged, failed)
-
-    return p

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1702,13 +1702,13 @@ def _array_muller(f, x0, x1, x2, args, tol, rtol,
         )
 
         if should_mask_args:
-            masked_args = tuple(arg[~converged] if isinstance(arg, np.ndarray)
+            args = tuple(arg[~converged] if isinstance(arg, np.ndarray)
                                 else arg for arg in args)
 
         f0[~converged], f1[~converged], f2[~converged] = (
             f1[~converged],
             f2[~converged],
-            f(p2[~converged], *masked_args),
+            f(p2[~converged], *args),
         )
     
     failed = np.isnan(p)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -24,7 +24,7 @@ _FLOAT_EPS = finfo(float).eps
 
 bracket_methods = [zeros.bisect, zeros.ridder, zeros.brentq, zeros.brenth,
                    zeros.toms748]
-gradient_methods = [zeros.newton, zeros.muller]
+gradient_methods = [zeros.newton, zeros._muller]
 all_methods = bracket_methods + gradient_methods
 
 # A few test functions used frequently:
@@ -960,20 +960,20 @@ def test_maxiter_int_check_gh10236(method):
     # gh-10236 reported that the error message when `maxiter` is not an integer
     # was difficult to interpret. Check that this was resolved (by gh-10907).
     message = "'float' object cannot be interpreted as an integer"
-    if method != zeros.muller:
+    if method != zeros._muller:
         with pytest.raises(TypeError, match=message):
             method(f1, 0.0, 1.0, maxiter=72.45)
     else:
         with pytest.raises(TypeError, match=message):
             method(f1, 0.0, 1.0, 2.0, maxiter=72.45)
 
-class TestMuller(TestScalarRootFinders):
-    def test_muller_real_roots(self):
+class Test_muller(TestScalarRootFinders):
+    def test__muller_real_roots(self):
         for f in [f1, f2]:
-            x = zeros.muller(f, x0=3, x1=4, x2=5, tol=1e-6)
+            x = zeros._muller(f, x0=3, x1=4, x2=5, tol=1e-6)
             assert_allclose(f(x), 0, atol=1e-6)
         
-    def test_muller_complex_roots(self):
+    def test__muller_complex_roots(self):
         def f1(x):
             return x + 1+1j
         
@@ -984,77 +984,34 @@ class TestMuller(TestScalarRootFinders):
             return x**4 + 1j
         
         for f in [f1, f2, f3]:
-            x = zeros.muller(f, x0=1, x1=2, x2=3, tol=1e-6)
+            x = zeros._muller(f, x0=1, x1=2, x2=3, tol=1e-6)
             assert_allclose(f(x), 0, atol=1e-6)
 
-            x = zeros.muller(f, x0=1.5j, x1=2j, x2=3, tol=1e-6)
+            x = zeros._muller(f, x0=1.5j, x1=2j, x2=3, tol=1e-6)
             assert_allclose(f(x), 0, atol=1e-6)
 
 
-    def test_muller_by_name(self):
-        r"""Invoke muller through root_scalar()"""
+    def test__muller_by_name(self):
+        r"""Invoke _muller through root_scalar()"""
         for f in [f1, f2]:
             r = root_scalar(f, method='muller', x0=3, x1=4, x2=5, xtol=1e-6)
             assert_allclose(f(r.root), 0, atol=1e-6)
 
 
-    def test_muller_fail(self):
+    def test__muller_fail(self):
         message = 'x0, x1, and x2 must be different'
         with pytest.raises(ValueError, match=message):
-            zeros.muller(f1, x0=3, x1=3, x2=5, tol=1e-6)
+            zeros._muller(f1, x0=3, x1=3, x2=5, tol=1e-6)
         with pytest.raises(ValueError, match=message):
-            zeros.muller(f1, x0=3, x1=5, x2=5, tol=1e-6)
+            zeros._muller(f1, x0=3, x1=5, x2=5, tol=1e-6)
         with pytest.raises(ValueError, match=message):
-            zeros.muller(f1, x0=3, x1=5, x2=3, tol=1e-6)
+            zeros._muller(f1, x0=3, x1=5, x2=3, tol=1e-6)
         with pytest.raises(ValueError, match=message):
-            zeros.muller(f1, x0=3, x1=3, x2=3, tol=1e-6)
-
-    def test_array_muller(self):
-        """test muller with array"""
-
-        def f1(x, *a):
-            b = a[0] + x * a[3]
-            return a[1] - a[2] * (np.exp(b / a[5]) - 1.0) - b / a[4] - x
+            zeros._muller(f1, x0=3, x1=3, x2=3, tol=1e-6)
 
 
-        a0 = np.array([
-            5.32725221, 5.48673747, 5.49539973,
-            5.36387202, 4.80237316, 1.43764452,
-            5.23063958, 5.46094772, 5.50512718,
-            5.42046290
-        ])
-        a1 = (np.sin(range(10)) + 1.0) * 7.0
-        args = (a0, a1, 1e-09, 0.004, 10, 0.27456)
-        x0 = [7.0] * 10
-        x1 = [6.0] * 10
-        x2 = [8.0] * 10
-        x = zeros.muller(f1, x0, x1, x2, args)
-        x_expected = (
-            6.17264965, 11.7702805, 12.2219954,
-            7.11017681, 1.18151293, 0.143707955,
-            4.31928228, 10.5419107, 12.7552490,
-            8.91225749
-        )
-        assert_allclose(x, x_expected)
 
-        def f2(x, a):
-            return x**2 + a
-        
-        a0 = np.linspace(0, 100, 1001)
-        x0 = np.sqrt(5) * np.linspace(0, 10, 1001)
-        x1 = np.sqrt(3) * np.linspace(0, 10, 1001) * 1j
-        x2 = -np.sqrt(2) * np.linspace(0, 10, 1001)
-        # This is expected to fail for some values because zeros overlap.
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in divide")
-            x, converged, failed = zeros.muller(f2, x0, x1, x2, args=(a0, ),
-                                                tol=1e-6, full_output=True)
-        
-        assert_allclose(f2(x[converged], a0[converged]), 0, atol=1e-6)
-        assert_allclose(f2(x[~failed], a0[~failed]), 0, atol=1e-6)
-
-
-    def test_muller_full_output(self, capsys):
+    def test__muller_full_output(self, capsys):
         # Test the full_output capability, both when converging and not.
         # Use simple polynomials, to avoid hitting platform dependencies
         # (e.g., exp & trig) in number of iterations
@@ -1070,7 +1027,7 @@ class TestMuller(TestScalarRootFinders):
 
         kwargs = {'tol': 1e-6, 'full_output': True, }
 
-        x, r = zeros.muller(f1, x0, x1, x2, disp=False, **kwargs)
+        x, r = zeros._muller(f1, x0, x1, x2, disp=False, **kwargs)
         assert_(r.converged)
         assert_equal(x, r.root)
         assert_equal((r.iterations, r.function_calls), expected_counts)
@@ -1078,7 +1035,7 @@ class TestMuller(TestScalarRootFinders):
 
         # Now repeat, allowing one fewer iteration to force convergence failure
         iters = r.iterations - 1
-        x, r = zeros.muller(f1, x0, x1, x2, maxiter=iters, disp=False, **kwargs)
+        x, r = zeros._muller(f1, x0, x1, x2, maxiter=iters, disp=False, **kwargs)
         assert_(not r.converged)
         assert_equal(x, r.root)
         assert_equal(r.iterations, iters)
@@ -1087,26 +1044,5 @@ class TestMuller(TestScalarRootFinders):
         with pytest.raises(RuntimeError, match=msg):
             x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
-    def test_muller_does_not_modify_x0(self):
-        # https://github.com/scipy/scipy/issues/9964
-        def f2(x, a):
-            return x**2 + a
-        
-        a0 = np.linspace(0, 100, 1001)
-        x0 = np.sqrt(5) * np.linspace(0, 10, 1001)
-        x1 = np.sqrt(3) * np.linspace(0, 10, 1001) * 1j
-        x2 = -np.sqrt(2) * np.linspace(0, 10, 1001)
-
-        x0_copy = x0.copy()
-        x1_copy = x1.copy()
-        x2_copy = x2.copy()
-
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in divide")
-            x, converged, failed = zeros.muller(f2, x0, x1, x2, args=(a0, ), 
-                                                tol=1e-6, full_output=True)
-        
-        assert_array_equal(x0, x0_copy)
-        assert_array_equal(x1, x1_copy)
-        assert_array_equal(x2, x2_copy)
+    
 


### PR DESCRIPTION
#### Reference issue

Toward #21126

#### What does this implement/fix?

This is an implementation of Muller's method (as discussed in #21126). It supports vectorized operations. The method is usable from `root_scalar()` as well.

#### Additional information

I've decided to implement this as a separate method inside of `_zeros_py.py`. We discussed adding it to `newton()` but the function is already quite unwieldy. Given that, and the more specialized nature of this algorithm, I've decided to make it into it's own function. Of course, pending discussion, the function can be made private and simply called from `newton()`. Usefulness of this function lies in the fact that it has reasonable convergence (slightly higher than the secant method), and unlike Newton's method it doesn't require a derivative. It also converges towards complex roots even with completely real initial guesses. My primary use of this is searching for multiple roots using a `np.linspace` of initial guesses in a certain region.

This is the first time I'm contributing to SciPy, so I'm looking forward to your helpful suggestions. I've tried to mimic the implementation of `newton()` for consistency with existing codebase. There are some notes in the comments as well regarding the specific implementation decisions and why were they chosen over alternatives.
