### PR TITLE
TST: dev.py quietly ignores user markers

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -266,7 +266,7 @@ The following pytest markers are available:
 * ``array_api_backends``: this marker is automatically added by the ``xp`` fixture to
   all tests that use it. This is useful e.g. to select all and only such tests::
 
-    python dev.py test -b all -- -m array_api_backends
+    python dev.py test -b all -m array_api_backends
 
   Note that this includes tests that use the ``xp`` fixture indirectly through another
   array API fixture, such as ``@pytest.mark.usefixtures("skip_xp_backends")``, even if

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -95,8 +95,12 @@ class PytestTester:
 
         pytest_args = ['--showlocals', '--tb=short']
 
-        if extra_argv:
-            pytest_args += list(extra_argv)
+        if extra_argv is None:
+            extra_argv = []
+        pytest_args += extra_argv
+        if any(arg == "-m" or arg == "--markers" for arg in extra_argv):
+            # Likely conflict with default --mode=fast
+            raise ValueError("Must specify -m before --")
 
         if verbose and int(verbose) > 1:
             pytest_args += ["-" + "v"*(int(verbose)-1)]


### PR DESCRIPTION
Fix a UI issue in ``python dev.py tests -- -m something``, where the user-provided markers would be quitly ignored in favour of the default `-m not slow`.