### PR TITLE
MAINT: stats: replace nonstandard calls in (mostly) array API compatible functions/tests

### DIFF
--- a/scipy/stats/_continued_fraction.py
+++ b/scipy/stats/_continued_fraction.py
@@ -300,7 +300,7 @@ def _continued_fraction(a, b, *, args=(), tolerances=None, maxiter=100, log=Fals
 
     xp = array_namespace(fs_a[0], fs_b[0], *args)
 
-    shape = xp.broadcast_shapes(shape_a, shape_b)
+    shape = np.broadcast_shapes(shape_a, shape_b)  # OK to use NumPy on tuples
     dtype = xp.result_type(dtype_a, dtype_b)
     an = xp.astype(xp_ravel(xp.broadcast_to(xp.reshape(fs_a[0], shape_a), shape)), dtype)  # noqa: E501
     bn = xp.astype(xp_ravel(xp.broadcast_to(xp.reshape(fs_b[0], shape_b), shape)), dtype)  # noqa: E501

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -188,7 +188,7 @@ class TestTrimmedStats:
 
         # check that if a full slice is masked, the output returns a
         # nan instead of a garbage value.
-        x = xp.arange(16).reshape(4, 4)
+        x = xp.reshape(xp.arange(16), (4, 4))
         res = stats.tmin(x, lowerlimit=4, axis=1)
         xp_assert_equal(res, xp.asarray([np.nan, 4, 8, 12]))
 


### PR DESCRIPTION
#### Reference issue
mdhaber/marray#71

#### What does this implement/fix?
This fixes two calls to functions/methods not included in the array API standard in a function/test that is otherwise array API compatible.