### PR TITLE
BUG: zpk2tf works correctly with complex k, real p, z

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1183,26 +1183,6 @@ def zpk2tf(z, p, k):
         b = k * poly(z)
     a = atleast_1d(poly(p))
 
-    # Use real output if possible. Copied from np.poly, since
-    # we can't depend on a specific version of numpy.
-    if issubclass(b.dtype.type, np.complexfloating):
-        # if complex roots are all complex conjugates, the roots are real.
-        roots = np.asarray(z, complex)
-        pos_roots = np.compress(roots.imag > 0, roots)
-        neg_roots = np.conjugate(np.compress(roots.imag < 0, roots))
-        if len(pos_roots) == len(neg_roots):
-            if np.all(np.sort_complex(neg_roots) == np.sort_complex(pos_roots)):
-                b = b.real.copy()
-
-    if issubclass(a.dtype.type, np.complexfloating):
-        # if complex roots are all complex conjugates, the roots are real.
-        roots = np.asarray(p, complex)
-        pos_roots = np.compress(roots.imag > 0, roots)
-        neg_roots = np.conjugate(np.compress(roots.imag < 0, roots))
-        if len(pos_roots) == len(neg_roots):
-            if np.all(np.sort_complex(neg_roots) == np.sort_complex(pos_roots)):
-                a = a.real.copy()
-
     return b, a
 
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -215,6 +215,35 @@ class TestZpk2Tf:
         xp_assert_equal(a, a_r)
         assert isinstance(a, np.ndarray)
 
+    def test_conj_pair(self):
+        # conjugate pairs give real-coeff num & den
+        z = np.array([1j, -1j, 2j, -2j])
+        # shouldn't need elements of pairs to be adjacent
+        p = np.array([1+1j, 3-100j, 3+100j, 1-1j])
+        k = 23
+
+        # np.poly should do the right thing, but be explicit about
+        # taking real part
+        b = k * np.poly(z).real
+        a = np.poly(p).real
+
+        bp, ap = zpk2tf(z, p, k)
+
+        xp_assert_close(b, bp)
+        xp_assert_close(a, ap)
+
+        assert np.isrealobj(bp)
+        assert np.isrealobj(ap)
+
+    def test_complexk(self):
+        # regression: z, p real, k complex k gave real b, a
+        b, a = np.array([1j, 1j]), np.array([1.0, 2])
+        z, p, k = tf2zpk(b, a)
+        xp_assert_close(k, 1j)
+        bp, ap = zpk2tf(z, p, k)
+        xp_assert_close(b, bp)
+        xp_assert_close(a, ap)
+
 
 class TestSos2Zpk:
 


### PR DESCRIPTION
#### Reference issue

None, but see gh-19771.

#### What does this implement/fix?

zpk2tf works with complex k, real p, z; tf2zpk and zpk2tf now round-trip for this case (see unit test).

Removed code defending against old Numpy: [1] was included in Numpy 1.12.0, and minimum Numpy now is 1.23.5.  See [2] for context.

[1] https://github.com/numpy/numpy/pull/4073
[2] https://github.com/scipy/scipy/pull/3085#discussion_r67079381
