### PR TITLE
DEP: linalg.solve_toeplitz/matmul_toeplitz: warn on n-D `c`, `r`

### DIFF
--- a/doc/source/release/1.15.0-notes.rst
+++ b/doc/source/release/1.15.0-notes.rst
@@ -368,9 +368,9 @@ with support added for SciPy ``1.15.0`` include:
   and for other backends will transit via NumPy arrays on the host.
 
 
-*******************
-Deprecated features
-*******************
+**************************************
+Deprecated features and future changes
+**************************************
 - Functions `scipy.linalg.interpolative.rand` and
   `scipy.linalg.interpolative.seed` have been deprecated and will be removed
   in SciPy ``1.17.0``.
@@ -380,7 +380,7 @@ Deprecated features
 - `scipy.spatial.distance.kulczynski1` and
   `scipy.spatial.distance.sokalmichener` were deprecated and will be removed
   in SciPy ``1.17.0``.
-- `scipy.stats.find_repeats` is deprecated as of SciPy ``1.15.0`` and will be
+- `scipy.stats.find_repeats` is deprecated and will be
   removed in SciPy ``1.17.0``. Please use
   ``numpy.unique``/``numpy.unique_counts`` instead.
 - `scipy.linalg.kron` is deprecated in favour of ``numpy.kron``.
@@ -388,16 +388,16 @@ Deprecated features
   convolution/correlation functions (`scipy.signal.correlate`,
   `scipy.signal.convolve` and `scipy.signal.choose_conv_method`) and
   filtering functions (`scipy.signal.lfilter`, `scipy.signal.sosfilt`) has
-  been deprecated as of SciPy ``1.15.0`` and will be removed in SciPy
-  ``1.17.0``.
+  been deprecated and will be removed in SciPy ``1.17.0``.
 - `scipy.stats.linregress` has deprecated one-argument use; the two
   variables must be specified as separate arguments.
 - ``scipy.stats.trapz`` is deprecated in favor of `scipy.stats.trapezoid`.
 - `scipy.special.lpn` is deprecated in favor of `scipy.special.legendre_p_all`.
 - `scipy.special.lpmn` and `scipy.special.clpmn` are deprecated in favor of
   `scipy.special.assoc_legendre_p_all`.
-- The raveling of multi-dimensional input by `scipy.linalg.toeplitz` has
-  been deprecated. It will support batching in SciPy ``1.17.0``.
+- Multi-dimensional ``r`` and ``c`` arrays passed to `scipy.linalg.toeplitz`,
+  `scipy.linalg.matmul_toeplitz`, or `scipy.linalg.solve_toeplitz` will be
+  treated as batches of 1-D coefficients beginning in SciPy ``1.17.0``.
 - The ``random_state`` and ``permutations`` arguments of
   `scipy.stats.ttest_ind` are deprecated. Use ``method`` to perform a
   permutation test, instead.

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -4,6 +4,7 @@
 # w/ additions by Travis Oliphant, March 2002
 #              and Jake Vanderplas, August 2012
 
+import warnings
 from warnings import warn
 from itertools import product
 import numpy as np
@@ -783,21 +784,25 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
 
 
 def solve_toeplitz(c_or_cr, b, check_finite=True):
-    """Solve a Toeplitz system using Levinson Recursion
+    r"""Solve a Toeplitz system using Levinson Recursion
 
     The Toeplitz matrix has constant diagonals, with c as its first column
     and r as its first row. If r is not given, ``r == conjugate(c)`` is
     assumed.
 
+    .. warning::
+
+        Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
+        not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
+        before passing them to `toeplitz`.
+
     Parameters
     ----------
     c_or_cr : array_like or tuple of (array_like, array_like)
-        The vector ``c``, or a tuple of arrays (``c``, ``r``). Whatever the
-        actual shape of ``c``, it will be converted to a 1-D array. If not
+        The vector ``c``, or a tuple of arrays (``c``, ``r``). If not
         supplied, ``r = conjugate(c)`` is assumed; in this case, if c[0] is
         real, the Toeplitz matrix is Hermitian. r[0] is ignored; the first row
-        of the Toeplitz matrix is ``[c[0], r[1:]]``. Whatever the actual shape
-        of ``r``, it will be converted to a 1-D array.
+        of the Toeplitz matrix is ``[c[0], r[1:]]``.
     b : (M,) or (M, K) array_like
         Right-hand side in ``T x = b``.
     check_finite : bool, optional
@@ -1919,11 +1924,20 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
 
     if isinstance(c_or_cr, tuple):
         c, r = c_or_cr
-        c = _asarray_validated(c, check_finite=check_finite).ravel()
-        r = _asarray_validated(r, check_finite=check_finite).ravel()
+        c = _asarray_validated(c, check_finite=check_finite)
+        r = _asarray_validated(r, check_finite=check_finite)
     else:
-        c = _asarray_validated(c_or_cr, check_finite=check_finite).ravel()
+        c = _asarray_validated(c_or_cr, check_finite=check_finite)
         r = c.conjugate()
+
+    if c.ndim > 1 or r.ndim > 1:
+        msg = ("Beginning in SciPy 1.17, multidimensional input will be treated as a "
+               "batch, not `ravel`ed. To preserve the existing behavior and silence "
+               "this warning, `ravel` arguments before passing them to "
+               "`solve_toeplitz`.")
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        c = c.ravel()
+        r = r.ravel()
 
     if b is None:
         raise ValueError('`b` must be an array, not None.')

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -794,7 +794,7 @@ def solve_toeplitz(c_or_cr, b, check_finite=True):
 
         Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
         not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
-        before passing them to `toeplitz`.
+        before passing them to `solve_toeplitz`.
 
     Parameters
     ----------
@@ -1934,7 +1934,7 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
         msg = ("Beginning in SciPy 1.17, multidimensional input will be treated as a "
                "batch, not `ravel`ed. To preserve the existing behavior and silence "
                "this warning, `ravel` arguments before passing them to "
-               "`solve_toeplitz`.")
+               "`toeplitz`, `matmul_toeplitz`, and `solve_toeplitz`.")
         warnings.warn(msg, FutureWarning, stacklevel=2)
         c = c.ravel()
         r = r.ravel()
@@ -1973,9 +1973,9 @@ def matmul_toeplitz(c_or_cr, x, check_finite=False, workers=None):
 
     .. warning::
 
-    Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
-    not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
-    before passing them to `toeplitz`.
+        Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
+        not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
+        before passing them to `matmul_toeplitz`.
 
     Parameters
     ----------

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1962,7 +1962,7 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
 
 
 def matmul_toeplitz(c_or_cr, x, check_finite=False, workers=None):
-    """Efficient Toeplitz Matrix-Matrix Multiplication using FFT
+    r"""Efficient Toeplitz Matrix-Matrix Multiplication using FFT
 
     This function returns the matrix multiplication between a Toeplitz
     matrix and a dense matrix.
@@ -1971,15 +1971,19 @@ def matmul_toeplitz(c_or_cr, x, check_finite=False, workers=None):
     and r as its first row. If r is not given, ``r == conjugate(c)`` is
     assumed.
 
+    .. warning::
+
+    Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
+    not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
+    before passing them to `toeplitz`.
+
     Parameters
     ----------
     c_or_cr : array_like or tuple of (array_like, array_like)
-        The vector ``c``, or a tuple of arrays (``c``, ``r``). Whatever the
-        actual shape of ``c``, it will be converted to a 1-D array. If not
+        The vector ``c``, or a tuple of arrays (``c``, ``r``). If not
         supplied, ``r = conjugate(c)`` is assumed; in this case, if c[0] is
         real, the Toeplitz matrix is Hermitian. r[0] is ignored; the first row
-        of the Toeplitz matrix is ``[c[0], r[1:]]``. Whatever the actual shape
-        of ``r``, it will be converted to a 1-D array.
+        of the Toeplitz matrix is ``[c[0], r[1:]]``.
     x : (M,) or (M, K) array_like
         Matrix with which to multiply.
     check_finite : bool, optional

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -27,19 +27,17 @@ def toeplitz(c, r=None):
     Parameters
     ----------
     c : array_like
-        First column of the matrix.  Whatever the actual shape of `c`, it
-        will be converted to a 1-D array.
+        First column of the matrix.
     r : array_like, optional
         First row of the matrix. If None, ``r = conjugate(c)`` is assumed;
         in this case, if c[0] is real, the result is a Hermitian matrix.
         r[0] is ignored; the first row of the returned matrix is
-        ``[c[0], r[1:]]``.  Whatever the actual shape of `r`, it will be
-        converted to a 1-D array.
+        ``[c[0], r[1:]]``.
 
         .. warning::
 
             Beginning in SciPy 1.17, multidimensional input will be treated as a batch,
-            not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` aruments
+            not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
             before passing them to `toeplitz`.
 
     Returns
@@ -81,7 +79,7 @@ def toeplitz(c, r=None):
     if c.ndim > 1 or r.ndim > 1:
         msg = ("Beginning in SciPy 1.17, multidimensional input will be treated as a "
                "batch, not `ravel`ed. To preserve the existing behavior and silence "
-               "this warning, `ravel` aruments before passing them to `toeplitz`.")
+               "this warning, `ravel` arguments before passing them to `toeplitz`.")
         warnings.warn(msg, FutureWarning, stacklevel=2)
 
     c, r = c.ravel(), r.ravel()

--- a/scipy/linalg/tests/test_matmul_toeplitz.py
+++ b/scipy/linalg/tests/test_matmul_toeplitz.py
@@ -1,6 +1,7 @@
 """Test functions for linalg.matmul_toeplitz function
 """
 
+import pytest
 import numpy as np
 from scipy.linalg import toeplitz, matmul_toeplitz
 
@@ -125,11 +126,12 @@ class TestMatmulToeplitz:
 
     # For toeplitz matrices, matmul_toeplitz() should be equivalent to @.
     def do(self, x, c, r=None, check_finite=False, workers=None):
+        c = np.ravel(c)
         if r is None:
             actual = matmul_toeplitz(c, x, check_finite, workers)
         else:
             r = np.ravel(r)
             actual = matmul_toeplitz((c, r), x, check_finite)
-        desired = toeplitz(np.ravel(c), r) @ x
+        desired = toeplitz(c, r) @ x
         assert_allclose(actual, desired,
             rtol=self.tolerance, atol=self.tolerance)

--- a/scipy/linalg/tests/test_matmul_toeplitz.py
+++ b/scipy/linalg/tests/test_matmul_toeplitz.py
@@ -1,7 +1,6 @@
 """Test functions for linalg.matmul_toeplitz function
 """
 
-import pytest
 import numpy as np
 from scipy.linalg import toeplitz, matmul_toeplitz
 

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 from scipy.linalg._solve_toeplitz import levinson
-from scipy.linalg import solve, toeplitz, solve_toeplitz
+from scipy.linalg import solve, toeplitz, solve_toeplitz, matmul_toeplitz
 from numpy.testing import assert_equal, assert_allclose
 
 import pytest
@@ -136,13 +136,15 @@ def test_empty(dt_c, dt_b):
     assert x1.dtype == x.dtype
 
 
-def test_nd_FutureWarning():
+@pytest.mark.parametrize('fun', [solve_toeplitz, matmul_toeplitz])
+def test_nd_FutureWarning(fun):
+    # Test future warnings with n-D `c`/`r`
     rng = np.random.default_rng(283592436523456)
     c = rng.random((2, 3, 4))
     r = rng.random((2, 3, 4))
-    b = rng.random(24)
+    b_or_x = rng.random(24)
     message = "Beginning in SciPy 1.17, multidimensional input will be..."
     with pytest.warns(FutureWarning, match=message):
-         solve_toeplitz(c, b)
+         fun(c, b_or_x)
     with pytest.warns(FutureWarning, match=message):
-         solve_toeplitz((c, r), b)
+         fun((c, r), b_or_x)

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -134,3 +134,15 @@ def test_empty(dt_c, dt_b):
     x1 = solve_toeplitz(c, b)
     assert x1.shape == (0, 0)
     assert x1.dtype == x.dtype
+
+
+def test_nd_FutureWarning():
+    rng = np.random.default_rng(283592436523456)
+    c = rng.random((2, 3, 4))
+    r = rng.random((2, 3, 4))
+    b = rng.random(24)
+    message = "Beginning in SciPy 1.17, multidimensional input will be..."
+    with pytest.warns(FutureWarning, match=message):
+         solve_toeplitz(c, b)
+    with pytest.warns(FutureWarning, match=message):
+         solve_toeplitz((c, r), b)


### PR DESCRIPTION
#### Reference issue
Toward gh-21466
gh-21446

#### What does this implement/fix?
`linalg.toeplitz`, `linalg.solve_toeplitz`, `linalg.matmul_toeplitz` document that `c` and `r` with dimensionality greater than 1 will be `ravel`ed.

gh-21446 added a warning that`toeplitz` would no longer `ravel` in 1.17; rather, multidimensional arrays would be treated as batches of 1-D arrays.

This adds similar warnings to `linalg.solve_toeplitz` and `linalg.matmul_toeplitz`. It also removes the documentation that n-D arrays will be raveled; it is still implicit in the admonition, and we don't really want to advertise it for new uses.

#### Additional information
@tylerjereddy any chance we can get this into 1.15 from the perspective that `toeplitz`, `solve_toeplitz`, `matmul_toeplitz` are a tuple and _should_ have been treated together? This also fixes typos in the existing warnings.

If not, I propose that we still document that this behavior will be changed in 1.17. Our [public deprecation policy](https://docs.scipy.org/doc/scipy/reference/#api-definition) is
> a deprecation warning will be raised for one SciPy release before the change is made.

and in the [Core Developer Guide](https://scipy.github.io/devdocs/dev/core-dev/index.html#deprecations), it says the change can be implemented 6 months after the release that includes the warning (and historically, the winter release tends to be >6 months after the summer release). I know we usually give two releases, but it would be nice to finish these up at the same time, and I expect these will be very low impact.