### PR TITLE
ENH: io: throw `FileNotFoundError` exception when the source file does not exist in `io.mmread`

### DIFF
--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -194,6 +194,8 @@ def _get_read_cursor(source, parallelism=None):
             source = bz2.BZ2File(path, 'rb')
             ret_stream_to_close = source
         else:
+            if not os.path.isfile(path):
+                raise FileNotFoundError(f"The source file does not exist: {path}")
             return _fmm_core.open_read_file(path, parallelism), ret_stream_to_close
 
     # Stream object.

--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -194,7 +194,7 @@ def _get_read_cursor(source, parallelism=None):
             source = bz2.BZ2File(path, 'rb')
             ret_stream_to_close = source
         else:
-            if not os.path.isfile(path):
+            if not os.path.exists(path):
                 raise FileNotFoundError(f"The source file does not exist: {path}")
             return _fmm_core.open_read_file(path, parallelism), ret_stream_to_close
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -823,3 +823,9 @@ def test_threadpoolctl():
 
     with threadpoolctl.threadpool_limits(limits=2, user_api='scipy'):
         assert_equal(fmm.PARALLELISM, 2)
+
+
+def test_gh21999_file_not_exist():
+    tmpdir = mkdtemp(suffix=str(threading.get_native_id()))
+    wrong_fn = os.path.join(tmpdir, 'not_exist_test_file.mtx')
+    assert_raises(FileNotFoundError, mmread, wrong_fn)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #21999 

#### What does this implement/fix?
<!--Please explain your changes.-->
Improved `io.mmread` to throw `FileNotFoundError` exception when the source file does not exist.
And, a test was added.

#### Additional information
<!--Any additional information you think is important.-->
