### PR TITLE
bug fix: deleting undefine name 'obj'

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -357,7 +357,7 @@ docdict_discrete['default'] = _doc_default_disc
 # clean up all the separate docstring elements, we do not need them anymore
 for obj in [s for s in dir() if s.startswith('_doc_')]:
     exec('del ' + obj)
-del obj
+#del obj
 
 
 def _moment(data, n, mu=None):


### PR DESCRIPTION
Fixes a bug in distn_infrastructure where attempting to delete an undefined variable (obj) using del obj raised a NameError exception. The problematic line has been commented out to prevent the error.