### PR TITLE
TST: fix thread safety issue in interpolate.bsplines memmap test

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2,6 +2,7 @@ import os
 import operator
 import itertools
 import math
+import threading
 
 import numpy as np
 from numpy.testing import suppress_warnings
@@ -658,11 +659,12 @@ class TestBSpline:
 
         expected = b(xx)
 
-        t_mm = np.memmap(
-            str(tmpdir.join('t.dat')), mode='w+', dtype=b.t.dtype, shape=b.t.shape)
+        tid = threading.get_native_id()
+        t_mm = np.memmap(str(tmpdir.join(f't{tid}.dat')), mode='w+',
+                         dtype=b.t.dtype, shape=b.t.shape)
         t_mm[:] = b.t
-        c_mm = np.memmap(
-            str(tmpdir.join('c.dat')), mode='w+', dtype=b.c.dtype, shape=b.c.shape)
+        c_mm = np.memmap(str(tmpdir.join(f'c{tid}.dat')), mode='w+',
+                         dtype=b.c.dtype, shape=b.c.shape)
         c_mm[:] = b.c
         b.t = t_mm
         b.c = c_mm


### PR DESCRIPTION
This test was recently introduced in gh-22158. It causes a crash when running the test suite with `pytest-run-parallel`, because of writing to the same tempfile from multiple threads.

Note that the `get_native_id` pattern to make filenames unique is present in multiple other places in the test suite.

