### PR TITLE
TYP: temporarily ignore the `numpy==2.2.1` mypy errors

### DIFF
--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -40,8 +40,8 @@ expected_types = ['numeric', 'numeric', 'numeric', 'numeric', 'nominal']
 missing = pjoin(data_path, 'missing.arff')
 expect_missing_raw = np.array([[1, 5], [2, 4], [np.nan, np.nan]])
 expect_missing = np.empty(3, [('yop', float), ('yap', float)])
-expect_missing['yop'] = expect_missing_raw[:, 0]
-expect_missing['yap'] = expect_missing_raw[:, 1]
+expect_missing['yop'] = expect_missing_raw[:, 0]  # type: ignore[call-overload]
+expect_missing['yap'] = expect_missing_raw[:, 1]  # type: ignore[call-overload]
 
 
 class TestData:
@@ -328,7 +328,7 @@ class TestRelationalAttributeLong:
 class TestQuotedNominal:
     """
     Regression test for issue #10232:
-    
+
     Exception in loadarff with quoted nominal attributes.
     """
 
@@ -376,7 +376,7 @@ class TestQuotedNominal:
 class TestQuotedNominalSpaces:
     """
     Regression test for issue #10232:
-    
+
     Exception in loadarff with quoted nominal attributes.
     """
 

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -512,7 +512,7 @@ NDT_ARRAY_FLAGS = MDTYPES[native_code]['dtypes']['array_flags']
 class VarWriter5:
     ''' Generic matlab matrix writing class '''
     mat_tag = np.zeros((), NDT_TAG_FULL)
-    mat_tag['mdtype'] = miMATRIX
+    mat_tag['mdtype'] = miMATRIX  # type: ignore[call-overload]
 
     def __init__(self, file_writer):
         self.file_stream = file_writer.file_stream


### PR DESCRIPTION
This temporarily ignores the 3 mypy errors that are caused by a regression in `numpy == 2.2.1`, that will be fixed in `numpy == 2.2.2` (see https://github.com/numpy/numpy/pull/28053).

ref: https://github.com/scipy/scipy/pull/22156#issuecomment-2558580240
