### PR TITLE
DOC: Fix incorrect reference to "Random Variable Transition Guide" notebook

### DIFF
--- a/doc/source/tutorial/stats/rv_infrastructure.md
+++ b/doc/source/tutorial/stats/rv_infrastructure.md
@@ -14,7 +14,7 @@ kernelspec:
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
 ```{eval-rst}
-.. jupyterlite:: ../../_contents/hypothesis_bartlett.ipynb
+.. jupyterlite:: ../../_contents/rv_infrastructure.ipynb
    :new_tab: True
 ```
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-22123

#### What does this implement/fix?
<!--Please explain your changes.-->

A small PR to fix the reference to this notebook in the docs, which was introduced in gh-22025. Thanks for noticing this, @lucascolley (apologies if you were fixing it in the background!).

#### Additional information
<!--Any additional information you think is important.-->

N/A.
