### PR TITLE
TST: ndimage: array API-related cosmetic tweaks in tests

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -345,9 +345,8 @@ class TestNdimageFilters:
         output = ndimage.convolve(array, kernel)
         assert_array_almost_equal(xp.asarray([[6, 8, 9], [9, 11, 12]]), output)
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_kernel', types)
     def test_correlate13(self, dtype_array, dtype_kernel, xp):
@@ -367,9 +366,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([[6, 8, 9], [9, 11, 12]]), output)
         assert output.dtype.type == dtype_kernel
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate14(self, dtype_array, dtype_output, xp):
@@ -389,9 +387,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([[6, 8, 9], [9, 11, 12]]), output)
         assert output.dtype.type == dtype_output
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     def test_correlate15(self, dtype_array, xp):
         dtype_array = getattr(xp, dtype_array)
@@ -408,9 +405,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([[6, 8, 9], [9, 11, 12]]), output)
         assert output.dtype.type == xp.float32
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     def test_correlate16(self, dtype_array, xp):
         dtype_array = getattr(xp, dtype_array)
@@ -440,9 +436,8 @@ class TestNdimageFilters:
         output = ndimage.convolve1d(array, kernel, origin=-1)
         assert_array_almost_equal(tcov, output)
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     def test_correlate18(self, dtype_array, xp):
         dtype_array = getattr(xp, dtype_array)
@@ -471,9 +466,8 @@ class TestNdimageFilters:
         with assert_raises(RuntimeError):
             ndimage.convolve(array, kernel, mode=['nearest', 'reflect'])
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     def test_correlate19(self, dtype_array, xp):
         dtype_array = getattr(xp, dtype_array)
@@ -494,9 +488,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([[3, 5, 6], [6, 8, 9]]), output)
         assert output.dtype.type == xp.float32
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate20(self, dtype_array, dtype_output, xp):
@@ -523,9 +516,8 @@ class TestNdimageFilters:
         output = ndimage.convolve1d(array, weights, axis=0)
         assert_array_almost_equal(output, expected)
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_array', types)
     @pytest.mark.parametrize('dtype_output', types)
     def test_correlate22(self, dtype_array, dtype_output, xp):
@@ -611,9 +603,8 @@ class TestNdimageFilters:
         y = ndimage.correlate1d(xp.ones(1), xp.ones(5), mode='mirror')
         xp_assert_equal(y, xp.asarray([5.]))
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @xfail_xp_backends(np_only=True, exceptions=["cupy"],
+                       reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
@@ -630,9 +621,8 @@ class TestNdimageFilters:
         self._validate_complex(xp, array, kernel, dtype_output,
                                check_warnings=num_parallel_threads == 1)
 
-    @xfail_xp_backends(np_only=True,
-                       reason="output=dtype is numpy-specific",
-                       exceptions=['cupy'],)
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="output=dtype is numpy-specific")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
@@ -645,7 +635,7 @@ class TestNdimageFilters:
         dtype_output = getattr(xp, dtype_output)
 
         if is_cupy(xp) and mode == 'grid-constant':
-            pytest.xfail('https://github.com/cupy/cupy/issues/8404')
+            pytest.xfail('cupy/cupy#8404')
 
         # test use of non-zero cval with complex inputs
         # also verifies that mode 'grid-constant' does not segfault
@@ -741,10 +731,9 @@ class TestNdimageFilters:
         self._validate_complex(xp, array, kernel, dtype_output,
                                check_warnings=num_parallel_threads == 1)
 
-    @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
-    @skip_xp_backends(np_only=True,
-                      reason='output=dtype is numpy-specific',
-                      exceptions=['cupy'])
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason='output=dtype is numpy-specific')
+    @xfail_xp_backends("cupy", reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
@@ -776,10 +765,9 @@ class TestNdimageFilters:
         self._validate_complex(xp, array, kernel, dtype_output,
                                check_warnings=num_parallel_threads == 1)
 
-    @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
-    @skip_xp_backends(np_only=True,
-                      reason="output=dtype is numpy-specific",
-                      exceptions=['cupy'],)
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="output=dtype is numpy-specific")
+    @xfail_xp_backends("cupy", reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     def test_correlate_complex_input_and_kernel_cval(self, dtype,
@@ -810,19 +798,17 @@ class TestNdimageFilters:
         self._validate_complex(xp, array, kernel, dtype_output,
                                check_warnings=num_parallel_threads == 1)
 
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="output=dtype is numpy-specific")
+    @xfail_xp_backends("cupy", reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     def test_correlate1d_complex_input_and_kernel_cval(self, dtype,
                                                        dtype_output, xp,
                                                        num_parallel_threads):
-        if not (is_numpy(xp) or is_cupy(xp)):
-            pytest.xfail("output=dtype is numpy-specific")
 
         dtype = getattr(xp, dtype)
         dtype_output = getattr(xp, dtype_output)
-
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8405")
 
         kernel = xp.asarray([1, 1 + 1j], dtype=dtype)
         array = xp.asarray([1, 2j, 3, 1 + 4j, 5, 6j], dtype=dtype)
@@ -843,10 +829,8 @@ class TestNdimageFilters:
         assert input.dtype == output.dtype
         assert input.shape == output.shape
 
+    @xfail_xp_backends("cupy", reason="cupy/cupy#8403")
     def test_gauss03(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8403")
-
         # single precision data
         input = xp.arange(100 * 100, dtype=xp.float32)
         input = xp.reshape(input, (100, 100))
@@ -862,10 +846,9 @@ class TestNdimageFilters:
         assert_almost_equal(o_sum, i_sum, decimal=0)
         assert sumsq(input, output) > 1.0
 
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="output=dtype is numpy-specific")
     def test_gauss04(self, xp):
-        if not (is_numpy(xp) or is_cupy(xp)):
-            pytest.xfail("output=dtype is numpy-specific")
-
         input = xp.arange(100 * 100, dtype=xp.float32)
         input = xp.reshape(input, (100, 100))
         otype = xp.float64
@@ -874,10 +857,9 @@ class TestNdimageFilters:
         assert input.shape == output.shape
         assert sumsq(input, output) > 1.0
 
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="output=dtype is numpy-specific")
     def test_gauss05(self, xp):
-        if not (is_numpy(xp) or is_cupy(xp)):
-            pytest.xfail("output=dtype is numpy-specific")
-
         input = xp.arange(100 * 100, dtype=xp.float32)
         input = xp.reshape(input, (100, 100))
         otype = xp.float64
@@ -906,6 +888,7 @@ class TestNdimageFilters:
         ndimage.gaussian_filter(input, 1.0, output=input)
         assert_array_almost_equal(output1, input)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize(('filter_func', 'extra_args', 'size0', 'size'),
                              [(ndimage.gaussian_filter, (), 0, 1.0),
                               (ndimage.uniform_filter, (), 1, 3),
@@ -920,9 +903,6 @@ class TestNdimageFilters:
         + tuple(itertools.combinations(range(-3, 3), 2))
         + ((0, 1, 2),))
     def test_filter_axes(self, filter_func, extra_args, size0, size, axes, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         # Note: `size` is called `sigma` in `gaussian_filter`
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
@@ -1051,6 +1031,7 @@ class TestNdimageFilters:
     @skip_xp_backends("array_api_strict",
          reason="fancy indexing is only available in 2024 version",
     )
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize("filter_func, size0, size, kwargs",
                              [(ndimage.gaussian_filter, 0, 1.0, kwargs_gauss),
                               (ndimage.uniform_filter, 1, 3, kwargs_other),
@@ -1061,10 +1042,6 @@ class TestNdimageFilters:
                               (ndimage.percentile_filter, 1, 3, kwargs_rank)])
     @pytest.mark.parametrize('axes', itertools.combinations(range(-3, 3), 2))
     def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes, xp):
-
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
 
@@ -1105,6 +1082,7 @@ class TestNdimageFilters:
         xp_assert_close(output, expected)
 
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize("filter_func, kwargs",
                              [(ndimage.convolve, {}),
                               (ndimage.correlate, {}),
@@ -1114,9 +1092,6 @@ class TestNdimageFilters:
                               (ndimage.rank_filter, {"rank": 1}),
                               (ndimage.percentile_filter, {"percentile": 30})])
     def test_filter_weights_subset_axes_origins(self, filter_func, kwargs, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         axes = (-2, -1)
         origins = (0, 1)
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
@@ -1149,6 +1124,7 @@ class TestNdimageFilters:
                 output[:, :, origins[1]:], output0[:, :, :-origins[1]])
 
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize(
         'filter_func, args',
         [(ndimage.convolve, (np.ones((3, 3, 3)),)),  # args = (weights,)
@@ -1164,9 +1140,6 @@ class TestNdimageFilters:
         'axes', [(1.5,), (0, 1, 2, 3), (3,), (-4,)]
     )
     def test_filter_invalid_axes(self, filter_func, args, axes, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
         args = [
@@ -1182,6 +1155,7 @@ class TestNdimageFilters:
         with pytest.raises(error_class, match=match):
             filter_func(array, *args, axes=axes)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize(
         'filter_func, kwargs',
         [(ndimage.convolve, {}),
@@ -1197,9 +1171,6 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('separable_footprint', [False, True])
     def test_filter_invalid_footprint_ndim(self, filter_func, kwargs, axes,
                                            separable_footprint, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
         # create a footprint with one too many dimensions
@@ -1223,14 +1194,12 @@ class TestNdimageFilters:
         with pytest.raises(RuntimeError, match=match):
             filter_func(array, axes=axes, **kwargs)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize('n_mismatch', [1, 3])
     @pytest.mark.parametrize('filter_func, kwargs, key, val',
                              _cases_axes_tuple_length_mismatch())
     def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
                                           kwargs, key, val, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         # Test for the intended RuntimeError when a kwargs has an invalid size
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
@@ -1773,6 +1742,7 @@ class TestNdimageFilters:
                                               [7, 9, 8, 9, 7],
                                               [8, 8, 8, 7, 7]]), output)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize(
         'axes', tuple(itertools.combinations(range(-3, 3), 2))
     )
@@ -1785,9 +1755,6 @@ class TestNdimageFilters:
          (ndimage.percentile_filter, dict(percentile=60))]
     )
     def test_minmax_nonseparable_axes(self, filter_func, axes, kwargs, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/pull/8339")
-
         array = xp.arange(6 * 8 * 12, dtype=xp.float32)
         array = xp.reshape(array, (6, 8, 12))
         # use 2D triangular footprint because it is non-separable
@@ -1862,12 +1829,11 @@ class TestNdimageFilters:
         output = ndimage.percentile_filter(array, 17, size=(2, 3))
         xp_assert_equal(expected, output)
 
+    @xfail_xp_backends("cupy", reason="cupy/cupy#8406")
     @skip_xp_backends("jax.numpy",
         reason="assignment destination is read-only",
     )
     def test_rank06_overlap(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8406")
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [5, 8, 3, 7, 1],
                             [5, 6, 9, 3, 5]])
@@ -2077,13 +2043,12 @@ class TestNdimageFilters:
             y = ndimage.rank_filter(x, -2, size=3)
             assert y.dtype == x.dtype
 
-    @skip_xp_backends(np_only=True, reason="off-by-ones on alt backends")
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason="off-by-ones on alt backends")
+    @xfail_xp_backends("cupy", reason="does not support extra_arguments")
     @pytest.mark.parametrize('dtype', types)
     def test_generic_filter1d01(self, dtype, xp):
         weights = xp.asarray([1.1, 2.2, 3.3])
-
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not support extra_arguments")
 
         def _filter_func(input, output, fltr, total):
             fltr = fltr / total
@@ -2091,6 +2056,7 @@ class TestNdimageFilters:
                 output[ii] = input[ii] * fltr[0]
                 output[ii] += input[ii + 1] * fltr[1]
                 output[ii] += input[ii + 2] * fltr[2]
+
         a = np.arange(12, dtype=dtype).reshape(3, 4)
         a = xp.asarray(a)
         dtype = getattr(xp, dtype)
@@ -2102,10 +2068,9 @@ class TestNdimageFilters:
             extra_keywords={'total': xp.sum(weights)})
         assert_array_almost_equal(r1, r2)
 
+    @xfail_xp_backends("cupy", reason="does not support extra_arguments")
     @pytest.mark.parametrize('dtype', types)
     def test_generic_filter01(self, dtype, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not support extra_arguments")
         if is_torch(xp) and dtype in ("uint16", "uint32", "uint64"):
             pytest.xfail("https://github.com/pytorch/pytorch/issues/58734")
 
@@ -2294,10 +2259,8 @@ class TestNdimageFilters:
         xp_assert_equal(output, expected_value)
 
 
+@xfail_xp_backends("cupy", reason="TypeError")
 def test_ticket_701(xp):
-    if is_cupy(xp):
-        pytest.xfail("CuPy raises a TypeError.")
-
     # Test generic filter sizes
     arr = xp.asarray(np.arange(4).reshape(2, 2))
     def func(x):
@@ -2337,9 +2300,8 @@ def test_gh_5430():
     ndimage._ni_support._normalize_sequence(x, 0)
 
 
+@skip_xp_backends("cupy", reason="tests a private scipy utility")
 def test_gaussian_kernel1d(xp):
-    if is_cupy(xp):
-        pytest.skip("This test tests a private scipy utility.")
     radius = 10
     sigma = 2
     sigma2 = sigma * sigma
@@ -2370,13 +2332,12 @@ def test_orders_gauss(xp):
     assert_raises(ValueError, ndimage.gaussian_filter1d, arr, 1, -1, -1)
 
 
+@xfail_xp_backends("cupy", reason="TypeError")
 def test_valid_origins(xp):
     """Regression test for #1311."""
-    if is_cupy(xp):
-        pytest.xfail("CuPy raises a TypeError.")
-
     def func(x):
         return xp.mean(x)
+
     data = xp.asarray([1, 2, 3, 4, 5], dtype=xp.float64)
     assert_raises(ValueError, ndimage.generic_filter, data, func, size=3,
                   origin=2)
@@ -2639,10 +2600,8 @@ def test_gaussian_truncate(xp):
     assert n == 15
 
 
+@xfail_xp_backends("cupy", reason="cupy/cupy#8402")
 def test_gaussian_radius(xp):
-    if is_cupy(xp):
-        pytest.xfail("https://github.com/cupy/cupy/issues/8402")
-
     # Test that Gaussian filters with radius argument produce the same
     # results as the filters with corresponding truncate argument.
     # radius = int(truncate * sigma + 0.5)
@@ -2671,10 +2630,8 @@ def test_gaussian_radius(xp):
     xp_assert_equal(f1, f2)
 
 
+@xfail_xp_backends("cupy", reason="cupy/cupy#8402")
 def test_gaussian_radius_invalid(xp):
-    if is_cupy(xp):
-        pytest.xfail("https://github.com/cupy/cupy/issues/8402")
-
     # radius must be a nonnegative integer
     with assert_raises(ValueError):
         ndimage.gaussian_filter1d(xp.zeros(8), sigma=1, radius=-1)
@@ -2695,10 +2652,9 @@ class TestThreading:
         for i in range(n):
             fun(*args, output=out[i, ...])
 
+    @xfail_xp_backends("cupy", 
+                       reason="XXX thread exception; cannot repro outside of pytest")
     def test_correlate1d(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("XXX thread exception; cannot repro outside of pytest")
-
         d = np.random.randn(5000)
         os = np.empty((4, d.size))
         ot = np.empty_like(os)
@@ -2710,10 +2666,9 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate1d, (d, k), ot)
         xp_assert_equal(os, ot)
 
+    @xfail_xp_backends("cupy", 
+                       reason="XXX thread exception; cannot repro outside of pytest")
     def test_correlate(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("XXX thread exception; cannot repro outside of pytest")
-
         d = xp.asarray(np.random.randn(500, 500))
         k = xp.asarray(np.random.randn(10, 10))
         os = xp.empty([4] + list(d.shape))
@@ -2722,10 +2677,9 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate, (d, k), ot)
         xp_assert_equal(os, ot)
 
+    @xfail_xp_backends("cupy", 
+                       reason="XXX thread exception; cannot repro outside of pytest")
     def test_median_filter(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("XXX thread exception; cannot repro outside of pytest")
-
         d = xp.asarray(np.random.randn(500, 500))
         os = xp.empty([4] + list(d.shape))
         ot = xp.empty_like(os)
@@ -2733,10 +2687,9 @@ class TestThreading:
         self.check_func_thread(4, ndimage.median_filter, (d, 3), ot)
         xp_assert_equal(os, ot)
 
+    @xfail_xp_backends("cupy", 
+                       reason="XXX thread exception; cannot repro outside of pytest")
     def test_uniform_filter1d(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("XXX thread exception; cannot repro outside of pytest")
-
         d = np.random.randn(5000)
         os = np.empty((4, d.size))
         ot = np.empty_like(os)
@@ -2747,10 +2700,9 @@ class TestThreading:
         self.check_func_thread(4, ndimage.uniform_filter1d, (d, 5), ot)
         xp_assert_equal(os, ot)
 
+    @xfail_xp_backends("cupy", 
+                       reason="XXX thread exception; cannot repro outside of pytest")
     def test_minmax_filter(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("XXX thread exception; cannot repro outside of pytest")
-
         d = xp.asarray(np.random.randn(500, 500))
         os = xp.empty([4] + list(d.shape))
         ot = xp.empty_like(os)
@@ -2791,9 +2743,8 @@ def test_minmaximum_filter1d(xp):
     xp_assert_equal(xp.asarray([9, 9, 4, 5, 6, 7, 8, 9, 9, 9]), out)
 
 
+@xfail_xp_backends("cupy", reason="cupy/cupy#8401")
 def test_uniform_filter1d_roundoff_errors(xp):
-    if is_cupy(xp):
-        pytest.xfail("https://github.com/cupy/cupy/issues/8401")
     # gh-6930
     in_ = np.repeat([0, 1, 0], [9, 9, 9])
     in_ = xp.asarray(in_)
@@ -2811,10 +2762,8 @@ def test_footprint_all_zeros(xp):
         ndimage.maximum_filter(arr, footprint=kernel)
 
 
+@xfail_xp_backends("cupy", reason="does not raise")
 def test_gaussian_filter(xp):
-    if is_cupy(xp):
-        pytest.xfail("CuPy does not raise")
-
     if not hasattr(xp, "float16"):
         pytest.xfail(f"{xp} does not have float16")
 
@@ -2826,10 +2775,8 @@ def test_gaussian_filter(xp):
         ndimage.gaussian_filter(data, sigma)
 
 
+@xfail_xp_backends("cupy", reason="does not raise")
 def test_rank_filter_noninteger_rank(xp):
-    if is_cupy(xp):
-        pytest.xfail("CuPy does not raise")
-
     # regression test for issue 9388: ValueError for
     # non integer rank when performing rank_filter
     arr = xp.asarray(np.random.random((10, 20, 30)))

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -177,12 +177,12 @@ class TestNdimageFourier:
                               ndimage.fourier_gaussian,
                               ndimage.fourier_uniform])
     def test_fourier_zero_length_dims(self, shape, dtype, test_func, xp):
-        if is_cupy(xp):
-           if (test_func.__name__ == "fourier_ellipsoid" and
-               math.prod(shape) == 0):
-               pytest.xfail(
-                   "CuPy's fourier_ellipsoid does not accept size==0 arrays"
-               )
+        if (
+            is_cupy(xp)
+            and test_func.__name__ == "fourier_ellipsoid" 
+            and math.prod(shape) == 0
+        ):
+            pytest.xfail("CuPy's fourier_ellipsoid does not accept size==0 arrays")
         dtype = getattr(xp, dtype)
         a = xp.ones(shape, dtype=dtype)
         b = test_func(a, 3)

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -6,7 +6,7 @@ from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close,
     assert_array_almost_equal,
 )
-from scipy._lib._array_api import is_cupy, is_jax, _asarray, array_namespace
+from scipy._lib._array_api import is_jax, _asarray, array_namespace
 
 import pytest
 from pytest import raises as assert_raises
@@ -16,7 +16,9 @@ from . import types
 
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends"),
+              pytest.mark.usefixtures("xfail_xp_backends"),
               skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'],)]
 
 
@@ -796,11 +798,9 @@ class TestAffineTransform:
                                        (3, 4), order=order)
         assert_array_almost_equal(out, data)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8394")
     @pytest.mark.parametrize('order', range(0, 6))
     def test_affine_transform20(self, order, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8394")
-
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
@@ -809,11 +809,9 @@ class TestAffineTransform:
                                        order=order)
         assert_array_almost_equal(out, xp.asarray([1, 3]))
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8394")
     @pytest.mark.parametrize('order', range(0, 6))
     def test_affine_transform21(self, order, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8394")
-
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
@@ -893,10 +891,8 @@ class TestAffineTransform:
                                                        [0, 4, 1, 3],
                                                        [0, 7, 6, 8]]))
 
+    @xfail_xp_backends("cupy", reason="does not raise")
     def test_affine_transform27(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not raise")
-
         # test valid homogeneous transformation matrix
         data = xp.asarray([[4, 1, 3, 2],
                            [7, 6, 8, 5],
@@ -1475,10 +1471,9 @@ class TestRotate:
         #assert_array_almost_equal(out, expected)
         xp_assert_close(out, expected, rtol=1e-6, atol=2e-6)
 
-    def test_rotate_exact_180(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("https://github.com/cupy/cupy/issues/8400")
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8400")
+    def test_rotate_exact_180(self, xp):
         a = np.tile(xp.arange(5), (5, 1))
         b = ndimage.rotate(ndimage.rotate(a, 180), -180)
         xp_assert_equal(a, b)

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy._lib._array_api import (
-    is_cupy, is_numpy, is_torch, array_namespace,
+    is_cupy, is_numpy, array_namespace,
     xp_assert_close, xp_assert_equal, assert_array_almost_equal
 )
 import pytest
@@ -118,7 +118,7 @@ class TestNdimageMorphology:
                      [0, 1, 2, 3, 4, 5, 6, 7, 8],
                      [0, 1, 2, 3, 4, 5, 6, 7, 8]]]
         expected = xp.asarray(expected)
-        assert_array_almost_equal(expected, ft)
+        assert_array_almost_equal(ft, expected)
 
     @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
     @pytest.mark.parametrize('dtype', types)
@@ -224,7 +224,7 @@ class TestNdimageMorphology:
         for ft in fts:
             assert_array_almost_equal(tft, ft)
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
+    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf')
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf05(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -273,7 +273,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
+    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf')
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf06(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -322,10 +322,8 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
     def test_distance_transform_bf07(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_bf.")
-
         # test input validation per discussion on PR #13302
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -341,11 +339,10 @@ class TestNdimageMorphology:
                 data, return_distances=False, return_indices=False
             )
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt01(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_cdt.")
 
         # chamfer type distance (cdt) transform
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -383,12 +380,10 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt02(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_cdt.")
-
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 1, 1, 1, 0, 0, 0],
@@ -500,13 +495,11 @@ class TestNdimageMorphology:
                 indices=indices_out
             )
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
+    @xfail_xp_backends("torch", reason="int overflow")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt05(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_cdt.")
-        elif is_torch(xp):
-            pytest.xfail("int overflow")
 
         # test custom metric type per discussion on issue #17381
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -522,11 +515,10 @@ class TestNdimageMorphology:
         actual = ndimage.distance_transform_cdt(data, metric=metric_arg)
         assert xp.sum(actual) == -21
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt01(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_bf")
 
         # euclidean distance transform (edt)
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -617,11 +609,10 @@ class TestNdimageMorphology:
         for ft in fts:
             assert_array_almost_equal(tft, ft)
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt03(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_bf")
 
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -634,13 +625,12 @@ class TestNdimageMorphology:
                            [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=dtype)
         ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 2])
         out = ndimage.distance_transform_edt(data, sampling=[2, 2])
-        assert_array_almost_equal(ref, out)
+        assert_array_almost_equal(out, ref)
 
+    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt4(self, dtype, xp):
         dtype = getattr(xp, dtype)
-        if is_cupy(xp):
-            pytest.xfail("CuPy does not have distance_transform_bf")
 
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -653,14 +643,14 @@ class TestNdimageMorphology:
                            [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=dtype)
         ref = ndimage.distance_transform_bf(data, 'euclidean', sampling=[2, 1])
         out = ndimage.distance_transform_edt(data, sampling=[2, 1])
-        assert_array_almost_equal(ref, out)
+        assert_array_almost_equal(out, ref)
 
     def test_distance_transform_edt5(self, xp):
         # Ticket #954 regression test
         out = ndimage.distance_transform_edt(False)
         assert_array_almost_equal(out, [0.])
 
-    @skip_xp_backends(
+    @xfail_xp_backends(
         np_only=True, reason='XXX: does not raise unless indices is a numpy array'
     )
     def test_distance_transform_edt6(self, xp):
@@ -1039,10 +1029,10 @@ class TestNdimageMorphology:
                                      origin=(-1, -1))
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends(
+        "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
+    )
     def test_binary_erosion27(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1098,10 +1088,10 @@ class TestNdimageMorphology:
                                iterations=2, output=out)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends(
+        "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
+    )
     def test_binary_erosion29(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1126,13 +1116,11 @@ class TestNdimageMorphology:
                                      border_value=1, iterations=3)
         assert_array_almost_equal(out, expected)
 
-    @skip_xp_backends(
-        np_only=True, reason='inplace out= arguments are numpy-specific'
-    )
+    @skip_xp_backends(np_only=True, exceptions=["numpy"],
+                      reason='inplace out= arguments are numpy-specific')
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_erosion30(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1196,10 +1184,9 @@ class TestNdimageMorphology:
                                iterations=1, output=out, origin=(-1, -1))
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_erosion32(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1224,10 +1211,9 @@ class TestNdimageMorphology:
                                      border_value=1, iterations=2)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_erosion33(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1337,10 +1323,9 @@ class TestNdimageMorphology:
                                origin=(-1, -1), mask=mask)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_erosion36(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 0, 1],
                   [0, 1, 0]]
@@ -1801,10 +1786,9 @@ class TestNdimageMorphology:
         out = ndimage.binary_dilation(data, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation29(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 0, 0],
@@ -1823,10 +1807,11 @@ class TestNdimageMorphology:
         out = ndimage.binary_dilation(data, struct, iterations=2)
         assert_array_almost_equal(out, expected)
 
-    @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason='output= arrays are numpy-specific')
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation30(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 0, 0],
@@ -1847,10 +1832,9 @@ class TestNdimageMorphology:
         ndimage.binary_dilation(data, struct, iterations=2, output=out)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation31(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 1, 0],
@@ -1869,11 +1853,11 @@ class TestNdimageMorphology:
         out = ndimage.binary_dilation(data, struct, iterations=3)
         assert_array_almost_equal(out, expected)
 
-    @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason='output= arrays are numpy-specific')
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation32(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1],
                   [1, 1]]
         expected = [[0, 0, 0, 1, 0],
@@ -1894,9 +1878,9 @@ class TestNdimageMorphology:
         ndimage.binary_dilation(data, struct, iterations=3, output=out)
         assert_array_almost_equal(out, expected)
 
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation33(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -1933,13 +1917,11 @@ class TestNdimageMorphology:
                                       mask=mask, border_value=0)
         assert_array_almost_equal(out, expected)
 
-    @skip_xp_backends(
-        np_only=True, reason='inplace output= arrays are numpy-specific',
-    )
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
+                      reason='inplace output= arrays are numpy-specific')
+    @xfail_xp_backends("cupy",
+                       reason="NotImplementedError: only brute_force iteration")
     def test_binary_dilation34(self, xp):
-        if is_cupy(xp):
-            pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
         struct = [[0, 1, 0],
                   [1, 1, 1],
                   [0, 1, 0]]
@@ -2437,7 +2419,7 @@ class TestNdimageMorphology:
         tmp = ndimage.grey_dilation(array, footprint=footprint)
         expected = ndimage.grey_erosion(tmp, footprint=footprint)
         output = ndimage.grey_closing(array, footprint=footprint)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     def test_grey_closing02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2451,7 +2433,7 @@ class TestNdimageMorphology:
                                         structure=structure)
         output = ndimage.grey_closing(array, footprint=footprint,
                                       structure=structure)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
     def test_morphological_gradient01(self, xp):
@@ -2468,7 +2450,7 @@ class TestNdimageMorphology:
         output = xp.zeros(array.shape, dtype=array.dtype)
         ndimage.morphological_gradient(array, footprint=footprint,
                                        structure=structure, output=output)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     def test_morphological_gradient02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2483,7 +2465,7 @@ class TestNdimageMorphology:
         expected = tmp1 - tmp2
         output = ndimage.morphological_gradient(array, footprint=footprint,
                                                 structure=structure)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
     def test_morphological_laplace01(self, xp):
@@ -2500,7 +2482,7 @@ class TestNdimageMorphology:
         output = xp.zeros(array.shape, dtype=array.dtype)
         ndimage.morphological_laplace(array, footprint=footprint,
                                       structure=structure, output=output)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     def test_morphological_laplace02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2515,7 +2497,7 @@ class TestNdimageMorphology:
         expected = tmp1 + tmp2 - 2 * array
         output = ndimage.morphological_laplace(array, footprint=footprint,
                                                structure=structure)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
     def test_white_tophat01(self, xp):
@@ -2530,7 +2512,7 @@ class TestNdimageMorphology:
         output = xp.zeros(array.shape, dtype=array.dtype)
         ndimage.white_tophat(array, footprint=footprint,
                              structure=structure, output=output)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     def test_white_tophat02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2543,7 +2525,7 @@ class TestNdimageMorphology:
         expected = array - tmp
         output = ndimage.white_tophat(array, footprint=footprint,
                                       structure=structure)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     @xfail_xp_backends('cupy', reason="cupy#8399")
     def test_white_tophat03(self, xp):
@@ -2568,7 +2550,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
 
         output = ndimage.white_tophat(array, structure=structure)
-        xp_assert_equal(expected, output)
+        xp_assert_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
     def test_white_tophat04(self, xp):
@@ -2595,7 +2577,7 @@ class TestNdimageMorphology:
         output = xp.zeros(array.shape, dtype=array.dtype)
         ndimage.black_tophat(array, footprint=footprint,
                              structure=structure, output=output)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     def test_black_tophat02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2608,7 +2590,7 @@ class TestNdimageMorphology:
         expected = tmp - array
         output = ndimage.black_tophat(array, footprint=footprint,
                                       structure=structure)
-        assert_array_almost_equal(expected, output)
+        assert_array_almost_equal(output, expected)
 
     @xfail_xp_backends('cupy', reason="cupy/cupy#8399")
     def test_black_tophat03(self, xp):
@@ -2633,7 +2615,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
 
         output = ndimage.black_tophat(array, structure=structure)
-        xp_assert_equal(expected, output)
+        xp_assert_equal(output, expected)
 
     @skip_xp_backends("jax.numpy", reason="output array is read-only.")
     def test_black_tophat04(self, xp):
@@ -2729,7 +2711,7 @@ class TestNdimageMorphology:
                            [0, 0, 0, 0, 0]], dtype=dtype)
         out = xp.asarray(np.zeros(data.shape, dtype=bool))
         ndimage.binary_hit_or_miss(data, struct, output=out)
-        assert_array_almost_equal(expected, out)
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
     def test_hit_or_miss02(self, dtype, xp):
@@ -2748,7 +2730,7 @@ class TestNdimageMorphology:
                            [0, 1, 0, 1, 1, 1, 1, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0]], dtype=dtype)
         out = ndimage.binary_hit_or_miss(data, struct)
-        assert_array_almost_equal(expected, out)
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
     def test_hit_or_miss03(self, dtype, xp):
@@ -2779,7 +2761,7 @@ class TestNdimageMorphology:
                            [0, 1, 1, 1, 1, 1, 1, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0]], dtype=dtype)
         out = ndimage.binary_hit_or_miss(data, struct1, struct2)
-        assert_array_almost_equal(expected, out)
+        assert_array_almost_equal(out, expected)
 
 
 class TestDilateFix:
@@ -2802,7 +2784,6 @@ class TestDilateFix:
         else:
             astype = array_namespace(dilated3x3).astype
             self.dilated3x3 = astype(dilated3x3, xp.uint8)
-
 
     def test_dilation_square_structure(self, xp):
         self._setup(xp)
@@ -2874,14 +2855,12 @@ def test_binary_closing_noninteger_iterations(xp):
     assert_raises(TypeError, ndimage.binary_closing, data, iterations=1.5)
 
 
+@xfail_xp_backends(
+    "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
+)
 def test_binary_closing_noninteger_brute_force_passes_when_true(xp):
-    # regression test for gh-9905, gh-9909: ValueError for
-    # non integer iterations
-    if is_cupy(xp):
-        pytest.xfail("CuPy: NotImplementedError: only brute_force iteration")
-
+    # regression test for gh-9905, gh-9909: ValueError for non integer iterations
     data = xp.ones([1])
-
     xp_assert_equal(ndimage.binary_erosion(data, iterations=2, brute_force=1.5),
                     ndimage.binary_erosion(data, iterations=2, brute_force=bool(1.5))
     )
@@ -2908,13 +2887,12 @@ def test_binary_input_as_output(function, iterations, brute_force, xp):
 
     # data should now contain the expected result
     ndi_func(data, brute_force=brute_force, iterations=iterations, output=data)
-    xp_assert_equal(expected, data)
+    xp_assert_equal(data, expected)
 
 
+@skip_xp_backends(np_only=True, exception=["cupy"],
+                  reason="inplace output= is numpy-specific")
 def test_binary_hit_or_miss_input_as_output(xp):
-    if not (is_numpy(xp) or is_cupy(xp)):
-        pytest.xfail("inplace output= is numpy-specific")
-
     rstate = np.random.RandomState(123)
     data = rstate.randint(low=0, high=2, size=100).astype(bool)
 
@@ -2925,13 +2903,12 @@ def test_binary_hit_or_miss_input_as_output(xp):
 
     # data should now contain the expected result
     ndimage.binary_hit_or_miss(data, output=data)
-    xp_assert_equal(expected, data)
+    xp_assert_equal(data, expected)
 
 
+@xfail_xp_backends("cupy",
+                   reason="CuPy does not have distance_transform_cdt")
 def test_distance_transform_cdt_invalid_metric(xp):
-    if is_cupy(xp):
-        pytest.xfail("CuPy does not have distance_transform_cdt")
-
     msg = 'invalid metric provided'
     with pytest.raises(ValueError, match=msg):
         ndimage.distance_transform_cdt(xp.ones((5, 5)),


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
- change a bunch of `pytest.xfail` and `pytest.skip` conditional to one backend or another to `xfail_xp_backends` or `skip_xp_backends`
- swap parameters in `assert_array_equals(expected, actual)` (it matters as the xp is inferred from the second parameter)
- assorted cosmetic nits