### PR TITLE
MAINT/DOC: Doctests fix scpdt 1.6

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -487,6 +487,14 @@ if HAVE_SCPDT:
         'scipy.optimize.show_options',  # does not have much to doctest
         'scipy.signal.normalize',       # manipulates warnings (XXX temp skip)
         'scipy.sparse.linalg.norm',     # XXX temp skip
+        # these below test things which inherit from np.ndarray
+        # cross-ref https://github.com/numpy/numpy/issues/28019
+        'scipy.io.matlab.MatlabObject.strides',
+        'scipy.io.matlab.MatlabObject.dtype',
+        'scipy.io.matlab.MatlabOpaque.dtype',
+        'scipy.io.matlab.MatlabOpaque.strides',
+        'scipy.io.matlab.MatlabFunction.strides',
+        'scipy.io.matlab.MatlabFunction.dtype'
     ])
 
     # these are affected by NumPy 2.0 scalar repr: rely on string comparison

--- a/scipy/sparse/linalg/_dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/_dsolve/_add_newdocs.py
@@ -136,18 +136,12 @@ add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU', ('perm_c',
     """
     Permutation Pc represented as an array of indices.
 
-    The column permutation matrix can be reconstructed via:
-
-    >>> Pc = np.zeros((n, n))
-    >>> Pc[np.arange(n), perm_c] = 1
+    See the `SuperLU` docstring for details.
     """))
 
 add_newdoc('scipy.sparse.linalg._dsolve._superlu', 'SuperLU', ('perm_r',
     """
     Permutation Pr represented as an array of indices.
 
-    The row permutation matrix can be reconstructed via:
-
-    >>> Pr = np.zeros((n, n))
-    >>> Pr[perm_r, np.arange(n)] = 1
+    See the `SuperLU` docstring for details.
     """))


### PR DESCRIPTION
Fix/skip several issues in docstring examples, smoked out by the recent `scipy_doctest==1.6` update. 

In short, the update fixes a problem with collections, several docstrings were never tested, and now they are, and the results are not entirely unexpected. 

cross-ref a related issue in numpy: https://github.com/numpy/numpy/issues/28019

cc @tylerjereddy you might want to either backport this PR or pin `scipy-doctest==1.5.1` in the maintenance branch