### PR TITLE
MAINT: Use `ENUM_CHECK_NAME` for avoiding memory leaks in `_superluobject.c`

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -915,20 +915,11 @@ static int trans_cvt(PyObject * input, trans_t * value)
 {
     ENUM_CHECK_INIT;
     ENUM_CHECK(NOTRANS);
+    ENUM_CHECK_NAME(NOTRANS, "N");
     ENUM_CHECK(TRANS);
+    ENUM_CHECK_NAME(TRANS, "T");
     ENUM_CHECK(CONJ);
-    if (my_strxcmp(s, "N") == 0) {
-        *value = NOTRANS;
-        return 1;
-    }
-    if (my_strxcmp(s, "T") == 0) {
-        *value = TRANS;
-        return 1;
-    }
-    if (my_strxcmp(s, "H") == 0) {
-        *value = CONJ;
-        return 1;
-    }
+    ENUM_CHECK_NAME(CONJ, "H");
     ENUM_CHECK_FINISH("invalid value for 'Trans' parameter");
 }
 
@@ -967,34 +958,13 @@ static int milu_cvt(PyObject * input, milu_t * value)
 static int droprule_one_cvt(PyObject * input, int *value)
 {
     ENUM_CHECK_INIT;
-    if (my_strxcmp(s, "BASIC") == 0) {
-        *value = DROP_BASIC;
-        return 1;
-    }
-    if (my_strxcmp(s, "PROWS") == 0) {
-        *value = DROP_PROWS;
-        return 1;
-    }
-    if (my_strxcmp(s, "COLUMN") == 0) {
-        *value = DROP_COLUMN;
-        return 1;
-    }
-    if (my_strxcmp(s, "AREA") == 0) {
-        *value = DROP_AREA;
-        return 1;
-    }
-    if (my_strxcmp(s, "SECONDARY") == 0) {
-        *value = DROP_SECONDARY;
-        return 1;
-    }
-    if (my_strxcmp(s, "DYNAMIC") == 0) {
-        *value = DROP_DYNAMIC;
-        return 1;
-    }
-    if (my_strxcmp(s, "INTERP") == 0) {
-        *value = DROP_INTERP;
-        return 1;
-    }
+    ENUM_CHECK_NAME(DROP_BASIC, "BASIC");
+    ENUM_CHECK_NAME(DROP_PROWS, "PROWS");
+    ENUM_CHECK_NAME(DROP_COLUMN, "COLUMN");
+    ENUM_CHECK_NAME(DROP_AREA, "AREA");
+    ENUM_CHECK_NAME(DROP_SECONDARY, "SECONDARY");
+    ENUM_CHECK_NAME(DROP_DYNAMIC, "DYNAMIC");
+    ENUM_CHECK_NAME(DROP_INTERP, "INTERP");
     ENUM_CHECK_FINISH("invalid value for 'ILU_DropRule' parameter");
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/16234

@Snape3058 I think this change increases code safety. It uses already existing macro `ENUM_CHECK_NAME` which always does `Py_XDECREF(tmpobj)` before returning. Regarding, manually destroying `tmpobj`, I think it's not safe. That pattern is also not used elsewhere in SciPy.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
