### PR TITLE
TST: TestBracketMinimum MPS shims

### DIFF
--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -855,7 +855,7 @@ class TestBracketMinimum:
 
         result = _bracket_minimum(f, xp.asarray(0.5535723499480897), xmin=xmin,
                                   xmax=xmax)
-        assert xmin == result.xl
+        xp_assert_close(result.xl, xmin)
 
     def test_gh_20562_right(self, xp):
         # Regression test for https://github.com/scipy/scipy/issues/20562
@@ -868,4 +868,4 @@ class TestBracketMinimum:
 
         result = _bracket_minimum(f, xp.asarray(-0.5535723499480897),
                                   xmin=xmin, xmax=xmax)
-        assert xmax == result.xr
+        xp_assert_close(result.xr, xmax)


### PR DESCRIPTION
* Two tests in `TestBracketMinimum` were failing with the MPS backend + `torch` on ARM Mac. The tests were asserting for exact equality between floats--it seems that if we just do the usual thing of `xp_assert_close()` when comparing floats the test passes just fine without needing additional checks for default dtype, and this seems like the right approach even if the tests were not failing.

[skip circle] [skip cirrus]
