### PR TITLE
ENH: sparse.csgraph.yen: performance improvements

### DIFF
--- a/benchmarks/benchmarks/sparse_csgraph_yen.py
+++ b/benchmarks/benchmarks/sparse_csgraph_yen.py
@@ -1,0 +1,38 @@
+"""benchmarks for the scipy.sparse.csgraph module"""
+import numpy as np
+import scipy.sparse
+
+from .common import Benchmark, safe_import
+
+with safe_import():
+    from scipy.sparse.csgraph import yen
+
+
+class Yen(Benchmark):
+    params = [
+        [30, 300, 3000],
+        [10, 100, 300],
+    ]
+    param_names = ['n', 'K']
+
+    def setup(self, n, K):
+        # make a random connectivity matrix
+        data = scipy.sparse.rand(
+            n, n, density=0.4, format='lil', random_state=42, dtype=np.bool_
+        )
+        data.setdiag(np.zeros(n, dtype=np.bool_))
+        self.data = data
+        self.source = np.random.randint(n)
+        sink = np.random.randint(n)
+        while self.source == sink:
+            sink = np.random.randint(n)
+        self.sink = sink
+
+    def time_yen(self, n, K):
+        yen(
+            csgraph=self.data,
+            source=self.source,
+            sink=self.sink,
+            K=K,
+            directed=False,
+        )

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -445,6 +445,23 @@ def test_yen_directed():
     assert_allclose(predecessors, directed_2SP_0_to_3)
 
 
+def test_yen_dense():
+    dense_undirected_G = np.array([
+                       [0, 3, 3, 1, 2],
+                       [3, 0, 7, 6, 5],
+                       [3, 7, 0, 4, 0],
+                       [1, 6, 4, 0, 2],
+                       [2, 5, 0, 2, 0]], dtype=float)
+    distances = yen(
+                dense_undirected_G,
+                source=0,
+                sink=4,
+                K=5,
+                directed=False,
+            )
+    assert_allclose(distances, [2., 3., 8., 9., 11.])
+
+
 def test_yen_undirected():
     distances = yen(
         undirected_G,


### PR DESCRIPTION
#### Reference issue
Closes [gh-20366.](https://github.com/scipy/scipy/issues/20366)

#### What does this implement?
1. Introduce a benchmark for Yen's algorithm, allowing measuring performance improvement of following commits.
2. Create a dedicated class to manage the container of found paths.
3. Introduce [Lawler's modification](https://en.wikipedia.org/wiki/Yen%27s_algorithm#Lawler's_modification) to Yen's algorithm.

#### Additional information
We use a **sorted vector** of varying size to store the found paths. This container allows:
1. Access to the minimal and maximal distances in the container in O(1).
2. Insertion in O(K).
3. Controlled size - this is an important performance factor because when the graphs are large- plenty of possible paths are found. Data structures that don't allow controlling size (e.g., `priority_queue`) tend to be huge, and managing them such data structures impacts performance significantly.

After trying multiple possible containers, this one gives the best performance/complexity trade-off balance.
Remember that managing this container is a fraction of the Yen's algorithm total run-time.

#### Performance comparison

Adding the managed sorted vector container for found paths does not noticeably impact performance.
```
python dev.py bench -t sparse_csgraph_yen.Yen --compare b36655bc0 --compare 83d3beb2c
...
(Sorted vector)
             --                      K                  
             ------ ------------------------------------
               n        10         100          300     
             ====== ========== ============ ============
               30    411±20μs   2.41±0.2ms    8.11±2ms  
              300    6.15±1ms    56.8±3ms     225±20ms  
              3000   541±40ms   4.18±0.2s    12.6±0.01s 
             ====== ========== ============ ============

...
(Benchmark over main)
              --                      K                  
              ------ ------------------------------------
                n        10         100          300     
              ====== ========== ============ ============
                30    396±30μs   2.61±0.2ms   9.33±0.3ms 
               300    6.30±1ms   52.6±10ms     183±10ms  
               3000   608±40ms   4.26±0.05s   11.4±0.2s  
              ====== ========== ============ ============
BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```

However, Lawler's modification does improve performance significantly
```
python dev.py bench -t sparse_csgraph_yen.Yen --compare acc857e24 --compare b36655bc0
...
(Lawler's modification)
             --                       K                   
             ------ --------------------------------------
               n         10          100          300     
             ====== ============ ============ ============
               30     431±90μs    1.86±0.2ms   4.16±0.1ms 
              300    4.55±0.6ms    43.1±9ms     164±50ms  
              3000   457±100ms    3.62±0.3s    10.3±0.2s  
             ====== ============ ============ ============

...
(Sorted vector)
              --                       K                   
              ------ --------------------------------------
                n         10          100          300     
              ====== ============ ============ ============
                30     464±50μs    3.19±0.3ms   8.46±0.5ms 
               300    5.76±0.5ms    52.3±5ms     208±10ms  
               3000    593±40ms    4.87±0.07s    18.6±2s   
              ====== ============ ============ ============

| Change   | Before [b36655bc0] <sery/enh_yen~1>   | After [acc857e24 ] <sery/enh_yen>   |   Ratio | Benchmark (Parameter)                    |
|----------|--------------------------------------|-----------------------------------|---------|------------------------------------------|
| -        | 3.19±0.3ms                           | 1.86±0.2ms                        |    0.58 | sparse_csgraph_yen.Yen.time_yen(30, 100) |
| -        | 8.46±0.5ms                           | 4.16±0.1ms                        |    0.49 | sparse_csgraph_yen.Yen.time_yen(30, 300) |

``` 
