### PR TITLE
CI: array api: test arrays-api-strict getting rid of __array__

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis array-api-strict spin
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis spin
+        python -m pip install git+https://github.com/ev-br/array-api-strict.git@buffer_protocol    # XXX
 
     - name: Install PyTorch CPU
       run: |


### PR DESCRIPTION
A matching PR for https://github.com/data-apis/array-api-strict/pull/115, which removes an undocumented `__array__` from array-api-strict and replaces it the python 3.12+ implementation of the buffer protocol.

Do not merge as is: this currently gets `array-api-strict` from a branch of a fork.