### PR TITLE
DOC: sparse.linalg: fix doctest in scipy.sparse.linalg._norm.py

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -253,7 +253,7 @@ is the same:
 Now we can compute norm of the error with:
 
 >>> err = norm(x-x_)
->>> err < 1e-10
+>>> err < 1e-9
 True
 
 It should be small :)

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -144,7 +144,7 @@ def norm(x, ord=None, axis=None):
             raise ValueError('Duplicate axes given.')
         if ord == 2:
             # Only solver="lobpcg" supports all numpy dtypes
-            _, s, _ = svds(x, k=1, solver="lobpcg", maxiter=50)
+            _, s, _ = svds(x, k=1, solver="lobpcg")
             return s[0]
         elif ord == -2:
             raise NotImplementedError

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -107,7 +107,7 @@ def norm(x, ord=None, axis=None):
     The matrix 2-norm or the spectral norm is the largest singular
     value, computed approximately and with limitations.
 
-    >>> b = diags_array([-1, 1], [0, 1], shape=(9, 10))
+    >>> b = diags_array([-1, 1], offsets=[0, 1], shape=(9, 10))
     >>> norm(b, 2)
     1.9753...
     """
@@ -144,7 +144,7 @@ def norm(x, ord=None, axis=None):
             raise ValueError('Duplicate axes given.')
         if ord == 2:
             # Only solver="lobpcg" supports all numpy dtypes
-            _, s, _ = svds(x, k=1, solver="lobpcg")
+            _, s, _ = svds(x, k=1, solver="lobpcg", maxiter=50)
             return s[0]
         elif ord == -2:
             raise NotImplementedError


### PR DESCRIPTION
In response to #22180 I make this PR in order to fix the doctests in `scipy.sparse.linalg._norm.py`.

I was not able to recreate the failed doctest from #22180 so maybe that has already been fixed elsewhere. There's a lot going into sparse.linalg lately. This PR corrects the syntax on a call to `diags_array` so it actually runs. And it increases the `maxiter` value to `50` on norm with `ord=2`. That helps the doc-test pass. But I'm not sure if this change is acceptable because it makes maxiter=50 whenever `norm(A, ord=2)` is called.

There is currently no way for users of `norm` to provide parameters to the underlying functions of each type of norm. In this case, `svds()` is called to provide `norm(A, ord=2)` but we can't increase the `maxiter` value to allow it to proceed to convergence.  This PR sets the `maxiter` value to 50 (the default value is 20). That seems to give convergence -- at least in the example of the docstring. Changing that parameter value is why I am not running the CI with `docs-only`. I don't think it will cause anything to change, but it isn't a doc change.

On my machine the result shows a `np.float64(1.9....)`. But I think there is CI magic to make that work with `1.9....`.  I'm not very experienced with smoke-docs. So let me know if something should be changed.