### PR TITLE
DEP: optimize.nnls: deprecate unused atol parameter

### DIFF
--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -1,9 +1,16 @@
 import numpy as np
 from ._cython_nnls import _nnls
+from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 
 
 __all__ = ['nnls']
 
+_nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in "
+                     "SciPy 1.18.0. It is not used in the implementation.")
+
+@_deprecate_positional_args(version='1.18.0',
+                           deprecated_args={'atol'},
+                           custom_message=_nnls_dep_message)
 
 def nnls(A, b, maxiter=None, *, atol=_NoValue):
     """
@@ -23,7 +30,7 @@ def nnls(A, b, maxiter=None, *, atol=_NoValue):
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
     atol : float, optional
-        .. deprecated:: 1.16.0
+        .. deprecated:: 1.18.0
             This parameter is deprecated and will be removed in SciPy 1.18.0.
             It is not used in the implementation.
 
@@ -67,15 +74,6 @@ def nnls(A, b, maxiter=None, *, atol=_NoValue):
     (array([0., 0.]), 1.7320508075688772)
 
     """
-
-    if atol is not _NoValue:
-        import warnings
-        warnings.warn(
-            "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0. "
-            "It is not used in the implementation.",
-            DeprecationWarning,
-            stacklevel=2
-        )
 
     A = np.asarray_chkfinite(A, dtype=np.float64, order='C')
     b = np.asarray_chkfinite(b, dtype=np.float64)

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -5,7 +5,7 @@ from ._cython_nnls import _nnls
 __all__ = ['nnls']
 
 
-def nnls(A, b, maxiter=None, atol=None):
+def nnls(A, b, maxiter=None):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 
@@ -22,8 +22,6 @@ def nnls(A, b, maxiter=None, atol=None):
         Right-hand side vector.
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
-    atol: float, optional
-        Deprecated and unused parameter. Will be removed in SciPy 1.16.[X].
 
     Returns
     -------
@@ -65,14 +63,6 @@ def nnls(A, b, maxiter=None, atol=None):
     (array([0., 0.]), 1.7320508075688772)
 
     """
-
-    if atol is not None:
-        import warnings
-        warnings.warn(
-            "The 'atol' parameter is deprecated and will be removed in SciPy 1.16.[X].",
-            DeprecationWarning,
-            stacklevel=2
-        )
 
     A = np.asarray_chkfinite(A, dtype=np.float64, order='C')
     b = np.asarray_chkfinite(b, dtype=np.float64)

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -12,7 +12,6 @@ _nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in 
                             deprecated_args={'atol'},
                             custom_message=_nnls_dep_message)
 def nnls(A, b, *, maxiter=None, atol=_NoValue):
-    """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 
     This problem, often called as NonNegative Least Squares, is a convex

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -5,7 +5,7 @@ from ._cython_nnls import _nnls
 __all__ = ['nnls']
 
 
-def nnls(A, b, maxiter=None, *, atol=None):
+def nnls(A, b, maxiter=None, atol=None):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 
@@ -22,13 +22,8 @@ def nnls(A, b, maxiter=None, *, atol=None):
         Right-hand side vector.
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
-    atol: float
-        Tolerance value used in the algorithm to assess closeness to zero in
-        the projected residual ``(A.T @ (A x - b)`` entries. Increasing this
-        value relaxes the solution constraints. A typical relaxation value can
-        be selected as ``max(m, n) * np.linalg.norm(a, 1) * np.spacing(1.)``.
-        This value is not set as default since the norm operation becomes
-        expensive for large problems hence can be used only when necessary.
+    atol: float, optional
+        Deprecated and unused parameter. Will be removed in SciPy 1.16.[X].
 
     Returns
     -------
@@ -70,6 +65,14 @@ def nnls(A, b, maxiter=None, *, atol=None):
     (array([0., 0.]), 1.7320508075688772)
 
     """
+
+    if atol is not None:
+        import warnings
+        warnings.warn(
+            "The 'atol' parameter is deprecated and will be removed in SciPy 1.16.[X].",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
     A = np.asarray_chkfinite(A, dtype=np.float64, order='C')
     b = np.asarray_chkfinite(b, dtype=np.float64)

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -67,7 +67,7 @@ def nnls(A, b, maxiter=None, *, atol=_NoValue):
 
     """
 
-    if atol is not None:
+    if atol is not _NoValue:
         import warnings
         warnings.warn(
             "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0. "

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -9,8 +9,7 @@ _nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in 
                      "SciPy 1.18.0. It is not used in the implementation.")
 
 @_deprecate_positional_args(version='1.18.0',
-                            deprecated_args={'atol'},
-                            custom_message=_nnls_dep_message)
+                            deprecated_args={'atol'})
 def nnls(A, b, *, maxiter=None, atol=_NoValue):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -12,6 +12,7 @@ _nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in 
                             deprecated_args={'atol'},
                             custom_message=_nnls_dep_message)
 def nnls(A, b, *, maxiter=None, atol=_NoValue):
+    """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 
     This problem, often called as NonNegative Least Squares, is a convex

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -5,8 +5,6 @@ from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 
 __all__ = ['nnls']
 
-_nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in "
-                     "SciPy 1.18.0. It is not used in the implementation.")
 
 @_deprecate_positional_args(version='1.18.0',
                             deprecated_args={'atol'})

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -43,17 +43,14 @@ def nnls(A, b, *, maxiter=None, atol=_NoValue):
 
     Notes
     -----
-    The code is based on [2]_ which is an improved version of the classical
-    algorithm of [1]_. It utilizes an active set method and solves the KKT
-    (Karush-Kuhn-Tucker) conditions for the non-negative least squares problem.
+    The code is based on the classical algorithm of [1]_. It utilizes an active
+    set method and solves the KKK (Karush-Kuhn-Tucker) conditions for the
+    non-negative least squares problem.
 
     References
     ----------
     .. [1] : Lawson C., Hanson R.J., "Solving Least Squares Problems", SIAM,
        1995, :doi:`10.1137/1.9781611971217`
-    .. [2] : Bro, Rasmus and de Jong, Sijmen, "A Fast Non-Negativity-
-       Constrained Least Squares Algorithm", Journal Of Chemometrics, 1997,
-       :doi:`10.1002/(SICI)1099-128X(199709/10)11:5<393::AID-CEM483>3.0.CO;2-L`
 
      Examples
     --------

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -5,7 +5,7 @@ from ._cython_nnls import _nnls
 __all__ = ['nnls']
 
 
-def nnls(A, b, maxiter=None, atol=None):
+def nnls(A, b, maxiter=None, *, atol=_NoValue):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -23,8 +23,9 @@ def nnls(A, b, maxiter=None, *, atol=_NoValue):
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
     atol : float, optional
-        This parameter is deprecated and will be removed in SciPy 1.18.0.
-        It was never used in the implementation.
+        .. deprecated:: 1.16.0
+            This parameter is deprecated and will be removed in SciPy 1.18.0.
+            It is not used in the implementation.
 
     Returns
     -------

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -9,10 +9,9 @@ _nnls_dep_message = ("The 'atol' parameter is deprecated and will be removed in 
                      "SciPy 1.18.0. It is not used in the implementation.")
 
 @_deprecate_positional_args(version='1.18.0',
-                           deprecated_args={'atol'},
-                           custom_message=_nnls_dep_message)
-
-def nnls(A, b, maxiter=None, *, atol=_NoValue):
+                            deprecated_args={'atol'},
+                            custom_message=_nnls_dep_message)
+def nnls(A, b, *, maxiter=None, atol=_NoValue):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -71,7 +71,7 @@ def nnls(A, b, maxiter=None, *, atol=_NoValue):
         import warnings
         warnings.warn(
             "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0. "
-            "It was never used in the implementation.",
+            "It is not used in the implementation.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -5,7 +5,7 @@ from ._cython_nnls import _nnls
 __all__ = ['nnls']
 
 
-def nnls(A, b, maxiter=None):
+def nnls(A, b, maxiter=None, atol=None):
     """
     Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
 
@@ -22,6 +22,9 @@ def nnls(A, b, maxiter=None):
         Right-hand side vector.
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
+    atol : float, optional
+        This parameter is deprecated and will be removed in SciPy 1.18.0.
+        It was never used in the implementation.
 
     Returns
     -------
@@ -63,6 +66,15 @@ def nnls(A, b, maxiter=None):
     (array([0., 0.]), 1.7320508075688772)
 
     """
+
+    if atol is not None:
+        import warnings
+        warnings.warn(
+            "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0. "
+            "It was never used in the implementation.",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
     A = np.asarray_chkfinite(A, dtype=np.float64, order='C')
     b = np.asarray_chkfinite(b, dtype=np.float64)

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from pytest import raises as assert_raises
 from scipy.optimize import nnls
-
+import pytest
 
 class TestNNLS:
     def setup_method(self):
@@ -427,3 +427,12 @@ class TestNNLS:
         assert_allclose(sol, np.array([0.0, 0.0, 76.3611306173957, 0.0, 0.0]),
                         atol=5e-14)
         assert np.abs(np.linalg.norm(A@sol - b) - res) < 5e-14
+
+    def test_atol_deprecation_warning(self):
+        """Test that using atol parameter triggers deprecation warning"""
+        a = np.array([[1, 0], [1, 0], [0, 1]])
+        b = np.array([2, 1, 1])
+        
+        message = "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0"
+        with pytest.warns(DeprecationWarning, match=message):
+            nnls(a, b, atol=1e-8)

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -4,6 +4,7 @@ from pytest import raises as assert_raises
 from scipy.optimize import nnls
 import pytest
 
+
 class TestNNLS:
     def setup_method(self):
         self.rng = np.random.default_rng(1685225766635251)

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -21,7 +21,7 @@ class TestNNLS:
         x = np.abs(self.rng.uniform(low=-2, high=2, size=[10]))
         x[::2] = 0
         b = a @ x
-        xact, rnorm = nnls(a, b, atol=500*np.linalg.norm(a, 1)*np.spacing(1.))
+        xact, rnorm = nnls(a, b)
         assert_allclose(xact, x, rtol=0., atol=1e-10)
         assert rnorm < 1e-12
 
@@ -32,7 +32,7 @@ class TestNNLS:
         x = np.abs(self.rng.uniform(low=-2, high=2, size=[120]))
         x[::2] = 0
         b = a @ x
-        xact, rnorm = nnls(a, b, atol=500*np.linalg.norm(a, 1)*np.spacing(1.))
+        xact, rnorm = nnls(a, b)
         assert_allclose(xact, x, rtol=0., atol=1e-10)
         assert rnorm < 1e-12
 
@@ -153,7 +153,7 @@ class TestNNLS:
         k[nz] = 0
         W = np.diag(w)
 
-        dact, _ = nnls(W @ A, W @ k, atol=1e-7)
+        dact, _ = nnls(W @ A, W @ k)
 
         p = np.cumsum(dact)
         assert np.all(dact >= 0)
@@ -433,6 +433,7 @@ class TestNNLS:
         a = np.array([[1, 0], [1, 0], [0, 1]])
         b = np.array([2, 1, 1])
         
-        message = "The 'atol' parameter is deprecated and will be removed in SciPy 1.18.0"
+        message = ("The 'atol' parameter is deprecated and will be removed in "
+                  "SciPy 1.18.0")
         with pytest.warns(DeprecationWarning, match=message):
             nnls(a, b, atol=1e-8)

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -433,7 +433,5 @@ class TestNNLS:
         a = np.array([[1, 0], [1, 0], [0, 1]])
         b = np.array([2, 1, 1])
         
-        message = ("The 'atol' parameter is deprecated and will be removed in "
-                  "SciPy 1.18.0")
-        with pytest.warns(DeprecationWarning, match=message):
+        with pytest.warns(DeprecationWarning, match="{'atol'}"):
             nnls(a, b, atol=1e-8)


### PR DESCRIPTION
#### Reference issue
Closes gh-21484

#### What does this implement/fix?
Removes the unused `atol` parameter from `scipy.optimize.nnls`. The parameter has never been used in the implementation, so this change simply removes it from:

- The function signature
- The function's documentation

#### Additional information
The `atol` parameter has been present in the function signature but has never been used in the implementation.