### PR TITLE
ENH: signal.upfirdn: array API standard support

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -751,3 +751,6 @@ ignore_errors = True
 
 [mypy-scipy._lib.array_api_compat.*]
 ignore_errors = True
+
+[mypy-scipy._lib.array_api_extra.*]
+ignore_errors = True

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -219,11 +219,22 @@ py3.install_sources(
 
 py3.install_sources(
   [
+    'array_api_extra/src/array_api_extra/_lib/_utils/__init__.py',
+    'array_api_extra/src/array_api_extra/_lib/_utils/_compat.py',
+    'array_api_extra/src/array_api_extra/_lib/_utils/_compat.pyi',    
+    'array_api_extra/src/array_api_extra/_lib/_utils/_helpers.py',
+    'array_api_extra/src/array_api_extra/_lib/_utils/_typing.py',
+
+  ],
+  subdir: 'scipy/_lib/array_api_extra/_lib/_utils',
+)
+
+py3.install_sources(
+  [
     'array_api_extra/src/array_api_extra/_lib/__init__.py',
-    'array_api_extra/src/array_api_extra/_lib/_compat.py',
-    'array_api_extra/src/array_api_extra/_lib/_compat.pyi',    
-    'array_api_extra/src/array_api_extra/_lib/_utils.py',
-    'array_api_extra/src/array_api_extra/_lib/_typing.py',
+    'array_api_extra/src/array_api_extra/_lib/_backends.py',
+    'array_api_extra/src/array_api_extra/_lib/_funcs.py',    
+    'array_api_extra/src/array_api_extra/_lib/_testing.py',
   ],
   subdir: 'scipy/_lib/array_api_extra/_lib',
 )
@@ -231,7 +242,7 @@ py3.install_sources(
 py3.install_sources(
   [
     'array_api_extra/src/array_api_extra/__init__.py',
-    'array_api_extra/src/array_api_extra/_funcs.py',
+    'array_api_extra/src/array_api_extra/_delegation.py',
   ],
   subdir: 'scipy/_lib/array_api_extra',
 )

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -33,6 +33,7 @@
 
 import numpy as np
 
+from scipy._lib._array_api import array_namespace
 from ._upfirdn_apply import _output_len, _apply, mode_enum
 
 __all__ = ['upfirdn', '_output_len']
@@ -210,7 +211,9 @@ def upfirdn(h, x, up=1, down=1, axis=-1, mode='constant', cval=0):
            [ 6.,  7.],
            [ 6.,  7.]])
     """
+    xp = array_namespace(h, x)
+
     x = np.asarray(x)
     ufd = _UpFIRDn(h, x.dtype, up, down)
     # This is equivalent to (but faster than) using np.apply_along_axis
-    return ufd.apply_filter(x, axis, mode, cval)
+    return xp.asarray(ufd.apply_filter(x, axis, mode, cval))

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -157,28 +157,27 @@ class TestUpfirdn:
         expected = np.asarray(expected, dtype=np.float64)
         xp_assert_close(y, expected)
 
+    @pytest.mark.parametrize('dtype', [int, np.float32, np.complex64, float, complex])
     @pytest.mark.parametrize('down, want_len', [  # lengths from MATLAB
         (2, 5015),
         (11, 912),
         (79, 127),
     ])
-    def test_vs_convolve(self, down, want_len):
+    def test_vs_convolve(self, down, want_len, dtype):
         # Check that up=1.0 gives same answer as convolve + slicing
         random_state = np.random.RandomState(17)
-        try_types = (int, np.float32, np.complex64, float, complex)
         size = 10000
 
-        for dtype in try_types:
-            x = random_state.randn(size).astype(dtype)
-            if dtype in (np.complex64, np.complex128):
-                x += 1j * random_state.randn(size)
+        x = random_state.randn(size).astype(dtype)
+        if dtype in (np.complex64, np.complex128):
+            x += 1j * random_state.randn(size)
 
-            h = firwin(31, 1. / down, window='hamming')
-            yl = upfirdn_naive(x, h, 1, down)
-            y = upfirdn(h, x, up=1, down=down)
-            assert y.shape == (want_len,)
-            assert yl.shape[0] == y.shape[0]
-            xp_assert_close(yl, y, atol=1e-7, rtol=1e-7)
+        h = firwin(31, 1. / down, window='hamming')
+        yl = upfirdn_naive(x, h, 1, down)
+        y = upfirdn(h, x, up=1, down=down)
+        assert y.shape == (want_len,)
+        assert yl.shape[0] == y.shape[0]
+        xp_assert_close(yl, y, atol=1e-7, rtol=1e-7)
 
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h', (1., 1j))

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -35,7 +35,9 @@
 import numpy as np
 from itertools import product
 
-from scipy._lib._array_api import xp_assert_close
+from scipy._lib._array_api import (
+    xp_assert_close, array_namespace, is_torch, is_array_api_strict
+)
 from pytest import raises as assert_raises
 import pytest
 
@@ -43,12 +45,16 @@ from scipy.signal import upfirdn, firwin
 from scipy.signal._upfirdn import _output_len, _upfirdn_modes
 from scipy.signal._upfirdn_apply import _pad_test
 
+skip_xp_backends = pytest.mark.skip_xp_backends
+
+
 
 def upfirdn_naive(x, h, up=1, down=1):
     """Naive upfirdn processing in Python.
 
     Note: arg order (x, h) differs to facilitate apply_along_axis use.
     """
+    x = np.asarray(x)
     h = np.asarray(h)
     out = np.zeros(len(x) * up, x.dtype)
     out[::up] = x
@@ -110,33 +116,37 @@ class UpFIRDnCase:
         xp_assert_close(yr.astype(y.dtype), y)
 
 
-_UPFIRDN_TYPES = (int, np.float32, np.complex64, float, complex)
+_UPFIRDN_TYPES = ("int64", "float32", "complex64", "float64", "complex128")
 
 
+@skip_xp_backends(cpu_only=True, reason='Cython implementation')
 class TestUpfirdn:
 
-    def test_valid_input(self):
+    @skip_xp_backends(np_only=True, reason="enough to only test on numpy")
+    def test_valid_input(self, xp):
         assert_raises(ValueError, upfirdn, [1], [1], 1, 0)  # up or down < 1
         assert_raises(ValueError, upfirdn, [], [1], 1, 1)  # h.ndim != 1
         assert_raises(ValueError, upfirdn, [[1]], [1], 1, 1)
 
     @pytest.mark.parametrize('len_h', [1, 2, 3, 4, 5])
     @pytest.mark.parametrize('len_x', [1, 2, 3, 4, 5])
-    def test_singleton(self, len_h, len_x):
+    def test_singleton(self, len_h, len_x, xp):
         # gh-9844: lengths producing expected outputs
-        h = np.zeros(len_h)
+        h = xp.zeros(len_h)
         h[len_h // 2] = 1.  # make h a delta
-        x = np.ones(len_x)
+        x = xp.ones(len_x)
         y = upfirdn(h, x, 1, 1)
-        want = np.pad(x, (len_h // 2, (len_h - 1) // 2), 'constant')
+        want = xpx.pad(x, (len_h // 2, (len_h - 1) // 2), 'constant', xp=xp)
         xp_assert_close(y, want)
 
-    def test_shift_x(self):
+    def test_shift_x(self, xp):
         # gh-9844: shifted x can change values?
-        y = upfirdn([1, 1], [1.], 1, 1)
-        xp_assert_close(y, np.asarray([1.0, 1.0]))  # was [0, 1] in the issue
-        y = upfirdn([1, 1], [0., 1.], 1, 1)
-        xp_assert_close(y, np.asarray([0.0, 1.0, 1.0]))
+        y = upfirdn(xp.asarray([1, 1]), xp.asarray([1.]), 1, 1)
+        xp_assert_close(
+            y, xp.asarray([1.0, 1.0], dtype=xp.float64)  # was [0, 1] in the issue
+        )
+        y = upfirdn(xp.asarray([1, 1]), xp.asarray([0., 1.]), 1, 1)
+        xp_assert_close(y, xp.asarray([0.0, 1.0, 1.0], dtype=xp.float64))
 
     # A bunch of lengths/factors chosen because they exposed differences
     # between the "old way" and new way of computing length, and then
@@ -148,48 +158,56 @@ class TestUpfirdn:
         (3, 2, 6, 2, [1, 0, 0, 1, 0]),
         (4, 11, 3, 5, [1, 0, 0, 1, 0, 0, 1]),
     ])
-    def test_length_factors(self, len_h, len_x, up, down, expected):
+    def test_length_factors(self, len_h, len_x, up, down, expected, xp):
         # gh-9844: weird factors
-        h = np.zeros(len_h)
+        h = xp.zeros(len_h)
         h[0] = 1.
-        x = np.ones(len_x)
+        x = xp.ones(len_x, dtype=xp.float64)
         y = upfirdn(h, x, up, down)
-        expected = np.asarray(expected, dtype=np.float64)
+        expected = xp.asarray(expected, dtype=xp.float64)
         xp_assert_close(y, expected)
 
-    @pytest.mark.parametrize('dtype', [int, np.float32, np.complex64, float, complex])
+    @pytest.mark.parametrize(
+        'dtype', ["int64", "float32", "complex64", "float64", "complex128"]
+    )
     @pytest.mark.parametrize('down, want_len', [  # lengths from MATLAB
         (2, 5015),
         (11, 912),
         (79, 127),
     ])
-    def test_vs_convolve(self, down, want_len, dtype):
+    def test_vs_convolve(self, down, want_len, dtype, xp):
         # Check that up=1.0 gives same answer as convolve + slicing
         random_state = np.random.RandomState(17)
         size = 10000
 
-        x = random_state.randn(size).astype(dtype)
-        if dtype in (np.complex64, np.complex128):
+        np_dtype = getattr(np, dtype)
+        x = random_state.randn(size).astype(np_dtype)
+        if np_dtype in (np.complex64, np.complex128):
             x += 1j * random_state.randn(size)
 
-        h = firwin(31, 1. / down, window='hamming')
-        yl = upfirdn_naive(x, h, 1, down)
+        dtype = getattr(xp, dtype)
+        x = xp.asarray(x, dtype=dtype)
+
+        h = xp.asarray(firwin(31, 1. / down, window='hamming'))
+        yl = xp.asarray(upfirdn_naive(x, h, 1, down))
         y = upfirdn(h, x, up=1, down=down)
         assert y.shape == (want_len,)
         assert yl.shape[0] == y.shape[0]
         xp_assert_close(yl, y, atol=1e-7, rtol=1e-7)
 
+    @skip_xp_backends(np_only=True, reason="apply_along_axis")
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h', (1., 1j))
     @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
-    def test_vs_naive_delta(self, x_dtype, h, up, down):
+    def test_vs_naive_delta(self, x_dtype, h, up, down, xp):
         UpFIRDnCase(up, down, h, x_dtype)()
 
+    @skip_xp_backends(np_only=True, reason="apply_along_axis")
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('p_max, q_max',
                              list(product((10, 100), (10, 100))))
-    def test_vs_naive(self, x_dtype, h_dtype, p_max, q_max):
+    def test_vs_naive(self, x_dtype, h_dtype, p_max, q_max, xp):
         tests = self._random_factors(p_max, q_max, h_dtype, x_dtype)
         for test in tests:
             test()
@@ -219,27 +237,34 @@ class TestUpfirdn:
         return tests
 
     @pytest.mark.parametrize('mode', _upfirdn_modes)
-    def test_extensions(self, mode):
+    def test_extensions(self, mode, xp):
         """Test vs. manually computed results for modes not in numpy's pad."""
-        x = np.array([1, 2, 3, 1], dtype=float)
+        x = np.asarray([1, 2, 3, 1], dtype=np.float64)
         npre, npost = 6, 6
         y = _pad_test(x, npre=npre, npost=npost, mode=mode)
+
+        x = xp.asarray(x)
+        y = xp.asarray(y)
         if mode == 'antisymmetric':
-            y_expected = np.asarray(
+            y_expected = xp.asarray(
                 [3.0, 1, -1, -3, -2, -1, 1, 2, 3, 1, -1, -3, -2, -1, 1, 2])
         elif mode == 'antireflect':
-            y_expected = np.asarray(
+            y_expected = xp.asarray(
                 [1.0, 2, 3, 1, -1, 0, 1, 2, 3, 1, -1, 0, 1, 2, 3, 1])
         elif mode == 'smooth':
-            y_expected = np.asarray(
+            y_expected = xp.asarray(
                 [-5.0, -4, -3, -2, -1, 0, 1, 2, 3, 1, -1, -3, -5, -7, -9, -11])
         elif mode == "line":
-            lin_slope = (x[-1] - x[0]) / (len(x) - 1)
-            left = x[0] + np.arange(-npre, 0, 1) * lin_slope
-            right = x[-1] + np.arange(1, npost + 1) * lin_slope
-            y_expected = np.concatenate((left, x, right))
+            lin_slope = (x[-1] - x[0]) / (x.shape[0] - 1)
+            left = x[0] + xp.arange(-npre, 0, 1, dtype=xp.float64) * lin_slope
+            right = x[-1] + xp.arange(1, npost + 1, dtype=xp.float64) * lin_slope
+            concat = array_namespace(left).concat
+            y_expected = concat((left, x, right))
         else:
-            y_expected = np.pad(x, (npre, npost), mode=mode)
+            y_expected = np.pad(np.asarray(x), (npre, npost), mode=mode)
+            y_expected = xp.asarray(y_expected)
+
+        y_expected = xp.asarray(y_expected, dtype=xp.float64)
         xp_assert_close(y, y_expected)
 
     @pytest.mark.parametrize(
@@ -248,32 +273,41 @@ class TestUpfirdn:
             [8],
             [4, 5, 26],  # include cases with h_len > 2*size
             _upfirdn_modes,
-            [np.float32, np.float64, np.complex64, np.complex128],
+            ["float32", "float64", "complex64", "complex128"],
         )
     )
-    def test_modes(self, size, h_len, mode, dtype):
+    def test_modes(self, size, h_len, mode, dtype, xp):
+        dtype_np = getattr(np, dtype)
+        dtype_xp = getattr(xp, dtype)
+
         random_state = np.random.RandomState(5)
-        x = random_state.randn(size).astype(dtype)
-        if dtype in (np.complex64, np.complex128):
+        x = random_state.randn(size).astype(dtype_np)
+        if dtype in ("complex64", "complex128"):
             x += 1j * random_state.randn(size)
         h = np.arange(1, 1 + h_len, dtype=x.real.dtype)
+
+        x = xp.asarray(x, dtype=dtype_xp)
+        h = xp.asarray(h)
 
         y = upfirdn(h, x, up=1, down=1, mode=mode)
         # expected result: pad the input, filter with zero padding, then crop
         npad = h_len - 1
         if mode in ['antisymmetric', 'antireflect', 'smooth', 'line']:
             # use _pad_test test function for modes not supported by np.pad.
-            xpad = _pad_test(x, npre=npad, npost=npad, mode=mode)
+            xpad = _pad_test(np.asarray(x), npre=npad, npost=npad, mode=mode)
         else:
-            xpad = np.pad(x, npad, mode=mode)
+            xpad = np.pad(np.asarray(x), npad, mode=mode)
+
+        xpad = xp.asarray(xpad)
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')
         y_expected = ypad[npad:-npad]
 
-        atol = rtol = np.finfo(dtype).eps * 1e2
+        atol = rtol = xp.finfo(dtype_xp).eps * 1e2
         xp_assert_close(y, y_expected, atol=atol, rtol=rtol)
 
 
-def test_output_len_long_input():
+@skip_xp_backends(cpu_only=True, reason='Cython implementation')
+def test_output_len_long_input(xp):
     # Regression test for gh-17375.  On Windows, a large enough input
     # that should have been well within the capabilities of 64 bit integers
     # would result in a 32 bit overflow because of a bug in Cython 0.29.32.

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -35,12 +35,13 @@
 import numpy as np
 from itertools import product
 
-from scipy._lib._array_api import (
-    xp_assert_close, array_namespace, is_torch, is_array_api_strict
-)
 from pytest import raises as assert_raises
 import pytest
 
+from scipy._lib import array_api_extra as xpx
+from scipy._lib._array_api import (
+    xp_assert_close, array_namespace, is_torch, is_array_api_strict
+)
 from scipy.signal import upfirdn, firwin
 from scipy.signal._upfirdn import _output_len, _upfirdn_modes
 from scipy.signal._upfirdn_apply import _pad_test
@@ -133,7 +134,7 @@ class TestUpfirdn:
     def test_singleton(self, len_h, len_x, xp):
         # gh-9844: lengths producing expected outputs
         h = xp.zeros(len_h)
-        h[len_h // 2] = 1.  # make h a delta
+        h = xpx.at(h)[len_h // 2].set(1.)  # make h a delta
         x = xp.ones(len_x)
         y = upfirdn(h, x, 1, 1)
         want = xpx.pad(x, (len_h // 2, (len_h - 1) // 2), 'constant', xp=xp)
@@ -161,7 +162,7 @@ class TestUpfirdn:
     def test_length_factors(self, len_h, len_x, up, down, expected, xp):
         # gh-9844: weird factors
         h = xp.zeros(len_h)
-        h[0] = 1.
+        h = xpx.at(h)[0].set(1.)
         x = xp.ones(len_x, dtype=xp.float64)
         y = upfirdn(h, x, up, down)
         expected = xp.asarray(expected, dtype=xp.float64)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -40,7 +40,7 @@ import pytest
 
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api import (
-    xp_assert_close, array_namespace, is_torch, is_array_api_strict
+    xp_assert_close, array_namespace
 )
 from scipy.signal import upfirdn, firwin
 from scipy.signal._upfirdn import _output_len, _upfirdn_modes


### PR DESCRIPTION
Add alt backend support to `scipy.signal.upfirdn`. The implementation is in Cython and is numpy-only, the the code change is minimal and trivial; tests needed some tweaking, as usual.