### PR TITLE
BENCH: sparse.csgraph.dijkstra: add benchmark

### DIFF
--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -55,7 +55,8 @@ class DijkstraDensity(Benchmark):
     param_names = ["n", "density"]
 
     def setup(self, n, density):
-       self.graph = (scipy.sparse.rand(n, n, density, format='csr') * 100).astype(np.uint32)
+       G = scipy.sparse.rand(n, n, density, format='csr') * 100
+       self.graph = G.astype(np.uint32)
 
 
     def time_test_shortest_path(self, n, density):

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -61,13 +61,13 @@ class DijkstraDensity(Benchmark):
             raise NotImplementedError("skipped")
 
         rng = np.random.default_rng(42)
-        G = scipy.sparse.random_array(
+        self.graph = scipy.sparse.random_array(
             shape=(n, n),
             density=density,
             format='csr',
             rng=rng,
-        ) * 100
-        self.graph = G.astype(np.uint32)
+            data_sampler=lambda size: rng.integers(100, size=size, dtype=np.uint32),
+        )
 
 
     def time_test_shortest_path(self, n, density):

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -5,7 +5,7 @@ import scipy.sparse
 from .common import Benchmark, safe_import
 
 with safe_import():
-    from scipy.sparse.csgraph import dijkstra
+    from scipy.sparse.csgraph import dijkstra, shortest_path
 
 
 class Dijkstra(Benchmark):
@@ -40,3 +40,23 @@ class Dijkstra(Benchmark):
                  directed=False,
                  indices=self.indices,
                  min_only=min_only)
+
+
+class DijkstraDensity(Benchmark):
+    """
+    Benchmark performance of Dijkstra, adapted from [^1]
+
+    [^1]: https://github.com/scipy/scipy/pull/20717#issuecomment-2562795171
+    """
+    params = [
+        [10, 100, 1000],
+        [0.1, 0.3, 0.5, 0.9],
+    ]
+    param_names = ["n", "density"]
+
+    def setup(self, n, density):
+       self.graph = (scipy.sparse.rand(n, n, density, format='csr') * 100).astype(np.uint32)
+
+
+    def time_test_shortest_path(self, n, density):
+        shortest_path(self.graph, method="D", directed=False)

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -1,6 +1,4 @@
 """benchmarks for the scipy.sparse.csgraph module"""
-from functools import partial
-
 import numpy as np
 import scipy.sparse
 

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -4,7 +4,7 @@ from functools import partial
 import numpy as np
 import scipy.sparse
 
-from .common import Benchmark, safe_import
+from .common import Benchmark, safe_import, is_xslow
 
 with safe_import():
     from scipy.sparse.csgraph import dijkstra, shortest_path
@@ -57,6 +57,9 @@ class DijkstraDensity(Benchmark):
     param_names = ["n", "density"]
 
     def setup(self, n, density):
+        if n >= 1000 and not is_xslow():
+            raise NotImplementedError("skipped")
+
         rng = np.random.default_rng(42)
         G = scipy.sparse.random_array(
             shape=(n, n),

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -1,4 +1,6 @@
 """benchmarks for the scipy.sparse.csgraph module"""
+from functools import partial
+
 import numpy as np
 import scipy.sparse
 
@@ -55,8 +57,14 @@ class DijkstraDensity(Benchmark):
     param_names = ["n", "density"]
 
     def setup(self, n, density):
-       G = scipy.sparse.rand(n, n, density, format='csr') * 100
-       self.graph = G.astype(np.uint32)
+        rng = np.random.default_rng(42)
+        G = scipy.sparse.random_array(
+            shape=(n, n),
+            density=density,
+            format='csr',
+            rng=rng,
+        ) * 100
+        self.graph = G.astype(np.uint32)
 
 
     def time_test_shortest_path(self, n, density):


### PR DESCRIPTION
gh-20717 was the first of multiple planned improvements to SciPy. We should track performance changes appropriately for any future work.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None, See gh-20717 for context

#### What does this implement/fix?
This benchmark tracks the performance of the changes in gh-20717. As there are more changes that may be coming, we should have the infrastructure set up to track performance. 

#### Additional information
This benchmark has been adapted from @czgdp1807's work from this [comment](https://github.com/scipy/scipy/pull/20717#issuecomment-2562795171)
