### PR TITLE
DOC: Add time complexities of csgraph algorithms

### DIFF
--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -112,7 +112,7 @@ def laplacian(
     The normalization is symmetric, making the normalized Laplacian also
     symmetric if the input csgraph was symmetric.
 
-    The algorithmic complexity is for a graph with V
+    The algorithmic complexity is for a graph with ``V``
     vertices is ``O(V^2)``.
 
     References

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -112,6 +112,9 @@ def laplacian(
     The normalization is symmetric, making the normalized Laplacian also
     symmetric if the input csgraph was symmetric.
 
+    The algorithmic complexity is for a graph with V
+    vertices is O(V^2).
+
     References
     ----------
     .. [1] Laplacian matrix. https://en.wikipedia.org/wiki/Laplacian_matrix

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -113,7 +113,7 @@ def laplacian(
     symmetric if the input csgraph was symmetric.
 
     The algorithmic complexity is for a graph with V
-    vertices is O(V^2).
+    vertices is ``O(V^2)``.
 
     References
     ----------

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -359,7 +359,7 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The time complexity of this algorithm is ``O(V^3)``, where V is the number of
+    The time complexity of this algorithm is ``O(V^3)``, where ``V`` is the number of
     vertices in the input graph.
 
     References

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -359,6 +359,9 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
+    The time complexity of this algorithm is O(V^3), where V is the number of
+    vertices in the input graph.
+
     References
     ----------
     .. [1] Richard Manning Karp:

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -359,7 +359,7 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The time complexity of this algorithm is O(V^3), where V is the number of
+    The time complexity of this algorithm is ``O(V^3)``, where V is the number of
     vertices in the input graph.
 
     References

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -58,8 +58,8 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is ``O(E*logV)``.
+    Algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(E*logV)``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -58,6 +58,9 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
+    Algorithmic complexity for a graph with V number of vertices and E number of
+    edges is O(E*logV).
+
     Examples
     --------
     The following example shows the computation of a minimum spanning tree

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -59,7 +59,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     Python version.
 
     Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is O(E*logV).
+    edges is ``O(E*logV)``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -16,15 +16,15 @@ include 'parameters.pxi'
 def reverse_cuthill_mckee(graph, symmetric_mode=False):
     """
     reverse_cuthill_mckee(graph, symmetric_mode=False)
-    
+
     Returns the permutation array that orders a sparse CSR or CSC matrix
-    in Reverse-Cuthill McKee ordering.  
-    
-    It is assumed by default, ``symmetric_mode=False``, that the input matrix 
-    is not symmetric and works on the matrix ``A+A.T``. If you are 
-    guaranteed that the matrix is symmetric in structure (values of matrix 
+    in Reverse-Cuthill McKee ordering.
+
+    It is assumed by default, ``symmetric_mode=False``, that the input matrix
+    is not symmetric and works on the matrix ``A+A.T``. If you are
+    guaranteed that the matrix is symmetric in structure (values of matrix
     elements do not matter) then set ``symmetric_mode=True``.
-    
+
     Parameters
     ----------
     graph : sparse array or matrix
@@ -36,7 +36,7 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
     -------
     perm : ndarray
         Array of permuted row and column indices.
- 
+
     Notes
     -----
     .. versionadded:: 0.15.0
@@ -70,7 +70,7 @@ def reverse_cuthill_mckee(graph, symmetric_mode=False):
 
     >>> reverse_cuthill_mckee(graph)
     array([3, 2, 1, 0], dtype=int32)
-    
+
     """
     graph = convert_pydata_sparse_to_scipy(graph)
     if not issparse(graph):
@@ -93,7 +93,7 @@ cdef _node_degrees(
     """
     cdef np.npy_intp ii, jj
     cdef np.ndarray[int32_or_int64] degree = np.zeros(num_rows, dtype=ind.dtype)
-    
+
     for ii in range(num_rows):
         degree[ii] = ptr[ii + 1] - ptr[ii]
         for jj in range(ptr[ii], ptr[ii + 1]):
@@ -102,13 +102,13 @@ cdef _node_degrees(
                 degree[ii] += 1
                 break
     return degree
-    
+
 
 def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
         np.ndarray[int32_or_int64, ndim=1, mode="c"] ptr,
         np.npy_intp num_rows):
     """
-    Reverse Cuthill-McKee ordering of a sparse symmetric CSR or CSC matrix.  
+    Reverse Cuthill-McKee ordering of a sparse symmetric CSR or CSC matrix.
     We follow the original Cuthill-McKee paper and always start the routine
     at a node of lowest degree for each connected component.
     """
@@ -120,7 +120,7 @@ def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
     cdef np.ndarray[np.npy_intp] rev_inds = np.argsort(inds)
     cdef np.ndarray[ITYPE_t] temp_degrees = np.zeros(np.max(degree), dtype=ITYPE)
     cdef int32_or_int64 i, j, seed, temp2
-    
+
     # loop over zz takes into account possible disconnected graph.
     for zz in range(num_rows):
         if inds[zz] != -1:   # Do BFS with seed=inds[zz]
@@ -150,7 +150,7 @@ def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
                     for kk in range(N_old, N):
                         temp_degrees[level_len] = degree[order[kk]]
                         level_len += 1
-                
+
                     # Do insertion sort for nodes from lowest to highest degree
                     for kk in range(1,level_len):
                         temp = temp_degrees[kk]
@@ -162,7 +162,7 @@ def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
                             ll -= 1
                         temp_degrees[ll] = temp
                         order[N_old+ll] = temp2
-                
+
                 # set next level start and end ranges
                 level_start = level_end
                 level_end = N
@@ -177,13 +177,13 @@ def _reverse_cuthill_mckee(np.ndarray[int32_or_int64, ndim=1, mode="c"] ind,
 def structural_rank(graph):
     """
     structural_rank(graph)
-    
-    Compute the structural rank of a graph (matrix) with a given 
+
+    Compute the structural rank of a graph (matrix) with a given
     sparsity pattern.
 
-    The structural rank of a matrix is the number of entries in the maximum 
-    transversal of the corresponding bipartite graph, and is an upper bound 
-    on the numerical rank of the matrix. A graph has full structural rank 
+    The structural rank of a matrix is the number of entries in the maximum
+    transversal of the corresponding bipartite graph, and is an upper bound
+    on the numerical rank of the matrix. A graph has full structural rank
     if it is possible to permute the elements to make the diagonal zero-free.
 
     .. versionadded:: 0.19.0

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -200,7 +200,7 @@ def structural_rank(graph):
 
     Notes
     -----
-    Algorithmic complexity is :math:`O(\lvert E \rvert \sqrt{\lvert V \rvert})`,
+    Algorithmic complexity is :math:`O(E \sqrt{V})`,
     where E is the number of edges and V is the number of vertices.
 
     References

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -201,7 +201,8 @@ def structural_rank(graph):
     Notes
     -----
     Algorithmic complexity is :math:`O(E \sqrt{V})`,
-    where E is the number of edges and V is the number of vertices.
+    where ``E`` is the number of edges and ``V``
+    is the number of vertices.
 
     References
     ----------

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -197,12 +197,17 @@ def structural_rank(graph):
     -------
     rank : int
         The structural rank of the sparse graph.
-    
+
+    Notes
+    -----
+    Algorithmic complexity is :math:`O(\lvert E \rvert \sqrt{\lvert V \rvert})`,
+    where E is the number of edges and V is the number of vertices.
+
     References
     ----------
-    .. [1] I. S. Duff, "Computing the Structural Index", SIAM J. Alg. Disc. 
+    .. [1] I. S. Duff, "Computing the Structural Index", SIAM J. Alg. Disc.
             Meth., Vol. 7, 594 (1986).
-    
+
     .. [2] http://www.cise.ufl.edu/research/sparse/matrices/legend.html
 
     Examples

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -343,7 +343,7 @@ def floyd_warshall(csgraph, directed=True,
     Python version.
 
     The algorithmic complexity is for a graph with V
-    vertices is O(V^3).
+    vertices is ``O(V^3)``.
 
     Examples
     --------
@@ -576,7 +576,7 @@ def dijkstra(csgraph, directed=True, indices=None,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The algorithmic complexity is approximately O(I * (E + N) * log(N)),
+    The algorithmic complexity is approximately ``O(I * (E + N) * log(N))``,
     where N is the number of vertices, E is the number of edges
     in the graph, and I = len(indices) if indices is passed. Otherwise, I = N.
 
@@ -938,7 +938,7 @@ def bellman_ford(csgraph, directed=True, indices=None,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Computational cost is approximately O(V * E), where
+    Computational cost is approximately ``O(V * E)``, where
     V is the number of vertices and E is the number of edges
     in the graph.
 
@@ -1186,7 +1186,7 @@ def johnson(csgraph, directed=True, indices=None,
     Python version.
 
     The algorithmic complexity for a graph with V vertices and E edges is,
-    O(V^2 * log V + V * E).
+    ``O(V^2 * log V + V * E)``.
 
     Examples
     --------
@@ -1480,7 +1480,7 @@ def yen(
     Python version.
 
     The algorithmic complexity for a graph with V number of vertices and E
-    number of edges is O(K*V*(E + V*logV)).
+    number of edges is ``O(K*V*(E + V*logV))``.
 
     References
     ----------

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -342,6 +342,9 @@ def floyd_warshall(csgraph, directed=True,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
+    The algorithmic complexity is for a graph with V
+    vertices is O(V^3).
+
     Examples
     --------
     >>> from scipy.sparse import csr_array
@@ -572,6 +575,10 @@ def dijkstra(csgraph, directed=True, indices=None,
 
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    The algorithmic complexity is approximately O(I * (E + N) * log(N)),
+    where N is the number of vertices, E is the number of edges
+    in the graph, and I = len(indices) if indices is passed. Otherwise, I = N.
 
     Examples
     --------
@@ -931,6 +938,10 @@ def bellman_ford(csgraph, directed=True, indices=None,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
+    Computational cost is approximately O(V * E), where
+    V is the number of vertices and E is the number of edges
+    in the graph.
+
     Examples
     --------
     >>> from scipy.sparse import csr_array
@@ -1173,6 +1184,9 @@ def johnson(csgraph, directed=True, indices=None,
 
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    The algorithmic complexity for a graph with V vertices and E edges is,
+    O(V^2 * log V + V * E).
 
     Examples
     --------
@@ -1464,6 +1478,9 @@ def yen(
 
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    The algorithmic complexity for a graph with V number of vertices and E
+    number of edges is O(K*V*(E + V*logV)).
 
     References
     ----------

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -344,8 +344,7 @@ def floyd_warshall(csgraph, directed=True,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The algorithmic complexity is for a graph with V
-    vertices is ``O(V^3)``.
+    The algorithmic complexity is for a graph with ``V`` vertices is ``O(V^3)``.
 
     Examples
     --------
@@ -579,8 +578,8 @@ def dijkstra(csgraph, directed=True, indices=None,
     Python version.
 
     The algorithmic complexity is approximately ``O(I * (E + N) * log(N))``,
-    where N is the number of vertices, E is the number of edges
-    in the graph, and I = len(indices) if indices is passed. Otherwise, I = N.
+    where ``N`` is the number of vertices, ``E`` is the number of edges
+    in the graph, and ``I = len(indices)`` if indices is passed. Otherwise, ``I = N``.
 
     Examples
     --------
@@ -1188,7 +1187,7 @@ def johnson(csgraph, directed=True, indices=None,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The algorithmic complexity for a graph with V vertices and E edges is,
+    The algorithmic complexity for a graph with ``V`` vertices and ``E`` edges is,
     ``O(V^2 * log V + V * E)``.
 
     Examples
@@ -1482,8 +1481,8 @@ def yen(
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    The algorithmic complexity for a graph with V number of vertices and E
-    number of edges is ``O(K*V*(E + V*logV))``.
+    The algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(K*V*(E + V*logV))``.
 
     References
     ----------

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -81,9 +81,11 @@ def shortest_path(csgraph, method='auto',
            'BF'   -- Bellman-Ford algorithm.
                      This algorithm can be used when weights are negative.
                      If a negative cycle is encountered, an error will be raised.
-                     Computational cost is approximately ``O[N(N^2 k)]``, where
-                     ``k`` is the average number of connected edges per node.
-                     The input csgraph will be converted to a csr representation.
+                     Computational cost of the algorithm is ``O(I * N^2 * k)``,
+                     where ``k`` is the average number of connected edges per node
+                     and ``I = len(indices)``. If ``I = N``, then the time complexity
+                     will be ``O[N(N^2 k)]``. The input csgraph will be converted
+                     to a csr representation.
 
            'J'    -- Johnson's algorithm.
                      Like the Bellman-Ford algorithm, Johnson's algorithm is
@@ -938,9 +940,10 @@ def bellman_ford(csgraph, directed=True, indices=None,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Computational cost is approximately ``O(V * E)``, where
-    V is the number of vertices and E is the number of edges
-    in the graph.
+    Computational cost of the algorithm is ``O(I * N^2 * k)``, where
+    ``N`` is the number of vertices in the graph, ``k`` is the average number
+    of connected edges per node and ``I = len(indices)``. If ``I = N``, then
+    the time complexity will be ``O[N(N^2 k)]``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -442,7 +442,7 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     Notes
     -----
-    The algorithmic complexity for a graph with N vertices is ``O(N*logN)``.
+    The algorithmic complexity for a graph with ``N`` vertices is ``O(N*logN)``.
 
     Examples
     --------
@@ -568,8 +568,8 @@ def construct_dist_matrix(graph,
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
 
-    The algorithmic complexity is ``O(V^3)`` where V is the number of vertices
-    in the input graph.
+    The algorithmic complexity is ``O(V^3)`` where ``V`` is the number
+    of vertices in the input graph.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -568,7 +568,7 @@ def construct_dist_matrix(graph,
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
 
-    The algorithmic complexity is O(V^3) where V is the number of vertices
+    The algorithmic complexity is ``O(V^3)`` where V is the number of vertices
     in the input graph.
 
     Examples

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -440,6 +440,10 @@ def reconstruct_path(csgraph, predecessors, directed=True):
         The N x N directed compressed-sparse representation of the tree drawn
         from csgraph which is encoded by the predecessor list.
 
+    Notes
+    -----
+    The algorithmic complexity for a graph with N vertices is O(N*logN).
+
     Examples
     --------
     >>> import numpy as np
@@ -563,6 +567,9 @@ def construct_dist_matrix(graph,
     predecessors[i, j] gives the index of the previous node in the path from
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
+
+    The algorithmic complexity is O(V^3) where V is the number of vertices
+    in the input graph.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -442,7 +442,7 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     Notes
     -----
-    The algorithmic complexity for a graph with N vertices is O(N*logN).
+    The algorithmic complexity for a graph with N vertices is ``O(N*logN)``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -163,7 +163,7 @@ def breadth_first_tree(csgraph, i_start, directed=True):
     Python version.
 
     Algorithmic complexity for a graph with V number of vertices and E number
-    of edges is O(V + E).
+    of edges is ``O(V + E)``.
 
     Examples
     --------
@@ -546,7 +546,7 @@ cpdef depth_first_order(csgraph, i_start,
     Python version.
 
     Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is O(V + E).
+    edges is ``O(V + E)``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -56,6 +56,11 @@ def connected_components(csgraph, directed=True, connection='weak',
     labels: ndarray
         The length-N array of labels of the connected components.
 
+    Notes
+    -----
+    The algorithmic complexity is for a graph with E edges and V
+    vertices is O(E + V).
+
     References
     ----------
     .. [1] D. J. Pearce, "An Improved Algorithm for Finding the Strongly
@@ -157,6 +162,9 @@ def breadth_first_tree(csgraph, i_start, directed=True):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
+    Algorithmic complexity for a graph with V number of vertices and E number
+    of edges is O(V + E).
+
     Examples
     --------
     The following example shows the computation of a depth-first tree
@@ -232,6 +240,9 @@ def depth_first_tree(csgraph, i_start, directed=True):
     -----
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    Algorithmic complexity for a graph with V number of vertices and E number
+    of edges is O(V + E).
 
     Examples
     --------
@@ -321,6 +332,9 @@ cpdef breadth_first_order(csgraph, i_start,
     -----
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    Algorithmic complexity for a graph with V number of vertices and E number of
+    edges is O(V + E).
 
     Examples
     --------
@@ -530,6 +544,9 @@ cpdef depth_first_order(csgraph, i_start,
     -----
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
+
+    Algorithmic complexity for a graph with V number of vertices and E number of
+    edges is O(V + E).
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -162,8 +162,8 @@ def breadth_first_tree(csgraph, i_start, directed=True):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Algorithmic complexity for a graph with V number of vertices and E number
-    of edges is ``O(V + E)``.
+    Algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(V + E)``.
 
     Examples
     --------
@@ -241,8 +241,8 @@ def depth_first_tree(csgraph, i_start, directed=True):
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Algorithmic complexity for a graph with V number of vertices and E number
-    of edges is ``O(V + E)``.
+    Algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(V + E)``.
 
     Examples
     --------
@@ -333,8 +333,8 @@ cpdef breadth_first_order(csgraph, i_start,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is ``O(V + E)``.
+    Algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(V + E)``.
 
     Examples
     --------
@@ -545,8 +545,8 @@ cpdef depth_first_order(csgraph, i_start,
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
 
-    Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is ``O(V + E)``.
+    Algorithmic complexity for a graph with ``V`` number of vertices and
+    ``E`` number of edges is ``O(V + E)``.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -59,7 +59,7 @@ def connected_components(csgraph, directed=True, connection='weak',
     Notes
     -----
     The algorithmic complexity is for a graph with E edges and V
-    vertices is O(E + V).
+    vertices is ``O(E + V)``.
 
     References
     ----------
@@ -242,7 +242,7 @@ def depth_first_tree(csgraph, i_start, directed=True):
     Python version.
 
     Algorithmic complexity for a graph with V number of vertices and E number
-    of edges is O(V + E).
+    of edges is ``O(V + E)``.
 
     Examples
     --------
@@ -334,7 +334,7 @@ cpdef breadth_first_order(csgraph, i_start,
     Python version.
 
     Algorithmic complexity for a graph with V number of vertices and E number of
-    edges is O(V + E).
+    edges is ``O(V + E)``.
 
     Examples
     --------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/5346

#### What does this implement/fix?
<!--Please explain your changes.-->

- [x] [connected_components](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.connected_components.html#scipy.sparse.csgraph.connected_components)
- [x] [laplacian](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.laplacian.html#scipy.sparse.csgraph.laplacian)
- [x] [shortest_path](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.shortest_path.html#scipy.sparse.csgraph.shortest_path)
- [x] [dijkstra](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.dijkstra.html#scipy.sparse.csgraph.dijkstra)
- [x] [floyd_warshall](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.floyd_warshall.html#scipy.sparse.csgraph.floyd_warshall)
- [x] [bellman_ford](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.bellman_ford.html#scipy.sparse.csgraph.bellman_ford)
- [x] [johnson](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.johnson.html#scipy.sparse.csgraph.johnson)
- [x] [yen](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.yen.html#scipy.sparse.csgraph.yen)
- [x] [breadth_first_order](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.breadth_first_order.html#scipy.sparse.csgraph.breadth_first_order)
- [x] [depth_first_order](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.depth_first_order.html#scipy.sparse.csgraph.depth_first_order)
- [x] [breadth_first_tree](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.breadth_first_tree.html#scipy.sparse.csgraph.breadth_first_tree)
- [x] [depth_first_tree](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.depth_first_tree.html#scipy.sparse.csgraph.depth_first_tree)
- [x] [minimum_spanning_tree](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.minimum_spanning_tree.html#scipy.sparse.csgraph.minimum_spanning_tree)
- [x] [reverse_cuthill_mckee](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.reverse_cuthill_mckee.html#scipy.sparse.csgraph.reverse_cuthill_mckee)
- [x] [maximum_flow](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.maximum_flow.html#scipy.sparse.csgraph.maximum_flow)
- [x] [maximum_bipartite_matching](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.maximum_bipartite_matching.html#scipy.sparse.csgraph.maximum_bipartite_matching)
- [x] [min_weight_full_bipartite_matching](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.min_weight_full_bipartite_matching.html#scipy.sparse.csgraph.min_weight_full_bipartite_matching)
- [x] [structural_rank](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.structural_rank.html#scipy.sparse.csgraph.structural_rank)
- [x] [construct_dist_matrix](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.construct_dist_matrix.html#scipy.sparse.csgraph.construct_dist_matrix)
- [x] ~[csgraph_from_dense](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.csgraph_from_dense.html#scipy.sparse.csgraph.csgraph_from_dense) - Do we need to mention time complexity for this?~
- [x] ~[csgraph_from_masked](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.csgraph_from_masked.html#scipy.sparse.csgraph.csgraph_from_masked) - Do we need to mention time complexity for this?~
- [x] ~[csgraph_masked_from_dense](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.csgraph_masked_from_dense.html#scipy.sparse.csgraph.csgraph_masked_from_dense) - Do we need to mention time complexity for this?~
- [x] ~[csgraph_to_dense](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.csgraph_to_dense.html#scipy.sparse.csgraph.csgraph_to_dense) - Do we need to mention time complexity for this?~
- [x] ~[csgraph_to_masked](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.csgraph_to_masked.html#scipy.sparse.csgraph.csgraph_to_masked) - Do we need to mention time complexity for this?~
- [x] [reconstruct_path](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.sparse.csgraph.reconstruct_path.html#scipy.sparse.csgraph.reconstruct_path)

#### Additional information
<!--Any additional information you think is important.-->
