### PR TITLE
MAINT: Stop installing `libhighs`

### DIFF
--- a/scipy/optimize/_highspy/meson.build
+++ b/scipy/optimize/_highspy/meson.build
@@ -46,8 +46,7 @@ _highslib = static_library(
     # private symbols don't get re-exported.
     gnu_symbol_visibility: 'inlineshidden',
     pic: true,
-    install: true,
-    install_dir: py3.get_install_dir() / 'scipy/optimize/_highspy',
+    install: false,
 )
 
 _highs_dep = declare_dependency(


### PR DESCRIPTION
Fix suggested by @drew-parsons , and seems to work alright, `highs` symbols are present in `_core.so` anyway.

Closes #22349
