### PR TITLE
DOC: 1.15.0 release note updates

### DIFF
--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -41,6 +41,7 @@ Highlights of this release
   probability calculations.
 - Several new features support vectorized calculations with Python Array API
   Standard compatible input (see "Array API Standard Support" below):
+
   - `scipy.differentiate` is a new top-level submodule for accurate
     estimation of derivatives of black box functions.
   - `scipy.optimize.elementwise` contains new functions for root-finding and
@@ -48,6 +49,7 @@ Highlights of this release
   - `scipy.integrate` offers new functions ``cubature``, ``tanhsinh``, and
     ``nsum`` for multivariate integration, univariate integration, and
     univariate series summation, respectively.
+
 - `scipy.interpolate.AAA` adds the AAA algorithm for barycentric rational
   approximation of real or complex functions.
 
@@ -242,7 +244,7 @@ and support several Array API compatible array libraries in addition to NumPy
 - A new probability distribution infrastructure has been added for the
   implementation of univariate, continuous distributions. It has several
   speed, accuracy, memory, and interface advantages compared to the
-  previous infrastructure. See :doc:`rv_infrastructure` for a tutorial.
+  previous infrastructure. See :ref:`rv_infrastructure` for a tutorial.
 
   - Use `scipy.stats.make_distribution` to treat an existing continuous
     distribution (e.g. `scipy.stats.norm`) with the new infrastructure.

--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -39,11 +39,15 @@ Highlights of this release
 - New probability distribution features in `scipy.stats` can be used to improve
   the speed and accuracy of existing continuous distributions and perform new
   probability calculations.
-- `scipy.differentiate` is a new top-level submodule for accurate
-  estimation of derivatives of black box functions.
-- `scipy.optimize.elementwise` provides vectorized root-finding and
-  minimization of univariate functions, and it supports the array API
-  as do new ``integrate`` functions ``tanhsinh``, ``nsum``, and ``cubature``.
+- Several new features support vectorized calculations with Python Array API
+  Standard compatible input (see "Array API Standard Support" below):
+  - `scipy.differentiate` is a new top-level submodule for accurate
+    estimation of derivatives of black box functions.
+  - `scipy.optimize.elementwise` contains new functions for root-finding and
+    minimization of univariate functions.
+  - `scipy.integrate` offers new functions ``cubature``, ``tanhsinh``, and
+    ``nsum`` for multivariate integration, univariate integration, and
+    univariate series summation, respectively.
 - `scipy.interpolate.AAA` adds the AAA algorithm for barycentric rational
   approximation of real or complex functions.
 
@@ -71,17 +75,16 @@ and support several Array API compatible array libraries in addition to NumPy
 
 `scipy.integrate` improvements
 ==============================
-- The ``QUADPACK`` Fortran77 package has been ported to C.
-- `scipy.integrate.lebedev_rule` computes abscissae and weights for
-  integration over the surface of a sphere.
-- `scipy.integrate.nsum` evaluates finite and infinite series and their
-  logarithms.
-- `scipy.integrate.tanhsinh` is now exposed for public use, allowing
-  evaluation of a convergent integral using tanh-sinh quadrature.
 - The new `scipy.integrate.cubature` function supports multidimensional
   integration, and has support for approximating integrals with
   one or more sets of infinite limits.
-
+- `scipy.integrate.tanhsinh` is now exposed for public use, allowing
+  evaluation of a convergent integral using tanh-sinh quadrature.
+- `scipy.integrate.nsum` evaluates finite and infinite series and their
+  logarithms.
+- `scipy.integrate.lebedev_rule` computes abscissae and weights for
+  integration over the surface of a sphere.
+- The ``QUADPACK`` Fortran77 package has been ported to C.
 
 `scipy.interpolate` improvements
 ================================
@@ -237,22 +240,24 @@ and support several Array API compatible array libraries in addition to NumPy
 `scipy.stats` improvements
 ==========================
 - A new probability distribution infrastructure has been added for the
-  implementation of univariate, continuous distributions with speed,
-  accuracy, and memory advantages:
+  implementation of univariate, continuous distributions. It has several
+  speed, accuracy, memory, and interface advantages compared to the
+  previous infrastructure. See :doc:`rv_infrastructure` for a tutorial.
 
-  - `scipy.stats.Normal` represents the normal distribution with the new
-    interface. In typical cases, its methods are faster and more accurate than
-    those of `scipy.stats.norm`.
   - Use `scipy.stats.make_distribution` to treat an existing continuous
     distribution (e.g. `scipy.stats.norm`) with the new infrastructure.
     This can improve the speed and accuracy of existing distributions,
-    especially for methods not overridden with custom formulas in the
-    implementation.
+    especially those with methods not overridden with distribution-specific
+    formulas.
+  - `scipy.stats.Normal` and `scipy.stats.Uniform` are pre-defined classes
+    to represents the normal and uniform distributions, respectively.
+    Their interfaces may be faster and more convenient than those produced by
+    ``make_distribution``.
+  - `scipy.stats.Mixture` can be used to represent mixture distributions.
 
-- `scipy.stats.Mixture` has been added to represent mixture distributions.
-- Instances of `scipy.stats.Normal` and the classes returned by
-  `scipy.stats.make_distribution` are supported by several new mathematical
-  transformations.
+- Instances of `scipy.stats.Normal`, `scipy.stats.Uniform`, and the classes
+  returned by `scipy.stats.make_distribution` are supported by several new
+  mathematical transformations.
 
   - `scipy.stats.truncate` for truncation of the support.
   - `scipy.stats.order_statistic` for the order statistics of a given number

--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -252,7 +252,7 @@ and support several Array API compatible array libraries in addition to NumPy
     especially those with methods not overridden with distribution-specific
     formulas.
   - `scipy.stats.Normal` and `scipy.stats.Uniform` are pre-defined classes
-    to represents the normal and uniform distributions, respectively.
+    to represent the normal and uniform distributions, respectively.
     Their interfaces may be faster and more convenient than those produced by
     ``make_distribution``.
   - `scipy.stats.Mixture` can be used to represent mixture distributions.

--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -56,8 +56,8 @@ Highlights of this release
 New features
 ************
 
-`scipy.differentiate` introduction
-==================================
+``scipy.differentiate`` introduction
+====================================
 The new `scipy.differentiate` sub-package contains functions for accurate
 estimation of derivatives of black box functions.
 
@@ -73,8 +73,8 @@ step size. To facilitate batch computation, these functions are vectorized
 and support several Array API compatible array libraries in addition to NumPy
 (see "Array API Standard Support" below).
 
-`scipy.integrate` improvements
-==============================
+``scipy.integrate`` improvements
+================================
 - The new `scipy.integrate.cubature` function supports multidimensional
   integration, and has support for approximating integrals with
   one or more sets of infinite limits.
@@ -86,8 +86,8 @@ and support several Array API compatible array libraries in addition to NumPy
   integration over the surface of a sphere.
 - The ``QUADPACK`` Fortran77 package has been ported to C.
 
-`scipy.interpolate` improvements
-================================
+``scipy.interpolate`` improvements
+==================================
 - `scipy.interpolate.AAA` adds the AAA algorithm for barycentric rational
   approximation of real or complex functions.
 - `scipy.interpolate.FloaterHormannInterpolator` adds barycentric rational
@@ -104,8 +104,8 @@ and support several Array API compatible array libraries in addition to NumPy
   selection that ``splrep`` and ``*UnivariateSpline`` was using.
 
 
-`scipy.linalg` improvements
-===========================
+``scipy.linalg`` improvements
+=============================
 - `scipy.linalg.interpolative` Fortran77 code has been ported to Cython.
 - `scipy.linalg.solve` supports several new values for the ``assume_a``
   argument, enabling faster computation for diagonal, tri-diagonal, banded, and
@@ -128,8 +128,8 @@ and support several Array API compatible array libraries in addition to NumPy
 - ``id_dist`` Fortran code was rewritten in Cython.
 
 
-`scipy.ndimage` improvements
-============================
+``scipy.ndimage`` improvements
+==============================
 - Several additional filtering functions now support an ``axes`` argument
   that specifies which axes of the input filtering is to be performed on.
   These include ``correlate``, ``convolve``, ``generic_laplace``, ``laplace``,
@@ -143,8 +143,8 @@ and support several Array API compatible array libraries in addition to NumPy
 
 
 
-`scipy.optimize` improvements
-=============================
+``scipy.optimize`` improvements
+===============================
 - The vendored HiGHS library has been upgraded from ``1.4.0`` to ``1.8.0``,
   bringing accuracy and performance improvements to solvers.
 - The ``MINPACK`` Fortran77 package has been ported to C.
@@ -165,8 +165,8 @@ and support several Array API compatible array libraries in addition to NumPy
 - ``HessianUpdateStrategy`` now supports ``__matmul__``.
 
 
-`scipy.signal` improvements
-===========================
+``scipy.signal`` improvements
+=============================
 - Add functionality of complex-valued waveforms to ``signal.chirp()``.
 - `scipy.signal.lombscargle` has two new arguments, ``weights`` and
   ``floating_mean``, enabling sample weighting and removal of an unknown
@@ -177,8 +177,8 @@ and support several Array API compatible array libraries in addition to NumPy
   real or complex valued signal.
 
 
-`scipy.sparse` improvements
-===========================
+``scipy.sparse`` improvements
+=============================
 - A :ref:`migration guide<migration_to_sparray>` is now available for
   moving from sparse.matrix to sparse.array in your code/library.
 - Sparse arrays now support indexing for 1-D and 2-D arrays. So, sparse
@@ -201,14 +201,14 @@ and support several Array API compatible array libraries in addition to NumPy
   available to facilitate index array casting in ``sparse``.
 
 
-`scipy.spatial` improvements
-============================
+``scipy.spatial`` improvements
+==============================
 - ``Rotation.concatenate`` now accepts a bare ``Rotation`` object, and will
   return a copy of it.
 
 
-`scipy.special` improvements
-============================
+``scipy.special`` improvements
+==============================
 - The factorial functions ``special.{factorial,factorial2,factorialk}`` now
   offer an extension to the complex domain by passing the kwarg
   ``extend='complex'``. This is opt-in because it changes the values for
@@ -237,8 +237,8 @@ and support several Array API compatible array libraries in addition to NumPy
   GPUs.
 - `scipy.special.ndtr` is now more efficient.
 
-`scipy.stats` improvements
-==========================
+``scipy.stats`` improvements
+============================
 - A new probability distribution infrastructure has been added for the
   implementation of univariate, continuous distributions. It has several
   speed, accuracy, memory, and interface advantages compared to the


### PR DESCRIPTION
#### What does this implement/fix?
A few other updates to the release notes:
- Organizes the highlights related to vectorized/ Array API compatible new features into a top-level bullet
- Reorders `integrate` improvements
- Improves note about new distribution infrastructure

Also, Iupdated table of contents entries to link to the appropriate section of the release notes rather than the API documentation of the subpackage. ~~It looks like the reason this doesn't happen automatically is that the section headings already include a link. As an experiment, I'm seeing whether this works if the sub-package names are just monospaced font rather than links. If this doesn't work, any ideas?~~ It worked! 

Do others agree this would be more expected behavior and more useful?
