### PR TITLE
ENH: linalg: add batch support to several remaining functions

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -281,6 +281,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
+@_apply_over_batch(('a', 2), ('b', 2))
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
          subset_by_value=None, driver=None):

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -913,6 +913,7 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
                homogeneous_eigvals=homogeneous_eigvals)
 
 
+@_apply_over_batch(('a', 2), ('b', 2))
 def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
              overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
              subset_by_value=None, driver=None):

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -1,14 +1,13 @@
 from collections.abc import Iterable
 import numpy as np
 
-from scipy._lib._util import _asarray_validated, _apply_over_batch
+from scipy._lib._util import _asarray_validated
 from scipy.linalg import block_diag, LinAlgError
 from .lapack import _compute_lwork, get_lapack_funcs
 
 __all__ = ['cossin']
 
 
-@_apply_over_batch(('X', 2))
 def cossin(X, p=None, q=None, separate=False,
            swap_sign=False, compute_u=True, compute_vh=True):
     """

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -1,13 +1,14 @@
 from collections.abc import Iterable
 import numpy as np
 
-from scipy._lib._util import _asarray_validated
+from scipy._lib._util import _asarray_validated, _apply_over_batch
 from scipy.linalg import block_diag, LinAlgError
 from .lapack import _compute_lwork, get_lapack_funcs
 
 __all__ = ['cossin']
 
 
+@_apply_over_batch(('X', 2))
 def cossin(X, p=None, q=None, separate=False,
            swap_sign=False, compute_u=True, compute_vh=True):
     """

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -319,6 +319,7 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     return result[0], result[1], result[-4], result[-3]
 
 
+@_apply_over_batch(('A', 2), ('B', 2))
 def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
           overwrite_b=False, check_finite=True):
     """QZ decomposition for a pair of matrices with reordering.

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 from numpy import asarray_chkfinite
+from scipy._lib._util import _apply_over_batch
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from .lapack import get_lapack_funcs
 
@@ -142,6 +143,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     return result, gges.typecode
 
 
+@_apply_over_batch(('A', 2), ('B', 2))
 def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
        overwrite_b=False, check_finite=True):
     """

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -249,6 +249,7 @@ def _castCopy(type, *arrays):
         return cast_arrays
 
 
+@_apply_over_batch(('T', 2), ('Z', 2))
 def rsf2csf(T, Z, check_finite=True):
     """
     Convert real Schur form to complex Schur form.

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -177,6 +177,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         return s
 
 
+@_apply_over_batch(('a', 2))
 def svdvals(a, overwrite_a=False, check_finite=True):
     """
     Compute singular values of a matrix.

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -434,6 +434,7 @@ def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
     return Q
 
 
+@_apply_over_batch(('A', 2), ('B', 2))
 def subspace_angles(A, B):
     r"""
     Compute the subspace angles between two matrices.

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -7,6 +7,7 @@ from scipy._lib._util import _apply_over_batch
 __all__ = ['expm_frechet', 'expm_cond']
 
 
+@_apply_over_batch(('A', 2), ('E', 2))
 def expm_frechet(A, E, method=None, compute_expm=True, check_finite=True):
     """
     Frechet derivative of the matrix exponential of A in the direction E.

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -813,6 +813,7 @@ def signm(A, disp=True):
         return S0, errest
 
 
+@_apply_over_batch(('a', 2), ('b', 2))
 def khatri_rao(a, b):
     r"""
     Khatri-rao product

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -3,12 +3,14 @@ Solve the orthogonal Procrustes problem.
 
 """
 import numpy as np
+from scipy._lib._util import _apply_over_batch
 from ._decomp_svd import svd
 
 
 __all__ = ['orthogonal_procrustes']
 
 
+@_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """
     Compute the matrix solution of the orthogonal (or unitary) Procrustes problem.

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 from numpy.linalg import inv, LinAlgError, norm, cond, svd
 
+from scipy._lib._util import _apply_over_batch
 from ._basic import solve, solve_triangular, matrix_balance
 from .lapack import get_lapack_funcs
 from ._decomp_schur import schur
@@ -27,6 +28,7 @@ __all__ = ['solve_sylvester',
            'solve_continuous_are', 'solve_discrete_are']
 
 
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2))
 def solve_sylvester(a, b, q):
     """
     Computes a solution (X) to the Sylvester equation :math:`AX + XB = Q`.

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -544,6 +544,7 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     return (x + x.conj().T)/2
 
 
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
 def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     r"""
     Solves the discrete-time algebraic Riccati equation (DARE).

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -338,6 +338,7 @@ def solve_discrete_lyapunov(a, q, method=None):
     return x
 
 
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
 def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     r"""
     Solves the continuous-time algebraic Riccati equation (CARE).

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -114,6 +114,7 @@ def solve_sylvester(a, b, q):
     return np.dot(np.dot(u, y), v.conj().transpose())
 
 
+@_apply_over_batch(('a', 2), ('q', 2))
 def solve_continuous_lyapunov(a, q):
     """
     Solves the continuous Lyapunov equation :math:`AX + XA^H = Q`.
@@ -247,6 +248,7 @@ def _solve_discrete_lyapunov_bilinear(a, q):
     return solve_lyapunov(b.conj().transpose(), -c)
 
 
+@_apply_over_batch(('a', 2), ('q', 2))
 def solve_discrete_lyapunov(a, q, method=None):
     """
     Solves the discrete Lyapunov equation :math:`AXA^H - X + Q = 0`.

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -220,6 +220,15 @@ class TestOneArrayIn:
         kwargs = dict(eigvals_only=True) if (n_out == 1 and fun==linalg.eigh) else {}
         self.batch_test(fun, args, n_out=n_out, kwargs=kwargs)
 
+    @pytest.mark.parametrize('compute_expm', [False, True])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_expm_frechet(self, compute_expm, dtype, rng):
+        A = get_random((1, 3, 4, 4), dtype=dtype, rng=rng)
+        E = get_random((2, 1, 4, 4), dtype=dtype, rng=rng)
+        n_out = 2 if compute_expm else 1
+        self.batch_test(linalg.expm_frechet, (A, E), n_out=n_out,
+                        kwargs=dict(compute_expm=compute_expm))
+
     @pytest.mark.parametrize('dtype', floating)
     def test_subspace_angles(self, dtype, rng):
         A = get_random((1, 3, 4, 3), dtype=dtype, rng=rng)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -261,3 +261,16 @@ class TestOneArrayIn:
         B = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         C = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         self.batch_test(linalg.solve_sylvester, (A, B, C))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_continuous_are(self, dtype, rng):
+        a = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        b = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        q = get_nearly_hermitian((2, 3, 5, 5), dtype=dtype, atol=0, rng=rng)
+        r = get_nearly_hermitian((2, 3, 5, 5), dtype=dtype, atol=0, rng=rng)
+        a = a + 5*np.eye(5)  # making these positive definite seems to help
+        b = b + 5*np.eye(5)
+        q = q + 5*np.eye(5)
+        r = r + 5*np.eye(5)
+        # can't easily generate valid random e, s
+        self.batch_test(linalg.solve_continuous_are, (a, b, q, r))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -204,3 +204,15 @@ class TestOneArrayIn:
     def test_eigvals_banded(self, dtype, rng):
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.eigvals_banded, A)
+
+    @pytest.mark.parametrize('two_in', [False, True])
+    @pytest.mark.parametrize('two_out', [False, True])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_eigh(self, two_in, two_out, dtype, rng):
+        A = get_nearly_hermitian((1, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
+        B = get_nearly_hermitian((2, 1, 4, 4), dtype, 0, rng)  # exactly Hermitian
+        B = B + 4*np.eye(4).astype(dtype)  # needs to be positive definite
+        args = (A, B) if two_in else (A,)
+        kwargs = dict(eigvals_only=True) if not two_out else {}
+        n_out = 2 if two_out else 1
+        self.batch_test(linalg.eigh, args, n_out=n_out, kwargs=kwargs)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -254,3 +254,10 @@ class TestOneArrayIn:
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         self.batch_test(fun, (A, B), n_out=n_out)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_sylvester(self, dtype, rng):
+        A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        B = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        C = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        self.batch_test(linalg.solve_sylvester, (A, B, C))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -247,12 +247,14 @@ class TestOneArrayIn:
         self.batch_test(fun, A)
 
     @pytest.mark.parametrize('fun_n_out', [(linalg.orthogonal_procrustes, 2),
-                                           (linalg.khatri_rao, 1)])
+                                           (linalg.khatri_rao, 1),
+                                           (linalg.solve_continuous_lyapunov, 1),
+                                           (linalg.solve_discrete_lyapunov, 1)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_orthogonal_procrustes_khatri_rao(self, fun_n_out, dtype, rng):
+    def test_orthogonal_procrustes_khatri_rao_lyapunov(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out
-        A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
-        B = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
+        A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
+        B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, (A, B), n_out=n_out)
 
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -229,3 +229,9 @@ class TestOneArrayIn:
         A = get_random((1, 3, M, N), dtype=dtype, rng=rng)
         B = get_random((2, 1, M, K), dtype=dtype, rng=rng)
         assert linalg.subspace_angles(A, B).shape == (2, 3, min(N, K))
+
+    @pytest.mark.parametrize('fun', [linalg.svdvals])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_svdvals(self, fun, dtype, rng):
+        A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
+        self.batch_test(fun, A)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -245,3 +245,10 @@ class TestOneArrayIn:
     def test_svdvals(self, fun, dtype, rng):
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         self.batch_test(fun, A)
+
+    @pytest.mark.parametrize('fun', [linalg.orthogonal_procrustes])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_orthogonal_procrustes(self, fun, dtype, rng):
+        A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
+        B = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
+        self.batch_test(fun, (A, B), n_out=2)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -2,7 +2,7 @@ import inspect
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from scipy import linalg
+from scipy import linalg, stats
 
 
 real_floating = [np.float32, np.float64]
@@ -251,7 +251,7 @@ class TestOneArrayIn:
                                            (linalg.solve_continuous_lyapunov, 1),
                                            (linalg.solve_discrete_lyapunov, 1),
                                            (linalg.qz, 4),
-                                           (linalg.ordqz, 6)])
+                                           (linalg.ordqz, 6),])
     @pytest.mark.parametrize('dtype', floating)
     def test_two_generic_matrix_inputs(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out
@@ -286,3 +286,12 @@ class TestOneArrayIn:
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         T, Z = linalg.schur(A)
         self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_cossin(self, dtype, rng):
+        if dtype in complex_floating:
+            X = stats.unitary_group.rvs(5, size=6, random_state=rng)
+        else:
+            X = stats.ortho_group.rvs(5, size=6, random_state=rng)
+        X = X.reshape((2, 3, 5, 5)).astype(dtype)
+        self.batch_test(linalg.cossin, X, n_out=3, kwargs=dict(p=1, q=2))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -246,9 +246,11 @@ class TestOneArrayIn:
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         self.batch_test(fun, A)
 
-    @pytest.mark.parametrize('fun', [linalg.orthogonal_procrustes])
+    @pytest.mark.parametrize('fun_n_out', [(linalg.orthogonal_procrustes, 2),
+                                           (linalg.khatri_rao, 1)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_orthogonal_procrustes(self, fun, dtype, rng):
+    def test_orthogonal_procrustes_khatri_rao(self, fun_n_out, dtype, rng):
+        fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
-        self.batch_test(fun, (A, B), n_out=2)
+        self.batch_test(fun, (A, B), n_out=n_out)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -208,16 +208,17 @@ class TestOneArrayIn:
         self.batch_test(linalg.eigvals_banded, A)
 
     @pytest.mark.parametrize('two_in', [False, True])
-    @pytest.mark.parametrize('two_out', [False, True])
+    @pytest.mark.parametrize('fun_n_nout', [(linalg.eigh, 1), (linalg.eigh, 2),
+                                            (linalg.eigvalsh, 1)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_eigh(self, two_in, two_out, dtype, rng):
+    def test_eigh(self, two_in, fun_n_nout, dtype, rng):
+        fun, n_out = fun_n_nout
         A = get_nearly_hermitian((1, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
         B = get_nearly_hermitian((2, 1, 4, 4), dtype, 0, rng)  # exactly Hermitian
         B = B + 4*np.eye(4).astype(dtype)  # needs to be positive definite
         args = (A, B) if two_in else (A,)
-        kwargs = dict(eigvals_only=True) if not two_out else {}
-        n_out = 2 if two_out else 1
-        self.batch_test(linalg.eigh, args, n_out=n_out, kwargs=kwargs)
+        kwargs = dict(eigvals_only=True) if (n_out == 1 and fun==linalg.eigh) else {}
+        self.batch_test(fun, args, n_out=n_out, kwargs=kwargs)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_subspace_angles(self, dtype, rng):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -2,7 +2,7 @@ import inspect
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from scipy import linalg, stats
+from scipy import linalg
 
 
 real_floating = [np.float32, np.float64]
@@ -251,7 +251,7 @@ class TestOneArrayIn:
                                            (linalg.solve_continuous_lyapunov, 1),
                                            (linalg.solve_discrete_lyapunov, 1),
                                            (linalg.qz, 4),
-                                           (linalg.ordqz, 6),])
+                                           (linalg.ordqz, 6)])
     @pytest.mark.parametrize('dtype', floating)
     def test_two_generic_matrix_inputs(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out
@@ -286,12 +286,3 @@ class TestOneArrayIn:
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         T, Z = linalg.schur(A)
         self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)
-
-    @pytest.mark.parametrize('dtype', floating)
-    def test_cossin(self, dtype, rng):
-        if dtype in complex_floating:
-            X = stats.unitary_group.rvs(5, size=6, random_state=rng)
-        else:
-            X = stats.ortho_group.rvs(5, size=6, random_state=rng)
-        X = X.reshape((2, 3, 5, 5)).astype(dtype)
-        self.batch_test(linalg.cossin, X, n_out=3, kwargs=dict(p=1, q=2))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -250,7 +250,8 @@ class TestOneArrayIn:
                                            (linalg.khatri_rao, 1),
                                            (linalg.solve_continuous_lyapunov, 1),
                                            (linalg.solve_discrete_lyapunov, 1),
-                                           (linalg.qz, 4)])
+                                           (linalg.qz, 4),
+                                           (linalg.ordqz, 6)])
     @pytest.mark.parametrize('dtype', floating)
     def test_two_generic_matrix_inputs(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -262,8 +262,10 @@ class TestOneArrayIn:
         C = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         self.batch_test(linalg.solve_sylvester, (A, B, C))
 
+    @pytest.mark.parametrize('fun', [linalg.solve_continuous_are,
+                                     linalg.solve_discrete_are])
     @pytest.mark.parametrize('dtype', floating)
-    def test_continuous_are(self, dtype, rng):
+    def test_are(self, fun, dtype, rng):
         a = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         b = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         q = get_nearly_hermitian((2, 3, 5, 5), dtype=dtype, atol=0, rng=rng)
@@ -273,4 +275,4 @@ class TestOneArrayIn:
         q = q + 5*np.eye(5)
         r = r + 5*np.eye(5)
         # can't easily generate valid random e, s
-        self.batch_test(linalg.solve_continuous_are, (a, b, q, r))
+        self.batch_test(fun, (a, b, q, r))

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -280,3 +280,9 @@ class TestOneArrayIn:
         r = r + 5*np.eye(5)
         # can't easily generate valid random e, s
         self.batch_test(fun, (a, b, q, r))
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_rsf2cs(self, dtype, rng):
+        A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
+        T, Z = linalg.schur(A)
+        self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -249,9 +249,10 @@ class TestOneArrayIn:
     @pytest.mark.parametrize('fun_n_out', [(linalg.orthogonal_procrustes, 2),
                                            (linalg.khatri_rao, 1),
                                            (linalg.solve_continuous_lyapunov, 1),
-                                           (linalg.solve_discrete_lyapunov, 1)])
+                                           (linalg.solve_discrete_lyapunov, 1),
+                                           (linalg.qz, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_orthogonal_procrustes_khatri_rao_lyapunov(self, fun_n_out, dtype, rng):
+    def test_two_generic_matrix_inputs(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -10,13 +10,6 @@ from scipy.linalg import orthogonal_procrustes
 from scipy.sparse._sputils import matrix
 
 
-def test_orthogonal_procrustes_ndim_too_large():
-    rng = np.random.RandomState(1234)
-    A = rng.randn(3, 4, 5)
-    B = rng.randn(3, 4, 5)
-    assert_raises(ValueError, orthogonal_procrustes, A, B)
-
-
 def test_orthogonal_procrustes_ndim_too_small():
     rng = np.random.RandomState(1234)
     A = rng.randn(3)


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-22133
Toward gh-21466

#### What does this implement/fix?
This PR adds support for n-dimensional batch input to many of the remaining `linalg` functions, which typically accept more than one array.

#### Additional information
I couldn't do `cossin` because its first argument can be an iterable containing four arrays instead of just one array.

@j-bowhay (or anyone else) would you like to add some of the rest of these in a separate PR? Note that functions like `solve`, in which the second argument has core dimension 1 but can be batched, probably can't be handled by the decorator, so i'd stay away from those. (@ilayn it would be great if those could be the first to be vectorized in compiled code.)