### PR TITLE
ENH: `_lib`: deobfuscate `jax.jit` crash in `_asarray`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -103,11 +103,8 @@ def _compliance_scipy(arrays):
 
 def _check_finite(array: Array, xp: ModuleType) -> None:
     """Check for NaNs or Infs."""
-    msg = "array must not contain infs or NaNs"
-    try:
-        if not xp.all(xp.isfinite(array)):
-            raise ValueError(msg)
-    except TypeError:
+    if not xp.all(xp.isfinite(array)):
+        msg = "array must not contain infs or NaNs"
         raise ValueError(msg)
 
 


### PR DESCRIPTION
```python
>>> import jax
>>> import jax.numpy as xp
>>> from scipy._lib._array_api import _asarray
>>> a = xp.asarray([0])
>>> def f(a):
...     return _asarray(a, check_finite=True)
>>> jax.jit(f)(a)
```
Before:
```
ValueError: array must not contain infs or NaNs
```
After:
```
TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[].
The error occurred while tracing the function kmeans at /home/crusaderky/github/scipy/build-install/lib/python3.12/site-packages/scipy/cluster/vq.py:332 for jit. This concrete value was not available in Python because it depends on the value of the argument obs.
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError
```

Outside of JAX, it makes perfect sense to me that if you call _asarray(..., check_finite=True) on an array of strings you ought to get a meaningful TypeError.