### PR TITLE
MAINT: optimize: switch suppress_warnings to catch_warnings

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -32,6 +32,7 @@ try:
     from sksparse.cholmod import cholesky as cholmod  # noqa: F401
     from sksparse.cholmod import analyze as cholmod_analyze
     from sksparse.cholmod import CholmodTypeConversionWarning
+    from warnings import catch_warnings
 except ImportError:
     has_cholmod = False
 try:
@@ -98,8 +99,9 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                 # except Exception:
                 #     _get_solver.cholmod_factor = cholmod_analyze(M)
                 #     _get_solver.cholmod_factor.cholesky_inplace(M)
-                with np.testing.suppress_warnings() as sup:
-                    sup.filter(CholmodTypeConversionWarning)
+                with catch_warnings(
+                    action='ignore', category=CholmodTypeConversionWarning
+                ):
                     try:
                         # Will raise an exception in the first call,
                         # or when the matrix changes due to a new problem

--- a/scipy/optimize/_trustregion_constr/projections.py
+++ b/scipy/optimize/_trustregion_constr/projections.py
@@ -11,7 +11,7 @@ except ImportError:
     import warnings
     sksparse_available = False
 import numpy as np
-from warnings import warn
+from warnings import warn, catch_warnings
 
 __all__ = [
     'orthogonality',
@@ -61,8 +61,7 @@ def normal_equation_projections(A, m, n, orth_tol, max_refin, tol):
     # TODO: revert this once the warning bug fix in sksparse is merged/released
     # Add suppression of spurious warning bug from sksparse with csc_array gh-22089
     # factor = cholesky_AAt(A)
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(CholmodTypeConversionWarning, "converting matrix of class")
+    with catch_warnings(action='ignore', category=CholmodTypeConversionWarning):
         factor = cholesky_AAt(A)
 
     # z = x - A.T inv(A A.T) A x


### PR DESCRIPTION
In order to avoid using `np.testing.suppress_warnings` in production (non-testing) code, this switches to `warnings.catch_warnings`.  These two occurrances are recent additions that unknowingly added the incorrect idiom.

Thanks @h-vetinari for catching this!!  And @rgommers for describing how "suppress_warnings is no longer very relevant, it was written mainly because of an issue that was fixed in Python 3.4.".

This should be backported to 1.15 @tylerjereddy 
