### PR TITLE
ENH: `signal.{envelope,resample,resample_poly}`: array API standard support

### DIFF
--- a/scipy/ndimage/_delegators.py
+++ b/scipy/ndimage/_delegators.py
@@ -25,7 +25,7 @@ for func in funcs:
 """
 import numpy as np
 from scipy._lib._array_api import array_namespace
-from scipy.ndimage._ni_support import _skip_if_dtype, _skip_if_int
+from scipy.ndimage._ni_support import _skip_if_dtype
 
 
 def affine_transform_signature(
@@ -202,7 +202,7 @@ uniform_filter1d_signature = maximum_filter1d_signature
 
 
 def maximum_signature(input, labels=None, index=None):
-    return array_namespace(input, labels, _skip_if_int(index))
+    return array_namespace(input, labels, index)
 
 minimum_signature = maximum_signature
 median_signature = maximum_signature

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -137,7 +137,3 @@ def _skip_if_dtype(arg):
         return None if issubclass(arg, np.generic) else arg
     else:
         return None if isinstance(arg, np.dtype) else arg
-
-
-def _skip_if_int(arg):
-    return None if (arg is None or isinstance(arg, int)) else arg

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -28,8 +28,7 @@ are arrays.
 
 """
 import numpy as np
-from scipy._lib._array_api import array_namespace
-from scipy.ndimage._ni_support import _skip_if_int
+from scipy._lib._array_api import array_namespace, np_compat
 
 
 def _skip_if_lti(arg):
@@ -56,9 +55,6 @@ def _skip_if_str_or_tuple(window):
 def _skip_if_poly1d(arg):
     return None if isinstance(arg, np.poly1d) else arg
 
-
-def _skip_if_float(arg):
-    return None if isinstance(arg, float) else arg
 
 ###################
 
@@ -301,7 +297,7 @@ def deconvolve_signature(signal, divisor):
 
 
 def detrend_signature(data, axis=1, type='linear', bp=0, *args, **kwds):
-    return array_namespace(data, _skip_if_int(bp))
+    return array_namespace(data, bp)
 
 
 def filtfilt_signature(b, a, x, *args, **kwds):
@@ -310,6 +306,10 @@ def filtfilt_signature(b, a, x, *args, **kwds):
 
 def lfilter_signature(b, a, x, axis=-1, zi=None):
     return array_namespace(b, a, x, zi)
+
+
+def envelope_signature(z, *args, **kwds):
+    return array_namespace(z)
 
 
 def find_peaks_signature(
@@ -334,7 +334,11 @@ def firls_signature(numtaps, bands, desired, *, weight=None, fs=None):
 
 
 def firwin_signature(numtaps, cutoff, *args, **kwds):
-    return array_namespace(cutoff)
+    if isinstance(cutoff, int | float):
+        xp = np_compat
+    else:
+        xp = array_namespace(cutoff)
+    return xp
 
 
 def firwin2_signature(numtaps, freq, gain, *args, **kwds):
@@ -342,19 +346,19 @@ def firwin2_signature(numtaps, freq, gain, *args, **kwds):
 
 
 def freqs_zpk_signature(z, p, k, worN, *args, **kwds):
-    return array_namespace(z, p, _skip_if_int(worN))
+    return array_namespace(z, p, worN)
 
 freqz_zpk_signature = freqs_zpk_signature
 
 
 def freqs_signature(b, a, worN=200, *args, **kwds):
-    return array_namespace(b, a, _skip_if_int(worN))
+    return array_namespace(b, a, worN)
 
 freqz_signature = freqs_signature
 
 
 def freqz_sos_signature(sos, worN=512, *args, **kwds):
-    return array_namespace(sos, _skip_if_int(worN))
+    return array_namespace(sos, worN)
 
 sosfreqz_signature = freqz_sos_signature
 
@@ -365,7 +369,7 @@ def gausspulse_signature(t, *args, **kwds):
 
 
 def group_delay_signature(system, w=512, whole=False, fs=6.283185307179586):
-    return array_namespace(_skip_if_str_or_tuple(system), _skip_if_int(w))
+    return array_namespace(_skip_if_str_or_tuple(system), w)
 
 
 def hilbert_signature(x, N=None, axis=-1):
@@ -522,7 +526,7 @@ def symiirorder1_signature(signal, c0, z1, precision=-1.0):
 
 
 def symiirorder2_signature(input, r, omega, precision=-1.0):
-    return array_namespace(input, _skip_if_float(r), _skip_if_float(omega))
+    return array_namespace(input, r, omega)
 
 
 def cspline1d_signature(signal, *args, **kwds):

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -383,7 +383,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     nyq = 0.5 * fs
 
-    cutoff = xp.asarray(cutoff, dtype=xp.float64)
+    cutoff = xp.asarray(cutoff, dtype=xp_default_dtype(xp))
     cutoff = xpx.atleast_nd(cutoff, ndim=1, xp=xp) / float(nyq)
 
     # Check for invalid input.

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1,18 +1,19 @@
 """Functions for FIR filter design."""
 
-from math import ceil, log
-import operator
+from math import ceil, log, log2
 import warnings
 from typing import Literal
 
 import numpy as np
-from numpy.fft import irfft, fft, ifft
-from scipy.special import sinc
+from scipy.fft import irfft, fft, ifft
 from scipy.linalg import (toeplitz, hankel, solve, LinAlgError, LinAlgWarning,
                           lstsq)
 from scipy.signal._arraytools import _validate_fs
 
 from . import _sigtools
+
+from scipy._lib._array_api import array_namespace, xp_size, xp_default_dtype
+import scipy._lib.array_api_extra as xpx
 
 
 __all__ = ['kaiser_beta', 'kaiser_atten', 'kaiserord',
@@ -372,6 +373,9 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     array([ 0.04890915,  0.91284326,  0.04890915])
 
     """
+    # NB: scipy's version of array_namespace returns `np_compat` for int or floats
+    xp = array_namespace(cutoff)
+
     # The major enhancements to this function added in November 2010 were
     # developed by Tom Krauss (see ticket #902).
     fs = _validate_fs(fs, allow_none=True)
@@ -379,18 +383,19 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     nyq = 0.5 * fs
 
-    cutoff = np.atleast_1d(cutoff) / float(nyq)
+    cutoff = xp.asarray(cutoff, dtype=xp.float64)
+    cutoff = xpx.atleast_nd(cutoff, ndim=1) / float(nyq)
 
     # Check for invalid input.
     if cutoff.ndim > 1:
         raise ValueError("The cutoff argument must be at most "
                          "one-dimensional.")
-    if cutoff.size == 0:
+    if xp_size(cutoff) == 0:
         raise ValueError("At least one cutoff frequency must be given.")
-    if cutoff.min() <= 0 or cutoff.max() >= 1:
+    if xp.min(cutoff) <= 0 or xp.max(cutoff) >= 1:
         raise ValueError("Invalid cutoff frequency: frequencies must be "
                          "greater than 0 and less than fs/2.")
-    if np.any(np.diff(cutoff) <= 0):
+    if xp.any(cutoff[1:] - cutoff[:-1] <= 0):
         raise ValueError("Invalid cutoff frequencies: the frequencies "
                          "must be strictly increasing.")
 
@@ -401,51 +406,49 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         beta = kaiser_beta(atten)
         window = ('kaiser', beta)
 
-    if isinstance(pass_zero, str):
-        if pass_zero in ('bandstop', 'lowpass'):
-            if pass_zero == 'lowpass':
-                if cutoff.size != 1:
-                    raise ValueError('cutoff must have one element if '
-                                     f'pass_zero=="lowpass", got {cutoff.shape}')
-            elif cutoff.size <= 1:
-                raise ValueError('cutoff must have at least two elements if '
-                                 f'pass_zero=="bandstop", got {cutoff.shape}')
-            pass_zero = True
-        elif pass_zero in ('bandpass', 'highpass'):
-            if pass_zero == 'highpass':
-                if cutoff.size != 1:
-                    raise ValueError('cutoff must have one element if '
-                                     f'pass_zero=="highpass", got {cutoff.shape}')
-            elif cutoff.size <= 1:
-                raise ValueError('cutoff must have at least two elements if '
-                                 f'pass_zero=="bandpass", got {cutoff.shape}')
-            pass_zero = False
-        else:
-            raise ValueError('pass_zero must be True, False, "bandpass", '
-                             '"lowpass", "highpass", or "bandstop", got '
-                             f'{pass_zero}')
-    pass_zero = bool(operator.index(pass_zero))  # ensure bool-like
+    if pass_zero in ('bandstop', 'lowpass'):
+        if pass_zero == 'lowpass':
+            if xp_size(cutoff) != 1:
+                raise ValueError('cutoff must have one element if '
+                                 f'pass_zero=="lowpass", got {cutoff.shape}')
+        elif xp_size(cutoff) <= 1:
+            raise ValueError('cutoff must have at least two elements if '
+                             f'pass_zero=="bandstop", got {cutoff.shape}')
+        pass_zero = True
+    elif pass_zero in ('bandpass', 'highpass'):
+        if pass_zero == 'highpass':
+            if xp_size(cutoff) != 1:
+                raise ValueError('cutoff must have one element if '
+                                 f'pass_zero=="highpass", got {cutoff.shape}')
+        elif xp_size(cutoff) <= 1:
+            raise ValueError('cutoff must have at least two elements if '
+                             f'pass_zero=="bandpass", got {cutoff.shape}')
+        pass_zero = False
+    elif not (pass_zero is True or pass_zero is False):
+        raise ValueError(f"Parameter {pass_zero=} not in (True, False, 'bandpass', " +
+                         "'lowpass', 'highpass', 'bandstop')")
 
-    pass_nyquist = bool(cutoff.size & 1) ^ pass_zero
+    pass_nyquist = (xp_size(cutoff) % 2 == 0) == pass_zero
     if pass_nyquist and numtaps % 2 == 0:
         raise ValueError("A filter with an even number of coefficients must "
                          "have zero response at the Nyquist frequency.")
 
     # Insert 0 and/or 1 at the ends of cutoff so that the length of cutoff
     # is even, and each pair in cutoff corresponds to passband.
-    cutoff = np.hstack(([0.0] * pass_zero, cutoff, [1.0] * pass_nyquist))
+    cutoff = xp.concat((xp.zeros(int(pass_zero)), cutoff, xp.ones(int(pass_nyquist))))
+
 
     # `bands` is a 2-D array; each row gives the left and right edges of
     # a passband.
-    bands = cutoff.reshape(-1, 2)
+    bands = xp.reshape(cutoff, (-1, 2))
 
     # Build up the coefficients.
     alpha = 0.5 * (numtaps - 1)
-    m = np.arange(0, numtaps) - alpha
+    m = xp.arange(0, numtaps) - alpha
     h = 0
     for left, right in bands:
-        h += right * sinc(right * m)
-        h -= left * sinc(left * m)
+        h += right * xpx.sinc(right * m, xp=xp)
+        h -= left * xpx.sinc(left * m, xp=xp)
 
     # Get and apply the window function.
     from .windows import get_window
@@ -462,7 +465,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
             scale_frequency = 1.0
         else:
             scale_frequency = 0.5 * (left + right)
-        c = np.cos(np.pi * m * scale_frequency)
+        c = xp.cos(xp.pi * m * scale_frequency)
         s = np.sum(h * c)
         h /= s
 
@@ -573,11 +576,14 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     [-0.02286961 -0.06362756  0.57310236  0.57310236 -0.06362756 -0.02286961]
 
     """
+    xp = array_namespace(freq, gain)
+    freq, gain = xp.asarray(freq), xp.asarray(gain)
+
     fs = _validate_fs(fs, allow_none=True)
     fs = 2 if fs is None else fs
     nyq = 0.5 * fs
 
-    if len(freq) != len(gain):
+    if freq.shape[0] != gain.shape[0]:
         raise ValueError('freq and gain must be of same length.')
 
     if nfreqs is not None and numtaps >= nfreqs:
@@ -588,11 +594,11 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
 
     if freq[0] != 0 or freq[-1] != nyq:
         raise ValueError('freq must start with 0 and end with fs/2.')
-    d = np.diff(freq)
-    if (d < 0).any():
+    d = freq[1:] - freq[:-1]
+    if xp.any(d < 0):
         raise ValueError('The values in freq must be nondecreasing.')
     d2 = d[:-1] + d[1:]
-    if (d2 == 0).any():
+    if xp.any(d2 == 0):
         raise ValueError('A value in freq must not occur more than twice.')
     if freq[1] == 0:
         raise ValueError('Value 0 must not be repeated in freq')
@@ -623,28 +629,30 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     if nfreqs is None:
         nfreqs = 1 + 2 ** int(ceil(log(numtaps, 2)))
 
-    if (d == 0).any():
+    if xp.any(d == 0):
         # Tweak any repeated values in freq so that interp works.
-        freq = np.array(freq, copy=True)
-        eps = np.finfo(float).eps * nyq
-        for k in range(len(freq) - 1):
+        freq = xp.asarray(freq, copy=True)
+        eps = xp.finfo(xp_default_dtype(xp)).eps * nyq
+        for k in range(freq.shape[0] - 1):
             if freq[k] == freq[k + 1]:
                 freq[k] = freq[k] - eps
                 freq[k + 1] = freq[k + 1] + eps
         # Check if freq is strictly increasing after tweak
-        d = np.diff(freq)
-        if (d <= 0).any():
+        d = freq[1:] - freq[:-1]
+        if xp.any(d <= 0):
             raise ValueError("freq cannot contain numbers that are too close "
                              "(within eps * (fs/2): "
                              f"{eps}) to a repeated value")
 
     # Linearly interpolate the desired response on a uniform mesh `x`.
     x = np.linspace(0.0, nyq, nfreqs)
-    fx = np.interp(x, freq, gain)
+    fx = np.interp(x, np.asarray(freq), np.asarray(gain))  # XXX array-api-extra#193
+    x = xp.asarray(x)
+    fx = xp.asarray(fx)
 
     # Adjust the phases of the coefficients so that the first `ntaps` of the
     # inverse FFT are the desired filter coefficients.
-    shift = np.exp(-(numtaps - 1) / 2. * 1.j * np.pi * x / nyq)
+    shift = xp.exp(-(numtaps - 1) / 2. * 1j * xp.pi * x / nyq)
     if ftype > 2:
         shift *= 1j
 
@@ -656,7 +664,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     if window is not None:
         # Create the window to apply to the filter coefficients.
         from .windows import get_window
-        wind = get_window(window, numtaps, fftbins=False)
+        wind = get_window(window, numtaps, fftbins=False, xp=xp)
     else:
         wind = 1
 
@@ -665,7 +673,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     out = out_full[:numtaps] * wind
 
     if ftype == 3:
-        out[out.size // 2] = 0.0
+        out[xp_size(out) // 2] = 0.0
 
     return out
 
@@ -822,6 +830,12 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
     >>> plt.show()
 
     """
+    xp = array_namespace(bands, desired, weight)
+    bands = np.asarray(bands)
+    desired = np.asarray(desired)
+    if weight:
+        weight = np.asarray(weight)
+
     fs = _validate_fs(fs, allow_none=True)
     fs = 1.0 if fs is None else fs
 
@@ -837,8 +851,9 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
         weight = [1] * len(desired)
 
     bands = np.asarray(bands).copy()
-    return _sigtools._remez(numtaps, bands, desired, weight, tnum, fs,
-                            maxiter, grid_density)
+    result = _sigtools._remez(numtaps, bands, desired, weight, tnum, fs,
+                              maxiter, grid_density)
+    return xp.asarray(result)
 
 
 def firls(numtaps, bands, desired, *, weight=None, fs=None):
@@ -951,6 +966,10 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
     >>> plt.show()
 
     """
+    xp = array_namespace(bands, desired)
+    bands = np.asarray(bands)
+    desired = np.asarray(desired)
+
     fs = _validate_fs(fs, allow_none=True)
     fs = 2 if fs is None else fs
     nyq = 0.5 * fs
@@ -1054,10 +1073,10 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
 
     # make coefficients symmetric (linear phase)
     coeffs = np.hstack((a[:0:-1], 2 * a[0], a[1:]))
-    return coeffs
+    return xp.asarray(coeffs)
 
 
-def _dhtm(mag):
+def _dhtm(mag, xp):
     """Compute the modified 1-D discrete Hilbert transform
 
     Parameters
@@ -1068,20 +1087,20 @@ def _dhtm(mag):
     """
     # Adapted based on code by Niranjan Damera-Venkata,
     # Brian L. Evans and Shawn R. McCaslin (see refs for `minimum_phase`)
-    sig = np.zeros(len(mag))
+    sig = xp.zeros(mag.shape[0])
     # Leave Nyquist and DC at 0, knowing np.abs(fftfreq(N)[midpt]) == 0.5
-    midpt = len(mag) // 2
+    midpt = mag.shape[0] // 2
     sig[1:midpt] = 1
     sig[midpt+1:] = -1
     # eventually if we want to support complex filters, we will need a
     # np.abs() on the mag inside the log, and should remove the .real
-    recon = ifft(mag * np.exp(fft(sig * ifft(np.log(mag))))).real
+    recon = xp.real(ifft(mag * xp.exp(fft(sig * ifft(xp.log(mag))))))
     return recon
 
 
-def minimum_phase(h: np.ndarray,
+def minimum_phase(h,
                   method: Literal['homomorphic', 'hilbert'] = 'homomorphic',
-                  n_fft: int | None = None, *, half: bool = True) -> np.ndarray:
+                  n_fft: int | None = None, *, half: bool = True):
     """Convert a linear-phase FIR filter to minimum phase
 
     Parameters
@@ -1232,13 +1251,16 @@ def minimum_phase(h: np.ndarray,
     linear filter `h` whereas the other minimum phase filters have only half the order
     and the square root  of the magnitude response.
     """
-    h = np.asarray(h)
-    if np.iscomplexobj(h):
+    xp = array_namespace(h)
+
+    h = xp.asarray(h)
+    if xp.isdtype(h.dtype, "complex floating"):
         raise ValueError('Complex filters not supported')
-    if h.ndim != 1 or h.size <= 2:
+    if h.ndim != 1 or h.shape[0] <= 2:
         raise ValueError('h must be 1-D and at least 2 samples long')
-    n_half = len(h) // 2
-    if not np.allclose(h[-n_half:][::-1], h[:n_half]):
+    n_half = h.shape[0] // 2
+
+    if not xp.any(xp.flip(h[-n_half:]) - h[:n_half] <= 1e-8 + 1e-6*abs(h[:n_half])):
         warnings.warn('h does not appear to by symmetric, conversion may fail',
                       RuntimeWarning, stacklevel=2)
     if not isinstance(method, str) or method not in \
@@ -1247,45 +1269,46 @@ def minimum_phase(h: np.ndarray,
     if method == "hilbert" and not half:
         raise ValueError("`half=False` is only supported when `method='homomorphic'`")
     if n_fft is None:
-        n_fft = 2 ** int(np.ceil(np.log2(2 * (len(h) - 1) / 0.01)))
+        n_fft = 2 ** int(ceil(log2(2 * (h.shape[0] - 1) / 0.01)))
     n_fft = int(n_fft)
-    if n_fft < len(h):
+    if n_fft < h.shape[0]:
         raise ValueError(f'n_fft must be at least len(h)=={len(h)}')
+
     if method == 'hilbert':
-        w = np.arange(n_fft) * (2 * np.pi / n_fft * n_half)
-        H = np.real(fft(h, n_fft) * np.exp(1j * w))
+        w = xp.arange(n_fft, dtype=xp.float64) * (2 * xp.pi / n_fft * n_half)
+        H = xp.real(fft(h, n_fft) * xp.exp(1j * w))
         dp = max(H) - 1
         ds = 0 - min(H)
-        S = 4. / (np.sqrt(1+dp+ds) + np.sqrt(1-dp+ds)) ** 2
+        S = 4. / (xp.sqrt(1+dp+ds) + xp.sqrt(1-dp+ds)) ** 2
         H += ds
         H *= S
-        H = np.sqrt(H, out=H)
+        H = xp.sqrt(H)
         H += 1e-10  # ensure that the log does not explode
-        h_minimum = _dhtm(H)
+        h_minimum = _dhtm(H, xp)
     else:  # method == 'homomorphic'
         # zero-pad; calculate the DFT
-        h_temp = np.abs(fft(h, n_fft))
+        h_temp = xp.abs(fft(h, n_fft))
         # take 0.25*log(|H|**2) = 0.5*log(|H|)
-        h_temp += 1e-7 * h_temp[h_temp > 0].min()  # don't let log blow up
-        np.log(h_temp, out=h_temp)
+        h_temp += 1e-7 * xp.min(h_temp[h_temp > 0])  # don't let log blow up
+        h_temp = xp.log(h_temp)
         if half:  # halving of magnitude spectrum optional
             h_temp *= 0.5
         # IDFT
-        h_temp = ifft(h_temp).real
+        h_temp = xp.real(ifft(h_temp))
         # multiply pointwise by the homomorphic filter
         # lmin[n] = 2u[n] - d[n]
         # i.e., double the positive frequencies and zero out the negative ones;
         # Oppenheim+Shafer 3rd ed p991 eq13.42b and p1004 fig13.7
-        win = np.zeros(n_fft)
+        win = xp.zeros(n_fft)
         win[0] = 1
         stop = n_fft // 2
         win[1:stop] = 2
         if n_fft % 2:
             win[stop] = 1
         h_temp *= win
-        h_temp = ifft(np.exp(fft(h_temp)))
+        h_temp = ifft(xp.exp(fft(h_temp)))
         h_minimum = h_temp.real
-    n_out = (n_half + len(h) % 2) if half else len(h)
+    n_out = (n_half + h.shape[0] % 2) if half else h.shape[0]
     return h_minimum[:n_out]
 
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -27,7 +27,7 @@ from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
-    array_namespace, is_torch, is_numpy, xp_copy, xp_size,
+    array_namespace, is_torch, is_numpy, xp_copy, xp_size, xp_default_dtype
 
 )
 from scipy._lib.array_api_compat import is_array_api_obj
@@ -3769,6 +3769,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
         W = xp.asarray(window, copy=True)  # prevent modifying the function parameters
     else:
         W = sp_fft.fftshift(get_window(window, n_x, xp=xp))
+        W = xp.astype(W, xp_default_dtype(xp))   # get_window always returns float64
 
     if domain == 'time' and not xp.isdtype(x.dtype, 'complex floating'):  # use rfft():
         X = sp_fft.rfft(x)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -27,7 +27,7 @@ from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
-    array_namespace, is_torch, is_numpy, xp_copy, xp_size, xp_device,
+    array_namespace, is_torch, is_numpy, xp_copy, xp_size,
 
 )
 from scipy._lib.array_api_compat import is_array_api_obj

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -27,9 +27,10 @@ from ._fir_filter_design import firwin
 from ._sosfilt import _sosfilt
 
 from scipy._lib._array_api import (
-    array_namespace, is_torch, is_numpy, xp_copy, xp_size
+    array_namespace, is_torch, is_numpy, xp_copy, xp_size, xp_device,
 
 )
+from scipy._lib.array_api_compat import is_array_api_obj
 import scipy._lib.array_api_compat.numpy as np_compat
 import scipy._lib.array_api_extra as xpx
 
@@ -2653,10 +2654,10 @@ def hilbert2(x, N=None):
     return x
 
 
-def envelope(z: np.ndarray, bp_in: tuple[int | None, int | None] = (1, None), *,
+def envelope(z, bp_in: tuple[int | None, int | None] = (1, None), *,
              n_out: int | None = None, squared: bool = False,
              residual: Literal['lowpass', 'all', None] = 'lowpass',
-             axis: int = -1) -> np.ndarray:
+             axis: int = -1):
     r"""Compute the envelope of a real- or complex-valued signal.
 
     Parameters
@@ -2899,7 +2900,8 @@ def envelope(z: np.ndarray, bp_in: tuple[int | None, int | None] = (1, None), *,
     if xp.isdtype(z.dtype, 'complex floating'):
         Z = sp_fft.fft(z)
     else:  # avoid calculating negative frequency bins for real signals:
-        Z = xp.zeros_like(z, dtype=sp_fft.rfft(z.flat[:1]).dtype)
+        dt = sp_fft.rfft(z[..., :1]).dtype
+        Z = xp.zeros_like(z, dtype=dt)
         Z[..., :n//2 + 1] = sp_fft.rfft(z)
         if bp.start > 0:  # make signal analytic within bp_in band:
             Z[..., bp] *= 2
@@ -2911,7 +2913,7 @@ def envelope(z: np.ndarray, bp_in: tuple[int | None, int | None] = (1, None), *,
         bp_shift = slice(bp.start + n//2, bp.stop + n//2)
         z_bb = sp_fft.ifft(sp_fft.fftshift(Z, axes=-1)[..., bp_shift], n=n_out) * fak
 
-    z_env = xp.abs(z_bb) if not squared else z_bb.real ** 2 + z_bb.imag ** 2
+    z_env = xp.abs(z_bb) if not squared else xp.real(z_bb) ** 2 + xp.imag(z_bb) ** 2
     z_env = xp.moveaxis(z_env, -1, axis)
 
     # Calculate the residual from the input bandpass filter:
@@ -3629,7 +3631,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     spectrum without antialiasing filter, which is a periodic continuation of the input
     spectrum. The blue x's and orange dots depict the FFT values of the signal created
     by the naive approach as well as this function's result.
-    
+
     >>> import matplotlib.pyplot as plt
     >>> import numpy as np
     >>> from scipy.fft import fftshift, fftfreq, fft, rfft, irfft
@@ -3672,7 +3674,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     ...     ax1.grid()
     ...     fig.legend(loc='outside lower center', ncols=4)    
     >>> plt.show()
-    
+
     The first figure shows that upsampling an odd number of samples produces identical
     results. The second figure illustrates that the signal produced with the naive
     approach (dashed blue line) from an even number of samples does not touch all
@@ -3739,7 +3741,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     illustrates that for some use cases, adpating the `resample_poly` parameters may
     be beneficial. `resample` has a big advantage in this regard: It uses the ideal
     antialiasing filter with the maximum bandwidth by default.
-    
+
     Note that the doubled spectral magnitude at the Nyqist frequency of 64 Hz is due the
     even number of ``n1=128`` output samples, which requires a special treatment as 
     discussed in the previous example. 
@@ -3766,13 +3768,13 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
                              "is not equal to number of frequency bins!")
         W = xp.asarray(window, copy=True)  # prevent modifying the function parameters
     else:
-        W = sp_fft.fftshift(get_window(window, n_x))
+        W = sp_fft.fftshift(get_window(window, n_x, xp=xp))
 
     if domain == 'time' and not xp.isdtype(x.dtype, 'complex floating'):  # use rfft():
         X = sp_fft.rfft(x)
         if W is not None:  # fold window, i.e., W1[l] = (W[l] + W[-l]) / 2 for l > 0
             n_X = X.shape[-1]
-            W[1:n_X] += W[:-n_X:-1]
+            W[1:n_X] += xp.flip(W[-n_X+1:])  #W[:-n_X:-1]
             W[1:n_X] /= 2
             X *= W[:n_X]  # apply window
         X = X[..., :m2]  # extract relevant data
@@ -3926,7 +3928,9 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     >>> plt.show()
 
     """
-    x = np.asarray(x)
+    xp = array_namespace(x)
+
+    x = xp.asarray(x)
     if up != int(up):
         raise ValueError("up must be an integer")
     if down != int(down):
@@ -3945,31 +3949,29 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     up //= g_
     down //= g_
     if up == down == 1:
-        return x.copy()
+        return xp.asarray(x, copy=True)
     n_in = x.shape[axis]
     n_out = n_in * up
     n_out = n_out // down + bool(n_out % down)
 
-    if isinstance(window, (list | np.ndarray)):
-        window = np.array(window)  # use array to force a copy (we modify it)
+    if isinstance(window, list) or is_array_api_obj(window):
+        window = xp.asarray(window, copy=True)  # force a copy (we modify `window`)
         if window.ndim > 1:
             raise ValueError('window must be 1-D')
-        half_len = (window.size - 1) // 2
+        half_len = (xp_size(window) - 1) // 2
         h = window
     else:
         # Design a linear-phase low-pass FIR filter
         max_rate = max(up, down)
         f_c = 1. / max_rate  # cutoff of FIR filter (rel. to Nyquist)
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
-        if np.issubdtype(x.dtype, np.complexfloating):
-            h = firwin(2 * half_len + 1, f_c,
-                       window=window).astype(x.dtype)  # match dtype of x
-        elif np.issubdtype(x.dtype, np.floating):
-            h = firwin(2 * half_len + 1, f_c,
-                       window=window).astype(x.dtype)  # match dtype of x
+        if xp.isdtype(x.dtype, ("real floating", "complex floating")):
+            h = firwin(2 * half_len + 1, f_c, window=window)
+            h = xp.asarray(h, dtype=x.dtype)    # match dtype of x
         else:
-            h = firwin(2 * half_len + 1, f_c,
-                       window=window)
+            h = firwin(2 * half_len + 1, f_c, window=window)
+            h = xp.asarray(h)
+
     h *= up
 
     # Zero-pad our filter to put the output samples at the center
@@ -3977,16 +3979,20 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     n_post_pad = 0
     n_pre_remove = (half_len + n_pre_pad) // down
     # We should rarely need to do this given our filter lengths...
-    while _output_len(len(h) + n_pre_pad + n_post_pad, n_in,
+    while _output_len(h.shape[0] + n_pre_pad + n_post_pad, n_in,
                       up, down) < n_out + n_pre_remove:
         n_post_pad += 1
-    h = np.concatenate((np.zeros(n_pre_pad, dtype=h.dtype), h,
-                        np.zeros(n_post_pad, dtype=h.dtype)))
+    h = xp.concat((xp.zeros(n_pre_pad, dtype=h.dtype), h,
+                   xp.zeros(n_post_pad, dtype=h.dtype)))
     n_pre_remove_end = n_pre_remove + n_out
 
+    # XXX consider using stats.quantile, which is natively Array API compatible
+    def _median(x, *args, **kwds):
+        return xp.asarray(np.median(np.asarray(x), *args, **kwds))
+
     # Remove background depending on the padtype option
-    funcs = {'mean': np.mean, 'median': np.median,
-             'minimum': np.amin, 'maximum': np.amax}
+    funcs = {'mean': xp.mean, 'median': _median,
+             'minimum': xp.min, 'maximum': xp.max}
     upfirdn_kwargs = {'mode': 'constant', 'cval': 0}
     if padtype in funcs:
         background_values = funcs[padtype](x, axis=axis, keepdims=True)
@@ -4841,6 +4847,8 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     if edge > 0:
         # Slice the actual signal from the extended signal.
         y = axis_slice(y, start=edge, stop=-edge, axis=axis)
+        if is_torch(xp):
+            y = y.copy()    #  pytorch/pytorch#59786 : no negative strides in pytorch
 
     return xp.asarray(y)
 

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -20,10 +20,11 @@ JAX_SIGNAL_FUNCS = [
 ]
 
 # some cupyx.scipy.signal functions are incompatible with their scipy counterparts
-CUPY_BLACKLIST = ['lfilter_zi', 'sosfilt_zi', 'get_window']
+CUPY_BLACKLIST = ['lfilter_zi', 'sosfilt_zi', 'get_window', 'envelope', 'remez']
 
 # freqz_sos is a sosfreqz rename, and cupy does not have the new name yet (in v13.x)
 CUPY_RENAMES = {'freqz_sos': 'sosfreqz'}
+
 
 def delegate_xp(delegator, module_name):
     def inner(func):

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -1,18 +1,23 @@
+import math
 import numpy as np
+
 from numpy.testing import assert_warns
-from scipy._lib._array_api import (
-    xp_assert_close, xp_assert_equal,
-    assert_almost_equal, assert_array_almost_equal,
-)
 from pytest import raises as assert_raises
 import pytest
 
+import scipy._lib.array_api_extra as xpx
+from scipy._lib._array_api import (
+    xp_assert_close, xp_assert_equal, assert_almost_equal, assert_array_almost_equal,
+    array_namespace, xp_default_dtype, np_compat
+)
 from scipy.fft import fft, fft2
-from scipy.special import sinc
-from scipy.signal import kaiser_beta, kaiser_atten, kaiserord, \
-    firwin, firwin2, freqz, remez, firls, minimum_phase, \
-    convolve2d
-from scipy.signal._fir_filter_design import firwin_2d
+from scipy.signal import (kaiser_beta, kaiser_atten, kaiserord,
+    firwin, firwin2, freqz, remez, firls, minimum_phase, convolve2d, firwin_2d
+)
+
+skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
+
 
 def test_kaiser_beta():
     b = kaiser_beta(58.7)
@@ -41,17 +46,19 @@ def test_kaiserord():
 class TestFirwin:
 
     def check_response(self, h, expected_response, tol=.05):
-        N = len(h)
+        xp = array_namespace(h)
+        N = h.shape[0]
         alpha = 0.5 * (N-1)
-        m = np.arange(0,N) - alpha   # time indices of taps
+        m = xp.arange(0, N) - alpha   # time indices of taps
         for freq, expected in expected_response:
-            actual = abs(np.sum(h*np.exp(-1.j*np.pi*m*freq)))
-            mse = abs(actual-expected)**2
+            actual = abs(xp.sum(h * xp.exp(-1j * xp.pi * m * freq)))
+            mse = abs(actual - expected)**2
             assert mse < tol, f'response not as expected, mse={mse:g} > {tol:g}'
 
-    def test_response(self):
+    def test_response(self, xp):
         N = 51
         f = .5
+
         # increase length just to try even/odd
         h = firwin(N, f)  # low-pass from 0 to f
         self.check_response(h, [(.25,1), (.75,0)])
@@ -97,7 +104,7 @@ class TestFirwin:
         mse = np.mean(abs(abs(H)-Hideal)**2)
         return mse
 
-    def test_scaling(self):
+    def test_scaling(self, xp):
         """
         For one lowpass, bandpass, and highpass example filter, this test
         checks two things:
@@ -130,29 +137,38 @@ class TestFirwin:
             firwin(51, .5, fs=np.array([10, 20]))
 
 
+@skip_xp_backends(cpu_only=True, reason="TODO convert freqs/freqz")
 class TestFirWinMore:
     """Different author, different style, different tests..."""
 
-    def test_lowpass(self):
+    def test_lowpass(self, xp):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
         kwargs = dict(cutoff=0.5, window=('kaiser', beta), scale=False)
         taps = firwin(ntaps, **kwargs)
 
         # Check the symmetry of taps.
-        assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
+        assert_array_almost_equal(
+            taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1], xp=np_compat
+        )
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.array([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                                    [1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
+
+        freqs = xp.asarray(freqs)    # XXX: convert freqz
+        response = xp.asarray(response)
+
+        assert_array_almost_equal(
+            xp.abs(response),
+            xp.asarray([1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5
+        )
 
         taps_str = firwin(ntaps, pass_zero='lowpass', **kwargs)
-        xp_assert_close(taps, taps_str)
+        xp_assert_close(taps, taps_str, xp=np_compat)
 
-    def test_highpass(self):
+    def test_highpass(self, xp):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
 
@@ -163,39 +179,47 @@ class TestFirWinMore:
         taps = firwin(ntaps, pass_zero=False, **kwargs)
 
         # Check the symmetry of taps.
-        assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
+        assert_array_almost_equal(
+            taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1], xp=np_compat
+        )
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.array([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                                    [0.0, 0.0, 0.0, 1.0, 1.0, 1.0], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+
+        assert_array_almost_equal(xp.abs(response),
+                                  xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='highpass', **kwargs)
-        xp_assert_close(taps, taps_str)
+        xp_assert_close(taps, taps_str, xp=np_compat)
 
-    def test_bandpass(self):
+    def test_bandpass(self, xp):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
         kwargs = dict(cutoff=[0.3, 0.7], window=('kaiser', beta), scale=False)
         taps = firwin(ntaps, pass_zero=False, **kwargs)
 
         # Check the symmetry of taps.
-        assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
+        assert_array_almost_equal(
+            taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1], xp=np_compat
+        )
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.array([0.0, 0.2, 0.3-width/2, 0.3+width/2, 0.5,
-                                0.7-width/2, 0.7+width/2, 0.8, 1.0])
+        freq_samples = xp.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
+                                   0.7 - width/2, 0.7 + width/2, 0.8, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+
+        assert_array_almost_equal(xp.abs(response),
+                xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='bandpass', **kwargs)
-        xp_assert_close(taps, taps_str)
+        xp_assert_close(taps, taps_str, xp=np_compat)
 
-    def test_bandstop_multi(self):
+    def test_bandstop_multi(self, xp):
         width = 0.04
         ntaps, beta = kaiserord(120, width)
         kwargs = dict(cutoff=[0.2, 0.5, 0.8], window=('kaiser', beta),
@@ -203,22 +227,28 @@ class TestFirWinMore:
         taps = firwin(ntaps, **kwargs)
 
         # Check the symmetry of taps.
-        assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
+        assert_array_almost_equal(
+            taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1], xp=np_compat
+        )
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.array([0.0, 0.1, 0.2-width/2, 0.2+width/2, 0.35,
-                                0.5-width/2, 0.5+width/2, 0.65,
-                                0.8-width/2, 0.8+width/2, 0.9, 1.0])
+        freq_samples = xp.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
+                                   0.5 - width/2, 0.5 + width/2, 0.65,
+                                   0.8 - width/2, 0.8 + width/2, 0.9, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-                decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+
+        assert_array_almost_equal(
+            xp.abs(response),
+            xp.asarray([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+            decimal=5
+        )
 
         taps_str = firwin(ntaps, pass_zero='bandstop', **kwargs)
-        xp_assert_close(taps, taps_str)
+        xp_assert_close(taps, taps_str, xp=np_compat)
 
-    def test_fs_nyq(self):
+    def test_fs_nyq(self, xp):
         """Test the fs and nyq keywords."""
         nyquist = 1000
         width = 40.0
@@ -228,17 +258,22 @@ class TestFirWinMore:
                         pass_zero=False, scale=False, fs=2*nyquist)
 
         # Check the symmetry of taps.
-        assert_array_almost_equal(taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2-1:-1])
+        assert_array_almost_equal(
+            taps[:ntaps//2], taps[ntaps:ntaps-ntaps//2 - 1:-1], xp=np_compat
+        )
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.array([0.0, 200, 300-width/2, 300+width/2, 500,
-                                700-width/2, 700+width/2, 800, 1000])
+        freq_samples = xp.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
+                                   700 - width/2, 700 + width/2, 800, 1000])
         freqs, response = freqz(taps, worN=np.pi*freq_samples/nyquist)
-        assert_array_almost_equal(np.abs(response),
-                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
 
-    def test_bad_cutoff(self):
+        assert_array_almost_equal(xp.abs(response),
+                xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
+
+    @skip_xp_backends(np_only=True)
+    def test_bad_cutoff(self, xp):
         """Test that invalid cutoff argument raises ValueError."""
         # cutoff values must be greater than 0 and less than 1.
         assert_raises(ValueError, firwin, 99, -0.5)
@@ -257,17 +292,19 @@ class TestFirWinMore:
         assert_raises(ValueError, firwin, 99, 50.0, fs=80)
         assert_raises(ValueError, firwin, 99, [10, 20, 30], fs=50)
 
+    @skip_xp_backends(np_only=True)
     def test_even_highpass_raises_value_error(self):
         """Test that attempt to create a highpass filter with an even number
         of taps raises a ValueError exception."""
         assert_raises(ValueError, firwin, 40, 0.5, pass_zero=False)
         assert_raises(ValueError, firwin, 40, [.25, 0.5])
 
+    @skip_xp_backends(np_only=True)
     def test_bad_pass_zero(self):
         """Test degenerate pass_zero cases."""
-        with assert_raises(ValueError, match='pass_zero must be'):
+        with assert_raises(ValueError, match="^Parameter pass_zero='foo' not in "):
             firwin(41, 0.5, pass_zero='foo')
-        with assert_raises(TypeError, match='cannot be interpreted'):
+        with assert_raises(ValueError, match="^Parameter pass_zero=1.0 not in "):
             firwin(41, 0.5, pass_zero=1.)
         for pass_zero in ('lowpass', 'highpass'):
             with assert_raises(ValueError, match='cutoff must have one'):
@@ -276,14 +313,17 @@ class TestFirWinMore:
             with assert_raises(ValueError, match='must have at least two'):
                 firwin(41, [0.5], pass_zero=pass_zero)
 
+    @skip_xp_backends(np_only=True)
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             firwin2(51, .5, 1, fs=np.array([10, 20]))
 
 
+@skip_xp_backends(cpu_only=True, reason="firwin2 uses np.interp")
 class TestFirwin2:
 
-    def test_invalid_args(self):
+    @skip_xp_backends(np_only=True)
+    def test_invalid_args(self, xp):
         # `freq` and `gain` have different lengths.
         with assert_raises(ValueError, match='must be of same length'):
             firwin2(50, [0, 0.5, 1], [0.0, 1.0])
@@ -330,110 +370,142 @@ class TestFirwin2:
         with assert_raises(ValueError, match='Type IV filter'):
             firwin2(16, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0], antisymmetric=True)
 
-    def test01(self):
+    def test01(self, xp):
         width = 0.04
         beta = 12.0
         ntaps = 400
         # Filter is 1 from w=0 to w=0.5, then decreases linearly from 1 to 0 as w
         # increases from w=0.5 to w=1  (w=1 is the Nyquist frequency).
-        freq = [0.0, 0.5, 1.0]
-        gain = [1.0, 1.0, 0.0]
+        freq = xp.asarray([0.0, 0.5, 1.0])
+        gain = xp.asarray([1.0, 1.0, 0.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = np.array([0.0, 0.25, 0.5-width/2, 0.5+width/2,
-                                                        0.75, 1.0-width/2])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
+                                                        0.75, 1.0 - width/2])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                        [1.0, 1.0, 1.0, 1.0-width, 0.5, width], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        assert_array_almost_equal(
+            xp.abs(response),
+            xp.asarray([1.0, 1.0, 1.0, 1.0 - width, 0.5, width]), decimal=5
+        )
 
-    def test02(self):
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test02(self, xp):
         width = 0.04
         beta = 12.0
         # ntaps must be odd for positive gain at Nyquist.
         ntaps = 401
         # An ideal highpass filter.
-        freq = [0.0, 0.5, 0.5, 1.0]
-        gain = [0.0, 0.0, 1.0, 1.0]
+        freq = xp.asarray([0.0, 0.5, 0.5, 1.0])
+        gain = xp.asarray([0.0, 0.0, 1.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = np.array([0.0, 0.25, 0.5-width, 0.5+width, 0.75, 1.0])
+        freq_samples = np.array([0.0, 0.25, 0.5 - width, 0.5 + width, 0.75, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        assert_array_almost_equal(
+            xp.abs(response),
+            xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
+        )
 
-    def test03(self):
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test03(self, xp):
         width = 0.02
         ntaps, beta = kaiserord(120, width)
         # ntaps must be odd for positive gain at Nyquist.
         ntaps = int(ntaps) | 1
-        freq = [0.0, 0.4, 0.4, 0.5, 0.5, 1.0]
-        gain = [1.0, 1.0, 0.0, 0.0, 1.0, 1.0]
+        freq = xp.asarray([0.0, 0.4, 0.4, 0.5, 0.5, 1.0])
+        gain = xp.asarray([1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = np.array([0.0, 0.4-width, 0.4+width, 0.45,
-                                    0.5-width, 0.5+width, 0.75, 1.0])
+        freq_samples = np.array([0.0, 0.4 - width, 0.4 + width, 0.45,
+                                    0.5 - width, 0.5 + width, 0.75, 1.0])
         freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        assert_array_almost_equal(np.abs(response),
-                    [1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0], decimal=5)
+        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        assert_array_almost_equal(
+            xp.abs(response),
+            xp.asarray([1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
+        )
 
-    def test04(self):
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test04(self, xp):
         """Test firwin2 when window=None."""
         ntaps = 5
         # Ideal lowpass: gain is 1 on [0,0.5], and 0 on [0.5, 1.0]
-        freq = [0.0, 0.5, 0.5, 1.0]
-        gain = [1.0, 1.0, 0.0, 0.0]
+        freq = xp.asarray([0.0, 0.5, 0.5, 1.0])
+        gain = xp.asarray([1.0, 1.0, 0.0, 0.0])
+
         taps = firwin2(ntaps, freq, gain, window=None, nfreqs=8193)
         alpha = 0.5 * (ntaps - 1)
-        m = np.arange(0, ntaps) - alpha
-        h = 0.5 * sinc(0.5 * m)
+        m = xp.arange(0, ntaps, dtype=freq.dtype) - alpha
+        h = 0.5 * xpx.sinc(0.5 * m)
         assert_array_almost_equal(h, taps)
 
-    def test05(self):
+    def test05(self, xp):
         """Test firwin2 for calculating Type IV filters"""
         ntaps = 1500
 
-        freq = [0.0, 1.0]
-        gain = [0.0, 1.0]
+        freq = xp.asarray([0.0, 1.0])
+        gain = xp.asarray([0.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=None, antisymmetric=True)
-        assert_array_almost_equal(taps[: ntaps // 2], -taps[ntaps // 2:][::-1])
 
-        freqs, response = freqz(taps, worN=2048)
-        assert_array_almost_equal(abs(response), freqs / np.pi, decimal=4)
+        flip = array_namespace(freq).flip
+        dec = {'decimal': 4.5} if xp_default_dtype(xp) == xp.float32 else {}
+        assert_array_almost_equal(taps[: ntaps // 2], flip(-taps[ntaps // 2:]), **dec)
 
-    def test06(self):
+        freqs, response = freqz(np.asarray(taps), worN=2048)    # XXX convert freqz
+        assert_array_almost_equal(abs(xp.asarray(response)),
+                                  xp.asarray(freqs / np.pi), decimal=4)
+
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test06(self, xp):
         """Test firwin2 for calculating Type III filters"""
         ntaps = 1501
 
-        freq = [0.0, 0.5, 0.55, 1.0]
-        gain = [0.0, 0.5, 0.0, 0.0]
+        freq = xp.asarray([0.0, 0.5, 0.55, 1.0])
+        gain = xp.asarray([0.0, 0.5, 0.0, 0.0])
         taps = firwin2(ntaps, freq, gain, window=None, antisymmetric=True)
         assert taps[ntaps // 2] == 0.0
-        assert_array_almost_equal(taps[: ntaps // 2], -taps[ntaps // 2 + 1:][::-1])
 
-        freqs, response1 = freqz(taps, worN=2048)
-        response2 = np.interp(freqs / np.pi, freq, gain)
+        flip = array_namespace(freq).flip
+        dec = {'decimal': 4.5} if xp_default_dtype(xp) == xp.float32 else {}
+        assert_array_almost_equal(taps[: ntaps // 2],
+                                  flip(-taps[ntaps // 2 + 1:]), **dec
+        )
+
+        freqs, response1 = freqz(np.asarray(taps), worN=2048)  # XXX convert freqz
+        response1 = xp.asarray(response1)
+        response2 = xp.asarray(
+            np.interp(np.asarray(freqs) / np.pi, np.asarray(freq), np.asarray(gain))
+        )
         assert_array_almost_equal(abs(response1), response2, decimal=3)
 
-    def test_fs_nyq(self):
-        taps1 = firwin2(80, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0])
-        taps2 = firwin2(80, [0.0, 30.0, 60.0], [1.0, 1.0, 0.0], fs=120.0)
+    def test_fs_nyq(self, xp):
+        taps1 = firwin2(80, xp.asarray([0.0, 0.5, 1.0]), xp.asarray([1.0, 1.0, 0.0]))
+        taps2 = firwin2(80, xp.asarray([0.0, 30.0, 60.0]), xp.asarray([1.0, 1.0, 0.0]),
+                        fs=120.0)
         assert_array_almost_equal(taps1, taps2)
 
-    def test_tuple(self):
+    @skip_xp_backends(np_only=True, reason="test array-likes")
+    def test_tuple(self, xp):
         taps1 = firwin2(150, (0.0, 0.5, 0.5, 1.0), (1.0, 1.0, 0.0, 0.0))
         taps2 = firwin2(150, [0.0, 0.5, 0.5, 1.0], [1.0, 1.0, 0.0, 0.0])
         assert_array_almost_equal(taps1, taps2)
 
-    def test_input_modyfication(self):
-        freq1 = np.array([0.0, 0.5, 0.5, 1.0])
-        freq2 = np.array(freq1)
-        firwin2(80, freq1, [1.0, 1.0, 0.0, 0.0])
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test_input_modyfication(self, xp):
+        freq1 = xp.asarray([0.0, 0.5, 0.5, 1.0])
+        freq2 = xp.asarray(freq1)
+        firwin2(80, freq1, xp.asarray([1.0, 1.0, 0.0, 0.0]))
         xp_assert_equal(freq1, freq2)
 
 
+@skip_xp_backends(cpu_only=True)
 class TestRemez:
 
-    def test_bad_args(self):
+    @skip_xp_backends(np_only=True)
+    def test_bad_args(self, xp):
         assert_raises(ValueError, remez, 11, [0.1, 0.4], [1], type='pooka')
 
-    def test_hilbert(self):
+    @skip_xp_backends(np_only=True)
+    def test_hilbert(self, xp):
         N = 11  # number of taps in the filter
         a = 0.1  # width of the transition band
 
@@ -462,14 +534,15 @@ class TestRemez:
         idx = np.logical_and(f > a, f < 0.5-a)
         assert (abs(Hmag[idx] - 1) < 0.015).all(), "Pass Band Close To Unity"
 
-    def test_compare(self):
+    def test_compare(self, xp):
         # test comparison to MATLAB
         k = [0.024590270518440, -0.041314581814658, -0.075943803756711,
              -0.003530911231040, 0.193140296954975, 0.373400753484939,
              0.373400753484939, 0.193140296954975, -0.003530911231040,
              -0.075943803756711, -0.041314581814658, 0.024590270518440]
-        h = remez(12, [0, 0.3, 0.5, 1], [1, 0], fs=2.)
-        xp_assert_close(h, k)
+        h = remez(12, xp.asarray([0, 0.3, 0.5, 1]), xp.asarray([1, 0]), fs=2.)
+        atol_arg = {'atol': 1e-8} if xp_default_dtype(xp) == xp.float32 else {}
+        xp_assert_close(h, xp.asarray(k, dtype=xp.float64), **atol_arg)
 
         h = [-0.038976016082299, 0.018704846485491, -0.014644062687875,
              0.002879152556419, 0.016849978528150, -0.043276706138248,
@@ -478,15 +551,24 @@ class TestRemez:
              0.129770906801075, -0.103908158578635, 0.073641298245579,
              -0.043276706138248, 0.016849978528150, 0.002879152556419,
              -0.014644062687875, 0.018704846485491, -0.038976016082299]
-        xp_assert_close(remez(21, [0, 0.8, 0.9, 1], [0, 1], fs=2.), h)
+        atol_arg = {'atol': 3e-8} if xp_default_dtype(xp) == xp.float32 else {}
+        xp_assert_close(
+            remez(21, xp.asarray([0, 0.8, 0.9, 1]), xp.asarray([0, 1]), fs=2.),
+            xp.asarray(h, dtype=xp.float64), **atol_arg
+        )
 
-    def test_fs_validation(self):
+    @skip_xp_backends(np_only=True)
+    def test_fs_validation(self, xp):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             remez(11, .1, 1, fs=np.array([10, 20]))
 
+
+
+@skip_xp_backends(cpu_only=True, reason="lstsq")
 class TestFirls:
 
-    def test_bad_args(self):
+    @skip_xp_backends(np_only=True)
+    def test_bad_args(self, xp):
         # even numtaps
         assert_raises(ValueError, firls, 10, [0.1, 0.2], [0, 0])
         # odd bands
@@ -505,112 +587,131 @@ class TestFirls:
         # negative weight
         assert_raises(ValueError, firls, 11, [0.1, 0.2], [0, 0], weight=[-1])
 
-    def test_firls(self):
+    @skip_xp_backends("dask.array", reason="dask fancy indexing shape=(nan,)")
+    def test_firls(self, xp):
         N = 11  # number of taps in the filter
         a = 0.1  # width of the transition band
 
         # design a halfband symmetric low-pass filter
-        h = firls(11, [0, a, 0.5-a, 0.5], [1, 1, 0, 0], fs=1.0)
+        h = firls(11, xp.asarray([0, a, 0.5 - a, 0.5]), xp.asarray([1, 1, 0, 0]),
+                  fs=1.0)
 
         # make sure the filter has correct # of taps
         assert h.shape[0] == N
 
         # make sure it is symmetric
         midx = (N-1) // 2
-        assert_array_almost_equal(h[:midx], h[:-midx-1:-1])
+        flip = array_namespace(h).flip
+        assert_array_almost_equal(h[:midx],  flip(h[midx+1:])) # h[:-midx-1:-1])
 
         # make sure the center tap is 0.5
-        assert_almost_equal(h[midx], 0.5)
+        assert math.isclose(h[midx], 0.5, abs_tol=1e-8) 
 
         # For halfband symmetric, odd coefficients (except the center)
         # should be zero (really small)
-        hodd = np.hstack((h[1:midx:2], h[-midx+1::2]))
-        assert_array_almost_equal(hodd, np.zeros_like(hodd))
+        hodd = xp.stack((h[1:midx:2], h[-midx+1::2]))
+        assert_array_almost_equal(hodd, xp.zeros_like(hodd))
 
         # now check the frequency response
-        w, H = freqz(h, 1)
-        f = w/2/np.pi
-        Hmag = np.abs(H)
+        w, H = freqz(np.asarray(h), 1)
+        w, H = xp.asarray(w), xp.asarray(H)
+        f = w/2/xp.pi
+        Hmag = xp.abs(H)
 
         # check that the pass band is close to unity
-        idx = np.logical_and(f > 0, f < a)
-        assert_array_almost_equal(Hmag[idx], np.ones_like(Hmag[idx]), decimal=3)
+        idx = xp.logical_and(f > 0, f < a)
+        assert_array_almost_equal(Hmag[idx], xp.ones_like(Hmag[idx]), decimal=3)
 
         # check that the stop band is close to zero
-        idx = np.logical_and(f > 0.5-a, f < 0.5)
-        assert_array_almost_equal(Hmag[idx], np.zeros_like(Hmag[idx]), decimal=3)
+        idx = xp.logical_and(f > 0.5 - a, f < 0.5)
+        assert_array_almost_equal(Hmag[idx], xp.zeros_like(Hmag[idx]), decimal=3)
 
-    def test_compare(self):
+    def test_compare(self, xp):
         # compare to OCTAVE output
-        taps = firls(9, [0, 0.5, 0.55, 1], [1, 1, 0, 0], weight=[1, 2])
+        taps = firls(9, xp.asarray([0, 0.5, 0.55, 1]),
+                    xp.asarray([1, 1, 0, 0]), weight=xp.asarray([1, 2]))
         # >> taps = firls(8, [0 0.5 0.55 1], [1 1 0 0], [1, 2]);
         known_taps = [-6.26930101730182e-04, -1.03354450635036e-01,
                       -9.81576747564301e-03, 3.17271686090449e-01,
                       5.11409425599933e-01, 3.17271686090449e-01,
                       -9.81576747564301e-03, -1.03354450635036e-01,
                       -6.26930101730182e-04]
-        xp_assert_close(taps, known_taps)
+        atol_arg = {'atol': 5e-8} if xp_default_dtype(xp) == xp.float32 else {}
+        known_taps = xp.asarray(known_taps, dtype=xp.float64)
+        xp_assert_close(taps, known_taps, **atol_arg)
 
         # compare to MATLAB output
-        taps = firls(11, [0, 0.5, 0.5, 1], [1, 1, 0, 0], weight=[1, 2])
+        taps = firls(11, xp.asarray([0, 0.5, 0.5, 1]),
+                     xp.asarray([1, 1, 0, 0]), weight=xp.asarray([1, 2]))
         # >> taps = firls(10, [0 0.5 0.5 1], [1 1 0 0], [1, 2]);
         known_taps = [
             0.058545300496815, -0.014233383714318, -0.104688258464392,
             0.012403323025279, 0.317930861136062, 0.488047220029700,
             0.317930861136062, 0.012403323025279, -0.104688258464392,
             -0.014233383714318, 0.058545300496815]
-        xp_assert_close(taps, known_taps)
+        known_taps = xp.asarray(known_taps, dtype=xp.float64)
+        atol_arg = {'atol': 3e-8} if xp_default_dtype(xp) == xp.float32 else {}
+        xp_assert_close(taps, known_taps, **atol_arg)
 
         # With linear changes:
-        taps = firls(7, (0, 1, 2, 3, 4, 5), [1, 0, 0, 1, 1, 0], fs=20)
+        taps = firls(7, xp.asarray((0, 1, 2, 3, 4, 5)),
+                     xp.asarray([1, 0, 0, 1, 1, 0]), fs=20)
         # >> taps = firls(6, [0, 0.1, 0.2, 0.3, 0.4, 0.5], [1, 0, 0, 1, 1, 0])
         known_taps = [
             1.156090832768218, -4.1385894727395849, 7.5288619164321826,
             -8.5530572592947856, 7.5288619164321826, -4.1385894727395849,
             1.156090832768218]
+        known_taps = xp.asarray(known_taps, dtype=xp.float64)
         xp_assert_close(taps, known_taps)
 
-    def test_rank_deficient(self):
+    def test_rank_deficient(self, xp):
         # solve() runs but warns (only sometimes, so here we don't use match)
-        x = firls(21, [0, 0.1, 0.9, 1], [1, 1, 0, 0])
-        w, h = freqz(x, fs=2.)
-        absh2 = np.abs(h[:2])
-        xp_assert_close(absh2, np.ones_like(absh2), atol=1e-5)
-        absh2 = np.abs(h[-2:])
-        xp_assert_close(absh2, np.zeros_like(absh2), atol=1e-6, rtol=1e-7)
+        x = firls(21, xp.asarray([0, 0.1, 0.9, 1]), xp.asarray([1, 1, 0, 0]))
+        w, h = freqz(np.asarray(x), fs=2.)
+        w, h = map(xp.asarray, (w, h))   # XXX convert freqz
+        absh2 = xp.abs(h[:2])
+        xp_assert_close(absh2, xp.ones_like(absh2), atol=1e-5)
+        absh2 = xp.abs(h[-2:])
+        xp_assert_close(absh2, xp.zeros_like(absh2), atol=1e-6, rtol=1e-7)
         # switch to pinvh (tolerances could be higher with longer
         # filters, but using shorter ones is faster computationally and
         # the idea is the same)
-        x = firls(101, [0, 0.01, 0.99, 1], [1, 1, 0, 0])
-        w, h = freqz(x, fs=2.)
-        mask = w < 0.01
-        assert mask.sum() > 3
-        habs = np.abs(h[mask])
-        xp_assert_close(habs, np.ones_like(habs), atol=1e-4)
-        mask = w > 0.99
-        assert mask.sum() > 3
-        habs = np.abs(h[mask])
-        xp_assert_close(habs, np.zeros_like(habs), atol=1e-4)
+        x = firls(101, xp.asarray([0, 0.01, 0.99, 1]), xp.asarray([1, 1, 0, 0]))
+        w, h = freqz(np.asarray(x), fs=2.)
+        w, h = map(xp.asarray, (w, h))   # XXX convert freqz
+        mask = xp.asarray(w < 0.01)
+        h = xp.asarray(h)
+        assert xp.sum(xp.astype(mask, xp.int64)) > 3
+        habs = xp.abs(h[mask])
+        xp_assert_close(habs, xp.ones_like(habs), atol=1e-4)
+        mask = xp.asarray(w > 0.99)
+        assert xp.sum(xp.astype(mask, xp.int64)) > 3
+        habs = xp.abs(h[mask])
+        xp_assert_close(habs, xp.zeros_like(habs), atol=1e-4)
 
+    @skip_xp_backends(np_only=True)
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             firls(11, .1, 1, fs=np.array([10, 20]))
 
 class TestMinimumPhase:
+
+    @skip_xp_backends(np_only=True)
     @pytest.mark.thread_unsafe
-    def test_bad_args(self):
+    def test_bad_args(self, xp):
         # not enough taps
         assert_raises(ValueError, minimum_phase, [1.])
         assert_raises(ValueError, minimum_phase, [1., 1.])
         assert_raises(ValueError, minimum_phase, np.full(10, 1j))
-        assert_raises(ValueError, minimum_phase, 'foo')
+        assert_raises((ValueError, TypeError), minimum_phase, 'foo')
         assert_raises(ValueError, minimum_phase, np.ones(10), n_fft=8)
         assert_raises(ValueError, minimum_phase, np.ones(10), method='foo')
         assert_warns(RuntimeWarning, minimum_phase, np.arange(3))
         with pytest.raises(ValueError, match="is only supported when"):
             minimum_phase(np.ones(3), method='hilbert', half=False)
 
-    def test_homomorphic(self):
+    @skip_xp_backends(np_only=True)
+    def test_homomorphic(self, xp):
         # check that it can recover frequency responses of arbitrary
         # linear-phase filters
 
@@ -630,7 +731,9 @@ class TestMinimumPhase:
             assert len(h_linear) == len(h_new)
             xp_assert_close(np.abs(fft(h_new)), np.abs(fft(h_linear)), rtol=1e-4)
 
-    def test_hilbert(self):
+    @skip_xp_backends("dask.array", reason="too slow")
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    def test_hilbert(self, xp):
         # compare to MATLAB output of reference implementation
 
         # f=[0 0.3 0.5 1];
@@ -639,6 +742,8 @@ class TestMinimumPhase:
         h = remez(12, [0, 0.3, 0.5, 1], [1, 0], fs=2.)
         k = [0.349585548646686, 0.373552164395447, 0.326082685363438,
              0.077152207480935, -0.129943946349364, -0.059355880509749]
+        h = xp.asarray(h)
+        k = xp.asarray(k, dtype=xp.float64)
         m = minimum_phase(h, 'hilbert')
         xp_assert_close(m, k, rtol=5e-3)
 
@@ -650,6 +755,8 @@ class TestMinimumPhase:
              -0.157957283165866, 0.151739294892963, -0.129293146705090,
              0.100787844523204, -0.065832656741252, 0.035361328741024,
              -0.014977068692269, -0.158416139047557]
+        h = xp.asarray(h)
+        k = xp.asarray(k, dtype=xp.float64)
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
         xp_assert_close(m, k, rtol=2e-3)
 

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -137,7 +137,6 @@ class TestFirwin:
             firwin(51, .5, fs=np.array([10, 20]))
 
 
-@skip_xp_backends(cpu_only=True, reason="TODO convert freqs/freqz")
 class TestFirWinMore:
     """Different author, different style, different tests..."""
 
@@ -272,8 +271,12 @@ class TestFirWinMore:
         assert_array_almost_equal(xp.abs(response),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
 
-    @skip_xp_backends(np_only=True)
-    def test_bad_cutoff(self, xp):
+    def test_array_cutoff(self, xp):
+        taps = firwin(3, xp.asarray([.1, .2]))
+        # the value is as computed by scipy==1.5.2
+        xp_assert_close(taps, xp.asarray([-0.00801395, 1.0160279, -0.00801395]), atol=1e-8)
+
+    def test_bad_cutoff(self):
         """Test that invalid cutoff argument raises ValueError."""
         # cutoff values must be greater than 0 and less than 1.
         assert_raises(ValueError, firwin, 99, -0.5)
@@ -292,14 +295,12 @@ class TestFirWinMore:
         assert_raises(ValueError, firwin, 99, 50.0, fs=80)
         assert_raises(ValueError, firwin, 99, [10, 20, 30], fs=50)
 
-    @skip_xp_backends(np_only=True)
     def test_even_highpass_raises_value_error(self):
         """Test that attempt to create a highpass filter with an even number
         of taps raises a ValueError exception."""
         assert_raises(ValueError, firwin, 40, 0.5, pass_zero=False)
         assert_raises(ValueError, firwin, 40, [.25, 0.5])
 
-    @skip_xp_backends(np_only=True)
     def test_bad_pass_zero(self):
         """Test degenerate pass_zero cases."""
         with assert_raises(ValueError, match="^Parameter pass_zero='foo' not in "):
@@ -313,7 +314,6 @@ class TestFirWinMore:
             with assert_raises(ValueError, match='must have at least two'):
                 firwin(41, [0.5], pass_zero=pass_zero)
 
-    @skip_xp_backends(np_only=True)
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             firwin2(51, .5, 1, fs=np.array([10, 20]))

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1424,6 +1424,7 @@ class TestResample:
     @pytest.mark.parametrize('window', (None, 'hamming'))
     @pytest.mark.parametrize('N', (20, 19))
     @pytest.mark.parametrize('num', (100, 101, 10, 11))
+    @skip_xp_backends('jax.numpy', reason='immutable arrays')
     def test_rfft(self, N, num, window, xp):
         # Make sure the speed up using rfft gives the same result as the normal
         # way using fft

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -34,7 +34,7 @@ from scipy._lib import _testutils
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
     assert_array_almost_equal, assert_almost_equal,
-    xp_copy, xp_size, xp_default_dtype
+    xp_copy, xp_size, xp_default_dtype, array_namespace
 )
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
@@ -1381,14 +1381,19 @@ padtype_options = ["mean", "median", "minimum", "maximum", "line"]
 padtype_options += _upfirdn_modes
 
 
-@skip_xp_backends(np_only=True)
+@skip_xp_backends("dask.array", reason="XXX something in dask")
 class TestResample:
+
+    @skip_xp_backends("jax.numpy", reason="immutable arrays")
+    @skip_xp_backends(
+        cpu_only=True, reason="resample_poly/upfirdn is CPU only"
+    )
     def test_basic(self, xp):
         # Some basic tests
 
         # Regression test for issue #3603.
         # window.shape must equal to sig.shape[0]
-        sig = np.arange(128)
+        sig = xp.arange(128, dtype=xp.float64)
         num = 256
         win = signal.get_window(('kaiser', 8.0), 160)
         assert_raises(ValueError, signal.resample, sig, num, window=win)
@@ -1405,7 +1410,7 @@ class TestResample:
         assert_raises(ValueError, signal.resample_poly, sig, 2, 1, window=np.eye(2))
 
         # test for issue #6505 - should not modify window.shape when axis ≠ 0
-        sig2 = np.tile(np.arange(160), (2, 1))
+        sig2 = xp.tile(xp.arange(160, dtype=xp.float64), (2, 1))
         signal.resample(sig2, num, axis=-1, window=win)
         assert win.shape == (160,)
 
@@ -1422,21 +1427,30 @@ class TestResample:
     def test_rfft(self, N, num, window, xp):
         # Make sure the speed up using rfft gives the same result as the normal
         # way using fft
-        x = np.linspace(0, 10, N, endpoint=False)
-        y = np.cos(-x**2/6.0)
-        xp_assert_close(signal.resample(y, num, window=window),
-                        signal.resample(y + 0j, num, window=window).real)
+        dt_r = xp_default_dtype(xp)
+        dt_c = xp.complex64 if dt_r == xp.float32 else xp.complex128
 
-        y = np.array([np.cos(-x**2/6.0), np.sin(-x**2/6.0)])
-        y_complex = y + 0j
+        x = xp.linspace(0, 10, N, endpoint=False)
+        y = xp.cos(-x**2/6.0)
+        desired = signal.resample(xp.astype(y, dt_c), num, window=window)
+        xp_assert_close(signal.resample(y, num, window=window),
+                        xp.real(desired))
+
+        y = xp.stack([xp.cos(-x**2/6.0), xp.sin(-x**2/6.0)])
+        y_complex = xp.astype(y, dt_c)
+        resampled = signal.resample(y_complex, num, axis=1, window=window)
+
+        atol = 1e-9 if dt_r == xp.float64 else 3e-7
+
         xp_assert_close(
             signal.resample(y, num, axis=1, window=window),
-            signal.resample(y_complex, num, axis=1, window=window).real,
-            atol=1e-9)
+            xp.real(resampled),
+            atol=atol)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_input_domain(self, xp):
         # Test if both input domain modes produce the same results.
-        tsig = np.arange(256) + 0j
+        tsig = xp.astype(xp.arange(256), xp.complex128)
         fsig = sp_fft.fft(tsig)
         num = 256
         xp_assert_close(
@@ -1444,39 +1458,54 @@ class TestResample:
             signal.resample(tsig, num, domain='time'),
             atol=1e-9)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize('nx', (1, 2, 3, 5, 8))
     @pytest.mark.parametrize('ny', (1, 2, 3, 5, 8))
-    @pytest.mark.parametrize('dtype', ('float', 'complex'))
+    @pytest.mark.parametrize('dtype', ('float64', 'complex128'))
     def test_dc(self, nx, ny, dtype, xp):
-        x = np.array([1] * nx, dtype)
+        dtype = getattr(xp, dtype)
+        x = xp.asarray([1] * nx, dtype=dtype)
         y = signal.resample(x, ny)
-        xp_assert_close(y, np.asarray([1] * ny, dtype=y.dtype))
+        xp_assert_close(y, xp.asarray([1] * ny, dtype=y.dtype))
 
+    @skip_xp_backends(cpu_only=True, reason="resample_poly/upfirdn is CPU only")
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype, xp):
         # Test that a mutable window is not modified
-        impulse = np.zeros(3)
-        window = np.random.RandomState(0).randn(2)
-        window_orig = window.copy()
+        impulse = xp.zeros(3)
+        window = xp.asarray(np.random.RandomState(0).randn(2))
+        window_orig = xp.asarray(window, copy=True)
         signal.resample_poly(impulse, 5, 1, window=window, padtype=padtype)
         xp_assert_equal(window, window_orig)
 
+    @skip_xp_backends(
+        cpu_only=True, reason="resample_poly/upfirdn is CPU only"
+    )
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_output_float32(self, padtype, xp):
         # Test that float32 inputs yield a float32 output
-        x = np.arange(10, dtype=np.float32)
-        h = np.array([1, 1, 1], dtype=np.float32)
+        x = xp.arange(10, dtype=xp.float32)
+        h = xp.asarray([1, 1, 1], dtype=xp.float32)
         y = signal.resample_poly(x, 1, 2, window=h, padtype=padtype)
-        assert y.dtype == np.float32
+        assert y.dtype == xp.float32
 
+
+    @skip_xp_backends(
+        cpu_only=True, reason="resample_poly/upfirdn is CPU only"
+    )
     @pytest.mark.parametrize('padtype', padtype_options)
-    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
     def test_output_match_dtype(self, padtype, dtype, xp):
         # Test that the dtype of x is preserved per issue #14733
-        x = np.arange(10, dtype=dtype)
+        dtype = getattr(xp, dtype)
+        x = xp.arange(10, dtype=dtype)
         y = signal.resample_poly(x, 1, 2, padtype=padtype)
         assert y.dtype == x.dtype
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
+    @skip_xp_backends(
+        cpu_only=True, reason="resample_poly/upfirdn is CPU only"
+    )
     @pytest.mark.parametrize(
         "method, ext, padtype",
         [("fft", False, None)]
@@ -1492,13 +1521,13 @@ class TestResample:
         rates_to = [49, 50, 51, 99, 100, 101, 199, 200, 201]
 
         # Sinusoids, windowed to avoid edge artifacts
-        t = np.arange(rate) / float(rate)
-        freqs = np.array((1., 10., 40.))[:, np.newaxis]
-        x = np.sin(2 * np.pi * freqs * t) * hann(rate)
+        t = xp.arange(rate, dtype=xp.float64) / float(rate)
+        freqs = xp.asarray((1., 10., 40.))[:, xp.newaxis]
+        x = xp.sin(2 * xp.pi * freqs * t) * hann(rate, xp=xp)
 
         for rate_to in rates_to:
-            t_to = np.arange(rate_to) / float(rate_to)
-            y_tos = np.sin(2 * np.pi * freqs * t_to) * hann(rate_to)
+            t_to = xp.arange(rate_to, dtype=xp.float64) / float(rate_to)
+            y_tos = xp.sin(2 * xp.pi * freqs * t_to) * hann(rate_to, xp=xp)
             if method == 'fft':
                 y_resamps = signal.resample(x, rate_to, axis=-1)
             else:
@@ -1519,9 +1548,13 @@ class TestResample:
                 y_resamps = signal.resample_poly(x, rate_to, rate, axis=-1,
                                                  **polyargs)
 
-            for y_to, y_resamp, freq in zip(y_tos, y_resamps, freqs):
+            for i in range(y_tos.shape[0]):
+                y_to = y_tos[i, :]
+                y_resamp = y_resamps[i, :]
+                freq = float(freqs[i, 0])
                 if freq >= 0.5 * rate_to:
-                    y_to.fill(0.)  # mostly low-passed away
+                    #y_to.fill(0.)  # mostly low-passed away
+                    y_to = xp.zeros_like(y_to)  # mostly low-passed away
                     if padtype in ['minimum', 'maximum']:
                         xp_assert_close(y_resamp, y_to, atol=3e-1)
                     else:
@@ -1534,9 +1567,10 @@ class TestResample:
         # Random data
         rng = np.random.RandomState(0)
         x = hann(rate) * np.cumsum(rng.randn(rate))  # low-pass, wind
+        x = xp.asarray(x)
         for rate_to in rates_to:
             # random data
-            t_to = np.arange(rate_to) / float(rate_to)
+            t_to = xp.arange(rate_to, dtype=xp.float64) / float(rate_to)
             y_to = np.interp(t_to, t, x)
             if method == 'fft':
                 y_resamp = signal.resample(x, rate_to)
@@ -1544,21 +1578,20 @@ class TestResample:
                 y_resamp = signal.resample_poly(x, rate_to, rate,
                                                 padtype=padtype)
             assert y_to.shape == y_resamp.shape
-            corr = np.corrcoef(y_to, y_resamp)[0, 1]
+            corr = xp.asarray(np.corrcoef(y_to, np.asarray(y_resamp))[0, 1])
             assert corr > 0.99, corr
 
         # More tests of fft method (Master 0.18.1 fails these)
         if method == 'fft':
-            x1 = np.array([1.+0.j, 0.+0.j])
+            x1 = xp.asarray([1.+0.j, 0.+0.j])
             y1_test = signal.resample(x1, 4)
             # upsampling a complex array
-            y1_true = np.array([1.+0.j, 0.5+0.j, 0.+0.j, 0.5+0.j])
+            y1_true = xp.asarray([1.+0.j, 0.5+0.j, 0.+0.j, 0.5+0.j])
             xp_assert_close(y1_test, y1_true, atol=1e-12)
-            x2 = np.array([1., 0.5, 0., 0.5])
+            x2 = xp.asarray([1., 0.5, 0., 0.5])
             y2_test = signal.resample(x2, 2)  # downsampling a real array
-            y2_true = np.array([1., 0.])
+            y2_true = xp.asarray([1., 0.])
             xp_assert_close(y2_test, y2_true, atol=1e-12)
-
 
     @pytest.mark.parametrize("n_in", (8, 9))
     @pytest.mark.parametrize("n_out", (3, 4))
@@ -1606,48 +1639,62 @@ class TestResample:
         xp_assert_close(y1_r, x1, atol=1e-12)
         xp_assert_close(y1_c.real, x1, atol=1e-12)
 
-    def test_poly_vs_filtfilt(self, xp):
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
+    @skip_xp_backends(
+        cpu_only=True, exceptions=["cupy"], reason="filtfilt is CPU-only"
+    )
+    @pytest.mark.parametrize('down_factor', [2, 11, 79])
+    def test_poly_vs_filtfilt(self, down_factor, xp):
         # Check that up=1.0 gives same answer as filtfilt + slicing
         random_state = np.random.RandomState(17)
         try_types = (int, np.float32, np.complex64, float, complex)
         size = 10000
-        down_factors = [2, 11, 79]
 
         for dtype in try_types:
             x = random_state.randn(size).astype(dtype)
             if dtype in (np.complex64, np.complex128):
                 x += 1j * random_state.randn(size)
+            x = xp.asarray(x)
 
             # resample_poly assumes zeros outside of signl, whereas filtfilt
             # can only constant-pad. Make them equivalent:
             x[0] = 0
             x[-1] = 0
 
-            for down in down_factors:
-                h = signal.firwin(31, 1. / down, window='hamming')
-                yf = filtfilt(h, 1.0, x, padtype='constant')[::down]
+            h = signal.firwin(31, 1. / down_factor, window='hamming')
+            h = xp.asarray(h)   # XXX: convert firwin
+            yf = filtfilt(h, 1.0, x, padtype='constant')[::down_factor]
 
-                # Need to pass convolved version of filter to resample_poly,
-                # since filtfilt does forward and backward, but resample_poly
-                # only goes forward
-                hc = convolve(h, h[::-1])
-                y = signal.resample_poly(x, 1, down, window=hc)
-                xp_assert_close(yf, y, atol=1e-7, rtol=1e-7)
+            # Need to pass convolved version of filter to resample_poly,
+            # since filtfilt does forward and backward, but resample_poly
+            # only goes forward
+            hc = convolve(h, xp.flip(h))
+            y = signal.resample_poly(x, 1, down_factor, window=hc)
+            xp_assert_close(yf, y, atol=1e-7, rtol=1e-7)
 
+    @skip_xp_backends(
+        cpu_only=True, exceptions=["cupy"], reason="correlate1d is CPU-only"
+    )
     def test_correlate1d(self, xp):
         for down in [2, 4]:
             for nx in range(1, 40, down):
                 for nweights in (32, 33):
                     x = np.random.random((nx,))
                     weights = np.random.random((nweights,))
-                    y_g = correlate1d(x, weights[::-1], mode='constant')
+                    x, weights = map(xp.asarray, (x, weights))
+                    flip = array_namespace(x).flip
+                    y_g = correlate1d(x, flip(weights), mode='constant')
                     y_s = signal.resample_poly(
                         x, up=1, down=down, window=weights)
                     xp_assert_close(y_g[::down], y_s)
 
-    @pytest.mark.parametrize('dtype', [np.int32, np.float32])
+    @skip_xp_backends(
+        cpu_only=True, reason="resample_poly/upfirdn is CPU only"
+    )
+    @pytest.mark.parametrize('dtype', ['int32', 'float32'])
     def test_gh_15620(self, dtype, xp):
-        data = np.array([0, 1, 2, 3, 2, 1, 0], dtype=dtype)
+        dtype = getattr(xp, dtype)
+        data = xp.asarray([0, 1, 2, 3, 2, 1, 0], dtype=dtype)
         actual = signal.resample_poly(data,
                                       up=2,
                                       down=1,
@@ -3457,14 +3504,18 @@ class TestHilbert2:
         assert xp.real(signal.hilbert2(in_typed)).dtype == dtype
 
 
-@skip_xp_backends(np_only=True)
 class TestEnvelope:
     """Unit tests for function `._signaltools.envelope()`. """
 
     @staticmethod
-    def assert_close(actual, desired, msg):
+    def assert_close(actual, desired, msg, xp):
+        a_r_tol = ({'atol': 1e-12, 'rtol': 1e-12}
+                   if xp_default_dtype(xp) == xp.float64
+                   else {'atol': 1e-5, 'rtol': 1e-5}
+        )
+
         """Little helper to compare to arrays with proper tolerances"""
-        xp_assert_close(actual, desired, atol=1e-12, rtol=1e-12, err_msg=msg)
+        xp_assert_close(actual, desired, **a_r_tol, err_msg=msg)
 
     def test_envelope_invalid_parameters(self, xp):
         """For `envelope()` Raise all exceptions that are used to verify function
@@ -3474,72 +3525,85 @@ class TestEnvelope:
             envelope(np.ones(3), axis=2)
         with pytest.raises(ValueError,
                            match=r"z.shape\[axis\] not > 0 for z.shape=.*"):
-            envelope(np.ones((3, 0)), axis=1)
+            envelope(xp.ones((3, 0)), axis=1)
         for bp_in in [(0, 1, 2), (0, 2.), (None, 2.)]:
             ts = ', '.join(map(str, bp_in))
             with pytest.raises(ValueError,
                                match=rf"bp_in=\({ts}\) isn't a 2-tuple of.*"):
                 # noinspection PyTypeChecker
-                envelope(np.ones(4), bp_in=bp_in)
+                envelope(xp.ones(4), bp_in=bp_in)
         with pytest.raises(ValueError,
                            match="n_out=10.0 is not a positive integer or.*"):
             # noinspection PyTypeChecker
-            envelope(np.ones(4), n_out=10.)
+            envelope(xp.ones(4), n_out=10.)
         for bp_in in [(-1, 3), (1, 1), (0, 10)]:
             with pytest.raises(ValueError,
                                match=r"`-n//2 <= bp_in\[0\] < bp_in\[1\] <=.*"):
-                envelope(np.ones(4), bp_in=bp_in)
+                envelope(xp.ones(4), bp_in=bp_in)
         with pytest.raises(ValueError, match="residual='undefined' not in .*"):
             # noinspection PyTypeChecker
-            envelope(np.ones(4), residual='undefined')
+            envelope(xp.ones(4), residual='undefined')
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_parameters(self, xp):
         """Ensure that the various parametrizations produce compatible results. """
-        Z, Zr_a = [4, 2, 2, 3, 0], [4, 0, 0, 6, 0, 0, 0, 0]
+        dt_r = xp_default_dtype(xp)
+        dt_c = xp.complex64 if dt_r == xp.float32 else xp.complex128
+
+        Z = xp.asarray([4.0, 2, 2, 3, 0], dtype=dt_r)
+        Zr_a = xp.asarray([4.0, 0, 0, 6, 0, 0, 0, 0], dtype=dt_r)
         z = sp_fft.irfft(Z)
-        n = len(z)
+        n = z.shape[0]
 
         # the reference envelope:
-        ze2_0, zr_0 = envelope(z, (1, 3), residual='all', squared=True)
-        self.assert_close(sp_fft.rfft(ze2_0), np.array([4, 2, 0, 0, 0]).astype(complex),
-                          msg="Envelope calculation error")
-        self.assert_close(sp_fft.rfft(zr_0), np.array([4, 0, 0, 3, 0]).astype(complex),
-                          msg="Residual calculation error")
+        ze2_0, zr_0 = xp.unstack(envelope(z, (1, 3), residual='all', squared=True))
+        self.assert_close(sp_fft.rfft(ze2_0),
+                          xp.asarray([4, 2, 0, 0, 0], dtype=dt_c),
+                          msg="Envelope calculation error", xp=xp)
+        self.assert_close(sp_fft.rfft(zr_0),
+                          xp.asarray([4, 0, 0, 3, 0], dtype=dt_c),
+                          msg="Residual calculation error", xp=xp)
 
-        ze_1, zr_1 = envelope(z, (1, 3), residual='all', squared=False)
+        ze_1, zr_1 = xp.unstack(envelope(z, (1, 3), residual='all', squared=False))
         self.assert_close(ze_1**2, ze2_0,
-                          msg="Unsquared versus Squared envelope calculation error")
+                          msg="Unsquared versus Squared envelope calculation error",
+                          xp=xp)
         self.assert_close(zr_1, zr_0,
-                          msg="Unsquared versus Squared residual calculation error")
+                          msg="Unsquared versus Squared residual calculation error",
+                          xp=xp)
 
-        ze2_2, zr_2 = envelope(z, (1, 3), residual='all', squared=True, n_out=3*n)
+        ze2_2, zr_2 = xp.unstack(
+            envelope(z, (1, 3), residual='all', squared=True, n_out=3*n)
+        )
         self.assert_close(ze2_2[::3], ze2_0,
-                          msg="3x up-sampled envelope calculation error")
+                          msg="3x up-sampled envelope calculation error", xp=xp)
         self.assert_close(zr_2[::3], zr_0,
-                          msg="3x up-sampled residual calculation error")
+                          msg="3x up-sampled residual calculation error", xp=xp)
 
-        ze2_3, zr_3 = envelope(z, (1, 3), residual='lowpass', squared=True)
+        ze2_3, zr_3 = xp.unstack(envelope(z, (1, 3), residual='lowpass', squared=True))
         self.assert_close(ze2_3, ze2_0,
-                          msg="`residual='lowpass'` envelope calculation error")
-        self.assert_close(sp_fft.rfft(zr_3), np.array([4, 0, 0, 0, 0]).astype(complex),
-                          msg="`residual='lowpass'` residual calculation error")
+                          msg="`residual='lowpass'` envelope calculation error", xp=xp)
+        self.assert_close(sp_fft.rfft(zr_3),
+                          xp.asarray([4, 0, 0, 0, 0], dtype=dt_c),
+                          msg="`residual='lowpass'` residual calculation error", xp=xp)
 
         ze2_4 = envelope(z, (1, 3), residual=None, squared=True)
         self.assert_close(ze2_4, ze2_0,
-                          msg="`residual=None` envelope calculation error")
+                          msg="`residual=None` envelope calculation error", xp=xp)
 
         # compare complex analytic signal to real version
-        Z_a = np.copy(Z)
+        Z_a = xp.asarray(Z, copy=True)
         Z_a[1:] *= 2
         z_a = sp_fft.ifft(Z_a, n=n)  # analytic signal of Z
-        self.assert_close(z_a.real, z,
-                          msg="Reference analytic signal error")
-        ze2_a, zr_a = envelope(z_a, (1, 3), residual='all', squared=True)
-        self.assert_close(ze2_a, ze2_0.astype(complex),  # dtypes must match
-                          msg="Complex envelope calculation error")
-        self.assert_close(sp_fft.fft(zr_a), np.array(Zr_a).astype(complex),
-                          msg="Complex residual calculation error")
+        self.assert_close(xp.real(z_a), z,
+                          msg="Reference analytic signal error", xp=xp)
+        ze2_a, zr_a = xp.unstack(envelope(z_a, (1, 3), residual='all', squared=True))
+        self.assert_close(ze2_a, xp.astype(ze2_0, dt_c),  # dtypes must match
+                          msg="Complex envelope calculation error", xp=xp)
+        self.assert_close(sp_fft.fft(zr_a), xp.asarray(Zr_a, dtype=dt_c),
+                          msg="Complex residual calculation error", xp=xp)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize(
         "               Z,        bp_in,     Ze2_desired,      Zr_desired",
         [([1, 0, 2, 2, 0],    (1, None), [4, 2, 0, 0, 0], [1, 0, 0, 0, 0]),
@@ -3559,25 +3623,30 @@ class TestEnvelope:
         determined by an FFT and that the absolute square of a Fourier series is again
         a Fourier series.
         """
+        Z = xp.asarray(Z, dtype=xp.float64)
+        Ze2_desired = xp.asarray(Ze2_desired, dtype=xp.float64)
+        Zr_desired = xp.asarray(Zr_desired, dtype=xp.float64)
+
         z = sp_fft.irfft(Z)
-        ze2, zr = envelope(z, bp_in, residual='all', squared=True)
-        ze2_lp, zr_lp = envelope(z, bp_in, residual='lowpass', squared=True)
+        ze2, zr = xp.unstack(envelope(z, bp_in, residual='all', squared=True))
+        ze2_lp, zr_lp = xp.unstack(envelope(z, bp_in, residual='lowpass', squared=True))
         Ze2, Zr, Ze2_lp, Zr_lp = (sp_fft.rfft(z_) for z_ in (ze2, zr, ze2_lp, zr_lp))
 
-        Ze2_desired = np.array(Ze2_desired).astype(complex)
-        Zr_desired = np.array(Zr_desired).astype(complex)
+        Ze2_desired = xp.asarray(Ze2_desired, dtype=xp.complex128)
+        Zr_desired = xp.asarray(Zr_desired, dtype=xp.complex128)
         self.assert_close(Ze2, Ze2_desired,
-                          msg="Envelope calculation error (residual='all')")
+                          msg="Envelope calculation error (residual='all')", xp=xp)
         self.assert_close(Zr, Zr_desired,
-                          msg="Residual calculation error (residual='all')")
+                          msg="Residual calculation error (residual='all')", xp=xp)
 
         if bp_in[1] is not None:
             Zr_desired[bp_in[1]:] = 0
         self.assert_close(Ze2_lp, Ze2_desired,
-                          msg="Envelope calculation error (residual='lowpass')")
+                          msg="Envelope calculation error (residual='lowpass')", xp=xp)
         self.assert_close(Zr_lp, Zr_desired,
-                          msg="Residual calculation error (residual='lowpass')")
+                          msg="Residual calculation error (residual='lowpass')", xp=xp)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize(
         "               Z,        bp_in,         Ze2_desired,         Zr_desired",
         [([0, 5, 0, 5, 0], (None, None),    [5, 0, 10, 0, 5],    [0, 0, 0, 0, 0]),
@@ -3590,56 +3659,92 @@ class TestEnvelope:
         We only need to test for the complex envelope here, since the ``Nones``s in the
         bandpass filter were already tested in the previous test.
         """
+        Z = xp.asarray(Z, dtype=xp.float64)
+        Ze2_desired = xp.asarray(Ze2_desired, dtype=xp.complex128)
+        Zr_desired = xp.asarray(Zr_desired, dtype=xp.complex128)
+
         z = sp_fft.ifft(sp_fft.ifftshift(Z))
-        ze2, zr = envelope(z, bp_in, residual='all', squared=True)
+        ze2, zr = xp.unstack(envelope(z, bp_in, residual='all', squared=True))
         Ze2, Zr = (sp_fft.fftshift(sp_fft.fft(z_)) for z_ in (ze2, zr))
 
-        self.assert_close(Ze2, np.array(Ze2_desired).astype(complex),
-                          msg="Envelope calculation error")
-        self.assert_close(Zr, np.array(Zr_desired).astype(complex),
-                          msg="Residual calculation error")
+        self.assert_close(Ze2, Ze2_desired,
+                          msg="Envelope calculation error", xp=xp)
+        self.assert_close(Zr, Zr_desired,
+                          msg="Residual calculation error", xp=xp)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_axis_parameter(self, xp):
         """Test for multi-channel envelope calculations. """
-        z = sp_fft.irfft([[1, 0, 2, 2, 0], [7, 0, 4, 4, 0]])
-        Ze2_desired = np.array([[4, 2, 0, 0, 0], [16, 8, 0, 0, 0]],
-                               dtype=complex)
-        Zr_desired = np.array([[1, 0, 0, 0, 0], [7, 0, 0, 0, 0]], dtype=complex)
+        dt_r = xp_default_dtype(xp)
+        dt_c = xp.complex64 if dt_r == xp.float32 else xp.complex128
 
-        ze2, zr = envelope(z, squared=True, axis=1)
-        ye2T, yrT = envelope(z.T, squared=True, axis=0)
+        z = sp_fft.irfft(xp.asarray([[1.0, 0, 2, 2, 0], [7, 0, 4, 4, 0]], dtype=dt_r))
+        Ze2_desired = xp.asarray([[4, 2, 0, 0, 0], [16, 8, 0, 0, 0]],
+                                 dtype=dt_c)
+        Zr_desired = xp.asarray([[1, 0, 0, 0, 0], [7, 0, 0, 0, 0]], dtype=dt_c)
+
+        ze2, zr = xp.unstack(envelope(z, squared=True, axis=1))
+        ye2T, yrT = xp.unstack(envelope(z.T, squared=True, axis=0))
         Ze2, Ye2, Zr, Yr = (sp_fft.rfft(z_) for z_ in (ze2, ye2T.T, zr, yrT.T))
 
-        self.assert_close(Ze2, Ze2_desired, msg="2d envelope calculation error")
-        self.assert_close(Zr, Zr_desired,  msg="2d residual calculation error")
-        self.assert_close(Ye2, Ze2_desired, msg="Transposed 2d envelope calc. error")
-        self.assert_close(Yr, Zr_desired, msg="Transposed 2d residual calc. error")
+        self.assert_close(Ze2, Ze2_desired, msg="2d envelope calculation error", xp=xp)
+        self.assert_close(Zr, Zr_desired,  msg="2d residual calculation error", xp=xp)
+        self.assert_close(
+            Ye2, Ze2_desired, msg="Transposed 2d envelope calc. error", xp=xp
+        )
+        self.assert_close(
+            Yr, Zr_desired, msg="Transposed 2d residual calc. error", xp=xp
+        )
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_axis_parameter_complex(self, xp):
         """Test for multi-channel envelope calculations with complex values. """
-        z = sp_fft.ifft(sp_fft.ifftshift([[1, 5, 0, 5, 2], [1, 10, 0, 10, 2]], axes=1))
-        Ze2_des = np.array([[5, 0, 10, 0, 5], [20, 0, 40, 0, 20],],
-                           dtype=complex)
-        Zr_des = np.array([[1, 0, 0, 0, 2], [1, 0, 0, 0, 2]], dtype=complex)
+        dt_r = xp_default_dtype(xp)
+        dt_c = xp.complex64 if dt_r == xp.float32 else xp.complex128
+        inp = xp.asarray([[1.0, 5, 0, 5, 2], [1, 10, 0, 10, 2]], dtype=dt_r)
+        z = sp_fft.ifft(sp_fft.ifftshift(inp, axes=1))
+        Ze2_des = xp.asarray([[5, 0, 10, 0, 5], [20, 0, 40, 0, 20],], dtype=dt_c)
+        Zr_des = xp.asarray([[1, 0, 0, 0, 2], [1, 0, 0, 0, 2]], dtype=dt_c)
 
         kw = dict(bp_in=(-1, 2), residual='all', squared=True)
-        ze2, zr = envelope(z, axis=1, **kw)
-        ye2T, yrT = envelope(z.T, axis=0, **kw)
+        ze2, zr = xp.unstack(envelope(z, axis=1, **kw))
+        ye2T, yrT = xp.unstack(envelope(z.T, axis=0, **kw))
         Ze2, Ye2, Zr, Yr = (sp_fft.fftshift(sp_fft.fft(z_), axes=1)
                             for z_ in (ze2, ye2T.T, zr, yrT.T))
 
-        self.assert_close(Ze2, Ze2_des, msg="2d envelope calculation error")
-        self.assert_close(Zr, Zr_des, msg="2d residual calculation error")
-        self.assert_close(Ye2, Ze2_des,  msg="Transposed 2d envelope calc. error")
-        self.assert_close(Yr, Zr_des,  msg="Transposed 2d residual calc. error")
+        self.assert_close(Ze2, Ze2_des, msg="2d envelope calculation error", xp=xp)
+        self.assert_close(Zr, Zr_des, msg="2d residual calculation error", xp=xp)
+        self.assert_close(
+            Ye2, Ze2_des,  msg="Transposed 2d envelope calc. error", xp=xp
+        )
+        self.assert_close(Yr, Zr_des,  msg="Transposed 2d residual calc. error", xp=xp)
 
+    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize('X', [[4, 0, 0, 1, 2], [4, 0, 0, 2, 1, 2]])
     def test_compare_envelope_hilbert(self, X, xp):
         """Compare output of `envelope()` and `hilbert()`. """
+        X = xp.asarray(X, dtype=xp.float64)
         x = sp_fft.irfft(X)
-        e_hil = np.abs(hilbert(x))
+        e_hil = xp.abs(hilbert(x))
         e_env = envelope(x, (None, None), residual=None)
-        self.assert_close(e_hil, e_env, msg="Hilbert-Envelope comparison error")
+        self.assert_close(e_hil, e_env, msg="Hilbert-Envelope comparison error", xp=xp)
+
+    def test_nyquist(self):
+        """Test behavior when input is a cosine at the Nyquist frequency.
+
+        Resampling even length signals, requires accounting for unpaired bins at the
+        Nyquist frequency (consults the source code of `resample`).
+
+        Since `envelope` excludes the Nyquist frequency from the envelope calculation,
+        only the residues need to be investigated.
+        """
+        x4 = sp_fft.irfft([0, 0, 8])  # = [2, -2, 2, -2]
+        x6 = signal.resample(x4, num=6)  # = [2, -1, -1, 2, -1, -1]
+        y6, y6_res = envelope(x4, n_out=6, residual='all')  # real-valued case
+        z6, z6_res = envelope(x4 + 0j, n_out=6, residual='all')  # complex-valued case
+
+        xp_assert_close(y6, np.zeros(6), atol=1e-12)
+        xp_assert_close(y6_res, x6, atol=1e-12)
 
     def test_nyquist(self):
         """Test behavior when input is a cosine at the Nyquist frequency.

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3746,23 +3746,6 @@ class TestEnvelope:
         xp_assert_close(y6, np.zeros(6), atol=1e-12)
         xp_assert_close(y6_res, x6, atol=1e-12)
 
-    def test_nyquist(self):
-        """Test behavior when input is a cosine at the Nyquist frequency.
-
-        Resampling even length signals, requires accounting for unpaired bins at the
-        Nyquist frequency (consults the source code of `resample`).
-
-        Since `envelope` excludes the Nyquist frequency from the envelope calculation,
-        only the residues need to be investigated.
-        """
-        x4 = sp_fft.irfft([0, 0, 8])  # = [2, -2, 2, -2]
-        x6 = signal.resample(x4, num=6)  # = [2, -1, -1, 2, -1, -1]
-        y6, y6_res = envelope(x4, n_out=6, residual='all')  # real-valued case
-        z6, z6_res = envelope(x4 + 0j, n_out=6, residual='all')  # complex-valued case
-
-        xp_assert_close(y6, np.zeros(6), atol=1e-12)
-        xp_assert_close(y6_res, x6, atol=1e-12)
-
         xp_assert_close(z6, np.zeros(6, dtype=z6.dtype), atol=1e-12)
         xp_assert_close(z6_res, x6.astype(z6.dtype), atol=1e-12)
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/20678

#### What does this implement/fix?
<!--Please explain your changes.-->

Convert `envelope`, `resample` and `resample_poly` to be array API compatible.

- [x] envelope
- [x] resample
- [x] resample_poly

This completes the conversion of the 'filtering' rubic of scipy.signal (https://docs.scipy.org/doc/scipy/reference/signal.html#filtering)

While at it, convert

- [x] remez
- [x] firwin
- [x] firwin2
- [x] firls
- [x] minimum_phase

This completes `tests/test_fir_filter_design.py`

