### PR TITLE
ENH: linalg.sqrtm: add structure detection and `assume_a` argument

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -201,12 +201,11 @@ def sqrtm(A, disp=True, blocksize=64, *, assume_a='general'):
         X.fill(np.nan)
     else:
         if assume_a == "general":
-            ZH = np.conjugate(Z).T
-            X = Z.dot(R).dot(ZH)
+            X = Z @ R @ Z.conj().T
         elif assume_a == "upper triangular":
-            X = Z
+            X = R
         elif assume_a == "lower triangular":
-            X = Z.T
+            X = R.T
         dtype = np.result_type(A.dtype, 1j if np.iscomplexobj(X) else 1)
         X = X.astype(dtype, copy=False) 
 

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -183,14 +183,16 @@ def sqrtm(A, disp=True, blocksize=64):
     failflag = False
     try:
         R = _sqrtm_triu(T, blocksize=blocksize)
-        ZH = np.conjugate(Z).T
-        X = Z.dot(R).dot(ZH)
-        dtype = np.result_type(A.dtype, 1j if np.iscomplexobj(X) else 1)
-        X = X.astype(dtype, copy=False)
     except SqrtmError:
         failflag = True
         X = np.empty_like(A)
         X.fill(np.nan)
+    else:
+        ZH = np.conjugate(Z).T
+        X = Z.dot(R).dot(ZH)
+        dtype = np.result_type(A.dtype, 1j if np.iscomplexobj(X) else 1)
+        X = X.astype(dtype, copy=False)
+
 
     if disp:
         if failflag:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -523,18 +523,23 @@ class TestSqrtM:
         with pytest.raises(ValueError, match="Invalid"):
             sqrtm(np.eye(2), assume_a="cheese")
 
-    @pytest.mark.parametrize('assume_a', ['upper triangular', 'lower triangular'])
+    @pytest.mark.parametrize('mat_type', ['general', 'upper triangular', 
+                                          'lower triangular'])
+    @pytest.mark.parametrize('detect_structure', [True, False])
     @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-    def test_assume_a(self, assume_a, dtype):
+    def test_assume_a(self, mat_type, detect_structure, dtype):
+        if mat_type == "general" and not detect_structure:
+            pytest.skip("`res` and `ref` function calls are identical.")
         rng = np.random.default_rng(74667588384801)
         n = 20
         A = rng.random((n, n)) + rng.random((n, n))*1j
         if np.issubdtype(dtype, np.floating):
             A = A.real
         A = A.astype(dtype)
-        A = np.triu(A) if assume_a == "upper triangular" else np.tril(A)
+        A = np.triu(A) if mat_type == "upper triangular" else np.tril(A)
+        assume_a = None if detect_structure else mat_type
         res = sqrtm(A, assume_a=assume_a)
-        ref = sqrtm(A)
+        ref = sqrtm(A, assume_a='general')
         assert_allclose(ref, res)
 
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -523,6 +523,20 @@ class TestSqrtM:
         with pytest.raises(ValueError, match="Invalid"):
             sqrtm(np.eye(2), assume_a="cheese")
 
+    @pytest.mark.parametrize('assume_a', ['upper triangular', 'lower triangular'])
+    @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+    def test_assume_a(self, assume_a, dtype):
+        rng = np.random.default_rng(74667588384801)
+        n = 20
+        A = rng.random((n, n)) + rng.random((n, n))*1j
+        if np.issubdtype(dtype, np.floating):
+            A = A.real
+        A = A.astype(dtype)
+        A = np.triu(A) if assume_a == "upper triangular" else np.tril(A)
+        res = sqrtm(A, assume_a=assume_a)
+        ref = sqrtm(A)
+        assert_allclose(ref, res)
+
 
 class TestFractionalMatrixPower:
     def test_round_trip_random_complex(self):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -518,6 +518,10 @@ class TestSqrtM:
 
         assert s.shape == (0, 0)
         assert s.dtype == s0.dtype
+    
+    def test_bad_assume_a(self):
+        with pytest.raises(ValueError, match="Invalid"):
+            sqrtm(np.eye(2), assume_a="cheese")
 
 
 class TestFractionalMatrixPower:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #12994
#### What does this implement/fix?
<!--Please explain your changes.-->
In #12994 it was requested that we expose the private function `_sqrtm_triu`. As pointed out by @ilayn, we probably don't want to expose _another_ function to the public API. Instead, this pr does two things:

1. Adds an `assume_a` argument so the user can specify the matrix structure 
2. If no structure is provided then it is automatically determined

This is useful as if the matrix is upper or lower triangular it avoids unnecessarily computing the schur decomposition.

#### Additional information
<!--Any additional information you think is important.-->
