### PR TITLE
ENH: linalg: add batch support for remaining cholesky functions

### DIFF
--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -105,6 +105,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
     return c
 
 
+@_apply_over_batch(("a", 2))
 def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
     """
     Compute the Cholesky decomposition of a matrix, to use in cho_solve

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -247,6 +247,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     return x
 
 
+@_apply_over_batch(("ab", 2))
 def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     """
     Cholesky decompose a banded Hermitian positive-definite matrix

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -160,7 +160,8 @@ class TestOneArrayIn:
         A = np.asarray([np.triu(A, k) for k in range(-3, 3)]).reshape((2, 3, 4, 4))
         self.batch_test(linalg.bandwidth, A, n_out=2)
 
-    @pytest.mark.parametrize('fun_n_out', [(linalg.cholesky, 1), (linalg.ldl, 3)])
+    @pytest.mark.parametrize('fun_n_out', [(linalg.cholesky, 1), (linalg.ldl, 3),
+                                           (linalg.cho_factor, 2)])
     @pytest.mark.parametrize('dtype', floating)
     def test_ldl_cholesky(self, fun_n_out, dtype, rng):
         fun, n_out = fun_n_out

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -287,3 +287,10 @@ class TestOneArrayIn:
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         T, Z = linalg.schur(A)
         self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_cholesky_banded(self, dtype, rng):
+        ab = get_random((5, 4, 3, 6), dtype=dtype, rng=rng)
+        ab[..., 0, 0] = 0
+        ab[..., -1, :] = 10  # make diagonal dominant
+        self.batch_test(linalg.cholesky_banded, ab)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow-up to gh-22133
Toward gh-21466
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds batch support to `cho_factor` and `cholesky_banded`
#### Additional information
<!--Any additional information you think is important.-->
Still draft while I figure out the test for `cholesky_banded`