### PR TITLE
DOC: sparse.linalg: add two recent functions to namespace and fix doctests

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -44,7 +44,7 @@ Direct methods for linear equation systems:
    spsolve -- Solve the sparse linear system Ax=b
    spsolve_triangular -- Solve sparse linear system Ax=b for a triangular A.
    is_sptriangular -- Check if sparse A is triangular.
-   spbandwidth -- find the bandwidth of a sparse matrix.
+   spbandwidth -- Find the bandwidth of a sparse matrix.
    factorized -- Pre-factorize matrix to a function solving a linear system
    MatrixRankWarning -- Warning on exactly singular matrices
    use_solver -- Select direct solver to use

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -43,6 +43,8 @@ Direct methods for linear equation systems:
 
    spsolve -- Solve the sparse linear system Ax=b
    spsolve_triangular -- Solve sparse linear system Ax=b for a triangular A.
+   is_sptriangular -- Check if sparse A is triangular.
+   spbandwidth -- find the bandwidth of a sparse matrix.
    factorized -- Pre-factorize matrix to a function solving a linear system
    MatrixRankWarning -- Warning on exactly singular matrices
    use_solver -- Select direct solver to use

--- a/scipy/sparse/linalg/_dsolve/__init__.py
+++ b/scipy/sparse/linalg/_dsolve/__init__.py
@@ -62,8 +62,8 @@ from . import linsolve
 
 __all__ = [
     'MatrixRankWarning', 'SuperLU', 'factorized',
-    'spilu', 'splu', 'spsolve',
-    'spsolve_triangular', 'use_solver'
+    'spilu', 'splu', 'spsolve', 'is_sptriangular',
+    'spsolve_triangular', 'use_solver', 'spbandwidth',
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -776,11 +776,12 @@ def is_sptriangular(A):
     --------
     >>> import numpy as np
     >>> from scipy.sparse import csc_array, eye_array
+    >>> from scipy.sparse.linalg import is_sptriangular
     >>> A = csc_array([[3, 0, 0], [1, -1, 0], [2, 0, 1]], dtype=float)
-    >>> scipy.sparse.linalg.is_sptriangular(A)
+    >>> is_sptriangular(A)
     (True, False)
-    >>> D = eye_array((3,3), format='csr')
-    >>> scipy.sparse.linalg.is_sptriangular(D)
+    >>> D = eye_array(3, format='csr')
+    >>> is_sptriangular(D)
     (True, True)
     """
     if not (issparse(A) and A.format in ("csc", "csr", "coo", "dia", "dok", "lil")):
@@ -849,12 +850,13 @@ def spbandwidth(A):
     Examples
     --------
     >>> import numpy as np
+    >>> from scipy.sparse.linalg import spbandwidth
     >>> from scipy.sparse import csc_array, eye_array
     >>> A = csc_array([[3, 0, 0], [1, -1, 0], [2, 0, 1]], dtype=float)
-    >>> scipy.sparse.linalg.spbandwidth(A)
+    >>> spbandwidth(A)
     (2, 0)
-    >>> D = eye_array((3,3), format='csr')
-    >>> scipy.sparse.linalg.spbandwidth(D)
+    >>> D = eye_array(3, format='csr')
+    >>> spbandwidth(D)
     (0, 0)
     """
     if not (issparse(A) and A.format in ("csc", "csr", "coo", "dia", "dok")):


### PR DESCRIPTION
Adds `spbandwidth` and `is_sptriangular` to the `scipy/sparse/linalg` namespace as was originally intended.

While trying to help with smoke-doc failures in `scipy/sparse/linalg` I found that the two recently provided functions `spbandwidth` and `is_sptriangular` were not added to the `sparse.linalg` namespace in `__init__.py`.

This PR adds them to the namespace and then  updates the doc_strings to use those imports. It helps to have valid imports to get your doctests to pass. :)

[Edited:]
The PR to add these functions was #21799 and was merged in November.  The 1.15 release notes announce these functions and they do exist there, but they involve e.g. `scipy.sparse.linalg._dsolve.is_sptriangular` which has a private part of the access path.  This makes it `scipy.sparse.linalg.is_sptriangular`. I'm not sure if that means this should be backported. But I'm adding that label so people think about whether it should be backported. I'm fine either way.