### PR TITLE
TST: Mark with `xp` all tests in Array API-compatible modules

### DIFF
--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -53,7 +53,7 @@ class TestConvertTemperature:
                         xp.asarray([273.15, 0.], dtype=xp.float64), rtol=0., atol=1e-13)
 
     @skip_xp_backends(np_only=True, reason='Python list input uses NumPy backend')
-    def test_convert_temperature_array_like(self):
+    def test_convert_temperature_array_like(self, xp):
         assert_allclose(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
                         [273.15, 0.], rtol=0., atol=1e-13)
 

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -40,7 +40,7 @@ class TestDerivative:
 
     @pytest.mark.skip_xp_backends(np_only=True)
     @pytest.mark.parametrize('case', stats._distr_params.distcont)
-    def test_accuracy(self, case):
+    def test_accuracy(self, case, xp):
         distname, params = case
         dist = getattr(stats, distname)(*params)
         x = dist.median() + 0.1
@@ -435,7 +435,7 @@ class TestDerivative:
         (lambda x: (x - 1) ** 3, 1),
         (lambda x: np.where(x > 1, (x - 1) ** 5, (x - 1) ** 3), 1)
     ))
-    def test_saddle_gh18811(self, case):
+    def test_saddle_gh18811(self, case, xp):
         # With default settings, `derivative` will not always converge when
         # the true derivative is exactly zero. This tests that specifying a
         # (tight) `atol` alleviates the problem. See discussion in gh-18811.

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -305,7 +305,7 @@ class TestFFT:
 
     @skip_xp_backends(np_only=True)
     @pytest.mark.parametrize("dtype", [np.float16, np.longdouble])
-    def test_dtypes_nonstandard(self, dtype):
+    def test_dtypes_nonstandard(self, dtype, xp):
         x = random(30).astype(dtype)
         out_dtypes = {np.float16: np.complex64, np.longdouble: np.clongdouble}
         x_complex = x.astype(out_dtypes[dtype])
@@ -368,7 +368,7 @@ class TestFFT:
         "fft",
         [fft.fft, fft.fft2, fft.fftn,
          fft.ifft, fft.ifft2, fft.ifftn])
-def test_fft_with_order(dtype, order, fft):
+def test_fft_with_order(dtype, order, fft, xp):
     # Check that FFT/IFFT produces identical results for C, Fortran and
     # non contiguous arrays
     rng = np.random.RandomState(42)
@@ -450,7 +450,7 @@ class TestFFTThreadSafe:
 
 @skip_xp_backends(np_only=True)
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
-def test_multiprocess(func):
+def test_multiprocess(func, xp):
     # Test that fft still works after fork (gh-10422)
 
     with multiprocessing.Pool(2) as p:

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -26,7 +26,8 @@ _5_smooth_numbers = [
     2**3 * 3**3 * 5**2,
 ]
 
-def test_next_fast_len():
+@skip_xp_backends(np_only=True)
+def test_next_fast_len(xp):
     for n in _5_smooth_numbers:
         assert_equal(next_fast_len(n), n)
 
@@ -56,7 +57,7 @@ def _assert_n_smooth(x, n):
 @skip_xp_backends(np_only=True)
 class TestNextFastLen:
 
-    def test_next_fast_len(self):
+    def test_next_fast_len(self, xp):
         np.random.seed(1234)
 
         def nums():
@@ -71,14 +72,14 @@ class TestNextFastLen:
             m = next_fast_len(n, True)
             _assert_n_smooth(m, 5)
 
-    def test_np_integers(self):
+    def test_np_integers(self, xp):
         ITYPES = [np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64]
         for ityp in ITYPES:
             x = ityp(12345)
             testN = next_fast_len(x)
             assert_equal(testN, next_fast_len(int(x)))
 
-    def testnext_fast_len_small(self):
+    def testnext_fast_len_small(self, xp):
         hams = {
             1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 8, 8: 8, 14: 15, 15: 15,
             16: 16, 17: 18, 1021: 1024, 1536: 1536, 51200000: 51200000
@@ -89,7 +90,7 @@ class TestNextFastLen:
     @pytest.mark.xfail(sys.maxsize < 2**32,
                        reason="Hamming Numbers too large for 32-bit",
                        raises=ValueError, strict=True)
-    def testnext_fast_len_big(self):
+    def testnext_fast_len_big(self, xp):
         hams = {
             510183360: 510183360, 510183360 + 1: 512000000,
             511000000: 512000000,
@@ -123,14 +124,14 @@ class TestNextFastLen:
         for x, y in hams.items():
             assert_equal(next_fast_len(x, True), y)
 
-    def test_keyword_args(self):
+    def test_keyword_args(self, xp):
         assert next_fast_len(11, real=True) == 12
         assert next_fast_len(target=7, real=False) == 7
 
 @skip_xp_backends(np_only=True)
 class TestPrevFastLen:
 
-    def test_prev_fast_len(self):
+    def test_prev_fast_len(self, xp):
         np.random.seed(1234)
 
         def nums():
@@ -145,7 +146,7 @@ class TestPrevFastLen:
             m = prev_fast_len(n, True)
             _assert_n_smooth(m, 5)
 
-    def test_np_integers(self):
+    def test_np_integers(self, xp):
         ITYPES = [np.int16, np.int32, np.int64, np.uint16, np.uint32, 
                     np.uint64]
         for ityp in ITYPES:
@@ -156,7 +157,7 @@ class TestPrevFastLen:
             testN = prev_fast_len(x, real=True)
             assert_equal(testN, prev_fast_len(int(x), real=True))
 
-    def testprev_fast_len_small(self):
+    def testprev_fast_len_small(self, xp):
         hams = {
             1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 6, 8: 8, 14: 12, 15: 15,
             16: 16, 17: 16, 1021: 1000, 1536: 1536, 51200000: 51200000
@@ -176,7 +177,7 @@ class TestPrevFastLen:
     @pytest.mark.xfail(sys.maxsize < 2**32,
                        reason="Hamming Numbers too large for 32-bit",
                        raises=ValueError, strict=True)
-    def testprev_fast_len_big(self):
+    def testprev_fast_len_big(self, xp):
         hams = {
             # 2**6 * 3**13 * 5**1
             510183360: 510183360,
@@ -238,7 +239,7 @@ class TestPrevFastLen:
         for x, y in hams.items():
             assert_equal(prev_fast_len(x, True), y)
 
-    def test_keyword_args(self):
+    def test_keyword_args(self, xp):
         assert prev_fast_len(11, real=True) == 10
         assert prev_fast_len(target=7, real=False) == 7
 

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -52,7 +52,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize, xp):
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 @pytest.mark.parametrize("overwrite_x", [True, False])
 def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
-                               overwrite_x):
+                               overwrite_x, xp):
     # Test the identity f^-1(f(x)) == x
     x = np.random.rand(7, 8).astype(dtype)
     x_orig = x.copy()
@@ -130,7 +130,7 @@ def test_identity_nd(forward, backward, type, shape, axes, norm,
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 @pytest.mark.parametrize("overwrite_x", [False, True])
 def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
-                               norm, overwrite_x):
+                               norm, overwrite_x, xp):
     # Test the identity f^-1(f(x)) == x
 
     x = np.random.random(shape).astype(dtype)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2007,7 +2007,7 @@ class TestNdimageFilters:
         xp_assert_equal(expected, output)
 
     @skip_xp_backends(np_only=True, reason="test list input")
-    def test_rank16(self):
+    def test_rank16(self, xp):
         # test that lists are accepted and interpreted as numpy arrays
         array = [3, 2, 5, 1, 4]
         # expected values are: median(3, 2, 5) = 3, median(2, 5, 1) = 2, etc
@@ -2272,7 +2272,8 @@ def test_ticket_701(xp):
     xp_assert_equal(res, res2)
 
 
-def test_gh_5430():
+@skip_xp_backends(np_only=True)
+def test_gh_5430(xp):
     # At least one of these raises an error unless gh-5430 is
     # fixed. In py2k an int is implemented using a C long, so
     # which one fails depends on your system. In py3k there is only

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1585,7 +1585,7 @@ class TestResample:
                     xp_assert_close(y_g[::down], y_s)
 
     @pytest.mark.parametrize('dtype', [np.int32, np.float32])
-    def test_gh_15620(self, dtype):
+    def test_gh_15620(self, dtype, xp):
         data = np.array([0, 1, 2, 3, 2, 1, 0], dtype=dtype)
         actual = signal.resample_poly(data,
                                       up=2,
@@ -3421,7 +3421,7 @@ class TestEnvelope:
         self.assert_close(Zr, np.array(Zr_desired).astype(complex),
                           msg="Residual calculation error")
 
-    def test_envelope_verify_axis_parameter(self):
+    def test_envelope_verify_axis_parameter(self, xp):
         """Test for multi-channel envelope calculations. """
         z = sp_fft.irfft([[1, 0, 2, 2, 0], [7, 0, 4, 4, 0]])
         Ze2_desired = np.array([[4, 2, 0, 0, 0], [16, 8, 0, 0, 0]],
@@ -3503,7 +3503,7 @@ class TestPartialFractionExpansion:
         xp_assert_close(unique, [1.0, 2.0, 3.0])
         xp_assert_close(multiplicity, [3, 2, 1])
 
-    def test_residue_general(self):
+    def test_residue_general(self, xp):
         # Test are taken from issue #4464, note that poles in scipy are
         # in increasing by absolute value order, opposite to MATLAB.
         r, p, k = residue([5, 3, -2, 7], [-4, 0, 8, 3])

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1879,7 +1879,7 @@ class TestKstatVar:
     @skip_xp_backends(np_only=True,
                       reason='input validation of `n` does not depend on backend')
     @pytest.mark.usefixtures("skip_xp_backends")
-    def test_bad_arg(self):
+    def test_bad_arg(self, xp):
         # Raise ValueError is n is not 1 or 2.
         data = [1]
         n = 10

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -380,7 +380,7 @@ class TestPearsonrWilkinson:
 @skip_xp_backends(cpu_only=True)
 class TestPearsonr:
     @skip_xp_backends(np_only=True)
-    def test_pearsonr_result_attributes(self):
+    def test_pearsonr_result_attributes(self, xp):
         res = stats.pearsonr(X, X)
         attributes = ('correlation', 'pvalue')
         check_named_results(res, attributes)
@@ -557,7 +557,7 @@ class TestPearsonr:
              ('two-sided', 0.325800137536, -0.992306975236, 0.81493896884, -1),
              ('less', 0.1629000687684, -1.0, 0.6785654158217636, -1),
              ('greater', 0.8370999312316, -0.985600937290653, 1.0, -1)])
-    def test_basic_example(self, alternative, pval, rlow, rhigh, sign):
+    def test_basic_example(self, alternative, pval, rlow, rhigh, sign, xp):
         x = [1, 2, 3, 4]
         y = np.array([0, 1, 0.5, 1]) * sign
         result = stats.pearsonr(x, y, alternative=alternative)
@@ -593,7 +593,7 @@ class TestPearsonr:
         xp_assert_equal(high, one)
 
     @pytest.mark.skip_xp_backends(np_only=True)
-    def test_input_validation(self):
+    def test_input_validation(self, xp):
         x = [1, 2, 3]
         y = [4, 5]
         message = '`x` and `y` must have the same length along `axis`.'
@@ -626,7 +626,7 @@ class TestPearsonr:
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))
     @pytest.mark.parametrize('method_name',
                              ('permutation', 'monte_carlo', 'monte_carlo2'))
-    def test_resampling_pvalue(self, method_name, alternative):
+    def test_resampling_pvalue(self, method_name, alternative, xp):
         rng = np.random.default_rng(24623935790378923)
         size = (2, 100) if method_name == 'permutation' else (2, 1000)
         x = rng.normal(size=size)
@@ -648,7 +648,7 @@ class TestPearsonr:
 
     @pytest.mark.skip_xp_backends(np_only=True)
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))
-    def test_bootstrap_ci(self, alternative):
+    def test_bootstrap_ci(self, alternative, xp):
         rng = np.random.default_rng(2462935790378923)
         x = rng.normal(size=(2, 100))
         y = rng.normal(size=(2, 100))
@@ -6700,7 +6700,7 @@ class TestJarqueBera:
 
     @skip_xp_backends(np_only=True)
     @pytest.mark.usefixtures("skip_xp_backends")
-    def test_jarque_bera_array_like(self):
+    def test_jarque_bera_array_like(self, xp):
         # array-like only relevant for NumPy
         np.random.seed(987654321)
         x = np.random.normal(0, 1, 100000)

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -33,7 +33,7 @@ class TestVariation:
         xp_assert_close(v, expected, rtol=1e-10)
 
     @skip_xp_backends(np_only=True, reason="test plain python scalar input")
-    def test_scalar(self):
+    def test_scalar(self, xp):
         # A scalar is treated like a 1-d sequence with length 1.
         assert variation(4.0) == 0.0
 


### PR DESCRIPTION
Following #22260, I've executed

```bash
$ python dev.py test -b all -m "array_api_compatible and not array_api_backends" -- --collect-only
```
to find all tests marked by the soon-to-be-removed `array_api_compatible` marker but that don't use the xp fixture.
It seems that they're all tests that are either already marked with `@skip_xp_backends(np_only=True)` or that should, so this PR is just cosmetic.