### PR TITLE
BUG: datasets: add headers to fetchers to avoid 403 errors

### DIFF
--- a/scipy/datasets/_download_all.py
+++ b/scipy/datasets/_download_all.py
@@ -39,7 +39,7 @@ def download_all(path=None):
     if path is None:
         path = pooch.os_cache('scipy-data')
     # https://github.com/scipy/scipy/issues/21879
-    downloader = pooch.HTTPDownloader(headers={"User-Agent": f"SciPy"})
+    downloader = pooch.HTTPDownloader(headers={"User-Agent": "SciPy"})
     for dataset_name, dataset_hash in _registry.registry.items():
         pooch.retrieve(url=_registry.registry_urls[dataset_name],
                        known_hash=dataset_hash,

--- a/scipy/datasets/_download_all.py
+++ b/scipy/datasets/_download_all.py
@@ -38,10 +38,12 @@ def download_all(path=None):
                           "conda to install 'pooch'.")
     if path is None:
         path = pooch.os_cache('scipy-data')
+    # https://github.com/scipy/scipy/issues/21879
+    downloader = pooch.HTTPDownloader(headers={"User-Agent": f"SciPy"})
     for dataset_name, dataset_hash in _registry.registry.items():
         pooch.retrieve(url=_registry.registry_urls[dataset_name],
                        known_hash=dataset_hash,
-                       fname=dataset_name, path=path)
+                       fname=dataset_name, path=path, downloader=downloader)
 
 
 def main():

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -28,7 +28,7 @@ def fetch_data(dataset_name, data_fetcher=data_fetcher):
                           "for scipy.datasets module. Please use pip or "
                           "conda to install 'pooch'.")
     # https://github.com/scipy/scipy/issues/21879
-    downloader = pooch.HTTPDownloader(headers={"User-Agent": "agent"})
+    downloader = pooch.HTTPDownloader(headers={"User-Agent": f"SciPy {sys.modules['scipy'].__version__}"})
     # The "fetch" method returns the full path to the downloaded data file.
     return data_fetcher.fetch(dataset_name, downloader=downloader)
 

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -1,3 +1,5 @@
+import sys
+
 from numpy import array, frombuffer, load
 from ._registry import registry, registry_urls
 

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -27,8 +27,10 @@ def fetch_data(dataset_name, data_fetcher=data_fetcher):
         raise ImportError("Missing optional dependency 'pooch' required "
                           "for scipy.datasets module. Please use pip or "
                           "conda to install 'pooch'.")
+    # https://github.com/scipy/scipy/issues/21879
+    downloader = pooch.HTTPDownloader(headers={"User-Agent": "agent"})
     # The "fetch" method returns the full path to the downloaded data file.
-    return data_fetcher.fetch(dataset_name)
+    return data_fetcher.fetch(dataset_name, downloader=downloader)
 
 
 def ascent():

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -30,7 +30,9 @@ def fetch_data(dataset_name, data_fetcher=data_fetcher):
                           "for scipy.datasets module. Please use pip or "
                           "conda to install 'pooch'.")
     # https://github.com/scipy/scipy/issues/21879
-    downloader = pooch.HTTPDownloader(headers={"User-Agent": f"SciPy {sys.modules['scipy'].__version__}"})
+    downloader = pooch.HTTPDownloader(
+        headers={"User-Agent": f"SciPy {sys.modules['scipy'].__version__}"}
+    )
     # The "fetch" method returns the full path to the downloaded data file.
     return data_fetcher.fetch(dataset_name, downloader=downloader)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #21879
See https://github.com/readthedocs/readthedocs.org/issues/11763

#### What does this implement/fix?
<!--Please explain your changes.-->
Add headers to fetchers to avoid 403 errors when using scipy dataset fetch in readthedocs.

#### Additional information
<!--Any additional information you think is important.-->
