### PR TITLE
TST: optimize: suppress incorrect sparray warning from scikit-sparse

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -94,7 +94,7 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                     _get_solver.cholmod_factor.cholesky_inplace(M)
                 except Exception:
                     with np.testing.suppress_warnings() as sup:
-                        sup.filter(CholmodTypeConversionWarning, "converting matrix of class")
+                        sup.filter(CholmodTypeConversionWarning, "converting *of class")
                         _get_solver.cholmod_factor = cholmod_analyze(M)
                         _get_solver.cholmod_factor.cholesky_inplace(M)
                 solve = _get_solver.cholmod_factor

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -88,13 +88,13 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                 def solve(r, sym_pos=False):
                     return sps.linalg.lsqr(M, r)[0]
             elif cholesky:
-                try:
-                    # Will raise an exception in the first call,
-                    # or when the matrix changes due to a new problem
-                    _get_solver.cholmod_factor.cholesky_inplace(M)
-                except Exception:
-                    with np.testing.suppress_warnings() as sup:
-                        sup.filter(CholmodTypeConversionWarning, "converting *of class")
+                with np.testing.suppress_warnings() as sup:
+                    sup.filter(CholmodTypeConversionWarning)
+                    try:
+                        # Will raise an exception in the first call,
+                        # or when the matrix changes due to a new problem
+                        _get_solver.cholmod_factor.cholesky_inplace(M)
+                    except Exception:
                         _get_solver.cholmod_factor = cholmod_analyze(M)
                         _get_solver.cholmod_factor.cholesky_inplace(M)
                 solve = _get_solver.cholmod_factor

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -31,6 +31,7 @@ try:
     import sksparse  # noqa: F401
     from sksparse.cholmod import cholesky as cholmod  # noqa: F401
     from sksparse.cholmod import analyze as cholmod_analyze
+    from sksparse.cholmod import CholmodTypeConversionWarning
 except ImportError:
     has_cholmod = False
 try:
@@ -92,8 +93,10 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                     # or when the matrix changes due to a new problem
                     _get_solver.cholmod_factor.cholesky_inplace(M)
                 except Exception:
-                    _get_solver.cholmod_factor = cholmod_analyze(M)
-                    _get_solver.cholmod_factor.cholesky_inplace(M)
+                    with np.testing.suppress_warnings() as sup:
+                        sup.filter(CholmodTypeConversionWarning, "converting matrix of class")
+                        _get_solver.cholmod_factor = cholmod_analyze(M)
+                        _get_solver.cholmod_factor.cholesky_inplace(M)
                 solve = _get_solver.cholmod_factor
             else:
                 if has_umfpack and sym_pos:

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -88,6 +88,16 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                 def solve(r, sym_pos=False):
                     return sps.linalg.lsqr(M, r)[0]
             elif cholesky:
+                # TODO: revert this suppress_warning once the warning bug fix in
+                # sksparse is merged/released
+                # Suppress spurious warning bug from sksparse with csc_array gh-22089
+                # try:
+                #     # Will raise an exception in the first call,
+                #     # or when the matrix changes due to a new problem
+                #     _get_solver.cholmod_factor.cholesky_inplace(M)
+                # except Exception:
+                #     _get_solver.cholmod_factor = cholmod_analyze(M)
+                #     _get_solver.cholmod_factor.cholesky_inplace(M)
                 with np.testing.suppress_warnings() as sup:
                     sup.filter(CholmodTypeConversionWarning)
                     try:

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -59,7 +59,7 @@ def normal_equation_projections(A, m, n, orth_tol, max_refin, tol):
     """
     # Cholesky factorization
     # TODO: revert this once the warning bug fix in sksparse is merged/released
-    # Add suppression of spurious warning bug from sksparse when csc_array is used
+    # Add suppression of spurious warning bug from sksparse with csc_array gh-22089
     # factor = cholesky_AAt(A)
     with np.testing.suppress_warnings() as sup:
         sup.filter(CholmodTypeConversionWarning, "converting matrix of class")

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -5,7 +5,7 @@ from scipy.sparse.linalg import LinearOperator
 import scipy.linalg
 import scipy.sparse.linalg
 try:
-    from sksparse.cholmod import cholesky_AAt
+    from sksparse.cholmod import cholesky_AAt, CholmodTypeConversionWarning
     sksparse_available = True
 except ImportError:
     import warnings
@@ -58,7 +58,12 @@ def normal_equation_projections(A, m, n, orth_tol, max_refin, tol):
     """Return linear operators for matrix A using ``NormalEquation`` approach.
     """
     # Cholesky factorization
-    factor = cholesky_AAt(A)
+    # TODO: revert this once the warning bug fix in sksparse is merged/released
+    # Add suppression of spurious warning bug from sksparse when csc_array is used
+    # factor = cholesky_AAt(A)
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(CholmodTypeConversionWarning, "converting matrix of class")
+        factor = cholesky_AAt(A)
 
     # z = x - A.T inv(A A.T) A x
     def null_space(x):


### PR DESCRIPTION
Fix for CI failures using scikit-sparse...    Related to migration from spmatrix to sparray: #22068
This PR suppresses a warning so the scipy CI tests pass.   

During the migration from spmatrix to sparray, #22068 revealed a minor bug in `scikit-sparse` which causes a warning to be raised when an `sparray` is used with `Cholesky_AAt`. 

I have submitted a fix to scikit-sparse/scikit-sparse#133 

We can remove this warning suppression when enough time has passed that the upstream fix is merged and released and likely to be the commonly used release most of the time. But I don't think we can predict how long that will be.
