### PR TITLE
MAINT: Fix a dtype check in `scipy.signal._waveforms.py`

### DIFF
--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -73,7 +73,7 @@ def sawtooth(t, width=1):
     mask2 = (1 - mask1) & (tmod < w * 2 * pi)
     tsub = extract(mask2, tmod)
     wsub = extract(mask2, w)
-    values = (tsub / (pi * wsub) - 1)
+    values = tsub / (pi * wsub) - 1
     place(y, mask2, values.astype(y.dtype))
 
     # on the interval width*2*pi to 2*pi function is

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -73,7 +73,8 @@ def sawtooth(t, width=1):
     mask2 = (1 - mask1) & (tmod < w * 2 * pi)
     tsub = extract(mask2, tmod)
     wsub = extract(mask2, w)
-    place(y, mask2, tsub / (pi * wsub) - 1)
+    values = (tsub / (pi * wsub) - 1)
+    place(y, mask2, values.astype(y.dtype))
 
     # on the interval width*2*pi to 2*pi function is
     #  (pi*(w+1)-tmod) / (pi*(1-w))
@@ -81,7 +82,8 @@ def sawtooth(t, width=1):
     mask3 = (1 - mask1) & (1 - mask2)
     tsub = extract(mask3, tmod)
     wsub = extract(mask3, w)
-    place(y, mask3, (pi * (wsub + 1) - tsub) / (pi * (1 - wsub)))
+    values = (pi * (wsub + 1) - tsub) / (pi * (1 - wsub))
+    place(y, mask3, values.astype(y.dtype))
     return y
 
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -55,7 +55,7 @@ def sawtooth(t, width=1):
     t, w = asarray(t), asarray(width)
     w = asarray(w + (t - t))
     t = asarray(t + (w - w))
-    if t.dtype.char in ['fFdD']:
+    if t.dtype.char in 'fFdD':
         ytype = t.dtype.char
     else:
         ytype = 'd'
@@ -137,7 +137,7 @@ def square(t, duty=0.5):
     t, w = asarray(t), asarray(duty)
     w = asarray(w + (t - t))
     t = asarray(t + (w - w))
-    if t.dtype.char in ['fFdD']:
+    if t.dtype.char in 'fFdD':
         ytype = t.dtype.char
     else:
         ytype = 'd'

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -378,3 +378,23 @@ class TestUnitImpulse:
 
         imp = waveforms.unit_impulse((5, 2), (3, 1), dtype=complex)
         assert np.issubdtype(imp.dtype, np.complexfloating)
+
+
+class TestSawtoothWaveform:
+    def test_dtype(self):
+        waveform = waveforms.sawtooth(
+            np.array(1, dtype=np.float32), width=np.float32(1)
+        )
+        assert waveform.dtype == np.float32
+
+        waveform = waveforms.sawtooth(1)
+        assert waveform.dtype == np.float64
+
+
+class TestSquareWaveform:
+    def test_dtype(self):
+        waveform = waveforms.square(np.array(1, dtype=np.float32), duty=np.float32(0.5))
+        assert waveform.dtype == np.float32
+
+        waveform = waveforms.square(1)
+        assert waveform.dtype == np.float64


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #22252.

#### What does this implement/fix?
<!--Please explain your changes.-->
The old code used to call `dtype.char` and then check if it was contained with a list of a single string `['fdFD']`. This of course would never pass because a `'f'` is not a member of `['fdFD']` but it is a member of `'fdFD'`.

This is likely a mistake in the code and so this commit fixes it.
