### PR TITLE
MAINT: fix url for array-api-extra git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/cobyqa/cobyqa.git
 [submodule "scipy/_lib/array_api_extra"]
 	path = scipy/_lib/array_api_extra
-	url = https://github.com/lucascolley/array-api-extra.git
+	url = https://github.com/data-apis/array-api-extra.git
 # All submodules used as a Meson `subproject` are required to be under the
 # subprojects/ directory - see:
 # https://mesonbuild.com/Subprojects.html#why-must-all-subprojects-be-inside-a-single-directory


### PR DESCRIPTION
This somehow slipped in, that's not ideal. @lucascolley please make sure to not delete your fork or any branches that previous commits may have pointed at. The `v1.15.0` tag has the same problem, so this should be backported.