### PR TITLE
ENH: Add __repr__ method to scipy.spatial.transform.Rotation

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3616,6 +3616,10 @@ cdef class Rotation:
         else:
             return cls.from_matrix(C), rssd
 
+    def __repr__(Rotation self):
+        q = np.asarray(self._quat).squeeze()
+        return f"Rotation({q!r})"
+
 class Slerp:
     """Spherical Linear Interpolation of Rotations.
 

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3617,8 +3617,7 @@ cdef class Rotation:
             return cls.from_matrix(C), rssd
 
     def __repr__(Rotation self):
-        q = np.asarray(self._quat).squeeze()
-        return f"Rotation({q!r})"
+        return f"Rotation.from_quat({self.as_quat()!r})"
 
 class Slerp:
     """Spherical Linear Interpolation of Rotations.

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3617,7 +3617,10 @@ cdef class Rotation:
             return cls.from_matrix(C), rssd
 
     def __repr__(Rotation self):
-        return f"Rotation.from_quat({self.as_quat()!r})"
+        m = f"{self.as_matrix()!r}".splitlines()
+        # bump indent (+21 characters)
+        m[1:] = [" " * 21 + m[i] for i in range(1, len(m))]
+        return "Rotation.from_matrix(" + "\n".join(m) + ")"
 
 class Slerp:
     """Spherical Linear Interpolation of Rotations.

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1524,6 +1524,22 @@ def test_align_vectors_primary_only():
         assert np.isclose(rssd, 0, atol=atol)
 
 
+def test_repr_single_rotation():
+    q = np.array([[0, 1, 0, 1]]) / np.sqrt(2)
+    actual = repr(Rotation.from_quat(q))
+    # drop whitespace for comparison
+    assert actual.replace(" ", "") == "Rotation(array([0.,0.70710678,0.,0.70710678]))"
+
+
+def test_repr_rotation_sequence():
+    q = np.array([[0, 1, 0, 1], [0, 0, 1, 1]]) / np.sqrt(2)
+    actual = f"{Rotation.from_quat(q)!r}"
+    # drop whitespace for comparison
+    expected = """Rotation(array([[0.,0.70710678,0.,0.70710678],
+                                  [0.,0.,0.70710678,0.70710678]]))""".replace(" ", "")
+    assert actual.replace(" ", "") == expected
+
+
 def test_slerp():
     rnd = np.random.RandomState(0)
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1527,17 +1527,25 @@ def test_align_vectors_primary_only():
 def test_repr_single_rotation():
     q = np.array([0, 0, 0, 1])
     actual = repr(Rotation.from_quat(q))
-    # drop whitespace for comparison
-    assert actual.replace(" ", "") == "Rotation.from_quat(array([0.,0.,0.,1.]))"
+    expected = """\
+Rotation.from_matrix(array([[1., 0., 0.],
+                            [0., 1., 0.],
+                            [0., 0., 1.]]))"""
+    assert actual == expected
 
 
 def test_repr_rotation_sequence():
     q = np.array([[0, 1, 0, 1], [0, 0, 1, 1]]) / np.sqrt(2)
     actual = f"{Rotation.from_quat(q)!r}"
-    # drop whitespace for comparison
-    expected = ("Rotation.from_quat(array([[0.,0.70710678,0.,0.70710678],\n" +
-                "[0.,0.,0.70710678,0.70710678]]))")
-    assert actual.replace(" ", "") == expected
+    expected = """\
+Rotation.from_matrix(array([[[ 0.,  0.,  1.],
+                             [ 0.,  1.,  0.],
+                             [-1.,  0.,  0.]],
+                     
+                            [[ 0., -1.,  0.],
+                             [ 1.,  0.,  0.],
+                             [ 0.,  0.,  1.]]]))"""
+    assert actual == expected
 
 
 def test_slerp():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1525,18 +1525,18 @@ def test_align_vectors_primary_only():
 
 
 def test_repr_single_rotation():
-    q = np.array([[0, 1, 0, 1]]) / np.sqrt(2)
+    q = np.array([0, 0, 0, 1])
     actual = repr(Rotation.from_quat(q))
     # drop whitespace for comparison
-    assert actual.replace(" ", "") == "Rotation(array([0.,0.70710678,0.,0.70710678]))"
+    assert actual.replace(" ", "") == "Rotation.from_quat(array([0.,0.,0.,1.]))"
 
 
 def test_repr_rotation_sequence():
     q = np.array([[0, 1, 0, 1], [0, 0, 1, 1]]) / np.sqrt(2)
     actual = f"{Rotation.from_quat(q)!r}"
     # drop whitespace for comparison
-    expected = """Rotation(array([[0.,0.70710678,0.,0.70710678],
-                                  [0.,0.,0.70710678,0.70710678]]))""".replace(" ", "")
+    expected = ("Rotation.from_quat(array([[0.,0.70710678,0.,0.70710678],\n" +
+                "[0.,0.,0.70710678,0.70710678]]))")
     assert actual.replace(" ", "") == expected
 
 


### PR DESCRIPTION
Very small & simple PR, but hopefully provides some QoL improvements to analysts/devs. 😄 

---

#### What does this implement/fix?

This PR implements the `__repr__` method for `Rotation` (in `scipy.spatial.transform`).

#### Additional information

The interactive console and debugger call `repr` to inspect objects. Without a custom `__repr__` implementation, we see something like this:

```python
>>> from scipy.spatial.transform import Rotation as R
>> R.from_quat([0, 1, 0, 1])
<scipy.spatial.transform._rotation.Rotation object at 0x000002281258FD20>
```

As a best practice, the string returned by `__repr__` should match the source code necessary to re-create the represented object. I implemented by falling back on Numpy's `array` representation, so now we have:

````python
>> R.from_quat([0, 1, 0, 1])
Rotation(array([0.        , 0.70710678, 0.        , 0.70710678]))

>> R.from_quat([[0, 1, 0, 1], [0, 0, 1, 1]])
Rotation(array([[0.        , 0.70710678, 0.        , 0.70710678],
        [0.        , 0.        , 0.70710678, 0.70710678]]))

# or, using f-strings:
>>> print(f"{R.from_quat([0, 1, 0, 1])!r}")
Rotation(array([0.        , 0.70710678, 0.        , 0.70710678]))
````

`__repr__` is also a fallback for `str` (`__str__`), so this works too:

```python
>>> print(R.from_quat([0, 1, 0, 1]))
Rotation(array([0.        , 0.70710678, 0.        , 0.70710678]))
````

---

I added a couple of tests and ran the tests + linter, so things should be good. 👍 