### PR TITLE
TST: Make `@pytest.mark.usefixtures("skip_xp_backends")` redundant

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -243,14 +243,12 @@ The following pytest markers are available:
 
 * ``skip_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)``:
   skip certain backends or categories of backends.
-  ``@pytest.mark.usefixtures("skip_xp_backends")`` must be used alongside this
-  marker for the skips to apply. See the fixture's docstring in ``scipy.conftest``
-  for information on how use this marker to skip tests.
+  See docstring of ``scipy.conftest.skip_or_xfail_xp_backends`` for information on how
+  to use this marker to skip tests.
 * ``xfail_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)``:
   xfail certain backends or categories of backends.
-  ``@pytest.mark.usefixtures("xfail_xp_backends")`` must be used alongside this
-  marker for the xfails to apply. See the fixture's docstring in ``scipy.conftest``
-  for information on how use this marker to xfail tests.
+  See docstring of ``scipy.conftest.skip_or_xfail_xp_backends`` for information on how
+  to use this marker to xfail tests.
 * ``skip_xp_invalid_arg`` is used to skip tests that use arguments which
   are invalid when ``SCIPY_ARRAY_API`` is enabled. For instance, some tests of
   `scipy.stats` functions pass masked arrays to the function being tested, but
@@ -268,11 +266,9 @@ The following pytest markers are available:
 
     python dev.py test -b all -m array_api_backends
 
-  Note that this includes tests that use the ``xp`` fixture indirectly through another
-  array API fixture, such as ``@pytest.mark.usefixtures("skip_xp_backends")``, even if
-  they don't explicitly consume ``xp`` themselves.
-
 * OBSOLETE: ``array_api_compatible`` (does nothing; pending removal)
+* OBSOLETE: ``pytest.mark.usefixtures("skip_xp_backends")`` (does nothing; pending removal)
+* OBSOLETE: ``pytest.mark.usefixtures("xfail_xp_backends")`` (does nothing; pending removal)
 
 ``scipy._lib._array_api`` contains array-agnostic assertions such as ``xp_assert_close``
 which can be used to replace assertions from `numpy.testing`.
@@ -289,17 +285,13 @@ The following examples demonstrate how to use the markers::
   from scipy._lib._array_api import xp_assert_close
   ...
   @pytest.mark.skip_xp_backends(np_only=True, reason='skip reason')
-  @pytest.mark.usefixtures("skip_xp_backends")
   def test_toto1(self, xp):
       a = xp.asarray([1, 2, 3])
       b = xp.asarray([0, 2, 5])
       xp_assert_close(toto(a, b), a)
   ...
-  @pytest.mark.skip_xp_backends('array_api_strict',
-                                reason='skip reason 1')
-  @pytest.mark.skip_xp_backends('cupy',
-                                reason='skip reason 2')
-  @pytest.mark.usefixtures("skip_xp_backends")
+  @pytest.mark.skip_xp_backends('array_api_strict', reason='skip reason 1')
+  @pytest.mark.skip_xp_backends('cupy', reason='skip reason 2')
   def test_toto2(self, xp):
       ...
   ...
@@ -324,20 +316,8 @@ for compiled code::
   @pytest.mark.skip_xp_backends(cpu_only, exceptions=['jax.numpy'])
   @pytest.mark.skip_xp_backends('array_api_strict', reason='skip reason 1')
   @pytest.mark.skip_xp_backends('cupy', reason='skip reason 2')
-  @pytest.mark.usefixtures("skip_xp_backends")
   def test_toto(self, xp):
       ...
-
-When every test function in a file has been updated for array API
-compatibility, one can reduce verbosity by telling ``pytest`` to apply the
-markers to every test function using ``pytestmark``::
-
-    pytestmark = [pytest.mark.usefixtures("skip_xp_backends")]
-    skip_xp_backends = pytest.mark.skip_xp_backends
-    ...
-    @skip_xp_backends(np_only=True, reason='skip reason')
-    def test_toto1(self, xp):
-        ...
 
 After applying these markers, ``dev.py test`` can be used with the new option
 ``-b`` or ``--array-api-backend``::

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -48,7 +48,6 @@ from scipy.cluster.hierarchy import (
     _order_cluster_tree, _hierarchy, _LINKAGE_METHODS)
 from scipy.spatial.distance import pdist
 from scipy.cluster._hierarchy import Heap
-from scipy.conftest import array_api_compatible
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal
 
 from threading import Lock
@@ -68,8 +67,6 @@ try:
 except Exception:
     have_matplotlib = False
 
-
-pytestmark = [array_api_compatible, pytest.mark.usefixtures("skip_xp_backends")]
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
@@ -829,8 +826,8 @@ class TestMaxInconsts:
         R = xp.asarray(R)
         assert_raises(ValueError, maxinconsts, Z, R)
 
-    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment',
-                      cpu_only=True)
+    @skip_xp_backends(cpu_only=True, reason="implicit device->host transfer")
+    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment')
     def test_maxinconsts_one_cluster_linkage(self, xp):
         # Tests maxinconsts(Z, R) on linkage with one cluster.
         Z = xp.asarray([[0, 1, 0.3, 4]], dtype=xp.float64)
@@ -839,8 +836,8 @@ class TestMaxInconsts:
         expectedMD = calculate_maximum_inconsistencies(Z, R, xp=xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment',
-                      cpu_only=True)
+    @skip_xp_backends(cpu_only=True, reason="implicit device->host transfer")
+    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment')
     def test_maxinconsts_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             self.check_maxinconsts_Q_linkage(method, xp)
@@ -893,8 +890,8 @@ class TestMaxRStat:
         R = xp.asarray(R)
         assert_raises(ValueError, maxRstat, Z, R, i)
 
-    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment',
-                      cpu_only=True)
+    @skip_xp_backends(cpu_only=True, reason="implicit device->host transfer")
+    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment')
     def test_maxRstat_one_cluster_linkage(self, xp):
         for i in range(4):
             self.check_maxRstat_one_cluster_linkage(i, xp)
@@ -907,8 +904,8 @@ class TestMaxRStat:
         expectedMD = calculate_maximum_inconsistencies(Z, R, 1, xp)
         xp_assert_close(MD, expectedMD, atol=1e-15)
 
-    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment',
-                      cpu_only=True)
+    @skip_xp_backends(cpu_only=True, reason="implicit device->host transfer")
+    @skip_xp_backends('jax.numpy', reason='jax arrays do not support item assignment')
     def test_maxRstat_Q_linkage(self, xp):
         for method in ['single', 'complete', 'ward', 'centroid', 'median']:
             for i in range(4):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -215,9 +215,16 @@ def xp(request):
     You can select all and only the tests that use the `xp` fixture by
     passing `-m array_api_backends` to pytest.
 
-    Please read: https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html
+    You can select where individual tests run through the `@skip_xp_backends`,
+    `@xfail_xp_backends`, and `@skip_xp_invalid_arg` pytest markers.
+
+    Please read: https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html#adding-tests
     """
+    # Read all @pytest.marks.skip_xp_backends markers that decorate to the test,
+    # if any, and raise pytest.skip() if the current xp is in the list.
     skip_or_xfail_xp_backends(request, "skip")
+    # Read all @pytest.marks.xfail_xp_backends markers that decorate the test,
+    # if any, and raise pytest.xfail() if the current xp is in the list.
     skip_or_xfail_xp_backends(request, "xfail")
 
     if SCIPY_ARRAY_API:
@@ -263,16 +270,16 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
     backends = []
     kwargs = {}
     for marker in markers:
-        if marker.kwargs.get('np_only'):
+        if marker.kwargs.get('np_only', False):
             kwargs['np_only'] = True
             kwargs['exceptions'] = marker.kwargs.get('exceptions', [])
-            kwargs['reason'] = marker.kwargs.get('reason')
-        elif marker.kwargs.get('cpu_only'):
-            if not kwargs.get('np_only'):
+            kwargs['reason'] = marker.kwargs.get('reason', None)
+        elif marker.kwargs.get('cpu_only', False):
+            if not kwargs.get('np_only', False):
                 # if np_only is given, it is certainly cpu only
                 kwargs['cpu_only'] = True
                 kwargs['exceptions'] = marker.kwargs.get('exceptions', [])
-                kwargs['reason'] = marker.kwargs.get('reason')
+                kwargs['reason'] = marker.kwargs.get('reason', None)
 
         # add backends, if any
         if len(marker.args) == 1:

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -4,6 +4,7 @@ import os
 import warnings
 import tempfile
 from contextlib import contextmanager
+from typing import Literal
 
 import numpy as np
 import numpy.testing as npt
@@ -216,6 +217,9 @@ def xp(request):
 
     Please read: https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html
     """
+    skip_or_xfail_xp_backends(request, "skip")
+    skip_or_xfail_xp_backends(request, "xfail")
+
     if SCIPY_ARRAY_API:
         from scipy._lib._array_api import default_xp
 
@@ -228,7 +232,18 @@ def xp(request):
     else:
         yield request.param
 
+# OBSOLETE, pending removal
 array_api_compatible = pytest.mark.array_api_compatible
+
+@pytest.fixture
+def skip_xp_backends():
+    pass
+
+@pytest.fixture
+def xfail_xp_backends():
+    pass
+# /OBSOLETE, pending removal
+
 
 skip_xp_invalid_arg = pytest.mark.skipif(SCIPY_ARRAY_API,
     reason = ('Test involves masked arrays, object arrays, or other types '
@@ -251,91 +266,79 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
         if marker.kwargs.get('np_only'):
             kwargs['np_only'] = True
             kwargs['exceptions'] = marker.kwargs.get('exceptions', [])
-            kwargs['reason'] = marker.kwargs.get('reason', None)
+            kwargs['reason'] = marker.kwargs.get('reason')
         elif marker.kwargs.get('cpu_only'):
             if not kwargs.get('np_only'):
                 # if np_only is given, it is certainly cpu only
                 kwargs['cpu_only'] = True
                 kwargs['exceptions'] = marker.kwargs.get('exceptions', [])
-                kwargs['reason'] = marker.kwargs.get('reason', None)
+                kwargs['reason'] = marker.kwargs.get('reason')
 
         # add backends, if any
-        if len(marker.args) > 0:
-            backend = marker.args[0]  # was a tuple, ('numpy',) etc
+        if len(marker.args) == 1:
+            backend = marker.args[0]
             backends.append(backend)
             kwargs.update(**{backend: marker.kwargs})
+            for kwarg in ("cpu_only", "np_only", "exceptions"):
+                if marker.kwargs.get(kwarg):
+                    raise ValueError(f"{kwarg} is mutually exclusive with {backend}")
+        elif len(marker.args) > 1:
+            raise ValueError(
+                f"Please specify only one backend per marker: {marker.args}"
+            )
 
     return backends, kwargs
 
 
-@pytest.fixture
-def skip_xp_backends(xp, request):
-    """skip_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)
-
-    Skip a decorated test for the provided backend, or skip a category of backends.
-
-    See ``skip_or_xfail_backends`` docstring for details. Note that, contrary to
-    ``skip_or_xfail_backends``, the ``backend`` and ``reason`` arguments are optional
-    single strings: this function only skips a single backend at a time.
-    To skip multiple backends, provide multiple decorators.
-    """  # noqa: E501
-    if "skip_xp_backends" not in request.keywords:
-        return
-
-    backends, kwargs = _backends_kwargs_from_request(request, skip_or_xfail='skip')
-    skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip')
-
-
-@pytest.fixture
-def xfail_xp_backends(xp, request):
-    """xfail_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)
-
-    xfail a decorated test for the provided backend, or xfail a category of backends.
-
-    See ``skip_or_xfail_backends`` docstring for details. Note that, contrary to
-    ``skip_or_xfail_backends``, the ``backend`` and ``reason`` arguments are optional
-    single strings: this function only xfails a single backend at a time.
-    To xfail multiple backends, provide multiple decorators.
-    """  # noqa: E501
-    if "xfail_xp_backends" not in request.keywords:
-        return
-    backends, kwargs = _backends_kwargs_from_request(request, skip_or_xfail='xfail')
-    skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='xfail')
-
-
-def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
+def skip_or_xfail_xp_backends(request: pytest.FixtureRequest,
+                              skip_or_xfail: Literal['skip', 'xfail']) -> None:
     """
-    Skip based on the ``skip_xp_backends`` or ``xfail_xp_backends`` marker.
+    Helper of the `xp` fixture.
+    Skip or xfail based on the ``skip_xp_backends`` or ``xfail_xp_backends`` markers.
 
     See the "Support for the array API standard" docs page for usage examples.
 
+    Usage
+    -----
+    ::
+        skip_xp_backends = pytest.mark.skip_xp_backends
+        xfail_xp_backends = pytest.mark.xfail_xp_backends
+        ...
+
+        @skip_xp_backends(backend, *, reason=None)
+        @skip_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
+        @skip_xp_backends(*, np_only=True, exceptions=(), reason=None)
+
+        @xfail_xp_backends(backend, *, reason=None)
+        @xfail_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
+        @xfail_xp_backends(*, np_only=True, exceptions=(), reason=None)
+
     Parameters
     ----------
-    backends : tuple
-        Backends to skip/xfail, e.g. ``("array_api_strict", "torch")``.
-        These are overriden when ``np_only`` is ``True``, and are not
-        necessary to provide for non-CPU backends when ``cpu_only`` is ``True``.
-        For a custom reason to apply, you should pass
-        ``kwargs={<backend name>: {'reason': '...'}, ...}``.
+    backend : str, optional
+        Backend to skip/xfail, e.g. ``"torch"``.
+        Mutually exclusive with ``cpu_only`` and ``np_only``.
+    cpu_only : bool, optional
+        When ``True``, the test is skipped/xfailed on non-CPU devices,
+        minus exceptions. Mutually exclusive with ``backend``.
     np_only : bool, optional
         When ``True``, the test is skipped/xfailed for all backends other
-        than the default NumPy backend. There is no need to provide
-        any ``backends`` in this case. Default: ``False``.
-    cpu_only : bool, optional
-        When ``True``, the test is skipped/xfailed on non-CPU devices.
-        There is no need to provide any ``backends`` in this case,
-        but any ``backends`` will also be skipped on the CPU.
-        Default: ``False``.
+        than the default NumPy backend and the exceptions.
+        Mutually exclusive with ``backend``. Implies ``cpu_only``.
     reason : str, optional
-        A reason for the skip/xfail in the case of ``np_only=True`` or
-        ``cpu_only=True``. If omitted, a default reason is used.
-    exceptions : list, optional
+        A reason for the skip/xfail. If omitted, a default reason is used.
+    exceptions : list[str], optional
         A list of exceptions for use with ``cpu_only`` or ``np_only``.
         This should be provided when delegation is implemented for some,
         but not all, non-CPU/non-NumPy backends.
-    skip_or_xfail : str
-        ``'skip'`` to skip, ``'xfail'`` to xfail.
     """
+    if f"{skip_or_xfail}_xp_backends" not in request.keywords:
+        return
+
+    backends, kwargs = _backends_kwargs_from_request(
+        request, skip_or_xfail=skip_or_xfail
+    )
+    xp = request.param
     skip_or_xfail = getattr(pytest, skip_or_xfail)
     np_only = kwargs.get("np_only", False)
     cpu_only = kwargs.get("cpu_only", False)
@@ -348,19 +351,15 @@ def skip_or_xfail_xp_backends(xp, backends, kwargs, skip_or_xfail='skip'):
     if np_only and cpu_only:
         # np_only is a stricter subset of cpu_only
         cpu_only = False
-    if exceptions and not (cpu_only or np_only):
-        raise ValueError("`exceptions` is only valid alongside `cpu_only` or `np_only`")
 
     # Test explicit backends first so that their reason can override
-    # those from np_only/cpu_only
-    if backends is not None:
-        for i, backend in enumerate(backends):
-            if xp.__name__ == backend:
-                reason = kwargs[backend].get('reason')
-                if not reason:
-                    reason = f"do not run with array API backend: {backend}"
-
-                skip_or_xfail(reason=reason)
+    # those from cpu_only
+    for backend in backends:
+        if xp.__name__ == backend:
+            reason = kwargs[backend].get('reason')
+            if not reason:
+                reason = f"do not run with array API backend: {backend}"
+            skip_or_xfail(reason=reason)
 
     if np_only:
         reason = kwargs.get("reason")

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -193,8 +193,8 @@ def test_orthogonalize_noop(func, type, norm, xp):
 
 
 @skip_xp_backends('jax.numpy',
-                  reason='jax arrays do not support item assignment',
-                  cpu_only=True)
+                  reason='jax arrays do not support item assignment')
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 def test_orthogonalize_dct1(norm, xp):
     x = xp.asarray(np.random.rand(100))
@@ -212,8 +212,8 @@ def test_orthogonalize_dct1(norm, xp):
 
 
 @skip_xp_backends('jax.numpy',
-                  reason='jax arrays do not support item assignment',
-                  cpu_only=True)
+                  reason='jax arrays do not support item assignment')
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst2(func, norm, xp):
@@ -226,8 +226,8 @@ def test_orthogonalize_dcst2(func, norm, xp):
 
 
 @skip_xp_backends('jax.numpy',
-                  reason='jax arrays do not support item assignment',
-                  cpu_only=True)
+                  reason='jax arrays do not support item assignment')
+@skip_xp_backends(cpu_only=True)
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst3(func, norm, xp):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -761,7 +761,7 @@ class TestBartlett:
         check_named_results(res, attributes, xp=xp)
 
     @pytest.mark.skip_xp_backends(
-        "jax.numpy", cpu_only=True,
+        "jax.numpy",
         reason='`var` incorrect when `correction > n` (google/jax#21330)')
     @pytest.mark.usefixtures("skip_xp_backends")
     def test_empty_arg(self, xp):


### PR DESCRIPTION
Follow-up from #22132

Make `@pytest.mark.usefixtures("skip_xp_backends")` and `@pytest.mark.usefixtures("xfail_xp_backends")` redundant.
The legwork of removing the old markers has been delayed to a following PR for the sake of ease of review.

This PR also disallows putting both a backend and cpu_only/numpy_only=True on the same marker, as I find it extremely hard to read and error prone. Does this
```python
@skip_xp_backends("jax.numpy", cpu_only=True)
```
mean to 
1. only skip jax on CPU (jax on GPU is OK)?
2. skip jax, except on CPU where it is OK?
3. skip jax, regardless of device, and on top of that skip all other backends on the GPU?

The answer is (3), and it gets me confused every time I encounter it.