### PR TITLE
TST: `skip|xfail_xp_backends` disregards `reason=`

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -293,22 +293,20 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
         Backends to skip/xfail, e.g. ``("array_api_strict", "torch")``.
         These are overriden when ``np_only`` is ``True``, and are not
         necessary to provide for non-CPU backends when ``cpu_only`` is ``True``.
-        For a custom reason to apply, you should pass a dict ``{'reason': '...'}``
-        to a keyword matching the name of the backend.
-    reason : str, optional
-        A reason for the skip/xfail in the case of ``np_only=True``.
-        If unprovided, a default reason is used. Note that it is not possible
-        to specify a custom reason with ``cpu_only``.
+        For a custom reason to apply, you should pass
+        ``kwargs={<backend name>: {'reason': '...'}, ...}``.
     np_only : bool, optional
         When ``True``, the test is skipped/xfailed for all backends other
         than the default NumPy backend. There is no need to provide
-        any ``backends`` in this case. To specify a reason, pass a
-        value to ``reason``. Default: ``False``.
+        any ``backends`` in this case. Default: ``False``.
     cpu_only : bool, optional
         When ``True``, the test is skipped/xfailed on non-CPU devices.
         There is no need to provide any ``backends`` in this case,
         but any ``backends`` will also be skipped on the CPU.
         Default: ``False``.
+    reason : str, optional
+        A reason for the skip/xfail in the case of ``np_only=True`` or
+        ``cpu_only=True``. If omitted, a default reason is used.
     exceptions : list, optional
         A list of exceptions for use with ``cpu_only`` or ``np_only``.
         This should be provided when delegation is implemented for some,

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -331,6 +331,17 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
     if exceptions and not (cpu_only or np_only):
         raise ValueError("`exceptions` is only valid alongside `cpu_only` or `np_only`")
 
+    # Test explicit backends first so that their reason can override
+    # those from np_only/cpu_only
+    if backends is not None:
+        for i, backend in enumerate(backends):
+            if xp.__name__ == backend:
+                reason = kwargs[backend].get('reason')
+                if not reason:
+                    reason = f"do not run with array API backend: {backend}"
+
+                skip_or_xfail(reason=reason)
+
     if np_only:
         reason = kwargs.get("reason")
         if not reason:
@@ -357,15 +368,6 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
                 for d in xp.empty(0).devices():
                     if 'cpu' not in d.device_kind:
                         skip_or_xfail(reason=reason)
-
-    if backends is not None:
-        for i, backend in enumerate(backends):
-            if xp.__name__ == backend:
-                reason = kwargs[backend].get('reason')
-                if not reason:
-                    reason = f"do not run with array API backend: {backend}"
-
-                skip_or_xfail(reason=reason)
 
 
 # Following the approach of NumPy's conftest.py...


### PR DESCRIPTION
Fix bug where
```python
skip_xp_backends(cpu_only=True, reason=...)
skip_xp_backends(np_only=True, reason=...)
xfail_xp_backends(cpu_only=True, reason=...)
xfail_xp_backends(np_only=True, reason=...)
```
would disregard the user-provided reason and instead always used the default.

Also, when a test is decorated by 
```python
@skip_xp_backends(cpu_only=True)
@skip_xp_backends("torch")
```
the reason for the specific backend will now trump the one given for cpu_only (see evidence in comment below).