### PR TITLE
DOC: Harmonize summary line of docstrings of iterative sparse solvers.

### DIFF
--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -184,7 +184,7 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
 def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=None,
             m=20, k=None, CU=None, discard_C=False, truncate='oldest'):
     """
-    Solve a matrix equation using flexible GCROT(m,k) algorithm.
+    Solve ``Ax = b`` with the flexible GCROT(m,k) algorithm.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -306,7 +306,8 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
 
 def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None):
     """
-    Solve ``Ax = b`` with the Conjugate Gradient method, for a symmetric, positive-definite `A`.
+    Solve ``Ax = b`` with the Conjugate Gradient method, for a symmetric,
+    positive-definite `A`.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -22,7 +22,8 @@ def _get_atol_rtol(name, b_norm, atol=0., rtol=1e-5):
 
 
 def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None):
-    """Use BIConjugate Gradient iteration to solve ``Ax = b``.
+    """
+    Solve ``Ax = b`` with the BIConjugate Gradient method.
 
     Parameters
     ----------
@@ -156,7 +157,8 @@ def bicg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=No
 
 def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
              callback=None):
-    """Use BIConjugate Gradient STABilized iteration to solve ``Ax = b``.
+    """
+    Solve ``Ax = b`` with the BIConjugate Gradient STABilized method.
 
     Parameters
     ----------
@@ -303,7 +305,8 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
 
 
 def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None):
-    """Use Conjugate Gradient iteration to solve ``Ax = b``.
+    """
+    Solve ``Ax = b`` with the Conjugate Gradient method, for a symmetric, positive-definite `A`.
 
     Parameters
     ----------
@@ -423,7 +426,8 @@ def cg(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None
 
 
 def cgs(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=None):
-    """Use Conjugate Gradient Squared iteration to solve ``Ax = b``.
+    """
+    Solve ``Ax = b`` with the Conjugate Gradient Squared method.
 
     Parameters
     ----------
@@ -582,7 +586,7 @@ def cgs(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None, callback=Non
 def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=None,
           callback=None, callback_type=None):
     """
-    Use Generalized Minimal RESidual iteration to solve ``Ax = b``.
+    Solve ``Ax = b`` with the Generalized Minimal RESidual method.
 
     Parameters
     ----------
@@ -843,7 +847,8 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0., restart=None, maxiter=None, M=No
 
 def qmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M1=None, M2=None,
         callback=None):
-    """Use Quasi-Minimal Residual iteration to solve ``Ax = b``.
+    """
+    Solve ``Ax = b`` with the Quasi-Minimal Residual method.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -16,7 +16,7 @@ def lgmres(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback=
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
            prepend_outer_v=False):
     """
-    Solve a matrix equation using the LGMRES algorithm.
+    Solve ``Ax = b`` with the LGMRES algorithm.
 
     The LGMRES algorithm [1]_ [2]_ is designed to avoid some problems
     in the convergence in restarted GMRES, and often converges in fewer

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -10,7 +10,7 @@ __all__ = ['minres']
 def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
            M=None, callback=None, show=False, check=False):
     """
-    Use MINimum RESidual iteration to solve Ax=b
+    Solve ``Ax = b`` with the MINimum RESidual method, for a symmetric `A`.
 
     MINRES minimizes norm(Ax - b) for a real symmetric matrix A.  Unlike
     the Conjugate Gradient method, A can be indefinite or singular.

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -9,7 +9,7 @@ __all__ = ['tfqmr']
 def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
           callback=None, show=False):
     """
-    Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
+    Solve ``Ax = b`` with the Transpose-Free Quasi-Minimal Residual method.
 
     Parameters
     ----------


### PR DESCRIPTION
The summary lines are shown next to one another under "Solving linear problems" in the docs for sparse.linalg; give them all the same format and also clarify which methods require symmetry or positive-definiteness.

Currently, the docs (at https://scipy.github.io/devdocs/reference/sparse.linalg.html#solving-linear-problems) appear as
![Screenshot 2025-01-17 at 13 07 07](https://github.com/user-attachments/assets/fc085fcf-84fa-4b2e-a02b-057b3d862b5c)
note the inconsistent presentation and lack of indication of matrix requirements.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
