### PR TITLE
MAINT: backports for 1.15.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/cobyqa/cobyqa.git
 [submodule "scipy/_lib/array_api_extra"]
 	path = scipy/_lib/array_api_extra
-	url = https://github.com/lucascolley/array-api-extra.git
+	url = https://github.com/data-apis/array-api-extra.git
 # All submodules used as a Meson `subproject` are required to be under the
 # subprojects/ directory - see:
 # https://mesonbuild.com/Subprojects.html#why-must-all-subprojects-be-inside-a-single-directory

--- a/doc/source/release/1.15.1-notes.rst
+++ b/doc/source/release/1.15.1-notes.rst
@@ -5,19 +5,35 @@ SciPy 1.15.1 Release Notes
 .. contents::
 
 SciPy 1.15.1 is a bug-fix release with no new features
-compared to 1.15.0.
+compared to 1.15.0. Importantly, an issue with the
+import of `scipy.optimize` breaking other packages
+has been fixed.
 
 
 
 Authors
 =======
 * Name (commits)
+* Ralf Gommers (3)
+* Rohit Goswami (1)
+* Tyler Reddy (4)
+
+A total of 3 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.15.1
 ------------------------
 
+* `#22257 <https://github.com/scipy/scipy/issues/22257>`__: BUG: Importing scipy.optimize break highspy
 
 
 Pull requests for 1.15.1
 ------------------------
+
+* `#22235 <https://github.com/scipy/scipy/pull/22235>`__: REL, MAINT: prep for 1.15.1
+* `#22245 <https://github.com/scipy/scipy/pull/22245>`__: MAINT: fix url for array-api-extra git submodule
+* `#22270 <https://github.com/scipy/scipy/pull/22270>`__: BLD: fix some issues with undeclared internal build dependencies
+* `#22272 <https://github.com/scipy/scipy/pull/22272>`__: TST: fix thread safety issue in interpolate.bsplines memmap test
+* `#22292 <https://github.com/scipy/scipy/pull/22292>`__: MAINT: Update highs subproject commit

--- a/doc/source/release/1.15.1-notes.rst
+++ b/doc/source/release/1.15.1-notes.rst
@@ -16,9 +16,11 @@ Authors
 * Name (commits)
 * Ralf Gommers (3)
 * Rohit Goswami (1)
-* Tyler Reddy (4)
+* Matt Haberland (2)
+* Tyler Reddy (7)
+* Daniel Schmitz (1)
 
-A total of 3 people contributed to this release.
+A total of 5 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -27,6 +29,7 @@ Issues closed for 1.15.1
 ------------------------
 
 * `#22257 <https://github.com/scipy/scipy/issues/22257>`__: BUG: Importing scipy.optimize break highspy
+* `#22297 <https://github.com/scipy/scipy/issues/22297>`__: TST: TestDistributions.test_funcs[logcdf-methods10-x-Normal]...
 
 
 Pull requests for 1.15.1
@@ -36,4 +39,5 @@ Pull requests for 1.15.1
 * `#22245 <https://github.com/scipy/scipy/pull/22245>`__: MAINT: fix url for array-api-extra git submodule
 * `#22270 <https://github.com/scipy/scipy/pull/22270>`__: BLD: fix some issues with undeclared internal build dependencies
 * `#22272 <https://github.com/scipy/scipy/pull/22272>`__: TST: fix thread safety issue in interpolate.bsplines memmap test
+* `#22276 <https://github.com/scipy/scipy/pull/22276>`__: TST: stats.Normal: bump tolerance on test of logcdf
 * `#22292 <https://github.com/scipy/scipy/pull/22292>`__: MAINT: Update highs subproject commit

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2,6 +2,7 @@ import os
 import operator
 import itertools
 import math
+import threading
 
 import numpy as np
 from numpy.testing import suppress_warnings
@@ -658,11 +659,12 @@ class TestBSpline:
 
         expected = b(xx)
 
-        t_mm = np.memmap(
-            str(tmpdir.join('t.dat')), mode='w+', dtype=b.t.dtype, shape=b.t.shape)
+        tid = threading.get_native_id()
+        t_mm = np.memmap(str(tmpdir.join(f't{tid}.dat')), mode='w+',
+                         dtype=b.t.dtype, shape=b.t.shape)
         t_mm[:] = b.t
-        c_mm = np.memmap(
-            str(tmpdir.join('c.dat')), mode='w+', dtype=b.c.dtype, shape=b.c.shape)
+        c_mm = np.memmap(str(tmpdir.join(f'c{tid}.dat')), mode='w+',
+                         dtype=b.c.dtype, shape=b.c.shape)
         c_mm[:] = b.c
         b.t = t_mm
         b.c = c_mm

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -28,6 +28,7 @@ cython_linalg = custom_target('cython_linalg',
   install_tag: 'devel'
 )
 cython_blas_pxd = cython_linalg[2]
+cython_lapack_pxd = cython_linalg[3]
 
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
 linalg_init_cython_gen = generator(cython,
@@ -39,7 +40,7 @@ linalg_init_cython_gen = generator(cython,
 linalg_init_utils_cython_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, __init__py, _cy_array_utils_pxd])
+  depends : [_cython_tree, __init__py, _cy_array_utils_pxd, cython_lapack_pxd])
 
 # pyx -> c, pyx -> cpp generators, depending on copied pxd files and init
 linalg_cython_gen = generator(cython,
@@ -104,7 +105,7 @@ py3.extension_module('_flapack',
 
 # _decomp_interpolative
 py3.extension_module('_decomp_interpolative',
-  linalg_init_cython_gen.process('_decomp_interpolative.pyx'),
+  linalg_cython_gen.process('_decomp_interpolative.pyx'),
   c_args: cython_c_args,
   dependencies: np_dep,
   link_args: version_link_args,

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -8,7 +8,7 @@ _spatial_pxd = [
 spt_cython_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, _spatial_pxd, _lib_pxd])
+  depends : [_cython_tree, _spatial_pxd, _lib_pxd, cython_lapack_pxd])
 
 qhull_src = [
   'qhull_src/src/geom2_r.c',

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -426,6 +426,8 @@ def check_dist_func(dist, fname, arg, result_shape, methods):
         # can only expect about half of machine precision for optimization
         # because math
         tol_override = {'atol': 1e-6}
+    elif fname in {'logcdf'}:  # gh-22276
+        tol_override = {'rtol': 2e-7}
 
     if dist._overrides(f'_{fname}_formula'):
         methods.add('formula')


### PR DESCRIPTION
A fairly serious bug (gh-22257) was discovered and patched, warranting a prompt release of `1.15.1`.

Backports included so far:

1. gh-22245
2. gh-22270
3. gh-22272
4. gh-22292
5. gh-22276

TODO:

- [x] regular CI green
- [ ] wheels CI green as precaution before starting release proper (could skip maybe, backport count is small-ish)

- I had a few doc build warnings locally, but we have an issue open for that and it is "ok" in the release env usually I think.
- Locally, `TestCurveFit.test_curvefit_omitnan` had a small tolerance issue; `test_quad_vec_pool` failed because it took too long; I'll probably ignore both if CI is happy though