### PR TITLE
MAINT: signal: fixed build warning (`sprintf`) on MacOS

### DIFF
--- a/scipy/signal/_sigtoolsmodule.cc
+++ b/scipy/signal/_sigtoolsmodule.cc
@@ -907,7 +907,7 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
                     type, maxiter, grid_density, &niter);
     if (err < 0) {
         if (err == -1) {
-            sprintf(mystr, "Failure to converge at iteration %d, try reducing transition band width.\n", niter);
+            snprintf(mystr, sizeof(mystr), "Failure to converge at iteration %d, try reducing transition band width.\n", niter);
 	        PyErr_SetString(PyExc_ValueError, mystr);
 	        goto fail;
         }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #22086 

#### What does this implement/fix?
<!--Please explain your changes.-->
Used `snprintf` instead of `sprintf`
- `snprintf` requires an argument: number of bytes that will be written to the buffer. The buffer was already initialized with enough size. So just passed the length of the `mystr` to `snprintf`

#### Additional information
<!--Any additional information you think is important.-->
