### PR TITLE
BUG: sparse: revert NotImplemented return values in dot and matmul

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -685,7 +685,8 @@ class _spbase:
 
             return result
 
-        return NotImplemented
+        else:
+            raise ValueError('could not interpret dimensions')
 
     def __mul__(self, other):
         return self.multiply(other)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -866,10 +866,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             o_array = np.asanyarray(other)
 
             if o_array.ndim == 0 and o_array.dtype == np.object_:
-                # Not interpretable as an array; return NotImplemented so that
-                # other's __rmatmul__ can kick in if that's implemented.
-                return NotImplemented
-
+                raise TypeError(f"dot argument not supported type: '{type(other)}'")
             try:
                 other.shape
             except AttributeError:
@@ -1082,9 +1079,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             other_array = np.asanyarray(other)
 
             if other_array.ndim == 0 and other_array.dtype == np.object_:
-                # Not interpretable as an array; return NotImplemented
-                return NotImplemented
-
+                raise TypeError(f"tensordot arg not supported type: '{type(other)}'")
             try:
                 other.shape
             except AttributeError:

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -703,6 +703,18 @@ def test_dot_with_inconsistent_shapes():
         arr_a.dot(arr_b)
 
 
+def test_matmul_dot_not_implemented():
+    arr_a = coo_array([[1, 2], [3, 4]])
+    with pytest.raises(TypeError, match="argument not supported type"):
+        arr_a.dot(None)
+    with pytest.raises(TypeError, match="arg not supported type"):
+        arr_a.tensordot(None)
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        arr_a @ None
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        None @ arr_a
+
+
 dot_shapes = [
     ((3,3), (3,3)), ((4,6), (6,7)), ((1,4), (4,1)), # matrix multiplication 2-D
     ((3,2,4,7), (7,)), ((5,), (6,3,5,2)), # dot of n-D and 1-D arrays


### PR DESCRIPTION
Fixes: #22347 

Also allows [cupy 8881](https://github.com/cupy/cupy/pull/8881) to be closed and they no longer need to skip their tests of matmul with a non-numpy dense operand.

This reverts the feature in #21435 of returning `NotImplemented` from `dot` and `tensordot` and matmul, which was included in the new nD interface. But we can't use them with e.g. ndarrays because ndarrays operate on sparse by treating sparse as Object dtype which means the automatic calling of `__rmatmul__` on an ndarray doesn't work. 

And with `dot` and `tensordot` there is no `rdot`  and `rtensordot` (nor an operator to call them). So, it's best just to raise a TypeError.

The reintroduction of raising a ValueError instead of returning NotImplemented is never touched by our tests, but could be hit both other (like maybe cupy). It is the same idea as the others only inside `__rmatmul__`. Brings it back to what it was before the nD PR.

This should be backported.
