### PR TITLE
REL: set 1.15.0rc2 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.15.0rc1"
+version = "1.15.0rc2.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.15.0rc2` "unreleased."

[ci skip] [skip ci] [skip cirrus] [skip circle]