### PR TITLE
REL: set 1.15.0rc3 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.15.0rc2"
+version = "1.15.0rc3.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.15.0rc3.dev0` (unreleased).

[ci skip] [skip ci] [skip cirrus] [skip circle]

Note that while there are no plans to actually do an RC3, only time will tell what is really needed. In any case, if we don't need RC3 we can simply switch the version string after any additional backports, when ready.
