### PR TITLE
DOC: Add example to show usage of ``predecessors`` matrix returned from `sparse.csgraph.shortest_path`

### DIFF
--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -5,6 +5,8 @@ Compressed Sparse Graph Routines (`scipy.sparse.csgraph`)
 
 .. currentmodule:: scipy.sparse.csgraph
 
+.. _word-ladders-example:
+
 
 Example: Word Ladders
 ---------------------

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -170,6 +170,60 @@ def shortest_path(csgraph, method='auto',
     >>> predecessors
     array([-9999,     0,     0,     1], dtype=int32)
 
+    >>> graph = [
+    ... [0, 0, 7, 0],
+    ... [0, 0, 8, 5],
+    ... [7, 8, 0, 0],
+    ... [0, 5, 0, 0]
+    ... ]
+    >>> graph = csr_array(graph)
+    >>> print(graph)
+    <Compressed Sparse Row sparse array of dtype 'int64'
+    	with 6 stored elements and shape (4, 4)>
+    	Coords	Values
+    	(0, 2)	7
+    	(1, 2)	8
+    	(1, 3)	5
+    	(2, 0)	7
+    	(2, 1)	8
+    	(3, 1)	5
+
+    >>> sources = [0, 2]
+    >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=sources, return_predecessors=True)
+    >>> dist_matrix
+    array([[ 0., 15.,  7., 20.],
+           [ 7.,  8.,  0., 13.]])
+    >>> predecessors
+    array([[-9999,     2,     0,     1],
+           [    2,     2, -9999,     1]], dtype=int32)
+
+    >>> shortest_paths = {}
+    >>> for idx in range(len(sources)):
+    ...     for node in range(4):
+    ...         curr_node = node
+    ...         path = []
+    ...         while curr_node != -9999:
+    ...             path = [curr_node] + path
+    ...             curr_node = int(predecessors[idx][curr_node])
+    ...         shortest_paths[(sources[idx], node)] = path
+    ...
+
+    >>> shortest_paths[(0, 3)]
+    [0, 2, 1, 3]
+    >>> path03 = shortest_paths[(0, 3)]
+    >>> sum([graph[path03[0], path03[1]], graph[path03[1], path03[2]], graph[path03[2], path03[3]]])
+    np.int64(20)
+    >>> dist_matrix[0][3]
+    np.float64(20.0)
+
+    >>> shortest_paths[(2, 3)]
+    [2, 1, 3]
+    >>> path23 = shortest_paths[(2, 3)]
+    >>> sum([graph[path23[0], path23[1]], graph[path23[1], path23[2]]])
+    np.int64(13)
+    >>> dist_matrix[1][3]
+    np.float64(13.0)
+
     """
     csgraph = convert_pydata_sparse_to_scipy(csgraph, accept_fv=[0, np.inf, np.nan])
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1733,7 +1733,7 @@ cdef void _yen(
             if (
                 total_distance != INFINITY
                 and _yen_is_path_in_candidates(candidate_predecessors,
-                                               shortest_paths_predecessors[k-1], 
+                                               shortest_paths_predecessors[k-1],
                                                predecessor_matrix,
                                                spur_node, sink) == 0
             ):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -200,11 +200,11 @@ def shortest_path(csgraph, method='auto',
     >>> shortest_paths = {}
     >>> for idx in range(len(sources)):
     ...     for node in range(4):
-    ...         curr_node = node
+    ...         curr_node = node # start from the destination node
     ...         path = []
-    ...         while curr_node != -9999:
-    ...             path = [curr_node] + path
-    ...             curr_node = int(predecessors[idx][curr_node])
+    ...         while curr_node != -9999: # no previous node available, exit the loop
+    ...             path = [curr_node] + path # prefix the previous node obtained from the last iteration
+    ...             curr_node = int(predecessors[idx][curr_node]) # set current node to previous node
     ...         shortest_paths[(sources[idx], node)] = path
     ...
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -132,6 +132,12 @@ def shortest_path(csgraph, method='auto',
     NegativeCycleError:
         if there are negative cycles in the graph
 
+    See Also
+    --------
+    :ref:`word-ladders-example` : An illustratation of the ``shortest_path`` API with a meaninful example.
+                                  It also reconstructs the shortest path by using predecessors matrix returned
+                                  by this function.
+
     Notes
     -----
     As currently implemented, Dijkstra's algorithm and Johnson's algorithm

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -154,29 +154,6 @@ def shortest_path(csgraph, method='auto',
     >>> from scipy.sparse.csgraph import shortest_path
 
     >>> graph = [
-    ... [0, 1, 2, 0],
-    ... [0, 0, 0, 1],
-    ... [2, 0, 0, 3],
-    ... [0, 0, 0, 0]
-    ... ]
-    >>> graph = csr_array(graph)
-    >>> print(graph)
-    <Compressed Sparse Row sparse array of dtype 'int64'
-    	with 5 stored elements and shape (4, 4)>
-    	Coords	Values
-    	(0, 1)	1
-    	(0, 2)	2
-    	(1, 3)	1
-    	(2, 0)	2
-    	(2, 3)	3
-
-    >>> dist_matrix, predecessors = shortest_path(csgraph=graph, directed=False, indices=0, return_predecessors=True)
-    >>> dist_matrix
-    array([0., 1., 2., 2.])
-    >>> predecessors
-    array([-9999,     0,     0,     1], dtype=int32)
-
-    >>> graph = [
     ... [0, 0, 7, 0],
     ... [0, 0, 8, 5],
     ... [7, 8, 0, 0],

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -180,6 +180,8 @@ def shortest_path(csgraph, method='auto',
     array([[-9999,     2,     0,     1],
            [    2,     2, -9999,     1]], dtype=int32)
 
+    Reconstructing shortest paths from sources to all the nodes of the graph.
+
     >>> shortest_paths = {}
     >>> for idx in range(len(sources)):
     ...     for node in range(4):
@@ -191,6 +193,10 @@ def shortest_path(csgraph, method='auto',
     ...         shortest_paths[(sources[idx], node)] = path
     ...
 
+    Computing the length of the shortest path from node 0 to node 3
+    of the graph. It can be observed that computed length and the
+    ``dist_matrix`` value are exactly same.
+
     >>> shortest_paths[(0, 3)]
     [0, 2, 1, 3]
     >>> path03 = shortest_paths[(0, 3)]
@@ -198,6 +204,12 @@ def shortest_path(csgraph, method='auto',
     np.int64(20)
     >>> dist_matrix[0][3]
     np.float64(20.0)
+
+    Another example of computing shortest path length from node 2 to node 3.
+    Here, ``dist_matrix[1][3]`` is used to get the length of the path returned by
+    ``shortest_path``. This is because node 2 is the second source, so the
+    lengths of the path from it to other nodes in the graph will be at index 1
+    in ``dist_matrix``.
 
     >>> shortest_paths[(2, 3)]
     [2, 1, 3]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/13914

#### What does this implement/fix?
<!--Please explain your changes.-->

In this PR I have added one example to show how to use ``predecessors`` matrix returned from `sparse.csgraph.shortest_path`. This example will help in clearing up how to read the said matrix and use it to re-construct the shortest paths from sources to nodes. https://github.com/scipy/scipy/issues/13914 was opened due to the confusion in the format of ``predecessors`` matrix. The example I have added helps in clearing that up because it uses ``predecessors`` matrix to construct shortest paths (which is what it is meant for).

@bernstei Is this good? 

The documentation of `predecessors` is good enough, the example just adds on it and concretely shows how to read it.

#### Additional information
<!--Any additional information you think is important.-->
