### PR TITLE
WIP/MAINT: interpolate/BSpline: lock mutations of self.

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1,5 +1,6 @@
 import operator
 from math import prod
+import threading
 
 import numpy as np
 from scipy._lib._util import normalize_axis_index
@@ -16,6 +17,9 @@ from itertools import combinations
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
+
+
+_bspline_lock = threading.Lock()
 
 
 def _get_dtype(dtype):
@@ -538,9 +542,11 @@ class BSpline:
 
         """
         if not self.t.flags.c_contiguous:
-            self.t = self.t.copy()
+            with _bspline_lock:
+                self.t = self.t.copy()
         if not self.c.flags.c_contiguous:
-            self.c = self.c.copy()
+            with _bspline_lock:
+                self.c = self.c.copy()
 
     def derivative(self, nu=1):
         """Return a B-spline representing the derivative.

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -460,7 +460,6 @@ class TestBSpline:
         spl1 = BSpline(t, c[1], k)
         xp_assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
 
-    @pytest.mark.thread_unsafe
     def test_design_matrix_bc_types(self):
         '''
         Splines with different boundary conditions are built on different
@@ -635,7 +634,6 @@ class TestBSpline:
         b = BSpline(t=t, c=c, k=0)
         xp_assert_close(b(xx), np.ones_like(xx) * 3.0)
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to BSpline
         b = _make_random_spline()


### PR DESCRIPTION
Try adapting the BSpline code to work in the nogil context. 

Not knowning much about free-threading, I *assume* that 
- mutating attributes of `self` is not safe in the free-threaded context
- mutating attributes of `self` in `__init__(self, ...)` does not need manual locking though 
- a module-level `Lock` is enough and we do not need to carry a lock instance on each instance of a class
- python code which mutates function-scope python objects does not need manual locking