### PR TITLE
DEP: special: raise error for non-integer types with exact=True for comb and perm

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2728,12 +2728,9 @@ def comb(N, k, *, exact=False, repetition=False):
         if int(N) == N and int(k) == k:
             # _comb_int casts inputs to integers, which is safe & intended here
             return _comb_int(N, k)
-        # otherwise, we disregard `exact=True`; it makes no sense for
-        # non-integral arguments
-        msg = ("`exact=True` is deprecated for non-integer `N` and `k` and will raise "
-               "an error in SciPy 1.16.0")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        return comb(N, k)
+        else:
+            raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
+                             "supported.")
     else:
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)
@@ -2787,19 +2784,17 @@ def perm(N, k, exact=False):
         N = np.squeeze(N)[()]  # for backward compatibility (accepted size 1 arrays)
         k = np.squeeze(k)[()]
         if not (isscalar(N) and isscalar(k)):
-            raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
+            raise ValueError("`N` and `k` must be scalar integers with `exact=True`.")
 
         floor_N, floor_k = int(N), int(k)
         non_integral = not (floor_N == N and floor_k == k)
-        if (k > N) or (N < 0) or (k < 0):
-            if non_integral:
-                msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and "
-                       "will raise an error in SciPy 1.16.0.")
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            return 0
         if non_integral:
             raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
                              "supported.")
+
+        if (k > N) or (N < 0) or (k < 0):
+            return 0
+
         val = 1
         for i in range(floor_N - floor_k + 1, floor_N + 1):
             val *= i

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1491,10 +1491,13 @@ class TestCombinatorics:
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
 
     @pytest.mark.thread_unsafe
-    def test_comb_exact_non_int_dep(self):
+    def test_comb_exact_non_int_error(self):
         msg = "`exact=True`"
-        with pytest.deprecated_call(match=msg):
+        with pytest.raises(ValueError, match=msg):
             special.comb(3.4, 4, exact=True)
+        with pytest.raises(ValueError, match=msg):
+            special.comb(3, 4.4, exact=True)
+
 
     def test_perm(self):
         assert_allclose(special.perm([10, 10], [3, 4]), [720., 5040.])
@@ -1514,17 +1517,12 @@ class TestCombinatorics:
         with pytest.raises(ValueError, match="scalar integers"):
             special.perm([1, 2], [4, 5], exact=True)
 
-        # Non-integral scalars with N < k, or N,k < 0 used to return 0, this is now
-        # deprecated and will raise an error in SciPy 1.16.0
-        with pytest.deprecated_call(match="Non-integer"):
+        with pytest.raises(ValueError, match="Non-integer"):
             special.perm(4.6, 6, exact=True)
-        with pytest.deprecated_call(match="Non-integer"):
+        with pytest.raises(ValueError, match="Non-integer"):
             special.perm(-4.6, 3, exact=True)
-        with pytest.deprecated_call(match="Non-integer"):
+        with pytest.raises(ValueError, match="Non-integer"):
             special.perm(4, -3.9, exact=True)
-
-        # Non-integral scalars which aren't included in the cases above an raise an
-        # error directly without deprecation as this code never worked
         with pytest.raises(ValueError, match="Non-integer"):
             special.perm(6.0, 4.6, exact=True)
 


### PR DESCRIPTION
Follow up to https://github.com/scipy/scipy/pull/20780 and https://github.com/scipy/scipy/pull/20909