### PR TITLE
BUG: sparse: better error message for unsupported dtypes

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -134,7 +134,7 @@ def getdtype(dtype, a=None, default=None):
 
     if newdtype not in supported_dtypes:
         supported_dtypes_fmt = ", ".join(t.__name__ for t in supported_dtypes)
-        raise ValueError(f"scipy.sparse does not support dtype {newdtype.name}. "
+        raise ValueError(f"scipy.sparse does not support dtype {newdtype}. "
                          f"The only supported types are: {supported_dtypes_fmt}.")
     return newdtype
 


### PR DESCRIPTION
Fixes #22258 

Big endian dtypes have name 'float32' and are not supported, so the error message says that "float32 is not supported" and then lists `float32` as a supported dtype.  That is confusing.

This PR changes the error message to print the dtype itself rather than `dtype.name`. This shows big endian as `>f4` instead of `float32` which is much more helpful for figuring out what the error actually is.

