### PR TITLE
BUG: sparse.csgraph.floyd_warshall: do not set to infinity for masked array

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -329,9 +329,9 @@ def floyd_warshall(csgraph, directed=True,
     dist_matrix = validate_graph(csgraph, directed, DTYPE,
                                  csr_output=False,
                                  copy_if_dense=not overwrite)
-    if not issparse(csgraph):
-        # for dense array input, zero entries represent non-edge
-        dist_matrix[dist_matrix == 0] = INFINITY
+    if not (issparse(csgraph) or np.ma.isMaskedArray(csgraph)):
+         # for dense array input, zero entries represent non-edge
+         dist_matrix[dist_matrix == 0] = INFINITY
 
     if unweighted:
         dist_matrix[~np.isinf(dist_matrix)] = 1

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1671,7 +1671,7 @@ cdef void _yen(
             if (
                 total_distance != INFINITY
                 and _yen_is_path_in_candidates(candidate_predecessors,
-                                               shortest_paths_predecessors[k-1], 
+                                               shortest_paths_predecessors[k-1],
                                                predecessor_matrix,
                                                spur_node, sink) == 0
             ):

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -389,22 +389,21 @@ def test_masked_input():
     for method in methods:
         check(method)
 
+
 @pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
 def test_masked_invalid_input(method):
     # Reference - https://github.com/scipy/scipy/pull/22286
     csgraph = np.array(
         [[0, 1, 0],
-        [1, 0, 0],
-        [0, 0, 0]]
+         [1, 0, 0],
+         [0, 0, 0]]
     )
     csgraph_masked = np.ma.masked_invalid(csgraph)
-
     zeros = np.zeros((3, 3))
 
     SP = shortest_path(csgraph_masked, method=method, directed=True,
-                        overwrite=False)
+                       overwrite=False)
     assert_equal(SP, zeros)
-
 
 
 def test_overwrite():

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -386,6 +386,24 @@ def test_masked_input():
     for method in methods:
         check(method)
 
+def test_masked_invalid_input():
+    csgraph = np.array(
+        [[0, 1, 0],
+        [1, 0, 0],
+        [0, 0, 0]]
+    )
+    csgraph_masked = np.ma.masked_invalid(csgraph)
+
+    zeros = np.zeros((3, 3))
+
+    def check(method):
+        SP = shortest_path(csgraph_masked, method=method, directed=True,
+                           overwrite=False)
+        assert_array_equal(SP, zeros)
+
+    for method in methods:
+        check(method)
+
 
 def test_overwrite():
     G = np.array([[0, 3, 3, 1, 2],

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -386,7 +386,9 @@ def test_masked_input():
     for method in methods:
         check(method)
 
-def test_masked_invalid_input():
+@pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
+def test_masked_invalid_input(method):
+    # Reference - https://github.com/scipy/scipy/pull/22286
     csgraph = np.array(
         [[0, 1, 0],
         [1, 0, 0],
@@ -396,13 +398,10 @@ def test_masked_invalid_input():
 
     zeros = np.zeros((3, 3))
 
-    def check(method):
-        SP = shortest_path(csgraph_masked, method=method, directed=True,
-                           overwrite=False)
-        assert_array_equal(SP, zeros)
+    SP = shortest_path(csgraph_masked, method=method, directed=True,
+                        overwrite=False)
+    assert_array_equal(SP, zeros)
 
-    for method in methods:
-        check(method)
 
 
 def test_overwrite():

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,7 +1,10 @@
 from io import StringIO
 import warnings
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
+from numpy.testing import (assert_array_almost_equal,
+                           assert_array_equal,
+                           assert_allclose,
+                           assert_equal)
 from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix, yen,
@@ -400,7 +403,7 @@ def test_masked_invalid_input(method):
 
     SP = shortest_path(csgraph_masked, method=method, directed=True,
                         overwrite=False)
-    assert_array_equal(SP, zeros)
+    assert_equal(SP, zeros)
 
 
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -392,7 +392,7 @@ def test_masked_input():
 
 @pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
 def test_masked_invalid_input(method):
-    # Reference - https://github.com/scipy/scipy/pull/22286
+    # Reference - https://github.com/scipy/scipy/issues/12424
     csgraph = np.array(
         [[0, 1, 0],
          [1, 0, 0],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/12424

#### What does this implement/fix?
<!--Please explain your changes.-->

Simple fix - just added an extra condition in floyd warhsall algorithm. It avoids setting infinity for masked arrays as well. Then its output is exactly same as other algorithms.

#### Additional information
<!--Any additional information you think is important.-->
