### PR TITLE
TST: interpolate: small tolerance bump to TestAAA.test_basic_functions

### DIFF
--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -201,7 +201,7 @@ class TestAAA:
                              [(lambda x: np.abs(x + 0.5 + 0.01j), 5e-13, 1e-7),
                               (lambda x: np.sin(1/(1.05 - x)), 2e-13, 1e-7),
                               (lambda x: np.exp(-1/(x**2)), 3.5e-13, 0),
-                              (lambda x: np.exp(-100*x**2), 7e-13, 0),
+                              (lambda x: np.exp(-100*x**2), 8e-13, 0),
                               (lambda x: np.exp(-10/(1.2 - x)), 1e-14, 0),
                               (lambda x: 1/(1+np.exp(100*(x + 0.5))), 2e-13, 1e-7),
                               (lambda x: np.abs(x - 0.95), 1e-6, 1e-7)])


### PR DESCRIPTION
Closes #22355

The above issue reported a small tolerance violation with a different BLAS. This is expected as the algorithm is quite sensitive to an SVD calculation so a tiny tolerance bump is required.