### PR TITLE
MAINT: linalg.solve: raise when diagonal matrix is exactly singular

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -284,7 +284,7 @@ def solve(a, b, lower=False, overwrite_a=False,
                                  overwrite_a=overwrite_a,
                                  overwrite_b=overwrite_b)
         _solve_check(n, info)
-        rcond, info = hecon(lu, ipvt, anorm)
+        rcond, info = hecon(lu, ipvt, anorm, lower=lower)
     # Symmetric case 'sysv'
     elif assume_a in {'symmetric', 'sym'}:
         sycon, sysv, sysv_lw = get_lapack_funcs(('sycon', 'sysv',
@@ -295,7 +295,7 @@ def solve(a, b, lower=False, overwrite_a=False,
                                  overwrite_a=overwrite_a,
                                  overwrite_b=overwrite_b)
         _solve_check(n, info)
-        rcond, info = sycon(lu, ipvt, anorm)
+        rcond, info = sycon(lu, ipvt, anorm, lower=lower)
     # Diagonal case
     elif assume_a == 'diagonal':
         diag_a = np.diag(a1)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -39,7 +39,7 @@ def _solve_check(n, info, lamch=None, rcond=None):
     """ Check arguments during the different steps of the solution phase """
     if info < 0:
         raise ValueError(f'LAPACK reported an illegal value in {-info}-th argument.')
-    elif 0 < info:
+    elif 0 < info or rcond == 0:
         raise LinAlgError('Matrix is singular.')
 
     if lamch is None:
@@ -301,7 +301,8 @@ def solve(a, b, lower=False, overwrite_a=False,
         diag_a = np.diag(a1)
         x = (b1.T / diag_a).T
         abs_diag_a = np.abs(diag_a)
-        rcond = abs_diag_a.min() / abs_diag_a.max()
+        diag_min = abs_diag_a.min()
+        rcond = diag_min if diag_min == 0 else diag_min / abs_diag_a.max()
     # Tri-diagonal case
     elif assume_a == 'tridiagonal':
         a1 = a1.T if transposed else a1

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -135,7 +135,7 @@ def solve(a, b, lower=False, overwrite_a=False,
     ValueError
         If size mismatches detected or input a is not square.
     LinAlgError
-        If the matrix is singular.
+        If the computation fails because of matrix singularity.
     LinAlgWarning
         If an ill-conditioned input a is detected.
     NotImplementedError

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -45,7 +45,7 @@ def _solve_check(n, info, lamch=None, rcond=None):
     if lamch is None:
         return
     E = lamch('E')
-    if rcond < E:
+    if not (rcond >= E):  # `rcond < E` doesn't handle NaN
         warn(f'Ill-conditioned matrix (rcond={rcond:.6g}): '
              'result may not be accurate.',
              LinAlgWarning, stacklevel=3)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -799,14 +799,7 @@ class TestSolve:
         n = 10
         A = np.zeros((n, n))
         b = np.ones(n)
-        message = "Ill-conditioned matrix..."
-        if structure in {'diagonal', None}:
-            with (pytest.warns(LinAlgWarning, match=message),
-                  np.errstate(all='ignore')):
-                solve(A, b, assume_a=structure)
-            return
-
-        with pytest.raises(LinAlgError, match="singular."):
+        with (pytest.raises(LinAlgError, match="singular"), np.errstate(all='ignore')):
             solve(A, b, assume_a=structure)
 
     def test_multiple_rhs(self):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -736,7 +736,7 @@ class TestSolve:
 
     @pytest.mark.parametrize("assume_a", ['her', 'sym'])
     def test_symmetric_hermitian(self, assume_a):
-        # An upper triangular matrix will be used for hermitian matrix a
+        # An upper triangular matrix will be used for symmetric/hermitian matrix a
         a = np.array([[-1.84, 0.11-0.11j, -1.78-1.18j, 3.91-1.50j],
                       [0, -4.63, -1.84+0.03j, 2.21+0.21j],
                       [0, 0, -8.87, 1.58-0.90j],
@@ -753,9 +753,8 @@ class TestSolve:
 
         x = solve(a, b, assume_a=assume_a)
         assert_array_almost_equal(x, ref)
-        # Also conjugate a and test for lower triangular data
+        # Also transpose(/conjugate) `a` and test for lower triangular data
         # This also tests gh-22265 resolution; otherwise, a warning would be emitted
-
         x = solve(a2, b, assume_a=assume_a, lower=True)
         assert_array_almost_equal(x, ref)
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -795,7 +795,7 @@ class TestSolve:
                              ('diagonal', 'tridiagonal', 'lower triangular',
                               'upper triangular', 'symmetric', 'hermitian',
                               'positive definite', 'general', None))
-    def test_exactly_singular_gh22265(self, structure):
+    def test_exactly_singular_gh22263(self, structure):
         n = 10
         A = np.zeros((n, n))
         b = np.ones(n)


### PR DESCRIPTION
#### Reference issue
Closes gh-22263
Closes gh-22265

#### What does this implement/fix?
gh-22263 noted that `solve` no longer raises when the input matrix is all zeros; this is because the the matrix is now treated as diagonal, and the computation does not fail. Typical NumPy warnings were emitted, but no `LinAlgWarning` was emitted because `rcond` is NaN rather than a small number.

This PR ensures that the `LinAlgWarning` is emitted when `rcond` is NaN by checking `not (rcond >= E)` instead of `rcond < lamch('E')`. It also makes the documented reason for raising a `LinAlgError` more precise, and it adds a test for the warning/error produced for an all-zero matrix. (I already added a test for an ill-conditioned but not *exactly* singular in gh-21363.)

gh-22265 noted that with this change, a test would fail due to a warning being emitted. The source of the problem was identified there (missing `lower` arg in calls to `sycon`/`hecon`, and this fixes it).