### PR TITLE
TST: replace `pytest.xfail` with `skip/xfail_xp_backends`

### DIFF
--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import suppress_warnings
 
 from scipy._lib._array_api import (
-    is_jax,
     is_torch,
     array_namespace,
     xp_assert_equal,
@@ -22,6 +21,7 @@ import scipy.ndimage as ndimage
 from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 IS_WINDOWS_AND_NP1 = os.name == 'nt' and np.__version__ < '2'
@@ -364,10 +364,8 @@ def test_label_output_dtype(xp):
         assert output.dtype == t
 
 
+@skip_xp_backends("jax.numpy", reason="JAX does not raise")
 def test_label_output_wrong_size(xp):
-    if is_jax(xp):
-        pytest.xfail("JAX does not raise")
-
     data = xp.ones([5])
     for t in types:
         dtype = getattr(xp, t)
@@ -1136,11 +1134,9 @@ def test_maximum_position06(xp):
         assert output[1] == (1, 1)
 
 
+@xfail_xp_backends("torch", reason="output[1] is wrong on pytorch")
 def test_maximum_position07(xp):
     # Test float labels
-    if is_torch(xp):
-        pytest.xfail("output[1] is wrong on pytorch")
-
     labels = xp.asarray([1.0, 2.5, 0.0, 4.5])
     for type in types:
         dtype = getattr(xp, type)

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -272,12 +272,12 @@ class TestDifferentialEntropy:
         'vasicek',
         'van es',
         pytest.param(
-    'ebrahimi',
+            'ebrahimi',
             marks=skip_xp_backends("jax.numpy",
                                    reason="JAX doesn't support item assignment")
         ),
         pytest.param(
-    'correa',
+            'correa',
             marks=skip_xp_backends("array_api_strict",
                                    reason="Needs fancy indexing.")
         )

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -230,12 +230,12 @@ class TestDifferentialEntropy:
         'vasicek',
         'van es',
         pytest.param(
-    'ebrahimi',
+            'ebrahimi',
             marks=skip_xp_backends("jax.numpy",
                                    reason="JAX doesn't support item assignment")
         ),
         pytest.param(
-    'correa',
+            'correa',
             marks=skip_xp_backends("array_api_strict",
                                    reason="Needs fancy indexing.")
         )

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -6,9 +6,11 @@ import numpy as np
 
 from scipy import stats
 from scipy.stats import norm, expon  # type: ignore[attr-defined]
-from scipy._lib._array_api import array_namespace, is_array_api_strict, is_jax
+from scipy._lib._array_api import array_namespace
 from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
                                          xp_assert_less)
+
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 class TestEntropy:
     def test_entropy_positive(self, xp):
@@ -224,13 +226,21 @@ class TestDifferentialEntropy:
         with pytest.raises(ValueError, match=message):
             stats.differential_entropy(x, method='ekki-ekki')
 
-    @pytest.mark.parametrize('method', ['vasicek', 'van es',
-                                        'ebrahimi', 'correa'])
+    @pytest.mark.parametrize('method', [
+        'vasicek',
+        'van es',
+        pytest.param(
+    'ebrahimi',
+            marks=skip_xp_backends("jax.numpy",
+                                   reason="JAX doesn't support item assignment")
+        ),
+        pytest.param(
+    'correa',
+            marks=skip_xp_backends("array_api_strict",
+                                   reason="Needs fancy indexing.")
+        )
+    ])
     def test_consistency(self, method, xp):
-        if is_jax(xp) and method == 'ebrahimi':
-            pytest.xfail("Needs array assignment.")
-        elif is_array_api_strict(xp) and method == 'correa':
-            pytest.xfail("Needs fancy indexing.")
         # test that method is a consistent estimator
         n = 10000 if method == 'correa' else 1000000
         rvs = stats.norm.rvs(size=n, random_state=0)
@@ -258,17 +268,25 @@ class TestDifferentialEntropy:
     rmse_std_cases = {norm: norm_rmse_std_cases,
                       expon: expon_rmse_std_cases}
 
-    @pytest.mark.parametrize('method', ['vasicek', 'van es', 'ebrahimi', 'correa'])
+    @pytest.mark.parametrize('method', [
+        'vasicek',
+        'van es',
+        pytest.param(
+    'ebrahimi',
+            marks=skip_xp_backends("jax.numpy",
+                                   reason="JAX doesn't support item assignment")
+        ),
+        pytest.param(
+    'correa',
+            marks=skip_xp_backends("array_api_strict",
+                                   reason="Needs fancy indexing.")
+        )
+    ])
     @pytest.mark.parametrize('dist', [norm, expon])
     def test_rmse_std(self, method, dist, xp):
         # test that RMSE and standard deviation of estimators matches values
         # given in differential_entropy reference [6]. Incidentally, also
         # tests vectorization.
-        if is_jax(xp) and method == 'ebrahimi':
-            pytest.xfail("Needs array assignment.")
-        elif is_array_api_strict(xp) and method == 'correa':
-            pytest.xfail("Needs fancy indexing.")
-
         reps, n, m = 10000, 50, 7
         expected = self.rmse_std_cases[dist][method]
         rmse_expected, std_expected = xp.asarray(expected[0]), xp.asarray(expected[1])
@@ -282,12 +300,15 @@ class TestDifferentialEntropy:
         xp_test = array_namespace(res)
         xp_assert_close(xp_test.std(res, correction=0), std_expected, atol=0.002)
 
-    @pytest.mark.parametrize('n, method', [(8, 'van es'),
-                                           (12, 'ebrahimi'),
-                                           (1001, 'vasicek')])
+    @pytest.mark.parametrize('n, method', [
+        (8, 'van es'),
+        pytest.param(
+            12, 'ebrahimi',
+            marks=skip_xp_backends("jax.numpy", reason="Needs array assignment")
+        ),
+        (1001, 'vasicek')
+    ])
     def test_method_auto(self, n, method, xp):
-        if is_jax(xp) and method == 'ebrahimi':
-            pytest.xfail("Needs array assignment.")
         rvs = stats.norm.rvs(size=(n,), random_state=0)
         rvs = xp.asarray(rvs.tolist())
         res1 = stats.differential_entropy(rvs)
@@ -296,14 +317,20 @@ class TestDifferentialEntropy:
 
     @pytest.mark.skip_xp_backends('jax.numpy',
                                   reason="JAX doesn't support item assignment")
-    @pytest.mark.parametrize('method', ["vasicek", "van es", "correa", "ebrahimi"])
+    @pytest.mark.parametrize('method', [
+        "vasicek",
+        "van es",
+        pytest.param(
+            "correa",
+            marks=skip_xp_backends("array_api_strict", reason="Needs fancy indexing.")
+        ),
+        "ebrahimi"
+    ])
     @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
     def test_dtypes_gh21192(self, xp, method, dtype):
         # gh-21192 noted a change in the output of method='ebrahimi'
         # with integer input. Check that the output is consistent regardless
         # of input dtype.
-        if is_array_api_strict(xp) and method == 'correa':
-            pytest.xfail("Needs fancy indexing.")
         x = [1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11]
         dtype_in = getattr(xp, str(dtype), None)
         dtype_out = getattr(xp, str(dtype), xp.asarray(1.).dtype)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
