### PR TITLE
TST: array types: enforce namespace in tests

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -15,24 +15,8 @@ permissions:
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
   INSTALLDIR: "build-install"
-  XP_TESTS: >-
-    -t scipy.cluster
-    -t scipy.constants
-    -t scipy.fft
-    -t scipy.special.tests.test_logsumexp
-    -t scipy.special.tests.test_support_alternative_backends
-    -t scipy._lib.tests.test_array_api
-    -t scipy._lib.tests.test__util
-    -t scipy.differentiate.tests.test_differentiate
-    -t scipy.integrate.tests.test_tanhsinh
-    -t scipy.integrate.tests.test_cubature
-    -t scipy.optimize.tests.test_bracket
-    -t scipy.optimize.tests.test_chandrupatla
-    -t scipy.optimize.tests.test_optimize
-    -t scipy.stats
-    -t scipy.ndimage
-    -t scipy.integrate.tests.test_quadrature
-    -t scipy.signal.tests.test_signaltools
+  # Only run tests that use the `xp` fixture
+  XP_TESTS: -m array_api_backends
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -111,6 +95,5 @@ jobs:
     - name: Test SciPy
       run: |
         export OMP_NUM_THREADS=2
-        # expand as more modules are supported by adding to `XP_TESTS` above
         python dev.py --no-build test -b all $XP_TESTS -- --durations 3 --timeout=60
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,12 @@ filterwarnings =
     ignore:Using the slower implementation::cupy
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
+
+markers =
+    slow: Tests that are very slow
+    xslow: mark test as extremely slow (not run unless explicitly requested)
+    xfail_on_32bit: mark test as failing on 32-bit platforms
+    array_api_backends: test iterates on all array API backends
+    array_api_compatible: test is compatible with array API
+    skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired skip configuration for the `skip_xp_backends` fixture
+    xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -8,6 +8,9 @@ https://data-apis.org/array-api/latest/use_cases.html#use-case-scipy
 """
 import os
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from types import ModuleType
 from typing import Any, Literal, TypeAlias
 
@@ -29,7 +32,7 @@ from scipy._lib.array_api_compat import (
 
 __all__ = [
     '_asarray', 'array_namespace', 'assert_almost_equal', 'assert_array_almost_equal',
-    'get_xp_devices',
+    'get_xp_devices', 'default_xp',
     'is_array_api_strict', 'is_complex', 'is_cupy', 'is_jax', 'is_numpy', 'is_torch', 
     'SCIPY_ARRAY_API', 'SCIPY_DEVICE', 'scipy_namespace_for',
     'xp_assert_close', 'xp_assert_equal', 'xp_assert_less',
@@ -220,12 +223,41 @@ def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array:
     return _asarray(x, copy=True, xp=xp)
 
 
+_default_xp_ctxvar: ContextVar[ModuleType] = ContextVar("_default_xp")
+
+@contextmanager
+def default_xp(xp: ModuleType) -> Generator[None, None, None]:
+    """In all ``xp_assert_*`` and ``assert_*`` function calls executed within this
+    context manager, test by default that the array namespace is 
+    the provided across all arrays, unless one explicitly passes the ``xp=``
+    parameter or ``check_namespace=False``.
+
+    Without this context manager, the default value for `xp` is the namespace
+    for the desired array (the second parameter of the tests).
+    """
+    token = _default_xp_ctxvar.set(xp)
+    try:
+        yield
+    finally:
+        _default_xp_ctxvar.reset(token)
+
+
 def _strict_check(actual, desired, xp, *,
                   check_namespace=True, check_dtype=True, check_shape=True,
                   check_0d=True):
     __tracebackhide__ = True  # Hide traceback for py.test
+
+    if xp is None:
+        try:
+            xp = _default_xp_ctxvar.get()
+        except LookupError:
+            xp = array_namespace(desired)
+        else:
+            # Wrap namespace if needed
+            xp = array_namespace(xp.asarray(0))
+ 
     if check_namespace:
-        _assert_matching_namespace(actual, desired)
+        _assert_matching_namespace(actual, desired, xp)
 
     # only NumPy distinguishes between scalars and arrays; we do if check_0d=True.
     # do this first so we can then cast to array (and thus use the array API) below.
@@ -247,28 +279,32 @@ def _strict_check(actual, desired, xp, *,
         assert actual.shape == desired.shape, _msg
 
     desired = xp.broadcast_to(desired, actual.shape)
-    return actual, desired
+    return actual, desired, xp
 
 
-def _assert_matching_namespace(actual, desired):
+def _assert_matching_namespace(actual, desired, xp):
     __tracebackhide__ = True  # Hide traceback for py.test
-    actual = actual if isinstance(actual, tuple) else (actual,)
-    desired_space = array_namespace(desired)
-    for arr in actual:
-        arr_space = array_namespace(arr)
-        _msg = (f"Namespaces do not match.\n"
-                f"Actual: {arr_space.__name__}\n"
-                f"Desired: {desired_space.__name__}")
-        assert arr_space == desired_space, _msg
+
+    desired_arr_space = array_namespace(desired)
+    _msg = ("Namespace of desired array does not match expectations "
+            "set by the `default_xp` context manager or by the `xp`"
+            "pytest fixture.\n"
+            f"Desired array's space: {desired_arr_space.__name__}\n"
+            f"Expected namespace: {xp.__name__}")
+    assert desired_arr_space == xp, _msg
+
+    actual_arr_space = array_namespace(actual)
+    _msg = ("Namespace of actual and desired arrays do not match.\n"
+            f"Actual: {actual_arr_space.__name__}\n"
+            f"Desired: {xp.__name__}")
+    assert actual_arr_space == xp, _msg
 
 
 def xp_assert_equal(actual, desired, *, check_namespace=True, check_dtype=True,
                     check_shape=True, check_0d=True, err_msg='', xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
-    if xp is None:
-        xp = array_namespace(actual)
 
-    actual, desired = _strict_check(
+    actual, desired, xp = _strict_check(
         actual, desired, xp, check_namespace=check_namespace,
         check_dtype=check_dtype, check_shape=check_shape,
         check_0d=check_0d
@@ -290,10 +326,8 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
                     check_dtype=True, check_shape=True, check_0d=True,
                     err_msg='', xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
-    if xp is None:
-        xp = array_namespace(actual)
 
-    actual, desired = _strict_check(
+    actual, desired, xp = _strict_check(
         actual, desired, xp,
         check_namespace=check_namespace, check_dtype=check_dtype,
         check_shape=check_shape, check_0d=check_0d
@@ -323,10 +357,8 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
 def xp_assert_less(actual, desired, *, check_namespace=True, check_dtype=True,
                    check_shape=True, check_0d=True, err_msg='', verbose=True, xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test
-    if xp is None:
-        xp = array_namespace(actual)
 
-    actual, desired = _strict_check(
+    actual, desired, xp = _strict_check(
         actual, desired, xp, check_namespace=check_namespace,
         check_dtype=check_dtype, check_shape=check_shape,
         check_0d=check_0d

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -97,8 +97,16 @@ class TestArrayAPI:
         if xp == np:
             xp_assert_equal(x, y, **options)
         else:
-            with pytest.raises(AssertionError, match="Namespaces do not match."):
+            with pytest.raises(
+                AssertionError,
+                match="Namespace of desired array does not match",
+            ):
                 xp_assert_equal(x, y, **options)
+            with pytest.raises(
+                AssertionError,
+                match="Namespace of actual and desired arrays do not match",
+            ):
+                xp_assert_equal(y, x, **options)
 
         options = dict(zip(kwarg_names, [False, True, False, False]))
         if y.dtype.name in str(x.dtype):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2006,7 +2006,8 @@ class TestNdimageFilters:
                                      origin=[-1, 0])
         xp_assert_equal(expected, output)
 
-    def test_rank16(self, xp):
+    @skip_xp_backends(np_only=True, reason="test list input")
+    def test_rank16(self):
         # test that lists are accepted and interpreted as numpy arrays
         array = [3, 2, 5, 1, 4]
         # expected values are: median(3, 2, 5) = 3, median(2, 5, 1) = 2, etc

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -296,54 +296,58 @@ class TestGeometricTransform:
         assert_array_almost_equal(out, xp.asarray([1, 2, 3, 4], dtype=out.dtype))
 
     def test_geometric_transform15(self, order, xp):
-        data = [1, 2, 3, 4]
+        data = xp.asarray([1, 2, 3, 4])
 
         def mapping(x):
             return (x[0] / 2,)
 
         out = ndimage.geometric_transform(data, mapping, [8], order=order)
-        assert_array_almost_equal(out[::2], [1, 2, 3, 4])
+        assert_array_almost_equal(out[::2], xp.asarray([1, 2, 3, 4]))
 
     def test_geometric_transform16(self, order, xp):
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9.0, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0], x[1] * 2)
 
         out = ndimage.geometric_transform(data, mapping, (3, 2),
                                           order=order)
-        assert_array_almost_equal(out, [[1, 3], [5, 7], [9, 11]])
+        assert_array_almost_equal(out, xp.asarray([[1, 3], [5, 7], [9, 11]]))
 
     def test_geometric_transform17(self, order, xp):
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0] * 2, x[1])
 
         out = ndimage.geometric_transform(data, mapping, (1, 4),
                                           order=order)
-        assert_array_almost_equal(out, [[1, 2, 3, 4]])
+        assert_array_almost_equal(out, xp.asarray([[1, 2, 3, 4]]))
 
     def test_geometric_transform18(self, order, xp):
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0] * 2, x[1] * 2)
 
         out = ndimage.geometric_transform(data, mapping, (1, 2),
                                           order=order)
-        assert_array_almost_equal(out, [[1, 3]])
+        assert_array_almost_equal(out, xp.asarray([[1, 3]]))
 
     def test_geometric_transform19(self, order, xp):
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0], x[1] / 2)
@@ -356,6 +360,7 @@ class TestGeometricTransform:
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0] / 2, x[1])
@@ -368,6 +373,7 @@ class TestGeometricTransform:
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (x[0] / 2, x[1] / 2)
@@ -377,9 +383,10 @@ class TestGeometricTransform:
         assert_array_almost_equal(out[::2, ::2], data)
 
     def test_geometric_transform22(self, order, xp):
-        data = xp.asarray([[1, 2, 3, 4],
-                           [5, 6, 7, 8],
-                           [9, 10, 11, 12]], dtype=xp.float64)
+        data = [[1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11, 12]]
+        data = xp.asarray(data, dtype=xp.float64)
 
         def mapping1(x):
             return (x[0] / 2, x[1] / 2)
@@ -397,18 +404,19 @@ class TestGeometricTransform:
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x):
             return (1, x[0] * 2)
 
         out = ndimage.geometric_transform(data, mapping, (2,), order=order)
-        out = out.astype(np.int32)
-        assert_array_almost_equal(out, [5, 7])
+        assert_array_almost_equal(out, xp.asarray([5, 7]))
 
     def test_geometric_transform24(self, order, xp):
         data = [[1, 2, 3, 4],
                 [5, 6, 7, 8],
                 [9, 10, 11, 12]]
+        data = xp.asarray(data)
 
         def mapping(x, a, b):
             return (a, x[0] * b)
@@ -416,7 +424,7 @@ class TestGeometricTransform:
         out = ndimage.geometric_transform(
             data, mapping, (2,), order=order, extra_arguments=(1,),
             extra_keywords={'b': 2})
-        assert_array_almost_equal(out, [5, 7])
+        assert_array_almost_equal(out, xp.asarray([5, 7]))
 
 
 @skip_xp_backends("cupy", reason="CuPy does not have geometric_transform")
@@ -1474,6 +1482,6 @@ class TestRotate:
 
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8400")
     def test_rotate_exact_180(self, xp):
-        a = np.tile(xp.arange(5), (5, 1))
+        a = xp.asarray(np.tile(np.arange(5), (5, 1)))
         b = ndimage.rotate(ndimage.rotate(a, 180), -180)
         xp_assert_equal(a, b)

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -112,6 +112,7 @@ class Test_measurements_stats:
             xp_assert_equal(centers, np.asarray([0.5, 8.0]))
 
 
+@skip_xp_backends(np_only=True, reason='test internal numpy-only helpers')
 class Test_measurements_select:
     """ndimage._measurements._select() is a utility used by other functions."""
 

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -645,10 +645,13 @@ class TestNdimageMorphology:
         out = ndimage.distance_transform_edt(data, sampling=[2, 1])
         assert_array_almost_equal(out, ref)
 
+    @xfail_xp_backends(
+        "cupy", reason="Only 2D and 3D distance transforms are supported in CuPy"
+    )
     def test_distance_transform_edt5(self, xp):
         # Ticket #954 regression test
-        out = ndimage.distance_transform_edt(False)
-        assert_array_almost_equal(out, [0.])
+        out = ndimage.distance_transform_edt(xp.asarray(False))
+        assert_array_almost_equal(out, xp.asarray([0.]))
 
     @xfail_xp_backends(
         np_only=True, reason='XXX: does not raise unless indices is a numpy array'
@@ -673,20 +676,28 @@ class TestNdimageMorphology:
                 distances=distances_out
             )
 
+    @skip_xp_backends(np_only=True,
+                      reason="generate_binary_structure always generates numpy objects")
     def test_generate_structure01(self, xp):
         struct = ndimage.generate_binary_structure(0, 1)
         assert struct == 1
 
+    @skip_xp_backends(np_only=True,
+                      reason="generate_binary_structure always generates numpy objects")
     def test_generate_structure02(self, xp):
         struct = ndimage.generate_binary_structure(1, 1)
         assert_array_almost_equal(struct, [1, 1, 1])
 
+    @skip_xp_backends(np_only=True,
+                      reason="generate_binary_structure always generates numpy objects")
     def test_generate_structure03(self, xp):
         struct = ndimage.generate_binary_structure(2, 1)
         assert_array_almost_equal(struct, [[0, 1, 0],
                                            [1, 1, 1],
                                            [0, 1, 0]])
 
+    @skip_xp_backends(np_only=True,
+                      reason="generate_binary_structure always generates numpy objects")
     def test_generate_structure04(self, xp):
         struct = ndimage.generate_binary_structure(2, 2)
         assert_array_almost_equal(struct, [[1, 1, 1],
@@ -2870,6 +2881,9 @@ def test_binary_closing_noninteger_brute_force_passes_when_true(xp):
     )
 
 
+@skip_xp_backends(np_only=True, exceptions=["cupy"],
+                  reason="inplace output= is numpy-specific")
+@xfail_xp_backends("cupy", reason="NotImplementedError: only brute_force iteration")
 @pytest.mark.parametrize(
     'function',
     ['binary_erosion', 'binary_dilation', 'binary_opening', 'binary_closing'],
@@ -2879,6 +2893,7 @@ def test_binary_closing_noninteger_brute_force_passes_when_true(xp):
 def test_binary_input_as_output(function, iterations, brute_force, xp):
     rstate = np.random.RandomState(123)
     data = rstate.randint(low=0, high=2, size=100).astype(bool)
+    data = xp.asarray(data)
     ndi_func = getattr(ndimage, function)
 
     # input data is not modified
@@ -2896,6 +2911,7 @@ def test_binary_input_as_output(function, iterations, brute_force, xp):
 def test_binary_hit_or_miss_input_as_output(xp):
     rstate = np.random.RandomState(123)
     data = rstate.randint(low=0, high=2, size=100).astype(bool)
+    data = xp.asarray(data)
 
     # input data is not modified
     data_orig = data.copy()

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -179,7 +179,7 @@ class TestBracketRoot:
             ref_attr = [xp.asarray(getattr(ref, attr)) for ref in refs]
             res_attr = getattr(res, attr)
             xp_assert_close(xp_ravel(res_attr, xp=xp), xp.stack(ref_attr))
-            xp_assert_equal(res_attr.shape, shape)
+            assert res_attr.shape == shape
 
         xp_test = array_namespace(xp.asarray(1.))
         assert res.success.dtype == xp_test.bool
@@ -784,7 +784,7 @@ class TestBracketMinimum:
             ref_attr = [xp.asarray(getattr(ref, attr)) for ref in refs]
             res_attr = getattr(res, attr)
             xp_assert_close(xp_ravel(res_attr, xp=xp), xp.stack(ref_attr))
-            xp_assert_equal(res_attr.shape, shape)
+            assert res_attr.shape == shape
 
         xp_test = array_namespace(xp.asarray(1.))
         assert res.success.dtype == xp_test.bool

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -716,7 +716,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     elif in1.ndim != in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
     elif xp_size(in1) == 0 or xp_size(in2) == 0:  # empty arrays
-        return xp.array([])
+        return xp.asarray([])
 
     in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes,
                                           sorted_axes=False)
@@ -933,7 +933,7 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     elif in1.ndim != in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
     elif in1.size == 0 or in2.size == 0:  # empty arrays
-        return np.array([])
+        return xp.asarray([])
     elif in1.shape == in2.shape:  # Equivalent to fftconvolve
         return fftconvolve(in1, in2, mode=mode, axes=axes)
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -17,13 +17,13 @@ except ImportError:
 
 @pytest.mark.skipif(not HAVE_ARRAY_API_STRICT,
                     reason="`array_api_strict` not installed")
-def test_dispatch_to_unrecognize_library():
+def test_dispatch_to_unrecognized_library():
     xp = array_api_strict
     f = get_array_special_func('ndtr', xp=xp, n_array_args=1)
     x = [1, 2, 3]
     res = f(xp.asarray(x))
     ref = xp.asarray(special.ndtr(np.asarray(x)))
-    xp_assert_close(res, ref, xp=xp)
+    xp_assert_close(res, ref)
 
 
 @pytest.mark.parametrize('dtype', ['float32', 'float64', 'int64'])
@@ -34,16 +34,20 @@ def test_rel_entr_generic(dtype):
     f = get_array_special_func('rel_entr', xp=xp, n_array_args=2)
     dtype_np = getattr(np, dtype)
     dtype_xp = getattr(xp, dtype)
-    x, y = [-1, 0, 0, 1], [1, 0, 2, 3]
+    x = [-1, 0, 0, 1]
+    y = [1, 0, 2, 3]
 
-    x_xp, y_xp = xp.asarray(x, dtype=dtype_xp), xp.asarray(y, dtype=dtype_xp)
+    x_xp = xp.asarray(x, dtype=dtype_xp)
+    y_xp = xp.asarray(y, dtype=dtype_xp)
     res = f(x_xp, y_xp)
 
-    x_np, y_np = np.asarray(x, dtype=dtype_np), np.asarray(y, dtype=dtype_np)
+    x_np = np.asarray(x, dtype=dtype_np)
+    y_np = np.asarray(y, dtype=dtype_np)
     ref = special.rel_entr(x_np[-1], y_np[-1])
     ref = np.asarray([np.inf, 0, 0, ref], dtype=ref.dtype)
+    ref = xp.asarray(ref)
 
-    xp_assert_close(res, xp.asarray(ref), xp=xp)
+    xp_assert_close(res, ref)
 
 
 @pytest.mark.fail_slow(5)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2873,9 +2873,9 @@ class TestZmapZscore:
 
     def test_zmap_axis(self, xp):
         # Test use of 'axis' keyword in zmap.
-        x = np.array([[0.0, 0.0, 1.0, 1.0],
-                      [1.0, 1.0, 1.0, 2.0],
-                      [2.0, 0.0, 2.0, 0.0]])
+        x = xp.asarray([[0.0, 0.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 2.0],
+                        [2.0, 0.0, 2.0, 0.0]])
 
         t1 = 1.0/(2.0/3)**0.5
         t2 = 3.**0.5/3
@@ -2890,6 +2890,8 @@ class TestZmapZscore:
         z1_expected = [[-1.0, -1.0, 1.0, 1.0],
                        [-t2, -t2, -t2, 3.**0.5],
                        [1.0, -1.0, 1.0, -1.0]]
+        z0_expected = xp.asarray(z0_expected)
+        z1_expected = xp.asarray(z1_expected)
 
         xp_assert_close(z0, z0_expected)
         xp_assert_close(z1, z1_expected)

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -32,9 +32,10 @@ class TestVariation:
         expected = xp.asarray(sgn*math.sqrt(2)/3)
         xp_assert_close(v, expected, rtol=1e-10)
 
-    def test_scalar(self, xp):
+    @skip_xp_backends(np_only=True, reason="test plain python scalar input")
+    def test_scalar(self):
         # A scalar is treated like a 1-d sequence with length 1.
-        xp_assert_equal(variation(4.0), 0.0)
+        assert variation(4.0) == 0.0
 
     @pytest.mark.parametrize('nan_policy, expected',
                              [('propagate', np.nan),


### PR DESCRIPTION
I found several tests for the array API backends that were 

- completely disregarding `xp` and just running in plain numpy, or
- running with the correct `xp`, but then the tested function would return a plain numpy array and there was no error because the desired outcome was _also_ a plain numpy array

This PR causes all calls to
- `assert_array_almost_equal`
- `assert_almost_equal`
- `xp_assert_equal`
- `xp_assert_close`
- `xp_assert_less`

to raise if either the actual or the desired array don't match the `xp` defined by the test fixture.

Additionally, this PR makes the `@array_api_compatible` decorator obsolete. I have not removed it yet to facilitate code review. I plan to trivially clean it up in a later PR.

Finally, this PR introduces a new pytest mark, `array_api_backends`, which automatically selects all and only the tests that use the `xp` parameter. This means that we no longer need to keep an inventory of array API tests in the github CI script. To figure out which tests are involved in array API, just run
```bash
$ pytest -m array_api_backends --collect-only
```
or
```bash
$ python dev.py -- -m array_api_backends --collect-only
```
Variations of the same commands could be used e.g. to figure out which tests have been missed for whatever reason.