### PR TITLE
DOC: optimize.root: switch x - y coordinates in example

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -1467,18 +1467,18 @@ The problem we have can now be solved as follows:
        d2x = zeros_like(P)
        d2y = zeros_like(P)
 
-       d2x[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2]) / hx/hx
-       d2x[0]    = (P[1]    - 2*P[0]    + P_left)/hx/hx
-       d2x[-1]   = (P_right - 2*P[-1]   + P[-2])/hx/hx
+       d2x[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hx/hx
+       d2x[:,0]    = (P[:,1]  - 2*P[:,0]    + P_left)/hx/hx
+       d2x[:,-1]   = (P_right   - 2*P[:,-1]   + P[:,-2])/hx/hx
 
-       d2y[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hy/hy
-       d2y[:,0]    = (P[:,1]  - 2*P[:,0]    + P_bottom)/hy/hy
-       d2y[:,-1]   = (P_top   - 2*P[:,-1]   + P[:,-2])/hy/hy
+       d2y[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2]) / hy/hy
+       d2y[0]    = (P[1]    - 2*P[0]    + P_bottom)/hy/hy
+       d2y[-1]   = (P_top - 2*P[-1]   + P[-2])/hy/hy
 
        return d2x + d2y + 5*cosh(P).mean()**2
 
     # solve
-    guess = zeros((nx, ny), float)
+    guess = zeros((ny, nx), float)
     sol = root(residual, guess, method='krylov', options={'disp': True})
     #sol = root(residual, guess, method='broyden2', options={'disp': True, 'max_rank': 50})
     #sol = root(residual, guess, method='anderson', options={'disp': True, 'M': 10})
@@ -1486,7 +1486,7 @@ The problem we have can now be solved as follows:
 
     # visualize
     import matplotlib.pyplot as plt
-    x, y = mgrid[0:1:(nx*1j), 0:1:(ny*1j)]
+    y, x = mgrid[0:1:(ny*1j), 0:1:(nx*1j)]
     plt.pcolormesh(x, y, sol.x, shading='gouraud')
     plt.colorbar()
     plt.show()

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -1469,11 +1469,11 @@ The problem we have can now be solved as follows:
 
        d2x[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hx/hx
        d2x[:,0]    = (P[:,1]  - 2*P[:,0]    + P_left)/hx/hx
-       d2x[:,-1]   = (P_right   - 2*P[:,-1]   + P[:,-2])/hx/hx
+       d2x[:,-1]   = (P_right - 2*P[:,-1]   + P[:,-2])/hx/hx
 
-       d2y[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2]) / hy/hy
+       d2y[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2])/hy/hy
        d2y[0]    = (P[1]    - 2*P[0]    + P_bottom)/hy/hy
-       d2y[-1]   = (P_top - 2*P[-1]   + P[-2])/hy/hy
+       d2y[-1]   = (P_top   - 2*P[-1]   + P[-2])/hy/hy
 
        return d2x + d2y + 5*cosh(P).mean()**2
 

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -200,7 +200,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     Residual: 5.7972e-06  # may vary
 
     >>> import matplotlib.pyplot as plt
-    >>> y, x = np.mgrid[0:1:(nx*1j), 0:1:(ny*1j)]
+    >>> y, x = np.mgrid[0:1:(ny*1j), 0:1:(nx*1j)]
     >>> plt.pcolormesh(x, y, sol.x, shading='gouraud')
     >>> plt.colorbar()
     >>> plt.show()

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -194,7 +194,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     ...
     ...    return d2x + d2y - 10*np.cosh(P).mean()**2
 
-    >>> guess = np.zeros((nx, ny), float)
+    >>> guess = np.zeros((ny, nx), float)
     >>> sol = optimize.root(residual, guess, method='krylov')
     >>> print('Residual: %g' % abs(residual(sol.x)).max())
     Residual: 5.7972e-06  # may vary

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -184,13 +184,13 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     ...    d2x = np.zeros_like(P)
     ...    d2y = np.zeros_like(P)
     ...
-    ...    d2x[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2]) / hx/hx
-    ...    d2x[0]    = (P[1]    - 2*P[0]    + P_left)/hx/hx
-    ...    d2x[-1]   = (P_right - 2*P[-1]   + P[-2])/hx/hx
+    ...    d2x[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hx/hx
+    ...    d2x[:,0]    = (P[:,1]  - 2*P[:,0]    + P_left)/hx/hx
+    ...    d2x[:,-1]   = (P_right - 2*P[:,-1]   + P[:,-2])/hx/hx
     ...
-    ...    d2y[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hy/hy
-    ...    d2y[:,0]    = (P[:,1]  - 2*P[:,0]    + P_bottom)/hy/hy
-    ...    d2y[:,-1]   = (P_top   - 2*P[:,-1]   + P[:,-2])/hy/hy
+    ...    d2y[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2]) / hy/hy
+    ...    d2y[0]    = (P[1]    - 2*P[0]    + P_bottom)/hy/hy
+    ...    d2y[-1]   = (P_top   - 2*P[-1]   + P[-2])/hy/hy
     ...
     ...    return d2x + d2y - 10*np.cosh(P).mean()**2
 
@@ -200,7 +200,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     Residual: 5.7972e-06  # may vary
 
     >>> import matplotlib.pyplot as plt
-    >>> x, y = np.mgrid[0:1:(nx*1j), 0:1:(ny*1j)]
+    >>> y, x = np.mgrid[0:1:(nx*1j), 0:1:(ny*1j)]
     >>> plt.pcolormesh(x, y, sol.x, shading='gouraud')
     >>> plt.colorbar()
     >>> plt.show()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
no reference issue given, as I had the fix already

#### What does this implement/fix?

The coordinates x and y were mixed up in the function residual(P) ( especially the border conditions P_left, ... P_bottom)
but were mixed up again with the 'np.mgrid' function, so the end result at the display is correct.
The issue can be seen by looking closer at the optimization results 'sol.x'.

#### Additional information
see also the description for pcolormesh in https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolormesh.html#axes-pcolormesh-grid-orientation:

> The grid orientation follows the standard matrix convention: An array C with shape (nrows, ncolumns) is plotted with the column number as X and the row number as Y.

