### PR TITLE
ENH: optimize: migrate to sparray (docs)

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -48,7 +48,7 @@ class NonlinearConstraint:
         'cs'} select a finite difference scheme for the numerical estimation.
         A callable must have the following signature::
 
-            jac(x) -> {ndarray, sparse matrix}, shape (m, n)
+            jac(x) -> {ndarray, sparse array}, shape (m, n)
 
         Default is '2-point'.
     hess : {callable, '2-point', '3-point', 'cs', HessianUpdateStrategy, None}, optional
@@ -63,7 +63,7 @@ class NonlinearConstraint:
 
         A callable must return the Hessian matrix of ``dot(fun, v)`` and
         must have the following signature:
-        ``hess(x, v) -> {LinearOperator, sparse matrix, array_like}, shape (n, n)``.
+        ``hess(x, v) -> {LinearOperator, sparse array, array_like}, shape (n, n)``.
         Here ``v`` is ndarray with shape (m,) containing Lagrange multipliers.
     keep_feasible : array_like of bool, optional
         Whether to keep the constraint components feasible throughout
@@ -73,7 +73,7 @@ class NonlinearConstraint:
         Relative step size for the finite difference approximation. Default is
         None, which will select a reasonable value automatically depending
         on a finite difference scheme.
-    finite_diff_jac_sparsity: {None, array_like, sparse matrix}, optional
+    finite_diff_jac_sparsity: {None, array_like, sparse array}, optional
         Defines the sparsity structure of the Jacobian matrix for finite
         difference estimation, its shape must be (m, n). If the Jacobian has
         only few non-zero elements in *each* row, providing the sparsity
@@ -135,7 +135,7 @@ class LinearConstraint:
 
     Parameters
     ----------
-    A : {array_like, sparse matrix}, shape (m, n)
+    A : {array_like, sparse array}, shape (m, n)
         Matrix defining the constraint.
     lb, ub : dense array_like, optional
         Lower and upper limits on the constraint. Each array must have the

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -867,12 +867,12 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         when Mehrota's predictor-corrector is not in use (uncommon).
     sparse : bool (default: False)
         Set to ``True`` if the problem is to be treated as sparse after
-        presolve. If either ``A_eq`` or ``A_ub`` is a sparse matrix,
+        presolve. If either ``A_eq`` or ``A_ub`` is sparse,
         this option will automatically be set ``True``, and the problem
         will be treated as sparse even during presolve. If your constraint
         matrices contain mostly zeros and the problem is not very small (less
         than about 100 constraints or variables), consider setting ``True``
-        or providing ``A_eq`` and ``A_ub`` as sparse matrices.
+        or providing ``A_eq`` and ``A_ub`` as sparse arrays.
     lstsq : bool (default: ``False``)
         Set to ``True`` if the problem is expected to be very poorly
         conditioned. This should always be left ``False`` unless severe

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -258,7 +258,7 @@ def build_quadratic_1d(J, g, s, diag=None, s0=None):
 
     Parameters
     ----------
-    J : ndarray, sparse matrix or LinearOperator shape (m, n)
+    J : ndarray, sparse array or LinearOperator shape (m, n)
         Jacobian matrix, affects the quadratic term.
     g : ndarray, shape (n,)
         Gradient, defines the linear term.
@@ -329,7 +329,7 @@ def evaluate_quadratic(J, g, s, diag=None):
 
     Parameters
     ----------
-    J : ndarray, sparse matrix or LinearOperator, shape (m, n)
+    J : ndarray, sparse array or LinearOperator, shape (m, n)
         Jacobian matrix, affects the quadratic term.
     g : ndarray, shape (n,)
         Gradient, defines the linear term.

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -283,7 +283,7 @@ def least_squares(
         always uses the '2-point' scheme. If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
-        is applied), a sparse matrix (csr_array preferred for performance) or
+        is applied), a sparse array (csr_array preferred for performance) or
         a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like or `Bounds`, optional
         There are two ways to specify bounds:
@@ -423,7 +423,7 @@ def least_squares(
           normal equation, which improves convergence if the Jacobian is
           rank-deficient [Byrd]_ (eq. 3.4).
 
-    jac_sparsity : {None, array_like, sparse matrix}, optional
+    jac_sparsity : {None, array_like, sparse array}, optional
         Defines the sparsity structure of the Jacobian matrix for finite
         difference estimation, its shape must be (m, n). If the Jacobian has
         only few non-zero elements in *each* row, providing the sparsity
@@ -456,7 +456,7 @@ def least_squares(
             Value of the cost function at the solution.
         fun : ndarray, shape (m,)
             Vector of residuals at the solution.
-        jac : ndarray, sparse matrix or LinearOperator, shape (m, n)
+        jac : ndarray, sparse array or LinearOperator, shape (m, n)
             Modified Jacobian matrix at the solution, in the sense that J^T J
             is a Gauss-Newton approximation of the Hessian of the cost function.
             The type is the same as the one used by the algorithm.

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -50,7 +50,7 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
 
     Parameters
     ----------
-    A : array_like, sparse matrix of LinearOperator, shape (m, n)
+    A : array_like, sparse array or LinearOperator, shape (m, n)
         Design matrix. Can be `scipy.sparse.linalg.LinearOperator`.
     b : array_like, shape (m,)
         Target vector.
@@ -222,18 +222,18 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
 
     Examples
     --------
-    In this example, a problem with a large sparse matrix and bounds on the
+    In this example, a problem with a large sparse arrays and bounds on the
     variables is solved.
 
     >>> import numpy as np
-    >>> from scipy.sparse import rand
+    >>> from scipy.sparse import random_array
     >>> from scipy.optimize import lsq_linear
     >>> rng = np.random.default_rng()
     ...
     >>> m = 2000
     >>> n = 1000
     ...
-    >>> A = rand(m, n, density=1e-4, random_state=rng)
+    >>> A = random_array((m, n), density=1e-4, random_state=rng)
     >>> b = rng.standard_normal(m)
     ...
     >>> lb = rng.standard_normal(n)

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -221,7 +221,7 @@ def group_columns(A, order=0):
 
     Parameters
     ----------
-    A : array_like or sparse matrix, shape (m, n)
+    A : array_like or sparse array, shape (m, n)
         Matrix of which to group columns.
     order : int, iterable of int with shape (n,) or None
         Permutation array which defines the order of columns enumeration.
@@ -325,20 +325,20 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         case the bound will be the same for all variables. Use it to limit the
         range of function evaluation. Bounds checking is not implemented
         when `as_linear_operator` is True.
-    sparsity : {None, array_like, sparse matrix, 2-tuple}, optional
+    sparsity : {None, array_like, sparse array, 2-tuple}, optional
         Defines a sparsity structure of the Jacobian matrix. If the Jacobian
         matrix is known to have only few non-zero elements in each row, then
         it's possible to estimate its several columns by a single function
         evaluation [3]_. To perform such economic computations two ingredients
         are required:
 
-        * structure : array_like or sparse matrix of shape (m, n). A zero
+        * structure : array_like or sparse array of shape (m, n). A zero
           element means that a corresponding element of the Jacobian
           identically equals to zero.
         * groups : array_like of shape (n,). A column grouping for a given
           sparsity structure, use `group_columns` to obtain it.
 
-        A single array or a sparse matrix is interpreted as a sparsity
+        A single array or a sparse array is interpreted as a sparsity
         structure, and groups are computed inside the function. A tuple is
         interpreted as (structure, groups). If None (default), a standard
         dense differencing will be used.
@@ -347,7 +347,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         matrices where each row contains few non-zero elements.
     as_linear_operator : bool, optional
         When True the function returns an `scipy.sparse.linalg.LinearOperator`.
-        Otherwise it returns a dense array or a sparse matrix depending on
+        Otherwise it returns a dense array or a sparse array depending on
         `sparsity`. The linear operator provides an efficient way of computing
         ``J.dot(p)`` for any vector ``p`` of shape (n,), but does not allow
         direct access to individual elements of the matrix. By default
@@ -358,11 +358,11 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
 
     Returns
     -------
-    J : {ndarray, sparse matrix, LinearOperator}
+    J : {ndarray, sparse array, LinearOperator}
         Finite difference approximation of the Jacobian matrix.
         If `as_linear_operator` is True returns a LinearOperator
         with shape (m, n). Otherwise it returns a dense array or sparse
-        matrix depending on how `sparsity` is defined. If `sparsity`
+        array depending on how `sparsity` is defined. If `sparsity`
         is None then a ndarray with shape (m, n) is returned. If
         `sparsity` is not None returns a csr_array or csr_matrix with
         shape (m, n) following the array/matrix type of the incoming structure.
@@ -721,7 +721,7 @@ def check_derivative(fun, jac, x0, bounds=(-np.inf, np.inf), args=(),
     jac : callable
         Function which computes Jacobian matrix of `fun`. It must work with
         argument x the same way as `fun`. The return value must be array_like
-        or sparse matrix with an appropriate shape.
+        or sparse array with an appropriate shape.
     x0 : array_like of shape (n,) or float
         Point at which to estimate the derivatives. Float will be converted
         to 1-D array.

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -2096,7 +2096,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                     hcalls += 1
             else:
                 # hess was supplied as a callable or hessian update strategy, so
-                # A is a dense numpy array or sparse matrix
+                # A is a dense numpy array or sparse array
                 Ap = A.dot(psupi)
             # check curvature
             Ap = asarray(Ap).squeeze()  # get rid of matrices...

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -112,14 +112,14 @@ def _remove_redundancy_pivot_dense(A, rhs, true_rank=None):
 
     Parameters
     ----------
-    A : 2-D sparse matrix
+    A : 2-D array
         An matrix representing the left-hand side of a system of equations
     rhs : 1-D array
         An array representing the right-hand side of a system of equations
 
     Returns
     -------
-    A : 2-D sparse matrix
+    A : 2-D array
         A matrix representing the left-hand side of a system of equations
     rhs : 1-D array
         An array representing the right-hand side of a system of equations
@@ -239,14 +239,14 @@ def _remove_redundancy_pivot_sparse(A, rhs):
 
     Parameters
     ----------
-    A : 2-D sparse matrix
+    A : 2-D sparse array
         An matrix representing the left-hand side of a system of equations
     rhs : 1-D array
         An array representing the right-hand side of a system of equations
 
     Returns
     -------
-    A : 2-D sparse matrix
+    A : 2-D sparse array
         A matrix representing the left-hand side of a system of equations
     rhs : 1-D array
         An array representing the right-hand side of a system of equations

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -265,7 +265,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         Optimization method used.
     constr : list of ndarray
         List of constraint values at the solution.
-    jac : list of {ndarray, sparse matrix}
+    jac : list of {ndarray, sparse array}
         List of the Jacobian matrices of the constraints at the solution.
     v : list of ndarray
         List of the Lagrange multipliers for the constraints at the solution.

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -293,7 +293,7 @@ def projections(A, method=None, orth_tol=1e-12, max_refin=3, tol=1e-15):
 
     Parameters
     ----------
-    A : sparse matrix (or ndarray), shape (m, n)
+    A : sparse array (or ndarray), shape (m, n)
         Matrix ``A`` used in the projection.
     method : string, optional
         Method used for compute the given linear
@@ -374,7 +374,7 @@ def projections(A, method=None, orth_tol=1e-12, max_refin=3, tol=1e-15):
         if method is None:
             method = "AugmentedSystem"
         if method not in ("NormalEquation", "AugmentedSystem"):
-            raise ValueError("Method not allowed for sparse matrix.")
+            raise ValueError("Method not allowed for sparse array.")
         if method == "NormalEquation" and not sksparse_available:
             warnings.warn("Only accepts 'NormalEquation' option when "
                           "scikit-sparse is available. Using "

--- a/scipy/optimize/_trustregion_constr/qp_subproblem.py
+++ b/scipy/optimize/_trustregion_constr/qp_subproblem.py
@@ -25,11 +25,11 @@ def eqp_kktfact(H, c, A, b):
 
     Parameters
     ----------
-    H : sparse matrix, shape (n, n)
+    H : sparse array, shape (n, n)
         Hessian matrix of the EQP problem.
     c : array_like, shape (n,)
         Gradient of the quadratic objective function.
-    A : sparse matrix
+    A : sparse array
         Jacobian matrix of the EQP problem.
     b : array_like, shape (m,)
         Right-hand side of the constraint equation.
@@ -321,10 +321,10 @@ def modified_dogleg(A, Y, b, trust_radius, lb, ub):
 
     Parameters
     ----------
-    A : LinearOperator (or sparse matrix or ndarray), shape (m, n)
+    A : LinearOperator (or sparse array or ndarray), shape (m, n)
         Matrix ``A`` in the minimization problem. It should have
         dimension ``(m, n)`` such that ``m < n``.
-    Y : LinearOperator (or sparse matrix or ndarray), shape (n, m)
+    Y : LinearOperator (or sparse array or ndarray), shape (n, m)
         LinearOperator that apply the projection matrix
         ``Q = A.T inv(A A.T)`` to the vector. The obtained vector
         ``y = Q x`` being the minimum norm solution of ``A y = x``.
@@ -421,13 +421,13 @@ def projected_cg(H, c, Z, Y, b, trust_radius=np.inf,
 
     Parameters
     ----------
-    H : LinearOperator (or sparse matrix or ndarray), shape (n, n)
+    H : LinearOperator (or sparse array or ndarray), shape (n, n)
         Operator for computing ``H v``.
     c : array_like, shape (n,)
         Gradient of the quadratic objective function.
-    Z : LinearOperator (or sparse matrix or ndarray), shape (n, n)
+    Z : LinearOperator (or sparse array or ndarray), shape (n, n)
         Operator for projecting ``x`` into the null space of A.
-    Y : LinearOperator,  sparse matrix, ndarray, shape (n, m)
+    Y : LinearOperator,  sparse array, ndarray, shape (n, m)
         Operator that, for a given a vector ``b``, compute smallest
         norm solution of ``A x + b = 0``.
     b : array_like, shape (m,)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1070,7 +1070,7 @@ class TestDifferentialEvolutionSolver:
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
         # now repeat the same solve, using the same overall constraints,
-        # but using a sparse matrix for the LinearConstraint instead of an
+        # but using a sparse array for the LinearConstraint instead of an
         # array
 
         L = LinearConstraint(csr_array(A), -np.inf, b)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3236,8 +3236,8 @@ def test_gh12594():
                                          coo_array, csr_array, csc_array])
 def test_sparse_hessian(method, sparse_type):
     # gh-8792 reported an error for minimization with `newton_cg` when `hess`
-    # returns a sparse matrix. Check that results are the same whether `hess`
-    # returns a dense or sparse matrix for optimization methods that accept
+    # returns a sparse array. Check that results are the same whether `hess`
+    # returns a dense or sparse array for optimization methods that accept
     # sparse Hessian matrices.
 
     def sparse_rosen_hess(x):


### PR DESCRIPTION
This PR converts the optimize package **docs** from spmatrix to sparray.

It is a companion to #22068 which only changes the code. This builds on that PR by making doc changes.

These changes are mostly straight-forward name switches.