### PR TITLE
MAINT: Add `__str__` overrides for distributions in new infra to fix plot titles

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4996,7 +4996,7 @@ class FoldedDistribution(TransformedDistribution):
 
     def __str__(self):
         with np.printoptions(threshold=10):
-            return f"abs({repr(self._dist)})"
+            return f"abs({str(self._dist)})"
 
 
 def abs(X, /):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1114,17 +1114,15 @@ class TestMakeDistribution:
             assert hasattr(stats, dist)
 
         dist = stats.make_distribution(stats.gamma)
-        if np.__version__ < "2":
-            assert str(dist(a=2)) == "Gamma(a=2.0)"
-        else:
-            assert str(dist(a=2)) == "Gamma(a=np.float64(2.0))"
+        assert str(dist(a=2)) == "Gamma(a=2.0)"
+        if np.__version__ >= "2":
+            assert repr(dist(a=2)) == "Gamma(a=np.float64(2.0))"
         assert 'Gamma' in dist.__doc__
 
         dist = stats.make_distribution(stats.halfgennorm)
-        if np.__version__ < "2":
-            str(dist(beta=2)) == "HalfGeneralizedNormal(beta=2.0)"
-        else:
-            assert str(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
+        assert str(dist(beta=2)) == "HalfGeneralizedNormal(beta=2.0)"
+        if np.__version__ >= "2":
+            assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
 
@@ -1389,16 +1387,11 @@ class TestTransforms:
         # don't fit well above
 
         X = Uniform(a=1, b=2)
-        X_repr = (
-            "Uniform(a=1.0, b=2.0)" if np.__version__ < "2"
-            else "Uniform(a=np.float64(1.0), b=np.float64(2.0))"
-        )
+        X_str = "Uniform(a=1.0, b=2.0)"
 
-        assert repr(stats.log(X)) == str(stats.log(X)) == (
-            f"log({X_repr})"
-        )
-        assert repr(1 / X) == str(1 / X) == f"1/({X_repr})"
-        assert repr(stats.exp(X)) == str(stats.exp(X)) == f"exp({X_repr})"
+        assert str(stats.log(X)) == f"log({X_str})"
+        assert str(1 / X) == f"1/({X_str})"
+        assert str(stats.exp(X)) == f"exp({X_str})"
 
         X = Uniform(a=-1, b=2)
         message = "Division by a random variable is only implemented when the..."


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes a regression in the titles of plots produced by the `plot` method of distributions from the new infrastructure that was pointed out here: https://github.com/scipy/scipy/pull/22025#discussion_r1884759224. It was introduced in https://github.com/scipy/scipy/pull/22037, because we used the more informative `__repr__` overrides for `__str__`, with the unintended consequence that obtrusive datatype info appears in the plot titles like this:

![normal_plot](https://github.com/user-attachments/assets/e866c2ab-6b43-4ac3-ab43-4d9eea4f34b2)

To fix this, I've defined `__str__` overrides which are just direct copy pastes of the `__repr__` overrides, but with `repr` replaced by `str` throughout. I also needed to update `MonotonicTransformedDistribution` to take a `str_pattern` in addition to `repr_pattern`, because there were some cases where this is needed.

With these changes, the above plot looks like this:

![normal_plot2](https://github.com/user-attachments/assets/12c956f1-73d7-4f29-9645-8108607ab293)

I also updated some tests for `__str__` which were assuming `str` was the same as `repr`.

#### Additional information
<!--Any additional information you think is important.-->

We could do something fancier to reduce code duplication, but since it's really pushing it whether this can be backported, I figured it would be better to put in the easiest thing to confirm is correct.