### PR TITLE
ENH: sparse: enhance dtype checking in constructors

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -137,7 +137,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                 self._shape = check_shape(shape)
 
         if dtype is not None:
-            self.data = self.data.astype(dtype, copy=False)
+            self.data = self.data.astype(getdtype(dtype, self.data), copy=False)
 
         self.check_format(full_check=False)
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -65,13 +65,13 @@ class _coo_base(_data_matrix, _minmax_mixin):
             if issparse(arg1):
                 if arg1.format == self.format and copy:
                     self.coords = tuple(idx.copy() for idx in arg1.coords)
-                    self.data = arg1.data.copy()
+                    self.data = arg1.data.astype(getdtype(dtype, arg1))  # copy=True
                     self._shape = check_shape(arg1.shape, allow_nd=self._allow_nd)
                     self.has_canonical_format = arg1.has_canonical_format
                 else:
                     coo = arg1.tocoo()
                     self.coords = tuple(coo.coords)
-                    self.data = coo.data
+                    self.data = coo.data.astype(getdtype(dtype, coo), copy=False)
                     self._shape = check_shape(coo.shape, allow_nd=self._allow_nd)
                     self.has_canonical_format = False
             else:
@@ -92,15 +92,11 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 coords = M.nonzero()
                 self.coords = tuple(idx.astype(index_dtype, copy=False)
                                      for idx in coords)
-                self.data = M[coords]
+                self.data = getdata(M[coords], copy=copy, dtype=dtype)
                 self.has_canonical_format = True
 
         if len(self._shape) > 2:
             self.coords = tuple(idx.astype(np.int64, copy=False) for idx in self.coords)
-
-        if dtype is not None:
-            newdtype = getdtype(dtype)
-            self.data = self.data.astype(newdtype, copy=False)
 
         self._check()
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2186,11 +2186,11 @@ class _TestCommon:
     def test_dtype_check(self):
         a = np.array([[3.5, 0, 1.1], [0, 0, 0]], dtype=np.float16)
         with assert_raises(ValueError, match="does not support dtype"):
-            A = self.spcreator(a)
+            self.spcreator(a)
 
         A32 = self.spcreator(a.astype(np.float32))
         with assert_raises(ValueError, match="does not support dtype"):
-            A = self.spcreator(A32, dtype=np.float16)
+            self.spcreator(A32, dtype=np.float16)
 
     def test_pickle(self):
         import pickle

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2183,6 +2183,15 @@ class _TestCommon:
             assert_array_equal(spm.todok().toarray(), m)
             assert_array_equal(spm.tobsr().toarray(), m)
 
+    def test_dtype_check(self):
+        a = np.array([[3.5, 0, 1.1], [0, 0, 0]], dtype=np.float16)
+        with assert_raises(ValueError, match="does not support dtype"):
+            A = self.spcreator(a)
+
+        A32 = self.spcreator(a.astype(np.float32))
+        with assert_raises(ValueError, match="does not support dtype"):
+            A = self.spcreator(A32, dtype=np.float16)
+
     def test_pickle(self):
         import pickle
         sup = suppress_warnings()


### PR DESCRIPTION
This hopefully completes the work from #20754 and the issue #20207 to implement dtype checking in sparse constructors. We discovered some cases where the constructor logic was avoiding the checks. This covers the cases:

- dense input to COO with invalid data dtype (this also affects CSR, CSC, DIA, BSR which call COO as part of handling dense input)
- sparse input to BSR with invalid dtype keyword  

I've added tests for these cases on all formats and added dtype checking in COO and BSR.

The COO code removes the check at the end of data construction because that code wasn't checking the faulty `dtype is None` case and it duplicated checking done in the if/else logic structure. I moved the check inside the if/else structure where needed. The dense branch didn't have any coverage when `dtype is None`. It just used the incoming dense dtype even if not valid for sparse (i.e. float16, python object, etc). The sparse input branch needed checks. All others were already covered. Now all branches of the if/else structure check for a valid dtype.

The BSR change is pretty straightforward.

This should be backported to 1.15 because it fills in missed spots in this new feature of 1.15. And it is described in the release notes in a bullet on dtype checking.