### PR TITLE
MAINT: remove temporary `# type: ignore`'s from #22162

### DIFF
--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -40,8 +40,8 @@ expected_types = ['numeric', 'numeric', 'numeric', 'numeric', 'nominal']
 missing = pjoin(data_path, 'missing.arff')
 expect_missing_raw = np.array([[1, 5], [2, 4], [np.nan, np.nan]])
 expect_missing = np.empty(3, [('yop', float), ('yap', float)])
-expect_missing['yop'] = expect_missing_raw[:, 0]  # type: ignore[call-overload]
-expect_missing['yap'] = expect_missing_raw[:, 1]  # type: ignore[call-overload]
+expect_missing['yop'] = expect_missing_raw[:, 0]
+expect_missing['yap'] = expect_missing_raw[:, 1]
 
 
 class TestData:

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -516,7 +516,7 @@ NDT_ARRAY_FLAGS = MDTYPES[native_code]['dtypes']['array_flags']
 class VarWriter5:
     ''' Generic matlab matrix writing class '''
     mat_tag = np.zeros((), NDT_TAG_FULL)
-    mat_tag['mdtype'] = miMATRIX  # type: ignore[call-overload]
+    mat_tag['mdtype'] = miMATRIX
 
     def __init__(self, file_writer):
         self.file_stream = file_writer.file_stream


### PR DESCRIPTION
Now that [NumPy `v2.2.2`](https://github.com/numpy/numpy/releases/tag/v2.2.2) has been released, there's no need anymore for the temporary `# type: ignore` comments from #22162, which closes #22164.