### PR TITLE
DOC: sparse: correct `eye_array` docs for first shape input to fix #22095

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -349,7 +349,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
 
     Parameters
     ----------
-    m : int or tuple of ints
+    m : int
         Number of rows requested.
     n : int, optional
         Number of columns. Default: `m`.


### PR DESCRIPTION
Closes #22095 

Removes the incorrect description of the first argument `m` which should be an `int` while the current docs state it could instead be a tuple of ints (a shape). The code correctly follows the array api for the `eye` function. So the docs should reflect this.

It would be good if  this gets backported to the 1.15 maint branch. And if there is going to ever be a 1.14.2 release, this should be included in that as well.