### PR TITLE
TST: make torch default dtype configurable

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -95,8 +95,6 @@ jobs:
     - name: Test SciPy
       run: |
         export OMP_NUM_THREADS=2
-        export SCIPY_DEFAULT_DTYPE="float64"
-        # expand as more modules are supported by adding to `XP_TESTS` above
         python dev.py --no-build test -b all $XP_TESTS -- --durations 3 --timeout=60
 
     - name: Test SciPy with torch/float32

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -95,5 +95,12 @@ jobs:
     - name: Test SciPy
       run: |
         export OMP_NUM_THREADS=2
+        export SCIPY_DEFAULT_DTYPE="float64"
+        # expand as more modules are supported by adding to `XP_TESTS` above
         python dev.py --no-build test -b all $XP_TESTS -- --durations 3 --timeout=60
+
+    - name: Test SciPy with torch/float32
+      run: |
+        export SCIPY_DEFAULT_DTYPE="float32"
+        python dev.py --no-build test -b torch $XP_TESTS -- --durations 3 --timeout=60
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -616,3 +616,14 @@ def xp_float_to_complex(arr: Array, xp: ModuleType | None = None) -> Array:
         arr = xp.astype(arr, xp.complex128)
 
     return arr
+
+
+def xp_default_dtype(xp):
+    """Query the namespace-dependent default floating-point dtype.
+    """
+    if is_torch(xp):
+        # historically, we allow pytorch to keep its default of float32
+        return xp.get_default_dtype()
+    else:
+        # we default to float64
+        return xp.float64

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -4,7 +4,7 @@ import pytest
 from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import (
     _GLOBAL_CONFIG, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
-    np_compat,
+    np_compat, xp_default_dtype
 )
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api_no_0d import xp_assert_equal as xp_assert_equal_no_0d
@@ -194,3 +194,7 @@ class TestArrayAPI:
         # scalars-vs-0d passes (if values match) also with regular python objects
         xp_assert_equal_no_0d(0., xp.asarray(0.))
         xp_assert_equal_no_0d(42, xp.asarray(42))
+
+    @array_api_compatible
+    def test_default_dtype(self, xp):
+        assert xp_default_dtype(xp) == xp.asarray(1.).dtype

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -148,6 +148,14 @@ if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
         xp_available_backends.update({'torch': torch})
         # can use `mps` or `cpu`
         torch.set_default_device(SCIPY_DEVICE)
+
+        # default dtype: XXX flip the default to float64
+        default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float32')
+        if default == 'float64':
+            torch.set_default_dtype(torch.float64)
+
+        print(f"default dtype set for {torch.get_default_dtype()}")
+
     except ImportError:
         pass
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -149,13 +149,15 @@ if SCIPY_ARRAY_API and isinstance(SCIPY_ARRAY_API, str):
         # can use `mps` or `cpu`
         torch.set_default_device(SCIPY_DEVICE)
 
-        # default dtype: XXX flip the default to float64
-        default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float32')
+        # default to float64 unless explicitly requested
+        default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float64')
         if default == 'float64':
             torch.set_default_dtype(torch.float64)
-
-        print(f"default dtype set for {torch.get_default_dtype()}")
-
+        elif default != "float32":
+            raise ValueError(
+                "SCIPY_DEFAULT_DTYPE env var, if set, can only be either 'float64' "
+               f"or 'float32'. Got '{default}' instead."
+            )
     except ImportError:
         pass
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -35,7 +35,7 @@ from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
     array_namespace,
     assert_array_almost_equal, assert_almost_equal,
-    xp_copy, xp_size,
+    xp_copy, xp_size, xp_default_dtype
 )
 from scipy.conftest import array_api_compatible
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -4338,7 +4338,7 @@ class TestDetrend:
         # regression test for https://github.com/scipy/scipy/issues/18675
         rng = np.random.RandomState(12345)
         x = rng.rand(10)
-        x = xp.asarray(x)
+        x = xp.asarray(x, dtype=xp_default_dtype(xp))
         if isinstance(bp, np.ndarray):
             bp = xp.asarray(bp)
         else:
@@ -4350,9 +4350,8 @@ class TestDetrend:
             -1.11128506e-01, -1.69470553e-01,  1.14710683e-01,  6.35468419e-02,
             3.53533144e-01, -3.67877935e-02, -2.00417675e-02, -1.94362049e-01])
 
-        # torch default float if f32
-        dtype_arg = {"check_dtype": False} if is_torch(xp) else {}
-        xp_assert_close(res, res_scipy_191, atol=1e-14, **dtype_arg)
+        atol = 3e-7 if xp_default_dtype(xp) == xp.float32 else 1e-14
+        xp_assert_close(res, res_scipy_191, atol=atol)
 
 
 @skip_xp_backends(np_only=True)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -40,8 +40,8 @@ from scipy.stats._stats_py import (_permutation_distribution_t, _chk_asarray, _m
                                    LinregressResult, _xp_mean, _xp_var, _SimpleChi2)
 from scipy._lib._util import AxisError
 from scipy.conftest import array_api_compatible, skip_xp_invalid_arg
-from scipy._lib._array_api import (array_namespace, xp_copy, is_numpy,
-                                   is_torch, xp_size, SCIPY_ARRAY_API)
+from scipy._lib._array_api import (array_namespace, xp_copy, is_numpy, is_torch,
+                                   xp_size, SCIPY_ARRAY_API, xp_default_dtype)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -3986,7 +3986,7 @@ class TestStudentTest:
         # x = c(2.75532884,  0.93892217,  0.94835861,  1.49489446, -0.62396595,
         #      -1.88019867, -1.55684465,  4.88777104,  5.15310979,  4.34656348)
         # t.test(x, conf.level=0.85, alternative='l')
-        dtype = xp.float32 if is_torch(xp) else xp.float64  # use default dtype
+        dtype = xp.asarray(1.0).dtype
         x = xp.asarray(x, dtype=dtype)
         popmean = xp.asarray(popmean, dtype=dtype)
 
@@ -6225,8 +6225,9 @@ def test_ttest_uniform_pvalues(xp):
     x, y = xp.asarray([2, 3, 5]), xp.asarray([1.5])
 
     res = stats.ttest_ind(x, y, equal_var=True)
-    xp_assert_close(res.statistic, xp.asarray(1.0394023007754))
-    xp_assert_close(res.pvalue, xp.asarray(0.407779907736))
+    rtol = 1e-6 if xp_default_dtype(xp) == xp.float32 else 1e-10
+    xp_assert_close(res.statistic, xp.asarray(1.0394023007754), rtol=rtol)
+    xp_assert_close(res.pvalue, xp.asarray(0.407779907736), rtol=rtol)
 
 
 def _convert_pvalue_alternative(t, p, alt, xp):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards gh-22210

#### What does this implement/fix?
<!--Please explain your changes.-->

Parametrize the array API CI job to test with pytorch defaulting to f32 and f64 dtypes.

#### Additional information
<!--Any additional information you think is important.-->
