### PR TITLE
BUG:scipy.special.stirling2.h: Fixed malloc failure #22336

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1424,14 +1424,25 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         solver if either A or M is a general linear operator.
         Alternatively, the user can supply the matrix or operator OPinv,
         which gives ``x = OPinv @ b = [A - sigma * M]^-1 @ b``.
+        Regardless of the selected mode (normal, cayley, or buckling),
+        users should always supply the operator x = OPinv @ b = [A - sigma * M]^-1 @ b,
+        which represents the inverse of the shifted matrix.
+        This ensures consistency in the interface and simplifies user input.
+        The solver will internally handle the necessary transformations for different modes,
+        so the user does not need to adjust the operator depending on the mode.
+        The correct eigenvalue transformation 
+        (e.g., for Cayley or buckling modes) will be applied automatically.
         Note that when sigma is specified, the keyword 'which' refers to
         the shifted eigenvalues ``w'[i]`` where:
 
-            if mode == 'normal', ``w'[i] = 1 / (w[i] - sigma)``.
+            if mode == 'normal':
+                ``w'[i] = 1 / (w[i] - sigma)``.
 
-            if mode == 'cayley', ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
+            if mode == 'cayley':
+                  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
 
-            if mode == 'buckling', ``w'[i] = w[i] / (w[i] - sigma)``.
+            if mode == 'buckling':
+                  ``w'[i] = w[i] / (w[i] - sigma)``.
 
         (see further discussion in 'mode' below)
     v0 : ndarray, optional

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1422,27 +1422,19 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         unspecified.  This is computed internally via a (sparse) LU
         decomposition for explicit matrices A & M, or via an iterative
         solver if either A or M is a general linear operator.
-        Alternatively, the user can supply the matrix or operator OPinv,
+        Alternatively, the user can supply the matrix or operator `OPinv`,
         which gives ``x = OPinv @ b = [A - sigma * M]^-1 @ b``.
         Regardless of the selected mode (normal, cayley, or buckling),
-        users should always supply the operator x = OPinv @ b = [A - sigma * M]^-1 @ b,
-        which represents the inverse of the shifted matrix.
-        This ensures consistency in the interface and simplifies user input.
-        The solver will internally handle the necessary transformations for different modes,
-        so the user does not need to adjust the operator depending on the mode.
-        The correct eigenvalue transformation 
-        (e.g., for Cayley or buckling modes) will be applied automatically.
+        `OPinv` should always be supplied as ``OPinv = [A - sigma * M]^-1``.
+
         Note that when sigma is specified, the keyword 'which' refers to
         the shifted eigenvalues ``w'[i]`` where:
 
-            if mode == 'normal':
-                ``w'[i] = 1 / (w[i] - sigma)``.
+            if ``mode == 'normal'``: ``w'[i] = 1 / (w[i] - sigma)``.
 
-            if mode == 'cayley':
-                  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
+            if ``mode == 'cayley'``:  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
 
-            if mode == 'buckling':
-                  ``w'[i] = w[i] / (w[i] - sigma)``.
+            if ``mode == 'buckling'``: ``w'[i] = w[i] / (w[i] - sigma)``.
 
         (see further discussion in 'mode' below)
     v0 : ndarray, optional

--- a/scipy/special/stirling2.h
+++ b/scipy/special/stirling2.h
@@ -41,6 +41,11 @@ double _stirling2_dp(double n, double k){
     }
     int arraySize = k <= n - k + 1 ? k : n - k + 1;
     double *curr = (double *) malloc(arraySize * sizeof(double));
+     if (curr == NULL) {
+        // if Memory allocation fails handling it with error message 
+        fprintf(stderr, "Memory allocation failed\n");
+        return NAN; // Returning NAN if memory allocation fails instead of terminating the program
+    }
     for (int i = 0; i < arraySize; i++){
         curr[i] = 1.;
     }


### PR DESCRIPTION
#### Reference issue
#22336 

#### What does this implement/fix?
Added a null check for the malloc return value.
Prints an error message (Memory allocation failed) and returns NAN to prevent crashes due to null pointer dereferencing.
Ensures the function exits safely without crashing Python or other dependent programs.
