### PR TITLE
ENH: io.wavfile: read unseekable files

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -334,6 +334,47 @@ def test_write_roundtrip_rf64(tmpdir):
     data2[0] = 0
 
 
+# Fake a non-seekable file-like object without resorting to subprocesses.
+class Nonseekable:
+    def __init__(self, fp):
+        self.fp = fp
+
+    def seekable(self):
+        return False
+    
+    def read(self, size=-1, /):
+        return self.fp.read(size)
+    
+    def close(self):
+        self.fp.close()
+
+
+def test_streams():
+    for filename in ['test-44100Hz-le-1ch-4bytes.wav',
+                     'test-8000Hz-le-2ch-1byteu.wav',
+                     'test-44100Hz-2ch-32bit-float-le.wav',
+                     'test-44100Hz-2ch-32bit-float-be.wav',
+                     'test-8000Hz-le-5ch-9S-5bit.wav',
+                     'test-8000Hz-le-4ch-9S-12bit.wav',
+                     'test-8000Hz-le-3ch-5S-24bit.wav',
+                     'test-1234Hz-le-1ch-10S-20bit-extra.wav',
+                     'test-8000Hz-le-3ch-5S-36bit.wav',
+                     'test-8000Hz-le-3ch-5S-45bit.wav',
+                     'test-8000Hz-le-3ch-5S-53bit.wav',
+                     'test-8000Hz-le-3ch-5S-64bit.wav',
+                     'test-44100Hz-be-1ch-4bytes.wav', # RIFX
+                     'test-44100Hz-le-1ch-4bytes-rf64.wav']:
+        dfname = datafile(filename)
+        with open(dfname, 'rb') as fp1, open(dfname, 'rb') as fp2:
+            rate1, data1 = wavfile.read(fp1)
+            rate2, data2 = wavfile.read(Nonseekable(fp2))
+            rate3, data3 = wavfile.read(dfname, mmap=False)
+            assert_array_equal(rate1, rate3)
+            assert_array_equal(rate2, rate3)
+            assert_array_equal(data1, data3)
+            assert_array_equal(data2, data3)
+
+
 def test_read_unknown_filetype_fail():
     # Not an RIFF
     for mmap in [False, True]:

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -369,10 +369,10 @@ def test_streams():
             rate1, data1 = wavfile.read(fp1)
             rate2, data2 = wavfile.read(Nonseekable(fp2))
             rate3, data3 = wavfile.read(dfname, mmap=False)
-            assert_array_equal(rate1, rate3)
-            assert_array_equal(rate2, rate3)
-            assert_array_equal(data1, data3)
-            assert_array_equal(data2, data3)
+            assert_equal(rate1, rate3)
+            assert_equal(rate2, rate3)
+            assert_equal(data1, data3)
+            assert_equal(data2, data3)
 
 
 def test_read_unknown_filetype_fail():


### PR DESCRIPTION
#### Reference issue
Closes gh-11328

#### What does this implement/fix?
Allow scipy.io.wavfile.read() to read non-seekable files.

#### Additional information
Allow scipy.io.wavfile.read() to read non-seekable files.

  * If passed stream is not seekable, wrap it in a SeekEmulatingReader, which tracks current position and implements tell() to report it.

Most seek()s in wavfile.read() simply seek forward from the current position by a fixed amount. To address these:

  * Support limited SeekEmulatingReader.seek() that emulates seek()s that can be supported by read()ing and discarding the result.

Befor returning, read() attempts to seek back to the start of the file. This is nice when possible, but if it isn't we shouldn't blow up. So:

  * Avoid final fid.seek(0) if underlying stream isn't seekable.

The remaining seek()s are in RF64 support, where chunk size is global and stored in the RIFF header rather than in the chunk header. _read_data_chunk() currently seeks back to a fixed offset from the file origin to grab the chunk size. To address this:

  * Modify RF64 support to parse and store the chunk size in _read_riff_chunk() so that _read_data_chunk() doesn't have to seek() back for it. This applies whether or not reading from a seekable stream.

To test this, I added test_streams(), which ensures that wavfile reads the same data no matter whether a path, seekable stream, or unseekable stream is passed to read().
