### PR TITLE
MAINT: accept ndarray subclasses in interpolate._dierckx

### DIFF
--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -15,7 +15,7 @@
 static int
 check_array(PyObject *obj, npy_intp ndim, int typenum) {
 
-    int cond = (PyArray_CheckExact(obj) &&
+    int cond = (PyArray_Check(obj) &&
                (PyArray_TYPE((PyArrayObject*)obj) == typenum) &&
                (PyArray_NDIM((PyArrayObject*)obj) == ndim) &&
                 PyArray_CHKFLAGS((PyArrayObject*)obj, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -658,9 +658,11 @@ class TestBSpline:
 
         expected = b(xx)
 
-        t_mm = np.memmap(str(tmpdir.join('t.dat')), mode='w+', dtype=b.t.dtype, shape=b.t.shape)
+        t_mm = np.memmap(
+            str(tmpdir.join('t.dat')), mode='w+', dtype=b.t.dtype, shape=b.t.shape)
         t_mm[:] = b.t
-        c_mm = np.memmap(str(tmpdir.join('c.dat')), mode='w+', dtype=b.c.dtype, shape=b.c.shape)
+        c_mm = np.memmap(
+            str(tmpdir.join('c.dat')), mode='w+', dtype=b.c.dtype, shape=b.c.shape)
         c_mm[:] = b.c
         b.t = t_mm
         b.c = c_mm


### PR DESCRIPTION
#### Reference issue
Fix https://github.com/scipy/scipy/issues/22143

#### What does this implement/fix?
This uses `PyArray_Check` rather than `PyArray_CheckExact` in order to accept ndarray subclasses at least that's my understanding of the [C API doc](https://numpy.org/devdocs/reference/c-api/array.html#general-check-of-python-type).

The reason for this is than in the scikit-learn tests `obj` can be a `np.memmap` which is a subclass of `ndarray`. 

cc @ev-br