### PR TITLE
TST: turn off dtype check due to endianness

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2164,7 +2164,9 @@ class TestSmoothingSpline:
         # such tolerance is explained by the fact that the spline is built
         # using an iterative algorithm for minimizing the GCV criteria. These
         # algorithms may vary, so the tolerance should be rather low.
-        xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4)
+        # Not checking dtypes as gcvspl.npz stores little endian arrays, which
+        # result in conflicting dtypes on big endian systems. 
+        xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4, check_dtype=False)
 
     def test_non_regularized_case(self):
         """


### PR DESCRIPTION
#### Reference issue
N/A

On big endian systems (s390x), the test test_compare_with_GCVSPL fails with dtypes do not match.
```

INFO     |   _________________ TestSmoothingSpline.test_compare_with_GCVSPL _________________
INFO     |   [gw1] linux -- Python 3.13.1 $PREFIX/bin/python
INFO     |   ../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.13/site-packages/scipy/interpolate/tests/test_bsplines.py:2167: in test_compare_with_GCVSPL
INFO     |       xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4)
INFO     |   E   AssertionError: dtypes do not match.
INFO     |   E   Actual: float64
INFO     |   E   Desired: <f8
INFO     |           data       = NpzFile 'object' with keys: x, y, y_GCVSPL
INFO     |           self       = <scipy.interpolate.tests.test_bsplines.TestSmoothingSpline object at 0x3ff557c8cd0>
INFO     |           x          = array([-1.97516593, -1.97294375, -1.9449262 , -1.82670375, -1.81057888,
INFO     |          -1.78450526, -1.77153745, -1.76076311, ...,  1.69947051,  1.73256041,
INFO     |           1.80571506,  1.83255741,  1.83520705,  1.92801897,  1.96832586],
INFO     |         dtype='<f8')
INFO     |           y          = array([-0.53566623, -0.4277627 , -0.79540805, -0.27144091, -0.93146848,
INFO     |          -1.17723332, -1.49384435, -1.27436961, ...,  1.70322587, -0.08698282,
INFO     |           0.298767  ,  1.14771802,  0.95787061,  1.57306914,  0.19723692],
INFO     |         dtype='<f8')
INFO     |           y_GCVSPL   = array([-0.86934054, -0.86977361, -0.87522579, -0.89717033, -0.89990233,
INFO     |          -0.9041072 , -0.90608369, -0.9076613 , ...,  0.90529273,  0.90530736,
INFO     |           0.90485928,  0.90458777,  0.90455804,  0.90317193,  0.90239065],
INFO     |         dtype='<f8')
INFO     |           y_compr    = array([-0.86933814, -0.86977123, -0.87522362, -0.897169  , -0.89990111,
INFO     |          -0.90410616, -0.90608273, -0.9076604 , ...475499,  0.90510192,  0.90529202,  0.90530654,
INFO     |           0.90485822,  0.90458662,  0.90455688,  0.90317046,  0.90238903])
```

#### What does this implement/fix?

This test loads `gcvspl.npz` which is a set of 3 little endian arrays.
The array `y_GCVSPL` is compared to computed `y_compr` On big endian systems, `y_compr` is big endian, resulting in different dtypes. `xp_assert_close` checks that dtypes are matching by default. Before https://github.com/scipy/scipy/pull/21117, `assert_allclose` was used.

This change disables dtype checks for this test.



#### Additional information

N/A