### PR TITLE
BUG: sparse.linalg.norm: add test for and fix return type

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -150,13 +150,13 @@ def norm(x, ord=None, axis=None):
             raise NotImplementedError
             #return _multi_svd_norm(x, row_axis, col_axis, amin)
         elif ord == 1:
-            return abs(x).sum(axis=row_axis).max().item()
+            return abs(x).sum(axis=row_axis).max()
         elif ord == np.inf:
-            return abs(x).sum(axis=col_axis).max().item()
+            return abs(x).sum(axis=col_axis).max()
         elif ord == -1:
-            return abs(x).sum(axis=row_axis).min().item()
+            return abs(x).sum(axis=row_axis).min()
         elif ord == -np.inf:
-            return abs(x).sum(axis=col_axis).min().item()
+            return abs(x).sum(axis=col_axis).min()
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
             return _sparse_frobenius_norm(x)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -23,7 +23,9 @@ def test_sparray_norm():
         for ax in [0, 1, None, (0, 1), (1, 0)]:
             for A in (test_arr, test_mat):
                 expected = npnorm(A.toarray(), ord=ord, axis=ax)
-                assert_equal(spnorm(A, ord=ord, axis=ax), expected)
+                actual = spnorm(A, ord=ord, axis=ax)
+                assert hasattr(actual, "dtype")
+                assert_equal(actual, expected)
     # test 1d array and 1d-like (column) matrix
     test_arr_1d = scipy.sparse.coo_array((data, (col,)), shape=(4,))
     test_mat_col = scipy.sparse.coo_matrix((data, (col, [0, 0, 0, 0])), shape=(4, 1))


### PR DESCRIPTION
[cupy-8866](https://github.com/cupy/cupy/issues/8866) reports that `sparse.linalg.norm` returns a python number instead of a 0-dim numpy array.  That changed in #21691 where I added a conversion to python number that was not desirable.

This PR adds a test for and fixes the return type of `scipy.sparse.linalg.norm` to be a numpy array rather than a python number.  This will allow cupy to use it as a 0-d numpy array.

We should backport this fix if possible. 