### PR TITLE
DOC: Correct version reference for `axis` in `scipy.stats.pearsonr`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4298,7 +4298,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         Axis along which to perform the calculation. Default is 0.
         If None, ravel both arrays before performing the calculation.
 
-        .. versionadded:: 1.13.0
+        .. versionadded:: 1.14.0
     alternative : {'two-sided', 'greater', 'less'}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
         The following options are available:


### PR DESCRIPTION
#### Reference Issue  
Closes gh-22004  

---

#### What does this implement/fix?  
This pull request updates the documentation for the `scipy.stats.pearsonr` function.  

- The version reference for the `axis` parameter is corrected from `1.13.0` to `1.14.0`.  
- The original documentation incorrectly stated that the `axis` parameter was introduced in version `1.13.0`. However, the feature was first added in version `1.14.0`.  

---

#### Additional Information  
This change ensures accuracy in the documentation and helps developers use the function with the correct version expectations.  
No code modifications are involved; this is strictly a documentation update.  

---

#### Checklist  
- [x] Verified the updated version number aligns with release notes for version `1.14.0`.  
- [x] Built documentation locally to confirm no errors.  
