### PR TITLE
DOC: release notes: ensure TOC links to headings below

### DIFF
--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -17,7 +17,7 @@ run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
 Our development attention will now shift to bug-fix releases on the
 1.16.x branch, and on adding new features on the main branch.
 
-This release requires Python 3.11-3.13 and NumPy 1.24.4 or greater.
+This release requires Python 3.11-3.13 and NumPy 1.26.4 or greater.
 
 
 **************************
@@ -29,45 +29,48 @@ Highlights of this release
 New features
 ************
 
-`scipy.cluster` improvements
-============================
+``scipy.cluster`` improvements
+==============================
 
 
-`scipy.interpolate` improvements
-================================
+``scipy.differentiate`` improvements
+====================================
 
 
-`scipy.linalg` improvements
-===========================
+``scipy.interpolate`` improvements
+==================================
 
 
-`scipy.ndimage` improvements
-============================
-
-
-`scipy.optimize` improvements
+``scipy.linalg`` improvements
 =============================
 
 
-`scipy.signal` improvements
-===========================
+``scipy.ndimage`` improvements
+==============================
 
 
-`scipy.sparse` improvements
-===========================
+``scipy.optimize`` improvements
+===============================
 
 
+``scipy.signal`` improvements
+=============================
 
-`scipy.spatial` improvements
+
+``scipy.sparse`` improvements
+=============================
+
+
+``scipy.spatial`` improvements
+==============================
+
+
+``scipy.special`` improvements
+==============================
+
+
+``scipy.stats`` improvements
 ============================
-
-
-`scipy.special` improvements
-============================
-
-
-`scipy.stats` improvements
-==========================
 
 
 
@@ -75,12 +78,12 @@ New features
 Deprecated features
 *******************
 
-`scipy.linalg` deprecations
-===========================
+``scipy.linalg`` deprecations
+=============================
 
 
-`scipy.spatial` deprecations
-============================
+``scipy.spatial`` deprecations
+==============================
 
 
 


### PR DESCRIPTION
#### Reference issue
gh-22104

#### What does this implement/fix?
Updates the release notes for 1.16 to ensure that the TOC links to section headings below rather than the API documentation.

Also updates minimum NumPy version to that which will be recommended by [SPEC 0](https://scientific-python.org/specs/spec-0000/), assuming we release in late June like last year. I imagine this will be consider too agressive of a jump, so perhaps we split the difference: 1.25.2 in SciPy 1.16.0, and NumPy 2.0.1 in SciPy 1.17.0?
