### PR TITLE
DOC: sparse: docstring example of random_array with uint32 data_sampler

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1158,6 +1158,13 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
            [  0.,   0.,   0.,   0.],
            [  0.,   0.,  36.,   0.]])
 
+    Providing a sampler for uint values:
+
+    >>> def random_uint32_to_100(size=None):
+    ...     return rng.integers(100, size=size, dtype=np.uint32)
+    >>> S = sp.sparse.random_array((3, 4), density=0.25, rng=rng,
+    ...                            data_sampler=random_uint32_to_100)
+
     Building a custom distribution.
     This example builds a squared normal from np.random:
 


### PR DESCRIPTION
Added a doc_string example to `random_array` showing how to use the `data_sampler` argument to produce random integer arrays.  