### PR TITLE
ENH: io: add invalid field name warning for `savemat`

### DIFF
--- a/scipy/io/matlab/__init__.py
+++ b/scipy/io/matlab/__init__.py
@@ -14,6 +14,7 @@ and writing MATLAB files.
    MatReadError - Exception indicating a read issue
    MatReadWarning - Warning class for read issues
    MatWriteError - Exception indicating a write issue
+   MatWriteWarning - Warning class for read issues
    mat_struct - Class used when ``struct_as_record=False``
    varmats_from_mat - Pull variables out of mat 5 file as a sequence of mat file objects
 
@@ -47,7 +48,7 @@ from ._mio import loadmat, savemat, whosmat
 from ._mio5 import MatlabFunction, varmats_from_mat
 from ._mio5_params import MatlabObject, MatlabOpaque, mat_struct
 from ._miobase import (matfile_version, MatReadError, MatReadWarning,
-                      MatWriteError)
+                      MatWriteError, MatWriteWarning)
 
 # Deprecated namespaces, to be removed in v2.0.0
 from .import (mio, mio5, mio5_params, mio4, byteordercodes,
@@ -56,7 +57,8 @@ from .import (mio, mio5, mio5_params, mio4, byteordercodes,
 __all__ = [
     'loadmat', 'savemat', 'whosmat', 'MatlabObject',
     'matfile_version', 'MatReadError', 'MatReadWarning',
-    'MatWriteError', 'mat_struct', 'MatlabOpaque', 'MatlabFunction', 'varmats_from_mat',
+    'MatWriteError', 'MatWriteWarning', 'mat_struct', 'MatlabOpaque',
+    'MatlabFunction', 'varmats_from_mat',
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/io/matlab/__init__.py
+++ b/scipy/io/matlab/__init__.py
@@ -14,7 +14,7 @@ and writing MATLAB files.
    MatReadError - Exception indicating a read issue
    MatReadWarning - Warning class for read issues
    MatWriteError - Exception indicating a write issue
-   MatWriteWarning - Warning class for read issues
+   MatWriteWarning - Warning class for write issues
    mat_struct - Class used when ``struct_as_record=False``
    varmats_from_mat - Pull variables out of mat 5 file as a sequence of mat file objects
 

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -267,7 +267,10 @@ def savemat(file_name, mdict,
         True``).
         Can also pass open file_like object.
     mdict : dict
-        Dictionary from which to save matfile variables.
+        Dictionary from which to save matfile variables. Note that this dict
+        has a key starting with `_` or sub dict has a key starting with `_`
+        or a digit, these key's items will not be saved in the mat file and
+        `MatWriteWarning` will be issued.
     appendmat : bool, optional
         True (the default) to append the .mat extension to the end of the
         given filename, if not already present.

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -267,8 +267,8 @@ def savemat(file_name, mdict,
         True``).
         Can also pass open file_like object.
     mdict : dict
-        Dictionary from which to save matfile variables. Note that this dict
-        has a key starting with `_` or sub dict has a key starting with `_`
+        Dictionary from which to save matfile variables. Note that if this dict
+        has a key starting with ``_`` or a sub-dict has a key starting with ``_``
         or a digit, these key's items will not be saved in the mat file and
         `MatWriteWarning` will be issued.
     appendmat : bool, optional

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -882,7 +882,8 @@ class MatFile5Writer:
         self._matrix_writer = VarWriter5(self)
         for name, var in mdict.items():
             if name[0] == '_':
-                msg = f"Starting field name with a underscore ({name}) is ignored"
+                msg = (f"Starting field name with a "
+                       f"underscore ({name}) is ignored")
                 warnings.warn(msg, MatWriteWarning, stacklevel=2)
                 continue
             is_global = name in self.global_vars

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -87,7 +87,7 @@ from ._byteordercodes import native_code, swapped_code
 
 from ._miobase import (MatFileReader, docfiller, matdims, read_dtype,
                       arr_to_chars, arr_dtype_number, MatWriteError,
-                      MatReadError, MatReadWarning)
+                      MatReadError, MatReadWarning, MatWriteWarning)
 
 # Reader object for matlab 5 format variables
 from ._mio5_utils import VarReader5
@@ -482,10 +482,13 @@ def to_writeable(source):
         dtype = []
         values = []
         for field, value in source.items():
-            if (isinstance(field, str) and
-                    field[0] not in '_0123456789'):
-                dtype.append((str(field), object))
-                values.append(value)
+            if isinstance(field, str):
+                if field[0] not in '_0123456789':
+                    dtype.append((str(field), object))
+                    values.append(value)
+                else:
+                    msg = f"Starting field name with a underscore or a digit ({field}) is ignored"
+                    warnings.warn(msg, MatWriteWarning, stacklevel=2)
         if dtype:
             return np.array([tuple(values)], dtype)
         else:
@@ -879,6 +882,8 @@ class MatFile5Writer:
         self._matrix_writer = VarWriter5(self)
         for name, var in mdict.items():
             if name[0] == '_':
+                msg = f"Starting field name with a underscore ({name}) is ignored"
+                warnings.warn(msg, MatWriteWarning, stacklevel=2)
                 continue
             is_global = name in self.global_vars
             if self.do_compression:

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -487,7 +487,8 @@ def to_writeable(source):
                     dtype.append((str(field), object))
                     values.append(value)
                 else:
-                    msg = f"Starting field name with a underscore or a digit ({field}) is ignored"
+                    msg = (f"Starting field name with a underscore "
+                           f"or a digit ({field}) is ignored")
                     warnings.warn(msg, MatWriteWarning, stacklevel=2)
         if dtype:
             return np.array([tuple(values)], dtype)

--- a/scipy/io/matlab/_miobase.py
+++ b/scipy/io/matlab/_miobase.py
@@ -14,7 +14,7 @@ from scipy._lib import doccer
 from . import _byteordercodes as boc
 
 __all__ = [
-    'MatReadError', 'MatReadWarning', 'MatWriteError',
+    'MatReadError', 'MatReadWarning', 'MatWriteError', 'MatWriteWarning',
 ]
 
 class MatReadError(Exception):
@@ -27,6 +27,9 @@ class MatWriteError(Exception):
 
 class MatReadWarning(UserWarning):
     """Warning class for read issues."""
+
+class MatWriteWarning(UserWarning):
+    """Warning class for write issues."""
 
 
 doc_dict = \

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -715,12 +715,12 @@ def test_to_writeable():
     assert_any_equal(to_writeable({'a':1,'b':2}), alternatives)
     # Fields with underscores discarded with a warning message.
     with pytest.warns(MatWriteWarning, match='Starting field name with'):
-        assert_any_equal(to_writeable({'a':1,'b':2, '_c':3}), alternatives)
+        assert_any_equal(to_writeable({'a':1, 'b':2, '_c':3}), alternatives)
     # Not-string fields discarded
     assert_any_equal(to_writeable({'a':1,'b':2, 100:3}), alternatives)
     # String fields that are valid Python identifiers discarded
     with pytest.warns(MatWriteWarning, match='Starting field name with'):
-        assert_any_equal(to_writeable({'a':1,'b':2, '99':3}), alternatives)
+        assert_any_equal(to_writeable({'a':1, 'b':2, '99':3}), alternatives)
     # Object with field names is equivalent
 
     class klass:
@@ -1374,8 +1374,7 @@ def test_invalid_field_name_warning():
         ('mystr', mlarr('a string')))
     check_mat_write_warning(names_vars)
 
-    names_vars = (
-        ('mymap', {"a": 1, "_b": 2}),)
+    names_vars = (('mymap', {"a": 1, "_b": 2}),)
     check_mat_write_warning(names_vars)
 
     names_vars = (('mymap', {"a": 1, "1a": 2}),)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #5435, #6052, #16203

#### What does this implement/fix?
<!--Please explain your changes.-->
As repeatedly reported in the above issues, the current [savemat](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.savemat.html) function ignores elements 
1. where the top-level keys start with an underscore 
or
2. where sub-dictionary keys start with an underscore or a number when saving to a .mat file. 

However, since these elements are ignored without any logs, many users seem to be confused.

To address this, as suggested in #5435, I have made it so that a warning log is output when such invalid field names are ignored. 
Additionally, while there was a [MatReadWarning](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.matlab.MatReadWarning.html#scipy.io.matlab.MatReadWarning), there was no `MatWriteWarning`, so I have newly defined it. 
And I updated the savemat function’s docstring to explain this behavior.
I have also made modifications to existing unit tests where warnings are issued and added new unit tests.

#### Additional information
<!--Any additional information you think is important.-->
