### PR TITLE
TST: stats.Normal: bump tolerance on test of logcdf

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -426,7 +426,7 @@ def check_dist_func(dist, fname, arg, result_shape, methods):
         # can only expect about half of machine precision for optimization
         # because math
         tol_override = {'atol': 1e-6}
-    elif fname in {'logcdf'}:
+    elif fname in {'logcdf'}:  # gh-22276
         tol_override = {'rtol': 2e-7}
 
     if dist._overrides(f'_{fname}_formula'):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -426,6 +426,8 @@ def check_dist_func(dist, fname, arg, result_shape, methods):
         # can only expect about half of machine precision for optimization
         # because math
         tol_override = {'atol': 1e-6}
+    elif fname in {'logcdf'}:
+        tol_override = {'rtol': 2e-7}
 
     if dist._overrides(f'_{fname}_formula'):
         methods.add('formula')


### PR DESCRIPTION
#### Reference issue
e.g. gh-22274

#### What does this implement/fix?
There is a test failing in main with the latest release of `hypothesis`. It looks like it is able to find a little region where quadrature is less accurate than usual:
```python3
import numpy as np
from scipy import stats
X = stats.Normal(mu=-0.044622861356271804, sigma=1.234783885368829)
X.logcdf(-0.84)       - X.logcdf(-0.84, method='quadrature')        # np.float64(0.0)
X.logcdf(-0.84693408) - X.logcdf(-0.84693408, method='quadrature')  # np.float64(1.1598066906870486e-07)
X.logcdf(-0.85)       - X.logcdf(-0.85, method='quadrature')        # np.float64(0.0)
```

So this bumps the tolerance slightly.