### PR TITLE
DOC: differentiate.jacobian: correct/improve documentation about callable interface

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -823,7 +823,7 @@ def jacobian(f, x, *, tolerances=None, maxiter=10, order=8, initial_step=0.5,
     ``(m, k, ...)`` and return an array of shape ``(n, k, ...)``, and the ``df``
     attribute of the result would have shape ``(n, m, k)``.
 
-`   Suppose the desired callable ``f_not_vectorized`` is not vectorized; it can
+    Suppose the desired callable ``f_not_vectorized`` is not vectorized; it can
     only accept an array of shape ``(m,)``. A simple solution to satisfy the required
     interface is to wrap ``f_not_vectorized`` as follows::
 


### PR DESCRIPTION
#### Reference issue
Closes gh-22128

#### What does this implement/fix?
The Notes section of [`scipy.differentiate.jacobian`](https://scipy.github.io/devdocs/reference/generated/scipy.differentiate.jacobian.html) included statements like

> argument `f` must be vectorized to accept an array of shape `(m, p)`

but it was not clear that `p` could refer to either a single integer `p` or a tuple of integers `p1, p2`. This PR addresses this by replacing `p` with `...` and documenting that `...` may represent an arbitrary tuple of integers. I'd rather not be more specific than that because I would like to give us some flexibility in the implementation.

To help users satisfy this interface if their function is not vectorized or is vectorized for only one batch dimension, the Notes now provide simple wrappers that the user can copy-paste to adapt their function to the required interface. A documentation improvement is the best we can do before the 1.15.0 release. (And personally, I'd rather let the user take the small steps necessary to translate between their preferred interface and the one required by the function rather than requiring us to accommodate all possibilities efficiently + exhaustively test them.)

#### Additional information
It looks like `hessian` already uses the `...` notation, so I didn't make any changes there. We could copy-paste the wrappers over to those notes if desired, or maybe just refer users of `hessian` to the notes of `jacobian` for the wrappers.

Thanks @andyfaff for noting this before release!