### PR TITLE
MAINT: fix extension module not declaring free-threading support, and wheel build changes

### DIFF
--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -144,7 +144,7 @@ py3.extension_module('_bspl',
 py3.extension_module('_dierckx',
     ['src/_dierckxmodule.cc'],
     include_directories: 'src/',
-    dependencies: [py3_dep, np_dep, __fitpack_dep],
+    dependencies: [np_dep, __fitpack_dep],
     link_args: version_link_args,
     install: true,
     subdir: 'scipy/interpolate'

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -754,7 +754,18 @@ static struct PyModuleDef dierckxmodule = {
 PyMODINIT_FUNC
 PyInit__dierckx(void)
 {
+    PyObject *module;
+
     import_array();
 
-    return PyModule_Create(&dierckxmodule);
+    module = PyModule_Create(&dierckxmodule);
+    if (module == NULL) {
+        return NULL;
+    }
+
+#if Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return module;
 }

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -24,8 +24,8 @@ FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_conf
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    # python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11 pythran
+    python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11
 fi
 
 # Install Openblas

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -66,8 +66,8 @@ FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_conf
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    # python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11 pythran
+    python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11
 fi
 
 # Install Openblas

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -17,10 +17,8 @@ FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_conf
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U --pre pip
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    # TODO: Remove meson installation from source once a new release
-    # that includes https://github.com/mesonbuild/meson/pull/13851 is available
-    python -m pip install git+https://github.com/mesonbuild/meson
-    python -m pip install ninja meson-python pybind11 pythran
+    python -m pip install git+https://github.com/serge-sans-paille/pythran
+    python -m pip install ninja meson-python pybind11
 fi
 
 # delvewheel is the equivalent of delocate/auditwheel for windows.

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -2,10 +2,14 @@ set -xe
 
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    # TODO: delete when importing numpy no longer enables the GIL
-    # setting to zero ensures the GIL is disabled while running the
-    # tests under free-threaded python
-    export PYTHON_GIL=0
+    # Manually check that importing SciPy does not re-enable the GIL.
+    # In principle the tests should catch this but it seems harmless to leave it
+    # here as a final sanity check before uploading broken wheels
+    if [[ $(python -c "import scipy.stats" 2>&1) == *"The global interpreter lock (GIL) has been enabled"* ]]; then
+        echo "Error: Importing SciPy re-enables the GIL in the free-threaded build"
+        exit 1
+    fi
+
 fi
 
 python -c "import sys; import scipy; sys.exit(not scipy.test())"


### PR DESCRIPTION
Pythran 0.17.1 isn't yet out, so build with Pythran master for `cp313t`.

@ev-br ping for visibility on the `interpolate` changes. Hopefully the added CI check will catch any future extension modules with the same problem.

@tylerjereddy this also needs backporting. I tested wheel builds on my fork, so not triggering the whole battery here.