### PR TITLE
DOC: interpolate: add missing method `integrate` for `PchipInterpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -185,6 +185,7 @@ class PchipInterpolator(CubicHermiteSpline):
     __call__
     derivative
     antiderivative
+    integrate
     roots
 
     See Also


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #22072 

#### What does this implement/fix?
<!--Please explain your changes.-->
Added a missing method `integrate` for `PchipInterpolator` doc string.

#### Additional information
<!--Any additional information you think is important.-->
