### PR TITLE
ENH: `linalg.qr_*`: add batch support

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1235,9 +1235,13 @@ def _apply_over_batch(*argdefs):
             for i, (array, ndim) in enumerate(zip(arrays, ndims)):
                 array = None if array is None else np.asarray(array)
                 shape = () if array is None else array.shape
+
+                if ndim == "1|2":  # special case for `solve`, etc.
+                    ndim = 2 if array.ndim >= 2 else 1
+
                 arrays[i] = array
                 batch_shapes.append(shape[:-ndim] if ndim > 0 else shape)
-                core_shapes.append(shape[-ndim:] if ndim > 0 else shape)
+                core_shapes.append(shape[-ndim:] if ndim > 0 else ())
 
             # Early exit if call is not batched
             if not any(batch_shapes):

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -217,6 +217,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     return (Q,) + Rj
 
 
+@_apply_over_batch(('a', 2), ('c', '1|2'))
 def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
                 overwrite_a=False, overwrite_c=False):
     """

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -71,6 +71,7 @@ from . cimport cython_blas as blas_pointers
 from . cimport cython_lapack as lapack_pointers
 
 import numpy as np
+from scipy._lib._util import _apply_over_batch
 
 #------------------------------------------------------------------------------
 # These are a set of fused type wrappers around the BLAS and LAPACK calls used.
@@ -2030,6 +2031,7 @@ RCONDS = ['&frc', '&drc', '&cfrc', '&cdrc']
                     raise MemoryError("Unable to allocate memory for array")
         return q1, rnew
 
+@_apply_over_batch(('Q', 2), ('R', 2), ('u', '1|2'), ('v', '1|2'))
 @cython.embedsignature(True)
 def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
     """

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1615,6 +1615,7 @@ def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
     else:
         raise ValueError("'which' must be either 'row' or 'col'")
 
+@_apply_over_batch(('Q', 2), ('R', 2), ('u', '1|2'), ('k', 0))
 @cython.embedsignature(True)
 def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_finite=True):
     """

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1398,6 +1398,7 @@ cdef void* extract(cnp.ndarray arr, int* arrs) noexcept:
             arrs[1] = 0
     return cnp.PyArray_DATA(arr)
 
+@_apply_over_batch(('Q', 2), ('R', 2), ('k', 0))
 @cython.embedsignature(True)
 def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
               check_finite=True):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -230,6 +230,20 @@ class TestBatch:
             assert_allclose(res[0][i], ref_i[0])
             assert_allclose(res[1][i], ref_i[1])
 
+    @pytest.mark.parametrize('kdim', [(), (4,)])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_qr_delete(self, kdim, dtype, rng):
+        A = get_random((4, 5, 5), dtype=dtype, rng=rng)
+        k = rng.integers(0, 4, size=kdim)
+        q, r = linalg.qr(A)
+        res = linalg.qr_delete(q, r, k)
+        for i in range(4):
+            qi, ri = q[i], r[i]
+            ki = k if k.ndim == 0 else k[i]
+            ref_i = linalg.qr_delete(qi, ri, ki)
+            assert_allclose(res[0][i], ref_i[0])
+            assert_allclose(res[1][i], ref_i[1])
+
     @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
     def test_schur_lu(self, fun, dtype, rng):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -213,6 +213,23 @@ class TestBatch:
             assert_allclose(res[0][i], ref_i[0])
             assert_allclose(res[1][i], ref_i[1])
 
+    @pytest.mark.parametrize('udim', [(5,), (4, 3, 5)])
+    @pytest.mark.parametrize('kdim', [(), (4,)])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_qr_insert(self, udim, kdim, dtype, rng):
+        A = get_random((4, 5, 5), dtype=dtype, rng=rng)
+        u = get_random(udim, dtype=dtype, rng=rng)
+        k = rng.integers(0, 5, size=kdim)
+        q, r = linalg.qr(A)
+        res = linalg.qr_insert(q, r, u, k)
+        for i in range(4):
+            qi, ri = q[i], r[i]
+            ki = k if k.ndim == 0 else k[i]
+            ui = u if u.ndim == 1 else u[i]
+            ref_i = linalg.qr_insert(qi, ri, ui, ki)
+            assert_allclose(res[0][i], ref_i[0])
+            assert_allclose(res[1][i], ref_i[1])
+
     @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
     def test_schur_lu(self, fun, dtype, rng):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -185,6 +185,18 @@ class TestBatch:
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A, n_out=2)
 
+    @pytest.mark.parametrize('cdim', [(5,), (5, 4), (2, 3, 5, 4)])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_qr_multiply(self, cdim, dtype, rng):
+        A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
+        c = get_random(cdim, dtype=dtype, rng=rng)
+        res = linalg.qr_multiply(A, c, mode='left')
+        q, r = linalg.qr(A)
+        ref = q @ c
+        atol = 1e-6 if dtype in {np.float32, np.complex64} else 1e-12
+        assert_allclose(res[0], ref, atol=atol)
+        assert_allclose(res[1], r, atol=atol)
+
     @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
     def test_schur_lu(self, fun, dtype, rng):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -197,6 +197,22 @@ class TestBatch:
         assert_allclose(res[0], ref, atol=atol)
         assert_allclose(res[1], r, atol=atol)
 
+    @pytest.mark.parametrize('uvdim', [[(5,), (3,)], [(4, 5, 2), (4, 3, 2)]])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_qr_update(self, uvdim, dtype, rng):
+        udim, vdim = uvdim
+        A = get_random((4, 5, 3), dtype=dtype, rng=rng)
+        u = get_random(udim, dtype=dtype, rng=rng)
+        v = get_random(vdim, dtype=dtype, rng=rng)
+        q, r = linalg.qr(A)
+        res = linalg.qr_update(q, r, u, v)
+        for i in range(4):
+            qi, ri = q[i], r[i]
+            ui, vi = (u, v) if u.ndim == 1 else (u[i], v[i])
+            ref_i = linalg.qr_update(qi, ri, ui, vi)
+            assert_allclose(res[0][i], ref_i[0])
+            assert_allclose(res[1][i], ref_i[1])
+
     @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
     def test_schur_lu(self, fun, dtype, rng):


### PR DESCRIPTION
#### Reference issue
Toward gh-21466

#### What does this implement/fix?
Adds batch support to `linalg.qr_` functions.

#### Additional information
Aside from `linalg.interpolative` (which I don't plan to add) and the `toeplitz` functions (which need a deprecation period), these should be the last of the lot.

Modifies the `_apply_over_batch` decorator as in gh-22192 for dealing with variable number of core dimensions.

Ran across gh-22200 while working on this.


