### PR TITLE
ENH: sparse: nD cleanup and docs

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -1415,17 +1415,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _broadcast_to(self, shape, copy=False):
         if self.shape == shape:
             return self.copy() if copy else self
-        
+
         shape = check_shape(shape, allow_nd=(self._allow_nd))
 
         if broadcast_shapes(self.shape, shape) != shape:
             raise ValueError("cannot be broadcast")
-        
+
         if len(self.shape) == 1 and len(shape) == 1:
             self.sum_duplicates()
             if self.nnz == 0: # array has no non zero elements
                 return self.__class__(shape, dtype=self.dtype, copy=False)
-            
+
             N = shape[0]
             data = np.full(N, self.data[0])
             indices = np.arange(0,N)
@@ -1434,14 +1434,14 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # treat 1D as a 2D row
         old_shape = self._shape_as_2d
-            
+
         if len(shape) != 2:
             ndim = len(shape)
             raise ValueError(f'CSR/CSC broadcast_to cannot have shape >2D. Got {ndim}D')
-        
+
         if self.nnz == 0: # array has no non zero elements
             return self.__class__(shape, dtype=self.dtype, copy=False)
-        
+
         self.sum_duplicates()
         M, N = self._swap(shape)
         oM, oN = self._swap(old_shape)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -86,8 +86,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 raise ValueError(f"unrecognized {self.__class__.__name__} "
                                  f"constructor input: {arg1}") from e
-            if isinstance(self, sparray) and arg1.ndim < 2 and self.format == "csc":
+            if isinstance(self, sparray) and arg1.ndim != 2 and self.format == "csc":
                 raise ValueError(f"CSC arrays don't support {arg1.ndim}D input. Use 2D")
+            if arg1.ndim > 2:
+                raise ValueError(f"CSR arrays don't yet support {arg1.ndim}D.")
+
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, self._shape = arrays

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -831,7 +831,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         Parameters
         ----------
-        other : array_like (dense of sparse)
+        other : array_like (dense or sparse)
             Second array
 
         Returns
@@ -997,8 +997,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         The tensordot differs from dot and matmul in that any axis can be
         chosen for each of the first and second array and the sum of the
-        producs is computed just like for matrix multiplication, only not
-        just for the rows fo the first times the columns of the second. It
+        products is computed just like for matrix multiplication, only not
+        just for the rows of the first times the columns of the second. It
         takes the dot product of the collection of vectors along the specified
         axes.  Here we can even take the sum of the products along two or even
         more axes if desired. So, tensordot is a dot product computation
@@ -1008,7 +1008,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         Given two tensors, `a` and `b`, and the desired axes specified as a
         2-tuple/list/array containing two sequences of axis numbers,
         ``(a_axes, b_axes)``, sum the products of `a`'s and `b`'s elements
-        (components) over the axes specified by``a_axes`` and ``b_axes``.
+        (components) over the axes specified by ``a_axes`` and ``b_axes``.
         The `axes` input can be a single non-negative integer, ``N``;
         if it is, then the last ``N`` dimensions of `a` and the first
         ``N`` dimensions of `b` are summed over.

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1112,6 +1112,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         # Reshape the COO array to match the new dimensions
         self = self.reshape(shape)
 
+        idx_dtype = get_index_dtype(self.coords, maxval=max(new_shape))
         coords = self.coords
         new_data = self.data
         new_coords = coords[-1:]  # Copy last coordinate to start
@@ -1121,7 +1122,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             repeat_count = new_shape[-1]
             cum_repeat *= repeat_count
             new_data = np.tile(new_data, repeat_count)
-            new_dim = np.repeat(np.arange(0, repeat_count), self.nnz)
+            new_dim = np.repeat(np.arange(0, repeat_count, dtype=idx_dtype), self.nnz)
             new_coords = (new_dim,)
 
         for i in range(-2, -(len(shape)+1), -1):
@@ -1135,7 +1136,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 new_coords = tuple(np.tile(new_coords[i+1:], repeat_count))
 
                 # Create new dimensions and stack them
-                new_dim = np.repeat(np.arange(0, repeat_count), nnz)
+                new_dim = np.repeat(np.arange(0, repeat_count, dtype=idx_dtype), nnz)
                 new_coords = (new_dim,) + new_coords
             else:
                 # If no broadcasting needed, tile the coordinates

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -44,7 +44,7 @@ class _dok_base(_spbase, IndexMixin, dict):
                 raise TypeError('Invalid input format.') from e
 
             if arg1.ndim > 2:
-                raise TypeError('Expected rank <=2 dense array or matrix.')
+                raise ValueError(f"DOK arrays don't yet support {arg1.ndim}D input.")
 
             if arg1.ndim == 1:
                 if dtype is not None:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1057,11 +1057,11 @@ class _TestCommon:
         datsp = self.spcreator(dat)
 
         def check(dtype):
-            dat_mean = dat.mean(dtype=dtype)
-            datsp_mean = datsp.mean(dtype=dtype)
+            dat_sum = dat.sum(dtype=dtype)
+            datsp_sum = datsp.sum(dtype=dtype)
 
-            assert_array_almost_equal(dat_mean, datsp_mean)
-            assert_equal(dat_mean.dtype, datsp_mean.dtype)
+            assert_array_almost_equal(dat_sum, datsp_sum)
+            assert_equal(dat_sum.dtype, datsp_sum.dtype)
 
         for dtype in self.checked_dtypes:
             check(dtype)
@@ -1094,11 +1094,11 @@ class _TestCommon:
                      [-6, 7, 9]])
         datsp = self.spcreator(dat)
 
-        dat_mean = np.sum(dat)
-        datsp_mean = np.sum(datsp)
+        dat_sum = np.sum(dat)
+        datsp_sum = np.sum(datsp)
 
-        assert_array_almost_equal(dat_mean, datsp_mean)
-        assert_equal(dat_mean.dtype, datsp_mean.dtype)
+        assert_array_almost_equal(dat_sum, datsp_sum)
+        assert_equal(dat_sum.dtype, datsp_sum.dtype)
 
     def test_mean(self):
         keep = not self.is_array_test

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -43,6 +43,16 @@ def test_no_1d_support_in_init(spcreator):
         spcreator([0, 1, 2, 3])
 
 
+# Test init with nD dense input
+# sparrays which do not yet support nD
+@pytest.mark.parametrize(
+    "spcreator", [csr_array, dok_array, bsr_array, csc_array, dia_array, lil_array]
+)
+def test_no_nd_support_in_init(spcreator):
+    with pytest.raises(ValueError, match="arrays don't.*support 3D"):
+        spcreator(np.ones((3, 2, 4)))
+
+
 # Main tests class
 @pytest.mark.parametrize("spcreator", spcreators)
 class TestCommon1D:

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -418,7 +418,7 @@ def test_tuple_constructor_for_dim_size_zero():
 
     empty_arr = coo_array(([], ([], [], [], [])), shape=(4,0,2,3))
     assert_equal(empty_arr.toarray(), np.empty((4,0,2,3)))
-    
+
 
 @pytest.mark.parametrize(('shape', 'new_shape'), [((4,9,6,5), (3,6,15,4)),
                                                   ((4,9,6,5), (36,30)),
@@ -626,8 +626,8 @@ def test_nd_matmul_vector(mat_shape, vec_shape):
 
 
 mat_mat_shapes = [
-    ((2, 3, 4, 5), (2, 3, 5, 7)), 
-    ((0, 0), (0,)), 
+    ((2, 3, 4, 5), (2, 3, 5, 7)),
+    ((0, 0), (0,)),
     ((4, 4, 2, 0), (0,)),
     ((7, 8, 3), (3,)),
     ((7, 8, 3), (3, 1)),
@@ -670,7 +670,7 @@ def test_nd_matmul_sparse_with_inconsistent_arrays():
         sp_x @ sp_y
     with pytest.raises(ValueError, match="matmul: dimension mismatch with signature"):
         sp_x @ (sp_y.toarray())
-    
+
     sp_z = random_array((1,5,3,2), density=0.6, random_state=rng, dtype=int)
     with pytest.raises(ValueError, match="Batch dimensions are not broadcastable"):
         sp_x @ sp_z
@@ -688,7 +688,7 @@ def test_dot_1d_1d(): # 1-D inner product
     assert_equal(res, exp)
 
 
-def test_dot_sparse_scalar():    
+def test_dot_sparse_scalar():
     a = coo_array([[1, 2], [3, 4], [5, 6]])
     b = 3
     res = a.dot(b)
@@ -696,7 +696,7 @@ def test_dot_sparse_scalar():
     assert_equal(res.toarray(), exp)
 
 
-def test_dot_with_inconsistent_shapes(): 
+def test_dot_with_inconsistent_shapes():
     arr_a = coo_array([[[1, 2]], [[3, 4]]])
     arr_b = coo_array([4, 5, 6])
     with pytest.raises(ValueError, match="not aligned for n-D dot"):
@@ -708,12 +708,12 @@ dot_shapes = [
     ((3,2,4,7), (7,)), ((5,), (6,3,5,2)), # dot of n-D and 1-D arrays
     ((3,2,4,7), (7,1)), ((1,5,), (6,3,5,2)),
     ((4,6), (3,2,6,4)), ((2,8,7), (4,5,7,7,2)), # dot of n-D and m-D arrays
-    ((4,5,7,6), (3,2,6,4)), 
+    ((4,5,7,6), (3,2,6,4)),
 ]
 @pytest.mark.parametrize(('a_shape', 'b_shape'), dot_shapes)
-def test_dot_nd(a_shape, b_shape): 
+def test_dot_nd(a_shape, b_shape):
     rng = np.random.default_rng(23409823)
-    
+
     arr_a = random_array(a_shape, density=0.6, random_state=rng, dtype=int)
     arr_b = random_array(b_shape, density=0.6, random_state=rng, dtype=int)
 
@@ -739,9 +739,9 @@ tensordot_shapes_and_axes = [
     ((2,3,4), (2,3,4), ([0, 1, 2], [0, 1, 2])),
 ]
 @pytest.mark.parametrize(('a_shape', 'b_shape', 'axes'), tensordot_shapes_and_axes)
-def test_tensordot(a_shape, b_shape, axes): 
+def test_tensordot(a_shape, b_shape, axes):
     rng = np.random.default_rng(23409823)
-    
+
     arr_a = random_array(a_shape, density=0.6, random_state=rng, dtype=int)
     arr_b = random_array(b_shape, density=0.6, random_state=rng, dtype=int)
 
@@ -759,11 +759,11 @@ def test_tensordot(a_shape, b_shape, axes):
         assert_equal(res.toarray(), exp)
     else:
         assert_equal(res, exp)
-        
 
-def test_tensordot_with_invalid_args(): 
+
+def test_tensordot_with_invalid_args():
     rng = np.random.default_rng(23409823)
-    
+
     arr_a = random_array((3,4,5), density=0.6, random_state=rng, dtype=int)
     arr_b = random_array((3,4,6), density=0.6, random_state=rng, dtype=int)
 
@@ -787,7 +787,7 @@ def test_tensordot_with_invalid_args():
                           ((1,1,1), (4,5,6)), ((1,3,1,5,4), (8,2,3,9,5,4)),])
 def test_broadcast_to(actual_shape, broadcast_shape):
     rng = np.random.default_rng(23409823)
-    
+
     arr = random_array(actual_shape, density=0.6, random_state=rng, dtype=int)
     res = arr._broadcast_to(broadcast_shape)
     exp = np.broadcast_to(arr.toarray(), broadcast_shape)

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -203,7 +203,7 @@ def test_broadcast_to():
     assert_array_equal(res_c.toarray(), np.broadcast_to(b, (2,4)))
     assert_array_equal(res_d.toarray(), np.broadcast_to(b, (1,)))
     assert_array_equal(res_e.toarray(), np.broadcast_to(e, (4,0)))
-    
+
     with pytest.raises(ValueError, match="cannot be broadcast"):
         csr_matrix([[1, 2, 0], [3, 0, 1]])._broadcast_to(shape=(2, 1))
 


### PR DESCRIPTION
Fixes #22112 

This cleanup was inspired from the stubs work in #22112 which showed that:
- CSC format could be created as an nD array.
- `tensordot` had no doc_string

While investigating I found CSR could also almost create nD...and the resulting error was not clear.
Also, the new function `dot` did not have a doc_string.  In addition, there is quite q bit of spurious whitespace from the nD PRs.  I also found and fixed an idx_dtype error in the new `_broadcast_to` method. And finally that `test_base.py` have tests for sum and mean that were copied and never changed the var names from mean to sum. So, there are a number of small changes here.  Each has it's own commit.

-remove spurious whitespace
-align exception messages for 3D input across formats (adds test too)
- fix idx_dtype error in `_broadcast_to`
- change test_base.py varnames to match quantity computed
- add doc_strings to dot and tensordot with examples.

This should be backported to the maintenance branch. 