### PR TITLE
BUG, DOC: fixup md5 hash reporting

### DIFF
--- a/tools/write_release_and_log.py
+++ b/tools/write_release_and_log.py
@@ -86,7 +86,7 @@ MD5
 ~~~
 
 """)
-        ftarget.writelines(['{c}\n' for c in compute_md5(idirs)])
+        ftarget.writelines([f'{c}\n' for c in compute_md5(idirs)])
         ftarget.writelines("""
 SHA256
 ~~~~~~


### PR DESCRIPTION
* Fixes gh-22077.

* Fix a missing f-string prefix in `write_release_task()` that was causing an omission of md5 release asset hashes in the SciPy `1.15.0rc1` release notes. As you might expect, the problem snuck in as a side effect of modernization away from printf-style string substitution in gh-21361.

[skip ci] [skip cirrus] [skip circle]