### PR TITLE
BUG: sparse: fix selecting wrong dtype for coo coords

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -148,7 +148,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             new_coords = np.unravel_index(flat_coords, shape, order=order)
 
-        idx_dtype = self._get_index_dtype(new_coords, maxval=max(shape))
+        idx_dtype = self._get_index_dtype(self.coords, maxval=max(shape))
         new_coords = tuple(np.asarray(co, dtype=idx_dtype) for co in new_coords)
 
         # Handle copy here rather than passing on to the constructor so that no

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -148,7 +148,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             new_coords = np.unravel_index(flat_coords, shape, order=order)
 
-        idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.shape))
+        idx_dtype = self._get_index_dtype(new_coords, maxval=max(shape))
         new_coords = tuple(np.asarray(co, dtype=idx_dtype) for co in new_coords)
 
         # Handle copy here rather than passing on to the constructor so that no

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -129,6 +129,14 @@ def test_non_subscriptability():
                        match="'coo_array' object is not subscriptable"):
         coo_2d[0, :]
 
+def test_reshape_overflow():
+    # see gh-22353 : new idx_dtype needs to be int64 instead of int32
+    M, N = (1045507, 523266)
+    coords = (np.array([M - 1], dtype='int32'), np.array([N - 1], dtype='int32'))
+    A = coo_array(([3.3], coords), shape=(M, N))
+    B = A.reshape((M * N, 1))
+    assert B.coords[0][0] == (M * N) - 1
+
 def test_reshape():
     arr1d = coo_array([1, 0, 3])
     assert arr1d.shape == (3,)

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -130,12 +130,20 @@ def test_non_subscriptability():
         coo_2d[0, :]
 
 def test_reshape_overflow():
-    # see gh-22353 : new idx_dtype needs to be int64 instead of int32
+    # see gh-22353 : new idx_dtype can need to be int64 instead of int32
     M, N = (1045507, 523266)
     coords = (np.array([M - 1], dtype='int32'), np.array([N - 1], dtype='int32'))
     A = coo_array(([3.3], coords), shape=(M, N))
+
+    # need new idx_dtype to not overflow
     B = A.reshape((M * N, 1))
+    assert B.coords[0].dtype == np.dtype('int64')
     assert B.coords[0][0] == (M * N) - 1
+
+    # need idx_dtype to stay int32 if before and after can be int32
+    C = A.reshape(N, M)
+    assert C.coords[0].dtype == np.dtype('int32')
+    assert C.coords[0][0] == N - 1
 
 def test_reshape():
     arr1d = coo_array([1, 0, 3])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This fixes a bug triggered by CVXPY where reshaping a (1045507, 523266) matrix to (547078265862, 1) causes a negative index to be formed because the index type is being selected based on the old coordinates and shape and not the new one.

This seems to be a regression from 1.14.1

#### Additional information
<!--Any additional information you think is important.-->
