### PR TITLE
MAINT: signal.oaconvolve: avoid xp <-> numpy conversions

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -7,6 +7,9 @@ import numpy as np
 from scipy._lib._array_api import array_namespace
 
 
+_init_nd_shape_and_axes = _helper._init_nd_shape_and_axes
+
+
 def next_fast_len(target, real=False):
     """Find the next fast size of input data to ``fft``, for zero-padding, etc.
 
@@ -138,40 +141,6 @@ _sig_prev_fast_len = inspect.signature(prev_fast_len)
 prev_fast_len = update_wrapper(lru_cache()(_helper.prev_good_size), prev_fast_len)
 prev_fast_len.__wrapped__ = _helper.prev_good_size
 prev_fast_len.__signature__ = _sig_prev_fast_len
-
-
-def _init_nd_shape_and_axes(x, shape, axes):
-    """Handle shape and axes arguments for N-D transforms.
-
-    Returns the shape and axes in a standard form, taking into account negative
-    values and checking for various potential errors.
-
-    Parameters
-    ----------
-    x : array_like
-        The input array.
-    shape : int or array_like of ints or None
-        The shape of the result. If both `shape` and `axes` (see below) are
-        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
-        If `shape` is -1, the size of the corresponding dimension of `x` is
-        used.
-    axes : int or array_like of ints or None
-        Axes along which the calculation is computed.
-        The default is over all axes.
-        Negative indices are automatically converted to their positive
-        counterparts.
-
-    Returns
-    -------
-    shape : tuple
-        The shape of the result as a tuple of integers.
-    axes : list
-        Axes along which the calculation is computed, as a list of integers.
-
-    """
-    x = np.asarray(x)
-    return _helper._init_nd_shape_and_axes(x, shape, axes)
 
 
 def fftfreq(n, d=1.0, *, xp=None, device=None):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -44,7 +44,35 @@ def _iterable_of_int(x, name=None):
 
 
 def _init_nd_shape_and_axes(x, shape, axes):
-    """Handles shape and axes arguments for nd transforms"""
+    """
+    Handle shape and axes arguments for N-D transforms.
+
+    Returns the shape and axes in a standard form, taking into account negative
+    values and checking for various potential errors.
+
+    Parameters
+    ----------
+    x : ndarray
+        The input array.
+    shape : int or array_like of ints or None
+        The shape of the result. If both `shape` and `axes` (see below) are
+        None, `shape` is ``x.shape``; if `shape` is None but `axes` is
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
+        If `shape` is -1, the size of the corresponding dimension of `x` is
+        used.
+    axes : int or array_like of ints or None
+        Axes along which the calculation is computed.
+        The default is over all axes.
+        Negative indices are automatically converted to their positive
+        counterparts.
+
+    Returns
+    -------
+    shape : tuple
+        The shape of the result as a tuple of integers.
+    axes : list
+        Axes along which the calculation is computed, as a list of integers.
+    """
     noshape = shape is None
     noaxes = axes is None
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -850,6 +850,7 @@ def _swapaxes(x, ax1, ax2, xp):
     return xp.permute_dims(x, shp)
 
 
+# may want to look at moving _swapaxes and this to array-api-extra,
 # cross-ref https://github.com/data-apis/array-api-extra/issues/97
 def _split(x, indices_or_sections, axis, xp):
     """A simplified version of np.split, with `indices` being an list.

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -27,7 +27,7 @@ from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
-    array_namespace, is_torch, is_numpy, is_array_api_strict, xp_copy, xp_size
+    array_namespace, is_torch, is_numpy, xp_copy, xp_size
 
 )
 import scipy._lib.array_api_compat.numpy as np_compat

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -850,6 +850,7 @@ def _swapaxes(x, ax1, ax2, xp):
     return xp.permute_dims(x, shp)
 
 
+# cross-ref https://github.com/data-apis/array-api-extra/issues/97
 def _split(x, indices_or_sections, axis, xp):
     """A simplified version of np.split, with `indices` being an list.
     """

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -870,29 +870,6 @@ def _split(x, indices_or_sections, axis, xp):
     return sub_arys
 
 
-def xp_pad(x, pad_width, mode='constant', *, xp, **kwargs):
-    # xp.pad is available on numpy, cupy and jax.numpy; on torch, reuse
-    # http://github.com/pytorch/pytorch/blob/main/torch/_numpy/_funcs_impl.py#L2045
-    # for mode = 'constant'
-    if mode != 'constant':
-        raise NotImplementedError()
-
-    value = kwargs.get("constant_values", 0)
-
-    if is_array_api_strict(xp):
-        np_x = np.asarray(x)
-        padded = np.pad(np_x, pad_width, mode=mode, **kwargs)
-        return xp.asarray(padded)
-    elif is_torch(xp):
-        pad_width = xp.asarray(pad_width)
-        pad_width = xp.broadcast_to(pad_width, (x.ndim, 2))
-        pad_width = xp.flip(pad_width, axis=(0,)).flatten()
-        return xp.nn.functional.pad(x, tuple(pad_width), value=value)
-
-    else:
-        return xp.pad(x, pad_width, mode=mode, **kwargs)
-
-
 def oaconvolve(in1, in2, mode="full", axes=None):
     """Convolve two N-dimensional arrays using the overlap-add method.
 
@@ -1053,10 +1030,10 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     # Pad the array to a size that can be reshaped to the desired shape
     # if necessary.
     if not all(curpad == (0, 0) for curpad in pad_size1):
-        in1 = xp_pad(in1, pad_size1, mode='constant', constant_values=0, xp=xp)
+        in1 = xpx.pad(in1, pad_size1, mode='constant', constant_values=0, xp=xp)
 
     if not all(curpad == (0, 0) for curpad in pad_size2):
-         in2 = xp_pad(in2, pad_size2, mode='constant', constant_values=0, xp=xp)
+         in2 = xpx.pad(in2, pad_size2, mode='constant', constant_values=0, xp=xp)
 
     # Reshape the overlap-add parts to input block sizes.
     split_axes = [iax+i for i, iax in enumerate(axes)]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -33,7 +33,7 @@ from scipy._lib._util import ComplexWarning
 
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
-    array_namespace, assert_array_almost_equal, assert_almost_equal,
+    assert_array_almost_equal, assert_almost_equal,
     xp_copy, xp_size, xp_default_dtype
 )
 skip_xp_backends = pytest.mark.skip_xp_backends

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -33,7 +33,7 @@ from scipy._lib._util import ComplexWarning
 
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
-    assert_array_almost_equal, assert_almost_equal,
+    array_namespace, assert_array_almost_equal, assert_almost_equal,
     xp_copy, xp_size, xp_default_dtype
 )
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -964,7 +964,6 @@ def gen_oa_shapes_eq(sizes):
             if a >= b]
 
 
-@skip_xp_backends(cpu_only=True, exceptions=['cupy'])
 @skip_xp_backends("jax.numpy", reason="fails all around")
 class TestOAConvolve:
     @pytest.mark.slow()


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

`scipy.signal.oaconvolve` is pure python + numpy, thus is a potentially good candidate for arrap API conversion. Previously, it was converting to numpy for `np.pad` and `np.split`, neither of which is in the array API spec. Thus draft (simplified) replacements and use them to remove xp <-> np convsersions in `oaconvolve`. 

#### Additional information
<!--Any additional information you think is important.-->

For now, I dropped both `_split` and `xp_pad`  into `_signaltools.py`; They can either stay where they are, or move into `array_api_extra`.