### PR TITLE
ENH: linalg.block_diag: add batch support

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -408,9 +408,9 @@ def kron(a, b):
 
 def block_diag(*arrs):
     """
-    Create a block diagonal matrix from provided arrays.
+    Create a block diagonal array from provided arrays.
 
-    Given the inputs `A`, `B` and `C`, the output will have these
+    For example, given 2-D inputs `A`, `B` and `C`, the output will have these
     arrays arranged on the diagonal::
 
         [[A, 0, 0],
@@ -419,15 +419,17 @@ def block_diag(*arrs):
 
     Parameters
     ----------
-    A, B, C, ... : array_like, up to 2-D
-        Input arrays.  A 1-D array or array_like sequence of length `n` is
-        treated as a 2-D array with shape ``(1,n)``.
+    A, B, C, ... : array_like
+        Input arrays.  A 1-D array or array_like sequence of length ``n`` is
+        treated as a 2-D array with shape ``(1, n)``. Any dimensions before
+        the last two are treated as batch dimensions; see :ref:`linalg_batch`.
 
     Returns
     -------
     D : ndarray
-        Array with `A`, `B`, `C`, ... on the diagonal. `D` has the
-        same dtype as `A`.
+        Array with `A`, `B`, `C`, ... on the diagonal of the last two
+        dimensions. `D` has the same dtype as the result type of the
+        inputs.
 
     Notes
     -----
@@ -435,7 +437,8 @@ def block_diag(*arrs):
     block diagonal matrix.
 
     Empty sequences (i.e., array-likes of zero size) will not be ignored.
-    Noteworthy, both [] and [[]] are treated as matrices with shape ``(1,0)``.
+    Noteworthy, both ``[]`` and ``[[]]`` are treated as matrices with shape
+    ``(1,0)``.
 
     Examples
     --------

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -29,7 +29,8 @@ def get_nearly_hermitian(shape, dtype, atol, rng):
 class TestOneArrayIn:
     # Test the functions that accept one array argument
 
-    def batch_test(self, fun, arrays, core_dim=2, n_out=1, kwargs=None, dtype=None):
+    def batch_test(self, fun, arrays, *, core_dim=2, n_out=1, kwargs=None, dtype=None,
+                   broadcast=True, check_kwargs=True):
         # Check that all outputs of batched call `fun(A, **kwargs)` are the same
         # as if we loop over the separate vectors/matrices in `A`. Also check
         # that `fun` accepts `A` by position or keyword and that results are
@@ -44,16 +45,18 @@ class TestOneArrayIn:
         arrays = (arrays,) if not isinstance(arrays, tuple) else arrays
 
         # Identical results when passing argument by keyword or position
-        res1 = fun(**dict(zip(parameters, arrays)), **kwargs)
         res2 = fun(*arrays, **kwargs)
-        for out1, out2 in zip(res1, res2):  # even a single array output is iterable...
-            np.testing.assert_equal(out1, out2)
+        if check_kwargs:
+            res1 = fun(**dict(zip(parameters, arrays)), **kwargs)
+            for out1, out2 in zip(res1, res2):  # even a single array output is iterable...
+                np.testing.assert_equal(out1, out2)
 
         # Check results vs looping over
         res = (res2,) if n_out == 1 else res2
         # This is not the general behavior (only batch dimensions get
         # broadcasted by the decorator) but it's easier for testing.
-        arrays = np.broadcast_arrays(*arrays)
+        if broadcast:
+            arrays = np.broadcast_arrays(*arrays)
         batch_shape = arrays[0].shape[:-core_dim]
         for i in range(batch_shape[0]):
             for j in range(batch_shape[1]):
@@ -69,7 +72,7 @@ class TestOneArrayIn:
             out_dtype = ref[k].dtype if dtype is None else dtype
             assert res[k].dtype == out_dtype
 
-        return res1  # return original, non-tuplized result
+        return res2  # return original, non-tuplized result
 
     @pytest.fixture
     def rng(self):
@@ -294,3 +297,21 @@ class TestOneArrayIn:
         ab[..., 0, 0] = 0
         ab[..., -1, :] = 10  # make diagonal dominant
         self.batch_test(linalg.cholesky_banded, ab)
+
+    @pytest.mark.parametrize('dtype', floating)
+    def test_block_diag(self, dtype, rng):
+        a = get_random((1, 3, 1, 3), dtype=dtype, rng=rng)
+        b = get_random((2, 1, 3, 6), dtype=dtype, rng=rng)
+        c = get_random((1, 1, 3, 2), dtype=dtype, rng=rng)
+
+        # batch_test doesn't have the logic to broadcast just the batch shapes,
+        # so do it manually.
+        a2 = np.broadcast_to(a, (2, 3, 1, 3))
+        b2 = np.broadcast_to(b, (2, 3, 3, 6))
+        c2 = np.broadcast_to(c, (2, 3, 3, 2))
+        ref = self.batch_test(linalg.block_diag, (a2, b2, c2),
+                              check_kwargs=False, broadcast=False)
+
+        # Check that `block_diag` broadcasts the batch shapes as expected.
+        res = linalg.block_diag(a, b, c)
+        assert_allclose(res, ref)

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -172,9 +172,6 @@ class TestBlockDiag:
         a = block_diag([2, 3], 4)
         assert_array_equal(a, [[2, 3, 0], [0, 0, 4]])
 
-    def test_bad_arg(self):
-        assert_raises(ValueError, block_diag, [[[1]]])
-
     def test_no_args(self):
         a = block_diag()
         assert_equal(a.ndim, 2)


### PR DESCRIPTION
#### Reference issue
Toward gh-21466

#### What does this implement/fix?
Adds batch support (manually) to `scipy.linalg.block_diag`.
