### PR TITLE
DOC: integrate: fix quad documentation to correctly describe QAGS algorithm

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -284,7 +284,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is based on 21-point Gauss-Kronrod 
+        several types. The integration is performed using a 21-point Gauss-Kronrod 
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -211,9 +211,11 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     For the 'cos' and 'sin' weighting, additional inputs and outputs are
     available.
 
-    For finite integration limits, the integration is performed using a
-    Clenshaw-Curtis method which uses Chebyshev moments. For repeated
-    calculations, these moments are saved in the output dictionary:
+    For finite integration limits, the integration is performed using a 
+    Clenshaw-Curtis method, which uses Chebyshev moments. This method is 
+    particularly suited for handling weighted integrals, such as those 
+    involving singular weight functions or singularities near the integration limits. 
+    For repeated calculations, these moments are saved in the output dictionary:
 
     'momcom'
         The maximum level of Chebyshev moments that have been computed,

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -280,7 +280,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     The following provides a short description from [1]_ for each
     routine.
 
-    qagse (QAGS)
+    qagse
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation by the epsilon 
         algorithm. The integration is based on 21-point Gauss-Kronrod 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -211,8 +211,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     For the 'cos' and 'sin' weighting, additional inputs and outputs are
     available.
 
-    For weighted integrals with finite integration limits, the integration is performed using a 
-    Clenshaw-Curtis method, which uses Chebyshev moments.
+    For weighted integrals with finite integration limits, the integration
+    is performed using a Clenshaw-Curtis method, which uses Chebyshev moments.
     For repeated calculations, these moments are saved in the output dictionary:
 
     'momcom'
@@ -746,7 +746,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is based on 21-point Gauss-Kronrod 
+        several types. The integration is is performed using a 21-point Gauss-Kronrod 
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
@@ -879,7 +879,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is based on 21-point Gauss-Kronrod 
+        several types. The integration is is performed using a 21-point Gauss-Kronrod 
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
@@ -1069,7 +1069,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is based on 21-point Gauss-Kronrod 
+        several types. The integration is is performed using a 21-point Gauss-Kronrod 
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -875,7 +875,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     are infinite. The following provides a short description from [1]_ for each
     routine.
 
-    qagse (QAGS)
+    qagse
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation by the epsilon 
         algorithm. The integration is based on 21-point Gauss-Kronrod 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -211,10 +211,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     For the 'cos' and 'sin' weighting, additional inputs and outputs are
     available.
 
-    For finite integration limits, the integration is performed using a 
-    Clenshaw-Curtis method, which uses Chebyshev moments. This method is 
-    particularly suited for handling weighted integrals, such as those 
-    involving singular weight functions or singularities near the integration limits. 
+    For weighted integrals with finite integration limits, the integration is performed using a 
+    Clenshaw-Curtis method, which uses Chebyshev moments.
     For repeated calculations, these moments are saved in the output dictionary:
 
     'momcom'

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -282,10 +282,10 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     qagse
         is an integrator based on globally adaptive interval
-        subdivision and extrapolation by the epsilon 
-        algorithm. The integration is based on 21-point Gauss-Kronrod 
-        quadrature within each subinterval, which will eliminate the 
-        effects of integrand singularities of several types.
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -744,10 +744,10 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
 
     qagse
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation by the epsilon 
-        algorithm. The integration is based on 21-point Gauss-Kronrod 
-        quadrature within each subinterval, which will eliminate the 
-        effects of integrand singularities of several types.
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -877,10 +877,10 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     qagse
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation by the epsilon 
-        algorithm. The integration is based on 21-point Gauss-Kronrod 
-        quadrature within each subinterval, which will eliminate the 
-        effects of integrand singularities of several types.
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -1067,10 +1067,10 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
 
     qagse
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation by the epsilon 
-        algorithm. The integration is based on 21-point Gauss-Kronrod 
-        quadrature within each subinterval, which will eliminate the 
-        effects of integrand singularities of several types.
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -1065,7 +1065,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     The following provides a short description from [1]_ for each
     routine.
 
-    qagse (QAGS)
+    qagse
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation by the epsilon 
         algorithm. The integration is based on 21-point Gauss-Kronrod 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -280,11 +280,12 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     The following provides a short description from [1]_ for each
     routine.
 
-    qagse
+    qagse (QAGS)
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation, which will
-        eliminate the effects of integrand singularities of
-        several types.
+        subdivision in connection with extrapolation by the epsilon 
+        algorithm. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval, which will eliminate the 
+        effects of integrand singularities of several types.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -741,11 +742,12 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     are infinite. The following provides a short description from [1]_ for each
     routine.
 
-    qagse
+    qagse (QAGS)
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation, which will
-        eliminate the effects of integrand singularities of
-        several types.
+        subdivision in connection with extrapolation by the epsilon 
+        algorithm. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval, which will eliminate the 
+        effects of integrand singularities of several types.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -873,11 +875,12 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     are infinite. The following provides a short description from [1]_ for each
     routine.
 
-    qagse
+    qagse (QAGS)
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation, which will
-        eliminate the effects of integrand singularities of
-        several types.
+        subdivision in connection with extrapolation by the epsilon 
+        algorithm. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval, which will eliminate the 
+        effects of integrand singularities of several types.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
@@ -1062,11 +1065,12 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     The following provides a short description from [1]_ for each
     routine.
 
-    qagse
+    qagse (QAGS)
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation, which will
-        eliminate the effects of integrand singularities of
-        several types.
+        subdivision in connection with extrapolation by the epsilon 
+        algorithm. The integration is based on 21-point Gauss-Kronrod 
+        quadrature within each subinterval, which will eliminate the 
+        effects of integrand singularities of several types.
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -282,7 +282,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     qagse
         is an integrator based on globally adaptive interval
-        subdivision in connection with extrapolation by the epsilon 
+        subdivision and extrapolation by the epsilon 
         algorithm. The integration is based on 21-point Gauss-Kronrod 
         quadrature within each subinterval, which will eliminate the 
         effects of integrand singularities of several types.

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -742,7 +742,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     are infinite. The following provides a short description from [1]_ for each
     routine.
 
-    qagse (QAGS)
+    qagse
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation by the epsilon 
         algorithm. The integration is based on 21-point Gauss-Kronrod 


### PR DESCRIPTION
The documentation incorrectly stated that quad uses Clenshaw-Curtis method for finite integration limits. This PR updates the documentation to correctly reflect that QAGS uses 21-point Gauss-Kronrod quadrature with epsilon algorithm acceleration.

References:
- QUADPACK book (Piessens et al., Section 3.3.5, p. 63)
- [Wikipedia QUADPACK article](https://en.wikipedia.org/wiki/QUADPACK)

Fixes #22093