### PR TITLE
DEP: update version in deprecation warning of interpnd

### DIFF
--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -13,7 +13,7 @@ __all__ = ["_deprecated"]
 _NoValue = object()
 
 def _sub_module_deprecation(*, sub_package, module, private_modules, all,
-                            attribute, correct_module=None):
+                            attribute, correct_module=None, dep_version="1.16.0"):
     """Helper function for deprecating modules that are public but were
     intended to be private.
 
@@ -33,6 +33,8 @@ def _sub_module_deprecation(*, sub_package, module, private_modules, all,
     correct_module : str, optional
         Module in `sub_package` that `attribute` should be imported from.
         Default is that `attribute` should be imported from ``scipy.sub_package``.
+    dep_version : str, optional
+        Version in which deprecated attributes will be removed.
     """
     if correct_module is not None:
         correct_import = f"scipy.{sub_package}.{correct_module}"
@@ -59,7 +61,7 @@ def _sub_module_deprecation(*, sub_package, module, private_modules, all,
             f"`scipy.{sub_package}.{module}.{attribute}` is deprecated along with "
             f"the `scipy.{sub_package}.{module}` namespace. "
             f"`scipy.{sub_package}.{module}.{attribute}` will be removed "
-            f"in SciPy 1.14.0, and the `scipy.{sub_package}.{module}` namespace "
+            f"in SciPy {dep_version}, and the `scipy.{sub_package}.{module}` namespace "
             f"will be removed in SciPy 2.0.0."
         )
 


### PR DESCRIPTION
Closes #22097

It was reported that `interpolate.interpnd.GradientEstimationWarning` etc raised a warning saying they would be removed in 1.14. In fact they were only deprecated in this cycle and the version in the warning was outdated. This pr updates the version number so they can be removed in the next release.