### PR TITLE
ENH: linalg: add batch support for functions that accept a single array

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1719,7 +1719,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
         return B
 
 
-@_apply_over_batch(('a', 2))
+@_apply_over_batch(('A', 2))
 def matrix_balance(A, permute=True, scale=True, separate=False,
                    overwrite_a=False):
     """

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -8,6 +8,7 @@ from warnings import warn
 from itertools import product
 import numpy as np
 from numpy import atleast_1d, atleast_2d
+from scipy._lib._util import _apply_over_batch
 from .lapack import get_lapack_funcs, _compute_lwork
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated
@@ -1089,6 +1090,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
 
 # matrix inversion
+@_apply_over_batch(('a', 2))
 def inv(a, overwrite_a=False, check_finite=True):
     """
     Compute the inverse of a matrix.

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1719,6 +1719,7 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
         return B
 
 
+@_apply_over_batch(('a', 2))
 def matrix_balance(A, permute=True, scale=True, separate=False,
                    overwrite_a=False):
     """

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1501,6 +1501,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 lstsq.default_lapack_driver = 'gelsd'
 
 
+@_apply_over_batch(('a', 2))
 def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
@@ -1624,6 +1625,7 @@ def pinv(a, *, atol=None, rtol=None, return_rank=False, check_finite=True):
         return B
 
 
+@_apply_over_batch(('a', 2))
 def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
           check_finite=True):
     """

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -90,6 +90,7 @@ cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noe
 # ============================================================================
 
 
+@_apply_over_batch(('a', 2))
 @cython.embedsignature(True)
 def bandwidth(a):
     """Return the lower and upper bandwidth of a 2D numeric array.

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1391,6 +1391,7 @@ def _check_info(info, driver, positive='did not converge (LAPACK info=%d)'):
         raise LinAlgError(("%s " + positive) % (driver, info,))
 
 
+@_apply_over_batch(('a', 2))
 def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
     """
     Compute Hessenberg form of a matrix.

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -657,6 +657,7 @@ def _check_select(select, select_range, max_ev, max_len):
     return select, vl, vu, il, iu, max_ev
 
 
+@_apply_over_batch(('a_band', 2))
 def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
                select='a', select_range=None, max_ev=0, check_finite=True):
     """
@@ -1029,6 +1030,7 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
                 driver=driver)
 
 
+@_apply_over_batch(('a_band', 2))
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                    select='a', select_range=None, check_finite=True):
     """

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy import asarray_chkfinite, asarray, atleast_2d, empty_like
 
 # Local imports
+from scipy._lib._util import _apply_over_batch
 from ._misc import LinAlgError, _datacopied
 from .lapack import get_lapack_funcs
 
@@ -43,6 +44,7 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
     return c, lower
 
 
+@_apply_over_batch(('a', 2))
 def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
     """
     Compute the Cholesky decomposition of a matrix.

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -3,13 +3,14 @@ from warnings import warn
 import numpy as np
 from numpy import (atleast_2d, arange, zeros_like, imag, diag,
                    iscomplexobj, tril, triu, argsort, empty_like)
-from scipy._lib._util import ComplexWarning
+from scipy._lib._util import ComplexWarning, _apply_over_batch
 from ._decomp import _asarray_validated
 from .lapack import get_lapack_funcs, _compute_lwork
 
 __all__ = ['ldl']
 
 
+@_apply_over_batch(('A', 2))
 def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     """ Computes the LDLt or Bunch-Kaufman factorization of a symmetric/
     hermitian matrix.

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -6,6 +6,8 @@ from numpy import asarray, asarray_chkfinite
 import numpy as np
 from itertools import product
 
+from scipy._lib._util import _apply_over_batch
+
 # Local imports
 from ._misc import _datacopied, LinAlgWarning
 from .lapack import get_lapack_funcs
@@ -17,6 +19,7 @@ lapack_cast_dict = {x: ''.join([y for y in 'fdFD' if np.can_cast(x, y)])
 __all__ = ['lu', 'lu_solve', 'lu_factor']
 
 
+@_apply_over_batch(('a', 2))
 def lu_factor(a, overwrite_a=False, check_finite=True):
     """
     Compute pivoted LU decomposition of a matrix.

--- a/scipy/linalg/_decomp_polar.py
+++ b/scipy/linalg/_decomp_polar.py
@@ -1,10 +1,12 @@
 import numpy as np
+from scipy._lib._util import _apply_over_batch
 from scipy.linalg import svd
 
 
 __all__ = ['polar']
 
 
+@_apply_over_batch(('a', 2))
 def polar(a, side="right"):
     """
     Compute the polar decomposition.

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -1,6 +1,8 @@
 """QR decomposition functions."""
 import numpy as np
 
+from scipy._lib._util import _apply_over_batch
+
 # Local imports
 from .lapack import get_lapack_funcs
 from ._misc import _datacopied
@@ -23,6 +25,7 @@ def safecall(f, name, *args, **kwargs):
     return ret[:-2]
 
 
+@_apply_over_batch(('a', 2))
 def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
        check_finite=True):
     """
@@ -366,6 +369,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     return (cQ,) + raw[1:]
 
 
+@_apply_over_batch(('a', 2))
 def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     """
     Compute RQ decomposition of a matrix.

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy import asarray_chkfinite, single, asarray, array
 from numpy.linalg import norm
 
-
+from scipy._lib._util import _apply_over_batch
 # Local imports.
 from ._misc import LinAlgError, _datacopied
 from .lapack import get_lapack_funcs
@@ -14,6 +14,7 @@ __all__ = ['schur', 'rsf2csf']
 _double_precision = ['i', 'l', 'd']
 
 
+@_apply_over_batch(('a', 2))
 def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
           check_finite=True):
     """

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -2,10 +2,13 @@
 import numpy as np
 from numpy import zeros, r_, diag, dot, arccos, arcsin, where, clip
 
+from scipy._lib._util import _apply_over_batch
+
 # Local imports.
 from ._misc import LinAlgError, _datacopied
 from .lapack import get_lapack_funcs, _compute_lwork
 from ._decomp import _asarray_validated
+
 
 __all__ = ['svd', 'svdvals', 'diagsvd', 'orth', 'subspace_angles', 'null_space']
 
@@ -249,6 +252,7 @@ def svdvals(a, overwrite_a=False, check_finite=True):
                check_finite=check_finite)
 
 
+@_apply_over_batch(('s', 1))
 def diagsvd(s, M, N):
     """
     Construct the sigma matrix in SVD from singular values and size M, N.

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -353,6 +353,7 @@ def orth(A, rcond=None):
     return Q
 
 
+@_apply_over_batch(('s', 2))
 def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
                lapack_driver='gesdd'):
     """

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -306,6 +306,7 @@ def diagsvd(s, M, N):
 
 # Orthonormal decomposition
 
+@_apply_over_batch(('A', 2))
 def orth(A, rcond=None):
     """
     Construct an orthonormal basis for the range of A using SVD

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -13,6 +13,7 @@ from ._decomp import _asarray_validated
 __all__ = ['svd', 'svdvals', 'diagsvd', 'orth', 'subspace_angles', 'null_space']
 
 
+@_apply_over_batch(('a', 2))
 def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         check_finite=True, lapack_driver='gesdd'):
     """

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -353,7 +353,7 @@ def orth(A, rcond=None):
     return Q
 
 
-@_apply_over_batch(('s', 2))
+@_apply_over_batch(('A', 2))
 def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
                lapack_driver='gesdd'):
     """

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -97,6 +97,7 @@ def _maybe_real(A, B, tol=None):
 # Matrix functions.
 
 
+@_apply_over_batch(('A', 2))
 def fractional_matrix_power(A, t):
     """
     Compute the fractional power of a matrix.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -8,6 +8,8 @@ import numpy as np
 from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
 
+from scipy._lib._util import _apply_over_batch
+
 # Local imports
 from scipy.linalg import LinAlgError, bandwidth
 from ._misc import norm
@@ -627,6 +629,7 @@ def tanhm(A):
     return _maybe_real(A, solve(coshm(A), sinhm(A)))
 
 
+@_apply_over_batch(('A', 2))
 def funm(A, func, disp=True):
     """
     Evaluate a matrix function specified by a callable.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -724,6 +724,7 @@ def funm(A, func, disp=True):
         return F, err
 
 
+@_apply_over_batch(('A', 2))
 def signm(A, disp=True):
     """
     Matrix sign function.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -144,6 +144,7 @@ def fractional_matrix_power(A, t):
     return scipy.linalg._matfuncs_inv_ssq._fractional_matrix_power(A, t)
 
 
+@_apply_over_batch(('A', 2))
 def logm(A, disp=True):
     """
     Compute matrix logarithm.
@@ -394,6 +395,7 @@ def _exp_sinch(x):
     return lexp_diff
 
 
+@_apply_over_batch(('A', 2))
 def cosm(A):
     """
     Compute the matrix cosine.
@@ -434,6 +436,7 @@ def cosm(A):
         return expm(1j*A).real
 
 
+@_apply_over_batch(('A', 2))
 def sinm(A):
     """
     Compute the matrix sine.
@@ -474,6 +477,7 @@ def sinm(A):
         return expm(1j*A).imag
 
 
+@_apply_over_batch(('A', 2))
 def tanm(A):
     """
     Compute the matrix tangent.
@@ -513,6 +517,7 @@ def tanm(A):
     return _maybe_real(A, solve(cosm(A), sinm(A)))
 
 
+@_apply_over_batch(('A', 2))
 def coshm(A):
     """
     Compute the hyperbolic matrix cosine.
@@ -552,6 +557,7 @@ def coshm(A):
     return _maybe_real(A, 0.5 * (expm(A) + expm(-A)))
 
 
+@_apply_over_batch(('A', 2))
 def sinhm(A):
     """
     Compute the hyperbolic matrix sine.
@@ -591,6 +597,7 @@ def sinhm(A):
     return _maybe_real(A, 0.5 * (expm(A) - expm(-A)))
 
 
+@_apply_over_batch(('A', 2))
 def tanhm(A):
     """
     Compute the hyperbolic matrix tangent.

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -8,7 +8,7 @@ __all__ = ['sqrtm']
 
 import numpy as np
 
-from scipy._lib._util import _asarray_validated
+from scipy._lib._util import _asarray_validated, _apply_over_batch
 
 # Local imports
 from ._misc import norm
@@ -115,6 +115,7 @@ def _sqrtm_triu(T, blocksize=64):
     return R
 
 
+@_apply_over_batch(('A', 2))
 def sqrtm(A, disp=True, blocksize=64):
     """
     Matrix square root.

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from scipy._lib._util import (check_random_state, rng_integers,
-                              _transition_to_rng, _apply_over_batch)
+                              _transition_to_rng)
 from scipy.sparse import csc_matrix
 
 __all__ = ['clarkson_woodruff_transform']
@@ -53,7 +53,6 @@ def cwt_matrix(n_rows, n_columns, rng=None):
     return S
 
 
-@_apply_over_batch(('input_matrix', 2))
 @_transition_to_rng("seed", position_num=2)
 def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
     r"""

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from scipy._lib._util import (check_random_state, rng_integers,
-                              _transition_to_rng)
+                              _transition_to_rng, _apply_over_batch)
 from scipy.sparse import csc_matrix
 
 __all__ = ['clarkson_woodruff_transform']
@@ -53,6 +53,7 @@ def cwt_matrix(n_rows, n_columns, rng=None):
     return S
 
 
+@_apply_over_batch(('input_matrix', 2))
 @_transition_to_rng("seed", position_num=2)
 def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
     r"""

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -194,3 +194,16 @@ class TestOneArrayIn:
         A = get_random((2, 3, 6, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.clarkson_woodruff_transform, A,
                         kwargs=dict(sketch_size=5, rng=23598158972358))
+
+    @pytest.mark.parametrize('eigvals_only', [False, True])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_eig_banded(self, eigvals_only, dtype, rng):
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        n_out = 1 if eigvals_only else 2
+        self.batch_test(linalg.eig_banded, A, n_out=n_out,
+                        kwargs=dict(eigvals_only=eigvals_only))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_eigvals_banded(self, dtype, rng):
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        self.batch_test(linalg.eigvals_banded, A)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -96,8 +96,6 @@ class TestMatrixInScalarOut:
 
     @pytest.mark.parametrize('dtype', floating)
     def test_logm(self, dtype, rng):
-        with warnings.catch_warnings():  # "result not accurate"
-            warnings.simplefilter("ignore", RuntimeWarning)
-            A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-            A = A + 3*np.eye(4)  # avoid complex output for real input
-            self.batch_test(linalg.logm, A)
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        A = A + 3*np.eye(4)  # avoid complex output for real input
+        self.batch_test(linalg.logm, A)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -73,3 +73,8 @@ class TestMatrixInScalarOut:
     def test_inv(self, dtype, rng):
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.inv, A)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_null_space(self, dtype, rng):
+        A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
+        res = self.batch_test(linalg.null_space, A)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -189,12 +189,6 @@ class TestOneArrayIn:
         n_out = 2 if calc_q else 1
         self.batch_test(linalg.hessenberg, A, n_out=n_out, kwargs=dict(calc_q=calc_q))
 
-    @pytest.mark.parametrize('dtype', floating)
-    def test_cwt(self, dtype, rng):
-        A = get_random((2, 3, 6, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.clarkson_woodruff_transform, A,
-                        kwargs=dict(sketch_size=5, rng=23598158972358))
-
     @pytest.mark.parametrize('eigvals_only', [False, True])
     @pytest.mark.parametrize('dtype', floating)
     def test_eig_banded(self, eigvals_only, dtype, rng):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -169,3 +169,8 @@ class TestOneArrayIn:
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         n_out = 3 if compute_uv else 1
         self.batch_test(linalg.svd, A, n_out=n_out, kwargs=dict(compute_uv=compute_uv))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_polar(self, dtype, rng):
+        A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
+        self.batch_test(linalg.polar, A, n_out=2)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -69,7 +69,7 @@ class TestMatrixInScalarOut:
         A = rng.random((5, 3, 4)).astype(dtype)
         self.batch_test(linalg.diagsvd, A, args=(6, 4), core_dim=1)
 
-    @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm])
+    @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm, linalg.signm])
     @pytest.mark.parametrize('dtype', floating)
     def test_matmat(self, fun, dtype, rng):  # matrix in, matrix out
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -154,3 +154,8 @@ class TestOneArrayIn:
         A = get_random((4, 4), dtype=dtype, rng=rng)
         A = np.asarray([np.triu(A, k) for k in range(-3, 3)]).reshape((2, 3, 4, 4))
         self.batch_test(linalg.bandwidth, A, n_out=2)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_ldl(self, dtype, rng):
+        A = get_nearly_hermitian((5, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
+        self.batch_test(linalg.ldl, A, n_out=3)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -170,7 +170,20 @@ class TestOneArrayIn:
         n_out = 3 if compute_uv else 1
         self.batch_test(linalg.svd, A, n_out=n_out, kwargs=dict(compute_uv=compute_uv))
 
+    @pytest.mark.parametrize('fun', [linalg.polar, linalg.qr, linalg.rq])
     @pytest.mark.parametrize('dtype', floating)
-    def test_polar(self, dtype, rng):
+    def test_polar_qr_rq(self, fun, dtype, rng):
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.polar, A, n_out=2)
+        self.batch_test(fun, A, n_out=2)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_schur(self, dtype, rng):
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        self.batch_test(linalg.schur, A, n_out=2)
+
+    @pytest.mark.parametrize('calc_q', [False, True])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_hessenberg(self, calc_q, dtype, rng):
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        n_out = 2 if calc_q else 1
+        self.batch_test(linalg.hessenberg, A, n_out=n_out, kwargs=dict(calc_q=calc_q))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -25,7 +25,8 @@ def get_nearly_hermitian(shape, dtype, atol, rng):
     return A + At + noise
 
 
-class TestMatrixInScalarOut:
+class TestOneArrayIn:
+    # Test the functions that accept one array argument
 
     def batch_test(self, fun, A, core_dim=2, n_out=1, args=(), kwargs=None, dtype=None):
         kwargs = {} if kwargs is None else kwargs
@@ -112,3 +113,9 @@ class TestMatrixInScalarOut:
     def test_pinv(self, dtype, rng):
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.pinv, A, n_out=2, kwargs=dict(return_rank=True))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_matrix_balance(self, dtype, rng):
+        A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+        self.batch_test(linalg.matrix_balance, A, n_out=2)
+        self.batch_test(linalg.matrix_balance, A, n_out=4, kwargs={'separate':True})

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -100,7 +100,7 @@ class TestOneArrayIn:
     @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm, linalg.signm,
                                      linalg.sinm, linalg.cosm, linalg.tanhm,
                                      linalg.sinhm, linalg.coshm, linalg.tanhm,
-                                     linalg.pinv, linalg.pinvh])
+                                     linalg.pinv, linalg.pinvh, linalg.orth])
     @pytest.mark.parametrize('dtype', floating)
     def test_matmat(self, fun, dtype, rng):  # matrix in, matrix out
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
@@ -176,10 +176,11 @@ class TestOneArrayIn:
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A, n_out=2)
 
+    @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
-    def test_schur(self, dtype, rng):
+    def test_schur_lu(self, fun, dtype, rng):
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.schur, A, n_out=2)
+        self.batch_test(fun, A, n_out=2)
 
     @pytest.mark.parametrize('calc_q', [False, True])
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -187,3 +187,9 @@ class TestOneArrayIn:
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         n_out = 2 if calc_q else 1
         self.batch_test(linalg.hessenberg, A, n_out=n_out, kwargs=dict(calc_q=calc_q))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_cwt(self, dtype, rng):
+        A = get_random((2, 3, 6, 4), dtype=dtype, rng=rng)
+        self.batch_test(linalg.clarkson_woodruff_transform, A,
+                        kwargs=dict(sketch_size=5, rng=23598158972358))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -159,3 +159,10 @@ class TestOneArrayIn:
     def test_ldl(self, dtype, rng):
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
         self.batch_test(linalg.ldl, A, n_out=3)
+
+    @pytest.mark.parametrize('compute_uv', [False, True])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_svd(self, compute_uv, dtype, rng):
+        A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
+        n_out = 3 if compute_uv else 1
+        self.batch_test(linalg.svd, A, n_out=n_out, kwargs=dict(compute_uv=compute_uv))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -148,3 +148,9 @@ class TestOneArrayIn:
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.matrix_balance, A, n_out=2)
         self.batch_test(linalg.matrix_balance, A, n_out=2, kwargs={'separate':True})
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_bandwidth(self, dtype, rng):
+        A = get_random((4, 4), dtype=dtype, rng=rng)
+        A = np.asarray([np.triu(A, k) for k in range(-3, 3)]).reshape((2, 3, 4, 4))
+        self.batch_test(linalg.bandwidth, A, n_out=2)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -69,7 +71,9 @@ class TestMatrixInScalarOut:
         A = rng.random((5, 3, 4)).astype(dtype)
         self.batch_test(linalg.diagsvd, A, args=(6, 4), core_dim=1)
 
-    @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm, linalg.signm])
+    @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm, linalg.signm,
+                                     linalg.sinm, linalg.cosm, linalg.tanhm,
+                                     linalg.sinhm, linalg.coshm, linalg.tanhm])
     @pytest.mark.parametrize('dtype', floating)
     def test_matmat(self, fun, dtype, rng):  # matrix in, matrix out
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
@@ -89,3 +93,11 @@ class TestMatrixInScalarOut:
     def test_fractional_matrix_power(self, dtype, rng):
         A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
         self.batch_test(linalg.fractional_matrix_power, A, args=(1.5,))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_logm(self, dtype, rng):
+        with warnings.catch_warnings():  # "result not accurate"
+            warnings.simplefilter("ignore", RuntimeWarning)
+            A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+            A = A + 3*np.eye(4)  # avoid complex output for real input
+            self.batch_test(linalg.logm, A)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -155,10 +155,13 @@ class TestOneArrayIn:
         A = np.asarray([np.triu(A, k) for k in range(-3, 3)]).reshape((2, 3, 4, 4))
         self.batch_test(linalg.bandwidth, A, n_out=2)
 
+    @pytest.mark.parametrize('fun_n_out', [(linalg.cholesky, 1), (linalg.ldl, 3)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_ldl(self, dtype, rng):
+    def test_ldl_cholesky(self, fun_n_out, dtype, rng):
+        fun, n_out = fun_n_out
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
-        self.batch_test(linalg.ldl, A, n_out=3)
+        A = A + 4*np.eye(4, dtype=dtype)  # ensure positive definite for Cholesky
+        self.batch_test(fun, A, n_out=n_out)
 
     @pytest.mark.parametrize('compute_uv', [False, True])
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -84,3 +84,8 @@ class TestMatrixInScalarOut:
     def test_funm(self, dtype, rng):
         A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
         self.batch_test(linalg.funm, A, kwargs=dict(func=np.sin))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_fractional_matrix_power(self, dtype, rng):
+        A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
+        self.batch_test(linalg.fractional_matrix_power, A, args=(1.5,))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -69,12 +69,18 @@ class TestMatrixInScalarOut:
         A = rng.random((5, 3, 4)).astype(dtype)
         self.batch_test(linalg.diagsvd, A, args=(6, 4), core_dim=1)
 
+    @pytest.mark.parametrize('fun', [linalg.inv, linalg.sqrtm])
     @pytest.mark.parametrize('dtype', floating)
-    def test_inv(self, dtype, rng):
+    def test_matmat(self, fun, dtype, rng):  # matrix in, matrix out
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.inv, A)
+        self.batch_test(fun, A)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_null_space(self, dtype, rng):
         A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
-        res = self.batch_test(linalg.null_space, A)
+        self.batch_test(linalg.null_space, A)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_funm(self, dtype, rng):
+        A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
+        self.batch_test(linalg.funm, A, kwargs=dict(func=np.sin))

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -19,8 +19,6 @@ def test_bandwidth_dtypes():
 def test_bandwidth_non2d_input():
     A = np.array([1, 2, 3])
     raises(ValueError, bandwidth, A)
-    A = np.array([[[1, 2, 3], [4, 5, 6]]])
-    raises(ValueError, bandwidth, A)
 
 
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-22127
Toward gh-21466

#### What does this implement/fix?
This adds support for n-dimensional batch input to `linalg` functions `diagsvd`, `inv`, `null_space`, `logm`, `sinm`, `cosm`, `tanm`, `sinhn`, `coshm`, `tanhm`, `sqrtm`, `funm`, `signm`, `fractional_matrix_power`, `pinv`, `pinvh`, `matrix_balance`, `bandwidth`, `svd`, `ldl`, `cholesky`, `polar`, `qr`, `rq`, `hessenberg`, `schur`, `orth`, `lu_factor`, `eig_banded`, and `eigvals_banded` because they all accept only one array input. (Please check me on this.)

#### Additional information
Even though functions like `cosm` are expressed in terms of `expm`, we might as well apply the decorator to them separately because `expm` just loops in Python, too. This is less work and we get the batch support documentation for free.
