### PR TITLE
DEP: special: deprecation warning for `sph_harm` + comments

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -5887,8 +5887,8 @@ const char *sph_harm_doc = R"(
     where :math:`P_n^m` are the associated Legendre functions; see `lpmv`.
 
     .. deprecated:: 1.15.0
-        This function is deprecated and will be removed in a future version.
-        Use `scipy.special.sph_harm_y` instead.
+        This function is deprecated and will be removed in SciPy 1.17.0.
+        Please use `scipy.special.sph_harm_y` instead.
 
     Parameters
     ----------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4652,3 +4652,8 @@ class TestLegendreDeprecation:
         message = f"`scipy.special.{xlpmn.__name__}` is deprecated..."
         with pytest.deprecated_call(match=message):
             _ = xlpmn(1, 1, 0)
+
+    def test_warn_sph_harm(self):
+        msg = "`scipy.special.sph_harm` is deprecated..."
+        with pytest.deprecated_call(match=msg):
+            _ = special.sph_harm(1, 1, 0, 0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4110,6 +4110,8 @@ class TestRound:
         rndrl = (10,10,10,11)
         assert_array_equal(rnd,rndrl)
 
+# sph_harm is deprecated and is implemented as a shim around sph_harm_y.
+# The following two tests are maintained to verify the correctness of the shim.
 
 def test_sph_harm():
     # Tests derived from tables in

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4119,35 +4119,39 @@ def test_sph_harm():
     sqrt = np.sqrt
     sin = np.sin
     cos = np.cos
-    assert_array_almost_equal(sh(0,0,0,0),
-           0.5/sqrt(pi))
-    assert_array_almost_equal(sh(-2,2,0.,pi/4),
-           0.25*sqrt(15./(2.*pi)) *
-           (sin(pi/4))**2.)
-    assert_array_almost_equal(sh(-2,2,0.,pi/2),
-           0.25*sqrt(15./(2.*pi)))
-    assert_array_almost_equal(sh(2,2,pi,pi/2),
-           0.25*sqrt(15/(2.*pi)) *
-           exp(0+2.*pi*1j)*sin(pi/2.)**2.)
-    assert_array_almost_equal(sh(2,4,pi/4.,pi/3.),
-           (3./8.)*sqrt(5./(2.*pi)) *
-           exp(0+2.*pi/4.*1j) *
-           sin(pi/3.)**2. *
-           (7.*cos(pi/3.)**2.-1))
-    assert_array_almost_equal(sh(4,4,pi/8.,pi/6.),
-           (3./16.)*sqrt(35./(2.*pi)) *
-           exp(0+4.*pi/8.*1j)*sin(pi/6.)**4.)
+    with suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning)
+        assert_array_almost_equal(sh(0,0,0,0),
+               0.5/sqrt(pi))
+        assert_array_almost_equal(sh(-2,2,0.,pi/4),
+               0.25*sqrt(15./(2.*pi)) *
+               (sin(pi/4))**2.)
+        assert_array_almost_equal(sh(-2,2,0.,pi/2),
+               0.25*sqrt(15./(2.*pi)))
+        assert_array_almost_equal(sh(2,2,pi,pi/2),
+               0.25*sqrt(15/(2.*pi)) *
+               exp(0+2.*pi*1j)*sin(pi/2.)**2.)
+        assert_array_almost_equal(sh(2,4,pi/4.,pi/3.),
+               (3./8.)*sqrt(5./(2.*pi)) *
+               exp(0+2.*pi/4.*1j) *
+               sin(pi/3.)**2. *
+               (7.*cos(pi/3.)**2.-1))
+        assert_array_almost_equal(sh(4,4,pi/8.,pi/6.),
+               (3./16.)*sqrt(35./(2.*pi)) *
+               exp(0+4.*pi/8.*1j)*sin(pi/6.)**4.)
 
 
 def test_sph_harm_ufunc_loop_selection():
     # see https://github.com/scipy/scipy/issues/4895
     dt = np.dtype(np.complex128)
-    assert_equal(special.sph_harm(0, 0, 0, 0).dtype, dt)
-    assert_equal(special.sph_harm([0], 0, 0, 0).dtype, dt)
-    assert_equal(special.sph_harm(0, [0], 0, 0).dtype, dt)
-    assert_equal(special.sph_harm(0, 0, [0], 0).dtype, dt)
-    assert_equal(special.sph_harm(0, 0, 0, [0]).dtype, dt)
-    assert_equal(special.sph_harm([0], [0], [0], [0]).dtype, dt)
+    with suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning)
+        assert_equal(special.sph_harm(0, 0, 0, 0).dtype, dt)
+        assert_equal(special.sph_harm([0], 0, 0, 0).dtype, dt)
+        assert_equal(special.sph_harm(0, [0], 0, 0).dtype, dt)
+        assert_equal(special.sph_harm(0, 0, [0], 0).dtype, dt)
+        assert_equal(special.sph_harm(0, 0, 0, [0]).dtype, dt)
+        assert_equal(special.sph_harm([0], [0], [0], [0]).dtype, dt)
 
 
 class TestStruve:

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -187,7 +187,9 @@ def spherical_yn_(n, x):
     return spherical_yn(n.astype('l'), x)
 
 def sph_harm_(m, n, theta, phi):
-    y = sph_harm(m, n, theta, phi)
+    with suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning)
+        y = sph_harm(m, n, theta, phi)
     return (y.real, y.imag)
 
 def cexpm1(x, y):

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -56,6 +56,15 @@ def data_local(func, dataname, *a, **kw):
     return FuncData(func, DATASETS_LOCAL[dataname], *a, **kw)
 
 
+# The functions lpn, lpmn, clpmn, and sph_harm appearing below are
+# deprecated in favor of legendre_p_all, assoc_legendre_p_all,
+# assoc_legendre_p_all (assoc_legendre_p_all covers lpmn and clpmn),
+# and sph_harm_y respectively. The deprecated functions listed above are
+# implemented as shims around their respective replacements. The replacements
+# are tested separately, but tests for the deprecated functions remain to
+# verify the correctness of the shims.
+
+
 def ellipk_(k):
     return ellipk(k*k)
 

--- a/scipy/special/tests/test_legendre.py
+++ b/scipy/special/tests/test_legendre.py
@@ -10,6 +10,14 @@ from scipy import special
 from scipy.special import (legendre_p, legendre_p_all, assoc_legendre_p,
     assoc_legendre_p_all, sph_legendre_p, sph_legendre_p_all)
 
+# The functions lpn, lpmn, clpmn, appearing below are
+# deprecated in favor of legendre_p_all, assoc_legendre_p_all, and
+# assoc_legendre_p_all (assoc_legendre_p_all covers lpmn and clpmn)
+# respectively. The deprecated functions listed above are implemented as
+# shims around their respective replacements. The replacements are tested
+# separately, but tests for the deprecated functions remain to verify the
+# correctness of the shims.
+
 # Base polynomials come from Abrahmowitz and Stegan
 class TestLegendre:
     def test_legendre(self):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -671,6 +671,14 @@ def test_lambertw_smallz():
 # Systematic tests
 # ------------------------------------------------------------------------------
 
+# The functions lpn, lpmn, clpmn, and sph_harm appearing below are
+# deprecated in favor of legendre_p_all, assoc_legendre_p_all,
+# assoc_legendre_p_all (assoc_legendre_p_all covers lpmn and clpmn),
+# and sph_harm_y respectively. The deprecated functions listed above are
+# implemented as shims around their respective replacements. The replacements
+# are tested separately, but tests for the deprecated functions remain to
+# verify the correctness of the shims.
+
 HYPERKW = dict(maxprec=200, maxterms=200)
 
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -3,7 +3,7 @@ Test SciPy functions versus mpmath, if available.
 
 """
 import numpy as np
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import assert_, assert_allclose, suppress_warnings
 from numpy import pi
 import pytest
 import itertools
@@ -2009,7 +2009,9 @@ class TestSystematic:
         def spherharm(l, m, theta, phi):
             if m > l:
                 return np.nan
-            return sc.sph_harm(m, l, phi, theta)
+            with suppress_warnings() as sup:
+                sup.filter(category=DeprecationWarning)
+                return sc.sph_harm(m, l, phi, theta)
         assert_mpmath_equal(
             spherharm,
             mpmath.spherharm,

--- a/scipy/special/tests/test_sph_harm.py
+++ b/scipy/special/tests/test_sph_harm.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, suppress_warnings
 import scipy.special as sc
 
 class TestSphHarm:
@@ -75,7 +75,9 @@ def test_first_harmonics():
     theta, phi = np.meshgrid(theta, phi)
 
     for harm, m, n in zip(harms, m, n):
-        assert_allclose(sc.sph_harm(m, n, theta, phi),
-                        harm(theta, phi),
-                        rtol=1e-15, atol=1e-15,
-                        err_msg=f"Y^{m}_{n} incorrect")
+        with suppress_warnings() as sup:
+            sup.filter(category=DeprecationWarning)
+            assert_allclose(sc.sph_harm(m, n, theta, phi),
+                            harm(theta, phi),
+                            rtol=1e-15, atol=1e-15,
+                            err_msg=f"Y^{m}_{n} incorrect")

--- a/scipy/special/tests/test_sph_harm.py
+++ b/scipy/special/tests/test_sph_harm.py
@@ -53,6 +53,9 @@ def test_first_harmonics():
     # `phi` as the polar angle, and include the Condon-Shortley
     # phase.
 
+    # sph_harm is deprecated and is implemented as a shim around sph_harm_y.
+    # This test is maintained to verify the correctness of the shim.
+
     # Notation is Ymn
     def Y00(theta, phi):
         return 0.5*np.sqrt(1/np.pi)

--- a/scipy/special/xsf_special.h
+++ b/scipy/special/xsf_special.h
@@ -13,6 +13,14 @@ namespace {
 
 template <typename T>
 std::complex<T> sph_harm(long long int m, long long int n, T theta, T phi) {
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    PyErr_WarnEx(
+        PyExc_DeprecationWarning,
+        "`scipy.special.sph_harm` is deprecated as of SciPy 1.15.0 and will be "
+        "removed in SciPy 1.17.0. Please use `scipy.special.sph_harm_y` instead.",
+        1
+    );
+    PyGILState_Release(gstate);
     if (n < 0) {
         xsf::set_error("sph_harm", SF_ERROR_ARG, "n should not be negative");
         return std::numeric_limits<T>::quiet_NaN();


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This is a promised follow-up to #22156 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds a deprecation warning for `sph_harm`. It is done by calling [PyErr_WarnEx](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_WarnEx) from within the wrapper for `sph_harm` inside of `scipy/special/xsf_special.h`. This header is intended for SciPy specific modifications of `xsf` code, and as it turns, `sph_harm` already had a wrapper there in order to have a warning printed when floating point values are passed for arguments which should be integers.

I've also suppressed the warnings in the tests and added a test to check that the deprecation warning appears.

In addition, I've also added comments explaining why we specifically left in tests for the deprecated functions instead of updating them to use the new function, as promised here: https://github.com/scipy/scipy/pull/22156#discussion_r1895081141.

cc @h-vetinari, @jorenham 


#### Additional information
<!--Any additional information you think is important.-->

I'm fine if this gets squash merged.