### PR TITLE
DOC: sparse.linalg.eigsh: fix inconsistent definitions of OP and OPinv#18214

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1424,14 +1424,25 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         solver if either A or M is a general linear operator.
         Alternatively, the user can supply the matrix or operator OPinv,
         which gives ``x = OPinv @ b = [A - sigma * M]^-1 @ b``.
+        Regardless of the selected mode (normal, cayley, or buckling),
+        users should always supply the operator x = OPinv @ b = [A - sigma * M]^-1 @ b,
+        which represents the inverse of the shifted matrix.
+        This ensures consistency in the interface and simplifies user input.
+        The solver will internally handle the necessary transformations for different modes,
+        so the user does not need to adjust the operator depending on the mode.
+        The correct eigenvalue transformation 
+        (e.g., for Cayley or buckling modes) will be applied automatically.
         Note that when sigma is specified, the keyword 'which' refers to
         the shifted eigenvalues ``w'[i]`` where:
 
-            if mode == 'normal', ``w'[i] = 1 / (w[i] - sigma)``.
+            if mode == 'normal':
+                ``w'[i] = 1 / (w[i] - sigma)``.
 
-            if mode == 'cayley', ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
+            if mode == 'cayley':
+                  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
 
-            if mode == 'buckling', ``w'[i] = w[i] / (w[i] - sigma)``.
+            if mode == 'buckling':
+                  ``w'[i] = w[i] / (w[i] - sigma)``.
 
         (see further discussion in 'mode' below)
     v0 : ndarray, optional

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1422,27 +1422,19 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         unspecified.  This is computed internally via a (sparse) LU
         decomposition for explicit matrices A & M, or via an iterative
         solver if either A or M is a general linear operator.
-        Alternatively, the user can supply the matrix or operator OPinv,
+        Alternatively, the user can supply the matrix or operator `OPinv`,
         which gives ``x = OPinv @ b = [A - sigma * M]^-1 @ b``.
         Regardless of the selected mode (normal, cayley, or buckling),
-        users should always supply the operator x = OPinv @ b = [A - sigma * M]^-1 @ b,
-        which represents the inverse of the shifted matrix.
-        This ensures consistency in the interface and simplifies user input.
-        The solver will internally handle the necessary transformations for different modes,
-        so the user does not need to adjust the operator depending on the mode.
-        The correct eigenvalue transformation 
-        (e.g., for Cayley or buckling modes) will be applied automatically.
+        `OPinv` should always be supplied as ``OPinv = [A - sigma * M]^-1``.
+
         Note that when sigma is specified, the keyword 'which' refers to
         the shifted eigenvalues ``w'[i]`` where:
 
-            if mode == 'normal':
-                ``w'[i] = 1 / (w[i] - sigma)``.
+            if ``mode == 'normal'``: ``w'[i] = 1 / (w[i] - sigma)``.
 
-            if mode == 'cayley':
-                  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
+            if ``mode == 'cayley'``:  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
 
-            if mode == 'buckling':
-                  ``w'[i] = w[i] / (w[i] - sigma)``.
+            if ``mode == 'buckling'``: ``w'[i] = w[i] / (w[i] - sigma)``.
 
         (see further discussion in 'mode' below)
     v0 : ndarray, optional


### PR DESCRIPTION

#### Reference issue
Closes gh-18214.

#### What does this implement/fix?
This PR updates the documentation regarding the `sigma` shift-invert mode used in eigenvalue solvers. It clarifies the behavior and transformation of eigenvalues for different modes (`normal`, `cayley`, and `buckling`). The documentation now provides clear details on how eigenvalue transformations are applied in each mode, ensuring better understanding for users working with these modes in the solver.

#### Additional information
No code changes have been made; this is a documentation update only.
Location of the changes - 
scipy/scipy/sparse/linalg/_eigen/arpack/arpack.py
from line 1427 to 1434 .

