### PR TITLE
ENH: linalg: add batch support to remaining eigenvalue functions

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1207,6 +1207,7 @@ def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
         check_finite=check_finite, tol=tol, lapack_driver=lapack_driver)
 
 
+@_apply_over_batch(('d', 1), ('e', 1))
 def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
                      check_finite=True, tol=0., lapack_driver='auto'):
     """

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1126,6 +1126,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
                       select_range=select_range, check_finite=check_finite)
 
 
+@_apply_over_batch(('d', 1), ('e', 1))
 def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
                          check_finite=True, tol=0., lapack_driver='auto'):
     """

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -838,6 +838,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
     return w, v
 
 
+@_apply_over_batch(('a', 2), ('b', 2))
 def eigvals(a, b=None, overwrite_a=False, check_finite=True,
             homogeneous_eigvals=False):
     """

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -26,8 +26,8 @@ def get_nearly_hermitian(shape, dtype, atol, rng):
     return A + At + noise
 
 
-class TestOneArrayIn:
-    # Test the functions that accept one array argument
+class TestBatch:
+    # Test batch support for most linalg functions
 
     def batch_test(self, fun, arrays, *, core_dim=2, n_out=1, kwargs=None, dtype=None,
                    broadcast=True):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -296,10 +296,12 @@ class TestOneArrayIn:
         ab[..., -1, :] = 10  # make diagonal dominant
         self.batch_test(linalg.cholesky_banded, ab)
 
+    @pytest.mark.parametrize('fun_n_out', [(linalg.eigh_tridiagonal, 2),
+                                           (linalg.eigvalsh_tridiagonal, 1)])
     @pytest.mark.parametrize('dtype', real_floating)
     # "Only real arrays currently supported"
-    def test_eigh_tridiagonal(self, dtype, rng):
+    def test_eigh_tridiagonal(self, fun_n_out, dtype, rng):
+        fun, n_out = fun_n_out
         d = get_random((3, 4, 5), dtype=dtype, rng=rng)
         e = get_random((3, 4, 4), dtype=dtype, rng=rng)
-        self.batch_test(linalg.eigh_tridiagonal, (d, e),
-                        core_dim=1, n_out=2, broadcast=False)
+        self.batch_test(fun, (d, e), core_dim=1, n_out=n_out, broadcast=False)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -212,7 +212,7 @@ class TestOneArrayIn:
 
     @pytest.mark.parametrize('two_in', [False, True])
     @pytest.mark.parametrize('fun_n_nout', [(linalg.eigh, 1), (linalg.eigh, 2),
-                                            (linalg.eigvalsh, 1)])
+                                            (linalg.eigvalsh, 1), (linalg.eigvals, 1)])
     @pytest.mark.parametrize('dtype', floating)
     def test_eigh(self, two_in, fun_n_nout, dtype, rng):
         fun, n_out = fun_n_nout

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -305,3 +305,12 @@ class TestOneArrayIn:
         d = get_random((3, 4, 5), dtype=dtype, rng=rng)
         e = get_random((3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, (d, e), core_dim=1, n_out=n_out, broadcast=False)
+
+    @pytest.mark.parametrize('dtype', floating)
+    # "expected complex-conjugate pairs of eigenvalues"
+    def test_cdf2rdf(self, dtype, rng):
+        A = get_nearly_hermitian((3, 4, 6, 6), dtype=dtype, atol=0, rng=rng)
+        w, v = linalg.eigh(A)
+        wr, vr = linalg.cdf2rdf(w, v)
+        atol = 1e-5 if dtype in {np.float32, np.complex64} else 1e-12
+        assert_allclose(vr @ wr, A @ vr, atol=atol)

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -305,12 +305,3 @@ class TestOneArrayIn:
         d = get_random((3, 4, 5), dtype=dtype, rng=rng)
         e = get_random((3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, (d, e), core_dim=1, n_out=n_out, broadcast=False)
-
-    @pytest.mark.parametrize('dtype', floating)
-    # "expected complex-conjugate pairs of eigenvalues"
-    def test_cdf2rdf(self, dtype, rng):
-        A = get_nearly_hermitian((3, 4, 6, 6), dtype=dtype, atol=0, rng=rng)
-        w, v = linalg.eigh(A)
-        wr, vr = linalg.cdf2rdf(w, v)
-        atol = 1e-5 if dtype in {np.float32, np.complex64} else 1e-12
-        assert_allclose(vr @ wr, A @ vr, atol=atol)


### PR DESCRIPTION
#### Reference issue
Toward gh-21466

#### What does this implement/fix?
This adds batch support to the remaining eigenvalue functions, some of which were inadvertently omitted from the tracking list before. 

#### Additional information
I happened to find that `cdf2rdf` was attributed to one of our PRs, but actually it was already done. I went ahead and added a test using our little test framework for good measure, then looked and saw that its tests are already fine, so I reverted them.