### PR TITLE
MAINT: stats._SimpleDomain: ensure that instances do not share `symbols`

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -267,11 +267,10 @@ class _SimpleDomain(_Domain):
 
     """
     def __init__(self, endpoints=(-inf, inf), inclusive=(False, False)):
+        self.symbols = super().symbols.copy()
         a, b = endpoints
         self.endpoints = np.asarray(a)[()], np.asarray(b)[()]
         self.inclusive = inclusive
-        # self.all_inclusive = (endpoints == (-inf, inf)
-        #                       and inclusive == (True, True))
 
     def define_parameters(self, *parameters):
         r""" Records any parameters used to define the endpoints of the domain.

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -119,7 +119,7 @@ class Test_RealDomain:
 
     def test_symbols_gh22137(self):
         # `symbols` was accidentally shared between instances originally
-        # Check that this is not longer the case
+        # Check that this is no longer the case
         domain1 = _RealDomain(endpoints=(0, 1))
         domain2 = _RealDomain(endpoints=(0, 1))
         assert domain1.symbols is not domain2.symbols

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -117,6 +117,14 @@ class Test_RealDomain:
         ref = f"{left_bracket}{a}, {b}{right_bracket}"
         assert str(domain) == ref
 
+    def test_symbols_gh22137(self):
+        # `symbols` was accidentally shared between instances originally
+        # Check that this is not longer the case
+        domain1 = _RealDomain(endpoints=(0, 1))
+        domain2 = _RealDomain(endpoints=(0, 1))
+        assert domain1.symbols is not domain2.symbols
+
+
 def draw_distribution_from_family(family, data, rng, proportions, min_side=0):
     # If the distribution has parameters, choose a parameterization and
     # draw broadcastable shapes for the parameter arrays.


### PR DESCRIPTION
#### Reference issue
Closes gh-22137

#### What does this implement/fix?
Instances of `_SimpleDomain` were sharing the same instance of the `_Domain.symbols` attribute and mutating it, which could be mutated. This gives each instance their own `symbols` attribute.
