### PR TITLE
DOC: sparse.linalg: sparray updates in doc_strings and Sakurai and MikotaK methods

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -307,7 +307,7 @@ def lobpcg(
     ``A x = lambda x`` without constraints or preconditioning.
 
     >>> import numpy as np
-    >>> from scipy.sparse import spdiags
+    >>> from scipy.sparse import diags_array
     >>> from scipy.sparse.linalg import LinearOperator, aslinearoperator
     >>> from scipy.sparse.linalg import lobpcg
 
@@ -323,7 +323,7 @@ def lobpcg(
     the sparse diagonal matrix `A`
     of the eigenvalue problem ``A x = lambda x`` to solve.
 
-    >>> A = spdiags(vals, 0, n, n)
+    >>> A = diags_array(vals, offsets=0, shape=(n, n))
     >>> A = A.astype(np.int16)
     >>> A.toarray()
     array([[  1,   0,   0, ...,   0,   0,   0],

--- a/scipy/sparse/linalg/_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/_special_sparse_arrays.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
-from scipy.sparse import kron, eye, dia_array
+from scipy.sparse import kron, eye_array, dia_array
 
 __all__ = ['LaplacianNd']
 # Sakurai and Mikota classes are intended for tests and benchmarks
@@ -71,7 +71,7 @@ of_the_second_derivative
     --------
     >>> import numpy as np
     >>> from scipy.sparse.linalg import LaplacianNd
-    >>> from scipy.sparse import diags, csgraph
+    >>> from scipy.sparse import diags_array, csgraph
     >>> from scipy.linalg import eigvalsh
 
     The one-dimensional Laplacian demonstrated below for pure Neumann boundary
@@ -81,7 +81,7 @@ of_the_second_derivative
     famous tri-diagonal matrix:
 
     >>> n = 6
-    >>> G = diags(np.ones(n - 1), 1, format='csr')
+    >>> G = diags_array(np.ones(n - 1), offsets=1, format='csr')
     >>> Lf = csgraph.laplacian(G, symmetrized=True, form='function')
     >>> grid_shape = (n, )
     >>> lap = LaplacianNd(grid_shape, boundary_conditions='neumann')
@@ -107,7 +107,7 @@ of_the_second_derivative
     True
 
     Any number of extreme eigenvalues and/or eigenvectors can be computed.
-    
+
     >>> lap = LaplacianNd(grid_shape, boundary_conditions='periodic')
     >>> lap.eigenvalues()
     array([-4., -3., -3., -1., -1.,  0.])
@@ -292,13 +292,13 @@ of_the_second_derivative
 
     def eigenvalues(self, m=None):
         """Return the requested number of eigenvalues.
-        
+
         Parameters
         ----------
         m : int, optional
             The positive number of smallest eigenvalues to return.
             If not provided, then all eigenvalues will be returned.
-            
+
         Returns
         -------
         eigenvalues : float array
@@ -309,7 +309,7 @@ of_the_second_derivative
 
     def _ev1d(self, j, n):
         """Return 1 eigenvector in 1d with index `j`
-        and number of grid points `n` where ``j < n``. 
+        and number of grid points `n` where ``j < n``.
         """
         if self.boundary_conditions == 'dirichlet':
             i = np.pi * (np.arange(n) + 1) / (n + 1)
@@ -326,13 +326,13 @@ of_the_second_derivative
                 i = 2. * np.pi * (np.arange(n) + 0.5) / n
                 ev = np.sqrt(2. / n) * np.cos(i * np.floor((j + 1) / 2))
         # make small values exact zeros correcting round-off errors
-        # due to symmetry of eigenvectors the exact 0. is correct 
+        # due to symmetry of eigenvectors the exact 0. is correct
         ev[np.abs(ev) < np.finfo(np.float64).eps] = 0.
         return ev
 
     def _one_eve(self, k):
         """Return 1 eigenvector in Nd with multi-index `j`
-        as a tensor product of the corresponding 1d eigenvectors. 
+        as a tensor product of the corresponding 1d eigenvectors.
         """
         phi = [self._ev1d(j, n) for j, n in zip(k, self.grid_shape)]
         result = phi[0]
@@ -342,18 +342,18 @@ of_the_second_derivative
 
     def eigenvectors(self, m=None):
         """Return the requested number of eigenvectors for ordered eigenvalues.
-        
+
         Parameters
         ----------
         m : int, optional
             The positive number of eigenvectors to return. If not provided,
             then all eigenvectors will be returned.
-            
+
         Returns
         -------
         eigenvectors : float array
             An array with columns made of the requested `m` or all eigenvectors.
-            The columns are ordered according to the `m` ordered eigenvalues. 
+            The columns are ordered according to the `m` ordered eigenvalues.
         """
         _, ind = self._eigenvalue_ordering(m)
         if m is None:
@@ -466,9 +466,9 @@ of_the_second_derivative
                 L_i += t
 
             for j in range(i):
-                L_i = kron(eye(self.grid_shape[j], dtype=np.int8), L_i)
+                L_i = kron(eye_array(self.grid_shape[j], dtype=np.int8), L_i)
             for j in range(i + 1, N):
-                L_i = kron(L_i, eye(self.grid_shape[j], dtype=np.int8))
+                L_i = kron(L_i, eye_array(self.grid_shape[j], dtype=np.int8))
             L += L_i
         return L.astype(self.dtype)
 
@@ -556,7 +556,7 @@ class Sakurai(LinearOperator):
     `A` and `B` where `A` is the identity so we turn it into an eigenproblem
     just for the matrix `B` that this function outputs in various formats
     together with its eigenvalues.
-    
+
     .. versionadded:: 1.12.0
 
     References
@@ -602,7 +602,7 @@ class Sakurai(LinearOperator):
     The banded form can be used in scipy functions for banded matrices, e.g.,
 
     >>> e = eig_banded(sak.tobanded(), eigvals_only=True)
-    >>> np.allclose(sak.eigenvalues, e, atol= n * n * n * np.finfo(float).eps)
+    >>> np.allclose(sak.eigenvalues(), e, atol= n * n * n * np.finfo(float).eps)
     True
 
     """
@@ -614,13 +614,13 @@ class Sakurai(LinearOperator):
 
     def eigenvalues(self, m=None):
         """Return the requested number of eigenvalues.
-        
+
         Parameters
         ----------
         m : int, optional
             The positive number of smallest eigenvalues to return.
             If not provided, then all eigenvalues will be returned.
-            
+
         Returns
         -------
         eigenvalues : `np.float64` array
@@ -642,18 +642,18 @@ class Sakurai(LinearOperator):
 
     def tosparse(self):
         """
-        Construct the Sakurai matrix is a sparse format.
+        Construct the Sakurai matrix in a sparse format.
         """
-        from scipy.sparse import spdiags
+        from scipy.sparse import diags_array
         d = self.tobanded()
         # the banded format has the main diagonal at the bottom
-        # `spdiags` has no `dtype` parameter so inherits dtype from banded
-        return spdiags([d[0], d[1], d[2], d[1], d[0]], [-2, -1, 0, 1, 2],
-                       self.n, self.n)
+        # `diags_array` inherits dtype from banded
+        return diags_array([d[0], d[1], d[2], d[1], d[0]], offsets=[-2, -1, 0, 1, 2],
+                           shape=(self.n, self.n), dtype=d.dtype)
 
     def toarray(self):
         return self.tosparse().toarray()
-    
+
     def _matvec(self, x):
         """
         Construct matrix-free callable banded-matrix-vector multiplication by
@@ -675,7 +675,7 @@ class Sakurai(LinearOperator):
         Construct matrix-free callable matrix-matrix multiplication by
         the Sakurai matrix without constructing or storing the matrix itself
         by reusing the ``_matvec(x)`` that supports both 1D and 2D arrays ``x``.
-        """        
+        """
         return self._matvec(x)
 
     def _adjoint(self):
@@ -723,8 +723,9 @@ class MikotaM(LinearOperator):
         return self._diag()
 
     def tosparse(self):
-        from scipy.sparse import diags
-        return diags([self._diag()], [0], shape=self.shape, dtype=self.dtype)
+        from scipy.sparse import diags_array
+        return diags_array([self._diag()], offsets=[0],
+                           shape=self.shape, dtype=self.dtype)
 
     def toarray(self):
         return np.diag(self._diag()).astype(self.dtype)
@@ -743,7 +744,7 @@ class MikotaM(LinearOperator):
         Construct matrix-free callable matrix-matrix multiplication by
         the Mikota mass matrix without constructing or storing the matrix itself
         by reusing the ``_matvec(x)`` that supports both 1D and 2D arrays ``x``.
-        """     
+        """
         return self._matvec(x)
 
     def _adjoint(self):
@@ -758,7 +759,7 @@ class MikotaK(LinearOperator):
     Construct a stiffness matrix in various formats of Mikota pair.
 
     The stiffness matrix `K` is square real tri-diagonal symmetric
-    positive definite with integer entries. 
+    positive definite with integer entries.
 
     Parameters
     ----------
@@ -792,9 +793,9 @@ class MikotaK(LinearOperator):
         return np.array([np.pad(self._diag1, (1, 0), 'constant'), self._diag0])
 
     def tosparse(self):
-        from scipy.sparse import diags
-        return diags([self._diag1, self._diag0, self._diag1], [-1, 0, 1],
-                     shape=self.shape, dtype=self.dtype)
+        from scipy.sparse import diags_array
+        return diags_array([self._diag1, self._diag0, self._diag1], offsets=[-1, 0, 1],
+                           shape=self.shape, dtype=self.dtype)
 
     def toarray(self):
         return self.tosparse().toarray()
@@ -822,7 +823,7 @@ class MikotaK(LinearOperator):
         Construct matrix-free callable matrix-matrix multiplication by
         the Stiffness mass matrix without constructing or storing the matrix itself
         by reusing the ``_matvec(x)`` that supports both 1D and 2D arrays ``x``.
-        """  
+        """
         return self._matvec(x)
 
     def _adjoint(self):
@@ -870,7 +871,7 @@ class MikotaPair:
         A `LinearOperator` custom object for the stiffness matrix.
     MikotaM()
         A `LinearOperator` custom object for the mass matrix.
-    
+
     .. versionadded:: 1.12.0
 
     References
@@ -907,7 +908,7 @@ class MikotaPair:
         0.16666667])
     >>> mik_k.tosparse()
     <DIAgonal sparse array of dtype 'float64'
-        with 20 stored elements (3 diagonals) and shape (6, 6)>
+        with 16 stored elements (3 diagonals) and shape (6, 6)>
     >>> mik_m.tosparse()
     <DIAgonal sparse array of dtype 'float64'
         with 6 stored elements (1 diagonals) and shape (6, 6)>
@@ -916,7 +917,7 @@ class MikotaPair:
     >>> np.array_equal(mik_m(np.eye(n)), mik_m.toarray())
     True
     >>> mik.eigenvalues()
-    array([ 1,  4,  9, 16, 25, 36])  
+    array([ 1,  4,  9, 16, 25, 36])
     >>> mik.eigenvalues(2)
     array([ 1,  4])
 
@@ -930,13 +931,13 @@ class MikotaPair:
 
     def eigenvalues(self, m=None):
         """Return the requested number of eigenvalues.
-        
+
         Parameters
         ----------
         m : int, optional
             The positive number of smallest eigenvalues to return.
             If not provided, then all eigenvalues will be returned.
-            
+
         Returns
         -------
         eigenvalues : `np.uint64` array


### PR DESCRIPTION
This PR updates from spmatrix to sparray for some missed doctests and two methods (Sakurai and MikotaK) in scipy.sparse.linalg.  I'm not sure why I missed them in the docs PR for updates. But hopefully this completes the changes for sparse.linalg to migrate to sparray internally.

I included a bunch of white space changes too. I can remove them if that helps.