### PR TITLE
DOC: sparse: explicit dtypes for nonzero()

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -894,9 +894,9 @@ class _spbase:
         Examples
         --------
         >>> from scipy.sparse import csr_array
-        >>> A = csr_array([[1,2,0],[0,0,3],[4,0,5]])
+        >>> A = csr_array([[1, 2, 0], [0, 0, 3], [4, 0, 5]])
         >>> A.nonzero()
-        (array([0, 0, 1, 2, 2]), array([0, 1, 2, 0, 2]))
+        (array([0, 0, 1, 2, 2], dtype=int32), array([0, 1, 2, 0, 2], dtype=int32))
 
         """
 


### PR DESCRIPTION
`$ python dev.py smoke-docs` fails for me locally on dtype mismatch in sparse `.nonzero()` docstring. cc @dschult not sure if this is indeed a correct change?