### PR TITLE
BUG: Fix `Akima1DInterpolator` by returning linear interpolant for `y.shape[0] == 2`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -509,12 +509,13 @@ class Akima1DInterpolator(CubicHermiteSpline):
         # Akima extrapolation historically False; parent class defaults to True.
         extrapolate = False if extrapolate is None else extrapolate
 
-        if x.shape[0] == 2:
+        if y.shape[0] == 2:
             # edge case: only have two points, use linear interpolation
-            hk = x[1:] - x[:-1]
+            xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
+            hk = xp[1:] - xp[:-1]
             mk = (y[1:] - y[:-1]) / hk
-            t = np.zeros_like(x)
-            t[:] = mk
+            t = np.zeros_like(y)
+            t[...] = mk
         else:
             # determine slopes between breakpoints
             m = np.empty((x.size + 3, ) + y.shape[1:])

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -405,10 +405,10 @@ class Akima1DInterpolator(CubicHermiteSpline):
         .. versionadded:: 1.13.0
 
     extrapolate : {bool, None}, optional
-        If bool, determines whether to extrapolate to out-of-bounds points 
-        based on first and last intervals, or to return NaNs. If None, 
+        If bool, determines whether to extrapolate to out-of-bounds points
+        based on first and last intervals, or to return NaNs. If None,
         ``extrapolate`` is set to False.
-        
+
     Methods
     -------
     __call__
@@ -491,7 +491,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
     """
 
-    def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima", 
+    def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima",
                  extrapolate:bool | None = None):
         if method not in {"akima", "makima"}:
             raise NotImplementedError(f"`method`={method} is unsupported.")

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -906,6 +906,24 @@ class TestAkima1DInterpolator:
         yi[:, 1, 1] = 4. * yi_
         xp_assert_close(ak(xi), yi)
 
+    def test_linear_interpolant_edge_case(self):
+        # Reference - https://github.com/scipy/scipy/issues/22011
+        x = np.array([0.0, 1.0], dtype=float)
+        y = np.array([0.55, 0.55])
+        akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
+        xp_assert_close(akima(0.45), np.array(0.55))
+
+        x = np.array([0.0, 0.5, 1.0])
+        y = np.array([0.15, 0.67, 0.15])
+        akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
+        xp_assert_close(akima(0.45), np.array(0.6648))
+
+        x = np.array([0.0, 1.0])
+        y = np.array([0.55,  0.55])
+        akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
+        xp_assert_close(akima(0.45), np.array(0.55))
+
+
     def test_degenerate_case_multidimensional(self):
         # This test is for issue #5683.
         x = np.array([0, 1, 2])

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -923,6 +923,42 @@ class TestAkima1DInterpolator:
         akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
         xp_assert_close(akima(0.45), np.array(0.55))
 
+        # 2D case
+        x = np.array([0., 1.])
+        y = np.array([0., 1.])
+        y = np.column_stack((y, 2. * y, 3. * y, 4. * y))
+
+        ak = Akima1DInterpolator(x, y)
+        xi = np.array([0.5, 1.])
+        yi = np.array([[0.5, 1., 1.5, 2. ],
+                       [1., 2., 3., 4.]])
+        xp_assert_close(ak(xi), yi)
+
+        ak = Akima1DInterpolator(x, y.T, axis=1)
+        xp_assert_close(ak(xi), yi.T)
+
+        x = np.arange(0., 2.)
+        y_ = np.array([0., 1.])
+        y = np.empty((2, 2, 2))
+        y[:, 0, 0] = y_
+        y[:, 1, 0] = 2. * y_
+        y[:, 0, 1] = 3. * y_
+        y[:, 1, 1] = 4. * y_
+        ak = Akima1DInterpolator(x, y)
+        yi_ = np.array([0.5, 1.])
+        yi = np.empty((2, 2, 2))
+        yi[:, 0, 0] = yi_
+        yi[:, 1, 0] = 2. * yi_
+        yi[:, 0, 1] = 3. * yi_
+        yi[:, 1, 1] = 4. * yi_
+        xp_assert_close(ak(xi), yi)
+
+        ak = Akima1DInterpolator(x, y.transpose(1, 0, 2), axis=1)
+        xp_assert_close(ak(xi), yi.transpose(1, 0, 2))
+
+        ak = Akima1DInterpolator(x, y.transpose(2, 1, 0), axis=2)
+        xp_assert_close(ak(xi), yi.transpose(2, 1, 0))
+
 
     def test_degenerate_case_multidimensional(self):
         # This test is for issue #5683.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -906,24 +906,13 @@ class TestAkima1DInterpolator:
         yi[:, 1, 1] = 4. * yi_
         xp_assert_close(ak(xi), yi)
 
-    def test_linear_interpolant_edge_case(self):
-        # Reference - https://github.com/scipy/scipy/issues/22011
+    def test_linear_interpolant_edge_case_1d(self):
         x = np.array([0.0, 1.0], dtype=float)
-        y = np.array([0.55, 0.55])
+        y = np.array([0.5, 1.0])
         akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
-        xp_assert_close(akima(0.45), np.array(0.55))
+        xp_assert_close(akima(0.45), np.array(0.725))
 
-        x = np.array([0.0, 0.5, 1.0])
-        y = np.array([0.15, 0.67, 0.15])
-        akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
-        xp_assert_close(akima(0.45), np.array(0.6648))
-
-        x = np.array([0.0, 1.0])
-        y = np.array([0.55,  0.55])
-        akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
-        xp_assert_close(akima(0.45), np.array(0.55))
-
-        # 2D case
+    def test_linear_interpolant_edge_case_2d(self):
         x = np.array([0., 1.])
         y = np.array([0., 1.])
         y = np.column_stack((y, 2. * y, 3. * y, 4. * y))
@@ -937,6 +926,7 @@ class TestAkima1DInterpolator:
         ak = Akima1DInterpolator(x, y.T, axis=1)
         xp_assert_close(ak(xi), yi.T)
 
+    def test_linear_interpolant_edge_case_3d(self):
         x = np.arange(0., 2.)
         y_ = np.array([0., 1.])
         y = np.empty((2, 2, 2))
@@ -951,6 +941,7 @@ class TestAkima1DInterpolator:
         yi[:, 1, 0] = 2. * yi_
         yi[:, 0, 1] = 3. * yi_
         yi[:, 1, 1] = 4. * yi_
+        xi = yi_
         xp_assert_close(ak(xi), yi)
 
         ak = Akima1DInterpolator(x, y.transpose(1, 0, 2), axis=1)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -914,7 +914,6 @@ class TestAkima1DInterpolator:
 
     def test_linear_interpolant_edge_case_2d(self):
         x = np.array([0., 1.])
-        y = np.array([0., 1.])
         y = np.column_stack((x, 2. * x, 3. * x, 4. * x))
 
         ak = Akima1DInterpolator(x, y)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -915,7 +915,7 @@ class TestAkima1DInterpolator:
     def test_linear_interpolant_edge_case_2d(self):
         x = np.array([0., 1.])
         y = np.array([0., 1.])
-        y = np.column_stack((y, 2. * y, 3. * y, 4. * y))
+        y = np.column_stack((x, 2. * x, 3. * x, 4. * x))
 
         ak = Akima1DInterpolator(x, y)
         xi = np.array([0.5, 1.])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/22011

#### What does this implement/fix?
<!--Please explain your changes.-->

Does the fix as described in https://github.com/scipy/scipy/issues/22011#issuecomment-2525067847

cc: @ev-br 

#### Additional information
<!--Any additional information you think is important.-->
